### PR TITLE
fix(deps): atualizar PyJWT para 2.13.0 (auditoria de segurança CI)

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,7 +9,7 @@ psycopg2-binary==2.9.12
 alembic==1.14.0
 pydantic[email]==2.13.4
 pydantic-settings==2.14.1
-PyJWT[crypto]==2.12.1
+PyJWT[crypto]==2.13.0
 cryptography>=42.0.0
 bcrypt>=5.0.0,<6
 svix>=1.40.0


### PR DESCRIPTION
## Summary
- Atualiza `PyJWT[crypto]` de 2.12.1 para 2.13.0
- Corrige falha do job `backend` no CI (`pip-audit` reportava 4 vulnerabilidades PYSEC-2026-*)
- Desbloqueia merge de todos os PRs abertos que falhavam apenas na auditoria de segurança

## Test plan
- [ ] CI backend passa (pip-audit + testes)
- [ ] CI frontend passa