### PR TITLE
feat(setores/tickets): gerir vínculos de atendentes por setor

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import { RedeForm } from './pages/RedeForm'
 import { Empresas } from './pages/Empresas'
 import { EmpresaDetalhe } from './pages/EmpresaDetalhe'
 import { Setores } from './pages/Setores'
+import { SetorDetalhe } from './pages/SetorDetalhe'
 import { Atendentes } from './pages/Atendentes'
 import { FuncionariosRede } from './pages/FuncionariosRede'
 import { FuncionarioRedeDetalhe } from './pages/FuncionarioRedeDetalhe'
@@ -128,6 +129,14 @@ function AppRoutes() {
           element={
             <AdminRoute>
               <Setores />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="setores/:id"
+          element={
+            <AdminRoute>
+              <SetorDetalhe />
             </AdminRoute>
           }
         />

--- a/frontend/src/pages/Atendentes.tsx
+++ b/frontend/src/pages/Atendentes.tsx
@@ -241,22 +241,25 @@ export function Atendentes() {
                   { value: 'admin', label: 'Administrador' },
                 ]}
               />
-              {role === 'atendente' && (
-                <div>
-                  <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">Setores</label>
-                  <div className="flex flex-wrap gap-2">
-                    {setoresList.map((s) => (
-                      <CheckboxField
-                        key={s.id}
-                        checked={setorIds.includes(s.id)}
-                        onChange={() => toggleSetor(s.id)}
-                      >
-                        {s.nome}
-                      </CheckboxField>
-                    ))}
-                  </div>
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">Setores</label>
+                {role === 'admin' && (
+                  <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
+                    Opcional, mas recomendado: vincule administradores a setores para poderem ser responsáveis em tickets do setor.
+                  </p>
+                )}
+                <div className="flex flex-wrap gap-2">
+                  {setoresList.map((s) => (
+                    <CheckboxField
+                      key={s.id}
+                      checked={setorIds.includes(s.id)}
+                      onChange={() => toggleSetor(s.id)}
+                    >
+                      {s.nome}
+                    </CheckboxField>
+                  ))}
                 </div>
-              )}
+              </div>
               <Switch
                 checked={ativo}
                 onCheckedChange={setAtivo}

--- a/frontend/src/pages/SetorDetalhe.tsx
+++ b/frontend/src/pages/SetorDetalhe.tsx
@@ -1,0 +1,259 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { atendentes, setores, type Atendentes, type Setores } from '../api/client'
+import { coletarTodasPaginas } from '../api/collectPages'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { SelectComPesquisa } from '../components/ui/SelectComPesquisa'
+import { useToast } from '../components/ui/Toast'
+import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+
+/** Mesmo nome de setor = mesmo “setor lógico” (vários IDs no banco). */
+function idsSetoresMesmoNome(setoresList: Setores.Setor[], setorId: number): Set<number> {
+  const alvo = setoresList.find((x) => x.id === setorId)
+  if (!alvo) return new Set([setorId])
+  const nome = alvo.nome.trim().toLowerCase()
+  return new Set(setoresList.filter((x) => x.nome.trim().toLowerCase() === nome).map((x) => x.id))
+}
+
+export function SetorDetalhe() {
+  const { id } = useParams()
+  const toast = useToast()
+  const navigate = useNavigate()
+  const voltarAnterior = useVoltarAnterior('/setores')
+
+  const setorId = Number(id)
+  const [loading, setLoading] = useState(true)
+  const [setor, setSetor] = useState<Setores.Setor | null>(null)
+  const [setoresList, setSetoresList] = useState<Setores.Setor[]>([])
+
+  const [vinculados, setVinculados] = useState<Atendentes.Atendente[]>([])
+  const [todosAtendentes, setTodosAtendentes] = useState<Atendentes.Atendente[]>([])
+  const [addingId, setAddingId] = useState<number | ''>('')
+  const [saving, setSaving] = useState(false)
+
+  const grupoSetorIds = useMemo(() => {
+    if (!Number.isFinite(setorId) || setorId <= 0 || setoresList.length === 0) return new Set<number>()
+    return idsSetoresMesmoNome(setoresList, setorId)
+  }, [setorId, setoresList])
+
+  const vinculadosIds = useMemo(() => new Set(vinculados.map((a) => a.id)), [vinculados])
+
+  const candidatosParaAdicionar = useMemo(() => {
+    const ativos = todosAtendentes.filter((a) => a.ativo)
+    return ativos.filter((a) => !vinculadosIds.has(a.id)).sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR'))
+  }, [todosAtendentes, vinculadosIds])
+
+  const atendenteItems = useMemo(
+    () =>
+      candidatosParaAdicionar.map((a) => ({
+        id: a.id,
+        label: `${a.nome} — ${a.email}`,
+      })),
+    [candidatosParaAdicionar],
+  )
+
+  async function reload() {
+    if (!Number.isFinite(setorId) || setorId <= 0) {
+      setSetor(null)
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    try {
+      const [s, setoresAll, todos] = await Promise.all([
+        setores.get(setorId),
+        coletarTodasPaginas<Setores.Setor>((o, l) => setores.list({ incluir_inativos: true, offset: o, limit: l })),
+        coletarTodasPaginas<Atendentes.Atendente>((o, l) =>
+          atendentes.list({ incluir_inativos: true, offset: o, limit: l }),
+        ),
+      ])
+      setSetor(s)
+      setSetoresList(setoresAll)
+      setTodosAtendentes(todos)
+
+      const vinculadosDoGrupo = await atendentes.listPorSetor(setorId, { incluir_inativos: true })
+      setVinculados(vinculadosDoGrupo)
+    } catch (err) {
+      setSetor(null)
+      setVinculados([])
+      toast.showError(err instanceof Error ? err.message : 'Erro ao carregar setor')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void reload()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id])
+
+  async function updateVinculo(atendente: Atendentes.Atendente, nextSetorIds: number[]) {
+    await atendentes.update(atendente.id, { setor_ids: nextSetorIds })
+  }
+
+  async function handleAdd() {
+    if (addingId === '' || saving) return
+    const alvo = todosAtendentes.find((a) => a.id === Number(addingId))
+    if (!alvo) return
+    setSaving(true)
+    try {
+      const atual = new Set(alvo.setor_ids ?? [])
+      atual.add(setorId)
+      await updateVinculo(alvo, Array.from(atual))
+      toast.showSuccess('Atendente vinculado ao setor.')
+      setAddingId('')
+      await reload()
+    } catch (err) {
+      toast.showError(err instanceof Error ? err.message : 'Erro ao vincular atendente')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleRemove(atendente: Atendentes.Atendente) {
+    if (saving) return
+    if (!confirm(`Remover ${atendente.nome} deste setor?`)) return
+    setSaving(true)
+    try {
+      const atual = new Set(atendente.setor_ids ?? [])
+      // remove do “setor lógico” (todas duplicatas de mesmo nome)
+      for (const sid of grupoSetorIds) atual.delete(sid)
+      await updateVinculo(atendente, Array.from(atual))
+      toast.showSuccess('Vínculo removido.')
+      await reload()
+    } catch (err) {
+      toast.showError(err instanceof Error ? err.message : 'Erro ao remover vínculo')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center text-slate-500 dark:text-slate-400">
+        Carregando setor…
+      </div>
+    )
+  }
+
+  if (!setor) {
+    return (
+      <div className="space-y-4">
+        <p className="text-slate-600 dark:text-slate-400">Setor não encontrado.</p>
+        <button
+          type="button"
+          onClick={voltarAnterior}
+          className="font-medium text-slate-800 underline decoration-slate-400 underline-offset-2 hover:text-slate-950 dark:text-slate-200 dark:hover:text-white"
+        >
+          Voltar
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+        <button
+          type="button"
+          onClick={voltarAnterior}
+          className="font-medium text-slate-600 hover:text-slate-900 dark:text-slate-300 dark:hover:text-slate-100"
+        >
+          ← Voltar
+        </button>
+        <span aria-hidden className="text-slate-300 dark:text-slate-600">
+          /
+        </span>
+        <button
+          type="button"
+          onClick={() => navigate('/setores')}
+          className="font-medium text-slate-600 hover:text-slate-900 dark:text-slate-300 dark:hover:text-slate-100"
+        >
+          Setores
+        </button>
+        <span aria-hidden className="text-slate-300 dark:text-slate-600">
+          /
+        </span>
+        <span className="font-semibold text-slate-800 dark:text-slate-100">{setor.nome}</span>
+      </nav>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">{setor.nome}</h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Slug: <span className="font-mono">{setor.slug}</span> • {setor.ativo ? 'Ativo' : 'Inativo'}
+          </p>
+        </div>
+      </div>
+
+      <Card title="Atendentes vinculados">
+        <div className="space-y-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+            <div className="flex-1">
+              <SelectComPesquisa
+                id="setor-add-atendente"
+                label="Adicionar atendente"
+                value={addingId}
+                onChange={(v) => setAddingId(v)}
+                items={atendenteItems}
+              />
+            </div>
+            <div className="sm:pb-[2px]">
+              <Button onClick={handleAdd} disabled={addingId === ''} loading={saving}>
+                Adicionar
+              </Button>
+            </div>
+          </div>
+
+          {vinculados.length === 0 ? (
+            <p className="text-slate-500 dark:text-slate-400">Nenhum atendente vinculado.</p>
+          ) : (
+            <div className="-mx-2 overflow-x-auto rounded-lg">
+              <table className="w-full min-w-[680px] text-left text-sm">
+                <thead>
+                  <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+                    <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      Nome
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      E-mail
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      Perfil
+                    </th>
+                    <th className="w-px whitespace-nowrap px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      Ações
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                  {vinculados
+                    .slice()
+                    .sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR'))
+                    .map((a) => (
+                      <tr key={a.id} className="hover:bg-slate-50 dark:hover:bg-slate-800/50">
+                        <td className="px-4 py-3.5">
+                          <span className={`font-medium ${a.ativo ? 'text-slate-800 dark:text-slate-100' : 'text-slate-400'}`}>
+                            {a.nome}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3.5 text-slate-600 dark:text-slate-400">{a.email}</td>
+                        <td className="px-4 py-3.5 text-slate-600 dark:text-slate-400">{a.role === 'admin' ? 'Administrador' : 'Atendente'}</td>
+                        <td className="px-4 py-3.5 text-right">
+                          <Button variant="secondary" onClick={() => handleRemove(a)} loading={saving}>
+                            Remover
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </Card>
+    </div>
+  )
+}
+

--- a/frontend/src/pages/Setores.tsx
+++ b/frontend/src/pages/Setores.tsx
@@ -11,11 +11,13 @@ import { useToast } from '../components/ui/Toast'
 import { FiltroInativos } from '../components/ui/FiltroInativos'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
 import { Switch } from '../components/ui/Switch'
+import { useNavigate } from 'react-router-dom'
 
 type ColunaSetor = 'nome' | 'slug' | 'ativo'
 
 export function Setores() {
   const toast = useToast()
+  const navigate = useNavigate()
   const { ordenarPor, ordem, aoOrdenarColuna, sortParams } = useOrdenacaoLista<ColunaSetor>()
   const [list, setList] = useState<Setores.Setor[]>([])
   const [total, setTotal] = useState(0)
@@ -148,11 +150,11 @@ export function Setores() {
                     key={s.id}
                     role="button"
                     tabIndex={0}
-                    onClick={() => openEdit(s)}
+                    onClick={() => navigate(`/setores/${s.id}`)}
                     onKeyDown={(ev) => {
                       if (ev.key === 'Enter' || ev.key === ' ') {
                         ev.preventDefault()
-                        openEdit(s)
+                        navigate(`/setores/${s.id}`)
                       }
                     }}
                     className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50 focus:outline-none focus-visible:bg-slate-100 dark:focus-visible:bg-slate-800/60"
@@ -170,7 +172,11 @@ export function Setores() {
                     </td>
                     <td className="px-4 py-3.5 text-right sm:px-6" onClick={(ev) => ev.stopPropagation()}>
                       <div className="inline-flex gap-1.5">
-                        <Button variant="ghost" onClick={() => openEdit(s)} aria-label="Editar setor">
+                        <Button
+                          variant="ghost"
+                          onClick={() => openEdit(s)}
+                          aria-label="Editar setor"
+                        >
                           <IconPencil ariaHidden={false} />
                         </Button>
                         <Button variant="ghost" onClick={() => handleDelete(s.id)} aria-label="Excluir setor">


### PR DESCRIPTION
## Summary
- Adiciona página de detalhe de setor (/setores/:id) para listar e gerenciar atendentes vinculados (adicionar/remover).
- Permite vincular **administradores** a setores na tela de Atendentes (necessário para atribuição de tickets por setor).

## Issues
- #31
- #30

## Test plan
- [x] Em **Atendentes**, editar um admin e marcar ao menos 1 setor; salvar e confirmar que setor_ids foi persistido.
- [x] Em **Setores**, clicar em um setor e abrir /setores/:id.
- [x] Adicionar um atendente ao setor e validar que ele aparece na lista.
- [x] Remover um atendente do setor e validar que ele some da lista.
- [x] Em **Tickets**, atribuir ticket do setor para um admin vinculado e validar que a API aceita.

## Notes
- Remoção de vínculo remove do “setor lógico” (todas duplicatas de mesmo nome) para evitar inconsistência operacional.