### PR TITLE
feat: protocolos mensais #T/#C (YYYYMM) e UI (#138 #139)

### DIFF
--- a/backend/alembic/versions/017_protocol_sequences.py
+++ b/backend/alembic/versions/017_protocol_sequences.py
@@ -1,0 +1,52 @@
+"""Tabela de sequência mensal para protocolos #T / #C e alarga tickets.protocolo.
+
+Revision ID: 017_protocol_sequences
+Revises: 016_ticket_anexos
+Create Date: 2026-05-13
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "017_protocol_sequences"
+down_revision = "016_ticket_anexos"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("protocol_sequences"):
+        op.create_table(
+            "protocol_sequences",
+            sa.Column("kind", sa.String(length=1), nullable=False),
+            sa.Column("ano_mes", sa.String(length=7), nullable=False),
+            sa.Column("last_value", sa.Integer(), nullable=False, server_default="0"),
+            sa.PrimaryKeyConstraint("kind", "ano_mes", name="pk_protocol_sequences"),
+        )
+    cols = {c["name"] for c in insp.get_columns("tickets")} if insp.has_table("tickets") else set()
+    if "protocolo" in cols:
+        op.alter_column(
+            "tickets",
+            "protocolo",
+            existing_type=sa.String(length=20),
+            type_=sa.String(length=32),
+            existing_nullable=False,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("protocol_sequences"):
+        op.drop_table("protocol_sequences")
+    if insp.has_table("tickets"):
+        op.alter_column(
+            "tickets",
+            "protocolo",
+            existing_type=sa.String(length=32),
+            type_=sa.String(length=20),
+            existing_nullable=False,
+        )

--- a/backend/alembic/versions/018_protocol_sequences_yyyymm.py
+++ b/backend/alembic/versions/018_protocol_sequences_yyyymm.py
@@ -1,0 +1,63 @@
+"""protocol_sequences: chave mensal YYYYMM (sem hífen na data).
+
+Revision ID: 018_protocol_sequences_yyyymm
+Revises: 017_protocol_sequences
+Create Date: 2026-05-14
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import text
+
+
+revision = "018_protocol_sequences_yyyymm"
+down_revision = "017_protocol_sequences"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("protocol_sequences"):
+        return
+    # Legado: chave era YYYY-MM; protocolo exibido #T2026-05-0001 → passa a #T202605-0001
+    op.execute(
+        text(
+            """
+        UPDATE protocol_sequences
+        SET ano_mes = replace(ano_mes, '-', '')
+        WHERE ano_mes LIKE '%-%'
+        """
+        )
+    )
+    op.alter_column(
+        "protocol_sequences",
+        "ano_mes",
+        existing_type=sa.String(length=7),
+        type_=sa.String(length=6),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("protocol_sequences"):
+        return
+    op.alter_column(
+        "protocol_sequences",
+        "ano_mes",
+        existing_type=sa.String(length=6),
+        type_=sa.String(length=7),
+        existing_nullable=False,
+    )
+    op.execute(
+        text(
+            """
+        UPDATE protocol_sequences
+        SET ano_mes = substr(ano_mes, 1, 4) || '-' || substr(ano_mes, 5, 2)
+        WHERE length(ano_mes) = 6 AND ano_mes NOT LIKE '%-%'
+        """
+        )
+    )

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -52,7 +52,7 @@ class SituacaoTicket(str, Enum):
 
 
 def _gerar_protocolo(db: Session) -> str:
-    """Próximo protocolo de ticket no formato #TAAAA-MM-NNNN (mensal, America/Sao_Paulo)."""
+    """Próximo protocolo de ticket no formato #TYYYYMM-NNNN (mensal, America/Sao_Paulo)."""
     return gerar_protocolo_ticket(db)
 
 
@@ -100,7 +100,7 @@ def listar(
     rede_id: int | None = Query(None, description="Tickets de empresas desta rede"),
     setor_id: int | None = Query(None),
     status_id: int | None = Query(None),
-    protocolo: str | None = Query(None, description="Filtra por trecho do protocolo (ex.: #T2026-05-0001)"),
+    protocolo: str | None = Query(None, description="Filtra por trecho do protocolo (ex.: #T202605-0001)"),
     busca: str | None = Query(None, description="Protocolo, assunto ou nome da empresa"),
     sem_responsavel: bool = Query(
         False,

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -27,6 +27,7 @@ from app.core.setor_scope import (
     responsavel_elegivel_para_setor_do_ticket,
 )
 from app.services import ticket_anexo_storage
+from app.services.protocolo_mensal import gerar_protocolo_ticket
 
 router = APIRouter(prefix="/tickets", tags=["tickets"])
 
@@ -51,10 +52,8 @@ class SituacaoTicket(str, Enum):
 
 
 def _gerar_protocolo(db: Session) -> str:
-    """Gera próximo número de protocolo único (sequencial global)."""
-    from sqlalchemy import func
-    r = db.query(func.max(Ticket.id)).scalar() or 0
-    return str(10000 + r + 1)
+    """Próximo protocolo de ticket no formato #TAAAA-MM-NNNN (mensal, America/Sao_Paulo)."""
+    return gerar_protocolo_ticket(db)
 
 
 def _ticket_para_read(t: Ticket) -> TicketRead:
@@ -101,7 +100,7 @@ def listar(
     rede_id: int | None = Query(None, description="Tickets de empresas desta rede"),
     setor_id: int | None = Query(None),
     status_id: int | None = Query(None),
-    protocolo: str | None = Query(None, description="Legado: use busca"),
+    protocolo: str | None = Query(None, description="Filtra por trecho do protocolo (ex.: #T2026-05-0001)"),
     busca: str | None = Query(None, description="Protocolo, assunto ou nome da empresa"),
     sem_responsavel: bool = Query(
         False,

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -2,12 +2,12 @@ import logging
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem, WhatsappSettings
 from app.services import evolution_api
+from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.evolution_inbound import iter_inbound_whatsapp_messages
 from app.services.whatsapp_media_storage import gravar_base64_em_disco
 from datetime import date, datetime, timedelta
@@ -32,11 +32,6 @@ def _webhook_autorizado(request: Request, secret: str | None) -> bool:
 
 def _get_settings(db: Session) -> WhatsappSettings | None:
     return db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
-
-
-def _protocolo_proximo_chat(db: Session) -> str:
-    r = db.query(func.max(WhatsappChat.id)).scalar() or 0
-    return f"WCH-{20000 + int(r) + 1}"
 
 
 def _chat_aberto_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
@@ -368,7 +363,7 @@ def evolution_webhook(
         chat = _chat_aberto_por_wa_id(db, wa_id)
         if not chat:
             chat = WhatsappChat(
-                protocolo=_protocolo_proximo_chat(db),
+                protocolo=gerar_protocolo_chat(db),
                 wa_id=wa_id,
                 cliente_nome=push,
                 estado="aguardando_atendente",

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,6 +13,7 @@ from app.models.audit_log import AuditLog
 from app.models.ibge_municipio import IbgeMunicipio
 from app.models.app_cache_meta import AppCacheMeta
 from app.models.whatsapp_chat import WhatsappChat, WhatsappChatTicket, WhatsappMensagem, WhatsappSettings
+from app.models.protocol_sequence import ProtocolSequence
 
 __all__ = [
     "Rede",
@@ -37,4 +38,5 @@ __all__ = [
     "WhatsappChat",
     "WhatsappMensagem",
     "WhatsappChatTicket",
+    "ProtocolSequence",
 ]

--- a/backend/app/models/protocol_sequence.py
+++ b/backend/app/models/protocol_sequence.py
@@ -9,5 +9,5 @@ class ProtocolSequence(Base):
     __tablename__ = "protocol_sequences"
 
     kind = Column(String(1), primary_key=True)  # "T" | "C"
-    ano_mes = Column(String(7), primary_key=True)  # YYYY-MM (America/Sao_Paulo)
+    ano_mes = Column(String(6), primary_key=True)  # YYYYMM (America/Sao_Paulo)
     last_value = Column(Integer, nullable=False, default=0)

--- a/backend/app/models/protocol_sequence.py
+++ b/backend/app/models/protocol_sequence.py
@@ -1,0 +1,13 @@
+"""Contador mensal atómico para protocolos de tickets (#T…) e chats (#C…)."""
+
+from sqlalchemy import Column, Integer, String
+
+from app.database import Base
+
+
+class ProtocolSequence(Base):
+    __tablename__ = "protocol_sequences"
+
+    kind = Column(String(1), primary_key=True)  # "T" | "C"
+    ano_mes = Column(String(7), primary_key=True)  # YYYY-MM (America/Sao_Paulo)
+    last_value = Column(Integer, nullable=False, default=0)

--- a/backend/app/models/ticket.py
+++ b/backend/app/models/ticket.py
@@ -9,7 +9,7 @@ class Ticket(Base):
     __tablename__ = "tickets"
 
     id = Column(Integer, primary_key=True, index=True)
-    protocolo = Column(String(32), unique=True, nullable=False, index=True)  # #TAAAA-MM-NNNN (legado: numérico)
+    protocolo = Column(String(32), unique=True, nullable=False, index=True)  # #TYYYYMM-NNNN (legado: numérico)
     empresa_id = Column(Integer, ForeignKey("empresas.id"), nullable=False)
     setor_id = Column(Integer, ForeignKey("setores.id"), nullable=False)
     status_id = Column(Integer, ForeignKey("status_ticket.id"), nullable=False)

--- a/backend/app/models/ticket.py
+++ b/backend/app/models/ticket.py
@@ -9,7 +9,7 @@ class Ticket(Base):
     __tablename__ = "tickets"
 
     id = Column(Integer, primary_key=True, index=True)
-    protocolo = Column(String(20), unique=True, nullable=False, index=True)  # número único global
+    protocolo = Column(String(32), unique=True, nullable=False, index=True)  # #TAAAA-MM-NNNN (legado: numérico)
     empresa_id = Column(Integer, ForeignKey("empresas.id"), nullable=False)
     setor_id = Column(Integer, ForeignKey("setores.id"), nullable=False)
     status_id = Column(Integer, ForeignKey("status_ticket.id"), nullable=False)

--- a/backend/app/seed_demo_volume.py
+++ b/backend/app/seed_demo_volume.py
@@ -29,6 +29,7 @@ import bcrypt
 
 from app.database import SessionLocal
 from app.seed import run_seed
+from app.services.protocolo_mensal import gerar_protocolo_ticket
 from app.models import (
     Rede,
     Empresa,
@@ -49,11 +50,6 @@ def _hash_senha(senha: str) -> str:
 
 def _city_abbrev(cidade: str) -> str:
     return "".join(w[0] for w in cidade.split() if w)[:4].upper()
-
-
-def _gerar_protocolo(db) -> str:
-    r = db.query(func.max(Ticket.id)).scalar() or 0
-    return str(10000 + r + 1)
 
 
 def _ensure_setores(db) -> dict[str, Setor]:
@@ -263,7 +259,7 @@ def run_demo_volume(force: bool = False) -> None:
             if status.slug == "fechado":
                 fechado_em = datetime.now(timezone.utc)
 
-            protocolo = _gerar_protocolo(db)
+            protocolo = gerar_protocolo_ticket(db)
             ticket = Ticket(
                 protocolo=protocolo,
                 empresa_id=emp.id,

--- a/backend/app/services/protocolo_mensal.py
+++ b/backend/app/services/protocolo_mensal.py
@@ -1,0 +1,67 @@
+"""
+Protocolos humanos mensais (#TAAAA-MM-NNNN tickets, #CAAAA-MM-NNNN chats).
+
+Fuso de referência para YYYY-MM: America/Sao_Paulo (ver docs/PROTOCOLOS_TICKETS_CHATS.md).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.models.protocol_sequence import ProtocolSequence
+
+PROTOCOL_TZ = ZoneInfo("America/Sao_Paulo")
+
+
+def _ano_mes_referencia(ref: datetime | None) -> str:
+    tz = PROTOCOL_TZ
+    dt = ref or datetime.now(tz)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc).astimezone(tz)
+    else:
+        dt = dt.astimezone(tz)
+    return dt.strftime("%Y-%m")
+
+
+def _proximo_valor(db: Session, kind: str, ano_mes: str) -> int:
+    """Incrementa e devolve o próximo sequencial para (kind, ano_mes) na mesma transação."""
+    if kind not in ("T", "C"):
+        raise ValueError("kind deve ser T ou C")
+    for _ in range(32):
+        row = (
+            db.query(ProtocolSequence)
+            .filter(ProtocolSequence.kind == kind, ProtocolSequence.ano_mes == ano_mes)
+            .with_for_update()
+            .first()
+        )
+        if row is not None:
+            row.last_value += 1
+            v = row.last_value
+            db.flush()
+            return v
+        nested = db.begin_nested()
+        try:
+            db.add(ProtocolSequence(kind=kind, ano_mes=ano_mes, last_value=1))
+            db.flush()
+            nested.commit()
+            return 1
+        except IntegrityError:
+            nested.rollback()
+            continue
+    raise RuntimeError("Não foi possível obter sequência de protocolo (contenção).")
+
+
+def gerar_protocolo_ticket(db: Session, *, ref: datetime | None = None) -> str:
+    ano_mes = _ano_mes_referencia(ref)
+    n = _proximo_valor(db, "T", ano_mes)
+    return f"#T{ano_mes}-{n:04d}"
+
+
+def gerar_protocolo_chat(db: Session, *, ref: datetime | None = None) -> str:
+    ano_mes = _ano_mes_referencia(ref)
+    n = _proximo_valor(db, "C", ano_mes)
+    return f"#C{ano_mes}-{n:04d}"

--- a/backend/app/services/protocolo_mensal.py
+++ b/backend/app/services/protocolo_mensal.py
@@ -1,7 +1,7 @@
 """
-Protocolos humanos mensais (#TAAAA-MM-NNNN tickets, #CAAAA-MM-NNNN chats).
+Protocolos humanos mensais (#TYYYYMM-NNNN tickets, #CYYYYMM-NNNN chats).
 
-Fuso de referência para YYYY-MM: America/Sao_Paulo (ver docs/PROTOCOLOS_TICKETS_CHATS.md).
+Fuso de referência para YYYYMM: America/Sao_Paulo (ver docs/PROTOCOLOS_TICKETS_CHATS.md).
 """
 
 from __future__ import annotations
@@ -17,24 +17,25 @@ from app.models.protocol_sequence import ProtocolSequence
 PROTOCOL_TZ = ZoneInfo("America/Sao_Paulo")
 
 
-def _ano_mes_referencia(ref: datetime | None) -> str:
+def _periodo_mensal_ref(ref: datetime | None) -> str:
+    """Chave mensal YYYYMM (sem hífen) no fuso America/Sao_Paulo."""
     tz = PROTOCOL_TZ
     dt = ref or datetime.now(tz)
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc).astimezone(tz)
     else:
         dt = dt.astimezone(tz)
-    return dt.strftime("%Y-%m")
+    return dt.strftime("%Y%m")
 
 
-def _proximo_valor(db: Session, kind: str, ano_mes: str) -> int:
-    """Incrementa e devolve o próximo sequencial para (kind, ano_mes) na mesma transação."""
+def _proximo_valor(db: Session, kind: str, periodo: str) -> int:
+    """Incrementa e devolve o próximo sequencial para (kind, periodo YYYYMM) na mesma transação."""
     if kind not in ("T", "C"):
         raise ValueError("kind deve ser T ou C")
     for _ in range(32):
         row = (
             db.query(ProtocolSequence)
-            .filter(ProtocolSequence.kind == kind, ProtocolSequence.ano_mes == ano_mes)
+            .filter(ProtocolSequence.kind == kind, ProtocolSequence.ano_mes == periodo)
             .with_for_update()
             .first()
         )
@@ -45,7 +46,7 @@ def _proximo_valor(db: Session, kind: str, ano_mes: str) -> int:
             return v
         nested = db.begin_nested()
         try:
-            db.add(ProtocolSequence(kind=kind, ano_mes=ano_mes, last_value=1))
+            db.add(ProtocolSequence(kind=kind, ano_mes=periodo, last_value=1))
             db.flush()
             nested.commit()
             return 1
@@ -56,12 +57,12 @@ def _proximo_valor(db: Session, kind: str, ano_mes: str) -> int:
 
 
 def gerar_protocolo_ticket(db: Session, *, ref: datetime | None = None) -> str:
-    ano_mes = _ano_mes_referencia(ref)
-    n = _proximo_valor(db, "T", ano_mes)
-    return f"#T{ano_mes}-{n:04d}"
+    yyyymm = _periodo_mensal_ref(ref)
+    n = _proximo_valor(db, "T", yyyymm)
+    return f"#T{yyyymm}-{n:04d}"
 
 
 def gerar_protocolo_chat(db: Session, *, ref: datetime | None = None) -> str:
-    ano_mes = _ano_mes_referencia(ref)
-    n = _proximo_valor(db, "C", ano_mes)
-    return f"#C{ano_mes}-{n:04d}"
+    yyyymm = _periodo_mensal_ref(ref)
+    n = _proximo_valor(db, "C", yyyymm)
+    return f"#C{yyyymm}-{n:04d}"

--- a/backend/tests/test_protocolo_mensal.py
+++ b/backend/tests/test_protocolo_mensal.py
@@ -1,0 +1,103 @@
+"""Geração de protocolos mensais #T / #C (#138)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.services.protocolo_mensal import PROTOCOL_TZ, gerar_protocolo_chat, gerar_protocolo_ticket
+
+
+def test_protocolo_ticket_formato_e_sequencia(db_session, seed_base):
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        ref = datetime(2026, 1, 15, 12, 0, tzinfo=PROTOCOL_TZ)
+        p1 = gerar_protocolo_ticket(db, ref=ref)
+        p2 = gerar_protocolo_ticket(db, ref=ref)
+        assert p1 == "#T2026-01-0001"
+        assert p2 == "#T2026-01-0002"
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_protocolo_chat_independente_do_ticket(db_session, seed_base):
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        ref = datetime(2026, 2, 20, 8, 0, tzinfo=PROTOCOL_TZ)
+        c1 = gerar_protocolo_chat(db, ref=ref)
+        t1 = gerar_protocolo_ticket(db, ref=ref)
+        c2 = gerar_protocolo_chat(db, ref=ref)
+        assert c1 == "#C2026-02-0001"
+        assert t1 == "#T2026-02-0001"
+        assert c2 == "#C2026-02-0002"
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_protocolo_troca_de_mes(db_session, seed_base):
+    from app.database import SessionLocal
+
+    db = SessionLocal()
+    try:
+        p_abril = gerar_protocolo_ticket(db, ref=datetime(2026, 4, 30, 23, 0, tzinfo=PROTOCOL_TZ))
+        p_maio = gerar_protocolo_ticket(db, ref=datetime(2026, 5, 1, 1, 0, tzinfo=PROTOCOL_TZ))
+        assert "2026-04" in p_abril
+        assert "2026-05" in p_maio
+        assert p_maio.endswith("-0001")
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_post_ticket_retorna_protocolo_novo(client, seed_base, auth_headers):
+    t = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Proto",
+            "descricao": "x",
+        },
+    )
+    assert t.status_code == 201, t.text
+    body = t.json()
+    assert body["protocolo"].startswith("#T")
+    assert body["protocolo"].count("-") >= 2
+
+
+def test_webhook_chat_protocolo_novo(client, seed_base, auth_headers):
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "proto-test"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "proto-test"}
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json={
+            "event": "messages.upsert",
+            "data": {
+                "messages": [
+                    {
+                        "key": {
+                            "remoteJid": "5511777889900@s.whatsapp.net",
+                            "fromMe": False,
+                            "id": "mid-proto-1",
+                        },
+                        "message": {"conversation": "Oi"},
+                    }
+                ]
+            },
+        },
+        headers=h,
+    )
+    assert r.status_code == 200
+    fila = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()
+    assert len(fila) == 1
+    assert fila[0]["protocolo"].startswith("#C")

--- a/backend/tests/test_protocolo_mensal.py
+++ b/backend/tests/test_protocolo_mensal.py
@@ -15,8 +15,8 @@ def test_protocolo_ticket_formato_e_sequencia(db_session, seed_base):
         ref = datetime(2026, 1, 15, 12, 0, tzinfo=PROTOCOL_TZ)
         p1 = gerar_protocolo_ticket(db, ref=ref)
         p2 = gerar_protocolo_ticket(db, ref=ref)
-        assert p1 == "#T2026-01-0001"
-        assert p2 == "#T2026-01-0002"
+        assert p1 == "#T202601-0001"
+        assert p2 == "#T202601-0002"
         db.commit()
     finally:
         db.close()
@@ -31,9 +31,9 @@ def test_protocolo_chat_independente_do_ticket(db_session, seed_base):
         c1 = gerar_protocolo_chat(db, ref=ref)
         t1 = gerar_protocolo_ticket(db, ref=ref)
         c2 = gerar_protocolo_chat(db, ref=ref)
-        assert c1 == "#C2026-02-0001"
-        assert t1 == "#T2026-02-0001"
-        assert c2 == "#C2026-02-0002"
+        assert c1 == "#C202602-0001"
+        assert t1 == "#T202602-0001"
+        assert c2 == "#C202602-0002"
         db.commit()
     finally:
         db.close()
@@ -46,8 +46,8 @@ def test_protocolo_troca_de_mes(db_session, seed_base):
     try:
         p_abril = gerar_protocolo_ticket(db, ref=datetime(2026, 4, 30, 23, 0, tzinfo=PROTOCOL_TZ))
         p_maio = gerar_protocolo_ticket(db, ref=datetime(2026, 5, 1, 1, 0, tzinfo=PROTOCOL_TZ))
-        assert "2026-04" in p_abril
-        assert "2026-05" in p_maio
+        assert "202604" in p_abril
+        assert "202605" in p_maio
         assert p_maio.endswith("-0001")
         db.commit()
     finally:
@@ -68,7 +68,7 @@ def test_post_ticket_retorna_protocolo_novo(client, seed_base, auth_headers):
     assert t.status_code == 201, t.text
     body = t.json()
     assert body["protocolo"].startswith("#T")
-    assert body["protocolo"].count("-") >= 2
+    assert body["protocolo"].count("-") == 1
 
 
 def test_webhook_chat_protocolo_novo(client, seed_base, auth_headers):

--- a/docs/PROTOCOLOS_TICKETS_CHATS.md
+++ b/docs/PROTOCOLOS_TICKETS_CHATS.md
@@ -1,0 +1,25 @@
+# Protocolos de tickets (#T…) e chats (#C…)
+
+## Formato
+
+- **Ticket:** `#T` + `AAAA-MM` + `-` + sequencial de **4 dígitos** (ex.: `#T2026-05-0001`).
+- **Chat (WhatsApp):** `#C` + `AAAA-MM` + `-` + sequencial de **4 dígitos** (ex.: `#C2026-05-0001`).
+
+O caractere `#` faz parte do valor persistido na coluna `protocolo`, para coincidir com a exibição e com a busca.
+
+## Mês de referência e fuso
+
+O par `AAAA-MM` é calculado no fuso **`America/Sao_Paulo`** no instante da criação do registro (ticket ou chat). Ao cruzar a meia-noite local, o mês muda e o **sequencial reinicia** para aquele tipo (`T` ou `C`).
+
+## Concorrência e sequência
+
+A sequência por (`kind`, `AAAA-MM`) está na tabela `protocol_sequences`, atualizada na mesma transação da criação do ticket/chat, com incremento sob lock (`SELECT … FOR UPDATE` onde suportado), e *savepoint* + retentativa em caso de colisão na primeira inserção.
+
+## Dados legados
+
+Registros antigos podem manter:
+
+- Tickets: protocolo numérico (`10001`, …) sem prefixo `#T`.
+- Chats: prefixo `WCH-…`.
+
+Listagens e buscas (`ILIKE`) continuam a funcionar. A UI trata os dois formatos (ver `exibirProtocolo` no frontend).

--- a/docs/PROTOCOLOS_TICKETS_CHATS.md
+++ b/docs/PROTOCOLOS_TICKETS_CHATS.md
@@ -2,18 +2,18 @@
 
 ## Formato
 
-- **Ticket:** `#T` + `AAAA-MM` + `-` + sequencial de **4 dígitos** (ex.: `#T2026-05-0001`).
-- **Chat (WhatsApp):** `#C` + `AAAA-MM` + `-` + sequencial de **4 dígitos** (ex.: `#C2026-05-0001`).
+- **Ticket:** `#T` + `YYYYMM` + `-` + sequencial de **4 dígitos** (ex.: `#T202605-0001`).
+- **Chat (WhatsApp):** `#C` + `YYYYMM` + `-` + sequencial de **4 dígitos** (ex.: `#C202605-0001`).
 
-O caractere `#` faz parte do valor persistido na coluna `protocolo`, para coincidir com a exibição e com a busca.
+O caractere `#` faz parte do valor persistido na coluna `protocolo`, para coincidir com a exibição e com a busca. **Não há hífen entre ano e mês** (`202605` = maio de 2026); o único hífen separa o período do número sequencial.
 
 ## Mês de referência e fuso
 
-O par `AAAA-MM` é calculado no fuso **`America/Sao_Paulo`** no instante da criação do registro (ticket ou chat). Ao cruzar a meia-noite local, o mês muda e o **sequencial reinicia** para aquele tipo (`T` ou `C`).
+O par `YYYYMM` é calculado no fuso **`America/Sao_Paulo`** no instante da criação do registro (ticket ou chat). Ao cruzar a meia-noite local, o mês muda e o **sequencial reinicia** para aquele tipo (`T` ou `C`).
 
 ## Concorrência e sequência
 
-A sequência por (`kind`, `AAAA-MM`) está na tabela `protocol_sequences`, atualizada na mesma transação da criação do ticket/chat, com incremento sob lock (`SELECT … FOR UPDATE` onde suportado), e *savepoint* + retentativa em caso de colisão na primeira inserção.
+A sequência por (`kind`, `YYYYMM`) está na tabela `protocol_sequences`, atualizada na mesma transação da criação do ticket/chat, com incremento sob lock (`SELECT … FOR UPDATE` onde suportado), e *savepoint* + retentativa em caso de colisão na primeira inserção.
 
 ## Dados legados
 
@@ -21,5 +21,6 @@ Registros antigos podem manter:
 
 - Tickets: protocolo numérico (`10001`, …) sem prefixo `#T`.
 - Chats: prefixo `WCH-…`.
+- Protocolos já gerados no formato antigo com hífen na data (`#T2026-05-0001`): permanecem como estão até novos registros usarem `YYYYMM`.
 
 Listagens e buscas (`ILIKE`) continuam a funcionar. A UI trata os dois formatos (ver `exibirProtocolo` no frontend).

--- a/docs/WHATSAPP_EVOLUTION.md
+++ b/docs/WHATSAPP_EVOLUTION.md
@@ -54,7 +54,7 @@ Campos persistidos em `whatsapp_settings` (via **Configurações → WhatsApp**,
 
 ## Ciclo de vida do chat
 
-1. Primeira mensagem inbound de um `wa_id` → cria **chat** em `aguardando_atendente` com protocolo `#CAAAA-MM-NNNN` (mensal, distinto dos tickets `#T…`; chats antigos podem manter `WCH-*`).
+1. Primeira mensagem inbound de um `wa_id` → cria **chat** em `aguardando_atendente` com protocolo `#CYYYYMM-NNNN` (mensal, distinto dos tickets `#T…`; chats antigos podem manter `WCH-*`).
 2. Atendente **assume** → `em_atendimento`, `atendimento_inicio_at`.
 3. **Encerrar** → `encerrado`, `encerramento_at`.
 4. Nova mensagem do mesmo cliente **após encerramento** → **novo** chat e novo protocolo.

--- a/docs/WHATSAPP_EVOLUTION.md
+++ b/docs/WHATSAPP_EVOLUTION.md
@@ -54,7 +54,7 @@ Campos persistidos em `whatsapp_settings` (via **Configurações → WhatsApp**,
 
 ## Ciclo de vida do chat
 
-1. Primeira mensagem inbound de um `wa_id` → cria **chat** em `aguardando_atendente` com protocolo `WCH-*` (numerador distinto dos tickets).
+1. Primeira mensagem inbound de um `wa_id` → cria **chat** em `aguardando_atendente` com protocolo `#CAAAA-MM-NNNN` (mensal, distinto dos tickets `#T…`; chats antigos podem manter `WCH-*`).
 2. Atendente **assume** → `em_atendimento`, `atendimento_inicio_at`.
 3. **Encerrar** → `encerrado`, `encerramento_at`.
 4. Nova mensagem do mesmo cliente **após encerramento** → **novo** chat e novo protocolo.

--- a/frontend/src/components/TicketsTabelaContexto.tsx
+++ b/frontend/src/components/TicketsTabelaContexto.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { Tickets } from '../api/client'
+import { exibirProtocolo } from '../lib/exibirProtocolo'
 import { Button } from './ui/Button'
 import { IconEye } from './ui/IconEye'
 
@@ -45,8 +46,11 @@ export function TicketsTabelaContexto({
               key={t.id}
               className="transition-colors hover:bg-slate-50/80 dark:hover:bg-slate-800/40"
             >
-              <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-slate-800 dark:text-slate-100 sm:px-6">
-                {t.protocolo}
+              <td
+                className="max-w-[11rem] truncate px-4 py-3 font-mono text-xs text-slate-800 dark:text-slate-100 sm:px-6"
+                title={exibirProtocolo(t.protocolo)}
+              >
+                {exibirProtocolo(t.protocolo)}
               </td>
               {showEmpresaColumn ? (
                 <td
@@ -76,7 +80,7 @@ export function TicketsTabelaContexto({
                 {t.atendente_nome ?? '—'}
               </td>
               <td className="px-4 py-3 text-right sm:px-6">
-                <Link to={`/tickets/${t.id}`} aria-label={`Ver ticket ${t.protocolo}`}>
+                <Link to={`/tickets/${t.id}`} aria-label={`Ver ticket ${exibirProtocolo(t.protocolo)}`}>
                   <Button
                     type="button"
                     variant="ghost"

--- a/frontend/src/lib/exibirProtocolo.ts
+++ b/frontend/src/lib/exibirProtocolo.ts
@@ -1,0 +1,10 @@
+/**
+ * Texto de protocolo para UI: formato novo (#T… / #C…), legado numérico ou WCH-… (#139).
+ */
+export function exibirProtocolo(raw: string | null | undefined): string {
+  const s = (raw || '').trim()
+  if (!s) return '—'
+  if (s.startsWith('#')) return s
+  if (/^\d+$/.test(s)) return `#${s}`
+  return s
+}

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -65,7 +65,7 @@ function rotuloEstadoConexao(estadoRaw: string | null): {
 }
 
 const DEFAULT_MSG_ESPERA =
-  'Olá, {{nome_cliente}}, Seja Bem-Vindo(a) a {{nome_empresa}}.\n\n✅protocolo de atendimento: *#{{protocolo}}*\n\nAbertura: *{{data_abertura}}*\n'
+  'Olá, {{nome_cliente}}, Seja Bem-Vindo(a) a {{nome_empresa}}.\n\n✅protocolo de atendimento: *{{protocolo}}*\n\nAbertura: *{{data_abertura}}*\n'
 const DEFAULT_MSG_ASSUMIDO =
   'Olá, {nome}! Sou o {atendente} atendente responsável pelo seu atendimento. Como posso ajudar?'
 const DEFAULT_MSG_ENCERRADO =

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -9,6 +9,7 @@ import { IconEye } from '../components/ui/IconEye'
 import { useToast } from '../components/ui/Toast'
 import { SemPermissao } from './SemPermissao'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
+import { exibirProtocolo } from '../lib/exibirProtocolo'
 
 type ColunaUltimos = 'protocolo' | 'empresa' | 'assunto' | 'status'
 
@@ -181,7 +182,12 @@ export function Dashboard() {
               <tbody>
                 {ultimosOrdenados.map((t) => (
                   <tr key={t.id} className="border-b border-slate-100 dark:border-slate-700/60">
-                    <td className="py-3 pr-4 font-mono text-slate-800 dark:text-slate-100">{t.protocolo}</td>
+                    <td
+                      className="max-w-[10rem] truncate py-3 pr-4 font-mono text-slate-800 dark:text-slate-100"
+                      title={exibirProtocolo(t.protocolo)}
+                    >
+                      {exibirProtocolo(t.protocolo)}
+                    </td>
                     <td className="py-3 pr-4">{t.empresa_nome ?? t.empresa_id}</td>
                     <td className="py-3 pr-4">{t.assunto}</td>
                     <td className="py-3 pr-4">{t.status_nome ?? t.status_id}</td>

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -1043,7 +1043,16 @@ export function TicketDetalhe() {
                   variant="secondary"
                   disabled={Boolean(ticket.fechado_em)}
                   onClick={() => fileInputRef.current?.click()}
+                  className="inline-flex items-center gap-2"
                 >
+                  <svg className="size-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"
+                    />
+                  </svg>
                   Anexar arquivos
                 </Button>
                 {anexosSelecionados.length > 0 && (

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -26,6 +26,7 @@ import { refetchPendenciasResumo } from '../hooks/useAlertaFilaSemResponsavel'
 import { SemPermissao } from './SemPermissao'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+import { exibirProtocolo } from '../lib/exibirProtocolo'
 
 const ROTULO_CAMPO: Record<string, string> = {
   status_id: 'Status',
@@ -681,7 +682,12 @@ export function TicketDetalhe() {
         <span aria-hidden className="text-slate-300 dark:text-slate-600">
           /
         </span>
-        <span className="font-semibold text-slate-800 dark:text-slate-100">#{ticket.protocolo}</span>
+        <span
+          className="min-w-0 truncate font-semibold text-slate-800 dark:text-slate-100"
+          title={exibirProtocolo(ticket.protocolo)}
+        >
+          {exibirProtocolo(ticket.protocolo)}
+        </span>
       </nav>
 
       <div className="flex flex-wrap items-start justify-between gap-4">
@@ -772,7 +778,7 @@ export function TicketDetalhe() {
                       to={`/whatsapp/c/${c.id}`}
                       className="text-sm font-medium text-cyan-700 underline hover:text-cyan-900 dark:text-cyan-400 dark:hover:text-cyan-300"
                     >
-                      {c.protocolo}
+                      {exibirProtocolo(c.protocolo)}
                       {c.estado === 'encerrado' ? ' (encerrado)' : ''}
                     </Link>
                   </li>

--- a/frontend/src/pages/TicketNovo.tsx
+++ b/frontend/src/pages/TicketNovo.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ApiError, tickets, empresas, setores, type Empresas, type Setores } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
@@ -32,6 +32,7 @@ export function TicketNovo() {
   const [descricao, setDescricao] = useState('')
   const [anexosSelecionados, setAnexosSelecionados] = useState<File[]>([])
   const [loading, setLoading] = useState(false)
+  const anexosInputRef = useRef<HTMLInputElement>(null)
 
   /** Setores já vêm filtrados pelo backend (#38); não restringir por `user.setor_ids` no cliente (evita perder homônimos). */
   const setoresFiltrados = useMemo(() => {
@@ -264,14 +265,48 @@ export function TicketNovo() {
               </div>
 
               <div className="mt-4">
-                <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">Anexos (opcional)</label>
-                <input
-                  type="file"
-                  multiple
-                  onChange={onSelecionarAnexos}
-                  disabled={semSetorPermitido || semEmpresasNoEscopo || loading}
-                  aria-label="Selecionar anexos"
-                />
+                <label
+                  htmlFor="ticket-novo-anexos"
+                  className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300"
+                >
+                  Anexos (opcional)
+                </label>
+                <div className="flex flex-wrap items-center gap-3">
+                  <input
+                    ref={anexosInputRef}
+                    id="ticket-novo-anexos"
+                    type="file"
+                    multiple
+                    className="sr-only"
+                    onChange={onSelecionarAnexos}
+                    disabled={semSetorPermitido || semEmpresasNoEscopo || loading}
+                    aria-label="Selecionar arquivos para anexar ao ticket"
+                  />
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    disabled={semSetorPermitido || semEmpresasNoEscopo || loading}
+                    onClick={() => anexosInputRef.current?.click()}
+                    className="inline-flex items-center gap-2"
+                  >
+                    <svg className="size-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"
+                      />
+                    </svg>
+                    Adicionar arquivos
+                  </Button>
+                  {anexosSelecionados.length > 0 ? (
+                    <span className="text-xs font-medium text-slate-600 dark:text-slate-300">
+                      {anexosSelecionados.length} arquivo(s) na fila
+                    </span>
+                  ) : (
+                    <span className="text-xs text-slate-500 dark:text-slate-400">Nenhum arquivo selecionado</span>
+                  )}
+                </div>
                 <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                   Até {MAX_ANEXOS_COUNT} arquivo(s), no máximo 25 MB cada. Alguns tipos podem ser bloqueados por segurança.
                 </p>

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -24,6 +24,7 @@ import { useAuth } from '../contexts/AuthContext'
 import { useAlertaFilaSemResponsavel } from '../hooks/useAlertaFilaSemResponsavel'
 import { SemPermissao } from './SemPermissao'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { exibirProtocolo } from '../lib/exibirProtocolo'
 
 type ColunaOrdenacao =
   | 'protocolo'
@@ -330,7 +331,7 @@ export function Tickets() {
                   setBusca(e.target.value)
                   resetarPagina()
                 }}
-                placeholder="Buscar por protocolo, assunto ou empresa…"
+                placeholder="Buscar por protocolo (ex.: #T2026-04-0001), assunto ou empresa…"
                 disabled={loading}
                 className="w-full rounded-xl border-0 bg-slate-50 py-2.5 pl-10 pr-4 text-sm text-slate-900 shadow-inner ring-1 ring-slate-200/80 transition-shadow placeholder:text-slate-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-slate-400/25 dark:bg-slate-900/60 dark:text-slate-100 dark:ring-slate-700 dark:placeholder:text-slate-500 dark:focus:bg-slate-900"
                 aria-label="Buscar tickets"
@@ -444,7 +445,7 @@ export function Tickets() {
                 {!isAdmin && empresasOpt.length === 0 && (
                   <p className="mt-1.5 text-xs leading-relaxed text-slate-500 dark:text-slate-400">
                     Empresas no filtro aparecem só para redes que já tiveram ticket nos setores que você atende. Até lá,
-                    use a busca por protocolo ou assunto.
+                    use a busca por protocolo (inclui # e hífen), assunto ou empresa.
                   </p>
                 )}
               </div>
@@ -572,7 +573,12 @@ export function Tickets() {
                   >
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0">
-                        <p className="font-mono text-xs text-slate-500 dark:text-slate-400">#{t.protocolo}</p>
+                        <p
+                          className="min-w-0 truncate font-mono text-xs text-slate-500 dark:text-slate-400"
+                          title={exibirProtocolo(t.protocolo)}
+                        >
+                          {exibirProtocolo(t.protocolo)}
+                        </p>
                         <p className="mt-1 truncate font-semibold text-slate-900 dark:text-slate-100">
                           {t.empresa_nome ?? String(t.empresa_id)}
                         </p>
@@ -727,8 +733,11 @@ export function Tickets() {
                     }}
                     className="cursor-pointer transition-colors hover:bg-slate-50/90 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-slate-800/50 dark:focus-visible:bg-slate-800/60"
                   >
-                    <td className="whitespace-nowrap px-4 py-3.5 align-top font-mono text-sm text-slate-900 sm:px-6 dark:text-slate-100">
-                      {t.protocolo}
+                    <td
+                      className="max-w-[10rem] truncate px-4 py-3.5 align-top font-mono text-sm text-slate-900 sm:max-w-[12rem] sm:px-6 dark:text-slate-100"
+                      title={exibirProtocolo(t.protocolo)}
+                    >
+                      {exibirProtocolo(t.protocolo)}
                     </td>
                     <td
                       className="hidden px-4 py-3.5 align-top text-slate-600 lg:table-cell sm:px-6 dark:text-slate-400"

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -331,7 +331,7 @@ export function Tickets() {
                   setBusca(e.target.value)
                   resetarPagina()
                 }}
-                placeholder="Buscar por protocolo (ex.: #T2026-04-0001), assunto ou empresa…"
+                placeholder="Buscar por protocolo (ex.: #T202605-0001), assunto ou empresa…"
                 disabled={loading}
                 className="w-full rounded-xl border-0 bg-slate-50 py-2.5 pl-10 pr-4 text-sm text-slate-900 shadow-inner ring-1 ring-slate-200/80 transition-shadow placeholder:text-slate-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-slate-400/25 dark:bg-slate-900/60 dark:text-slate-100 dark:ring-slate-700 dark:placeholder:text-slate-500 dark:focus:bg-slate-900"
                 aria-label="Buscar tickets"

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -5,6 +5,7 @@ import { Card } from '../../components/ui/Card'
 import { Button } from '../../components/ui/Button'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { exibirProtocolo } from '../../lib/exibirProtocolo'
 
 // Componente para cálculo de tempo de espera
 function TempoEspera({ data }: { data?: string | null }) {
@@ -119,7 +120,12 @@ export function WhatsappAtendendo() {
                     <div className="flex items-start justify-between">
                       <div className="min-w-0">
                         <div className="flex items-center gap-2 mb-1">
-                          <span className="font-mono text-[10px] font-bold text-cyan-600">{c.protocolo}</span>
+                          <span
+                            className="min-w-0 truncate font-mono text-[10px] font-bold text-cyan-600"
+                            title={exibirProtocolo(c.protocolo)}
+                          >
+                            {exibirProtocolo(c.protocolo)}
+                          </span>
                           <TempoEspera data={c.created_at} />
                         </div>
                         <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</h3>
@@ -168,7 +174,12 @@ export function WhatsappAtendendo() {
                     <div className="flex flex-col h-full justify-between gap-4">
                       <div>
                         <div className="flex justify-between items-start mb-2">
-                          <span className="text-[10px] font-bold text-cyan-600 uppercase">{c.protocolo}</span>
+                          <span
+                            className="min-w-0 truncate text-[10px] font-bold text-cyan-600"
+                            title={exibirProtocolo(c.protocolo)}
+                          >
+                            {exibirProtocolo(c.protocolo)}
+                          </span>
                           <span className="relative flex h-2 w-2">
                             <span className="absolute h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75"></span>
                             <span className="relative h-2 w-2 rounded-full bg-emerald-500"></span>

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -33,6 +33,8 @@ import { useToast } from '../../components/ui/Toast'
 
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 
+import { exibirProtocolo } from '../../lib/exibirProtocolo'
+
 import { useAuth } from '../../contexts/AuthContext'
 
 
@@ -544,7 +546,9 @@ useEffect(() => {
 
                   </div>
 
-                  <p className="truncate text-[10px] font-mono text-slate-400">{c.protocolo}</p>
+                  <p className="truncate text-[10px] font-mono text-slate-400" title={exibirProtocolo(c.protocolo)}>
+                    {exibirProtocolo(c.protocolo)}
+                  </p>
 
                 </div>
 
@@ -578,7 +582,9 @@ useEffect(() => {
 
               <div className="flex items-center gap-2 text-[10px]">
 
-                <span className="font-mono text-cyan-600 uppercase font-bold">{chat?.protocolo}</span>
+                <span className="min-w-0 truncate font-mono font-bold text-cyan-600" title={exibirProtocolo(chat?.protocolo)}>
+                  {exibirProtocolo(chat?.protocolo)}
+                </span>
 
                 <span className="text-slate-300">•</span>
 

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -57,7 +57,7 @@ export function WhatsappHistorico() {
         <div className="flex flex-1 max-w-md gap-2">
           <div className="relative flex-1">
             <Input 
-              placeholder="Buscar por nome, telefone ou protocolo (ex.: #C2026-04-0001)…" 
+              placeholder="Buscar por nome, telefone ou protocolo (ex.: #C202604-0001)…" 
               value={busca}
               onChange={(e) => setBusca(e.target.value)}
               className="pl-10"

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -6,6 +6,7 @@ import { Button } from '../../components/ui/Button'
 import { Input } from '../../components/ui/Input'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { exibirProtocolo } from '../../lib/exibirProtocolo'
 
 const PAGE_SIZE = 15 // Reduzi para 15 para melhorar o fôlego da página em listas longas
 
@@ -56,7 +57,7 @@ export function WhatsappHistorico() {
         <div className="flex flex-1 max-w-md gap-2">
           <div className="relative flex-1">
             <Input 
-              placeholder="Buscar por nome ou protocolo..." 
+              placeholder="Buscar por nome, telefone ou protocolo (ex.: #C2026-04-0001)…" 
               value={busca}
               onChange={(e) => setBusca(e.target.value)}
               className="pl-10"
@@ -100,7 +101,12 @@ export function WhatsappHistorico() {
                         <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</h3>
                         <span className="font-mono text-[10px] font-bold text-slate-400">{c.wa_id}</span>
                       </div>
-                      <p className="font-mono text-xs font-bold text-cyan-600 dark:text-cyan-400">{c.protocolo}</p>
+                      <p
+                        className="truncate font-mono text-xs font-bold text-cyan-600 dark:text-cyan-400"
+                        title={exibirProtocolo(c.protocolo)}
+                      >
+                        {exibirProtocolo(c.protocolo)}
+                      </p>
                     </div>
                   </div>
 


### PR DESCRIPTION
## Objetivo
Implementa as issues **#138** (backend) e **#139** (frontend): protocolos humanos mensais para tickets e chats WhatsApp, com UI consistente e legado suportado.

## Formato
- **Tickets:** \#TYYYYMM-NNNN\ (ex.: \#T202605-0001\) — mês em \YYYYMM\ (sem hífen na data), fuso \America/Sao_Paulo\.
- **Chats:** \#CYYYYMM-NNNN\ com a mesma regra.
- Sequência na tabela \protocol_sequences\, incremento na mesma transação.

## Backend
- Serviço \protocolo_mensal\ + modelo \ProtocolSequence\.
- Migrações \