### PR TITLE
feat(auth): redefinição de senha por e-mail (#105, #106)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,6 +18,7 @@ LOG_LEVEL=INFO
 # DX_CONNECT_MULTI_TENANT=false   # padrão; true só em dev legado (vários clientes no mesmo Postgres)
 # DEFAULT_TENANT_ID=1
 # CLIENT_APP_HOST=duplexsoft.connect.duplexsoft.com.br   # URL pública do painel (GET /tenant/atual)
+# PASSWORD_RESET_TOKEN_EXPIRE_HOURS=1   # validade do link «esqueci minha senha»
 #
 # --- Multi-tenant legado (só se DX_CONNECT_MULTI_TENANT=true) ---
 # CONNECT_APP_BASE_DOMAIN=connect.duplexsoft.com.br

--- a/backend/alembic/versions/030_password_reset_tokens.py
+++ b/backend/alembic/versions/030_password_reset_tokens.py
@@ -1,0 +1,36 @@
+"""Tabela de tokens para redefinição de senha (#105).
+
+Revision ID: 030_password_reset_tokens
+Revises: 029_merge_ticket_parent_outbox
+Create Date: 2026-05-29
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "030_password_reset_tokens"
+down_revision = "029_merge_ticket_parent_outbox"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "password_reset_tokens",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("atendente_id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["atendente_id"], ["atendentes.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_password_reset_tokens_atendente_id", "password_reset_tokens", ["atendente_id"])
+    op.create_index("ix_password_reset_tokens_token_hash", "password_reset_tokens", ["token_hash"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_password_reset_tokens_token_hash", table_name="password_reset_tokens")
+    op.drop_index("ix_password_reset_tokens_atendente_id", table_name="password_reset_tokens")
+    op.drop_table("password_reset_tokens")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -5,6 +5,8 @@ from sqlalchemy.orm import Session
 from app.database import get_db
 from app.models.atendente import Atendente
 from app.schemas.atendente import AtendenteLogin, RefreshTokenRequest, Token
+from app.schemas.password_reset import MensagemAuth, RedefinirSenhaComToken, SolicitarRedefinicaoSenha
+from app.services.password_reset import MSG_SOLICITACAO_OK, redefinir_senha_com_token, solicitar_redefinicao
 from app.core.security import criar_access_token, criar_refresh_token, decodificar_refresh_token, verificar_senha
 from app.core.login_protection import check_login_rate_limit, delay_on_auth_failure
 from app.core.tenant_context import (
@@ -77,3 +79,29 @@ async def refresh(
         refresh_token=data.refresh_token,
         must_change_password=bool(getattr(atendente, "must_change_password", False)),
     )
+
+
+@router.post("/solicitar-redefinicao-senha", response_model=MensagemAuth)
+async def solicitar_redefinicao_senha(
+    request: Request,
+    data: SolicitarRedefinicaoSenha,
+    db: Session = Depends(get_db),
+):
+    check_login_rate_limit(request)
+    msg = solicitar_redefinicao(db, data.email)
+    return MensagemAuth(detail=msg)
+
+
+@router.post("/redefinir-senha", response_model=MensagemAuth)
+async def redefinir_senha(
+    request: Request,
+    data: RedefinirSenhaComToken,
+    db: Session = Depends(get_db),
+):
+    check_login_rate_limit(request)
+    try:
+        redefinir_senha_com_token(db, data.token, data.senha_nova)
+    except ValueError as e:
+        await delay_on_auth_failure()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    return MensagemAuth(detail="Senha atualizada com sucesso. Faça login com a nova senha.")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -64,6 +64,8 @@ class Settings(BaseSettings):
     # URL pública do painel em single-tenant (ex.: duplexsoft.connect.duplexsoft.com.br).
     # Se vazio, GET /tenant/atual usa {tenant_id}.CONNECT_APP_BASE_DOMAIN só em multi-tenant.
     CLIENT_APP_HOST: str | None = None
+    # Validade do link de redefinição de senha (#105).
+    PASSWORD_RESET_TOKEN_EXPIRE_HOURS: int = 1
 
     # Multi-tenant: subdomínio {tenant_id}.CONNECT_APP_BASE_DOMAIN e endereços {local}@INBOUND_EMAIL_DOMAIN
     CONNECT_APP_BASE_DOMAIN: str = "connect.duplexsoft.com.br"

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -20,6 +20,7 @@ from app.models.email_inbound_received import EmailInboundReceived
 from app.models.ticket_email_message_id import TicketEmailMessageId
 from app.models.tenant import Tenant
 from app.models.tenant_inbound_address import TenantInboundAddress
+from app.models.password_reset_token import PasswordResetToken
 
 __all__ = [
     "Rede",
@@ -51,4 +52,5 @@ __all__ = [
     "TicketEmailMessageId",
     "Tenant",
     "TenantInboundAddress",
+    "PasswordResetToken",
 ]

--- a/backend/app/models/password_reset_token.py
+++ b/backend/app/models/password_reset_token.py
@@ -1,0 +1,18 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class PasswordResetToken(Base):
+    __tablename__ = "password_reset_tokens"
+
+    id = Column(Integer, primary_key=True, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    token_hash = Column(String(64), nullable=False, unique=True, index=True)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    used_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    atendente = relationship("Atendente", backref="password_reset_tokens")

--- a/backend/app/schemas/password_reset.py
+++ b/backend/app/schemas/password_reset.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, Field
+
+
+class SolicitarRedefinicaoSenha(BaseModel):
+    email: str = Field(..., min_length=3, max_length=255)
+
+
+class RedefinirSenhaComToken(BaseModel):
+    token: str = Field(..., min_length=16, max_length=512)
+    senha_nova: str = Field(..., min_length=8, max_length=128)
+
+
+class MensagemAuth(BaseModel):
+    detail: str

--- a/backend/app/services/password_reset.py
+++ b/backend/app/services/password_reset.py
@@ -1,0 +1,146 @@
+"""Redefinição de senha por e-mail (instância single-tenant)."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.atendente import Atendente
+from app.models.password_reset_token import PasswordResetToken
+from app.services.email_send_sistema import enviar_mensagem_texto_sistema
+
+logger = logging.getLogger(__name__)
+
+MSG_SOLICITACAO_OK = (
+    "Se o e-mail estiver cadastrado e ativo, você receberá instruções para redefinir a senha em breve."
+)
+MSG_LINK_INVALIDO = "Link inválido ou expirado. Solicite uma nova redefinição de senha."
+
+
+def _as_utc_aware(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _hash_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _public_app_origin() -> str:
+    host = (settings.CLIENT_APP_HOST or "").strip()
+    if host:
+        host = host.removeprefix("https://").removeprefix("http://").split("/")[0]
+        proto = "https" if settings.is_production else "http"
+        return f"{proto}://{host}"
+    if not settings.is_production:
+        return "http://localhost:5173"
+    base = (settings.CONNECT_APP_BASE_DOMAIN or "").strip()
+    if base:
+        return f"https://{base}"
+    return "http://localhost:5173"
+
+
+def build_reset_link(raw_token: str) -> str:
+    origin = _public_app_origin().rstrip("/")
+    return f"{origin}/redefinir-senha?token={raw_token}"
+
+
+def _invalidate_pending_tokens(db: Session, atendente_id: int) -> None:
+    now = datetime.now(timezone.utc)
+    pending = (
+        db.query(PasswordResetToken)
+        .filter(
+            PasswordResetToken.atendente_id == atendente_id,
+            PasswordResetToken.used_at.is_(None),
+        )
+        .all()
+    )
+    for row in pending:
+        if _as_utc_aware(row.expires_at) > now:
+            row.used_at = now
+
+
+def solicitar_redefinicao(db: Session, email: str) -> str:
+    """
+    Cria token e envia e-mail se existir atendente ativo.
+    Sempre retorna a mesma mensagem genérica (não revela existência do e-mail).
+    """
+    email_norm = email.strip().lower()
+    atendente = (
+        db.query(Atendente)
+        .filter(
+            func.lower(Atendente.email) == email_norm,
+            Atendente.ativo.is_(True),
+        )
+        .first()
+    )
+    if not atendente:
+        return MSG_SOLICITACAO_OK
+
+    raw = secrets.token_urlsafe(32)
+    expires = datetime.now(timezone.utc) + timedelta(hours=settings.PASSWORD_RESET_TOKEN_EXPIRE_HOURS)
+    _invalidate_pending_tokens(db, atendente.id)
+    row = PasswordResetToken(
+        atendente_id=atendente.id,
+        token_hash=_hash_token(raw),
+        expires_at=expires,
+    )
+    db.add(row)
+    db.commit()
+
+    link = build_reset_link(raw)
+    nome = (atendente.nome or "").strip() or "usuário"
+    subject = "Redefinição de senha — DX Connect"
+    body = (
+        f"Olá, {nome},\n\n"
+        "Recebemos um pedido para redefinir a senha da sua conta no DX Connect.\n\n"
+        f"Acesse o link abaixo (válido por {settings.PASSWORD_RESET_TOKEN_EXPIRE_HOURS} hora(s)):\n"
+        f"{link}\n\n"
+        "Se você não solicitou esta alteração, ignore este e-mail.\n\n"
+        "— Equipe DX Connect"
+    )
+    try:
+        enviar_mensagem_texto_sistema(db, to_addr=atendente.email, subject=subject, body=body)
+    except ValueError as e:
+        logger.warning("Redefinição de senha: envio de e-mail indisponível (%s)", e)
+    except Exception:
+        logger.exception("Redefinição de senha: falha ao enviar e-mail para atendente_id=%s", atendente.id)
+    return MSG_SOLICITACAO_OK
+
+
+def redefinir_senha_com_token(db: Session, raw_token: str, senha_nova: str) -> None:
+    """Aplica nova senha ou levanta ValueError com mensagem para o cliente."""
+    from app.core.security import hash_senha, verificar_senha
+
+    token = raw_token.strip()
+    if not token:
+        raise ValueError(MSG_LINK_INVALIDO)
+
+    now = datetime.now(timezone.utc)
+    row = (
+        db.query(PasswordResetToken)
+        .filter(PasswordResetToken.token_hash == _hash_token(token))
+        .first()
+    )
+    if not row or row.used_at is not None or _as_utc_aware(row.expires_at) <= now:
+        raise ValueError(MSG_LINK_INVALIDO)
+
+    atendente = db.query(Atendente).filter(Atendente.id == row.atendente_id, Atendente.ativo.is_(True)).first()
+    if not atendente:
+        raise ValueError(MSG_LINK_INVALIDO)
+
+    if verificar_senha(senha_nova, atendente.senha_hash):
+        raise ValueError("A nova senha deve ser diferente da senha atual.")
+
+    atendente.senha_hash = hash_senha(senha_nova)
+    atendente.must_change_password = False
+    row.used_at = now
+    _invalidate_pending_tokens(db, atendente.id)
+    db.commit()

--- a/backend/tests/test_password_reset.py
+++ b/backend/tests/test_password_reset.py
@@ -1,0 +1,79 @@
+"""Redefinição de senha por e-mail (#105)."""
+
+from datetime import datetime, timedelta, timezone
+
+from app.core.security import hash_senha, verificar_senha
+from app.models.password_reset_token import PasswordResetToken
+from app.services.password_reset import (
+    MSG_SOLICITACAO_OK,
+    _hash_token,
+    build_reset_link,
+    redefinir_senha_com_token,
+    solicitar_redefinicao,
+)
+
+
+def test_solicitar_resposta_generica_sem_vazar_email(client, seed_base):
+    r1 = client.post("/v1/auth/solicitar-redefinicao-senha", json={"email": seed_base["admin"].email})
+    r2 = client.post("/v1/auth/solicitar-redefinicao-senha", json={"email": "naoexiste@example.com"})
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r1.json()["detail"] == MSG_SOLICITACAO_OK
+    assert r2.json()["detail"] == MSG_SOLICITACAO_OK
+
+
+def test_fluxo_completo_reset_senha(client, db_session, seed_base, monkeypatch):
+    sent: list[dict] = []
+
+    def fake_enviar(db, *, to_addr, subject, body, in_reply_to=None, references=None):
+        sent.append({"to": to_addr, "subject": subject, "body": body})
+        return "msg-id"
+
+    monkeypatch.setattr("app.services.password_reset.enviar_mensagem_texto_sistema", fake_enviar)
+
+    admin = seed_base["admin"]
+    res = client.post("/v1/auth/solicitar-redefinicao-senha", json={"email": admin.email})
+    assert res.status_code == 200
+    assert len(sent) == 1
+
+    row = db_session.query(PasswordResetToken).filter(PasswordResetToken.atendente_id == admin.id).first()
+    assert row is not None
+
+    raw = "token-teste-reset-12345678901234567890123456789012"
+    row.token_hash = _hash_token(raw)
+    db_session.commit()
+
+    api_res = client.post(
+        "/v1/auth/redefinir-senha",
+        json={"token": raw, "senha_nova": "novaSenhaSegura1"},
+    )
+    assert api_res.status_code == 200, api_res.text
+
+    db_session.refresh(admin)
+    assert verificar_senha("novaSenhaSegura1", admin.senha_hash)
+    assert admin.must_change_password is False
+
+    login_res = client.post("/v1/auth/login", json={"email": admin.email, "senha": "novaSenhaSegura1"})
+    assert login_res.status_code == 200
+
+
+def test_token_expirado_rejeitado(db_session, seed_base):
+    admin = seed_base["admin"]
+    raw = "token-expirado-teste-abcdefghijklmnopqrstuvwxyz"
+    row = PasswordResetToken(
+        atendente_id=admin.id,
+        token_hash=_hash_token(raw),
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+    )
+    db_session.add(row)
+    db_session.commit()
+
+    import pytest
+
+    with pytest.raises(ValueError, match="inválido|expirado"):
+        redefinir_senha_com_token(db_session, raw, "outraSenha123")
+
+
+def test_build_reset_link_dev():
+    link = build_reset_link("abc")
+    assert link.startswith("http://localhost:5173/redefinir-senha?token=abc")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,8 @@ import { ThemeProvider } from './contexts/ThemeContext'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
 import { Layout } from './components/Layout'
 import { Login } from './pages/Login'
+import { EsqueciSenha } from './pages/EsqueciSenha'
+import { RedefinirSenha } from './pages/RedefinirSenha'
 import { Dashboard } from './pages/Dashboard'
 import { Tickets } from './pages/Tickets'
 import { TicketNovo } from './pages/TicketNovo'
@@ -69,6 +71,8 @@ function AppRoutes() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
+      <Route path="/esqueci-senha" element={<EsqueciSenha />} />
+      <Route path="/redefinir-senha" element={<RedefinirSenha />} />
       <Route
         path="/"
         element={

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -160,6 +160,16 @@ export const auth = {
       method: 'POST',
       body: JSON.stringify({ email, senha }),
     }),
+  solicitarRedefinicaoSenha: (email: string) =>
+    api<{ detail: string }>('/auth/solicitar-redefinicao-senha', {
+      method: 'POST',
+      body: JSON.stringify({ email }),
+    }),
+  redefinirSenha: (token: string, senha_nova: string) =>
+    api<{ detail: string }>('/auth/redefinir-senha', {
+      method: 'POST',
+      body: JSON.stringify({ token, senha_nova }),
+    }),
 };
 
 function withParams(path: string, params?: Record<string, string | number | boolean | undefined>) {

--- a/frontend/src/pages/EsqueciSenha.tsx
+++ b/frontend/src/pages/EsqueciSenha.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { auth } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Button } from '../components/ui/Button'
+import { useToast } from '../components/ui/Toast'
+
+const fieldClass =
+  'w-full rounded-xl border border-white/10 bg-white/[0.06] px-3.5 py-3 text-[0.9375rem] text-slate-100 placeholder:text-slate-500 shadow-inner shadow-black/20 backdrop-blur-sm transition-colors focus:border-cyan-400/50 focus:outline-none focus:ring-2 focus:ring-cyan-400/25'
+
+export function EsqueciSenha() {
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [enviado, setEnviado] = useState(false)
+  const { showError, showSuccess } = useToast()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const trimmed = email.trim()
+    if (!trimmed || !trimmed.includes('@')) {
+      showError('Informe um e-mail válido.')
+      return
+    }
+    setLoading(true)
+    try {
+      const res = await auth.solicitarRedefinicaoSenha(trimmed)
+      setEnviado(true)
+      showSuccess(res.detail)
+    } catch (err) {
+      showError(mensagemFalhaParaToast(err, 'Não foi possível processar o pedido. Tente novamente.'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="relative flex min-h-dvh flex-col justify-center bg-[#050810] px-4 py-10 font-[family-name:'Plus_Jakarta_Sans',system-ui,sans-serif] text-slate-100 antialiased">
+      <div className="mx-auto w-full max-w-[400px] space-y-6">
+        <header className="text-center">
+          <h1 className="text-2xl font-semibold text-white">Esqueci minha senha</h1>
+          <p className="mt-2 text-sm text-slate-400">
+            Informe o e-mail da sua conta. Se estiver cadastrado, enviaremos um link para redefinir a senha.
+          </p>
+        </header>
+
+        <div className="rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 shadow-2xl shadow-black/40 backdrop-blur-md sm:p-6">
+          {enviado ? (
+            <p className="text-center text-sm leading-relaxed text-slate-300">
+              Verifique sua caixa de entrada (e o spam). O link expira em pouco tempo por segurança.
+            </p>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-5" noValidate>
+              <div>
+                <label htmlFor="reset-email" className="mb-1.5 block text-sm font-medium text-slate-300">
+                  E-mail
+                </label>
+                <input
+                  id="reset-email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  autoComplete="email"
+                  placeholder="nome@empresa.com"
+                  className={fieldClass}
+                />
+              </div>
+              <Button
+                type="submit"
+                className="w-full rounded-xl py-3 text-base font-semibold shadow-lg shadow-cyan-500/25 disabled:opacity-60"
+                loading={loading}
+              >
+                Enviar link
+              </Button>
+            </form>
+          )}
+        </div>
+
+        <p className="text-center text-sm">
+          <Link to="/login" className="text-cyan-400/90 hover:text-cyan-300">
+            Voltar ao login
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
@@ -194,6 +194,15 @@ export function Login() {
                     )}
                   </button>
                 </div>
+              </div>
+
+              <div className="text-right">
+                <Link
+                  to="/esqueci-senha"
+                  className="text-sm text-cyan-400/90 transition-colors hover:text-cyan-300"
+                >
+                  Esqueci minha senha
+                </Link>
               </div>
 
               <label className="flex cursor-pointer items-start gap-3 text-sm text-slate-400">

--- a/frontend/src/pages/RedefinirSenha.tsx
+++ b/frontend/src/pages/RedefinirSenha.tsx
@@ -1,0 +1,138 @@
+import { useState } from 'react'
+import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { auth } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Button } from '../components/ui/Button'
+import { useToast } from '../components/ui/Toast'
+import { IconEye, IconEyeOff } from '../components/ui/IconEye'
+
+const fieldClass =
+  'w-full rounded-xl border border-white/10 bg-white/[0.06] px-3.5 py-3 text-[0.9375rem] text-slate-100 placeholder:text-slate-500 shadow-inner shadow-black/20 backdrop-blur-sm transition-colors focus:border-cyan-400/50 focus:outline-none focus:ring-2 focus:ring-cyan-400/25'
+
+export function RedefinirSenha() {
+  const [searchParams] = useSearchParams()
+  const token = searchParams.get('token')?.trim() ?? ''
+  const [senhaNova, setSenhaNova] = useState('')
+  const [senhaConf, setSenhaConf] = useState('')
+  const [mostrarNova, setMostrarNova] = useState(false)
+  const [mostrarConf, setMostrarConf] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const { showError, showSuccess } = useToast()
+  const navigate = useNavigate()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!token) {
+      showError('Link inválido. Solicite uma nova redefinição de senha.')
+      return
+    }
+    if (senhaNova.length < 8) {
+      showError('A nova senha deve ter pelo menos 8 caracteres.')
+      return
+    }
+    if (senhaNova !== senhaConf) {
+      showError('A confirmação não coincide com a nova senha.')
+      return
+    }
+    setLoading(true)
+    try {
+      const res = await auth.redefinirSenha(token, senhaNova)
+      showSuccess(res.detail)
+      navigate('/login', { replace: true })
+    } catch (err) {
+      showError(mensagemFalhaParaToast(err, 'Não foi possível redefinir a senha.'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!token) {
+    return (
+      <div className="flex min-h-dvh flex-col items-center justify-center bg-[#050810] px-4 text-center text-slate-100">
+        <p className="mb-4 text-sm text-slate-400">Link inválido ou incompleto.</p>
+        <Link to="/esqueci-senha" className="text-cyan-400/90 hover:text-cyan-300">
+          Solicitar novo link
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative flex min-h-dvh flex-col justify-center bg-[#050810] px-4 py-10 font-[family-name:'Plus_Jakarta_Sans',system-ui,sans-serif] text-slate-100 antialiased">
+      <div className="mx-auto w-full max-w-[400px] space-y-6">
+        <header className="text-center">
+          <h1 className="text-2xl font-semibold text-white">Nova senha</h1>
+          <p className="mt-2 text-sm text-slate-400">Defina uma senha forte com pelo menos 8 caracteres.</p>
+        </header>
+
+        <div className="rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 shadow-2xl shadow-black/40 backdrop-blur-md sm:p-6">
+          <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+            <div>
+              <label htmlFor="pwd-nova" className="mb-1.5 block text-sm font-medium text-slate-300">
+                Nova senha
+              </label>
+              <div className="relative">
+                <input
+                  id="pwd-nova"
+                  type={mostrarNova ? 'text' : 'password'}
+                  value={senhaNova}
+                  onChange={(e) => setSenhaNova(e.target.value)}
+                  autoComplete="new-password"
+                  className={`${fieldClass} pr-12`}
+                  minLength={8}
+                  required
+                />
+                <button
+                  type="button"
+                  onClick={() => setMostrarNova((v) => !v)}
+                  className="absolute right-1.5 top-1/2 flex size-10 -translate-y-1/2 items-center justify-center rounded-lg text-cyan-400/85 hover:bg-white/5"
+                  aria-label={mostrarNova ? 'Ocultar senha' : 'Mostrar senha'}
+                >
+                  {mostrarNova ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
+                </button>
+              </div>
+            </div>
+            <div>
+              <label htmlFor="pwd-conf" className="mb-1.5 block text-sm font-medium text-slate-300">
+                Confirmar senha
+              </label>
+              <div className="relative">
+                <input
+                  id="pwd-conf"
+                  type={mostrarConf ? 'text' : 'password'}
+                  value={senhaConf}
+                  onChange={(e) => setSenhaConf(e.target.value)}
+                  autoComplete="new-password"
+                  className={`${fieldClass} pr-12`}
+                  minLength={8}
+                  required
+                />
+                <button
+                  type="button"
+                  onClick={() => setMostrarConf((v) => !v)}
+                  className="absolute right-1.5 top-1/2 flex size-10 -translate-y-1/2 items-center justify-center rounded-lg text-cyan-400/85 hover:bg-white/5"
+                  aria-label={mostrarConf ? 'Ocultar confirmação' : 'Mostrar confirmação'}
+                >
+                  {mostrarConf ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
+                </button>
+              </div>
+            </div>
+            <Button
+              type="submit"
+              className="w-full rounded-xl py-3 text-base font-semibold shadow-lg shadow-cyan-500/25 disabled:opacity-60"
+              loading={loading}
+            >
+              Salvar senha
+            </Button>
+          </form>
+        </div>
+
+        <p className="text-center text-sm">
+          <Link to="/login" className="text-cyan-400/90 hover:text-cyan-300">
+            Voltar ao login
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **#105:** fluxo de redefinição de senha — tokens de uso único (1h), migration `030_password_reset_tokens`, endpoints públicos `POST /v1/auth/solicitar-redefinicao-senha` e `POST /v1/auth/redefinir-senha`, e-mail via Resend.
- **#106:** telas `/esqueci-senha` e `/redefinir-senha?token=...`, link no login.

Resposta genérica na solicitação (não revela se o e-mail existe). Rate limit alinhado ao login.

## Test plan

- [x] `docker compose run --rm -e DX_CONNECT_TESTING=1 backend pytest -q`
- [x] `alembic upgrade head` no ambiente de deploy
- [x] Login → Esqueci minha senha → e-mail recebido → nova senha → login com senha nova
- [x] Confirmar `CLIENT_APP_HOST` (ou localhost em dev) no link do e-mail

## Migrações

- `030_password_reset_tokens` — rodar `alembic upgrade head` antes ou no deploy.