### PR TITLE
Tickets: anexos (upload, listagem e download)

### DIFF
--- a/backend/alembic/versions/016_ticket_anexos.py
+++ b/backend/alembic/versions/016_ticket_anexos.py
@@ -1,0 +1,59 @@
+"""Tickets: anexos (upload/download).
+
+Revision ID: 016_ticket_anexos
+Revises: 015_wpp_citacao
+Create Date: 2026-04-25
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "016_ticket_anexos"
+down_revision = "015_wpp_citacao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("ticket_anexos"):
+        op.create_table(
+            "ticket_anexos",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("ticket_id", sa.Integer(), sa.ForeignKey("tickets.id", ondelete="CASCADE"), nullable=False),
+            sa.Column(
+                "mensagem_id",
+                sa.Integer(),
+                sa.ForeignKey("ticket_mensagens.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "atendente_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("visibilidade", sa.String(length=20), nullable=False, server_default="publico"),
+            sa.Column("nome_original", sa.String(length=255), nullable=False),
+            sa.Column("content_type", sa.String(length=128), nullable=True),
+            sa.Column("tamanho_bytes", sa.Integer(), nullable=False),
+            sa.Column("storage_key", sa.String(length=500), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        )
+        op.create_index("ix_ticket_anexos_ticket_id", "ticket_anexos", ["ticket_id"])
+        op.create_index("ix_ticket_anexos_mensagem_id", "ticket_anexos", ["mensagem_id"])
+        op.create_index("ix_ticket_anexos_atendente_id", "ticket_anexos", ["atendente_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("ticket_anexos"):
+        return
+    op.drop_index("ix_ticket_anexos_atendente_id", table_name="ticket_anexos")
+    op.drop_index("ix_ticket_anexos_mensagem_id", table_name="ticket_anexos")
+    op.drop_index("ix_ticket_anexos_ticket_id", table_name="ticket_anexos")
+    op.drop_table("ticket_anexos")
+

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -1,12 +1,14 @@
 from datetime import datetime, timezone
 from enum import Enum
 
-from fastapi import APIRouter, Depends, HTTPException, status, Query
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
+from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import or_, asc, desc, nullslast
 
 from app.database import get_db
 from app.models import Ticket, TicketHistorico, TicketMensagem, Empresa, Setor, StatusTicket, Atendente, Rede
+from app.models.ticket_anexo import TicketAnexo
 from app.schemas.ticket import (
     TicketCreate,
     TicketUpdate,
@@ -15,6 +17,7 @@ from app.schemas.ticket import (
     TicketMensagemCreate,
     TicketMensagemRead,
 )
+from app.schemas.ticket_anexo import TicketAnexoCreateResponse, TicketAnexoRead
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import obter_atendente_atual
 from app.core.ordenacao_lista import OrdemLista, expr_ordem
@@ -23,6 +26,7 @@ from app.core.setor_scope import (
     ids_setores_visiveis_atendente,
     responsavel_elegivel_para_setor_do_ticket,
 )
+from app.services import ticket_anexo_storage
 
 router = APIRouter(prefix="/tickets", tags=["tickets"])
 
@@ -411,6 +415,141 @@ def _registrar_historico(db: Session, ticket_id: int, atendente_id: int | None, 
         valor_antigo=valor_antigo,
         valor_novo=valor_novo,
     ))
+
+
+def _anexo_para_read(a: TicketAnexo) -> TicketAnexoRead:
+    return TicketAnexoRead(
+        id=a.id,
+        ticket_id=a.ticket_id,
+        mensagem_id=a.mensagem_id,
+        atendente_id=a.atendente_id,
+        atendente_nome=a.atendente.nome if a.atendente else None,
+        visibilidade=(a.visibilidade or "publico"),  # type: ignore[arg-type]
+        nome_original=a.nome_original,
+        content_type=a.content_type,
+        tamanho_bytes=a.tamanho_bytes,
+        created_at=a.created_at,
+    )
+
+
+@router.get("/{ticket_id}/anexos", response_model=list[TicketAnexoRead])
+def listar_anexos(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if not _pode_ver_ticket(db, atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+    rows = (
+        db.query(TicketAnexo)
+        .options(joinedload(TicketAnexo.atendente))
+        .filter(TicketAnexo.ticket_id == ticket_id)
+        .order_by(TicketAnexo.created_at.asc(), TicketAnexo.id.asc())
+        .all()
+    )
+    return [_anexo_para_read(a) for a in rows]
+
+
+@router.get("/{ticket_id}/anexos/{anexo_id}/download")
+def download_anexo(
+    ticket_id: int,
+    anexo_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if not _pode_ver_ticket(db, atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+
+    a = (
+        db.query(TicketAnexo)
+        .filter(TicketAnexo.id == anexo_id, TicketAnexo.ticket_id == ticket_id)
+        .first()
+    )
+    if not a:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Anexo não encontrado")
+    p = ticket_anexo_storage.caminho_absoluto_arquivo(a.storage_key)
+    if not p:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Arquivo não encontrado no storage")
+
+    # Força download (evita execução inline de tipos perigosos).
+    return FileResponse(
+        path=str(p),
+        filename=a.nome_original,
+        media_type="application/octet-stream",
+    )
+
+
+@router.post("/{ticket_id}/anexos", response_model=TicketAnexoCreateResponse, status_code=201)
+def upload_anexo(
+    ticket_id: int,
+    file: UploadFile = File(...),
+    mensagem_id: int | None = Form(None, description="Opcional: associa o anexo a uma mensagem do ticket"),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if not _pode_ver_ticket(db, atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+    if ticket.fechado_em is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Ticket fechado. Reabra o ticket para enviar anexos.",
+        )
+
+    msg: TicketMensagem | None = None
+    vis = "publico"
+    if mensagem_id is not None:
+        msg = (
+            db.query(TicketMensagem)
+            .filter(TicketMensagem.id == mensagem_id, TicketMensagem.ticket_id == ticket_id)
+            .first()
+        )
+        if not msg:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Mensagem inválida para este ticket")
+        if msg.tipo == "interno":
+            vis = "interno"
+
+    data = file.file.read()
+    try:
+        nome_original, mime = ticket_anexo_storage.validar_upload(file.filename, file.content_type, len(data))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+    try:
+        storage_key = ticket_anexo_storage.gravar_bytes_em_disco(data, mimetype=mime, nome_original=nome_original)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except OSError:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Falha ao gravar arquivo")
+
+    a = TicketAnexo(
+        ticket_id=ticket_id,
+        mensagem_id=msg.id if msg else None,
+        atendente_id=atendente.id,
+        visibilidade=vis,
+        nome_original=nome_original,
+        content_type=mime,
+        tamanho_bytes=len(data),
+        storage_key=storage_key,
+    )
+    db.add(a)
+    db.flush()
+    _registrar_historico(db, ticket_id, atendente.id, "anexo", "", f"{a.id}")
+    db.commit()
+    db.refresh(a)
+
+    return TicketAnexoCreateResponse(
+        anexo=_anexo_para_read(a),
+        download_url=f"/v1/tickets/{ticket_id}/anexos/{a.id}/download",
+    )
 
 
 @router.post("/{ticket_id}/reabrir", response_model=TicketRead)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -48,6 +48,11 @@ class Settings(BaseSettings):
     # Tamanho máximo (bytes) ao descodificar base64 da Evolution antes de gravar em disco.
     WHATSAPP_MEDIA_MAX_BYTES: int = 25 * 1024 * 1024
 
+    # Diretório para anexos de tickets (caminho relativo ao cwd ou absoluto). Em Docker: mapear volume em /app/data.
+    TICKET_ANEXOS_DIR: str = "data/ticket_anexos"
+    # Tamanho máximo (bytes) para cada anexo de ticket.
+    TICKET_ANEXOS_MAX_BYTES: int = 25 * 1024 * 1024
+
     @property
     def evolution_embutida_disponivel(self) -> bool:
         return bool(

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.setor import Setor
 from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
 from app.models.status_ticket import StatusTicket
 from app.models.ticket import Ticket, TicketHistorico, TicketMensagem
+from app.models.ticket_anexo import TicketAnexo
 from app.models.ticket_read import TicketRead
 from app.models.whatsapp_chat_read import WhatsappChatRead
 from app.models.audit_log import AuditLog
@@ -26,6 +27,7 @@ __all__ = [
     "Ticket",
     "TicketHistorico",
     "TicketMensagem",
+    "TicketAnexo",
     "TicketRead",
     "WhatsappChatRead",
     "AuditLog",

--- a/backend/app/models/ticket_anexo.py
+++ b/backend/app/models/ticket_anexo.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class TicketAnexo(Base):
+    __tablename__ = "ticket_anexos"
+
+    id = Column(Integer, primary_key=True, index=True)
+    ticket_id = Column(Integer, ForeignKey("tickets.id", ondelete="CASCADE"), nullable=False, index=True)
+    # Opcional: anexo associado a uma mensagem (publico/interno/abertura)
+    mensagem_id = Column(Integer, ForeignKey("ticket_mensagens.id", ondelete="SET NULL"), nullable=True, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True, index=True)
+
+    visibilidade = Column(String(20), nullable=False, default="publico")  # publico | interno
+    nome_original = Column(String(255), nullable=False)
+    content_type = Column(String(128), nullable=True)
+    tamanho_bytes = Column(Integer, nullable=False)
+    storage_key = Column(String(500), nullable=False)  # basename no disco/object storage
+
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    ticket = relationship("Ticket", backref="anexos")
+    mensagem = relationship("TicketMensagem", backref="anexos")
+    atendente = relationship("Atendente", backref="ticket_anexos_enviados")
+

--- a/backend/app/schemas/ticket_anexo.py
+++ b/backend/app/schemas/ticket_anexo.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class TicketAnexoRead(BaseModel):
+    id: int
+    ticket_id: int
+    mensagem_id: int | None = None
+    atendente_id: int | None = None
+    atendente_nome: str | None = None
+    visibilidade: Literal["publico", "interno"]
+    nome_original: str
+    content_type: str | None = None
+    tamanho_bytes: int
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TicketAnexoCreateResponse(BaseModel):
+    anexo: TicketAnexoRead
+    # URL relativa do download (para o frontend usar quando existir)
+    download_url: str = Field(..., examples=["/v1/tickets/123/anexos/456/download"])
+

--- a/backend/app/services/ticket_anexo_storage.py
+++ b/backend/app/services/ticket_anexo_storage.py
@@ -1,0 +1,121 @@
+"""Gravação local de anexos de tickets (UploadFile / bytes)."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from pathlib import Path
+
+from app.config import settings
+
+
+def _normalizar_mimetype(mime: str | None) -> str | None:
+    if not mime:
+        return None
+    return mime.split(";")[0].strip().lower() or None
+
+
+def _sanitizar_nome_ficheiro(name: str | None) -> str:
+    raw = (name or "arquivo").strip() or "arquivo"
+    # Mantém só caracteres “seguros” para exibição; não usado no path do disco.
+    safe = "".join(ch for ch in raw if ch.isalnum() or ch in "._- ()[]{}@+")
+    safe = safe.strip(" .") or "arquivo"
+    return safe[:200]
+
+
+_BLOCK_MIME = {
+    "application/x-msdownload",
+    "application/x-dosexec",
+    "application/x-sh",
+    "application/x-bat",
+    "application/x-msdos-program",
+}
+
+_BLOCK_EXT = {
+    ".exe",
+    ".dll",
+    ".msi",
+    ".bat",
+    ".cmd",
+    ".com",
+    ".ps1",
+    ".vbs",
+    ".js",
+    ".jar",
+    ".sh",
+}
+
+
+def validar_upload(nome_original: str | None, content_type: str | None, tamanho_bytes: int) -> tuple[str, str | None]:
+    """Valida e normaliza metadados. Retorna (nome_original_sanitizado, mimetype_normalizado)."""
+    if tamanho_bytes <= 0:
+        raise ValueError("Arquivo vazio.")
+    if tamanho_bytes > settings.TICKET_ANEXOS_MAX_BYTES:
+        raise ValueError("Arquivo excede o tamanho máximo permitido.")
+    nome = _sanitizar_nome_ficheiro(nome_original)
+    ext = Path(nome).suffix.lower()
+    mime = _normalizar_mimetype(content_type)
+    if ext in _BLOCK_EXT:
+        raise ValueError("Tipo de arquivo não permitido.")
+    if mime and mime in _BLOCK_MIME:
+        raise ValueError("Tipo de arquivo não permitido.")
+    return nome, mime
+
+
+def diretorio_anexos() -> Path:
+    p = Path(settings.TICKET_ANEXOS_DIR)
+    if not p.is_absolute():
+        p = Path.cwd() / p
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _extensao_para_mimetype(mimetype: str | None, fallback_nome: str) -> str:
+    # Preferir a extensão do nome original quando existir (mantém UX em downloads).
+    ext = Path(fallback_nome).suffix
+    if ext and len(ext) <= 10:
+        return ext
+    m = _normalizar_mimetype(mimetype)
+    if not m:
+        return ".bin"
+    if m == "application/pdf":
+        return ".pdf"
+    if m.startswith("image/"):
+        return ".img"
+    if m.startswith("audio/"):
+        return ".audio"
+    if m.startswith("video/"):
+        return ".video"
+    if m.startswith("text/"):
+        return ".txt"
+    return ".bin"
+
+
+def gravar_bytes_em_disco(data: bytes, *, mimetype: str | None, nome_original: str) -> str:
+    """Grava bytes no diretório de anexos. Devolve basename (storage_key)."""
+    if len(data) == 0:
+        raise ValueError("Arquivo vazio.")
+    if len(data) > settings.TICKET_ANEXOS_MAX_BYTES:
+        raise ValueError("Arquivo excede o tamanho máximo permitido.")
+    ext = _extensao_para_mimetype(mimetype, nome_original)
+    name = f"{uuid.uuid4().hex}{ext}"
+    path = diretorio_anexos() / name
+    path.write_bytes(data)
+    return name
+
+
+def caminho_absoluto_arquivo(storage_key: str | None) -> Path | None:
+    if not storage_key or not str(storage_key).strip():
+        return None
+    base = diretorio_anexos()
+    # Evita traversal; só aceita basenames simples.
+    s = str(storage_key).strip()
+    if re.search(r"[\\/]", s):
+        return None
+    p = (base / s).resolve()
+    try:
+        p.relative_to(base.resolve())
+    except ValueError:
+        return None
+    return p if p.is_file() else None
+

--- a/backend/tests/test_ticket_anexos.py
+++ b/backend/tests/test_ticket_anexos.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+
+def _create_ticket(client, headers: dict[str, str], empresa_id: int, setor_id: int):
+    r = client.post(
+        "/v1/tickets",
+        headers=headers,
+        json={"empresa_id": empresa_id, "setor_id": setor_id, "assunto": "Teste", "descricao": "Desc"},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def test_upload_list_download_anexo_ticket(client, seed_base, auth_headers):
+    t = _create_ticket(client, auth_headers["admin"], seed_base["empresa"].id, seed_base["setor1"].id)
+
+    up = client.post(
+        f"/v1/tickets/{t['id']}/anexos",
+        headers=auth_headers["admin"],
+        files={"file": ("teste.txt", b"ola", "text/plain")},
+    )
+    assert up.status_code == 201, up.text
+    body = up.json()
+    assert body["anexo"]["ticket_id"] == t["id"]
+    assert body["anexo"]["nome_original"] == "teste.txt"
+    assert body["download_url"].endswith("/download")
+
+    lst = client.get(f"/v1/tickets/{t['id']}/anexos", headers=auth_headers["admin"])
+    assert lst.status_code == 200, lst.text
+    items = lst.json()
+    assert len(items) == 1
+    assert items[0]["nome_original"] == "teste.txt"
+
+    dl = client.get(body["download_url"], headers=auth_headers["admin"])
+    assert dl.status_code == 200
+    assert dl.content == b"ola"
+
+
+def test_anexo_respeita_rbac_ticket(client, seed_base, auth_headers):
+    # Ticket em setor2 (admin cria); a1 não pode ver.
+    t = _create_ticket(client, auth_headers["admin"], seed_base["empresa"].id, seed_base["setor2"].id)
+    up = client.post(
+        f"/v1/tickets/{t['id']}/anexos",
+        headers=auth_headers["admin"],
+        files={"file": ("teste.txt", b"ola", "text/plain")},
+    )
+    assert up.status_code == 201, up.text
+    url = up.json()["download_url"]
+
+    r1 = client.get(f"/v1/tickets/{t['id']}/anexos", headers=auth_headers["a1"])
+    assert r1.status_code == 403
+    r2 = client.get(url, headers=auth_headers["a1"])
+    assert r2.status_code == 403
+
+
+def test_nao_permite_upload_em_ticket_fechado(client, seed_base, auth_headers, db_session):
+    from app.models import StatusTicket
+
+    # Cria status Fechado.
+    fechado = StatusTicket(nome="Fechado", slug="fechado", ordem=99, ativo=True)
+    db_session.add(fechado)
+    db_session.commit()
+    db_session.refresh(fechado)
+
+    t = _create_ticket(client, auth_headers["admin"], seed_base["empresa"].id, seed_base["setor1"].id)
+    r = client.patch(f"/v1/tickets/{t['id']}", headers=auth_headers["admin"], json={"status_id": fechado.id})
+    assert r.status_code == 200, r.text
+
+    up = client.post(
+        f"/v1/tickets/{t['id']}/anexos",
+        headers=auth_headers["admin"],
+        files={"file": ("teste.txt", b"ola", "text/plain")},
+    )
+    assert up.status_code == 400
+

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -490,6 +490,21 @@ export async function fetchWhatsAppMidiaBlob(chatId: number, mensagemId: number)
   return res.blob()
 }
 
+export async function fetchTicketAnexoBlob(ticketId: number, anexoId: number): Promise<Blob> {
+  const token = getAuthToken()
+  const headers: Record<string, string> = {}
+  if (token) headers.Authorization = `Bearer ${token}`
+  const res = await fetch(
+    `${BASE}${API_VERSION_PREFIX}/tickets/${ticketId}/anexos/${anexoId}/download`,
+    { headers },
+  )
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({}))
+    throw new ApiError(mensagemErroApi(errBody, res.status), res.status, errBody)
+  }
+  return res.blob()
+}
+
 export const whatsappChats = {
   fila: () => api<WhatsappChats.Chat[]>('/whatsapp/chats/fila'),
   meus: () => api<WhatsappChats.Chat[]>('/whatsapp/chats/meus'),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -90,10 +90,12 @@ export async function api<T>(
   options: RequestInit = {}
 ): Promise<T> {
   const token = getToken();
+  const isFormData =
+    typeof FormData !== 'undefined' && options.body != null && options.body instanceof FormData
   const headers: HeadersInit = {
-    'Content-Type': 'application/json',
+    ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
     ...(options.headers as object),
-  };
+  }
   if (token) {
     (headers as Record<string, string>)['Authorization'] = `Bearer ${token}`;
   }
@@ -565,6 +567,13 @@ export const tickets = {
   reabrir: (id: number) => api<Tickets.Ticket>(`/tickets/${id}/reabrir`, { method: 'POST' }),
   create: (data: Tickets.Create) => api<Tickets.Ticket>('/tickets', { method: 'POST', body: JSON.stringify(data) }),
   update: (id: number, data: Tickets.Update) => api<Tickets.Ticket>(`/tickets/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  anexosList: (id: number) => api<Tickets.Anexo[]>(`/tickets/${id}/anexos`),
+  uploadAnexo: (id: number, file: File, mensagemId?: number | null) => {
+    const fd = new FormData()
+    fd.append('file', file)
+    if (mensagemId != null) fd.append('mensagem_id', String(mensagemId))
+    return api<Tickets.AnexoUploadResponse>(`/tickets/${id}/anexos`, { method: 'POST', body: fd })
+  },
 };
 
 export const dashboard = {
@@ -957,6 +966,26 @@ export namespace Tickets {
     setor_id?: number;
     status_id?: number;
     atendente_id?: number | null;
+  }
+
+  export type AnexoVisibilidade = 'publico' | 'interno'
+
+  export interface Anexo {
+    id: number
+    ticket_id: number
+    mensagem_id?: number | null
+    atendente_id?: number | null
+    atendente_nome?: string | null
+    visibilidade: AnexoVisibilidade
+    nome_original: string
+    content_type?: string | null
+    tamanho_bytes: number
+    created_at: string
+  }
+
+  export interface AnexoUploadResponse {
+    anexo: Anexo
+    download_url: string
   }
 }
 

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -8,6 +8,7 @@ import {
   atendentes,
   setores,
   whatsappChats,
+  fetchTicketAnexoBlob,
   type StatusTicket,
   type Atendentes,
   type Setores,
@@ -116,6 +117,7 @@ export function TicketDetalhe() {
   const [ticket, setTicket] = useState<Tickets.Ticket | null>(null)
   const [historico, setHistorico] = useState<Tickets.Historico[]>([])
   const [mensagens, setMensagens] = useState<Tickets.Mensagem[]>([])
+  const [anexos, setAnexos] = useState<Tickets.Anexo[]>([])
   const [statusList, setStatusList] = useState<StatusTicket.Status[]>([])
   const [atendentesList, setAtendentesList] = useState<Atendentes.Atendente[]>([])
   /** Atendentes elegíveis no modal (carga direta por setor no backend). */
@@ -335,12 +337,13 @@ export function TicketDetalhe() {
     setLoading(true)
     setCarregamentoFalhou(null)
     setForbidden(false)
-    Promise.all([tickets.get(numId), tickets.getHistorico(numId), tickets.listMensagens(numId)])
-      .then(([t, h, m]) => {
+    Promise.all([tickets.get(numId), tickets.getHistorico(numId), tickets.listMensagens(numId), tickets.anexosList(numId)])
+      .then(([t, h, m, a]) => {
         if (cancelled) return
         setTicket(t)
         setHistorico(h)
         setMensagens(m)
+        setAnexos(a)
         setEditSetor(t.setor_id)
         setEditStatus(t.status_id)
         setEditAtendente(t.atendente_id ?? '')
@@ -360,6 +363,7 @@ export function TicketDetalhe() {
           setTicket(null)
           setHistorico([])
           setMensagens([])
+          setAnexos([])
           setCarregamentoFalhou(interpretarFalhaCarregamento(err, 'Ticket não encontrado.'))
         }
       })
@@ -370,6 +374,34 @@ export function TicketDetalhe() {
       cancelled = true
     }
   }, [id])
+
+  async function baixarOuVisualizarAnexo(a: Tickets.Anexo) {
+    if (!ticket) return
+    try {
+      const blob = await fetchTicketAnexoBlob(ticket.id, a.id)
+      const fixed = new Blob([blob], { type: a.content_type || 'application/octet-stream' })
+      const url = URL.createObjectURL(fixed)
+      const viewable = Boolean(
+        a.content_type?.startsWith('image/') ||
+          a.content_type === 'application/pdf' ||
+          a.content_type?.startsWith('text/'),
+      )
+      if (viewable) {
+        window.open(url, '_blank', 'noopener,noreferrer')
+        setTimeout(() => URL.revokeObjectURL(url), 60_000)
+        return
+      }
+      const link = document.createElement('a')
+      link.href = url
+      link.download = a.nome_original || `anexo-${a.id}`
+      document.body.appendChild(link)
+      link.click()
+      link.remove()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível baixar o anexo.'))
+    }
+  }
 
   useEffect(() => {
     if (!ticket?.id) {
@@ -540,6 +572,8 @@ export function TicketDetalhe() {
       }
       const m = await tickets.listMensagens(ticket.id)
       setMensagens(m)
+      const a = await tickets.anexosList(ticket.id)
+      setAnexos(a)
       setNovaMensagemTexto('')
       setAnexosSelecionados([])
       if (fileInputRef.current) fileInputRef.current.value = ''
@@ -778,6 +812,31 @@ export function TicketDetalhe() {
           )}
         </p>
         <div className="space-y-4">
+          {anexos.some((a) => a.mensagem_id == null) && (
+            <div className="rounded-xl border border-slate-200/90 bg-slate-50/70 px-4 py-3 text-sm dark:border-slate-700/70 dark:bg-slate-900/30">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Anexos do ticket
+              </p>
+              <ul className="mt-2 space-y-2">
+                {anexos
+                  .filter((a) => a.mensagem_id == null)
+                  .map((a) => (
+                    <li key={a.id} className="flex flex-wrap items-center justify-between gap-2">
+                      <button
+                        type="button"
+                        onClick={() => baixarOuVisualizarAnexo(a)}
+                        className="text-left text-sm font-medium text-cyan-700 underline hover:text-cyan-900 dark:text-cyan-400 dark:hover:text-cyan-300"
+                      >
+                        {a.nome_original}
+                      </button>
+                      <span className="text-xs text-slate-500 dark:text-slate-400">
+                        {(a.tamanho_bytes / 1024).toFixed(1)} KB
+                      </span>
+                    </li>
+                  ))}
+              </ul>
+            </div>
+          )}
           {mensagens.length === 0 ? (
             <p className="text-sm text-slate-500 dark:text-slate-400">Nenhuma mensagem ainda.</p>
           ) : (
@@ -788,6 +847,7 @@ export function TicketDetalhe() {
                 const autor =
                   msg.atendente_nome ??
                   (isAbertura ? 'Registro legado / sistema' : '—')
+                const anexosDaMsg = anexos.filter((a) => a.mensagem_id === msg.id)
                 return (
                   <li
                     key={msg.id}
@@ -814,6 +874,29 @@ export function TicketDetalhe() {
                       )}
                     </div>
                     <p className="mt-2 whitespace-pre-wrap text-slate-800 dark:text-slate-200">{msg.corpo}</p>
+                    {anexosDaMsg.length > 0 && (
+                      <div className="mt-3 rounded-lg border border-slate-200/80 bg-slate-50/70 px-3 py-2 dark:border-slate-700/70 dark:bg-slate-900/30">
+                        <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                          Anexos
+                        </p>
+                        <ul className="mt-2 space-y-1">
+                          {anexosDaMsg.map((a) => (
+                            <li key={a.id} className="flex flex-wrap items-center justify-between gap-2">
+                              <button
+                                type="button"
+                                onClick={() => baixarOuVisualizarAnexo(a)}
+                                className="text-left text-xs font-medium text-cyan-700 underline hover:text-cyan-900 dark:text-cyan-400 dark:hover:text-cyan-300"
+                              >
+                                {a.nome_original}
+                              </button>
+                              <span className="text-[10px] text-slate-500 dark:text-slate-400">
+                                {(a.tamanho_bytes / 1024).toFixed(1)} KB
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
                     <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
                       {autor}
                       <span className="text-slate-400 dark:text-slate-500"> · </span>

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useRef, useState, useEffect, useMemo } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import {
   ApiError,
@@ -131,6 +131,9 @@ export function TicketDetalhe() {
   const [novaMensagemTexto, setNovaMensagemTexto] = useState('')
   const [tipoNovaMensagem, setTipoNovaMensagem] = useState<'publico' | 'interno'>('publico')
   const [enviandoMensagem, setEnviandoMensagem] = useState(false)
+  const [anexosSelecionados, setAnexosSelecionados] = useState<File[]>([])
+  const [enviandoAnexos, setEnviandoAnexos] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
   const [modalGerirAberto, setModalGerirAberto] = useState(false)
   const [modalFecharAberto, setModalFecharAberto] = useState(false)
   /** Qual bloco do modal recebe destaque ao abrir (chips no cabeçalho). */
@@ -517,17 +520,29 @@ export function TicketDetalhe() {
       return
     }
     const texto = novaMensagemTexto.trim()
-    if (!texto) {
-      toast.showWarning('Escreva uma mensagem antes de enviar.')
+    if (!texto && anexosSelecionados.length === 0) {
+      toast.showWarning('Escreva uma mensagem ou selecione anexos.')
       return
     }
     const tipo = podeMensagemPublica ? tipoNovaMensagem : 'interno'
     setEnviandoMensagem(true)
     try {
-      await tickets.addMensagem(ticket.id, { corpo: texto, tipo })
+      const msg = texto ? await tickets.addMensagem(ticket.id, { corpo: texto, tipo }) : null
+      if (anexosSelecionados.length > 0) {
+        setEnviandoAnexos(true)
+        try {
+          for (const f of anexosSelecionados) {
+            await tickets.uploadAnexo(ticket.id, f, msg?.id ?? null)
+          }
+        } finally {
+          setEnviandoAnexos(false)
+        }
+      }
       const m = await tickets.listMensagens(ticket.id)
       setMensagens(m)
       setNovaMensagemTexto('')
+      setAnexosSelecionados([])
+      if (fileInputRef.current) fileInputRef.current.value = ''
       toast.showSuccess(tipo === 'interno' ? 'Comentário interno registrado.' : 'Mensagem enviada.')
     } catch (err) {
       toast.showWarning(err instanceof Error ? err.message : 'Erro ao enviar')
@@ -568,7 +583,8 @@ export function TicketDetalhe() {
   }
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto max-w-6xl pb-10">
+      <div className="sticky top-0 z-30 -mx-3 border-b border-slate-200/70 bg-white/90 px-3 py-4 backdrop-blur dark:border-slate-700/70 dark:bg-slate-950/70 sm:mx-0 sm:rounded-2xl sm:border sm:px-5 sm:py-5">
       <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
         <button
           type="button"
@@ -748,7 +764,9 @@ export function TicketDetalhe() {
           </Button>
         </div>
       </div>
+      </div>
 
+      <div className="mt-6">
       <Card title="Conversa">
         <p className="mb-4 text-sm text-slate-500 dark:text-slate-400">
           Mensagens da equipe para o andamento; comentários internos só para atendentes.
@@ -763,7 +781,7 @@ export function TicketDetalhe() {
           {mensagens.length === 0 ? (
             <p className="text-sm text-slate-500 dark:text-slate-400">Nenhuma mensagem ainda.</p>
           ) : (
-            <ul className="space-y-3">
+            <ul className="max-h-[55vh] space-y-3 overflow-y-auto pr-1">
               {mensagens.map((msg) => {
                 const isAbertura = msg.tipo === 'abertura'
                 const isInterno = msg.tipo === 'interno'
@@ -862,17 +880,48 @@ export function TicketDetalhe() {
               }
               className="w-full rounded-xl border-0 bg-slate-50 px-3 py-2 text-sm text-slate-900 shadow-inner ring-1 ring-slate-200/90 placeholder:text-slate-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-slate-400/35 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-900/80 dark:text-slate-100 dark:ring-slate-600 dark:placeholder:text-slate-500 dark:focus:bg-slate-900 dark:focus:ring-slate-500/50"
             />
+            <div className="mt-2 flex flex-wrap items-center gap-2">
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                className="hidden"
+                onChange={(e) => {
+                  const files = e.target.files ? Array.from(e.target.files) : []
+                  setAnexosSelecionados(files)
+                }}
+              />
+              <Button
+                type="button"
+                variant="secondary"
+                disabled={Boolean(ticket.fechado_em)}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                Anexar arquivos
+              </Button>
+              {anexosSelecionados.length > 0 && (
+                <span className="text-xs text-slate-500 dark:text-slate-400">
+                  {anexosSelecionados.length} arquivo(s) selecionado(s)
+                </span>
+              )}
+            </div>
             <div className="mt-2">
-              <Button type="button" onClick={handleEnviarMensagem} loading={enviandoMensagem} disabled={Boolean(ticket.fechado_em)}>
+              <Button
+                type="button"
+                onClick={handleEnviarMensagem}
+                loading={enviandoMensagem || enviandoAnexos}
+                disabled={Boolean(ticket.fechado_em)}
+              >
                 Enviar
               </Button>
             </div>
           </div>
         </div>
       </Card>
+      </div>
 
       {historico.length > 0 && (
-        <div className="rounded-xl border border-slate-200/90 bg-white shadow-sm dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-none dark:ring-1 dark:ring-white/5">
+        <div className="mt-6 rounded-xl border border-slate-200/90 bg-white shadow-sm dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-none dark:ring-1 dark:ring-white/5">
           <button
             type="button"
             onClick={() => setHistoricoAberto((o) => !o)}

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -584,7 +584,7 @@ export function TicketDetalhe() {
 
   return (
     <div className="mx-auto max-w-6xl pb-10">
-      <div className="sticky top-0 z-30 -mx-3 border-b border-slate-200/70 bg-white/90 px-3 py-4 backdrop-blur dark:border-slate-700/70 dark:bg-slate-950/70 sm:mx-0 sm:rounded-2xl sm:border sm:px-5 sm:py-5">
+      <div className="sticky top-14 z-10 -mx-3 border-b border-slate-200/70 bg-white/90 px-3 py-4 backdrop-blur dark:border-slate-700/70 dark:bg-slate-950/70 sm:mx-0 sm:rounded-2xl sm:border sm:px-5 sm:py-5">
       <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
         <button
           type="button"
@@ -880,32 +880,32 @@ export function TicketDetalhe() {
               }
               className="w-full rounded-xl border-0 bg-slate-50 px-3 py-2 text-sm text-slate-900 shadow-inner ring-1 ring-slate-200/90 placeholder:text-slate-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-slate-400/35 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-900/80 dark:text-slate-100 dark:ring-slate-600 dark:placeholder:text-slate-500 dark:focus:bg-slate-900 dark:focus:ring-slate-500/50"
             />
-            <div className="mt-2 flex flex-wrap items-center gap-2">
-              <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                className="hidden"
-                onChange={(e) => {
-                  const files = e.target.files ? Array.from(e.target.files) : []
-                  setAnexosSelecionados(files)
-                }}
-              />
-              <Button
-                type="button"
-                variant="secondary"
-                disabled={Boolean(ticket.fechado_em)}
-                onClick={() => fileInputRef.current?.click()}
-              >
-                Anexar arquivos
-              </Button>
-              {anexosSelecionados.length > 0 && (
-                <span className="text-xs text-slate-500 dark:text-slate-400">
-                  {anexosSelecionados.length} arquivo(s) selecionado(s)
-                </span>
-              )}
-            </div>
-            <div className="mt-2">
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  className="hidden"
+                  onChange={(e) => {
+                    const files = e.target.files ? Array.from(e.target.files) : []
+                    setAnexosSelecionados(files)
+                  }}
+                />
+                <Button
+                  type="button"
+                  variant="secondary"
+                  disabled={Boolean(ticket.fechado_em)}
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  Anexar arquivos
+                </Button>
+                {anexosSelecionados.length > 0 && (
+                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                    {anexosSelecionados.length} arquivo(s) selecionado(s)
+                  </span>
+                )}
+              </div>
               <Button
                 type="button"
                 onClick={handleEnviarMensagem}

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -136,6 +136,7 @@ export function TicketDetalhe() {
   const [anexosSelecionados, setAnexosSelecionados] = useState<File[]>([])
   const [enviandoAnexos, setEnviandoAnexos] = useState(false)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
   const [modalGerirAberto, setModalGerirAberto] = useState(false)
   const [modalFecharAberto, setModalFecharAberto] = useState(false)
   /** Qual bloco do modal recebe destaque ao abrir (chips no cabeçalho). */
@@ -387,7 +388,14 @@ export function TicketDetalhe() {
           a.content_type?.startsWith('text/'),
       )
       if (viewable) {
-        window.open(url, '_blank', 'noopener,noreferrer')
+        // `window.open` pode ser bloqueado por pop-up blocker; usa link com target=_blank.
+        const link = document.createElement('a')
+        link.href = url
+        link.target = '_blank'
+        link.rel = 'noopener noreferrer'
+        document.body.appendChild(link)
+        link.click()
+        link.remove()
         setTimeout(() => URL.revokeObjectURL(url), 60_000)
         return
       }
@@ -540,10 +548,16 @@ export function TicketDetalhe() {
   }
 
   useEffect(() => {
-    if (!podeMensagemPublica && tipoNovaMensagem === 'publico') {
-      setTipoNovaMensagem('interno')
+    if (!ticket || !user) return
+    // Regra de UX:
+    // - Se o ticket está atribuído a mim → default "publico"
+    // - Caso contrário → default "interno" (evita enviar mensagem pública sem querer)
+    if (ticket.atendente_id != null && ticket.atendente_id === user.id) {
+      setTipoNovaMensagem('publico')
+      return
     }
-  }, [podeMensagemPublica, tipoNovaMensagem])
+    setTipoNovaMensagem('interno')
+  }, [ticket?.id, ticket?.atendente_id, user?.id])
 
   async function handleEnviarMensagem() {
     if (!ticket) return
@@ -583,6 +597,41 @@ export function TicketDetalhe() {
     } finally {
       setEnviandoMensagem(false)
     }
+  }
+
+  function handlePasteNoCampoMensagem(e: React.ClipboardEvent<HTMLTextAreaElement>) {
+    const items = Array.from(e.clipboardData?.items ?? [])
+    const files = items
+      .filter((i) => i.kind === 'file')
+      .map((i) => i.getAsFile())
+      .filter((f): f is File => Boolean(f))
+
+    if (files.length === 0) return
+
+    // Evita colar binário como texto; transforma em anexos e deixa um marcador no texto.
+    e.preventDefault()
+
+    setAnexosSelecionados((cur) => [...cur, ...files])
+
+    const ta = textareaRef.current
+    if (!ta) return
+    const start = ta.selectionStart ?? novaMensagemTexto.length
+    const end = ta.selectionEnd ?? novaMensagemTexto.length
+    const markers = files
+      .map((f) => `[Anexo: ${(f.name || 'imagem').trim() || 'imagem'}]`)
+      .join('\n')
+    const insert = (novaMensagemTexto ? '\n' : '') + markers + '\n'
+    const next = novaMensagemTexto.slice(0, start) + insert + novaMensagemTexto.slice(end)
+    setNovaMensagemTexto(next)
+    // Move cursor para depois dos marcadores (próximo tick do React).
+    setTimeout(() => {
+      try {
+        const pos = start + insert.length
+        ta.setSelectionRange(pos, pos)
+      } catch {
+        // noop
+      }
+    }, 0)
   }
 
   if (loading) {
@@ -935,7 +984,7 @@ export function TicketDetalhe() {
                       : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200'
                   }`}
                 >
-                  Mensagem da equipe
+                  Mensagem ao cliente
                 </button>
               )}
               <button
@@ -951,8 +1000,10 @@ export function TicketDetalhe() {
               </button>
             </div>
             <textarea
+              ref={textareaRef}
               value={novaMensagemTexto}
               onChange={(e) => setNovaMensagemTexto(e.target.value)}
+              onPaste={handlePasteNoCampoMensagem}
               spellCheck={false}
               rows={4}
               disabled={Boolean(ticket.fechado_em)}
@@ -961,7 +1012,11 @@ export function TicketDetalhe() {
                   ? 'Anotação visível apenas para atendentes…'
                   : 'Descreva o que foi feito, testado ou o que falta…'
               }
-              className="w-full rounded-xl border-0 bg-slate-50 px-3 py-2 text-sm text-slate-900 shadow-inner ring-1 ring-slate-200/90 placeholder:text-slate-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-slate-400/35 disabled:cursor-not-allowed disabled:opacity-60 dark:bg-slate-900/80 dark:text-slate-100 dark:ring-slate-600 dark:placeholder:text-slate-500 dark:focus:bg-slate-900 dark:focus:ring-slate-500/50"
+              className={`w-full rounded-xl border-0 px-3 py-2 text-sm text-slate-900 shadow-inner ring-1 placeholder:text-slate-400 focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-60 dark:text-slate-100 dark:placeholder:text-slate-500 ${
+                tipoNovaMensagem === 'interno' || !podeMensagemPublica
+                  ? 'bg-amber-50 ring-amber-200/90 focus:bg-amber-50 focus:ring-amber-400/30 dark:bg-amber-950/25 dark:ring-amber-800/60 dark:focus:bg-amber-950/25 dark:focus:ring-amber-700/35'
+                  : 'bg-slate-50 ring-slate-200/90 focus:bg-white focus:ring-slate-400/35 dark:bg-slate-900/80 dark:ring-slate-600 dark:focus:bg-slate-900 dark:focus:ring-slate-500/50'
+              }`}
             />
             <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
               <div className="flex flex-wrap items-center gap-2">

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -118,6 +118,11 @@ export function TicketDetalhe() {
   const [historico, setHistorico] = useState<Tickets.Historico[]>([])
   const [mensagens, setMensagens] = useState<Tickets.Mensagem[]>([])
   const [anexos, setAnexos] = useState<Tickets.Anexo[]>([])
+  const [previewAnexo, setPreviewAnexo] = useState<{
+    nome: string
+    url: string
+    contentType: string
+  } | null>(null)
   const [statusList, setStatusList] = useState<StatusTicket.Status[]>([])
   const [atendentesList, setAtendentesList] = useState<Atendentes.Atendente[]>([])
   /** Atendentes elegíveis no modal (carga direta por setor no backend). */
@@ -388,15 +393,12 @@ export function TicketDetalhe() {
           a.content_type?.startsWith('text/'),
       )
       if (viewable) {
-        // `window.open` pode ser bloqueado por pop-up blocker; usa link com target=_blank.
-        const link = document.createElement('a')
-        link.href = url
-        link.target = '_blank'
-        link.rel = 'noopener noreferrer'
-        document.body.appendChild(link)
-        link.click()
-        link.remove()
-        setTimeout(() => URL.revokeObjectURL(url), 60_000)
+        // Evita abrir `blob:` em nova aba (pode disparar search/popup blockers). Pré-visualiza no app.
+        setPreviewAnexo({
+          nome: a.nome_original || `anexo-${a.id}`,
+          url,
+          contentType: a.content_type || 'application/octet-stream',
+        })
         return
       }
       const link = document.createElement('a')
@@ -889,7 +891,7 @@ export function TicketDetalhe() {
           {mensagens.length === 0 ? (
             <p className="text-sm text-slate-500 dark:text-slate-400">Nenhuma mensagem ainda.</p>
           ) : (
-            <ul className="max-h-[55vh] space-y-3 overflow-y-auto pr-1">
+            <ul className="space-y-3">
               {mensagens.map((msg) => {
                 const isAbertura = msg.tipo === 'abertura'
                 const isInterno = msg.tipo === 'interno'
@@ -1057,6 +1059,58 @@ export function TicketDetalhe() {
         </div>
       </Card>
       </div>
+
+      {previewAnexo && (
+        <div
+          className="fixed inset-0 z-[600] flex items-center justify-center bg-slate-950/60 p-4 backdrop-blur-[2px]"
+          role="presentation"
+          onClick={() => {
+            URL.revokeObjectURL(previewAnexo.url)
+            setPreviewAnexo(null)
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            className="flex max-h-[90vh] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-xl dark:border-slate-700 dark:bg-slate-950"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between gap-3 border-b border-slate-200 px-4 py-3 dark:border-slate-700">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
+                  {previewAnexo.nome}
+                </div>
+                <div className="truncate text-xs text-slate-500 dark:text-slate-400">{previewAnexo.contentType}</div>
+              </div>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => {
+                  URL.revokeObjectURL(previewAnexo.url)
+                  setPreviewAnexo(null)
+                }}
+              >
+                Fechar
+              </Button>
+            </div>
+            <div className="flex-1 overflow-auto bg-slate-50 p-3 dark:bg-slate-900/40">
+              {previewAnexo.contentType.startsWith('image/') ? (
+                <img
+                  src={previewAnexo.url}
+                  alt={previewAnexo.nome}
+                  className="mx-auto max-h-[80vh] max-w-full rounded-lg border border-slate-200 dark:border-slate-700"
+                />
+              ) : previewAnexo.contentType === 'application/pdf' ? (
+                <iframe title={previewAnexo.nome} src={previewAnexo.url} className="h-[80vh] w-full rounded-lg" />
+              ) : (
+                <div className="text-sm text-slate-600 dark:text-slate-300">
+                  Pré-visualização indisponível para este tipo. Use o download.
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {historico.length > 0 && (
         <div className="mt-6 rounded-xl border border-slate-200/90 bg-white shadow-sm dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-none dark:ring-1 dark:ring-white/5">


### PR DESCRIPTION
## Resumo
- Adiciona **anexos em tickets** com upload (multipart), listagem e download autenticado.
- Implementa **preview no detalhe do ticket** (imagem/PDF) e download para outros tipos.
- Armazena anexos em disco (dir configurável) com validação de tamanho e bloqueio de tipos perigosos.
- Migração Alembic: `ticket_anexos`.
- Testes cobrindo upload/list/download, RBAC e bloqueio de upload em ticket fechado.

## Endpoints (API v1)
- `POST /v1/tickets/{ticket_id}/anexos`
- `GET /v1/tickets/{ticket_id}/anexos`
- `GET /v1/tickets/{ticket_id}/anexos/{anexo_id}/download`

## Configuração
- `TICKET_ANEXOS_DIR` (default: `data/ticket_anexos`)
- `TICKET_ANEXOS_MAX_BYTES` (default: 25 MB)

## Test plan
- [x] `docker compose run --rm --no-deps backend pytest -q` (28 passed)
- [x] Teste manual no `TicketDetalhe`: anexar → enviar → listar → abrir preview/baixar