### PR TITLE
fix(alembic): corrigir cadeia de migrations (005 -> 004_must_pwd)

### DIFF
--- a/.github/pr_alembic_revision_chain.md
+++ b/.github/pr_alembic_revision_chain.md
@@ -1,0 +1,22 @@
+## Contexto
+
+Deploy em produção/staging falhou ao executar `alembic upgrade head` com erro:
+
+- `KeyError: '004_atendente_must_change_password'`
+
+Isso ocorreu porque a migration `005_rede_login_retaguarda` referenciava um `down_revision` que **não existe** como `revision` no repositório.
+
+## O que foi feito
+
+- Ajuste da cadeia Alembic: `005_rede_login_retaguarda` agora referencia o `revision` correto (`004_must_pwd`).
+- Documentação: adiciona `docs/ALEMBIC_MIGRATIONS.md` e reforça o checklist em `docs/PRE_DEPLOY_CHECKLIST.md`.
+
+## Por que assim (e não “renomear” o revision antigo)
+
+Alterar o `revision` de uma migration existente pode quebrar ambientes que já tenham essa revisão aplicada (valor registrado em `alembic_version`). O ajuste no `down_revision` resolve o problema sem exigir re-stamp do banco.
+
+## Test plan
+
+- Em ambiente do backend: `alembic history` / `alembic heads` (deve funcionar sem warnings/KeyError)
+- No VPS antes do `up --build`: `docker compose -f docker-compose.prod.yml run --rm backend alembic upgrade head`
+

--- a/backend/alembic/versions/005_rede_login_retaguarda.py
+++ b/backend/alembic/versions/005_rede_login_retaguarda.py
@@ -1,7 +1,7 @@
 """Rede: adicionar login_retaguarda.
 
 Revision ID: 005_rede_login_retaguarda
-Revises: 004_atendente_must_change_password
+Revises: 004_must_pwd
 Create Date: 2026-04-14
 """
 
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 revision = "005_rede_login_retaguarda"
-down_revision = "004_atendente_must_change_password"
+down_revision = "004_must_pwd"
 branch_labels = None
 depends_on = None
 

--- a/docs/ALEMBIC_MIGRATIONS.md
+++ b/docs/ALEMBIC_MIGRATIONS.md
@@ -1,0 +1,29 @@
+# Alembic: padrão de revisions (evitar quebra em deploy)
+
+## Regra de ouro
+
+- O encadeamento das migrations é definido pelos IDs **internos** `revision` e `down_revision`.
+- O `down_revision` deve apontar para um **`revision` que existe** (em algum arquivo dentro de `backend/alembic/versions/`).
+- **Nome do arquivo não é referência**. Se o arquivo chama `004_atendente_must_change_password.py`, isso **não** significa que o `revision` seja `"004_atendente_must_change_password"`.
+
+Quando esse encadeamento fica inconsistente, o comando `alembic upgrade head` falha antes mesmo de consultar o banco, com erros do tipo `KeyError`/`Revision ... is not present`.
+
+## Boas práticas para evitar o problema
+
+- **Ao criar uma migration nova**, sempre confira:
+  - o `revision` gerado
+  - o `down_revision` que ela referencia
+  - se o `down_revision` bate com o `revision` real da migration anterior
+- **Evite trocar o valor de `revision`** de uma migration que já pode ter sido aplicada em algum ambiente. Se precisar padronizar IDs antigos, prefira planejar isso como uma ação controlada (ex.: com `alembic stamp`) e documentar para todos os ambientes.
+
+## Checagem rápida (local/CI)
+
+No container/ambiente do backend:
+
+```bash
+alembic heads
+alembic history
+```
+
+Se `history`/`heads` já falhar, há inconsistência de `revision`/`down_revision`.
+

--- a/docs/PRE_DEPLOY_CHECKLIST.md
+++ b/docs/PRE_DEPLOY_CHECKLIST.md
@@ -22,6 +22,7 @@ Legenda: **OK** atendido no repositório | **Você** validação manual no servi
 |------|--------|
 | PostgreSQL em todos os ambientes | **OK** — não há SQLite no caminho principal. |
 | Migrations versionadas (Alembic) | **Parcial** — existe pasta `alembic/versions/`, mas o startup ainda usa `create_all` + scripts ad hoc; ideal evoluir para `alembic upgrade head` como fonte única do schema em produção. |
+| Cadeia de migrations consistente (`revision`/`down_revision`) | **OK** — ver `docs/ALEMBIC_MIGRATIONS.md` (evita quebra de deploy com `KeyError`/`Revision ... is not present`). |
 | Subir banco do zero e rodar app | **Você** — primeiro deploy: criar DB/usuário no provedor; API cria tabelas no startup. |
 | Persistência após reinício | **Você** — dados ficam no PostgreSQL do provedor; reiniciar só o container não apaga o DB. |
 


### PR DESCRIPTION
## Contexto

Deploy em produção/staging falhou ao executar `alembic upgrade head` com erro:

- `KeyError: '004_atendente_must_change_password'`

Isso ocorreu porque a migration `005_rede_login_retaguarda` referenciava um `down_revision` que **não existe** como `revision` no repositório.

## O que foi feito

- Ajuste da cadeia Alembic: `005_rede_login_retaguarda` agora referencia o `revision` correto (`004_must_pwd`).
- Documentação: adiciona `docs/ALEMBIC_MIGRATIONS.md` e reforça o checklist em `docs/PRE_DEPLOY_CHECKLIST.md`.

## Por que assim (e não “renomear” o revision antigo)

Alterar o `revision` de uma migration existente pode quebrar ambientes que já tenham essa revisão aplicada (valor registrado em `alembic_version`). O ajuste no `down_revision` resolve o problema sem exigir re-stamp do banco.

## Test plan

- Em ambiente do backend: `alembic history` / `alembic heads` (deve funcionar sem warnings/KeyError)
- No VPS antes do `up --build`: `docker compose -f docker-compose.prod.yml run --rm backend alembic upgrade head`

