### PR TITLE
fix(frontend): mensagens de erro amigáveis + reabrir ticket

### DIFF
--- a/frontend/src/api/errorMessage.ts
+++ b/frontend/src/api/errorMessage.ts
@@ -2,6 +2,30 @@
  * Converte corpo JSON típico do FastAPI (detail string | lista | objeto) em texto para o usuário.
  */
 export function mensagemErroApi(body: unknown, status: number): string {
+  function sanitizarTextoUsuario(input: string): string {
+    let s = input
+
+    // Remove URLs completas (http/https) e também "www.".
+    s = s.replace(/\bhttps?:\/\/[^\s)]+/gi, '')
+    s = s.replace(/\bwww\.[^\s)]+/gi, '')
+
+    // Remove hostnames comuns (ex.: api.exemplo.com.br) e IPs.
+    s = s.replace(/\b[a-z0-9-]+(\.[a-z0-9-]+)+\b/gi, '')
+    s = s.replace(/\b\d{1,3}(?:\.\d{1,3}){3}\b/g, '')
+
+    // Remove caminhos aparentes de API (ex.: /v1/tickets/2/reabrir) e trechos com /api/.
+    s = s.replace(/(?:\s|^)(\/(?:v\d+|api)\/[^\s)]+)(?=\s|$)/gi, ' ')
+
+    // Remove métodos + paths (ex.: "POST /v1/..." ou "GET /...")
+    s = s.replace(/\b(GET|POST|PUT|PATCH|DELETE)\s+\/[^\s)]+/gi, '')
+
+    // Normaliza espaços/pontuação residual.
+    s = s.replace(/\s{2,}/g, ' ').trim()
+    s = s.replace(/^[\-–—:;,. ]+|[\-–—:;,. ]+$/g, '').trim()
+
+    return s
+  }
+
   if (body !== null && typeof body === 'object') {
     const o = body as Record<string, unknown>
     const detail = o.detail
@@ -10,32 +34,44 @@ export function mensagemErroApi(body: unknown, status: number): string {
       const d = detail.trim()
       // Alguns proxies/backends retornam mensagens genéricas ("Not Found") que não ajudam o usuário
       // e podem vazar detalhes técnicos. Para esses casos, preferimos o fallback por status.
-      if (!/^not found$/i.test(d) && !/^404\b/i.test(d)) return d
+      if (!/^not found$/i.test(d) && !/^404\b/i.test(d)) {
+        const safe = sanitizarTextoUsuario(d)
+        if (safe) return safe
+      }
     }
 
     if (Array.isArray(detail)) {
       const linhas: string[] = []
       for (const item of detail) {
-        if (typeof item === 'string' && item.trim()) linhas.push(item.trim())
+        if (typeof item === 'string' && item.trim()) linhas.push(sanitizarTextoUsuario(item.trim()))
         else if (item !== null && typeof item === 'object') {
           const row = item as Record<string, unknown>
-          if (typeof row.msg === 'string' && row.msg.trim()) linhas.push(row.msg.trim())
-          else if (typeof row.message === 'string' && row.message.trim()) linhas.push(row.message.trim())
+          if (typeof row.msg === 'string' && row.msg.trim()) linhas.push(sanitizarTextoUsuario(row.msg.trim()))
+          else if (typeof row.message === 'string' && row.message.trim()) linhas.push(sanitizarTextoUsuario(row.message.trim()))
         }
       }
       if (linhas.length) {
-        const resumo = [...new Set(linhas)].join(' ')
+        const resumo = [...new Set(linhas.filter(Boolean))].join(' ')
         return `Os dados da solicitação não são aceitos pelo servidor. ${resumo}`
       }
     }
 
     if (detail !== null && typeof detail === 'object') {
       const d = detail as Record<string, unknown>
-      if (typeof d.msg === 'string' && d.msg.trim()) return d.msg.trim()
-      if (typeof d.message === 'string' && d.message.trim()) return d.message.trim()
+      if (typeof d.msg === 'string' && d.msg.trim()) {
+        const safe = sanitizarTextoUsuario(d.msg.trim())
+        if (safe) return safe
+      }
+      if (typeof d.message === 'string' && d.message.trim()) {
+        const safe = sanitizarTextoUsuario(d.message.trim())
+        if (safe) return safe
+      }
     }
 
-    if (typeof o.message === 'string' && o.message.trim()) return o.message.trim()
+    if (typeof o.message === 'string' && o.message.trim()) {
+      const safe = sanitizarTextoUsuario(o.message.trim())
+      if (safe) return safe
+    }
   }
 
   if (status === 404) return 'Registro não encontrado.'

--- a/frontend/src/api/errorMessage.ts
+++ b/frontend/src/api/errorMessage.ts
@@ -6,7 +6,12 @@ export function mensagemErroApi(body: unknown, status: number): string {
     const o = body as Record<string, unknown>
     const detail = o.detail
 
-    if (typeof detail === 'string' && detail.trim()) return detail.trim()
+    if (typeof detail === 'string' && detail.trim()) {
+      const d = detail.trim()
+      // Alguns proxies/backends retornam mensagens genéricas ("Not Found") que não ajudam o usuário
+      // e podem vazar detalhes técnicos. Para esses casos, preferimos o fallback por status.
+      if (!/^not found$/i.test(d) && !/^404\b/i.test(d)) return d
+    }
 
     if (Array.isArray(detail)) {
       const linhas: string[] = []

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -12,7 +12,9 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
-    console.error('[ErrorBoundary]', error, info.componentStack)
+    if (import.meta.env.DEV) {
+      console.error('[ErrorBoundary]', error, info.componentStack)
+    }
   }
 
   render() {
@@ -21,7 +23,7 @@ export class ErrorBoundary extends Component<Props, State> {
         <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-slate-50 p-6 text-center">
           <h1 className="text-xl font-semibold text-slate-800">Algo deu errado</h1>
           <p className="max-w-lg text-sm text-slate-600">
-            A interface encontrou um erro. Abra o console do navegador (F12) para detalhes ou recarregue a página.
+            A interface encontrou um erro. Recarregue a página e tente novamente.
           </p>
           <pre className="max-h-40 max-w-2xl overflow-auto rounded-lg bg-red-50 p-3 text-left text-xs text-red-800">
             {this.state.error.message}

--- a/frontend/src/components/ui/InputCepComBusca.tsx
+++ b/frontend/src/components/ui/InputCepComBusca.tsx
@@ -3,6 +3,7 @@ import { Input } from './Input'
 import { useToast } from './Toast'
 import { cadastroAux, type CadastroAux } from '../../api/client'
 import { digitsOnly, maskCep } from '../../utils/masks'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
 
 type Props = {
   id?: string
@@ -31,7 +32,7 @@ export function InputCepComBusca({ id, label = 'CEP', value, onChange, onEnderec
       onEnderecoCompleto(r)
       toast.showSuccess('Endereço preenchido pelo CEP.')
     } catch (err) {
-      toast.showWarning(err instanceof Error ? err.message : 'Não foi possível consultar o CEP.')
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível consultar o CEP.'))
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/AlterarSenha.tsx
+++ b/frontend/src/pages/AlterarSenha.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../contexts/AuthContext'
 import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
 import { IconEye, IconEyeOff } from '../components/ui/IconEye'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 const fieldClass =
   'w-full rounded-xl border border-slate-200 bg-white px-3.5 py-3 text-[0.9375rem] text-slate-900 shadow-inner placeholder:text-slate-400 focus:border-cyan-500/50 focus:outline-none focus:ring-2 focus:ring-cyan-400/25 dark:border-white/10 dark:bg-white/[0.06] dark:text-slate-100 dark:placeholder:text-slate-500'
@@ -38,8 +39,7 @@ export function AlterarSenha() {
       toast.showSuccess('Senha alterada com sucesso.')
       navigate('/', { replace: true })
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Não foi possível alterar a senha.'
-      toast.showError(message)
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar a senha.'))
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/Atendentes.tsx
+++ b/frontend/src/pages/Atendentes.tsx
@@ -156,7 +156,7 @@ export function Atendentes() {
       setModalOpen(false)
       load()
     } catch (err) {
-      toast.showError(err instanceof Error ? err.message : 'Erro')
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o atendente.'))
     } finally {
       setSaving(false)
     }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -8,7 +8,7 @@ import { Button } from '../components/ui/Button'
 import { IconEye } from '../components/ui/IconEye'
 import { useToast } from '../components/ui/Toast'
 import { SemPermissao } from './SemPermissao'
-import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 
 type ColunaUltimos = 'protocolo' | 'empresa' | 'assunto' | 'status'
 
@@ -37,7 +37,7 @@ export function Dashboard() {
         const m = interpretarFalhaCarregamento(err, 'Não encontramos os dados do dashboard.')
         const msg = [m.titulo, m.detalhe].filter(Boolean).join(' ')
         setError(msg)
-        toast.showError(msg)
+        toast.showError(mensagemFalhaParaToast(err, msg))
       })
       .finally(() => setLoading(false))
     // eslint-disable-next-line react-hooks/exhaustive-deps -- recarrega só quando reloadKey muda

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -15,7 +15,7 @@ import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
 import { maskCnpjCpf } from '../utils/maskCnpjCpf'
 import { maskCep, formatTelefoneBrExibicao } from '../utils/masks'
-import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
@@ -189,7 +189,7 @@ export function EmpresaDetalhe() {
       toast.showSuccess('Empresa excluída.')
       navigate('/empresas', { replace: true })
     } catch (err) {
-      toast.showWarning(err instanceof Error ? err.message : 'Não foi possível excluir.')
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível excluir a empresa.'))
     }
   }
 

--- a/frontend/src/pages/Empresas.tsx
+++ b/frontend/src/pages/Empresas.tsx
@@ -277,7 +277,7 @@ export function Empresas() {
       setTelefone(data.telefone ? maskTelefoneBr(data.telefone) : '')
       toast.showSuccess('Dados preenchidos com sucesso.')
     } catch (err) {
-      toast.showError(err instanceof Error ? err.message : 'Erro ao consultar CNPJ')
+      toast.showError(mensagemFalhaParaToast(err, 'Erro ao consultar CNPJ.'))
     } finally {
       setLoadingCnpj(false)
     }
@@ -345,7 +345,7 @@ export function Empresas() {
         navigate(`/empresas/${criada.id}`, { replace: true })
       }
     } catch (err) {
-      toast.showError(err instanceof Error ? err.message : 'Erro')
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a empresa.'))
     } finally {
       setSaving(false)
     }
@@ -366,7 +366,7 @@ export function Empresas() {
       await apiEmpresas.delete(id)
       load()
     } catch (err) {
-      toast.showWarning(err instanceof Error ? err.message : 'Erro ao excluir')
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível excluir a empresa.'))
     }
   }
 

--- a/frontend/src/pages/FuncionarioRedeDetalhe.tsx
+++ b/frontend/src/pages/FuncionarioRedeDetalhe.tsx
@@ -5,7 +5,7 @@ import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { SemPermissao } from './SemPermissao'
-import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
 const tipoLabel: Record<string, string> = {
@@ -167,7 +167,7 @@ export function FuncionarioRedeDetalhe() {
       toast.showSuccess('Funcionário excluído.')
       voltarAnterior()
     } catch (err) {
-      toast.showWarning(err instanceof Error ? err.message : 'Não foi possível excluir.')
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível excluir o funcionário.'))
     }
   }
 

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -13,7 +13,7 @@ import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { FormSection } from '../components/ui/FormSection'
 import { SemPermissao } from './SemPermissao'
-import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
 type Tipo = 'socio' | 'supervisor' | 'colaborador'
@@ -182,7 +182,7 @@ export function FuncionarioRedeForm() {
       }
       navigate(`/funcionarios-rede/${saved.id}`, { replace: true })
     } catch (err) {
-      toast.showError(err instanceof Error ? err.message : 'Erro')
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o funcionário.'))
     } finally {
       setSaving(false)
     }

--- a/frontend/src/pages/FuncionariosRede.tsx
+++ b/frontend/src/pages/FuncionariosRede.tsx
@@ -79,7 +79,7 @@ export function FuncionariosRede() {
       await funcionariosRede.delete(id)
       load()
     } catch (err) {
-      toast.showWarning(err instanceof Error ? err.message : 'Erro ao excluir')
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível excluir o funcionário.'))
     }
   }
 

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 const REMEMBER_EMAIL_KEY = 'dx-connect-login-email'
 
@@ -94,8 +95,7 @@ export function Login() {
       showSuccess('Login realizado com sucesso. Redirecionando...')
       navigate('/', { replace: true })
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Falha no login'
-      showError(message)
+      showError(mensagemFalhaParaToast(err, 'Falha no login. Verifique suas credenciais e tente novamente.'))
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/RedeDetalhe.tsx
+++ b/frontend/src/pages/RedeDetalhe.tsx
@@ -50,7 +50,7 @@ import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { Switch } from '../components/ui/Switch'
 import { CheckboxField } from '../components/ui/CheckboxField'
 import { SemPermissao } from './SemPermissao'
-import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
 type Aba = 'empresas' | 'funcionarios' | 'tickets'
@@ -579,7 +579,7 @@ export function RedeDetalhe() {
       setTelefoneEmpresa(maskTelefoneBr(data.telefone ?? ''))
       toast.showSuccess('Dados preenchidos.')
     } catch (err) {
-      toast.showError(err instanceof Error ? err.message : 'Erro ao consultar CNPJ')
+      toast.showError(mensagemFalhaParaToast(err, 'Erro ao consultar CNPJ.'))
     } finally {
       setLoadingCnpjEmpresa(false)
     }
@@ -640,7 +640,7 @@ export function RedeDetalhe() {
       loadRedeEEmpresas()
       loadFuncionarios()
     } catch (err) {
-      toast.showError(err instanceof Error ? err.message : 'Erro')
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a empresa.'))
     } finally {
       setSavingEmpresa(false)
     }
@@ -653,7 +653,7 @@ export function RedeDetalhe() {
       loadRedeEEmpresas()
       loadFuncionarios()
     } catch (err) {
-      toast.showWarning(err instanceof Error ? err.message : 'Erro ao excluir')
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível excluir a empresa.'))
     }
   }
 
@@ -756,7 +756,7 @@ export function RedeDetalhe() {
       }
       navigate(`/funcionarios-rede/${idDetalhe}`)
     } catch (err) {
-      toast.showError(err instanceof Error ? err.message : 'Erro ao salvar')
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o funcionário.'))
     } finally {
       setSavingFuncionario(false)
     }
@@ -769,7 +769,7 @@ export function RedeDetalhe() {
       loadRedeEEmpresas()
       loadFuncionarios()
     } catch (err) {
-      toast.showWarning(err instanceof Error ? err.message : 'Erro ao excluir')
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível excluir o funcionário.'))
     }
   }
 

--- a/frontend/src/pages/RedeForm.tsx
+++ b/frontend/src/pages/RedeForm.tsx
@@ -9,7 +9,7 @@ import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { FormSection } from '../components/ui/FormSection'
 import { SemPermissao } from './SemPermissao'
-import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
 export function RedeForm() {
@@ -91,7 +91,7 @@ export function RedeForm() {
       }
       navigate(`/redes/${r.id}`, { replace: true })
     } catch (err) {
-      toast.showError(err instanceof Error ? err.message : 'Erro')
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a rede.'))
     } finally {
       setSaving(false)
     }

--- a/frontend/src/pages/Redes.tsx
+++ b/frontend/src/pages/Redes.tsx
@@ -72,7 +72,7 @@ export function Redes() {
       await redes.delete(id)
       load()
     } catch (err) {
-      toast.showWarning(err instanceof Error ? err.message : 'Erro ao excluir')
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível excluir a rede.'))
     }
   }
 

--- a/frontend/src/pages/SetorDetalhe.tsx
+++ b/frontend/src/pages/SetorDetalhe.tsx
@@ -8,7 +8,7 @@ import { SelectComPesquisa } from '../components/ui/SelectComPesquisa'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { SemPermissao } from './SemPermissao'
-import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
 /** Mesmo nome de setor = mesmo “setor lógico” (vários IDs no banco). */
@@ -124,7 +124,7 @@ export function SetorDetalhe() {
       setAddingId('')
       await reload()
     } catch (err) {
-      toast.showError(err instanceof Error ? err.message : 'Erro ao vincular atendente')
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível vincular o atendente.'))
     } finally {
       setSaving(false)
     }
@@ -142,7 +142,7 @@ export function SetorDetalhe() {
       toast.showSuccess('Vínculo removido.')
       await reload()
     } catch (err) {
-      toast.showError(err instanceof Error ? err.message : 'Erro ao remover vínculo')
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível remover o vínculo.'))
     } finally {
       setSaving(false)
     }

--- a/frontend/src/pages/Setores.tsx
+++ b/frontend/src/pages/Setores.tsx
@@ -118,7 +118,7 @@ export function Setores() {
       setModalOpen(false)
       load()
     } catch (err) {
-      toast.showError(err instanceof Error ? err.message : 'Erro')
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o setor.'))
     } finally {
       setSaving(false)
     }
@@ -130,7 +130,7 @@ export function Setores() {
       await setores.delete(id)
       load()
     } catch (err) {
-      toast.showWarning(err instanceof Error ? err.message : 'Erro ao excluir')
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível excluir o setor.'))
     }
   }
 

--- a/frontend/src/pages/StatusTicket.tsx
+++ b/frontend/src/pages/StatusTicket.tsx
@@ -118,7 +118,7 @@ export function StatusTicketPage() {
       setModalOpen(false)
       load()
     } catch (err) {
-      toast.showError(err instanceof Error ? err.message : 'Erro')
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o status de ticket.'))
     } finally {
       setSaving(false)
     }

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -118,6 +118,7 @@ export function TicketDetalhe() {
   const [tipoNovaMensagem, setTipoNovaMensagem] = useState<'publico' | 'interno'>('publico')
   const [enviandoMensagem, setEnviandoMensagem] = useState(false)
   const [modalGerirAberto, setModalGerirAberto] = useState(false)
+  const [modalFecharAberto, setModalFecharAberto] = useState(false)
   /** Qual bloco do modal recebe destaque ao abrir (chips no cabeçalho). */
   const [modalGerirFoco, setModalGerirFoco] = useState<'geral' | 'setor' | 'status' | 'atendente'>('geral')
   const [historicoAberto, setHistoricoAberto] = useState(false)
@@ -415,9 +416,33 @@ export function TicketDetalhe() {
         toast.showSuccess('Alterações aplicadas.')
       }
     } catch (err) {
-      toast.showWarning(err instanceof Error ? err.message : 'Erro ao salvar')
+      toast.showWarning(mensagemFalhaParaToast(err, 'Erro ao salvar.'))
     } finally {
       setSaving(false)
+    }
+  }
+
+  async function fecharTicketConfirmado() {
+    if (!ticket) return
+    if (!statusFechado) {
+      toast.showWarning('Não existe um status com slug "fechado". Cadastre/ajuste em Status de ticket.')
+      return
+    }
+    setFechando(true)
+    try {
+      const updated = await tickets.update(ticket.id, { status_id: statusFechado.id })
+      setTicket(updated)
+      setEditStatus(updated.status_id)
+      setEditAtendente(updated.atendente_id ?? '')
+      const hist = await tickets.getHistorico(updated.id)
+      setHistorico(hist)
+      toast.showSuccess('Ticket fechado.')
+      void refetchPendenciasResumo()
+      setModalFecharAberto(false)
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível fechar.'))
+    } finally {
+      setFechando(false)
     }
   }
 
@@ -645,22 +670,7 @@ export function TicketDetalhe() {
                   toast.showWarning('Não existe um status com slug "fechado". Cadastre/ajuste em Status de ticket.')
                   return
                 }
-                if (!confirm('Fechar este ticket? Ele sairá da lista de abertos e não permitirá novas mensagens.')) return
-                setFechando(true)
-                try {
-                  const updated = await tickets.update(ticket.id, { status_id: statusFechado.id })
-                  setTicket(updated)
-                  setEditStatus(updated.status_id)
-                  setEditAtendente(updated.atendente_id ?? '')
-                  const hist = await tickets.getHistorico(updated.id)
-                  setHistorico(hist)
-                  toast.showSuccess('Ticket fechado.')
-                  void refetchPendenciasResumo()
-                } catch (err) {
-                  toast.showWarning(err instanceof Error ? err.message : 'Não foi possível fechar.')
-                } finally {
-                  setFechando(false)
-                }
+                setModalFecharAberto(true)
               }}
             >
               Fechar ticket
@@ -946,6 +956,45 @@ export function TicketDetalhe() {
               </Button>
               <Button type="button" onClick={handleSalvar} loading={saving}>
                 {modalApenasUmCampo ? 'Salvar' : 'Aplicar'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {modalFecharAberto && (
+        <div
+          className="fixed inset-0 z-[520] flex items-end justify-center bg-slate-950/60 p-4 backdrop-blur-[2px] sm:items-center dark:bg-slate-950/70"
+          role="presentation"
+          onClick={() => {
+            if (fechando) return
+            setModalFecharAberto(false)
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="ticket-fechar-titulo"
+            className="w-full max-w-md rounded-2xl border border-slate-200 bg-white p-5 shadow-xl dark:border-slate-600 dark:bg-slate-900 dark:shadow-2xl dark:ring-1 dark:ring-white/10"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 id="ticket-fechar-titulo" className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              Fechar ticket
+            </h2>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              Ao fechar, o ticket sairá da lista de abertos e não permitirá novas mensagens.
+            </p>
+            <div className="mt-5 flex flex-wrap justify-end gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setModalFecharAberto(false)}
+                disabled={fechando}
+              >
+                Cancelar
+              </Button>
+              <Button type="button" variant="danger" onClick={fecharTicketConfirmado} loading={fechando}>
+                Fechar ticket
               </Button>
             </div>
           </div>

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -10,7 +10,7 @@ import { useAuth } from '../contexts/AuthContext'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { refetchPendenciasResumo } from '../hooks/useAlertaFilaSemResponsavel'
 import { SemPermissao } from './SemPermissao'
-import { interpretarFalhaCarregamento } from '../api/errorMessage'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
 const ROTULO_CAMPO: Record<string, string> = {
@@ -616,7 +616,13 @@ export function TicketDetalhe() {
                   setHistorico(hist)
                   toast.showSuccess('Ticket reaberto.')
                 } catch (err) {
-                  toast.showWarning(err instanceof Error ? err.message : 'Não foi possível reabrir.')
+                  if (err instanceof ApiError && err.status === 404) {
+                    toast.showWarning(
+                      'Função de reabrir indisponível no servidor. Atualize a página ou contate o suporte.',
+                    )
+                    return
+                  }
+                  toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível reabrir.'))
                 }
               }}
             >

--- a/frontend/src/pages/TiposNegocio.tsx
+++ b/frontend/src/pages/TiposNegocio.tsx
@@ -113,7 +113,7 @@ export function TiposNegocio() {
       setModalOpen(false)
       load()
     } catch (err) {
-      toast.showError(err instanceof Error ? err.message : 'Erro')
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o tipo de negócio.'))
     } finally {
       setSaving(false)
     }
@@ -125,7 +125,7 @@ export function TiposNegocio() {
       await tiposNegocio.delete(id)
       load()
     } catch (err) {
-      toast.showWarning(err instanceof Error ? err.message : 'Erro ao excluir')
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível excluir o tipo de negócio.'))
     }
   }
 


### PR DESCRIPTION
## Contexto
Em produção, o fluxo de **reabrir ticket** retornava erro e a UI exibia mensagens genéricas/técnicas.

## O que foi feito
- Sanitização central de mensagens para **não expor URLs/hostnames/rotas** ao usuário
- Padronização de toasts com mensagens amigáveis
- Tratamento específico de 404 no fluxo de **Reabrir**
- Substituição do confirm() do navegador por **modal nativo** ao **Fechar ticket**

## Issues
- Closes #79
- Closes #80

## Test plan
- [x] Local: fechar ticket (modal nativo)
- [x] Local: reabrir ticket e validar toasts
- [x] Produção (staging deploy): validar reabrir/fechar e ausência de mensagens técnicas/rotas
