### PR TITLE
RBAC: admin como responsável em tickets (issue #38)

### DIFF
--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -138,7 +138,7 @@ def listar_atendentes_por_setor(
     db: Session = Depends(get_db),
     atendente_logado: Atendente = Depends(obter_atendente_atual),
 ):
-    """Atendentes vinculados ao setor (e duplicatas de mesmo nome). Qualquer usuário autenticado com acesso ao setor."""
+    """Atendentes vinculados ao setor (e homônimos) + administradores (elegíveis como responsáveis sem vínculo ao setor; #38)."""
     if not db.query(Setor).filter(Setor.id == setor_id).first():
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Setor não encontrado")
     if atendente_logado.role != "admin":
@@ -155,7 +155,19 @@ def listar_atendentes_por_setor(
     if not incluir_inativos:
         q = q.filter(Atendente.ativo.is_(True))
     rows = q.order_by(Atendente.nome).all()
-    return [_atendente_para_read(a) for a in rows]
+    by_id = {a.id: a for a in rows}
+    q_admins = (
+        db.query(Atendente)
+        .options(joinedload(Atendente.setores))
+        .filter(Atendente.role == "admin")
+    )
+    if not incluir_inativos:
+        q_admins = q_admins.filter(Atendente.ativo.is_(True))
+    for a in q_admins.order_by(Atendente.nome).all():
+        if a.id not in by_id:
+            by_id[a.id] = a
+    merged = sorted(by_id.values(), key=lambda x: ((x.nome or "").lower(), x.id))
+    return [_atendente_para_read(a) for a in merged]
 
 
 @router.get("/{atendente_id}", response_model=AtendenteRead)

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -18,7 +18,11 @@ from app.schemas.ticket import (
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import obter_atendente_atual
 from app.core.ordenacao_lista import OrdemLista, expr_ordem
-from app.core.setor_scope import ids_setores_visiveis_atendente, atendente_atende_algum_id_setor
+from app.core.setor_scope import (
+    atendente_atende_algum_id_setor,
+    ids_setores_visiveis_atendente,
+    responsavel_elegivel_para_setor_do_ticket,
+)
 
 router = APIRouter(prefix="/tickets", tags=["tickets"])
 
@@ -482,17 +486,30 @@ def atualizar(
 
     setor_final = update["setor_id"] if "setor_id" in update else ticket.setor_id
 
-    if "atendente_id" in update and update["atendente_id"] is not None:
-        if not atendente_atende_algum_id_setor(db, update["atendente_id"], setor_final):
+    if "atendente_id" in update and atendente.role != "admin":
+        novo_at = update["atendente_id"]
+        if novo_at is not None and novo_at != atendente.id:
             raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="O responsável indicado não está vinculado ao setor do ticket.",
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Somente administradores podem definir outro responsável.",
             )
 
-    # Transferência: se o responsável atual não atende o setor de destino, volta à fila (sem responsável).
+    if "atendente_id" in update and update["atendente_id"] is not None:
+        if not responsavel_elegivel_para_setor_do_ticket(db, update["atendente_id"], setor_final):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="O responsável indicado não pode ser atribuído a este setor.",
+            )
+
+    # Transferência de setor: se o responsável atual não atende o setor de destino, volta à fila.
+    # Administradores permanecem responsáveis mesmo sem vínculo ao setor (#38).
     if "setor_id" in update and update["setor_id"] != ticket.setor_id and "atendente_id" not in update:
-        if ticket.atendente_id is not None and not atendente_atende_algum_id_setor(db, ticket.atendente_id, update["setor_id"]):
-            update["atendente_id"] = None
+        if ticket.atendente_id is not None:
+            atual_resp = db.query(Atendente).filter(Atendente.id == ticket.atendente_id).first()
+            if atual_resp and atual_resp.role == "admin":
+                pass
+            elif not atendente_atende_algum_id_setor(db, ticket.atendente_id, update["setor_id"]):
+                update["atendente_id"] = None
 
     if "status_id" in update:
         antigo = str(ticket.status_id)

--- a/backend/app/core/setor_scope.py
+++ b/backend/app/core/setor_scope.py
@@ -43,3 +43,22 @@ def atendente_atende_algum_id_setor(db: Session, atendente_id: int, setor_id: in
         return False
     atend_ids = {s.id for s in a.setores}
     return bool(atend_ids & ids_alvo)
+
+
+def responsavel_elegivel_para_setor_do_ticket(db: Session, responsavel_id: int, setor_id: int) -> bool:
+    """True se o usuário pode ser responsável por um ticket neste setor.
+
+    - `admin`: sempre elegível (operam sem vínculo obrigatório ao setor do ticket; issue #38).
+    - demais: devem atender o setor (incluindo homônimos).
+    """
+    alvo = (
+        db.query(Atendente)
+        .options(joinedload(Atendente.setores))
+        .filter(Atendente.id == responsavel_id)
+        .first()
+    )
+    if not alvo:
+        return False
+    if alvo.role == "admin":
+        return True
+    return atendente_atende_algum_id_setor(db, responsavel_id, setor_id)


### PR DESCRIPTION
## Resumo
Implementa a parte **#38** relacionada a **administrador como responsável** sem exigir vínculo ao setor do ticket (consolidado com a antiga #25).

## Backend
- Novo helper `responsavel_elegivel_para_setor_do_ticket`: `admin` sempre elegível; demais usuários seguem `atendente_atende_algum_id_setor`.
- `PATCH /tickets/{id}`: validação de `atendente_id` com a regra acima; **atendentes** só podem definir **a si mesmos** como responsável (não outra pessoa).
- Ao mudar só o **setor** do ticket: se o responsável atual é **admin**, permanece atribuído (antes caía na regra de “não atende setor” e ia para a fila).
- `GET /atendentes/por-setor/{id}`: inclui **todos os administradores** na lista (além dos vinculados ao setor), para o select “Gerir ticket” listar quem pode ser responsável.

## Frontend
Sem alteração: já usa `listPorSetor` no modal.

Refs #38 — entrega o bloco **responsável admin / lista por setor / PATCH**; a matriz completa de RBAC na issue permanece para próximos PRs.
