### PR TITLE
Testes: tickets + RBAC (issue #47)

### DIFF
--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -9,10 +9,11 @@ O `docker-compose.yml` compila o backend com **`INSTALL_DEV=1`**, instalando `re
 ```bash
 # Na raiz do repositório
 docker compose build backend
-docker compose run --rm backend pytest -q
+docker compose run --rm -v ./backend:/app backend pytest -q
 ```
 
 - `pytest` substitui o comando padrão (`uvicorn`) só nesta execução.
+- O bind mount (`-v ./backend:/app`) garante que **os testes do seu workspace** sejam executados (inclusive novos arquivos em `backend/tests/`).
 - Se a imagem já existia de antes da issue #46, faça **`build`** de novo para incluir as dev deps.
 
 ## Sem Docker (máquina local)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -40,3 +40,88 @@ def db_session(client):
         yield db
     finally:
         db.close()
+
+
+@pytest.fixture(autouse=True)
+def _clean_db(db_session):
+    """Limpa dados entre testes (SQLite :memory: é compartilhado via StaticPool)."""
+    from app.database import Base
+
+    for table in reversed(Base.metadata.sorted_tables):
+        db_session.execute(table.delete())
+    db_session.commit()
+    yield
+
+
+@pytest.fixture
+def seed_base(db_session):
+    """Dados mínimos para testes de RBAC/tickets (sem depender de seed automático)."""
+    from app.core.security import hash_senha
+    from app.models import Atendente, Empresa, Rede, Setor, StatusTicket
+
+    # Setores
+    s1 = Setor(nome="Suporte", slug="suporte", ativo=True)
+    s2 = Setor(nome="Financeiro", slug="financeiro", ativo=True)
+    db_session.add_all([s1, s2])
+
+    # Rede/Empresa (Ticket exige empresa_id)
+    r = Rede(nome="Rede Teste", ativo=True)
+    db_session.add(r)
+    db_session.flush()
+    e = Empresa(rede_id=r.id, nome="Empresa Teste", ativo=True)
+    db_session.add(e)
+
+    # Status inicial (Ticket.create exige ao menos um status ativo)
+    st = StatusTicket(nome="Aguardando atendimento", slug="aguardando_atendimento", ordem=1, ativo=True)
+    db_session.add(st)
+
+    # Usuários
+    admin = Atendente(
+        email="admin@test.local",
+        nome="Admin",
+        senha_hash=hash_senha("admin123"),
+        role="admin",
+        ativo=True,
+        must_change_password=False,
+    )
+    a1 = Atendente(
+        email="atendente1@test.local",
+        nome="Atendente 1",
+        senha_hash=hash_senha("at123"),
+        role="atendente",
+        ativo=True,
+        must_change_password=False,
+    )
+    a2 = Atendente(
+        email="atendente2@test.local",
+        nome="Atendente 2",
+        senha_hash=hash_senha("at123"),
+        role="atendente",
+        ativo=True,
+        must_change_password=False,
+    )
+    db_session.add_all([admin, a1, a2])
+    db_session.flush()
+
+    # Vínculos de setor (admin sem setores; atendentes em setores distintos)
+    a1.setores.append(s1)
+    a2.setores.append(s2)
+
+    db_session.commit()
+    return {"setor1": s1, "setor2": s2, "rede": r, "empresa": e, "status": st, "admin": admin, "a1": a1, "a2": a2}
+
+
+@pytest.fixture
+def auth_headers(seed_base):
+    """Cabeçalhos Authorization para os usuários seed."""
+    from app.core.security import criar_access_token
+
+    def headers_for(email: str) -> dict[str, str]:
+        tok = criar_access_token({"sub": email})
+        return {"Authorization": f"Bearer {tok}"}
+
+    return {
+        "admin": headers_for(seed_base["admin"].email),
+        "a1": headers_for(seed_base["a1"].email),
+        "a2": headers_for(seed_base["a2"].email),
+    }

--- a/backend/tests/test_rbac_tickets.py
+++ b/backend/tests/test_rbac_tickets.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+
+def _create_ticket(client, headers: dict[str, str], empresa_id: int, setor_id: int, assunto: str = "Teste", descricao: str = "Desc"):
+    r = client.post(
+        "/v1/tickets",
+        headers=headers,
+        json={"empresa_id": empresa_id, "setor_id": setor_id, "assunto": assunto, "descricao": descricao},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def test_atendente_nao_acessa_ticket_fora_do_setor(client, seed_base, auth_headers):
+    # Ticket no setor 2 criado por admin
+    t = _create_ticket(client, auth_headers["admin"], seed_base["empresa"].id, seed_base["setor2"].id, assunto="S2")
+
+    # Atendente 1 (setor 1) não pode visualizar ticket do setor 2
+    r = client.get(f"/v1/tickets/{t['id']}", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_atendente_nao_define_outro_responsavel(client, seed_base, auth_headers):
+    t = _create_ticket(client, auth_headers["admin"], seed_base["empresa"].id, seed_base["setor1"].id, assunto="S1")
+
+    # Atendente 1 tenta definir atendente 2 como responsável
+    r = client.patch(f"/v1/tickets/{t['id']}", headers=auth_headers["a1"], json={"atendente_id": seed_base["a2"].id})
+    assert r.status_code == 403
+
+
+def test_admin_pode_atribuir_admin_sem_vinculo_setor(client, seed_base, auth_headers, db_session):
+    # Cria outro admin (sem setor)
+    from app.core.security import hash_senha
+    from app.models import Atendente
+
+    admin2 = Atendente(
+        email="admin2@test.local",
+        nome="Admin 2",
+        senha_hash=hash_senha("admin123"),
+        role="admin",
+        ativo=True,
+        must_change_password=False,
+    )
+    db_session.add(admin2)
+    db_session.commit()
+    db_session.refresh(admin2)
+
+    t = _create_ticket(client, auth_headers["admin"], seed_base["empresa"].id, seed_base["setor1"].id, assunto="S1")
+    r = client.patch(f"/v1/tickets/{t['id']}", headers=auth_headers["admin"], json={"atendente_id": admin2.id})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["atendente_id"] == admin2.id
+
+
+def test_mudar_setor_mantem_admin_responsavel(client, seed_base, auth_headers):
+    t = _create_ticket(client, auth_headers["admin"], seed_base["empresa"].id, seed_base["setor1"].id, assunto="S1")
+
+    # Admin vira responsável
+    r1 = client.patch(f"/v1/tickets/{t['id']}", headers=auth_headers["admin"], json={"atendente_id": seed_base["admin"].id})
+    assert r1.status_code == 200, r1.text
+    assert r1.json()["atendente_id"] == seed_base["admin"].id
+
+    # Mudança de setor sem informar atendente_id deve manter admin responsável
+    r2 = client.patch(f"/v1/tickets/{t['id']}", headers=auth_headers["admin"], json={"setor_id": seed_base["setor2"].id})
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["setor_id"] == seed_base["setor2"].id
+    assert r2.json()["atendente_id"] == seed_base["admin"].id
+
+
+def test_listar_atendentes_por_setor_inclui_admins(client, seed_base, auth_headers, db_session):
+    from app.core.security import hash_senha
+    from app.models import Atendente
+
+    # Outro admin para garantir que vem no endpoint
+    admin2 = Atendente(
+        email="admin3@test.local",
+        nome="Admin 3",
+        senha_hash=hash_senha("admin123"),
+        role="admin",
+        ativo=True,
+        must_change_password=False,
+    )
+    db_session.add(admin2)
+    db_session.commit()
+    db_session.refresh(admin2)
+
+    r = client.get(f"/v1/atendentes/por-setor/{seed_base['setor1'].id}", headers=auth_headers["a1"])
+    assert r.status_code == 200, r.text
+    ids = {a["id"] for a in r.json()}
+    assert seed_base["a1"].id in ids  # vinculado ao setor
+    assert seed_base["admin"].id in ids  # admin sempre deve aparecer
+    assert admin2.id in ids  # admin adicional também
+


### PR DESCRIPTION
## Resumo
Adiciona testes automatizados de API para tickets e escopo RBAC conforme a issue #47.

## O que foi coberto
- Atendente não acessa ticket fora do setor (403)
- Atendente não define outro responsável (403)
- Admin pode atribuir admin como responsável sem vínculo ao setor
- Mudança de setor mantém admin responsável (sem cair para a fila)
- `GET /atendentes/por-setor/{id}` inclui administradores na lista

## Infra
- Fixtures de dados e JWT no `conftest.py`
- Limpeza do DB entre testes (SQLite em memória compartilhado)
- README atualizado com comando Docker recomendado

Closes #47