### PR TITLE
feat: respostas prontas (#113, #114) e cadastros admin em telas separadas

### DIFF
--- a/backend/alembic/versions/031_respostas_prontas.py
+++ b/backend/alembic/versions/031_respostas_prontas.py
@@ -1,0 +1,40 @@
+"""Respostas prontas (macros) por setor ou global (#113).
+
+Revision ID: 031_respostas_prontas
+Revises: 030_password_reset_tokens
+Create Date: 2026-05-29
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "031_respostas_prontas"
+down_revision = "030_password_reset_tokens"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "respostas_prontas",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sa.Integer(), nullable=False),
+        sa.Column("setor_id", sa.Integer(), nullable=True),
+        sa.Column("titulo", sa.String(length=200), nullable=False),
+        sa.Column("corpo", sa.Text(), nullable=False),
+        sa.Column("ordem", sa.SmallInteger(), server_default="0", nullable=False),
+        sa.Column("ativo", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["setor_id"], ["setores.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_respostas_prontas_tenant_id", "respostas_prontas", ["tenant_id"])
+    op.create_index("ix_respostas_prontas_setor_id", "respostas_prontas", ["setor_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_respostas_prontas_setor_id", table_name="respostas_prontas")
+    op.drop_index("ix_respostas_prontas_tenant_id", table_name="respostas_prontas")
+    op.drop_table("respostas_prontas")

--- a/backend/app/api/respostas_prontas.py
+++ b/backend/app/api/respostas_prontas.py
@@ -1,0 +1,209 @@
+from enum import Enum
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.audit import registrar_audit
+from app.core.auth import exigir_admin, obter_atendente_atual
+from app.core.ordenacao_lista import OrdemLista, expr_ordem
+from app.core.setor_scope import ids_setores_visiveis_atendente
+from app.database import get_db
+from app.models import RespostaPronta, Setor
+from app.models.atendente import Atendente
+from app.schemas.lista_paginada import ListaPaginada
+from app.schemas.resposta_pronta import (
+    RespostaProntaCreate,
+    RespostaProntaRead,
+    RespostaProntaUpdate,
+)
+
+router = APIRouter(prefix="/respostas-prontas", tags=["respostas-prontas"])
+
+_MAX_PAGE = 100
+_DEFAULT_PAGE = 20
+
+
+class OrdenarRespostasProntasPor(str, Enum):
+    titulo = "titulo"
+    ordem = "ordem"
+    ativo = "ativo"
+
+
+def _to_read(row: RespostaPronta) -> RespostaProntaRead:
+    return RespostaProntaRead(
+        id=row.id,
+        titulo=row.titulo,
+        corpo=row.corpo,
+        setor_id=row.setor_id,
+        setor_nome=row.setor.nome if row.setor else None,
+        ordem=int(row.ordem or 0),
+        ativo=bool(row.ativo),
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _validar_setor(db: Session, tenant_id: int, setor_id: int | None) -> None:
+    if setor_id is None:
+        return
+    setor = (
+        db.query(Setor)
+        .filter(Setor.id == setor_id, Setor.tenant_id == tenant_id, Setor.ativo.is_(True))
+        .first()
+    )
+    if not setor:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Setor inválido.")
+
+
+def _assert_acesso_setor(atendente: Atendente, db: Session, setor_id: int) -> None:
+    if atendente.role == "admin":
+        return
+    vis = ids_setores_visiveis_atendente(db, atendente)
+    if setor_id not in vis:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este setor.")
+
+
+@router.get("/disponiveis", response_model=list[RespostaProntaRead])
+def listar_disponiveis(
+    setor_id: int = Query(..., description="Setor do ticket"),
+    busca: str | None = Query(None, description="Filtra por título ou corpo"),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    _assert_acesso_setor(atendente, db, setor_id)
+    q = (
+        db.query(RespostaPronta)
+        .options(joinedload(RespostaPronta.setor))
+        .filter(
+            RespostaPronta.tenant_id == atendente.tenant_id,
+            RespostaPronta.ativo.is_(True),
+            or_(RespostaPronta.setor_id.is_(None), RespostaPronta.setor_id == setor_id),
+        )
+    )
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter(or_(RespostaPronta.titulo.ilike(term), RespostaPronta.corpo.ilike(term)))
+    rows = q.order_by(RespostaPronta.ordem.asc(), RespostaPronta.titulo.asc(), RespostaPronta.id.asc()).all()
+    return [_to_read(r) for r in rows]
+
+
+@router.get("", response_model=ListaPaginada[RespostaProntaRead])
+def listar(
+    incluir_inativos: bool = Query(False),
+    busca: str | None = Query(None),
+    setor_id: int | None = Query(None, description="Filtrar por setor; omitir = todos"),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    ordenar_por: OrdenarRespostasProntasPor | None = Query(None),
+    ordem: OrdemLista = Query(OrdemLista.asc),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_admin),
+):
+    q = db.query(RespostaPronta).options(joinedload(RespostaPronta.setor))
+    if not incluir_inativos:
+        q = q.filter(RespostaPronta.ativo.is_(True))
+    if setor_id is not None:
+        q = q.filter(or_(RespostaPronta.setor_id.is_(None), RespostaPronta.setor_id == setor_id))
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter(or_(RespostaPronta.titulo.ilike(term), RespostaPronta.corpo.ilike(term)))
+    total = q.count()
+    if ordenar_por is None:
+        order_cols = [RespostaPronta.ordem.asc(), RespostaPronta.titulo.asc(), RespostaPronta.id.asc()]
+    elif ordenar_por == OrdenarRespostasProntasPor.titulo:
+        order_cols = [expr_ordem(RespostaPronta.titulo, ordem), expr_ordem(RespostaPronta.id, ordem)]
+    elif ordenar_por == OrdenarRespostasProntasPor.ordem:
+        order_cols = [expr_ordem(RespostaPronta.ordem, ordem), expr_ordem(RespostaPronta.id, ordem)]
+    else:
+        order_cols = [expr_ordem(RespostaPronta.ativo, ordem), expr_ordem(RespostaPronta.id, ordem)]
+    rows = q.order_by(*order_cols).offset(offset).limit(limit).all()
+    return ListaPaginada(items=[_to_read(r) for r in rows], total=total)
+
+
+@router.post("", response_model=RespostaProntaRead, status_code=201)
+def criar(
+    data: RespostaProntaCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    _validar_setor(db, atendente.tenant_id, data.setor_id)
+    row = RespostaPronta(
+        tenant_id=atendente.tenant_id,
+        setor_id=data.setor_id,
+        titulo=data.titulo.strip(),
+        corpo=data.corpo,
+        ordem=data.ordem,
+        ativo=data.ativo,
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(db, "resposta_pronta", row.id, "create", atendente.id)
+    db.commit()
+    db.refresh(row)
+    row = (
+        db.query(RespostaPronta)
+        .options(joinedload(RespostaPronta.setor))
+        .filter(RespostaPronta.id == row.id)
+        .first()
+    )
+    return _to_read(row)
+
+
+@router.get("/{resposta_id}", response_model=RespostaProntaRead)
+def obter(
+    resposta_id: int,
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_admin),
+):
+    row = (
+        db.query(RespostaPronta)
+        .options(joinedload(RespostaPronta.setor))
+        .filter(RespostaPronta.id == resposta_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resposta pronta não encontrada.")
+    return _to_read(row)
+
+
+@router.patch("/{resposta_id}", response_model=RespostaProntaRead)
+def atualizar(
+    resposta_id: int,
+    data: RespostaProntaUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = db.query(RespostaPronta).filter(RespostaPronta.id == resposta_id).first()
+    if not row:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resposta pronta não encontrada.")
+    payload = data.model_dump(exclude_unset=True)
+    if "setor_id" in payload:
+        _validar_setor(db, atendente.tenant_id, payload["setor_id"])
+    if "titulo" in payload and payload["titulo"] is not None:
+        payload["titulo"] = payload["titulo"].strip()
+    for k, v in payload.items():
+        setattr(row, k, v)
+    registrar_audit(db, "resposta_pronta", row.id, "update", atendente.id)
+    db.commit()
+    row = (
+        db.query(RespostaPronta)
+        .options(joinedload(RespostaPronta.setor))
+        .filter(RespostaPronta.id == row.id)
+        .first()
+    )
+    return _to_read(row)
+
+
+@router.delete("/{resposta_id}", status_code=204)
+def excluir(
+    resposta_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = db.query(RespostaPronta).filter(RespostaPronta.id == resposta_id).first()
+    if not row:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Resposta pronta não encontrada.")
+    registrar_audit(db, "resposta_pronta", row.id, "delete", atendente.id)
+    db.delete(row)
+    db.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from app.api import (
     whatsapp_webhook,
     email_inbound_webhook,
     resend_inbound_webhook,
+    respostas_prontas,
     system_settings,
     tenant,
 )
@@ -273,6 +274,7 @@ app.include_router(whatsapp_chats.router, prefix=API_V1_PREFIX)
 app.include_router(whatsapp_webhook.router, prefix=API_V1_PREFIX)
 app.include_router(email_inbound_webhook.router, prefix=API_V1_PREFIX)
 app.include_router(resend_inbound_webhook.router, prefix=API_V1_PREFIX)
+app.include_router(respostas_prontas.router, prefix=API_V1_PREFIX)
 app.include_router(system_settings.router, prefix=API_V1_PREFIX)
 app.include_router(tenant.router, prefix=API_V1_PREFIX)
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -21,6 +21,7 @@ from app.models.ticket_email_message_id import TicketEmailMessageId
 from app.models.tenant import Tenant
 from app.models.tenant_inbound_address import TenantInboundAddress
 from app.models.password_reset_token import PasswordResetToken
+from app.models.resposta_pronta import RespostaPronta
 
 __all__ = [
     "Rede",
@@ -53,4 +54,5 @@ __all__ = [
     "Tenant",
     "TenantInboundAddress",
     "PasswordResetToken",
+    "RespostaPronta",
 ]

--- a/backend/app/models/resposta_pronta.py
+++ b/backend/app/models/resposta_pronta.py
@@ -1,0 +1,23 @@
+from sqlalchemy import Column, ForeignKey, Integer, SmallInteger, String, Boolean, DateTime, Text
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class RespostaPronta(Base):
+    """Macro de texto reutilizável no ticket (global ou por setor)."""
+
+    __tablename__ = "respostas_prontas"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    setor_id = Column(Integer, ForeignKey("setores.id", ondelete="SET NULL"), nullable=True, index=True)
+    titulo = Column(String(200), nullable=False)
+    corpo = Column(Text, nullable=False)
+    ordem = Column(SmallInteger, default=0, nullable=False)
+    ativo = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    setor = relationship("Setor", foreign_keys=[setor_id])

--- a/backend/app/schemas/resposta_pronta.py
+++ b/backend/app/schemas/resposta_pronta.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RespostaProntaBase(BaseModel):
+    titulo: str = Field(..., min_length=1, max_length=200)
+    corpo: str = Field(..., min_length=1)
+    setor_id: int | None = None
+    ordem: int = 0
+    ativo: bool = True
+
+
+class RespostaProntaCreate(RespostaProntaBase):
+    pass
+
+
+class RespostaProntaUpdate(BaseModel):
+    titulo: str | None = Field(None, min_length=1, max_length=200)
+    corpo: str | None = Field(None, min_length=1)
+    setor_id: int | None = None
+    ordem: int | None = None
+    ativo: bool | None = None
+
+
+class RespostaProntaRead(RespostaProntaBase):
+    id: int
+    setor_nome: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/tests/test_respostas_prontas.py
+++ b/backend/tests/test_respostas_prontas.py
@@ -1,0 +1,85 @@
+"""Respostas prontas (#113)."""
+
+from app.models.resposta_pronta import RespostaPronta
+
+
+def test_admin_crud_e_disponiveis(client, auth_headers, seed_base):
+    create = client.post(
+        "/v1/respostas-prontas",
+        headers=auth_headers["admin"],
+        json={
+            "titulo": "Pedir versão",
+            "corpo": "Por favor informe a versão do sistema.",
+            "setor_id": None,
+            "ordem": 1,
+            "ativo": True,
+        },
+    )
+    assert create.status_code == 201, create.text
+    rid = create.json()["id"]
+
+    setor = client.post(
+        "/v1/respostas-prontas",
+        headers=auth_headers["admin"],
+        json={
+            "titulo": "Suporte NF",
+            "corpo": "Envie o XML da nota fiscal.",
+            "setor_id": seed_base["setor1"].id,
+            "ordem": 2,
+            "ativo": True,
+        },
+    )
+    assert setor.status_code == 201
+
+    lista = client.get("/v1/respostas-prontas", headers=auth_headers["admin"])
+    assert lista.status_code == 200
+    assert lista.json()["total"] >= 2
+
+    disp = client.get(
+        f"/v1/respostas-prontas/disponiveis?setor_id={seed_base['setor1'].id}",
+        headers=auth_headers["admin"],
+    )
+    assert disp.status_code == 200
+    titulos = {r["titulo"] for r in disp.json()}
+    assert "Pedir versão" in titulos
+    assert "Suporte NF" in titulos
+
+    outro = client.get(
+        f"/v1/respostas-prontas/disponiveis?setor_id={seed_base['setor2'].id}",
+        headers=auth_headers["admin"],
+    )
+    assert outro.status_code == 200
+    titulos2 = {r["titulo"] for r in outro.json()}
+    assert "Pedir versão" in titulos2
+    assert "Suporte NF" not in titulos2
+
+    patch = client.patch(
+        f"/v1/respostas-prontas/{rid}",
+        headers=auth_headers["admin"],
+        json={"corpo": "Informe versão e build."},
+    )
+    assert patch.status_code == 200
+    assert patch.json()["corpo"] == "Informe versão e build."
+
+    delete = client.delete(f"/v1/respostas-prontas/{rid}", headers=auth_headers["admin"])
+    assert delete.status_code == 204
+
+
+def test_disponiveis_respeita_ativo(client, auth_headers, seed_base, db_session):
+    row = RespostaPronta(
+        tenant_id=seed_base["tenant"].id,
+        setor_id=None,
+        titulo="Inativa",
+        corpo="Não deve aparecer",
+        ordem=0,
+        ativo=False,
+    )
+    db_session.add(row)
+    db_session.commit()
+
+    res = client.get(
+        f"/v1/respostas-prontas/disponiveis?setor_id={seed_base['setor1'].id}",
+        headers=auth_headers["admin"],
+    )
+    assert res.status_code == 200
+    assert all(r["titulo"] != "Inativa" for r in res.json())

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,16 +13,27 @@ import { Redes } from './pages/Redes'
 import { RedeDetalhe } from './pages/RedeDetalhe'
 import { RedeForm } from './pages/RedeForm'
 import { Empresas } from './pages/Empresas'
+import { EmpresaForm } from './pages/EmpresaForm'
 import { EmpresaDetalhe } from './pages/EmpresaDetalhe'
 import { Setores } from './pages/Setores'
+import { SetorForm } from './pages/SetorForm'
 import { SetorDetalhe } from './pages/SetorDetalhe'
 import { Atendentes } from './pages/Atendentes'
+import { AtendenteForm } from './pages/AtendenteForm'
+import { AtendenteDetalhe } from './pages/AtendenteDetalhe'
 import { FuncionariosRede } from './pages/FuncionariosRede'
 import { FuncionarioRedeDetalhe } from './pages/FuncionarioRedeDetalhe'
 import { FuncionarioRedeForm } from './pages/FuncionarioRedeForm'
 import { StatusTicketPage } from './pages/StatusTicket'
+import { StatusTicketForm } from './pages/StatusTicketForm'
+import { StatusTicketDetalhe } from './pages/StatusTicketDetalhe'
+import { RespostasProntasPage } from './pages/RespostasProntas'
+import { RespostaProntaForm } from './pages/RespostaProntaForm'
+import { RespostaProntaDetalhe } from './pages/RespostaProntaDetalhe'
 import { Auditoria } from './pages/Auditoria'
 import { TiposNegocio } from './pages/TiposNegocio'
+import { TipoNegocioForm } from './pages/TipoNegocioForm'
+import { TipoNegocioDetalhe } from './pages/TipoNegocioDetalhe'
 import { ConfigWhatsapp } from './pages/ConfigWhatsapp'
 import { ConfigEmpresaEmail } from './pages/ConfigEmpresaEmail'
 import { WhatsappLayout } from './pages/whatsapp/WhatsappLayout'
@@ -127,6 +138,22 @@ function AppRoutes() {
           }
         />
         <Route
+          path="empresas/novo"
+          element={
+            <AdminRoute>
+              <EmpresaForm />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="empresas/:id/editar"
+          element={
+            <AdminRoute>
+              <EmpresaForm />
+            </AdminRoute>
+          }
+        />
+        <Route
           path="empresas/:id"
           element={
             <AdminRoute>
@@ -143,6 +170,22 @@ function AppRoutes() {
           }
         />
         <Route
+          path="setores/novo"
+          element={
+            <AdminRoute>
+              <SetorForm />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="setores/:id/editar"
+          element={
+            <AdminRoute>
+              <SetorForm />
+            </AdminRoute>
+          }
+        />
+        <Route
           path="setores"
           element={
             <AdminRoute>
@@ -155,6 +198,30 @@ function AppRoutes() {
           element={
             <AdminRoute>
               <SetorDetalhe />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="atendentes/novo"
+          element={
+            <AdminRoute>
+              <AtendenteForm />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="atendentes/:id/editar"
+          element={
+            <AdminRoute>
+              <AtendenteForm />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="atendentes/:id"
+          element={
+            <AdminRoute>
+              <AtendenteDetalhe />
             </AdminRoute>
           }
         />
@@ -199,6 +266,62 @@ function AppRoutes() {
           }
         />
         <Route
+          path="respostas-prontas/novo"
+          element={
+            <AdminRoute>
+              <RespostaProntaForm />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="respostas-prontas/:id/editar"
+          element={
+            <AdminRoute>
+              <RespostaProntaForm />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="respostas-prontas/:id"
+          element={
+            <AdminRoute>
+              <RespostaProntaDetalhe />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="respostas-prontas"
+          element={
+            <AdminRoute>
+              <RespostasProntasPage />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="status-ticket/novo"
+          element={
+            <AdminRoute>
+              <StatusTicketForm />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="status-ticket/:id/editar"
+          element={
+            <AdminRoute>
+              <StatusTicketForm />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="status-ticket/:id"
+          element={
+            <AdminRoute>
+              <StatusTicketDetalhe />
+            </AdminRoute>
+          }
+        />
+        <Route
           path="status-ticket"
           element={
             <AdminRoute>
@@ -211,6 +334,30 @@ function AppRoutes() {
           element={
             <AdminRoute>
               <Auditoria />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="tipos-negocio/novo"
+          element={
+            <AdminRoute>
+              <TipoNegocioForm />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="tipos-negocio/:id/editar"
+          element={
+            <AdminRoute>
+              <TipoNegocioForm />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="tipos-negocio/:id"
+          element={
+            <AdminRoute>
+              <TipoNegocioDetalhe />
             </AdminRoute>
           }
         />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -385,6 +385,28 @@ export const statusTicket = {
   delete: (id: number) => api<void>(`/status-ticket/${id}`, { method: 'DELETE' }),
 };
 
+export const respostasProntas = {
+  list: (params?: {
+    incluir_inativos?: boolean;
+    busca?: string;
+    setor_id?: number;
+    ordenar_por?: 'titulo' | 'ordem' | 'ativo';
+    ordem?: 'asc' | 'desc';
+    offset?: number;
+    limit?: number;
+  }) => listPaginated<RespostasProntas.Resposta>('/respostas-prontas', params),
+  get: (id: number) => api<RespostasProntas.Resposta>(`/respostas-prontas/${id}`),
+  create: (data: RespostasProntas.Create) =>
+    api<RespostasProntas.Resposta>('/respostas-prontas', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id: number, data: RespostasProntas.Update) =>
+    api<RespostasProntas.Resposta>(`/respostas-prontas/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  delete: (id: number) => api<void>(`/respostas-prontas/${id}`, { method: 'DELETE' }),
+  disponiveis: (setorId: number, busca?: string) =>
+    api<RespostasProntas.Resposta[]>(
+      withParams('/respostas-prontas/disponiveis', { setor_id: setorId, busca: busca || undefined }),
+    ),
+};
+
 export const audit = {
   list: (params?: {
     entity_type?: string;
@@ -1094,6 +1116,32 @@ export namespace StatusTicket {
   export interface Update {
     nome?: string;
     slug?: string;
+    ordem?: number;
+    ativo?: boolean;
+  }
+}
+
+export namespace RespostasProntas {
+  export interface Resposta {
+    id: number;
+    titulo: string;
+    corpo: string;
+    setor_id: number | null;
+    setor_nome?: string | null;
+    ordem: number;
+    ativo: boolean;
+  }
+  export interface Create {
+    titulo: string;
+    corpo: string;
+    setor_id?: number | null;
+    ordem?: number;
+    ativo?: boolean;
+  }
+  export interface Update {
+    titulo?: string;
+    corpo?: string;
+    setor_id?: number | null;
     ordem?: number;
     ativo?: boolean;
   }

--- a/frontend/src/components/RespostasProntasPicker.tsx
+++ b/frontend/src/components/RespostasProntasPicker.tsx
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { respostasProntas, type RespostasProntas } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Button } from './ui/Button'
+import { Input } from './ui/Input'
+import { useToast } from './ui/Toast'
+
+type Props = {
+  setorId: number
+  disabled?: boolean
+  onInserir: (texto: string) => void
+}
+
+export function RespostasProntasPicker({ setorId, disabled, onInserir }: Props) {
+  const toast = useToast()
+  const [aberto, setAberto] = useState(false)
+  const [busca, setBusca] = useState('')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+  const [itens, setItens] = useState<RespostasProntas.Resposta[]>([])
+  const [loading, setLoading] = useState(false)
+  const painelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBusca(busca.trim()), 300)
+    return () => clearTimeout(t)
+  }, [busca])
+
+  const carregar = useCallback(() => {
+    setLoading(true)
+    respostasProntas
+      .disponiveis(setorId, debouncedBusca || undefined)
+      .then(setItens)
+      .catch((err) => {
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar respostas prontas.'))
+        setItens([])
+      })
+      .finally(() => setLoading(false))
+  }, [debouncedBusca, setorId, toast])
+
+  useEffect(() => {
+    if (!aberto) return
+    carregar()
+  }, [aberto, carregar])
+
+  useEffect(() => {
+    if (!aberto) return
+    function onDocClick(e: MouseEvent) {
+      if (painelRef.current && !painelRef.current.contains(e.target as Node)) {
+        setAberto(false)
+      }
+    }
+    document.addEventListener('mousedown', onDocClick)
+    return () => document.removeEventListener('mousedown', onDocClick)
+  }, [aberto])
+
+  function escolher(item: RespostasProntas.Resposta) {
+    onInserir(item.corpo)
+    setAberto(false)
+    setBusca('')
+  }
+
+  return (
+    <div className="relative" ref={painelRef}>
+      <Button
+        type="button"
+        variant="secondary"
+        disabled={disabled}
+        onClick={() => setAberto((v) => !v)}
+        className="inline-flex items-center gap-2 text-xs sm:text-sm"
+      >
+        <svg className="size-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+        </svg>
+        Respostas prontas
+      </Button>
+      {aberto ? (
+        <div className="absolute bottom-full left-0 z-30 mb-2 w-[min(100vw-2rem,22rem)] rounded-xl border border-slate-200 bg-white p-3 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+          <Input
+            value={busca}
+            onChange={(e) => setBusca(e.target.value)}
+            placeholder="Buscar por título…"
+            className="mb-2 text-sm"
+            autoFocus
+          />
+          <div className="max-h-56 overflow-y-auto">
+            {loading ? (
+              <p className="py-4 text-center text-xs text-slate-500 dark:text-slate-400">Carregando…</p>
+            ) : itens.length === 0 ? (
+              <p className="py-4 text-center text-xs text-slate-500 dark:text-slate-400">Nenhuma resposta encontrada.</p>
+            ) : (
+              <ul className="space-y-1">
+                {itens.map((item) => (
+                  <li key={item.id}>
+                    <button
+                      type="button"
+                      onClick={() => escolher(item)}
+                      className="w-full rounded-lg px-2 py-2 text-left text-sm transition-colors hover:bg-slate-100 dark:hover:bg-slate-800"
+                    >
+                      <span className="font-medium text-slate-900 dark:text-slate-100">{item.titulo}</span>
+                      {item.setor_nome ? (
+                        <span className="ml-1 text-xs text-slate-500 dark:text-slate-400">· {item.setor_nome}</span>
+                      ) : (
+                        <span className="ml-1 text-xs text-slate-500 dark:text-slate-400">· Global</span>
+                      )}
+                      <p className="mt-0.5 line-clamp-2 text-xs text-slate-600 dark:text-slate-400">{item.corpo}</p>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -198,6 +198,7 @@ const navStructure: NavItem[] = [
       { to: '/atendentes', label: 'Atendentes', icon: 'atendentes' },
       { to: '/tipos-negocio', label: 'Tipos de negócio', icon: 'tiposNegocio' },
       { to: '/status-ticket', label: 'Status de ticket', icon: 'status' },
+      { to: '/respostas-prontas', label: 'Respostas prontas', icon: 'status' },
       { to: '/configuracoes/empresa-email', label: 'Empresa & e-mail', icon: 'empresas' },
       { to: '/configuracoes/whatsapp', label: 'WhatsApp (Evolution)', icon: 'whatsapp' },
       { to: '/auditoria', label: 'Auditoria', icon: 'auditoria' },

--- a/frontend/src/components/ui/BadgeAtivo.tsx
+++ b/frontend/src/components/ui/BadgeAtivo.tsx
@@ -1,0 +1,19 @@
+type Props = {
+  ativo: boolean
+  labelAtivo?: string
+  labelInativo?: string
+}
+
+export function BadgeAtivo({ ativo, labelAtivo = 'Ativo', labelInativo = 'Inativo' }: Props) {
+  return (
+    <span
+      className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${
+        ativo
+          ? 'bg-emerald-50 text-emerald-800 ring-1 ring-emerald-600/15 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-600/30'
+          : 'bg-slate-100 text-slate-600 ring-1 ring-slate-300/60 dark:bg-slate-800 dark:text-slate-400 dark:ring-slate-600/40'
+      }`}
+    >
+      {ativo ? labelAtivo : labelInativo}
+    </span>
+  )
+}

--- a/frontend/src/components/ui/CadastroFormPageShell.tsx
+++ b/frontend/src/components/ui/CadastroFormPageShell.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+
+type Props = {
+  children: ReactNode
+  onVoltar: () => void
+  /** Largura máxima do conteúdo (padrão: listagens simples). */
+  wide?: boolean
+}
+
+export function CadastroFormPageShell({ children, onVoltar, wide }: Props) {
+  return (
+    <div className={`mx-auto space-y-6 pb-10 ${wide ? 'max-w-6xl' : 'max-w-5xl'}`}>
+      <div>
+        <button
+          type="button"
+          onClick={onVoltar}
+          className="inline-flex items-center gap-1 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100"
+        >
+          <span aria-hidden>←</span> Voltar
+        </button>
+      </div>
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/DetailRow.tsx
+++ b/frontend/src/components/ui/DetailRow.tsx
@@ -1,0 +1,20 @@
+type Props = {
+  label: string
+  value: string | null | undefined
+  mono?: boolean
+  multiline?: boolean
+}
+
+export function DetailRow({ label, value, mono, multiline }: Props) {
+  const v = value?.trim()
+  return (
+    <div className="grid grid-cols-1 gap-0.5 border-b border-slate-100 py-3 last:border-0 sm:grid-cols-[minmax(0,10rem)_1fr] sm:gap-6 sm:py-3.5 dark:border-slate-800">
+      <dt className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">{label}</dt>
+      <dd
+        className={`text-sm leading-relaxed text-slate-800 dark:text-slate-100 ${mono ? 'font-mono' : ''} ${multiline ? 'whitespace-pre-wrap' : ''}`}
+      >
+        {v ? v : '—'}
+      </dd>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/InlineCadastroPanel.tsx
+++ b/frontend/src/components/ui/InlineCadastroPanel.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef, type ReactNode } from 'react'
+import { Card } from './Card'
+import { Button } from './Button'
+
+type PanelProps = {
+  title: string
+  className?: string
+  children: ReactNode
+  /** Rola suavemente até o formulário ao abrir. */
+  scrollIntoView?: boolean
+}
+
+export function InlineCadastroPanel({ title, className = '', children, scrollIntoView = true }: PanelProps) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!scrollIntoView) return
+    ref.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }, [scrollIntoView, title])
+
+  return (
+    <div ref={ref} className="scroll-mt-24">
+      <Card title={title} className={className}>
+        {children}
+      </Card>
+    </div>
+  )
+}
+
+type FooterProps = {
+  onCancel: () => void
+  saving?: boolean
+  submitLabel?: string
+}
+
+export function InlineCadastroFooter({ onCancel, saving, submitLabel = 'Salvar' }: FooterProps) {
+  return (
+    <div className="mt-6 flex flex-col-reverse gap-2 border-t border-slate-200 pt-4 dark:border-slate-700 sm:flex-row sm:justify-end">
+      <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={onCancel}>
+        Cancelar
+      </Button>
+      <Button type="submit" loading={saving} className="w-full sm:w-auto">
+        {submitLabel}
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/ListaAcoesVerEditar.tsx
+++ b/frontend/src/components/ui/ListaAcoesVerEditar.tsx
@@ -1,0 +1,36 @@
+import { Button } from './Button'
+import { IconEye } from './IconEye'
+import { IconPencil } from './IconPencil'
+import { IconTrash } from './IconTrash'
+
+type Props = {
+  onVer: () => void
+  onEditar: () => void
+  onExcluir?: () => void
+  verLabel?: string
+  editarLabel?: string
+}
+
+export function ListaAcoesVerEditar({
+  onVer,
+  onEditar,
+  onExcluir,
+  verLabel = 'Visualizar',
+  editarLabel = 'Editar',
+}: Props) {
+  return (
+    <div className="inline-flex gap-0.5">
+      <Button variant="ghost" onClick={onVer} aria-label={verLabel}>
+        <IconEye ariaHidden={false} />
+      </Button>
+      <Button variant="ghost" onClick={onEditar} aria-label={editarLabel}>
+        <IconPencil ariaHidden={false} />
+      </Button>
+      {onExcluir ? (
+        <Button variant="ghost" onClick={onExcluir} aria-label="Excluir">
+          <IconTrash ariaHidden={false} />
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/pages/AtendenteDetalhe.tsx
+++ b/frontend/src/pages/AtendenteDetalhe.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ApiError, atendentes, setores, type Atendentes, type Setores } from '../api/client'
+import { coletarTodasPaginas } from '../api/collectPages'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { DetailRow } from '../components/ui/DetailRow'
+import { BadgeAtivo } from '../components/ui/BadgeAtivo'
+import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { SemPermissao } from './SemPermissao'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+import { interpretarFalhaCarregamento } from '../api/errorMessage'
+
+const roleLabel: Record<string, string> = { admin: 'Administrador', atendente: 'Atendente' }
+
+export function AtendenteDetalhe() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const voltarAnterior = useVoltarAnterior('/atendentes')
+  const atendenteId = id ? parseInt(id, 10) : NaN
+
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [falha, setFalha] = useState<{ titulo: string; detalhe?: string } | null>(null)
+  const [atendente, setAtendente] = useState<Atendentes.Atendente | null>(null)
+  const [setoresList, setSetoresList] = useState<Setores.Setor[]>([])
+
+  useEffect(() => {
+    if (!id || Number.isNaN(atendenteId)) {
+      setFalha({ titulo: 'Atendente não encontrado.', detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setFalha(null)
+    Promise.all([
+      atendentes.get(atendenteId),
+      coletarTodasPaginas<Setores.Setor>((o, l) => setores.list({ incluir_inativos: true, offset: o, limit: l })),
+    ])
+      .then(([a, setoresAll]) => {
+        if (cancelled) return
+        setAtendente(a)
+        setSetoresList(setoresAll)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        setFalha(interpretarFalhaCarregamento(err, 'Atendente não encontrado.'))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, atendenteId])
+
+  const setoresVinculados = useMemo(() => {
+    if (!atendente) return '—'
+    const ids = new Set(atendente.setor_ids ?? [])
+    const nomes = setoresList.filter((s) => ids.has(s.id)).map((s) => s.nome)
+    return nomes.length > 0 ? nomes.join(', ') : 'Nenhum setor vinculado'
+  }, [atendente, setoresList])
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </div>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para acessar este atendente."
+        voltarPara="/atendentes"
+        voltarLabel="Voltar para Atendentes"
+      />
+    )
+  }
+
+  if (falha) {
+    return <CarregamentoFalhou titulo={falha.titulo} detalhe={falha.detalhe} onVoltar={voltarAnterior} />
+  }
+
+  if (!atendente) return null
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <button
+        type="button"
+        onClick={voltarAnterior}
+        className="inline-flex items-center gap-1 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100"
+      >
+        <span aria-hidden>←</span> Voltar
+      </button>
+
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">{atendente.nome}</h1>
+          <div className="flex flex-wrap items-center gap-2">
+            <BadgeAtivo ativo={atendente.ativo} labelAtivo="Ativo" labelInativo="Inativo" />
+            <span className="text-sm text-slate-600 dark:text-slate-400">{roleLabel[atendente.role] ?? atendente.role}</span>
+          </div>
+        </div>
+        <Button onClick={() => navigate(`/atendentes/${atendente.id}/editar`)}>Editar</Button>
+      </header>
+
+      <Card title="Dados do atendente">
+        <dl>
+          <DetailRow label="ID" value={String(atendente.id)} mono />
+          <DetailRow label="Nome" value={atendente.nome} />
+          <DetailRow label="E-mail" value={atendente.email} />
+          <DetailRow label="Perfil" value={roleLabel[atendente.role] ?? atendente.role} />
+          <DetailRow label="Setores" value={setoresVinculados} />
+          <DetailRow label="Situação" value={atendente.ativo ? 'Ativo' : 'Inativo'} />
+          {atendente.must_change_password ? (
+            <DetailRow label="Senha" value="Deve alterar a senha no próximo acesso" />
+          ) : null}
+        </dl>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ApiError, atendentes, setores, type Setores } from '../api/client'
+import { coletarTodasPaginas } from '../api/collectPages'
+import { Card } from '../components/ui/Card'
+import { Input } from '../components/ui/Input'
+import { IconEye, IconEyeOff } from '../components/ui/IconEye'
+import { Switch } from '../components/ui/Switch'
+import { CheckboxField } from '../components/ui/CheckboxField'
+import { Select } from '../components/ui/Select'
+import { useToast } from '../components/ui/Toast'
+import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { FormSection } from '../components/ui/FormSection'
+import { InlineCadastroFooter } from '../components/ui/InlineCadastroPanel'
+import { CadastroFormPageShell } from '../components/ui/CadastroFormPageShell'
+import { SemPermissao } from './SemPermissao'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
+
+export function AtendenteForm() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const voltarAnterior = useVoltarAnterior('/atendentes')
+
+  const atendenteId = id ? parseInt(id, 10) : NaN
+  const isEdit = id != null
+
+  const [loading, setLoading] = useState(isEdit)
+  const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [inexistente, setInexistente] = useState<{ detalhe?: string } | null>(null)
+  const [setoresList, setSetoresList] = useState<Setores.Setor[]>([])
+  const [email, setEmail] = useState('')
+  const [nome, setNome] = useState('')
+  const [senha, setSenha] = useState('')
+  const [mostrarSenha, setMostrarSenha] = useState(false)
+  const [role, setRole] = useState<'admin' | 'atendente'>('atendente')
+  const [ativo, setAtivo] = useState(true)
+  const [setorIds, setSetorIds] = useState<number[]>([])
+
+  useEffect(() => {
+    coletarTodasPaginas<Setores.Setor>((o, l) =>
+      setores.list({ incluir_inativos: true, offset: o, limit: l }),
+    ).then(setSetoresList)
+  }, [])
+
+  useEffect(() => {
+    if (!isEdit) return
+    if (!id || Number.isNaN(atendenteId)) {
+      setInexistente({ detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setInexistente(null)
+    atendentes
+      .get(atendenteId)
+      .then((a) => {
+        if (cancelled) return
+        setEmail(a.email)
+        setNome(a.nome)
+        setSenha('')
+        setMostrarSenha(false)
+        setRole((a.role as 'admin') || 'atendente')
+        setAtivo(a.ativo)
+        setSetorIds(a.setor_ids ?? [])
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setInexistente({})
+          return
+        }
+        const m = interpretarFalhaCarregamento(err, 'Atendente não encontrado.')
+        toast.showWarning([m.titulo, m.detalhe].filter(Boolean).join(' '))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, isEdit, atendenteId, toast])
+
+  function toggleSetor(setorId: number) {
+    setSetorIds((prev) => (prev.includes(setorId) ? prev.filter((x) => x !== setorId) : [...prev, setorId]))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    try {
+      if (isEdit && !Number.isNaN(atendenteId)) {
+        await atendentes.update(atendenteId, {
+          email,
+          nome: nome.trim(),
+          role,
+          ativo,
+          setor_ids: setorIds,
+          ...(senha ? { senha } : {}),
+        })
+        toast.showSuccess('Atendente atualizado.')
+        navigate(`/atendentes/${atendenteId}`, { replace: true })
+      } else {
+        if (!senha) throw new Error('Senha obrigatória para novo atendente')
+        const created = await atendentes.create({
+          email,
+          nome: nome.trim(),
+          senha,
+          role,
+          setor_ids: setorIds,
+          ativo,
+        })
+        toast.showSuccess('Atendente cadastrado.')
+        navigate(`/atendentes/${created.id}`, { replace: true })
+      }
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o atendente.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <CadastroFormPageShell onVoltar={voltarAnterior}>
+        <div className="h-72 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </CadastroFormPageShell>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para editar atendentes."
+        voltarPara="/atendentes"
+        voltarLabel="Voltar para Atendentes"
+      />
+    )
+  }
+
+  if (inexistente) {
+    return (
+      <CarregamentoFalhou
+        className="mx-auto max-w-5xl space-y-4 pb-10"
+        titulo="Atendente não encontrado."
+        detalhe={inexistente.detalhe}
+        onVoltar={voltarAnterior}
+      />
+    )
+  }
+
+  return (
+    <CadastroFormPageShell onVoltar={voltarAnterior}>
+      <Card title={isEdit ? 'Editar atendente' : 'Novo atendente'}>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-6">
+            <FormSection title="Dados do atendente">
+              <Input label="E-mail" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
+              <Input
+                label={isEdit ? 'Nova senha (deixe em branco para manter)' : 'Senha'}
+                type={mostrarSenha ? 'text' : 'password'}
+                value={senha}
+                onChange={(e) => setSenha(e.target.value)}
+                required={!isEdit}
+                endAdornment={
+                  <button
+                    type="button"
+                    onClick={() => setMostrarSenha((v) => !v)}
+                    className="inline-flex size-9 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/30 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-200"
+                    aria-label={mostrarSenha ? 'Ocultar senha' : 'Mostrar senha'}
+                    aria-pressed={mostrarSenha}
+                  >
+                    {mostrarSenha ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
+                  </button>
+                }
+              />
+              <Select
+                label="Perfil"
+                value={role}
+                onChange={(v) => setRole(v === 'admin' ? 'admin' : 'atendente')}
+                options={[
+                  { value: 'atendente', label: 'Atendente' },
+                  { value: 'admin', label: 'Administrador' },
+                ]}
+              />
+            </FormSection>
+            <FormSection title="Setores">
+              {role === 'admin' && (
+                <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
+                  Opcional, mas recomendado: vincule administradores a setores para poderem ser responsáveis em tickets do setor.
+                </p>
+              )}
+              <div className="max-h-44 overflow-auto rounded-lg border border-slate-200 p-3 dark:border-slate-700/80">
+                <div className="flex flex-wrap gap-2">
+                  {setoresList.map((s) => (
+                    <CheckboxField key={s.id} checked={setorIds.includes(s.id)} onChange={() => toggleSetor(s.id)}>
+                      {s.nome}
+                    </CheckboxField>
+                  ))}
+                </div>
+              </div>
+            </FormSection>
+            <FormSection title="Situação no sistema">
+              <Switch
+                bare
+                checked={ativo}
+                onCheckedChange={setAtivo}
+                label="Atendente ativo"
+                description="Inativos não acessam o sistema."
+                showStatusPill
+                statusOnText="Ativo"
+                statusOffText="Inativo"
+              />
+            </FormSection>
+          </div>
+          <InlineCadastroFooter onCancel={voltarAnterior} saving={saving} />
+        </form>
+      </Card>
+    </CadastroFormPageShell>
+  )
+}

--- a/frontend/src/pages/Atendentes.tsx
+++ b/frontend/src/pages/Atendentes.tsx
@@ -1,20 +1,14 @@
 import { useState, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
-import { ApiError, atendentes, setores, type Atendentes, type Setores } from '../api/client'
-import { coletarTodasPaginas } from '../api/collectPages'
+import { ApiError, atendentes, type Atendentes } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
-import { Input } from '../components/ui/Input'
-import { IconEye, IconEyeOff } from '../components/ui/IconEye'
-import { IconPencil } from '../components/ui/IconPencil'
+import { ListaAcoesVerEditar } from '../components/ui/ListaAcoesVerEditar'
 import { FiltroInativos } from '../components/ui/FiltroInativos'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
-import { Switch } from '../components/ui/Switch'
-import { CheckboxField } from '../components/ui/CheckboxField'
-import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
-import { FormSection } from '../components/ui/FormSection'
 import { SemPermissao } from './SemPermissao'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 
@@ -23,6 +17,7 @@ type ColunaAtendente = 'nome' | 'email' | 'role'
 const roleLabel: Record<string, string> = { admin: 'Administrador', atendente: 'Atendente' }
 
 export function Atendentes() {
+  const navigate = useNavigate()
   const toast = useToast()
   const { ordenarPor, ordem, aoOrdenarColuna, sortParams } = useOrdenacaoLista<ColunaAtendente>()
   const [list, setList] = useState<Atendentes.Atendente[]>([])
@@ -30,29 +25,9 @@ export function Atendentes() {
   const [page, setPage] = useState(1)
   const [busca, setBusca] = useState('')
   const [debouncedBusca, setDebouncedBusca] = useState('')
-  const [setoresList, setSetoresList] = useState<Setores.Setor[]>([])
   const [loading, setLoading] = useState(true)
   const [incluirInativos, setIncluirInativos] = useState(false)
-  const [modalOpen, setModalOpen] = useState(false)
-  const [editingId, setEditingId] = useState<number | null>(null)
-  const [email, setEmail] = useState('')
-  const [nome, setNome] = useState('')
-  const [senha, setSenha] = useState('')
-  const [mostrarSenha, setMostrarSenha] = useState(false)
-  const [role, setRole] = useState<'admin' | 'atendente'>('atendente')
-  const [ativo, setAtivo] = useState(true)
-  const [setorIds, setSetorIds] = useState<number[]>([])
-  const [saving, setSaving] = useState(false)
   const [forbidden, setForbidden] = useState(false)
-
-  useEffect(() => {
-    if (!modalOpen) return
-    const prevOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    return () => {
-      document.body.style.overflow = prevOverflow
-    }
-  }, [modalOpen])
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -94,74 +69,6 @@ export function Atendentes() {
     load()
   }, [load])
 
-  useEffect(() => {
-    coletarTodasPaginas<Setores.Setor>((o, l) =>
-      setores.list({ incluir_inativos: true, offset: o, limit: l }),
-    ).then(setSetoresList)
-  }, [])
-
-  function openCreate() {
-    setEditingId(null)
-    setEmail('')
-    setNome('')
-    setSenha('')
-    setMostrarSenha(false)
-    setRole('atendente')
-    setAtivo(true)
-    setSetorIds([])
-    setModalOpen(true)
-  }
-
-  function openEdit(item: Atendentes.Atendente) {
-    setEditingId(item.id)
-    setEmail(item.email)
-    setNome(item.nome)
-    setSenha('')
-    setMostrarSenha(false)
-    setRole((item.role as 'admin') || 'atendente')
-    setAtivo(item.ativo)
-    setSetorIds(item.setor_ids ?? [])
-    setModalOpen(true)
-  }
-
-  function toggleSetor(id: number) {
-    setSetorIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    setSaving(true)
-    try {
-      if (editingId) {
-        await atendentes.update(editingId, {
-          email,
-          nome: nome.trim(),
-          role,
-          ativo,
-          setor_ids: setorIds,
-          ...(senha ? { senha } : {}),
-        })
-      } else {
-        if (!senha) throw new Error('Senha obrigatória para novo atendente')
-        await atendentes.create({
-          email,
-          nome: nome.trim(),
-          senha,
-          role,
-          setor_ids: setorIds,
-          ativo,
-        })
-      }
-      toast.showSuccess(editingId ? 'Atendente atualizado.' : 'Atendente cadastrado.')
-      setModalOpen(false)
-      load()
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o atendente.'))
-    } finally {
-      setSaving(false)
-    }
-  }
-
   if (forbidden) {
     return (
       <div className="mx-auto max-w-6xl space-y-6 pb-10">
@@ -179,20 +86,20 @@ export function Atendentes() {
     <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <div className="flex justify-between">
         <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Atendentes</h1>
-        <Button onClick={openCreate}>Novo atendente</Button>
+        <Button onClick={() => navigate('/atendentes/novo')}>Novo atendente</Button>
       </div>
-      {!modalOpen && (
-        <Card>
-          <BarraBuscaPaginacao
-            busca={busca}
-            onBuscaChange={setBusca}
-            placeholder="Buscar por nome ou e-mail"
-            page={page}
-            total={total}
-            onPageChange={setPage}
-            disabled={loading}
-            extra={<FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />}
-          />
+
+      <Card>
+        <BarraBuscaPaginacao
+          busca={busca}
+          onBuscaChange={setBusca}
+          placeholder="Buscar por nome ou e-mail"
+          page={page}
+          total={total}
+          onPageChange={setPage}
+          disabled={loading}
+          extra={<FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />}
+        />
         {loading ? (
           <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
         ) : list.length === 0 ? (
@@ -216,11 +123,11 @@ export function Atendentes() {
                     key={a.id}
                     role="button"
                     tabIndex={0}
-                    onClick={() => openEdit(a)}
+                    onClick={() => navigate(`/atendentes/${a.id}`)}
                     onKeyDown={(ev) => {
                       if (ev.key === 'Enter' || ev.key === ' ') {
                         ev.preventDefault()
-                        openEdit(a)
+                        navigate(`/atendentes/${a.id}`)
                       }
                     }}
                     className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
@@ -240,106 +147,20 @@ export function Atendentes() {
                       {roleLabel[a.role] ?? a.role}
                     </td>
                     <td className="px-4 py-3.5 text-right sm:px-6" onClick={(ev) => ev.stopPropagation()}>
-                      <Button variant="ghost" onClick={() => openEdit(a)} aria-label="Editar">
-                        <IconPencil />
-                      </Button>
+                      <ListaAcoesVerEditar
+                        onVer={() => navigate(`/atendentes/${a.id}`)}
+                        onEditar={() => navigate(`/atendentes/${a.id}/editar`)}
+                        verLabel="Visualizar atendente"
+                        editarLabel="Editar atendente"
+                      />
                     </td>
                   </tr>
                 ))}
               </tbody>
             </table>
           </div>
-
         )}
-        </Card>
-      )}
-
-      {modalOpen && (
-        <div className="fixed inset-y-0 left-0 right-0 z-20 flex items-start justify-center bg-black/85 px-4 pb-6 pt-16 sm:px-6 md:left-[var(--sidebar-w)]">
-          <Card title={editingId ? 'Editar atendente' : 'Novo atendente'} className="w-full max-w-lg">
-            <form onSubmit={handleSubmit}>
-              <div className="space-y-6">
-                <FormSection title="Dados do atendente">
-                  <Input label="E-mail" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
-                  <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-                  <Input
-                    label={editingId ? 'Nova senha (deixe em branco para manter)' : 'Senha'}
-                    type={mostrarSenha ? 'text' : 'password'}
-                    value={senha}
-                    onChange={(e) => setSenha(e.target.value)}
-                    required={!editingId}
-                    endAdornment={
-                      <button
-                        type="button"
-                        onClick={() => setMostrarSenha((v) => !v)}
-                        className="inline-flex size-9 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/30 dark:text-slate-400 dark:hover:bg-slate-800/70 dark:hover:text-slate-200"
-                        aria-label={mostrarSenha ? 'Ocultar senha' : 'Mostrar senha'}
-                        aria-pressed={mostrarSenha}
-                      >
-                        {mostrarSenha ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
-                      </button>
-                    }
-                  />
-                  <Select
-                    label="Perfil"
-                    value={role}
-                    onChange={(v) => setRole(v === 'admin' ? 'admin' : 'atendente')}
-                    options={[
-                      { value: 'atendente', label: 'Atendente' },
-                      { value: 'admin', label: 'Administrador' },
-                    ]}
-                  />
-                </FormSection>
-
-                <FormSection title="Setores">
-                  {role === 'admin' && (
-                    <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
-                      Opcional, mas recomendado: vincule administradores a setores para poderem ser responsáveis em tickets do setor.
-                    </p>
-                  )}
-                  <div className="max-h-44 overflow-auto rounded-lg border border-slate-200 p-3 dark:border-slate-700/80">
-                    <div className="flex flex-wrap gap-2">
-                      {setoresList.map((s) => (
-                        <CheckboxField
-                          key={s.id}
-                          checked={setorIds.includes(s.id)}
-                          onChange={() => toggleSetor(s.id)}
-                        >
-                          {s.nome}
-                        </CheckboxField>
-                      ))}
-                    </div>
-                  </div>
-                </FormSection>
-
-                <FormSection title="Situação no sistema">
-                  <Switch
-                    bare
-                    checked={ativo}
-                    onCheckedChange={setAtivo}
-                    label="Atendente ativo"
-                    description="Inativos não acessam o sistema."
-                    showStatusPill
-                    statusOnText="Ativo"
-                    statusOffText="Inativo"
-                  />
-                </FormSection>
-              </div>
-
-              <div className="sticky bottom-0 -mx-6 mt-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-900">
-                <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-                  <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => setModalOpen(false)}>
-                    Cancelar
-                  </Button>
-                  <Button type="submit" loading={saving} className="w-full sm:w-auto">
-                    Salvar
-                  </Button>
-                </div>
-              </div>
-            </form>
-          </Card>
-        </div>
-      )}
+      </Card>
     </div>
   )
 }

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -179,7 +179,7 @@ export function EmpresaDetalhe() {
 
   function abrirEdicao() {
     if (!empresa) return
-    navigate('/empresas', { state: { empresaEditId: empresa.id } })
+    navigate(`/empresas/${empresa.id}/editar`)
   }
 
   async function handleExcluir() {

--- a/frontend/src/pages/EmpresaForm.tsx
+++ b/frontend/src/pages/EmpresaForm.tsx
@@ -1,0 +1,625 @@
+import { useState, useEffect, useMemo } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import {
+  ApiError,
+  empresas as apiEmpresas,
+  redes,
+  tiposNegocio,
+  type Empresas,
+  type Redes,
+  type TiposNegocio,
+} from '../api/client'
+import { coletarTodasPaginas } from '../api/collectPages'
+import { Card } from '../components/ui/Card'
+import { Input } from '../components/ui/Input'
+import { FormSection } from '../components/ui/FormSection'
+import {
+  EMPRESA_HINT_ATIVA,
+  EMPRESA_SECAO_DOCUMENTO_NOMES,
+  EMPRESA_SECAO_RESPONSAVEL_LEGAL,
+  nomeParaApiEmpresa,
+} from '../components/empresa/empresaFormCopy'
+import { useToast } from '../components/ui/Toast'
+import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { SelectComPesquisa } from '../components/ui/SelectComPesquisa'
+import { Select } from '../components/ui/Select'
+import { SelectUf } from '../components/ui/SelectUf'
+import { SelectCidadeUf } from '../components/ui/SelectCidadeUf'
+import { InputCepComBusca } from '../components/ui/InputCepComBusca'
+import { maskCnpjCpf, isCnpj } from '../utils/maskCnpjCpf'
+import { digitsOnly, maskCep, maskTelefoneBr, maskInscricaoEstadual } from '../utils/masks'
+import { ESTADOS_CIVIS_BR, type EstadoCivilBr } from '../constants/estadosCivis'
+import { Switch } from '../components/ui/Switch'
+import { InlineCadastroFooter } from '../components/ui/InlineCadastroPanel'
+import { CadastroFormPageShell } from '../components/ui/CadastroFormPageShell'
+import { SemPermissao } from './SemPermissao'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
+
+function aplicarEmpresaNoFormulario(e: Empresas.Empresa, setters: {
+  setRedeId: (v: number | '') => void
+  setTipoNegocioId: (v: number | '') => void
+  setCnpjCpf: (v: string) => void
+  setRazaoSocial: (v: string) => void
+  setNomeFantasia: (v: string) => void
+  setInscricaoEstadual: (v: string) => void
+  setEndereco: (v: string) => void
+  setNumero: (v: string) => void
+  setComplemento: (v: string) => void
+  setBairro: (v: string) => void
+  setCidade: (v: string) => void
+  setEstado: (v: string) => void
+  setCep: (v: string) => void
+  setEmail: (v: string) => void
+  setTelefone: (v: string) => void
+  setRespLegalNome: (v: string) => void
+  setRespLegalCpf: (v: string) => void
+  setRespLegalRg: (v: string) => void
+  setRespLegalOrgaoEmissor: (v: string) => void
+  setRespLegalNacionalidade: (v: string) => void
+  setRespLegalEstadoCivil: (v: string) => void
+  setRespLegalCargo: (v: string) => void
+  setRespLegalEmail: (v: string) => void
+  setRespLegalTelefone: (v: string) => void
+  setRespLegalEndereco: (v: string) => void
+  setRespLegalNumero: (v: string) => void
+  setRespLegalComplemento: (v: string) => void
+  setRespLegalBairro: (v: string) => void
+  setRespLegalCidade: (v: string) => void
+  setRespLegalEstado: (v: string) => void
+  setRespLegalCep: (v: string) => void
+  setAtivo: (v: boolean) => void
+}) {
+  setters.setRedeId(e.rede_id)
+  setters.setTipoNegocioId(e.tipo_negocio_id ?? '')
+  setters.setCnpjCpf(e.cnpj_cpf ? maskCnpjCpf(e.cnpj_cpf) : '')
+  setters.setRazaoSocial(e.razao_social ?? '')
+  setters.setNomeFantasia(e.nome_fantasia ?? '')
+  setters.setInscricaoEstadual(e.inscricao_estadual ?? '')
+  setters.setEndereco(e.endereco ?? '')
+  setters.setNumero(e.numero ?? '')
+  setters.setComplemento(e.complemento ?? '')
+  setters.setBairro(e.bairro ?? '')
+  setters.setCidade(e.cidade ?? '')
+  setters.setEstado((e.estado ?? '').toUpperCase().slice(0, 2))
+  setters.setCep(e.cep ? maskCep(e.cep.replace(/\D/g, '')) : '')
+  setters.setEmail(e.email ?? '')
+  setters.setTelefone(e.telefone ? maskTelefoneBr(e.telefone) : '')
+  setters.setRespLegalNome(e.resp_legal_nome ?? '')
+  setters.setRespLegalCpf(e.resp_legal_cpf ? maskCnpjCpf(e.resp_legal_cpf) : '')
+  setters.setRespLegalRg(e.resp_legal_rg ?? '')
+  setters.setRespLegalOrgaoEmissor(e.resp_legal_orgao_emissor ?? '')
+  setters.setRespLegalNacionalidade(e.resp_legal_nacionalidade ?? '')
+  setters.setRespLegalEstadoCivil(e.resp_legal_estado_civil ?? '')
+  setters.setRespLegalCargo(e.resp_legal_cargo ?? '')
+  setters.setRespLegalEmail(e.resp_legal_email ?? '')
+  setters.setRespLegalTelefone(e.resp_legal_telefone ? maskTelefoneBr(e.resp_legal_telefone) : '')
+  setters.setRespLegalEndereco(e.resp_legal_endereco ?? '')
+  setters.setRespLegalNumero(e.resp_legal_numero ?? '')
+  setters.setRespLegalComplemento(e.resp_legal_complemento ?? '')
+  setters.setRespLegalBairro(e.resp_legal_bairro ?? '')
+  setters.setRespLegalCidade(e.resp_legal_cidade ?? '')
+  setters.setRespLegalEstado((e.resp_legal_estado ?? '').toUpperCase().slice(0, 2))
+  setters.setRespLegalCep(e.resp_legal_cep ? maskCep(e.resp_legal_cep.replace(/\D/g, '')) : '')
+  setters.setAtivo(e.ativo)
+}
+
+export function EmpresaForm() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const voltarAnterior = useVoltarAnterior('/empresas')
+
+  const empresaId = id ? parseInt(id, 10) : NaN
+  const isEdit = id != null
+
+  const [loading, setLoading] = useState(isEdit)
+  const [metaLoading, setMetaLoading] = useState(true)
+  const [redeId, setRedeId] = useState<number | ''>('')
+  const [tipoNegocioId, setTipoNegocioId] = useState<number | ''>('')
+  const [cnpjCpf, setCnpjCpf] = useState('')
+  const [razaoSocial, setRazaoSocial] = useState('')
+  const [nomeFantasia, setNomeFantasia] = useState('')
+  const [inscricaoEstadual, setInscricaoEstadual] = useState('')
+  const [endereco, setEndereco] = useState('')
+  const [numero, setNumero] = useState('')
+  const [complemento, setComplemento] = useState('')
+  const [bairro, setBairro] = useState('')
+  const [cidade, setCidade] = useState('')
+  const [estado, setEstado] = useState('')
+  const [cep, setCep] = useState('')
+  const [email, setEmail] = useState('')
+  const [telefone, setTelefone] = useState('')
+  const [respLegalNome, setRespLegalNome] = useState('')
+  const [respLegalCpf, setRespLegalCpf] = useState('')
+  const [respLegalRg, setRespLegalRg] = useState('')
+  const [respLegalOrgaoEmissor, setRespLegalOrgaoEmissor] = useState('')
+  const [respLegalNacionalidade, setRespLegalNacionalidade] = useState('')
+  const [respLegalEstadoCivil, setRespLegalEstadoCivil] = useState('')
+  const [respLegalCargo, setRespLegalCargo] = useState('')
+  const [respLegalEmail, setRespLegalEmail] = useState('')
+  const [respLegalTelefone, setRespLegalTelefone] = useState('')
+  const [respLegalEndereco, setRespLegalEndereco] = useState('')
+  const [respLegalNumero, setRespLegalNumero] = useState('')
+  const [respLegalComplemento, setRespLegalComplemento] = useState('')
+  const [respLegalBairro, setRespLegalBairro] = useState('')
+  const [respLegalCidade, setRespLegalCidade] = useState('')
+  const [respLegalEstado, setRespLegalEstado] = useState('')
+  const [respLegalCep, setRespLegalCep] = useState('')
+  const [ativo, setAtivo] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [loadingCnpj, setLoadingCnpj] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [inexistente, setInexistente] = useState<{ detalhe?: string } | null>(null)
+  const [redesList, setRedesList] = useState<Redes.Rede[]>([])
+  const [tiposList, setTiposList] = useState<TiposNegocio.Tipo[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    setMetaLoading(true)
+    Promise.all([
+      coletarTodasPaginas<Redes.Rede>((o, l) => redes.list({ incluir_inativos: true, offset: o, limit: l })),
+      coletarTodasPaginas<TiposNegocio.Tipo>((o, l) =>
+        tiposNegocio.list({ incluir_inativos: true, offset: o, limit: l }),
+      ),
+    ])
+      .then(([redesAll, tiposAll]) => {
+        if (cancelled) return
+        setRedesList(redesAll)
+        setTiposList(tiposAll)
+        if (!isEdit && redeId === '') {
+          const sorted = [...redesAll].sort(
+            (a, b) => (Date.parse(b.created_at ?? '') || 0) - (Date.parse(a.created_at ?? '') || 0),
+          )
+          setRedeId(sorted[0]?.id ?? '')
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setMetaLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [isEdit, redeId])
+
+  useEffect(() => {
+    if (!isEdit) {
+      setLoading(false)
+      return
+    }
+    if (!id || Number.isNaN(empresaId)) {
+      setInexistente({ detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setInexistente(null)
+    apiEmpresas
+      .get(empresaId)
+      .then((emp) => {
+        if (cancelled) return
+        aplicarEmpresaNoFormulario(emp, {
+          setRedeId,
+          setTipoNegocioId,
+          setCnpjCpf,
+          setRazaoSocial,
+          setNomeFantasia,
+          setInscricaoEstadual,
+          setEndereco,
+          setNumero,
+          setComplemento,
+          setBairro,
+          setCidade,
+          setEstado,
+          setCep,
+          setEmail,
+          setTelefone,
+          setRespLegalNome,
+          setRespLegalCpf,
+          setRespLegalRg,
+          setRespLegalOrgaoEmissor,
+          setRespLegalNacionalidade,
+          setRespLegalEstadoCivil,
+          setRespLegalCargo,
+          setRespLegalEmail,
+          setRespLegalTelefone,
+          setRespLegalEndereco,
+          setRespLegalNumero,
+          setRespLegalComplemento,
+          setRespLegalBairro,
+          setRespLegalCidade,
+          setRespLegalEstado,
+          setRespLegalCep,
+          setAtivo,
+        })
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setInexistente({})
+          return
+        }
+        const m = interpretarFalhaCarregamento(err, 'Empresa não encontrada.')
+        toast.showWarning([m.titulo, m.detalhe].filter(Boolean).join(' '))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, isEdit, empresaId, toast])
+
+  function handleCnpjCpfChange(value: string) {
+    setCnpjCpf(maskCnpjCpf(value))
+  }
+
+  async function handleConsultarCnpj() {
+    const d = digitsOnly(cnpjCpf)
+    if (!isCnpj(cnpjCpf)) {
+      toast.showWarning('Informe um CNPJ com 14 dígitos para consultar. CPF não possui consulta automática.')
+      return
+    }
+    setLoadingCnpj(true)
+    try {
+      const data = await apiEmpresas.consultarCnpj(d)
+      setRazaoSocial(data.razao_social ?? '')
+      setNomeFantasia(data.nome_fantasia ?? '')
+      setEndereco(data.endereco ?? '')
+      setNumero(data.numero ?? '')
+      setComplemento(data.complemento ?? '')
+      setBairro(data.bairro ?? '')
+      setCidade(data.cidade ?? '')
+      setEstado(data.estado ?? '')
+      setCep(data.cep ? maskCep(data.cep.replace(/\D/g, '')) : '')
+      setEmail(data.email ?? '')
+      setTelefone(data.telefone ? maskTelefoneBr(data.telefone) : '')
+      toast.showSuccess('Dados preenchidos com sucesso.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Erro ao consultar CNPJ.'))
+    } finally {
+      setLoadingCnpj(false)
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!redeId) {
+      toast.showWarning('Selecione a rede.')
+      return
+    }
+    const nomeGravado = nomeParaApiEmpresa(nomeFantasia, razaoSocial)
+    if (!nomeGravado) {
+      toast.showWarning('Informe o nome fantasia ou a razão social.')
+      return
+    }
+    setSaving(true)
+    try {
+      const payload = {
+        rede_id: Number(redeId),
+        tipo_negocio_id: tipoNegocioId === '' ? null : Number(tipoNegocioId),
+        nome: nomeGravado,
+        cnpj_cpf: cnpjCpf.replace(/\D/g, '') || null,
+        razao_social: razaoSocial.trim() || null,
+        nome_fantasia: nomeFantasia.trim() || null,
+        inscricao_estadual: inscricaoEstadual.trim() || null,
+        endereco: endereco.trim() || null,
+        numero: numero.trim() || null,
+        complemento: complemento.trim() || null,
+        bairro: bairro.trim() || null,
+        cidade: cidade.trim() || null,
+        estado: estado.trim() || null,
+        cep: cep.replace(/\D/g, '') || null,
+        email: email.trim() || null,
+        telefone: digitsOnly(telefone) || null,
+        resp_legal_nome: respLegalNome.trim() || null,
+        resp_legal_cpf: digitsOnly(respLegalCpf) || null,
+        resp_legal_rg: respLegalRg.trim() || null,
+        resp_legal_orgao_emissor: respLegalOrgaoEmissor.trim() || null,
+        resp_legal_nacionalidade: respLegalNacionalidade.trim() || null,
+        resp_legal_estado_civil: respLegalEstadoCivil.trim() || null,
+        resp_legal_cargo: respLegalCargo.trim() || null,
+        resp_legal_email: respLegalEmail.trim() || null,
+        resp_legal_telefone: digitsOnly(respLegalTelefone) || null,
+        resp_legal_endereco: respLegalEndereco.trim() || null,
+        resp_legal_numero: respLegalNumero.trim() || null,
+        resp_legal_complemento: respLegalComplemento.trim() || null,
+        resp_legal_bairro: respLegalBairro.trim() || null,
+        resp_legal_cidade: respLegalCidade.trim() || null,
+        resp_legal_estado: respLegalEstado.trim() || null,
+        resp_legal_cep: respLegalCep.replace(/\D/g, '') || null,
+        ativo,
+      }
+      if (isEdit && !Number.isNaN(empresaId)) {
+        await apiEmpresas.update(empresaId, payload)
+        toast.showSuccess('Empresa atualizada.')
+        navigate(`/empresas/${empresaId}`, { replace: true })
+      } else {
+        const criada = await apiEmpresas.create(payload)
+        toast.showSuccess('Empresa cadastrada.')
+        navigate(`/empresas/${criada.id}`, { replace: true })
+      }
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a empresa.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const opcoesEstadoCivil = useMemo(() => {
+    const base = ESTADOS_CIVIS_BR.map((c) => ({ value: c, label: c }))
+    const cur = respLegalEstadoCivil.trim()
+    if (cur && !ESTADOS_CIVIS_BR.includes(cur as EstadoCivilBr)) {
+      return [{ value: cur, label: `${cur} (cadastro atual)` }, ...base]
+    }
+    return base
+  }, [respLegalEstadoCivil])
+
+  if (loading || metaLoading) {
+    return (
+      <CadastroFormPageShell onVoltar={voltarAnterior} wide>
+        <div className="h-96 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </CadastroFormPageShell>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para editar empresas."
+        voltarPara="/empresas"
+        voltarLabel="Voltar para Empresas"
+      />
+    )
+  }
+
+  if (inexistente) {
+    return (
+      <CarregamentoFalhou
+        className="mx-auto max-w-6xl space-y-4 pb-10"
+        titulo="Empresa não encontrada."
+        detalhe={inexistente.detalhe}
+        onVoltar={voltarAnterior}
+      />
+    )
+  }
+
+  return (
+    <CadastroFormPageShell onVoltar={voltarAnterior} wide>
+      <Card title={isEdit ? 'Editar empresa' : 'Nova empresa'}>
+        <form onSubmit={handleSubmit} className="space-y-5 sm:space-y-6">
+                <FormSection title="Classificação">
+                  <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:gap-5">
+                    <SelectComPesquisa
+                      id="empresa-rede"
+                      label="Rede"
+                      value={redeId}
+                      onChange={(id) => setRedeId(id)}
+                      required
+                      items={redesList.map((r) => ({
+                        id: r.id,
+                        label: r.nome,
+                        createdAt: r.created_at,
+                      }))}
+                    />
+                    <Select
+                      label="Tipo de negócio"
+                      value={tipoNegocioId}
+                      onChange={(v) => setTipoNegocioId(v === '' ? '' : Number(v))}
+                      options={tiposList.map((t) => ({ value: t.id, label: t.nome }))}
+                      includeEmpty
+                      emptyLabel="Selecione"
+                      placeholder="Selecione"
+                    />
+                  </div>
+                </FormSection>
+
+              <FormSection title="Documento e nomes" description={EMPRESA_SECAO_DOCUMENTO_NOMES}>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:items-end lg:gap-5">
+                  <Input
+                    id="empresa-cnpj"
+                    label="CNPJ / CPF"
+                    inputMode="numeric"
+                    placeholder="00.000.000/0001-00 ou CPF"
+                    value={cnpjCpf}
+                    onChange={(e) => handleCnpjCpfChange(e.target.value)}
+                    endAdornment={
+                      <button
+                        type="button"
+                        onClick={handleConsultarCnpj}
+                        disabled={loadingCnpj}
+                        className="inline-flex size-8 shrink-0 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 disabled:pointer-events-none disabled:opacity-45 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+                        aria-label="Consultar CNPJ na Receita"
+                      >
+                        {loadingCnpj ? (
+                          <span
+                            className="size-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+                            aria-hidden
+                          />
+                        ) : (
+                          <svg className="size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                          </svg>
+                        )}
+                      </button>
+                    }
+                  />
+                  <Input
+                    label="Inscrição estadual"
+                    value={inscricaoEstadual}
+                    onChange={(e) => setInscricaoEstadual(maskInscricaoEstadual(e.target.value))}
+                  />
+                </div>
+                <Input label="Razão social" value={razaoSocial} onChange={(e) => setRazaoSocial(e.target.value)} />
+                <Input label="Nome fantasia" value={nomeFantasia} onChange={(e) => setNomeFantasia(e.target.value)} />
+              </FormSection>
+
+              <FormSection title="Endereço">
+                <Input label="Logradouro" value={endereco} onChange={(e) => setEndereco(e.target.value)} />
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                  <Input label="Número" value={numero} onChange={(e) => setNumero(e.target.value)} />
+                  <Input label="Complemento" value={complemento} onChange={(e) => setComplemento(e.target.value)} />
+                  <Input label="Bairro" value={bairro} onChange={(e) => setBairro(e.target.value)} />
+                </div>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                  <div className="xl:col-span-1">
+                    <SelectUf
+                      id="empresa-uf"
+                      value={estado}
+                      onChange={(uf) => {
+                        setEstado(uf)
+                        setCidade('')
+                      }}
+                    />
+                  </div>
+                  <div className="sm:col-span-2 xl:col-span-1">
+                    <SelectCidadeUf id="empresa-cidade" uf={estado} value={cidade} onChange={setCidade} />
+                  </div>
+                  <InputCepComBusca
+                    id="empresa-cep"
+                    value={cep}
+                    onChange={setCep}
+                    onEnderecoCompleto={(d) => {
+                      setEndereco(d.logradouro)
+                      setBairro(d.bairro)
+                      setCidade(d.localidade)
+                      setEstado(d.uf)
+                      if (d.complemento) setComplemento(d.complemento)
+                    }}
+                  />
+                </div>
+              </FormSection>
+
+              <FormSection title="Contato">
+                <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:gap-5">
+                  <Input label="E-mail" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+                  <Input
+                    label="Telefone"
+                    inputMode="tel"
+                    placeholder="(00) 00000-0000"
+                    value={telefone}
+                    onChange={(e) => setTelefone(maskTelefoneBr(e.target.value))}
+                  />
+                </div>
+              </FormSection>
+
+              <FormSection title="Responsável legal" description={EMPRESA_SECAO_RESPONSAVEL_LEGAL}>
+                <Input label="Nome completo" value={respLegalNome} onChange={(e) => setRespLegalNome(e.target.value)} />
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:gap-5">
+                  <Input
+                    label="CPF"
+                    inputMode="numeric"
+                    placeholder="000.000.000-00"
+                    value={respLegalCpf}
+                    onChange={(e) => setRespLegalCpf(maskCnpjCpf(e.target.value))}
+                  />
+                  <Input label="RG" value={respLegalRg} onChange={(e) => setRespLegalRg(e.target.value)} />
+                </div>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:gap-5">
+                  <Input
+                    label="Órgão emissor"
+                    placeholder="Ex.: SSP/SP"
+                    value={respLegalOrgaoEmissor}
+                    onChange={(e) => setRespLegalOrgaoEmissor(e.target.value)}
+                  />
+                  <Input
+                    label="Nacionalidade"
+                    placeholder="Ex.: Brasileira"
+                    value={respLegalNacionalidade}
+                    onChange={(e) => setRespLegalNacionalidade(e.target.value)}
+                  />
+                </div>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:gap-5">
+                  <Select
+                    id="empresa-resp-estado-civil"
+                    label="Estado civil"
+                    value={respLegalEstadoCivil}
+                    onChange={(v) => setRespLegalEstadoCivil(v === '' ? '' : String(v))}
+                    options={opcoesEstadoCivil}
+                    includeEmpty
+                    emptyLabel="Selecione"
+                    placeholder="Selecione"
+                  />
+                  <Input
+                    label="Cargo na empresa"
+                    placeholder="Ex.: Sócio administrador"
+                    value={respLegalCargo}
+                    onChange={(e) => setRespLegalCargo(e.target.value)}
+                  />
+                </div>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:gap-5">
+                  <Input label="E-mail" type="email" value={respLegalEmail} onChange={(e) => setRespLegalEmail(e.target.value)} />
+                  <Input
+                    label="Telefone"
+                    inputMode="tel"
+                    placeholder="(00) 00000-0000"
+                    value={respLegalTelefone}
+                    onChange={(e) => setRespLegalTelefone(maskTelefoneBr(e.target.value))}
+                  />
+                </div>
+                <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                  Endereço residencial
+                </p>
+                <Input label="Logradouro" value={respLegalEndereco} onChange={(e) => setRespLegalEndereco(e.target.value)} />
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                  <Input label="Número" value={respLegalNumero} onChange={(e) => setRespLegalNumero(e.target.value)} />
+                  <Input label="Complemento" value={respLegalComplemento} onChange={(e) => setRespLegalComplemento(e.target.value)} />
+                  <Input label="Bairro" value={respLegalBairro} onChange={(e) => setRespLegalBairro(e.target.value)} />
+                </div>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                  <div className="xl:col-span-1">
+                    <SelectUf
+                      id="empresa-resp-uf"
+                      value={respLegalEstado}
+                      onChange={(uf) => {
+                        setRespLegalEstado(uf)
+                        setRespLegalCidade('')
+                      }}
+                    />
+                  </div>
+                  <div className="sm:col-span-2 xl:col-span-1">
+                    <SelectCidadeUf
+                      id="empresa-resp-cidade"
+                      uf={respLegalEstado}
+                      value={respLegalCidade}
+                      onChange={setRespLegalCidade}
+                    />
+                  </div>
+                  <InputCepComBusca
+                    id="empresa-resp-cep"
+                    value={respLegalCep}
+                    onChange={setRespLegalCep}
+                    onEnderecoCompleto={(d) => {
+                      setRespLegalEndereco(d.logradouro)
+                      setRespLegalBairro(d.bairro)
+                      setRespLegalCidade(d.localidade)
+                      setRespLegalEstado(d.uf)
+                      if (d.complemento) setRespLegalComplemento(d.complemento)
+                    }}
+                  />
+                </div>
+              </FormSection>
+
+              <FormSection title="Situação no sistema">
+                <Switch
+                  bare
+                  showStatusPill
+                  checked={ativo}
+                  onCheckedChange={setAtivo}
+                  label="Empresa ativa"
+                  description={EMPRESA_HINT_ATIVA}
+                />
+              </FormSection>
+
+          <InlineCadastroFooter onCancel={voltarAnterior} saving={saving} />
+        </form>
+      </Card>
+    </CadastroFormPageShell>
+  )
+}

--- a/frontend/src/pages/Empresas.tsx
+++ b/frontend/src/pages/Empresas.tsx
@@ -1,41 +1,16 @@
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
-import { useNavigate, useLocation } from 'react-router-dom'
-import {
-  ApiError,
-  empresas as apiEmpresas,
-  redes,
-  tiposNegocio,
-  type Empresas,
-  type Redes,
-  type TiposNegocio,
-} from '../api/client'
+import { useNavigate } from 'react-router-dom'
+import { ApiError, empresas as apiEmpresas, redes, type Empresas, type Redes } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
-import { Input } from '../components/ui/Input'
-import { FormSection } from '../components/ui/FormSection'
-import {
-  EMPRESA_HINT_ATIVA,
-  EMPRESA_SECAO_DOCUMENTO_NOMES,
-  EMPRESA_SECAO_RESPONSAVEL_LEGAL,
-  nomeParaApiEmpresa,
-} from '../components/empresa/empresaFormCopy'
-import { IconPencil } from '../components/ui/IconPencil'
-import { IconTrash } from '../components/ui/IconTrash'
+import { ListaAcoesVerEditar } from '../components/ui/ListaAcoesVerEditar'
 import { useToast } from '../components/ui/Toast'
 import { FiltroInativos } from '../components/ui/FiltroInativos'
-import { SelectComPesquisa } from '../components/ui/SelectComPesquisa'
-import { Select } from '../components/ui/Select'
-import { SelectUf } from '../components/ui/SelectUf'
-import { SelectCidadeUf } from '../components/ui/SelectCidadeUf'
-import { InputCepComBusca } from '../components/ui/InputCepComBusca'
-import { maskCnpjCpf, isCnpj } from '../utils/maskCnpjCpf'
-import { digitsOnly, maskCep, maskTelefoneBr, maskInscricaoEstadual } from '../utils/masks'
-import { ESTADOS_CIVIS_BR, type EstadoCivilBr } from '../constants/estadosCivis'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
-import { Switch } from '../components/ui/Switch'
+import { maskCnpjCpf } from '../utils/maskCnpjCpf'
 import { SemPermissao } from './SemPermissao'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 
@@ -44,7 +19,6 @@ type ColunaEmpresa = 'nome' | 'cnpj_cpf' | 'rede'
 export function Empresas() {
   const navigate = useNavigate()
   const { ordenarPor, ordem, aoOrdenarColuna, sortParams } = useOrdenacaoLista<ColunaEmpresa>()
-  const location = useLocation()
   const toast = useToast()
   const [list, setList] = useState<Empresas.Empresa[]>([])
   const [total, setTotal] = useState(0)
@@ -52,55 +26,9 @@ export function Empresas() {
   const [busca, setBusca] = useState('')
   const [debouncedBusca, setDebouncedBusca] = useState('')
   const [redesList, setRedesList] = useState<Redes.Rede[]>([])
-  const [tiposList, setTiposList] = useState<TiposNegocio.Tipo[]>([])
   const [loading, setLoading] = useState(true)
   const [incluirInativos, setIncluirInativos] = useState(false)
-  const [modalOpen, setModalOpen] = useState(false)
-  const [editingId, setEditingId] = useState<number | null>(null)
-  const [redeId, setRedeId] = useState<number | ''>('')
-  const [tipoNegocioId, setTipoNegocioId] = useState<number | ''>('')
-  const [cnpjCpf, setCnpjCpf] = useState('')
-  const [razaoSocial, setRazaoSocial] = useState('')
-  const [nomeFantasia, setNomeFantasia] = useState('')
-  const [inscricaoEstadual, setInscricaoEstadual] = useState('')
-  const [endereco, setEndereco] = useState('')
-  const [numero, setNumero] = useState('')
-  const [complemento, setComplemento] = useState('')
-  const [bairro, setBairro] = useState('')
-  const [cidade, setCidade] = useState('')
-  const [estado, setEstado] = useState('')
-  const [cep, setCep] = useState('')
-  const [email, setEmail] = useState('')
-  const [telefone, setTelefone] = useState('')
-  const [respLegalNome, setRespLegalNome] = useState('')
-  const [respLegalCpf, setRespLegalCpf] = useState('')
-  const [respLegalRg, setRespLegalRg] = useState('')
-  const [respLegalOrgaoEmissor, setRespLegalOrgaoEmissor] = useState('')
-  const [respLegalNacionalidade, setRespLegalNacionalidade] = useState('')
-  const [respLegalEstadoCivil, setRespLegalEstadoCivil] = useState('')
-  const [respLegalCargo, setRespLegalCargo] = useState('')
-  const [respLegalEmail, setRespLegalEmail] = useState('')
-  const [respLegalTelefone, setRespLegalTelefone] = useState('')
-  const [respLegalEndereco, setRespLegalEndereco] = useState('')
-  const [respLegalNumero, setRespLegalNumero] = useState('')
-  const [respLegalComplemento, setRespLegalComplemento] = useState('')
-  const [respLegalBairro, setRespLegalBairro] = useState('')
-  const [respLegalCidade, setRespLegalCidade] = useState('')
-  const [respLegalEstado, setRespLegalEstado] = useState('')
-  const [respLegalCep, setRespLegalCep] = useState('')
-  const [ativo, setAtivo] = useState(true)
-  const [saving, setSaving] = useState(false)
-  const [loadingCnpj, setLoadingCnpj] = useState(false)
   const [forbidden, setForbidden] = useState(false)
-
-  useEffect(() => {
-    if (!modalOpen) return
-    const prevOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    return () => {
-      document.body.style.overflow = prevOverflow
-    }
-  }, [modalOpen])
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -148,217 +76,7 @@ export function Empresas() {
     coletarTodasPaginas<Redes.Rede>((o, l) => redes.list({ incluir_inativos: true, offset: o, limit: l })).then(
       setRedesList,
     )
-    coletarTodasPaginas<TiposNegocio.Tipo>((o, l) =>
-      tiposNegocio.list({ incluir_inativos: true, offset: o, limit: l }),
-    ).then(setTiposList)
   }, [])
-
-  function openCreate() {
-    setEditingId(null)
-    const sorted = [...redesList].sort(
-      (a, b) => (Date.parse(b.created_at ?? '') || 0) - (Date.parse(a.created_at ?? '') || 0),
-    )
-    setRedeId(sorted[0]?.id ?? '')
-    setTipoNegocioId('')
-    setCnpjCpf('')
-    setRazaoSocial('')
-    setNomeFantasia('')
-    setInscricaoEstadual('')
-    setEndereco('')
-    setNumero('')
-    setComplemento('')
-    setBairro('')
-    setCidade('')
-    setEstado('')
-    setCep('')
-    setEmail('')
-    setTelefone('')
-    setRespLegalNome('')
-    setRespLegalCpf('')
-    setRespLegalRg('')
-    setRespLegalOrgaoEmissor('')
-    setRespLegalNacionalidade('')
-    setRespLegalEstadoCivil('')
-    setRespLegalCargo('')
-    setRespLegalEmail('')
-    setRespLegalTelefone('')
-    setRespLegalEndereco('')
-    setRespLegalNumero('')
-    setRespLegalComplemento('')
-    setRespLegalBairro('')
-    setRespLegalCidade('')
-    setRespLegalEstado('')
-    setRespLegalCep('')
-    setAtivo(true)
-    setModalOpen(true)
-  }
-
-  function openEdit(e: Empresas.Empresa) {
-    setEditingId(e.id)
-    setRedeId(e.rede_id)
-    setTipoNegocioId(e.tipo_negocio_id ?? '')
-    setCnpjCpf(e.cnpj_cpf ? maskCnpjCpf(e.cnpj_cpf) : '')
-    setRazaoSocial(e.razao_social ?? '')
-    setNomeFantasia(e.nome_fantasia ?? '')
-    setInscricaoEstadual(e.inscricao_estadual ?? '')
-    setEndereco(e.endereco ?? '')
-    setNumero(e.numero ?? '')
-    setComplemento(e.complemento ?? '')
-    setBairro(e.bairro ?? '')
-    setCidade(e.cidade ?? '')
-    setEstado((e.estado ?? '').toUpperCase().slice(0, 2))
-    setCep(e.cep ? maskCep(e.cep.replace(/\D/g, '')) : '')
-    setEmail(e.email ?? '')
-    setTelefone(e.telefone ? maskTelefoneBr(e.telefone) : '')
-    setRespLegalNome(e.resp_legal_nome ?? '')
-    setRespLegalCpf(e.resp_legal_cpf ? maskCnpjCpf(e.resp_legal_cpf) : '')
-    setRespLegalRg(e.resp_legal_rg ?? '')
-    setRespLegalOrgaoEmissor(e.resp_legal_orgao_emissor ?? '')
-    setRespLegalNacionalidade(e.resp_legal_nacionalidade ?? '')
-    setRespLegalEstadoCivil(e.resp_legal_estado_civil ?? '')
-    setRespLegalCargo(e.resp_legal_cargo ?? '')
-    setRespLegalEmail(e.resp_legal_email ?? '')
-    setRespLegalTelefone(e.resp_legal_telefone ? maskTelefoneBr(e.resp_legal_telefone) : '')
-    setRespLegalEndereco(e.resp_legal_endereco ?? '')
-    setRespLegalNumero(e.resp_legal_numero ?? '')
-    setRespLegalComplemento(e.resp_legal_complemento ?? '')
-    setRespLegalBairro(e.resp_legal_bairro ?? '')
-    setRespLegalCidade(e.resp_legal_cidade ?? '')
-    setRespLegalEstado((e.resp_legal_estado ?? '').toUpperCase().slice(0, 2))
-    setRespLegalCep(e.resp_legal_cep ? maskCep(e.resp_legal_cep.replace(/\D/g, '')) : '')
-    setAtivo(e.ativo)
-    setModalOpen(true)
-  }
-
-  useEffect(() => {
-    const editId = (location.state as { empresaEditId?: number } | null)?.empresaEditId
-    if (editId == null) return
-    navigate('/empresas', { replace: true, state: {} })
-    apiEmpresas
-      .get(editId)
-      .then((emp) => openEdit(emp))
-      .catch((err) => {
-        if (err instanceof ApiError && err.status === 403) {
-          setForbidden(true)
-          return
-        }
-        if (err instanceof ApiError && err.status === 404) {
-          toast.showWarning('Empresa não encontrada.')
-          return
-        }
-        toast.showWarning(mensagemFalhaParaToast(err, 'Empresa não encontrada.'))
-      })
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- abre edição ao retornar da tela de detalhe com state
-  }, [location.state])
-
-  function handleCnpjCpfChange(value: string) {
-    setCnpjCpf(maskCnpjCpf(value))
-  }
-
-  async function handleConsultarCnpj() {
-    const d = digitsOnly(cnpjCpf)
-    if (!isCnpj(cnpjCpf)) {
-      toast.showWarning('Informe um CNPJ com 14 dígitos para consultar. CPF não possui consulta automática.')
-      return
-    }
-    setLoadingCnpj(true)
-    try {
-      const data = await apiEmpresas.consultarCnpj(d)
-      setRazaoSocial(data.razao_social ?? '')
-      setNomeFantasia(data.nome_fantasia ?? '')
-      setEndereco(data.endereco ?? '')
-      setNumero(data.numero ?? '')
-      setComplemento(data.complemento ?? '')
-      setBairro(data.bairro ?? '')
-      setCidade(data.cidade ?? '')
-      setEstado(data.estado ?? '')
-      setCep(data.cep ? maskCep(data.cep.replace(/\D/g, '')) : '')
-      setEmail(data.email ?? '')
-      setTelefone(data.telefone ? maskTelefoneBr(data.telefone) : '')
-      toast.showSuccess('Dados preenchidos com sucesso.')
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Erro ao consultar CNPJ.'))
-    } finally {
-      setLoadingCnpj(false)
-    }
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    if (!redeId) {
-      toast.showWarning('Selecione a rede.')
-      return
-    }
-    const nomeGravado = nomeParaApiEmpresa(nomeFantasia, razaoSocial)
-    if (!nomeGravado) {
-      toast.showWarning('Informe o nome fantasia ou a razão social.')
-      return
-    }
-    setSaving(true)
-    try {
-      const payload = {
-        rede_id: Number(redeId),
-        tipo_negocio_id: tipoNegocioId === '' ? null : Number(tipoNegocioId),
-        nome: nomeGravado,
-        cnpj_cpf: cnpjCpf.replace(/\D/g, '') || null,
-        razao_social: razaoSocial.trim() || null,
-        nome_fantasia: nomeFantasia.trim() || null,
-        inscricao_estadual: inscricaoEstadual.trim() || null,
-        endereco: endereco.trim() || null,
-        numero: numero.trim() || null,
-        complemento: complemento.trim() || null,
-        bairro: bairro.trim() || null,
-        cidade: cidade.trim() || null,
-        estado: estado.trim() || null,
-        cep: cep.replace(/\D/g, '') || null,
-        email: email.trim() || null,
-        telefone: digitsOnly(telefone) || null,
-        resp_legal_nome: respLegalNome.trim() || null,
-        resp_legal_cpf: digitsOnly(respLegalCpf) || null,
-        resp_legal_rg: respLegalRg.trim() || null,
-        resp_legal_orgao_emissor: respLegalOrgaoEmissor.trim() || null,
-        resp_legal_nacionalidade: respLegalNacionalidade.trim() || null,
-        resp_legal_estado_civil: respLegalEstadoCivil.trim() || null,
-        resp_legal_cargo: respLegalCargo.trim() || null,
-        resp_legal_email: respLegalEmail.trim() || null,
-        resp_legal_telefone: digitsOnly(respLegalTelefone) || null,
-        resp_legal_endereco: respLegalEndereco.trim() || null,
-        resp_legal_numero: respLegalNumero.trim() || null,
-        resp_legal_complemento: respLegalComplemento.trim() || null,
-        resp_legal_bairro: respLegalBairro.trim() || null,
-        resp_legal_cidade: respLegalCidade.trim() || null,
-        resp_legal_estado: respLegalEstado.trim() || null,
-        resp_legal_cep: respLegalCep.replace(/\D/g, '') || null,
-        ativo,
-      }
-      if (editingId) {
-        await apiEmpresas.update(editingId, payload)
-        toast.showSuccess('Empresa atualizada.')
-        setModalOpen(false)
-        load()
-        navigate(`/empresas/${editingId}`, { replace: true })
-      } else {
-        const criada = await apiEmpresas.create(payload)
-        toast.showSuccess('Empresa cadastrada.')
-        setModalOpen(false)
-        load()
-        navigate(`/empresas/${criada.id}`, { replace: true })
-      }
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a empresa.'))
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  const opcoesEstadoCivil = useMemo(() => {
-    const base = ESTADOS_CIVIS_BR.map((c) => ({ value: c, label: c }))
-    const cur = respLegalEstadoCivil.trim()
-    if (cur && !ESTADOS_CIVIS_BR.includes(cur as EstadoCivilBr)) {
-      return [{ value: cur, label: `${cur} (cadastro atual)` }, ...base]
-    }
-    return base
-  }, [respLegalEstadoCivil])
 
   async function handleDelete(id: number) {
     if (!confirm('Excluir esta empresa?')) return
@@ -385,277 +103,22 @@ export function Empresas() {
 
   return (
     <div className="mx-auto max-w-6xl space-y-6 pb-10">
-      {!modalOpen && (
-        <div className="flex justify-between">
-          <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Empresas</h1>
-          <Button onClick={openCreate} disabled={modalOpen}>Nova empresa</Button>
-        </div>
-      )}
+      <div className="flex justify-between">
+        <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Empresas</h1>
+        <Button onClick={() => navigate('/empresas/novo')}>Nova empresa</Button>
+      </div>
 
-      {modalOpen && (
-        <div className="fixed inset-y-0 left-0 right-0 z-20 flex items-start justify-center bg-black/85 px-4 pb-6 pt-16 sm:px-6 md:left-[var(--sidebar-w)]">
-          <Card
-            title={editingId ? 'Editar empresa' : 'Nova empresa'}
-            className="max-h-[min(92vh,56rem)] w-full max-w-6xl overflow-y-auto rounded-2xl bg-white dark:bg-slate-900"
-          >
-            <form onSubmit={handleSubmit} className="space-y-5 sm:space-y-6">
-              <div className="space-y-5 pb-24 sm:space-y-6">
-                <FormSection title="Classificação">
-                  <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:gap-5">
-                    <SelectComPesquisa
-                      id="empresa-rede"
-                      label="Rede"
-                      value={redeId}
-                      onChange={(id) => setRedeId(id)}
-                      required
-                      items={redesList.map((r) => ({
-                        id: r.id,
-                        label: r.nome,
-                        createdAt: r.created_at,
-                      }))}
-                    />
-                    <Select
-                      label="Tipo de negócio"
-                      value={tipoNegocioId}
-                      onChange={(v) => setTipoNegocioId(v === '' ? '' : Number(v))}
-                      options={tiposList.map((t) => ({ value: t.id, label: t.nome }))}
-                      includeEmpty
-                      emptyLabel="Selecione"
-                      placeholder="Selecione"
-                    />
-                  </div>
-                </FormSection>
-
-              <FormSection title="Documento e nomes" description={EMPRESA_SECAO_DOCUMENTO_NOMES}>
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:items-end lg:gap-5">
-                  <Input
-                    id="empresa-cnpj"
-                    label="CNPJ / CPF"
-                    inputMode="numeric"
-                    placeholder="00.000.000/0001-00 ou CPF"
-                    value={cnpjCpf}
-                    onChange={(e) => handleCnpjCpfChange(e.target.value)}
-                    endAdornment={
-                      <button
-                        type="button"
-                        onClick={handleConsultarCnpj}
-                        disabled={loadingCnpj}
-                        className="inline-flex size-8 shrink-0 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 disabled:pointer-events-none disabled:opacity-45 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100"
-                        aria-label="Consultar CNPJ na Receita"
-                      >
-                        {loadingCnpj ? (
-                          <span
-                            className="size-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-                            aria-hidden
-                          />
-                        ) : (
-                          <svg className="size-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                          </svg>
-                        )}
-                      </button>
-                    }
-                  />
-                  <Input
-                    label="Inscrição estadual"
-                    value={inscricaoEstadual}
-                    onChange={(e) => setInscricaoEstadual(maskInscricaoEstadual(e.target.value))}
-                  />
-                </div>
-                <Input label="Razão social" value={razaoSocial} onChange={(e) => setRazaoSocial(e.target.value)} />
-                <Input label="Nome fantasia" value={nomeFantasia} onChange={(e) => setNomeFantasia(e.target.value)} />
-              </FormSection>
-
-              <FormSection title="Endereço">
-                <Input label="Logradouro" value={endereco} onChange={(e) => setEndereco(e.target.value)} />
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                  <Input label="Número" value={numero} onChange={(e) => setNumero(e.target.value)} />
-                  <Input label="Complemento" value={complemento} onChange={(e) => setComplemento(e.target.value)} />
-                  <Input label="Bairro" value={bairro} onChange={(e) => setBairro(e.target.value)} />
-                </div>
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                  <div className="xl:col-span-1">
-                    <SelectUf
-                      id="empresa-uf"
-                      value={estado}
-                      onChange={(uf) => {
-                        setEstado(uf)
-                        setCidade('')
-                      }}
-                    />
-                  </div>
-                  <div className="sm:col-span-2 xl:col-span-1">
-                    <SelectCidadeUf id="empresa-cidade" uf={estado} value={cidade} onChange={setCidade} />
-                  </div>
-                  <InputCepComBusca
-                    id="empresa-cep"
-                    value={cep}
-                    onChange={setCep}
-                    onEnderecoCompleto={(d) => {
-                      setEndereco(d.logradouro)
-                      setBairro(d.bairro)
-                      setCidade(d.localidade)
-                      setEstado(d.uf)
-                      if (d.complemento) setComplemento(d.complemento)
-                    }}
-                  />
-                </div>
-              </FormSection>
-
-              <FormSection title="Contato">
-                <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:gap-5">
-                  <Input label="E-mail" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
-                  <Input
-                    label="Telefone"
-                    inputMode="tel"
-                    placeholder="(00) 00000-0000"
-                    value={telefone}
-                    onChange={(e) => setTelefone(maskTelefoneBr(e.target.value))}
-                  />
-                </div>
-              </FormSection>
-
-              <FormSection title="Responsável legal" description={EMPRESA_SECAO_RESPONSAVEL_LEGAL}>
-                <Input label="Nome completo" value={respLegalNome} onChange={(e) => setRespLegalNome(e.target.value)} />
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:gap-5">
-                  <Input
-                    label="CPF"
-                    inputMode="numeric"
-                    placeholder="000.000.000-00"
-                    value={respLegalCpf}
-                    onChange={(e) => setRespLegalCpf(maskCnpjCpf(e.target.value))}
-                  />
-                  <Input label="RG" value={respLegalRg} onChange={(e) => setRespLegalRg(e.target.value)} />
-                </div>
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:gap-5">
-                  <Input
-                    label="Órgão emissor"
-                    placeholder="Ex.: SSP/SP"
-                    value={respLegalOrgaoEmissor}
-                    onChange={(e) => setRespLegalOrgaoEmissor(e.target.value)}
-                  />
-                  <Input
-                    label="Nacionalidade"
-                    placeholder="Ex.: Brasileira"
-                    value={respLegalNacionalidade}
-                    onChange={(e) => setRespLegalNacionalidade(e.target.value)}
-                  />
-                </div>
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:gap-5">
-                  <Select
-                    id="empresa-resp-estado-civil"
-                    label="Estado civil"
-                    value={respLegalEstadoCivil}
-                    onChange={(v) => setRespLegalEstadoCivil(v === '' ? '' : String(v))}
-                    options={opcoesEstadoCivil}
-                    includeEmpty
-                    emptyLabel="Selecione"
-                    placeholder="Selecione"
-                  />
-                  <Input
-                    label="Cargo na empresa"
-                    placeholder="Ex.: Sócio administrador"
-                    value={respLegalCargo}
-                    onChange={(e) => setRespLegalCargo(e.target.value)}
-                  />
-                </div>
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:gap-5">
-                  <Input label="E-mail" type="email" value={respLegalEmail} onChange={(e) => setRespLegalEmail(e.target.value)} />
-                  <Input
-                    label="Telefone"
-                    inputMode="tel"
-                    placeholder="(00) 00000-0000"
-                    value={respLegalTelefone}
-                    onChange={(e) => setRespLegalTelefone(maskTelefoneBr(e.target.value))}
-                  />
-                </div>
-                <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
-                  Endereço residencial
-                </p>
-                <Input label="Logradouro" value={respLegalEndereco} onChange={(e) => setRespLegalEndereco(e.target.value)} />
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                  <Input label="Número" value={respLegalNumero} onChange={(e) => setRespLegalNumero(e.target.value)} />
-                  <Input label="Complemento" value={respLegalComplemento} onChange={(e) => setRespLegalComplemento(e.target.value)} />
-                  <Input label="Bairro" value={respLegalBairro} onChange={(e) => setRespLegalBairro(e.target.value)} />
-                </div>
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                  <div className="xl:col-span-1">
-                    <SelectUf
-                      id="empresa-resp-uf"
-                      value={respLegalEstado}
-                      onChange={(uf) => {
-                        setRespLegalEstado(uf)
-                        setRespLegalCidade('')
-                      }}
-                    />
-                  </div>
-                  <div className="sm:col-span-2 xl:col-span-1">
-                    <SelectCidadeUf
-                      id="empresa-resp-cidade"
-                      uf={respLegalEstado}
-                      value={respLegalCidade}
-                      onChange={setRespLegalCidade}
-                    />
-                  </div>
-                  <InputCepComBusca
-                    id="empresa-resp-cep"
-                    value={respLegalCep}
-                    onChange={setRespLegalCep}
-                    onEnderecoCompleto={(d) => {
-                      setRespLegalEndereco(d.logradouro)
-                      setRespLegalBairro(d.bairro)
-                      setRespLegalCidade(d.localidade)
-                      setRespLegalEstado(d.uf)
-                      if (d.complemento) setRespLegalComplemento(d.complemento)
-                    }}
-                  />
-                </div>
-              </FormSection>
-
-              <FormSection title="Situação no sistema">
-                <Switch
-                  bare
-                  showStatusPill
-                  checked={ativo}
-                  onCheckedChange={setAtivo}
-                  label="Empresa ativa"
-                  description={EMPRESA_HINT_ATIVA}
-                />
-              </FormSection>
-              </div>
-
-              <div className="sticky bottom-0 -mx-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-900">
-                <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    className="w-full sm:w-auto"
-                    onClick={() => setModalOpen(false)}
-                  >
-                    Cancelar
-                  </Button>
-                  <Button type="submit" loading={saving} className="w-full sm:w-auto">
-                    Salvar
-                  </Button>
-                </div>
-              </div>
-            </form>
-          </Card>
-        </div>
-      )}
-
-      {!modalOpen && (
-        <Card>
-          <BarraBuscaPaginacao
-            busca={busca}
-            onBuscaChange={setBusca}
-            placeholder="Buscar por nome, razão social, CNPJ ou e-mail"
-            page={page}
-            total={total}
-            onPageChange={setPage}
-            disabled={loading}
-            extra={<FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />}
-          />
+      <Card>
+        <BarraBuscaPaginacao
+          busca={busca}
+          onBuscaChange={setBusca}
+          placeholder="Buscar por nome, razão social, CNPJ ou e-mail"
+          page={page}
+          total={total}
+          onPageChange={setPage}
+          disabled={loading}
+          extra={<FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />}
+        />
         {loading ? (
           <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
         ) : list.length === 0 ? (
@@ -729,21 +192,13 @@ export function Empresas() {
                         {redeNome}
                       </td>
                       <td className="py-3 pr-2 text-right" onClick={(ev) => ev.stopPropagation()}>
-                        <div className="inline-flex gap-0.5">
-                          <Button
-                            variant="ghost"
-                            onClick={(ev) => {
-                              ev.stopPropagation()
-                              openEdit(e)
-                            }}
-                            aria-label="Editar empresa"
-                          >
-                            <IconPencil ariaHidden={false} />
-                          </Button>
-                          <Button variant="ghost" onClick={() => handleDelete(e.id)} aria-label="Excluir empresa">
-                            <IconTrash ariaHidden={false} />
-                          </Button>
-                        </div>
+                        <ListaAcoesVerEditar
+                          onVer={() => navigate(`/empresas/${e.id}`)}
+                          onEditar={() => navigate(`/empresas/${e.id}/editar`)}
+                          onExcluir={() => handleDelete(e.id)}
+                          verLabel="Visualizar empresa"
+                          editarLabel="Editar empresa"
+                        />
                       </td>
                     </tr>
                   )
@@ -752,8 +207,7 @@ export function Empresas() {
             </table>
           </div>
         )}
-        </Card>
-      )}
+      </Card>
     </div>
   )
 }

--- a/frontend/src/pages/RespostaProntaDetalhe.tsx
+++ b/frontend/src/pages/RespostaProntaDetalhe.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ApiError, respostasProntas } from '../api/client'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { DetailRow } from '../components/ui/DetailRow'
+import { BadgeAtivo } from '../components/ui/BadgeAtivo'
+import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { SemPermissao } from './SemPermissao'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+import { interpretarFalhaCarregamento } from '../api/errorMessage'
+
+export function RespostaProntaDetalhe() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const voltarAnterior = useVoltarAnterior('/respostas-prontas')
+  const respostaId = id ? parseInt(id, 10) : NaN
+
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [falha, setFalha] = useState<{ titulo: string; detalhe?: string } | null>(null)
+  const [item, setItem] = useState<Awaited<ReturnType<typeof respostasProntas.get>> | null>(null)
+
+  useEffect(() => {
+    if (!id || Number.isNaN(respostaId)) {
+      setFalha({ titulo: 'Resposta pronta não encontrada.', detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setFalha(null)
+    respostasProntas
+      .get(respostaId)
+      .then((r) => {
+        if (!cancelled) setItem(r)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        setFalha(interpretarFalhaCarregamento(err, 'Resposta pronta não encontrada.'))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, respostaId])
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <div className="h-56 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </div>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para acessar esta resposta pronta."
+        voltarPara="/respostas-prontas"
+        voltarLabel="Voltar para Respostas prontas"
+      />
+    )
+  }
+
+  if (falha) {
+    return <CarregamentoFalhou titulo={falha.titulo} detalhe={falha.detalhe} onVoltar={voltarAnterior} />
+  }
+
+  if (!item) return null
+
+  const escopo = item.setor_nome ?? (item.setor_id != null ? `Setor #${item.setor_id}` : 'Global (todos os setores)')
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <button
+        type="button"
+        onClick={voltarAnterior}
+        className="inline-flex items-center gap-1 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100"
+      >
+        <span aria-hidden>←</span> Voltar
+      </button>
+
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">{item.titulo}</h1>
+          <BadgeAtivo ativo={item.ativo} />
+        </div>
+        <Button onClick={() => navigate(`/respostas-prontas/${item.id}/editar`)}>Editar</Button>
+      </header>
+
+      <Card title="Conteúdo">
+        <dl>
+          <DetailRow label="ID" value={String(item.id)} mono />
+          <DetailRow label="Título" value={item.titulo} />
+          <DetailRow label="Corpo" value={item.corpo} multiline />
+        </dl>
+      </Card>
+
+      <Card title="Escopo e ordem">
+        <dl>
+          <DetailRow label="Escopo" value={escopo} />
+          <DetailRow label="Ordem" value={String(item.ordem)} mono />
+          <DetailRow label="Situação" value={item.ativo ? 'Ativa' : 'Inativa'} />
+        </dl>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/RespostaProntaForm.tsx
+++ b/frontend/src/pages/RespostaProntaForm.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ApiError, respostasProntas, setores, type Setores } from '../api/client'
+import { coletarTodasPaginas } from '../api/collectPages'
+import { Card } from '../components/ui/Card'
+import { Input } from '../components/ui/Input'
+import { Switch } from '../components/ui/Switch'
+import { useToast } from '../components/ui/Toast'
+import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { FormSection } from '../components/ui/FormSection'
+import { InlineCadastroFooter } from '../components/ui/InlineCadastroPanel'
+import { CadastroFormPageShell } from '../components/ui/CadastroFormPageShell'
+import { SemPermissao } from './SemPermissao'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
+
+export function RespostaProntaForm() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const voltarAnterior = useVoltarAnterior('/respostas-prontas')
+
+  const respostaId = id ? parseInt(id, 10) : NaN
+  const isEdit = id != null
+
+  const [loading, setLoading] = useState(isEdit)
+  const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [inexistente, setInexistente] = useState<{ detalhe?: string } | null>(null)
+  const [setoresOpts, setSetoresOpts] = useState<Setores.Setor[]>([])
+  const [titulo, setTitulo] = useState('')
+  const [corpo, setCorpo] = useState('')
+  const [setorId, setSetorId] = useState('')
+  const [ordemVal, setOrdemVal] = useState(0)
+  const [ativo, setAtivo] = useState(true)
+
+  useEffect(() => {
+    coletarTodasPaginas<Setores.Setor>((o, l) =>
+      setores.list({ incluir_inativos: true, offset: o, limit: l }),
+    )
+      .then(setSetoresOpts)
+      .catch(() => setSetoresOpts([]))
+  }, [])
+
+  useEffect(() => {
+    if (isEdit) return
+    respostasProntas.list({ limit: 1, offset: 0 }).then(({ total }) => setOrdemVal(total))
+  }, [isEdit])
+
+  useEffect(() => {
+    if (!isEdit) return
+    if (!id || Number.isNaN(respostaId)) {
+      setInexistente({ detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setInexistente(null)
+    respostasProntas
+      .get(respostaId)
+      .then((item) => {
+        if (cancelled) return
+        setTitulo(item.titulo)
+        setCorpo(item.corpo)
+        setSetorId(item.setor_id != null ? String(item.setor_id) : '')
+        setOrdemVal(item.ordem)
+        setAtivo(item.ativo)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setInexistente({})
+          return
+        }
+        const m = interpretarFalhaCarregamento(err, 'Resposta pronta não encontrada.')
+        toast.showWarning([m.titulo, m.detalhe].filter(Boolean).join(' '))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, isEdit, respostaId, toast])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!titulo.trim() || !corpo.trim()) {
+      toast.showError('Informe título e corpo.')
+      return
+    }
+    setSaving(true)
+    const payload = {
+      titulo: titulo.trim(),
+      corpo,
+      setor_id: setorId ? Number(setorId) : null,
+      ordem: ordemVal,
+      ativo,
+    }
+    try {
+      if (isEdit && !Number.isNaN(respostaId)) {
+        await respostasProntas.update(respostaId, payload)
+        toast.showSuccess('Resposta pronta atualizada.')
+        navigate(`/respostas-prontas/${respostaId}`, { replace: true })
+      } else {
+        const created = await respostasProntas.create(payload)
+        toast.showSuccess('Resposta pronta cadastrada.')
+        navigate(`/respostas-prontas/${created.id}`, { replace: true })
+      }
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <CadastroFormPageShell onVoltar={voltarAnterior}>
+        <div className="h-72 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </CadastroFormPageShell>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para gerenciar respostas prontas."
+        voltarPara="/respostas-prontas"
+        voltarLabel="Voltar para Respostas prontas"
+      />
+    )
+  }
+
+  if (inexistente) {
+    return (
+      <CarregamentoFalhou
+        className="mx-auto max-w-5xl space-y-4 pb-10"
+        titulo="Resposta pronta não encontrada."
+        detalhe={inexistente.detalhe}
+        onVoltar={voltarAnterior}
+      />
+    )
+  }
+
+  return (
+    <CadastroFormPageShell onVoltar={voltarAnterior}>
+      <Card title={isEdit ? 'Editar resposta pronta' : 'Nova resposta pronta'}>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-6">
+            <FormSection title="Conteúdo">
+              <Input label="Título" value={titulo} onChange={(e) => setTitulo(e.target.value)} required />
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+                Corpo
+                <textarea
+                  value={corpo}
+                  onChange={(e) => setCorpo(e.target.value)}
+                  rows={8}
+                  required
+                  className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-900 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+                />
+              </label>
+            </FormSection>
+            <FormSection title="Escopo">
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+                Setor (vazio = global)
+                <select
+                  value={setorId}
+                  onChange={(e) => setSetorId(e.target.value)}
+                  className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-900 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+                >
+                  <option value="">Global — todos os setores</option>
+                  {setoresOpts.map((s) => (
+                    <option key={s.id} value={String(s.id)}>
+                      {s.nome}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <Input
+                label="Ordem"
+                type="number"
+                value={String(ordemVal)}
+                onChange={(e) => setOrdemVal(Number(e.target.value) || 0)}
+              />
+              <Switch
+                bare
+                checked={ativo}
+                onCheckedChange={setAtivo}
+                label="Resposta ativa"
+                showStatusPill
+                statusOnText="Ativo"
+                statusOffText="Inativo"
+              />
+            </FormSection>
+          </div>
+          <InlineCadastroFooter onCancel={voltarAnterior} saving={saving} />
+        </form>
+      </Card>
+    </CadastroFormPageShell>
+  )
+}

--- a/frontend/src/pages/RespostasProntas.tsx
+++ b/frontend/src/pages/RespostasProntas.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { ApiError, respostasProntas, type RespostasProntas } from '../api/client'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
-import { ApiError, tiposNegocio, type TiposNegocio } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { ListaAcoesVerEditar } from '../components/ui/ListaAcoesVerEditar'
@@ -12,13 +12,13 @@ import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBus
 import { SemPermissao } from './SemPermissao'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 
-type ColunaTipo = 'nome' | 'ativo'
+type Coluna = 'titulo' | 'ordem' | 'ativo'
 
-export function TiposNegocio() {
+export function RespostasProntasPage() {
   const navigate = useNavigate()
   const toast = useToast()
-  const { ordenarPor, ordem, aoOrdenarColuna, sortParams } = useOrdenacaoLista<ColunaTipo>()
-  const [list, setList] = useState<TiposNegocio.Tipo[]>([])
+  const { ordenarPor, ordem: ordemLista, aoOrdenarColuna, sortParams } = useOrdenacaoLista<Coluna>()
+  const [list, setList] = useState<RespostasProntas.Resposta[]>([])
   const [total, setTotal] = useState(0)
   const [page, setPage] = useState(1)
   const [busca, setBusca] = useState('')
@@ -34,12 +34,12 @@ export function TiposNegocio() {
 
   useEffect(() => {
     setPage(1)
-  }, [debouncedBusca, incluirInativos, ordenarPor, ordem])
+  }, [debouncedBusca, incluirInativos, ordenarPor, ordemLista])
 
   const load = useCallback(() => {
     setLoading(true)
     setForbidden(false)
-    tiposNegocio
+    respostasProntas
       .list({
         incluir_inativos: incluirInativos,
         busca: debouncedBusca || undefined,
@@ -58,7 +58,7 @@ export function TiposNegocio() {
           setTotal(0)
           return
         }
-        toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos a lista de tipos de negócio.'))
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos a lista de respostas prontas.'))
         setList([])
         setTotal(0)
       })
@@ -70,40 +70,41 @@ export function TiposNegocio() {
   }, [load])
 
   async function handleDelete(id: number) {
-    if (!confirm('Excluir este tipo de negócio?')) return
+    if (!window.confirm('Excluir esta resposta pronta?')) return
     try {
-      await tiposNegocio.delete(id)
+      await respostasProntas.delete(id)
+      toast.showSuccess('Resposta pronta excluída.')
       load()
     } catch (err) {
-      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível excluir o tipo de negócio.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível excluir.'))
     }
   }
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
-        <SemPermissao
-          title="Você não tem permissão para listar tipos de negócio."
-          detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
-          voltarPara="/"
-          voltarLabel="Voltar para o Dashboard"
-        />
-      </div>
+      <SemPermissao
+        title="Você não tem permissão para gerenciar respostas prontas."
+        voltarPara="/"
+        voltarLabel="Voltar para o Dashboard"
+      />
     )
   }
 
   return (
     <div className="mx-auto max-w-6xl space-y-6 pb-10">
-      <div className="flex justify-between">
-        <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Tipos de negócio</h1>
-        <Button onClick={() => navigate('/tipos-negocio/novo')}>Novo tipo</Button>
+      <div className="flex justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Respostas prontas</h1>
+          <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">Macros reutilizáveis no ticket — globais ou por setor.</p>
+        </div>
+        <Button onClick={() => navigate('/respostas-prontas/novo')}>Nova resposta</Button>
       </div>
 
       <Card>
         <BarraBuscaPaginacao
           busca={busca}
           onBuscaChange={setBusca}
-          placeholder="Buscar por nome"
+          placeholder="Buscar por título ou texto"
           page={page}
           total={total}
           onPageChange={setPage}
@@ -111,53 +112,51 @@ export function TiposNegocio() {
           extra={<FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />}
         />
         {loading ? (
-          <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
+          <p className="text-slate-500 dark:text-slate-400">Carregando…</p>
         ) : list.length === 0 ? (
-          <p className="text-slate-500 dark:text-slate-400">Nenhum tipo encontrado.</p>
+          <p className="text-slate-500 dark:text-slate-400">Nenhuma resposta cadastrada.</p>
         ) : (
           <div className="overflow-x-auto">
-            <table className="w-full min-w-[520px] text-left text-sm">
+            <table className="w-full min-w-[640px] text-left text-sm">
               <thead>
                 <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
-                  <CabecalhoOrdenavel coluna="nome" rotulo="Nome" ordenarPor={ordenarPor} ordem={ordem} aoOrdenar={aoOrdenarColuna} />
-                  <CabecalhoOrdenavel coluna="ativo" rotulo="Situação" ordenarPor={ordenarPor} ordem={ordem} aoOrdenar={aoOrdenarColuna} />
+                  <CabecalhoOrdenavel coluna="titulo" rotulo="Título" ordenarPor={ordenarPor} ordem={ordemLista} aoOrdenar={aoOrdenarColuna} />
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 dark:text-slate-400">Escopo</th>
+                  <CabecalhoOrdenavel coluna="ordem" rotulo="Ordem" ordenarPor={ordenarPor} ordem={ordemLista} aoOrdenar={aoOrdenarColuna} />
+                  <CabecalhoOrdenavel coluna="ativo" rotulo="Situação" ordenarPor={ordenarPor} ordem={ordemLista} aoOrdenar={aoOrdenarColuna} />
                   <th className="w-px px-4 py-3 text-right text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
                     <span className="sr-only">Ações</span>
                   </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
-                {list.map((t) => (
+                {list.map((item) => (
                   <tr
-                    key={t.id}
+                    key={item.id}
                     role="button"
                     tabIndex={0}
-                    onClick={() => navigate(`/tipos-negocio/${t.id}`)}
+                    onClick={() => navigate(`/respostas-prontas/${item.id}`)}
                     onKeyDown={(ev) => {
                       if (ev.key === 'Enter' || ev.key === ' ') {
                         ev.preventDefault()
-                        navigate(`/tipos-negocio/${t.id}`)
+                        navigate(`/respostas-prontas/${item.id}`)
                       }
                     }}
                     className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
                   >
-                    <td className="px-4 py-3.5 sm:px-6">
-                      <span className={`font-medium ${t.ativo ? 'text-slate-800 dark:text-slate-100' : 'text-slate-400'}`}>{t.nome}</span>
+                    <td className="px-4 py-3.5 font-medium text-slate-800 sm:px-6 dark:text-slate-100">{item.titulo}</td>
+                    <td className="px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400">
+                      {item.setor_nome ?? 'Global (todos os setores)'}
                     </td>
-                    <td className="whitespace-nowrap px-4 py-3.5 sm:px-6">
-                      {t.ativo ? (
-                        <span className="text-slate-600 dark:text-slate-400">Ativo</span>
-                      ) : (
-                        <span className="rounded bg-slate-200 px-2 py-0.5 text-xs text-slate-600 dark:bg-slate-700 dark:text-slate-400">Inativo</span>
-                      )}
-                    </td>
+                    <td className="px-4 py-3.5 tabular-nums text-slate-600 sm:px-6 dark:text-slate-400">{item.ordem}</td>
+                    <td className="px-4 py-3.5 sm:px-6">{item.ativo ? 'Ativo' : 'Inativo'}</td>
                     <td className="px-4 py-3.5 text-right sm:px-6" onClick={(ev) => ev.stopPropagation()}>
                       <ListaAcoesVerEditar
-                        onVer={() => navigate(`/tipos-negocio/${t.id}`)}
-                        onEditar={() => navigate(`/tipos-negocio/${t.id}/editar`)}
-                        onExcluir={() => handleDelete(t.id)}
-                        verLabel="Visualizar tipo"
-                        editarLabel="Editar tipo"
+                        onVer={() => navigate(`/respostas-prontas/${item.id}`)}
+                        onEditar={() => navigate(`/respostas-prontas/${item.id}/editar`)}
+                        onExcluir={() => handleDelete(item.id)}
+                        verLabel="Visualizar resposta"
+                        editarLabel="Editar resposta"
                       />
                     </td>
                   </tr>

--- a/frontend/src/pages/SetorDetalhe.tsx
+++ b/frontend/src/pages/SetorDetalhe.tsx
@@ -4,6 +4,8 @@ import { ApiError, atendentes, setores, type Atendentes, type Setores } from '..
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
+import { DetailRow } from '../components/ui/DetailRow'
+import { BadgeAtivo } from '../components/ui/BadgeAtivo'
 import { SelectComPesquisa } from '../components/ui/SelectComPesquisa'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
@@ -205,14 +207,24 @@ export function SetorDetalhe() {
         <span className="font-semibold text-slate-800 dark:text-slate-100">{setor.nome}</span>
       </nav>
 
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">{setor.nome}</h1>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-            Slug: <span className="font-mono">{setor.slug}</span> • {setor.ativo ? 'Ativo' : 'Inativo'}
-          </p>
+          <div className="mt-2">
+            <BadgeAtivo ativo={setor.ativo} />
+          </div>
         </div>
+        <Button onClick={() => navigate(`/setores/${setor.id}/editar`)}>Editar</Button>
       </div>
+
+      <Card title="Dados do setor">
+        <dl>
+          <DetailRow label="ID" value={String(setor.id)} mono />
+          <DetailRow label="Nome" value={setor.nome} />
+          <DetailRow label="Slug" value={setor.slug} mono />
+          <DetailRow label="Situação" value={setor.ativo ? 'Ativo' : 'Inativo'} />
+        </dl>
+      </Card>
 
       <Card title="Atendentes vinculados">
         <div className="space-y-4">

--- a/frontend/src/pages/SetorForm.tsx
+++ b/frontend/src/pages/SetorForm.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ApiError, setores } from '../api/client'
+import { Card } from '../components/ui/Card'
+import { Input } from '../components/ui/Input'
+import { Switch } from '../components/ui/Switch'
+import { useToast } from '../components/ui/Toast'
+import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { FormSection } from '../components/ui/FormSection'
+import { InlineCadastroFooter } from '../components/ui/InlineCadastroPanel'
+import { CadastroFormPageShell } from '../components/ui/CadastroFormPageShell'
+import { SemPermissao } from './SemPermissao'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
+
+export function SetorForm() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const voltarAnterior = useVoltarAnterior('/setores')
+
+  const setorId = id ? parseInt(id, 10) : NaN
+  const isEdit = id != null
+
+  const [loading, setLoading] = useState(isEdit)
+  const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [inexistente, setInexistente] = useState<{ detalhe?: string } | null>(null)
+  const [nome, setNome] = useState('')
+  const [slug, setSlug] = useState('')
+  const [ativo, setAtivo] = useState(true)
+
+  useEffect(() => {
+    if (!isEdit) return
+    if (!id || Number.isNaN(setorId)) {
+      setInexistente({ detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setInexistente(null)
+    setores
+      .get(setorId)
+      .then((s) => {
+        if (cancelled) return
+        setNome(s.nome)
+        setSlug(s.slug)
+        setAtivo(s.ativo)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setInexistente({})
+          return
+        }
+        const m = interpretarFalhaCarregamento(err, 'Setor não encontrado.')
+        toast.showWarning([m.titulo, m.detalhe].filter(Boolean).join(' '))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, isEdit, setorId, toast])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    try {
+      let savedId: number
+      if (isEdit && !Number.isNaN(setorId)) {
+        await setores.update(setorId, { nome: nome.trim(), slug: slug.trim(), ativo })
+        savedId = setorId
+        toast.showSuccess('Setor atualizado.')
+      } else {
+        const created = await setores.create({ nome: nome.trim(), slug: slug.trim(), ativo })
+        savedId = created.id
+        toast.showSuccess('Setor cadastrado.')
+      }
+      navigate(`/setores/${savedId}`, { replace: true })
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o setor.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <CadastroFormPageShell onVoltar={voltarAnterior}>
+        <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </CadastroFormPageShell>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para editar setores."
+        voltarPara="/setores"
+        voltarLabel="Voltar para Setores"
+      />
+    )
+  }
+
+  if (inexistente) {
+    return (
+      <CarregamentoFalhou
+        className="mx-auto max-w-5xl space-y-4 pb-10"
+        titulo="Setor não encontrado."
+        detalhe={inexistente.detalhe}
+        onVoltar={voltarAnterior}
+      />
+    )
+  }
+
+  return (
+    <CadastroFormPageShell onVoltar={voltarAnterior}>
+      <Card title={isEdit ? 'Editar setor' : 'Novo setor'}>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-6">
+            <FormSection title="Dados do setor">
+              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
+              <Input
+                label="Slug"
+                value={slug}
+                onChange={(e) => setSlug(e.target.value)}
+                placeholder="ex: suporte"
+                required
+              />
+            </FormSection>
+            <FormSection title="Situação no sistema">
+              <Switch
+                bare
+                checked={ativo}
+                onCheckedChange={setAtivo}
+                label="Setor ativo"
+                showStatusPill
+                statusOnText="Ativo"
+                statusOffText="Inativo"
+              />
+            </FormSection>
+          </div>
+          <InlineCadastroFooter onCancel={voltarAnterior} saving={saving} />
+        </form>
+      </Card>
+    </CadastroFormPageShell>
+  )
+}

--- a/frontend/src/pages/Setores.tsx
+++ b/frontend/src/pages/Setores.tsx
@@ -4,15 +4,11 @@ import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { ApiError, setores, type Setores } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
-import { Input } from '../components/ui/Input'
-import { IconPencil } from '../components/ui/IconPencil'
-import { IconTrash } from '../components/ui/IconTrash'
+import { ListaAcoesVerEditar } from '../components/ui/ListaAcoesVerEditar'
 import { useToast } from '../components/ui/Toast'
 import { FiltroInativos } from '../components/ui/FiltroInativos'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
-import { Switch } from '../components/ui/Switch'
 import { useNavigate } from 'react-router-dom'
-import { FormSection } from '../components/ui/FormSection'
 import { SemPermissao } from './SemPermissao'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 
@@ -29,22 +25,7 @@ export function Setores() {
   const [debouncedBusca, setDebouncedBusca] = useState('')
   const [loading, setLoading] = useState(true)
   const [incluirInativos, setIncluirInativos] = useState(false)
-  const [modalOpen, setModalOpen] = useState(false)
-  const [editingId, setEditingId] = useState<number | null>(null)
-  const [nome, setNome] = useState('')
-  const [slug, setSlug] = useState('')
-  const [ativo, setAtivo] = useState(true)
-  const [saving, setSaving] = useState(false)
   const [forbidden, setForbidden] = useState(false)
-
-  useEffect(() => {
-    if (!modalOpen) return
-    const prevOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    return () => {
-      document.body.style.overflow = prevOverflow
-    }
-  }, [modalOpen])
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -88,42 +69,6 @@ export function Setores() {
     load()
   }, [load])
 
-  function openCreate() {
-    setEditingId(null)
-    setNome('')
-    setSlug('')
-    setAtivo(true)
-    setModalOpen(true)
-  }
-
-  function openEdit(item: { id: number; nome: string; slug: string; ativo: boolean }) {
-    setEditingId(item.id)
-    setNome(item.nome)
-    setSlug(item.slug)
-    setAtivo(item.ativo)
-    setModalOpen(true)
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    setSaving(true)
-    try {
-      if (editingId) {
-        await setores.update(editingId, { nome: nome.trim(), slug: slug.trim(), ativo })
-        toast.showSuccess('Setor atualizado.')
-      } else {
-        await setores.create({ nome: nome.trim(), slug: slug.trim(), ativo })
-        toast.showSuccess('Setor cadastrado.')
-      }
-      setModalOpen(false)
-      load()
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o setor.'))
-    } finally {
-      setSaving(false)
-    }
-  }
-
   async function handleDelete(id: number) {
     if (!confirm('Excluir este setor?')) return
     try {
@@ -151,20 +96,20 @@ export function Setores() {
     <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <div className="flex justify-between">
         <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Setores</h1>
-        <Button onClick={openCreate}>Novo setor</Button>
+        <Button onClick={() => navigate('/setores/novo')}>Novo setor</Button>
       </div>
-      {!modalOpen && (
-        <Card>
-          <BarraBuscaPaginacao
-            busca={busca}
-            onBuscaChange={setBusca}
-            placeholder="Buscar por nome"
-            page={page}
-            total={total}
-            onPageChange={setPage}
-            disabled={loading}
-            extra={<FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />}
-          />
+
+      <Card>
+        <BarraBuscaPaginacao
+          busca={busca}
+          onBuscaChange={setBusca}
+          placeholder="Buscar por nome"
+          page={page}
+          total={total}
+          onPageChange={setPage}
+          disabled={loading}
+          extra={<FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />}
+        />
         {loading ? (
           <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
         ) : list.length === 0 ? (
@@ -209,18 +154,13 @@ export function Setores() {
                       )}
                     </td>
                     <td className="px-4 py-3.5 text-right sm:px-6" onClick={(ev) => ev.stopPropagation()}>
-                      <div className="inline-flex gap-1.5">
-                        <Button
-                          variant="ghost"
-                          onClick={() => openEdit(s)}
-                          aria-label="Editar setor"
-                        >
-                          <IconPencil ariaHidden={false} />
-                        </Button>
-                        <Button variant="ghost" onClick={() => handleDelete(s.id)} aria-label="Excluir setor">
-                          <IconTrash ariaHidden={false} />
-                        </Button>
-                      </div>
+                      <ListaAcoesVerEditar
+                        onVer={() => navigate(`/setores/${s.id}`)}
+                        onEditar={() => navigate(`/setores/${s.id}/editar`)}
+                        onExcluir={() => handleDelete(s.id)}
+                        editarLabel="Editar setor"
+                        verLabel="Visualizar setor"
+                      />
                     </td>
                   </tr>
                 ))}
@@ -228,52 +168,7 @@ export function Setores() {
             </table>
           </div>
         )}
-        </Card>
-      )}
-
-      {modalOpen && (
-        <div className="fixed inset-y-0 left-0 right-0 z-20 flex items-start justify-center bg-black/85 px-4 pb-6 pt-16 sm:px-6 md:left-[var(--sidebar-w)]">
-          <Card title={editingId ? 'Editar setor' : 'Novo setor'} className="w-full max-w-lg">
-            <form onSubmit={handleSubmit}>
-              <div className="space-y-6">
-                <FormSection title="Dados do setor">
-                  <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-                  <Input
-                    label="Slug"
-                    value={slug}
-                    onChange={(e) => setSlug(e.target.value)}
-                    placeholder="ex: suporte"
-                    required
-                  />
-                </FormSection>
-
-                <FormSection title="Situação no sistema">
-                  <Switch
-                    bare
-                    checked={ativo}
-                    onCheckedChange={setAtivo}
-                    label="Setor ativo"
-                    showStatusPill
-                    statusOnText="Ativo"
-                    statusOffText="Inativo"
-                  />
-                </FormSection>
-              </div>
-
-              <div className="sticky bottom-0 -mx-6 mt-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-900">
-                <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-                  <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => setModalOpen(false)}>
-                    Cancelar
-                  </Button>
-                  <Button type="submit" loading={saving} className="w-full sm:w-auto">
-                    Salvar
-                  </Button>
-                </div>
-              </div>
-            </form>
-          </Card>
-        </div>
-      )}
+      </Card>
     </div>
   )
 }

--- a/frontend/src/pages/StatusTicket.tsx
+++ b/frontend/src/pages/StatusTicket.tsx
@@ -1,22 +1,21 @@
 import { useState, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { ApiError, statusTicket, type StatusTicket } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
-import { Input } from '../components/ui/Input'
-import { IconPencil } from '../components/ui/IconPencil'
+import { ListaAcoesVerEditar } from '../components/ui/ListaAcoesVerEditar'
 import { FiltroInativos } from '../components/ui/FiltroInativos'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
-import { Switch } from '../components/ui/Switch'
 import { useToast } from '../components/ui/Toast'
-import { FormSection } from '../components/ui/FormSection'
 import { SemPermissao } from './SemPermissao'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 type ColunaStatus = 'nome' | 'slug' | 'ordem' | 'ativo'
 
 export function StatusTicketPage() {
+  const navigate = useNavigate()
   const toast = useToast()
   const { ordenarPor, ordem: ordemLista, aoOrdenarColuna, sortParams } = useOrdenacaoLista<ColunaStatus>()
   const [list, setList] = useState<StatusTicket.Status[]>([])
@@ -26,23 +25,7 @@ export function StatusTicketPage() {
   const [debouncedBusca, setDebouncedBusca] = useState('')
   const [loading, setLoading] = useState(true)
   const [incluirInativos, setIncluirInativos] = useState(false)
-  const [modalOpen, setModalOpen] = useState(false)
-  const [editingId, setEditingId] = useState<number | null>(null)
-  const [nome, setNome] = useState('')
-  const [slug, setSlug] = useState('')
-  const [ordem, setOrdem] = useState(0)
-  const [ativo, setAtivo] = useState(true)
-  const [saving, setSaving] = useState(false)
   const [forbidden, setForbidden] = useState(false)
-
-  useEffect(() => {
-    if (!modalOpen) return
-    const prevOverflow = document.body.style.overflow
-    document.body.style.overflow = 'hidden'
-    return () => {
-      document.body.style.overflow = prevOverflow
-    }
-  }, [modalOpen])
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -86,44 +69,6 @@ export function StatusTicketPage() {
     load()
   }, [load])
 
-  function openCreate() {
-    setEditingId(null)
-    setNome('')
-    setSlug('')
-    setOrdem(total)
-    setAtivo(true)
-    setModalOpen(true)
-  }
-
-  function openEdit(item: StatusTicket.Status) {
-    setEditingId(item.id)
-    setNome(item.nome)
-    setSlug(item.slug)
-    setOrdem(item.ordem)
-    setAtivo(item.ativo)
-    setModalOpen(true)
-  }
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    setSaving(true)
-    try {
-      if (editingId) {
-        await statusTicket.update(editingId, { nome: nome.trim(), slug: slug.trim(), ordem, ativo })
-        toast.showSuccess('Status atualizado.')
-      } else {
-        await statusTicket.create({ nome: nome.trim(), slug: slug.trim(), ordem, ativo })
-        toast.showSuccess('Status cadastrado.')
-      }
-      setModalOpen(false)
-      load()
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o status de ticket.'))
-    } finally {
-      setSaving(false)
-    }
-  }
-
   if (forbidden) {
     return (
       <div className="mx-auto max-w-6xl space-y-6 pb-10">
@@ -141,20 +86,20 @@ export function StatusTicketPage() {
     <div className="mx-auto max-w-6xl space-y-6 pb-10">
       <div className="flex justify-between">
         <h1 className="text-2xl font-bold text-slate-800 dark:text-slate-100">Status de ticket</h1>
-        <Button onClick={openCreate}>Novo status</Button>
+        <Button onClick={() => navigate('/status-ticket/novo')}>Novo status</Button>
       </div>
-      {!modalOpen && (
-        <Card>
-          <BarraBuscaPaginacao
-            busca={busca}
-            onBuscaChange={setBusca}
-            placeholder="Buscar por nome ou slug"
-            page={page}
-            total={total}
-            onPageChange={setPage}
-            disabled={loading}
-            extra={<FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />}
-          />
+
+      <Card>
+        <BarraBuscaPaginacao
+          busca={busca}
+          onBuscaChange={setBusca}
+          placeholder="Buscar por nome ou slug"
+          page={page}
+          total={total}
+          onPageChange={setPage}
+          disabled={loading}
+          extra={<FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />}
+        />
         {loading ? (
           <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
         ) : list.length === 0 ? (
@@ -179,11 +124,11 @@ export function StatusTicketPage() {
                     key={s.id}
                     role="button"
                     tabIndex={0}
-                    onClick={() => openEdit(s)}
+                    onClick={() => navigate(`/status-ticket/${s.id}`)}
                     onKeyDown={(ev) => {
                       if (ev.key === 'Enter' || ev.key === ' ') {
                         ev.preventDefault()
-                        openEdit(s)
+                        navigate(`/status-ticket/${s.id}`)
                       }
                     }}
                     className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-slate-800/50 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
@@ -201,9 +146,12 @@ export function StatusTicketPage() {
                       )}
                     </td>
                     <td className="px-4 py-3.5 text-right sm:px-6" onClick={(ev) => ev.stopPropagation()}>
-                      <Button variant="ghost" onClick={() => openEdit(s)} aria-label="Editar">
-                        <IconPencil />
-                      </Button>
+                      <ListaAcoesVerEditar
+                        onVer={() => navigate(`/status-ticket/${s.id}`)}
+                        onEditar={() => navigate(`/status-ticket/${s.id}/editar`)}
+                        verLabel="Visualizar status"
+                        editarLabel="Editar status"
+                      />
                     </td>
                   </tr>
                 ))}
@@ -211,53 +159,7 @@ export function StatusTicketPage() {
             </table>
           </div>
         )}
-        </Card>
-      )}
-
-      {modalOpen && (
-        <div className="fixed inset-y-0 left-0 right-0 z-20 flex items-start justify-center bg-black/85 px-4 pb-6 pt-16 sm:px-6 md:left-[var(--sidebar-w)]">
-          <Card title={editingId ? 'Editar status' : 'Novo status'} className="w-full max-w-lg">
-            <form onSubmit={handleSubmit}>
-              <div className="space-y-6">
-                <FormSection title="Dados do status">
-                  <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-                  <Input
-                    label="Slug"
-                    value={slug}
-                    onChange={(e) => setSlug(e.target.value)}
-                    placeholder="ex: aguardando_atendimento"
-                    required
-                  />
-                  <Input label="Ordem" type="number" value={ordem} onChange={(e) => setOrdem(Number(e.target.value))} />
-                </FormSection>
-
-                <FormSection title="Situação no sistema">
-                  <Switch
-                    bare
-                    checked={ativo}
-                    onCheckedChange={setAtivo}
-                    label="Status ativo"
-                    showStatusPill
-                    statusOnText="Ativo"
-                    statusOffText="Inativo"
-                  />
-                </FormSection>
-              </div>
-
-              <div className="sticky bottom-0 -mx-6 mt-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-900">
-                <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-                  <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={() => setModalOpen(false)}>
-                    Cancelar
-                  </Button>
-                  <Button type="submit" loading={saving} className="w-full sm:w-auto">
-                    Salvar
-                  </Button>
-                </div>
-              </div>
-            </form>
-          </Card>
-        </div>
-      )}
+      </Card>
     </div>
   )
 }

--- a/frontend/src/pages/StatusTicketDetalhe.tsx
+++ b/frontend/src/pages/StatusTicketDetalhe.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ApiError, statusTicket } from '../api/client'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { DetailRow } from '../components/ui/DetailRow'
+import { BadgeAtivo } from '../components/ui/BadgeAtivo'
+import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { SemPermissao } from './SemPermissao'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+import { interpretarFalhaCarregamento } from '../api/errorMessage'
+
+export function StatusTicketDetalhe() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const voltarAnterior = useVoltarAnterior('/status-ticket')
+  const statusId = id ? parseInt(id, 10) : NaN
+
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [falha, setFalha] = useState<{ titulo: string; detalhe?: string } | null>(null)
+  const [item, setItem] = useState<Awaited<ReturnType<typeof statusTicket.get>> | null>(null)
+
+  useEffect(() => {
+    if (!id || Number.isNaN(statusId)) {
+      setFalha({ titulo: 'Status não encontrado.', detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setFalha(null)
+    statusTicket
+      .get(statusId)
+      .then((s) => {
+        if (!cancelled) setItem(s)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        setFalha(interpretarFalhaCarregamento(err, 'Status não encontrado.'))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, statusId])
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <div className="h-48 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </div>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para acessar este status."
+        voltarPara="/status-ticket"
+        voltarLabel="Voltar para Status de ticket"
+      />
+    )
+  }
+
+  if (falha) {
+    return <CarregamentoFalhou titulo={falha.titulo} detalhe={falha.detalhe} onVoltar={voltarAnterior} />
+  }
+
+  if (!item) return null
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <button
+        type="button"
+        onClick={voltarAnterior}
+        className="inline-flex items-center gap-1 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100"
+      >
+        <span aria-hidden>←</span> Voltar
+      </button>
+
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">{item.nome}</h1>
+          <BadgeAtivo ativo={item.ativo} />
+        </div>
+        <Button onClick={() => navigate(`/status-ticket/${item.id}/editar`)}>Editar</Button>
+      </header>
+
+      <Card title="Dados do status">
+        <dl>
+          <DetailRow label="ID" value={String(item.id)} mono />
+          <DetailRow label="Nome" value={item.nome} />
+          <DetailRow label="Slug" value={item.slug} mono />
+          <DetailRow label="Ordem" value={String(item.ordem)} mono />
+          <DetailRow label="Situação" value={item.ativo ? 'Ativo' : 'Inativo'} />
+        </dl>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/StatusTicketForm.tsx
+++ b/frontend/src/pages/StatusTicketForm.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ApiError, statusTicket } from '../api/client'
+import { Card } from '../components/ui/Card'
+import { Input } from '../components/ui/Input'
+import { Switch } from '../components/ui/Switch'
+import { useToast } from '../components/ui/Toast'
+import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { FormSection } from '../components/ui/FormSection'
+import { InlineCadastroFooter } from '../components/ui/InlineCadastroPanel'
+import { CadastroFormPageShell } from '../components/ui/CadastroFormPageShell'
+import { SemPermissao } from './SemPermissao'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
+
+export function StatusTicketForm() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const voltarAnterior = useVoltarAnterior('/status-ticket')
+
+  const statusId = id ? parseInt(id, 10) : NaN
+  const isEdit = id != null
+
+  const [loading, setLoading] = useState(isEdit)
+  const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [inexistente, setInexistente] = useState<{ detalhe?: string } | null>(null)
+  const [nome, setNome] = useState('')
+  const [slug, setSlug] = useState('')
+  const [ordem, setOrdem] = useState(0)
+  const [ativo, setAtivo] = useState(true)
+
+  useEffect(() => {
+    if (isEdit) return
+    statusTicket.list({ limit: 1, offset: 0 }).then(({ total }) => setOrdem(total))
+  }, [isEdit])
+
+  useEffect(() => {
+    if (!isEdit) return
+    if (!id || Number.isNaN(statusId)) {
+      setInexistente({ detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setInexistente(null)
+    statusTicket
+      .get(statusId)
+      .then((s) => {
+        if (cancelled) return
+        setNome(s.nome)
+        setSlug(s.slug)
+        setOrdem(s.ordem)
+        setAtivo(s.ativo)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setInexistente({})
+          return
+        }
+        const m = interpretarFalhaCarregamento(err, 'Status não encontrado.')
+        toast.showWarning([m.titulo, m.detalhe].filter(Boolean).join(' '))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, isEdit, statusId, toast])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    try {
+      if (isEdit && !Number.isNaN(statusId)) {
+        await statusTicket.update(statusId, { nome: nome.trim(), slug: slug.trim(), ordem, ativo })
+        toast.showSuccess('Status atualizado.')
+        navigate(`/status-ticket/${statusId}`, { replace: true })
+      } else {
+        const created = await statusTicket.create({ nome: nome.trim(), slug: slug.trim(), ordem, ativo })
+        toast.showSuccess('Status cadastrado.')
+        navigate(`/status-ticket/${created.id}`, { replace: true })
+      }
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o status de ticket.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <CadastroFormPageShell onVoltar={voltarAnterior}>
+        <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </CadastroFormPageShell>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para editar status de ticket."
+        voltarPara="/status-ticket"
+        voltarLabel="Voltar para Status de ticket"
+      />
+    )
+  }
+
+  if (inexistente) {
+    return (
+      <CarregamentoFalhou
+        className="mx-auto max-w-5xl space-y-4 pb-10"
+        titulo="Status não encontrado."
+        detalhe={inexistente.detalhe}
+        onVoltar={voltarAnterior}
+      />
+    )
+  }
+
+  return (
+    <CadastroFormPageShell onVoltar={voltarAnterior}>
+      <Card title={isEdit ? 'Editar status' : 'Novo status'}>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-6">
+            <FormSection title="Dados do status">
+              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
+              <Input
+                label="Slug"
+                value={slug}
+                onChange={(e) => setSlug(e.target.value)}
+                placeholder="ex: aguardando_atendimento"
+                required
+              />
+              <Input label="Ordem" type="number" value={ordem} onChange={(e) => setOrdem(Number(e.target.value))} />
+            </FormSection>
+            <FormSection title="Situação no sistema">
+              <Switch
+                bare
+                checked={ativo}
+                onCheckedChange={setAtivo}
+                label="Status ativo"
+                showStatusPill
+                statusOnText="Ativo"
+                statusOffText="Inativo"
+              />
+            </FormSection>
+          </div>
+          <InlineCadastroFooter onCancel={voltarAnterior} saving={saving} />
+        </form>
+      </Card>
+    </CadastroFormPageShell>
+  )
+}

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -36,6 +36,7 @@ import { MODAL_PANEL_COMPACT, MODAL_PANEL_SCROLLABLE } from '../lib/modalPanel'
 import { autorRodapeMensagem, corpoMensagemEmailVisivel } from '../lib/ticketMensagemEmail'
 import { mensagemEmFilaEmail } from '../lib/ticketMensagemEmailOutbox'
 import { TicketMensagemEmailOutbox } from '../components/TicketMensagemEmailOutbox'
+import { RespostasProntasPicker } from '../components/RespostasProntasPicker'
 
 const ROTULO_CAMPO: Record<string, string> = {
   status_id: 'Status',
@@ -943,6 +944,25 @@ export function TicketDetalhe() {
     }, 0)
   }
 
+  function inserirRespostaPronta(texto: string) {
+    const ta = textareaRef.current
+    const start = ta?.selectionStart ?? novaMensagemTexto.length
+    const end = ta?.selectionEnd ?? novaMensagemTexto.length
+    const sep = novaMensagemTexto && !novaMensagemTexto.endsWith('\n') ? '\n\n' : novaMensagemTexto ? '' : ''
+    const insert = sep + texto
+    const next = novaMensagemTexto.slice(0, start) + insert + novaMensagemTexto.slice(end)
+    setNovaMensagemTexto(next)
+    setTimeout(() => {
+      try {
+        const pos = start + insert.length
+        ta?.setSelectionRange(pos, pos)
+        ta?.focus()
+      } catch {
+        // noop
+      }
+    }, 0)
+  }
+
   if (loading) {
     return (
       <div className="flex min-h-[40vh] items-center justify-center text-slate-500 dark:text-slate-400">
@@ -1508,6 +1528,11 @@ export function TicketDetalhe() {
             ) : null}
             <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
               <div className="flex flex-wrap items-center gap-2">
+                <RespostasProntasPicker
+                  setorId={ticket.setor_id}
+                  disabled={Boolean(ticket.fechado_em)}
+                  onInserir={inserirRespostaPronta}
+                />
                 <input
                   ref={fileInputRef}
                   type="file"

--- a/frontend/src/pages/TipoNegocioDetalhe.tsx
+++ b/frontend/src/pages/TipoNegocioDetalhe.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ApiError, tiposNegocio } from '../api/client'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { DetailRow } from '../components/ui/DetailRow'
+import { BadgeAtivo } from '../components/ui/BadgeAtivo'
+import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { SemPermissao } from './SemPermissao'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+import { interpretarFalhaCarregamento } from '../api/errorMessage'
+
+export function TipoNegocioDetalhe() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const voltarAnterior = useVoltarAnterior('/tipos-negocio')
+  const tipoId = id ? parseInt(id, 10) : NaN
+
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [falha, setFalha] = useState<{ titulo: string; detalhe?: string } | null>(null)
+  const [item, setItem] = useState<Awaited<ReturnType<typeof tiposNegocio.get>> | null>(null)
+
+  useEffect(() => {
+    if (!id || Number.isNaN(tipoId)) {
+      setFalha({ titulo: 'Tipo de negócio não encontrado.', detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setFalha(null)
+    tiposNegocio
+      .get(tipoId)
+      .then((t) => {
+        if (!cancelled) setItem(t)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        setFalha(interpretarFalhaCarregamento(err, 'Tipo de negócio não encontrado.'))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, tipoId])
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <div className="h-40 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </div>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para acessar este tipo de negócio."
+        voltarPara="/tipos-negocio"
+        voltarLabel="Voltar para Tipos de negócio"
+      />
+    )
+  }
+
+  if (falha) {
+    return <CarregamentoFalhou titulo={falha.titulo} detalhe={falha.detalhe} onVoltar={voltarAnterior} />
+  }
+
+  if (!item) return null
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <button
+        type="button"
+        onClick={voltarAnterior}
+        className="inline-flex items-center gap-1 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100"
+      >
+        <span aria-hidden>←</span> Voltar
+      </button>
+
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">{item.nome}</h1>
+          <BadgeAtivo ativo={item.ativo} />
+        </div>
+        <Button onClick={() => navigate(`/tipos-negocio/${item.id}/editar`)}>Editar</Button>
+      </header>
+
+      <Card title="Dados do tipo de negócio">
+        <dl>
+          <DetailRow label="ID" value={String(item.id)} mono />
+          <DetailRow label="Nome" value={item.nome} />
+          <DetailRow label="Situação" value={item.ativo ? 'Ativo' : 'Inativo'} />
+        </dl>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/TipoNegocioForm.tsx
+++ b/frontend/src/pages/TipoNegocioForm.tsx
@@ -1,0 +1,145 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ApiError, tiposNegocio } from '../api/client'
+import { Card } from '../components/ui/Card'
+import { Input } from '../components/ui/Input'
+import { Switch } from '../components/ui/Switch'
+import { useToast } from '../components/ui/Toast'
+import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { FormSection } from '../components/ui/FormSection'
+import { InlineCadastroFooter } from '../components/ui/InlineCadastroPanel'
+import { CadastroFormPageShell } from '../components/ui/CadastroFormPageShell'
+import { SemPermissao } from './SemPermissao'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
+
+export function TipoNegocioForm() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const voltarAnterior = useVoltarAnterior('/tipos-negocio')
+
+  const tipoId = id ? parseInt(id, 10) : NaN
+  const isEdit = id != null
+
+  const [loading, setLoading] = useState(isEdit)
+  const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [inexistente, setInexistente] = useState<{ detalhe?: string } | null>(null)
+  const [nome, setNome] = useState('')
+  const [ativo, setAtivo] = useState(true)
+
+  useEffect(() => {
+    if (!isEdit) return
+    if (!id || Number.isNaN(tipoId)) {
+      setInexistente({ detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setInexistente(null)
+    tiposNegocio
+      .get(tipoId)
+      .then((t) => {
+        if (cancelled) return
+        setNome(t.nome)
+        setAtivo(t.ativo)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setInexistente({})
+          return
+        }
+        const m = interpretarFalhaCarregamento(err, 'Tipo de negócio não encontrado.')
+        toast.showWarning([m.titulo, m.detalhe].filter(Boolean).join(' '))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, isEdit, tipoId, toast])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    try {
+      if (isEdit && !Number.isNaN(tipoId)) {
+        await tiposNegocio.update(tipoId, { nome: nome.trim(), ativo })
+        toast.showSuccess('Tipo de negócio atualizado.')
+        navigate(`/tipos-negocio/${tipoId}`, { replace: true })
+      } else {
+        const created = await tiposNegocio.create({ nome: nome.trim(), ativo })
+        toast.showSuccess('Tipo de negócio cadastrado.')
+        navigate(`/tipos-negocio/${created.id}`, { replace: true })
+      }
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o tipo de negócio.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <CadastroFormPageShell onVoltar={voltarAnterior}>
+        <div className="h-48 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </CadastroFormPageShell>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para editar tipos de negócio."
+        voltarPara="/tipos-negocio"
+        voltarLabel="Voltar para Tipos de negócio"
+      />
+    )
+  }
+
+  if (inexistente) {
+    return (
+      <CarregamentoFalhou
+        className="mx-auto max-w-5xl space-y-4 pb-10"
+        titulo="Tipo de negócio não encontrado."
+        detalhe={inexistente.detalhe}
+        onVoltar={voltarAnterior}
+      />
+    )
+  }
+
+  return (
+    <CadastroFormPageShell onVoltar={voltarAnterior}>
+      <Card title={isEdit ? 'Editar tipo' : 'Novo tipo de negócio'}>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-6">
+            <FormSection title="Dados do tipo de negócio">
+              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
+            </FormSection>
+            <FormSection title="Situação no sistema">
+              <Switch
+                bare
+                checked={ativo}
+                onCheckedChange={setAtivo}
+                label="Tipo ativo"
+                showStatusPill
+                statusOnText="Ativo"
+                statusOffText="Inativo"
+              />
+            </FormSection>
+          </div>
+          <InlineCadastroFooter onCancel={voltarAnterior} saving={saving} />
+        </form>
+      </Card>
+    </CadastroFormPageShell>
+  )
+}


### PR DESCRIPTION
## Summary
- Implementa respostas prontas no backend (migration `031`, CRUD admin, endpoint de picker por setor) e no frontend (admin, picker no detalhe do ticket).
- Refatora cadastros admin (setores, status, tipos, atendentes, empresas, respostas prontas) para rotas separadas: listagem, detalhe com todos os campos e formulário novo/editar.
- Adiciona ações Visualizar e Editar nas listagens e botão Editar nas telas de detalhe.

## Test plan
- [x] Rodar `alembic upgrade head` e validar tabela `respostas_prontas`
- [x] Rodar `pytest backend/tests/test_respostas_prontas.py`
- [x] Admin: CRUD em `/respostas-prontas` (listagem, detalhe, novo, editar)
- [x] Ticket: picker de respostas prontas insere texto no composer
- [x] Cadastros admin: listagem ocupa largura total; detalhe exibe campos; formulário em rota própria
- [x] `npm run build` no frontend

Closes #113
Closes #114