### PR TITLE
feat(tickets): vínculos, hierarquia, filhos em massa e coordenação de rede (#115, #116)

### DIFF
--- a/backend/alembic/versions/032_ticket_vinculos.py
+++ b/backend/alembic/versions/032_ticket_vinculos.py
@@ -1,0 +1,46 @@
+"""ticket_vinculos: relações duplicado_de / relacionado_a entre tickets.
+
+Revision ID: 032_ticket_vinculos
+Revises: 031_respostas_prontas
+Create Date: 2026-05-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "032_ticket_vinculos"
+down_revision = "031_respostas_prontas"
+branch_labels = None
+depends_on = None
+
+TIPOS = ("duplicado_de", "relacionado_a")
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ticket_vinculos",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sa.Integer(), nullable=False),
+        sa.Column("ticket_id", sa.Integer(), nullable=False),
+        sa.Column("related_ticket_id", sa.Integer(), nullable=False),
+        sa.Column("tipo", sa.String(length=32), nullable=False),
+        sa.Column("created_by_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.ForeignKeyConstraint(["created_by_id"], ["atendentes.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["related_ticket_id"], ["tickets.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["ticket_id"], ["tickets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("ticket_id", "related_ticket_id", "tipo", name="uq_ticket_vinculos_par_tipo"),
+        sa.CheckConstraint("ticket_id <> related_ticket_id", name="ck_ticket_vinculos_distintos"),
+    )
+    op.create_index("ix_ticket_vinculos_tenant_id", "ticket_vinculos", ["tenant_id"], unique=False)
+    op.create_index("ix_ticket_vinculos_ticket_id", "ticket_vinculos", ["ticket_id"], unique=False)
+    op.create_index("ix_ticket_vinculos_related_ticket_id", "ticket_vinculos", ["related_ticket_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ticket_vinculos_related_ticket_id", table_name="ticket_vinculos")
+    op.drop_index("ix_ticket_vinculos_ticket_id", table_name="ticket_vinculos")
+    op.drop_index("ix_ticket_vinculos_tenant_id", table_name="ticket_vinculos")
+    op.drop_table("ticket_vinculos")

--- a/backend/alembic/versions/033_ticket_rede_id.py
+++ b/backend/alembic/versions/033_ticket_rede_id.py
@@ -1,0 +1,41 @@
+"""tickets: rede_id para ticket de coordenação de rede.
+
+Revision ID: 033_ticket_rede_id
+Revises: 032_ticket_vinculos
+Create Date: 2026-05-28
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "033_ticket_rede_id"
+down_revision = "032_ticket_vinculos"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("tickets", sa.Column("rede_id", sa.Integer(), nullable=True))
+    op.create_index("ix_tickets_rede_id", "tickets", ["rede_id"], unique=False)
+    op.create_foreign_key(
+        "fk_tickets_rede_id_redes",
+        "tickets",
+        "redes",
+        ["rede_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+    op.execute(
+        """
+        UPDATE tickets t
+        SET rede_id = e.rede_id
+        FROM empresas e
+        WHERE t.empresa_id = e.id AND t.rede_id IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_tickets_rede_id_redes", "tickets", type_="foreignkey")
+    op.drop_index("ix_tickets_rede_id", table_name="tickets")
+    op.drop_column("tickets", "rede_id")

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, Response
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import or_, asc, desc, nullslast, inspect as sa_inspect
 
@@ -11,6 +11,7 @@ from app.models import Ticket, TicketHistorico, TicketMensagem, Empresa, Setor, 
 from app.models.email_inbound_received import EmailInboundReceived
 from app.models.funcionario_rede import FuncionarioRede
 from app.models.ticket_anexo import TicketAnexo
+from app.models.ticket_vinculo import TIPO_DUPLICADO_DE, TicketVinculo
 from app.schemas.ticket import (
     EmpresaVinculoSugerida,
     TicketChildBrief,
@@ -24,6 +25,14 @@ from app.schemas.ticket import (
     TicketRead,
     TicketTriagemInbound,
     TicketUpdate,
+    TicketVinculoCreate,
+    TicketVinculoOutroBrief,
+    TicketVinculoRead,
+    TicketFilhosMassaCreate,
+    TicketFilhosMassaOpcoesRead,
+    TicketFilhosMassaRead,
+    TicketFilhoMassaCriado,
+    TicketFilhoMassaEmpresaOpcao,
 )
 from app.schemas.ticket_anexo import TicketAnexoCreateResponse, TicketAnexoRead
 from app.schemas.lista_paginada import ListaPaginada
@@ -36,6 +45,20 @@ from app.core.setor_scope import (
 )
 from app.services import ticket_anexo_storage
 from app.services.protocolo_mensal import gerar_protocolo_ticket
+from app.services.ticket_vinculos import (
+    criar_vinculo as criar_vinculo_ticket,
+    fechar_ticket_como_duplicado,
+    listar_vinculos,
+    outro_ticket_id,
+    rotulo_vinculo,
+)
+from app.services.ticket_filhos_massa import criar_filhos_em_massa, listar_opcoes_filhos_massa
+from app.services.ticket_escopo import (
+    rede_id_de_empresa,
+    rede_id_efetivo_ticket,
+    ticket_e_coordenacao_rede,
+    validar_escopo_criacao_manual,
+)
 from app.services.funcionario_rede_resolver import resolver_remetente_por_email
 from app.services.ticket_client_email import extrair_email_de_from_address
 from app.services.ticket_mensagem_email_outbox import (
@@ -112,13 +135,18 @@ def _assert_parent_valido(
 ) -> None:
     if filho_ticket_id is not None and parent_id == filho_ticket_id:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Um ticket não pode ser pai de si mesmo.")
-    parent = db.query(Ticket).filter(Ticket.id == parent_id).first()
+    parent = (
+        db.query(Ticket)
+        .options(joinedload(Ticket.rede), joinedload(Ticket.empresa))
+        .filter(Ticket.id == parent_id)
+        .first()
+    )
     if not parent:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket pai não encontrado")
     if not _pode_ver_ticket(db, atendente, parent):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para vincular a este ticket pai")
     r_filho = _rede_id_empresa(db, filho_empresa_id)
-    r_pai = _rede_id_empresa(db, parent.empresa_id)
+    r_pai = rede_id_efetivo_ticket(db, parent)
     if r_filho is None or r_pai is None or r_filho != r_pai:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
@@ -134,6 +162,7 @@ def _assert_parent_valido(
 def _opcoes_carregamento_ticket_detalhe():
     return (
         joinedload(Ticket.empresa).joinedload(Empresa.rede),
+        joinedload(Ticket.rede),
         joinedload(Ticket.setor),
         joinedload(Ticket.status),
         joinedload(Ticket.atendente),
@@ -174,6 +203,46 @@ def _triagem_inbound_para_ticket(db: Session, t: Ticket) -> TicketTriagemInbound
     )
 
 
+def _ticket_vinculo_brief(t: Ticket) -> TicketVinculoOutroBrief:
+    return TicketVinculoOutroBrief(
+        id=t.id,
+        protocolo=t.protocolo,
+        assunto=t.assunto,
+        status_nome=t.status.nome if t.status else None,
+    )
+
+
+def _vinculo_para_read(
+    v: TicketVinculo,
+    perspectiva_ticket_id: int,
+    db: Session,
+    *,
+    duplicado_fechado: bool = False,
+) -> TicketVinculoRead:
+    other_id = outro_ticket_id(v, perspectiva_ticket_id)
+    other = v.related_ticket if v.related_ticket_id == other_id else v.ticket
+    if other is None or other.id != other_id:
+        other = (
+            db.query(Ticket)
+            .options(joinedload(Ticket.status))
+            .filter(Ticket.id == other_id)
+            .first()
+        )
+    if other is None:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Ticket vinculado em falta")
+    return TicketVinculoRead(
+        id=v.id,
+        tipo=v.tipo,
+        rotulo=rotulo_vinculo(v, perspectiva_ticket_id),
+        outro_ticket=_ticket_vinculo_brief(other),
+        duplicado_fechado=duplicado_fechado,
+    )
+
+
+def _vinculos_para_read(db: Session, t: Ticket) -> list[TicketVinculoRead]:
+    return [_vinculo_para_read(v, t.id, db) for v in listar_vinculos(db, t.id)]
+
+
 def _ticket_para_read(t: Ticket, db: Session | None = None) -> TicketRead:
     parent_brief = None
     if t.parent_ticket_id and _attr_relacionamento_carregado(t, "parent") and t.parent is not None:
@@ -199,14 +268,17 @@ def _ticket_para_read(t: Ticket, db: Session | None = None) -> TicketRead:
                 )
             )
     triagem = _triagem_inbound_para_ticket(db, t) if db is not None else None
-    rede_id = t.empresa.rede_id if t.empresa else None
-    rede_nome = t.empresa.rede.nome if t.empresa and t.empresa.rede else None
-    if db and triagem and triagem.requer_cadastro_funcionario is False and rede_id is None and t.aberto_por_id:
+    rede_id_out = t.rede_id
+    rede_nome_out = t.rede.nome if t.rede is not None else None
+    if rede_id_out is None and t.empresa is not None:
+        rede_id_out = t.empresa.rede_id
+        rede_nome_out = t.empresa.rede.nome if t.empresa.rede else rede_nome_out
+    if db and triagem and triagem.requer_cadastro_funcionario is False and rede_id_out is None and t.aberto_por_id:
         f = db.query(FuncionarioRede).filter(FuncionarioRede.id == t.aberto_por_id).first()
         if f and f.rede_id:
-            rede_id = f.rede_id
+            rede_id_out = f.rede_id
             r = db.query(Rede).filter(Rede.id == f.rede_id).first()
-            rede_nome = r.nome if r else None
+            rede_nome_out = r.nome if r else rede_nome_out
     return TicketRead(
         id=t.id,
         protocolo=t.protocolo,
@@ -220,15 +292,17 @@ def _ticket_para_read(t: Ticket, db: Session | None = None) -> TicketRead:
         fechado_em=t.fechado_em,
         created_at=t.created_at,
         updated_at=t.updated_at,
-        rede_id=rede_id,
+        rede_id=rede_id_out,
         empresa_nome=t.empresa.nome if t.empresa else None,
-        rede_nome=rede_nome,
+        rede_nome=rede_nome_out,
+        coordenacao_rede=ticket_e_coordenacao_rede(t),
         setor_nome=t.setor.nome if t.setor else None,
         status_nome=t.status.nome if t.status else None,
         atendente_nome=t.atendente.nome if t.atendente else None,
         parent_ticket_id=t.parent_ticket_id,
         parent=parent_brief,
         children=children_out,
+        vinculos=_vinculos_para_read(db, t) if db is not None else [],
         triagem_inbound=triagem,
     )
 
@@ -327,7 +401,7 @@ def listar(
     if empresa_id is not None:
         q = q.filter(Ticket.empresa_id == empresa_id)
     if rede_id is not None:
-        q = q.filter(Empresa.rede_id == rede_id)
+        q = q.filter(or_(Ticket.rede_id == rede_id, Empresa.rede_id == rede_id))
     if setor_id is not None:
         q = q.filter(Ticket.setor_id == setor_id)
     if status_id is not None:
@@ -395,6 +469,7 @@ def listar(
     rows = (
         q.options(
             joinedload(Ticket.empresa).joinedload(Empresa.rede),
+            joinedload(Ticket.rede),
             joinedload(Ticket.setor),
             joinedload(Ticket.status),
             joinedload(Ticket.atendente),
@@ -418,13 +493,15 @@ def criar(
         vis = ids_setores_visiveis_atendente(db, atendente)
         if data.setor_id not in vis:
             raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este setor")
-    empresa = (
-        db.query(Empresa)
-        .filter(Empresa.id == data.empresa_id, Empresa.tenant_id == atendente.tenant_id)
-        .first()
-    )
-    if not empresa:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Empresa não encontrada")
+    try:
+        modo = validar_escopo_criacao_manual(
+            empresa_id=data.empresa_id,
+            rede_id=data.rede_id,
+            parent_ticket_id=data.parent_ticket_id,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
     setor = (
         db.query(Setor)
         .filter(Setor.id == data.setor_id, Setor.tenant_id == atendente.tenant_id)
@@ -432,6 +509,34 @@ def criar(
     )
     if not setor:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Setor não encontrado")
+
+    ticket_empresa_id: int | None
+    ticket_rede_id: int | None
+    if modo == "empresa":
+        empresa = (
+            db.query(Empresa)
+            .filter(Empresa.id == data.empresa_id, Empresa.tenant_id == atendente.tenant_id)
+            .first()
+        )
+        if not empresa:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Empresa não encontrada")
+        if not empresa.ativo:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Empresa inativa")
+        ticket_empresa_id = data.empresa_id
+        ticket_rede_id = empresa.rede_id
+    else:
+        rede = (
+            db.query(Rede)
+            .filter(Rede.id == data.rede_id, Rede.tenant_id == atendente.tenant_id)
+            .first()
+        )
+        if not rede:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Rede não encontrada")
+        if not rede.ativo:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Rede inativa")
+        ticket_empresa_id = None
+        ticket_rede_id = rede.id
+
     if data.parent_ticket_id is not None:
         _assert_parent_valido(
             db,
@@ -448,7 +553,8 @@ def criar(
     ticket = Ticket(
         tenant_id=atendente.tenant_id,
         protocolo=protocolo,
-        empresa_id=data.empresa_id,
+        empresa_id=ticket_empresa_id,
+        rede_id=ticket_rede_id,
         setor_id=data.setor_id,
         status_id=status_inicial.id,
         assunto=data.assunto,
@@ -537,6 +643,211 @@ def historico(
         )
         for h in rows
     ]
+
+
+@router.post("/{ticket_id}/vinculos", response_model=TicketVinculoRead, status_code=status.HTTP_201_CREATED)
+def criar_vinculo(
+    ticket_id: int,
+    data: TicketVinculoCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if not _pode_ver_ticket(db, atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+    related = db.query(Ticket).filter(Ticket.id == data.related_ticket_id).first()
+    if not related:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket relacionado não encontrado")
+    if not _pode_ver_ticket(db, atendente, related):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Sem permissão para vincular a este ticket",
+        )
+    try:
+        v = criar_vinculo_ticket(
+            db,
+            ticket=ticket,
+            related=related,
+            tipo=data.tipo,
+            atendente=atendente,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+    duplicado_fechado = False
+    if data.tipo == TIPO_DUPLICADO_DE and data.fechar_como_duplicado:
+        try:
+            status_antigo = ticket.status_id
+            if fechar_ticket_como_duplicado(db, duplicado=ticket, original=related, atendente=atendente):
+                duplicado_fechado = True
+                _registrar_historico(
+                    db,
+                    ticket.id,
+                    atendente.id,
+                    "status_id",
+                    str(status_antigo),
+                    str(ticket.status_id),
+                )
+                _registrar_historico(
+                    db,
+                    ticket.id,
+                    atendente.id,
+                    "fechado_em",
+                    "",
+                    ticket.fechado_em.isoformat() if ticket.fechado_em else "",
+                )
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+    _registrar_historico(
+        db,
+        ticket.id,
+        atendente.id,
+        "vinculo_ticket",
+        "",
+        f"{data.tipo}:{related.id}",
+    )
+    db.commit()
+    db.refresh(v)
+    return _vinculo_para_read(v, ticket.id, db, duplicado_fechado=duplicado_fechado)
+
+
+@router.delete("/{ticket_id}/vinculos/{vinculo_id}", status_code=status.HTTP_204_NO_CONTENT)
+def remover_vinculo(
+    ticket_id: int,
+    vinculo_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if not _pode_ver_ticket(db, atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+    v = db.query(TicketVinculo).filter(TicketVinculo.id == vinculo_id).first()
+    if not v:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vínculo não encontrado")
+    if ticket_id not in (v.ticket_id, v.related_ticket_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Vínculo não encontrado neste ticket")
+    other_id = outro_ticket_id(v, ticket_id)
+    other = db.query(Ticket).filter(Ticket.id == other_id).first()
+    if other and not _pode_ver_ticket(db, atendente, other):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para remover este vínculo")
+    _registrar_historico(
+        db,
+        ticket.id,
+        atendente.id,
+        "vinculo_ticket",
+        f"{v.tipo}:{other_id}",
+        "",
+    )
+    db.delete(v)
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get("/{ticket_id}/filhos-em-massa/opcoes", response_model=TicketFilhosMassaOpcoesRead)
+def opcoes_filhos_em_massa(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket = (
+        db.query(Ticket)
+        .options(joinedload(Ticket.empresa).joinedload(Empresa.rede), joinedload(Ticket.rede))
+        .filter(Ticket.id == ticket_id)
+        .first()
+    )
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if not _pode_ver_ticket(db, atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+    try:
+        rede_id, rede_nome, opcoes = listar_opcoes_filhos_massa(db, ticket)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    return TicketFilhosMassaOpcoesRead(
+        rede_id=rede_id,
+        rede_nome=rede_nome,
+        assunto_padrao=ticket.assunto,
+        descricao_padrao=ticket.descricao,
+        setor_id=ticket.setor_id,
+        empresas=[
+            TicketFilhoMassaEmpresaOpcao(id=o.id, nome=o.nome, ja_tem_filho=o.ja_tem_filho) for o in opcoes
+        ],
+    )
+
+
+@router.post("/{ticket_id}/filhos-em-massa", response_model=TicketFilhosMassaRead, status_code=status.HTTP_201_CREATED)
+def criar_filhos_em_massa_endpoint(
+    ticket_id: int,
+    data: TicketFilhosMassaCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if not _pode_ver_ticket(db, atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+
+    setor_id = data.setor_id if data.setor_id is not None else ticket.setor_id
+    if atendente.role != "admin":
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        if setor_id not in vis:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este setor")
+    setor = db.query(Setor).filter(Setor.id == setor_id, Setor.tenant_id == atendente.tenant_id).first()
+    if not setor:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Setor não encontrado")
+
+    assunto = (data.assunto if data.assunto is not None else ticket.assunto).strip()
+    if not assunto:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Assunto é obrigatório")
+    descricao = data.descricao if data.descricao is not None else ticket.descricao
+
+    for empresa_id in data.empresa_ids:
+        _assert_parent_valido(
+            db,
+            atendente,
+            filho_empresa_id=empresa_id,
+            filho_ticket_id=None,
+            parent_id=ticket.id,
+        )
+
+    try:
+        criados = criar_filhos_em_massa(
+            db,
+            parent=ticket,
+            atendente=atendente,
+            empresa_ids=data.empresa_ids,
+            assunto=assunto,
+            descricao=descricao,
+            setor_id=setor_id,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+    _registrar_historico(db, ticket.id, atendente.id, "filhos_em_massa", "", str(len(criados)))
+    db.commit()
+
+    empresa_nomes = {
+        e.id: e.nome
+        for e in db.query(Empresa).filter(Empresa.id.in_([t.empresa_id for t in criados if t.empresa_id])).all()
+    }
+    return TicketFilhosMassaRead(
+        criados=[
+            TicketFilhoMassaCriado(
+                id=t.id,
+                protocolo=t.protocolo,
+                empresa_id=t.empresa_id,
+                empresa_nome=empresa_nomes.get(t.empresa_id, ""),
+            )
+            for t in criados
+        ],
+        total=len(criados),
+    )
 
 
 def _mensagem_para_read(m: TicketMensagem) -> TicketMensagemRead:
@@ -1088,6 +1399,7 @@ def atualizar(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Esta empresa não está vinculada ao funcionário remetente do e-mail.",
                 )
+            ticket.rede_id = empresa.rede_id
         antigo = str(ticket.empresa_id) if ticket.empresa_id is not None else ""
         novo = str(novo_eid) if novo_eid is not None else ""
         _registrar_historico(db, ticket.id, atendente.id, "empresa_id", antigo, novo)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -22,6 +22,7 @@ from app.models.tenant import Tenant
 from app.models.tenant_inbound_address import TenantInboundAddress
 from app.models.password_reset_token import PasswordResetToken
 from app.models.resposta_pronta import RespostaPronta
+from app.models.ticket_vinculo import TicketVinculo
 
 __all__ = [
     "Rede",
@@ -55,4 +56,5 @@ __all__ = [
     "TenantInboundAddress",
     "PasswordResetToken",
     "RespostaPronta",
+    "TicketVinculo",
 ]

--- a/backend/app/models/rede.py
+++ b/backend/app/models/rede.py
@@ -17,4 +17,5 @@ class Rede(Base):
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
     empresas = relationship("Empresa", back_populates="rede")
+    tickets = relationship("Ticket", back_populates="rede")
     socios = relationship("FuncionarioRede", back_populates="rede", foreign_keys="FuncionarioRede.rede_id")

--- a/backend/app/models/ticket.py
+++ b/backend/app/models/ticket.py
@@ -12,6 +12,7 @@ class Ticket(Base):
     tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
     protocolo = Column(String(32), unique=True, nullable=False, index=True)  # #TYYYYMM-NNNN (legado: numérico)
     empresa_id = Column(Integer, ForeignKey("empresas.id"), nullable=True)
+    rede_id = Column(Integer, ForeignKey("redes.id"), nullable=True, index=True)
     setor_id = Column(Integer, ForeignKey("setores.id"), nullable=False)
     status_id = Column(Integer, ForeignKey("status_ticket.id"), nullable=False)
     atendente_id = Column(Integer, ForeignKey("atendentes.id"), nullable=True)  # responsável
@@ -24,6 +25,7 @@ class Ticket(Base):
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
     empresa = relationship("Empresa", back_populates="tickets")
+    rede = relationship("Rede", back_populates="tickets")
     setor = relationship("Setor", back_populates="tickets")
     status = relationship("StatusTicket", back_populates="tickets")
     atendente = relationship("Atendente", back_populates="tickets_atendidos")
@@ -38,6 +40,16 @@ class Ticket(Base):
         "Ticket",
         foreign_keys=[parent_ticket_id],
         back_populates="parent",
+    )
+    vinculos_saida = relationship(
+        "TicketVinculo",
+        foreign_keys="TicketVinculo.ticket_id",
+        back_populates="ticket",
+    )
+    vinculos_entrada = relationship(
+        "TicketVinculo",
+        foreign_keys="TicketVinculo.related_ticket_id",
+        back_populates="related_ticket",
     )
     historicos = relationship("TicketHistorico", back_populates="ticket", order_by="TicketHistorico.created_at")
     mensagens = relationship(

--- a/backend/app/models/ticket_vinculo.py
+++ b/backend/app/models/ticket_vinculo.py
@@ -1,0 +1,31 @@
+"""Vínculos laterais entre tickets (#115): duplicado_de, relacionado_a."""
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint, CheckConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+TIPO_DUPLICADO_DE = "duplicado_de"
+TIPO_RELACIONADO_A = "relacionado_a"
+TIPOS_VINCULO = frozenset({TIPO_DUPLICADO_DE, TIPO_RELACIONADO_A})
+
+
+class TicketVinculo(Base):
+    __tablename__ = "ticket_vinculos"
+    __table_args__ = (
+        UniqueConstraint("ticket_id", "related_ticket_id", "tipo", name="uq_ticket_vinculos_par_tipo"),
+        CheckConstraint("ticket_id <> related_ticket_id", name="ck_ticket_vinculos_distintos"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    ticket_id = Column(Integer, ForeignKey("tickets.id", ondelete="CASCADE"), nullable=False, index=True)
+    related_ticket_id = Column(Integer, ForeignKey("tickets.id", ondelete="CASCADE"), nullable=False, index=True)
+    tipo = Column(String(32), nullable=False)
+    created_by_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    ticket = relationship("Ticket", foreign_keys=[ticket_id], back_populates="vinculos_saida")
+    related_ticket = relationship("Ticket", foreign_keys=[related_ticket_id], back_populates="vinculos_entrada")
+    created_by = relationship("Atendente")

--- a/backend/app/schemas/ticket.py
+++ b/backend/app/schemas/ticket.py
@@ -1,19 +1,28 @@
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from datetime import datetime
 
 
-class TicketBase(BaseModel):
-    empresa_id: int
+class TicketCreate(BaseModel):
+    empresa_id: int | None = None
+    rede_id: int | None = None
     setor_id: int
     assunto: str
     descricao: str | None = None
     aberto_por_id: int | None = None
-
-
-class TicketCreate(TicketBase):
     parent_ticket_id: int | None = None
+
+    @model_validator(mode="after")
+    def validar_escopo(self):
+        e, r = self.empresa_id, self.rede_id
+        if e is not None and r is not None:
+            raise ValueError("Informe a empresa ou a rede (coordenação), não ambos.")
+        if e is None and r is None:
+            raise ValueError("Informe a empresa ou a rede (ticket de coordenação).")
+        if self.parent_ticket_id is not None and e is None:
+            raise ValueError("Ticket filho exige empresa vinculada.")
+        return self
 
 
 class TicketUpdate(BaseModel):
@@ -47,6 +56,66 @@ class TicketChildBrief(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class TicketVinculoOutroBrief(BaseModel):
+    id: int
+    protocolo: str
+    assunto: str
+    status_nome: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TicketVinculoRead(BaseModel):
+    id: int
+    tipo: str
+    rotulo: str
+    outro_ticket: TicketVinculoOutroBrief
+    duplicado_fechado: bool = False
+
+
+class TicketVinculoCreate(BaseModel):
+    related_ticket_id: int
+    tipo: Literal["duplicado_de", "relacionado_a"]
+    fechar_como_duplicado: bool = Field(
+        default=True,
+        description="Se tipo=duplicado_de, encerra este ticket e registra mensagem pública apontando para o original.",
+    )
+
+
+class TicketFilhoMassaEmpresaOpcao(BaseModel):
+    id: int
+    nome: str
+    ja_tem_filho: bool
+
+
+class TicketFilhosMassaOpcoesRead(BaseModel):
+    rede_id: int
+    rede_nome: str | None = None
+    assunto_padrao: str
+    descricao_padrao: str | None = None
+    setor_id: int
+    empresas: list[TicketFilhoMassaEmpresaOpcao] = Field(default_factory=list)
+
+
+class TicketFilhosMassaCreate(BaseModel):
+    empresa_ids: list[int] = Field(..., min_length=1)
+    assunto: str | None = Field(None, max_length=500)
+    descricao: str | None = None
+    setor_id: int | None = None
+
+
+class TicketFilhoMassaCriado(BaseModel):
+    id: int
+    protocolo: str
+    empresa_id: int
+    empresa_nome: str
+
+
+class TicketFilhosMassaRead(BaseModel):
+    criados: list[TicketFilhoMassaCriado]
+    total: int
+
+
 class EmpresaVinculoSugerida(BaseModel):
     id: int
     nome: str
@@ -74,6 +143,7 @@ class TicketRead(BaseModel):
     updated_at: datetime | None = None
     # opcional: nomes para exibição
     rede_id: int | None = None
+    coordenacao_rede: bool = False
     empresa_nome: str | None = None
     rede_nome: str | None = None
     setor_nome: str | None = None
@@ -82,6 +152,7 @@ class TicketRead(BaseModel):
     parent_ticket_id: int | None = None
     parent: TicketParentBrief | None = None
     children: list[TicketChildBrief] = Field(default_factory=list)
+    vinculos: list[TicketVinculoRead] = Field(default_factory=list)
     triagem_inbound: TicketTriagemInbound | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/ticket_escopo.py
+++ b/backend/app/services/ticket_escopo.py
@@ -1,0 +1,48 @@
+"""Escopo de ticket: empresa, coordenação de rede ou triagem (sem empresa/rede)."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.empresa import Empresa
+from app.models.ticket import Ticket
+
+
+def validar_escopo_criacao_manual(
+    *,
+    empresa_id: int | None,
+    rede_id: int | None,
+    parent_ticket_id: int | None,
+) -> str:
+    """Retorna 'empresa' ou 'coordenacao'. Levanta ValueError se inválido."""
+    if empresa_id is not None and rede_id is not None:
+        raise ValueError("Informe a empresa ou a rede (coordenação), não ambos.")
+    if empresa_id is None and rede_id is None:
+        raise ValueError("Informe a empresa ou a rede (ticket de coordenação).")
+    if parent_ticket_id is not None and empresa_id is None:
+        raise ValueError("Ticket filho exige empresa vinculada.")
+    if empresa_id is not None:
+        return "empresa"
+    return "coordenacao"
+
+
+def rede_id_de_empresa(db: Session, empresa_id: int, *, tenant_id: int) -> int | None:
+    return (
+        db.query(Empresa.rede_id)
+        .filter(Empresa.id == empresa_id, Empresa.tenant_id == tenant_id)
+        .scalar()
+    )
+
+
+def rede_id_efetivo_ticket(db: Session, ticket: Ticket) -> int | None:
+    if ticket.rede_id is not None:
+        return ticket.rede_id
+    if ticket.empresa is not None and ticket.empresa.rede_id is not None:
+        return ticket.empresa.rede_id
+    if ticket.empresa_id is None:
+        return None
+    return rede_id_de_empresa(db, ticket.empresa_id, tenant_id=ticket.tenant_id)
+
+
+def ticket_e_coordenacao_rede(ticket: Ticket) -> bool:
+    return ticket.empresa_id is None and ticket.rede_id is not None

--- a/backend/app/services/ticket_filhos_massa.py
+++ b/backend/app/services/ticket_filhos_massa.py
@@ -1,0 +1,139 @@
+"""Abertura de tickets filhos em massa por empresa da rede (#117)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.models.atendente import Atendente
+from app.models.empresa import Empresa
+from app.models.rede import Rede
+from app.models.status_ticket import StatusTicket
+from app.models.ticket import Ticket, TicketMensagem
+from app.services.protocolo_mensal import gerar_protocolo_ticket
+from app.services.ticket_escopo import rede_id_efetivo_ticket
+
+MAX_FILHOS_MASSA = 100
+
+
+@dataclass(frozen=True)
+class EmpresaFilhoMassaOpcao:
+    id: int
+    nome: str
+    ja_tem_filho: bool
+
+
+def _rede_id_do_ticket(db: Session, ticket: Ticket) -> int:
+    rede_id = rede_id_efetivo_ticket(db, ticket)
+    if rede_id is None:
+        raise ValueError("O ticket pai precisa ter rede definida para abrir filhos em massa.")
+    return rede_id
+
+
+def listar_opcoes_filhos_massa(db: Session, parent: Ticket) -> tuple[int, str | None, list[EmpresaFilhoMassaOpcao]]:
+    rede_id = _rede_id_do_ticket(db, parent)
+    rede_nome = None
+    if parent.rede is not None:
+        rede_nome = parent.rede.nome
+    elif parent.empresa is not None and parent.empresa.rede is not None:
+        rede_nome = parent.empresa.rede.nome
+    else:
+        rede = db.query(Rede).filter(Rede.id == rede_id, Rede.tenant_id == parent.tenant_id).first()
+        rede_nome = rede.nome if rede else None
+
+    empresas = (
+        db.query(Empresa)
+        .filter(
+            Empresa.tenant_id == parent.tenant_id,
+            Empresa.rede_id == rede_id,
+            Empresa.ativo.is_(True),
+        )
+        .order_by(Empresa.nome.asc(), Empresa.id.asc())
+        .all()
+    )
+    com_filho = {
+        eid
+        for (eid,) in db.query(Ticket.empresa_id)
+        .filter(Ticket.parent_ticket_id == parent.id, Ticket.empresa_id.isnot(None))
+        .all()
+        if eid is not None
+    }
+    opcoes = [EmpresaFilhoMassaOpcao(id=e.id, nome=e.nome, ja_tem_filho=e.id in com_filho) for e in empresas]
+    return rede_id, rede_nome, opcoes
+
+
+def criar_filhos_em_massa(
+    db: Session,
+    *,
+    parent: Ticket,
+    atendente: Atendente,
+    empresa_ids: list[int],
+    assunto: str,
+    descricao: str | None,
+    setor_id: int,
+) -> list[Ticket]:
+    if not empresa_ids:
+        raise ValueError("Selecione ao menos uma empresa.")
+    if len(empresa_ids) > MAX_FILHOS_MASSA:
+        raise ValueError(f"Máximo de {MAX_FILHOS_MASSA} tickets filhos por operação.")
+
+    rede_id = _rede_id_do_ticket(db, parent)
+    ids_unicos = list(dict.fromkeys(empresa_ids))
+    if len(ids_unicos) != len(empresa_ids):
+        raise ValueError("Lista de empresas contém duplicatas.")
+
+    empresas = (
+        db.query(Empresa)
+        .filter(
+            Empresa.id.in_(ids_unicos),
+            Empresa.tenant_id == parent.tenant_id,
+            Empresa.rede_id == rede_id,
+            Empresa.ativo.is_(True),
+        )
+        .all()
+    )
+    if len(empresas) != len(ids_unicos):
+        raise ValueError("Uma ou mais empresas são inválidas ou não pertencem à rede do ticket pai.")
+
+    com_filho = {
+        eid
+        for (eid,) in db.query(Ticket.empresa_id)
+        .filter(Ticket.parent_ticket_id == parent.id, Ticket.empresa_id.isnot(None))
+        .all()
+        if eid is not None
+    }
+    for e in empresas:
+        if e.id in com_filho:
+            raise ValueError(f"Já existe ticket filho para a empresa «{e.nome}».")
+
+    status_inicial = db.query(StatusTicket).filter(StatusTicket.ativo.is_(True)).order_by(StatusTicket.ordem).first()
+    if not status_inicial:
+        raise ValueError("Cadastre ao menos um status de ticket ativo.")
+
+    corpo = (descricao or "").strip() or "—"
+    criados: list[Ticket] = []
+    for empresa in sorted(empresas, key=lambda x: x.nome.lower()):
+        ticket = Ticket(
+            tenant_id=parent.tenant_id,
+            protocolo=gerar_protocolo_ticket(db),
+            empresa_id=empresa.id,
+            rede_id=empresa.rede_id,
+            setor_id=setor_id,
+            status_id=status_inicial.id,
+            assunto=assunto.strip(),
+            descricao=descricao,
+            parent_ticket_id=parent.id,
+        )
+        db.add(ticket)
+        db.flush()
+        db.add(
+            TicketMensagem(
+                ticket_id=ticket.id,
+                atendente_id=atendente.id,
+                tipo="abertura",
+                corpo=corpo,
+            )
+        )
+        criados.append(ticket)
+    return criados

--- a/backend/app/services/ticket_from_inbound_email.py
+++ b/backend/app/services/ticket_from_inbound_email.py
@@ -19,6 +19,7 @@ from app.services.email_send_sistema import enviar_mensagem_texto_sistema
 from app.services.email_inbound_parse import ParsedInboundEmail, thread_lookup_message_ids
 from app.services.system_email_config import get_singleton_email_settings, transactional_config_from_row
 from app.services.protocolo_mensal import gerar_protocolo_ticket
+from app.services.ticket_escopo import rede_id_de_empresa
 from app.services.email_body_sanitize import sanitize_inbound_email_body
 from app.services.ticket_email_index import registar_message_id_para_ticket
 
@@ -113,6 +114,7 @@ def _criar_ticket_triagem_pos_fecho(
         tenant_id=tenant_id,
         protocolo=protocolo,
         empresa_id=empresa_id,
+        rede_id=rede_id_de_empresa(db, empresa_id, tenant_id=tenant_id) if empresa_id else None,
         setor_id=setor_id,
         status_id=status_inicial.id,
         assunto=assunto,
@@ -238,6 +240,7 @@ def processar_email_inbound(
         tenant_id=tenant_id,
         protocolo=protocolo,
         empresa_id=empresa_id,
+        rede_id=rede_id_de_empresa(db, empresa_id, tenant_id=tenant_id) if empresa_id else None,
         setor_id=setor_id,
         status_id=status_inicial.id,
         assunto=assunto,

--- a/backend/app/services/ticket_vinculos.py
+++ b/backend/app/services/ticket_vinculos.py
@@ -1,0 +1,179 @@
+"""Criação e listagem de vínculos entre tickets (#115)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import func, or_
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.atendente import Atendente
+from app.models.empresa import Empresa
+from app.models.status_ticket import StatusTicket
+from app.models.ticket import Ticket, TicketMensagem
+from app.models.ticket_vinculo import TIPO_DUPLICADO_DE, TIPO_RELACIONADO_A, TIPOS_VINCULO, TicketVinculo
+
+
+def _protocolo_exibicao(protocolo: str) -> str:
+    s = (protocolo or "").strip()
+    if not s:
+        return "—"
+    if s.startswith("#"):
+        return s
+    if s.isdigit():
+        return f"#{s}"
+    return s
+
+
+def normalizar_par_vinculo(*, ticket_id: int, related_ticket_id: int, tipo: str) -> tuple[int, int]:
+    if tipo == TIPO_RELACIONADO_A:
+        a, b = sorted((ticket_id, related_ticket_id))
+        return a, b
+    return ticket_id, related_ticket_id
+
+
+def listar_vinculos(db: Session, ticket_id: int) -> list[TicketVinculo]:
+    return (
+        db.query(TicketVinculo)
+        .options(
+            joinedload(TicketVinculo.ticket).joinedload(Ticket.status),
+            joinedload(TicketVinculo.related_ticket).joinedload(Ticket.status),
+        )
+        .filter(or_(TicketVinculo.ticket_id == ticket_id, TicketVinculo.related_ticket_id == ticket_id))
+        .order_by(TicketVinculo.id.asc())
+        .all()
+    )
+
+
+def vinculo_ja_existe(db: Session, *, ticket_id: int, related_ticket_id: int, tipo: str) -> bool:
+    tid, rid = normalizar_par_vinculo(ticket_id=ticket_id, related_ticket_id=related_ticket_id, tipo=tipo)
+    return (
+        db.query(TicketVinculo.id)
+        .filter(
+            TicketVinculo.ticket_id == tid,
+            TicketVinculo.related_ticket_id == rid,
+            TicketVinculo.tipo == tipo,
+        )
+        .first()
+        is not None
+    )
+
+
+def outro_ticket_id(v: TicketVinculo, perspectiva_ticket_id: int) -> int:
+    if v.ticket_id == perspectiva_ticket_id:
+        return v.related_ticket_id
+    return v.ticket_id
+
+
+def rotulo_vinculo(v: TicketVinculo, perspectiva_ticket_id: int) -> str:
+    if v.tipo == TIPO_RELACIONADO_A:
+        return "Relacionado a"
+    if v.ticket_id == perspectiva_ticket_id:
+        return "Duplicado de"
+    return "É duplicado deste"
+
+
+def _rede_id_do_ticket(db: Session, ticket: Ticket) -> int | None:
+    if ticket.rede_id is not None:
+        return ticket.rede_id
+    if ticket.empresa_id is None:
+        return None
+    if ticket.empresa is not None and ticket.empresa.rede_id is not None:
+        return ticket.empresa.rede_id
+    return db.query(Empresa.rede_id).filter(Empresa.id == ticket.empresa_id).scalar()
+
+
+def validar_duplicado_mesma_rede_empresa(db: Session, *, ticket: Ticket, related: Ticket) -> None:
+    if ticket.empresa_id is None or related.empresa_id is None:
+        raise ValueError("Para marcar como duplicado, ambos os tickets precisam ter empresa definida.")
+    if ticket.empresa_id != related.empresa_id:
+        raise ValueError("Tickets duplicados devem ser da mesma empresa.")
+    rede_ticket = _rede_id_do_ticket(db, ticket)
+    rede_related = _rede_id_do_ticket(db, related)
+    if rede_ticket is None or rede_related is None:
+        raise ValueError("Para marcar como duplicado, ambos os tickets precisam pertencer a uma rede.")
+    if rede_ticket != rede_related:
+        raise ValueError("Tickets duplicados devem ser da mesma rede.")
+
+
+def criar_vinculo(
+    db: Session,
+    *,
+    ticket: Ticket,
+    related: Ticket,
+    tipo: str,
+    atendente: Atendente,
+) -> TicketVinculo:
+    if tipo not in TIPOS_VINCULO:
+        raise ValueError(f"Tipo de vínculo inválido: {tipo}")
+    if ticket.id == related.id:
+        raise ValueError("Um ticket não pode ser vinculado a si mesmo.")
+    if ticket.tenant_id != related.tenant_id:
+        raise ValueError("Os tickets devem pertencer ao mesmo tenant.")
+    if tipo == TIPO_DUPLICADO_DE:
+        validar_duplicado_mesma_rede_empresa(db, ticket=ticket, related=related)
+    if vinculo_ja_existe(db, ticket_id=ticket.id, related_ticket_id=related.id, tipo=tipo):
+        raise ValueError("Este vínculo já existe.")
+
+    tid, rid = normalizar_par_vinculo(ticket_id=ticket.id, related_ticket_id=related.id, tipo=tipo)
+    row = TicketVinculo(
+        tenant_id=ticket.tenant_id,
+        ticket_id=tid,
+        related_ticket_id=rid,
+        tipo=tipo,
+        created_by_id=atendente.id,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def remover_vinculo(db: Session, *, vinculo_id: int, ticket_id: int) -> None:
+    row = (
+        db.query(TicketVinculo)
+        .filter(
+            TicketVinculo.id == vinculo_id,
+            or_(TicketVinculo.ticket_id == ticket_id, TicketVinculo.related_ticket_id == ticket_id),
+        )
+        .first()
+    )
+    if not row:
+        raise ValueError("Vínculo não encontrado.")
+    db.delete(row)
+
+
+def fechar_ticket_como_duplicado(
+    db: Session,
+    *,
+    duplicado: Ticket,
+    original: Ticket,
+    atendente: Atendente,
+) -> bool:
+    """Fecha o ticket duplicado e registra mensagem pública apontando para o original."""
+    if duplicado.fechado_em is not None:
+        return False
+
+    status_fechado = (
+        db.query(StatusTicket)
+        .filter(func.lower(StatusTicket.slug) == "fechado", StatusTicket.ativo.is_(True))
+        .first()
+    )
+    if status_fechado is None:
+        raise ValueError('Cadastre um status ativo com slug "fechado" para encerrar tickets duplicados.')
+
+    proto = _protocolo_exibicao(original.protocolo)
+    corpo = (
+        f"Este chamado foi identificado como duplicado de {proto}. "
+        f"O atendimento continua no ticket original ({proto} — {original.assunto})."
+    )
+    db.add(
+        TicketMensagem(
+            ticket_id=duplicado.id,
+            atendente_id=atendente.id,
+            tipo="publico",
+            corpo=corpo,
+        )
+    )
+    duplicado.status_id = status_fechado.id
+    duplicado.fechado_em = datetime.now(timezone.utc)
+    return True

--- a/backend/tests/test_ticket_coordenacao_rede.py
+++ b/backend/tests/test_ticket_coordenacao_rede.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+
+def _create_ticket(
+    client,
+    headers: dict[str, str],
+    *,
+    setor_id: int,
+    assunto: str = "Teste",
+    descricao: str = "Desc",
+    empresa_id: int | None = None,
+    rede_id: int | None = None,
+    parent_ticket_id: int | None = None,
+):
+    body: dict = {"setor_id": setor_id, "assunto": assunto, "descricao": descricao}
+    if empresa_id is not None:
+        body["empresa_id"] = empresa_id
+    if rede_id is not None:
+        body["rede_id"] = rede_id
+    if parent_ticket_id is not None:
+        body["parent_ticket_id"] = parent_ticket_id
+    return client.post("/v1/tickets", headers=headers, json=body)
+
+
+def test_criar_ticket_coordenacao_rede(client, seed_base, auth_headers):
+    r = _create_ticket(
+        client,
+        auth_headers["admin"],
+        rede_id=seed_base["rede"].id,
+        setor_id=seed_base["setor1"].id,
+        assunto="Rollout v2",
+        descricao="Atualização em toda a rede",
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["empresa_id"] is None
+    assert body["rede_id"] == seed_base["rede"].id
+    assert body["coordenacao_rede"] is True
+    assert body["rede_nome"] == seed_base["rede"].nome
+
+
+def test_rejeita_create_sem_empresa_sem_rede(client, seed_base, auth_headers):
+    r = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={"setor_id": seed_base["setor1"].id, "assunto": "X", "descricao": "Y"},
+    )
+    assert r.status_code == 422
+
+
+def test_rejeita_create_empresa_e_rede(client, seed_base, auth_headers):
+    r = _create_ticket(
+        client,
+        auth_headers["admin"],
+        empresa_id=seed_base["empresa"].id,
+        rede_id=seed_base["rede"].id,
+        setor_id=seed_base["setor1"].id,
+    )
+    assert r.status_code == 422
+
+
+def test_filhos_em_massa_com_pai_coordenacao(client, seed_base, auth_headers, db_session):
+    from app.models import Empresa
+
+    e2 = Empresa(tenant_id=1, rede_id=seed_base["rede"].id, nome="Filial 2", ativo=True)
+    db_session.add(e2)
+    db_session.commit()
+
+    pai = _create_ticket(
+        client,
+        auth_headers["admin"],
+        rede_id=seed_base["rede"].id,
+        setor_id=seed_base["setor1"].id,
+        assunto="Coordenação rollout",
+    )
+    assert pai.status_code == 201, pai.text
+    parent_id = pai.json()["id"]
+
+    op = client.get(f"/v1/tickets/{parent_id}/filhos-em-massa/opcoes", headers=auth_headers["admin"])
+    assert op.status_code == 200, op.text
+    ids = [e["id"] for e in op.json()["empresas"] if not e["ja_tem_filho"]]
+
+    criar = client.post(
+        f"/v1/tickets/{parent_id}/filhos-em-massa",
+        headers=auth_headers["admin"],
+        json={"empresa_ids": ids},
+    )
+    assert criar.status_code == 201, criar.text
+    assert criar.json()["total"] == 2
+
+    det = client.get(f"/v1/tickets/{parent_id}", headers=auth_headers["admin"])
+    assert len(det.json()["children"]) == 2
+
+
+def test_filho_exige_empresa(client, seed_base, auth_headers):
+    pai = _create_ticket(
+        client,
+        auth_headers["admin"],
+        rede_id=seed_base["rede"].id,
+        setor_id=seed_base["setor1"].id,
+        assunto="Pai coordenação",
+    )
+    assert pai.status_code == 201
+    r = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "rede_id": seed_base["rede"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Filho inválido",
+            "descricao": "x",
+            "parent_ticket_id": pai.json()["id"],
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_pai_coordenacao_bloqueia_fechamento_com_filho_aberto(client, seed_base, auth_headers, db_session):
+    from app.models import StatusTicket
+
+    fechado = StatusTicket(nome="Fechado", slug="fechado", ordem=99, ativo=True)
+    db_session.add(fechado)
+    db_session.commit()
+    db_session.refresh(fechado)
+
+    pai = _create_ticket(
+        client,
+        auth_headers["admin"],
+        rede_id=seed_base["rede"].id,
+        setor_id=seed_base["setor1"].id,
+        assunto="Coordenação",
+    )
+    assert pai.status_code == 201
+    parent_id = pai.json()["id"]
+
+    client.post(
+        f"/v1/tickets/{parent_id}/filhos-em-massa",
+        headers=auth_headers["admin"],
+        json={"empresa_ids": [seed_base["empresa"].id]},
+    )
+
+    r = client.patch(
+        f"/v1/tickets/{parent_id}",
+        headers=auth_headers["admin"],
+        json={"status_id": fechado.id},
+    )
+    assert r.status_code == 400
+    assert "filho" in r.json()["detail"].lower()

--- a/backend/tests/test_ticket_filhos_massa.py
+++ b/backend/tests/test_ticket_filhos_massa.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+
+def _create_ticket(
+    client,
+    headers: dict[str, str],
+    empresa_id: int,
+    setor_id: int,
+    *,
+    assunto: str = "Teste",
+    descricao: str = "Desc",
+    parent_ticket_id: int | None = None,
+):
+    body: dict = {"empresa_id": empresa_id, "setor_id": setor_id, "assunto": assunto, "descricao": descricao}
+    if parent_ticket_id is not None:
+        body["parent_ticket_id"] = parent_ticket_id
+    return client.post("/v1/tickets", headers=headers, json=body)
+
+
+def _add_empresas_rede(db_session, rede_id: int, nomes: list[str]):
+    from app.models import Empresa
+
+    rows = [Empresa(tenant_id=1, rede_id=rede_id, nome=n, ativo=True) for n in nomes]
+    db_session.add_all(rows)
+    db_session.commit()
+    return rows
+
+
+def test_opcoes_e_criacao_filhos_em_massa(client, seed_base, auth_headers, db_session):
+    extras = _add_empresas_rede(db_session, seed_base["rede"].id, ["Loja B", "Loja C"])
+
+    pai = _create_ticket(
+        client,
+        auth_headers["admin"],
+        seed_base["empresa"].id,
+        seed_base["setor1"].id,
+        assunto="Atualização de sistema",
+        descricao="Deploy v2 em toda a rede",
+    )
+    assert pai.status_code == 201, pai.text
+    parent_id = pai.json()["id"]
+
+    op = client.get(f"/v1/tickets/{parent_id}/filhos-em-massa/opcoes", headers=auth_headers["admin"])
+    assert op.status_code == 200, op.text
+    body = op.json()
+    assert body["rede_id"] == seed_base["rede"].id
+    assert body["assunto_padrao"] == "Atualização de sistema"
+    assert len(body["empresas"]) == 3
+    assert all(not e["ja_tem_filho"] for e in body["empresas"])
+
+    ids = [e["id"] for e in body["empresas"]]
+    criar = client.post(
+        f"/v1/tickets/{parent_id}/filhos-em-massa",
+        headers=auth_headers["admin"],
+        json={"empresa_ids": ids},
+    )
+    assert criar.status_code == 201, criar.text
+    res = criar.json()
+    assert res["total"] == 3
+    assert len(res["criados"]) == 3
+    assert {c["empresa_id"] for c in res["criados"]} == set(ids)
+
+    det = client.get(f"/v1/tickets/{parent_id}", headers=auth_headers["admin"])
+    assert det.status_code == 200
+    assert len(det.json()["children"]) == 3
+
+    hist = client.get(f"/v1/tickets/{parent_id}/historico", headers=auth_headers["admin"])
+    assert hist.status_code == 200
+    assert any(h["campo"] == "filhos_em_massa" and h["valor_novo"] == "3" for h in hist.json())
+
+    op2 = client.get(f"/v1/tickets/{parent_id}/filhos-em-massa/opcoes", headers=auth_headers["admin"])
+    assert op2.status_code == 200
+    assert all(e["ja_tem_filho"] for e in op2.json()["empresas"])
+
+    dup = client.post(
+        f"/v1/tickets/{parent_id}/filhos-em-massa",
+        headers=auth_headers["admin"],
+        json={"empresa_ids": [extras[0].id]},
+    )
+    assert dup.status_code == 400
+    assert "Já existe ticket filho" in dup.json()["detail"]
+
+
+def test_filhos_em_massa_assunto_customizado(client, seed_base, auth_headers):
+    pai = _create_ticket(
+        client,
+        auth_headers["admin"],
+        seed_base["empresa"].id,
+        seed_base["setor1"].id,
+        assunto="Pai",
+    )
+    assert pai.status_code == 201
+    parent_id = pai.json()["id"]
+
+    criar = client.post(
+        f"/v1/tickets/{parent_id}/filhos-em-massa",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_ids": [seed_base["empresa"].id],
+            "assunto": "Filho custom",
+            "descricao": "Instruções específicas",
+        },
+    )
+    assert criar.status_code == 201, criar.text
+    filho_id = criar.json()["criados"][0]["id"]
+    filho = client.get(f"/v1/tickets/{filho_id}", headers=auth_headers["admin"])
+    assert filho.status_code == 200
+    assert filho.json()["assunto"] == "Filho custom"
+    assert filho.json()["descricao"] == "Instruções específicas"
+
+
+def test_filhos_em_massa_rbac_setor(client, seed_base, auth_headers, db_session):
+    _add_empresas_rede(db_session, seed_base["rede"].id, ["Outra loja"])
+    pai = _create_ticket(
+        client,
+        auth_headers["admin"],
+        seed_base["empresa"].id,
+        seed_base["setor2"].id,
+        assunto="Pai financeiro",
+    )
+    assert pai.status_code == 201
+    parent_id = pai.json()["id"]
+
+    op = client.get(f"/v1/tickets/{parent_id}/filhos-em-massa/opcoes", headers=auth_headers["a1"])
+    assert op.status_code == 403
+
+    ids = [e["id"] for e in client.get(
+        f"/v1/tickets/{parent_id}/filhos-em-massa/opcoes",
+        headers=auth_headers["admin"],
+    ).json()["empresas"]]
+
+    criar = client.post(
+        f"/v1/tickets/{parent_id}/filhos-em-massa",
+        headers=auth_headers["a1"],
+        json={"empresa_ids": ids[:1]},
+    )
+    assert criar.status_code == 403

--- a/backend/tests/test_ticket_vinculos.py
+++ b/backend/tests/test_ticket_vinculos.py
@@ -1,0 +1,238 @@
+"""Vínculos entre tickets duplicado / relacionado (#115)."""
+
+from __future__ import annotations
+
+
+def _ensure_status_fechado(db_session):
+    from sqlalchemy import func
+
+    from app.models import StatusTicket
+
+    st = db_session.query(StatusTicket).filter(func.lower(StatusTicket.slug) == "fechado").first()
+    if st:
+        st.ativo = True
+        db_session.commit()
+        return st
+    st = StatusTicket(nome="Fechado", slug="fechado", ordem=99, ativo=True)
+    db_session.add(st)
+    db_session.commit()
+    db_session.refresh(st)
+    return st
+
+
+def _create_ticket(client, auth_headers, seed_base, assunto: str = "Ticket base"):
+    r = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": assunto,
+            "descricao": "Teste",
+        },
+    )
+    assert r.status_code == 201
+    return r.json()
+
+
+def test_criar_vinculo_duplicado_e_relacionado(client, seed_base, auth_headers, db_session):
+    _ensure_status_fechado(db_session)
+    a = _create_ticket(client, auth_headers, seed_base, "Original")
+    b = _create_ticket(client, auth_headers, seed_base, "Cópia")
+    c = _create_ticket(client, auth_headers, seed_base, "Outro")
+
+    r1 = client.post(
+        f"/v1/tickets/{b['id']}/vinculos",
+        headers=auth_headers["admin"],
+        json={"related_ticket_id": a["id"], "tipo": "duplicado_de"},
+    )
+    assert r1.status_code == 201, r1.text
+    j1 = r1.json()
+    assert j1["tipo"] == "duplicado_de"
+    assert j1["rotulo"] == "Duplicado de"
+    assert j1["outro_ticket"]["id"] == a["id"]
+    assert j1["duplicado_fechado"] is True
+
+    g_b_fechado = client.get(f"/v1/tickets/{b['id']}", headers=auth_headers["admin"])
+    assert g_b_fechado.json()["fechado_em"] is not None
+
+    msgs_b = client.get(f"/v1/tickets/{b['id']}/mensagens", headers=auth_headers["admin"])
+    assert msgs_b.status_code == 200
+    publicas = [m for m in msgs_b.json() if m["tipo"] == "publico"]
+    assert any("duplicado de" in m["corpo"].lower() for m in publicas)
+
+    r2 = client.post(
+        f"/v1/tickets/{b['id']}/vinculos",
+        headers=auth_headers["admin"],
+        json={"related_ticket_id": c["id"], "tipo": "relacionado_a"},
+    )
+    assert r2.status_code == 201, r2.text
+
+    g_b = client.get(f"/v1/tickets/{b['id']}", headers=auth_headers["admin"])
+    assert g_b.status_code == 200
+    assert len(g_b.json()["vinculos"]) == 2
+
+    g_a = client.get(f"/v1/tickets/{a['id']}", headers=auth_headers["admin"])
+    assert g_a.status_code == 200
+    vinculos_a = g_a.json()["vinculos"]
+    assert len(vinculos_a) == 1
+    assert vinculos_a[0]["rotulo"] == "É duplicado deste"
+    assert vinculos_a[0]["outro_ticket"]["id"] == b["id"]
+
+
+def test_nao_vincula_a_si(client, seed_base, auth_headers):
+    t = _create_ticket(client, auth_headers, seed_base)
+    r = client.post(
+        f"/v1/tickets/{t['id']}/vinculos",
+        headers=auth_headers["admin"],
+        json={"related_ticket_id": t["id"], "tipo": "relacionado_a"},
+    )
+    assert r.status_code == 400
+
+
+def test_vinculo_duplicado_rejeitado(client, seed_base, auth_headers, db_session):
+    _ensure_status_fechado(db_session)
+    a = _create_ticket(client, auth_headers, seed_base, "A")
+    b = _create_ticket(client, auth_headers, seed_base, "B")
+    payload = {"related_ticket_id": a["id"], "tipo": "duplicado_de"}
+    assert client.post(f"/v1/tickets/{b['id']}/vinculos", headers=auth_headers["admin"], json=payload).status_code == 201
+    r2 = client.post(f"/v1/tickets/{b['id']}/vinculos", headers=auth_headers["admin"], json=payload)
+    assert r2.status_code == 400
+
+
+def test_remover_vinculo(client, seed_base, auth_headers):
+    a = _create_ticket(client, auth_headers, seed_base, "Manter")
+    b = _create_ticket(client, auth_headers, seed_base, "Remover")
+    r = client.post(
+        f"/v1/tickets/{b['id']}/vinculos",
+        headers=auth_headers["admin"],
+        json={"related_ticket_id": a["id"], "tipo": "relacionado_a"},
+    )
+    vid = r.json()["id"]
+    d = client.delete(f"/v1/tickets/{b['id']}/vinculos/{vid}", headers=auth_headers["admin"])
+    assert d.status_code == 204
+    g = client.get(f"/v1/tickets/{b['id']}", headers=auth_headers["admin"])
+    assert g.json()["vinculos"] == []
+
+
+def test_atendente_sem_acesso_ao_outro_ticket(client, seed_base, auth_headers):
+    a = _create_ticket(client, auth_headers, seed_base, "Setor1")
+    b = _create_ticket(client, auth_headers, seed_base, "Setor1 B")
+    # atendente1 só vê setor1 - ok for both same setor
+    r_ok = client.post(
+        f"/v1/tickets/{b['id']}/vinculos",
+        headers=auth_headers["a1"],
+        json={"related_ticket_id": a["id"], "tipo": "relacionado_a"},
+    )
+    assert r_ok.status_code == 201
+
+    # ticket em setor2 invisível para a1
+    t2 = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor2"].id,
+            "assunto": "Financeiro",
+            "descricao": "x",
+        },
+    ).json()
+    r_denied = client.post(
+        f"/v1/tickets/{a['id']}/vinculos",
+        headers=auth_headers["a1"],
+        json={"related_ticket_id": t2["id"], "tipo": "relacionado_a"},
+    )
+    assert r_denied.status_code == 403
+
+
+def test_duplicado_sem_fechar_mantem_ticket_aberto(client, seed_base, auth_headers):
+    a = _create_ticket(client, auth_headers, seed_base, "Original")
+    b = _create_ticket(client, auth_headers, seed_base, "Cópia aberta")
+
+    r = client.post(
+        f"/v1/tickets/{b['id']}/vinculos",
+        headers=auth_headers["admin"],
+        json={
+            "related_ticket_id": a["id"],
+            "tipo": "duplicado_de",
+            "fechar_como_duplicado": False,
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["duplicado_fechado"] is False
+
+    g_b = client.get(f"/v1/tickets/{b['id']}", headers=auth_headers["admin"])
+    assert g_b.json()["fechado_em"] is None
+
+
+def test_duplicado_rejeita_empresa_diferente(client, seed_base, auth_headers, db_session):
+    from app.models import Empresa
+
+    _ensure_status_fechado(db_session)
+    outra = Empresa(tenant_id=seed_base["tenant"].id, rede_id=seed_base["rede"].id, nome="Empresa B", ativo=True)
+    db_session.add(outra)
+    db_session.commit()
+    db_session.refresh(outra)
+
+    original = _create_ticket(client, auth_headers, seed_base, "Original")
+    outro = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": outra.id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Outra empresa",
+            "descricao": "Teste",
+        },
+    )
+    assert outro.status_code == 201
+
+    r = client.post(
+        f"/v1/tickets/{outro.json()['id']}/vinculos",
+        headers=auth_headers["admin"],
+        json={
+            "related_ticket_id": original["id"],
+            "tipo": "duplicado_de",
+            "fechar_como_duplicado": False,
+        },
+    )
+    assert r.status_code == 400
+    assert "mesma empresa" in r.json()["detail"].lower()
+
+
+def test_duplicado_rejeita_rede_diferente(client, seed_base, auth_headers, db_session):
+    from app.models import Empresa, Rede
+
+    _ensure_status_fechado(db_session)
+    rede2 = Rede(tenant_id=seed_base["tenant"].id, nome="Rede B", ativo=True)
+    db_session.add(rede2)
+    db_session.flush()
+    emp2 = Empresa(tenant_id=seed_base["tenant"].id, rede_id=rede2.id, nome="Empresa rede B", ativo=True)
+    db_session.add(emp2)
+    db_session.commit()
+    db_session.refresh(emp2)
+
+    original = _create_ticket(client, auth_headers, seed_base, "Original rede A")
+    outro = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": emp2.id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Outra rede",
+            "descricao": "Teste",
+        },
+    )
+    assert outro.status_code == 201
+
+    r = client.post(
+        f"/v1/tickets/{outro.json()['id']}/vinculos",
+        headers=auth_headers["admin"],
+        json={
+            "related_ticket_id": original["id"],
+            "tipo": "duplicado_de",
+            "fechar_como_duplicado": False,
+        },
+    )
+    assert r.status_code == 400
+    assert "mesma rede" in r.json()["detail"].lower() or "mesma empresa" in r.json()["detail"].lower()

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,15 +44,12 @@ import { AlterarSenha } from './pages/AlterarSenha'
 import { AcessoNegado } from './pages/AcessoNegado'
 import { ToastProvider } from './components/ui/Toast'
 import { ErrorBoundary } from './components/ErrorBoundary'
+import { PageLoading } from './components/ui/PageLoading'
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth()
   if (loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-950">
-        <span className="text-slate-500 dark:text-slate-400">Carregando...</span>
-      </div>
-    )
+    return <PageLoading fullscreen label="Carregando sessão…" />
   }
   if (!user) {
     return <Navigate to="/login" replace />
@@ -63,11 +60,7 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 function AdminRoute({ children }: { children: React.ReactNode }) {
   const { user, loading } = useAuth()
   if (loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-slate-50 dark:bg-slate-950">
-        <span className="text-slate-500 dark:text-slate-400">Carregando...</span>
-      </div>
-    )
+    return <PageLoading fullscreen label="Carregando sessão…" />
   }
   if (!user) {
     return <Navigate to="/login" replace />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -795,6 +795,17 @@ export const tickets = {
   reabrir: (id: number) => api<Tickets.Ticket>(`/tickets/${id}/reabrir`, { method: 'POST' }),
   create: (data: Tickets.Create) => api<Tickets.Ticket>('/tickets', { method: 'POST', body: JSON.stringify(data) }),
   update: (id: number, data: Tickets.Update) => api<Tickets.Ticket>(`/tickets/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  addVinculo: (ticketId: number, data: Tickets.VinculoCreate) =>
+    api<Tickets.TicketVinculo>(`/tickets/${ticketId}/vinculos`, { method: 'POST', body: JSON.stringify(data) }),
+  removeVinculo: (ticketId: number, vinculoId: number) =>
+    api<void>(`/tickets/${ticketId}/vinculos/${vinculoId}`, { method: 'DELETE' }),
+  filhosMassaOpcoes: (ticketId: number) =>
+    api<Tickets.FilhosMassaOpcoes>(`/tickets/${ticketId}/filhos-em-massa/opcoes`),
+  criarFilhosMassa: (ticketId: number, data: Tickets.FilhosMassaCreate) =>
+    api<Tickets.FilhosMassaResult>(`/tickets/${ticketId}/filhos-em-massa`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   anexosList: (id: number) => api<Tickets.Anexo[]>(`/tickets/${id}/anexos`),
   uploadAnexo: (id: number, file: File, mensagemId?: number | null) => {
     const fd = new FormData()
@@ -1204,13 +1215,63 @@ export namespace Tickets {
     rede_id?: number | null;
     empresa_nome?: string | null;
     rede_nome?: string;
+    coordenacao_rede?: boolean;
     setor_nome?: string;
     status_nome?: string;
     atendente_nome?: string;
     parent_ticket_id?: number | null;
     parent?: TicketParentBrief | null;
     children?: TicketChildBrief[];
+    vinculos?: TicketVinculo[];
     triagem_inbound?: TriagemInbound | null;
+  }
+  export type TicketVinculoTipo = 'duplicado_de' | 'relacionado_a';
+  export interface TicketVinculoOutro {
+    id: number;
+    protocolo: string;
+    assunto: string;
+    status_nome?: string | null;
+  }
+  export interface TicketVinculo {
+    id: number;
+    tipo: TicketVinculoTipo;
+    rotulo: string;
+    outro_ticket: TicketVinculoOutro;
+    duplicado_fechado?: boolean;
+  }
+  export interface VinculoCreate {
+    related_ticket_id: number;
+    tipo: TicketVinculoTipo;
+    fechar_como_duplicado?: boolean;
+  }
+  export interface FilhoMassaEmpresaOpcao {
+    id: number;
+    nome: string;
+    ja_tem_filho: boolean;
+  }
+  export interface FilhosMassaOpcoes {
+    rede_id: number;
+    rede_nome?: string | null;
+    assunto_padrao: string;
+    descricao_padrao?: string | null;
+    setor_id: number;
+    empresas: FilhoMassaEmpresaOpcao[];
+  }
+  export interface FilhosMassaCreate {
+    empresa_ids: number[];
+    assunto?: string | null;
+    descricao?: string | null;
+    setor_id?: number | null;
+  }
+  export interface FilhoMassaCriado {
+    id: number;
+    protocolo: string;
+    empresa_id: number;
+    empresa_nome: string;
+  }
+  export interface FilhosMassaResult {
+    criados: FilhoMassaCriado[];
+    total: number;
   }
   export interface Historico {
     id: number;
@@ -1223,7 +1284,8 @@ export namespace Tickets {
     created_at: string;
   }
   export interface Create {
-    empresa_id: number;
+    empresa_id?: number | null;
+    rede_id?: number | null;
     setor_id: number;
     assunto: string;
     descricao?: string;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -32,10 +32,12 @@ export function Layout() {
   }
 
   const sidebarW = sidebarExpanded ? '280px' : '80px'
+  const scrollInternoNaPagina =
+    /^\/tickets\/\d+\/?$/.test(location.pathname) || location.pathname === '/tickets/novo'
 
   return (
     <div
-      className="min-h-screen bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95 md:grid md:h-dvh md:max-h-dvh md:min-h-0 md:overflow-hidden md:grid-cols-[var(--sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
+      className="flex h-dvh max-h-dvh min-h-0 overflow-hidden bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95 md:grid md:grid-cols-[var(--sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
       style={
         {
           ['--sidebar-w' as never]: sidebarW,
@@ -52,10 +54,8 @@ export function Layout() {
         onLogout={logout}
       />
 
-      {/* Coluna principal: no desktop alinhada à sidebar via grid (sem margin-left) */}
-      <div className="flex min-h-screen min-w-0 flex-col md:col-start-2 md:row-start-1 md:h-full md:min-h-0 md:overflow-hidden">
-          {/* Top bar: mobile-first, área de toque generosa */}
-          <header className="sticky top-0 z-30 flex h-14 min-h-[56px] shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-800 dark:bg-slate-950 md:gap-3 md:px-6">
+      <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden md:col-start-2 md:row-start-1">
+          <header className="z-30 flex h-14 min-h-[56px] shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-800 dark:bg-slate-950 md:gap-3 md:px-6">
             <button
               type="button"
               onClick={() => {
@@ -71,9 +71,8 @@ export function Layout() {
             >
               {menuIcon}
             </button>
-            
-            {/* Logo DX Connect visível apenas no mobile */}
-            <div className="flex items-center overflow-hidden rounded-lg gap-2 md:hidden">
+
+            <div className="flex items-center gap-2 overflow-hidden rounded-lg md:hidden">
               <img
                 src="/dx-connect-mark.png"
                 alt=""
@@ -88,7 +87,7 @@ export function Layout() {
                 <span className="font-medium text-slate-700 dark:text-slate-200"> Connect</span>
               </span>
             </div>
-            
+
             <div className="min-w-0 flex-1" />
             <NavbarNotificacoes enabled={notificacoesEnabled} />
             <ThemeToggle />
@@ -98,8 +97,16 @@ export function Layout() {
             </div>
           </header>
 
-          <main className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto p-4 md:p-6">
-            <Outlet />
+          <main className="min-h-0 flex-1 overflow-hidden">
+            <div
+              className={
+                scrollInternoNaPagina
+                  ? 'flex h-full min-h-0 flex-col overflow-hidden px-4 pt-4 md:px-6 md:pt-6'
+                  : 'h-full min-h-0 overflow-x-hidden overflow-y-auto p-4 md:p-6'
+              }
+            >
+              <Outlet />
+            </div>
           </main>
       </div>
     </div>

--- a/frontend/src/components/TicketBuscaPicker.tsx
+++ b/frontend/src/components/TicketBuscaPicker.tsx
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useState } from 'react'
+import { tickets, type Tickets } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { exibirProtocolo } from '../lib/exibirProtocolo'
+import { Input } from './ui/Input'
+import { useToast } from './ui/Toast'
+
+type Props = {
+  /** Ticket atual — nunca aparece na lista. */
+  ticketAtualId: number
+  /** IDs adicionais a omitir (já vinculados, filhos, etc.). */
+  excluirIds?: number[]
+  /** Restringe a listagem (ex.: duplicado = mesma rede e empresa). */
+  filtroEmpresaId?: number | null
+  filtroRedeId?: number | null
+  label?: string
+  hint?: string
+  disabled?: boolean
+  loadingExterno?: boolean
+  onSelecionar: (ticket: Tickets.Ticket) => void
+}
+
+export function TicketBuscaPicker({
+  ticketAtualId,
+  excluirIds = [],
+  filtroEmpresaId,
+  filtroRedeId,
+  label = 'Buscar ticket em aberto',
+  hint = 'Liste tickets abertos; filtre por protocolo, assunto ou empresa.',
+  disabled,
+  loadingExterno,
+  onSelecionar,
+}: Props) {
+  const toast = useToast()
+  const [busca, setBusca] = useState('')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+  const [itens, setItens] = useState<Tickets.Ticket[]>([])
+  const [loading, setLoading] = useState(false)
+
+  const omitir = useCallback(
+    (id: number) => id === ticketAtualId || excluirIds.includes(id),
+    [excluirIds, ticketAtualId],
+  )
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBusca(busca.trim()), 300)
+    return () => clearTimeout(t)
+  }, [busca])
+
+  const filtrosAtivos = filtroEmpresaId != null || filtroRedeId != null
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    tickets
+      .list({
+        situacao: 'abertos',
+        busca: debouncedBusca || undefined,
+        empresa_id: filtroEmpresaId ?? undefined,
+        rede_id: filtroRedeId ?? undefined,
+        limit: 20,
+        ordenar_por: 'protocolo',
+        ordem: 'desc',
+      })
+      .then((r) => {
+        if (cancelled) return
+        setItens(r.items.filter((t) => !omitir(t.id)))
+      })
+      .catch((err) => {
+        if (cancelled) return
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível buscar tickets.'))
+        setItens([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [debouncedBusca, filtroEmpresaId, filtroRedeId, omitir, toast])
+
+  const bloqueado = disabled || loadingExterno
+
+  return (
+    <div className="min-w-0">
+      <Input
+        label={label}
+        value={busca}
+        onChange={(e) => setBusca(e.target.value)}
+        placeholder="Protocolo, assunto ou empresa…"
+        disabled={bloqueado}
+      />
+      {hint ? <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{hint}</p> : null}
+      <div
+        className="mt-2 max-h-52 overflow-y-auto rounded-lg border border-slate-200/90 bg-white dark:border-slate-700/80 dark:bg-slate-950/40"
+        role="listbox"
+        aria-label="Tickets em aberto"
+      >
+        {loading ? (
+          <p className="px-3 py-4 text-center text-sm text-slate-500 dark:text-slate-400">Carregando…</p>
+        ) : itens.length === 0 ? (
+          <p className="px-3 py-4 text-center text-sm text-slate-500 dark:text-slate-400">
+            {debouncedBusca
+              ? 'Nenhum ticket em aberto encontrado.'
+              : filtrosAtivos
+                ? 'Nenhum outro ticket em aberto na mesma rede e empresa.'
+                : 'Nenhum ticket em aberto disponível para vincular.'}
+          </p>
+        ) : (
+          <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+            {itens.map((t) => (
+              <li key={t.id}>
+                <button
+                  type="button"
+                  role="option"
+                  disabled={bloqueado}
+                  onClick={() => onSelecionar(t)}
+                  className="flex w-full flex-col gap-0.5 px-3 py-2.5 text-left transition-colors hover:bg-cyan-50/80 disabled:opacity-50 dark:hover:bg-cyan-950/30"
+                >
+                  <span className="font-mono text-xs font-semibold text-cyan-800 dark:text-cyan-300">
+                    {exibirProtocolo(t.protocolo)}
+                  </span>
+                  <span className="line-clamp-2 text-sm text-slate-800 dark:text-slate-100">{t.assunto}</span>
+                  <span className="text-xs text-slate-500 dark:text-slate-400">
+                    {[t.empresa_nome, t.setor_nome, t.status_nome].filter(Boolean).join(' · ') || `Ticket #${t.id}`}
+                  </span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/tickets/TicketDetalheSkeleton.tsx
+++ b/frontend/src/components/tickets/TicketDetalheSkeleton.tsx
@@ -1,0 +1,59 @@
+function Pulse({ className }: { className: string }) {
+  return <div className={`animate-pulse rounded-lg bg-slate-200/90 dark:bg-slate-800/70 ${className}`} aria-hidden />
+}
+
+export function TicketDetalheSkeleton() {
+  return (
+    <div
+      className="-m-4 flex h-full min-h-0 flex-col overflow-hidden md:-m-6"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Carregando ticket"
+    >
+      <div className="shrink-0 border-b border-slate-200/70 bg-white dark:border-slate-700/70 dark:bg-slate-950 sm:rounded-b-2xl sm:border sm:border-t-0">
+        <div className="mx-auto max-w-6xl space-y-3 px-3 py-2.5 sm:px-5 sm:py-4 lg:py-5">
+          <Pulse className="h-4 w-16" />
+          <div className="flex items-start justify-between gap-3">
+            <Pulse className="h-6 w-32 lg:h-8 lg:w-40" />
+            <div className="hidden gap-2 lg:flex">
+              <Pulse className="h-9 w-14" />
+              <Pulse className="h-9 w-16" />
+            </div>
+          </div>
+          <Pulse className="h-5 w-full max-w-xl sm:h-6" />
+          <Pulse className="h-4 w-2/3 max-w-sm" />
+          <div className="flex gap-2 overflow-hidden pt-1">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Pulse key={i} className="h-7 w-20 shrink-0 rounded-full" />
+            ))}
+          </div>
+          <Pulse className="h-3 w-40" />
+          <div className="border-t border-slate-100 pt-2 lg:hidden dark:border-slate-800">
+            <div className="grid grid-cols-2 gap-1.5">
+              <Pulse className="h-9 w-full" />
+              <Pulse className="h-9 w-full" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-6xl space-y-4 px-3 py-3 sm:space-y-6 sm:px-5 sm:py-4 md:px-6">
+          <div className="rounded-xl border border-slate-200/90 bg-white p-4 dark:border-slate-700/80 dark:bg-slate-950/40">
+            <Pulse className="mb-3 h-4 w-28" />
+            <div className="space-y-3">
+              <Pulse className="h-16 w-full rounded-xl" />
+              <Pulse className="h-16 w-full rounded-xl" />
+              <Pulse className="h-24 w-full rounded-xl" />
+            </div>
+          </div>
+          <div className="rounded-xl border border-slate-200/90 bg-white p-4 dark:border-slate-700/80 dark:bg-slate-950/40">
+            <Pulse className="mb-3 h-4 w-24" />
+            <Pulse className="h-28 w-full rounded-xl" />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/tickets/TicketFilhosMassaPanel.tsx
+++ b/frontend/src/components/tickets/TicketFilhosMassaPanel.tsx
@@ -1,0 +1,200 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ApiError, tickets, type Tickets } from '../../api/client'
+import { Button } from '../ui/Button'
+import { CheckboxField } from '../ui/CheckboxField'
+import { Input } from '../ui/Input'
+import { useToast } from '../ui/Toast'
+import { exibirProtocolo } from '../../lib/exibirProtocolo'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+
+interface Props {
+  ticketId: number
+  disabled?: boolean
+  onCriados: () => void | Promise<void>
+}
+
+export function TicketFilhosMassaPanel({ ticketId, disabled, onCriados }: Props) {
+  const toast = useToast()
+  const [opcoes, setOpcoes] = useState<Tickets.FilhosMassaOpcoes | null>(null)
+  const [carregandoOpcoes, setCarregandoOpcoes] = useState(true)
+  const [erroOpcoes, setErroOpcoes] = useState<string | null>(null)
+  const [selecionados, setSelecionados] = useState<Set<number>>(new Set())
+  const [assunto, setAssunto] = useState('')
+  const [descricao, setDescricao] = useState('')
+  const [criando, setCriando] = useState(false)
+  const [ultimosCriados, setUltimosCriados] = useState<Tickets.FilhoMassaCriado[]>([])
+
+  const elegiveis = useMemo(
+    () => opcoes?.empresas.filter((e) => !e.ja_tem_filho) ?? [],
+    [opcoes],
+  )
+
+  const carregarOpcoes = useCallback(async () => {
+    setCarregandoOpcoes(true)
+    setErroOpcoes(null)
+    try {
+      const data = await tickets.filhosMassaOpcoes(ticketId)
+      setOpcoes(data)
+      setAssunto(data.assunto_padrao)
+      setDescricao(data.descricao_padrao ?? '')
+      const ids = data.empresas.filter((e) => !e.ja_tem_filho).map((e) => e.id)
+      setSelecionados(new Set(ids))
+      setUltimosCriados([])
+    } catch (err) {
+      const msg =
+        err instanceof ApiError ? err.message : mensagemFalhaParaToast(err, 'Não foi possível carregar as empresas.')
+      setErroOpcoes(msg)
+      setOpcoes(null)
+    } finally {
+      setCarregandoOpcoes(false)
+    }
+  }, [ticketId])
+
+  useEffect(() => {
+    void carregarOpcoes()
+  }, [carregarOpcoes])
+
+  const toggleEmpresa = (id: number) => {
+    setSelecionados((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  const selecionarTodos = () => setSelecionados(new Set(elegiveis.map((e) => e.id)))
+  const limparSelecao = () => setSelecionados(new Set())
+
+  const handleCriar = async () => {
+    if (selecionados.size === 0) {
+      toast.showWarning('Selecione ao menos uma empresa.')
+      return
+    }
+    const assuntoTrim = assunto.trim()
+    if (!assuntoTrim) {
+      toast.showWarning('Informe o assunto dos tickets filhos.')
+      return
+    }
+    setCriando(true)
+    try {
+      const res = await tickets.criarFilhosMassa(ticketId, {
+        empresa_ids: Array.from(selecionados),
+        assunto: assuntoTrim,
+        descricao: descricao.trim() || null,
+      })
+      setUltimosCriados(res.criados)
+      toast.showSuccess(`${res.total} ticket${res.total === 1 ? '' : 's'} filho${res.total === 1 ? '' : 's'} criado${res.total === 1 ? '' : 's'}.`)
+      await onCriados()
+      await carregarOpcoes()
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível criar os tickets filhos.'))
+    } finally {
+      setCriando(false)
+    }
+  }
+
+  if (carregandoOpcoes) {
+    return <p className="text-sm text-slate-500 dark:text-slate-400">Carregando empresas da rede…</p>
+  }
+
+  if (erroOpcoes) {
+    return <p className="text-sm text-amber-700 dark:text-amber-400">{erroOpcoes}</p>
+  }
+
+  if (!opcoes) return null
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-slate-500 dark:text-slate-400">
+        Rede: <span className="font-medium text-slate-700 dark:text-slate-200">{opcoes.rede_nome ?? `#${opcoes.rede_id}`}</span>
+        {' · '}
+        Um ticket filho será aberto para cada empresa selecionada, vinculado a este ticket pai.
+      </p>
+
+      <Input
+        label="Assunto dos filhos"
+        value={assunto}
+        onChange={(e) => setAssunto(e.target.value)}
+        disabled={disabled || criando}
+      />
+
+      <label className="block text-sm">
+        <span className="mb-1 block font-medium text-slate-700 dark:text-slate-200">Descrição dos filhos</span>
+        <textarea
+          className="min-h-[72px] w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-500/30 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+          value={descricao}
+          onChange={(e) => setDescricao(e.target.value)}
+          disabled={disabled || criando}
+          rows={3}
+        />
+      </label>
+
+      <div>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            Empresas ({selecionados.size}/{elegiveis.length} selecionadas)
+          </p>
+          {elegiveis.length > 1 && (
+            <div className="flex gap-2">
+              <Button type="button" variant="ghost" className="px-2 py-1 text-xs" disabled={disabled || criando} onClick={selecionarTodos}>
+                Todas
+              </Button>
+              <Button type="button" variant="ghost" className="px-2 py-1 text-xs" disabled={disabled || criando} onClick={limparSelecao}>
+                Nenhuma
+              </Button>
+            </div>
+          )}
+        </div>
+
+        {elegiveis.length === 0 ? (
+          <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
+            Todas as empresas ativas desta rede já possuem ticket filho vinculado.
+          </p>
+        ) : (
+          <div className="mt-2 flex max-h-48 flex-wrap gap-2 overflow-y-auto">
+            {opcoes.empresas.map((emp) => (
+              <CheckboxField
+                key={emp.id}
+                checked={selecionados.has(emp.id)}
+                disabled={disabled || criando || emp.ja_tem_filho}
+                onChange={() => toggleEmpresa(emp.id)}
+              >
+                {emp.nome}
+                {emp.ja_tem_filho ? ' (já tem filho)' : ''}
+              </CheckboxField>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {ultimosCriados.length > 0 && (
+        <ul className="rounded-lg border border-emerald-200 bg-emerald-50/80 px-3 py-2 text-sm dark:border-emerald-900/50 dark:bg-emerald-950/30">
+          {ultimosCriados.map((c) => (
+            <li key={c.id}>
+              <Link
+                to={`/tickets/${c.id}`}
+                className="font-medium text-emerald-800 underline hover:text-emerald-950 dark:text-emerald-300 dark:hover:text-emerald-200"
+              >
+                {exibirProtocolo(c.protocolo)}
+              </Link>
+              <span className="text-emerald-700 dark:text-emerald-400"> — {c.empresa_nome}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Button
+        type="button"
+        variant="primary"
+        loading={criando}
+        disabled={disabled || elegiveis.length === 0 || selecionados.size === 0}
+        onClick={() => void handleCriar()}
+      >
+        Criar {selecionados.size > 0 ? selecionados.size : ''} ticket{selecionados.size === 1 ? '' : 's'} filho
+        {selecionados.size === 1 ? '' : 's'}
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/components/tickets/TicketMetaChip.tsx
+++ b/frontend/src/components/tickets/TicketMetaChip.tsx
@@ -1,0 +1,22 @@
+type Props = {
+  label: string
+  value: string
+  onClick: () => void
+  disabled?: boolean
+}
+
+export function TicketMetaChip({ label, value, onClick, disabled }: Props) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="inline-flex shrink-0 items-center gap-1 rounded-full border border-slate-200/90 bg-slate-50/80 px-2.5 py-1 text-left text-[11px] shadow-sm transition-[transform,colors] hover:border-slate-300 hover:bg-slate-100/90 active:scale-[0.98] disabled:pointer-events-none disabled:opacity-50 dark:border-slate-600 dark:bg-slate-800/70 dark:hover:border-slate-500 dark:hover:bg-slate-800 touch-manipulation sm:gap-1.5 sm:px-3 sm:py-1.5 sm:text-xs"
+    >
+      <span className="shrink-0 font-medium text-slate-500 dark:text-slate-400">{label}</span>
+      <span className="max-w-[7.5rem] truncate font-semibold text-slate-800 sm:max-w-[10rem] dark:text-slate-100">
+        {value}
+      </span>
+    </button>
+  )
+}

--- a/frontend/src/components/ui/PageLoading.tsx
+++ b/frontend/src/components/ui/PageLoading.tsx
@@ -1,0 +1,46 @@
+type Props = {
+  label?: string
+  /** Ocupa a tela inteira (ex.: sessão / auth). */
+  fullscreen?: boolean
+  className?: string
+}
+
+export function PageLoading({
+  label = 'Carregando…',
+  fullscreen = false,
+  className = '',
+}: Props) {
+  const shell = fullscreen
+    ? 'h-dvh max-h-dvh bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95'
+    : 'min-h-[40vh]'
+
+  return (
+    <div
+      className={`flex flex-col items-center justify-center px-6 ${shell} ${className}`.trim()}
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label={label}
+    >
+      <div className="relative flex size-11 items-center justify-center">
+        <span
+          className="absolute inset-0 rounded-full border border-cyan-200/80 dark:border-cyan-900/60"
+          aria-hidden
+        />
+        <span
+          className="absolute inset-0 animate-spin rounded-full border-2 border-transparent border-t-cyan-600 dark:border-t-cyan-400"
+          aria-hidden
+        />
+        <img
+          src="/dx-connect-mark.png"
+          alt=""
+          width={22}
+          height={22}
+          className="relative size-[22px] object-contain opacity-90 dark:brightness-0 dark:invert"
+        />
+      </div>
+      <p className="mt-4 text-sm font-medium tracking-tight text-slate-700 dark:text-slate-200">{label}</p>
+      <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">Só um instante</p>
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,6 +7,8 @@
   html {
     -webkit-tap-highlight-color: transparent;
     -webkit-text-size-adjust: 100%;
+    height: 100%;
+    overflow: hidden;
   }
 
   html.dark {
@@ -15,11 +17,17 @@
 
   body {
     margin: 0;
-    min-height: 100vh;
-    min-height: 100dvh;
+    height: 100dvh;
+    max-height: 100dvh;
+    overflow: hidden;
     font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-    overflow-x: hidden;
     @apply bg-slate-50 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100;
+  }
+
+  #root {
+    height: 100%;
+    max-height: 100dvh;
+    overflow: hidden;
   }
 }
 

--- a/frontend/src/pages/EsqueciSenha.tsx
+++ b/frontend/src/pages/EsqueciSenha.tsx
@@ -34,7 +34,7 @@ export function EsqueciSenha() {
   }
 
   return (
-    <div className="relative flex min-h-dvh flex-col justify-center bg-[#050810] px-4 py-10 font-[family-name:'Plus_Jakarta_Sans',system-ui,sans-serif] text-slate-100 antialiased">
+    <div className="relative flex h-dvh max-h-dvh min-h-0 flex-col overflow-y-auto bg-[#050810] px-4 py-10 font-[family-name:'Plus_Jakarta_Sans',system-ui,sans-serif] text-slate-100 antialiased">
       <div className="mx-auto w-full max-w-[400px] space-y-6">
         <header className="text-center">
           <h1 className="text-2xl font-semibold text-white">Esqueci minha senha</h1>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -103,7 +103,7 @@ export function Login() {
 
   return (
     <div
-      className="relative flex min-h-dvh flex-col bg-[#050810] font-[family-name:'Plus_Jakarta_Sans',system-ui,sans-serif] text-slate-100 antialiased lg:flex-row"
+      className="relative flex h-dvh max-h-dvh min-h-0 flex-col overflow-y-auto bg-[#050810] font-[family-name:'Plus_Jakarta_Sans',system-ui,sans-serif] text-slate-100 antialiased lg:flex-row"
       style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
     >
       <LoginMeshBg />

--- a/frontend/src/pages/RedefinirSenha.tsx
+++ b/frontend/src/pages/RedefinirSenha.tsx
@@ -48,7 +48,7 @@ export function RedefinirSenha() {
 
   if (!token) {
     return (
-      <div className="flex min-h-dvh flex-col items-center justify-center bg-[#050810] px-4 text-center text-slate-100">
+      <div className="flex h-dvh max-h-dvh flex-col items-center justify-center overflow-y-auto bg-[#050810] px-4 text-center text-slate-100">
         <p className="mb-4 text-sm text-slate-400">Link inválido ou incompleto.</p>
         <Link to="/esqueci-senha" className="text-cyan-400/90 hover:text-cyan-300">
           Solicitar novo link
@@ -58,7 +58,7 @@ export function RedefinirSenha() {
   }
 
   return (
-    <div className="relative flex min-h-dvh flex-col justify-center bg-[#050810] px-4 py-10 font-[family-name:'Plus_Jakarta_Sans',system-ui,sans-serif] text-slate-100 antialiased">
+    <div className="relative flex h-dvh max-h-dvh min-h-0 flex-col overflow-y-auto bg-[#050810] px-4 py-10 font-[family-name:'Plus_Jakarta_Sans',system-ui,sans-serif] text-slate-100 antialiased">
       <div className="mx-auto w-full max-w-[400px] space-y-6">
         <header className="text-center">
           <h1 className="text-2xl font-semibold text-white">Nova senha</h1>

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -37,6 +37,11 @@ import { autorRodapeMensagem, corpoMensagemEmailVisivel } from '../lib/ticketMen
 import { mensagemEmFilaEmail } from '../lib/ticketMensagemEmailOutbox'
 import { TicketMensagemEmailOutbox } from '../components/TicketMensagemEmailOutbox'
 import { RespostasProntasPicker } from '../components/RespostasProntasPicker'
+import { CheckboxField } from '../components/ui/CheckboxField'
+import { TicketBuscaPicker } from '../components/TicketBuscaPicker'
+import { TicketFilhosMassaPanel } from '../components/tickets/TicketFilhosMassaPanel'
+import { TicketMetaChip } from '../components/tickets/TicketMetaChip'
+import { TicketDetalheSkeleton } from '../components/tickets/TicketDetalheSkeleton'
 
 const ROTULO_CAMPO: Record<string, string> = {
   status_id: 'Status',
@@ -46,6 +51,8 @@ const ROTULO_CAMPO: Record<string, string> = {
   assunto: 'Assunto',
   descricao: 'Descrição',
   parent_ticket_id: 'Ticket pai',
+  filhos_em_massa: 'Tickets filhos em massa',
+  vinculo_ticket: 'Vínculo com ticket',
 }
 
 function resolverValorHistorico(
@@ -187,15 +194,26 @@ export function TicketDetalhe() {
   const [modalFecharAberto, setModalFecharAberto] = useState(false)
   /** Qual bloco do modal recebe destaque ao abrir (chips no cabeçalho). */
   const [modalGerirFoco, setModalGerirFoco] = useState<
-    'geral' | 'setor' | 'status' | 'atendente' | 'hierarquia'
+    'geral' | 'setor' | 'status' | 'atendente' | 'hierarquia' | 'relacionados'
   >('geral')
   const [historicoAberto, setHistoricoAberto] = useState(false)
 
-  const [idFilhoParaVincular, setIdFilhoParaVincular] = useState('')
-  const [idPaiParaVincular, setIdPaiParaVincular] = useState('')
+  const [tipoVinculoRelacionado, setTipoVinculoRelacionado] = useState<Tickets.TicketVinculoTipo>('relacionado_a')
+  const [fecharComoDuplicado, setFecharComoDuplicado] = useState(true)
+  const [vinculandoRelacionado, setVinculandoRelacionado] = useState(false)
+  const [removendoVinculoId, setRemovendoVinculoId] = useState<number | null>(null)
   const [vinculandoFilho, setVinculandoFilho] = useState(false)
   const [vinculandoPai, setVinculandoPai] = useState(false)
   const [desvinculandoHierarquia, setDesvinculandoHierarquia] = useState(false)
+
+  const idsTicketsExcluirBusca = useMemo(() => {
+    if (!ticket) return []
+    const ids = new Set<number>([ticket.id])
+    if (ticket.parent_ticket_id != null) ids.add(ticket.parent_ticket_id)
+    for (const c of ticket.children ?? []) ids.add(c.id)
+    for (const v of ticket.vinculos ?? []) ids.add(v.outro_ticket.id)
+    return [...ids]
+  }, [ticket])
 
   const setoresParaSelect = useMemo(() => {
     const ativos = setoresList.filter((s) => s.ativo)
@@ -289,6 +307,13 @@ export function TicketDetalhe() {
     if (temPai && n === 0) return 'Com pai'
     if (!temPai && n > 0) return `${n} filho${n === 1 ? '' : 's'}`
     return `Pai + ${n} filho${n === 1 ? '' : 's'}`
+  }, [ticket])
+
+  const rotuloChipRelacionados = useMemo(() => {
+    if (!ticket) return '—'
+    const n = ticket.vinculos?.length ?? 0
+    if (n === 0) return 'Sem vínculos'
+    return `${n} relacionado${n === 1 ? '' : 's'}`
   }, [ticket])
 
   const podeEditarHierarquia = !!ticket && (!ticket.fechado_em || isAdmin)
@@ -618,7 +643,9 @@ export function TicketDetalhe() {
     }
   }, [modalGerirAberto, editSetor, editAtendente, atendentesList, setoresList])
 
-  function abrirModalGerir(foco: 'geral' | 'setor' | 'status' | 'atendente' | 'hierarquia' = 'geral') {
+  function abrirModalGerir(
+    foco: 'geral' | 'setor' | 'status' | 'atendente' | 'hierarquia' | 'relacionados' = 'geral',
+  ) {
     if (!ticket) return
     setEditSetor(ticket.setor_id)
     setEditStatus(ticket.status_id)
@@ -627,10 +654,6 @@ export function TicketDetalhe() {
     setEditEmpresa(ticket.empresa_id ?? '')
     setModalGerirFoco(foco)
     setModalGerirAberto(true)
-    if (foco === 'hierarquia') {
-      setIdFilhoParaVincular('')
-      setIdPaiParaVincular('')
-    }
   }
 
   useEffect(() => {
@@ -677,7 +700,8 @@ export function TicketDetalhe() {
       .catch(() => setEmpresasModalList([]))
   }, [modalGerirAberto, editRede, editEmpresa, empresasVinculoSugeridas.length])
 
-  const modalApenasUmCampo = modalGerirFoco !== 'geral' && modalGerirFoco !== 'hierarquia'
+  const modalApenasUmCampo =
+    modalGerirFoco !== 'geral' && modalGerirFoco !== 'hierarquia' && modalGerirFoco !== 'relacionados'
 
   async function handleSalvar() {
     if (!ticket) return
@@ -743,20 +767,14 @@ export function TicketDetalhe() {
     }
   }
 
-  async function handleVincularFilhoExistente() {
-    if (!ticket) return
-    const id = Number(idFilhoParaVincular.trim())
-    if (!Number.isFinite(id) || id < 1 || id === ticket.id) {
-      toast.showWarning('Informe o número de outro ticket (filho) válido, diferente deste.')
-      return
-    }
+  async function handleVincularFilhoExistente(alvo: Tickets.Ticket) {
+    if (!ticket || alvo.id === ticket.id) return
     setVinculandoFilho(true)
     try {
-      await tickets.update(id, { parent_ticket_id: ticket.id })
+      await tickets.update(alvo.id, { parent_ticket_id: ticket.id })
       const atualizado = await tickets.get(ticket.id)
       setTicket(atualizado)
-      setIdFilhoParaVincular('')
-      toast.showSuccess('Ticket vinculado como filho.')
+      toast.showSuccess(`Ticket ${exibirProtocolo(alvo.protocolo)} vinculado como filho.`)
     } catch (err) {
       toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível vincular o ticket.'))
     } finally {
@@ -764,24 +782,24 @@ export function TicketDetalhe() {
     }
   }
 
-  async function handleVincularAoPai() {
-    if (!ticket) return
-    const id = Number(idPaiParaVincular.trim())
-    if (!Number.isFinite(id) || id < 1 || id === ticket.id) {
-      toast.showWarning('Informe o número de um ticket pai válido, diferente deste.')
-      return
-    }
+  async function handleVincularAoPai(alvo: Tickets.Ticket) {
+    if (!ticket || alvo.id === ticket.id) return
     setVinculandoPai(true)
     try {
-      const atualizado = await tickets.update(ticket.id, { parent_ticket_id: id })
+      const atualizado = await tickets.update(ticket.id, { parent_ticket_id: alvo.id })
       setTicket(atualizado)
-      setIdPaiParaVincular('')
-      toast.showSuccess('Ticket vinculado ao pai indicado.')
+      toast.showSuccess(`Vinculado ao ticket ${exibirProtocolo(alvo.protocolo)}.`)
     } catch (err) {
       toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível vincular ao ticket pai.'))
     } finally {
       setVinculandoPai(false)
     }
+  }
+
+  async function recarregarTicketAtual() {
+    if (!ticket) return
+    const atualizado = await tickets.get(ticket.id)
+    setTicket(atualizado)
   }
 
   async function handleDesvincularDoPai() {
@@ -810,6 +828,59 @@ export function TicketDetalhe() {
       toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível desvincular o filho.'))
     } finally {
       setDesvinculandoHierarquia(false)
+    }
+  }
+
+  async function handleAdicionarVinculoRelacionado(alvo: Tickets.Ticket) {
+    if (!ticket || alvo.id === ticket.id) return
+    setVinculandoRelacionado(true)
+    try {
+      const fechar =
+        tipoVinculoRelacionado === 'duplicado_de' ? fecharComoDuplicado : false
+      const resultado = await tickets.addVinculo(ticket.id, {
+        related_ticket_id: alvo.id,
+        tipo: tipoVinculoRelacionado,
+        fechar_como_duplicado: fechar,
+      })
+      const [atualizado, mensagensAtualizadas, historicoAtualizado] = await Promise.all([
+        tickets.get(ticket.id),
+        tickets.listMensagens(ticket.id),
+        tickets.getHistorico(ticket.id),
+      ])
+      setTicket(atualizado)
+      setMensagens(mensagensAtualizadas)
+      setHistorico(historicoAtualizado)
+      setEditStatus(atualizado.status_id)
+      if (resultado.duplicado_fechado) {
+        void refetchPendenciasResumo()
+        toast.showSuccess(
+          `Ticket fechado como duplicado de ${exibirProtocolo(alvo.protocolo)}. O atendimento continua no original.`,
+        )
+        setModalGerirAberto(false)
+      } else if (tipoVinculoRelacionado === 'duplicado_de') {
+        toast.showSuccess(`Vínculo de duplicado com ${exibirProtocolo(alvo.protocolo)} registrado (ticket mantido aberto).`)
+      } else {
+        toast.showSuccess(`Vínculo com ${exibirProtocolo(alvo.protocolo)} adicionado.`)
+      }
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível adicionar o vínculo.'))
+    } finally {
+      setVinculandoRelacionado(false)
+    }
+  }
+
+  async function handleRemoverVinculoRelacionado(vinculoId: number) {
+    if (!ticket) return
+    setRemovendoVinculoId(vinculoId)
+    try {
+      await tickets.removeVinculo(ticket.id, vinculoId)
+      const atualizado = await tickets.get(ticket.id)
+      setTicket(atualizado)
+      toast.showSuccess('Vínculo removido.')
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível remover o vínculo.'))
+    } finally {
+      setRemovendoVinculoId(null)
     }
   }
 
@@ -964,11 +1035,7 @@ export function TicketDetalhe() {
   }
 
   if (loading) {
-    return (
-      <div className="flex min-h-[40vh] items-center justify-center text-slate-500 dark:text-slate-400">
-        Carregando ticket…
-      </div>
-    )
+    return <TicketDetalheSkeleton />
   }
 
   if (forbidden) {
@@ -994,280 +1061,286 @@ export function TicketDetalhe() {
     return null
   }
 
-  return (
-    <div className="mx-auto max-w-6xl pb-10">
-      <div className="sticky top-14 z-10 -mx-3 border-b border-slate-200/70 bg-white/90 px-3 py-4 backdrop-blur dark:border-slate-700/70 dark:bg-slate-950/70 sm:mx-0 sm:rounded-2xl sm:border sm:px-5 sm:py-5">
-      <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
-        <button
-          type="button"
-          onClick={voltarAnterior}
-          className="font-medium text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
-        >
-          ← Voltar
-        </button>
-        <span aria-hidden className="text-slate-300 dark:text-slate-600">
-          /
-        </span>
-        <span
-          className="min-w-0 truncate font-semibold text-slate-800 dark:text-slate-100"
-          title={exibirProtocolo(ticket.protocolo)}
-        >
-          {exibirProtocolo(ticket.protocolo)}
-        </span>
-      </nav>
+  function tentarEditarTicket(acao: () => void) {
+    if (ticket.fechado_em && !isAdmin) {
+      toast.showWarning('Ticket fechado — apenas admin pode alterar.')
+      return
+    }
+    acao()
+  }
 
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-400 dark:text-slate-500">Assunto</p>
-          <h1 className="mt-0.5 text-xl font-semibold tracking-tight text-slate-900 dark:text-slate-100 sm:text-2xl">
-            {ticket.assunto}
-          </h1>
-          {(ticket.empresa_nome || ticket.rede_nome) && (
-            <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
-              {ticket.rede_nome && (
-                <span className="text-slate-500 dark:text-slate-400">{ticket.rede_nome}</span>
-              )}
-              {ticket.rede_nome && ticket.empresa_nome && (
-                <span className="mx-1.5 text-slate-400 dark:text-slate-500">·</span>
-              )}
-              {ticket.empresa_nome && (
-                <span className="font-medium text-slate-800 dark:text-slate-200">{ticket.empresa_nome}</span>
-              )}
-            </p>
-          )}
-          {triagemInbound && (
-            <div
-              className={`mt-3 rounded-lg border px-3 py-2.5 text-sm ${
-                requerCadastroFuncionario
-                  ? 'border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-800/60 dark:bg-amber-950/40 dark:text-amber-100'
-                  : 'border-sky-200 bg-sky-50 text-sky-950 dark:border-sky-800/60 dark:bg-sky-950/40 dark:text-sky-100'
-              }`}
-            >
-              {requerCadastroFuncionario ? (
-                <>
-                  <p className="font-medium">Remetente sem cadastro de funcionário</p>
-                  <p className="mt-1 text-xs opacity-90">
-                    {triagemInbound.conflito_multiplas_redes
-                      ? 'O e-mail está associado a mais de uma rede — corrija o cadastro antes de vincular o ticket.'
-                      : `E-mail ${triagemInbound.remetente_email || 'desconhecido'}: cadastre o funcionário numa rede e empresa para os próximos e-mails abrirem já vinculados.`}
-                  </p>
-                  {isAdmin && (
-                    <Link
-                      to={linkCadastroFuncionario}
-                      className="mt-2 inline-block text-xs font-semibold underline underline-offset-2"
-                    >
-                      Cadastrar funcionário
-                    </Link>
-                  )}
-                </>
-              ) : (
-                <>
-                  <p className="font-medium">Defina a empresa do ticket</p>
-                  <p className="mt-1 text-xs opacity-90">
-                    O remetente está em mais de uma empresa da rede
-                    {ticket.rede_nome ? ` ${ticket.rede_nome}` : ''}. Escolha a empresa em Gerir ticket.
-                  </p>
-                  <button
-                    type="button"
-                    onClick={() => abrirModalGerir('geral')}
-                    className="mt-2 text-xs font-semibold underline underline-offset-2"
-                  >
-                    Gerir ticket
-                  </button>
-                </>
-              )}
-            </div>
-          )}
-          {podeAtribuirAMim && (
-            <p className="mt-2 text-sm text-slate-500 dark:text-slate-400">
-              Este ticket está na fila do setor sem responsável. Atribua a você para dar andamento.
-            </p>
-          )}
-          <div className="mt-3 flex flex-wrap gap-2" role="group" aria-label="Ações rápidas do ticket">
-            <button
-              type="button"
-              onClick={() => {
-                if (ticket.fechado_em && !isAdmin) {
-                  toast.showWarning('Ticket fechado — apenas admin pode alterar.')
-                  return
-                }
-                abrirModalGerir('setor')
-              }}
-              className="inline-flex max-w-full items-center gap-2 rounded-full border border-slate-200/90 bg-slate-50/80 px-3 py-1.5 text-left text-xs shadow-sm transition-colors hover:border-slate-300 hover:bg-slate-100/90 dark:border-slate-600 dark:bg-slate-800/70 dark:hover:border-slate-500 dark:hover:bg-slate-800"
-            >
-              <span className="shrink-0 font-medium text-slate-500 dark:text-slate-400">Setor</span>
-              <span className="min-w-0 truncate font-semibold text-slate-800 dark:text-slate-100">
-                {ticket.setor_nome ?? `Setor #${ticket.setor_id}`}
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                if (ticket.fechado_em && !isAdmin) {
-                  toast.showWarning('Ticket fechado — apenas admin pode alterar.')
-                  return
-                }
-                abrirModalGerir('status')
-              }}
-              className="inline-flex max-w-full items-center gap-2 rounded-full border border-slate-200/90 bg-slate-50/80 px-3 py-1.5 text-left text-xs shadow-sm transition-colors hover:border-slate-300 hover:bg-slate-100/90 dark:border-slate-600 dark:bg-slate-800/70 dark:hover:border-slate-500 dark:hover:bg-slate-800"
-            >
-              <span className="shrink-0 font-medium text-slate-500 dark:text-slate-400">Status</span>
-              <span className="min-w-0 truncate font-semibold text-slate-800 dark:text-slate-100">
-                {ticket.status_nome ?? String(ticket.status_id)}
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                if (ticket.fechado_em && !isAdmin) {
-                  toast.showWarning('Ticket fechado — apenas admin pode alterar.')
-                  return
-                }
-                abrirModalGerir('atendente')
-              }}
-              className="inline-flex max-w-full items-center gap-2 rounded-full border border-slate-200/90 bg-slate-50/80 px-3 py-1.5 text-left text-xs shadow-sm transition-colors hover:border-slate-300 hover:bg-slate-100/90 dark:border-slate-600 dark:bg-slate-800/70 dark:hover:border-slate-500 dark:hover:bg-slate-800"
-            >
-              <span className="shrink-0 font-medium text-slate-500 dark:text-slate-400">Responsável</span>
-              <span className="min-w-0 truncate font-semibold text-slate-800 dark:text-slate-100">
-                {ticket.atendente_nome ?? '—'}
-              </span>
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                if (ticket.fechado_em && !isAdmin) {
-                  toast.showWarning('Ticket fechado — apenas admin pode alterar.')
-                  return
-                }
-                abrirModalGerir('hierarquia')
-              }}
-              className="inline-flex max-w-full items-center gap-2 rounded-full border border-slate-200/90 bg-slate-50/80 px-3 py-1.5 text-left text-xs shadow-sm transition-colors hover:border-slate-300 hover:bg-slate-100/90 dark:border-slate-600 dark:bg-slate-800/70 dark:hover:border-slate-500 dark:hover:bg-slate-800"
-            >
-              <span className="shrink-0 font-medium text-slate-500 dark:text-slate-400">Hierarquia</span>
-              <span className="min-w-0 truncate font-semibold text-slate-800 dark:text-slate-100">
-                {rotuloChipHierarquia}
-              </span>
-            </button>
-          </div>
-          <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500 dark:text-slate-400">
-            <span>
-              Aberto em {ticket.created_at ? new Date(ticket.created_at).toLocaleString('pt-BR') : '—'}
-            </span>
-            {ticket.fechado_em && (
-              <span className="font-medium text-emerald-700 dark:text-emerald-400">
-                Fechado em {new Date(ticket.fechado_em).toLocaleString('pt-BR')}
-              </span>
-            )}
-          </div>
-          {chatsWhatsapp.length > 0 && (
-            <div className="mt-4 rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2 dark:border-slate-700 dark:bg-slate-900/40">
-              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                Chats vinculados (WhatsApp)
-              </p>
-              <ul className="mt-2 flex flex-wrap gap-2">
-                {chatsWhatsapp.map((c) => (
-                  <li key={c.id}>
-                    <Link
-                      to={`/whatsapp/c/${c.id}`}
-                      className="text-sm font-medium text-cyan-700 underline hover:text-cyan-900 dark:text-cyan-400 dark:hover:text-cyan-300"
-                    >
-                      {exibirProtocolo(c.protocolo)}
-                      {c.estado === 'encerrado' ? ' (encerrado)' : ''}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </div>
-        <div className="flex shrink-0 flex-wrap items-center gap-2">
-          {isAdmin && ticket.fechado_em && (
-            <Button
-              type="button"
-              onClick={async () => {
-                try {
-                  const updated = await tickets.reabrir(ticket.id)
-                  setTicket(updated)
-                  setEditStatus(updated.status_id)
-                  setEditAtendente(updated.atendente_id ?? '')
-                  const hist = await tickets.getHistorico(updated.id)
-                  setHistorico(hist)
-                  toast.showSuccess('Ticket reaberto.')
-                } catch (err) {
-                  if (err instanceof ApiError && err.status === 404) {
-                    toast.showWarning(
-                      'Função de reabrir indisponível no servidor. Atualize a página ou contate o suporte.',
-                    )
-                    return
-                  }
-                  toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível reabrir.'))
-                }
-              }}
-            >
-              Reabrir
-            </Button>
-          )}
-          {podeAtribuirAMim && !ticket.fechado_em && (
-            <Button type="button" onClick={handleAtribuirAMim} loading={atribuindo}>
-              Atribuir a mim
-            </Button>
-          )}
-          {!ticket.fechado_em && (
-            <Button
-              type="button"
-              variant="secondary"
-              loading={fechando}
-              onClick={async () => {
-                if (!ticket) return
-                if (!statusFechado) {
-                  toast.showWarning('Não existe um status com slug "fechado". Cadastre/ajuste em Status de ticket.')
-                  return
-                }
-                setModalFecharAberto(true)
-              }}
-            >
-              Fechar ticket
-            </Button>
-          )}
-          <Button
-            type="button"
-            variant="secondary"
-            disabled={Boolean(ticket.fechado_em) && !isAdmin}
-            onClick={() => {
-              if (ticket.fechado_em && !isAdmin) {
-                toast.showWarning('Ticket fechado — apenas admin pode alterar.')
+  const dataAberturaCurta = ticket.created_at
+    ? new Date(ticket.created_at).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: 'numeric' })
+    : '—'
+
+  const classeBtnAcao = 'h-9 w-full px-3 text-xs lg:w-auto sm:h-auto sm:text-sm'
+
+  const linkVoltar = (
+    <button
+      type="button"
+      onClick={voltarAnterior}
+      className="-ml-1 mb-2 inline-flex items-center gap-1.5 rounded-lg px-2 py-1.5 text-sm font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900 dark:text-slate-400 dark:hover:bg-slate-800/80 dark:hover:text-slate-100"
+      aria-label="Voltar"
+    >
+      <span aria-hidden className="text-base leading-none">
+        ←
+      </span>
+      Voltar
+    </button>
+  )
+
+  const botoesAcaoTicket = (
+    <>
+      {isAdmin && ticket.fechado_em && (
+        <Button
+          type="button"
+          variant="secondary"
+          className={`${classeBtnAcao} border border-emerald-200 bg-emerald-50 text-emerald-900 hover:bg-emerald-100 dark:border-emerald-800/60 dark:bg-emerald-950/40 dark:text-emerald-100 dark:hover:bg-emerald-950/60`}
+          onClick={async () => {
+            try {
+              const updated = await tickets.reabrir(ticket.id)
+              setTicket(updated)
+              setEditStatus(updated.status_id)
+              setEditAtendente(updated.atendente_id ?? '')
+              const hist = await tickets.getHistorico(updated.id)
+              setHistorico(hist)
+              toast.showSuccess('Ticket reaberto.')
+            } catch (err) {
+              if (err instanceof ApiError && err.status === 404) {
+                toast.showWarning(
+                  'Função de reabrir indisponível no servidor. Atualize a página ou contate o suporte.',
+                )
                 return
               }
-              abrirModalGerir('geral')
+              toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível reabrir.'))
+            }
+          }}
+        >
+          Reabrir
+        </Button>
+      )}
+      {podeAtribuirAMim && !ticket.fechado_em && (
+        <Button
+          type="button"
+          className={classeBtnAcao}
+          onClick={handleAtribuirAMim}
+          loading={atribuindo}
+        >
+          Atribuir a mim
+        </Button>
+      )}
+      <Button
+        type="button"
+        variant="secondary"
+        className={`${classeBtnAcao} border border-cyan-200/90 bg-cyan-50/90 text-cyan-950 hover:bg-cyan-100 dark:border-cyan-800/70 dark:bg-cyan-950/45 dark:text-cyan-100 dark:hover:bg-cyan-950/70`}
+        disabled={Boolean(ticket.fechado_em) && !isAdmin}
+        onClick={() => tentarEditarTicket(() => abrirModalGerir('geral'))}
+      >
+        Gerir
+      </Button>
+      {!ticket.fechado_em && (
+        <>
+          <span
+            className="hidden h-7 w-px shrink-0 bg-slate-200 dark:bg-slate-700 sm:inline-block"
+            aria-hidden
+          />
+          <Button
+            type="button"
+            variant="danger"
+            className={classeBtnAcao}
+            loading={fechando}
+            onClick={() => {
+              if (!statusFechado) {
+                toast.showWarning('Não existe um status com slug "fechado". Cadastre/ajuste em Status de ticket.')
+                return
+              }
+              setModalFecharAberto(true)
             }}
           >
-            Gerir ticket
+            Fechar
           </Button>
-          <Button variant="secondary" onClick={voltarAnterior}>
-            Voltar
-          </Button>
-        </div>
-      </div>
-      </div>
+        </>
+      )}
+    </>
+  )
 
-      <div className="mt-6 space-y-6">
-        {!temVinculosHierarquia ? (
-          <p className="text-sm text-slate-600 dark:text-slate-400">
-            Este ticket não está vinculado a um ticket pai nem possui filhos vinculados.
-            {podeEditarHierarquia ? (
-              <>
-                {' '}
-                <button
-                  type="button"
-                  className="font-medium text-cyan-700 underline decoration-cyan-700/30 underline-offset-2 hover:text-cyan-900 dark:text-cyan-400 dark:hover:text-cyan-300"
-                  onClick={() => abrirModalGerir('hierarquia')}
-                >
-                  Gerir vínculos
-                </button>
-              </>
-            ) : null}
-          </p>
-        ) : (
+  const barraAcoesDesktop = (
+    <div className="hidden shrink-0 items-center gap-2 lg:flex">{botoesAcaoTicket}</div>
+  )
+
+  return (
+    <>
+      <div className="-m-4 flex h-full min-h-0 flex-col overflow-hidden md:-m-6">
+        <div className="relative z-20 shrink-0 border-b border-slate-200/70 bg-white shadow-sm dark:border-slate-700/70 dark:bg-slate-950 sm:rounded-b-2xl sm:border sm:border-t-0">
+          <div className="mx-auto max-w-6xl px-3 py-2.5 sm:px-5 sm:py-4 lg:py-5">
+            {linkVoltar}
+
+            <div className="flex items-start justify-between gap-3 lg:items-center">
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-x-2.5 gap-y-1.5">
+                  <span
+                    className="font-mono text-xs font-bold tracking-tight text-cyan-800 sm:text-sm lg:text-lg xl:text-xl dark:text-cyan-300"
+                    title={exibirProtocolo(ticket.protocolo)}
+                  >
+                    {exibirProtocolo(ticket.protocolo)}
+                  </span>
+                  {ticket.fechado_em ? (
+                    <span className="inline-flex shrink-0 rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold uppercase text-emerald-800 lg:text-xs dark:bg-emerald-950/50 dark:text-emerald-200">
+                      Fechado
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              {barraAcoesDesktop}
+            </div>
+
+            <h1 className="mt-1.5 line-clamp-2 text-sm font-semibold leading-snug text-slate-900 sm:mt-2 sm:text-base md:text-lg lg:line-clamp-3 lg:text-xl dark:text-slate-100">
+              {ticket.assunto}
+            </h1>
+
+            {(ticket.coordenacao_rede || (!ticket.empresa_id && ticket.rede_id)) && (
+              <span className="mt-1 inline-flex rounded-md bg-violet-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-violet-800 sm:text-[11px] dark:bg-violet-950/50 dark:text-violet-200">
+                Coordenação de rede
+              </span>
+            )}
+
+            {(ticket.empresa_nome || ticket.rede_nome) && (
+              <p className="mt-1 truncate text-[11px] text-slate-600 sm:text-xs md:text-sm dark:text-slate-400">
+                {ticket.rede_nome &&
+                  (ticket.rede_id != null ? (
+                    <Link
+                      to={`/redes/${ticket.rede_id}`}
+                      className="font-medium text-cyan-700 underline decoration-cyan-700/35 underline-offset-2 hover:text-cyan-900 dark:text-cyan-400 dark:decoration-cyan-400/35 dark:hover:text-cyan-300"
+                    >
+                      {ticket.rede_nome}
+                    </Link>
+                  ) : (
+                    <span className="text-slate-500 dark:text-slate-400">{ticket.rede_nome}</span>
+                  ))}
+                {ticket.rede_nome && ticket.empresa_nome && (
+                  <span className="mx-1 text-slate-400 dark:text-slate-500">·</span>
+                )}
+                {ticket.empresa_nome &&
+                  (ticket.empresa_id != null ? (
+                    <Link
+                      to={`/empresas/${ticket.empresa_id}`}
+                      className="font-medium text-cyan-700 underline decoration-cyan-700/35 underline-offset-2 hover:text-cyan-900 dark:text-cyan-400 dark:decoration-cyan-400/35 dark:hover:text-cyan-300"
+                    >
+                      {ticket.empresa_nome}
+                    </Link>
+                  ) : (
+                    <span className="font-medium text-slate-800 dark:text-slate-200">{ticket.empresa_nome}</span>
+                  ))}
+              </p>
+            )}
+
+            {triagemInbound && (
+              <div
+                className={`mt-2 rounded-lg border px-2.5 py-2 text-[11px] sm:px-3 sm:text-xs ${
+                  requerCadastroFuncionario
+                    ? 'border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-800/60 dark:bg-amber-950/40 dark:text-amber-100'
+                    : 'border-sky-200 bg-sky-50 text-sky-950 dark:border-sky-800/60 dark:bg-sky-950/40 dark:text-sky-100'
+                }`}
+              >
+                {requerCadastroFuncionario ? (
+                  <>
+                    <p className="font-medium">Remetente sem cadastro</p>
+                    {isAdmin && (
+                      <Link to={linkCadastroFuncionario} className="mt-1 inline-block font-semibold underline underline-offset-2">
+                        Cadastrar funcionário
+                      </Link>
+                    )}
+                  </>
+                ) : (
+                  <>
+                    <p className="font-medium">Defina a empresa do ticket</p>
+                    <button
+                      type="button"
+                      onClick={() => abrirModalGerir('geral')}
+                      className="mt-1 font-semibold underline underline-offset-2"
+                    >
+                      Gerir ticket
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
+
+            {podeAtribuirAMim && (
+              <p className="mt-1.5 hidden text-xs text-slate-500 sm:block dark:text-slate-400">
+                Na fila sem responsável — atribua a você para dar andamento.
+              </p>
+            )}
+
+            <div
+              className="mt-2 -mx-3 overflow-x-auto overscroll-x-contain px-3 [scrollbar-width:none] sm:mx-0 sm:mt-3 sm:px-0 [&::-webkit-scrollbar]:hidden"
+              role="group"
+              aria-label="Metadados do ticket"
+            >
+              <div className="flex w-max flex-nowrap gap-1.5 sm:w-auto sm:max-w-full sm:flex-wrap sm:gap-2">
+                <TicketMetaChip
+                  label="Setor"
+                  value={ticket.setor_nome ?? `#${ticket.setor_id}`}
+                  onClick={() => tentarEditarTicket(() => abrirModalGerir('setor'))}
+                />
+                <TicketMetaChip
+                  label="Status"
+                  value={ticket.status_nome ?? String(ticket.status_id)}
+                  onClick={() => tentarEditarTicket(() => abrirModalGerir('status'))}
+                />
+                <TicketMetaChip
+                  label="Resp."
+                  value={ticket.atendente_nome ?? '—'}
+                  onClick={() => tentarEditarTicket(() => abrirModalGerir('atendente'))}
+                />
+                <TicketMetaChip
+                  label="Hier."
+                  value={rotuloChipHierarquia}
+                  onClick={() => tentarEditarTicket(() => abrirModalGerir('hierarquia'))}
+                />
+                <TicketMetaChip
+                  label="Relacionados"
+                  value={rotuloChipRelacionados}
+                  onClick={() => tentarEditarTicket(() => abrirModalGerir('relacionados'))}
+                />
+              </div>
+            </div>
+
+            <p className="mt-1.5 text-[10px] text-slate-500 sm:text-xs dark:text-slate-400">
+              <span className="sm:hidden">Aberto {dataAberturaCurta}</span>
+              <span className="hidden sm:inline">
+                Aberto em {ticket.created_at ? new Date(ticket.created_at).toLocaleString('pt-BR') : '—'}
+              </span>
+              {ticket.fechado_em ? (
+                <span className="ml-2 font-medium text-emerald-700 dark:text-emerald-400">
+                  · Fechado {new Date(ticket.fechado_em).toLocaleDateString('pt-BR')}
+                </span>
+              ) : null}
+            </p>
+
+            {chatsWhatsapp.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {chatsWhatsapp.map((c) => (
+                  <Link
+                    key={c.id}
+                    to={`/whatsapp/c/${c.id}`}
+                    className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-cyan-700 sm:text-xs dark:border-slate-700 dark:bg-slate-900/40 dark:text-cyan-400"
+                  >
+                    WA {exibirProtocolo(c.protocolo)}
+                  </Link>
+                ))}
+              </div>
+            )}
+
+            <div className="mt-2 border-t border-slate-100 pt-2 sm:pt-3 lg:hidden dark:border-slate-800">
+              <div className="grid grid-cols-2 gap-1.5 sm:gap-2">{botoesAcaoTicket}</div>
+            </div>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
+          <div className="mx-auto max-w-6xl space-y-4 px-3 pb-8 pt-3 sm:space-y-6 sm:px-5 sm:pb-10 sm:pt-4 md:px-6">
+        {temVinculosHierarquia && (
           <div className="rounded-xl border border-slate-200/90 bg-slate-50/50 px-3 py-2.5 text-sm dark:border-slate-700/80 dark:bg-slate-900/35">
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="min-w-0 flex-1 space-y-2 text-slate-700 dark:text-slate-200">
@@ -1578,7 +1651,6 @@ export function TicketDetalhe() {
           </div>
         </div>
       </Card>
-      </div>
 
       {previewAnexo && (
         <div
@@ -1646,7 +1718,7 @@ export function TicketDetalhe() {
       )}
 
       {historico.length > 0 && (
-        <div className="mt-6 rounded-xl border border-slate-200/90 bg-white shadow-sm dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-none dark:ring-1 dark:ring-white/5">
+        <div className="mt-4 rounded-xl border border-slate-200/90 bg-white shadow-sm sm:mt-6 dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-none dark:ring-1 dark:ring-white/5">
           <button
             type="button"
             onClick={() => setHistoricoAberto((o) => !o)}
@@ -1689,6 +1761,10 @@ export function TicketDetalhe() {
         </div>
       )}
 
+          </div>
+        </div>
+      </div>
+
       {modalGerirAberto && (
         <div
           className="fixed inset-0 z-[500] flex items-end justify-center bg-slate-950/60 p-4 backdrop-blur-[2px] sm:items-center dark:bg-slate-950/70"
@@ -1705,17 +1781,21 @@ export function TicketDetalhe() {
             <h2 id="ticket-gerir-titulo" className="text-lg font-semibold text-slate-900 dark:text-slate-100">
               {modalGerirFoco === 'hierarquia'
                 ? 'Hierarquia de tickets'
-                : modalGerirFoco === 'setor'
-                  ? 'Transferir de setor'
-                  : modalGerirFoco === 'status'
-                    ? 'Alterar status'
-                    : modalGerirFoco === 'atendente'
-                      ? 'Transferir responsável'
-                      : 'Gerir ticket'}
+                : modalGerirFoco === 'relacionados'
+                  ? 'Tickets relacionados'
+                  : modalGerirFoco === 'setor'
+                    ? 'Transferir de setor'
+                    : modalGerirFoco === 'status'
+                      ? 'Alterar status'
+                      : modalGerirFoco === 'atendente'
+                        ? 'Transferir responsável'
+                        : 'Gerir ticket'}
             </h2>
             <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
               {modalGerirFoco === 'hierarquia' &&
                 'Crie um filho novo, vincule tickets existentes como filhos ou defina um ticket pai (mesma rede, com acesso).'}
+              {modalGerirFoco === 'relacionados' &&
+                'Duplicado encerra este ticket e aponta para o original. Relacionado apenas liga assuntos distintos, sem fechar.'}
               {modalGerirFoco === 'geral' &&
                 'Vincule rede e empresa, transfira de setor, altere o status ou atribua a outro atendente.'}
               {modalGerirFoco === 'setor' && 'Escolha o setor que passará a tratar este ticket.'}
@@ -1806,6 +1886,24 @@ export function TicketDetalhe() {
                 </div>
 
                 {podeEditarHierarquia && (
+                  <div className="rounded-lg border border-cyan-200/90 bg-cyan-50/50 p-3 dark:border-cyan-900/40 dark:bg-cyan-950/20">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-cyan-800 dark:text-cyan-300">
+                      Abrir filhos em massa (por empresa da rede)
+                    </p>
+                    <p className="mt-1 text-xs text-slate-600 dark:text-slate-400">
+                      Cria um ticket filho para cada empresa selecionada — útil para rollouts ou tarefas iguais em toda a rede.
+                    </p>
+                    <div className="mt-3">
+                      <TicketFilhosMassaPanel
+                        ticketId={ticket.id}
+                        disabled={desvinculandoHierarquia || vinculandoFilho || vinculandoPai}
+                        onCriados={recarregarTicketAtual}
+                      />
+                    </div>
+                  </div>
+                )}
+
+                {podeEditarHierarquia && (
                   <div className="flex flex-wrap gap-2">
                     <Button
                       type="button"
@@ -1827,26 +1925,17 @@ export function TicketDetalhe() {
                       Vincular ticket existente como filho
                     </p>
                     <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                      ID do ticket que passará a ser filho deste (não pode ser o próprio).
+                      Escolha um ticket em aberto na lista; ele passará a ser filho deste.
                     </p>
-                    <div className="mt-3 flex flex-wrap items-end gap-2">
-                      <Input
-                        id="ticket-vincular-filho-id"
-                        label="ID do ticket (filho)"
-                        type="number"
-                        min={1}
-                        value={idFilhoParaVincular}
-                        onChange={(e) => setIdFilhoParaVincular(e.target.value)}
+                    <div className="mt-3">
+                      <TicketBuscaPicker
+                        ticketAtualId={ticket.id}
+                        excluirIds={idsTicketsExcluirBusca}
+                        label="Ticket filho"
                         disabled={vinculandoFilho || desvinculandoHierarquia || vinculandoPai}
+                        loadingExterno={vinculandoFilho}
+                        onSelecionar={(alvo) => void handleVincularFilhoExistente(alvo)}
                       />
-                      <Button
-                        type="button"
-                        onClick={handleVincularFilhoExistente}
-                        loading={vinculandoFilho}
-                        disabled={desvinculandoHierarquia || vinculandoPai}
-                      >
-                        Vincular
-                      </Button>
                     </div>
                   </div>
                 )}
@@ -1857,33 +1946,139 @@ export function TicketDetalhe() {
                       {ticket.parent_ticket_id != null ? 'Alterar ticket pai' : 'Vincular a um ticket pai'}
                     </p>
                     <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
-                      ID do ticket que será o pai deste. Substitui o vínculo atual se já houver um pai.
+                      Escolha o ticket pai na lista (substitui o vínculo atual, se houver).
                     </p>
-                    <div className="mt-3 flex flex-wrap items-end gap-2">
-                      <Input
-                        id="ticket-vincular-pai-id"
-                        label="ID do ticket (pai)"
-                        type="number"
-                        min={1}
-                        value={idPaiParaVincular}
-                        onChange={(e) => setIdPaiParaVincular(e.target.value)}
+                    <div className="mt-3">
+                      <TicketBuscaPicker
+                        ticketAtualId={ticket.id}
+                        excluirIds={idsTicketsExcluirBusca}
+                        label="Ticket pai"
                         disabled={vinculandoPai || desvinculandoHierarquia || vinculandoFilho}
+                        loadingExterno={vinculandoPai}
+                        onSelecionar={(alvo) => void handleVincularAoPai(alvo)}
                       />
-                      <Button
-                        type="button"
-                        onClick={handleVincularAoPai}
-                        loading={vinculandoPai}
-                        disabled={desvinculandoHierarquia || vinculandoFilho}
-                      >
-                        Aplicar vínculo
-                      </Button>
                     </div>
                   </div>
                 )}
               </div>
             )}
 
-            {modalGerirFoco !== 'hierarquia' && (
+            {modalGerirFoco === 'relacionados' && ticket && (
+              <div className="mt-4 space-y-4 text-sm text-slate-700 dark:text-slate-200">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                    Vínculos atuais
+                  </p>
+                  {(ticket.vinculos?.length ?? 0) === 0 ? (
+                    <p className="mt-1 text-slate-500 dark:text-slate-400">Nenhum vínculo lateral.</p>
+                  ) : (
+                    <ul className="mt-2 divide-y divide-slate-200 rounded-lg border border-slate-200 dark:divide-slate-700 dark:border-slate-700">
+                      {(ticket.vinculos ?? []).map((v) => (
+                        <li key={v.id} className="flex flex-wrap items-center justify-between gap-2 px-3 py-2">
+                          <div className="min-w-0">
+                            <span className="text-xs font-medium text-slate-500 dark:text-slate-400">{v.rotulo}</span>
+                            <Link
+                              to={`/tickets/${v.outro_ticket.id}`}
+                              className="ml-2 font-medium text-cyan-700 underline hover:text-cyan-900 dark:text-cyan-400 dark:hover:text-cyan-300"
+                              onClick={() => setModalGerirAberto(false)}
+                            >
+                              {exibirProtocolo(v.outro_ticket.protocolo)} — {v.outro_ticket.assunto}
+                            </Link>
+                            {v.outro_ticket.status_nome ? (
+                              <span className="ml-2 text-xs text-slate-500 dark:text-slate-400">
+                                ({v.outro_ticket.status_nome})
+                              </span>
+                            ) : null}
+                          </div>
+                          {podeEditarHierarquia && (
+                            <Button
+                              type="button"
+                              variant="secondary"
+                              loading={removendoVinculoId === v.id}
+                              onClick={() => void handleRemoverVinculoRelacionado(v.id)}
+                            >
+                              Remover
+                            </Button>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                {podeEditarHierarquia && (
+                  <div className="rounded-lg border border-slate-200/90 bg-slate-50/70 p-3 dark:border-slate-700/70 dark:bg-slate-900/30">
+                    <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                      Adicionar vínculo
+                    </p>
+                    <div className="mt-3 space-y-3">
+                      <Select
+                        label="Tipo de vínculo"
+                        value={tipoVinculoRelacionado}
+                        onChange={(v) => setTipoVinculoRelacionado(v as Tickets.TicketVinculoTipo)}
+                        options={[
+                          { value: 'relacionado_a', label: 'Relacionado a — assuntos ligados, ambos podem seguir abertos' },
+                          { value: 'duplicado_de', label: 'Duplicado de — mesma solicitação; encerra este ticket' },
+                        ]}
+                      />
+                      {tipoVinculoRelacionado === 'duplicado_de' ? (
+                        <div className="space-y-2">
+                          <p className="text-xs text-slate-600 dark:text-slate-400">
+                            Este ticket será tratado como cópia do original na{' '}
+                            <strong>mesma rede e empresa</strong>. O atendimento oficial fica no ticket que você
+                            escolher abaixo.
+                          </p>
+                          <CheckboxField
+                            checked={fecharComoDuplicado}
+                            onChange={(e) => setFecharComoDuplicado(e.target.checked)}
+                            disabled={vinculandoRelacionado || Boolean(ticket.fechado_em)}
+                          >
+                            Fechar este ticket e registrar mensagem pública apontando para o original
+                          </CheckboxField>
+                          {ticket.fechado_em ? (
+                            <p className="text-xs text-amber-700 dark:text-amber-400">
+                              Este ticket já está fechado — apenas o vínculo será registrado.
+                            </p>
+                          ) : null}
+                        </div>
+                      ) : (
+                        <p className="text-xs text-slate-600 dark:text-slate-400">
+                          Use quando os chamados são diferentes, mas você quer mantê-los visíveis um ao outro.
+                        </p>
+                      )}
+                      {tipoVinculoRelacionado === 'duplicado_de' && ticket.empresa_id == null ? (
+                        <p className="text-xs text-amber-700 dark:text-amber-400">
+                          Defina a empresa deste ticket (em Gerir) antes de marcar um duplicado — só chamados da mesma
+                          rede e empresa podem ser duplicados.
+                        </p>
+                      ) : (
+                        <TicketBuscaPicker
+                          ticketAtualId={ticket.id}
+                          excluirIds={idsTicketsExcluirBusca}
+                          filtroEmpresaId={
+                            tipoVinculoRelacionado === 'duplicado_de' ? ticket.empresa_id : undefined
+                          }
+                          filtroRedeId={tipoVinculoRelacionado === 'duplicado_de' ? ticket.rede_id : undefined}
+                          label="Buscar ticket em aberto"
+                          hint={
+                            tipoVinculoRelacionado === 'duplicado_de'
+                              ? `Somente tickets abertos da mesma rede e empresa${
+                                  ticket.empresa_nome ? ` (${ticket.empresa_nome})` : ''
+                                }.`
+                              : 'Clique em um ticket da lista para vincular.'
+                          }
+                          disabled={vinculandoRelacionado}
+                          loadingExterno={vinculandoRelacionado}
+                          onSelecionar={(alvo) => void handleAdicionarVinculoRelacionado(alvo)}
+                        />
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {modalGerirFoco !== 'hierarquia' && modalGerirFoco !== 'relacionados' && (
               <div className="mt-5 space-y-4">
                 {modalGerirFoco === 'geral' && (
                   <>
@@ -2013,7 +2208,7 @@ export function TicketDetalhe() {
               </p>
             )}
 
-            {modalGerirFoco !== 'hierarquia' ? (
+            {modalGerirFoco !== 'hierarquia' && modalGerirFoco !== 'relacionados' ? (
               <div className="mt-6 flex flex-wrap justify-end gap-2">
                 <Button type="button" variant="secondary" onClick={() => setModalGerirAberto(false)}>
                   Cancelar
@@ -2088,7 +2283,7 @@ export function TicketDetalhe() {
           </div>
         </div>
       )}
-    </div>
+    </>
   )
 }
 

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -21,7 +21,6 @@ import {
 } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
-import { Input } from '../components/ui/Input'
 import { Select } from '../components/ui/Select'
 import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
@@ -1061,8 +1060,10 @@ export function TicketDetalhe() {
     return null
   }
 
+  const ticketAtual = ticket
+
   function tentarEditarTicket(acao: () => void) {
-    if (ticket.fechado_em && !isAdmin) {
+    if (ticketAtual.fechado_em && !isAdmin) {
       toast.showWarning('Ticket fechado — apenas admin pode alterar.')
       return
     }
@@ -2189,11 +2190,7 @@ export function TicketDetalhe() {
                   type="button"
                   variant="secondary"
                   className="mt-3"
-                  onClick={() => {
-                    setIdFilhoParaVincular('')
-                    setIdPaiParaVincular('')
-                    setModalGerirFoco('hierarquia')
-                  }}
+                  onClick={() => setModalGerirFoco('hierarquia')}
                 >
                   Gerir hierarquia…
                 </Button>

--- a/frontend/src/pages/TicketNovo.tsx
+++ b/frontend/src/pages/TicketNovo.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
-import { ApiError, tickets, empresas, setores, type Empresas, type Setores, type Tickets } from '../api/client'
+import { ApiError, tickets, empresas, setores, redes, type Empresas, type Setores, type Redes, type Tickets } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
@@ -11,6 +11,7 @@ import { useToast } from '../components/ui/Toast'
 import { useAuth } from '../contexts/AuthContext'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { FormSection } from '../components/ui/FormSection'
+import { CheckboxField } from '../components/ui/CheckboxField'
 import { SemPermissao } from './SemPermissao'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 const MAX_ANEXO_BYTES = 25 * 1024 * 1024
@@ -27,8 +28,11 @@ export function TicketNovo() {
   const [paiCarregando, setPaiCarregando] = useState(false)
 
   const [empresasList, setEmpresasList] = useState<Empresas.EmpresaListaItem[]>([])
+  const [redesList, setRedesList] = useState<Redes.Rede[]>([])
   const [setoresList, setSetoresList] = useState<Setores.Setor[]>([])
+  const [modoCoordenacao, setModoCoordenacao] = useState(false)
   const [empresaId, setEmpresaId] = useState<number | ''>('')
+  const [redeId, setRedeId] = useState<number | ''>('')
   const [setorId, setSetorId] = useState<number | ''>('')
   const [assunto, setAssunto] = useState('')
   const [descricao, setDescricao] = useState('')
@@ -52,6 +56,14 @@ export function TicketNovo() {
     [empresasList],
   )
 
+  const redeItems = useMemo(
+    () =>
+      redesList
+        .filter((r) => r.ativo)
+        .map((r) => ({ id: r.id, label: r.nome })),
+    [redesList],
+  )
+
   useEffect(() => {
     setForbidden(false)
     coletarTodasPaginas<Empresas.EmpresaListaItem>((o, l) => empresas.list({ offset: o, limit: l }))
@@ -65,6 +77,16 @@ export function TicketNovo() {
         }
         toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos empresas para abrir o chamado.'))
         setEmpresasList([])
+      })
+    coletarTodasPaginas<Redes.Rede>((o, l) => redes.list({ incluir_inativos: true, offset: o, limit: l }))
+      .then(setRedesList)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setRedesList([])
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos redes para abrir o chamado.'))
+        setRedesList([])
       })
     coletarTodasPaginas<Setores.Setor>((o, l) => setores.list({ incluir_inativos: true, offset: o, limit: l }))
       .then(setSetoresList)
@@ -98,7 +120,10 @@ export function TicketNovo() {
       .then((p) => {
         if (!cancelled) {
           setPaiResumo(p)
-          setEmpresaId(p.empresa_id ?? '')
+          if (p.empresa_id != null) setEmpresaId(p.empresa_id)
+          if (p.coordenacao_rede && p.rede_id != null) {
+            setModoCoordenacao(false)
+          }
         }
       })
       .catch(() => {
@@ -154,19 +179,33 @@ export function TicketNovo() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (!empresaId || !setorId || !assunto.trim() || !descricao.trim()) {
-      toast.showWarning('Preencha empresa, setor, assunto e o relato do problema.')
+    if (!setorId || !assunto.trim() || !descricao.trim()) {
+      toast.showWarning('Preencha setor, assunto e o relato do problema.')
+      return
+    }
+    if (modoCoordenacao) {
+      if (!redeId) {
+        toast.showWarning('Selecione a rede para o ticket de coordenação.')
+        return
+      }
+    } else if (!empresaId) {
+      toast.showWarning('Selecione a empresa ou use o modo de coordenação de rede.')
       return
     }
     setLoading(true)
     try {
-      const created = await tickets.create({
-        empresa_id: Number(empresaId),
+      const payload: Tickets.Create = {
         setor_id: Number(setorId),
         assunto: assunto.trim(),
         descricao: descricao.trim(),
         ...(paiResumo ? { parent_ticket_id: paiResumo.id } : {}),
-      })
+      }
+      if (modoCoordenacao) {
+        payload.rede_id = Number(redeId)
+      } else {
+        payload.empresa_id = Number(empresaId)
+      }
+      const created = await tickets.create(payload)
       if (anexosSelecionados.length > 0) {
         let ok = 0
         for (const f of anexosSelecionados) {
@@ -191,10 +230,11 @@ export function TicketNovo() {
 
   const semSetorPermitido = !isAdmin && setoresFiltrados.length === 0
   const semEmpresasNoEscopo = !isAdmin && !semSetorPermitido && empresasList.length === 0
+  const formDesabilitado = semSetorPermitido || (!modoCoordenacao && !paiResumo && semEmpresasNoEscopo)
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-3xl space-y-6 pb-10">
+      <div className="mx-auto max-w-3xl space-y-6">
         <SemPermissao
           title="Você não tem permissão para abrir tickets."
           detail="Seu usuário não conseguiu carregar setores/empresas necessários para criar um chamado. Peça ao administrador para ajustar seu perfil e vínculos de setor."
@@ -206,7 +246,13 @@ export function TicketNovo() {
   }
 
   return (
-    <div className="mx-auto max-w-3xl space-y-6 pb-10">
+    <form
+      className="flex h-full min-h-0 flex-col"
+      onSubmit={handleSubmit}
+      noValidate
+    >
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        <div className="mx-auto max-w-3xl space-y-6 pb-4">
       <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
         <button
           type="button"
@@ -232,8 +278,10 @@ export function TicketNovo() {
         <div className="rounded-lg border border-sky-200 bg-sky-50 px-4 py-3 text-sm text-sky-950 dark:border-sky-800/60 dark:bg-sky-950/40 dark:text-sky-100">
           Este chamado será aberto como <strong>filho</strong> do ticket{' '}
           <span className="font-mono font-semibold">{paiResumo.protocolo}</span>
-          {paiResumo.assunto ? ` — ${paiResumo.assunto}` : ''}. A empresa foi pré-preenchida para manter a mesma rede do
-          pai.
+          {paiResumo.assunto ? ` — ${paiResumo.assunto}` : ''}.
+          {paiResumo.coordenacao_rede
+            ? ' Escolha a empresa deste filho (mesma rede do ticket pai).'
+            : ' A empresa foi pré-preenchida para manter a mesma rede do pai.'}
         </div>
       )}
 
@@ -244,11 +292,11 @@ export function TicketNovo() {
         </div>
       )}
 
-      {semEmpresasNoEscopo && (
+      {semEmpresasNoEscopo && !modoCoordenacao && !paiResumo && (
         <div className="rounded-lg border border-sky-200 bg-sky-50 px-4 py-3 text-sm text-sky-950 dark:border-sky-800/60 dark:bg-sky-950/40 dark:text-sky-100">
           Ainda não há empresas listáveis no seu escopo: a API só mostra clientes de redes que já tiveram ticket nos setores
           que você atende. Peça a um administrador para registrar o primeiro chamado dessa rede (ou ajustar cadastro), ou
-          use uma empresa que já apareça na lista de tickets.
+          use uma empresa que já apareça na lista de tickets, ou marque <strong>Coordenação de rede</strong> abaixo.
         </div>
       )}
 
@@ -257,20 +305,48 @@ export function TicketNovo() {
           O ticket entra na <strong>fila do setor</strong> (sem responsável). Qualquer atendente do setor pode abrir o chamado e usar{' '}
           <strong>Atribuir a mim</strong> para assumir o atendimento.
         </p>
-        <form onSubmit={handleSubmit}>
           <div className="space-y-6">
             <FormSection title="Identificação">
-              <SelectComPesquisa
-                id="ticket-empresa"
-                label="Empresa *"
-                value={empresaId}
-                onChange={(id) => setEmpresaId(id)}
-                items={empresaItems}
-                placeholder="Buscar empresa..."
-                required
-                disabled={semSetorPermitido || semEmpresasNoEscopo || Boolean(paiResumo)}
-                recentCount={10}
-              />
+              {!paiResumo && (
+                <CheckboxField
+                  checked={modoCoordenacao}
+                  disabled={semSetorPermitido}
+                  onChange={(e) => {
+                    const next = e.target.checked
+                    setModoCoordenacao(next)
+                    if (next) setEmpresaId('')
+                    else setRedeId('')
+                  }}
+                >
+                  Coordenação de rede (sem empresa — ex.: rollout em várias lojas)
+                </CheckboxField>
+              )}
+
+              {modoCoordenacao && !paiResumo ? (
+                <SelectComPesquisa
+                  id="ticket-rede"
+                  label="Rede *"
+                  value={redeId}
+                  onChange={(id) => setRedeId(id)}
+                  items={redeItems}
+                  placeholder="Buscar rede..."
+                  required
+                  disabled={semSetorPermitido || redeItems.length === 0}
+                  recentCount={10}
+                />
+              ) : (
+                <SelectComPesquisa
+                  id="ticket-empresa"
+                  label="Empresa *"
+                  value={empresaId}
+                  onChange={(id) => setEmpresaId(id)}
+                  items={empresaItems}
+                  placeholder="Buscar empresa..."
+                  required
+                  disabled={semSetorPermitido || semEmpresasNoEscopo || Boolean(paiResumo && paiResumo.empresa_id != null)}
+                  recentCount={10}
+                />
+              )}
 
               <div>
                 <Select
@@ -282,7 +358,7 @@ export function TicketNovo() {
                   includeEmpty
                   emptyLabel="Selecione"
                   placeholder="Selecione"
-                  disabled={semSetorPermitido || semEmpresasNoEscopo}
+                  disabled={formDesabilitado}
                 />
                 {!isAdmin && setoresFiltrados.length > 0 && (
                   <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
@@ -298,7 +374,7 @@ export function TicketNovo() {
                 value={assunto}
                 onChange={(e) => setAssunto(e.target.value)}
                 required
-                disabled={semSetorPermitido || semEmpresasNoEscopo}
+                disabled={formDesabilitado}
               />
               <div>
                 <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">Relato do problema *</label>
@@ -311,7 +387,7 @@ export function TicketNovo() {
                   spellCheck={false}
                   rows={5}
                   required
-                  disabled={semSetorPermitido || semEmpresasNoEscopo}
+                  disabled={formDesabilitado}
                   className="w-full rounded-xl border-0 bg-white px-3 py-2 text-sm shadow-sm ring-1 ring-slate-200/90 focus:outline-none focus:ring-2 focus:ring-slate-400/35 dark:bg-slate-900 dark:text-slate-100 dark:ring-slate-700"
                 />
               </div>
@@ -331,13 +407,13 @@ export function TicketNovo() {
                     multiple
                     className="sr-only"
                     onChange={onSelecionarAnexos}
-                    disabled={semSetorPermitido || semEmpresasNoEscopo || loading}
+                    disabled={formDesabilitado || loading}
                     aria-label="Selecionar arquivos para anexar ao ticket"
                   />
                   <Button
                     type="button"
                     variant="secondary"
-                    disabled={semSetorPermitido || semEmpresasNoEscopo || loading}
+                    disabled={formDesabilitado || loading}
                     onClick={() => anexosInputRef.current?.click()}
                     className="inline-flex items-center gap-2"
                   >
@@ -390,24 +466,25 @@ export function TicketNovo() {
               </div>
             </FormSection>
           </div>
-
-          <div className="sticky bottom-0 -mx-6 mt-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-700 dark:bg-slate-900">
-            <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
-              <Button type="button" variant="secondary" onClick={voltarAnterior} className="w-full sm:w-auto">
-                Cancelar
-              </Button>
-              <Button
-                type="submit"
-                loading={loading}
-                disabled={semSetorPermitido || semEmpresasNoEscopo}
-                className="w-full sm:w-auto"
-              >
-                Criar ticket
-              </Button>
-            </div>
-          </div>
-        </form>
       </Card>
-    </div>
+        </div>
+      </div>
+
+      <div className="z-10 -mx-4 shrink-0 border-t border-slate-200 bg-white px-4 py-4 shadow-[0_-8px_24px_-4px_rgba(15,23,42,0.12)] dark:border-slate-700 dark:bg-slate-900 dark:shadow-[0_-8px_24px_-4px_rgba(0,0,0,0.45)] md:-mx-6 md:px-6">
+        <div className="mx-auto flex max-w-3xl flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button type="button" variant="secondary" onClick={voltarAnterior} className="w-full sm:w-auto">
+            Cancelar
+          </Button>
+          <Button
+            type="submit"
+            loading={loading}
+            disabled={formDesabilitado}
+            className="w-full sm:w-auto"
+          >
+            Criar ticket
+          </Button>
+        </div>
+      </div>
+    </form>
   )
 }


### PR DESCRIPTION
## Summary
- **#115 (backend):** tabela `ticket_vinculos`, API de duplicado/relacionado, validação mesma rede/empresa, fechamento automático como duplicado.
- **#116 (frontend):** chips e modais de hierarquia/vínculos no detalhe do ticket, busca interativa de tickets e UX do cabeçalho.
- **Extensões:** tickets filhos em massa por empresa da rede; ticket pai de **coordenação de rede** (`rede_id` sem empresa); bloqueio de fechamento do pai com filhos abertos.

## Migrações
- `032_ticket_vinculos`
- `033_ticket_rede_id`

## Test plan
- [x] `pytest tests/test_ticket_vinculos.py tests/test_ticket_filhos_massa.py tests/test_ticket_coordenacao_rede.py tests/test_ticket_parent.py` (22 passed)
- [x] `npx tsc --noEmit`
- [ ] Abrir ticket de coordenação de rede e criar filhos em massa com seleção de empresas
- [ ] Vincular duplicado/relacionado e validar fechamento de duplicado
- [ ] `alembic upgrade head` em staging/prod após merge
