### PR TITLE
fix(ui): sidebar fixa no desktop ao rolar paginas longas (#188)

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -35,7 +35,7 @@ export function Layout() {
 
   return (
     <div
-      className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95 md:grid md:min-h-screen md:grid-cols-[var(--sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
+      className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95 md:grid md:h-dvh md:max-h-dvh md:min-h-0 md:overflow-hidden md:grid-cols-[var(--sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
       style={
         {
           ['--sidebar-w' as never]: sidebarW,
@@ -53,7 +53,7 @@ export function Layout() {
       />
 
       {/* Coluna principal: no desktop alinhada à sidebar via grid (sem margin-left) */}
-      <div className="flex min-h-screen min-w-0 flex-col md:col-start-2 md:row-start-1">
+      <div className="flex min-h-screen min-w-0 flex-col md:col-start-2 md:row-start-1 md:h-full md:min-h-0 md:overflow-hidden">
           {/* Top bar: mobile-first, área de toque generosa */}
           <header className="sticky top-0 z-30 flex h-14 min-h-[56px] shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-800 dark:bg-slate-950 md:gap-3 md:px-6">
             <button
@@ -98,7 +98,7 @@ export function Layout() {
             </div>
           </header>
 
-          <main className="p-4 md:p-6">
+          <main className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto p-4 md:p-6">
             <Outlet />
           </main>
       </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -432,7 +432,7 @@ export function Sidebar({
         </ul>
       </nav>
 
-      <div className={`border-t border-slate-200 p-2 dark:border-slate-800 ${!expanded ? 'md:px-2' : ''}`}>
+      <div className={`shrink-0 border-t border-slate-200 p-2 dark:border-slate-800 ${!expanded ? 'md:px-2' : ''}`}>
         <div
           className={`flex items-center gap-3 px-3 py-2 text-slate-600 dark:text-slate-400 ${
             expanded ? 'opacity-100' : 'md:hidden'
@@ -482,9 +482,9 @@ export function Sidebar({
         aria-hidden
       />
 
-      {/* Sidebar: drawer no mobile; no desktop ocupa a 1ª coluna do grid (sem fixed) */}
+      {/* Sidebar: drawer no mobile; no desktop coluna fixa do grid (scroll só no nav interno) */}
       <aside
-        className={`fixed inset-0 z-50 flex h-full min-w-0 max-w-[100vw] flex-col overflow-x-hidden bg-white shadow-xl transition-[transform] duration-200 ease-out dark:bg-slate-950 max-md:transition-[transform,width] md:relative md:col-start-1 md:row-start-1 md:z-40 md:h-screen md:max-w-none md:w-full md:translate-x-0 md:overflow-x-hidden md:overflow-y-auto md:border-r md:border-slate-200 md:shadow-none md:dark:border-slate-800 ${
+        className={`fixed inset-0 z-50 flex h-full min-w-0 max-w-[100vw] flex-col overflow-x-hidden bg-white shadow-xl transition-[transform] duration-200 ease-out dark:bg-slate-950 max-md:transition-[transform,width] md:relative md:col-start-1 md:row-start-1 md:z-40 md:h-full md:min-h-0 md:max-h-full md:max-w-none md:w-full md:translate-x-0 md:overflow-hidden md:border-r md:border-slate-200 md:shadow-none md:dark:border-slate-800 ${
           mobileOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
         }`}
         aria-label="Menu lateral"


### PR DESCRIPTION
## Summary

- Corrige o menu lateral que subia junto com o scroll em paginas longas (ex.: detalhe do ticket) no desktop.
- O shell do layout passa a usar altura do viewport (h-dvh) com overflow contido; apenas a coluna principal rola.
- A sidebar permanece na coluna do grid; scroll interno restrito ao <nav>.

## Test plan

- [x] TicketDetalhe com timeline longa: itens do menu (Dashboard, Tickets, etc.) permanecem visiveis ao rolar.
- [x] Navbar superior continua alinhado sem faixa vazia entre sidebar e header.
- [x] Mobile: drawer continua funcionando.
- [x] Temas claro e escuro.

Closes #188

Made with [Cursor](https://cursor.com)