### PR TITLE
release(staging): cadastros funcionários e PDVs por empresa

### DIFF
--- a/backend/alembic/versions/034_funcionario_escopo_empresas.py
+++ b/backend/alembic/versions/034_funcionario_escopo_empresas.py
@@ -1,0 +1,47 @@
+"""funcionario escopo_empresas (all | selected)
+
+Revision ID: 034_funcionario_escopo
+Revises: 033_ticket_rede_id
+Create Date: 2026-06-06
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "034_funcionario_escopo"
+down_revision = "033_ticket_rede_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "funcionarios_rede",
+        sa.Column("escopo_empresas", sa.String(20), nullable=False, server_default="selected"),
+    )
+    op.execute(
+        """
+        UPDATE funcionarios_rede
+        SET escopo_empresas = 'all'
+        WHERE tipo = 'socio'
+        """
+    )
+    # Colaboradores: garantir vínculo na tabela N:N para consultas unificadas
+    op.execute(
+        """
+        INSERT INTO funcionario_rede_empresa (funcionario_id, empresa_id)
+        SELECT f.id, f.empresa_id
+        FROM funcionarios_rede f
+        WHERE f.tipo = 'colaborador'
+          AND f.empresa_id IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM funcionario_rede_empresa fre
+            WHERE fre.funcionario_id = f.id AND fre.empresa_id = f.empresa_id
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("funcionarios_rede", "escopo_empresas")

--- a/backend/alembic/versions/035_empresa_pdvs.py
+++ b/backend/alembic/versions/035_empresa_pdvs.py
@@ -1,0 +1,61 @@
+"""PDVs por empresa + catálogos globais
+
+Revision ID: 035_empresa_pdvs
+Revises: 034_funcionario_escopo
+Create Date: 2026-06-06
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "035_empresa_pdvs"
+down_revision = "034_funcionario_escopo"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pdv_rotulos",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("nome", sa.String(120), nullable=False),
+        sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("ordem_exibicao", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_table(
+        "pdv_tipos_acesso_remoto",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("nome", sa.String(120), nullable=False),
+        sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("ordem_exibicao", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_table(
+        "empresa_pdvs",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("empresa_id", sa.Integer(), sa.ForeignKey("empresas.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("codigo", sa.String(32), nullable=False),
+        sa.Column("rotulo_id", sa.Integer(), sa.ForeignKey("pdv_rotulos.id"), nullable=False),
+        sa.Column("papel", sa.String(20), nullable=False),
+        sa.Column("usa_tef", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("tipo_acesso_remoto_id", sa.Integer(), sa.ForeignKey("pdv_tipos_acesso_remoto.id"), nullable=True),
+        sa.Column("acesso_remoto_id", sa.String(255), nullable=True),
+        sa.Column("acesso_remoto_senha_cifrada", sa.Text(), nullable=True),
+        sa.Column("observacoes", sa.Text(), nullable=True),
+        sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("empresa_id", "codigo", name="uq_empresa_pdv_codigo"),
+    )
+    op.create_index("ix_empresa_pdvs_empresa_id", "empresa_pdvs", ["empresa_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_empresa_pdvs_empresa_id", table_name="empresa_pdvs")
+    op.drop_table("empresa_pdvs")
+    op.drop_table("pdv_tipos_acesso_remoto")
+    op.drop_table("pdv_rotulos")

--- a/backend/app/api/empresa_pdvs.py
+++ b/backend/app/api/empresa_pdvs.py
@@ -1,0 +1,184 @@
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.audit import registrar_audit
+from app.core.auth import exigir_admin, obter_atendente_atual
+from app.database import get_db
+from app.models import Empresa
+from app.models.atendente import Atendente
+from app.models.empresa_pdv import EmpresaPdv, PdvRotulo, PdvTipoAcessoRemoto
+from app.schemas.lista_paginada import ListaPaginada
+from app.schemas.pdv import (
+    EmpresaPdvCreate,
+    EmpresaPdvCredencialRead,
+    EmpresaPdvRead,
+    EmpresaPdvUpdate,
+)
+from app.services.empresa_pdv_rules import validar_papel_principal_auxiliar
+from app.services.secret_box import decrypt_str, encrypt_str
+
+router = APIRouter(prefix="/empresas", tags=["empresa-pdvs"])
+
+
+def _empresa_or_404(db: Session, empresa_id: int) -> Empresa:
+    emp = db.query(Empresa).filter(Empresa.id == empresa_id).first()
+    if not emp:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Empresa não encontrada")
+    return emp
+
+
+def _to_read(row: EmpresaPdv) -> EmpresaPdvRead:
+    return EmpresaPdvRead(
+        id=row.id,
+        empresa_id=row.empresa_id,
+        codigo=row.codigo,
+        rotulo_id=row.rotulo_id,
+        rotulo_nome=row.rotulo.nome if row.rotulo else None,
+        papel=row.papel,
+        usa_tef=bool(row.usa_tef),
+        tipo_acesso_remoto_id=row.tipo_acesso_remoto_id,
+        tipo_acesso_remoto_nome=row.tipo_acesso_remoto.nome if row.tipo_acesso_remoto else None,
+        acesso_remoto_id=row.acesso_remoto_id,
+        observacoes=row.observacoes,
+        ativo=bool(row.ativo),
+        tem_senha_remota=bool(row.acesso_remoto_senha_cifrada),
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _validar_refs(db: Session, data: EmpresaPdvCreate | EmpresaPdvUpdate, empresa_id: int) -> None:
+    rotulo_id = getattr(data, "rotulo_id", None)
+    if rotulo_id is not None:
+        rot = db.query(PdvRotulo).filter(PdvRotulo.id == rotulo_id, PdvRotulo.ativo.is_(True)).first()
+        if not rot:
+            raise HTTPException(status_code=400, detail="Rótulo de dispositivo inválido ou inativo.")
+    tipo_id = getattr(data, "tipo_acesso_remoto_id", None)
+    if tipo_id is not None:
+        tipo = (
+            db.query(PdvTipoAcessoRemoto)
+            .filter(PdvTipoAcessoRemoto.id == tipo_id, PdvTipoAcessoRemoto.ativo.is_(True))
+            .first()
+        )
+        if not tipo:
+            raise HTTPException(status_code=400, detail="Tipo de acesso remoto inválido ou inativo.")
+
+
+@router.get("/{empresa_id}/pdvs", response_model=ListaPaginada[EmpresaPdvRead])
+def listar_pdvs(
+    empresa_id: int,
+    incluir_inativos: bool = Query(False),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(obter_atendente_atual),
+):
+    _empresa_or_404(db, empresa_id)
+    q = (
+        db.query(EmpresaPdv)
+        .options(joinedload(EmpresaPdv.rotulo), joinedload(EmpresaPdv.tipo_acesso_remoto))
+        .filter(EmpresaPdv.empresa_id == empresa_id)
+    )
+    if not incluir_inativos:
+        q = q.filter(EmpresaPdv.ativo.is_(True))
+    rows = q.order_by(EmpresaPdv.codigo.asc(), EmpresaPdv.id.asc()).all()
+    return ListaPaginada(items=[_to_read(r) for r in rows], total=len(rows))
+
+
+@router.post("/{empresa_id}/pdvs", response_model=EmpresaPdvRead, status_code=201)
+def criar_pdv(
+    empresa_id: int,
+    data: EmpresaPdvCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    _empresa_or_404(db, empresa_id)
+    _validar_refs(db, data, empresa_id)
+    codigo = data.codigo.strip()
+    if db.query(EmpresaPdv).filter(EmpresaPdv.empresa_id == empresa_id, EmpresaPdv.codigo == codigo).first():
+        raise HTTPException(status_code=400, detail="Já existe um PDV com este código nesta empresa.")
+    senha_cifrada = None
+    if data.acesso_remoto_senha and data.acesso_remoto_senha.strip():
+        senha_cifrada = encrypt_str(data.acesso_remoto_senha.strip())
+    row = EmpresaPdv(
+        empresa_id=empresa_id,
+        codigo=codigo,
+        rotulo_id=data.rotulo_id,
+        papel=data.papel,
+        usa_tef=data.usa_tef,
+        tipo_acesso_remoto_id=data.tipo_acesso_remoto_id,
+        acesso_remoto_id=(data.acesso_remoto_id or "").strip() or None,
+        acesso_remoto_senha_cifrada=senha_cifrada,
+        observacoes=(data.observacoes or "").strip() or None,
+        ativo=data.ativo,
+    )
+    db.add(row)
+    db.flush()
+    try:
+        validar_papel_principal_auxiliar(db, empresa_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    registrar_audit(db, "empresa_pdv", row.id, "create", atendente.id)
+    db.commit()
+    row = (
+        db.query(EmpresaPdv)
+        .options(joinedload(EmpresaPdv.rotulo), joinedload(EmpresaPdv.tipo_acesso_remoto))
+        .filter(EmpresaPdv.id == row.id)
+        .first()
+    )
+    return _to_read(row)
+
+
+@router.patch("/{empresa_id}/pdvs/{pdv_id}", response_model=EmpresaPdvRead)
+def atualizar_pdv(
+    empresa_id: int,
+    pdv_id: int,
+    data: EmpresaPdvUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    _empresa_or_404(db, empresa_id)
+    row = (
+        db.query(EmpresaPdv)
+        .options(joinedload(EmpresaPdv.rotulo), joinedload(EmpresaPdv.tipo_acesso_remoto))
+        .filter(EmpresaPdv.id == pdv_id, EmpresaPdv.empresa_id == empresa_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="PDV não encontrado")
+    payload = data.model_dump(exclude_unset=True)
+    senha = payload.pop("acesso_remoto_senha", None)
+    _validar_refs(db, data, empresa_id)
+    for k, v in payload.items():
+        setattr(row, k, v)
+    if senha is not None:
+        row.acesso_remoto_senha_cifrada = encrypt_str(senha.strip()) if senha.strip() else None
+    db.flush()
+    try:
+        validar_papel_principal_auxiliar(db, empresa_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    registrar_audit(db, "empresa_pdv", row.id, "update", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return _to_read(row)
+
+
+@router.get("/{empresa_id}/pdvs/{pdv_id}/credencial", response_model=EmpresaPdvCredencialRead)
+def revelar_credencial(
+    empresa_id: int,
+    pdv_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    _empresa_or_404(db, empresa_id)
+    row = db.query(EmpresaPdv).filter(EmpresaPdv.id == pdv_id, EmpresaPdv.empresa_id == empresa_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="PDV não encontrado")
+    if not row.acesso_remoto_senha_cifrada:
+        raise HTTPException(status_code=404, detail="Este PDV não possui senha cadastrada.")
+    try:
+        senha = decrypt_str(row.acesso_remoto_senha_cifrada)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Não foi possível decifrar a credencial.") from e
+    registrar_audit(db, "empresa_pdv", row.id, "reveal_credential", atendente.id)
+    db.commit()
+    return EmpresaPdvCredencialRead(acesso_remoto_senha=senha)

--- a/backend/app/api/funcionarios_rede.py
+++ b/backend/app/api/funcionarios_rede.py
@@ -15,6 +15,11 @@ from app.schemas.funcionario_rede import (
     FuncionarioRedeUpdate,
     RemetenteFuncionarioResolveRead,
 )
+from app.services.funcionario_escopo import (
+    escopo_efetivo,
+    sincronizar_vinculos_empresas,
+    validar_empresa_ids_na_rede,
+)
 from app.services.funcionario_rede_resolver import assert_email_unico_por_rede, resolver_remetente_por_email
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import exigir_admin
@@ -34,17 +39,26 @@ class OrdenarFuncionariosPor(str, Enum):
     rede_id = "rede_id"
 
 
+def _empresa_ids_leitura(f: FuncionarioRede) -> list[int]:
+    if escopo_efetivo(f) == "all":
+        return []
+    ids = [e.empresa_id for e in f.empresas_supervisor]
+    if f.empresa_id is not None and int(f.empresa_id) not in ids:
+        ids.insert(0, int(f.empresa_id))
+    return ids
+
+
 def _para_read(f: FuncionarioRede) -> FuncionarioRedeRead:
-    empresa_ids = [e.empresa_id for e in f.empresas_supervisor] if f.tipo == "supervisor" else []
     return FuncionarioRedeRead(
         id=f.id,
         nome=f.nome,
         email=f.email,
         tipo=f.tipo,
+        escopo_empresas=escopo_efetivo(f),
         ativo=f.ativo,
         rede_id=f.rede_id,
         empresa_id=f.empresa_id,
-        empresa_ids=empresa_ids,
+        empresa_ids=_empresa_ids_leitura(f),
         created_at=f.created_at,
         updated_at=f.updated_at,
     )
@@ -68,13 +82,20 @@ def listar(
     if rede_id is not None:
         q = q.filter(FuncionarioRede.rede_id == rede_id)
     if empresa_id is not None:
+        emp = db.query(Empresa).filter(Empresa.id == empresa_id).first()
+        if not emp:
+            return ListaPaginada(items=[], total=0)
+        sub_junction = db.query(FuncionarioRedeEmpresa.funcionario_id).filter(
+            FuncionarioRedeEmpresa.empresa_id == empresa_id
+        )
         q = q.filter(
-            (FuncionarioRede.empresa_id == empresa_id) |
-            (FuncionarioRede.id.in_(
-                db.query(FuncionarioRedeEmpresa.funcionario_id).filter(
-                    FuncionarioRedeEmpresa.empresa_id == empresa_id
-                )
-            ))
+            FuncionarioRede.rede_id == emp.rede_id,
+            or_(
+                FuncionarioRede.escopo_empresas == "all",
+                FuncionarioRede.tipo == "socio",
+                FuncionarioRede.empresa_id == empresa_id,
+                FuncionarioRede.id.in_(sub_junction),
+            ),
         )
     if tipo:
         q = q.filter(FuncionarioRede.tipo == tipo)
@@ -129,29 +150,30 @@ def criar(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(exigir_admin),
 ):
-    if data.tipo == "socio" and not data.rede_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Sócio deve ter rede_id")
-    if data.tipo == "colaborador" and not data.empresa_id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Colaborador deve ter empresa_id")
-    if data.tipo == "supervisor" and not data.empresa_ids:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Supervisor deve ter ao menos uma empresa")
+    escopo = (data.escopo_empresas or "selected").strip().lower()
+    if escopo not in ("all", "selected"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="escopo_empresas deve ser all ou selected")
+    empresa_ids = list(data.empresa_ids or [])
+    if data.empresa_id and data.empresa_id not in empresa_ids:
+        empresa_ids.insert(0, data.empresa_id)
     rede_id_final = data.rede_id
-    if data.tipo == "supervisor":
-        emps = db.query(Empresa).filter(Empresa.id.in_(data.empresa_ids)).all()
-        if len(emps) != len(set(data.empresa_ids)):
-            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Empresa inválida na lista")
-        redes_emp = {e.rede_id for e in emps}
-        if len(redes_emp) != 1:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Supervisor: todas as empresas devem pertencer à mesma rede.",
-            )
-        rede_id_final = list(redes_emp)[0]
-    elif data.tipo == "colaborador" and data.empresa_id:
-        emp = db.query(Empresa).filter(Empresa.id == data.empresa_id).first()
-        if not emp:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Empresa não encontrada")
-        rede_id_final = emp.rede_id
+    if escopo == "selected" and not empresa_ids:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Selecione ao menos uma empresa ou marque todas as empresas da rede.",
+        )
+    if escopo == "selected":
+        if rede_id_final is None and empresa_ids:
+            emp = db.query(Empresa).filter(Empresa.id == empresa_ids[0]).first()
+            if not emp:
+                raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Empresa não encontrada")
+            rede_id_final = emp.rede_id
+        try:
+            validar_empresa_ids_na_rede(db, int(rede_id_final), empresa_ids)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    elif not rede_id_final:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe a rede.")
     if rede_id_final is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="rede_id não definido para o vínculo.")
     try:
@@ -162,16 +184,21 @@ def criar(
         nome=data.nome,
         email=data.email,
         tipo=data.tipo,
+        escopo_empresas=escopo,
         ativo=data.ativo,
         rede_id=rede_id_final,
-        empresa_id=data.empresa_id,
+        empresa_id=data.empresa_id if escopo == "selected" and data.tipo == "colaborador" else None,
     )
     db.add(f)
     db.flush()
     registrar_audit(db, "funcionario_rede", f.id, "create", atendente.id)
-    if data.tipo == "supervisor":
-        for emp_id in data.empresa_ids:
-            db.add(FuncionarioRedeEmpresa(funcionario_id=f.id, empresa_id=emp_id))
+    sincronizar_vinculos_empresas(
+        db,
+        f,
+        escopo=escopo,
+        rede_id=int(rede_id_final),
+        empresa_ids=empresa_ids if escopo == "selected" else None,
+    )
     db.commit()
     db.refresh(f)
     return _para_read(f)
@@ -201,27 +228,42 @@ def atualizar(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Funcionário não encontrado")
     update = data.model_dump(exclude_unset=True)
     empresa_ids = update.pop("empresa_ids", None)
+    empresa_id_upd = update.pop("empresa_id", None)
+    escopo_upd = update.pop("escopo_empresas", None)
     for k, v in update.items():
         setattr(f, k, v)
-    if empresa_ids is not None and f.tipo == "supervisor":
-        if empresa_ids:
-            emps = db.query(Empresa).filter(Empresa.id.in_(empresa_ids)).all()
-            if len(emps) != len(set(empresa_ids)):
-                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Empresa inválida na lista")
-            redes_emp = {e.rede_id for e in emps}
-            if len(redes_emp) != 1:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Supervisor: todas as empresas devem pertencer à mesma rede.",
-                )
-            f.rede_id = list(redes_emp)[0]
-        db.query(FuncionarioRedeEmpresa).filter(FuncionarioRedeEmpresa.funcionario_id == f.id).delete()
-        for emp_id in empresa_ids:
-            db.add(FuncionarioRedeEmpresa(funcionario_id=f.id, empresa_id=emp_id))
-    if f.tipo == "colaborador" and f.empresa_id:
-        emp = db.query(Empresa).filter(Empresa.id == f.empresa_id).first()
-        if emp:
-            f.rede_id = emp.rede_id
+    escopo = (escopo_upd or escopo_efetivo(f)).strip().lower()
+    if escopo not in ("all", "selected"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="escopo_empresas deve ser all ou selected")
+    ids = list(empresa_ids) if empresa_ids is not None else _empresa_ids_leitura(f)
+    if empresa_id_upd is not None and empresa_id_upd not in ids:
+        ids.insert(0, empresa_id_upd)
+    rede_id = f.rede_id
+    if escopo == "selected":
+        if not ids:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Selecione ao menos uma empresa ou marque todas as empresas da rede.",
+            )
+        if rede_id is None and ids:
+            emp = db.query(Empresa).filter(Empresa.id == ids[0]).first()
+            if emp:
+                rede_id = emp.rede_id
+        if rede_id is None:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="rede_id não definido.")
+        try:
+            validar_empresa_ids_na_rede(db, int(rede_id), ids)
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    elif rede_id is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe a rede.")
+    sincronizar_vinculos_empresas(
+        db,
+        f,
+        escopo=escopo,
+        rede_id=int(rede_id),
+        empresa_ids=ids if escopo == "selected" else None,
+    )
     if f.rede_id is not None:
         try:
             assert_email_unico_por_rede(

--- a/backend/app/api/pdv_catalogos.py
+++ b/backend/app/api/pdv_catalogos.py
@@ -1,0 +1,143 @@
+from enum import Enum
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.core.auth import exigir_admin, obter_atendente_atual
+from app.core.ordenacao_lista import OrdemLista, expr_ordem
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.models.empresa_pdv import PdvRotulo, PdvTipoAcessoRemoto
+from app.schemas.lista_paginada import ListaPaginada
+from app.schemas.pdv import (
+    PdvRotuloCreate,
+    PdvRotuloRead,
+    PdvRotuloUpdate,
+    PdvTipoAcessoRemotoCreate,
+    PdvTipoAcessoRemotoRead,
+    PdvTipoAcessoRemotoUpdate,
+)
+
+router = APIRouter(tags=["pdv-catalogos"])
+
+_MAX_PAGE = 100
+_DEFAULT_PAGE = 50
+
+
+class OrdenarCatalogo(str, Enum):
+    nome = "nome"
+    ordem_exibicao = "ordem_exibicao"
+    ativo = "ativo"
+
+
+def _listar_catalogo(db, model, incluir_inativos, busca, offset, limit, ordenar_por, ordem):
+    q = db.query(model)
+    if not incluir_inativos:
+        q = q.filter(model.ativo.is_(True))
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter(model.nome.ilike(term))
+    total = q.count()
+    if ordenar_por == OrdenarCatalogo.nome:
+        order_cols = [expr_ordem(model.nome, ordem), expr_ordem(model.id, ordem)]
+    elif ordenar_por == OrdenarCatalogo.ativo:
+        order_cols = [expr_ordem(model.ativo, ordem), expr_ordem(model.ordem_exibicao, ordem)]
+    else:
+        order_cols = [expr_ordem(model.ordem_exibicao, ordem), expr_ordem(model.nome, ordem)]
+    items = q.order_by(*order_cols).offset(offset).limit(limit).all()
+    return ListaPaginada(items=items, total=total)
+
+
+@router.get("/pdv-rotulos", response_model=ListaPaginada[PdvRotuloRead])
+def listar_rotulos(
+    incluir_inativos: bool = Query(False),
+    busca: str | None = Query(None),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    ordenar_por: OrdenarCatalogo | None = Query(OrdenarCatalogo.ordem_exibicao),
+    ordem: OrdemLista = Query(OrdemLista.asc),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(obter_atendente_atual),
+):
+    return _listar_catalogo(db, PdvRotulo, incluir_inativos, busca, offset, limit, ordenar_por, ordem)
+
+
+@router.post("/pdv-rotulos", response_model=PdvRotuloRead, status_code=201)
+def criar_rotulo(
+    data: PdvRotuloCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = PdvRotulo(**data.model_dump())
+    db.add(row)
+    db.flush()
+    registrar_audit(db, "pdv_rotulo", row.id, "create", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.patch("/pdv-rotulos/{rotulo_id}", response_model=PdvRotuloRead)
+def atualizar_rotulo(
+    rotulo_id: int,
+    data: PdvRotuloUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = db.query(PdvRotulo).filter(PdvRotulo.id == rotulo_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Rótulo não encontrado")
+    for k, v in data.model_dump(exclude_unset=True).items():
+        setattr(row, k, v)
+    registrar_audit(db, "pdv_rotulo", row.id, "update", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.get("/pdv-tipos-acesso-remoto", response_model=ListaPaginada[PdvTipoAcessoRemotoRead])
+def listar_tipos_acesso(
+    incluir_inativos: bool = Query(False),
+    busca: str | None = Query(None),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    ordenar_por: OrdenarCatalogo | None = Query(OrdenarCatalogo.ordem_exibicao),
+    ordem: OrdemLista = Query(OrdemLista.asc),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(obter_atendente_atual),
+):
+    return _listar_catalogo(db, PdvTipoAcessoRemoto, incluir_inativos, busca, offset, limit, ordenar_por, ordem)
+
+
+@router.post("/pdv-tipos-acesso-remoto", response_model=PdvTipoAcessoRemotoRead, status_code=201)
+def criar_tipo_acesso(
+    data: PdvTipoAcessoRemotoCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = PdvTipoAcessoRemoto(**data.model_dump())
+    db.add(row)
+    db.flush()
+    registrar_audit(db, "pdv_tipo_acesso_remoto", row.id, "create", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.patch("/pdv-tipos-acesso-remoto/{tipo_id}", response_model=PdvTipoAcessoRemotoRead)
+def atualizar_tipo_acesso(
+    tipo_id: int,
+    data: PdvTipoAcessoRemotoUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = db.query(PdvTipoAcessoRemoto).filter(PdvTipoAcessoRemoto.id == tipo_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Tipo de acesso remoto não encontrado")
+    for k, v in data.model_dump(exclude_unset=True).items():
+        setattr(row, k, v)
+    registrar_audit(db, "pdv_tipo_acesso_remoto", row.id, "update", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,6 +30,8 @@ from app.api import (
     email_inbound_webhook,
     resend_inbound_webhook,
     respostas_prontas,
+    pdv_catalogos,
+    empresa_pdvs,
     system_settings,
     tenant,
 )
@@ -275,6 +277,8 @@ app.include_router(whatsapp_webhook.router, prefix=API_V1_PREFIX)
 app.include_router(email_inbound_webhook.router, prefix=API_V1_PREFIX)
 app.include_router(resend_inbound_webhook.router, prefix=API_V1_PREFIX)
 app.include_router(respostas_prontas.router, prefix=API_V1_PREFIX)
+app.include_router(pdv_catalogos.router, prefix=API_V1_PREFIX)
+app.include_router(empresa_pdvs.router, prefix=API_V1_PREFIX)
 app.include_router(system_settings.router, prefix=API_V1_PREFIX)
 app.include_router(tenant.router, prefix=API_V1_PREFIX)
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -23,6 +23,7 @@ from app.models.tenant_inbound_address import TenantInboundAddress
 from app.models.password_reset_token import PasswordResetToken
 from app.models.resposta_pronta import RespostaPronta
 from app.models.ticket_vinculo import TicketVinculo
+from app.models.empresa_pdv import EmpresaPdv, PdvRotulo, PdvTipoAcessoRemoto
 
 __all__ = [
     "Rede",
@@ -57,4 +58,7 @@ __all__ = [
     "PasswordResetToken",
     "RespostaPronta",
     "TicketVinculo",
+    "PdvRotulo",
+    "PdvTipoAcessoRemoto",
+    "EmpresaPdv",
 ]

--- a/backend/app/models/empresa.py
+++ b/backend/app/models/empresa.py
@@ -52,3 +52,4 @@ class Empresa(Base):
     tickets = relationship("Ticket", back_populates="empresa")
     colaboradores = relationship("FuncionarioRede", back_populates="empresa", foreign_keys="FuncionarioRede.empresa_id")
     empresas_supervisor = relationship("FuncionarioRedeEmpresa", back_populates="empresa", foreign_keys="FuncionarioRedeEmpresa.empresa_id")
+    pdvs = relationship("EmpresaPdv", back_populates="empresa", cascade="all, delete-orphan")

--- a/backend/app/models/empresa_pdv.py
+++ b/backend/app/models/empresa_pdv.py
@@ -1,0 +1,54 @@
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class PdvRotulo(Base):
+    __tablename__ = "pdv_rotulos"
+
+    id = Column(Integer, primary_key=True, index=True)
+    nome = Column(String(120), nullable=False)
+    ativo = Column(Boolean, default=True, nullable=False)
+    ordem_exibicao = Column(Integer, default=0, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    pdvs = relationship("EmpresaPdv", back_populates="rotulo")
+
+
+class PdvTipoAcessoRemoto(Base):
+    __tablename__ = "pdv_tipos_acesso_remoto"
+
+    id = Column(Integer, primary_key=True, index=True)
+    nome = Column(String(120), nullable=False)
+    ativo = Column(Boolean, default=True, nullable=False)
+    ordem_exibicao = Column(Integer, default=0, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    pdvs = relationship("EmpresaPdv", back_populates="tipo_acesso_remoto")
+
+
+class EmpresaPdv(Base):
+    __tablename__ = "empresa_pdvs"
+    __table_args__ = (UniqueConstraint("empresa_id", "codigo", name="uq_empresa_pdv_codigo"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    empresa_id = Column(Integer, ForeignKey("empresas.id", ondelete="CASCADE"), nullable=False, index=True)
+    codigo = Column(String(32), nullable=False)
+    rotulo_id = Column(Integer, ForeignKey("pdv_rotulos.id"), nullable=False)
+    papel = Column(String(20), nullable=False)  # principal | auxiliar
+    usa_tef = Column(Boolean, default=False, nullable=False)
+    tipo_acesso_remoto_id = Column(Integer, ForeignKey("pdv_tipos_acesso_remoto.id"), nullable=True)
+    acesso_remoto_id = Column(String(255), nullable=True)
+    acesso_remoto_senha_cifrada = Column(Text, nullable=True)
+    observacoes = Column(Text, nullable=True)
+    ativo = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    empresa = relationship("Empresa", back_populates="pdvs")
+    rotulo = relationship("PdvRotulo", back_populates="pdvs")
+    tipo_acesso_remoto = relationship("PdvTipoAcessoRemoto", back_populates="pdvs")

--- a/backend/app/models/funcionario_rede.py
+++ b/backend/app/models/funcionario_rede.py
@@ -21,6 +21,7 @@ class FuncionarioRede(Base):
     nome = Column(String(255), nullable=False)
     email = Column(String(255), nullable=False, index=True)  # único por contexto (rede/empresa)
     tipo = Column(String(20), nullable=False)  # socio | supervisor | colaborador
+    escopo_empresas = Column(String(20), nullable=False, default="selected")  # all | selected
     ativo = Column(Boolean, default=True)
     # Sócio: preenchido rede_id
     rede_id = Column(Integer, ForeignKey("redes.id"), nullable=True)

--- a/backend/app/schemas/funcionario_rede.py
+++ b/backend/app/schemas/funcionario_rede.py
@@ -6,19 +6,21 @@ class FuncionarioRedeBase(BaseModel):
     nome: str
     email: EmailStr
     tipo: str  # socio | supervisor | colaborador
+    escopo_empresas: str = "selected"  # all | selected
     ativo: bool = True
 
 
 class FuncionarioRedeCreate(FuncionarioRedeBase):
-    rede_id: int | None = None      # obrigatório se tipo == socio
-    empresa_id: int | None = None   # obrigatório se tipo == colaborador
-    empresa_ids: list[int] = []     # obrigatório se tipo == supervisor
+    rede_id: int | None = None
+    empresa_id: int | None = None  # legado colaborador (preferir empresa_ids)
+    empresa_ids: list[int] = []  # obrigatório se escopo_empresas == selected
 
 
 class FuncionarioRedeUpdate(BaseModel):
     nome: str | None = None
     email: EmailStr | None = None
     tipo: str | None = None
+    escopo_empresas: str | None = None
     ativo: bool | None = None
     rede_id: int | None = None
     empresa_id: int | None = None
@@ -29,7 +31,7 @@ class FuncionarioRedeRead(FuncionarioRedeBase):
     id: int
     rede_id: int | None = None
     empresa_id: int | None = None
-    empresa_ids: list[int] = []
+    empresa_ids: list[int] = []  # preenchido quando escopo_empresas == selected
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/backend/app/schemas/pdv.py
+++ b/backend/app/schemas/pdv.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PdvCatalogoBase(BaseModel):
+    nome: str = Field(min_length=1, max_length=120)
+    ativo: bool = True
+    ordem_exibicao: int = 0
+
+
+class PdvRotuloCreate(PdvCatalogoBase):
+    pass
+
+
+class PdvRotuloUpdate(BaseModel):
+    nome: str | None = Field(default=None, min_length=1, max_length=120)
+    ativo: bool | None = None
+    ordem_exibicao: int | None = None
+
+
+class PdvRotuloRead(PdvCatalogoBase):
+    id: int
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PdvTipoAcessoRemotoCreate(PdvCatalogoBase):
+    pass
+
+
+class PdvTipoAcessoRemotoUpdate(BaseModel):
+    nome: str | None = Field(default=None, min_length=1, max_length=120)
+    ativo: bool | None = None
+    ordem_exibicao: int | None = None
+
+
+class PdvTipoAcessoRemotoRead(PdvCatalogoBase):
+    id: int
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    model_config = ConfigDict(from_attributes=True)
+
+
+class EmpresaPdvBase(BaseModel):
+    codigo: str = Field(min_length=1, max_length=32)
+    rotulo_id: int
+    papel: str = Field(pattern=r"^(principal|auxiliar)$")
+    usa_tef: bool = False
+    tipo_acesso_remoto_id: int | None = None
+    acesso_remoto_id: str | None = Field(default=None, max_length=255)
+    observacoes: str | None = None
+    ativo: bool = True
+
+
+class EmpresaPdvCreate(EmpresaPdvBase):
+    acesso_remoto_senha: str | None = Field(default=None, max_length=500)
+
+
+class EmpresaPdvUpdate(BaseModel):
+    rotulo_id: int | None = None
+    papel: str | None = Field(default=None, pattern=r"^(principal|auxiliar)$")
+    usa_tef: bool | None = None
+    tipo_acesso_remoto_id: int | None = None
+    acesso_remoto_id: str | None = Field(default=None, max_length=255)
+    acesso_remoto_senha: str | None = Field(default=None, max_length=500)
+    observacoes: str | None = None
+    ativo: bool | None = None
+
+
+class EmpresaPdvRead(EmpresaPdvBase):
+    id: int
+    empresa_id: int
+    rotulo_nome: str | None = None
+    tipo_acesso_remoto_nome: str | None = None
+    tem_senha_remota: bool = False
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    model_config = ConfigDict(from_attributes=True)
+
+
+class EmpresaPdvCredencialRead(BaseModel):
+    acesso_remoto_senha: str

--- a/backend/app/services/empresa_pdv_rules.py
+++ b/backend/app/services/empresa_pdv_rules.py
@@ -1,0 +1,25 @@
+"""Regras de negócio para PDVs por empresa."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.empresa_pdv import EmpresaPdv
+
+
+def validar_papel_principal_auxiliar(
+    db: Session,
+    empresa_id: int,
+    *,
+    ignorar_pdv_id: int | None = None,
+) -> None:
+    q = db.query(EmpresaPdv).filter(EmpresaPdv.empresa_id == empresa_id, EmpresaPdv.ativo.is_(True))
+    if ignorar_pdv_id is not None:
+        q = q.filter(EmpresaPdv.id != ignorar_pdv_id)
+    rows = q.all()
+    tem_auxiliar = any(r.papel == "auxiliar" for r in rows)
+    tem_principal = any(r.papel == "principal" for r in rows)
+    if tem_auxiliar and not tem_principal:
+        raise ValueError(
+            "Com pelo menos um PDV auxiliar ativo, a empresa precisa de ao menos um PDV principal ativo."
+        )

--- a/backend/app/services/funcionario_escopo.py
+++ b/backend/app/services/funcionario_escopo.py
@@ -1,0 +1,116 @@
+"""Escopo de empresas visíveis por funcionário da rede (ALL vs SELECTED)."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.empresa import Empresa
+from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
+
+EscopoEmpresas = str  # "all" | "selected"
+
+
+def escopo_efetivo(funcionario: FuncionarioRede) -> str:
+    raw = (getattr(funcionario, "escopo_empresas", None) or "").strip().lower()
+    if raw in ("all", "selected"):
+        return raw
+    return "all" if funcionario.tipo == "socio" else "selected"
+
+
+def rede_id_efetiva(db: Session, funcionario: FuncionarioRede) -> int | None:
+    if funcionario.rede_id is not None:
+        return int(funcionario.rede_id)
+    if funcionario.tipo == "colaborador" and funcionario.empresa_id is not None:
+        emp = db.query(Empresa).filter(Empresa.id == funcionario.empresa_id).first()
+        return int(emp.rede_id) if emp else None
+    rows = (
+        db.query(FuncionarioRedeEmpresa)
+        .filter(FuncionarioRedeEmpresa.funcionario_id == funcionario.id)
+        .all()
+    )
+    if not rows:
+        return None
+    emp = db.query(Empresa).filter(Empresa.id == rows[0].empresa_id).first()
+    return int(emp.rede_id) if emp else None
+
+
+def empresa_ids_vinculados(db: Session, funcionario: FuncionarioRede, *, apenas_ativas: bool = True) -> set[int]:
+    escopo = escopo_efetivo(funcionario)
+    rede_id = rede_id_efetiva(db, funcionario)
+    if escopo == "all":
+        if rede_id is None:
+            return set()
+        q = db.query(Empresa.id).filter(Empresa.rede_id == rede_id)
+        if apenas_ativas:
+            q = q.filter(Empresa.ativo.is_(True))
+        return {int(r[0]) for r in q.all()}
+
+    ids: set[int] = set()
+    if funcionario.tipo == "colaborador" and funcionario.empresa_id is not None:
+        ids.add(int(funcionario.empresa_id))
+    rows = (
+        db.query(FuncionarioRedeEmpresa.empresa_id)
+        .filter(FuncionarioRedeEmpresa.funcionario_id == funcionario.id)
+        .all()
+    )
+    ids |= {int(r[0]) for r in rows}
+    if apenas_ativas and ids:
+        ativos = {
+            int(r[0])
+            for r in db.query(Empresa.id)
+            .filter(Empresa.id.in_(ids), Empresa.ativo.is_(True))
+            .all()
+        }
+        return ativos
+    return ids
+
+
+def funcionario_visivel_na_empresa(db: Session, funcionario: FuncionarioRede, empresa_id: int) -> bool:
+    emp = db.query(Empresa).filter(Empresa.id == empresa_id).first()
+    if not emp:
+        return False
+    rede_id = rede_id_efetiva(db, funcionario)
+    if rede_id is None or int(emp.rede_id) != int(rede_id):
+        return False
+    return int(empresa_id) in empresa_ids_vinculados(db, funcionario, apenas_ativas=False)
+
+
+def validar_empresa_ids_na_rede(db: Session, rede_id: int, empresa_ids: list[int]) -> None:
+    if not empresa_ids:
+        raise ValueError("Selecione ao menos uma empresa.")
+    emps = db.query(Empresa).filter(Empresa.id.in_(empresa_ids)).all()
+    if len(emps) != len(set(empresa_ids)):
+        raise ValueError("Empresa inválida na lista.")
+    redes = {int(e.rede_id) for e in emps}
+    if len(redes) != 1 or int(rede_id) not in redes:
+        raise ValueError("Todas as empresas devem pertencer à mesma rede.")
+
+
+def sincronizar_vinculos_empresas(
+    db: Session,
+    funcionario: FuncionarioRede,
+    *,
+    escopo: str,
+    rede_id: int,
+    empresa_ids: list[int] | None,
+) -> None:
+    funcionario.escopo_empresas = escopo
+    funcionario.rede_id = rede_id
+    if escopo == "all":
+        funcionario.empresa_id = None
+        db.query(FuncionarioRedeEmpresa).filter(
+            FuncionarioRedeEmpresa.funcionario_id == funcionario.id
+        ).delete()
+        return
+
+    ids = list(dict.fromkeys(empresa_ids or []))
+    validar_empresa_ids_na_rede(db, rede_id, ids)
+    if funcionario.tipo == "colaborador" and len(ids) == 1:
+        funcionario.empresa_id = ids[0]
+    else:
+        funcionario.empresa_id = None
+    db.query(FuncionarioRedeEmpresa).filter(
+        FuncionarioRedeEmpresa.funcionario_id == funcionario.id
+    ).delete()
+    for eid in ids:
+        db.add(FuncionarioRedeEmpresa(funcionario_id=funcionario.id, empresa_id=eid))

--- a/backend/app/services/funcionario_rede_resolver.py
+++ b/backend/app/services/funcionario_rede_resolver.py
@@ -13,7 +13,8 @@ from dataclasses import dataclass
 from sqlalchemy.orm import Session
 
 from app.models.empresa import Empresa
-from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
+from app.models.funcionario_rede import FuncionarioRede
+from app.services.funcionario_escopo import empresa_ids_vinculados, escopo_efetivo, rede_id_efetiva
 
 
 @dataclass(frozen=True)
@@ -34,16 +35,7 @@ def _normalizar_email(raw: str | None) -> str | None:
 
 
 def _empresas_do_funcionario(db: Session, f: FuncionarioRede) -> set[int]:
-    if f.tipo == "colaborador" and f.empresa_id is not None:
-        return {int(f.empresa_id)}
-    if f.tipo == "supervisor":
-        rows = (
-            db.query(FuncionarioRedeEmpresa.empresa_id)
-            .filter(FuncionarioRedeEmpresa.funcionario_id == f.id)
-            .all()
-        )
-        return {int(r[0]) for r in rows}
-    return set()
+    return empresa_ids_vinculados(db, f)
 
 
 def resolver_remetente_por_email(db: Session, email_raw: str | None) -> RemetenteFuncionarioResolve:
@@ -83,7 +75,7 @@ def resolver_remetente_por_email(db: Session, email_raw: str | None) -> Remetent
             continue
         empresa_ids |= _empresas_do_funcionario(db, f)
 
-    if rede_id is not None and not empresa_ids and any(f.tipo == "socio" for f in rows):
+    if rede_id is not None and not empresa_ids and any(escopo_efetivo(f) == "all" for f in rows):
         ids_rede = (
             db.query(Empresa.id)
             .filter(Empresa.rede_id == rede_id, Empresa.ativo.is_(True))

--- a/backend/tests/test_empresa_pdvs.py
+++ b/backend/tests/test_empresa_pdvs.py
@@ -1,0 +1,100 @@
+import pytest
+
+from app.models.empresa_pdv import EmpresaPdv, PdvRotulo, PdvTipoAcessoRemoto
+from app.services.empresa_pdv_rules import validar_papel_principal_auxiliar
+from app.services.secret_box import decrypt_str, encrypt_str
+
+
+@pytest.fixture
+def pdv_catalogo(db_session):
+    rot = PdvRotulo(nome="Caixa", ativo=True, ordem_exibicao=1)
+    tipo = PdvTipoAcessoRemoto(nome="AnyDesk", ativo=True, ordem_exibicao=1)
+    db_session.add_all([rot, tipo])
+    db_session.commit()
+    return {"rotulo": rot, "tipo": tipo}
+
+
+def test_validacao_auxiliar_exige_principal(db_session, seed_base, pdv_catalogo):
+    emp = seed_base["empresa"]
+    db_session.add(
+        EmpresaPdv(
+            empresa_id=emp.id,
+            codigo="001",
+            rotulo_id=pdv_catalogo["rotulo"].id,
+            papel="auxiliar",
+            ativo=True,
+        )
+    )
+    db_session.commit()
+    with pytest.raises(ValueError, match="principal"):
+        validar_papel_principal_auxiliar(db_session, emp.id)
+
+
+def test_principal_e_auxiliar_ok(db_session, seed_base, pdv_catalogo):
+    emp = seed_base["empresa"]
+    db_session.add_all(
+        [
+            EmpresaPdv(
+                empresa_id=emp.id,
+                codigo="001",
+                rotulo_id=pdv_catalogo["rotulo"].id,
+                papel="principal",
+                ativo=True,
+            ),
+            EmpresaPdv(
+                empresa_id=emp.id,
+                codigo="002",
+                rotulo_id=pdv_catalogo["rotulo"].id,
+                papel="auxiliar",
+                ativo=True,
+            ),
+        ]
+    )
+    db_session.commit()
+    validar_papel_principal_auxiliar(db_session, emp.id)
+
+
+def test_criptografia_senha_pdv():
+    raw = "senha-secreta-123"
+    cifrada = encrypt_str(raw)
+    assert cifrada != raw
+    assert decrypt_str(cifrada) == raw
+
+
+def test_api_listar_pdvs_sem_senha(client, auth_headers, seed_base, pdv_catalogo):
+    emp = seed_base["empresa"]
+    client.post(
+        f"/v1/empresas/{emp.id}/pdvs",
+        headers=auth_headers["admin"],
+        json={
+            "codigo": "001",
+            "rotulo_id": pdv_catalogo["rotulo"].id,
+            "papel": "principal",
+            "acesso_remoto_senha": "minha-senha",
+        },
+    )
+    r = client.get(f"/v1/empresas/{emp.id}/pdvs", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 1
+    item = body["items"][0]
+    assert item["tem_senha_remota"] is True
+    assert "acesso_remoto_senha" not in item
+
+
+def test_api_revelar_credencial_admin(client, auth_headers, seed_base, pdv_catalogo):
+    emp = seed_base["empresa"]
+    criado = client.post(
+        f"/v1/empresas/{emp.id}/pdvs",
+        headers=auth_headers["admin"],
+        json={
+            "codigo": "002",
+            "rotulo_id": pdv_catalogo["rotulo"].id,
+            "papel": "principal",
+            "acesso_remoto_senha": "revelar-me",
+        },
+    )
+    pdv_id = criado.json()["id"]
+    r = client.get(f"/v1/empresas/{emp.id}/pdvs/{pdv_id}/credencial", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    assert r.json()["acesso_remoto_senha"] == "revelar-me"

--- a/backend/tests/test_funcionario_escopo.py
+++ b/backend/tests/test_funcionario_escopo.py
@@ -1,0 +1,72 @@
+import pytest
+
+from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
+from app.services.funcionario_escopo import (
+    empresa_ids_vinculados,
+    escopo_efetivo,
+    funcionario_visivel_na_empresa,
+)
+
+
+def test_escopo_all_ve_todas_empresas_ativas(db_session, seed_base):
+    rede = seed_base["rede"]
+    emp = seed_base["empresa"]
+    f = FuncionarioRede(
+        nome="Z Rede",
+        email="z@rede.test",
+        tipo="socio",
+        escopo_empresas="all",
+        ativo=True,
+        rede_id=rede.id,
+    )
+    db_session.add(f)
+    db_session.commit()
+    assert escopo_efetivo(f) == "all"
+    ids = empresa_ids_vinculados(db_session, f)
+    assert emp.id in ids
+    assert funcionario_visivel_na_empresa(db_session, f, emp.id)
+
+
+def test_escopo_selected_uma_empresa(db_session, seed_base):
+    emp = seed_base["empresa"]
+    f = FuncionarioRede(
+        nome="Colab",
+        email="colab@emp.test",
+        tipo="colaborador",
+        escopo_empresas="selected",
+        ativo=True,
+        rede_id=emp.rede_id,
+        empresa_id=emp.id,
+    )
+    db_session.add(f)
+    db_session.flush()
+    db_session.add(FuncionarioRedeEmpresa(funcionario_id=f.id, empresa_id=emp.id))
+    db_session.commit()
+    ids = empresa_ids_vinculados(db_session, f)
+    assert ids == {emp.id}
+
+
+def test_escopo_selected_varias_empresas(db_session, seed_base):
+    from app.models.empresa import Empresa
+
+    rede = seed_base["rede"]
+    emp1 = seed_base["empresa"]
+    emp2 = Empresa(tenant_id=emp1.tenant_id, rede_id=rede.id, nome="Empresa B", ativo=True)
+    db_session.add(emp2)
+    db_session.commit()
+    f = FuncionarioRede(
+        nome="Super",
+        email="super@rede.test",
+        tipo="supervisor",
+        escopo_empresas="selected",
+        ativo=True,
+        rede_id=rede.id,
+    )
+    db_session.add(f)
+    db_session.flush()
+    for eid in (emp1.id, emp2.id):
+        db_session.add(FuncionarioRedeEmpresa(funcionario_id=f.id, empresa_id=eid))
+    db_session.commit()
+    ids = empresa_ids_vinculados(db_session, f)
+    assert ids == {emp1.id, emp2.id}
+    assert funcionario_visivel_na_empresa(db_session, f, emp2.id)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import { TiposNegocio } from './pages/TiposNegocio'
 import { TipoNegocioForm } from './pages/TipoNegocioForm'
 import { TipoNegocioDetalhe } from './pages/TipoNegocioDetalhe'
 import { ConfigWhatsapp } from './pages/ConfigWhatsapp'
+import { ConfigPdvCatalogos } from './pages/ConfigPdvCatalogos'
 import { ConfigEmpresaEmail } from './pages/ConfigEmpresaEmail'
 import { WhatsappLayout } from './pages/whatsapp/WhatsappLayout'
 import { WhatsappAtendendo } from './pages/whatsapp/WhatsappAtendendo'
@@ -375,6 +376,14 @@ function AppRoutes() {
           element={
             <AdminRoute>
               <ConfigEmpresaEmail />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="configuracoes/pdv-catalogos"
+          element={
+            <AdminRoute>
+              <ConfigPdvCatalogos />
             </AdminRoute>
           }
         />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1093,11 +1093,13 @@ export namespace Atendentes {
 }
 
 export namespace FuncionariosRede {
+  export type EscopoEmpresas = 'all' | 'selected';
   export interface Funcionario {
     id: number;
     nome: string;
     email: string;
     tipo: string;
+    escopo_empresas: EscopoEmpresas;
     ativo: boolean;
     rede_id?: number;
     empresa_id?: number;
@@ -1109,6 +1111,7 @@ export namespace FuncionariosRede {
     nome: string;
     email: string;
     tipo: string;
+    escopo_empresas?: EscopoEmpresas;
     ativo?: boolean;
     rede_id?: number;
     empresa_id?: number;
@@ -1118,10 +1121,104 @@ export namespace FuncionariosRede {
     nome?: string;
     email?: string;
     tipo?: string;
+    escopo_empresas?: EscopoEmpresas;
     ativo?: boolean;
     rede_id?: number;
     empresa_id?: number;
     empresa_ids?: number[];
+  }
+}
+
+export const pdvRotulos = {
+  list: (params?: { incluir_inativos?: boolean; busca?: string; offset?: number; limit?: number }) =>
+    listPaginated<PdvCatalogo.Item>('/pdv-rotulos', params),
+  create: (data: PdvCatalogo.Create) => api<PdvCatalogo.Item>('/pdv-rotulos', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id: number, data: PdvCatalogo.Update) =>
+    api<PdvCatalogo.Item>(`/pdv-rotulos/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+};
+
+export const pdvTiposAcessoRemoto = {
+  list: (params?: { incluir_inativos?: boolean; busca?: string; offset?: number; limit?: number }) =>
+    listPaginated<PdvCatalogo.Item>('/pdv-tipos-acesso-remoto', params),
+  create: (data: PdvCatalogo.Create) =>
+    api<PdvCatalogo.Item>('/pdv-tipos-acesso-remoto', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id: number, data: PdvCatalogo.Update) =>
+    api<PdvCatalogo.Item>(`/pdv-tipos-acesso-remoto/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+};
+
+export const empresaPdvs = {
+  list: (empresaId: number, params?: { incluir_inativos?: boolean }) =>
+    listPaginated<EmpresaPdv.Item>(`/empresas/${empresaId}/pdvs`, params),
+  create: (empresaId: number, data: EmpresaPdv.Create) =>
+    api<EmpresaPdv.Item>(`/empresas/${empresaId}/pdvs`, { method: 'POST', body: JSON.stringify(data) }),
+  update: (empresaId: number, pdvId: number, data: EmpresaPdv.Update) =>
+    api<EmpresaPdv.Item>(`/empresas/${empresaId}/pdvs/${pdvId}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  revelarCredencial: (empresaId: number, pdvId: number) =>
+    api<EmpresaPdv.Credencial>(`/empresas/${empresaId}/pdvs/${pdvId}/credencial`),
+};
+
+export namespace PdvCatalogo {
+  export interface Item {
+    id: number;
+    nome: string;
+    ativo: boolean;
+    ordem_exibicao: number;
+    created_at?: string | null;
+    updated_at?: string | null;
+  }
+  export interface Create {
+    nome: string;
+    ativo?: boolean;
+    ordem_exibicao?: number;
+  }
+  export interface Update {
+    nome?: string;
+    ativo?: boolean;
+    ordem_exibicao?: number;
+  }
+}
+
+export namespace EmpresaPdv {
+  export interface Item {
+    id: number;
+    empresa_id: number;
+    codigo: string;
+    rotulo_id: number;
+    rotulo_nome?: string | null;
+    papel: 'principal' | 'auxiliar';
+    usa_tef: boolean;
+    tipo_acesso_remoto_id?: number | null;
+    tipo_acesso_remoto_nome?: string | null;
+    acesso_remoto_id?: string | null;
+    observacoes?: string | null;
+    ativo: boolean;
+    tem_senha_remota: boolean;
+    created_at?: string | null;
+    updated_at?: string | null;
+  }
+  export interface Create {
+    codigo: string;
+    rotulo_id: number;
+    papel: 'principal' | 'auxiliar';
+    usa_tef?: boolean;
+    tipo_acesso_remoto_id?: number | null;
+    acesso_remoto_id?: string | null;
+    acesso_remoto_senha?: string | null;
+    observacoes?: string | null;
+    ativo?: boolean;
+  }
+  export interface Update {
+    rotulo_id?: number;
+    papel?: 'principal' | 'auxiliar';
+    usa_tef?: boolean;
+    tipo_acesso_remoto_id?: number | null;
+    acesso_remoto_id?: string | null;
+    acesso_remoto_senha?: string | null;
+    observacoes?: string | null;
+    ativo?: boolean;
+  }
+  export interface Credencial {
+    acesso_remoto_senha: string;
   }
 }
 

--- a/frontend/src/components/EmpresaPdvsPanel.tsx
+++ b/frontend/src/components/EmpresaPdvsPanel.tsx
@@ -1,0 +1,309 @@
+import { useCallback, useEffect, useState } from 'react'
+import { empresaPdvs, pdvRotulos, pdvTiposAcessoRemoto, type EmpresaPdv, type PdvCatalogo } from '../api/client'
+import { coletarTodasPaginas } from '../api/collectPages'
+import { Button } from './ui/Button'
+import { IconEye, IconEyeOff } from './ui/IconEye'
+import { IconPencil } from './ui/IconPencil'
+import { Input } from './ui/Input'
+import { Select } from './ui/Select'
+import { Switch } from './ui/Switch'
+import { useToast } from './ui/Toast'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { useAuth } from '../contexts/AuthContext'
+
+type Props = { empresaId: number }
+
+const emptyForm = (): EmpresaPdv.Create => ({
+  codigo: '',
+  rotulo_id: 0,
+  papel: 'principal',
+  usa_tef: false,
+  tipo_acesso_remoto_id: null,
+  acesso_remoto_id: '',
+  acesso_remoto_senha: '',
+  observacoes: '',
+  ativo: true,
+})
+
+export function EmpresaPdvsPanel({ empresaId }: Props) {
+  const toast = useToast()
+  const { user } = useAuth()
+  const isAdmin = user?.role === 'admin'
+  const [items, setItems] = useState<EmpresaPdv.Item[]>([])
+  const [loading, setLoading] = useState(true)
+  const [rotulos, setRotulos] = useState<PdvCatalogo.Item[]>([])
+  const [tipos, setTipos] = useState<PdvCatalogo.Item[]>([])
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editId, setEditId] = useState<number | null>(null)
+  const [form, setForm] = useState<EmpresaPdv.Create>(emptyForm())
+  const [saving, setSaving] = useState(false)
+  const [senhaRevelada, setSenhaRevelada] = useState<{ pdvId: number; senha: string } | null>(null)
+  const [revelandoPdvId, setRevelandoPdvId] = useState<number | null>(null)
+
+  const load = useCallback(() => {
+    setLoading(true)
+    empresaPdvs
+      .list(empresaId, { incluir_inativos: true })
+      .then((r) => setItems(r.items))
+      .catch((err) => toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar os PDVs.')))
+      .finally(() => setLoading(false))
+  }, [empresaId, toast])
+
+  useEffect(() => {
+    load()
+    coletarTodasPaginas<PdvCatalogo.Item>((o, l) => pdvRotulos.list({ offset: o, limit: l })).then(setRotulos)
+    coletarTodasPaginas<PdvCatalogo.Item>((o, l) => pdvTiposAcessoRemoto.list({ offset: o, limit: l })).then(setTipos)
+  }, [load])
+
+  function abrirNovo() {
+    setEditId(null)
+    setForm({ ...emptyForm(), rotulo_id: rotulos[0]?.id ?? 0 })
+    setSenhaRevelada(null)
+    setModalOpen(true)
+  }
+
+  function abrirEditar(row: EmpresaPdv.Item) {
+    setEditId(row.id)
+    setForm({
+      codigo: row.codigo,
+      rotulo_id: row.rotulo_id,
+      papel: row.papel,
+      usa_tef: row.usa_tef,
+      tipo_acesso_remoto_id: row.tipo_acesso_remoto_id ?? null,
+      acesso_remoto_id: row.acesso_remoto_id ?? '',
+      acesso_remoto_senha: '',
+      observacoes: row.observacoes ?? '',
+      ativo: row.ativo,
+    })
+    setSenhaRevelada(null)
+    setModalOpen(true)
+  }
+
+  async function revelarSenha(pdvId: number) {
+    if (!isAdmin) return
+    if (senhaRevelada?.pdvId === pdvId) {
+      setSenhaRevelada(null)
+      return
+    }
+    setRevelandoPdvId(pdvId)
+    try {
+      const r = await empresaPdvs.revelarCredencial(empresaId, pdvId)
+      setSenhaRevelada({ pdvId, senha: r.acesso_remoto_senha })
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível revelar a senha.'))
+    } finally {
+      setRevelandoPdvId(null)
+    }
+  }
+
+  async function salvar() {
+    if (!form.codigo.trim() || !form.rotulo_id) {
+      toast.showWarning('Informe o código e o rótulo do PDV.')
+      return
+    }
+    setSaving(true)
+    try {
+      if (editId) {
+        const payload: EmpresaPdv.Update = {
+          rotulo_id: form.rotulo_id,
+          papel: form.papel,
+          usa_tef: form.usa_tef,
+          tipo_acesso_remoto_id: form.tipo_acesso_remoto_id,
+          acesso_remoto_id: form.acesso_remoto_id || null,
+          observacoes: form.observacoes || null,
+          ativo: form.ativo,
+        }
+        if (form.acesso_remoto_senha?.trim()) payload.acesso_remoto_senha = form.acesso_remoto_senha.trim()
+        await empresaPdvs.update(empresaId, editId, payload)
+        toast.showSuccess('PDV atualizado.')
+      } else {
+        await empresaPdvs.create(empresaId, {
+          ...form,
+          codigo: form.codigo.trim(),
+          acesso_remoto_id: form.acesso_remoto_id?.trim() || null,
+          acesso_remoto_senha: form.acesso_remoto_senha?.trim() || null,
+          observacoes: form.observacoes?.trim() || null,
+        })
+        toast.showSuccess('PDV cadastrado.')
+      }
+      setModalOpen(false)
+      load()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o PDV.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          Terminais/pontos de venda desta empresa. O código (ex.: 001) permanece estável ao trocar hardware.
+        </p>
+        {isAdmin ? (
+          <Button type="button" onClick={abrirNovo}>
+            Novo PDV
+          </Button>
+        ) : null}
+      </div>
+
+      {loading && items.length === 0 ? (
+        <p className="text-sm text-slate-500">Carregando PDVs…</p>
+      ) : items.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-slate-300 p-6 text-center dark:border-slate-600">
+          <p className="text-sm text-slate-600 dark:text-slate-300">Nenhum PDV cadastrado.</p>
+          {isAdmin ? (
+            <Button type="button" className="mt-3" onClick={abrirNovo}>
+              Cadastrar primeiro PDV
+            </Button>
+          ) : null}
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px] text-left text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 bg-slate-50/60 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-800 dark:bg-slate-800/40">
+                <th className="px-4 py-3">Código</th>
+                <th className="px-4 py-3">Rótulo</th>
+                <th className="px-4 py-3">Papel</th>
+                <th className="px-4 py-3">TEF</th>
+                <th className="px-4 py-3">Acesso remoto</th>
+                <th className="px-4 py-3 text-right">Ações</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+              {items.map((row) => (
+                <tr key={row.id} className={!row.ativo ? 'opacity-60' : undefined}>
+                  <td className="px-4 py-3 font-mono font-medium">PDV {row.codigo}</td>
+                  <td className="px-4 py-3">{row.rotulo_nome ?? '—'}</td>
+                  <td className="px-4 py-3 capitalize">{row.papel}</td>
+                  <td className="px-4 py-3">{row.usa_tef ? 'Sim' : 'Não'}</td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="text-slate-600 dark:text-slate-300">
+                        {row.tipo_acesso_remoto_nome ?? '—'}
+                        {row.acesso_remoto_id ? ` · ${row.acesso_remoto_id}` : ''}
+                      </span>
+                      {row.tem_senha_remota && isAdmin ? (
+                        senhaRevelada?.pdvId === row.id ? (
+                          <span className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-slate-700 dark:bg-slate-800/80 dark:text-slate-200">
+                            {senhaRevelada.senha}
+                            <button
+                              type="button"
+                              className="rounded p-0.5 text-slate-400 transition hover:text-slate-600 dark:hover:text-slate-200"
+                              onClick={() => setSenhaRevelada(null)}
+                              aria-label="Ocultar senha"
+                            >
+                              <IconEyeOff className="size-3.5" ariaHidden={false} />
+                            </button>
+                          </span>
+                        ) : (
+                          <button
+                            type="button"
+                            className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 disabled:opacity-50 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+                            onClick={() => void revelarSenha(row.id)}
+                            disabled={revelandoPdvId === row.id}
+                            aria-label="Revelar senha de acesso remoto"
+                            title="Revelar senha"
+                          >
+                            {revelandoPdvId === row.id ? (
+                              <span className="size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                            ) : (
+                              <IconEye className="size-4" ariaHidden={false} />
+                            )}
+                          </button>
+                        )
+                      ) : null}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    {isAdmin ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className="!px-2 !py-2"
+                        onClick={() => abrirEditar(row)}
+                        aria-label={`Editar PDV ${row.codigo}`}
+                      >
+                        <IconPencil ariaHidden={false} />
+                      </Button>
+                    ) : null}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {modalOpen && isAdmin ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-2xl border border-slate-200 bg-white p-6 shadow-xl dark:border-slate-700 dark:bg-slate-900">
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-50">
+              {editId ? 'Editar PDV' : 'Novo PDV'}
+            </h3>
+            <div className="mt-4 space-y-4">
+              <Input
+                label="Código (ex.: 001)"
+                value={form.codigo}
+                onChange={(e) => setForm((f) => ({ ...f, codigo: e.target.value }))}
+                disabled={!!editId}
+                required
+              />
+              <Select
+                label="Rótulo do dispositivo"
+                value={form.rotulo_id || ''}
+                onChange={(v) => setForm((f) => ({ ...f, rotulo_id: Number(v) }))}
+                options={rotulos.map((r) => ({ value: r.id, label: r.nome }))}
+              />
+              <Select
+                label="Papel"
+                value={form.papel}
+                onChange={(v) => setForm((f) => ({ ...f, papel: v as 'principal' | 'auxiliar' }))}
+                options={[
+                  { value: 'principal', label: 'Principal' },
+                  { value: 'auxiliar', label: 'Auxiliar' },
+                ]}
+              />
+              <Switch bare checked={!!form.usa_tef} onCheckedChange={(v) => setForm((f) => ({ ...f, usa_tef: v }))} label="Usa TEF" />
+              <Select
+                label="Tipo de acesso remoto"
+                value={form.tipo_acesso_remoto_id ?? ''}
+                onChange={(v) =>
+                  setForm((f) => ({ ...f, tipo_acesso_remoto_id: v === '' ? null : Number(v) }))
+                }
+                options={[{ value: '', label: '—' }, ...tipos.map((t) => ({ value: t.id, label: t.nome }))]}
+              />
+              <Input
+                label="ID de acesso remoto"
+                value={form.acesso_remoto_id ?? ''}
+                onChange={(e) => setForm((f) => ({ ...f, acesso_remoto_id: e.target.value }))}
+              />
+              <Input
+                label={editId ? 'Nova senha (deixe vazio para manter)' : 'Senha de acesso remoto'}
+                type="password"
+                value={form.acesso_remoto_senha ?? ''}
+                onChange={(e) => setForm((f) => ({ ...f, acesso_remoto_senha: e.target.value }))}
+              />
+              <Input
+                label="Observações"
+                value={form.observacoes ?? ''}
+                onChange={(e) => setForm((f) => ({ ...f, observacoes: e.target.value }))}
+              />
+              <Switch bare checked={form.ativo ?? true} onCheckedChange={(v) => setForm((f) => ({ ...f, ativo: v }))} label="Ativo" />
+            </div>
+            <div className="mt-6 flex justify-end gap-2">
+              <Button type="button" variant="secondary" onClick={() => setModalOpen(false)}>
+                Cancelar
+              </Button>
+              <Button type="button" loading={saving} onClick={() => void salvar()}>
+                Salvar
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/components/FuncionariosEmpresaLista.tsx
+++ b/frontend/src/components/FuncionariosEmpresaLista.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import type { FuncionariosRede } from '../api/client'
 import { Button } from './ui/Button'
@@ -13,18 +14,25 @@ export type FuncionariosEmpresaListaProps = {
   items: FuncionariosRede.Funcionario[]
   loading: boolean
   emptyMessage?: string
+  emptyAction?: ReactNode
 }
 
 export function FuncionariosEmpresaLista({
   items,
   loading,
   emptyMessage = 'Nenhum funcionário vinculado a esta empresa.',
+  emptyAction,
 }: FuncionariosEmpresaListaProps) {
   if (loading && items.length === 0) {
     return <p className="text-sm text-slate-500 dark:text-slate-400">Carregando funcionários...</p>
   }
   if (items.length === 0) {
-    return <p className="text-sm text-slate-500 dark:text-slate-400">{emptyMessage}</p>
+    return (
+      <div className="rounded-xl border border-dashed border-slate-300 px-4 py-6 text-center dark:border-slate-600">
+        <p className="text-sm text-slate-500 dark:text-slate-400">{emptyMessage}</p>
+        {emptyAction}
+      </div>
+    )
   }
 
   return (

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -199,6 +199,7 @@ const navStructure: NavItem[] = [
       { to: '/tipos-negocio', label: 'Tipos de negócio', icon: 'tiposNegocio' },
       { to: '/status-ticket', label: 'Status de ticket', icon: 'status' },
       { to: '/respostas-prontas', label: 'Respostas prontas', icon: 'status' },
+      { to: '/configuracoes/pdv-catalogos', label: 'Catálogos PDV', icon: 'empresas' },
       { to: '/configuracoes/empresa-email', label: 'Empresa & e-mail', icon: 'empresas' },
       { to: '/configuracoes/whatsapp', label: 'WhatsApp (Evolution)', icon: 'whatsapp' },
       { to: '/auditoria', label: 'Auditoria', icon: 'auditoria' },

--- a/frontend/src/pages/ConfigPdvCatalogos.tsx
+++ b/frontend/src/pages/ConfigPdvCatalogos.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ApiError, pdvRotulos, pdvTiposAcessoRemoto, type PdvCatalogo } from '../api/client'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { Input } from '../components/ui/Input'
+import { Switch } from '../components/ui/Switch'
+import { useToast } from '../components/ui/Toast'
+import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+
+function CatalogoSection({
+  titulo,
+  items,
+  loading,
+  onReload,
+  onCreate,
+  onUpdate,
+}: {
+  titulo: string
+  items: PdvCatalogo.Item[]
+  loading: boolean
+  onReload: () => void
+  onCreate: (data: PdvCatalogo.Create) => Promise<void>
+  onUpdate: (id: number, data: PdvCatalogo.Update) => Promise<void>
+}) {
+  const [nome, setNome] = useState('')
+  const [ordem, setOrdem] = useState('0')
+  const [saving, setSaving] = useState(false)
+
+  async function adicionar() {
+    if (!nome.trim()) return
+    setSaving(true)
+    try {
+      await onCreate({ nome: nome.trim(), ordem_exibicao: Number(ordem) || 0, ativo: true })
+      setNome('')
+      setOrdem('0')
+      onReload()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Card title={titulo}>
+      <div className="mb-4 flex flex-wrap items-end gap-2">
+        <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} className="min-w-[12rem] flex-1" />
+        <Input label="Ordem" type="number" value={ordem} onChange={(e) => setOrdem(e.target.value)} className="w-24" />
+        <Button type="button" loading={saving} onClick={() => void adicionar()}>
+          Adicionar
+        </Button>
+      </div>
+      {loading ? (
+        <p className="text-sm text-slate-500">Carregando…</p>
+      ) : items.length === 0 ? (
+        <p className="text-sm text-slate-500">Nenhum item cadastrado.</p>
+      ) : (
+        <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+          {items.map((item) => (
+            <li key={item.id} className="flex flex-wrap items-center justify-between gap-2 py-3">
+              <div>
+                <span className="font-medium text-slate-800 dark:text-slate-100">{item.nome}</span>
+                <span className="ml-2 text-xs text-slate-500">ordem {item.ordem_exibicao}</span>
+              </div>
+              <Switch
+                bare
+                checked={item.ativo}
+                onCheckedChange={(ativo) => void onUpdate(item.id, { ativo })}
+                label="Ativo"
+                showStatusPill
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  )
+}
+
+export function ConfigPdvCatalogos() {
+  const toast = useToast()
+  const [forbidden, setForbidden] = useState(false)
+  const [rotulos, setRotulos] = useState<PdvCatalogo.Item[]>([])
+  const [tipos, setTipos] = useState<PdvCatalogo.Item[]>([])
+  const [loadingR, setLoadingR] = useState(true)
+  const [loadingT, setLoadingT] = useState(true)
+
+  const loadRotulos = useCallback(() => {
+    setLoadingR(true)
+    pdvRotulos
+      .list({ incluir_inativos: true, limit: 100 })
+      .then((r) => setRotulos(r.items))
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) setForbidden(true)
+        else toast.showWarning(mensagemFalhaParaToast(err, 'Erro ao carregar rótulos.'))
+      })
+      .finally(() => setLoadingR(false))
+  }, [toast])
+
+  const loadTipos = useCallback(() => {
+    setLoadingT(true)
+    pdvTiposAcessoRemoto
+      .list({ incluir_inativos: true, limit: 100 })
+      .then((r) => setTipos(r.items))
+      .catch((err) => toast.showWarning(mensagemFalhaParaToast(err, 'Erro ao carregar tipos.')))
+      .finally(() => setLoadingT(false))
+  }, [toast])
+
+  useEffect(() => {
+    loadRotulos()
+    loadTipos()
+  }, [loadRotulos, loadTipos])
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Apenas administradores podem gerir os catálogos de PDV."
+        voltarPara="/"
+        voltarLabel="Voltar"
+      />
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 pb-10">
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-900 dark:text-slate-50">Catálogos de PDV</h1>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          Padrões globais usados no cadastro de terminais por empresa (rótulos e tipos de acesso remoto).
+        </p>
+      </header>
+      <CatalogoSection
+        titulo="Rótulos de dispositivo"
+        items={rotulos}
+        loading={loadingR}
+        onReload={loadRotulos}
+        onCreate={(d) => pdvRotulos.create(d).then(() => toast.showSuccess('Rótulo criado.'))}
+        onUpdate={(id, d) => pdvRotulos.update(id, d).then(() => loadRotulos())}
+      />
+      <CatalogoSection
+        titulo="Tipos de acesso remoto"
+        items={tipos}
+        loading={loadingT}
+        onReload={loadTipos}
+        onCreate={(d) => pdvTiposAcessoRemoto.create(d).then(() => toast.showSuccess('Tipo criado.'))}
+        onUpdate={(id, d) => pdvTiposAcessoRemoto.update(id, d).then(() => loadTipos())}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -21,8 +21,9 @@ import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBus
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { TicketsTabelaContexto } from '../components/TicketsTabelaContexto'
 import { FuncionariosEmpresaLista } from '../components/FuncionariosEmpresaLista'
+import { EmpresaPdvsPanel } from '../components/EmpresaPdvsPanel'
 import { SemPermissao } from './SemPermissao'
-type Aba = 'geral' | 'tickets' | 'funcionarios'
+type Aba = 'geral' | 'tickets' | 'funcionarios' | 'pdvs'
 
 function DetailRow({ label, value }: { label: string; value: string | null | undefined }) {
   const v = value?.trim()
@@ -304,6 +305,7 @@ export function EmpresaDetalhe() {
             {tabBtn('geral', 'Geral')}
             {tabBtn('tickets', 'Tickets')}
             {tabBtn('funcionarios', 'Funcionários')}
+            {tabBtn('pdvs', 'PDVs')}
           </nav>
         </div>
       </header>
@@ -442,12 +444,33 @@ export function EmpresaDetalhe() {
             total={funcTotal}
             onPageChange={setPageF}
             disabled={loadingF}
+            extra={
+              <Link
+                to={`/funcionarios-rede/novo?empresa_id=${empresa.id}&rede_id=${empresa.rede_id}`}
+              >
+                <Button type="button">Adicionar funcionário</Button>
+              </Link>
+            }
           />
           <FuncionariosEmpresaLista
             items={funcItems}
             loading={loadingF}
             emptyMessage="Nenhum funcionário vinculado a esta empresa."
+            emptyAction={
+              <Link
+                to={`/funcionarios-rede/novo?empresa_id=${empresa.id}&rede_id=${empresa.rede_id}`}
+                className="mt-3 inline-block"
+              >
+                <Button type="button">Cadastrar ou vincular funcionário</Button>
+              </Link>
+            }
           />
+        </section>
+      )}
+
+      {aba === 'pdvs' && (
+        <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7">
+          <EmpresaPdvsPanel empresaId={empresa.id} />
         </section>
       )}
     </div>

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -17,6 +17,7 @@ import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/err
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
 type Tipo = 'socio' | 'supervisor' | 'colaborador'
+type Escopo = FuncionariosRede.EscopoEmpresas
 
 function redePadraoRecente(list: Redes.Rede[]) {
   const sorted = [...list].sort((a, b) => (Date.parse(b.created_at ?? '') || 0) - (Date.parse(a.created_at ?? '') || 0))
@@ -44,6 +45,7 @@ export function FuncionarioRedeForm() {
   const [nome, setNome] = useState('')
   const [email, setEmail] = useState('')
   const [tipo, setTipo] = useState<Tipo>('colaborador')
+  const [escopoEmpresas, setEscopoEmpresas] = useState<Escopo>('selected')
   const [ativo, setAtivo] = useState(true)
   const [redeId, setRedeId] = useState<number | ''>('')
   const [empresaId, setEmpresaId] = useState<number | ''>('')
@@ -68,6 +70,15 @@ export function FuncionarioRedeForm() {
     if (isEdit) return
     const em = searchParams.get('email')?.trim()
     if (em) setEmail(em)
+    const rid = searchParams.get('rede_id')
+    if (rid && !Number.isNaN(Number(rid))) setRedeId(Number(rid))
+    const eid = searchParams.get('empresa_id')
+    if (eid && !Number.isNaN(Number(eid))) {
+      const n = Number(eid)
+      setEmpresaId(n)
+      setEmpresaIds([n])
+      setEscopoEmpresas('selected')
+    }
   }, [isEdit, searchParams])
 
   useEffect(() => {
@@ -88,6 +99,7 @@ export function FuncionarioRedeForm() {
         setNome(item.nome)
         setEmail(item.email)
         setTipo(item.tipo as Tipo)
+        setEscopoEmpresas((item.escopo_empresas as Escopo) || (item.tipo === 'socio' ? 'all' : 'selected'))
         setAtivo(item.ativo)
         let r = item.rede_id ?? ('' as number | '')
         if (r === '' && item.tipo === 'colaborador' && item.empresa_id) {
@@ -141,21 +153,19 @@ export function FuncionarioRedeForm() {
     }
     const rid = Number(redeId)
     const empresasNaRede = empresasList.filter((em) => em.rede_id === rid)
-    if (tipo === 'colaborador') {
-      const em = empresasList.find((x) => x.id === empresaId)
-      if (!em || em.rede_id !== rid) {
-        toast.showWarning('Selecione uma empresa desta rede.')
+    const escopo = escopoEmpresas
+    let ids = [...empresaIds]
+    if (escopo === 'selected') {
+      if (tipo === 'colaborador' && empresaId) {
+        ids = [Number(empresaId)]
+      }
+      if (!ids.length) {
+        toast.showWarning('Marque ao menos uma empresa da rede ou escolha «Todas as empresas».')
         return
       }
-    }
-    if (tipo === 'supervisor') {
-      if (!empresaIds.length) {
-        toast.showWarning('Marque ao menos uma empresa da rede.')
-        return
-      }
-      const invalid = empresaIds.some((id) => !empresasNaRede.some((e) => e.id === id))
+      const invalid = ids.some((id) => !empresasNaRede.some((e) => e.id === id))
       if (invalid) {
-        toast.showWarning('Todas as empresas do supervisor devem ser da rede selecionada.')
+        toast.showWarning('Todas as empresas selecionadas devem pertencer à rede escolhida.')
         return
       }
     }
@@ -167,10 +177,11 @@ export function FuncionarioRedeForm() {
           nome: nome.trim(),
           email,
           tipo,
+          escopo_empresas: escopo,
           ativo,
-          rede_id: tipo === 'socio' ? rid : undefined,
-          empresa_id: tipo === 'colaborador' ? Number(empresaId) : undefined,
-          empresa_ids: tipo === 'supervisor' ? empresaIds : undefined,
+          rede_id: rid,
+          empresa_id: escopo === 'selected' && tipo === 'colaborador' && ids.length === 1 ? ids[0] : undefined,
+          empresa_ids: escopo === 'selected' ? ids : [],
         }
         saved = await funcionariosRede.update(funcionarioId, payload)
         toast.showSuccess('Funcionário atualizado.')
@@ -179,10 +190,11 @@ export function FuncionarioRedeForm() {
           nome: nome.trim(),
           email,
           tipo,
+          escopo_empresas: escopo,
           ativo,
-          rede_id: tipo === 'socio' ? rid : undefined,
-          empresa_id: tipo === 'colaborador' ? Number(empresaId) : undefined,
-          empresa_ids: tipo === 'supervisor' ? empresaIds : undefined,
+          rede_id: rid,
+          empresa_id: escopo === 'selected' && tipo === 'colaborador' && ids.length === 1 ? ids[0] : undefined,
+          empresa_ids: escopo === 'selected' ? ids : [],
         }
         saved = await funcionariosRede.create(payload)
         toast.showSuccess('Funcionário cadastrado.')
@@ -254,6 +266,7 @@ export function FuncionarioRedeForm() {
                   setTipo(t)
                   setEmpresaId('')
                   setEmpresaIds([])
+                  if (t === 'socio') setEscopoEmpresas('all')
                   if (t === 'socio' && !redeId) setRedeId(redePadraoRecente(redesList))
                 }}
                 options={[
@@ -277,40 +290,70 @@ export function FuncionarioRedeForm() {
               />
             </FormSection>
 
-            {tipo !== 'socio' && (
-              <FormSection title="Vínculo">
-                {tipo === 'colaborador' && (
-                  <SelectComPesquisa
-                    id="funcionario-empresa-form"
-                    label="Empresa desta rede"
-                    value={empresaId}
-                    onChange={(id) => setEmpresaId(id)}
-                    required
-                    disabled={!redeId}
-                    items={empresasDaRede.map((x) => ({ id: x.id, label: x.nome, createdAt: x.created_at }))}
-                    hint={!redeId ? 'Selecione a rede primeiro.' : 'Últimas empresas desta rede. Digite para buscar.'}
+            <FormSection title="Escopo de empresas">
+              <div className="flex flex-col gap-2 sm:flex-row sm:gap-6">
+                <label className="flex cursor-pointer items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                  <input
+                    type="radio"
+                    name="escopo-empresas"
+                    checked={escopoEmpresas === 'all'}
+                    onChange={() => {
+                      setEscopoEmpresas('all')
+                      setEmpresaId('')
+                      setEmpresaIds([])
+                    }}
                   />
-                )}
-                {tipo === 'supervisor' && (
-                  <div>
-                    <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200">Empresas desta rede</label>
-                    {!redeId ? (
-                      <p className="text-sm text-slate-500 dark:text-slate-400">Selecione a rede primeiro.</p>
-                    ) : empresasDaRede.length === 0 ? (
-                      <p className="text-sm text-slate-500 dark:text-slate-400">Nenhuma empresa ativa nesta rede.</p>
-                    ) : (
-                      <div className="flex max-h-44 flex-wrap gap-2 overflow-auto rounded-xl border border-slate-200 bg-slate-50/40 p-3 dark:border-slate-700 dark:bg-slate-800/40">
-                        {empresasDaRede.map((e) => (
-                          <CheckboxField key={e.id} checked={empresaIds.includes(e.id)} onChange={() => toggleEmpresa(e.id)}>
-                            {e.nome}
-                          </CheckboxField>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </FormSection>
-            )}
+                  Todas as empresas da rede
+                </label>
+                <label className="flex cursor-pointer items-center gap-2 text-sm text-slate-700 dark:text-slate-200">
+                  <input
+                    type="radio"
+                    name="escopo-empresas"
+                    checked={escopoEmpresas === 'selected'}
+                    onChange={() => setEscopoEmpresas('selected')}
+                  />
+                  Selecionar empresas
+                </label>
+              </div>
+              {escopoEmpresas === 'selected' && (
+                <div className="mt-3">
+                  {tipo === 'colaborador' ? (
+                    <SelectComPesquisa
+                      id="funcionario-empresa-form"
+                      label="Empresa desta rede"
+                      value={empresaId}
+                      onChange={(id) => {
+                        setEmpresaId(id)
+                        setEmpresaIds(id ? [id] : [])
+                      }}
+                      required
+                      disabled={!redeId}
+                      items={empresasDaRede.map((x) => ({ id: x.id, label: x.nome, createdAt: x.created_at }))}
+                      hint={!redeId ? 'Selecione a rede primeiro.' : 'Últimas empresas desta rede. Digite para buscar.'}
+                    />
+                  ) : (
+                    <>
+                      <label className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-200">
+                        Empresas desta rede
+                      </label>
+                      {!redeId ? (
+                        <p className="text-sm text-slate-500 dark:text-slate-400">Selecione a rede primeiro.</p>
+                      ) : empresasDaRede.length === 0 ? (
+                        <p className="text-sm text-slate-500 dark:text-slate-400">Nenhuma empresa ativa nesta rede.</p>
+                      ) : (
+                        <div className="flex max-h-44 flex-wrap gap-2 overflow-auto rounded-xl border border-slate-200 bg-slate-50/40 p-3 dark:border-slate-700 dark:bg-slate-800/40">
+                          {empresasDaRede.map((e) => (
+                            <CheckboxField key={e.id} checked={empresaIds.includes(e.id)} onChange={() => toggleEmpresa(e.id)}>
+                              {e.nome}
+                            </CheckboxField>
+                          ))}
+                        </div>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
+            </FormSection>
 
             <FormSection title="Situação no sistema">
               <Switch


### PR DESCRIPTION
## Summary

Promove para **main** o pacote de cadastros validado em staging via PR #216:

- Funcionários da rede com escopo **all/selected** por rede (#152, #153, #154)
- PDVs por empresa com catálogos globais, CRUD, senha cifrada e UI admin (#159, #160, #161)
- Migrações Alembic **034** e **035**

## Deploy / pós-merge

- [ ] Rodar lembic upgrade head no ambiente de produção
- [ ] Validar Configurações → Catálogos PDV
- [ ] Validar Empresa → abas Funcionários e PDVs

## Test plan

- [x] Testes backend (escopo + PDVs)
- [x] Typecheck frontend
- [x] Validação manual em staging/local antes do merge do PR #216
