### PR TITLE
feat(ux): mostrar/ocultar senha

### DIFF
--- a/frontend/src/components/ui/IconEye.tsx
+++ b/frontend/src/components/ui/IconEye.tsx
@@ -23,3 +23,22 @@ export function IconEye({ className = 'size-5', ariaHidden = true }: IconEyeProp
   )
 }
 
+export function IconEyeOff({ className = 'size-5', ariaHidden = true }: IconEyeProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden={ariaHidden}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"
+      />
+    </svg>
+  )
+}
+

--- a/frontend/src/pages/AlterarSenha.tsx
+++ b/frontend/src/pages/AlterarSenha.tsx
@@ -4,6 +4,7 @@ import { atendentes } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
+import { IconEye, IconEyeOff } from '../components/ui/IconEye'
 
 const fieldClass =
   'w-full rounded-xl border border-slate-200 bg-white px-3.5 py-3 text-[0.9375rem] text-slate-900 shadow-inner placeholder:text-slate-400 focus:border-cyan-500/50 focus:outline-none focus:ring-2 focus:ring-cyan-400/25 dark:border-white/10 dark:bg-white/[0.06] dark:text-slate-100 dark:placeholder:text-slate-500'
@@ -12,6 +13,9 @@ export function AlterarSenha() {
   const [senhaAtual, setSenhaAtual] = useState('')
   const [senhaNova, setSenhaNova] = useState('')
   const [senhaConf, setSenhaConf] = useState('')
+  const [mostrarAtual, setMostrarAtual] = useState(false)
+  const [mostrarNova, setMostrarNova] = useState(false)
+  const [mostrarConf, setMostrarConf] = useState(false)
   const [loading, setLoading] = useState(false)
   const { refreshUser } = useAuth()
   const navigate = useNavigate()
@@ -53,45 +57,78 @@ export function AlterarSenha() {
             <label htmlFor="pwd-atual" className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">
               Senha atual
             </label>
-            <input
-              id="pwd-atual"
-              type="password"
-              value={senhaAtual}
-              onChange={(e) => setSenhaAtual(e.target.value)}
-              autoComplete="current-password"
-              className={fieldClass}
-              required
-            />
+            <div className="relative">
+              <input
+                id="pwd-atual"
+                type={mostrarAtual ? 'text' : 'password'}
+                value={senhaAtual}
+                onChange={(e) => setSenhaAtual(e.target.value)}
+                autoComplete="current-password"
+                className={`${fieldClass} pr-12`}
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setMostrarAtual((v) => !v)}
+                className="absolute right-1.5 top-1/2 flex size-10 -translate-y-1/2 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/30 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-200"
+                aria-label={mostrarAtual ? 'Ocultar senha atual' : 'Mostrar senha atual'}
+                aria-pressed={mostrarAtual}
+              >
+                {mostrarAtual ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
+              </button>
+            </div>
           </div>
           <div>
             <label htmlFor="pwd-nova" className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">
               Nova senha
             </label>
-            <input
-              id="pwd-nova"
-              type="password"
-              value={senhaNova}
-              onChange={(e) => setSenhaNova(e.target.value)}
-              autoComplete="new-password"
-              className={fieldClass}
-              minLength={8}
-              required
-            />
+            <div className="relative">
+              <input
+                id="pwd-nova"
+                type={mostrarNova ? 'text' : 'password'}
+                value={senhaNova}
+                onChange={(e) => setSenhaNova(e.target.value)}
+                autoComplete="new-password"
+                className={`${fieldClass} pr-12`}
+                minLength={8}
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setMostrarNova((v) => !v)}
+                className="absolute right-1.5 top-1/2 flex size-10 -translate-y-1/2 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/30 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-200"
+                aria-label={mostrarNova ? 'Ocultar nova senha' : 'Mostrar nova senha'}
+                aria-pressed={mostrarNova}
+              >
+                {mostrarNova ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
+              </button>
+            </div>
           </div>
           <div>
             <label htmlFor="pwd-conf" className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">
               Confirmar nova senha
             </label>
-            <input
-              id="pwd-conf"
-              type="password"
-              value={senhaConf}
-              onChange={(e) => setSenhaConf(e.target.value)}
-              autoComplete="new-password"
-              className={fieldClass}
-              minLength={8}
-              required
-            />
+            <div className="relative">
+              <input
+                id="pwd-conf"
+                type={mostrarConf ? 'text' : 'password'}
+                value={senhaConf}
+                onChange={(e) => setSenhaConf(e.target.value)}
+                autoComplete="new-password"
+                className={`${fieldClass} pr-12`}
+                minLength={8}
+                required
+              />
+              <button
+                type="button"
+                onClick={() => setMostrarConf((v) => !v)}
+                className="absolute right-1.5 top-1/2 flex size-10 -translate-y-1/2 items-center justify-center rounded-lg text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/30 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-200"
+                aria-label={mostrarConf ? 'Ocultar confirmação' : 'Mostrar confirmação'}
+                aria-pressed={mostrarConf}
+              >
+                {mostrarConf ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
+              </button>
+            </div>
           </div>
           <Button type="submit" className="w-full" loading={loading}>
             Salvar e continuar

--- a/frontend/src/pages/Atendentes.tsx
+++ b/frontend/src/pages/Atendentes.tsx
@@ -6,6 +6,7 @@ import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { Input } from '../components/ui/Input'
+import { IconEye, IconEyeOff } from '../components/ui/IconEye'
 import { IconPencil } from '../components/ui/IconPencil'
 import { FiltroInativos } from '../components/ui/FiltroInativos'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
@@ -35,6 +36,7 @@ export function Atendentes() {
   const [email, setEmail] = useState('')
   const [nome, setNome] = useState('')
   const [senha, setSenha] = useState('')
+  const [mostrarSenha, setMostrarSenha] = useState(false)
   const [role, setRole] = useState<'admin' | 'atendente'>('atendente')
   const [ativo, setAtivo] = useState(true)
   const [setorIds, setSetorIds] = useState<number[]>([])
@@ -95,6 +97,7 @@ export function Atendentes() {
     setEmail('')
     setNome('')
     setSenha('')
+    setMostrarSenha(false)
     setRole('atendente')
     setAtivo(true)
     setSetorIds([])
@@ -106,6 +109,7 @@ export function Atendentes() {
     setEmail(item.email)
     setNome(item.nome)
     setSenha('')
+    setMostrarSenha(false)
     setRole((item.role as 'admin') || 'atendente')
     setAtivo(item.ativo)
     setSetorIds(item.setor_ids ?? [])
@@ -239,10 +243,21 @@ export function Atendentes() {
                   <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
                   <Input
                     label={editingId ? 'Nova senha (deixe em branco para manter)' : 'Senha'}
-                    type="password"
+                    type={mostrarSenha ? 'text' : 'password'}
                     value={senha}
                     onChange={(e) => setSenha(e.target.value)}
                     required={!editingId}
+                    endAdornment={
+                      <button
+                        type="button"
+                        onClick={() => setMostrarSenha((v) => !v)}
+                        className="inline-flex size-9 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/30 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-200"
+                        aria-label={mostrarSenha ? 'Ocultar senha' : 'Mostrar senha'}
+                        aria-pressed={mostrarSenha}
+                      >
+                        {mostrarSenha ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
+                      </button>
+                    }
                   />
                   <Select
                     label="Perfil"


### PR DESCRIPTION
## Summary
- Adiciona ícone de olho (mostrar/ocultar) nos campos de senha em:
  - AlterarSenha (senha atual, nova e confirmação)
  - Atendentes (senha no modal de criar/editar)

## Test plan
- [x] VITE_API_URL=https://ci.invalid.example npm run build

