### PR TITLE
Testes: infra pytest + SQLite (issue #46)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,13 @@ jobs:
       - name: Instalar requirements e pip-audit
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt pip-audit
+          python -m pip install -r requirements.txt -r requirements-dev.txt pip-audit
 
       - name: Auditoria de vulnerabilidades (PyPI)
         run: pip-audit -r requirements.txt
+
+      - name: Pytest
+        run: pytest -q
 
       - name: Verificar sintaxe Python
         run: python -m compileall -q app

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -2,6 +2,8 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+ARG INSTALL_DEV=0
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libpq-dev \
@@ -9,6 +11,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
+
+COPY requirements-dev.txt .
+RUN if [ "$INSTALL_DEV" = "1" ]; then pip install --no-cache-dir -r requirements-dev.txt; fi
 
 COPY . .
 

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,12 +1,26 @@
+import os
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.pool import StaticPool
 
 from app.config import settings
 
-engine = create_engine(
-    settings.DATABASE_URL,
-    pool_pre_ping=True,
-)
+
+def _create_engine():
+    url = settings.DATABASE_URL
+    # Pytest + SQLite :memory:: um pool estático para todas as conexões verem o mesmo schema (#46).
+    if os.environ.get("DX_CONNECT_TESTING") == "1" and url.startswith("sqlite"):
+        return create_engine(
+            url,
+            pool_pre_ping=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+    return create_engine(url, pool_pre_ping=True)
+
+
+engine = _create_engine()
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -35,6 +35,14 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Testes (pytest): schema mínimo sem seed, backfill nem thread IBGE — ver tests/conftest.py (#46).
+    import os
+
+    if os.environ.get("DX_CONNECT_TESTING") == "1":
+        dev_create_all_tables(engine, Base.metadata)
+        yield
+        return
+
     if settings.is_production:
         production_require_alembic(engine)
     else:

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Dependências apenas para desenvolvimento / CI (pytest).
+-r requirements.txt
+pytest==8.3.4
+httpx==0.28.1

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -1,0 +1,21 @@
+# Testes da API (pytest)
+
+## Pré-requisitos
+
+```bash
+cd backend
+python -m pip install -r requirements-dev.txt
+```
+
+## Executar
+
+```bash
+cd backend
+pytest
+```
+
+Variáveis de ambiente para SQLite em memória e `DX_CONNECT_TESTING=1` são definidas em `conftest.py` antes de importar a aplicação.
+
+## Próximo passo
+
+Casos de RBAC / tickets na issue **#47** (depende desta infra).

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -1,20 +1,31 @@
 # Testes da API (pytest)
 
-## Pré-requisitos
+O `conftest.py` define `DX_CONNECT_TESTING=1`, `DATABASE_URL` em **SQLite em memória** e `SECRET_KEY` de teste **antes** de importar a app. Os testes **não** usam o Postgres do `docker-compose` (evita apagar dados locais).
+
+## Com Docker (recomendado no projeto)
+
+O `docker-compose.yml` compila o backend com **`INSTALL_DEV=1`**, instalando `requirements-dev.txt` (pytest, httpx) na imagem.
+
+```bash
+# Na raiz do repositório
+docker compose build backend
+docker compose run --rm backend pytest -q
+```
+
+- `pytest` substitui o comando padrão (`uvicorn`) só nesta execução.
+- Se a imagem já existia de antes da issue #46, faça **`build`** de novo para incluir as dev deps.
+
+## Sem Docker (máquina local)
 
 ```bash
 cd backend
 python -m pip install -r requirements-dev.txt
-```
-
-## Executar
-
-```bash
-cd backend
 pytest
 ```
 
-Variáveis de ambiente para SQLite em memória e `DX_CONNECT_TESTING=1` são definidas em `conftest.py` antes de importar a aplicação.
+## PR e CI
+
+O merge do PR deve passar no job **Pytest** do GitHub Actions. Se quiser **só mergear depois de ver verde**, rode o comando Docker acima antes de aprovar.
 
 ## Próximo passo
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,42 @@
+"""
+Infra de testes (#46): variáveis de ambiente antes de importar `app`.
+
+`DX_CONNECT_TESTING=1` ativa lifespan mínimo em `app.main` (create_all, sem seed/IBGE).
+"""
+from __future__ import annotations
+
+import os
+
+# Sobrescreve .env local: SQLite em memória e modo de teste.
+os.environ["DX_CONNECT_TESTING"] = "1"
+os.environ["DATABASE_URL"] = "sqlite+pysqlite:///:memory:"
+os.environ["SECRET_KEY"] = "01234567890123456789012345678901"
+os.environ["ENVIRONMENT"] = "development"
+
+import pytest
+from starlette.testclient import TestClient
+
+
+@pytest.fixture(scope="session")
+def app():
+    from app.main import app as fastapi_app
+
+    return fastapi_app
+
+
+@pytest.fixture(scope="session")
+def client(app):
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def db_session(client):
+    """Sessão SQLAlchemy (tabelas já criadas pelo `TestClient` / lifespan)."""
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/tests/test_db_session.py
+++ b/backend/tests/test_db_session.py
@@ -1,0 +1,7 @@
+"""Garante que a sessão de teste vê o mesmo SQLite que o lifespan (StaticPool)."""
+
+from app.models import Atendente
+
+
+def test_db_session_shares_schema_with_app(client, db_session):
+    assert db_session.query(Atendente).count() == 0

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,4 @@
+def test_health_ok(client):
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     build:
       context: ./backend
       dockerfile: Dockerfile
+      args:
+        INSTALL_DEV: "1"
     container_name: dx-connect-api
     env_file:
       - ./backend/.env


### PR DESCRIPTION
## Resumo
Infraestrutura de **pytest** para a API, conforme **#46**.

## O que inclui
- `backend/requirements-dev.txt`: `pytest`, `httpx` (via `-r requirements.txt`).
- `backend/pytest.ini` e `backend/tests/conftest.py`: força `DATABASE_URL` SQLite em memória, `DX_CONNECT_TESTING=1`, `SECRET_KEY` de teste; fixtures `app`, `client`, `db_session`.
- `app.main`: se `DX_CONNECT_TESTING=1`, lifespan só executa `create_all` (sem seed, backfill, thread IBGE).
- `app.database`: com teste + SQLite, usa `StaticPool` para todas as conexões compartilharem o mesmo `:memory:`.
- Testes de fumaça: `GET /health` e sessão DB vê tabelas.
- **CI**: instala `requirements-dev.txt` e roda `pytest -q`.

## Como rodar localmente
Ver `backend/tests/README.md`.

Closes #46
