### PR TITLE
feat(ux): padronizar 403/404, falhas de carga e toasts por contexto

### DIFF
--- a/frontend/src/api/errorMessage.ts
+++ b/frontend/src/api/errorMessage.ts
@@ -39,3 +39,71 @@ export function mensagemErroApi(body: unknown, status: number): string {
   if (status >= 500) return 'Serviço indisponível no momento. Tente novamente em instantes.'
   return `Não foi possível concluir a solicitação (código ${status}).`
 }
+
+/** Falhas antes de resposta HTTP (rede, CORS, host inexistente). */
+export function isErroRedeOuConexao(err: unknown): boolean {
+  if (typeof TypeError !== 'undefined' && err instanceof TypeError) return true
+  if (err instanceof DOMException && err.name === 'AbortError') return false
+  const msg = err instanceof Error ? err.message : String(err)
+  return /failed to fetch|networkerror|load failed|network request failed/i.test(msg)
+}
+
+function statusEmErroApi(err: unknown): number | null {
+  if (err !== null && typeof err === 'object' && 'status' in err) {
+    const s = (err as { status: unknown }).status
+    return typeof s === 'number' && Number.isFinite(s) ? s : null
+  }
+  return null
+}
+
+function corpoEmErroApi(err: unknown): unknown {
+  if (err !== null && typeof err === 'object' && 'body' in err) {
+    return (err as { body: unknown }).body
+  }
+  return undefined
+}
+
+/**
+ * Mensagens para telas que substituem o conteúdo por erro (detalhe, edição).
+ * @param textoNaoEncontrado Frase exibida quando a API responde 404 (ex.: "Empresa não encontrada.").
+ */
+export function interpretarFalhaCarregamento(
+  err: unknown,
+  textoNaoEncontrado: string,
+): { titulo: string; detalhe?: string } {
+  const status = statusEmErroApi(err)
+  if (status === 404) {
+    return { titulo: textoNaoEncontrado }
+  }
+  if (err instanceof Error && err.name === 'ApiError' && status != null) {
+    const m = err.message.trim() || mensagemErroApi(corpoEmErroApi(err), status)
+    if (status >= 500) {
+      return {
+        titulo: m || 'Serviço indisponível no momento.',
+        detalhe: 'Tente novamente em alguns instantes.',
+      }
+    }
+    return { titulo: m || 'Não foi possível carregar os dados.' }
+  }
+  if (isErroRedeOuConexao(err)) {
+    return {
+      titulo: 'Não foi possível conectar ao servidor.',
+      detalhe: 'Verifique sua internet ou se o serviço está no ar e tente de novo.',
+    }
+  }
+  if (err instanceof Error && err.message.trim()) {
+    return { titulo: err.message.trim() }
+  }
+  return {
+    titulo: 'Não foi possível carregar os dados.',
+    detalhe: 'Tente novamente em alguns instantes.',
+  }
+}
+
+/**
+ * Toast / alerta curto quando uma listagem ou ação falha (sem tela dedicada).
+ * @param texto404 Frase quando a API responde 404 (padrão: registro genérico).
+ */
+export function mensagemFalhaParaToast(err: unknown, texto404 = 'Registro não encontrado.'): string {
+  return interpretarFalhaCarregamento(err, texto404).titulo
+}

--- a/frontend/src/components/ui/CarregamentoFalhou.tsx
+++ b/frontend/src/components/ui/CarregamentoFalhou.tsx
@@ -1,0 +1,29 @@
+type Props = {
+  titulo: string
+  detalhe?: string
+  onVoltar: () => void
+  voltarLabel?: string
+  className?: string
+}
+
+export function CarregamentoFalhou({
+  titulo,
+  detalhe,
+  onVoltar,
+  voltarLabel = 'Voltar',
+  className = 'mx-auto max-w-6xl space-y-4 pb-10',
+}: Props) {
+  return (
+    <div className={className}>
+      <p className="text-slate-800 dark:text-slate-100">{titulo}</p>
+      {detalhe ? <p className="text-sm text-slate-600 dark:text-slate-400">{detalhe}</p> : null}
+      <button
+        type="button"
+        onClick={onVoltar}
+        className="font-medium text-slate-800 underline decoration-slate-400 underline-offset-2 hover:text-slate-950 dark:text-slate-200 dark:hover:text-white"
+      >
+        {voltarLabel}
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/Atendentes.tsx
+++ b/frontend/src/pages/Atendentes.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
-import { atendentes, setores, type Atendentes, type Setores } from '../api/client'
+import { ApiError, atendentes, setores, type Atendentes, type Setores } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
@@ -15,6 +15,8 @@ import { CheckboxField } from '../components/ui/CheckboxField'
 import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
 import { FormSection } from '../components/ui/FormSection'
+import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 type ColunaAtendente = 'nome' | 'email' | 'role'
 
@@ -41,6 +43,7 @@ export function Atendentes() {
   const [ativo, setAtivo] = useState(true)
   const [setorIds, setSetorIds] = useState<number[]>([])
   const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
     if (!modalOpen) return
@@ -62,6 +65,7 @@ export function Atendentes() {
 
   const load = useCallback(() => {
     setLoading(true)
+    setForbidden(false)
     atendentes
       .list({
         incluir_inativos: incluirInativos,
@@ -77,7 +81,11 @@ export function Atendentes() {
       .catch((err) => {
         setList([])
         setTotal(0)
-        toast.showError(err instanceof Error ? err.message : 'Erro ao carregar atendentes')
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        toast.showError(mensagemFalhaParaToast(err, 'Não encontramos a lista de atendentes.'))
       })
       .finally(() => setLoading(false))
   }, [debouncedBusca, incluirInativos, page, sortParams, toast])
@@ -152,6 +160,19 @@ export function Atendentes() {
     } finally {
       setSaving(false)
     }
+  }
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para listar atendentes."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/"
+          voltarLabel="Voltar para o Dashboard"
+        />
+      </div>
+    )
   }
 
   return (

--- a/frontend/src/pages/Auditoria.tsx
+++ b/frontend/src/pages/Auditoria.tsx
@@ -1,10 +1,13 @@
 import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
-import { audit, type Audit } from '../api/client'
+import { ApiError, audit, type Audit } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
 import { Select } from '../components/ui/Select'
+import { useToast } from '../components/ui/Toast'
+import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 const entityTypeLabel: Record<string, string> = {
   rede: 'Rede',
@@ -23,6 +26,7 @@ const actionLabel: Record<string, string> = {
 type ColunaAudit = 'created_at' | 'entity_type' | 'entity_id' | 'action' | 'atendente'
 
 export function Auditoria() {
+  const toast = useToast()
   const { ordenarPor, ordem, aoOrdenarColuna, sortParams } = useOrdenacaoLista<ColunaAudit>()
   const [list, setList] = useState<Audit.AuditLogEntry[]>([])
   const [total, setTotal] = useState(0)
@@ -31,6 +35,7 @@ export function Auditoria() {
   const [debouncedBusca, setDebouncedBusca] = useState('')
   const [loading, setLoading] = useState(true)
   const [filtroTipo, setFiltroTipo] = useState<string>('')
+  const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -39,6 +44,7 @@ export function Auditoria() {
 
   const load = useCallback(() => {
     setLoading(true)
+    setForbidden(false)
     audit
       .list({
         entity_type: filtroTipo || undefined,
@@ -51,16 +57,34 @@ export function Auditoria() {
         setList(items)
         setTotal(t)
       })
-      .catch(() => {
+      .catch((err) => {
         setList([])
         setTotal(0)
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos registros de auditoria.'))
       })
       .finally(() => setLoading(false))
-  }, [debouncedBusca, filtroTipo, page, sortParams])
+  }, [debouncedBusca, filtroTipo, page, sortParams, toast])
 
   useEffect(() => {
     load()
   }, [load])
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para acessar a auditoria."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/"
+          voltarLabel="Voltar para o Dashboard"
+        />
+      </div>
+    )
+  }
 
   return (
     <div className="mx-auto max-w-6xl space-y-6 pb-10">

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -8,6 +8,7 @@ import { Button } from '../components/ui/Button'
 import { IconEye } from '../components/ui/IconEye'
 import { useToast } from '../components/ui/Toast'
 import { SemPermissao } from './SemPermissao'
+import { interpretarFalhaCarregamento } from '../api/errorMessage'
 
 type ColunaUltimos = 'protocolo' | 'empresa' | 'assunto' | 'status'
 
@@ -33,7 +34,8 @@ export function Dashboard() {
           toast.showWarning(err.message || 'Você não tem permissão para ver o dashboard.')
           return
         }
-        const msg = err instanceof Error ? err.message : 'Erro ao carregar'
+        const m = interpretarFalhaCarregamento(err, 'Não encontramos os dados do dashboard.')
+        const msg = [m.titulo, m.detalhe].filter(Boolean).join(' ')
         setError(msg)
         toast.showError(msg)
       })

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -15,6 +15,8 @@ import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
 import { maskCnpjCpf } from '../utils/maskCnpjCpf'
 import { maskCep, formatTelefoneBrExibicao } from '../utils/masks'
+import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { TicketsTabelaContexto } from '../components/TicketsTabelaContexto'
@@ -43,7 +45,7 @@ export function EmpresaDetalhe() {
   const [redeNome, setRedeNome] = useState<string>('')
   const [tipoNegocioNome, setTipoNegocioNome] = useState<string>('')
   const [loading, setLoading] = useState(true)
-  const [loadError, setLoadError] = useState(false)
+  const [loadFailure, setLoadFailure] = useState<{ titulo: string; detalhe?: string } | null>(null)
   const [forbidden, setForbidden] = useState(false)
   const [aba, setAba] = useState<Aba>('geral')
 
@@ -64,12 +66,15 @@ export function EmpresaDetalhe() {
   useEffect(() => {
     if (!id || isNaN(empresaId)) {
       setLoading(false)
-      setLoadError(true)
+      setLoadFailure({
+        titulo: 'Empresa não encontrada.',
+        detalhe: 'O identificador na URL é inválido.',
+      })
       return
     }
     let cancelled = false
     setLoading(true)
-    setLoadError(false)
+    setLoadFailure(null)
     setForbidden(false)
     apiEmpresas
       .get(empresaId)
@@ -98,7 +103,7 @@ export function EmpresaDetalhe() {
             setEmpresa(null)
             return
           }
-          setLoadError(true)
+          setLoadFailure(interpretarFalhaCarregamento(err, 'Empresa não encontrada.'))
           setEmpresa(null)
         }
       })
@@ -211,18 +216,9 @@ export function EmpresaDetalhe() {
     )
   }
 
-  if (loadError) {
+  if (loadFailure) {
     return (
-      <div className="mx-auto max-w-6xl space-y-4 pb-10">
-        <p className="text-slate-600 dark:text-slate-400">Empresa não encontrada.</p>
-        <button
-          type="button"
-          onClick={voltarAnterior}
-          className="font-medium text-slate-800 underline decoration-slate-400 underline-offset-2 hover:text-slate-950 dark:text-slate-200 dark:hover:text-white"
-        >
-          Voltar
-        </button>
-      </div>
+      <CarregamentoFalhou titulo={loadFailure.titulo} detalhe={loadFailure.detalhe} onVoltar={voltarAnterior} />
     )
   }
 

--- a/frontend/src/pages/Empresas.tsx
+++ b/frontend/src/pages/Empresas.tsx
@@ -2,7 +2,15 @@ import { useState, useEffect, useMemo, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { useNavigate, useLocation } from 'react-router-dom'
-import { empresas as apiEmpresas, redes, tiposNegocio, type Empresas, type Redes, type TiposNegocio } from '../api/client'
+import {
+  ApiError,
+  empresas as apiEmpresas,
+  redes,
+  tiposNegocio,
+  type Empresas,
+  type Redes,
+  type TiposNegocio,
+} from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
@@ -28,6 +36,8 @@ import { digitsOnly, maskCep, maskTelefoneBr, maskInscricaoEstadual } from '../u
 import { ESTADOS_CIVIS_BR, type EstadoCivilBr } from '../constants/estadosCivis'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
 import { Switch } from '../components/ui/Switch'
+import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 type ColunaEmpresa = 'nome' | 'cnpj_cpf' | 'rede'
 
@@ -81,6 +91,7 @@ export function Empresas() {
   const [ativo, setAtivo] = useState(true)
   const [saving, setSaving] = useState(false)
   const [loadingCnpj, setLoadingCnpj] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
     if (!modalOpen) return
@@ -102,6 +113,7 @@ export function Empresas() {
 
   const load = useCallback(() => {
     setLoading(true)
+    setForbidden(false)
     apiEmpresas
       .list<Empresas.Empresa>({
         incluir_inativos: incluirInativos,
@@ -114,8 +126,19 @@ export function Empresas() {
         setList(items)
         setTotal(t)
       })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          setTotal(0)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos a lista de empresas.'))
+        setList([])
+        setTotal(0)
+      })
       .finally(() => setLoading(false))
-  }, [debouncedBusca, incluirInativos, page, sortParams])
+  }, [debouncedBusca, incluirInativos, page, sortParams, toast])
 
   useEffect(() => {
     load()
@@ -214,7 +237,17 @@ export function Empresas() {
     apiEmpresas
       .get(editId)
       .then((emp) => openEdit(emp))
-      .catch(() => toast.showWarning('Empresa não encontrada.'))
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          toast.showWarning('Empresa não encontrada.')
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Empresa não encontrada.'))
+      })
   // eslint-disable-next-line react-hooks/exhaustive-deps -- abre edição ao retornar da tela de detalhe com state
   }, [location.state])
 
@@ -335,6 +368,19 @@ export function Empresas() {
     } catch (err) {
       toast.showWarning(err instanceof Error ? err.message : 'Erro ao excluir')
     }
+  }
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para listar empresas."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/"
+          voltarLabel="Voltar para o Dashboard"
+        />
+      </div>
+    )
   }
 
   return (

--- a/frontend/src/pages/FuncionarioRedeDetalhe.tsx
+++ b/frontend/src/pages/FuncionarioRedeDetalhe.tsx
@@ -5,6 +5,8 @@ import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { SemPermissao } from './SemPermissao'
+import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
 const tipoLabel: Record<string, string> = {
   socio: 'Sócio',
@@ -33,18 +35,21 @@ export function FuncionarioRedeDetalhe() {
   const [redeNome, setRedeNome] = useState('')
   const [vinculoExtra, setVinculoExtra] = useState<ReactNode>(null)
   const [loading, setLoading] = useState(true)
-  const [loadError, setLoadError] = useState(false)
+  const [loadFailure, setLoadFailure] = useState<{ titulo: string; detalhe?: string } | null>(null)
   const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
     if (!id || isNaN(funcionarioId)) {
       setLoading(false)
-      setLoadError(true)
+      setLoadFailure({
+        titulo: 'Funcionário não encontrado.',
+        detalhe: 'O identificador na URL é inválido.',
+      })
       return
     }
     let cancelled = false
     setLoading(true)
-    setLoadError(false)
+    setLoadFailure(null)
     setForbidden(false)
     setVinculoExtra(null)
 
@@ -137,7 +142,7 @@ export function FuncionarioRedeDetalhe() {
             setF(null)
             return
           }
-          setLoadError(true)
+          setLoadFailure(interpretarFalhaCarregamento(err, 'Funcionário não encontrado.'))
           setF(null)
         }
       })
@@ -189,18 +194,9 @@ export function FuncionarioRedeDetalhe() {
     )
   }
 
-  if (loadError) {
+  if (loadFailure) {
     return (
-      <div className="mx-auto max-w-6xl space-y-4 pb-10">
-        <p className="text-slate-600 dark:text-slate-400">Funcionário não encontrado.</p>
-        <button
-          type="button"
-          onClick={voltarAnterior}
-          className="font-medium text-slate-800 underline decoration-slate-400 underline-offset-2 hover:text-slate-950 dark:text-slate-200 dark:hover:text-white"
-        >
-          Voltar
-        </button>
-      </div>
+      <CarregamentoFalhou titulo={loadFailure.titulo} detalhe={loadFailure.detalhe} onVoltar={voltarAnterior} />
     )
   }
 

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -13,6 +13,8 @@ import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { FormSection } from '../components/ui/FormSection'
 import { SemPermissao } from './SemPermissao'
+import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
 type Tipo = 'socio' | 'supervisor' | 'colaborador'
 
@@ -33,7 +35,7 @@ export function FuncionarioRedeForm() {
   const [loading, setLoading] = useState(isEdit)
   const [saving, setSaving] = useState(false)
   const [forbidden, setForbidden] = useState(false)
-  const [notFound, setNotFound] = useState(false)
+  const [funcionarioInexistente, setFuncionarioInexistente] = useState<{ detalhe?: string } | null>(null)
 
   const [redesList, setRedesList] = useState<Redes.Rede[]>([])
   const [empresasList, setEmpresasList] = useState<Empresas.Empresa[]>([])
@@ -64,14 +66,14 @@ export function FuncionarioRedeForm() {
   useEffect(() => {
     if (!isEdit) return
     if (!id || Number.isNaN(funcionarioId)) {
-      toast.showWarning('Funcionário inválido.')
-      voltarAnterior()
+      setFuncionarioInexistente({ detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
       return
     }
     let cancelled = false
     setLoading(true)
     setForbidden(false)
-    setNotFound(false)
+    setFuncionarioInexistente(null)
     funcionariosRede
       .get(funcionarioId)
       .then((item) => {
@@ -100,10 +102,11 @@ export function FuncionarioRedeForm() {
             return
           }
           if (err instanceof ApiError && err.status === 404) {
-            setNotFound(true)
+            setFuncionarioInexistente({})
             return
           }
-          toast.showWarning(err instanceof Error ? err.message : 'Erro ao carregar funcionário.')
+          const m = interpretarFalhaCarregamento(err, 'Funcionário não encontrado.')
+          toast.showWarning([m.titulo, m.detalhe].filter(Boolean).join(' '))
         }
       })
       .finally(() => {
@@ -112,7 +115,7 @@ export function FuncionarioRedeForm() {
     return () => {
       cancelled = true
     }
-  }, [id, isEdit, funcionarioId, toast, voltarAnterior, empresasList])
+  }, [id, isEdit, funcionarioId, toast, empresasList])
 
   const empresasDaRede = useMemo(
     () => empresasList.filter((em) => em.rede_id === Number(redeId) && (em.ativo || em.id === empresaId || empresaIds.includes(em.id))),
@@ -207,18 +210,14 @@ export function FuncionarioRedeForm() {
     )
   }
 
-  if (notFound) {
+  if (funcionarioInexistente) {
     return (
-      <div className="mx-auto max-w-5xl space-y-4 pb-10">
-        <p className="text-slate-600 dark:text-slate-400">Funcionário não encontrado.</p>
-        <button
-          type="button"
-          onClick={voltarAnterior}
-          className="font-medium text-slate-800 underline decoration-slate-400 underline-offset-2 hover:text-slate-950 dark:text-slate-200 dark:hover:text-white"
-        >
-          Voltar
-        </button>
-      </div>
+      <CarregamentoFalhou
+        className="mx-auto max-w-5xl space-y-4 pb-10"
+        titulo="Funcionário não encontrado."
+        detalhe={funcionarioInexistente.detalhe}
+        onVoltar={voltarAnterior}
+      />
     )
   }
 

--- a/frontend/src/pages/FuncionariosRede.tsx
+++ b/frontend/src/pages/FuncionariosRede.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import {
+  ApiError,
   funcionariosRede,
   type FuncionariosRede as FuncionarioRedeTipo,
 } from '../api/client'
@@ -13,6 +14,8 @@ import { FiltroInativos } from '../components/ui/FiltroInativos'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
+import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 type Tipo = 'socio' | 'supervisor' | 'colaborador'
 type ColunaFuncionario = 'nome' | 'email' | 'tipo'
@@ -28,6 +31,7 @@ export function FuncionariosRede() {
   const [debouncedBusca, setDebouncedBusca] = useState('')
   const [loading, setLoading] = useState(true)
   const [incluirInativos, setIncluirInativos] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -36,6 +40,7 @@ export function FuncionariosRede() {
 
   const load = useCallback((override?: { busca?: string; page?: number }) => {
     setLoading(true)
+    setForbidden(false)
     const buscaEff = override?.busca !== undefined ? override.busca : debouncedBusca
     const pageEff = override?.page !== undefined ? override.page : page
     funcionariosRede
@@ -50,8 +55,19 @@ export function FuncionariosRede() {
         setList(items)
         setTotal(t)
       })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          setTotal(0)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos a lista de funcionários da rede.'))
+        setList([])
+        setTotal(0)
+      })
       .finally(() => setLoading(false))
-  }, [debouncedBusca, incluirInativos, page, sortParams])
+  }, [debouncedBusca, incluirInativos, page, sortParams, toast])
 
   useEffect(() => {
     load()
@@ -68,6 +84,19 @@ export function FuncionariosRede() {
   }
 
   const tipoLabel = { socio: 'Sócio', supervisor: 'Supervisor', colaborador: 'Colaborador' }
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para listar funcionários da rede."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/"
+          voltarLabel="Voltar para o Dashboard"
+        />
+      </div>
+    )
+  }
 
   return (
     <div className="mx-auto max-w-6xl space-y-6 pb-10">

--- a/frontend/src/pages/RedeDetalhe.tsx
+++ b/frontend/src/pages/RedeDetalhe.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useRef, useMemo, useCallback } from 'react'
+import { useState, useEffect, useMemo, useCallback } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import {
+  ApiError,
   redes,
   empresas,
   funcionariosRede,
@@ -48,6 +49,9 @@ import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { Switch } from '../components/ui/Switch'
 import { CheckboxField } from '../components/ui/CheckboxField'
+import { SemPermissao } from './SemPermissao'
+import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
 type Aba = 'empresas' | 'funcionarios' | 'tickets'
 type AbaModalEmpresa = 'geral' | 'tickets' | 'funcionarios'
@@ -88,8 +92,8 @@ export function RedeDetalhe() {
   const [debouncedBuscaEmpresas, setDebouncedBuscaEmpresas] = useState('')
   const [pageEmpresas, setPageEmpresas] = useState(1)
   const [loading, setLoading] = useState(true)
-  const [loadError, setLoadError] = useState(false)
-  const toastShownForInvalidIdRef = useRef(false)
+  const [loadFailure, setLoadFailure] = useState<{ titulo: string; detalhe?: string } | null>(null)
+  const [forbidden, setForbidden] = useState(false)
   const [aba, setAba] = useState<Aba>('empresas')
   const [abaModalEmpresa, setAbaModalEmpresa] = useState<AbaModalEmpresa>('geral')
   const [incluirInativos, setIncluirInativos] = useState(false)
@@ -381,9 +385,14 @@ export function RedeDetalhe() {
         setEmpresasList(e)
       })
       .catch((err) => {
-        toast.showWarning(
-          err instanceof Error ? err.message : 'Não foi possível atualizar os dados da rede.',
-        )
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setRede(null)
+          setEmpresasList([])
+          return
+        }
+        const msg = interpretarFalhaCarregamento(err, 'Rede não encontrada.')
+        toast.showWarning([msg.titulo, msg.detalhe].filter(Boolean).join(' '))
       })
   }
 
@@ -391,7 +400,8 @@ export function RedeDetalhe() {
     if (!redeId || isNaN(redeId)) return
     let cancelled = false
     setLoading(true)
-    setLoadError(false)
+    setLoadFailure(null)
+    setForbidden(false)
     Promise.all([
       redes.get(redeId),
       coletarTodasPaginas<Empresas.Empresa>((o, l) =>
@@ -405,11 +415,15 @@ export function RedeDetalhe() {
       })
       .catch((err) => {
         if (cancelled) return
-        const detalhe =
-          err instanceof Error ? err.message : 'Tente novamente em alguns instantes.'
-        toast.showWarning(`Não foi possível abrir esta rede. ${detalhe}`)
-        setLoadError(true)
-        navigate('/redes')
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setRede(null)
+          setEmpresasList([])
+          return
+        }
+        setLoadFailure(interpretarFalhaCarregamento(err, 'Rede não encontrada.'))
+        setRede(null)
+        setEmpresasList([])
       })
       .finally(() => {
         if (!cancelled) setLoading(false)
@@ -417,19 +431,11 @@ export function RedeDetalhe() {
     return () => {
       cancelled = true
     }
-  }, [redeId, navigate, toast])
+  }, [redeId, toast])
 
   useEffect(() => {
     loadFuncionarios()
   }, [loadFuncionarios])
-
-  useEffect(() => {
-    if (id && !isNaN(redeId)) return
-    if (toastShownForInvalidIdRef.current) return
-    toastShownForInvalidIdRef.current = true
-    toast.showWarning('Rede inválida.')
-    navigate('/redes')
-  }, [id, redeId, navigate, toast])
 
   useEffect(() => {
     coletarTodasPaginas<TiposNegocio.Tipo>((o, l) =>
@@ -768,15 +774,46 @@ export function RedeDetalhe() {
   }
 
   if (!id || isNaN(redeId)) {
-    return null
+    return (
+      <CarregamentoFalhou
+        titulo="Rede não encontrada."
+        detalhe="O identificador na URL é inválido."
+        onVoltar={voltarAnterior}
+      />
+    )
   }
 
-  if (loading && !rede && !loadError) {
-    return <p className="text-slate-500">Carregando...</p>
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para acessar esta rede."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/redes"
+          voltarLabel="Voltar para Redes"
+        />
+      </div>
+    )
   }
 
-  if (loadError || (!rede && !loading)) {
-    return null
+  if (loading && !rede && !loadFailure) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <div className="h-4 w-24 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
+        <div className="h-9 w-2/3 max-w-md animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+        <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </div>
+    )
+  }
+
+  if (loadFailure) {
+    return <CarregamentoFalhou titulo={loadFailure.titulo} detalhe={loadFailure.detalhe} onVoltar={voltarAnterior} />
+  }
+
+  if (!rede && !loading) {
+    return (
+      <CarregamentoFalhou titulo="Rede não encontrada." onVoltar={voltarAnterior} />
+    )
   }
 
   if (!rede) {

--- a/frontend/src/pages/RedeForm.tsx
+++ b/frontend/src/pages/RedeForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { redes, type Redes } from '../api/client'
+import { ApiError, redes, type Redes } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { Input } from '../components/ui/Input'
@@ -8,6 +8,9 @@ import { Switch } from '../components/ui/Switch'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { FormSection } from '../components/ui/FormSection'
+import { SemPermissao } from './SemPermissao'
+import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
 export function RedeForm() {
   const { id } = useParams<{ id?: string }>()
@@ -20,6 +23,9 @@ export function RedeForm() {
 
   const [loading, setLoading] = useState(isEdit)
   const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  /** Ausência da rede: URL inválida (detalhe) ou 404 da API (sem detalhe). */
+  const [redeInexistente, setRedeInexistente] = useState<{ detalhe?: string } | null>(null)
   const [nome, setNome] = useState('')
   const [loginRetaguarda, setLoginRetaguarda] = useState('')
   const [ativo, setAtivo] = useState(true)
@@ -27,12 +33,14 @@ export function RedeForm() {
   useEffect(() => {
     if (!isEdit) return
     if (!id || Number.isNaN(redeId)) {
-      toast.showWarning('Rede inválida.')
-      voltarAnterior()
+      setRedeInexistente({ detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
       return
     }
     let cancelled = false
     setLoading(true)
+    setForbidden(false)
+    setRedeInexistente(null)
     redes
       .get(redeId)
       .then((r) => {
@@ -41,10 +49,18 @@ export function RedeForm() {
         setLoginRetaguarda(r.login_retaguarda ?? '')
         setAtivo(r.ativo)
       })
-      .catch(() => {
+      .catch((err) => {
         if (!cancelled) {
-          toast.showWarning('Rede não encontrada.')
-          voltarAnterior()
+          if (err instanceof ApiError && err.status === 403) {
+            setForbidden(true)
+            return
+          }
+          if (err instanceof ApiError && err.status === 404) {
+            setRedeInexistente({})
+            return
+          }
+          const m = interpretarFalhaCarregamento(err, 'Rede não encontrada.')
+          toast.showWarning([m.titulo, m.detalhe].filter(Boolean).join(' '))
         }
       })
       .finally(() => {
@@ -53,7 +69,7 @@ export function RedeForm() {
     return () => {
       cancelled = true
     }
-  }, [id, isEdit, redeId, toast, voltarAnterior])
+  }, [id, isEdit, redeId, toast])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -87,6 +103,30 @@ export function RedeForm() {
         <div className="h-9 w-56 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-5xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para editar esta rede."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/redes"
+          voltarLabel="Voltar para Redes"
+        />
+      </div>
+    )
+  }
+
+  if (redeInexistente) {
+    return (
+      <CarregamentoFalhou
+        className="mx-auto max-w-5xl space-y-4 pb-10"
+        titulo="Rede não encontrada."
+        detalhe={redeInexistente.detalhe}
+        onVoltar={voltarAnterior}
+      />
     )
   }
 

--- a/frontend/src/pages/Redes.tsx
+++ b/frontend/src/pages/Redes.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { useNavigate } from 'react-router-dom'
-import { redes, type Redes } from '../api/client'
+import { ApiError, redes, type Redes } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { IconPencil } from '../components/ui/IconPencil'
@@ -10,6 +10,8 @@ import { IconTrash } from '../components/ui/IconTrash'
 import { useToast } from '../components/ui/Toast'
 import { FiltroInativos } from '../components/ui/FiltroInativos'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
+import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 type ColunaRede = 'nome' | 'ativo'
 
@@ -24,6 +26,7 @@ export function Redes() {
   const [debouncedBusca, setDebouncedBusca] = useState('')
   const [loading, setLoading] = useState(true)
   const [incluirInativos, setIncluirInativos] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -32,6 +35,7 @@ export function Redes() {
 
   const load = useCallback(() => {
     setLoading(true)
+    setForbidden(false)
     redes
       .list({
         incluir_inativos: incluirInativos,
@@ -44,8 +48,19 @@ export function Redes() {
         setList(items)
         setTotal(t)
       })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          setTotal(0)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos a lista de redes.'))
+        setList([])
+        setTotal(0)
+      })
       .finally(() => setLoading(false))
-  }, [debouncedBusca, incluirInativos, page, sortParams])
+  }, [debouncedBusca, incluirInativos, page, sortParams, toast])
 
   useEffect(() => {
     load()
@@ -59,6 +74,19 @@ export function Redes() {
     } catch (err) {
       toast.showWarning(err instanceof Error ? err.message : 'Erro ao excluir')
     }
+  }
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para listar redes."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/"
+          voltarLabel="Voltar para o Dashboard"
+        />
+      </div>
+    )
   }
 
   return (

--- a/frontend/src/pages/SetorDetalhe.tsx
+++ b/frontend/src/pages/SetorDetalhe.tsx
@@ -8,6 +8,8 @@ import { SelectComPesquisa } from '../components/ui/SelectComPesquisa'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { SemPermissao } from './SemPermissao'
+import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
 /** Mesmo nome de setor = mesmo “setor lógico” (vários IDs no banco). */
 function idsSetoresMesmoNome(setoresList: Setores.Setor[], setorId: number): Set<number> {
@@ -28,6 +30,7 @@ export function SetorDetalhe() {
   const [setor, setSetor] = useState<Setores.Setor | null>(null)
   const [setoresList, setSetoresList] = useState<Setores.Setor[]>([])
   const [forbidden, setForbidden] = useState(false)
+  const [carregamentoFalhou, setCarregamentoFalhou] = useState<{ titulo: string; detalhe?: string } | null>(null)
 
   const [vinculados, setVinculados] = useState<Atendentes.Atendente[]>([])
   const [todosAtendentes, setTodosAtendentes] = useState<Atendentes.Atendente[]>([])
@@ -58,11 +61,17 @@ export function SetorDetalhe() {
   async function reload() {
     if (!Number.isFinite(setorId) || setorId <= 0) {
       setSetor(null)
+      setVinculados([])
+      setCarregamentoFalhou({
+        titulo: 'Setor não encontrado.',
+        detalhe: 'O identificador na URL é inválido.',
+      })
       setLoading(false)
       return
     }
     setLoading(true)
     setForbidden(false)
+    setCarregamentoFalhou(null)
     try {
       const [s, setoresAll, todos] = await Promise.all([
         setores.get(setorId),
@@ -82,11 +91,12 @@ export function SetorDetalhe() {
         setForbidden(true)
         setSetor(null)
         setVinculados([])
+        setCarregamentoFalhou(null)
         return
       }
       setSetor(null)
       setVinculados([])
-      toast.showError(err instanceof Error ? err.message : 'Erro ao carregar setor')
+      setCarregamentoFalhou(interpretarFalhaCarregamento(err, 'Setor não encontrado.'))
     } finally {
       setLoading(false)
     }
@@ -159,19 +169,14 @@ export function SetorDetalhe() {
     )
   }
 
-  if (!setor) {
+  if (carregamentoFalhou) {
     return (
-      <div className="space-y-4">
-        <p className="text-slate-600 dark:text-slate-400">Setor não encontrado.</p>
-        <button
-          type="button"
-          onClick={voltarAnterior}
-          className="font-medium text-slate-800 underline decoration-slate-400 underline-offset-2 hover:text-slate-950 dark:text-slate-200 dark:hover:text-white"
-        >
-          Voltar
-        </button>
-      </div>
+      <CarregamentoFalhou titulo={carregamentoFalhou.titulo} detalhe={carregamentoFalhou.detalhe} onVoltar={voltarAnterior} />
     )
+  }
+
+  if (!setor) {
+    return null
   }
 
   return (

--- a/frontend/src/pages/Setores.tsx
+++ b/frontend/src/pages/Setores.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
-import { setores, type Setores } from '../api/client'
+import { ApiError, setores, type Setores } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { Input } from '../components/ui/Input'
@@ -13,6 +13,8 @@ import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBus
 import { Switch } from '../components/ui/Switch'
 import { useNavigate } from 'react-router-dom'
 import { FormSection } from '../components/ui/FormSection'
+import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 type ColunaSetor = 'nome' | 'slug' | 'ativo'
 
@@ -33,6 +35,7 @@ export function Setores() {
   const [slug, setSlug] = useState('')
   const [ativo, setAtivo] = useState(true)
   const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
     if (!modalOpen) return
@@ -54,6 +57,7 @@ export function Setores() {
 
   const load = useCallback(() => {
     setLoading(true)
+    setForbidden(false)
     setores
       .list({
         incluir_inativos: incluirInativos,
@@ -66,8 +70,19 @@ export function Setores() {
         setList(items)
         setTotal(t)
       })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          setTotal(0)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos a lista de setores.'))
+        setList([])
+        setTotal(0)
+      })
       .finally(() => setLoading(false))
-  }, [debouncedBusca, incluirInativos, page, sortParams])
+  }, [debouncedBusca, incluirInativos, page, sortParams, toast])
 
   useEffect(() => {
     load()
@@ -117,6 +132,19 @@ export function Setores() {
     } catch (err) {
       toast.showWarning(err instanceof Error ? err.message : 'Erro ao excluir')
     }
+  }
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para listar setores."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/"
+          voltarLabel="Voltar para o Dashboard"
+        />
+      </div>
+    )
   }
 
   return (

--- a/frontend/src/pages/StatusTicket.tsx
+++ b/frontend/src/pages/StatusTicket.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
-import { statusTicket, type StatusTicket } from '../api/client'
+import { ApiError, statusTicket, type StatusTicket } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { Input } from '../components/ui/Input'
@@ -11,6 +11,8 @@ import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBus
 import { Switch } from '../components/ui/Switch'
 import { useToast } from '../components/ui/Toast'
 import { FormSection } from '../components/ui/FormSection'
+import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 type ColunaStatus = 'nome' | 'slug' | 'ordem' | 'ativo'
 
@@ -31,6 +33,7 @@ export function StatusTicketPage() {
   const [ordem, setOrdem] = useState(0)
   const [ativo, setAtivo] = useState(true)
   const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
     if (!modalOpen) return
@@ -52,6 +55,7 @@ export function StatusTicketPage() {
 
   const load = useCallback(() => {
     setLoading(true)
+    setForbidden(false)
     statusTicket
       .list({
         incluir_inativos: incluirInativos,
@@ -64,8 +68,19 @@ export function StatusTicketPage() {
         setList(items)
         setTotal(t)
       })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          setTotal(0)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos a lista de status de ticket.'))
+        setList([])
+        setTotal(0)
+      })
       .finally(() => setLoading(false))
-  }, [debouncedBusca, incluirInativos, page, sortParams])
+  }, [debouncedBusca, incluirInativos, page, sortParams, toast])
 
   useEffect(() => {
     load()
@@ -107,6 +122,19 @@ export function StatusTicketPage() {
     } finally {
       setSaving(false)
     }
+  }
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para listar status de ticket."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/"
+          voltarLabel="Voltar para o Dashboard"
+        />
+      </div>
+    )
   }
 
   return (

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -10,6 +10,8 @@ import { useAuth } from '../contexts/AuthContext'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { refetchPendenciasResumo } from '../hooks/useAlertaFilaSemResponsavel'
 import { SemPermissao } from './SemPermissao'
+import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
 const ROTULO_CAMPO: Record<string, string> = {
   status_id: 'Status',
@@ -96,7 +98,7 @@ export function TicketDetalhe() {
   const [fechando, setFechando] = useState(false)
 
   const [loading, setLoading] = useState(true)
-  const [notFound, setNotFound] = useState(false)
+  const [carregamentoFalhou, setCarregamentoFalhou] = useState<{ titulo: string; detalhe?: string } | null>(null)
   const [forbidden, setForbidden] = useState(false)
   const [ticket, setTicket] = useState<Tickets.Ticket | null>(null)
   const [historico, setHistorico] = useState<Tickets.Historico[]>([])
@@ -298,16 +300,22 @@ export function TicketDetalhe() {
   }, [modalGerirAberto, setorAlvoModal])
 
   useEffect(() => {
-    if (!id) return
+    if (!id) {
+      setLoading(false)
+      return
+    }
     const numId = Number(id)
     if (Number.isNaN(numId)) {
-      setNotFound(true)
+      setCarregamentoFalhou({
+        titulo: 'Ticket não encontrado.',
+        detalhe: 'O identificador na URL é inválido.',
+      })
       setLoading(false)
       return
     }
     let cancelled = false
     setLoading(true)
-    setNotFound(false)
+    setCarregamentoFalhou(null)
     setForbidden(false)
     Promise.all([tickets.get(numId), tickets.getHistorico(numId), tickets.listMensagens(numId)])
       .then(([t, h, m]) => {
@@ -328,13 +336,13 @@ export function TicketDetalhe() {
           if (err instanceof ApiError && err.status === 403) {
             setForbidden(true)
             toast.showWarning(err.message || 'Sem permissão para este ticket.')
-            setNotFound(false)
+            setCarregamentoFalhou(null)
             return
           }
           setTicket(null)
           setHistorico([])
           setMensagens([])
-          setNotFound(true)
+          setCarregamentoFalhou(interpretarFalhaCarregamento(err, 'Ticket não encontrado.'))
         }
       })
       .finally(() => {
@@ -491,19 +499,14 @@ export function TicketDetalhe() {
     )
   }
 
-  if (notFound || !ticket) {
+  if (carregamentoFalhou) {
     return (
-      <div className="mx-auto max-w-6xl space-y-4 pb-10">
-        <p className="text-slate-600 dark:text-slate-400">Ticket não encontrado.</p>
-        <button
-          type="button"
-          onClick={voltarAnterior}
-          className="font-medium text-slate-800 underline decoration-slate-400 underline-offset-2 hover:text-slate-950 dark:text-slate-200 dark:hover:text-white"
-        >
-          Voltar
-        </button>
-      </div>
+      <CarregamentoFalhou titulo={carregamentoFalhou.titulo} detalhe={carregamentoFalhou.detalhe} onVoltar={voltarAnterior} />
     )
+  }
+
+  if (!ticket) {
+    return null
   }
 
   return (

--- a/frontend/src/pages/TicketNovo.tsx
+++ b/frontend/src/pages/TicketNovo.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '../contexts/AuthContext'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { FormSection } from '../components/ui/FormSection'
 import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 export function TicketNovo() {
   const { isAdmin } = useAuth()
@@ -49,28 +50,26 @@ export function TicketNovo() {
     coletarTodasPaginas<Empresas.EmpresaListaItem>((o, l) => empresas.list({ offset: o, limit: l }))
       .then(setEmpresasList)
       .catch((err) => {
-        const msg =
-          err instanceof ApiError && err.status === 403
-            ? 'Você não tem permissão para listar empresas.'
-            : err instanceof Error
-              ? err.message
-              : 'Erro ao carregar empresas'
-        toast.showWarning(msg)
+        if (err instanceof ApiError && err.status === 403) {
+          toast.showWarning('Você não tem permissão para listar empresas.')
+          setEmpresasList([])
+          setForbidden(true)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos empresas para abrir o chamado.'))
         setEmpresasList([])
-        if (err instanceof ApiError && err.status === 403) setForbidden(true)
       })
     coletarTodasPaginas<Setores.Setor>((o, l) => setores.list({ incluir_inativos: true, offset: o, limit: l }))
       .then(setSetoresList)
       .catch((err) => {
-        const msg =
-          err instanceof ApiError && err.status === 403
-            ? 'Você não tem permissão para listar setores.'
-            : err instanceof Error
-              ? err.message
-              : 'Erro ao carregar setores'
-        toast.showWarning(msg)
+        if (err instanceof ApiError && err.status === 403) {
+          toast.showWarning('Você não tem permissão para listar setores.')
+          setSetoresList([])
+          setForbidden(true)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err))
         setSetoresList([])
-        if (err instanceof ApiError && err.status === 403) setForbidden(true)
       })
   }, [])
 
@@ -98,8 +97,7 @@ export function TicketNovo() {
       toast.showSuccess('Ticket criado.')
       navigate(`/tickets/${created.id}`)
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Erro ao criar ticket'
-      toast.showError(msg)
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível localizar os dados para criar o ticket.'))
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -23,6 +23,7 @@ import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { useAuth } from '../contexts/AuthContext'
 import { useAlertaFilaSemResponsavel } from '../hooks/useAlertaFilaSemResponsavel'
 import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 type ColunaOrdenacao =
   | 'protocolo'
@@ -219,7 +220,7 @@ export function Tickets() {
           setTotal(0)
           return
         }
-        toast.showWarning('Não foi possível carregar os tickets.')
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos os tickets solicitados.'))
         setList([])
         setTotal(0)
       })

--- a/frontend/src/pages/TiposNegocio.tsx
+++ b/frontend/src/pages/TiposNegocio.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
-import { tiposNegocio, type TiposNegocio } from '../api/client'
+import { ApiError, tiposNegocio, type TiposNegocio } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { Input } from '../components/ui/Input'
@@ -12,6 +12,8 @@ import { FiltroInativos } from '../components/ui/FiltroInativos'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
 import { Switch } from '../components/ui/Switch'
 import { FormSection } from '../components/ui/FormSection'
+import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 type ColunaTipo = 'nome' | 'ativo'
 
@@ -30,6 +32,7 @@ export function TiposNegocio() {
   const [nome, setNome] = useState('')
   const [ativo, setAtivo] = useState(true)
   const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
     if (!modalOpen) return
@@ -51,6 +54,7 @@ export function TiposNegocio() {
 
   const load = useCallback(() => {
     setLoading(true)
+    setForbidden(false)
     tiposNegocio
       .list({
         incluir_inativos: incluirInativos,
@@ -63,8 +67,19 @@ export function TiposNegocio() {
         setList(items)
         setTotal(t)
       })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          setTotal(0)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos a lista de tipos de negócio.'))
+        setList([])
+        setTotal(0)
+      })
       .finally(() => setLoading(false))
-  }, [debouncedBusca, incluirInativos, page, sortParams])
+  }, [debouncedBusca, incluirInativos, page, sortParams, toast])
 
   useEffect(() => {
     load()
@@ -112,6 +127,19 @@ export function TiposNegocio() {
     } catch (err) {
       toast.showWarning(err instanceof Error ? err.message : 'Erro ao excluir')
     }
+  }
+
+  if (forbidden) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <SemPermissao
+          title="Você não tem permissão para listar tipos de negócio."
+          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
+          voltarPara="/"
+          voltarLabel="Voltar para o Dashboard"
+        />
+      </div>
+    )
   }
 
   return (


### PR DESCRIPTION
## Objetivo

Concluir o padrão de **403 → `SemPermissao`**, **404 / URL inválida → tela com título + detalhe + Voltar**, e **toasts** com mensagens coerentes (rede, 5xx, 404 por contexto).

## O que mudou

- **`interpretarFalhaCarregamento`** e **`mensagemFalhaParaToast(err, texto404?)`** em `errorMessage.ts` (detecção de rede, 404 contextual).
- **`CarregamentoFalhou`**: bloco reutilizável para erros de carga.
- **Detalhe / formulário**: `EmpresaDetalhe`, `FuncionarioRedeDetalhe`, `RedeDetalhe`, `SetorDetalhe`, `TicketDetalhe`, `RedeForm`, `FuncionarioRedeForm`.
- **Listagens admin + dashboard + tickets**: tratamento de 403 e toasts com `texto404` específico por tela.
- **`TicketNovo`**, **`Dashboard`**: mensagens alinhadas ao mesmo modelo.

## Verificação

- `npm run build` no frontend (com `VITE_API_URL` definido).
