### PR TITLE
feat(tickets): janela de edição antes do e-mail ao cliente

### DIFF
--- a/backend/alembic/versions/027_ticket_mensagem_email_outbox.py
+++ b/backend/alembic/versions/027_ticket_mensagem_email_outbox.py
@@ -1,0 +1,45 @@
+"""ticket_mensagens: fila de envio de e-mail com janela de edição (#140).
+
+Revision ID: 027_ticket_msg_email_outbox
+Revises: 026_ticket_msg_autor_ext
+Create Date: 2026-05-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "027_ticket_msg_email_outbox"
+down_revision = "026_ticket_msg_autor_ext"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("ticket_mensagens", sa.Column("email_status", sa.String(length=32), nullable=True))
+    op.add_column("ticket_mensagens", sa.Column("scheduled_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("ticket_mensagens", sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "ticket_mensagens",
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column("ticket_mensagens", sa.Column("edit_lock_token", sa.String(length=64), nullable=True))
+    op.add_column(
+        "ticket_mensagens",
+        sa.Column("edit_lock_expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_ticket_mensagens_email_status_scheduled",
+        "ticket_mensagens",
+        ["email_status", "scheduled_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ticket_mensagens_email_status_scheduled", table_name="ticket_mensagens")
+    op.drop_column("ticket_mensagens", "edit_lock_expires_at")
+    op.drop_column("ticket_mensagens", "edit_lock_token")
+    op.drop_column("ticket_mensagens", "updated_at")
+    op.drop_column("ticket_mensagens", "sent_at")
+    op.drop_column("ticket_mensagens", "scheduled_at")
+    op.drop_column("ticket_mensagens", "email_status")

--- a/backend/alembic/versions/028_email_settings_ticket_grace.py
+++ b/backend/alembic/versions/028_email_settings_ticket_grace.py
@@ -1,0 +1,31 @@
+"""email_settings: janela antes de enviar resposta ao cliente (#140).
+
+Revision ID: 028_email_ticket_grace
+Revises: 027_ticket_msg_email_outbox
+Create Date: 2026-05-21
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "028_email_ticket_grace"
+down_revision = "027_ticket_msg_email_outbox"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "email_settings",
+        sa.Column("ticket_mensagem_email_grace_seconds", sa.Integer(), nullable=True),
+    )
+    op.execute(
+        sa.text(
+            "UPDATE email_settings SET ticket_mensagem_email_grace_seconds = 120 "
+            "WHERE ticket_mensagem_email_grace_seconds IS NULL"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("email_settings", "ticket_mensagem_email_grace_seconds")

--- a/backend/app/api/system_settings.py
+++ b/backend/app/api/system_settings.py
@@ -8,7 +8,12 @@ from app.database import get_db
 from app.models.atendente import Atendente
 from app.models.email_settings import EmailSettings
 from app.models.empresa_sistema import EmpresaSistema
-from app.schemas.email_settings import EmailSettingsRead, EmailSettingsUpdate, EmailTestResult
+from app.schemas.email_settings import EmailSettingsRead, EmailSettingsUpdate, EmailTestResult, TicketEmailGraceOpcao
+from app.services.ticket_email_grace_config import (
+    grace_opcoes_dict,
+    resolver_grace_seconds,
+    validar_grace_seconds,
+)
 from app.schemas.system_company import EmpresaSistemaRead, EmpresaSistemaUpdate
 from app.services.email_send_sistema import enviar_mensagem_texto_sistema
 from app.services.secret_box import encrypt_str
@@ -68,7 +73,7 @@ def _get_or_create_email(db: Session) -> EmailSettings:
     return row
 
 
-def _email_out(row: EmailSettings | None) -> EmailSettingsRead:
+def _email_out(row: EmailSettings | None, db: Session) -> EmailSettingsRead:
     cfg = transactional_config_from_row(row)
     from_email = cfg.from_email if cfg else None
     from_name = cfg.from_name if cfg else None
@@ -86,6 +91,8 @@ def _email_out(row: EmailSettings | None) -> EmailSettingsRead:
         transactional_reply_to_email=reply_to,
         outbound_configured=bool(cfg),
         has_transactional_api_key=bool(row and row.transactional_api_key_enc and str(row.transactional_api_key_enc).strip()),
+        ticket_mensagem_email_grace_seconds=resolver_grace_seconds(db),
+        opcoes_ticket_mensagem_email_grace=[TicketEmailGraceOpcao(**o) for o in grace_opcoes_dict()],
     )
 
 
@@ -210,7 +217,7 @@ def get_email_settings(
     db: Session = Depends(get_db),
     _: Atendente = Depends(exigir_admin),
 ):
-    return _email_out(get_singleton_email_settings(db))
+    return _email_out(get_singleton_email_settings(db), db)
 
 
 @router.put("/email", response_model=EmailSettingsRead)
@@ -240,9 +247,19 @@ def put_email_settings(
         else:
             row.transactional_api_key_enc = encrypt_str(str(v))
 
+    if "ticket_mensagem_email_grace_seconds" in payload:
+        v = payload["ticket_mensagem_email_grace_seconds"]
+        if v is None:
+            row.ticket_mensagem_email_grace_seconds = None
+        else:
+            try:
+                row.ticket_mensagem_email_grace_seconds = validar_grace_seconds(int(v))
+            except ValueError as e:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
     db.commit()
     db.refresh(row)
-    return _email_out(row)
+    return _email_out(row, db)
 
 
 @router.post("/email/test-transactional", response_model=EmailTestResult)

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -17,6 +17,8 @@ from app.schemas.ticket import (
     TicketHistoricoRead,
     TicketMensagemCreate,
     TicketMensagemRead,
+    TicketMensagemStartEditRead,
+    TicketMensagemUpdate,
     TicketRead,
     TicketTriagemInbound,
     TicketUpdate,
@@ -33,8 +35,18 @@ from app.core.setor_scope import (
 from app.services import ticket_anexo_storage
 from app.services.protocolo_mensal import gerar_protocolo_ticket
 from app.services.funcionario_rede_resolver import resolver_remetente_por_email
-from app.services.ticket_client_email import enviar_resposta_equipa_por_email, extrair_email_de_from_address
-from app.services.ticket_email_index import registar_message_id_para_ticket
+from app.services.ticket_client_email import extrair_email_de_from_address
+from app.services.ticket_mensagem_email_outbox import (
+    EMAIL_STATUS_ENVIADA,
+    agendar_envio_email,
+    cancelar_envio,
+    forcar_envio_agora,
+    iniciar_edicao,
+    process_pending_ticket_mensagem_emails,
+    salvar_edicao,
+    validar_lock,
+    validar_pode_agendar_email_cliente,
+)
 
 router = APIRouter(prefix="/tickets", tags=["tickets"])
 
@@ -143,6 +155,35 @@ def _pode_enviar_mensagem_publica(atendente: Atendente, ticket: Ticket) -> bool:
     if ticket.atendente_id is None:
         return True
     return ticket.atendente_id == atendente.id
+
+
+def _pode_editar_mensagem_email(atendente: Atendente, mensagem: TicketMensagem) -> bool:
+    if atendente.role == "admin":
+        return True
+    return mensagem.atendente_id == atendente.id
+
+
+def _obter_mensagem_ticket(
+    db: Session,
+    *,
+    ticket_id: int,
+    mensagem_id: int,
+    atendente: Atendente,
+) -> tuple[Ticket, TicketMensagem]:
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if not _pode_ver_ticket(db, atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+    m = (
+        db.query(TicketMensagem)
+        .options(joinedload(TicketMensagem.atendente))
+        .filter(TicketMensagem.id == mensagem_id, TicketMensagem.ticket_id == ticket_id)
+        .first()
+    )
+    if not m:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mensagem não encontrada")
+    return ticket, m
 
 
 @router.get("", response_model=ListaPaginada[TicketRead])
@@ -405,7 +446,7 @@ def historico(
     ]
 
 
-def _mensagem_para_read(m: TicketMensagem, *, cliente_notificado_por_email: bool = False) -> TicketMensagemRead:
+def _mensagem_para_read(m: TicketMensagem) -> TicketMensagemRead:
     from app.services.email_body_sanitize import sanitize_inbound_email_body
 
     corpo = m.corpo
@@ -420,7 +461,11 @@ def _mensagem_para_read(m: TicketMensagem, *, cliente_notificado_por_email: bool
         tipo=m.tipo,
         corpo=corpo,
         created_at=m.created_at,
-        cliente_notificado_por_email=cliente_notificado_por_email,
+        cliente_notificado_por_email=m.email_status == EMAIL_STATUS_ENVIADA,
+        status=m.email_status,
+        scheduled_at=m.scheduled_at,
+        sent_at=m.sent_at,
+        updated_at=m.updated_at,
     )
 
 
@@ -477,10 +522,9 @@ def criar_mensagem(
     if not corpo:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Mensagem vazia")
 
-    out_mid: str | None = None
     if data.notificar_cliente_por_email:
         try:
-            out_mid = enviar_resposta_equipa_por_email(db, ticket=ticket, corpo=corpo)
+            validar_pode_agendar_email_cliente(db, ticket.id)
         except ValueError as e:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
@@ -490,10 +534,10 @@ def criar_mensagem(
         tipo=data.tipo,
         corpo=corpo,
     )
+    if data.notificar_cliente_por_email:
+        agendar_envio_email(m, db)
     db.add(m)
     db.flush()
-    if out_mid:
-        registar_message_id_para_ticket(db, ticket_id=ticket.id, message_id=out_mid, source="outbound")
     db.commit()
     db.refresh(m)
     m = (
@@ -503,7 +547,130 @@ def criar_mensagem(
         .first()
     )
     assert m is not None
-    return _mensagem_para_read(m, cliente_notificado_por_email=bool(out_mid))
+    return _mensagem_para_read(m)
+
+
+@router.post(
+    "/{ticket_id}/mensagens/{mensagem_id}/start-edit",
+    response_model=TicketMensagemStartEditRead,
+)
+def iniciar_edicao_mensagem(
+    ticket_id: int,
+    mensagem_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket, m = _obter_mensagem_ticket(db, ticket_id=ticket_id, mensagem_id=mensagem_id, atendente=atendente)
+    if ticket.fechado_em is not None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Ticket fechado.")
+    if m.tipo != "publico" or not m.email_status:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Mensagem sem fila de e-mail.")
+    if not _pode_enviar_mensagem_publica(atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão.")
+    if not _pode_editar_mensagem_email(atendente, m):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Só o autor ou admin pode editar.")
+    try:
+        token = iniciar_edicao(m)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    db.commit()
+    db.refresh(m)
+    m = (
+        db.query(TicketMensagem)
+        .options(joinedload(TicketMensagem.atendente))
+        .filter(TicketMensagem.id == m.id)
+        .first()
+    )
+    assert m is not None
+    return TicketMensagemStartEditRead(edit_lock_token=token, mensagem=_mensagem_para_read(m))
+
+
+@router.patch("/{ticket_id}/mensagens/{mensagem_id}", response_model=TicketMensagemRead)
+def atualizar_mensagem(
+    ticket_id: int,
+    mensagem_id: int,
+    data: TicketMensagemUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket, m = _obter_mensagem_ticket(db, ticket_id=ticket_id, mensagem_id=mensagem_id, atendente=atendente)
+    if ticket.fechado_em is not None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Ticket fechado.")
+    if not _pode_editar_mensagem_email(atendente, m):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Só o autor ou admin pode editar.")
+    corpo = data.corpo.strip()
+    if not corpo:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Mensagem vazia")
+    try:
+        validar_lock(m, data.edit_lock_token.strip())
+        salvar_edicao(m, db, corpo=corpo)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    db.commit()
+    db.refresh(m)
+    m = (
+        db.query(TicketMensagem)
+        .options(joinedload(TicketMensagem.atendente))
+        .filter(TicketMensagem.id == m.id)
+        .first()
+    )
+    assert m is not None
+    return _mensagem_para_read(m)
+
+
+@router.post("/{ticket_id}/mensagens/{mensagem_id}/cancel", response_model=TicketMensagemRead)
+def cancelar_mensagem_email(
+    ticket_id: int,
+    mensagem_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket, m = _obter_mensagem_ticket(db, ticket_id=ticket_id, mensagem_id=mensagem_id, atendente=atendente)
+    if not _pode_editar_mensagem_email(atendente, m):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Só o autor ou admin pode cancelar.")
+    try:
+        cancelar_envio(m)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    db.commit()
+    db.refresh(m)
+    m = (
+        db.query(TicketMensagem)
+        .options(joinedload(TicketMensagem.atendente))
+        .filter(TicketMensagem.id == m.id)
+        .first()
+    )
+    assert m is not None
+    return _mensagem_para_read(m)
+
+
+@router.post("/{ticket_id}/mensagens/{mensagem_id}/send-now", response_model=TicketMensagemRead)
+def enviar_mensagem_email_agora(
+    ticket_id: int,
+    mensagem_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket, m = _obter_mensagem_ticket(db, ticket_id=ticket_id, mensagem_id=mensagem_id, atendente=atendente)
+    if not _pode_enviar_mensagem_publica(atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão.")
+    if not _pode_editar_mensagem_email(atendente, m):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Só o autor ou admin pode enviar agora.")
+    try:
+        forcar_envio_agora(m)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    db.commit()
+    process_pending_ticket_mensagem_emails(db, limit=5)
+    db.commit()
+    m = (
+        db.query(TicketMensagem)
+        .options(joinedload(TicketMensagem.atendente))
+        .filter(TicketMensagem.id == m.id)
+        .first()
+    )
+    assert m is not None
+    return _mensagem_para_read(m)
 
 
 def _registrar_historico(db: Session, ticket_id: int, atendente_id: int | None, campo: str, valor_antigo: str | None, valor_novo: str | None):

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -448,6 +448,7 @@ def historico(
 
 def _mensagem_para_read(m: TicketMensagem) -> TicketMensagemRead:
     from app.services.email_body_sanitize import sanitize_inbound_email_body
+    from app.services.ticket_mensagem_email_outbox import _as_utc
 
     corpo = m.corpo
     if m.tipo in ("abertura", "email_cliente"):
@@ -463,9 +464,10 @@ def _mensagem_para_read(m: TicketMensagem) -> TicketMensagemRead:
         created_at=m.created_at,
         cliente_notificado_por_email=m.email_status == EMAIL_STATUS_ENVIADA,
         status=m.email_status,
-        scheduled_at=m.scheduled_at,
-        sent_at=m.sent_at,
-        updated_at=m.updated_at,
+        # Compat: alguns DBs/tests podem persistir datetimes sem tzinfo; a API sempre expõe em UTC.
+        scheduled_at=_as_utc(m.scheduled_at),
+        sent_at=_as_utc(m.sent_at),
+        updated_at=_as_utc(m.updated_at),
     )
 
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -53,6 +53,11 @@ class Settings(BaseSettings):
     # Tamanho máximo (bytes) para cada anexo de ticket.
     TICKET_ANEXOS_MAX_BYTES: int = 25 * 1024 * 1024
 
+    # Mensagem pública com notificação por e-mail (#140): janela antes do envio e TTL do lock de edição.
+    TICKET_MENSAGEM_EMAIL_GRACE_SECONDS: int = 120
+    TICKET_MENSAGEM_EDIT_LOCK_TTL_SECONDS: int = 300
+    TICKET_MENSAGEM_EMAIL_WORKER_INTERVAL_SECONDS: int = 5
+
     # Multi-tenant: subdomínio {tenant_id}.CONNECT_APP_BASE_DOMAIN e endereços {local}@INBOUND_EMAIL_DOMAIN
     CONNECT_APP_BASE_DOMAIN: str = "connect.duplexsoft.com.br"
     # Domínio Resend com Receiving (ex.: notify.duplexsoft.com.br). Endereços: {setor}.t{tenant}@domínio.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -160,6 +160,32 @@ async def lifespan(app: FastAPI):
 
     threading.Thread(target=ibge_municipios_sync_loop, daemon=True, name="ibge-municipios-sync").start()
 
+    def ticket_mensagem_email_outbox_loop() -> None:
+        from app.database import SessionLocal
+        from app.services.ticket_mensagem_email_outbox import process_pending_ticket_mensagem_emails
+
+        interval = max(2, settings.TICKET_MENSAGEM_EMAIL_WORKER_INTERVAL_SECONDS)
+        while True:
+            db = SessionLocal()
+            try:
+                n = process_pending_ticket_mensagem_emails(db, limit=30)
+                if n:
+                    db.commit()
+                else:
+                    db.rollback()
+            except Exception as e:
+                logger.warning("Worker e-mail de mensagens de ticket: %s", e)
+                db.rollback()
+            finally:
+                db.close()
+            time.sleep(interval)
+
+    threading.Thread(
+        target=ticket_mensagem_email_outbox_loop,
+        daemon=True,
+        name="ticket-mensagem-email-outbox",
+    ).start()
+
     yield
 
 

--- a/backend/app/models/email_settings.py
+++ b/backend/app/models/email_settings.py
@@ -33,6 +33,9 @@ class EmailSettings(Base):
     imap_use_ssl = Column(Boolean, default=True)
     imap_folder = Column(String(255), nullable=True)
 
+    # Segundos de espera antes de enviar resposta pública por e-mail (0 = imediato). #140
+    ticket_mensagem_email_grace_seconds = Column(Integer, nullable=True)
+
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/app/models/ticket.py
+++ b/backend/app/models/ticket.py
@@ -47,6 +47,13 @@ class TicketMensagem(Base):
     tipo = Column(String(20), nullable=False)
     corpo = Column(Text, nullable=False)
     autor_externo = Column(String(512), nullable=True)
+    # Fila de e-mail ao cliente (#140): só preenchido quando notificar_cliente_por_email na criação.
+    email_status = Column(String(32), nullable=True, index=True)
+    scheduled_at = Column(DateTime(timezone=True), nullable=True, index=True)
+    sent_at = Column(DateTime(timezone=True), nullable=True)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
+    edit_lock_token = Column(String(64), nullable=True)
+    edit_lock_expires_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     ticket = relationship("Ticket", back_populates="mensagens")

--- a/backend/app/schemas/email_settings.py
+++ b/backend/app/schemas/email_settings.py
@@ -1,6 +1,11 @@
 from pydantic import BaseModel, Field
 
 
+class TicketEmailGraceOpcao(BaseModel):
+    segundos: int
+    rotulo: str
+
+
 class EmailSettingsRead(BaseModel):
     """Estado do envio transaccional (sem expor segredos). Configuração efectiva: variáveis de ambiente no servidor."""
 
@@ -12,6 +17,14 @@ class EmailSettingsRead(BaseModel):
         default=False,
         description="Legado: API key gravada na BD (preferir RESEND_API_KEY no servidor).",
     )
+    ticket_mensagem_email_grace_seconds: int = Field(
+        default=120,
+        description="Espera antes de enviar e-mail ao cliente (0 = imediato).",
+    )
+    opcoes_ticket_mensagem_email_grace: list[TicketEmailGraceOpcao] = Field(
+        default_factory=list,
+        description="Opções disponíveis na UI de configurações.",
+    )
 
 
 class EmailSettingsUpdate(BaseModel):
@@ -21,6 +34,10 @@ class EmailSettingsUpdate(BaseModel):
     )
     transactional_from_email: str | None = None
     transactional_from_name: str | None = None
+    ticket_mensagem_email_grace_seconds: int | None = Field(
+        default=None,
+        description="Espera antes do envio (0 = imediato). Omitir para não alterar.",
+    )
 
 
 class EmailTestResult(BaseModel):

--- a/backend/app/schemas/ticket.py
+++ b/backend/app/schemas/ticket.py
@@ -67,7 +67,7 @@ class TicketMensagemCreate(BaseModel):
     tipo: Literal["publico", "interno"]
     notificar_cliente_por_email: bool = Field(
         default=False,
-        description="Se true e tipo=publico, envia e-mail SMTP ao último remetente do ticket (ingestão) e regista Message-ID (#165).",
+        description="Se true e tipo=publico, agenda envio por e-mail ao último remetente (janela de edição #140) e regista Message-ID após envio (#165).",
     )
 
 
@@ -81,8 +81,25 @@ class TicketMensagemRead(BaseModel):
     corpo: str
     created_at: datetime
     cliente_notificado_por_email: bool = False
+    status: str | None = Field(
+        None,
+        description="Estado da fila de e-mail (#140): pendente_envio, em_edicao, enviada, cancelada, etc.",
+    )
+    scheduled_at: datetime | None = None
+    sent_at: datetime | None = None
+    updated_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class TicketMensagemUpdate(BaseModel):
+    corpo: str = Field(..., min_length=1, max_length=20000)
+    edit_lock_token: str = Field(..., min_length=1, max_length=64)
+
+
+class TicketMensagemStartEditRead(BaseModel):
+    edit_lock_token: str
+    mensagem: TicketMensagemRead
 
 
 class TicketHistoricoRead(BaseModel):

--- a/backend/app/services/ticket_email_grace_config.py
+++ b/backend/app/services/ticket_email_grace_config.py
@@ -1,0 +1,49 @@
+"""
+Janela configurável antes de enviar e-mail ao cliente (mensagem pública #140).
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.services.system_email_config import get_singleton_email_settings
+
+# Valores permitidos na UI de configurações (admin).
+GRACE_OPCOES: list[tuple[int, str]] = [
+    (0, "Envio imediato"),
+    (30, "30 segundos"),
+    (60, "1 minuto"),
+    (120, "2 minutos"),
+    (180, "3 minutos"),
+    (300, "5 minutos"),
+]
+
+_GRACE_PERMITIDOS = {s for s, _ in GRACE_OPCOES}
+
+
+def grace_opcoes_dict() -> list[dict[str, int | str]]:
+    return [{"segundos": s, "rotulo": r} for s, r in GRACE_OPCOES]
+
+
+def grace_padrao_segundos() -> int:
+    return max(0, int(settings.TICKET_MENSAGEM_EMAIL_GRACE_SECONDS))
+
+
+def validar_grace_seconds(valor: int) -> int:
+    v = int(valor)
+    if v not in _GRACE_PERMITIDOS:
+        permitidos = ", ".join(str(s) for s in sorted(_GRACE_PERMITIDOS))
+        raise ValueError(f"Tempo de espera inválido. Opções permitidas (segundos): {permitidos}.")
+    return v
+
+
+def resolver_grace_seconds(db: Session) -> int:
+    """Preferência na BD (email_settings); fallback para variável de ambiente."""
+    row = get_singleton_email_settings(db)
+    if row is not None and row.ticket_mensagem_email_grace_seconds is not None:
+        try:
+            return validar_grace_seconds(row.ticket_mensagem_email_grace_seconds)
+        except ValueError:
+            pass
+    return grace_padrao_segundos()

--- a/backend/app/services/ticket_mensagem_email_outbox.py
+++ b/backend/app/services/ticket_mensagem_email_outbox.py
@@ -1,0 +1,257 @@
+"""
+Fila de envio de e-mail para mensagens públicas (#140): janela de graça, lock de edição e worker.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.ticket import Ticket, TicketMensagem
+from app.services.ticket_email_grace_config import resolver_grace_seconds
+from app.services.ticket_client_email import enviar_resposta_equipa_por_email, ultima_mensagem_inbound
+from app.services.ticket_email_index import registar_message_id_para_ticket
+
+logger = logging.getLogger(__name__)
+
+EMAIL_STATUS_PENDENTE = "pendente_envio"
+EMAIL_STATUS_EM_EDICAO = "em_edicao"
+EMAIL_STATUS_ENVIANDO = "enviando"
+EMAIL_STATUS_ENVIADA = "enviada"
+EMAIL_STATUS_CANCELADA = "cancelada"
+
+_STATUSES_EDITAVEIS = frozenset({EMAIL_STATUS_PENDENTE, EMAIL_STATUS_EM_EDICAO})
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _as_utc(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _dt_for_db(dt: datetime | None = None) -> datetime:
+    """Persistência em UTC naive (compatível SQLite/Postgres)."""
+    return _as_utc(dt or _utcnow()).replace(tzinfo=None)  # type: ignore[return-value]
+
+
+def grace_period_seconds(db: Session) -> int:
+    return resolver_grace_seconds(db)
+
+
+def edit_lock_ttl_seconds() -> int:
+    return max(30, int(settings.TICKET_MENSAGEM_EDIT_LOCK_TTL_SECONDS))
+
+
+def validar_pode_agendar_email_cliente(db: Session, ticket_id: int) -> None:
+    """Mesmas pré-condições de ``enviar_resposta_equipa_por_email``, sem enviar."""
+    row = ultima_mensagem_inbound(db, ticket_id)
+    if not row:
+        raise ValueError(
+            "Este ticket não tem histórico de e-mail recebido pelo webhook; não é possível notificar o cliente por e-mail."
+        )
+    from app.services.ticket_client_email import extrair_email_de_from_address
+
+    if not extrair_email_de_from_address(row.from_address):
+        raise ValueError(
+            "Não foi possível determinar o e-mail do cliente a partir do último remetente recebido. "
+            "Peça ao cliente um contacto válido ou use outro canal."
+        )
+    if not (row.message_id_normalized or "").strip():
+        raise ValueError("Message-ID da última mensagem recebida está em falta; não é possível encadear o e-mail.")
+
+    from app.services.system_email_config import get_singleton_email_settings, transactional_config_from_row
+
+    settings_row = get_singleton_email_settings(db)
+    if not transactional_config_from_row(settings_row):
+        raise ValueError(
+            "Envio de e-mail não configurado na plataforma. Contacte o administrador da instalação."
+        )
+
+
+def agendar_envio_email(m: TicketMensagem, db: Session, *, ref: datetime | None = None) -> None:
+    now = _dt_for_db(ref)
+    secs = grace_period_seconds(db)
+    m.email_status = EMAIL_STATUS_PENDENTE
+    m.scheduled_at = now if secs == 0 else now + timedelta(seconds=secs)
+    m.sent_at = None
+    m.edit_lock_token = None
+    m.edit_lock_expires_at = None
+    m.updated_at = now
+
+
+def _reagendar_apos_edicao(m: TicketMensagem, db: Session, *, now: datetime) -> None:
+    secs = grace_period_seconds(db)
+    m.scheduled_at = now if secs == 0 else now + timedelta(seconds=secs)
+
+
+def liberar_locks_expirados(db: Session, *, ref: datetime | None = None) -> int:
+    now = _dt_for_db(ref)
+    rows = (
+        db.query(TicketMensagem)
+        .filter(
+            TicketMensagem.email_status == EMAIL_STATUS_EM_EDICAO,
+            TicketMensagem.edit_lock_expires_at.isnot(None),
+        )
+        .all()
+    )
+    liberados = 0
+    for m in rows:
+        exp = _as_utc(m.edit_lock_expires_at)
+        if exp is None or exp.replace(tzinfo=None) >= now:
+            continue
+        m.email_status = EMAIL_STATUS_PENDENTE
+        m.edit_lock_token = None
+        m.edit_lock_expires_at = None
+        _reagendar_apos_edicao(m, db, now=now)
+        m.updated_at = now
+        liberados += 1
+    return liberados
+
+
+def _enviar_uma(db: Session, m: TicketMensagem, ticket: Ticket) -> bool:
+    if m.email_status == EMAIL_STATUS_ENVIADA:
+        return False
+    if m.email_status not in (EMAIL_STATUS_PENDENTE, EMAIL_STATUS_ENVIANDO):
+        return False
+    if m.email_status == EMAIL_STATUS_EM_EDICAO:
+        return False
+
+    now = _dt_for_db()
+    m.email_status = EMAIL_STATUS_ENVIANDO
+    m.updated_at = now
+    db.flush()
+
+    try:
+        out_mid = enviar_resposta_equipa_por_email(db, ticket=ticket, corpo=m.corpo)
+    except Exception:
+        m.email_status = EMAIL_STATUS_PENDENTE
+        m.scheduled_at = now + timedelta(seconds=60)
+        m.updated_at = now
+        raise
+
+    registar_message_id_para_ticket(db, ticket_id=ticket.id, message_id=out_mid, source="outbound")
+    m.email_status = EMAIL_STATUS_ENVIADA
+    m.sent_at = now
+    m.scheduled_at = None
+    m.edit_lock_token = None
+    m.edit_lock_expires_at = None
+    m.updated_at = now
+    return True
+
+
+def process_pending_ticket_mensagem_emails(db: Session, *, limit: int = 20) -> int:
+    """
+    Processa mensagens prontas para envio. Devolve quantas foram enviadas com sucesso.
+    """
+    liberar_locks_expirados(db)
+    now = _dt_for_db()
+
+    q = (
+        db.query(TicketMensagem)
+        .filter(
+            TicketMensagem.email_status == EMAIL_STATUS_PENDENTE,
+            TicketMensagem.scheduled_at.isnot(None),
+        )
+        .order_by(TicketMensagem.scheduled_at.asc())
+        .limit(limit)
+    )
+    try:
+        q = q.with_for_update(skip_locked=True)
+    except Exception:
+        q = q.with_for_update()
+
+    rows = q.all()
+    enviadas = 0
+    for m in rows:
+        if m.scheduled_at is None or m.scheduled_at > now:
+            continue
+        ticket = db.query(Ticket).filter(Ticket.id == m.ticket_id).first()
+        if not ticket:
+            continue
+        try:
+            if _enviar_uma(db, m, ticket):
+                enviadas += 1
+        except Exception as e:
+            logger.warning(
+                "Falha ao enviar e-mail da mensagem %s (ticket %s): %s",
+                m.id,
+                m.ticket_id,
+                e,
+            )
+    return enviadas
+
+
+def mensagem_em_fila_email(m: TicketMensagem) -> bool:
+    return m.email_status in _STATUSES_EDITAVEIS or m.email_status == EMAIL_STATUS_ENVIANDO
+
+
+def pode_editar_mensagem_email(m: TicketMensagem) -> bool:
+    return m.email_status in _STATUSES_EDITAVEIS
+
+
+def iniciar_edicao(m: TicketMensagem) -> str:
+    if not pode_editar_mensagem_email(m):
+        raise ValueError("Esta mensagem não pode ser editada (já enviada ou cancelada).")
+    now = _dt_for_db()
+    token = str(uuid.uuid4())
+    m.email_status = EMAIL_STATUS_EM_EDICAO
+    m.edit_lock_token = token
+    m.edit_lock_expires_at = now + timedelta(seconds=edit_lock_ttl_seconds())
+    m.updated_at = now
+    return token
+
+
+def validar_lock(m: TicketMensagem, token: str) -> None:
+    if m.email_status != EMAIL_STATUS_EM_EDICAO:
+        raise ValueError("A mensagem não está em edição.")
+    if not m.edit_lock_token or m.edit_lock_token != token:
+        raise ValueError("Token de edição inválido.")
+    exp = _as_utc(m.edit_lock_expires_at)
+    if exp and exp.replace(tzinfo=None) < _dt_for_db():
+        raise ValueError("O lock de edição expirou. Inicie a edição novamente.")
+
+
+def salvar_edicao(m: TicketMensagem, db: Session, *, corpo: str) -> None:
+    now = _dt_for_db()
+    m.corpo = corpo.strip()
+    m.email_status = EMAIL_STATUS_PENDENTE
+    m.edit_lock_token = None
+    m.edit_lock_expires_at = None
+    _reagendar_apos_edicao(m, db, now=now)
+    m.updated_at = now
+
+
+def cancelar_envio(m: TicketMensagem) -> None:
+    if m.email_status == EMAIL_STATUS_ENVIADA:
+        raise ValueError("Mensagem já enviada por e-mail; não é possível cancelar.")
+    if m.email_status == EMAIL_STATUS_CANCELADA:
+        return
+    now = _dt_for_db()
+    m.email_status = EMAIL_STATUS_CANCELADA
+    m.scheduled_at = None
+    m.edit_lock_token = None
+    m.edit_lock_expires_at = None
+    m.updated_at = now
+
+
+def forcar_envio_agora(m: TicketMensagem) -> None:
+    if m.email_status == EMAIL_STATUS_ENVIADA:
+        raise ValueError("Mensagem já enviada.")
+    if m.email_status == EMAIL_STATUS_CANCELADA:
+        raise ValueError("Mensagem cancelada.")
+    if m.email_status == EMAIL_STATUS_EM_EDICAO:
+        raise ValueError("Termine a edição antes de enviar agora.")
+    now = _dt_for_db()
+    m.email_status = EMAIL_STATUS_PENDENTE
+    m.scheduled_at = now
+    m.updated_at = now

--- a/backend/tests/test_system_settings_email_company.py
+++ b/backend/tests/test_system_settings_email_company.py
@@ -25,6 +25,31 @@ def test_admin_pode_salvar_empresa_sistema_e_cnpj_imutavel(client, auth_headers)
     assert r2.status_code == 400
 
 
+def test_email_settings_grace_opcoes_e_validacao(client, auth_headers):
+    r1 = client.get("/v1/settings/email", headers=auth_headers["admin"])
+    assert r1.status_code == 200
+    opcoes = r1.json().get("opcoes_ticket_mensagem_email_grace") or []
+    assert len(opcoes) >= 2
+    segundos = {o["segundos"] for o in opcoes}
+    assert 0 in segundos
+    assert 120 in segundos
+
+    r2 = client.put(
+        "/v1/settings/email",
+        headers=auth_headers["admin"],
+        json={"ticket_mensagem_email_grace_seconds": 60},
+    )
+    assert r2.status_code == 200
+    assert r2.json()["ticket_mensagem_email_grace_seconds"] == 60
+
+    r3 = client.put(
+        "/v1/settings/email",
+        headers=auth_headers["admin"],
+        json={"ticket_mensagem_email_grace_seconds": 999},
+    )
+    assert r3.status_code == 400
+
+
 def test_email_settings_nao_expoe_segredos(client, auth_headers):
     r1 = client.get("/v1/settings/email", headers=auth_headers["admin"])
     assert r1.status_code == 200

--- a/backend/tests/test_ticket_mensagem_email_grace_timing.py
+++ b/backend/tests/test_ticket_mensagem_email_grace_timing.py
@@ -1,0 +1,145 @@
+"""
+Teste de integração com tempo real (#140): janela de graça, edição e reagendamento.
+
+Requer grace curto via monkeypatch (8s). Demora ~20–25s no total.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+from app.models.ticket import TicketMensagem
+from app.services.ticket_mensagem_email_outbox import (
+    EMAIL_STATUS_ENVIADA,
+    EMAIL_STATUS_PENDENTE,
+    _as_utc,
+    process_pending_ticket_mensagem_emails,
+)
+from app.services.system_email_config import TransactionalEmailConfig
+
+
+def _rfc822(mid: str = "<grace-timing@dx.local>") -> str:
+    return (
+        f"From: Cliente <cliente@example.com>\r\n"
+        f"To: suporte@dxconnect.local\r\n"
+        f"Subject: Grace timing\r\n"
+        f"Message-ID: {mid}\r\n"
+        f"MIME-Version: 1.0\r\n"
+        f"Content-Type: text/plain; charset=utf-8\r\n"
+        f"\r\n"
+        f"Corpo.\r\n"
+    )
+
+
+def _mock_resend(monkeypatch):
+    _cfg = TransactionalEmailConfig(
+        api_key="re_test",
+        from_email="noreply@test.local",
+        from_name="Suporte",
+    )
+    for mod in ("app.services.ticket_client_email", "app.services.system_email_config"):
+        monkeypatch.setattr(f"{mod}.get_singleton_email_settings", lambda db: object())
+        monkeypatch.setattr(f"{mod}.transactional_config_from_row", lambda row: _cfg)
+    monkeypatch.setattr(
+        "app.services.ticket_client_email.enviar_mensagem_texto_sistema",
+        lambda *a, **k: "outbound-grace-timing@dx.test",
+    )
+
+
+def test_janela_edicao_reinicia_contagem_e_envia_depois(client, seed_base, auth_headers, monkeypatch, db_session):
+    """
+    1) Agenda envio em +8s
+    2) Após 3s ainda pendente (dá tempo de editar)
+    3) Editar reinicia scheduled_at (~+8s a partir da edição)
+    4) Só envia após o novo scheduled_at
+    """
+    grace = 8
+    monkeypatch.setattr("app.config.settings.TICKET_MENSAGEM_EMAIL_GRACE_SECONDS", grace)
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_WEBHOOK_SECRET", "gracet")
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_EMPRESA_ID", seed_base["empresa"].id)
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_SETOR_ID", seed_base["setor1"].id)
+    _mock_resend(monkeypatch)
+
+    r0 = client.post(
+        "/v1/webhooks/email-inbound",
+        headers={"X-Dx-Email-Webhook-Secret": "gracet"},
+        json={"rfc822": _rfc822()},
+    )
+    assert r0.status_code == 200
+    tid = r0.json()["ticket_id"]
+
+    t0 = time.perf_counter()
+    r1 = client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["admin"],
+        json={
+            "corpo": "Versão 1 — texto errado",
+            "tipo": "publico",
+            "notificar_cliente_por_email": True,
+        },
+    )
+    assert r1.status_code == 201, r1.text
+    mid = r1.json()["id"]
+    sched1 = _as_utc(datetime.fromisoformat(r1.json()["scheduled_at"].replace("Z", "+00:00")))
+    assert r1.json()["status"] == EMAIL_STATUS_PENDENTE
+
+    time.sleep(3)
+    process_pending_ticket_mensagem_emails(db_session, limit=10)
+    db_session.commit()
+    m = db_session.query(TicketMensagem).filter(TicketMensagem.id == mid).first()
+    assert m is not None
+    assert m.email_status == EMAIL_STATUS_PENDENTE, "Aos 3s ainda deve dar tempo de editar (não enviou)"
+
+    r_edit = client.post(
+        f"/v1/tickets/{tid}/mensagens/{mid}/start-edit",
+        headers=auth_headers["admin"],
+    )
+    assert r_edit.status_code == 200
+    token = r_edit.json()["edit_lock_token"]
+    t_antes_patch = time.perf_counter()
+    r_patch = client.patch(
+        f"/v1/tickets/{tid}/mensagens/{mid}",
+        headers=auth_headers["admin"],
+        json={"corpo": "Versão 2 — texto corrigido", "edit_lock_token": token},
+    )
+    assert r_patch.status_code == 200
+    db_session.expire_all()
+    m = db_session.query(TicketMensagem).filter(TicketMensagem.id == mid).first()
+    assert m is not None and m.scheduled_at is not None
+    sched2 = _as_utc(m.scheduled_at)
+    assert sched2 and sched1 and sched2 > sched1, "Edição deve reagendar para depois do horário original"
+    seg_ate_envio = (sched2 - datetime.now(timezone.utc)).total_seconds()
+    assert seg_ate_envio >= grace - 2, "Novo envio ~grace segundos após salvar edição"
+
+    # Antes do novo prazo: ainda pendente
+    wait_until = seg_ate_envio - 1.5
+    if wait_until > 0:
+        time.sleep(wait_until)
+    process_pending_ticket_mensagem_emails(db_session, limit=10)
+    db_session.commit()
+    db_session.refresh(m)
+    assert m.email_status == EMAIL_STATUS_PENDENTE, "Ainda não deve enviar antes do scheduled_at reagendado"
+
+    # Após o prazo reagendado: envia
+    restante = (sched2 - datetime.now(timezone.utc)).total_seconds() + 0.5
+    if restante > 0:
+        time.sleep(restante)
+    n = process_pending_ticket_mensagem_emails(db_session, limit=10)
+    db_session.commit()
+    db_session.refresh(m)
+    assert n >= 1
+    assert m.email_status == EMAIL_STATUS_ENVIADA
+    assert m.corpo == "Versão 2 — texto corrigido"
+    assert m.sent_at is not None
+
+    elapsed = time.perf_counter() - t0
+    elapsed_edit = time.perf_counter() - t_antes_patch
+    print(
+        f"\n[grace-timing] total={elapsed:.1f}s | "
+        f"editou aos ~{t_antes_patch - t0:.1f}s | "
+        f"enviou após reagendamento (grace={grace}s)\n"
+    )
+    assert elapsed >= grace + 3, "Tempo total cobre grace inicial + reagendamento após edição"

--- a/backend/tests/test_ticket_mensagem_email_outbox.py
+++ b/backend/tests/test_ticket_mensagem_email_outbox.py
@@ -1,0 +1,171 @@
+"""Fila de e-mail em mensagens públicas (#140)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models.ticket import TicketMensagem
+from app.services.system_email_config import TransactionalEmailConfig
+from app.services.ticket_mensagem_email_outbox import (
+    EMAIL_STATUS_CANCELADA,
+    EMAIL_STATUS_EM_EDICAO,
+    EMAIL_STATUS_PENDENTE,
+    _dt_for_db,
+    agendar_envio_email,
+    cancelar_envio,
+    iniciar_edicao,
+    liberar_locks_expirados,
+    salvar_edicao,
+    validar_lock,
+)
+
+
+def _mock_resend(monkeypatch):
+    _cfg = TransactionalEmailConfig(
+        api_key="re_test",
+        from_email="noreply@test.local",
+        from_name="Suporte",
+    )
+    for mod in ("app.services.ticket_client_email", "app.services.system_email_config"):
+        monkeypatch.setattr(f"{mod}.get_singleton_email_settings", lambda db: object())
+        monkeypatch.setattr(f"{mod}.transactional_config_from_row", lambda row: _cfg)
+
+
+def _minimal_rfc822(message_id: str = "<outbox-test@dx.local>") -> str:
+    return (
+        f"From: Cliente <cliente@example.com>\r\n"
+        f"To: suporte@dxconnect.local\r\n"
+        f"Subject: Teste outbox\r\n"
+        f"Message-ID: {message_id}\r\n"
+        f"MIME-Version: 1.0\r\n"
+        f"Content-Type: text/plain; charset=utf-8\r\n"
+        f"\r\n"
+        f"Corpo.\r\n"
+    )
+
+
+def test_criar_mensagem_agenda_sem_enviar_imediato(client, seed_base, auth_headers, monkeypatch):
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_WEBHOOK_SECRET", "ob140a")
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_EMPRESA_ID", seed_base["empresa"].id)
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_SETOR_ID", seed_base["setor1"].id)
+    _mock_resend(monkeypatch)
+    r0 = client.post(
+        "/v1/webhooks/email-inbound",
+        headers={"X-Dx-Email-Webhook-Secret": "ob140a"},
+        json={"rfc822": _minimal_rfc822("<ob140a@dx.local>")},
+    )
+    tid = r0.json()["ticket_id"]
+
+    r1 = client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["admin"],
+        json={"corpo": "Quase pronto", "tipo": "publico", "notificar_cliente_por_email": True},
+    )
+    assert r1.status_code == 201
+    j = r1.json()
+    assert j["status"] == EMAIL_STATUS_PENDENTE
+    assert j["scheduled_at"]
+    assert j["cliente_notificado_por_email"] is False
+
+
+def test_editar_cancelar_e_reagendar(client, seed_base, auth_headers, monkeypatch):
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_WEBHOOK_SECRET", "ob140b")
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_EMPRESA_ID", seed_base["empresa"].id)
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_SETOR_ID", seed_base["setor1"].id)
+    _mock_resend(monkeypatch)
+    r0 = client.post(
+        "/v1/webhooks/email-inbound",
+        headers={"X-Dx-Email-Webhook-Secret": "ob140b"},
+        json={"rfc822": _minimal_rfc822("<ob140b@dx.local>")},
+    )
+    tid = r0.json()["ticket_id"]
+    r1 = client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["admin"],
+        json={"corpo": "Texto errado", "tipo": "publico", "notificar_cliente_por_email": True},
+    )
+    mid = r1.json()["id"]
+
+    r_edit = client.post(
+        f"/v1/tickets/{tid}/mensagens/{mid}/start-edit",
+        headers=auth_headers["admin"],
+    )
+    assert r_edit.status_code == 200
+    token = r_edit.json()["edit_lock_token"]
+    assert r_edit.json()["mensagem"]["status"] == EMAIL_STATUS_EM_EDICAO
+
+    r_patch = client.patch(
+        f"/v1/tickets/{tid}/mensagens/{mid}",
+        headers=auth_headers["admin"],
+        json={"corpo": "Texto corrigido", "edit_lock_token": token},
+    )
+    assert r_patch.status_code == 200
+    assert r_patch.json()["status"] == EMAIL_STATUS_PENDENTE
+    assert r_patch.json()["corpo"] == "Texto corrigido"
+
+    r_cancel = client.post(
+        f"/v1/tickets/{tid}/mensagens/{mid}/cancel",
+        headers=auth_headers["admin"],
+    )
+    assert r_cancel.status_code == 200
+    assert r_cancel.json()["status"] == EMAIL_STATUS_CANCELADA
+
+
+def test_lock_expirado_libera_para_pendente(client, seed_base, auth_headers, monkeypatch, db_session):
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_WEBHOOK_SECRET", "ob140c")
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_EMPRESA_ID", seed_base["empresa"].id)
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_SETOR_ID", seed_base["setor1"].id)
+    _mock_resend(monkeypatch)
+    r0 = client.post(
+        "/v1/webhooks/email-inbound",
+        headers={"X-Dx-Email-Webhook-Secret": "ob140c"},
+        json={"rfc822": _minimal_rfc822("<ob140c@dx.local>")},
+    )
+    tid = r0.json()["ticket_id"]
+    r1 = client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["admin"],
+        json={"corpo": "x", "tipo": "publico", "notificar_cliente_por_email": True},
+    )
+    mid = r1.json()["id"]
+    r_edit = client.post(
+        f"/v1/tickets/{tid}/mensagens/{mid}/start-edit",
+        headers=auth_headers["admin"],
+    )
+    token = r_edit.json()["edit_lock_token"]
+    m = db_session.query(TicketMensagem).filter(TicketMensagem.id == mid).first()
+    assert m is not None
+    m.edit_lock_expires_at = _dt_for_db() - timedelta(seconds=1)
+    db_session.commit()
+    liberar_locks_expirados(db_session)
+    db_session.commit()
+    db_session.refresh(m)
+    assert m.email_status == EMAIL_STATUS_PENDENTE
+    with pytest.raises(ValueError):
+        validar_lock(m, token)
+
+
+def test_unit_salvar_edicao_reinicia_janela(monkeypatch, db_session):
+    monkeypatch.setattr("app.config.settings.TICKET_MENSAGEM_EMAIL_GRACE_SECONDS", 90)
+    from app.models.email_settings import EmailSettings
+
+    row = EmailSettings(ticket_mensagem_email_grace_seconds=90)
+    db_session.add(row)
+    db_session.flush()
+    m = TicketMensagem(ticket_id=1, atendente_id=1, tipo="publico", corpo="a")
+    agendar_envio_email(m, db_session)
+    t0 = m.scheduled_at
+    token = iniciar_edicao(m)
+    validar_lock(m, token)
+    salvar_edicao(m, db_session, corpo="b")
+    assert m.corpo == "b"
+    assert m.scheduled_at > t0
+
+
+def test_cancelar_envio(db_session):
+    m = TicketMensagem(ticket_id=1, atendente_id=1, tipo="publico", corpo="x")
+    agendar_envio_email(m, db_session)
+    cancelar_envio(m)
+    assert m.email_status == EMAIL_STATUS_CANCELADA

--- a/backend/tests/test_ticket_reply_email.py
+++ b/backend/tests/test_ticket_reply_email.py
@@ -8,6 +8,7 @@ from app.models.ticket_email_message_id import TicketEmailMessageId
 from app.services.system_email_config import TransactionalEmailConfig
 from app.services.ticket_client_email import extrair_email_de_from_address
 from app.services.ticket_email_index import registar_message_id_para_ticket
+from app.services.ticket_mensagem_email_outbox import process_pending_ticket_mensagem_emails
 
 
 def _headers(secret: str) -> dict[str, str]:
@@ -119,7 +120,13 @@ def test_notificar_email_webhook_grava_outbound_mid(client, seed_base, auth_head
     )
     assert r1.status_code == 201, r1.text
     j = r1.json()
-    assert j["cliente_notificado_por_email"] is True
+    assert j["status"] == "pendente_envio"
+    assert j["cliente_notificado_por_email"] is False
+    assert j["scheduled_at"] is not None
+
+    n = process_pending_ticket_mensagem_emails(db_session, limit=10)
+    assert n == 1
+    db_session.commit()
 
     rows = (
         db_session.query(TicketEmailMessageId)
@@ -198,6 +205,8 @@ def test_cliente_responde_a_mid_outbound_equipa_fica_no_mesmo_ticket(
         json={"corpo": "Resposta da equipa.", "tipo": "publico", "notificar_cliente_por_email": True},
     )
     assert r_team.status_code == 201, r_team.text
+    process_pending_ticket_mensagem_emails(db_session, limit=10)
+    db_session.commit()
 
     db_session.expire_all()
     follow = _rfc822_reply(message_id="<client-followup@dx.test>", in_reply_to=f"<{out_mid}>")

--- a/backend/tests/test_ticket_reply_email.py
+++ b/backend/tests/test_ticket_reply_email.py
@@ -28,6 +28,17 @@ def _minimal_rfc822(message_id: str = "<unique-test-msg@dx.local>") -> str:
     )
 
 
+def _mock_resend(monkeypatch):
+    _cfg = TransactionalEmailConfig(
+        api_key="re_test",
+        from_email="noreply@test.local",
+        from_name="Suporte",
+    )
+    for mod in ("app.services.ticket_client_email", "app.services.system_email_config"):
+        monkeypatch.setattr(f"{mod}.get_singleton_email_settings", lambda db: object())
+        monkeypatch.setattr(f"{mod}.transactional_config_from_row", lambda row: _cfg)
+
+
 def _create_ticket_via_api(client, auth_headers, seed_base):
     r = client.post(
         "/v1/tickets",
@@ -91,19 +102,8 @@ def test_notificar_email_webhook_grava_outbound_mid(client, seed_base, auth_head
     assert r0.status_code == 200
     tid = r0.json()["ticket_id"]
 
-    _cfg = TransactionalEmailConfig(
-        api_key="re_test",
-        from_email="noreply@test.local",
-        from_name="Suporte",
-    )
-    monkeypatch.setattr(
-        "app.services.ticket_client_email.get_singleton_email_settings",
-        lambda db: object(),
-    )
-    monkeypatch.setattr(
-        "app.services.ticket_client_email.transactional_config_from_row",
-        lambda row: _cfg,
-    )
+    _mock_resend(monkeypatch)
+    monkeypatch.setattr("app.config.settings.TICKET_MENSAGEM_EMAIL_GRACE_SECONDS", 0)
     monkeypatch.setattr(
         "app.services.ticket_client_email.enviar_mensagem_texto_sistema",
         lambda *a, **k: "outbound-team@dx.test",
@@ -181,19 +181,8 @@ def test_cliente_responde_a_mid_outbound_equipa_fica_no_mesmo_ticket(
     tid = r0.json()["ticket_id"]
 
     out_mid = "reply-from-staff-mid@dx.test"
-    _cfg = TransactionalEmailConfig(
-        api_key="re_test",
-        from_email="noreply@test.local",
-        from_name="Suporte",
-    )
-    monkeypatch.setattr(
-        "app.services.ticket_client_email.get_singleton_email_settings",
-        lambda db: object(),
-    )
-    monkeypatch.setattr(
-        "app.services.ticket_client_email.transactional_config_from_row",
-        lambda row: _cfg,
-    )
+    _mock_resend(monkeypatch)
+    monkeypatch.setattr("app.config.settings.TICKET_MENSAGEM_EMAIL_GRACE_SECONDS", 0)
     monkeypatch.setattr(
         "app.services.ticket_client_email.enviar_mensagem_texto_sistema",
         lambda *a, **k: out_mid,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -489,18 +489,26 @@ export namespace SystemSettings {
     cep?: string | null
   }
 
+  export interface TicketEmailGraceOpcao {
+    segundos: number
+    rotulo: string
+  }
+
   export interface EmailSettingsRead {
     transactional_from_email?: string | null
     transactional_from_name?: string | null
     transactional_reply_to_email?: string | null
     outbound_configured?: boolean
     has_transactional_api_key?: boolean
+    ticket_mensagem_email_grace_seconds?: number
+    opcoes_ticket_mensagem_email_grace?: TicketEmailGraceOpcao[]
   }
 
   export interface EmailSettingsUpdate {
     transactional_api_key?: string | null
     transactional_from_email?: string | null
     transactional_from_name?: string | null
+    ticket_mensagem_email_grace_seconds?: number | null
   }
 
   export interface EmailTestResult {
@@ -723,6 +731,17 @@ export const tickets = {
   listMensagens: (id: number) => api<Tickets.Mensagem[]>(`/tickets/${id}/mensagens`),
   addMensagem: (id: number, data: Tickets.MensagemCreate) =>
     api<Tickets.Mensagem>(`/tickets/${id}/mensagens`, { method: 'POST', body: JSON.stringify(data) }),
+  startEditMensagem: (ticketId: number, mensagemId: number) =>
+    api<Tickets.MensagemStartEdit>(`/tickets/${ticketId}/mensagens/${mensagemId}/start-edit`, { method: 'POST' }),
+  updateMensagem: (ticketId: number, mensagemId: number, data: Tickets.MensagemUpdate) =>
+    api<Tickets.Mensagem>(`/tickets/${ticketId}/mensagens/${mensagemId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+  cancelMensagemEmail: (ticketId: number, mensagemId: number) =>
+    api<Tickets.Mensagem>(`/tickets/${ticketId}/mensagens/${mensagemId}/cancel`, { method: 'POST' }),
+  sendNowMensagemEmail: (ticketId: number, mensagemId: number) =>
+    api<Tickets.Mensagem>(`/tickets/${ticketId}/mensagens/${mensagemId}/send-now`, { method: 'POST' }),
   reabrir: (id: number) => api<Tickets.Ticket>(`/tickets/${id}/reabrir`, { method: 'POST' }),
   create: (data: Tickets.Create) => api<Tickets.Ticket>('/tickets', { method: 'POST', body: JSON.stringify(data) }),
   update: (id: number, data: Tickets.Update) => api<Tickets.Ticket>(`/tickets/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
@@ -1128,12 +1147,26 @@ export namespace Tickets {
     corpo: string;
     created_at: string;
     cliente_notificado_por_email?: boolean;
+    status?: string | null;
+    scheduled_at?: string | null;
+    sent_at?: string | null;
+    updated_at?: string | null;
   }
 
   export interface MensagemCreate {
     corpo: string;
     tipo: 'publico' | 'interno';
     notificar_cliente_por_email?: boolean;
+  }
+
+  export interface MensagemUpdate {
+    corpo: string;
+    edit_lock_token: string;
+  }
+
+  export interface MensagemStartEdit {
+    edit_lock_token: string;
+    mensagem: Mensagem;
   }
 
   export interface Update {

--- a/frontend/src/components/TicketMensagemEmailOutbox.tsx
+++ b/frontend/src/components/TicketMensagemEmailOutbox.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState } from 'react'
+import { ApiError, tickets, type Tickets } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Button } from './ui/Button'
+import { useToast } from './ui/Toast'
+import {
+  mensagemEmFilaEmail,
+  rotuloStatusEmail,
+  segundosAteEnvio,
+  textoContagemEnvio,
+} from '../lib/ticketMensagemEmailOutbox'
+
+type Props = {
+  ticketId: number
+  msg: Tickets.Mensagem
+  podeGerir: boolean
+  onAtualizado: () => void | Promise<void>
+}
+
+export function TicketMensagemEmailOutbox({ ticketId, msg, podeGerir, onAtualizado }: Props) {
+  const toast = useToast()
+  const [tick, setTick] = useState(0)
+  const [busy, setBusy] = useState(false)
+  const [editando, setEditando] = useState(false)
+  const [editCorpo, setEditCorpo] = useState(msg.corpo)
+  const [lockToken, setLockToken] = useState<string | null>(null)
+
+  const status = msg.status
+  const rotulo = rotuloStatusEmail(status)
+  const seg = segundosAteEnvio(msg.scheduled_at)
+  const contagem = status === 'pendente_envio' ? textoContagemEnvio(seg) : ''
+
+  useEffect(() => {
+    if (!mensagemEmFilaEmail(status)) return
+    const id = window.setInterval(() => setTick((n) => n + 1), 1000)
+    return () => window.clearInterval(id)
+  }, [status, msg.scheduled_at])
+
+  void tick
+
+  if (!rotulo) return null
+
+  async function recarregar() {
+    await onAtualizado()
+  }
+
+  async function iniciarEdicao() {
+    setBusy(true)
+    try {
+      const r = await tickets.startEditMensagem(ticketId, msg.id)
+      setLockToken(r.edit_lock_token)
+      setEditCorpo(r.mensagem.corpo)
+      setEditando(true)
+      await recarregar()
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível iniciar a edição.'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function salvarEdicao() {
+    if (!lockToken) return
+    const texto = editCorpo.trim()
+    if (!texto) {
+      toast.showWarning('A mensagem não pode ficar vazia.')
+      return
+    }
+    setBusy(true)
+    try {
+      await tickets.updateMensagem(ticketId, msg.id, { corpo: texto, edit_lock_token: lockToken })
+      setEditando(false)
+      setLockToken(null)
+      toast.showSuccess('Mensagem atualizada; o envio por e-mail foi reagendado.')
+      await recarregar()
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function cancelarEdicaoLocal() {
+    setEditando(false)
+    setLockToken(null)
+    setEditCorpo(msg.corpo)
+    await recarregar()
+  }
+
+  async function cancelarEnvio() {
+    if (!confirm('Cancelar o envio desta mensagem por e-mail ao cliente?')) return
+    setBusy(true)
+    try {
+      await tickets.cancelMensagemEmail(ticketId, msg.id)
+      toast.showSuccess('Envio por e-mail cancelado.')
+      await recarregar()
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível cancelar.'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function enviarAgora() {
+    setBusy(true)
+    try {
+      await tickets.sendNowMensagemEmail(ticketId, msg.id)
+      toast.showSuccess('E-mail enviado ao cliente.')
+      await recarregar()
+    } catch (err) {
+      const det =
+        err instanceof ApiError && typeof err.body === 'object' && err.body && 'detail' in err.body
+          ? String((err.body as { detail: unknown }).detail)
+          : null
+      toast.showWarning(det || mensagemFalhaParaToast(err, 'Não foi possível enviar agora.'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const emFila = mensagemEmFilaEmail(status)
+  const badgeClass =
+    status === 'cancelada'
+      ? 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300'
+      : status === 'enviada' || msg.cliente_notificado_por_email
+        ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-200'
+        : 'bg-sky-100 text-sky-800 dark:bg-sky-950/40 dark:text-sky-200'
+
+  return (
+    <div className="mt-3 rounded-lg border border-sky-200/80 bg-sky-50/50 px-3 py-2 dark:border-sky-800/50 dark:bg-sky-950/20">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className={`rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide ${badgeClass}`}>
+          {rotulo}
+          {contagem ? ` · ${contagem}` : ''}
+        </span>
+      </div>
+
+      {editando ? (
+        <div className="mt-2 space-y-2">
+          <textarea
+            value={editCorpo}
+            onChange={(e) => setEditCorpo(e.target.value)}
+            rows={4}
+            className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+            disabled={busy}
+          />
+          <div className="flex flex-wrap gap-2">
+            <Button type="button" onClick={() => void salvarEdicao()} disabled={busy}>
+              Salvar e reagendar envio
+            </Button>
+            <Button type="button" variant="secondary" onClick={() => void cancelarEdicaoLocal()} disabled={busy}>
+              Desistir
+            </Button>
+          </div>
+        </div>
+      ) : (
+        emFila &&
+        podeGerir && (
+          <div className="mt-2 flex flex-wrap gap-2">
+            {status === 'pendente_envio' && (
+              <>
+                <Button type="button" variant="secondary" onClick={() => void iniciarEdicao()} disabled={busy}>
+                  Editar
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => void cancelarEnvio()} disabled={busy}>
+                  Cancelar e-mail
+                </Button>
+                <Button type="button" onClick={() => void enviarAgora()} disabled={busy}>
+                  Enviar agora
+                </Button>
+              </>
+            )}
+            {status === 'em_edicao' && (
+              <p className="text-xs text-sky-800 dark:text-sky-200">Outra sessão pode estar a editar. Atualize ou inicie edição.</p>
+            )}
+          </div>
+        )
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/ticketMensagemEmailOutbox.ts
+++ b/frontend/src/lib/ticketMensagemEmailOutbox.ts
@@ -1,0 +1,44 @@
+/** Estados da fila de e-mail em mensagens públicas (#140 / #141). */
+
+export type EmailOutboxStatus =
+  | 'pendente_envio'
+  | 'em_edicao'
+  | 'enviando'
+  | 'enviada'
+  | 'cancelada'
+
+export function rotuloStatusEmail(status: string | null | undefined): string | null {
+  switch (status) {
+    case 'pendente_envio':
+      return 'E-mail agendado'
+    case 'em_edicao':
+      return 'Em edição'
+    case 'enviando':
+      return 'A enviar e-mail…'
+    case 'enviada':
+      return 'E-mail enviado ao cliente'
+    case 'cancelada':
+      return 'Envio por e-mail cancelado'
+    default:
+      return null
+  }
+}
+
+export function mensagemEmFilaEmail(status: string | null | undefined): boolean {
+  return status === 'pendente_envio' || status === 'em_edicao' || status === 'enviando'
+}
+
+export function segundosAteEnvio(scheduledAt: string | null | undefined, nowMs = Date.now()): number | null {
+  if (!scheduledAt) return null
+  const t = new Date(scheduledAt).getTime()
+  if (Number.isNaN(t)) return null
+  return Math.max(0, Math.ceil((t - nowMs) / 1000))
+}
+
+export function textoContagemEnvio(segundos: number | null): string {
+  if (segundos == null) return ''
+  if (segundos <= 0) return 'envio imediato'
+  if (segundos < 60) return `envia em ${segundos}s`
+  const m = Math.ceil(segundos / 60)
+  return `envia em ~${m} min`
+}

--- a/frontend/src/pages/ConfigEmpresaEmail.tsx
+++ b/frontend/src/pages/ConfigEmpresaEmail.tsx
@@ -13,6 +13,7 @@ import { nomeParaApiEmpresa } from '../components/empresa/empresaFormCopy'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { InputCepComBusca } from '../components/ui/InputCepComBusca'
+import { Select } from '../components/ui/Select'
 import { SelectCidadeUf } from '../components/ui/SelectCidadeUf'
 import { SelectUf } from '../components/ui/SelectUf'
 import { useToast } from '../components/ui/Toast'
@@ -54,6 +55,8 @@ export function ConfigEmpresaEmail() {
   const [logoDeleting, setLogoDeleting] = useState(false)
 
   const [emailOutbound, setEmailOutbound] = useState<SystemSettings.EmailSettingsRead | null>(null)
+  const [graceSegundos, setGraceSegundos] = useState(120)
+  const [salvandoGrace, setSalvandoGrace] = useState(false)
   const [testandoTransactional, setTestandoTransactional] = useState(false)
 
   const tenantId = resolveTenantIdFromHostname()
@@ -108,6 +111,11 @@ export function ConfigEmpresaEmail() {
       }
 
       setEmailOutbound(mail)
+      setGraceSegundos(
+        typeof mail.ticket_mensagem_email_grace_seconds === 'number'
+          ? mail.ticket_mensagem_email_grace_seconds
+          : 120,
+      )
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar as configurações.'))
     } finally {
@@ -280,6 +288,23 @@ export function ConfigEmpresaEmail() {
       setTestandoTransactional(false)
     }
   }
+
+  async function salvarGraceEmail() {
+    setSalvandoGrace(true)
+    try {
+      const out = await systemSettings.putEmail({ ticket_mensagem_email_grace_seconds: graceSegundos })
+      setEmailOutbound(out)
+      setGraceSegundos(out.ticket_mensagem_email_grace_seconds ?? graceSegundos)
+      toast.showSuccess('Preferência de envio de respostas salva.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a preferência.'))
+    } finally {
+      setSalvandoGrace(false)
+    }
+  }
+
+  const opcoesGrace = emailOutbound?.opcoes_ticket_mensagem_email_grace ?? []
+
   if (loading) {
     return <p className="text-slate-500 dark:text-slate-400">Carregando…</p>
   }
@@ -586,6 +611,45 @@ export function ConfigEmpresaEmail() {
               <p className="mt-2 text-xs opacity-90">
                 O teste usa o e-mail do administrador em sessão.
               </p>
+
+              <div className="mt-5 border-t border-current/15 pt-4">
+                <h4 className="text-sm font-semibold">Respostas ao cliente no ticket</h4>
+                <p className="mt-1 text-xs leading-relaxed opacity-90">
+                  Quando o atendente marca <strong>notificar o cliente por e-mail</strong> numa mensagem pública, o
+                  sistema aguarda o tempo abaixo antes de enviar (permite editar ou cancelar).{' '}
+                  <strong>Envio imediato</strong> dispara no próximo ciclo do servidor (alguns segundos).
+                </p>
+                <div className="mt-3">
+                  <Select
+                    id="ce-grace"
+                    label="Tempo de espera antes do envio"
+                    value={graceSegundos}
+                    onChange={(v) => setGraceSegundos(Number(v))}
+                    options={
+                      opcoesGrace.length > 0
+                        ? opcoesGrace.map((o) => ({ value: o.segundos, label: o.rotulo }))
+                        : [
+                            { value: 0, label: 'Envio imediato' },
+                            { value: 30, label: '30 segundos' },
+                            { value: 60, label: '1 minuto' },
+                            { value: 120, label: '2 minutos' },
+                            { value: 180, label: '3 minutos' },
+                            { value: 300, label: '5 minutos' },
+                          ]
+                    }
+                    className="max-w-md"
+                  />
+                </div>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="mt-3"
+                  onClick={() => void salvarGraceEmail()}
+                  disabled={salvandoGrace}
+                >
+                  {salvandoGrace ? 'Salvando…' : 'Salvar tempo de espera'}
+                </Button>
+              </div>
             </div>
 
             <div className="max-w-3xl space-y-3 rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm leading-relaxed text-slate-700 dark:border-white/10 dark:bg-slate-900/40 dark:text-slate-300">

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -32,6 +32,8 @@ import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/err
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 import { exibirProtocolo } from '../lib/exibirProtocolo'
 import { autorRodapeMensagem, corpoMensagemEmailVisivel } from '../lib/ticketMensagemEmail'
+import { mensagemEmFilaEmail } from '../lib/ticketMensagemEmailOutbox'
+import { TicketMensagemEmailOutbox } from '../components/TicketMensagemEmailOutbox'
 
 const ROTULO_CAMPO: Record<string, string> = {
   status_id: 'Status',
@@ -247,6 +249,29 @@ export function TicketDetalhe() {
     if (ticket.atendente_id == null) return true
     return ticket.atendente_id === user.id
   }, [ticket, user, isAdmin])
+
+  const temMensagemEmailNaFila = useMemo(
+    () => mensagens.some((m) => mensagemEmFilaEmail(m.status)),
+    [mensagens],
+  )
+
+  useEffect(() => {
+    if (!ticket || !temMensagemEmailNaFila) return
+    let cancelled = false
+    const poll = () => {
+      tickets
+        .listMensagens(ticket.id)
+        .then((m) => {
+          if (!cancelled) setMensagens(m)
+        })
+        .catch(() => {})
+    }
+    const id = window.setInterval(poll, 5000)
+    return () => {
+      cancelled = true
+      window.clearInterval(id)
+    }
+  }, [ticket?.id, temMensagemEmailNaFila])
 
   const mapsHistorico = useMemo(() => {
     const status = new Map<number, string>()
@@ -679,6 +704,10 @@ export function TicketDetalhe() {
       if (fileInputRef.current) fileInputRef.current.value = ''
       if (tipo === 'interno') {
         toast.showSuccess('Comentário interno registrado.')
+      } else if (msg?.status === 'pendente_envio') {
+        toast.showSuccess(
+          'Mensagem registada. O e-mail ao cliente será enviado em breve — pode editar ou cancelar antes do envio.',
+        )
       } else if (msg?.cliente_notificado_por_email) {
         toast.showSuccess('Mensagem registada e cliente notificado por e-mail.')
       } else {
@@ -1046,6 +1075,9 @@ export function TicketDetalhe() {
                   isAbertura || isEmailCliente ? corpoMensagemEmailVisivel(msg.corpo) : msg.corpo
                 const autor = autorRodapeMensagem(msg)
                 const anexosDaMsg = anexos.filter((a) => a.mensagem_id === msg.id)
+                const podeGerirEmail =
+                  Boolean(user) &&
+                  (isAdmin || (msg.atendente_id != null && msg.atendente_id === user!.id))
                 return (
                   <li
                     key={msg.id}
@@ -1074,6 +1106,17 @@ export function TicketDetalhe() {
                       )}
                     </div>
                     <p className="mt-2 whitespace-pre-wrap text-slate-800 dark:text-slate-200">{corpoVisivel}</p>
+                    {msg.status && msg.tipo === 'publico' && ticket ? (
+                      <TicketMensagemEmailOutbox
+                        ticketId={ticket.id}
+                        msg={msg}
+                        podeGerir={podeGerirEmail}
+                        onAtualizado={async () => {
+                          const m = await tickets.listMensagens(ticket.id)
+                          setMensagens(m)
+                        }}
+                      />
+                    ) : null}
                     {anexosDaMsg.length > 0 && (
                       <div className="mt-3 rounded-lg border border-slate-200/80 bg-slate-50/70 px-3 py-2 dark:border-slate-700/70 dark:bg-slate-900/30">
                         <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">


### PR DESCRIPTION
## Summary
- Mensagens públicas com "notificar cliente por e-mail" passam a ser agendadas (janela de edição/cancelamento) em vez de enviar imediatamente.
- Adiciona endpoints para start-edit, update, cancel e send-now.
- Adiciona worker em background para processar a fila.
- Configurações: admin define o tempo de espera (inclui envio imediato) em Configurações → Empresa & e-mail → E-mail.
- UI: timeline do ticket exibe status/contagem e ações (editar/cancelar/enviar agora).

## Test plan
- [x] Teste local concluído (agendamento, edição reinicia contagem, cancelamento, envio imediato)
- [x] Pytest: settings + outbox + timing

