### PR TITLE
Tickets: fechamento, listas e UX (issue #41)

### DIFF
--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -34,6 +34,12 @@ class OrdenarTicketsPor(str, Enum):
     assunto = "assunto"
     status = "status"
     responsavel = "responsavel"
+    fechado_em = "fechado_em"
+
+class SituacaoTicket(str, Enum):
+    abertos = "abertos"
+    fechados = "fechados"
+    todos = "todos"
 
 
 def _gerar_protocolo(db: Session) -> str:
@@ -98,6 +104,10 @@ def listar(
         None,
         description="Filtrar por responsável (apenas administradores)",
     ),
+    situacao: SituacaoTicket = Query(
+        SituacaoTicket.abertos,
+        description="abertos = fechado_em vazio; fechados = fechado_em preenchido; todos = sem filtro",
+    ),
     offset: int = Query(0, ge=0),
     limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
     ordenar_por: OrdenarTicketsPor | None = Query(
@@ -134,6 +144,11 @@ def listar(
         q = q.filter(Ticket.atendente_id == atendente.id)
     if sem_responsavel:
         q = q.filter(Ticket.atendente_id.is_(None))
+
+    if situacao == SituacaoTicket.abertos:
+        q = q.filter(Ticket.fechado_em.is_(None))
+    elif situacao == SituacaoTicket.fechados:
+        q = q.filter(Ticket.fechado_em.is_not(None))
     if protocolo and protocolo.strip():
         q = q.filter(Ticket.protocolo.ilike(f"%{protocolo.strip()}%"))
     if busca and busca.strip():
@@ -148,7 +163,11 @@ def listar(
     total = q.count()
 
     if ordenar_por is None:
-        order_cols = [Ticket.created_at.desc(), Ticket.id.desc()]
+        # Em finalizados, o mais útil é ordenar por data de fechamento (mais recentes primeiro).
+        if situacao == SituacaoTicket.fechados:
+            order_cols = [Ticket.fechado_em.desc().nullslast(), Ticket.id.desc()]
+        else:
+            order_cols = [Ticket.created_at.desc(), Ticket.id.desc()]
     else:
         if ordenar_por == OrdenarTicketsPor.responsavel:
             q = q.outerjoin(Ticket.atendente)
@@ -167,6 +186,8 @@ def listar(
             primary = expr_ordem(Ticket.assunto, ordem)
         elif ordenar_por == OrdenarTicketsPor.status:
             primary = expr_ordem(StatusTicket.nome, ordem)
+        elif ordenar_por == OrdenarTicketsPor.fechado_em:
+            primary = nullslast(expr_ordem(Ticket.fechado_em, ordem))
         else:
             primary = nullslast(expr_ordem(Atendente.nome, ordem))
         tie = expr_ordem(Ticket.id, ordem)
@@ -345,6 +366,11 @@ def criar_mensagem(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
     if not _pode_ver_ticket(db, atendente, ticket):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+    if ticket.fechado_em is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Ticket fechado. Reabra o ticket para enviar novas mensagens.",
+        )
     if data.tipo == "publico" and not _pode_enviar_mensagem_publica(atendente, ticket):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
@@ -383,6 +409,46 @@ def _registrar_historico(db: Session, ticket_id: int, atendente_id: int | None, 
     ))
 
 
+@router.post("/{ticket_id}/reabrir", response_model=TicketRead)
+def reabrir(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    if atendente.role != "admin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Apenas administradores podem reabrir tickets")
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if ticket.fechado_em is None:
+        return _ticket_para_read(ticket)
+
+    # Status para retorno: primeiro status ativo que não seja "fechado"
+    status_reaberto = (
+        db.query(StatusTicket)
+        .filter(StatusTicket.ativo.is_(True))
+        .order_by(StatusTicket.ordem.asc(), StatusTicket.id.asc())
+        .all()
+    )
+    novo_status = None
+    for st in status_reaberto:
+        if (st.slug or "").lower() != "fechado":
+            novo_status = st
+            break
+    if not novo_status:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cadastre um status não-final para reabrir")
+
+    _registrar_historico(db, ticket.id, atendente.id, "fechado_em", str(ticket.fechado_em), "")
+    if ticket.status_id != novo_status.id:
+        _registrar_historico(db, ticket.id, atendente.id, "status_id", str(ticket.status_id), str(novo_status.id))
+
+    ticket.fechado_em = None
+    ticket.status_id = novo_status.id
+    db.commit()
+    db.refresh(ticket)
+    return _ticket_para_read(ticket)
+
+
 @router.patch("/{ticket_id}", response_model=TicketRead)
 def atualizar(
     ticket_id: int,
@@ -395,6 +461,11 @@ def atualizar(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
     if not _pode_ver_ticket(db, atendente, ticket):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+    if ticket.fechado_em is not None and atendente.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Ticket fechado. Apenas administradores podem reabrir ou alterar este ticket.",
+        )
     update = data.model_dump(exclude_unset=True)
 
     if "setor_id" in update:

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -364,13 +364,14 @@ export const tickets = {
     rede_id?: number;
     setor_id?: number;
     status_id?: number;
+    situacao?: 'abertos' | 'fechados' | 'todos';
     protocolo?: string;
     busca?: string;
     sem_responsavel?: boolean;
     meus?: boolean;
     atendente_id?: number;
     /** Coluna para ordenar (omitir = mais recentes primeiro). */
-    ordenar_por?: 'protocolo' | 'rede' | 'empresa' | 'setor' | 'assunto' | 'status' | 'responsavel';
+    ordenar_por?: 'protocolo' | 'rede' | 'empresa' | 'setor' | 'assunto' | 'status' | 'responsavel' | 'fechado_em';
     ordem?: 'asc' | 'desc';
     offset?: number;
     limit?: number;
@@ -380,6 +381,7 @@ export const tickets = {
   listMensagens: (id: number) => api<Tickets.Mensagem[]>(`/tickets/${id}/mensagens`),
   addMensagem: (id: number, data: Tickets.MensagemCreate) =>
     api<Tickets.Mensagem>(`/tickets/${id}/mensagens`, { method: 'POST', body: JSON.stringify(data) }),
+  reabrir: (id: number) => api<Tickets.Ticket>(`/tickets/${id}/reabrir`, { method: 'POST' }),
   create: (data: Tickets.Create) => api<Tickets.Ticket>('/tickets', { method: 'POST', body: JSON.stringify(data) }),
   update: (id: number, data: Tickets.Update) => api<Tickets.Ticket>(`/tickets/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
 };

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -39,12 +39,12 @@ export function Layout() {
       {/* Área principal: no mobile ocupa 100%; no desktop margem = largura do sidebar */}
       <div
         className={`min-h-screen transition-[margin-left] duration-200 ease-out ${
-          sidebarExpanded ? 'md:ml-[280px]' : 'md:ml-[72px]'
+          sidebarExpanded ? 'md:ml-[280px]' : 'md:ml-[80px]'
         }`}
         style={
           {
             // Usado por overlays/modais para respeitar o menu no desktop.
-            ['--sidebar-w' as never]: sidebarExpanded ? '280px' : '72px',
+            ['--sidebar-w' as never]: sidebarExpanded ? '280px' : '80px',
           } as React.CSSProperties
         }
       >

--- a/frontend/src/components/NavbarNotificacoes.tsx
+++ b/frontend/src/components/NavbarNotificacoes.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { Link } from 'react-router-dom'
 import { notificacoes, type Notificacoes } from '../api/client'
 import { usePendenciasResumo } from '../hooks/useAlertaFilaSemResponsavel'
@@ -25,9 +26,11 @@ function badgeText(n: number): string {
 export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
   const resumo = usePendenciasResumo(enabled)
   const [aberto, setAberto] = useState(false)
+  const [mobileVisible, setMobileVisible] = useState(false)
   const [itens, setItens] = useState<Notificacoes.Item[]>([])
   const [loadingItens, setLoadingItens] = useState(false)
   const wrapRef = useRef<HTMLDivElement>(null)
+  const mobileDrawerRef = useRef<HTMLDivElement>(null)
   const menuId = useId()
 
   const carregarItens = useCallback(async () => {
@@ -53,11 +56,41 @@ export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
   useEffect(() => {
     if (!aberto) return
     function onDoc(e: MouseEvent) {
-      const el = wrapRef.current
-      if (el && !el.contains(e.target as Node)) setAberto(false)
+      const t = e.target as Node
+      const wrap = wrapRef.current
+      const drawer = mobileDrawerRef.current
+      if (wrap?.contains(t) || drawer?.contains(t)) return
+      setAberto(false)
     }
     document.addEventListener('mousedown', onDoc)
     return () => document.removeEventListener('mousedown', onDoc)
+  }, [aberto])
+
+  useEffect(() => {
+    if (!aberto) return
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') setAberto(false)
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [aberto])
+
+  useEffect(() => {
+    if (aberto) {
+      setMobileVisible(true)
+      return
+    }
+    const t = window.setTimeout(() => setMobileVisible(false), 220)
+    return () => window.clearTimeout(t)
+  }, [aberto])
+
+  useEffect(() => {
+    if (!aberto) return
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prevOverflow
+    }
   }, [aberto])
 
   const total = resumo.total_pendencias
@@ -83,11 +116,82 @@ export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
         ) : null}
       </button>
 
+      {/* Mobile: portal para body — evita que `backdrop-filter` no header prenda `position:fixed` à faixa do topo */}
+      {typeof document !== 'undefined' &&
+        mobileVisible &&
+        createPortal(
+          <div
+            ref={mobileDrawerRef}
+            className={`fixed inset-0 z-[100] flex h-[100dvh] w-full flex-col bg-white shadow-xl transition-transform duration-200 ease-out dark:bg-slate-950 sm:hidden ${
+              aberto ? 'translate-x-0' : 'translate-x-full'
+            }`}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Pendências"
+          >
+            <div className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-slate-200/90 bg-white px-4 shadow-sm dark:border-slate-800/90 dark:bg-slate-950">
+              <p className="text-sm font-semibold tracking-tight text-slate-900 dark:text-slate-100">
+                Pendências
+              </p>
+              <button
+                type="button"
+                className="inline-flex size-10 items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 active:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-800 dark:active:bg-slate-700"
+                onClick={() => setAberto(false)}
+                aria-label="Fechar"
+              >
+                ×
+              </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto bg-white p-2 dark:bg-slate-950">
+              {loadingItens && itens.length === 0 ? (
+                <p className="px-3 py-10 text-center text-sm text-slate-500 dark:text-slate-400">Carregando…</p>
+              ) : itens.length === 0 ? (
+                <p className="px-3 py-10 text-center text-sm text-slate-500 dark:text-slate-400">Sem pendências</p>
+              ) : (
+                <ul className="space-y-2">
+                  {itens.map((item, idx) => (
+                    <li key={`${item.tipo}-${item.ticket_id ?? 'fila'}-${idx}`}>
+                      <Link
+                        role="menuitem"
+                        to={item.href}
+                        className="flex gap-3 rounded-2xl border border-slate-200/90 bg-white px-4 py-3 text-left text-sm shadow-sm transition-colors hover:bg-slate-50 dark:border-slate-800/80 dark:bg-slate-900/50 dark:hover:bg-slate-800/60"
+                        onClick={() => setAberto(false)}
+                      >
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate font-medium text-slate-900 dark:text-slate-100">{item.titulo}</p>
+                          <p className="mt-0.5 line-clamp-2 text-xs text-slate-500 dark:text-slate-400">{item.descricao}</p>
+                        </div>
+                        <div className="flex shrink-0 flex-col items-end gap-1">
+                          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                            {item.count}
+                          </span>
+                          <span className="text-xs font-medium text-cyan-600 dark:text-cyan-400">Ver</span>
+                        </div>
+                      </Link>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+
+            {(resumo.sem_responsavel_count > 0 || resumo.nao_lidas_count > 0) && (
+              <div className="shrink-0 border-t border-slate-200/90 bg-white px-4 py-3 text-xs text-slate-600 dark:border-slate-800/90 dark:bg-slate-950 dark:text-slate-300">
+                <span className="font-medium">Fila:</span> {resumo.sem_responsavel_count}
+                <span className="text-slate-400 dark:text-slate-600"> · </span>
+                <span className="font-medium">Não lidas:</span> {resumo.nao_lidas_count}
+              </div>
+            )}
+          </div>,
+          document.body
+        )}
+
+      {/* Desktop: dropdown */}
       {aberto ? (
         <div
           id={menuId}
           role="menu"
-          className="absolute right-0 top-full z-50 mt-2 w-[min(100vw-2rem,22rem)] rounded-xl border border-slate-200/90 bg-white py-2 shadow-lg dark:border-slate-700 dark:bg-slate-900"
+          className="absolute right-0 top-full z-50 mt-2 hidden w-[22rem] rounded-xl border border-slate-200/90 bg-white py-2 shadow-lg dark:border-slate-700 dark:bg-slate-900 sm:block"
         >
           <div className="border-b border-slate-100 px-3 pb-2 dark:border-slate-800">
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Pendências</p>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -182,22 +182,30 @@ export function Sidebar({
     }
   }, [location.pathname, isAdmin])
 
+  // No drawer mobile usamos acordeão (não flyout); evita estado do flyout “preso”
+  useEffect(() => {
+    if (mobileOpen) setOpenFlyout(null)
+  }, [mobileOpen])
+
   const linkClass = (to: string, base = '') =>
     `${base} flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors touch-manipulation min-h-[44px] ${
       location.pathname === to || (to !== '/' && location.pathname.startsWith(to))
         ? 'bg-cyan-50 text-slate-900 ring-1 ring-cyan-200/60 dark:bg-cyan-950/35 dark:text-slate-100 dark:ring-cyan-800/50'
         : 'text-slate-600 hover:bg-slate-100 active:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-800/80 dark:active:bg-slate-800'
-    } ${!expanded ? 'md:justify-center md:px-0 md:gap-0' : ''}`
+    } ${!expanded ? 'md:justify-center md:gap-0 md:px-2' : ''}`
 
   const isGroupOpen = (id: string) => openGroup === id
   const isFlyoutOpen = (id: string) => openFlyout === id
 
   const sidebarContent = (
     <>
-      <div className={`flex h-14 shrink-0 items-center justify-center border-b border-slate-200 dark:border-slate-800 ${expanded ? 'px-3' : 'md:px-0'}`}>
+      <div
+        className={`flex h-14 shrink-0 items-center justify-center border-b border-slate-200 dark:border-slate-800 ${expanded ? 'px-3' : 'md:px-2'}`}
+      >
         <Link
           to="/"
           onClick={onMobileClose}
+          title="Início"
           className={`flex items-center overflow-hidden rounded-lg ${expanded ? 'min-w-0 flex-1 gap-2.5' : 'md:w-full md:justify-center md:gap-0'}`}
         >
           <img
@@ -211,7 +219,7 @@ export function Sidebar({
           />
           <span
             className={`min-w-0 truncate text-[0.95rem] font-semibold leading-tight transition-all duration-200 ${
-              expanded ? 'opacity-100 w-auto' : 'md:opacity-0 md:w-0 md:overflow-hidden md:max-w-0'
+              expanded ? 'opacity-100 w-auto' : 'md:hidden'
             }`}
           >
             <span className="bg-gradient-to-r from-cyan-600 to-blue-600 bg-clip-text font-bold text-transparent">DX</span>
@@ -220,22 +228,28 @@ export function Sidebar({
         </Link>
       </div>
 
-      <nav className={`flex-1 overflow-y-auto py-3 px-2 ${!expanded ? 'md:px-0' : ''}`} aria-label="Menu principal">
-        <ul className={`space-y-0.5 px-2 ${!expanded ? 'md:px-0' : ''}`}>
+      <nav
+        className={`min-w-0 flex-1 overflow-y-auto py-3 px-2 max-md:overflow-x-hidden ${!expanded ? 'md:px-2' : ''}`}
+        aria-label="Menu principal"
+      >
+        <ul className={`min-w-0 space-y-0.5 px-2 ${!expanded ? 'md:px-0' : ''}`}>
           {items.map((item) => {
             if (item.type === 'link') {
               return (
-                <li key={item.to} className="w-full">
+                <li key={item.to} className="w-full min-w-0">
                   <Link
                     to={item.to}
                     onClick={onMobileClose}
+                    title={item.label}
                     className={linkClass(item.to)}
                   >
                     {icons[item.icon]}
                     <span
-                      className={`truncate transition-all duration-200 ${
-                        expanded ? 'opacity-100 w-auto' : 'md:opacity-0 md:w-0 md:overflow-hidden'
-                      }`}
+                      className={
+                        expanded
+                          ? 'min-w-0 truncate transition-all duration-200'
+                          : 'min-w-0 truncate transition-all duration-200 md:hidden'
+                      }
                     >
                       {item.label}
                     </span>
@@ -249,10 +263,12 @@ export function Sidebar({
             const open = isGroupOpen(group.id)
             const active = isPathInGroup(location.pathname, group.children)
 
+            const menuExpandido = expanded || mobileOpen
+
             return (
-              <li key={group.id} className="w-full">
-                {/* Desktop expandido: botão que expande/recolhe e mostra filhos abaixo */}
-                {expanded ? (
+              <li key={group.id} className="w-full min-w-0">
+                {/* Mobile (drawer) ou desktop com menu largo: filhos abaixo. Desktop ícone: flyout à direita */}
+                {menuExpandido ? (
                   <>
                     <button
                       type="button"
@@ -273,11 +289,11 @@ export function Sidebar({
                     </button>
                     <ul
                       id={`nav-group-${group.id}`}
-                      className={`overflow-hidden transition-all duration-200 ${open ? 'max-h-[500px] opacity-100' : 'max-h-0 opacity-0'}`}
+                      className={`min-w-0 overflow-hidden transition-all duration-200 ${open ? 'max-h-[500px] opacity-100' : 'max-h-0 opacity-0'}`}
                       role="group"
                     >
                       {group.children.map((child) => (
-                        <li key={child.to} className="pl-4">
+                        <li key={child.to} className="min-w-0 pl-4">
                           <Link
                             to={child.to}
                             onClick={onMobileClose}
@@ -291,11 +307,12 @@ export function Sidebar({
                     </ul>
                   </>
                 ) : (
-                  /* Desktop recolhido: ícone do grupo; ao clicar abre flyout */
-                  <div className="relative w-full">
+                  /* Desktop recolhido (md+): flyout à direita do ícone */
+                  <div className="relative w-full min-w-0">
                     <button
                       type="button"
                       onClick={() => setOpenFlyout(isFlyoutOpen(group.id) ? null : group.id)}
+                      title={group.label}
                       className={`flex w-full items-center justify-center rounded-lg py-2.5 text-slate-600 hover:bg-slate-100 min-h-[44px] px-2 dark:text-slate-400 dark:hover:bg-slate-800/80 md:px-0 ${
                         active ? 'bg-cyan-50 text-slate-900 ring-1 ring-cyan-200/60 dark:bg-cyan-950/35 dark:text-slate-100 dark:ring-cyan-800/50' : ''
                       }`}
@@ -308,7 +325,7 @@ export function Sidebar({
                       <>
                         <div
                           role="presentation"
-                          className="fixed inset-0 z-40 md:left-[72px]"
+                          className="fixed inset-0 z-40 md:left-[80px]"
                           onClick={() => setOpenFlyout(null)}
                         />
                         <ul
@@ -342,10 +359,10 @@ export function Sidebar({
         </ul>
       </nav>
 
-      <div className={`border-t border-slate-200 p-2 dark:border-slate-800 ${!expanded ? 'md:px-0' : ''}`}>
+      <div className={`border-t border-slate-200 p-2 dark:border-slate-800 ${!expanded ? 'md:px-2' : ''}`}>
         <div
           className={`flex items-center gap-3 px-3 py-2 text-slate-600 dark:text-slate-400 ${
-            expanded ? 'opacity-100' : 'md:opacity-0 md:overflow-hidden md:w-0 md:px-0'
+            expanded ? 'opacity-100' : 'md:hidden'
           }`}
         >
           <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-cyan-500 to-blue-600 text-xs font-semibold text-white shadow-sm shadow-cyan-500/25">
@@ -362,15 +379,18 @@ export function Sidebar({
             onMobileClose()
             onLogout()
           }}
+          title="Sair"
           className={`mt-2 flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium text-slate-600 hover:bg-slate-100 active:bg-slate-200 touch-manipulation min-h-[44px] dark:text-slate-400 dark:hover:bg-slate-800 dark:active:bg-slate-700 ${
-            expanded ? '' : 'md:justify-center md:px-0'
+            expanded ? '' : 'md:justify-center md:px-2'
           }`}
         >
           {icons.logout}
           <span
-            className={`truncate transition-all duration-200 ${
-              expanded ? 'opacity-100 w-auto' : 'md:opacity-0 md:w-0 md:overflow-hidden'
-            }`}
+            className={
+              expanded
+                ? 'min-w-0 truncate transition-all duration-200'
+                : 'min-w-0 truncate transition-all duration-200 md:hidden'
+            }
           >
             Sair
           </span>
@@ -381,25 +401,33 @@ export function Sidebar({
 
   return (
     <>
-      {/* Overlay mobile: fecha ao tocar fora */}
+      {/* Overlay mobile: bloqueia fundo (fullscreen) */}
       <div
-        role="button"
-        tabIndex={0}
-        aria-label="Fechar menu"
-        onClick={onMobileClose}
-        onKeyDown={(e) => e.key === 'Enter' && onMobileClose()}
         className={`fixed inset-0 z-40 bg-black/50 transition-opacity duration-200 md:hidden ${
           mobileOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
         }`}
+        aria-hidden
       />
 
       {/* Sidebar: drawer no mobile, fixo no desktop */}
       <aside
-        className={`fixed top-0 left-0 z-50 flex h-full w-[280px] flex-col bg-white shadow-xl transition-[transform,width] duration-200 ease-out dark:bg-slate-950 md:translate-x-0 md:shadow-none md:dark:shadow-[inset_-1px_0_0_0_rgb(30_41_59_/_0.6)] ${
+        className={`fixed inset-0 z-50 flex h-full min-w-0 max-w-[100vw] flex-col overflow-x-hidden bg-white shadow-xl transition-[transform,width] duration-200 ease-out dark:bg-slate-950 md:inset-auto md:top-0 md:left-0 md:h-full md:max-w-none md:w-auto md:translate-x-0 md:overflow-x-visible md:shadow-none md:dark:shadow-[inset_-1px_0_0_0_rgb(30_41_59_/_0.6)] ${
           mobileOpen ? 'translate-x-0' : '-translate-x-full'
-        } ${expanded ? 'md:w-[280px]' : 'md:w-[72px]'}`}
+        } ${expanded ? 'md:w-[280px]' : 'md:w-[80px]'}`}
         aria-label="Menu lateral"
       >
+        {/* Mobile header com "voltar/fechar" */}
+        <div className="flex h-14 shrink-0 items-center justify-between border-b border-slate-200/90 bg-white/95 px-4 shadow-sm backdrop-blur-sm dark:border-slate-800/90 dark:bg-slate-950/90 md:hidden">
+          <span className="text-sm font-semibold text-slate-900 dark:text-slate-100">Menu</span>
+          <button
+            type="button"
+            onClick={onMobileClose}
+            className="inline-flex size-10 items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 active:bg-slate-200 dark:text-slate-300 dark:hover:bg-slate-800 dark:active:bg-slate-700"
+            aria-label="Fechar menu"
+          >
+            ×
+          </button>
+        </div>
         {sidebarContent}
       </aside>
     </>

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -118,6 +118,7 @@ export function EmpresaDetalhe() {
     tickets
       .list({
         empresa_id: empresaId,
+        situacao: 'todos',
         offset: (pageT - 1) * PAGE_SIZE_PADRAO,
         limit: PAGE_SIZE_PADRAO,
         busca: debouncedBuscaT || undefined,

--- a/frontend/src/pages/RedeDetalhe.tsx
+++ b/frontend/src/pages/RedeDetalhe.tsx
@@ -282,6 +282,7 @@ export function RedeDetalhe() {
     tickets
       .list({
         rede_id: redeId,
+        situacao: 'todos',
         offset: (pageTicketsRede - 1) * PAGE_SIZE_PADRAO,
         limit: PAGE_SIZE_PADRAO,
         busca: debouncedBuscaTicketsRede || undefined,
@@ -307,6 +308,7 @@ export function RedeDetalhe() {
     tickets
       .list({
         empresa_id: editingEmpresaId,
+        situacao: 'todos',
         offset: (pageTicketsEmpModal - 1) * PAGE_SIZE_PADRAO,
         limit: PAGE_SIZE_PADRAO,
         busca: debouncedBuscaTicketsEmpModal || undefined,

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -92,6 +92,7 @@ export function TicketDetalhe() {
   const toast = useToast()
   const { isAdmin, user } = useAuth()
   const [atribuindo, setAtribuindo] = useState(false)
+  const [fechando, setFechando] = useState(false)
 
   const [loading, setLoading] = useState(true)
   const [notFound, setNotFound] = useState(false)
@@ -189,6 +190,10 @@ export function TicketDetalhe() {
       },
     ]
   }, [statusList, ticket])
+
+  const statusFechado = useMemo(() => {
+    return statusList.find((s) => (s.slug || '').toLowerCase() === 'fechado') ?? null
+  }, [statusList])
 
   /** Mensagem “da equipe” (público no fluxo): admin, responsável ou ticket ainda sem responsável. */
   const podeMensagemPublica = useMemo(() => {
@@ -423,6 +428,10 @@ export function TicketDetalhe() {
 
   async function handleEnviarMensagem() {
     if (!ticket) return
+    if (ticket.fechado_em) {
+      toast.showWarning('Ticket fechado. Apenas admin pode reabrir para enviar mensagens.')
+      return
+    }
     const texto = novaMensagemTexto.trim()
     if (!texto) {
       toast.showWarning('Escreva uma mensagem antes de enviar.')
@@ -501,7 +510,13 @@ export function TicketDetalhe() {
           <div className="mt-3 flex flex-wrap gap-2" role="group" aria-label="Ações rápidas do ticket">
             <button
               type="button"
-              onClick={() => abrirModalGerir('setor')}
+              onClick={() => {
+                if (ticket.fechado_em && !isAdmin) {
+                  toast.showWarning('Ticket fechado — apenas admin pode alterar.')
+                  return
+                }
+                abrirModalGerir('setor')
+              }}
               className="inline-flex max-w-full items-center gap-2 rounded-full border border-slate-200/90 bg-slate-50/80 px-3 py-1.5 text-left text-xs shadow-sm transition-colors hover:border-slate-300 hover:bg-slate-100/90 dark:border-slate-600 dark:bg-slate-800/70 dark:hover:border-slate-500 dark:hover:bg-slate-800"
             >
               <span className="shrink-0 font-medium text-slate-500 dark:text-slate-400">Setor</span>
@@ -511,7 +526,13 @@ export function TicketDetalhe() {
             </button>
             <button
               type="button"
-              onClick={() => abrirModalGerir('status')}
+              onClick={() => {
+                if (ticket.fechado_em && !isAdmin) {
+                  toast.showWarning('Ticket fechado — apenas admin pode alterar.')
+                  return
+                }
+                abrirModalGerir('status')
+              }}
               className="inline-flex max-w-full items-center gap-2 rounded-full border border-slate-200/90 bg-slate-50/80 px-3 py-1.5 text-left text-xs shadow-sm transition-colors hover:border-slate-300 hover:bg-slate-100/90 dark:border-slate-600 dark:bg-slate-800/70 dark:hover:border-slate-500 dark:hover:bg-slate-800"
             >
               <span className="shrink-0 font-medium text-slate-500 dark:text-slate-400">Status</span>
@@ -521,7 +542,13 @@ export function TicketDetalhe() {
             </button>
             <button
               type="button"
-              onClick={() => abrirModalGerir('atendente')}
+              onClick={() => {
+                if (ticket.fechado_em && !isAdmin) {
+                  toast.showWarning('Ticket fechado — apenas admin pode alterar.')
+                  return
+                }
+                abrirModalGerir('atendente')
+              }}
               className="inline-flex max-w-full items-center gap-2 rounded-full border border-slate-200/90 bg-slate-50/80 px-3 py-1.5 text-left text-xs shadow-sm transition-colors hover:border-slate-300 hover:bg-slate-100/90 dark:border-slate-600 dark:bg-slate-800/70 dark:hover:border-slate-500 dark:hover:bg-slate-800"
             >
               <span className="shrink-0 font-medium text-slate-500 dark:text-slate-400">Responsável</span>
@@ -542,12 +569,75 @@ export function TicketDetalhe() {
           </div>
         </div>
         <div className="flex shrink-0 flex-wrap items-center gap-2">
-          {podeAtribuirAMim && (
+          {isAdmin && ticket.fechado_em && (
+            <Button
+              type="button"
+              onClick={async () => {
+                try {
+                  const updated = await tickets.reabrir(ticket.id)
+                  setTicket(updated)
+                  setEditStatus(updated.status_id)
+                  setEditAtendente(updated.atendente_id ?? '')
+                  const hist = await tickets.getHistorico(updated.id)
+                  setHistorico(hist)
+                  toast.showSuccess('Ticket reaberto.')
+                } catch (err) {
+                  toast.showWarning(err instanceof Error ? err.message : 'Não foi possível reabrir.')
+                }
+              }}
+            >
+              Reabrir
+            </Button>
+          )}
+          {podeAtribuirAMim && !ticket.fechado_em && (
             <Button type="button" onClick={handleAtribuirAMim} loading={atribuindo}>
               Atribuir a mim
             </Button>
           )}
-          <Button type="button" variant="secondary" onClick={() => abrirModalGerir('geral')}>
+          {!ticket.fechado_em && (
+            <Button
+              type="button"
+              variant="secondary"
+              loading={fechando}
+              onClick={async () => {
+                if (!ticket) return
+                if (!statusFechado) {
+                  toast.showWarning('Não existe um status com slug "fechado". Cadastre/ajuste em Status de ticket.')
+                  return
+                }
+                if (!confirm('Fechar este ticket? Ele sairá da lista de abertos e não permitirá novas mensagens.')) return
+                setFechando(true)
+                try {
+                  const updated = await tickets.update(ticket.id, { status_id: statusFechado.id })
+                  setTicket(updated)
+                  setEditStatus(updated.status_id)
+                  setEditAtendente(updated.atendente_id ?? '')
+                  const hist = await tickets.getHistorico(updated.id)
+                  setHistorico(hist)
+                  toast.showSuccess('Ticket fechado.')
+                  void refetchPendenciasResumo()
+                } catch (err) {
+                  toast.showWarning(err instanceof Error ? err.message : 'Não foi possível fechar.')
+                } finally {
+                  setFechando(false)
+                }
+              }}
+            >
+              Fechar ticket
+            </Button>
+          )}
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={Boolean(ticket.fechado_em) && !isAdmin}
+            onClick={() => {
+              if (ticket.fechado_em && !isAdmin) {
+                toast.showWarning('Ticket fechado — apenas admin pode alterar.')
+                return
+              }
+              abrirModalGerir('geral')
+            }}
+          >
             Gerir ticket
           </Button>
           <Button variant="secondary" onClick={voltarAnterior}>
@@ -616,6 +706,20 @@ export function TicketDetalhe() {
 
           <div className="border-t border-slate-200 pt-4 dark:border-slate-700/90">
             <p className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-300">Nova mensagem</p>
+            {ticket.fechado_em ? (
+              <div className="rounded-xl border border-emerald-200 bg-emerald-50/70 px-4 py-3 text-sm text-emerald-900 dark:border-emerald-800/60 dark:bg-emerald-950/25 dark:text-emerald-100">
+                Ticket fechado — não é possível enviar novas mensagens.
+                {isAdmin ? (
+                  <span className="mt-1 block text-xs text-emerald-800/80 dark:text-emerald-200/80">
+                    Use o botão <span className="font-semibold">Reabrir</span> acima para voltar a responder.
+                  </span>
+                ) : (
+                  <span className="mt-1 block text-xs text-emerald-800/80 dark:text-emerald-200/80">
+                    Apenas um administrador pode reabrir este ticket.
+                  </span>
+                )}
+              </div>
+            ) : null}
             <div className="mb-3 inline-flex rounded-xl bg-slate-100 p-1 ring-1 ring-slate-200/80 dark:bg-slate-800/90 dark:ring-slate-600/80">
               {podeMensagemPublica && (
                 <button
@@ -647,15 +751,16 @@ export function TicketDetalhe() {
               onChange={(e) => setNovaMensagemTexto(e.target.value)}
               spellCheck={false}
               rows={4}
+              disabled={Boolean(ticket.fechado_em)}
               placeholder={
                 tipoNovaMensagem === 'interno'
                   ? 'Anotação visível apenas para atendentes…'
                   : 'Descreva o que foi feito, testado ou o que falta…'
               }
-              className="w-full rounded-xl border-0 bg-slate-50 px-3 py-2 text-sm text-slate-900 shadow-inner ring-1 ring-slate-200/90 placeholder:text-slate-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-slate-400/35 dark:bg-slate-900/80 dark:text-slate-100 dark:ring-slate-600 dark:placeholder:text-slate-500 dark:focus:bg-slate-900 dark:focus:ring-slate-500/50"
+              className="w-full rounded-xl border-0 bg-slate-50 px-3 py-2 text-sm text-slate-900 shadow-inner ring-1 ring-slate-200/90 placeholder:text-slate-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-slate-400/35 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-900/80 dark:text-slate-100 dark:ring-slate-600 dark:placeholder:text-slate-500 dark:focus:bg-slate-900 dark:focus:ring-slate-500/50"
             />
             <div className="mt-2">
-              <Button type="button" onClick={handleEnviarMensagem} loading={enviandoMensagem}>
+              <Button type="button" onClick={handleEnviarMensagem} loading={enviandoMensagem} disabled={Boolean(ticket.fechado_em)}>
                 Enviar
               </Button>
             </div>

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -30,6 +30,7 @@ type ColunaOrdenacao =
   | 'assunto'
   | 'status'
   | 'responsavel'
+  | 'fechado_em'
 
 const searchIcon = (
   <svg className="size-4 text-slate-400 dark:text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
@@ -43,6 +44,11 @@ export function Tickets() {
   const toast = useToast()
   const { isAdmin, user } = useAuth()
   useAlertaFilaSemResponsavel(Boolean(user))
+
+  const situacao = useMemo<'abertos' | 'fechados'>(() => {
+    const s = searchParams.get('situacao')
+    return s === 'fechados' ? 'fechados' : 'abertos'
+  }, [searchParams])
 
   const [list, setList] = useState<Tickets.Ticket[]>([])
   const [total, setTotal] = useState(0)
@@ -108,15 +114,25 @@ export function Tickets() {
     busca.trim() !== '' ||
     filtroEmpresa !== '' ||
     filtroSetor !== '' ||
-    filtroStatus !== '' ||
+    (situacao === 'abertos' && filtroStatus !== '') ||
     filtroFila !== '' ||
     (isAdmin && filtroAtendente !== '')
 
   const qtdFiltrosRefinamento =
     (filtroEmpresa !== '' ? 1 : 0) +
     (filtroSetor !== '' ? 1 : 0) +
-    (filtroStatus !== '' ? 1 : 0) +
+    (situacao === 'abertos' && filtroStatus !== '' ? 1 : 0) +
     (isAdmin && filtroAtendente !== '' ? 1 : 0)
+
+  useEffect(() => {
+    if (situacao !== 'fechados') return
+    if (filtroFila !== '') setFiltroFila('')
+  }, [situacao, filtroFila])
+
+  useEffect(() => {
+    if (situacao !== 'fechados') return
+    if (filtroStatus !== '') setFiltroStatus('')
+  }, [situacao, filtroStatus])
 
   useEffect(() => {
     const sr = searchParams.get('sem_responsavel')
@@ -176,8 +192,9 @@ export function Tickets() {
     setLoading(true)
     tickets
       .list({
+        situacao,
         busca: debouncedBusca || undefined,
-        status_id: filtroStatus !== '' ? Number(filtroStatus) : undefined,
+        status_id: situacao === 'abertos' && filtroStatus !== '' ? Number(filtroStatus) : undefined,
         empresa_id: filtroEmpresa !== '' ? Number(filtroEmpresa) : undefined,
         setor_id: filtroSetor !== '' ? Number(filtroSetor) : undefined,
         sem_responsavel: filtroFila === 'sem_responsavel' ? true : undefined,
@@ -200,6 +217,7 @@ export function Tickets() {
       .finally(() => setLoading(false))
   }, [
     page,
+    situacao,
     debouncedBusca,
     filtroStatus,
     filtroEmpresa,
@@ -226,14 +244,53 @@ export function Tickets() {
 
   return (
     <div className="mx-auto max-w-6xl space-y-8 pb-10">
-      <div className="flex flex-wrap items-end justify-between gap-4">
+      <div className="flex flex-col items-stretch gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-100">Tickets</h1>
           <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">Acompanhe e filtre as demandas do suporte.</p>
         </div>
-        <div className="flex flex-wrap items-center justify-end gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+          <div
+            className="inline-flex w-full flex-wrap rounded-2xl bg-slate-100/90 p-1 ring-1 ring-slate-200/60 dark:bg-slate-800/60 dark:ring-slate-700/80 sm:w-auto"
+            role="group"
+            aria-label="Filtrar tickets por situação"
+          >
+            {(
+              [
+                { id: 'abertos' as const, label: 'Abertos' },
+                { id: 'fechados' as const, label: 'Finalizados' },
+              ] as const
+            ).map(({ id, label }) => {
+              const ativo = situacao === id
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => {
+                    setPage(1)
+                    setSearchParams(
+                      (prev) => {
+                        const next = new URLSearchParams(prev)
+                        if (id === 'abertos') next.delete('situacao')
+                        else next.set('situacao', 'fechados')
+                        return next
+                      },
+                      { replace: true },
+                    )
+                  }}
+                  className={`min-h-[2.25rem] flex-1 rounded-xl px-3 py-2 text-center text-xs font-medium transition-all duration-200 sm:flex-none sm:px-4 sm:text-sm ${
+                    ativo
+                      ? 'bg-white text-slate-900 shadow-sm ring-1 ring-slate-200/80 dark:bg-slate-700 dark:text-slate-50 dark:ring-slate-600/50'
+                      : 'text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200'
+                  }`}
+                >
+                  {label}
+                </button>
+              )
+            })}
+          </div>
           <Link to="/tickets/novo">
-            <Button>Novo ticket</Button>
+            <Button className="w-full sm:w-auto">Novo ticket</Button>
           </Link>
         </div>
       </div>
@@ -256,18 +313,46 @@ export function Tickets() {
                 aria-label="Buscar tickets"
               />
             </div>
+            <button
+              type="button"
+              id={`${painelFiltrosId}-toggle`}
+              aria-expanded={maisFiltrosAberto}
+              aria-controls={painelFiltrosId}
+              onClick={() => setMaisFiltrosAberto((o) => !o)}
+              className="inline-flex w-full shrink-0 items-center justify-between gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition-colors hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/60 dark:text-slate-200 dark:hover:bg-slate-800 sm:w-auto sm:justify-start"
+            >
+              <span className="flex items-center gap-2">
+                <span
+                  className={`inline-flex size-8 items-center justify-center rounded-lg bg-slate-100 text-slate-500 transition-transform dark:bg-slate-800 dark:text-slate-400 ${
+                    maisFiltrosAberto ? 'rotate-180' : ''
+                  }`}
+                  aria-hidden
+                >
+                  <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                  </svg>
+                </span>
+                Mais filtros
+              </span>
+              {qtdFiltrosRefinamento > 0 && (
+                <span className="rounded-full bg-slate-200 px-2 py-0.5 text-xs font-semibold tabular-nums text-slate-700 dark:bg-slate-700 dark:text-slate-200">
+                  {qtdFiltrosRefinamento}
+                </span>
+              )}
+            </button>
             {temFiltrosAtivos && (
               <button
                 type="button"
                 onClick={limparFiltros}
-                className="shrink-0 rounded-lg px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800"
+                className="w-full shrink-0 rounded-lg px-3 py-2 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800 sm:w-auto"
               >
                 Limpar tudo
               </button>
             )}
           </div>
 
-          <div className="mt-5">
+          {situacao === 'abertos' && (
+            <div className="mt-5">
             <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-400 dark:text-slate-500">
               Fila
             </p>
@@ -308,75 +393,45 @@ export function Tickets() {
               <span className="font-medium text-slate-600 dark:text-slate-300">Na fila</span> mostra chamados sem responsável no setor.
               {isAdmin && ' Use «Mais filtros» para ver tickets de um atendente.'}
             </p>
-          </div>
+            </div>
+          )}
 
-          <div className="mt-6 border-t border-slate-200/70 pt-5 dark:border-slate-800">
-            <button
-              type="button"
-              id={`${painelFiltrosId}-toggle`}
-              aria-expanded={maisFiltrosAberto}
-              aria-controls={painelFiltrosId}
-              onClick={() => setMaisFiltrosAberto((o) => !o)}
-              className="group flex w-full items-center justify-between gap-2 rounded-xl py-1 text-left sm:w-auto sm:justify-start sm:gap-3"
+          {maisFiltrosAberto && (
+            <div
+              id={painelFiltrosId}
+              role="region"
+              aria-labelledby={`${painelFiltrosId}-toggle`}
+              className="mt-6 grid gap-4 border-t border-slate-200/70 pt-5 dark:border-slate-800 sm:grid-cols-2 lg:grid-cols-3"
             >
-              <span className="flex items-center gap-2 text-sm font-medium text-slate-700 dark:text-slate-200">
-                <span
-                  className={`inline-flex size-8 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-500 transition-transform dark:bg-slate-800 dark:text-slate-400 ${
-                    maisFiltrosAberto ? 'rotate-180' : ''
-                  }`}
-                  aria-hidden
-                >
-                  <svg className="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                  </svg>
-                </span>
-                Mais filtros
-                {qtdFiltrosRefinamento > 0 && (
-                  <span className="rounded-full bg-slate-200 px-2 py-0.5 text-xs font-semibold tabular-nums text-slate-700 dark:bg-slate-700 dark:text-slate-200">
-                    {qtdFiltrosRefinamento}
-                  </span>
-                )}
-              </span>
-              <span className="text-xs text-slate-400 dark:text-slate-500 sm:hidden">
-                {maisFiltrosAberto ? 'Recolher' : 'Empresa, setor, status'}
-              </span>
-            </button>
-
-            {maisFiltrosAberto && (
-              <div
-                id={painelFiltrosId}
-                role="region"
-                aria-labelledby={`${painelFiltrosId}-toggle`}
-                className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
-              >
-                <Select
-                  label="Empresa"
-                  labelStyle="overline"
-                  className="min-w-0"
-                  value={filtroEmpresa}
-                  onChange={(v) => {
-                    setFiltroEmpresa(v === '' ? '' : Number(v))
-                    resetarPagina()
-                  }}
-                  options={opcoesEmpresaFiltro}
-                  includeEmpty
-                  emptyLabel="Todas"
-                  placeholder="Todas"
-                />
-                <Select
-                  label="Setor"
-                  labelStyle="overline"
-                  className="min-w-0"
-                  value={filtroSetor}
-                  onChange={(v) => {
-                    setFiltroSetor(v === '' ? '' : Number(v))
-                    resetarPagina()
-                  }}
-                  options={opcoesSetorFiltro}
-                  includeEmpty
-                  emptyLabel="Todos"
-                  placeholder="Todos"
-                />
+              <Select
+                label="Empresa"
+                labelStyle="overline"
+                className="min-w-0"
+                value={filtroEmpresa}
+                onChange={(v) => {
+                  setFiltroEmpresa(v === '' ? '' : Number(v))
+                  resetarPagina()
+                }}
+                options={opcoesEmpresaFiltro}
+                includeEmpty
+                emptyLabel="Todas"
+                placeholder="Todas"
+              />
+              <Select
+                label="Setor"
+                labelStyle="overline"
+                className="min-w-0"
+                value={filtroSetor}
+                onChange={(v) => {
+                  setFiltroSetor(v === '' ? '' : Number(v))
+                  resetarPagina()
+                }}
+                options={opcoesSetorFiltro}
+                includeEmpty
+                emptyLabel="Todos"
+                placeholder="Todos"
+              />
+              {situacao === 'abertos' && (
                 <Select
                   label="Status"
                   labelStyle="overline"
@@ -391,27 +446,27 @@ export function Tickets() {
                   emptyLabel="Todos"
                   placeholder="Todos"
                 />
-                {isAdmin && (
-                  <Select
-                    label="Responsável (equipe)"
-                    labelStyle="overline"
-                    className="min-w-0 sm:col-span-2 lg:col-span-1"
-                    value={filtroAtendente}
-                    onChange={(v) => {
-                      setFiltroAtendente(v === '' ? '' : Number(v))
-                      if (v !== '') setFiltroFila('')
-                      resetarPagina()
-                    }}
-                    options={opcoesAtendenteFiltro}
-                    includeEmpty
-                    emptyLabel="Qualquer"
-                    placeholder="Qualquer"
-                    disabled={filtroFila !== ''}
-                  />
-                )}
-              </div>
-            )}
-          </div>
+              )}
+              {isAdmin && (
+                <Select
+                  label="Responsável (equipe)"
+                  labelStyle="overline"
+                  className="min-w-0 sm:col-span-2 lg:col-span-1"
+                  value={filtroAtendente}
+                  onChange={(v) => {
+                    setFiltroAtendente(v === '' ? '' : Number(v))
+                    if (v !== '') setFiltroFila('')
+                    resetarPagina()
+                  }}
+                  options={opcoesAtendenteFiltro}
+                  includeEmpty
+                  emptyLabel="Qualquer"
+                  placeholder="Qualquer"
+                  disabled={situacao === 'abertos' ? filtroFila !== '' : false}
+                />
+              )}
+            </div>
+          )}
         </div>
 
         <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-100 px-4 py-3 dark:border-slate-800 sm:px-6">
@@ -472,8 +527,65 @@ export function Tickets() {
             )}
           </div>
         ) : (
-          <div className="overflow-hidden">
-            <table className="w-full table-auto text-left text-sm">
+          <>
+            {/* Mobile: cards (melhor leitura/toque) */}
+            <div className="divide-y divide-slate-100 dark:divide-slate-800 sm:hidden">
+              {list.map((t) => {
+                const fechadoFmt = t.fechado_em ? new Date(t.fechado_em).toLocaleString('pt-BR') : null
+                return (
+                  <button
+                    key={t.id}
+                    type="button"
+                    onClick={() => navigate(`/tickets/${t.id}`)}
+                    className="w-full px-4 py-4 text-left transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-slate-800/40 dark:focus-visible:bg-slate-800/60"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="font-mono text-xs text-slate-500 dark:text-slate-400">#{t.protocolo}</p>
+                        <p className="mt-1 truncate font-semibold text-slate-900 dark:text-slate-100">
+                          {t.empresa_nome ?? String(t.empresa_id)}
+                        </p>
+                        <p className="mt-0.5 line-clamp-2 text-sm text-slate-600 dark:text-slate-400">
+                          {t.assunto}
+                        </p>
+                      </div>
+                      <div className="shrink-0 text-right">
+                        {situacao === 'fechados' ? (
+                          <span className="inline-flex rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-200">
+                            Fechado
+                          </span>
+                        ) : (
+                          <span className="inline-flex rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                            {t.status_nome ?? t.status_id}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
+                      <span className="truncate">
+                        <span className="font-medium text-slate-600 dark:text-slate-300">Setor:</span>{' '}
+                        {t.setor_nome ?? String(t.setor_id)}
+                      </span>
+                      <span className="truncate">
+                        <span className="font-medium text-slate-600 dark:text-slate-300">Resp.:</span>{' '}
+                        {t.atendente_nome ?? 'Na fila'}
+                      </span>
+                      {situacao === 'fechados' && (
+                        <span className="truncate">
+                          <span className="font-medium text-slate-600 dark:text-slate-300">Fechado em:</span>{' '}
+                          {fechadoFmt ?? '—'}
+                        </span>
+                      )}
+                    </div>
+                  </button>
+                )
+              })}
+            </div>
+
+            {/* Desktop/tablet: tabela */}
+            <div className="hidden overflow-hidden sm:block">
+              <table className="w-full table-auto text-left text-sm">
               <thead>
                 <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
                   <CabecalhoOrdenavel
@@ -531,17 +643,31 @@ export function Tickets() {
                     }}
                     className="hidden px-4 py-3 md:table-cell sm:px-6"
                   />
-                  <CabecalhoOrdenavel
-                    coluna="status"
-                    rotulo="Status"
-                    ordenarPor={ordenarPor}
-                    ordem={ordem}
-                    aoOrdenar={(c) => {
-                      resetarPagina()
-                      aoOrdenarColuna(c)
-                    }}
-                    className="whitespace-nowrap px-4 py-3 sm:px-6"
-                  />
+                  {situacao === 'fechados' ? (
+                    <CabecalhoOrdenavel
+                      coluna="fechado_em"
+                      rotulo="Fechado em"
+                      ordenarPor={ordenarPor}
+                      ordem={ordem}
+                      aoOrdenar={(c) => {
+                        resetarPagina()
+                        aoOrdenarColuna(c)
+                      }}
+                      className="whitespace-nowrap px-4 py-3 sm:px-6"
+                    />
+                  ) : (
+                    <CabecalhoOrdenavel
+                      coluna="status"
+                      rotulo="Status"
+                      ordenarPor={ordenarPor}
+                      ordem={ordem}
+                      aoOrdenar={(c) => {
+                        resetarPagina()
+                        aoOrdenarColuna(c)
+                      }}
+                      className="whitespace-nowrap px-4 py-3 sm:px-6"
+                    />
+                  )}
                   <CabecalhoOrdenavel
                     coluna="responsavel"
                     rotulo="Responsável"
@@ -598,11 +724,17 @@ export function Tickets() {
                     <td className="hidden px-4 py-3.5 align-top font-medium text-slate-900 md:table-cell sm:px-6 dark:text-slate-100" title={t.assunto}>
                       <span className="block break-words whitespace-normal leading-snug">{t.assunto}</span>
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3.5 align-top sm:px-6">
-                      <span className="inline-flex rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
-                        {t.status_nome ?? t.status_id}
-                      </span>
-                    </td>
+                    {situacao === 'fechados' ? (
+                      <td className="whitespace-nowrap px-4 py-3.5 align-top text-slate-600 sm:px-6 dark:text-slate-400">
+                        {t.fechado_em ? new Date(t.fechado_em).toLocaleString('pt-BR') : '—'}
+                      </td>
+                    ) : (
+                      <td className="whitespace-nowrap px-4 py-3.5 align-top sm:px-6">
+                        <span className="inline-flex rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                          {t.status_nome ?? t.status_id}
+                        </span>
+                      </td>
+                    )}
                     <td className="hidden px-4 py-3.5 align-top text-slate-600 lg:table-cell sm:px-6 dark:text-slate-400">
                       <span className="block break-words whitespace-normal leading-snug">
                         {t.atendente_nome ?? 'Na fila'}
@@ -612,7 +744,8 @@ export function Tickets() {
                 ))}
               </tbody>
             </table>
-          </div>
+            </div>
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Resumo
Implementa o fechamento de tickets (listas abertos/finalizados), regras de API e melhorias de UX ligadas à issue #41.

## Backend
- Listagem por situação e ordenação por data de fechamento quando aplicável.
- Reabertura por administrador e bloqueio de novas mensagens em ticket fechado.

## Frontend
- Tickets: abas Abertos/Finalizados, filtros alinhados à situação, coluna "Fechado em", layout responsivo (tabela no desktop e cards no mobile).
- Detalhe: ação de fechar, reabrir para admin e impedir envio de mensagem quando o ticket está fechado.
- Empresa e Rede: listagem de tickets considera todos os estados no contexto da página.
- Notificações no mobile: renderização via portal no documento, z-index acima do conteúdo (contorna o backdrop-filter do header).
- Menu lateral: rail recolhido em 80px no desktop, ícones centralizados; no drawer mobile, submenus em acordeão (sem painel lateral que gerava scroll horizontal).

Closes #41
