### PR TITLE
Promoção: notificações na navbar (#36)

### DIFF
--- a/backend/alembic/versions/006_ticket_reads.py
+++ b/backend/alembic/versions/006_ticket_reads.py
@@ -1,0 +1,46 @@
+"""Tabela ticket_reads e índice em ticket_mensagens.
+
+Revision ID: 006_ticket_reads
+Revises: 005_rede_login_retaguarda
+Create Date: 2026-04-14
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "006_ticket_reads"
+down_revision = "005_rede_login_retaguarda"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ticket_reads",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("atendente_id", sa.Integer(), nullable=False),
+        sa.Column("ticket_id", sa.Integer(), nullable=False),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["atendente_id"], ["atendentes.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["ticket_id"], ["tickets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("atendente_id", "ticket_id", name="uq_ticket_reads_atendente_ticket"),
+    )
+    op.create_index(op.f("ix_ticket_reads_id"), "ticket_reads", ["id"], unique=False)
+    op.create_index(op.f("ix_ticket_reads_atendente_id"), "ticket_reads", ["atendente_id"], unique=False)
+    op.create_index(op.f("ix_ticket_reads_ticket_id"), "ticket_reads", ["ticket_id"], unique=False)
+    op.create_index(
+        "ix_ticket_mensagens_ticket_id_created_at",
+        "ticket_mensagens",
+        ["ticket_id", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ticket_mensagens_ticket_id_created_at", table_name="ticket_mensagens")
+    op.drop_index(op.f("ix_ticket_reads_ticket_id"), table_name="ticket_reads")
+    op.drop_index(op.f("ix_ticket_reads_atendente_id"), table_name="ticket_reads")
+    op.drop_index(op.f("ix_ticket_reads_id"), table_name="ticket_reads")
+    op.drop_table("ticket_reads")

--- a/backend/app/api/notificacoes.py
+++ b/backend/app/api/notificacoes.py
@@ -1,0 +1,203 @@
+"""Resumo e itens de pendências (fila + mensagens não lidas)."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import exists, func, select
+from sqlalchemy.orm import Session, joinedload
+
+from app.database import get_db
+from app.models import Ticket, TicketMensagem, Atendente
+from app.models.ticket_read import TicketRead
+from app.schemas.notificacoes import NotificacaoResumo, NotificacaoItem, NotificacaoItensResponse
+from app.core.auth import obter_atendente_atual
+from app.core.setor_scope import ids_setores_visiveis_atendente
+from app.api.tickets import _pode_ver_ticket
+
+router = APIRouter(prefix="/notificacoes", tags=["notificacoes"])
+
+
+def _last_seen_scalar_subq(atendente_id: int):
+    return (
+        select(TicketRead.last_seen_at)
+        .where(
+            TicketRead.ticket_id == Ticket.id,
+            TicketRead.atendente_id == atendente_id,
+        )
+        .limit(1)
+        .scalar_subquery()
+    )
+
+
+def _effective_last_seen_expr(atendente_id: int):
+    return func.coalesce(_last_seen_scalar_subq(atendente_id), Ticket.created_at)
+
+
+def _exists_mensagem_nao_lida(atendente_id: int):
+    eff = _effective_last_seen_expr(atendente_id)
+    return exists(
+        select(TicketMensagem.id).where(
+            TicketMensagem.ticket_id == Ticket.id,
+            TicketMensagem.created_at > eff,
+        )
+    )
+
+
+def _count_sem_responsavel(db: Session, atendente: Atendente) -> int:
+    stmt = (
+        select(func.count())
+        .select_from(Ticket)
+        .where(
+            Ticket.fechado_em.is_(None),
+            Ticket.atendente_id.is_(None),
+        )
+    )
+    if atendente.role != "admin":
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        stmt = stmt.where(Ticket.setor_id.in_(vis))
+    return int(db.execute(stmt).scalar_one())
+
+
+def _count_tickets_com_nao_lidas(db: Session, atendente: Atendente) -> int:
+    stmt = select(func.count()).select_from(Ticket).where(
+        Ticket.fechado_em.is_(None),
+        Ticket.atendente_id.isnot(None),
+        _exists_mensagem_nao_lida(atendente.id),
+    )
+    if atendente.role != "admin":
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        stmt = stmt.where(Ticket.setor_id.in_(vis), Ticket.atendente_id == atendente.id)
+    return int(db.execute(stmt).scalar_one())
+
+
+def _unread_count_for_ticket(db: Session, ticket: Ticket, atendente_id: int) -> int:
+    ls = (
+        db.query(TicketRead.last_seen_at)
+        .filter(
+            TicketRead.ticket_id == ticket.id,
+            TicketRead.atendente_id == atendente_id,
+        )
+        .scalar()
+    )
+    eff = ls if ls is not None else ticket.created_at
+    n = (
+        db.query(func.count(TicketMensagem.id))
+        .filter(
+            TicketMensagem.ticket_id == ticket.id,
+            TicketMensagem.created_at > eff,
+        )
+        .scalar()
+    )
+    return int(n or 0)
+
+
+@router.get("/resumo", response_model=NotificacaoResumo)
+def resumo(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    sem = _count_sem_responsavel(db, atendente)
+    nao = _count_tickets_com_nao_lidas(db, atendente)
+    return NotificacaoResumo(
+        sem_responsavel_count=sem,
+        nao_lidas_count=nao,
+        total_pendencias=sem + nao,
+    )
+
+
+@router.get("/itens", response_model=NotificacaoItensResponse)
+def itens(
+    limit: int = Query(15, ge=1, le=50),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    out: list[NotificacaoItem] = []
+
+    sem = _count_sem_responsavel(db, atendente)
+    if sem > 0:
+        out.append(
+            NotificacaoItem(
+                tipo="fila_sem_responsavel",
+                ticket_id=None,
+                titulo="Tickets na fila",
+                descricao="Sem responsável — em aberto",
+                count=sem,
+                href="/tickets?sem_responsavel=1",
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+
+    stmt = (
+        select(Ticket)
+        .where(
+            Ticket.fechado_em.is_(None),
+            Ticket.atendente_id.isnot(None),
+            _exists_mensagem_nao_lida(atendente.id),
+        )
+        .options(
+            joinedload(Ticket.empresa),
+            joinedload(Ticket.setor),
+        )
+        .order_by(Ticket.updated_at.desc().nulls_last(), Ticket.id.desc())
+        .limit(limit)
+    )
+    if atendente.role != "admin":
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        stmt = stmt.where(Ticket.setor_id.in_(vis), Ticket.atendente_id == atendente.id)
+
+    rows = db.execute(stmt).unique().scalars().all()
+
+    for t in rows:
+        uc = _unread_count_for_ticket(db, t, atendente.id)
+        if uc <= 0:
+            continue
+        emp = t.empresa.nome if t.empresa else "—"
+        setor = t.setor.nome if t.setor else "—"
+        out.append(
+            NotificacaoItem(
+                tipo="mensagens_nao_lidas",
+                ticket_id=t.id,
+                titulo=f"{t.protocolo} — {t.assunto[:80]}{'…' if len(t.assunto) > 80 else ''}",
+                descricao=f"{emp} · {setor}",
+                count=uc,
+                href=f"/tickets/{t.id}",
+                created_at=t.updated_at or t.created_at,
+            )
+        )
+
+    return NotificacaoItensResponse(itens=out)
+
+
+@router.post("/tickets/{ticket_id}/visto", status_code=204)
+def marcar_visto(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if not _pode_ver_ticket(db, atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+
+    now = datetime.now(timezone.utc)
+    row = (
+        db.query(TicketRead)
+        .filter(
+            TicketRead.ticket_id == ticket_id,
+            TicketRead.atendente_id == atendente.id,
+        )
+        .first()
+    )
+    if row:
+        row.last_seen_at = now
+    else:
+        db.add(
+            TicketRead(
+                atendente_id=atendente.id,
+                ticket_id=ticket_id,
+                last_seen_at=now,
+            )
+        )
+    db.commit()
+    return None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.middleware.trustedhost import TrustedHostMiddleware
 
-from app.api import auth, redes, empresas, setores, atendentes, funcionarios_rede, status_ticket, tickets, dashboard, audit, tipo_negocio, cadastro_aux
+from app.api import auth, redes, empresas, setores, atendentes, funcionarios_rede, status_ticket, tickets, dashboard, audit, tipo_negocio, cadastro_aux, notificacoes
 from app.config import settings
 from app.core.lifecycle import dev_create_all_tables, production_require_alembic
 from app.database import Base, engine
@@ -196,6 +196,7 @@ app.include_router(dashboard.router, prefix=API_V1_PREFIX)
 app.include_router(audit.router, prefix=API_V1_PREFIX)
 app.include_router(tipo_negocio.router, prefix=API_V1_PREFIX)
 app.include_router(cadastro_aux.router, prefix=API_V1_PREFIX)
+app.include_router(notificacoes.router, prefix=API_V1_PREFIX)
 
 
 @app.get("/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.setor import Setor
 from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
 from app.models.status_ticket import StatusTicket
 from app.models.ticket import Ticket, TicketHistorico, TicketMensagem
+from app.models.ticket_read import TicketRead
 from app.models.audit_log import AuditLog
 from app.models.ibge_municipio import IbgeMunicipio
 from app.models.app_cache_meta import AppCacheMeta
@@ -23,6 +24,7 @@ __all__ = [
     "Ticket",
     "TicketHistorico",
     "TicketMensagem",
+    "TicketRead",
     "AuditLog",
     "IbgeMunicipio",
     "AppCacheMeta",

--- a/backend/app/models/ticket_read.py
+++ b/backend/app/models/ticket_read.py
@@ -1,0 +1,20 @@
+from sqlalchemy import Column, Integer, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class TicketRead(Base):
+    """Última vez que o atendente abriu/viu o ticket (marca mensagens como lidas)."""
+
+    __tablename__ = "ticket_reads"
+    __table_args__ = (UniqueConstraint("atendente_id", "ticket_id", name="uq_ticket_reads_atendente_ticket"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    ticket_id = Column(Integer, ForeignKey("tickets.id", ondelete="CASCADE"), nullable=False, index=True)
+    last_seen_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+
+    atendente = relationship("Atendente", backref="ticket_reads")
+    ticket = relationship("Ticket", backref="ticket_read_entries")

--- a/backend/app/schemas/notificacoes.py
+++ b/backend/app/schemas/notificacoes.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class NotificacaoResumo(BaseModel):
+    sem_responsavel_count: int = Field(ge=0)
+    nao_lidas_count: int = Field(
+        ge=0,
+        description="Quantidade de tickets com mensagens não lidas (com responsável)",
+    )
+    total_pendencias: int = Field(ge=0, description="Soma usada no badge (sem duplicar fila vs. não lidas)")
+
+
+class NotificacaoItem(BaseModel):
+    tipo: Literal["fila_sem_responsavel", "mensagens_nao_lidas"]
+    ticket_id: int | None = None
+    titulo: str
+    descricao: str
+    count: int = Field(ge=0)
+    href: str
+    created_at: datetime | None = None
+
+
+class NotificacaoItensResponse(BaseModel):
+    itens: list[NotificacaoItem]

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -385,6 +385,34 @@ export const dashboard = {
   get: () => api<Dashboard.Response>('/dashboard'),
 };
 
+export namespace Notificacoes {
+  export interface Resumo {
+    sem_responsavel_count: number;
+    nao_lidas_count: number;
+    total_pendencias: number;
+  }
+  export interface Item {
+    tipo: 'fila_sem_responsavel' | 'mensagens_nao_lidas';
+    ticket_id: number | null;
+    titulo: string;
+    descricao: string;
+    count: number;
+    href: string;
+    created_at?: string | null;
+  }
+  export interface ItensResponse {
+    itens: Item[];
+  }
+}
+
+export const notificacoes = {
+  resumo: () => api<Notificacoes.Resumo>('/notificacoes/resumo'),
+  itens: (params?: { limit?: number }) =>
+    api<Notificacoes.ItensResponse>(withParams('/notificacoes/itens', params)),
+  marcarVisto: (ticketId: number) =>
+    api<void>(`/notificacoes/tickets/${ticketId}/visto`, { method: 'POST' }),
+};
+
 export namespace Dashboard {
   export interface StatusCount {
     status_id: number;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Outlet, Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 import { Sidebar } from './Sidebar'
 import { ThemeToggle } from './ThemeToggle'
+import { NavbarNotificacoes } from './NavbarNotificacoes'
 import { useAlertaFilaSemResponsavel } from '../hooks/useAlertaFilaSemResponsavel'
 
 const menuIcon = (
@@ -83,6 +84,7 @@ export function Layout() {
             </div>
             
             <div className="min-w-0 flex-1" />
+            <NavbarNotificacoes enabled={Boolean(user)} />
             <ThemeToggle />
             <div className="hidden min-w-0 text-right sm:block">
               <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{user?.nome}</p>

--- a/frontend/src/components/NavbarNotificacoes.tsx
+++ b/frontend/src/components/NavbarNotificacoes.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { notificacoes, type Notificacoes } from '../api/client'
+import { usePendenciasResumo } from '../hooks/useAlertaFilaSemResponsavel'
+
+const POLL_ITENS_MS = 30_000
+
+const bellIcon = (
+  <svg className="size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.75}
+      d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+    />
+  </svg>
+)
+
+function badgeText(n: number): string {
+  if (n <= 0) return ''
+  if (n > 99) return '99+'
+  return String(n)
+}
+
+export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
+  const resumo = usePendenciasResumo(enabled)
+  const [aberto, setAberto] = useState(false)
+  const [itens, setItens] = useState<Notificacoes.Item[]>([])
+  const [loadingItens, setLoadingItens] = useState(false)
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const menuId = useId()
+
+  async function carregarItens() {
+    if (!enabled) return
+    setLoadingItens(true)
+    try {
+      const { itens: list } = await notificacoes.itens({ limit: 15 })
+      setItens(list)
+    } catch {
+      setItens([])
+    } finally {
+      setLoadingItens(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!aberto || !enabled) return
+    void carregarItens()
+    const id = window.setInterval(() => void carregarItens(), POLL_ITENS_MS)
+    return () => window.clearInterval(id)
+  }, [aberto, enabled])
+
+  useEffect(() => {
+    if (!aberto) return
+    function onDoc(e: MouseEvent) {
+      const el = wrapRef.current
+      if (el && !el.contains(e.target as Node)) setAberto(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [aberto])
+
+  const total = resumo.total_pendencias
+  const badge = badgeText(total)
+
+  return (
+    <div ref={wrapRef} className="relative">
+      <button
+        type="button"
+        className="relative flex size-10 shrink-0 items-center justify-center rounded-lg text-slate-600 transition-colors hover:bg-slate-100 active:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-800 dark:active:bg-slate-700 touch-manipulation md:size-9"
+        aria-label="Pendências"
+        aria-expanded={aberto}
+        aria-haspopup="true"
+        aria-controls={aberto ? menuId : undefined}
+        title="Pendências"
+        onClick={() => setAberto((o) => !o)}
+      >
+        {bellIcon}
+        {badge ? (
+          <span className="absolute -right-0.5 -top-0.5 flex min-w-[1.125rem] justify-center rounded-full bg-rose-600 px-1 text-[10px] font-semibold leading-4 text-white shadow-sm dark:bg-rose-500">
+            {badge}
+          </span>
+        ) : null}
+      </button>
+
+      {aberto ? (
+        <div
+          id={menuId}
+          role="menu"
+          className="absolute right-0 top-full z-50 mt-2 w-[min(100vw-2rem,22rem)] rounded-xl border border-slate-200/90 bg-white py-2 shadow-lg dark:border-slate-700 dark:bg-slate-900"
+        >
+          <div className="border-b border-slate-100 px-3 pb-2 dark:border-slate-800">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Pendências</p>
+          </div>
+          <div className="max-h-[min(70vh,24rem)] overflow-y-auto px-1 py-1">
+            {loadingItens && itens.length === 0 ? (
+              <p className="px-3 py-6 text-center text-sm text-slate-500 dark:text-slate-400">Carregando…</p>
+            ) : itens.length === 0 ? (
+              <p className="px-3 py-6 text-center text-sm text-slate-500 dark:text-slate-400">Sem pendências</p>
+            ) : (
+              <ul className="space-y-0.5">
+                {itens.map((item, idx) => (
+                  <li key={`${item.tipo}-${item.ticket_id ?? 'fila'}-${idx}`}>
+                    <Link
+                      role="menuitem"
+                      to={item.href}
+                      className="flex gap-2 rounded-lg px-2 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-800/80"
+                      onClick={() => setAberto(false)}
+                    >
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-medium text-slate-900 dark:text-slate-100">{item.titulo}</p>
+                        <p className="truncate text-xs text-slate-500 dark:text-slate-400">{item.descricao}</p>
+                      </div>
+                      <div className="flex shrink-0 flex-col items-end gap-1">
+                        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                          {item.count}
+                        </span>
+                        <span className="text-xs font-medium text-cyan-600 dark:text-cyan-400">Ver</span>
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+          {(resumo.sem_responsavel_count > 0 || resumo.nao_lidas_count > 0) && (
+            <div className="border-t border-slate-100 px-3 pt-2 text-[11px] text-slate-400 dark:border-slate-800 dark:text-slate-500">
+              Fila: {resumo.sem_responsavel_count} · Não lidas: {resumo.nao_lidas_count}
+            </div>
+          )}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -1,18 +1,25 @@
 import { useEffect, useState } from 'react'
-import { tickets } from '../api/client'
+import { notificacoes, type Notificacoes } from '../api/client'
 
 const LS_KEY_SOUND = 'dxconnect.alerta_fila_sem_responsavel.som'
 const LS_KEY_LAST_COUNT = 'dxconnect.alerta_fila_sem_responsavel.last_count'
 const DEFAULT_SOUND_ENABLED = true
 const POLL_MS = 30_000
 
-type Listener = (state: { count: number }) => void
+type ListenerFila = (state: { count: number }) => void
+type ListenerResumo = (state: Notificacoes.Resumo) => void
 
 let started = false
 let inFlight = false
 let currentCount = 0
+let currentResumo: Notificacoes.Resumo = {
+  sem_responsavel_count: 0,
+  nao_lidas_count: 0,
+  total_pendencias: 0,
+}
 let prevCount: number | null = null
-const listeners = new Set<Listener>()
+const listenersFila = new Set<ListenerFila>()
+const listenersResumo = new Set<ListenerResumo>()
 
 function getSoundEnabled(): boolean {
   try {
@@ -98,46 +105,81 @@ async function trySetAppBadge(count: number) {
   }
 }
 
+function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean) {
+  currentResumo = r
+  const sem = r.sem_responsavel_count
+  currentCount = sem
+  for (const l of listenersFila) l({ count: sem })
+  for (const l of listenersResumo) l(r)
+
+  if (atualizarSom) {
+    const prev = prevCount
+    prevCount = sem
+    setLastCount(sem)
+    if (getSoundEnabled() && prev != null && sem > prev) {
+      playBeep()
+    }
+  }
+
+  const total = r.total_pendencias
+  const base = (typeof document !== 'undefined' ? document.title : 'DX Connect').replace(/^\(\d+\)\s+/, '')
+  if (typeof document !== 'undefined') {
+    document.title = total > 0 ? `(${total}) ${base}` : base
+  }
+  void trySetAppBadge(total)
+}
+
+async function poll() {
+  if (inFlight) return
+  inFlight = true
+  try {
+    const r = await notificacoes.resumo()
+    applyResumo(r, true)
+  } catch {
+    // ignore
+  } finally {
+    inFlight = false
+  }
+}
+
+/** Atualiza contadores na UI (ex.: após marcar ticket como visto). Não dispara som de fila. */
+export async function refetchPendenciasResumo() {
+  if (inFlight) return
+  inFlight = true
+  try {
+    const r = await notificacoes.resumo()
+    applyResumo(r, false)
+  } catch {
+    // ignore
+  } finally {
+    inFlight = false
+  }
+}
+
 function ensureStarted() {
   if (started) return
   started = true
   prevCount = getLastCount()
 
-  const poll = async () => {
-    if (inFlight) return
-    inFlight = true
-    try {
-      const { total } = await tickets.list({
-        sem_responsavel: true,
-        offset: 0,
-        limit: 1,
-      })
-
-      currentCount = total
-      for (const l of listeners) l({ count: currentCount })
-
-      const prev = prevCount
-      prevCount = total
-      setLastCount(total)
-
-      if (getSoundEnabled() && prev != null && total > prev) {
-        playBeep()
-      }
-
-      const base = (typeof document !== 'undefined' ? document.title : 'DX Connect').replace(/^\(\d+\)\s+/, '')
-      if (typeof document !== 'undefined') {
-        document.title = total > 0 ? `(${total}) ${base}` : base
-      }
-      void trySetAppBadge(total)
-    } catch {
-      // ignore
-    } finally {
-      inFlight = false
-    }
-  }
-
   void poll()
-  window.setInterval(poll, POLL_MS)
+  window.setInterval(() => void poll(), POLL_MS)
+}
+
+export function usePendenciasResumo(enabled: boolean): Notificacoes.Resumo {
+  const [resumo, setResumo] = useState<Notificacoes.Resumo>(currentResumo)
+
+  useEffect(() => {
+    if (!enabled) return
+    ensureStarted()
+    const listener: ListenerResumo = (r) => setResumo(r)
+    listenersResumo.add(listener)
+    setResumo(currentResumo)
+    return () => {
+      listenersResumo.delete(listener)
+    }
+  }, [enabled])
+
+  return resumo
 }
 
 export function useAlertaFilaSemResponsavel(enabled: boolean) {
@@ -151,13 +193,11 @@ export function useAlertaFilaSemResponsavel(enabled: boolean) {
   useEffect(() => {
     if (!enabled) return
     ensureStarted()
-    const listener: Listener = ({ count }) => setCount(count)
-    listeners.add(listener)
-    // estado inicial imediato
+    const listener: ListenerFila = ({ count: c }) => setCount(c)
+    listenersFila.add(listener)
     setCount(currentCount)
     return () => {
-      listeners.delete(listener)
-      // Mantém o poll ativo globalmente enquanto houver user logado.
+      listenersFila.delete(listener)
     }
   }, [enabled])
 
@@ -167,4 +207,3 @@ export function useAlertaFilaSemResponsavel(enabled: boolean) {
     setSoundEnabled: setSoundEnabledState,
   }
 }
-

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
-import { tickets, statusTicket, atendentes, setores, type StatusTicket, type Atendentes, type Setores, type Tickets } from '../api/client'
+import { tickets, notificacoes, statusTicket, atendentes, setores, type StatusTicket, type Atendentes, type Setores, type Tickets } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
 import { Select } from '../components/ui/Select'
@@ -8,6 +8,7 @@ import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
 import { useAuth } from '../contexts/AuthContext'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { refetchPendenciasResumo } from '../hooks/useAlertaFilaSemResponsavel'
 
 const ROTULO_CAMPO: Record<string, string> = {
   status_id: 'Status',
@@ -292,6 +293,10 @@ export function TicketDetalhe() {
         setEditSetor(t.setor_id)
         setEditStatus(t.status_id)
         setEditAtendente(t.atendente_id ?? '')
+        void notificacoes
+          .marcarVisto(numId)
+          .then(() => refetchPendenciasResumo())
+          .catch(() => {})
       })
       .catch(() => {
         if (!cancelled) {

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useId } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import {
   tickets,
   statusTicket,
@@ -40,6 +40,7 @@ const searchIcon = (
 
 export function Tickets() {
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const toast = useToast()
   const { isAdmin, user } = useAuth()
   const { soundEnabled, setSoundEnabled, count: filaCount } = useAlertaFilaSemResponsavel(Boolean(user))
@@ -58,7 +59,10 @@ export function Tickets() {
   const [setoresOpt, setSetoresOpt] = useState<Setores.Setor[]>([])
   const [atendentesOpt, setAtendentesOpt] = useState<Atendentes.Atendente[]>([])
   /** '' | 'sem_responsavel' | 'meus' — fila do setor vs. atribuídos a mim */
-  const [filtroFila, setFiltroFila] = useState<'' | 'sem_responsavel' | 'meus'>('')
+  const [filtroFila, setFiltroFila] = useState<'' | 'sem_responsavel' | 'meus'>(() => {
+    const sr = searchParams.get('sem_responsavel')
+    return sr === '1' || sr === 'true' ? 'sem_responsavel' : ''
+  })
   const [filtroAtendente, setFiltroAtendente] = useState<number | ''>('')
   const [maisFiltrosAberto, setMaisFiltrosAberto] = useState(false)
   const painelFiltrosId = useId()
@@ -112,6 +116,21 @@ export function Tickets() {
     (filtroSetor !== '' ? 1 : 0) +
     (filtroStatus !== '' ? 1 : 0) +
     (isAdmin && filtroAtendente !== '' ? 1 : 0)
+
+  useEffect(() => {
+    const sr = searchParams.get('sem_responsavel')
+    if (sr === '1' || sr === 'true') {
+      setFiltroFila('sem_responsavel')
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev)
+          next.delete('sem_responsavel')
+          return next
+        },
+        { replace: true },
+      )
+    }
+  }, [searchParams, setSearchParams])
 
   useEffect(() => {
     coletarTodasPaginas<StatusTicket.Status>((o, l) =>


### PR DESCRIPTION
## Resumo
Integra em **staging** o commit da issue **#36** (pendências na navbar), já em \main\.

## Alterações
- API \/v1/notificacoes/resumo\, \/itens\, \POST .../visto\
- Migração **006** (\	icket_reads\ + índice em \	icket_mensagens\)
- UI: sino na navbar, dropdown, marcação ao abrir ticket, \?sem_responsavel=1\ na lista

## Checklist pós-merge (deploy)
- [x] \lembic upgrade head\ no ambiente alvo (nova tabela/índice)
- [x] Smoke: login, navbar, abrir ticket, fila sem responsável

Refs: #36

Made with [Cursor](https://cursor.com)