### PR TITLE
feat(rbac): catálogo + UX 403

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,14 @@ O frontend ficará acessível em `http://localhost:5173`.
 
 ### Scripts úteis
 
-No **backend** (a partir da pasta `backend`):
+No **backend** (com API já a subir via Docker, na raiz do repositório):
 
-- Aplicar seed manualmente:
+- Rodar testes (pytest na imagem; não precisa de Python local): `docker compose run --rm --no-deps backend pytest -q` na raiz do repo — ver [`backend/tests/README.md`](backend/tests/README.md).
+
+- Aplicar seed manualmente (com `docker compose up -d` em curso):
 
 ```bash
-python -m app.seed
+docker compose exec backend python -m app.seed
 ```
 
 No **frontend** (a partir da pasta `frontend`):
@@ -170,7 +172,22 @@ npm run dev
 - App: http://localhost:5173  
 - As requisições para `/api/*` são proxy para `http://localhost:8000`.
 
-### 3. Ordem sugerida de uso
+### 3. Testes do backend (pytest via Docker)
+
+Não é necessário instalar Python localmente: use a imagem do Compose (com dev deps).
+
+```bash
+# Na raiz do repositório
+docker compose build backend
+docker compose run --rm --no-deps backend pytest -q
+```
+
+- **`--no-deps`**: os testes usam SQLite em memória (`backend/tests/conftest.py`); o serviço `db` não precisa de estar a correr.
+- O volume `./backend:/app` no `docker-compose.yml` sincroniza código e `tests/`; alterações nos arquivos refletem-se de imediato no container (rebuild só após mudanças em `requirements` ou `Dockerfile`).
+
+Detalhes: [`backend/tests/README.md`](backend/tests/README.md). Matriz de rotas e perfis: [`docs/BACKEND_RBAC.md`](docs/BACKEND_RBAC.md).
+
+### 4. Ordem sugerida de uso
 
 1. Fazer login com o admin.
 2. Cadastrar **Redes** e **Empresas** (uma empresa pertence a uma rede).

--- a/backend/app/api/empresas.py
+++ b/backend/app/api/empresas.py
@@ -23,6 +23,7 @@ from app.schemas.empresa import (
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import exigir_admin, obter_atendente_atual
 from app.core.audit import registrar_audit
+from app.core.setor_scope import ids_setores_visiveis_atendente, select_rede_ids_com_ticket_nos_setores
 
 router = APIRouter(prefix="/empresas", tags=["empresas"])
 
@@ -50,9 +51,12 @@ def listar_empresas(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    """Admin: modelo completo. Atendente: apenas id, nome, rede e ativo (minimização de PII)."""
+    """Admin: modelo completo. Atendente: resumo (PII mínima) só de redes que já tiveram ticket nos setores que ele atende."""
     admin = atendente.role == "admin"
     q = db.query(Empresa)
+    if not admin:
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        q = q.filter(Empresa.rede_id.in_(select_rede_ids_com_ticket_nos_setores(vis)))
     if rede_id is not None:
         q = q.filter(Empresa.rede_id == rede_id)
     if not incluir_inativos:

--- a/backend/app/api/setores.py
+++ b/backend/app/api/setores.py
@@ -11,6 +11,7 @@ from app.schemas.setor import SetorCreate, SetorUpdate, SetorRead
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import obter_atendente_atual, exigir_admin
 from app.core.audit import registrar_audit
+from app.core.setor_scope import ids_setores_visiveis_atendente
 
 router = APIRouter(prefix="/setores", tags=["setores"])
 
@@ -33,9 +34,12 @@ def listar_setores(
     ordenar_por: OrdenarSetoresPor | None = Query(None),
     ordem: OrdemLista = Query(OrdemLista.asc),
     db: Session = Depends(get_db),
-    _: Atendente = Depends(obter_atendente_atual),
+    atendente: Atendente = Depends(obter_atendente_atual),
 ):
     q = db.query(Setor)
+    if atendente.role != "admin":
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        q = q.filter(Setor.id.in_(vis))
     if not incluir_inativos:
         q = q.filter(Setor.ativo.is_(True))
     if busca and busca.strip():

--- a/backend/app/core/setor_scope.py
+++ b/backend/app/core/setor_scope.py
@@ -1,10 +1,22 @@
 """Alcance de setor: trata duplicatas no cadastro (mesmo nome, IDs diferentes)."""
 
-from sqlalchemy import func
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session, joinedload
-
-from app.models import Setor
+from app.models import Empresa, Setor, Ticket
 from app.models.atendente import Atendente
+
+
+def select_rede_ids_com_ticket_nos_setores(setor_ids: set[int]):
+    """Subconsulta: `rede_id` distintos onde existe ticket da empresa nalgum dos setores indicados.
+
+    Usado para limitar listagens de cadastro (ex.: empresas) ao contexto operacional do atendente.
+    """
+    return (
+        select(Empresa.rede_id)
+        .join(Ticket, Ticket.empresa_id == Empresa.id)
+        .where(Ticket.setor_id.in_(setor_ids))
+        .distinct()
+    )
 
 
 def ids_setores_mesmo_nome(db: Session, setor_id: int) -> set[int]:

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -4,17 +4,17 @@ O `conftest.py` define `DX_CONNECT_TESTING=1`, `DATABASE_URL` em **SQLite em mem
 
 ## Com Docker (recomendado no projeto)
 
-O `docker-compose.yml` compila o backend com **`INSTALL_DEV=1`**, instalando `requirements-dev.txt` (pytest, httpx) na imagem.
+O `docker-compose.yml` compila o backend com **`INSTALL_DEV=1`**, instalando `requirements-dev.txt` (pytest, httpx) na imagem, e monta **`./backend` em `/app`**, para que alterações em `tests/` e em `app/` entrem no container **sem rebuild**.
 
 ```bash
-# Na raiz do repositório
-docker compose build backend
-docker compose run --rm -v ./backend:/app backend pytest -q
+# Na raiz do repositório (onde está docker-compose.yml)
+docker compose build backend   # primeira vez ou após mudar requirements / Dockerfile
+docker compose run --rm --no-deps backend pytest -q
 ```
 
 - `pytest` substitui o comando padrão (`uvicorn`) só nesta execução.
-- O bind mount (`-v ./backend:/app`) garante que **os testes do seu workspace** sejam executados (inclusive novos arquivos em `backend/tests/`).
-- Se a imagem já existia de antes da issue #46, faça **`build`** de novo para incluir as dev deps.
+- **`--no-deps`**: não sobe o Postgres; o `conftest.py` força SQLite em memória para os testes.
+- **Rebuild** só é necessário quando mudam `requirements*.txt`, `Dockerfile` ou outras dependências da imagem — não por cada alteração em `.py` de testes ou da app.
 
 ## Sem Docker (máquina local)
 
@@ -28,6 +28,6 @@ pytest
 
 O merge do PR deve passar no job **Pytest** do GitHub Actions. Se quiser **só mergear depois de ver verde**, rode o comando Docker acima antes de aprovar.
 
-## Próximo passo
+## Documentação de RBAC
 
-Casos de RBAC / tickets na issue **#47** (depende desta infra).
+Resumo das rotas v1 e perfis: [`../../docs/BACKEND_RBAC.md`](../../docs/BACKEND_RBAC.md).

--- a/backend/tests/test_rbac_admin_only.py
+++ b/backend/tests/test_rbac_admin_only.py
@@ -1,0 +1,61 @@
+"""Rotas de cadastro / auditoria: apenas admin (403 para atendente)."""
+
+from __future__ import annotations
+
+
+def test_atendente_403_redes(client, auth_headers):
+    r = client.get("/v1/redes", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_atendente_403_redes_post(client, auth_headers):
+    r = client.post(
+        "/v1/redes",
+        headers=auth_headers["a1"],
+        json={"nome": "X", "ativo": True},
+    )
+    assert r.status_code == 403
+
+
+def test_atendente_403_audit(client, auth_headers):
+    r = client.get("/v1/audit", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_atendente_403_atendentes_lista(client, auth_headers):
+    r = client.get("/v1/atendentes", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_atendente_403_funcionarios_rede(client, auth_headers):
+    r = client.get("/v1/funcionarios-rede", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_atendente_403_empresa_detalhe(client, seed_base, auth_headers):
+    r = client.get(f"/v1/empresas/{seed_base['empresa'].id}", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_atendente_403_empresa_patch(client, seed_base, auth_headers):
+    r = client.patch(
+        f"/v1/empresas/{seed_base['empresa'].id}",
+        headers=auth_headers["a1"],
+        json={"nome": "Hackeado"},
+    )
+    assert r.status_code == 403
+
+
+def test_atendente_403_setor_detalhe(client, seed_base, auth_headers):
+    r = client.get(f"/v1/setores/{seed_base['setor1'].id}", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_atendente_403_status_ticket_detalhe(client, seed_base, auth_headers):
+    r = client.get(f"/v1/status-ticket/{seed_base['status'].id}", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_atendente_403_cadastro_aux_sincronizar_municipios(client, auth_headers):
+    r = client.post("/v1/cadastro-aux/municipios/sincronizar", headers=auth_headers["a1"])
+    assert r.status_code == 403

--- a/backend/tests/test_rbac_catalogos.py
+++ b/backend/tests/test_rbac_catalogos.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+
+def _post_ticket(client, headers: dict[str, str], empresa_id: int, setor_id: int):
+    r = client.post(
+        "/v1/tickets",
+        headers=headers,
+        json={"empresa_id": empresa_id, "setor_id": setor_id, "assunto": "T", "descricao": "D"},
+    )
+    assert r.status_code == 201, r.text
+
+
+def test_atendente_lista_somente_setores_vinculados(client, seed_base, auth_headers):
+    r_admin = client.get("/v1/setores", headers=auth_headers["admin"])
+    assert r_admin.status_code == 200
+    assert r_admin.json()["total"] == 2
+
+    r_a1 = client.get("/v1/setores", headers=auth_headers["a1"])
+    assert r_a1.status_code == 200
+    assert r_a1.json()["total"] == 1
+    assert r_a1.json()["items"][0]["id"] == seed_base["setor1"].id
+
+
+def test_atendente_lista_empresas_somente_redes_com_ticket_no_escopo(client, seed_base, auth_headers, db_session):
+    from app.models import Empresa
+
+    # Sem tickets: nenhuma rede entra no filtro do atendente
+    r0 = client.get("/v1/empresas", headers=auth_headers["a1"])
+    assert r0.status_code == 200
+    assert r0.json()["total"] == 0
+
+    _post_ticket(client, auth_headers["admin"], seed_base["empresa"].id, seed_base["setor1"].id)
+
+    r1 = client.get("/v1/empresas", headers=auth_headers["a1"])
+    assert r1.status_code == 200
+    assert r1.json()["total"] == 1
+
+    # Outra empresa na mesma rede: aparece para quem já enxerga a rede via tickets no setor
+    e2 = Empresa(rede_id=seed_base["rede"].id, nome="Empresa 2", ativo=True)
+    db_session.add(e2)
+    db_session.commit()
+
+    r2 = client.get("/v1/empresas", headers=auth_headers["a1"])
+    assert r2.status_code == 200
+    assert r2.json()["total"] == 2
+
+    # Atendente do setor 2 não vê empresas só expostas por ticket no setor 1
+    r_a2 = client.get("/v1/empresas", headers=auth_headers["a2"])
+    assert r_a2.status_code == 200
+    assert r_a2.json()["total"] == 0
+
+
+def test_atendente_lista_empresas_apos_ticket_no_seu_setor(client, seed_base, auth_headers, db_session):
+    from app.models import Empresa
+
+    _post_ticket(client, auth_headers["admin"], seed_base["empresa"].id, seed_base["setor2"].id)
+
+    r_a2 = client.get("/v1/empresas", headers=auth_headers["a2"])
+    assert r_a2.status_code == 200
+    assert r_a2.json()["total"] == 1
+
+    db_session.add(Empresa(rede_id=seed_base["rede"].id, nome="Empresa S2", ativo=True))
+    db_session.commit()
+
+    r2 = client.get("/v1/empresas", headers=auth_headers["a2"])
+    assert r2.status_code == 200
+    assert r2.json()["total"] == 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,8 @@ services:
       db:
         condition: service_healthy
     volumes:
-      - ./backend/app:/app/app
+      # Código + tests + pytest.ini do host (evita rebuild só por alteração em tests/).
+      - ./backend:/app
 
 volumes:
   postgres_data:

--- a/docs/BACKEND_RBAC.md
+++ b/docs/BACKEND_RBAC.md
@@ -1,0 +1,50 @@
+# RBAC no backend (API v1)
+
+Política alinhada à issue **#38**: perfis **admin** e **atendente**, com escopo por **setor** (inclui setores homônimos — ver `app.core.setor_scope`).
+
+## Autenticação
+
+| Prefixo | Quem acessa |
+|---------|-------------|
+| `/v1/auth/*` | Público (login / refresh). |
+
+## Só administrador (`exigir_admin` → 403 para não admin)
+
+| Recurso | Rotas |
+|---------|--------|
+| Redes | `GET/POST/PATCH/DELETE /v1/redes`, `GET /v1/redes/{id}`, `GET /v1/redes/{id}/funcionarios` |
+| Empresa (detalhe / mutação / CNPJ) | `GET/PATCH/DELETE /v1/empresas/{id}`, `POST /v1/empresas`, `GET /v1/empresas/consultar-cnpj/...` |
+| Funcionários da rede | `GET/POST/PATCH/DELETE /v1/funcionarios-rede` e por id |
+| Atendentes (cadastro) | `GET/POST/PATCH/DELETE /v1/atendentes`, `GET /v1/atendentes/{id}` |
+| Setor (detalhe / mutação) | `GET/PATCH/DELETE /v1/setores/{id}`, `POST /v1/setores` |
+| Status de ticket (detalhe / mutação) | `GET/POST/PATCH/DELETE /v1/status-ticket/{id}`, `POST /v1/status-ticket` |
+| Tipos de negócio (detalhe / mutação) | `GET/POST/PATCH/DELETE /v1/tipos-negocio/{id}`, `POST /v1/tipos-negocio` |
+| Auditoria | `GET /v1/audit` |
+| Cadastro auxiliar (IBGE) | `POST /v1/cadastro-aux/municipios/sincronizar` |
+
+## Autenticado com escopo de setor (`obter_atendente_atual`)
+
+| Recurso | Comportamento |
+|---------|----------------|
+| **Tickets** | Listagem e operações respeitam setores visíveis; regras extra em `tickets.py` (responsável, fila, fechado, reabrir só admin). |
+| **Dashboard** | Agregações filtradas por setor para não admin. |
+| **Notificações** | Contagens e itens filtrados por setor / responsável. |
+| **GET /v1/setores** | Lista apenas setores aos quais o atendente está vinculado (e homônimos). |
+| **GET /v1/empresas** | Admin: modelo completo. Atendente: resumo mínimo (sem PII ampla) só de empresas cujas **redes** já tiveram ticket em algum dos seus setores (`select_rede_ids_com_ticket_nos_setores`). |
+| **GET /v1/atendentes/por-setor/{id}** | Só se o setor pertencer ao escopo do atendente (admin: qualquer). |
+| **GET /v1/atendentes/me** e **POST /v1/atendentes/me/trocar-senha** | Próprio utilizador. |
+| **Status / tipos de negócio — listagem** | `GET /v1/status-ticket`, `GET /v1/tipos-negocio` — leitura para UI de tickets (mutações continuam admin). |
+| **Cadastro auxiliar** | `GET` UFs/municípios/CEP: autenticado (evita uso anónimo de proxies externos). |
+
+## Referência de código
+
+- `app.core.auth`: `obter_atendente_atual`, `exigir_admin`.
+- `app.core.setor_scope`: `ids_setores_visiveis_atendente`, `ids_setores_mesmo_nome`, `responsavel_elegivel_para_setor_do_ticket`, `select_rede_ids_com_ticket_nos_setores`.
+- Testes: `backend/tests/test_rbac_tickets.py`, `test_rbac_catalogos.py`, `test_rbac_admin_only.py`.
+
+## Frontend (alinhamento)
+
+- **Menu**: grupos «Clientes» e «Configurações» só aparecem para `role === 'admin'` (`Sidebar.tsx`).
+- **Rotas**: páginas de cadastro usam `AdminRoute` em `App.tsx` — atendente vê `AcessoNegado` se aceder por URL.
+- **Tickets / novo ticket**: listas de **setores** e **empresas** seguem o filtro da API; não se recorta setor no cliente por `setor_ids` do `/me` (homônimos). Quando o atendente ainda não tem empresas no escopo, o UI explica o critério da rede com ticket nos setores dele.
+- **403**: mensagens vêm do corpo da API (`api/client` + `errorMessage.ts`).

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -14,6 +14,18 @@ const BASE = apiBaseUrl()
 /** Prefixo de versão da API (ex.: dev: `/api` + `/v1` + `/auth/login` → `/v1/auth/login` no backend). */
 export const API_VERSION_PREFIX = '/v1'
 
+export class ApiError extends Error {
+  status: number
+  body: unknown
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.body = body
+  }
+}
+
 const TOKEN_KEY = 'token'
 const REFRESH_TOKEN_KEY = 'refresh_token'
 
@@ -93,7 +105,7 @@ export async function api<T>(
     const err = await res.json().catch(() => ({}));
     let msg = mensagemErroApi(err, 401);
     if (msg.startsWith('Não foi possível concluir')) msg = 'E-mail ou senha inválidos.';
-    throw new Error(msg);
+    throw new ApiError(msg, 401, err);
   }
 
   if (res.status === 401) {
@@ -114,12 +126,12 @@ export async function api<T>(
     clearAuthToken()
     const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`
     window.location.href = `/login?returnTo=${encodeURIComponent(returnTo)}`
-    throw new Error(mensagemErroApi(err, 401));
+    throw new ApiError(mensagemErroApi(err, 401), 401, err);
   }
 
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
-    throw new Error(mensagemErroApi(err, res.status));
+    throw new ApiError(mensagemErroApi(err, res.status), res.status, err);
   }
   if (res.status === 204) return undefined as T;
   return res.json();

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -6,6 +6,12 @@ import { ThemeToggle } from './ThemeToggle'
 import { NavbarNotificacoes } from './NavbarNotificacoes'
 import { useAlertaFilaSemResponsavel } from '../hooks/useAlertaFilaSemResponsavel'
 
+function perfilExibicao(role: string | undefined): string {
+  if (role === 'admin') return 'Administrador'
+  if (role === 'atendente') return 'Atendente'
+  return role?.trim() || '—'
+}
+
 const menuIcon = (
   <svg className="size-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
@@ -32,7 +38,7 @@ export function Layout() {
         onMobileClose={() => setSidebarMobileOpen(false)}
         isAdmin={isAdmin ?? false}
         userNome={user?.nome ?? ''}
-        userRole={user?.role ?? ''}
+        userRole={perfilExibicao(user?.role)}
         onLogout={logout}
       />
 
@@ -88,7 +94,7 @@ export function Layout() {
             <ThemeToggle />
             <div className="hidden min-w-0 text-right sm:block">
               <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{user?.nome}</p>
-              <p className="truncate text-xs text-slate-500 dark:text-slate-400">{user?.role}</p>
+              <p className="truncate text-xs text-slate-500 dark:text-slate-400">{perfilExibicao(user?.role)}</p>
             </div>
           </header>
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -2,11 +2,12 @@ import { useState, useEffect, useMemo } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { Link } from 'react-router-dom'
-import { dashboard } from '../api/client'
+import { ApiError, dashboard } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { IconEye } from '../components/ui/IconEye'
 import { useToast } from '../components/ui/Toast'
+import { SemPermissao } from './SemPermissao'
 
 type ColunaUltimos = 'protocolo' | 'empresa' | 'assunto' | 'status'
 
@@ -17,14 +18,21 @@ export function Dashboard() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [reloadKey, setReloadKey] = useState(0)
+  const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
     setLoading(true)
     setError(null)
+    setForbidden(false)
     dashboard
       .get()
       .then(setData)
       .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          toast.showWarning(err.message || 'Você não tem permissão para ver o dashboard.')
+          return
+        }
         const msg = err instanceof Error ? err.message : 'Erro ao carregar'
         setError(msg)
         toast.showError(msg)
@@ -56,6 +64,19 @@ export function Dashboard() {
     return (
       <div className="flex min-h-[40vh] items-center justify-center">
         <span className="text-slate-500 dark:text-slate-400">Carregando dashboard...</span>
+      </div>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para acessar o dashboard."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil e vínculos de setor."
+          voltarPara="/tickets"
+          voltarLabel="Ir para Tickets"
+        />
       </div>
     )
   }

--- a/frontend/src/pages/SemPermissao.tsx
+++ b/frontend/src/pages/SemPermissao.tsx
@@ -1,0 +1,36 @@
+import { Link } from 'react-router-dom'
+
+export function SemPermissao({
+  title = 'Você não tem permissão para acessar este recurso.',
+  detail = 'Se isso estiver incorreto, solicite ao administrador o ajuste de setor/perfil.',
+  voltarPara = '/tickets',
+  voltarLabel = 'Ver tickets',
+}: {
+  title?: string
+  detail?: string
+  voltarPara?: string
+  voltarLabel?: string
+}) {
+  return (
+    <div className="mx-auto max-w-lg rounded-2xl border border-amber-200/80 bg-amber-50/90 p-6 text-amber-950 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
+      <p className="text-sm font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-300">403 — Sem permissão</p>
+      <h1 className="mt-2 text-lg font-semibold text-slate-900 dark:text-slate-100">{title}</h1>
+      <p className="mt-3 text-sm leading-relaxed text-slate-700 dark:text-slate-300">{detail}</p>
+      <div className="mt-6 flex flex-wrap gap-3">
+        <Link
+          to="/"
+          className="inline-flex rounded-lg bg-slate-900 px-4 py-2.5 text-sm font-medium text-white transition hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
+        >
+          Ir para o início
+        </Link>
+        <Link
+          to={voltarPara}
+          className="inline-flex rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
+        >
+          {voltarLabel}
+        </Link>
+      </div>
+    </div>
+  )
+}
+

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
-import { tickets, notificacoes, statusTicket, atendentes, setores, type StatusTicket, type Atendentes, type Setores, type Tickets } from '../api/client'
+import { ApiError, tickets, notificacoes, statusTicket, atendentes, setores, type StatusTicket, type Atendentes, type Setores, type Tickets } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
 import { Select } from '../components/ui/Select'
@@ -9,6 +9,7 @@ import { useToast } from '../components/ui/Toast'
 import { useAuth } from '../contexts/AuthContext'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { refetchPendenciasResumo } from '../hooks/useAlertaFilaSemResponsavel'
+import { SemPermissao } from './SemPermissao'
 
 const ROTULO_CAMPO: Record<string, string> = {
   status_id: 'Status',
@@ -96,6 +97,7 @@ export function TicketDetalhe() {
 
   const [loading, setLoading] = useState(true)
   const [notFound, setNotFound] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
   const [ticket, setTicket] = useState<Tickets.Ticket | null>(null)
   const [historico, setHistorico] = useState<Tickets.Historico[]>([])
   const [mensagens, setMensagens] = useState<Tickets.Mensagem[]>([])
@@ -118,14 +120,9 @@ export function TicketDetalhe() {
   const [modalGerirFoco, setModalGerirFoco] = useState<'geral' | 'setor' | 'status' | 'atendente'>('geral')
   const [historicoAberto, setHistoricoAberto] = useState(false)
 
-  const setorIdsPermitidos = useMemo(() => {
-    if (isAdmin) return null
-    return new Set(user?.setor_ids ?? [])
-  }, [isAdmin, user?.setor_ids])
-
   const setoresParaSelect = useMemo(() => {
     const ativos = setoresList.filter((s) => s.ativo)
-    let base = !setorIdsPermitidos ? ativos : ativos.filter((s) => setorIdsPermitidos.has(s.id))
+    let base = ativos
     if (ticket) {
       const cur = setoresList.find((s) => s.id === ticket.setor_id)
       if (cur && !base.some((s) => s.id === cur.id)) {
@@ -133,7 +130,7 @@ export function TicketDetalhe() {
       }
     }
     return [...base].sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR'))
-  }, [setoresList, setorIdsPermitidos, ticket])
+  }, [setoresList, ticket])
 
   /** Setor em edição no modal (ou do ticket); usado para priorizar atendentes vinculados a esse setor. */
   const setorAlvoModal = useMemo(() => {
@@ -221,10 +218,32 @@ export function TicketDetalhe() {
   useEffect(() => {
     coletarTodasPaginas<StatusTicket.Status>((o, l) =>
       statusTicket.list({ incluir_inativos: false, offset: o, limit: l }),
-    ).then(setStatusList)
+    )
+      .then(setStatusList)
+      .catch((err) => {
+        const msg =
+          err instanceof ApiError && err.status === 403
+            ? 'Você não tem permissão para listar status de ticket.'
+            : err instanceof Error
+              ? err.message
+              : 'Erro ao carregar status'
+        toast.showWarning(msg)
+        setStatusList([])
+      })
     coletarTodasPaginas<Setores.Setor>((o, l) =>
       setores.list({ incluir_inativos: true, offset: o, limit: l }),
-    ).then(setSetoresList)
+    )
+      .then(setSetoresList)
+      .catch((err) => {
+        const msg =
+          err instanceof ApiError && err.status === 403
+            ? 'Você não tem permissão para listar setores.'
+            : err instanceof Error
+              ? err.message
+              : 'Erro ao carregar setores'
+        toast.showWarning(msg)
+        setSetoresList([])
+      })
   }, [])
 
   /** Só administradores podem listar atendentes; depende de `user` para não rodar antes do /me. */
@@ -289,6 +308,7 @@ export function TicketDetalhe() {
     let cancelled = false
     setLoading(true)
     setNotFound(false)
+    setForbidden(false)
     Promise.all([tickets.get(numId), tickets.getHistorico(numId), tickets.listMensagens(numId)])
       .then(([t, h, m]) => {
         if (cancelled) return
@@ -303,8 +323,14 @@ export function TicketDetalhe() {
           .then(() => refetchPendenciasResumo())
           .catch(() => {})
       })
-      .catch(() => {
+      .catch((err) => {
         if (!cancelled) {
+          if (err instanceof ApiError && err.status === 403) {
+            setForbidden(true)
+            toast.showWarning(err.message || 'Sem permissão para este ticket.')
+            setNotFound(false)
+            return
+          }
           setTicket(null)
           setHistorico([])
           setMensagens([])
@@ -387,17 +413,9 @@ export function TicketDetalhe() {
     }
   }
 
-  const idsTicketSetorNome = useMemo(() => {
-    if (!ticket || setoresList.length === 0) return null
-    return idsSetoresMesmoNome(setoresList, ticket.setor_id)
-  }, [ticket, setoresList])
-
-  const podeAtribuirAMim =
-    !!ticket &&
-    !ticket.atendente_id &&
-    !!user &&
-    (isAdmin ||
-      (idsTicketSetorNome != null && (user.setor_ids ?? []).some((sid) => idsTicketSetorNome.has(sid))))
+  // Se o usuário conseguiu carregar o ticket, o backend já validou o escopo de setor.
+  // Aqui só bloqueamos o botão quando já existe responsável.
+  const podeAtribuirAMim = !!ticket && !ticket.atendente_id && !!user
 
   async function handleAtribuirAMim() {
     if (!ticket || !user || !podeAtribuirAMim) return
@@ -460,10 +478,23 @@ export function TicketDetalhe() {
     )
   }
 
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para acessar este ticket."
+          detail="Este chamado pertence a um setor fora do seu escopo. Se precisar, peça ao administrador para ajustar seus vínculos de setor."
+          voltarPara="/tickets"
+          voltarLabel="Voltar para Tickets"
+        />
+      </div>
+    )
+  }
+
   if (notFound || !ticket) {
     return (
       <div className="mx-auto max-w-6xl space-y-4 pb-10">
-        <p className="text-slate-600 dark:text-slate-400">Ticket não encontrado ou sem permissão.</p>
+        <p className="text-slate-600 dark:text-slate-400">Ticket não encontrado.</p>
         <button
           type="button"
           onClick={voltarAnterior}

--- a/frontend/src/pages/TicketNovo.tsx
+++ b/frontend/src/pages/TicketNovo.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { tickets, empresas, setores, type Empresas, type Setores } from '../api/client'
+import { ApiError, tickets, empresas, setores, type Empresas, type Setores } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
@@ -11,12 +11,14 @@ import { useToast } from '../components/ui/Toast'
 import { useAuth } from '../contexts/AuthContext'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { FormSection } from '../components/ui/FormSection'
+import { SemPermissao } from './SemPermissao'
 
 export function TicketNovo() {
-  const { isAdmin, user } = useAuth()
+  const { isAdmin } = useAuth()
   const toast = useToast()
   const navigate = useNavigate()
   const voltarAnterior = useVoltarAnterior('/tickets')
+  const [forbidden, setForbidden] = useState(false)
 
   const [empresasList, setEmpresasList] = useState<Empresas.EmpresaListaItem[]>([])
   const [setoresList, setSetoresList] = useState<Setores.Setor[]>([])
@@ -26,18 +28,11 @@ export function TicketNovo() {
   const [descricao, setDescricao] = useState('')
   const [loading, setLoading] = useState(false)
 
-  const setorIdsPermitidos = useMemo(() => {
-    if (isAdmin) return null
-    return new Set(user?.setor_ids ?? [])
-  }, [isAdmin, user?.setor_ids])
-
+  /** Setores já vêm filtrados pelo backend (#38); não restringir por `user.setor_ids` no cliente (evita perder homônimos). */
   const setoresFiltrados = useMemo(() => {
     const ativos = setoresList.filter((s) => s.ativo)
-    if (!setorIdsPermitidos) return ativos.sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR'))
-    return ativos
-      .filter((s) => setorIdsPermitidos.has(s.id))
-      .sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR'))
-  }, [setoresList, setorIdsPermitidos])
+    return [...ativos].sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR'))
+  }, [setoresList])
 
   const empresaItems = useMemo(
     () =>
@@ -50,12 +45,33 @@ export function TicketNovo() {
   )
 
   useEffect(() => {
-    coletarTodasPaginas<Empresas.EmpresaListaItem>((o, l) => empresas.list({ offset: o, limit: l })).then(
-      setEmpresasList,
-    )
-    coletarTodasPaginas<Setores.Setor>((o, l) =>
-      setores.list({ incluir_inativos: true, offset: o, limit: l }),
-    ).then(setSetoresList)
+    setForbidden(false)
+    coletarTodasPaginas<Empresas.EmpresaListaItem>((o, l) => empresas.list({ offset: o, limit: l }))
+      .then(setEmpresasList)
+      .catch((err) => {
+        const msg =
+          err instanceof ApiError && err.status === 403
+            ? 'Você não tem permissão para listar empresas.'
+            : err instanceof Error
+              ? err.message
+              : 'Erro ao carregar empresas'
+        toast.showWarning(msg)
+        setEmpresasList([])
+        if (err instanceof ApiError && err.status === 403) setForbidden(true)
+      })
+    coletarTodasPaginas<Setores.Setor>((o, l) => setores.list({ incluir_inativos: true, offset: o, limit: l }))
+      .then(setSetoresList)
+      .catch((err) => {
+        const msg =
+          err instanceof ApiError && err.status === 403
+            ? 'Você não tem permissão para listar setores.'
+            : err instanceof Error
+              ? err.message
+              : 'Erro ao carregar setores'
+        toast.showWarning(msg)
+        setSetoresList([])
+        if (err instanceof ApiError && err.status === 403) setForbidden(true)
+      })
   }, [])
 
   useEffect(() => {
@@ -69,10 +85,6 @@ export function TicketNovo() {
     e.preventDefault()
     if (!empresaId || !setorId || !assunto.trim() || !descricao.trim()) {
       toast.showWarning('Preencha empresa, setor, assunto e o relato do problema.')
-      return
-    }
-    if (!isAdmin && !setorIdsPermitidos?.has(Number(setorId))) {
-      toast.showWarning('Selecione um setor ao qual você tenha acesso.')
       return
     }
     setLoading(true)
@@ -94,6 +106,20 @@ export function TicketNovo() {
   }
 
   const semSetorPermitido = !isAdmin && setoresFiltrados.length === 0
+  const semEmpresasNoEscopo = !isAdmin && !semSetorPermitido && empresasList.length === 0
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para abrir tickets."
+          detail="Seu usuário não conseguiu carregar setores/empresas necessários para criar um chamado. Peça ao administrador para ajustar seu perfil e vínculos de setor."
+          voltarPara="/tickets"
+          voltarLabel="Voltar para Tickets"
+        />
+      </div>
+    )
+  }
 
   return (
     <div className="mx-auto max-w-3xl space-y-6 pb-10">
@@ -120,6 +146,14 @@ export function TicketNovo() {
         </div>
       )}
 
+      {semEmpresasNoEscopo && (
+        <div className="rounded-lg border border-sky-200 bg-sky-50 px-4 py-3 text-sm text-sky-950 dark:border-sky-800/60 dark:bg-sky-950/40 dark:text-sky-100">
+          Ainda não há empresas listáveis no seu escopo: a API só mostra clientes de redes que já tiveram ticket nos setores
+          que você atende. Peça a um administrador para registrar o primeiro chamado dessa rede (ou ajustar cadastro), ou
+          use uma empresa que já apareça na lista de tickets.
+        </div>
+      )}
+
       <Card title="Abrir ticket">
         <p className="mb-4 text-sm text-slate-600 dark:text-slate-400">
           O ticket entra na <strong>fila do setor</strong> (sem responsável). Qualquer atendente do setor pode abrir o chamado e usar{' '}
@@ -136,7 +170,7 @@ export function TicketNovo() {
                 items={empresaItems}
                 placeholder="Buscar empresa..."
                 required
-                disabled={semSetorPermitido}
+                disabled={semSetorPermitido || semEmpresasNoEscopo}
                 recentCount={10}
               />
 
@@ -150,10 +184,12 @@ export function TicketNovo() {
                   includeEmpty
                   emptyLabel="Selecione"
                   placeholder="Selecione"
-                  disabled={semSetorPermitido}
+                  disabled={semSetorPermitido || semEmpresasNoEscopo}
                 />
                 {!isAdmin && setoresFiltrados.length > 0 && (
-                  <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">Somente setores aos quais você está vinculado.</p>
+                  <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                    Lista conforme os setores que você atende no sistema (inclui homônimos no cadastro).
+                  </p>
                 )}
               </div>
             </FormSection>
@@ -164,7 +200,7 @@ export function TicketNovo() {
                 value={assunto}
                 onChange={(e) => setAssunto(e.target.value)}
                 required
-                disabled={semSetorPermitido}
+                disabled={semSetorPermitido || semEmpresasNoEscopo}
               />
               <div>
                 <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">Relato do problema *</label>
@@ -177,7 +213,7 @@ export function TicketNovo() {
                   spellCheck={false}
                   rows={5}
                   required
-                  disabled={semSetorPermitido}
+                  disabled={semSetorPermitido || semEmpresasNoEscopo}
                   className="w-full rounded-xl border-0 bg-white px-3 py-2 text-sm shadow-sm ring-1 ring-slate-200/90 focus:outline-none focus:ring-2 focus:ring-slate-400/35 dark:bg-slate-900 dark:text-slate-100 dark:ring-slate-700"
                 />
               </div>
@@ -189,7 +225,12 @@ export function TicketNovo() {
               <Button type="button" variant="secondary" onClick={voltarAnterior} className="w-full sm:w-auto">
                 Cancelar
               </Button>
-              <Button type="submit" loading={loading} disabled={semSetorPermitido} className="w-full sm:w-auto">
+              <Button
+                type="submit"
+                loading={loading}
+                disabled={semSetorPermitido || semEmpresasNoEscopo}
+                className="w-full sm:w-auto"
+              >
                 Criar ticket
               </Button>
             </div>

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -6,6 +6,7 @@ import {
   empresas,
   setores,
   atendentes,
+  ApiError,
   type Tickets,
   type StatusTicket,
   type Empresas,
@@ -21,6 +22,7 @@ import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { useAuth } from '../contexts/AuthContext'
 import { useAlertaFilaSemResponsavel } from '../hooks/useAlertaFilaSemResponsavel'
+import { SemPermissao } from './SemPermissao'
 
 type ColunaOrdenacao =
   | 'protocolo'
@@ -44,6 +46,7 @@ export function Tickets() {
   const toast = useToast()
   const { isAdmin, user } = useAuth()
   useAlertaFilaSemResponsavel(Boolean(user))
+  const [forbidden, setForbidden] = useState(false)
 
   const situacao = useMemo<'abertos' | 'fechados'>(() => {
     const s = searchParams.get('situacao')
@@ -75,13 +78,11 @@ export function Tickets() {
 
   const resetarPagina = useCallback(() => setPage(1), [])
 
+  /** Setores vêm filtrados pelo backend para atendentes; não recortar por `user.setor_ids` no cliente. */
   const setoresFiltro = useMemo(() => {
     const ativos = setoresOpt.filter((s) => s.ativo)
-    const sorted = [...ativos].sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR'))
-    if (isAdmin) return sorted
-    const ids = new Set(user?.setor_ids ?? [])
-    return sorted.filter((s) => ids.has(s.id))
-  }, [isAdmin, user?.setor_ids, setoresOpt])
+    return [...ativos].sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR'))
+  }, [setoresOpt])
 
   const empresasOrdenadas = useMemo(
     () => [...empresasOpt].sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR')),
@@ -190,6 +191,7 @@ export function Tickets() {
 
   useEffect(() => {
     setLoading(true)
+    setForbidden(false)
     tickets
       .list({
         situacao,
@@ -209,7 +211,14 @@ export function Tickets() {
         setList(items)
         setTotal(t)
       })
-      .catch(() => {
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          toast.showWarning(err.message || 'Você não tem permissão para ver estes tickets.')
+          setList([])
+          setTotal(0)
+          return
+        }
         toast.showWarning('Não foi possível carregar os tickets.')
         setList([])
         setTotal(0)
@@ -230,6 +239,19 @@ export function Tickets() {
     sortParams,
     toast,
   ])
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para listar tickets."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil e seus vínculos de setor."
+          voltarPara="/"
+          voltarLabel="Voltar para o Dashboard"
+        />
+      </div>
+    )
+  }
 
   function limparFiltros() {
     setBusca('')
@@ -403,20 +425,28 @@ export function Tickets() {
               aria-labelledby={`${painelFiltrosId}-toggle`}
               className="mt-6 grid gap-4 border-t border-slate-200/70 pt-5 dark:border-slate-800 sm:grid-cols-2 lg:grid-cols-3"
             >
-              <Select
-                label="Empresa"
-                labelStyle="overline"
-                className="min-w-0"
-                value={filtroEmpresa}
-                onChange={(v) => {
-                  setFiltroEmpresa(v === '' ? '' : Number(v))
-                  resetarPagina()
-                }}
-                options={opcoesEmpresaFiltro}
-                includeEmpty
-                emptyLabel="Todas"
-                placeholder="Todas"
-              />
+              <div className="min-w-0 sm:col-span-2 lg:col-span-1">
+                <Select
+                  label="Empresa"
+                  labelStyle="overline"
+                  className="min-w-0"
+                  value={filtroEmpresa}
+                  onChange={(v) => {
+                    setFiltroEmpresa(v === '' ? '' : Number(v))
+                    resetarPagina()
+                  }}
+                  options={opcoesEmpresaFiltro}
+                  includeEmpty
+                  emptyLabel="Todas"
+                  placeholder="Todas"
+                />
+                {!isAdmin && empresasOpt.length === 0 && (
+                  <p className="mt-1.5 text-xs leading-relaxed text-slate-500 dark:text-slate-400">
+                    Empresas no filtro aparecem só para redes que já tiveram ticket nos setores que você atende. Até lá,
+                    use a busca por protocolo ou assunto.
+                  </p>
+                )}
+              </div>
               <Select
                 label="Setor"
                 labelStyle="overline"


### PR DESCRIPTION
## Summary
- Aplica RBAC em catálogos: atendente lista apenas setores do seu escopo e empresas (resumo) restritas a redes que já tiveram tickets nos setores do atendente.
- Adiciona testes de RBAC (catálogos e rotas admin-only) e documentação (docs/BACKEND_RBAC.md).
- Alinha frontend ao RBAC: evita filtro duplicado por setor_ids, melhora mensagens e diferencia 403 vs 404 com página padrão SemPermissao.

## Test plan
- [x] docker compose run --rm --no-deps backend pytest -q
- [x] VITE_API_URL=https://ci.invalid.example npm run build (frontend)

## Notes
- docker-compose.yml passa a montar ./backend:/app para que alterações em 	ests/ não exijam rebuild.

Made with [Cursor](https://cursor.com)