### PR TITLE
WhatsApp (backend): envio de mídia + resposta citada (quoted)

### DIFF
--- a/backend/alembic/versions/015_wpp_mensagem_citacao.py
+++ b/backend/alembic/versions/015_wpp_mensagem_citacao.py
@@ -1,0 +1,43 @@
+"""WhatsApp: citação (reply) em mensagens.
+
+Revision ID: 015_wpp_citacao
+Revises: 014_wpp_reads
+Create Date: 2026-04-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "015_wpp_citacao"
+down_revision = "014_wpp_reads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = [c["name"] for c in insp.get_columns("whatsapp_mensagens")] if insp.has_table("whatsapp_mensagens") else []
+    if "quoted_wa_message_id" not in cols:
+        op.add_column(
+            "whatsapp_mensagens",
+            sa.Column("quoted_wa_message_id", sa.String(length=128), nullable=True),
+        )
+    if "quoted_corpo_preview" not in cols:
+        op.add_column(
+            "whatsapp_mensagens",
+            sa.Column("quoted_corpo_preview", sa.String(length=500), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_mensagens"):
+        return
+    cols = [c["name"] for c in insp.get_columns("whatsapp_mensagens")]
+    if "quoted_corpo_preview" in cols:
+        op.drop_column("whatsapp_mensagens", "quoted_corpo_preview")
+    if "quoted_wa_message_id" in cols:
+        op.drop_column("whatsapp_mensagens", "quoted_wa_message_id")

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -1,6 +1,7 @@
+import base64
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import desc
@@ -26,8 +27,9 @@ from app.schemas.whatsapp_chat import (
 from app.core.auth import obter_atendente_atual
 from app.api.tickets import _gerar_protocolo, _pode_ver_ticket
 from app.core.setor_scope import ids_setores_visiveis_atendente
+from app.config import settings
 from app.services import evolution_api
-from app.services.whatsapp_media_storage import caminho_absoluto_arquivo
+from app.services.whatsapp_media_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
 
 router = APIRouter(prefix="/whatsapp/chats", tags=["whatsapp-chats"])
 
@@ -53,6 +55,68 @@ def _settings_envio(db: Session) -> WhatsappSettings:
             detail="Integração WhatsApp incompleta. Administrador deve preencher URL, instância e API key.",
         )
     return row
+
+
+def _quoted_evolution_payload(db: Session, chat_id: int, quoted_wa_message_id: str) -> dict:
+    q = (quoted_wa_message_id or "").strip()
+    if not q:
+        raise HTTPException(status_code=400, detail="Citação inválida.")
+    ref = (
+        db.query(WhatsappMensagem)
+        .filter(WhatsappMensagem.chat_id == chat_id, WhatsappMensagem.wa_message_id == q)
+        .first()
+    )
+    if not ref:
+        raise HTTPException(
+            status_code=400,
+            detail="Mensagem citada não encontrada neste chat (use o id da mensagem no WhatsApp, "
+            "campo wa_message_id na listagem de mensagens).",
+        )
+    pv = ((ref.corpo or "").strip()[:2000] or " ")
+    return {"key": {"id": q}, "message": {"conversation": pv}}
+
+
+def _preview_citacao(ref: WhatsappMensagem) -> str | None:
+    s = (ref.corpo or "").strip()[:500]
+    return s or None
+
+
+def _mediatype_evolution(slug: str) -> str:
+    s = (slug or "").strip().lower()
+    return {
+        "imagem": "image",
+        "image": "image",
+        "video": "video",
+        "audio": "audio",
+        "documento": "document",
+        "document": "document",
+    }.get(s, "document")
+
+
+def _tipo_midia_db(slug: str) -> str:
+    s = (slug or "").strip().lower()
+    if s in ("imagem", "image"):
+        return "imagem"
+    if s == "video":
+        return "video"
+    if s == "audio":
+        return "audio"
+    return "documento"
+
+
+def _rotulo_midia_outbound(tipo_db: str) -> str:
+    return {
+        "imagem": "[Imagem enviada]",
+        "video": "[Vídeo enviado]",
+        "audio": "[Áudio enviado]",
+        "documento": "[Documento enviado]",
+    }.get(tipo_db, "[Ficheiro enviado]")
+
+
+def _sanitizar_nome_ficheiro(name: str | None, fallback: str) -> str:
+    raw = (name or fallback or "file").strip() or "file"
+    safe = "".join(ch for ch in raw if ch.isalnum() or ch in "._- ")
+    return (safe.strip() or fallback)[:200]
 
 
 def _render_template(
@@ -89,6 +153,7 @@ def _enviar_texto_whatsapp(
     texto: str,
     atendente: Atendente | None,
     evento_sistema: str | None,
+    quoted_wa_message_id: str | None = None,
 ) -> WhatsappMensagem:
     texto_eff = (texto or "").strip()
     if not texto_eff:
@@ -113,12 +178,25 @@ def _enviar_texto_whatsapp(
         if exist:
             return exist
     st = _settings_envio(db)
+    quoted_payload = None
+    q_wa: str | None = None
+    q_prev: str | None = None
+    if quoted_wa_message_id and str(quoted_wa_message_id).strip() and evento_sistema is None:
+        q_wa = str(quoted_wa_message_id).strip()
+        quoted_payload = _quoted_evolution_payload(db, chat.id, q_wa)
+        ref = (
+            db.query(WhatsappMensagem)
+            .filter(WhatsappMensagem.chat_id == chat.id, WhatsappMensagem.wa_message_id == q_wa)
+            .first()
+        )
+        q_prev = _preview_citacao(ref) if ref else None
     ok, err = evolution_api.evolution_send_text(
         st.evolution_base_url,
         st.evolution_instance_name,
         st.evolution_api_key,
         chat.wa_id,
         texto_eff,
+        quoted=quoted_payload,
     )
     if not ok:
         raise HTTPException(status_code=502, detail=err or "Falha ao enviar pela Evolution API")
@@ -130,6 +208,8 @@ def _enviar_texto_whatsapp(
         mimetype=None,
         midia_nome_arquivo=None,
         wa_message_id=None,
+        quoted_wa_message_id=q_wa,
+        quoted_corpo_preview=q_prev,
         atendente_id=atendente.id if atendente else None,
         evento_sistema=evento_sistema,
     )
@@ -173,6 +253,8 @@ def _mensagem_read(m: WhatsappMensagem) -> WhatsappMensagemRead:
         midia_disponivel=midia_ok,
         evento_sistema=getattr(m, "evento_sistema", None),
         wa_message_id=m.wa_message_id,
+        quoted_wa_message_id=getattr(m, "quoted_wa_message_id", None),
+        quoted_corpo_preview=getattr(m, "quoted_corpo_preview", None),
         atendente_id=m.atendente_id,
         atendente_nome=m.atendente.nome if m.atendente else None,
         created_at=m.created_at,
@@ -403,10 +485,116 @@ def enviar_mensagem(
     if atendente.role != "admin" and c.atendente_id != atendente.id:
         raise HTTPException(status_code=403, detail="Apenas o atendente responsável pode enviar mensagens")
     texto = data.texto.strip()
-    m = _enviar_texto_whatsapp(db, chat=c, texto=texto, atendente=atendente, evento_sistema=None)
+    m = _enviar_texto_whatsapp(
+        db,
+        chat=c,
+        texto=texto,
+        atendente=atendente,
+        evento_sistema=None,
+        quoted_wa_message_id=data.quoted_wa_message_id,
+    )
     m = db.query(WhatsappMensagem).options(joinedload(WhatsappMensagem.atendente)).filter(WhatsappMensagem.id == m.id).first()
     assert m is not None
     return _mensagem_read(m)
+
+
+@router.post("/{chat_id}/mensagens/midia", response_model=WhatsappMensagemRead, status_code=201)
+async def enviar_mensagem_midia(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+    file: UploadFile = File(...),
+    mediatipo: str = Form(..., description="imagem | video | audio | documento"),
+    caption: str = Form(""),
+    quoted_wa_message_id: str | None = Form(None),
+):
+    """Envia mídia para o cliente via Evolution API (base64). Opcionalmente cita uma mensagem anterior."""
+    c = db.query(WhatsappChat).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if atendente.role != "admin" and c.setor_id is not None:
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        if c.setor_id not in vis:
+            raise HTTPException(status_code=403, detail="Sem permissão para este setor")
+    if c.estado != "em_atendimento":
+        raise HTTPException(status_code=400, detail="Só é possível enviar mensagens em chats ativos")
+    if atendente.role != "admin" and c.atendente_id != atendente.id:
+        raise HTTPException(status_code=403, detail="Apenas o atendente responsável pode enviar mensagens")
+
+    data = await file.read()
+    if len(data) > settings.WHATSAPP_MEDIA_MAX_BYTES:
+        raise HTTPException(status_code=413, detail="Ficheiro excede o tamanho máximo permitido.")
+    if len(data) == 0:
+        raise HTTPException(status_code=400, detail="Ficheiro vazio.")
+
+    mime = (file.content_type or "application/octet-stream").split(";")[0].strip()
+    tipo_db = _tipo_midia_db(mediatipo)
+    nome_guardado = gravar_bytes_em_disco(data, mime)
+    if not nome_guardado:
+        raise HTTPException(status_code=500, detail="Não foi possível guardar o ficheiro em disco.")
+
+    cap = (caption or "").strip()
+    base_legenda = cap if cap else _rotulo_midia_outbound(tipo_db)
+    nome_atend = (atendente.nome or "").strip()
+    legenda_whatsapp = f"[ {nome_atend} ]: {base_legenda}" if nome_atend else base_legenda
+    corpo_eff = legenda_whatsapp
+
+    b64 = base64.b64encode(data).decode("ascii")
+    st = _settings_envio(db)
+    ev_mt = _mediatype_evolution(mediatipo)
+    fname = _sanitizar_nome_ficheiro(file.filename, f"envio.{tipo_db}")
+
+    quoted_payload = None
+    q_wa: str | None = None
+    q_prev: str | None = None
+    if quoted_wa_message_id and str(quoted_wa_message_id).strip():
+        q_wa = str(quoted_wa_message_id).strip()
+        quoted_payload = _quoted_evolution_payload(db, chat_id, q_wa)
+        ref = (
+            db.query(WhatsappMensagem)
+            .filter(WhatsappMensagem.chat_id == chat_id, WhatsappMensagem.wa_message_id == q_wa)
+            .first()
+        )
+        q_prev = _preview_citacao(ref) if ref else None
+
+    ok, err = evolution_api.evolution_send_media(
+        st.evolution_base_url,
+        st.evolution_instance_name,
+        st.evolution_api_key,
+        c.wa_id,
+        mediatype=ev_mt,
+        mimetype=mime,
+        caption=legenda_whatsapp,
+        media_base64=b64,
+        file_name=fname,
+        quoted=quoted_payload,
+    )
+    if not ok:
+        raise HTTPException(status_code=502, detail=err or "Falha ao enviar mídia pela Evolution API")
+
+    m = WhatsappMensagem(
+        chat_id=c.id,
+        direcao="outbound",
+        corpo=corpo_eff,
+        tipo_midia=tipo_db,
+        mimetype=mime,
+        midia_nome_arquivo=nome_guardado,
+        wa_message_id=None,
+        quoted_wa_message_id=q_wa,
+        quoted_corpo_preview=q_prev,
+        atendente_id=atendente.id,
+        evento_sistema=None,
+    )
+    db.add(m)
+    db.commit()
+    m2 = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == m.id)
+        .first()
+    )
+    assert m2 is not None
+    return _mensagem_read(m2)
 
 
 @router.post("/{chat_id}/comentarios-internos", response_model=WhatsappMensagemRead, status_code=201)

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -394,6 +394,9 @@ def evolution_webhook(
                 except Exception:
                     logger.exception("Falha ao enviar mensagem automática fora do horário (chat=%s)", chat.protocolo)
 
+        q_prev = item.get("quoted_corpo_preview")
+        if q_prev is not None and len(str(q_prev)) > 500:
+            q_prev = str(q_prev)[:500]
         msg = WhatsappMensagem(
             chat_id=chat.id,
             direcao="inbound",
@@ -402,6 +405,8 @@ def evolution_webhook(
             mimetype=mimetype_val,
             midia_nome_arquivo=midia_nome,
             wa_message_id=wa_mid,
+            quoted_wa_message_id=item.get("quoted_wa_message_id"),
+            quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
             atendente_id=None,
         )
         db.add(msg)

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -77,6 +77,9 @@ class WhatsappMensagem(Base):
     # Identifica mensagens automáticas disparadas pelo sistema (evita duplicação e ajuda auditoria).
     evento_sistema = Column(String(40), nullable=True, index=True)
     wa_message_id = Column(String(128), nullable=True, index=True)
+    # Mensagem citada (reply do WhatsApp): id da mensagem na origem + texto de pré-visualização
+    quoted_wa_message_id = Column(String(128), nullable=True)
+    quoted_corpo_preview = Column(String(500), nullable=True)
     atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -13,6 +13,8 @@ class WhatsappMensagemRead(BaseModel):
     midia_disponivel: bool = False
     evento_sistema: str | None = None
     wa_message_id: str | None = None
+    quoted_wa_message_id: str | None = None
+    quoted_corpo_preview: str | None = None
     atendente_id: int | None = None
     atendente_nome: str | None = None
     created_at: datetime | None = None
@@ -40,6 +42,11 @@ class WhatsappChatRead(BaseModel):
 
 class WhatsappChatMensagemCreate(BaseModel):
     texto: str = Field(..., min_length=1, max_length=4000)
+    quoted_wa_message_id: str | None = Field(
+        None,
+        max_length=128,
+        description="Id WhatsApp (key.id) da mensagem a citar, já existente neste chat.",
+    )
 
 
 class WhatsappChatComentarioInternoCreate(BaseModel):

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -94,21 +94,61 @@ def evolution_send_text(
     api_key: str,
     number_digits: str,
     text: str,
+    *,
+    quoted: dict[str, Any] | None = None,
 ) -> tuple[bool, str | None]:
     base = base_url.rstrip("/")
     path = f"/message/sendText/{instance}"
     url = base + path
     headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body: dict[str, Any] = {"number": number_digits, "text": text}
+    if quoted:
+        body["quoted"] = quoted
     code, _data, err = _request_json(
         "POST",
         url,
         headers=headers,
-        body={"number": number_digits, "text": text},
+        body=body,
     )
     if code in (200, 201):
         return True, None
     if err:
         return False, err[:800]
+    return False, f"HTTP {code}"
+
+
+def evolution_send_media(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    number_digits: str,
+    *,
+    mediatype: str,
+    mimetype: str,
+    caption: str,
+    media_base64: str,
+    file_name: str,
+    quoted: dict[str, Any] | None = None,
+) -> tuple[bool, str | None]:
+    """POST /message/sendMedia/{instance} — mediatype típico: image | video | audio | document."""
+    base = base_url.rstrip("/")
+    url = f"{base}/message/sendMedia/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body: dict[str, Any] = {
+        "number": number_digits,
+        "mediatype": mediatype,
+        "mimetype": mimetype,
+        "caption": caption or "",
+        "media": media_base64,
+        "fileName": file_name or "file",
+    }
+    if quoted:
+        body["quoted"] = quoted
+    code, _data, err = _request_json("POST", url, headers=headers, body=body, timeout=120)
+    if code in (200, 201):
+        return True, None
+    if err:
+        return False, err[:1200]
     return False, f"HTTP {code}"
 
 

--- a/backend/app/services/evolution_inbound.py
+++ b/backend/app/services/evolution_inbound.py
@@ -53,6 +53,50 @@ def _detect_media(inner: dict[str, Any]) -> tuple[str, dict[str, Any]] | None:
     return None
 
 
+_SUBCOM_KEYS = (
+    "extendedTextMessage",
+    "ExtendedTextMessage",
+    "imageMessage",
+    "ImageMessage",
+    "videoMessage",
+    "VideoMessage",
+    "audioMessage",
+    "AudioMessage",
+    "documentMessage",
+    "DocumentMessage",
+    "stickerMessage",
+    "StickerMessage",
+)
+
+
+def quoted_reply_from_inner(inner: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Extrai resposta citada: id da mensagem original (stanzaId) e texto de pré-visualização."""
+    for sub_key in _SUBCOM_KEYS:
+        sub = inner.get(sub_key)
+        if not isinstance(sub, dict):
+            continue
+        ctx = sub.get("contextInfo") or sub.get("ContextInfo")
+        if not isinstance(ctx, dict):
+            continue
+        sid = ctx.get("stanzaId") or ctx.get("StanzaId")
+        if not sid:
+            continue
+        wid = str(sid).strip()
+        if not wid:
+            continue
+        preview: str | None = None
+        qm = ctx.get("quotedMessage") or ctx.get("QuotedMessage")
+        if isinstance(qm, dict):
+            preview = _text_from_inner(qm)
+            if not preview:
+                md = _detect_media(qm)
+                if md:
+                    kind, _ = md
+                    preview = _ROTULO_TIPO.get(kind, "[Mídia]")
+        return wid, preview
+    return None, None
+
+
 def _mimetype_de_obj_midia(obj: dict[str, Any]) -> str | None:
     for k in ("mimetype", "mimeType", "Mimetype"):
         v = obj.get(k)
@@ -95,6 +139,7 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
     - corpo: texto ou legenda ou rótulo [Imagem] etc.
     - mimetype: opcional
     - raw_envelope: objeto completo da mensagem (para POST getBase64FromMediaMessage), só se tipo != texto
+    - quoted_wa_message_id, quoted_corpo_preview: se o cliente responde citando outra mensagem
     """
     event = webhook_body.get("event") or webhook_body.get("Event") or ""
     ev = str(event).lower()
@@ -123,6 +168,10 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
         if not isinstance(inner, dict):
             continue
 
+        q_wid, q_prev = quoted_reply_from_inner(inner)
+        if q_prev and len(q_prev) > 500:
+            q_prev = q_prev[:500]
+
         media = _detect_media(inner)
         if media:
             kind, obj = media
@@ -137,6 +186,8 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
                 "corpo": corpo,
                 "mimetype": mime,
                 "raw_envelope": m,
+                "quoted_wa_message_id": q_wid,
+                "quoted_corpo_preview": q_prev,
             }
             continue
 
@@ -151,6 +202,8 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
             "corpo": text,
             "mimetype": None,
             "raw_envelope": None,
+            "quoted_wa_message_id": q_wid,
+            "quoted_corpo_preview": q_prev,
         }
 
 

--- a/backend/app/services/whatsapp_media_storage.py
+++ b/backend/app/services/whatsapp_media_storage.py
@@ -59,6 +59,22 @@ def diretorio_midia() -> Path:
     return p
 
 
+def gravar_bytes_em_disco(data: bytes, mimetype: str | None) -> str | None:
+    """Grava bytes brutos (ex.: upload outbound). Devolve basename ou None."""
+    if len(data) > settings.WHATSAPP_MEDIA_MAX_BYTES:
+        return None
+    if len(data) == 0:
+        return None
+    ext = extensao_para_mimetype(mimetype)
+    name = f"{uuid.uuid4().hex}{ext}"
+    path = diretorio_midia() / name
+    try:
+        path.write_bytes(data)
+    except OSError:
+        return None
+    return name
+
+
 def gravar_base64_em_disco(b64: str, mimetype: str | None) -> str | None:
     """
     Grava bytes em disco. Devolve apenas o nome do ficheiro (basename) ou None se falhar/limite.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 # Necessário para `Form()` / `UploadFile` (envio de mídia WhatsApp, etc.).
-python-multipart==0.0.20
+python-multipart==0.0.26
 fastapi==0.135.3
 starlette==0.49.1
 uvicorn[standard]==0.32.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
-# python-multipart não é necessário: rotas usam JSON (Body), não Form()/upload.
-# Se no futuro houver formulários ou upload de ficheiros, adicionar: python-multipart==...
+# Necessário para `Form()` / `UploadFile` (envio de mídia WhatsApp, etc.).
+python-multipart==0.0.20
 fastapi==0.135.3
 starlette==0.49.1
 uvicorn[standard]==0.32.1

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -67,6 +67,48 @@ def test_fila_e_assumir(client, seed_base, auth_headers):
     assert client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json() == []
 
 
+def test_webhook_guarda_citacao_em_mensagem(client, seed_base, auth_headers):
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "cit"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "cit"}
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {
+                        "remoteJid": "5511333444555@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": "reply-msg-1",
+                    },
+                    "message": {
+                        "extendedTextMessage": {
+                            "text": "Resposta citando",
+                            "contextInfo": {
+                                "stanzaId": "orig-msg-1",
+                                "quotedMessage": {"conversation": "Texto original"},
+                            },
+                        }
+                    },
+                }
+            ]
+        },
+    }
+    r = client.post("/v1/webhooks/evolution", json=body, headers=h)
+    assert r.status_code == 200
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    r_msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"])
+    assert r_msgs.status_code == 200
+    rows = r_msgs.json()
+    assert len(rows) >= 1
+    last = rows[-1]
+    assert last.get("quoted_wa_message_id") == "orig-msg-1"
+    assert "original" in (last.get("quoted_corpo_preview") or "").lower()
+
+
 def test_abrir_ticket_vincula(client, seed_base, auth_headers):
     client.patch(
         "/v1/settings/whatsapp",


### PR DESCRIPTION
## Resumo\n- Adiciona suporte a **resposta citada** (quoted) no inbound e no envio de texto.\n- Adiciona envio de **mídia outbound** via Evolution (sendMedia) com persistência e endpoint.\n- Inclui migração Alembic e testes do backend.\n\n## Importante\nEste PR é **backend-only** para não conflitar com o reestilo/refator do frontend em andamento.\n\n## Test plan\n- [ ] Rodar migrações\n- [ ] Rodar testes: ackend/tests/test_whatsapp_chats.py\n- [ ] Validar envio de texto com quoted\n- [ ] Validar envio de mídia (imagem/documento)\n

Made with [Cursor](https://cursor.com)