### PR TITLE
fix(frontend): alinhar react-dom com react 19.2.7

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "qrcode.react": "^4.2.0",
         "react": "19.2.7",
-        "react-dom": "19.2.6",
+        "react-dom": "19.2.7",
         "react-router-dom": "^7.17.0"
       },
       "devDependencies": {
@@ -2403,14 +2403,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-router": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "qrcode.react": "^4.2.0",
     "react": "19.2.7",
-    "react-dom": "19.2.6",
+    "react-dom": "19.2.7",
     "react-router-dom": "^7.17.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Corrige incompatibilidade react@19.2.7 + react-dom@19.2.6 que causava erro React 327 e tela em branco no login.

Made with [Cursor](https://cursor.com)