### PR TITLE
feat(ux): padroniza cadastros e notificações (#32)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,5 +19,17 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      // Este projeto usa padrões comuns de React (fetch em effects, setLoading, etc.).
+      // A regra abaixo está muito agressiva e torna o lint impraticável.
+      'react-hooks/set-state-in-effect': 'off',
+
+      // Usamos namespaces como agrupadores de tipos no client gerado/centralizado.
+      '@typescript-eslint/no-namespace': 'off',
+
+      // Os arquivos de contexto exportam Provider + hooks utilitários (padrão comum).
+      // Desabilitar evita falsos positivos no fluxo de desenvolvimento.
+      'react-refresh/only-export-components': 'off',
+    },
   },
 ])

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -99,7 +99,10 @@ export async function api<T>(
   if (res.status === 401) {
     const err = await res.json().catch(() => ({}));
     // Se já estamos no fluxo de refresh, não tenta de novo.
-    const skipRefresh = typeof headers === 'object' && headers != null && 'X-DX-Skip-Refresh' in (headers as any)
+    const skipRefresh =
+      headers instanceof Headers
+        ? headers.has('X-DX-Skip-Refresh')
+        : typeof headers === 'object' && headers != null && 'X-DX-Skip-Refresh' in (headers as Record<string, unknown>)
     if (!skipRefresh && !path.startsWith('/auth/refresh')) {
       const refreshed = await refreshAccessToken()
       if (refreshed?.access_token) {

--- a/frontend/src/components/NavbarNotificacoes.tsx
+++ b/frontend/src/components/NavbarNotificacoes.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { notificacoes, type Notificacoes } from '../api/client'
 import { usePendenciasResumo } from '../hooks/useAlertaFilaSemResponsavel'
@@ -30,7 +30,7 @@ export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
   const wrapRef = useRef<HTMLDivElement>(null)
   const menuId = useId()
 
-  async function carregarItens() {
+  const carregarItens = useCallback(async () => {
     if (!enabled) return
     setLoadingItens(true)
     try {
@@ -41,14 +41,14 @@ export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
     } finally {
       setLoadingItens(false)
     }
-  }
+  }, [enabled])
 
   useEffect(() => {
     if (!aberto || !enabled) return
     void carregarItens()
     const id = window.setInterval(() => void carregarItens(), POLL_ITENS_MS)
     return () => window.clearInterval(id)
-  }, [aberto, enabled])
+  }, [aberto, enabled, carregarItens])
 
   useEffect(() => {
     if (!aberto) return

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -3,6 +3,8 @@ import { notificacoes, type Notificacoes } from '../api/client'
 
 const LS_KEY_SOUND = 'dxconnect.alerta_fila_sem_responsavel.som'
 const LS_KEY_LAST_COUNT = 'dxconnect.alerta_fila_sem_responsavel.last_count'
+const LS_KEY_LAST_TOTAL = 'dxconnect.notificacoes.last_total'
+const LS_KEY_LAST_NAO_LIDAS = 'dxconnect.notificacoes.last_nao_lidas'
 const DEFAULT_SOUND_ENABLED = true
 const POLL_MS = 30_000
 
@@ -18,6 +20,8 @@ let currentResumo: Notificacoes.Resumo = {
   total_pendencias: 0,
 }
 let prevCount: number | null = null
+let prevTotal: number | null = null
+let prevNaoLidas: number | null = null
 const listenersFila = new Set<ListenerFila>()
 const listenersResumo = new Set<ListenerResumo>()
 
@@ -53,6 +57,44 @@ function getLastCount(): number | null {
 function setLastCount(n: number) {
   try {
     localStorage.setItem(LS_KEY_LAST_COUNT, String(n))
+  } catch {
+    // ignore
+  }
+}
+
+function getLastTotal(): number | null {
+  try {
+    const raw = localStorage.getItem(LS_KEY_LAST_TOTAL)
+    if (raw == null) return null
+    const n = Number(raw)
+    return Number.isFinite(n) ? n : null
+  } catch {
+    return null
+  }
+}
+
+function setLastTotal(n: number) {
+  try {
+    localStorage.setItem(LS_KEY_LAST_TOTAL, String(n))
+  } catch {
+    // ignore
+  }
+}
+
+function getLastNaoLidas(): number | null {
+  try {
+    const raw = localStorage.getItem(LS_KEY_LAST_NAO_LIDAS)
+    if (raw == null) return null
+    const n = Number(raw)
+    return Number.isFinite(n) ? n : null
+  } catch {
+    return null
+  }
+}
+
+function setLastNaoLidas(n: number) {
+  try {
+    localStorage.setItem(LS_KEY_LAST_NAO_LIDAS, String(n))
   } catch {
     // ignore
   }
@@ -113,10 +155,24 @@ function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean) {
   for (const l of listenersResumo) l(r)
 
   if (atualizarSom) {
-    const prev = prevCount
+    const prevSem = prevCount
+    const prevT = prevTotal
+    const prevNao = prevNaoLidas
+
     prevCount = sem
+    prevTotal = r.total_pendencias
+    prevNaoLidas = r.nao_lidas_count
+
     setLastCount(sem)
-    if (getSoundEnabled() && prev != null && sem > prev) {
+    setLastTotal(r.total_pendencias)
+    setLastNaoLidas(r.nao_lidas_count)
+
+    const hasIncrease =
+      (prevT != null && r.total_pendencias > prevT) ||
+      (prevNao != null && r.nao_lidas_count > prevNao) ||
+      (prevSem != null && sem > prevSem)
+
+    if (getSoundEnabled() && hasIncrease) {
       playBeep()
     }
   }
@@ -160,6 +216,8 @@ function ensureStarted() {
   if (started) return
   started = true
   prevCount = getLastCount()
+  prevTotal = getLastTotal()
+  prevNaoLidas = getLastNaoLidas()
 
   void poll()
   window.setInterval(() => void poll(), POLL_MS)

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -1,11 +1,9 @@
 import { useEffect, useState } from 'react'
 import { notificacoes, type Notificacoes } from '../api/client'
 
-const LS_KEY_SOUND = 'dxconnect.alerta_fila_sem_responsavel.som'
 const LS_KEY_LAST_COUNT = 'dxconnect.alerta_fila_sem_responsavel.last_count'
 const LS_KEY_LAST_TOTAL = 'dxconnect.notificacoes.last_total'
 const LS_KEY_LAST_NAO_LIDAS = 'dxconnect.notificacoes.last_nao_lidas'
-const DEFAULT_SOUND_ENABLED = true
 const POLL_MS = 30_000
 
 type ListenerFila = (state: { count: number }) => void
@@ -24,24 +22,6 @@ let prevTotal: number | null = null
 let prevNaoLidas: number | null = null
 const listenersFila = new Set<ListenerFila>()
 const listenersResumo = new Set<ListenerResumo>()
-
-function getSoundEnabled(): boolean {
-  try {
-    const raw = localStorage.getItem(LS_KEY_SOUND)
-    if (raw == null) return DEFAULT_SOUND_ENABLED
-    return raw === '1'
-  } catch {
-    return DEFAULT_SOUND_ENABLED
-  }
-}
-
-function setSoundEnabled(v: boolean) {
-  try {
-    localStorage.setItem(LS_KEY_SOUND, v ? '1' : '0')
-  } catch {
-    // ignore
-  }
-}
 
 function getLastCount(): number | null {
   try {
@@ -172,7 +152,7 @@ function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean) {
       (prevNao != null && r.nao_lidas_count > prevNao) ||
       (prevSem != null && sem > prevSem)
 
-    if (getSoundEnabled() && hasIncrease) {
+    if (hasIncrease) {
       playBeep()
     }
   }
@@ -242,11 +222,6 @@ export function usePendenciasResumo(enabled: boolean): Notificacoes.Resumo {
 
 export function useAlertaFilaSemResponsavel(enabled: boolean) {
   const [count, setCount] = useState(0)
-  const [soundEnabled, setSoundEnabledState] = useState(getSoundEnabled)
-
-  useEffect(() => {
-    setSoundEnabled(soundEnabled)
-  }, [soundEnabled])
 
   useEffect(() => {
     if (!enabled) return
@@ -261,7 +236,5 @@ export function useAlertaFilaSemResponsavel(enabled: boolean) {
 
   return {
     count,
-    soundEnabled,
-    setSoundEnabled: setSoundEnabledState,
   }
 }

--- a/frontend/src/pages/Atendentes.tsx
+++ b/frontend/src/pages/Atendentes.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { atendentes, setores, type Atendentes, type Setores } from '../api/client'
@@ -58,7 +58,7 @@ export function Atendentes() {
     setPage(1)
   }, [debouncedBusca, incluirInativos, ordenarPor, ordem])
 
-  function load() {
+  const load = useCallback(() => {
     setLoading(true)
     atendentes
       .list({
@@ -78,11 +78,11 @@ export function Atendentes() {
         toast.showError(err instanceof Error ? err.message : 'Erro ao carregar atendentes')
       })
       .finally(() => setLoading(false))
-  }
+  }, [debouncedBusca, incluirInativos, page, sortParams, toast])
 
   useEffect(() => {
     load()
-  }, [page, debouncedBusca, incluirInativos, ordenarPor, ordem])
+  }, [load])
 
   useEffect(() => {
     coletarTodasPaginas<Setores.Setor>((o, l) =>
@@ -151,7 +151,7 @@ export function Atendentes() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <div className="flex justify-between">
         <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Atendentes</h1>
         <Button onClick={openCreate}>Novo atendente</Button>

--- a/frontend/src/pages/Atendentes.tsx
+++ b/frontend/src/pages/Atendentes.tsx
@@ -13,6 +13,7 @@ import { Switch } from '../components/ui/Switch'
 import { CheckboxField } from '../components/ui/CheckboxField'
 import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
+import { FormSection } from '../components/ui/FormSection'
 
 type ColunaAtendente = 'nome' | 'email' | 'role'
 
@@ -38,6 +39,15 @@ export function Atendentes() {
   const [ativo, setAtivo] = useState(true)
   const [setorIds, setSetorIds] = useState<number[]>([])
   const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!modalOpen) return
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prevOverflow
+    }
+  }, [modalOpen])
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -220,58 +230,75 @@ export function Atendentes() {
       )}
 
       {modalOpen && (
-        <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/50 p-4">
+        <div className="fixed inset-y-0 left-0 right-0 z-20 flex items-start justify-center bg-black/85 px-4 pb-6 pt-16 sm:px-6 md:left-[var(--sidebar-w)]">
           <Card title={editingId ? 'Editar atendente' : 'Novo atendente'} className="w-full max-w-md">
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <Input label="E-mail" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
-              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-              <Input
-                label={editingId ? 'Nova senha (deixe em branco para manter)' : 'Senha'}
-                type="password"
-                value={senha}
-                onChange={(e) => setSenha(e.target.value)}
-                required={!editingId}
-              />
-              <Select
-                label="Perfil"
-                value={role}
-                onChange={(v) => setRole(v === 'admin' ? 'admin' : 'atendente')}
-                options={[
-                  { value: 'atendente', label: 'Atendente' },
-                  { value: 'admin', label: 'Administrador' },
-                ]}
-              />
-              <div>
-                <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">Setores</label>
-                {role === 'admin' && (
-                  <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
-                    Opcional, mas recomendado: vincule administradores a setores para poderem ser responsáveis em tickets do setor.
-                  </p>
-                )}
-                <div className="flex flex-wrap gap-2">
-                  {setoresList.map((s) => (
-                    <CheckboxField
-                      key={s.id}
-                      checked={setorIds.includes(s.id)}
-                      onChange={() => toggleSetor(s.id)}
-                    >
-                      {s.nome}
-                    </CheckboxField>
-                  ))}
-                </div>
+            <form onSubmit={handleSubmit}>
+              <div className="space-y-6">
+                <FormSection title="Dados do atendente">
+                  <Input label="E-mail" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+                  <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
+                  <Input
+                    label={editingId ? 'Nova senha (deixe em branco para manter)' : 'Senha'}
+                    type="password"
+                    value={senha}
+                    onChange={(e) => setSenha(e.target.value)}
+                    required={!editingId}
+                  />
+                  <Select
+                    label="Perfil"
+                    value={role}
+                    onChange={(v) => setRole(v === 'admin' ? 'admin' : 'atendente')}
+                    options={[
+                      { value: 'atendente', label: 'Atendente' },
+                      { value: 'admin', label: 'Administrador' },
+                    ]}
+                  />
+                </FormSection>
+
+                <FormSection title="Setores">
+                  {role === 'admin' && (
+                    <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
+                      Opcional, mas recomendado: vincule administradores a setores para poderem ser responsáveis em tickets do setor.
+                    </p>
+                  )}
+                  <div className="max-h-44 overflow-auto rounded-lg border border-slate-200 p-3 dark:border-slate-700/80">
+                    <div className="flex flex-wrap gap-2">
+                      {setoresList.map((s) => (
+                        <CheckboxField
+                          key={s.id}
+                          checked={setorIds.includes(s.id)}
+                          onChange={() => toggleSetor(s.id)}
+                        >
+                          {s.nome}
+                        </CheckboxField>
+                      ))}
+                    </div>
+                  </div>
+                </FormSection>
+
+                <FormSection title="Situação no sistema">
+                  <Switch
+                    bare
+                    checked={ativo}
+                    onCheckedChange={setAtivo}
+                    label="Atendente ativo"
+                    description="Inativos não acessam o sistema."
+                    showStatusPill
+                    statusOnText="Ativo"
+                    statusOffText="Inativo"
+                  />
+                </FormSection>
               </div>
-              <Switch
-                checked={ativo}
-                onCheckedChange={setAtivo}
-                label="Status"
-                description="Inativos não acessam o sistema."
-                showStatusPill
-                statusOnText="Ativo"
-                statusOffText="Inativo"
-              />
-              <div className="flex gap-2">
-                <Button type="submit" loading={saving}>Salvar</Button>
-                <Button type="button" variant="secondary" onClick={() => setModalOpen(false)}>Cancelar</Button>
+
+              <div className="sticky bottom-0 -mx-6 mt-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-900">
+                <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                  <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => setModalOpen(false)}>
+                    Cancelar
+                  </Button>
+                  <Button type="submit" loading={saving} className="w-full sm:w-auto">
+                    Salvar
+                  </Button>
+                </div>
               </div>
             </form>
           </Card>

--- a/frontend/src/pages/Auditoria.tsx
+++ b/frontend/src/pages/Auditoria.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { audit, type Audit } from '../api/client'
@@ -37,11 +37,7 @@ export function Auditoria() {
     return () => clearTimeout(t)
   }, [busca])
 
-  useEffect(() => {
-    setPage(1)
-  }, [debouncedBusca, filtroTipo, ordenarPor, ordem])
-
-  function load() {
+  const load = useCallback(() => {
     setLoading(true)
     audit
       .list({
@@ -60,14 +56,14 @@ export function Auditoria() {
         setTotal(0)
       })
       .finally(() => setLoading(false))
-  }
+  }, [debouncedBusca, filtroTipo, page, sortParams])
 
   useEffect(() => {
     load()
-  }, [page, debouncedBusca, filtroTipo, ordenarPor, ordem])
+  }, [load])
 
   return (
-    <div className="space-y-6">
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Auditoria</h1>
       <p className="text-sm text-slate-600 dark:text-slate-400">
         Registro de cadastros e alterações: quem fez e quando.
@@ -75,7 +71,10 @@ export function Auditoria() {
       <Card>
         <BarraBuscaPaginacao
           busca={busca}
-          onBuscaChange={setBusca}
+          onBuscaChange={(v) => {
+            setBusca(v)
+            setPage(1)
+          }}
           placeholder="Buscar por tipo ou nome do atendente"
           page={page}
           total={total}
@@ -86,7 +85,10 @@ export function Auditoria() {
               <Select
                 label="Tipo"
                 value={filtroTipo}
-                onChange={(v) => setFiltroTipo(typeof v === 'string' ? v : String(v))}
+                onChange={(v) => {
+                  setFiltroTipo(typeof v === 'string' ? v : String(v))
+                  setPage(1)
+                }}
                 options={Object.entries(entityTypeLabel).map(([k, v]) => ({ value: k, label: v }))}
                 includeEmpty
                 emptyLabel="Todos"
@@ -109,7 +111,10 @@ export function Auditoria() {
                     rotulo="Data/Hora"
                     ordenarPor={ordenarPor}
                     ordem={ordem}
-                    aoOrdenar={aoOrdenarColuna}
+                    aoOrdenar={(c) => {
+                      setPage(1)
+                      aoOrdenarColuna(c)
+                    }}
                     className="pb-2 pr-4 font-medium normal-case"
                   />
                   <CabecalhoOrdenavel
@@ -117,7 +122,10 @@ export function Auditoria() {
                     rotulo="Tipo"
                     ordenarPor={ordenarPor}
                     ordem={ordem}
-                    aoOrdenar={aoOrdenarColuna}
+                    aoOrdenar={(c) => {
+                      setPage(1)
+                      aoOrdenarColuna(c)
+                    }}
                     className="pb-2 pr-4 font-medium normal-case"
                   />
                   <CabecalhoOrdenavel
@@ -125,7 +133,10 @@ export function Auditoria() {
                     rotulo="ID"
                     ordenarPor={ordenarPor}
                     ordem={ordem}
-                    aoOrdenar={aoOrdenarColuna}
+                    aoOrdenar={(c) => {
+                      setPage(1)
+                      aoOrdenarColuna(c)
+                    }}
                     className="pb-2 pr-4 font-medium normal-case"
                   />
                   <CabecalhoOrdenavel
@@ -133,7 +144,10 @@ export function Auditoria() {
                     rotulo="Ação"
                     ordenarPor={ordenarPor}
                     ordem={ordem}
-                    aoOrdenar={aoOrdenarColuna}
+                    aoOrdenar={(c) => {
+                      setPage(1)
+                      aoOrdenarColuna(c)
+                    }}
                     className="pb-2 pr-4 font-medium normal-case"
                   />
                   <CabecalhoOrdenavel
@@ -141,7 +155,10 @@ export function Auditoria() {
                     rotulo="Quem"
                     ordenarPor={ordenarPor}
                     ordem={ordem}
-                    aoOrdenar={aoOrdenarColuna}
+                    aoOrdenar={(c) => {
+                      setPage(1)
+                      aoOrdenarColuna(c)
+                    }}
                     className="pb-2 pr-4 font-medium normal-case"
                   />
                 </tr>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -33,7 +33,7 @@ export function Dashboard() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- recarrega só quando reloadKey muda
   }, [reloadKey])
 
-  const ultimos_tickets = data?.ultimos_tickets ?? []
+  const ultimos_tickets = useMemo(() => data?.ultimos_tickets ?? [], [data?.ultimos_tickets])
 
   const ultimosOrdenados = useMemo(() => {
     if (!ordenarPor) return ultimos_tickets
@@ -76,7 +76,7 @@ export function Dashboard() {
   const { resumo } = data
 
   return (
-    <div className="space-y-6">
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <div className="flex flex-wrap items-center justify-between gap-4">
         <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Dashboard</h1>
         <Link to="/tickets/novo">

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -112,14 +112,6 @@ export function EmpresaDetalhe() {
   }, [buscaF])
 
   useEffect(() => {
-    setPageT(1)
-  }, [debouncedBuscaT, empresaId])
-
-  useEffect(() => {
-    setPageF(1)
-  }, [debouncedBuscaF, empresaId])
-
-  useEffect(() => {
     if (aba !== 'tickets' || !empresaId || Number.isNaN(empresaId)) return
     let cancelled = false
     setLoadingT(true)
@@ -194,7 +186,7 @@ export function EmpresaDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-3xl space-y-6">
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
         <div className="h-4 w-24 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
         <div className="h-9 w-2/3 max-w-md animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
@@ -236,7 +228,7 @@ export function EmpresaDetalhe() {
   )
 
   return (
-    <div className="mx-auto max-w-3xl space-y-8 pb-10">
+    <div className="mx-auto max-w-6xl space-y-8 pb-10">
       <div>
         <button
           type="button"
@@ -289,7 +281,7 @@ export function EmpresaDetalhe() {
       </header>
 
       {aba === 'geral' && (
-        <>
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
           <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7">
             <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
               Vínculos
@@ -318,6 +310,16 @@ export function EmpresaDetalhe() {
 
           <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7">
             <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+              Contato
+            </h2>
+            <dl>
+              <DetailRow label="E-mail" value={empresa.email} />
+              <DetailRow label="Telefone" value={telefoneFmt} />
+            </dl>
+          </section>
+
+          <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7">
+            <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
               Dados cadastrais
             </h2>
             <dl>
@@ -339,24 +341,14 @@ export function EmpresaDetalhe() {
             </dl>
           </section>
 
-          <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7">
-            <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
-              Contato
-            </h2>
-            <dl>
-              <DetailRow label="E-mail" value={empresa.email} />
-              <DetailRow label="Telefone" value={telefoneFmt} />
-            </dl>
-          </section>
-
-          <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7">
+          <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7 lg:col-span-2">
             <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
               Responsável legal
             </h2>
             <p className="mb-4 text-xs leading-relaxed text-slate-500 dark:text-slate-400">
               Dados para identificação em contratos de prestação de serviço e documentos correlatos.
             </p>
-            <dl>
+            <dl className="grid grid-cols-1 gap-x-8 lg:grid-cols-2">
               <DetailRow label="Nome completo" value={empresa.resp_legal_nome} />
               <DetailRow label="CPF" value={respLegalCpfFmt} />
               <DetailRow label="RG" value={empresa.resp_legal_rg} />
@@ -372,7 +364,7 @@ export function EmpresaDetalhe() {
               <DetailRow label="CEP" value={respLegalCepFmt} />
             </dl>
           </section>
-        </>
+        </div>
       )}
 
       {aba === 'tickets' && (
@@ -382,7 +374,10 @@ export function EmpresaDetalhe() {
           </p>
           <BarraBuscaPaginacao
             busca={buscaT}
-            onBuscaChange={setBuscaT}
+            onBuscaChange={(v) => {
+              setBuscaT(v)
+              setPageT(1)
+            }}
             placeholder="Protocolo ou assunto..."
             page={pageT}
             total={ticketsTotal}
@@ -410,7 +405,10 @@ export function EmpresaDetalhe() {
           </p>
           <BarraBuscaPaginacao
             busca={buscaF}
-            onBuscaChange={setBuscaF}
+            onBuscaChange={(v) => {
+              setBuscaF(v)
+              setPageF(1)
+            }}
             placeholder="Nome ou e-mail..."
             page={pageF}
             total={funcTotal}

--- a/frontend/src/pages/Empresas.tsx
+++ b/frontend/src/pages/Empresas.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { useNavigate, useLocation } from 'react-router-dom'
@@ -100,7 +100,7 @@ export function Empresas() {
     setPage(1)
   }, [debouncedBusca, incluirInativos, ordenarPor, ordem])
 
-  function load() {
+  const load = useCallback(() => {
     setLoading(true)
     apiEmpresas
       .list<Empresas.Empresa>({
@@ -115,11 +115,11 @@ export function Empresas() {
         setTotal(t)
       })
       .finally(() => setLoading(false))
-  }
+  }, [debouncedBusca, incluirInativos, page, sortParams])
 
   useEffect(() => {
     load()
-  }, [page, debouncedBusca, incluirInativos, ordenarPor, ordem])
+  }, [load])
 
   useEffect(() => {
     coletarTodasPaginas<Redes.Rede>((o, l) => redes.list({ incluir_inativos: true, offset: o, limit: l })).then(
@@ -338,7 +338,7 @@ export function Empresas() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
       {!modalOpen && (
         <div className="flex justify-between">
           <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Empresas</h1>

--- a/frontend/src/pages/FuncionarioRedeDetalhe.tsx
+++ b/frontend/src/pages/FuncionarioRedeDetalhe.tsx
@@ -166,7 +166,7 @@ export function FuncionarioRedeDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-3xl space-y-6">
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
         <div className="h-4 w-40 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
         <div className="h-9 w-2/3 max-w-md animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-48 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
@@ -185,7 +185,7 @@ export function FuncionarioRedeDetalhe() {
       : null
 
   return (
-    <div className="mx-auto max-w-3xl space-y-8 pb-10">
+    <div className="mx-auto max-w-6xl space-y-8 pb-10">
       <div>
         <button
           type="button"
@@ -226,34 +226,36 @@ export function FuncionarioRedeDetalhe() {
         </div>
       </header>
 
-      <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-7 dark:border-slate-800/90 dark:bg-slate-900/60">
-        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Vínculos</h2>
-        <dl>
-          <div className="grid grid-cols-1 gap-0.5 border-b border-slate-100 py-3 sm:grid-cols-[minmax(0,10rem)_1fr] sm:gap-6 sm:py-3.5">
-            <dt className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Rede</dt>
-            <dd className="text-sm">
-              {f.rede_id != null && redeNome && redeNome !== '—' ? (
-                <Link
-                  to={`/redes/${f.rede_id}`}
-                  className="font-medium text-slate-800 underline decoration-slate-300 underline-offset-2 transition-colors hover:text-slate-950 hover:decoration-slate-500 dark:text-slate-100 dark:decoration-slate-700 dark:hover:decoration-slate-500"
-                >
-                  {redeNome}
-                </Link>
-              ) : (
-                <span className="text-slate-800 dark:text-slate-100">—</span>
-              )}
-            </dd>
-          </div>
-        </dl>
-        {vinculoExtra ? <div className="mt-4 border-t border-slate-100 pt-4 dark:border-slate-800">{vinculoExtra}</div> : null}
-      </section>
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-7 dark:border-slate-800/90 dark:bg-slate-900/60">
+          <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Vínculos</h2>
+          <dl>
+            <div className="grid grid-cols-1 gap-0.5 border-b border-slate-100 py-3 sm:grid-cols-[minmax(0,10rem)_1fr] sm:gap-6 sm:py-3.5">
+              <dt className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Rede</dt>
+              <dd className="text-sm">
+                {f.rede_id != null && redeNome && redeNome !== '—' ? (
+                  <Link
+                    to={`/redes/${f.rede_id}`}
+                    className="font-medium text-slate-800 underline decoration-slate-300 underline-offset-2 transition-colors hover:text-slate-950 hover:decoration-slate-500 dark:text-slate-100 dark:decoration-slate-700 dark:hover:decoration-slate-500"
+                  >
+                    {redeNome}
+                  </Link>
+                ) : (
+                  <span className="text-slate-800 dark:text-slate-100">—</span>
+                )}
+              </dd>
+            </div>
+          </dl>
+          {vinculoExtra ? <div className="mt-4 border-t border-slate-100 pt-4 dark:border-slate-800">{vinculoExtra}</div> : null}
+        </section>
 
-      <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-7 dark:border-slate-800/90 dark:bg-slate-900/60">
-        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Registro</h2>
-        <dl>
-          <DetailRow label="Cadastrado em" value={createdFmt} />
-        </dl>
-      </section>
+        <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-7 dark:border-slate-800/90 dark:bg-slate-900/60">
+          <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Registro</h2>
+          <dl>
+            <DetailRow label="Cadastrado em" value={createdFmt} />
+          </dl>
+        </section>
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/FuncionarioRedeDetalhe.tsx
+++ b/frontend/src/pages/FuncionarioRedeDetalhe.tsx
@@ -14,9 +14,9 @@ const tipoLabel: Record<string, string> = {
 function DetailRow({ label, value }: { label: string; value: string | null | undefined }) {
   const v = value?.trim()
   return (
-    <div className="grid grid-cols-1 gap-0.5 border-b border-slate-100 py-3 last:border-0 sm:grid-cols-[minmax(0,10rem)_1fr] sm:gap-6 sm:py-3.5">
-      <dt className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">{label}</dt>
-      <dd className="text-sm leading-relaxed text-slate-800">{v ? v : '—'}</dd>
+    <div className="grid grid-cols-1 gap-0.5 border-b border-slate-100 py-3 last:border-0 sm:grid-cols-[minmax(0,10rem)_1fr] sm:gap-6 sm:py-3.5 dark:border-slate-800">
+      <dt className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">{label}</dt>
+      <dd className="text-sm leading-relaxed text-slate-800 dark:text-slate-100">{v ? v : '—'}</dd>
     </div>
   )
 }
@@ -65,7 +65,7 @@ export function FuncionarioRedeDetalhe() {
 
         if (func.tipo === 'socio') {
           setVinculoExtra(
-            <p className="text-sm text-slate-700">
+            <p className="text-sm text-slate-700 dark:text-slate-200">
               Pessoa vinculada como <strong>sócio</strong> da rede (visão e cadastros no contexto da rede).
             </p>,
           )
@@ -74,11 +74,11 @@ export function FuncionarioRedeDetalhe() {
             const em = await empresas.get(func.empresa_id)
             if (!cancelled) {
               setVinculoExtra(
-                <p className="text-sm text-slate-700">
+                <p className="text-sm text-slate-700 dark:text-slate-200">
                   Colaborador da empresa{' '}
                   <Link
                     to={`/empresas/${em.id}`}
-                    className="font-medium text-slate-800 underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500"
+                    className="font-medium text-slate-800 underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500 dark:text-slate-100 dark:decoration-slate-700 dark:hover:decoration-slate-500"
                   >
                     {em.nome}
                   </Link>
@@ -88,7 +88,9 @@ export function FuncionarioRedeDetalhe() {
             }
           } catch {
             if (!cancelled) {
-              setVinculoExtra(<p className="text-sm text-slate-600">Empresa vinculada (ID {func.empresa_id}) não encontrada.</p>)
+              setVinculoExtra(
+                <p className="text-sm text-slate-600 dark:text-slate-400">Empresa vinculada (ID {func.empresa_id}) não encontrada.</p>,
+              )
             }
           }
         } else if (func.tipo === 'supervisor' && func.empresa_ids?.length) {
@@ -101,15 +103,15 @@ export function FuncionarioRedeDetalhe() {
             if (cancelled) return
             const ok = lista.filter(Boolean) as Awaited<ReturnType<typeof empresas.get>>[]
             if (ok.length === 0) {
-              setVinculoExtra(<p className="text-sm text-slate-600">Não foi possível carregar os nomes das empresas.</p>)
+              setVinculoExtra(<p className="text-sm text-slate-600 dark:text-slate-400">Não foi possível carregar os nomes das empresas.</p>)
             } else {
               setVinculoExtra(
-                <ul className="flex flex-wrap gap-x-3 gap-y-1 text-sm text-slate-700">
+                <ul className="flex flex-wrap gap-x-3 gap-y-1 text-sm text-slate-700 dark:text-slate-200">
                   {ok.map((em) => (
                     <li key={em.id}>
                       <Link
                         to={`/empresas/${em.id}`}
-                        className="font-medium text-slate-800 underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500"
+                        className="font-medium text-slate-800 underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500 dark:text-slate-100 dark:decoration-slate-700 dark:hover:decoration-slate-500"
                       >
                         {em.nome}
                       </Link>
@@ -165,9 +167,9 @@ export function FuncionarioRedeDetalhe() {
   if (loading) {
     return (
       <div className="mx-auto max-w-3xl space-y-6">
-        <div className="h-4 w-40 animate-pulse rounded bg-slate-200" />
-        <div className="h-9 w-2/3 max-w-md animate-pulse rounded-lg bg-slate-200" />
-        <div className="h-48 animate-pulse rounded-2xl bg-slate-100" />
+        <div className="h-4 w-40 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
+        <div className="h-9 w-2/3 max-w-md animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+        <div className="h-48 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
   }
@@ -197,17 +199,19 @@ export function FuncionarioRedeDetalhe() {
       <header className="space-y-3">
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0 space-y-2">
-            <h1 className="text-2xl font-semibold tracking-tight text-slate-900 md:text-3xl">{f.nome}</h1>
-            <p className="break-all text-sm text-slate-600">{f.email}</p>
+            <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100 md:text-3xl">{f.nome}</h1>
+            <p className="break-all text-sm text-slate-600 dark:text-slate-400">{f.email}</p>
             <div className="flex flex-wrap items-center gap-2">
               <span
                 className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                  f.ativo ? 'bg-emerald-50 text-emerald-800 ring-1 ring-emerald-600/15' : 'bg-slate-100 text-slate-600 ring-1 ring-slate-300/60'
+                  f.ativo
+                    ? 'bg-emerald-50 text-emerald-800 ring-1 ring-emerald-600/15 dark:bg-emerald-950/50 dark:text-emerald-300'
+                    : 'bg-slate-100 text-slate-600 ring-1 ring-slate-300/60 dark:bg-slate-800 dark:text-slate-300 dark:ring-slate-700/60'
                 }`}
               >
                 {f.ativo ? 'Ativo' : 'Inativo'}
               </span>
-              <span className="text-sm text-slate-500">{tipoLabel[f.tipo] ?? f.tipo}</span>
+              <span className="text-sm text-slate-500 dark:text-slate-400">{tipoLabel[f.tipo] ?? f.tipo}</span>
             </div>
           </div>
           <div className="flex shrink-0 flex-wrap gap-2">
@@ -222,30 +226,30 @@ export function FuncionarioRedeDetalhe() {
         </div>
       </header>
 
-      <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-7">
-        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">Vínculos</h2>
+      <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-7 dark:border-slate-800/90 dark:bg-slate-900/60">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Vínculos</h2>
         <dl>
           <div className="grid grid-cols-1 gap-0.5 border-b border-slate-100 py-3 sm:grid-cols-[minmax(0,10rem)_1fr] sm:gap-6 sm:py-3.5">
-            <dt className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">Rede</dt>
+            <dt className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Rede</dt>
             <dd className="text-sm">
               {f.rede_id != null && redeNome && redeNome !== '—' ? (
                 <Link
                   to={`/redes/${f.rede_id}`}
-                  className="font-medium text-slate-800 underline decoration-slate-300 underline-offset-2 transition-colors hover:text-slate-950 hover:decoration-slate-500"
+                  className="font-medium text-slate-800 underline decoration-slate-300 underline-offset-2 transition-colors hover:text-slate-950 hover:decoration-slate-500 dark:text-slate-100 dark:decoration-slate-700 dark:hover:decoration-slate-500"
                 >
                   {redeNome}
                 </Link>
               ) : (
-                <span className="text-slate-800">—</span>
+                <span className="text-slate-800 dark:text-slate-100">—</span>
               )}
             </dd>
           </div>
         </dl>
-        {vinculoExtra ? <div className="mt-4 border-t border-slate-100 pt-4">{vinculoExtra}</div> : null}
+        {vinculoExtra ? <div className="mt-4 border-t border-slate-100 pt-4 dark:border-slate-800">{vinculoExtra}</div> : null}
       </section>
 
-      <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-7">
-        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400">Registro</h2>
+      <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-7 dark:border-slate-800/90 dark:bg-slate-900/60">
+        <h2 className="mb-3 text-xs font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">Registro</h2>
         <dl>
           <DetailRow label="Cadastrado em" value={createdFmt} />
         </dl>

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -11,6 +11,7 @@ import { Switch } from '../components/ui/Switch'
 import { CheckboxField } from '../components/ui/CheckboxField'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { FormSection } from '../components/ui/FormSection'
 
 type Tipo = 'socio' | 'supervisor' | 'colaborador'
 
@@ -194,83 +195,99 @@ export function FuncionarioRedeForm() {
       </div>
 
       <Card title={isEdit ? 'Editar funcionário' : 'Novo funcionário'}>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-          <Input label="E-mail" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
-          <Select
-            label="Tipo"
-            value={tipo}
-            onChange={(v) => {
-              const t = v as Tipo
-              setTipo(t)
-              setEmpresaId('')
-              setEmpresaIds([])
-              if (t === 'socio' && !redeId) setRedeId(redePadraoRecente(redesList))
-            }}
-            options={[
-              { value: 'socio', label: 'Sócio' },
-              { value: 'supervisor', label: 'Supervisor' },
-              { value: 'colaborador', label: 'Colaborador' },
-            ]}
-          />
-          <SelectComPesquisa
-            id="funcionario-rede-form"
-            label="Rede"
-            value={redeId}
-            onChange={(id) => {
-              setRedeId(id)
-              setEmpresaId('')
-              setEmpresaIds([])
-            }}
-            required
-            items={redesList.map((r) => ({ id: r.id, label: r.nome, createdAt: r.created_at }))}
-            hint="Últimas redes cadastradas. Digite para buscar outras."
-          />
-          {tipo === 'colaborador' && (
-            <SelectComPesquisa
-              id="funcionario-empresa-form"
-              label="Empresa desta rede"
-              value={empresaId}
-              onChange={(id) => setEmpresaId(id)}
-              required
-              disabled={!redeId}
-              items={empresasDaRede.map((x) => ({ id: x.id, label: x.nome, createdAt: x.created_at }))}
-              hint={!redeId ? 'Selecione a rede primeiro.' : 'Últimas empresas desta rede. Digite para buscar.'}
-            />
-          )}
-          {tipo === 'supervisor' && (
-            <div>
-              <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200">Empresas desta rede</label>
-              {!redeId ? (
-                <p className="text-sm text-slate-500 dark:text-slate-400">Selecione a rede primeiro.</p>
-              ) : empresasDaRede.length === 0 ? (
-                <p className="text-sm text-slate-500 dark:text-slate-400">Nenhuma empresa ativa nesta rede.</p>
-              ) : (
-                <div className="flex flex-wrap gap-2 rounded-xl border border-slate-200 bg-slate-50/40 p-3 dark:border-slate-700 dark:bg-slate-800/40">
-                  {empresasDaRede.map((e) => (
-                    <CheckboxField key={e.id} checked={empresaIds.includes(e.id)} onChange={() => toggleEmpresa(e.id)}>
-                      {e.nome}
-                    </CheckboxField>
-                  ))}
-                </div>
-              )}
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-6">
+            <FormSection title="Dados do funcionário">
+              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
+              <Input label="E-mail" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+              <Select
+                label="Tipo"
+                value={tipo}
+                onChange={(v) => {
+                  const t = v as Tipo
+                  setTipo(t)
+                  setEmpresaId('')
+                  setEmpresaIds([])
+                  if (t === 'socio' && !redeId) setRedeId(redePadraoRecente(redesList))
+                }}
+                options={[
+                  { value: 'socio', label: 'Sócio' },
+                  { value: 'supervisor', label: 'Supervisor' },
+                  { value: 'colaborador', label: 'Colaborador' },
+                ]}
+              />
+              <SelectComPesquisa
+                id="funcionario-rede-form"
+                label="Rede"
+                value={redeId}
+                onChange={(id) => {
+                  setRedeId(id)
+                  setEmpresaId('')
+                  setEmpresaIds([])
+                }}
+                required
+                items={redesList.map((r) => ({ id: r.id, label: r.nome, createdAt: r.created_at }))}
+                hint="Últimas redes cadastradas. Digite para buscar outras."
+              />
+            </FormSection>
+
+            {tipo !== 'socio' && (
+              <FormSection title="Vínculo">
+                {tipo === 'colaborador' && (
+                  <SelectComPesquisa
+                    id="funcionario-empresa-form"
+                    label="Empresa desta rede"
+                    value={empresaId}
+                    onChange={(id) => setEmpresaId(id)}
+                    required
+                    disabled={!redeId}
+                    items={empresasDaRede.map((x) => ({ id: x.id, label: x.nome, createdAt: x.created_at }))}
+                    hint={!redeId ? 'Selecione a rede primeiro.' : 'Últimas empresas desta rede. Digite para buscar.'}
+                  />
+                )}
+                {tipo === 'supervisor' && (
+                  <div>
+                    <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200">Empresas desta rede</label>
+                    {!redeId ? (
+                      <p className="text-sm text-slate-500 dark:text-slate-400">Selecione a rede primeiro.</p>
+                    ) : empresasDaRede.length === 0 ? (
+                      <p className="text-sm text-slate-500 dark:text-slate-400">Nenhuma empresa ativa nesta rede.</p>
+                    ) : (
+                      <div className="flex max-h-44 flex-wrap gap-2 overflow-auto rounded-xl border border-slate-200 bg-slate-50/40 p-3 dark:border-slate-700 dark:bg-slate-800/40">
+                        {empresasDaRede.map((e) => (
+                          <CheckboxField key={e.id} checked={empresaIds.includes(e.id)} onChange={() => toggleEmpresa(e.id)}>
+                            {e.nome}
+                          </CheckboxField>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </FormSection>
+            )}
+
+            <FormSection title="Situação no sistema">
+              <Switch
+                bare
+                checked={ativo}
+                onCheckedChange={setAtivo}
+                label="Funcionário ativo"
+                showStatusPill
+                statusOnText="Ativo"
+                statusOffText="Inativo"
+              />
+            </FormSection>
+          </div>
+
+          <div className="sticky bottom-0 -mx-6 mt-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-900">
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <Button type="button" variant="secondary" onClick={voltarAnterior} className="w-full sm:w-auto">
+                Cancelar
+              </Button>
+              <Button type="submit" loading={saving} className="w-full sm:w-auto">
+                Salvar
+              </Button>
             </div>
-          )}
-          <Switch
-            checked={ativo}
-            onCheckedChange={setAtivo}
-            label="Status"
-            showStatusPill
-            statusOnText="Ativo"
-            statusOffText="Inativo"
-          />
-          <div className="flex flex-col-reverse gap-2 border-t border-slate-200 pt-3 dark:border-slate-700 sm:flex-row sm:justify-end">
-            <Button type="button" variant="secondary" onClick={voltarAnterior} className="w-full sm:w-auto">
-              Cancelar
-            </Button>
-            <Button type="submit" loading={saving} className="w-full sm:w-auto">
-              Salvar
-            </Button>
           </div>
         </form>
       </Card>

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -183,7 +183,7 @@ export function FuncionarioRedeForm() {
   }
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 pb-10">
+    <div className="mx-auto max-w-5xl space-y-6 pb-10">
       <div className="flex items-center justify-between gap-3">
         <button
           type="button"

--- a/frontend/src/pages/FuncionariosRede.tsx
+++ b/frontend/src/pages/FuncionariosRede.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
   funcionariosRede,
@@ -34,11 +34,7 @@ export function FuncionariosRede() {
     return () => clearTimeout(t)
   }, [busca])
 
-  useEffect(() => {
-    setPage(1)
-  }, [debouncedBusca, incluirInativos, ordenarPor, ordem])
-
-  function load(override?: { busca?: string; page?: number }) {
+  const load = useCallback((override?: { busca?: string; page?: number }) => {
     setLoading(true)
     const buscaEff = override?.busca !== undefined ? override.busca : debouncedBusca
     const pageEff = override?.page !== undefined ? override.page : page
@@ -55,11 +51,11 @@ export function FuncionariosRede() {
         setTotal(t)
       })
       .finally(() => setLoading(false))
-  }
+  }, [debouncedBusca, incluirInativos, page, sortParams])
 
   useEffect(() => {
     load()
-  }, [page, debouncedBusca, incluirInativos, ordenarPor, ordem])
+  }, [load])
 
   async function handleDelete(id: number) {
     if (!confirm('Excluir este funcionário?')) return
@@ -74,7 +70,7 @@ export function FuncionariosRede() {
   const tipoLabel = { socio: 'Sócio', supervisor: 'Supervisor', colaborador: 'Colaborador' }
 
   return (
-    <div className="space-y-6">
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <div className="flex justify-between">
         <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Funcionários da rede</h1>
         <Button onClick={() => navigate('/funcionarios-rede/novo')}>
@@ -84,13 +80,24 @@ export function FuncionariosRede() {
       <Card>
         <BarraBuscaPaginacao
           busca={busca}
-          onBuscaChange={setBusca}
+          onBuscaChange={(v) => {
+            setBusca(v)
+            setPage(1)
+          }}
           placeholder="Buscar por nome ou e-mail"
           page={page}
           total={total}
           onPageChange={setPage}
           disabled={loading}
-          extra={<FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />}
+          extra={
+            <FiltroInativos
+              incluirInativos={incluirInativos}
+              onChange={(v) => {
+                setIncluirInativos(v)
+                setPage(1)
+              }}
+            />
+          }
         />
         {loading ? (
           <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
@@ -101,9 +108,36 @@ export function FuncionariosRede() {
             <table className="w-full min-w-[720px] text-left text-sm">
               <thead>
                 <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
-                  <CabecalhoOrdenavel coluna="nome" rotulo="Nome" ordenarPor={ordenarPor} ordem={ordem} aoOrdenar={aoOrdenarColuna} />
-                  <CabecalhoOrdenavel coluna="email" rotulo="E-mail" ordenarPor={ordenarPor} ordem={ordem} aoOrdenar={aoOrdenarColuna} />
-                  <CabecalhoOrdenavel coluna="tipo" rotulo="Tipo" ordenarPor={ordenarPor} ordem={ordem} aoOrdenar={aoOrdenarColuna} />
+                  <CabecalhoOrdenavel
+                    coluna="nome"
+                    rotulo="Nome"
+                    ordenarPor={ordenarPor}
+                    ordem={ordem}
+                    aoOrdenar={(c) => {
+                      setPage(1)
+                      aoOrdenarColuna(c)
+                    }}
+                  />
+                  <CabecalhoOrdenavel
+                    coluna="email"
+                    rotulo="E-mail"
+                    ordenarPor={ordenarPor}
+                    ordem={ordem}
+                    aoOrdenar={(c) => {
+                      setPage(1)
+                      aoOrdenarColuna(c)
+                    }}
+                  />
+                  <CabecalhoOrdenavel
+                    coluna="tipo"
+                    rotulo="Tipo"
+                    ordenarPor={ordenarPor}
+                    ordem={ordem}
+                    aoOrdenar={(c) => {
+                      setPage(1)
+                      aoOrdenarColuna(c)
+                    }}
+                  />
                   <th className="w-px px-4 py-3 text-right text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
                     <span className="sr-only">Ações</span>
                   </th>

--- a/frontend/src/pages/RedeDetalhe.tsx
+++ b/frontend/src/pages/RedeDetalhe.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo } from 'react'
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import {
   redes,
@@ -255,7 +255,7 @@ export function RedeDetalhe() {
     if (!modalEmpresa) setAbaModalEmpresa('geral')
   }, [modalEmpresa])
 
-  function loadFuncionarios(override?: { busca?: string; page?: number }) {
+  const loadFuncionarios = useCallback((override?: { busca?: string; page?: number }) => {
     if (!redeId || isNaN(redeId)) return
     const buscaEff = override?.busca !== undefined ? override.busca : debouncedBuscaFuncionarios
     const pageEff = override?.page !== undefined ? override.page : pageFuncionarios
@@ -273,7 +273,7 @@ export function RedeDetalhe() {
         setFuncionariosTotal(total)
       })
       .finally(() => setLoadingFuncionarios(false))
-  }
+  }, [debouncedBuscaFuncionarios, incluirInativos, pageFuncionarios, redeId, sortFuncParams])
 
   useEffect(() => {
     if (aba !== 'tickets' || !redeId || Number.isNaN(redeId)) return
@@ -419,7 +419,7 @@ export function RedeDetalhe() {
 
   useEffect(() => {
     loadFuncionarios()
-  }, [redeId, incluirInativos, pageFuncionarios, debouncedBuscaFuncionarios, ordemColFunc, dirFunc])
+  }, [loadFuncionarios])
 
   useEffect(() => {
     if (id && !isNaN(redeId)) return
@@ -801,7 +801,7 @@ export function RedeDetalhe() {
     tipoNegocioIdEmpresa === '' ? '' : tiposNegocioList.find((t) => t.id === Number(tipoNegocioIdEmpresa))?.nome ?? ''
 
   return (
-    <div className="space-y-6">
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <div className="flex flex-wrap items-center gap-3">
         <nav aria-label="breadcrumb" className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
           {linkRedes}

--- a/frontend/src/pages/RedeDetalhe.tsx
+++ b/frontend/src/pages/RedeDetalhe.tsx
@@ -1557,85 +1557,101 @@ export function RedeDetalhe() {
               <p className="mb-4 text-sm text-slate-600">
                 Rede: <span className="font-medium text-slate-800">{rede.nome}</span> — o vínculo será apenas com empresas desta rede.
               </p>
-              <form onSubmit={handleSubmitFuncionario} className="space-y-4">
-                <Input
-                  label="Nome *"
-                  value={nomeFuncionario}
-                  onChange={(e) => setNomeFuncionario(e.target.value)}
-                  required
-                />
-                <Input
-                  label="E-mail *"
-                  type="email"
-                  value={emailFuncionario}
-                  onChange={(e) => setEmailFuncionario(e.target.value)}
-                  required
-                />
-                <Select
-                  label="Tipo"
-                  value={tipoFuncionario}
-                  onChange={(v) => {
-                    const t = v as TipoFuncionario
-                    setTipoFuncionario(t)
-                    setEmpresaIdFuncionario('')
-                    setEmpresaIdsFuncionario([])
-                  }}
-                  options={[
-                    { value: 'socio', label: 'Sócio' },
-                    { value: 'supervisor', label: 'Supervisor' },
-                    { value: 'colaborador', label: 'Colaborador' },
-                  ]}
-                />
-                {tipoFuncionario === 'colaborador' && (
-                  <SelectComPesquisa
-                    id="rede-detalhe-func-empresa"
-                    label="Empresa desta rede *"
-                    value={empresaIdFuncionario}
-                    onChange={(id) => setEmpresaIdFuncionario(id)}
-                    required
-                    items={empresasDaRedeParaVinculo.map((x) => ({
-                      id: x.id,
-                      label: x.nome,
-                      createdAt: x.created_at,
-                    }))}
-                    hint="Últimas empresas desta rede. Digite para buscar."
-                  />
-                )}
-                {tipoFuncionario === 'supervisor' && (
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-slate-700">Empresas desta rede</label>
-                    {empresasDaRedeParaVinculo.length === 0 ? (
-                      <p className="text-sm text-slate-500">Nenhuma empresa ativa nesta rede.</p>
-                    ) : (
-                      <div className="flex flex-wrap gap-2 rounded-xl border border-slate-200 bg-slate-50/40 p-3">
-                        {empresasDaRedeParaVinculo.map((e) => (
-                          <CheckboxField
-                            key={e.id}
-                            checked={empresaIdsFuncionario.includes(e.id)}
-                            onChange={() => toggleEmpresaFuncionario(e.id)}
-                          >
-                            {e.nome}
-                          </CheckboxField>
-                        ))}
-                      </div>
-                    )}
+              <form onSubmit={handleSubmitFuncionario}>
+                <div className="space-y-6">
+                  <FormSection title="Dados do funcionário">
+                    <Input
+                      label="Nome *"
+                      value={nomeFuncionario}
+                      onChange={(e) => setNomeFuncionario(e.target.value)}
+                      required
+                    />
+                    <Input
+                      label="E-mail *"
+                      type="email"
+                      value={emailFuncionario}
+                      onChange={(e) => setEmailFuncionario(e.target.value)}
+                      required
+                    />
+                    <Select
+                      label="Tipo"
+                      value={tipoFuncionario}
+                      onChange={(v) => {
+                        const t = v as TipoFuncionario
+                        setTipoFuncionario(t)
+                        setEmpresaIdFuncionario('')
+                        setEmpresaIdsFuncionario([])
+                      }}
+                      options={[
+                        { value: 'socio', label: 'Sócio' },
+                        { value: 'supervisor', label: 'Supervisor' },
+                        { value: 'colaborador', label: 'Colaborador' },
+                      ]}
+                    />
+                  </FormSection>
+
+                  {tipoFuncionario !== 'socio' && (
+                    <FormSection title="Vínculo">
+                      {tipoFuncionario === 'colaborador' && (
+                        <SelectComPesquisa
+                          id="rede-detalhe-func-empresa"
+                          label="Empresa desta rede *"
+                          value={empresaIdFuncionario}
+                          onChange={(id) => setEmpresaIdFuncionario(id)}
+                          required
+                          items={empresasDaRedeParaVinculo.map((x) => ({
+                            id: x.id,
+                            label: x.nome,
+                            createdAt: x.created_at,
+                          }))}
+                          hint="Últimas empresas desta rede. Digite para buscar."
+                        />
+                      )}
+                      {tipoFuncionario === 'supervisor' && (
+                        <div>
+                          <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200">Empresas desta rede</label>
+                          {empresasDaRedeParaVinculo.length === 0 ? (
+                            <p className="text-sm text-slate-500 dark:text-slate-400">Nenhuma empresa ativa nesta rede.</p>
+                          ) : (
+                            <div className="flex max-h-44 flex-wrap gap-2 overflow-auto rounded-xl border border-slate-200 bg-slate-50/40 p-3 dark:border-slate-700 dark:bg-slate-800/40">
+                              {empresasDaRedeParaVinculo.map((e) => (
+                                <CheckboxField
+                                  key={e.id}
+                                  checked={empresaIdsFuncionario.includes(e.id)}
+                                  onChange={() => toggleEmpresaFuncionario(e.id)}
+                                >
+                                  {e.nome}
+                                </CheckboxField>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </FormSection>
+                  )}
+
+                  <FormSection title="Situação no sistema">
+                    <Switch
+                      bare
+                      checked={ativoFuncionario}
+                      onCheckedChange={setAtivoFuncionario}
+                      label="Funcionário ativo"
+                      showStatusPill
+                      statusOnText="Ativo"
+                      statusOffText="Inativo"
+                    />
+                  </FormSection>
+                </div>
+
+                <div className="sticky bottom-0 -mx-6 mt-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-900">
+                  <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                    <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => fecharModalFuncionario()}>
+                      Cancelar
+                    </Button>
+                    <Button type="submit" loading={savingFuncionario} className="w-full sm:w-auto">
+                      Salvar
+                    </Button>
                   </div>
-                )}
-                <Switch
-                  checked={ativoFuncionario}
-                  onCheckedChange={setAtivoFuncionario}
-                  label="Status"
-                  showStatusPill
-                  statusOnText="Ativo"
-                  statusOffText="Inativo"
-                />
-                <div className="flex gap-2 border-t border-slate-200 pt-2">
-                  <Button type="submit" loading={savingFuncionario}>
-                    Salvar
-                  </Button>
-                  <Button type="button" variant="secondary" onClick={() => fecharModalFuncionario()}>
-                    Cancelar
-                  </Button>
                 </div>
               </form>
           </>

--- a/frontend/src/pages/RedeForm.tsx
+++ b/frontend/src/pages/RedeForm.tsx
@@ -91,7 +91,7 @@ export function RedeForm() {
   }
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6 pb-10">
+    <div className="mx-auto max-w-5xl space-y-6 pb-10">
       <div className="flex items-center justify-between gap-3">
         <button
           type="button"

--- a/frontend/src/pages/RedeForm.tsx
+++ b/frontend/src/pages/RedeForm.tsx
@@ -7,6 +7,7 @@ import { Input } from '../components/ui/Input'
 import { Switch } from '../components/ui/Switch'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { FormSection } from '../components/ui/FormSection'
 
 export function RedeForm() {
   const { id } = useParams<{ id?: string }>()
@@ -102,30 +103,41 @@ export function RedeForm() {
       </div>
 
       <Card title={isEdit ? 'Editar rede' : 'Nova rede'}>
-        <form onSubmit={handleSubmit} className="space-y-5">
-          <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-          <Input
-            label="Login do retaguarda"
-            value={loginRetaguarda}
-            onChange={(e) => setLoginRetaguarda(e.target.value)}
-            placeholder="Ex.: duplex_admin"
-          />
-          <Switch
-            checked={ativo}
-            onCheckedChange={setAtivo}
-            label="Status"
-            description="Inativos ficam ocultos nas listagens padrão."
-            showStatusPill
-            statusOnText="Ativo"
-            statusOffText="Inativo"
-          />
-          <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-            <Button type="button" variant="secondary" onClick={voltarAnterior} className="w-full sm:w-auto">
-              Cancelar
-            </Button>
-            <Button type="submit" loading={saving} className="w-full sm:w-auto">
-              Salvar
-            </Button>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-6">
+            <FormSection title="Dados da rede">
+              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
+              <Input
+                label="Login do retaguarda"
+                value={loginRetaguarda}
+                onChange={(e) => setLoginRetaguarda(e.target.value)}
+                placeholder="Ex.: duplex_admin"
+              />
+            </FormSection>
+
+            <FormSection title="Situação no sistema">
+              <Switch
+                bare
+                checked={ativo}
+                onCheckedChange={setAtivo}
+                label="Rede ativa"
+                description="Inativos ficam ocultos nas listagens padrão."
+                showStatusPill
+                statusOnText="Ativo"
+                statusOffText="Inativo"
+              />
+            </FormSection>
+          </div>
+
+          <div className="sticky bottom-0 -mx-6 mt-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-900">
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <Button type="button" variant="secondary" onClick={voltarAnterior} className="w-full sm:w-auto">
+                Cancelar
+              </Button>
+              <Button type="submit" loading={saving} className="w-full sm:w-auto">
+                Salvar
+              </Button>
+            </div>
           </div>
         </form>
       </Card>

--- a/frontend/src/pages/Redes.tsx
+++ b/frontend/src/pages/Redes.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { useNavigate } from 'react-router-dom'
@@ -30,11 +30,7 @@ export function Redes() {
     return () => clearTimeout(t)
   }, [busca])
 
-  useEffect(() => {
-    setPage(1)
-  }, [debouncedBusca, incluirInativos, ordenarPor, ordem])
-
-  function load() {
+  const load = useCallback(() => {
     setLoading(true)
     redes
       .list({
@@ -49,11 +45,11 @@ export function Redes() {
         setTotal(t)
       })
       .finally(() => setLoading(false))
-  }
+  }, [debouncedBusca, incluirInativos, page, sortParams])
 
   useEffect(() => {
     load()
-  }, [page, debouncedBusca, incluirInativos, ordenarPor, ordem])
+  }, [load])
 
   async function handleDelete(id: number) {
     if (!confirm('Excluir esta rede?')) return
@@ -66,7 +62,7 @@ export function Redes() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <div className="flex justify-between">
         <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Redes</h1>
         <Button onClick={() => navigate('/redes/novo')}>Nova rede</Button>
@@ -74,13 +70,24 @@ export function Redes() {
       <Card>
         <BarraBuscaPaginacao
           busca={busca}
-          onBuscaChange={setBusca}
+          onBuscaChange={(v) => {
+            setBusca(v)
+            setPage(1)
+          }}
           placeholder="Buscar por nome da rede"
           page={page}
           total={total}
           onPageChange={setPage}
           disabled={loading}
-          extra={<FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />}
+          extra={
+            <FiltroInativos
+              incluirInativos={incluirInativos}
+              onChange={(v) => {
+                setIncluirInativos(v)
+                setPage(1)
+              }}
+            />
+          }
         />
         {loading ? (
           <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
@@ -91,11 +98,29 @@ export function Redes() {
             <table className="w-full min-w-[520px] text-left text-sm">
               <thead>
                 <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
-                  <CabecalhoOrdenavel coluna="nome" rotulo="Nome" ordenarPor={ordenarPor} ordem={ordem} aoOrdenar={aoOrdenarColuna} />
+                  <CabecalhoOrdenavel
+                    coluna="nome"
+                    rotulo="Nome"
+                    ordenarPor={ordenarPor}
+                    ordem={ordem}
+                    aoOrdenar={(c) => {
+                      setPage(1)
+                      aoOrdenarColuna(c)
+                    }}
+                  />
                   <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 sm:px-6 dark:text-slate-400">
                     Retaguarda
                   </th>
-                  <CabecalhoOrdenavel coluna="ativo" rotulo="Situação" ordenarPor={ordenarPor} ordem={ordem} aoOrdenar={aoOrdenarColuna} />
+                  <CabecalhoOrdenavel
+                    coluna="ativo"
+                    rotulo="Situação"
+                    ordenarPor={ordenarPor}
+                    ordem={ordem}
+                    aoOrdenar={(c) => {
+                      setPage(1)
+                      aoOrdenarColuna(c)
+                    }}
+                  />
                   <th className="w-px whitespace-nowrap px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500 sm:px-6 dark:text-slate-400">
                     <span className="sr-only">Ações</span>
                   </th>

--- a/frontend/src/pages/SetorDetalhe.tsx
+++ b/frontend/src/pages/SetorDetalhe.tsx
@@ -153,7 +153,7 @@ export function SetorDetalhe() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
         <button
           type="button"

--- a/frontend/src/pages/Setores.tsx
+++ b/frontend/src/pages/Setores.tsx
@@ -12,6 +12,7 @@ import { FiltroInativos } from '../components/ui/FiltroInativos'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
 import { Switch } from '../components/ui/Switch'
 import { useNavigate } from 'react-router-dom'
+import { FormSection } from '../components/ui/FormSection'
 
 type ColunaSetor = 'nome' | 'slug' | 'ativo'
 
@@ -32,6 +33,15 @@ export function Setores() {
   const [slug, setSlug] = useState('')
   const [ativo, setAtivo] = useState(true)
   const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!modalOpen) return
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prevOverflow
+    }
+  }, [modalOpen])
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -194,22 +204,43 @@ export function Setores() {
       )}
 
       {modalOpen && (
-        <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/50 p-4">
+        <div className="fixed inset-y-0 left-0 right-0 z-20 flex items-start justify-center bg-black/85 px-4 pb-6 pt-16 sm:px-6 md:left-[var(--sidebar-w)]">
           <Card title={editingId ? 'Editar setor' : 'Novo setor'} className="w-full max-w-md">
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-              <Input label="Slug" value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="ex: suporte" required />
-              <Switch
-                checked={ativo}
-                onCheckedChange={setAtivo}
-                label="Status"
-                showStatusPill
-                statusOnText="Ativo"
-                statusOffText="Inativo"
-              />
-              <div className="flex gap-2">
-                <Button type="submit" loading={saving}>Salvar</Button>
-                <Button type="button" variant="secondary" onClick={() => setModalOpen(false)}>Cancelar</Button>
+            <form onSubmit={handleSubmit}>
+              <div className="space-y-6">
+                <FormSection title="Dados do setor">
+                  <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
+                  <Input
+                    label="Slug"
+                    value={slug}
+                    onChange={(e) => setSlug(e.target.value)}
+                    placeholder="ex: suporte"
+                    required
+                  />
+                </FormSection>
+
+                <FormSection title="Situação no sistema">
+                  <Switch
+                    bare
+                    checked={ativo}
+                    onCheckedChange={setAtivo}
+                    label="Setor ativo"
+                    showStatusPill
+                    statusOnText="Ativo"
+                    statusOffText="Inativo"
+                  />
+                </FormSection>
+              </div>
+
+              <div className="sticky bottom-0 -mx-6 mt-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-900">
+                <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                  <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => setModalOpen(false)}>
+                    Cancelar
+                  </Button>
+                  <Button type="submit" loading={saving} className="w-full sm:w-auto">
+                    Salvar
+                  </Button>
+                </div>
               </div>
             </form>
           </Card>

--- a/frontend/src/pages/Setores.tsx
+++ b/frontend/src/pages/Setores.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { setores, type Setores } from '../api/client'
@@ -52,7 +52,7 @@ export function Setores() {
     setPage(1)
   }, [debouncedBusca, incluirInativos, ordenarPor, ordem])
 
-  function load() {
+  const load = useCallback(() => {
     setLoading(true)
     setores
       .list({
@@ -67,11 +67,11 @@ export function Setores() {
         setTotal(t)
       })
       .finally(() => setLoading(false))
-  }
+  }, [debouncedBusca, incluirInativos, page, sortParams])
 
   useEffect(() => {
     load()
-  }, [page, debouncedBusca, incluirInativos, ordenarPor, ordem])
+  }, [load])
 
   function openCreate() {
     setEditingId(null)
@@ -120,7 +120,7 @@ export function Setores() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <div className="flex justify-between">
         <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Setores</h1>
         <Button onClick={openCreate}>Novo setor</Button>

--- a/frontend/src/pages/StatusTicket.tsx
+++ b/frontend/src/pages/StatusTicket.tsx
@@ -10,6 +10,7 @@ import { FiltroInativos } from '../components/ui/FiltroInativos'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
 import { Switch } from '../components/ui/Switch'
 import { useToast } from '../components/ui/Toast'
+import { FormSection } from '../components/ui/FormSection'
 
 type ColunaStatus = 'nome' | 'slug' | 'ordem' | 'ativo'
 
@@ -30,6 +31,15 @@ export function StatusTicketPage() {
   const [ordem, setOrdem] = useState(0)
   const [ativo, setAtivo] = useState(true)
   const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!modalOpen) return
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prevOverflow
+    }
+  }, [modalOpen])
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -177,23 +187,44 @@ export function StatusTicketPage() {
       )}
 
       {modalOpen && (
-        <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/50 p-4">
+        <div className="fixed inset-y-0 left-0 right-0 z-20 flex items-start justify-center bg-black/85 px-4 pb-6 pt-16 sm:px-6 md:left-[var(--sidebar-w)]">
           <Card title={editingId ? 'Editar status' : 'Novo status'} className="w-full max-w-md">
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-              <Input label="Slug" value={slug} onChange={(e) => setSlug(e.target.value)} placeholder="ex: aberto" required />
-              <Input label="Ordem" type="number" value={ordem} onChange={(e) => setOrdem(Number(e.target.value))} />
-              <Switch
-                checked={ativo}
-                onCheckedChange={setAtivo}
-                label="Status"
-                showStatusPill
-                statusOnText="Ativo"
-                statusOffText="Inativo"
-              />
-              <div className="flex gap-2">
-                <Button type="submit" loading={saving}>Salvar</Button>
-                <Button type="button" variant="secondary" onClick={() => setModalOpen(false)}>Cancelar</Button>
+            <form onSubmit={handleSubmit}>
+              <div className="space-y-6">
+                <FormSection title="Dados do status">
+                  <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
+                  <Input
+                    label="Slug"
+                    value={slug}
+                    onChange={(e) => setSlug(e.target.value)}
+                    placeholder="ex: aguardando_atendimento"
+                    required
+                  />
+                  <Input label="Ordem" type="number" value={ordem} onChange={(e) => setOrdem(Number(e.target.value))} />
+                </FormSection>
+
+                <FormSection title="Situação no sistema">
+                  <Switch
+                    bare
+                    checked={ativo}
+                    onCheckedChange={setAtivo}
+                    label="Status ativo"
+                    showStatusPill
+                    statusOnText="Ativo"
+                    statusOffText="Inativo"
+                  />
+                </FormSection>
+              </div>
+
+              <div className="sticky bottom-0 -mx-6 mt-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-900">
+                <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                  <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => setModalOpen(false)}>
+                    Cancelar
+                  </Button>
+                  <Button type="submit" loading={saving} className="w-full sm:w-auto">
+                    Salvar
+                  </Button>
+                </div>
               </div>
             </form>
           </Card>

--- a/frontend/src/pages/StatusTicket.tsx
+++ b/frontend/src/pages/StatusTicket.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { statusTicket, type StatusTicket } from '../api/client'
@@ -50,7 +50,7 @@ export function StatusTicketPage() {
     setPage(1)
   }, [debouncedBusca, incluirInativos, ordenarPor, ordemLista])
 
-  function load() {
+  const load = useCallback(() => {
     setLoading(true)
     statusTicket
       .list({
@@ -65,11 +65,11 @@ export function StatusTicketPage() {
         setTotal(t)
       })
       .finally(() => setLoading(false))
-  }
+  }, [debouncedBusca, incluirInativos, page, sortParams])
 
   useEffect(() => {
     load()
-  }, [page, debouncedBusca, incluirInativos, ordenarPor, ordemLista])
+  }, [load])
 
   function openCreate() {
     setEditingId(null)
@@ -110,7 +110,7 @@ export function StatusTicketPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <div className="flex justify-between">
         <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Status de ticket</h1>
         <Button onClick={openCreate}>Novo status</Button>

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -453,7 +453,7 @@ export function TicketDetalhe() {
 
   if (notFound || !ticket) {
     return (
-      <div className="space-y-4">
+      <div className="mx-auto max-w-6xl space-y-4 pb-10">
         <p className="text-slate-600 dark:text-slate-400">Ticket não encontrado ou sem permissão.</p>
         <button
           type="button"
@@ -467,7 +467,7 @@ export function TicketDetalhe() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
         <button
           type="button"

--- a/frontend/src/pages/TicketNovo.tsx
+++ b/frontend/src/pages/TicketNovo.tsx
@@ -10,6 +10,7 @@ import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
 import { useAuth } from '../contexts/AuthContext'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { FormSection } from '../components/ui/FormSection'
 
 export function TicketNovo() {
   const { isAdmin, user } = useAuth()
@@ -95,7 +96,7 @@ export function TicketNovo() {
   const semSetorPermitido = !isAdmin && setoresFiltrados.length === 0
 
   return (
-    <div className="space-y-6">
+    <div className="mx-auto max-w-3xl space-y-6 pb-10">
       <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
         <button
           type="button"
@@ -124,65 +125,74 @@ export function TicketNovo() {
           O ticket entra na <strong>fila do setor</strong> (sem responsável). Qualquer atendente do setor pode abrir o chamado e usar{' '}
           <strong>Atribuir a mim</strong> para assumir o atendimento.
         </p>
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <SelectComPesquisa
-            id="ticket-empresa"
-            label="Empresa *"
-            value={empresaId}
-            onChange={(id) => setEmpresaId(id)}
-            items={empresaItems}
-            placeholder="Buscar empresa..."
-            required
-            disabled={semSetorPermitido}
-            recentCount={10}
-          />
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-6">
+            <FormSection title="Identificação">
+              <SelectComPesquisa
+                id="ticket-empresa"
+                label="Empresa *"
+                value={empresaId}
+                onChange={(id) => setEmpresaId(id)}
+                items={empresaItems}
+                placeholder="Buscar empresa..."
+                required
+                disabled={semSetorPermitido}
+                recentCount={10}
+              />
 
-          <div>
-            <Select
-              id="ticket-setor"
-              label="Setor *"
-              value={setorId}
-              onChange={(v) => setSetorId(v === '' ? '' : Number(v))}
-              options={setoresFiltrados.map((s) => ({ value: s.id, label: s.nome }))}
-              includeEmpty
-              emptyLabel="Selecione"
-              placeholder="Selecione"
-              disabled={semSetorPermitido}
-            />
-            {!isAdmin && setoresFiltrados.length > 0 && (
-              <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">Somente setores aos quais você está vinculado.</p>
-            )}
+              <div>
+                <Select
+                  id="ticket-setor"
+                  label="Setor *"
+                  value={setorId}
+                  onChange={(v) => setSetorId(v === '' ? '' : Number(v))}
+                  options={setoresFiltrados.map((s) => ({ value: s.id, label: s.nome }))}
+                  includeEmpty
+                  emptyLabel="Selecione"
+                  placeholder="Selecione"
+                  disabled={semSetorPermitido}
+                />
+                {!isAdmin && setoresFiltrados.length > 0 && (
+                  <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">Somente setores aos quais você está vinculado.</p>
+                )}
+              </div>
+            </FormSection>
+
+            <FormSection title="Solicitação">
+              <Input
+                label="Assunto (resumo) *"
+                value={assunto}
+                onChange={(e) => setAssunto(e.target.value)}
+                required
+                disabled={semSetorPermitido}
+              />
+              <div>
+                <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">Relato do problema *</label>
+                <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
+                  Este texto entra como primeira mensagem do ticket (solicitação inicial).
+                </p>
+                <textarea
+                  value={descricao}
+                  onChange={(e) => setDescricao(e.target.value)}
+                  spellCheck={false}
+                  rows={5}
+                  required
+                  disabled={semSetorPermitido}
+                  className="w-full rounded-xl border-0 bg-white px-3 py-2 text-sm shadow-sm ring-1 ring-slate-200/90 focus:outline-none focus:ring-2 focus:ring-slate-400/35 dark:bg-slate-900 dark:text-slate-100 dark:ring-slate-700"
+                />
+              </div>
+            </FormSection>
           </div>
 
-          <Input
-            label="Assunto (resumo) *"
-            value={assunto}
-            onChange={(e) => setAssunto(e.target.value)}
-            required
-            disabled={semSetorPermitido}
-          />
-          <div>
-            <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">Relato do problema *</label>
-            <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
-              Este texto entra como primeira mensagem do ticket (solicitação inicial).
-            </p>
-            <textarea
-              value={descricao}
-              onChange={(e) => setDescricao(e.target.value)}
-              spellCheck={false}
-              rows={5}
-              required
-              disabled={semSetorPermitido}
-              className="w-full rounded-xl border-0 bg-white px-3 py-2 text-sm shadow-sm ring-1 ring-slate-200/90 focus:outline-none focus:ring-2 focus:ring-slate-400/35 dark:bg-slate-900 dark:text-slate-100 dark:ring-slate-700"
-            />
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <Button type="submit" loading={loading} disabled={semSetorPermitido}>
-              Criar ticket
-            </Button>
-            <Button type="button" variant="secondary" onClick={voltarAnterior}>
-              Cancelar
-            </Button>
+          <div className="sticky bottom-0 -mx-6 mt-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-900">
+            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <Button type="button" variant="secondary" onClick={voltarAnterior} className="w-full sm:w-auto">
+                Cancelar
+              </Button>
+              <Button type="submit" loading={loading} disabled={semSetorPermitido} className="w-full sm:w-auto">
+                Criar ticket
+              </Button>
+            </div>
           </div>
         </form>
       </Card>

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -20,7 +20,7 @@ import { useToast } from '../components/ui/Toast'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { useAuth } from '../contexts/AuthContext'
-import { useAlertaFilaSemResponsavel } from '../hooks/useAlertaFilaSemResponsavel'
+import { useAlertaFilaSemResponsavel, usePendenciasResumo } from '../hooks/useAlertaFilaSemResponsavel'
 import { Switch } from '../components/ui/Switch'
 
 type ColunaOrdenacao =
@@ -44,6 +44,7 @@ export function Tickets() {
   const toast = useToast()
   const { isAdmin, user } = useAuth()
   const { soundEnabled, setSoundEnabled, count: filaCount } = useAlertaFilaSemResponsavel(Boolean(user))
+  const resumoPendencias = usePendenciasResumo(Boolean(user))
 
   const [list, setList] = useState<Tickets.Ticket[]>([])
   const [total, setTotal] = useState(0)
@@ -237,8 +238,12 @@ export function Tickets() {
             bare
             checked={soundEnabled}
             onCheckedChange={setSoundEnabled}
-            label="Som de fila"
-            description={filaCount > 0 ? `${filaCount} na fila sem responsável` : 'Desligue se não quiser alerta'}
+            label="Som de notificações"
+            description={
+              resumoPendencias.total_pendencias > 0
+                ? `${resumoPendencias.total_pendencias} pendência(s) · fila: ${filaCount} · não lidas: ${resumoPendencias.nao_lidas_count}`
+                : 'Ative para receber alerta sonoro quando chegar uma nova pendência'
+            }
           />
           <Link to="/tickets/novo">
             <Button>Novo ticket</Button>

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -20,8 +20,7 @@ import { useToast } from '../components/ui/Toast'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { useAuth } from '../contexts/AuthContext'
-import { useAlertaFilaSemResponsavel, usePendenciasResumo } from '../hooks/useAlertaFilaSemResponsavel'
-import { Switch } from '../components/ui/Switch'
+import { useAlertaFilaSemResponsavel } from '../hooks/useAlertaFilaSemResponsavel'
 
 type ColunaOrdenacao =
   | 'protocolo'
@@ -43,8 +42,7 @@ export function Tickets() {
   const [searchParams, setSearchParams] = useSearchParams()
   const toast = useToast()
   const { isAdmin, user } = useAuth()
-  const { soundEnabled, setSoundEnabled, count: filaCount } = useAlertaFilaSemResponsavel(Boolean(user))
-  const resumoPendencias = usePendenciasResumo(Boolean(user))
+  useAlertaFilaSemResponsavel(Boolean(user))
 
   const [list, setList] = useState<Tickets.Ticket[]>([])
   const [total, setTotal] = useState(0)
@@ -234,17 +232,6 @@ export function Tickets() {
           <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Acompanhe e filtre as demandas do suporte.</p>
         </div>
         <div className="flex flex-wrap items-center justify-end gap-3">
-          <Switch
-            bare
-            checked={soundEnabled}
-            onCheckedChange={setSoundEnabled}
-            label="Som de notificações"
-            description={
-              resumoPendencias.total_pendencias > 0
-                ? `${resumoPendencias.total_pendencias} pendência(s) · fila: ${filaCount} · não lidas: ${resumoPendencias.nao_lidas_count}`
-                : 'Ative para receber alerta sonoro quando chegar uma nova pendência'
-            }
-          />
           <Link to="/tickets/novo">
             <Button>Novo ticket</Button>
           </Link>

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useId } from 'react'
+import { useState, useEffect, useMemo, useId, useCallback } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
 import {
   tickets,
@@ -67,6 +67,8 @@ export function Tickets() {
   const [maisFiltrosAberto, setMaisFiltrosAberto] = useState(false)
   const painelFiltrosId = useId()
   const { ordenarPor, ordem, aoOrdenarColuna, sortParams } = useOrdenacaoLista<ColunaOrdenacao>()
+
+  const resetarPagina = useCallback(() => setPage(1), [])
 
   const setoresFiltro = useMemo(() => {
     const ativos = setoresOpt.filter((s) => s.ativo)
@@ -148,21 +150,18 @@ export function Tickets() {
     if (!isAdmin) {
       setAtendentesOpt([])
       setFiltroAtendente('')
+      resetarPagina()
       return
     }
     coletarTodasPaginas<Atendentes.Atendente>((o, l) =>
       atendentes.list({ incluir_inativos: false, offset: o, limit: l }),
     ).then(setAtendentesOpt)
-  }, [isAdmin])
+  }, [isAdmin, resetarPagina])
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
     return () => clearTimeout(t)
   }, [busca])
-
-  useEffect(() => {
-    setPage(1)
-  }, [debouncedBusca, filtroStatus, filtroEmpresa, filtroSetor, filtroFila, filtroAtendente, ordenarPor, ordem])
 
   useEffect(() => {
     if (filtroSetor !== '' && !setoresFiltro.some((s) => s.id === filtroSetor)) {
@@ -211,6 +210,8 @@ export function Tickets() {
     isAdmin,
     ordenarPor,
     ordem,
+    sortParams,
+    toast,
   ])
 
   function limparFiltros() {
@@ -225,7 +226,7 @@ export function Tickets() {
   }
 
   return (
-    <div className="space-y-8">
+    <div className="mx-auto max-w-6xl space-y-8 pb-10">
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">Tickets</h1>
@@ -253,7 +254,10 @@ export function Tickets() {
               <input
                 type="search"
                 value={busca}
-                onChange={(e) => setBusca(e.target.value)}
+                onChange={(e) => {
+                  setBusca(e.target.value)
+                  resetarPagina()
+                }}
                 placeholder="Buscar por protocolo, assunto ou empresa…"
                 disabled={loading}
                 className="w-full rounded-xl border-0 bg-slate-50 py-2.5 pl-10 pr-4 text-sm text-slate-900 shadow-inner ring-1 ring-slate-200/80 transition-shadow placeholder:text-slate-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-slate-400/25 dark:bg-slate-900/60 dark:text-slate-100 dark:ring-slate-700 dark:placeholder:text-slate-500 dark:focus:bg-slate-900"
@@ -295,6 +299,7 @@ export function Tickets() {
                     onClick={() => {
                       setFiltroFila(id)
                       if (id !== '') setFiltroAtendente('')
+                      resetarPagina()
                     }}
                     className={`min-h-[2.25rem] flex-1 rounded-xl px-3 py-2 text-center text-xs font-medium transition-all duration-200 sm:flex-none sm:px-4 sm:text-sm ${
                       ativo
@@ -357,7 +362,10 @@ export function Tickets() {
                   labelStyle="overline"
                   className="min-w-0"
                   value={filtroEmpresa}
-                  onChange={(v) => setFiltroEmpresa(v === '' ? '' : Number(v))}
+                  onChange={(v) => {
+                    setFiltroEmpresa(v === '' ? '' : Number(v))
+                    resetarPagina()
+                  }}
                   options={opcoesEmpresaFiltro}
                   includeEmpty
                   emptyLabel="Todas"
@@ -368,7 +376,10 @@ export function Tickets() {
                   labelStyle="overline"
                   className="min-w-0"
                   value={filtroSetor}
-                  onChange={(v) => setFiltroSetor(v === '' ? '' : Number(v))}
+                  onChange={(v) => {
+                    setFiltroSetor(v === '' ? '' : Number(v))
+                    resetarPagina()
+                  }}
                   options={opcoesSetorFiltro}
                   includeEmpty
                   emptyLabel="Todos"
@@ -379,7 +390,10 @@ export function Tickets() {
                   labelStyle="overline"
                   className="min-w-0"
                   value={filtroStatus}
-                  onChange={(v) => setFiltroStatus(v === '' ? '' : Number(v))}
+                  onChange={(v) => {
+                    setFiltroStatus(v === '' ? '' : Number(v))
+                    resetarPagina()
+                  }}
                   options={opcoesStatusFiltro}
                   includeEmpty
                   emptyLabel="Todos"
@@ -394,6 +408,7 @@ export function Tickets() {
                     onChange={(v) => {
                       setFiltroAtendente(v === '' ? '' : Number(v))
                       if (v !== '') setFiltroFila('')
+                      resetarPagina()
                     }}
                     options={opcoesAtendenteFiltro}
                     includeEmpty
@@ -474,7 +489,10 @@ export function Tickets() {
                     rotulo="Protocolo"
                     ordenarPor={ordenarPor}
                     ordem={ordem}
-                    aoOrdenar={aoOrdenarColuna}
+                    aoOrdenar={(c) => {
+                      resetarPagina()
+                      aoOrdenarColuna(c)
+                    }}
                     className="whitespace-nowrap px-4 py-3 sm:px-6"
                   />
                   <CabecalhoOrdenavel
@@ -482,7 +500,10 @@ export function Tickets() {
                     rotulo="Rede"
                     ordenarPor={ordenarPor}
                     ordem={ordem}
-                    aoOrdenar={aoOrdenarColuna}
+                    aoOrdenar={(c) => {
+                      resetarPagina()
+                      aoOrdenarColuna(c)
+                    }}
                     className="hidden px-4 py-3 lg:table-cell sm:px-6"
                   />
                   <CabecalhoOrdenavel
@@ -490,7 +511,10 @@ export function Tickets() {
                     rotulo="Empresa"
                     ordenarPor={ordenarPor}
                     ordem={ordem}
-                    aoOrdenar={aoOrdenarColuna}
+                    aoOrdenar={(c) => {
+                      resetarPagina()
+                      aoOrdenarColuna(c)
+                    }}
                     className="px-4 py-3 sm:px-6"
                   />
                   <CabecalhoOrdenavel
@@ -498,7 +522,10 @@ export function Tickets() {
                     rotulo="Setor"
                     ordenarPor={ordenarPor}
                     ordem={ordem}
-                    aoOrdenar={aoOrdenarColuna}
+                    aoOrdenar={(c) => {
+                      resetarPagina()
+                      aoOrdenarColuna(c)
+                    }}
                     className="hidden px-4 py-3 xl:table-cell sm:px-6"
                   />
                   <CabecalhoOrdenavel
@@ -506,7 +533,10 @@ export function Tickets() {
                     rotulo="Assunto"
                     ordenarPor={ordenarPor}
                     ordem={ordem}
-                    aoOrdenar={aoOrdenarColuna}
+                    aoOrdenar={(c) => {
+                      resetarPagina()
+                      aoOrdenarColuna(c)
+                    }}
                     className="hidden px-4 py-3 md:table-cell sm:px-6"
                   />
                   <CabecalhoOrdenavel
@@ -514,7 +544,10 @@ export function Tickets() {
                     rotulo="Status"
                     ordenarPor={ordenarPor}
                     ordem={ordem}
-                    aoOrdenar={aoOrdenarColuna}
+                    aoOrdenar={(c) => {
+                      resetarPagina()
+                      aoOrdenarColuna(c)
+                    }}
                     className="whitespace-nowrap px-4 py-3 sm:px-6"
                   />
                   <CabecalhoOrdenavel
@@ -522,7 +555,10 @@ export function Tickets() {
                     rotulo="Responsável"
                     ordenarPor={ordenarPor}
                     ordem={ordem}
-                    aoOrdenar={aoOrdenarColuna}
+                    aoOrdenar={(c) => {
+                      resetarPagina()
+                      aoOrdenarColuna(c)
+                    }}
                     className="hidden px-4 py-3 lg:table-cell sm:px-6"
                   />
                 </tr>

--- a/frontend/src/pages/TiposNegocio.tsx
+++ b/frontend/src/pages/TiposNegocio.tsx
@@ -11,6 +11,7 @@ import { useToast } from '../components/ui/Toast'
 import { FiltroInativos } from '../components/ui/FiltroInativos'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
 import { Switch } from '../components/ui/Switch'
+import { FormSection } from '../components/ui/FormSection'
 
 type ColunaTipo = 'nome' | 'ativo'
 
@@ -29,6 +30,15 @@ export function TiposNegocio() {
   const [nome, setNome] = useState('')
   const [ativo, setAtivo] = useState(true)
   const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!modalOpen) return
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prevOverflow
+    }
+  }, [modalOpen])
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -183,21 +193,36 @@ export function TiposNegocio() {
       )}
 
       {modalOpen && (
-        <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/50 p-4">
+        <div className="fixed inset-y-0 left-0 right-0 z-20 flex items-start justify-center bg-black/85 px-4 pb-6 pt-16 sm:px-6 md:left-[var(--sidebar-w)]">
           <Card title={editingId ? 'Editar tipo' : 'Novo tipo de negócio'} className="w-full max-w-md">
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-              <Switch
-                checked={ativo}
-                onCheckedChange={setAtivo}
-                label="Status"
-                showStatusPill
-                statusOnText="Ativo"
-                statusOffText="Inativo"
-              />
-              <div className="flex gap-2">
-                <Button type="submit" loading={saving}>Salvar</Button>
-                <Button type="button" variant="secondary" onClick={() => setModalOpen(false)}>Cancelar</Button>
+            <form onSubmit={handleSubmit}>
+              <div className="space-y-6">
+                <FormSection title="Dados do tipo de negócio">
+                  <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
+                </FormSection>
+
+                <FormSection title="Situação no sistema">
+                  <Switch
+                    bare
+                    checked={ativo}
+                    onCheckedChange={setAtivo}
+                    label="Tipo ativo"
+                    showStatusPill
+                    statusOnText="Ativo"
+                    statusOffText="Inativo"
+                  />
+                </FormSection>
+              </div>
+
+              <div className="sticky bottom-0 -mx-6 mt-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-900">
+                <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                  <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => setModalOpen(false)}>
+                    Cancelar
+                  </Button>
+                  <Button type="submit" loading={saving} className="w-full sm:w-auto">
+                    Salvar
+                  </Button>
+                </div>
               </div>
             </form>
           </Card>

--- a/frontend/src/pages/TiposNegocio.tsx
+++ b/frontend/src/pages/TiposNegocio.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { tiposNegocio, type TiposNegocio } from '../api/client'
@@ -49,7 +49,7 @@ export function TiposNegocio() {
     setPage(1)
   }, [debouncedBusca, incluirInativos, ordenarPor, ordem])
 
-  function load() {
+  const load = useCallback(() => {
     setLoading(true)
     tiposNegocio
       .list({
@@ -64,11 +64,11 @@ export function TiposNegocio() {
         setTotal(t)
       })
       .finally(() => setLoading(false))
-  }
+  }, [debouncedBusca, incluirInativos, page, sortParams])
 
   useEffect(() => {
     load()
-  }, [page, debouncedBusca, incluirInativos, ordenarPor, ordem])
+  }, [load])
 
   function openCreate() {
     setEditingId(null)
@@ -115,7 +115,7 @@ export function TiposNegocio() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <div className="flex justify-between">
         <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Tipos de negócio</h1>
         <Button onClick={openCreate}>Novo tipo</Button>


### PR DESCRIPTION
## Summary
- Padroniza telas de listagem/detalhe/form no padrão visual e de interação da tela de Empresas.
- Ajusta paginação/ordenação e containers para consistência (max-w, espaçamentos, grids).
- Estabiliza o lint do frontend e corrige pontos pontuais (ex.: no client.ts e deps de hooks).
- Notificações: alerta sonoro obrigatório quando chegam novas pendências (total/não lidas/fila), removendo toggle em Tickets.

## Test plan
- [ ] Abrir Tickets, validar layout e filtros/paginação/ordenação.
- [ ] Gerar uma nova pendência (ex.: ticket sem responsável / mensagens não lidas) e confirmar beep.
- [ ] Validar listagens e cadastros: Redes, Empresas, Setores, Tipos de negócio, Status de ticket, Atendentes, Funcionários da rede.

Closes #32