### PR TITLE
fix(ux): padronizar 403/404 em telas de detalhe

### DIFF
--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import {
+  ApiError,
   empresas as apiEmpresas,
   redes,
   tiposNegocio,
@@ -18,6 +19,7 @@ import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBus
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { TicketsTabelaContexto } from '../components/TicketsTabelaContexto'
 import { FuncionariosEmpresaLista } from '../components/FuncionariosEmpresaLista'
+import { SemPermissao } from './SemPermissao'
 type Aba = 'geral' | 'tickets' | 'funcionarios'
 
 function DetailRow({ label, value }: { label: string; value: string | null | undefined }) {
@@ -42,6 +44,7 @@ export function EmpresaDetalhe() {
   const [tipoNegocioNome, setTipoNegocioNome] = useState<string>('')
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
   const [aba, setAba] = useState<Aba>('geral')
 
   const [pageT, setPageT] = useState(1)
@@ -67,6 +70,7 @@ export function EmpresaDetalhe() {
     let cancelled = false
     setLoading(true)
     setLoadError(false)
+    setForbidden(false)
     apiEmpresas
       .get(empresaId)
       .then(async (e) => {
@@ -87,8 +91,13 @@ export function EmpresaDetalhe() {
           }
         } else if (!cancelled) setTipoNegocioNome('')
       })
-      .catch(() => {
+      .catch((err) => {
         if (!cancelled) {
+          if (err instanceof ApiError && err.status === 403) {
+            setForbidden(true)
+            setEmpresa(null)
+            return
+          }
           setLoadError(true)
           setEmpresa(null)
         }
@@ -163,12 +172,6 @@ export function EmpresaDetalhe() {
     }
   }, [aba, empresaId, pageF, debouncedBuscaF])
 
-  useEffect(() => {
-    if (!loadError || loading) return
-    toast.showWarning('Empresa não encontrada.')
-    navigate('/empresas', { replace: true })
-  }, [loadError, loading, navigate, toast])
-
   function abrirEdicao() {
     if (!empresa) return
     navigate('/empresas', { state: { empresaEditId: empresa.id } })
@@ -191,6 +194,34 @@ export function EmpresaDetalhe() {
         <div className="h-4 w-24 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
         <div className="h-9 w-2/3 max-w-md animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </div>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para acessar esta empresa."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/empresas"
+          voltarLabel="Voltar para Empresas"
+        />
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-4 pb-10">
+        <p className="text-slate-600 dark:text-slate-400">Empresa não encontrada.</p>
+        <button
+          type="button"
+          onClick={voltarAnterior}
+          className="font-medium text-slate-800 underline decoration-slate-400 underline-offset-2 hover:text-slate-950 dark:text-slate-200 dark:hover:text-white"
+        >
+          Voltar
+        </button>
       </div>
     )
   }

--- a/frontend/src/pages/FuncionarioRedeDetalhe.tsx
+++ b/frontend/src/pages/FuncionarioRedeDetalhe.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { funcionariosRede, redes, empresas, type FuncionariosRede } from '../api/client'
+import { ApiError, funcionariosRede, redes, empresas, type FuncionariosRede } from '../api/client'
 import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { SemPermissao } from './SemPermissao'
 
 const tipoLabel: Record<string, string> = {
   socio: 'Sócio',
@@ -33,6 +34,7 @@ export function FuncionarioRedeDetalhe() {
   const [vinculoExtra, setVinculoExtra] = useState<ReactNode>(null)
   const [loading, setLoading] = useState(true)
   const [loadError, setLoadError] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
     if (!id || isNaN(funcionarioId)) {
@@ -43,6 +45,7 @@ export function FuncionarioRedeDetalhe() {
     let cancelled = false
     setLoading(true)
     setLoadError(false)
+    setForbidden(false)
     setVinculoExtra(null)
 
     funcionariosRede
@@ -127,8 +130,13 @@ export function FuncionarioRedeDetalhe() {
           setVinculoExtra(null)
         }
       })
-      .catch(() => {
+      .catch((err) => {
         if (!cancelled) {
+          if (err instanceof ApiError && err.status === 403) {
+            setForbidden(true)
+            setF(null)
+            return
+          }
           setLoadError(true)
           setF(null)
         }
@@ -141,12 +149,6 @@ export function FuncionarioRedeDetalhe() {
       cancelled = true
     }
   }, [id, funcionarioId])
-
-  useEffect(() => {
-    if (!loadError || loading) return
-    toast.showWarning('Funcionário não encontrado.')
-    voltarAnterior()
-  }, [loadError, loading, toast, voltarAnterior])
 
   function abrirEdicao() {
     if (!f) return
@@ -170,6 +172,34 @@ export function FuncionarioRedeDetalhe() {
         <div className="h-4 w-40 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
         <div className="h-9 w-2/3 max-w-md animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-48 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </div>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para acessar este funcionário."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/funcionarios-rede"
+          voltarLabel="Voltar para Funcionários"
+        />
+      </div>
+    )
+  }
+
+  if (loadError) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-4 pb-10">
+        <p className="text-slate-600 dark:text-slate-400">Funcionário não encontrado.</p>
+        <button
+          type="button"
+          onClick={voltarAnterior}
+          className="font-medium text-slate-800 underline decoration-slate-400 underline-offset-2 hover:text-slate-950 dark:text-slate-200 dark:hover:text-white"
+        >
+          Voltar
+        </button>
       </div>
     )
   }

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { funcionariosRede, redes, empresas, type FuncionariosRede, type Redes, type Empresas } from '../api/client'
+import { ApiError, funcionariosRede, redes, empresas, type FuncionariosRede, type Redes, type Empresas } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
@@ -12,6 +12,7 @@ import { CheckboxField } from '../components/ui/CheckboxField'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { FormSection } from '../components/ui/FormSection'
+import { SemPermissao } from './SemPermissao'
 
 type Tipo = 'socio' | 'supervisor' | 'colaborador'
 
@@ -31,6 +32,8 @@ export function FuncionarioRedeForm() {
 
   const [loading, setLoading] = useState(isEdit)
   const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [notFound, setNotFound] = useState(false)
 
   const [redesList, setRedesList] = useState<Redes.Rede[]>([])
   const [empresasList, setEmpresasList] = useState<Empresas.Empresa[]>([])
@@ -67,6 +70,8 @@ export function FuncionarioRedeForm() {
     }
     let cancelled = false
     setLoading(true)
+    setForbidden(false)
+    setNotFound(false)
     funcionariosRede
       .get(funcionarioId)
       .then((item) => {
@@ -88,10 +93,17 @@ export function FuncionarioRedeForm() {
         setEmpresaId(item.empresa_id ?? '')
         setEmpresaIds(item.empresa_ids ?? [])
       })
-      .catch(() => {
+      .catch((err) => {
         if (!cancelled) {
-          toast.showWarning('Funcionário não encontrado.')
-          voltarAnterior()
+          if (err instanceof ApiError && err.status === 403) {
+            setForbidden(true)
+            return
+          }
+          if (err instanceof ApiError && err.status === 404) {
+            setNotFound(true)
+            return
+          }
+          toast.showWarning(err instanceof Error ? err.message : 'Erro ao carregar funcionário.')
         }
       })
       .finally(() => {
@@ -178,6 +190,34 @@ export function FuncionarioRedeForm() {
       <div className="mx-auto max-w-3xl space-y-6">
         <div className="h-9 w-56 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-72 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </div>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-5xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para editar este funcionário."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/funcionarios-rede"
+          voltarLabel="Voltar para Funcionários"
+        />
+      </div>
+    )
+  }
+
+  if (notFound) {
+    return (
+      <div className="mx-auto max-w-5xl space-y-4 pb-10">
+        <p className="text-slate-600 dark:text-slate-400">Funcionário não encontrado.</p>
+        <button
+          type="button"
+          onClick={voltarAnterior}
+          className="font-medium text-slate-800 underline decoration-slate-400 underline-offset-2 hover:text-slate-950 dark:text-slate-200 dark:hover:text-white"
+        >
+          Voltar
+        </button>
       </div>
     )
   }

--- a/frontend/src/pages/SetorDetalhe.tsx
+++ b/frontend/src/pages/SetorDetalhe.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { atendentes, setores, type Atendentes, type Setores } from '../api/client'
+import { ApiError, atendentes, setores, type Atendentes, type Setores } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { SelectComPesquisa } from '../components/ui/SelectComPesquisa'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { SemPermissao } from './SemPermissao'
 
 /** Mesmo nome de setor = mesmo “setor lógico” (vários IDs no banco). */
 function idsSetoresMesmoNome(setoresList: Setores.Setor[], setorId: number): Set<number> {
@@ -26,6 +27,7 @@ export function SetorDetalhe() {
   const [loading, setLoading] = useState(true)
   const [setor, setSetor] = useState<Setores.Setor | null>(null)
   const [setoresList, setSetoresList] = useState<Setores.Setor[]>([])
+  const [forbidden, setForbidden] = useState(false)
 
   const [vinculados, setVinculados] = useState<Atendentes.Atendente[]>([])
   const [todosAtendentes, setTodosAtendentes] = useState<Atendentes.Atendente[]>([])
@@ -60,6 +62,7 @@ export function SetorDetalhe() {
       return
     }
     setLoading(true)
+    setForbidden(false)
     try {
       const [s, setoresAll, todos] = await Promise.all([
         setores.get(setorId),
@@ -75,6 +78,12 @@ export function SetorDetalhe() {
       const vinculadosDoGrupo = await atendentes.listPorSetor(setorId, { incluir_inativos: true })
       setVinculados(vinculadosDoGrupo)
     } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        setForbidden(true)
+        setSetor(null)
+        setVinculados([])
+        return
+      }
       setSetor(null)
       setVinculados([])
       toast.showError(err instanceof Error ? err.message : 'Erro ao carregar setor')
@@ -133,6 +142,19 @@ export function SetorDetalhe() {
     return (
       <div className="flex min-h-[40vh] items-center justify-center text-slate-500 dark:text-slate-400">
         Carregando setor…
+      </div>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para acessar este setor."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/setores"
+          voltarLabel="Voltar para Setores"
+        />
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- Padroniza o tratamento de erro em telas de detalhe/form (empresa, funcion?rio de rede, setor):
  - **403**: exibe `SemPermissao`
  - **404**: exibe estado de "n?o encontrado" com bot?o voltar
- Evita redirecionamento autom?tico em falha de carregamento (menos confus?o para o usu?rio).

## Test plan
- [x] `VITE_API_URL=https://ci.invalid.example npm run build`
