### PR TITLE
feat: classificação/prioridade de tickets e fix do menu lateral (#107/#108/#222)

### DIFF
--- a/backend/alembic/versions/036_ticket_classificacao_prioridade.py
+++ b/backend/alembic/versions/036_ticket_classificacao_prioridade.py
@@ -1,0 +1,116 @@
+"""Revision ID: 036_ticket_classificacao_prioridade
+Revises: 035_empresa_pdvs
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "036_ticket_classificacao"
+down_revision = "035_empresa_pdvs"
+branch_labels = None
+depends_on = None
+
+PRIORIDADE = sa.Enum("baixa", "normal", "alta", "urgente", name="ticket_prioridade", native_enum=False)
+
+NATUREZAS_SEED = (
+    ("Erro", "erro", 10),
+    ("Dúvida", "duvida", 20),
+    ("Solicitação", "solicitacao", 30),
+)
+
+MOTIVOS_SEED = (
+    ("erro", "Falha no PDV", "falha-pdv", 10),
+    ("erro", "Entrada de NF", "entrada-nf", 20),
+    ("erro", "Outros", "outros", 99),
+    ("duvida", "Operacional", "operacional", 10),
+    ("duvida", "Fiscal", "fiscal", 20),
+    ("duvida", "Outros", "outros", 99),
+    ("solicitacao", "Configuração", "configuracao", 10),
+    ("solicitacao", "Treinamento", "treinamento", 20),
+    ("solicitacao", "Outros", "outros", 99),
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ticket_naturezas",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("nome", sa.String(100), nullable=False),
+        sa.Column("slug", sa.String(50), nullable=False),
+        sa.Column("ordem", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("slug", name="uq_ticket_natureza_slug"),
+    )
+    op.create_index("ix_ticket_naturezas_slug", "ticket_naturezas", ["slug"])
+
+    op.create_table(
+        "ticket_motivos",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("natureza_id", sa.Integer(), sa.ForeignKey("ticket_naturezas.id", ondelete="RESTRICT"), nullable=False),
+        sa.Column("nome", sa.String(120), nullable=False),
+        sa.Column("slug", sa.String(50), nullable=False),
+        sa.Column("ordem", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("natureza_id", "slug", name="uq_ticket_motivo_natureza_slug"),
+    )
+    op.create_index("ix_ticket_motivos_natureza_id", "ticket_motivos", ["natureza_id"])
+
+    PRIORIDADE.create(op.get_bind(), checkfirst=True)
+    op.add_column(
+        "tickets",
+        sa.Column("prioridade", PRIORIDADE, nullable=False, server_default="normal"),
+    )
+    op.add_column("tickets", sa.Column("motivo_id", sa.Integer(), nullable=True))
+    op.add_column("tickets", sa.Column("motivo_outro_texto", sa.String(255), nullable=True))
+    op.create_foreign_key(
+        "fk_tickets_motivo_id",
+        "tickets",
+        "ticket_motivos",
+        ["motivo_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index("ix_tickets_motivo_id", "tickets", ["motivo_id"])
+
+    conn = op.get_bind()
+    slug_to_natureza_id: dict[str, int] = {}
+    for nome, slug, ordem in NATUREZAS_SEED:
+        r = conn.execute(
+            sa.text(
+                "INSERT INTO ticket_naturezas (nome, slug, ordem, ativo) "
+                "VALUES (:nome, :slug, :ordem, true) RETURNING id"
+            ),
+            {"nome": nome, "slug": slug, "ordem": ordem},
+        )
+        slug_to_natureza_id[slug] = r.scalar_one()
+
+    for natureza_slug, nome, motivo_slug, ordem in MOTIVOS_SEED:
+        conn.execute(
+            sa.text(
+                "INSERT INTO ticket_motivos (natureza_id, nome, slug, ordem, ativo) "
+                "VALUES (:natureza_id, :nome, :slug, :ordem, true)"
+            ),
+            {
+                "natureza_id": slug_to_natureza_id[natureza_slug],
+                "nome": nome,
+                "slug": motivo_slug,
+                "ordem": ordem,
+            },
+        )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_tickets_motivo_id", table_name="tickets")
+    op.drop_constraint("fk_tickets_motivo_id", "tickets", type_="foreignkey")
+    op.drop_column("tickets", "motivo_outro_texto")
+    op.drop_column("tickets", "motivo_id")
+    op.drop_column("tickets", "prioridade")
+    op.drop_index("ix_ticket_motivos_natureza_id", table_name="ticket_motivos")
+    op.drop_table("ticket_motivos")
+    op.drop_index("ix_ticket_naturezas_slug", table_name="ticket_naturezas")
+    op.drop_table("ticket_naturezas")
+    PRIORIDADE.drop(op.get_bind(), checkfirst=True)

--- a/backend/app/api/ticket_catalogos.py
+++ b/backend/app/api/ticket_catalogos.py
@@ -1,0 +1,231 @@
+from enum import Enum
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.auth import exigir_admin, obter_atendente_atual
+from app.core.audit import registrar_audit
+from app.core.ordenacao_lista import OrdemLista, expr_ordem
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.models.ticket import Ticket
+from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+from app.schemas.lista_paginada import ListaPaginada
+from app.schemas.ticket_classificacao import (
+    TicketMotivoCreate,
+    TicketMotivoRead,
+    TicketMotivoUpdate,
+    TicketNaturezaCreate,
+    TicketNaturezaRead,
+    TicketNaturezaUpdate,
+)
+
+router = APIRouter(tags=["ticket-catalogos"])
+
+_MAX_PAGE = 100
+_DEFAULT_PAGE = 50
+
+
+class OrdenarCatalogo(str, Enum):
+    nome = "nome"
+    slug = "slug"
+    ordem = "ordem"
+    ativo = "ativo"
+
+
+def _motivo_para_read(row: TicketMotivo) -> TicketMotivoRead:
+    return TicketMotivoRead(
+        id=row.id,
+        natureza_id=row.natureza_id,
+        nome=row.nome,
+        slug=row.slug,
+        ordem=row.ordem,
+        ativo=row.ativo,
+        natureza_nome=row.natureza.nome if row.natureza else None,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+@router.get("/ticket-naturezas", response_model=ListaPaginada[TicketNaturezaRead])
+def listar_naturezas(
+    incluir_inativos: bool = Query(False),
+    busca: str | None = Query(None),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    ordenar_por: OrdenarCatalogo | None = Query(OrdenarCatalogo.ordem),
+    ordem: OrdemLista = Query(OrdemLista.asc),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(obter_atendente_atual),
+):
+    q = db.query(TicketNatureza)
+    if not incluir_inativos:
+        q = q.filter(TicketNatureza.ativo.is_(True))
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter(or_(TicketNatureza.nome.ilike(term), TicketNatureza.slug.ilike(term)))
+    total = q.count()
+    if ordenar_por == OrdenarCatalogo.nome:
+        order_cols = [expr_ordem(TicketNatureza.nome, ordem), expr_ordem(TicketNatureza.id, ordem)]
+    elif ordenar_por == OrdenarCatalogo.slug:
+        order_cols = [expr_ordem(TicketNatureza.slug, ordem), expr_ordem(TicketNatureza.id, ordem)]
+    elif ordenar_por == OrdenarCatalogo.ativo:
+        order_cols = [expr_ordem(TicketNatureza.ativo, ordem), expr_ordem(TicketNatureza.ordem, ordem)]
+    else:
+        order_cols = [expr_ordem(TicketNatureza.ordem, ordem), expr_ordem(TicketNatureza.nome, ordem)]
+    items = q.order_by(*order_cols).offset(offset).limit(limit).all()
+    return ListaPaginada(items=items, total=total)
+
+
+@router.post("/ticket-naturezas", response_model=TicketNaturezaRead, status_code=201)
+def criar_natureza(
+    data: TicketNaturezaCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    if db.query(TicketNatureza).filter(TicketNatureza.slug == data.slug).first():
+        raise HTTPException(status_code=400, detail="Slug de natureza já existe.")
+    row = TicketNatureza(**data.model_dump())
+    db.add(row)
+    db.flush()
+    registrar_audit(db, "ticket_natureza", row.id, "create", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.patch("/ticket-naturezas/{natureza_id}", response_model=TicketNaturezaRead)
+def atualizar_natureza(
+    natureza_id: int,
+    data: TicketNaturezaUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = db.query(TicketNatureza).filter(TicketNatureza.id == natureza_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Natureza não encontrada.")
+    payload = data.model_dump(exclude_unset=True)
+    if "slug" in payload:
+        dup = (
+            db.query(TicketNatureza)
+            .filter(TicketNatureza.slug == payload["slug"], TicketNatureza.id != natureza_id)
+            .first()
+        )
+        if dup:
+            raise HTTPException(status_code=400, detail="Slug de natureza já existe.")
+    for k, v in payload.items():
+        setattr(row, k, v)
+    registrar_audit(db, "ticket_natureza", row.id, "update", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.get("/ticket-motivos", response_model=ListaPaginada[TicketMotivoRead])
+def listar_motivos(
+    natureza_id: int | None = Query(None),
+    incluir_inativos: bool = Query(False),
+    busca: str | None = Query(None),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    ordenar_por: OrdenarCatalogo | None = Query(OrdenarCatalogo.ordem),
+    ordem: OrdemLista = Query(OrdemLista.asc),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(obter_atendente_atual),
+):
+    q = db.query(TicketMotivo).options(joinedload(TicketMotivo.natureza))
+    if natureza_id is not None:
+        q = q.filter(TicketMotivo.natureza_id == natureza_id)
+    if not incluir_inativos:
+        q = q.filter(TicketMotivo.ativo.is_(True))
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter(or_(TicketMotivo.nome.ilike(term), TicketMotivo.slug.ilike(term)))
+    total = q.count()
+    if ordenar_por == OrdenarCatalogo.nome:
+        order_cols = [expr_ordem(TicketMotivo.nome, ordem), expr_ordem(TicketMotivo.id, ordem)]
+    elif ordenar_por == OrdenarCatalogo.slug:
+        order_cols = [expr_ordem(TicketMotivo.slug, ordem), expr_ordem(TicketMotivo.id, ordem)]
+    elif ordenar_por == OrdenarCatalogo.ativo:
+        order_cols = [expr_ordem(TicketMotivo.ativo, ordem), expr_ordem(TicketMotivo.ordem, ordem)]
+    else:
+        order_cols = [expr_ordem(TicketMotivo.ordem, ordem), expr_ordem(TicketMotivo.nome, ordem)]
+    items = q.order_by(*order_cols).offset(offset).limit(limit).all()
+    return ListaPaginada(items=[_motivo_para_read(i) for i in items], total=total)
+
+
+@router.post("/ticket-motivos", response_model=TicketMotivoRead, status_code=201)
+def criar_motivo(
+    data: TicketMotivoCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    natureza = db.query(TicketNatureza).filter(TicketNatureza.id == data.natureza_id).first()
+    if not natureza:
+        raise HTTPException(status_code=404, detail="Natureza não encontrada.")
+    dup = (
+        db.query(TicketMotivo)
+        .filter(TicketMotivo.natureza_id == data.natureza_id, TicketMotivo.slug == data.slug)
+        .first()
+    )
+    if dup:
+        raise HTTPException(status_code=400, detail="Slug de motivo já existe nesta natureza.")
+    row = TicketMotivo(**data.model_dump())
+    db.add(row)
+    db.flush()
+    registrar_audit(db, "ticket_motivo", row.id, "create", atendente.id)
+    db.commit()
+    db.refresh(row)
+    row = (
+        db.query(TicketMotivo)
+        .options(joinedload(TicketMotivo.natureza))
+        .filter(TicketMotivo.id == row.id)
+        .first()
+    )
+    return _motivo_para_read(row)
+
+
+@router.patch("/ticket-motivos/{motivo_id}", response_model=TicketMotivoRead)
+def atualizar_motivo(
+    motivo_id: int,
+    data: TicketMotivoUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = (
+        db.query(TicketMotivo)
+        .options(joinedload(TicketMotivo.natureza))
+        .filter(TicketMotivo.id == motivo_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Motivo não encontrado.")
+    payload = data.model_dump(exclude_unset=True)
+    natureza_id = payload.get("natureza_id", row.natureza_id)
+    if "natureza_id" in payload:
+        if not db.query(TicketNatureza).filter(TicketNatureza.id == natureza_id).first():
+            raise HTTPException(status_code=404, detail="Natureza não encontrada.")
+    if "slug" in payload or "natureza_id" in payload:
+        slug = payload.get("slug", row.slug)
+        dup = (
+            db.query(TicketMotivo)
+            .filter(
+                TicketMotivo.natureza_id == natureza_id,
+                TicketMotivo.slug == slug,
+                TicketMotivo.id != motivo_id,
+            )
+            .first()
+        )
+        if dup:
+            raise HTTPException(status_code=400, detail="Slug de motivo já existe nesta natureza.")
+    if payload.get("ativo") is False:
+        em_uso = db.query(Ticket.id).filter(Ticket.motivo_id == motivo_id).first()
+        if em_uso:
+            pass  # permitir desativar mesmo em uso — leitura histórica mantida
+    for k, v in payload.items():
+        setattr(row, k, v)
+    registrar_audit(db, "ticket_motivo", row.id, "update", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return _motivo_para_read(row)

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -12,6 +12,7 @@ from app.models.email_inbound_received import EmailInboundReceived
 from app.models.funcionario_rede import FuncionarioRede
 from app.models.ticket_anexo import TicketAnexo
 from app.models.ticket_vinculo import TIPO_DUPLICADO_DE, TicketVinculo
+from app.models.ticket_classificacao import TicketMotivo
 from app.schemas.ticket import (
     EmpresaVinculoSugerida,
     TicketChildBrief,
@@ -37,6 +38,12 @@ from app.schemas.ticket import (
 from app.schemas.ticket_anexo import TicketAnexoCreateResponse, TicketAnexoRead
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import obter_atendente_atual
+from app.core.ticket_prioridade import PrioridadeTicket
+from app.services.ticket_classificacao_rules import (
+    motivo_efetivo_no_ticket,
+    validar_classificacao,
+    validar_prioridade,
+)
 from app.core.ordenacao_lista import OrdemLista, expr_ordem
 from app.core.setor_scope import (
     atendente_atende_algum_id_setor,
@@ -166,6 +173,7 @@ def _opcoes_carregamento_ticket_detalhe():
         joinedload(Ticket.setor),
         joinedload(Ticket.status),
         joinedload(Ticket.atendente),
+        joinedload(Ticket.motivo).joinedload(TicketMotivo.natureza),
         joinedload(Ticket.parent).joinedload(Ticket.status),
         joinedload(Ticket.children).joinedload(Ticket.status),
         joinedload(Ticket.children).joinedload(Ticket.atendente),
@@ -292,6 +300,12 @@ def _ticket_para_read(t: Ticket, db: Session | None = None) -> TicketRead:
         fechado_em=t.fechado_em,
         created_at=t.created_at,
         updated_at=t.updated_at,
+        prioridade=t.prioridade if isinstance(t.prioridade, PrioridadeTicket) else PrioridadeTicket(t.prioridade or "normal"),
+        motivo_id=t.motivo_id,
+        motivo_nome=t.motivo.nome if t.motivo else None,
+        motivo_outro_texto=t.motivo_outro_texto,
+        natureza_id=t.motivo.natureza_id if t.motivo else None,
+        natureza_nome=t.motivo.natureza.nome if t.motivo and t.motivo.natureza else None,
         rede_id=rede_id_out,
         empresa_nome=t.empresa.nome if t.empresa else None,
         rede_nome=rede_nome_out,
@@ -473,6 +487,7 @@ def listar(
             joinedload(Ticket.setor),
             joinedload(Ticket.status),
             joinedload(Ticket.atendente),
+            joinedload(Ticket.motivo).joinedload(TicketMotivo.natureza),
         )
         .order_by(*order_cols)
         .offset(offset)
@@ -550,6 +565,7 @@ def criar(
     if not status_inicial:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cadastre ao menos um status de ticket")
     protocolo = _gerar_protocolo(db)
+    prioridade = validar_prioridade(data.prioridade)
     ticket = Ticket(
         tenant_id=atendente.tenant_id,
         protocolo=protocolo,
@@ -557,6 +573,7 @@ def criar(
         rede_id=ticket_rede_id,
         setor_id=data.setor_id,
         status_id=status_inicial.id,
+        prioridade=prioridade,
         assunto=data.assunto,
         descricao=data.descricao,
         aberto_por_id=data.aberto_por_id,
@@ -678,6 +695,35 @@ def criar_vinculo(
 
     duplicado_fechado = False
     if data.tipo == TIPO_DUPLICADO_DE and data.fechar_como_duplicado:
+        vinc_class = {}
+        if data.motivo_id is not None:
+            vinc_class["motivo_id"] = data.motivo_id
+        if data.motivo_outro_texto is not None:
+            vinc_class["motivo_outro_texto"] = data.motivo_outro_texto
+        mid, outro = motivo_efetivo_no_ticket(ticket, vinc_class)
+        mid, outro = validar_classificacao(
+            db, motivo_id=mid, motivo_outro_texto=outro, obrigatorio=True
+        )
+        if ticket.motivo_id != mid:
+            _registrar_historico(
+                db,
+                ticket.id,
+                atendente.id,
+                "motivo_id",
+                str(ticket.motivo_id) if ticket.motivo_id is not None else "",
+                str(mid) if mid is not None else "",
+            )
+            ticket.motivo_id = mid
+        if (ticket.motivo_outro_texto or "") != (outro or ""):
+            _registrar_historico(
+                db,
+                ticket.id,
+                atendente.id,
+                "motivo_outro_texto",
+                ticket.motivo_outro_texto or "",
+                outro or "",
+            )
+            ticket.motivo_outro_texto = outro
         try:
             status_antigo = ticket.status_id
             if fechar_ticket_como_duplicado(db, duplicado=ticket, original=related, atendente=atendente):
@@ -1297,6 +1343,33 @@ def atualizar(
                     detail="Não é possível fechar este ticket enquanto existir ticket filho direto ainda em aberto.",
                 )
 
+    fechando = False
+    if "status_id" in update:
+        st_novo = db.query(StatusTicket).filter(StatusTicket.id == update["status_id"]).first()
+        if st_novo and (st_novo.slug or "").lower() == "fechado":
+            fechando = True
+
+    ticket_fechado = ticket.fechado_em is not None
+
+    if "prioridade" in update:
+        update["prioridade"] = validar_prioridade(update["prioridade"])
+
+    classificacao_mudando = "motivo_id" in update or "motivo_outro_texto" in update
+    if fechando or (ticket_fechado and classificacao_mudando):
+        mid, outro = motivo_efetivo_no_ticket(ticket, update)
+        mid, outro = validar_classificacao(
+            db, motivo_id=mid, motivo_outro_texto=outro, obrigatorio=True
+        )
+        update["motivo_id"] = mid
+        update["motivo_outro_texto"] = outro
+    elif classificacao_mudando:
+        mid, outro = motivo_efetivo_no_ticket(ticket, update)
+        mid, outro = validar_classificacao(
+            db, motivo_id=mid, motivo_outro_texto=outro, obrigatorio=False
+        )
+        update["motivo_id"] = mid
+        update["motivo_outro_texto"] = outro
+
     if "parent_ticket_id" in update:
         novo_p = update["parent_ticket_id"]
         if novo_p != ticket.parent_ticket_id:
@@ -1403,6 +1476,19 @@ def atualizar(
         antigo = str(ticket.empresa_id) if ticket.empresa_id is not None else ""
         novo = str(novo_eid) if novo_eid is not None else ""
         _registrar_historico(db, ticket.id, atendente.id, "empresa_id", antigo, novo)
+
+    if "prioridade" in update:
+        antigo_p = ticket.prioridade.value if isinstance(ticket.prioridade, PrioridadeTicket) else str(ticket.prioridade or "normal")
+        novo_p = update["prioridade"].value if isinstance(update["prioridade"], PrioridadeTicket) else str(update["prioridade"])
+        _registrar_historico(db, ticket.id, atendente.id, "prioridade", antigo_p, novo_p)
+    if "motivo_id" in update:
+        antigo_m = str(ticket.motivo_id) if ticket.motivo_id is not None else ""
+        novo_m = str(update["motivo_id"]) if update["motivo_id"] is not None else ""
+        _registrar_historico(db, ticket.id, atendente.id, "motivo_id", antigo_m, novo_m)
+    if "motivo_outro_texto" in update:
+        antigo_o = ticket.motivo_outro_texto or ""
+        novo_o = update["motivo_outro_texto"] or ""
+        _registrar_historico(db, ticket.id, atendente.id, "motivo_outro_texto", antigo_o, novo_o)
 
     for k, v in update.items():
         setattr(ticket, k, v)

--- a/backend/app/core/ticket_prioridade.py
+++ b/backend/app/core/ticket_prioridade.py
@@ -1,0 +1,11 @@
+import enum
+
+
+class PrioridadeTicket(str, enum.Enum):
+    baixa = "baixa"
+    normal = "normal"
+    alta = "alta"
+    urgente = "urgente"
+
+
+PRIORIDADES_TICKET = tuple(p.value for p in PrioridadeTicket)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -31,6 +31,7 @@ from app.api import (
     resend_inbound_webhook,
     respostas_prontas,
     pdv_catalogos,
+    ticket_catalogos,
     empresa_pdvs,
     system_settings,
     tenant,
@@ -278,6 +279,7 @@ app.include_router(email_inbound_webhook.router, prefix=API_V1_PREFIX)
 app.include_router(resend_inbound_webhook.router, prefix=API_V1_PREFIX)
 app.include_router(respostas_prontas.router, prefix=API_V1_PREFIX)
 app.include_router(pdv_catalogos.router, prefix=API_V1_PREFIX)
+app.include_router(ticket_catalogos.router, prefix=API_V1_PREFIX)
 app.include_router(empresa_pdvs.router, prefix=API_V1_PREFIX)
 app.include_router(system_settings.router, prefix=API_V1_PREFIX)
 app.include_router(tenant.router, prefix=API_V1_PREFIX)
@@ -290,6 +292,7 @@ def _app_capabilities() -> dict[str, bool]:
         "settings_email": "/v1/settings/email" in paths,
         "tenant_atual": "/v1/tenant/atual" in paths,
         "pdv_catalogos": "/v1/pdv-rotulos" in paths,
+        "ticket_catalogos": "/v1/ticket-naturezas" in paths,
         "empresa_pdvs": "/v1/empresas/{empresa_id}/pdvs" in paths
         or any(p.startswith("/v1/empresas/") and "/pdvs" in p for p in paths),
         "multi_tenant_mode": settings.DX_CONNECT_MULTI_TENANT,

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -23,6 +23,7 @@ from app.models.tenant_inbound_address import TenantInboundAddress
 from app.models.password_reset_token import PasswordResetToken
 from app.models.resposta_pronta import RespostaPronta
 from app.models.ticket_vinculo import TicketVinculo
+from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
 from app.models.empresa_pdv import EmpresaPdv, PdvRotulo, PdvTipoAcessoRemoto
 
 __all__ = [
@@ -58,6 +59,8 @@ __all__ = [
     "PasswordResetToken",
     "RespostaPronta",
     "TicketVinculo",
+    "TicketNatureza",
+    "TicketMotivo",
     "PdvRotulo",
     "PdvTipoAcessoRemoto",
     "EmpresaPdv",

--- a/backend/app/models/ticket.py
+++ b/backend/app/models/ticket.py
@@ -1,7 +1,8 @@
-from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, Enum as SAEnum
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
+from app.core.ticket_prioridade import PrioridadeTicket
 from app.database import Base
 
 
@@ -18,6 +19,13 @@ class Ticket(Base):
     atendente_id = Column(Integer, ForeignKey("atendentes.id"), nullable=True)  # responsável
     aberto_por_id = Column(Integer, ForeignKey("funcionarios_rede.id"), nullable=True)  # quem abriu (portal futuro)
     parent_ticket_id = Column(Integer, ForeignKey("tickets.id", ondelete="SET NULL"), nullable=True)
+    prioridade = Column(
+        SAEnum(PrioridadeTicket, name="ticket_prioridade", native_enum=False, values_callable=lambda x: [e.value for e in x]),
+        nullable=False,
+        server_default=PrioridadeTicket.normal.value,
+    )
+    motivo_id = Column(Integer, ForeignKey("ticket_motivos.id", ondelete="SET NULL"), nullable=True, index=True)
+    motivo_outro_texto = Column(String(255), nullable=True)
     assunto = Column(String(500), nullable=False)
     descricao = Column(Text, nullable=True)
     fechado_em = Column(DateTime(timezone=True), nullable=True)
@@ -28,6 +36,7 @@ class Ticket(Base):
     rede = relationship("Rede", back_populates="tickets")
     setor = relationship("Setor", back_populates="tickets")
     status = relationship("StatusTicket", back_populates="tickets")
+    motivo = relationship("TicketMotivo", back_populates="tickets")
     atendente = relationship("Atendente", back_populates="tickets_atendidos")
     aberto_por = relationship("FuncionarioRede", back_populates="tickets_abertos")
     parent = relationship(

--- a/backend/app/models/ticket_classificacao.py
+++ b/backend/app/models/ticket_classificacao.py
@@ -1,0 +1,36 @@
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class TicketNatureza(Base):
+    __tablename__ = "ticket_naturezas"
+
+    id = Column(Integer, primary_key=True, index=True)
+    nome = Column(String(100), nullable=False)
+    slug = Column(String(50), unique=True, nullable=False, index=True)
+    ordem = Column(Integer, default=0, nullable=False)
+    ativo = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    motivos = relationship("TicketMotivo", back_populates="natureza", order_by="TicketMotivo.ordem")
+
+
+class TicketMotivo(Base):
+    __tablename__ = "ticket_motivos"
+    __table_args__ = (UniqueConstraint("natureza_id", "slug", name="uq_ticket_motivo_natureza_slug"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    natureza_id = Column(Integer, ForeignKey("ticket_naturezas.id", ondelete="RESTRICT"), nullable=False, index=True)
+    nome = Column(String(120), nullable=False)
+    slug = Column(String(50), nullable=False)
+    ordem = Column(Integer, default=0, nullable=False)
+    ativo = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    natureza = relationship("TicketNatureza", back_populates="motivos")
+    tickets = relationship("Ticket", back_populates="motivo")

--- a/backend/app/schemas/ticket.py
+++ b/backend/app/schemas/ticket.py
@@ -3,6 +3,8 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from datetime import datetime
 
+from app.core.ticket_prioridade import PrioridadeTicket
+
 
 class TicketCreate(BaseModel):
     empresa_id: int | None = None
@@ -12,6 +14,7 @@ class TicketCreate(BaseModel):
     descricao: str | None = None
     aberto_por_id: int | None = None
     parent_ticket_id: int | None = None
+    prioridade: PrioridadeTicket = PrioridadeTicket.normal
 
     @model_validator(mode="after")
     def validar_escopo(self):
@@ -33,6 +36,9 @@ class TicketUpdate(BaseModel):
     status_id: int | None = None
     atendente_id: int | None = None
     parent_ticket_id: int | None = None
+    prioridade: PrioridadeTicket | None = None
+    motivo_id: int | None = None
+    motivo_outro_texto: str | None = Field(None, max_length=255)
 
 
 class TicketParentBrief(BaseModel):
@@ -80,6 +86,8 @@ class TicketVinculoCreate(BaseModel):
         default=True,
         description="Se tipo=duplicado_de, encerra este ticket e registra mensagem pública apontando para o original.",
     )
+    motivo_id: int | None = None
+    motivo_outro_texto: str | None = Field(None, max_length=255)
 
 
 class TicketFilhoMassaEmpresaOpcao(BaseModel):
@@ -150,6 +158,12 @@ class TicketRead(BaseModel):
     status_nome: str | None = None
     atendente_nome: str | None = None
     parent_ticket_id: int | None = None
+    prioridade: PrioridadeTicket = PrioridadeTicket.normal
+    motivo_id: int | None = None
+    motivo_nome: str | None = None
+    motivo_outro_texto: str | None = None
+    natureza_id: int | None = None
+    natureza_nome: str | None = None
     parent: TicketParentBrief | None = None
     children: list[TicketChildBrief] = Field(default_factory=list)
     vinculos: list[TicketVinculoRead] = Field(default_factory=list)

--- a/backend/app/schemas/ticket_classificacao.py
+++ b/backend/app/schemas/ticket_classificacao.py
@@ -1,0 +1,57 @@
+from pydantic import BaseModel, ConfigDict, Field
+from datetime import datetime
+
+
+class TicketNaturezaBase(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=100)
+    slug: str = Field(..., min_length=1, max_length=50)
+    ordem: int = 0
+    ativo: bool = True
+
+
+class TicketNaturezaCreate(TicketNaturezaBase):
+    pass
+
+
+class TicketNaturezaUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=100)
+    slug: str | None = Field(None, min_length=1, max_length=50)
+    ordem: int | None = None
+    ativo: bool | None = None
+
+
+class TicketNaturezaRead(TicketNaturezaBase):
+    id: int
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TicketMotivoBase(BaseModel):
+    natureza_id: int
+    nome: str = Field(..., min_length=1, max_length=120)
+    slug: str = Field(..., min_length=1, max_length=50)
+    ordem: int = 0
+    ativo: bool = True
+
+
+class TicketMotivoCreate(TicketMotivoBase):
+    pass
+
+
+class TicketMotivoUpdate(BaseModel):
+    natureza_id: int | None = None
+    nome: str | None = Field(None, min_length=1, max_length=120)
+    slug: str | None = Field(None, min_length=1, max_length=50)
+    ordem: int | None = None
+    ativo: bool | None = None
+
+
+class TicketMotivoRead(TicketMotivoBase):
+    id: int
+    natureza_nome: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/ticket_classificacao_rules.py
+++ b/backend/app/services/ticket_classificacao_rules.py
@@ -1,0 +1,93 @@
+"""Regras de classificação (natureza/motivo) e prioridade de tickets."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.ticket_prioridade import PrioridadeTicket
+from app.models.ticket import Ticket
+from app.models.ticket_classificacao import TicketMotivo
+
+MOTIVO_OUTROS_SLUG = "outros"
+
+
+def normalizar_motivo_outro_texto(valor: str | None) -> str | None:
+    if valor is None:
+        return None
+    t = valor.strip()
+    return t or None
+
+
+def obter_motivo_ativo(db: Session, motivo_id: int) -> TicketMotivo | None:
+    return (
+        db.query(TicketMotivo)
+        .options(joinedload(TicketMotivo.natureza))
+        .filter(TicketMotivo.id == motivo_id)
+        .first()
+    )
+
+
+def validar_classificacao(
+    db: Session,
+    *,
+    motivo_id: int | None,
+    motivo_outro_texto: str | None,
+    obrigatorio: bool,
+) -> tuple[int | None, str | None]:
+    outro = normalizar_motivo_outro_texto(motivo_outro_texto)
+    if motivo_id is None:
+        if obrigatorio:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Informe o motivo do atendimento para encerrar o ticket.",
+            )
+        if outro:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="O texto complementar exige um motivo do tipo Outros.",
+            )
+        return None, None
+
+    motivo = obter_motivo_ativo(db, motivo_id)
+    if motivo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Motivo não encontrado.")
+    if not motivo.ativo:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Motivo inativo não pode ser selecionado.",
+        )
+    slug = (motivo.slug or "").lower()
+    if slug == MOTIVO_OUTROS_SLUG:
+        if not outro:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Descreva o atendimento quando o motivo for Outros.",
+            )
+    elif outro:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Texto complementar só é permitido para o motivo Outros.",
+        )
+    return motivo_id, outro
+
+
+def motivo_efetivo_no_ticket(ticket: Ticket, update: dict) -> tuple[int | None, str | None]:
+    mid = update["motivo_id"] if "motivo_id" in update else ticket.motivo_id
+    if "motivo_outro_texto" in update:
+        outro = normalizar_motivo_outro_texto(update["motivo_outro_texto"])
+    else:
+        outro = normalizar_motivo_outro_texto(ticket.motivo_outro_texto)
+    return mid, outro
+
+
+def validar_prioridade(valor: str | PrioridadeTicket) -> PrioridadeTicket:
+    if isinstance(valor, PrioridadeTicket):
+        return valor
+    try:
+        return PrioridadeTicket(valor)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Prioridade inválida. Use: baixa, normal, alta ou urgente.",
+        ) from e

--- a/backend/scripts/simular_classificacao_local.py
+++ b/backend/scripts/simular_classificacao_local.py
@@ -1,0 +1,287 @@
+"""Simulacao local de classificacao/prioridade (#107/#108). Uso: python scripts/simular_classificacao_local.py"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime
+
+BASE = "http://localhost:8000/v1"
+ERROS = 0
+
+
+def req(method: str, path: str, token: str | None = None, body: dict | None = None):
+    url = f"{BASE}{path}"
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    r = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(r, timeout=30) as resp:
+            raw = resp.read().decode()
+            return resp.status, json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode()
+        try:
+            detail = json.loads(raw)
+        except json.JSONDecodeError:
+            detail = {"detail": raw}
+        return e.code, detail
+
+
+def ok(msg: str):
+    print(f"[OK] {msg}")
+
+
+def fail(msg: str, extra: str = ""):
+    global ERROS
+    ERROS += 1
+    print(f"[FALHA] {msg}" + (f" -- {extra}" if extra else ""))
+
+
+def login(email: str, senha: str) -> str:
+    _, data = req("POST", "/auth/login", body={"email": email, "senha": senha})
+    return data["access_token"]
+
+
+def main() -> int:
+    token = login("admin@email.com", "admin123")
+
+    _, naturezas = req("GET", "/ticket-naturezas?limit=20", token)
+    _, motivos = req("GET", "/ticket-motivos?limit=50", token)
+    nat_items = naturezas["items"]
+    mot_items = motivos["items"]
+
+    nat_by_slug = {n["slug"]: n for n in nat_items}
+    mot_by_key = {(m["natureza_id"], m["slug"]): m for m in mot_items}
+
+    if len(nat_items) >= 3 and len(mot_items) >= 9:
+        ok(f"Catalogos seed ({len(nat_items)} naturezas, {len(mot_items)} motivos)")
+    else:
+        fail("Catalogos seed", f"n={len(nat_items)} m={len(mot_items)}")
+
+    _, empresas = req("GET", "/empresas?limit=1", token)
+    _, setores = req("GET", "/setores?limit=1", token)
+    _, statuses = req("GET", "/status-ticket?limit=50", token)
+    empresa_id = empresas["items"][0]["id"]
+    setor_id = setores["items"][0]["id"]
+    status_fechado = next(s for s in statuses["items"] if s["slug"] == "fechado")
+
+    def novo_ticket(prioridade: str = "normal") -> dict:
+        _, t = req(
+            "POST",
+            "/tickets",
+            token,
+            {
+                "empresa_id": empresa_id,
+                "setor_id": setor_id,
+                "assunto": f"Sim {prioridade} {datetime.now():%H%M%S}",
+                "descricao": "Simulacao automatica",
+                "prioridade": prioridade,
+            },
+        )
+        return t
+
+    def patch_ticket(tid: int, patch: dict) -> tuple[int, dict | None]:
+        return req("PATCH", f"/tickets/{tid}", token, patch)
+
+    # Prioridades
+    for p in ("baixa", "normal", "alta", "urgente"):
+        t = novo_ticket(p)
+        if t.get("prioridade") == p:
+            ok(f"Criar prioridade={p} (#{t['id']})")
+        else:
+            fail(f"Prioridade {p}", str(t.get("prioridade")))
+
+    code, _ = req(
+        "POST",
+        "/tickets",
+        token,
+        {
+            "empresa_id": empresa_id,
+            "setor_id": setor_id,
+            "assunto": "x",
+            "prioridade": "critica",
+        },
+    )
+    if code in (400, 422):
+        ok("Rejeita prioridade invalida")
+    else:
+        fail("Prioridade invalida", f"code={code}")
+
+    # Classificacao opcional aberto
+    t_ab = novo_ticket()
+    m_op = mot_by_key[(nat_by_slug["duvida"]["id"], "operacional")]
+    _, u = patch_ticket(t_ab["id"], {"motivo_id": m_op["id"]})
+    if u.get("motivo_nome") == "Operacional" and u.get("natureza_nome") == "Dúvida":
+        ok("Classificacao opcional em aberto")
+    else:
+        fail("Classificacao aberto", f"{u.get('natureza_nome')} / {u.get('motivo_nome')}")
+
+    # Fechar sem motivo
+    t_sem = novo_ticket("baixa")
+    code, err = patch_ticket(t_sem["id"], {"status_id": status_fechado["id"]})
+    if code == 400 and "motivo" in str(err.get("detail", "")).lower():
+        ok("Fechar sem motivo rejeitado")
+    else:
+        fail("Fechar sem motivo", f"code={code} {err}")
+
+    # Fechar cada motivo (Outros exige texto)
+    for n in nat_items:
+        for m in [x for x in mot_items if x["natureza_id"] == n["id"]]:
+            t = novo_ticket()
+            patch = {"status_id": status_fechado["id"], "motivo_id": m["id"]}
+            if m["slug"] == "outros":
+                code, err = patch_ticket(t["id"], patch)
+                if code != 400:
+                    fail(f"Outros sem texto ({n['nome']})", f"code={code}")
+                    continue
+                patch["motivo_outro_texto"] = f"Detalhe sim {n['slug']}"
+            _, closed = patch_ticket(t["id"], patch)
+            if closed and closed.get("fechado_em") and closed.get("motivo_id") == m["id"]:
+                ok(f"Fechar {n['nome']} -> {m['nome']}")
+            else:
+                fail(f"Fechar {n['nome']} -> {m['nome']}")
+
+    # Texto complementar fora de Outros
+    t_txt = novo_ticket()
+    m_falha = mot_by_key[(nat_by_slug["erro"]["id"], "falha-pdv")]
+    code, err = patch_ticket(
+        t_txt["id"],
+        {"motivo_id": m_falha["id"], "motivo_outro_texto": "nao permitido"},
+    )
+    if code == 400:
+        ok("Texto complementar so em Outros")
+    else:
+        fail("Texto complementar", f"code={code}")
+
+    # Admin altera fechado
+    t_adm = novo_ticket()
+    m1 = mot_by_key[(nat_by_slug["erro"]["id"], "falha-pdv")]
+    patch_ticket(t_adm["id"], {"status_id": status_fechado["id"], "motivo_id": m1["id"]})
+    m2 = mot_by_key[(nat_by_slug["duvida"]["id"], "fiscal")]
+    _, alt = patch_ticket(t_adm["id"], {"motivo_id": m2["id"], "prioridade": "urgente"})
+    if alt.get("prioridade") == "urgente" and alt.get("motivo_nome") == "Fiscal":
+        ok("Admin altera prioridade/motivo em fechado")
+    else:
+        fail("Admin altera fechado")
+
+    # CRUD catalogo
+    slug_n = f"sim-nat-{datetime.now():%H%M%S}"
+    _, nova = req(
+        "POST",
+        "/ticket-naturezas",
+        token,
+        {"nome": "Sim Natureza", "slug": slug_n, "ordem": 50, "ativo": True},
+    )
+    _, novo_m = req(
+        "POST",
+        "/ticket-motivos",
+        token,
+        {
+            "natureza_id": nova["id"],
+            "nome": "Sim Motivo",
+            "slug": "sim-mot",
+            "ordem": 1,
+            "ativo": True,
+        },
+    )
+    if nova.get("id") and novo_m.get("id"):
+        ok("Admin CRUD natureza/motivo")
+    else:
+        fail("Admin CRUD")
+
+    # Duplicado com motivo
+    t_orig = novo_ticket("alta")
+    t_dup = novo_ticket("alta")
+    _, v = req(
+        "POST",
+        f"/tickets/{t_dup['id']}/vinculos",
+        token,
+        {
+            "related_ticket_id": t_orig["id"],
+            "tipo": "duplicado_de",
+            "fechar_como_duplicado": True,
+            "motivo_id": m1["id"],
+        },
+    )
+    _, dup_closed = req("GET", f"/tickets/{t_dup['id']}", token)
+    if v.get("duplicado_fechado") and dup_closed.get("fechado_em") and dup_closed.get("motivo_id") == m1["id"]:
+        ok("Duplicado fecha com motivo")
+    else:
+        fail("Duplicado com motivo")
+
+    # Duplicado sem motivo
+    t_d2 = novo_ticket()
+    t_d3 = novo_ticket()
+    code, _ = req(
+        "POST",
+        f"/tickets/{t_d3['id']}/vinculos",
+        token,
+        {
+            "related_ticket_id": t_d2["id"],
+            "tipo": "duplicado_de",
+            "fechar_como_duplicado": True,
+        },
+    )
+    if code == 400:
+        ok("Duplicado sem motivo rejeitado")
+    else:
+        fail("Duplicado sem motivo", f"code={code}")
+
+    # Relacionado sem fechar
+    t_r1 = novo_ticket("baixa")
+    t_r2 = novo_ticket("baixa")
+    _, rel = req(
+        "POST",
+        f"/tickets/{t_r1['id']}/vinculos",
+        token,
+        {"related_ticket_id": t_r2["id"], "tipo": "relacionado_a"},
+    )
+    _, rel_open = req("GET", f"/tickets/{t_r1['id']}", token)
+    if rel.get("tipo") == "relacionado_a" and not rel_open.get("fechado_em"):
+        ok("Relacionado mantem aberto (sem motivo)")
+    else:
+        fail("Relacionado")
+
+    # Duplicado sem fechar (mantem aberto)
+    t_df1 = novo_ticket()
+    t_df2 = novo_ticket()
+    _, v2 = req(
+        "POST",
+        f"/tickets/{t_df2['id']}/vinculos",
+        token,
+        {
+            "related_ticket_id": t_df1["id"],
+            "tipo": "duplicado_de",
+            "fechar_como_duplicado": False,
+        },
+    )
+    _, df_open = req("GET", f"/tickets/{t_df2['id']}", token)
+    if not v2.get("duplicado_fechado") and not df_open.get("fechado_em"):
+        ok("Duplicado sem fechar (sem motivo)")
+    else:
+        fail("Duplicado sem fechar")
+
+    _, lista = req("GET", "/tickets?situacao=fechados&limit=5", token)
+    item = lista["items"][0] if lista.get("items") else {}
+    if "prioridade" in item:
+        ok("Lista retorna prioridade")
+    else:
+        fail("Lista prioridade")
+
+    print()
+    if ERROS == 0:
+        print(
+            f"Simulacao API: {len(nat_items)} naturezas, {len(mot_items)} motivos, "
+            "4 prioridades, duplicado/relacionado — 0 falhas."
+        )
+        return 0
+    print(f"Simulacao API: {ERROS} falha(s).")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_ticket_anexos.py
+++ b/backend/tests/test_ticket_anexos.py
@@ -55,15 +55,25 @@ def test_anexo_respeita_rbac_ticket(client, seed_base, auth_headers):
 
 def test_nao_permite_upload_em_ticket_fechado(client, seed_base, auth_headers, db_session):
     from app.models import StatusTicket
+    from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
 
     # Cria status Fechado.
     fechado = StatusTicket(nome="Fechado", slug="fechado", ordem=99, ativo=True)
     db_session.add(fechado)
+    n = TicketNatureza(nome="Dúvida", slug="duvida", ordem=20, ativo=True)
+    db_session.add(n)
+    db_session.flush()
+    m = TicketMotivo(natureza_id=n.id, nome="Operacional", slug="operacional", ordem=10, ativo=True)
+    db_session.add(m)
     db_session.commit()
     db_session.refresh(fechado)
 
     t = _create_ticket(client, auth_headers["admin"], seed_base["empresa"].id, seed_base["setor1"].id)
-    r = client.patch(f"/v1/tickets/{t['id']}", headers=auth_headers["admin"], json={"status_id": fechado.id})
+    r = client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"status_id": fechado.id, "motivo_id": m.id},
+    )
     assert r.status_code == 200, r.text
 
     up = client.post(

--- a/backend/tests/test_ticket_classificacao.py
+++ b/backend/tests/test_ticket_classificacao.py
@@ -1,0 +1,208 @@
+"""Classificação (natureza/motivo) e prioridade de tickets (#107, #108)."""
+
+from __future__ import annotations
+
+
+def _ensure_status_fechado(db_session):
+    from sqlalchemy import func
+
+    from app.models import StatusTicket
+
+    st = db_session.query(StatusTicket).filter(func.lower(StatusTicket.slug) == "fechado").first()
+    if st:
+        st.ativo = True
+        db_session.commit()
+        return st
+    st = StatusTicket(nome="Fechado", slug="fechado", ordem=99, ativo=True)
+    db_session.add(st)
+    db_session.commit()
+    db_session.refresh(st)
+    return st
+
+
+def _seed_classificacao(db_session):
+    from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+
+    n_erro = TicketNatureza(nome="Erro", slug="erro", ordem=10, ativo=True)
+    n_duv = TicketNatureza(nome="Dúvida", slug="duvida", ordem=20, ativo=True)
+    db_session.add_all([n_erro, n_duv])
+    db_session.flush()
+    m_falha = TicketMotivo(
+        natureza_id=n_erro.id, nome="Falha no PDV", slug="falha-pdv", ordem=10, ativo=True
+    )
+    m_outros = TicketMotivo(natureza_id=n_erro.id, nome="Outros", slug="outros", ordem=99, ativo=True)
+    m_op = TicketMotivo(
+        natureza_id=n_duv.id, nome="Operacional", slug="operacional", ordem=10, ativo=True
+    )
+    db_session.add_all([m_falha, m_outros, m_op])
+    db_session.commit()
+    return {
+        "erro": n_erro,
+        "duvida": n_duv,
+        "falha_pdv": m_falha,
+        "outros": m_outros,
+        "operacional": m_op,
+    }
+
+
+def _create_ticket(client, auth_headers, seed_base, **extra):
+    payload = {
+        "empresa_id": seed_base["empresa"].id,
+        "setor_id": seed_base["setor1"].id,
+        "assunto": extra.pop("assunto", "Ticket teste"),
+        "descricao": "Teste",
+        **extra,
+    }
+    r = client.post("/v1/tickets", headers=auth_headers["admin"], json=payload)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def test_criar_ticket_com_prioridade(client, seed_base, auth_headers):
+    t = _create_ticket(client, auth_headers, seed_base, prioridade="alta")
+    assert t["prioridade"] == "alta"
+
+
+def test_criar_ticket_prioridade_padrao_normal(client, seed_base, auth_headers):
+    t = _create_ticket(client, auth_headers, seed_base)
+    assert t["prioridade"] == "normal"
+
+
+def test_fechar_exige_motivo(client, seed_base, auth_headers, db_session):
+    cat = _seed_classificacao(db_session)
+    fechado = _ensure_status_fechado(db_session)
+    t = _create_ticket(client, auth_headers, seed_base)
+
+    r = client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"status_id": fechado.id},
+    )
+    assert r.status_code == 400
+    assert "motivo" in r.json()["detail"].lower()
+
+    r2 = client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"status_id": fechado.id, "motivo_id": cat["falha_pdv"].id},
+    )
+    assert r2.status_code == 200, r2.text
+    body = r2.json()
+    assert body["fechado_em"] is not None
+    assert body["motivo_id"] == cat["falha_pdv"].id
+    assert body["motivo_nome"] == "Falha no PDV"
+    assert body["natureza_nome"] == "Erro"
+
+
+def test_motivo_outros_exige_texto(client, seed_base, auth_headers, db_session):
+    cat = _seed_classificacao(db_session)
+    fechado = _ensure_status_fechado(db_session)
+    t = _create_ticket(client, auth_headers, seed_base)
+
+    r = client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"status_id": fechado.id, "motivo_id": cat["outros"].id},
+    )
+    assert r.status_code == 400
+
+    r2 = client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={
+            "status_id": fechado.id,
+            "motivo_id": cat["outros"].id,
+            "motivo_outro_texto": "Problema específico no caixa 3",
+        },
+    )
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["motivo_outro_texto"] == "Problema específico no caixa 3"
+
+
+def test_classificacao_opcional_enquanto_aberto(client, seed_base, auth_headers, db_session):
+    cat = _seed_classificacao(db_session)
+    t = _create_ticket(client, auth_headers, seed_base)
+
+    r = client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"motivo_id": cat["operacional"].id},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["motivo_nome"] == "Operacional"
+    assert r.json()["natureza_nome"] == "Dúvida"
+
+
+def test_admin_altera_classificacao_ticket_fechado(client, seed_base, auth_headers, db_session):
+    cat = _seed_classificacao(db_session)
+    fechado = _ensure_status_fechado(db_session)
+    t = _create_ticket(client, auth_headers, seed_base)
+
+    client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"status_id": fechado.id, "motivo_id": cat["falha_pdv"].id},
+    )
+
+    r = client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"motivo_id": cat["operacional"].id},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["motivo_id"] == cat["operacional"].id
+
+
+def test_atendente_nao_altera_ticket_fechado(client, seed_base, auth_headers, db_session):
+    cat = _seed_classificacao(db_session)
+    fechado = _ensure_status_fechado(db_session)
+    t = _create_ticket(client, auth_headers, seed_base)
+
+    client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"status_id": fechado.id, "motivo_id": cat["falha_pdv"].id},
+    )
+
+    r = client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["a1"],
+        json={"prioridade": "urgente"},
+    )
+    assert r.status_code == 403
+
+
+def test_crud_catalogos_admin(client, seed_base, auth_headers, db_session):
+    _seed_classificacao(db_session)
+
+    r_list = client.get("/v1/ticket-naturezas", headers=auth_headers["admin"])
+    assert r_list.status_code == 200
+    assert r_list.json()["total"] >= 2
+
+    r_n = client.post(
+        "/v1/ticket-naturezas",
+        headers=auth_headers["admin"],
+        json={"nome": "Reclamação", "slug": "reclamacao", "ordem": 40, "ativo": True},
+    )
+    assert r_n.status_code == 201
+    nid = r_n.json()["id"]
+
+    r_m = client.post(
+        "/v1/ticket-motivos",
+        headers=auth_headers["admin"],
+        json={
+            "natureza_id": nid,
+            "nome": "Atendimento",
+            "slug": "atendimento",
+            "ordem": 1,
+            "ativo": True,
+        },
+    )
+    assert r_m.status_code == 201
+
+    r_forbidden = client.post(
+        "/v1/ticket-naturezas",
+        headers=auth_headers["a1"],
+        json={"nome": "X", "slug": "x", "ordem": 1},
+    )
+    assert r_forbidden.status_code == 403

--- a/backend/tests/test_ticket_vinculos.py
+++ b/backend/tests/test_ticket_vinculos.py
@@ -3,6 +3,22 @@
 from __future__ import annotations
 
 
+def _seed_motivo_fechamento(db_session):
+    from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+
+    n = TicketNatureza(nome="Dúvida", slug="duvida", ordem=20, ativo=True)
+    db_session.add(n)
+    db_session.flush()
+    m = TicketMotivo(natureza_id=n.id, nome="Operacional", slug="operacional", ordem=10, ativo=True)
+    db_session.add(m)
+    db_session.commit()
+    return m
+
+
+def _payload_duplicado(related_id: int, motivo_id: int, **extra):
+    return {"related_ticket_id": related_id, "tipo": "duplicado_de", "motivo_id": motivo_id, **extra}
+
+
 def _ensure_status_fechado(db_session):
     from sqlalchemy import func
 
@@ -37,6 +53,7 @@ def _create_ticket(client, auth_headers, seed_base, assunto: str = "Ticket base"
 
 def test_criar_vinculo_duplicado_e_relacionado(client, seed_base, auth_headers, db_session):
     _ensure_status_fechado(db_session)
+    motivo = _seed_motivo_fechamento(db_session)
     a = _create_ticket(client, auth_headers, seed_base, "Original")
     b = _create_ticket(client, auth_headers, seed_base, "Cópia")
     c = _create_ticket(client, auth_headers, seed_base, "Outro")
@@ -44,7 +61,7 @@ def test_criar_vinculo_duplicado_e_relacionado(client, seed_base, auth_headers, 
     r1 = client.post(
         f"/v1/tickets/{b['id']}/vinculos",
         headers=auth_headers["admin"],
-        json={"related_ticket_id": a["id"], "tipo": "duplicado_de"},
+        json=_payload_duplicado(a["id"], motivo.id),
     )
     assert r1.status_code == 201, r1.text
     j1 = r1.json()
@@ -92,9 +109,10 @@ def test_nao_vincula_a_si(client, seed_base, auth_headers):
 
 def test_vinculo_duplicado_rejeitado(client, seed_base, auth_headers, db_session):
     _ensure_status_fechado(db_session)
+    motivo = _seed_motivo_fechamento(db_session)
     a = _create_ticket(client, auth_headers, seed_base, "A")
     b = _create_ticket(client, auth_headers, seed_base, "B")
-    payload = {"related_ticket_id": a["id"], "tipo": "duplicado_de"}
+    payload = _payload_duplicado(a["id"], motivo.id)
     assert client.post(f"/v1/tickets/{b['id']}/vinculos", headers=auth_headers["admin"], json=payload).status_code == 201
     r2 = client.post(f"/v1/tickets/{b['id']}/vinculos", headers=auth_headers["admin"], json=payload)
     assert r2.status_code == 400

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import { FuncionariosRede } from './pages/FuncionariosRede'
 import { FuncionarioRedeDetalhe } from './pages/FuncionarioRedeDetalhe'
 import { FuncionarioRedeForm } from './pages/FuncionarioRedeForm'
 import { StatusTicketPage } from './pages/StatusTicket'
+import { TicketNaturezaMotivoPage } from './pages/TicketNaturezaMotivo'
 import { StatusTicketForm } from './pages/StatusTicketForm'
 import { StatusTicketDetalhe } from './pages/StatusTicketDetalhe'
 import { RespostasProntasPage } from './pages/RespostasProntas'
@@ -336,6 +337,7 @@ function AppRoutes() {
           <Route path="setores" element={<Setores embedded />} />
           <Route path="atendentes" element={<Atendentes embedded />} />
           <Route path="status-ticket" element={<StatusTicketPage embedded />} />
+          <Route path="natureza-motivo" element={<TicketNaturezaMotivoPage embedded />} />
           <Route path="respostas-prontas" element={<RespostasProntasPage embedded />} />
         </Route>
         <Route

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1129,6 +1129,83 @@ export namespace FuncionariosRede {
   }
 }
 
+export const ticketClassificacao = {
+  listNaturezas: (params?: {
+    incluir_inativos?: boolean
+    busca?: string
+    offset?: number
+    limit?: number
+    ordenar_por?: 'nome' | 'slug' | 'ordem' | 'ativo'
+    ordem?: 'asc' | 'desc'
+  }) => listPaginated<TicketClassificacao.Natureza>('/ticket-naturezas', params),
+  createNatureza: (data: TicketClassificacao.NaturezaCreate) =>
+    api<TicketClassificacao.Natureza>('/ticket-naturezas', { method: 'POST', body: JSON.stringify(data) }),
+  updateNatureza: (id: number, data: TicketClassificacao.NaturezaUpdate) =>
+    api<TicketClassificacao.Natureza>(`/ticket-naturezas/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  listMotivos: (params?: {
+    natureza_id?: number
+    incluir_inativos?: boolean
+    busca?: string
+    offset?: number
+    limit?: number
+    ordenar_por?: 'nome' | 'slug' | 'ordem' | 'ativo'
+    ordem?: 'asc' | 'desc'
+  }) => listPaginated<TicketClassificacao.Motivo>('/ticket-motivos', params),
+  createMotivo: (data: TicketClassificacao.MotivoCreate) =>
+    api<TicketClassificacao.Motivo>('/ticket-motivos', { method: 'POST', body: JSON.stringify(data) }),
+  updateMotivo: (id: number, data: TicketClassificacao.MotivoUpdate) =>
+    api<TicketClassificacao.Motivo>(`/ticket-motivos/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+}
+
+export namespace TicketClassificacao {
+  export interface Natureza {
+    id: number
+    nome: string
+    slug: string
+    ordem: number
+    ativo: boolean
+    created_at?: string | null
+    updated_at?: string | null
+  }
+  export interface NaturezaCreate {
+    nome: string
+    slug: string
+    ordem?: number
+    ativo?: boolean
+  }
+  export interface NaturezaUpdate {
+    nome?: string
+    slug?: string
+    ordem?: number
+    ativo?: boolean
+  }
+  export interface Motivo {
+    id: number
+    natureza_id: number
+    nome: string
+    slug: string
+    ordem: number
+    ativo: boolean
+    natureza_nome?: string | null
+    created_at?: string | null
+    updated_at?: string | null
+  }
+  export interface MotivoCreate {
+    natureza_id: number
+    nome: string
+    slug: string
+    ordem?: number
+    ativo?: boolean
+  }
+  export interface MotivoUpdate {
+    natureza_id?: number
+    nome?: string
+    slug?: string
+    ordem?: number
+    ativo?: boolean
+  }
+}
+
 export const pdvRotulos = {
   list: (params?: { incluir_inativos?: boolean; busca?: string; offset?: number; limit?: number }) =>
     listPaginated<PdvCatalogo.Item>('/pdv-rotulos', params),
@@ -1317,6 +1394,12 @@ export namespace Tickets {
     status_nome?: string;
     atendente_nome?: string;
     parent_ticket_id?: number | null;
+    prioridade?: import('../lib/ticketPrioridade').PrioridadeTicket;
+    motivo_id?: number | null;
+    motivo_nome?: string | null;
+    motivo_outro_texto?: string | null;
+    natureza_id?: number | null;
+    natureza_nome?: string | null;
     parent?: TicketParentBrief | null;
     children?: TicketChildBrief[];
     vinculos?: TicketVinculo[];
@@ -1340,6 +1423,8 @@ export namespace Tickets {
     related_ticket_id: number;
     tipo: TicketVinculoTipo;
     fechar_como_duplicado?: boolean;
+    motivo_id?: number | null;
+    motivo_outro_texto?: string | null;
   }
   export interface FilhoMassaEmpresaOpcao {
     id: number;
@@ -1388,6 +1473,7 @@ export namespace Tickets {
     descricao?: string;
     aberto_por_id?: number;
     parent_ticket_id?: number | null;
+    prioridade?: import('../lib/ticketPrioridade').PrioridadeTicket;
   }
   export type MensagemTipo = 'abertura' | 'publico' | 'interno';
 
@@ -1429,6 +1515,9 @@ export namespace Tickets {
     status_id?: number;
     atendente_id?: number | null;
     parent_ticket_id?: number | null;
+    prioridade?: import('../lib/ticketPrioridade').PrioridadeTicket;
+    motivo_id?: number | null;
+    motivo_outro_texto?: string | null;
   }
 
   export type AnexoVisibilidade = 'publico' | 'interno'

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,5 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
+import { createPortal } from 'react-dom'
 import { Link, useLocation } from 'react-router-dom'
 
 const icons: Record<string, React.ReactNode> = {
@@ -241,6 +242,24 @@ export function Sidebar({
   const location = useLocation()
   const [openGroup, setOpenGroup] = useState<string | null>(null)
   const [openFlyout, setOpenFlyout] = useState<string | null>(null)
+  const [flyoutTop, setFlyoutTop] = useState<number | null>(null)
+
+  const closeFlyout = useCallback(() => {
+    setOpenFlyout(null)
+    setFlyoutTop(null)
+  }, [])
+
+  const toggleFlyout = useCallback(
+    (groupId: string, anchorTop: number) => {
+      if (openFlyout === groupId) {
+        closeFlyout()
+        return
+      }
+      setOpenFlyout(groupId)
+      setFlyoutTop(anchorTop)
+    },
+    [closeFlyout, openFlyout]
+  )
 
   const items = navStructure.filter(
     (item) => item.type === 'link' || !('adminOnly' in item && item.adminOnly) || isAdmin
@@ -262,8 +281,19 @@ export function Sidebar({
 
   // No drawer mobile usamos acordeão (não flyout); evita estado do flyout “preso”
   useEffect(() => {
-    if (mobileOpen) setOpenFlyout(null)
-  }, [mobileOpen])
+    if (mobileOpen) closeFlyout()
+  }, [mobileOpen, closeFlyout])
+
+  useEffect(() => {
+    if (!openFlyout) return
+    const onViewportChange = () => closeFlyout()
+    window.addEventListener('resize', onViewportChange)
+    window.addEventListener('scroll', onViewportChange, true)
+    return () => {
+      window.removeEventListener('resize', onViewportChange)
+      window.removeEventListener('scroll', onViewportChange, true)
+    }
+  }, [closeFlyout, openFlyout])
 
   const linkClass = (to: string, base = '') =>
     `${base} flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors touch-manipulation min-h-[44px] ${
@@ -274,6 +304,49 @@ export function Sidebar({
 
   const isGroupOpen = (id: string) => openGroup === id
   const isFlyoutOpen = (id: string) => openFlyout === id
+
+  const openFlyoutGroup = openFlyout
+    ? items.find((item): item is NavGroup => item.type === 'group' && item.id === openFlyout)
+    : null
+
+  const flyoutPortal =
+    openFlyoutGroup && flyoutTop != null && typeof document !== 'undefined'
+      ? createPortal(
+          <>
+            <div
+              role="presentation"
+              className="fixed inset-0 z-40 md:left-[var(--sidebar-w,80px)]"
+              onClick={closeFlyout}
+            />
+            <ul
+              className="fixed z-50 min-w-[200px] rounded-lg border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900"
+              style={{
+                left: 'calc(var(--sidebar-w, 80px) + 4px)',
+                top: flyoutTop,
+              }}
+              role="menu"
+            >
+              {openFlyoutGroup.children.map((child) => (
+                <li key={child.to} role="none">
+                  <Link
+                    to={child.to}
+                    onClick={() => {
+                      onMobileClose()
+                      closeFlyout()
+                    }}
+                    className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+                    role="menuitem"
+                  >
+                    {icons[child.icon]}
+                    {child.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </>,
+          document.body
+        )
+      : null
 
   const sidebarContent = (
     <>
@@ -307,7 +380,7 @@ export function Sidebar({
       </div>
 
       <nav
-        className={`min-w-0 flex-1 overflow-y-auto py-3 px-2 max-md:overflow-x-hidden ${!expanded ? 'md:px-2' : ''}`}
+        className={`min-w-0 flex-1 overflow-x-hidden overflow-y-auto py-3 px-2 ${!expanded ? 'md:px-2' : ''}`}
         aria-label="Menu principal"
       >
         <ul className={`min-w-0 space-y-0.5 px-2 ${!expanded ? 'md:px-0' : ''}`}>
@@ -386,10 +459,13 @@ export function Sidebar({
                   </>
                 ) : (
                   /* Desktop recolhido (md+): flyout à direita do ícone */
-                  <div className="relative w-full min-w-0">
+                  <div className="w-full min-w-0">
                     <button
                       type="button"
-                      onClick={() => setOpenFlyout(isFlyoutOpen(group.id) ? null : group.id)}
+                      onClick={(e) => {
+                        const top = e.currentTarget.getBoundingClientRect().top
+                        toggleFlyout(group.id, top)
+                      }}
                       title={group.label}
                       className={`flex w-full items-center justify-center rounded-lg py-2.5 text-slate-600 hover:bg-slate-100 min-h-[44px] px-2 dark:text-slate-400 dark:hover:bg-slate-800/80 md:px-0 ${
                         active ? 'bg-cyan-50 text-slate-900 ring-1 ring-cyan-200/60 dark:bg-cyan-950/35 dark:text-slate-100 dark:ring-cyan-800/50' : ''
@@ -399,36 +475,6 @@ export function Sidebar({
                     >
                       {icons[group.icon]}
                     </button>
-                    {isFlyoutOpen(group.id) && (
-                      <>
-                        <div
-                          role="presentation"
-                          className="fixed inset-0 z-40 md:left-[var(--sidebar-w,80px)]"
-                          onClick={() => setOpenFlyout(null)}
-                        />
-                        <ul
-                          className="absolute left-full top-0 z-50 ml-1 min-w-[200px] rounded-lg border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900"
-                          role="menu"
-                        >
-                          {group.children.map((child) => (
-                            <li key={child.to} role="none">
-                              <Link
-                                to={child.to}
-                                onClick={() => {
-                                  onMobileClose()
-                                  setOpenFlyout(null)
-                                }}
-                                className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
-                                role="menuitem"
-                              >
-                                {icons[child.icon]}
-                                {child.label}
-                              </Link>
-                            </li>
-                          ))}
-                        </ul>
-                      </>
-                    )}
                   </div>
                 )}
               </li>
@@ -507,6 +553,7 @@ export function Sidebar({
           </button>
         </div>
         {sidebarContent}
+        {flyoutPortal}
       </aside>
     </>
   )

--- a/frontend/src/components/tickets/TicketClassificacaoFields.tsx
+++ b/frontend/src/components/tickets/TicketClassificacaoFields.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useMemo, useState } from 'react'
+import { ApiError, ticketClassificacao, type TicketClassificacao } from '../../api/client'
+import { Select } from '../ui/Select'
+import { Input } from '../ui/Input'
+
+export type ClassificacaoFormValue = {
+  naturezaId: number | ''
+  motivoId: number | ''
+  motivoOutroTexto: string
+}
+
+type Props = {
+  value: ClassificacaoFormValue
+  onChange: (next: ClassificacaoFormValue) => void
+  disabled?: boolean
+  motivoLabel?: string
+}
+
+export function TicketClassificacaoFields({
+  value,
+  onChange,
+  disabled,
+  motivoLabel = 'Motivo',
+}: Props) {
+  const [naturezas, setNaturezas] = useState<TicketClassificacao.Natureza[]>([])
+  const [motivos, setMotivos] = useState<TicketClassificacao.Motivo[]>([])
+  const [loadingMotivos, setLoadingMotivos] = useState(false)
+
+  useEffect(() => {
+    ticketClassificacao
+      .listNaturezas({ limit: 100 })
+      .then(({ items }) => setNaturezas(items))
+      .catch((err) => {
+        if (!(err instanceof ApiError && err.status === 403)) {
+          setNaturezas([])
+        }
+      })
+  }, [])
+
+  useEffect(() => {
+    if (value.naturezaId === '') {
+      setMotivos([])
+      return
+    }
+    setLoadingMotivos(true)
+    ticketClassificacao
+      .listMotivos({ natureza_id: Number(value.naturezaId), limit: 100 })
+      .then(({ items }) => setMotivos(items))
+      .catch(() => setMotivos([]))
+      .finally(() => setLoadingMotivos(false))
+  }, [value.naturezaId])
+
+  const motivoSelecionado = useMemo(
+    () => motivos.find((m) => m.id === value.motivoId),
+    [motivos, value.motivoId],
+  )
+  const exigeOutroTexto = (motivoSelecionado?.slug ?? '').toLowerCase() === 'outros'
+
+  return (
+    <div className="space-y-3">
+      <Select
+        label="Natureza"
+        value={value.naturezaId}
+        onChange={(v) =>
+          onChange({
+            naturezaId: v === '' ? '' : Number(v),
+            motivoId: '',
+            motivoOutroTexto: '',
+          })
+        }
+        options={naturezas.map((n) => ({ value: n.id, label: n.nome }))}
+        includeEmpty
+        emptyLabel="— Selecione a natureza —"
+        disabled={disabled || naturezas.length === 0}
+      />
+      <Select
+        label={motivoLabel}
+        value={value.motivoId}
+        onChange={(v) =>
+          onChange({
+            ...value,
+            motivoId: v === '' ? '' : Number(v),
+            motivoOutroTexto: '',
+          })
+        }
+        options={motivos.map((m) => ({ value: m.id, label: m.nome }))}
+        includeEmpty
+        emptyLabel={
+          value.naturezaId === ''
+            ? '— Selecione a natureza primeiro —'
+            : loadingMotivos
+              ? 'Carregando motivos…'
+              : '— Selecione o motivo —'
+        }
+        disabled={disabled || value.naturezaId === '' || loadingMotivos}
+      />
+      {exigeOutroTexto ? (
+        <Input
+          label="Descreva o atendimento"
+          value={value.motivoOutroTexto}
+          onChange={(e) => onChange({ ...value, motivoOutroTexto: e.target.value })}
+          disabled={disabled}
+          maxLength={255}
+          placeholder="Obrigatório para motivo Outros"
+        />
+      ) : null}
+    </div>
+  )
+}
+
+export function classificacaoFromTicket(ticket: {
+  natureza_id?: number | null
+  motivo_id?: number | null
+  motivo_outro_texto?: string | null
+}): ClassificacaoFormValue {
+  return {
+    naturezaId: ticket.natureza_id ?? '',
+    motivoId: ticket.motivo_id ?? '',
+    motivoOutroTexto: ticket.motivo_outro_texto ?? '',
+  }
+}
+
+export function patchClassificacaoFromForm(
+  form: ClassificacaoFormValue,
+): { motivo_id: number; motivo_outro_texto?: string } | null {
+  if (form.motivoId === '') return null
+  const patch: { motivo_id: number; motivo_outro_texto?: string } = {
+    motivo_id: Number(form.motivoId),
+  }
+  const outro = form.motivoOutroTexto.trim()
+  if (outro) patch.motivo_outro_texto = outro
+  return patch
+}

--- a/frontend/src/lib/ticketPrioridade.ts
+++ b/frontend/src/lib/ticketPrioridade.ts
@@ -1,0 +1,26 @@
+export type PrioridadeTicket = 'baixa' | 'normal' | 'alta' | 'urgente'
+
+export const PRIORIDADE_OPCOES: { value: PrioridadeTicket; label: string }[] = [
+  { value: 'baixa', label: 'Baixa' },
+  { value: 'normal', label: 'Normal' },
+  { value: 'alta', label: 'Alta' },
+  { value: 'urgente', label: 'Urgente' },
+]
+
+export function rotuloPrioridade(valor: PrioridadeTicket | string | undefined | null): string {
+  const hit = PRIORIDADE_OPCOES.find((o) => o.value === valor)
+  return hit?.label ?? 'Normal'
+}
+
+export function classeBadgePrioridade(valor: PrioridadeTicket | string | undefined | null): string {
+  switch (valor) {
+    case 'urgente':
+      return 'bg-rose-100 text-rose-800 dark:bg-rose-950/50 dark:text-rose-200'
+    case 'alta':
+      return 'bg-amber-100 text-amber-900 dark:bg-amber-950/40 dark:text-amber-200'
+    case 'baixa':
+      return 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300'
+    default:
+      return 'bg-sky-50 text-sky-800 dark:bg-sky-950/40 dark:text-sky-200'
+  }
+}

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -18,6 +18,8 @@ import {
   type Empresas,
   type Tickets,
   type WhatsappChats,
+  ticketClassificacao,
+  type TicketClassificacao,
 } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
@@ -41,6 +43,17 @@ import { TicketBuscaPicker } from '../components/TicketBuscaPicker'
 import { TicketFilhosMassaPanel } from '../components/tickets/TicketFilhosMassaPanel'
 import { TicketMetaChip } from '../components/tickets/TicketMetaChip'
 import { TicketDetalheSkeleton } from '../components/tickets/TicketDetalheSkeleton'
+import {
+  TicketClassificacaoFields,
+  classificacaoFromTicket,
+  patchClassificacaoFromForm,
+  type ClassificacaoFormValue,
+} from '../components/tickets/TicketClassificacaoFields'
+import {
+  PRIORIDADE_OPCOES,
+  rotuloPrioridade,
+  type PrioridadeTicket,
+} from '../lib/ticketPrioridade'
 
 const ROTULO_CAMPO: Record<string, string> = {
   status_id: 'Status',
@@ -52,6 +65,9 @@ const ROTULO_CAMPO: Record<string, string> = {
   parent_ticket_id: 'Ticket pai',
   filhos_em_massa: 'Tickets filhos em massa',
   vinculo_ticket: 'Vínculo com ticket',
+  prioridade: 'Prioridade',
+  motivo_id: 'Motivo',
+  motivo_outro_texto: 'Detalhe do motivo',
 }
 
 function resolverValorHistorico(
@@ -62,10 +78,16 @@ function resolverValorHistorico(
     setor: Map<number, string>
     atendente: Map<number, string>
     empresa: Map<number, string>
+    motivo: Map<number, string>
   },
 ): string {
   if (valor == null || valor === '') return '—'
-  if (campo === 'status_id' || campo === 'setor_id' || campo === 'atendente_id' || campo === 'empresa_id') {
+  if (campo === 'prioridade') return rotuloPrioridade(valor)
+  if (campo === 'motivo_outro_texto') {
+    const t = (valor || '').trim()
+    return t || '—'
+  }
+  if (campo === 'status_id' || campo === 'setor_id' || campo === 'atendente_id' || campo === 'empresa_id' || campo === 'motivo_id') {
     const id = Number(valor)
     if (Number.isNaN(id)) return valor
     const m =
@@ -75,7 +97,9 @@ function resolverValorHistorico(
           ? maps.setor
           : campo === 'empresa_id'
             ? maps.empresa
-            : maps.atendente
+            : campo === 'motivo_id'
+              ? maps.motivo
+              : maps.atendente
     return m.get(id) ?? `#${id}`
   }
   const t = (valor || '').trim()
@@ -178,6 +202,23 @@ export function TicketDetalhe() {
   const [editAtendente, setEditAtendente] = useState<number | ''>('')
   const [editRede, setEditRede] = useState<number | ''>('')
   const [editEmpresa, setEditEmpresa] = useState<number | ''>('')
+  const [editPrioridade, setEditPrioridade] = useState<PrioridadeTicket>('normal')
+  const [editClassificacao, setEditClassificacao] = useState<ClassificacaoFormValue>({
+    naturezaId: '',
+    motivoId: '',
+    motivoOutroTexto: '',
+  })
+  const [fecharClassificacao, setFecharClassificacao] = useState<ClassificacaoFormValue>({
+    naturezaId: '',
+    motivoId: '',
+    motivoOutroTexto: '',
+  })
+  const [vinculoClassificacao, setVinculoClassificacao] = useState<ClassificacaoFormValue>({
+    naturezaId: '',
+    motivoId: '',
+    motivoOutroTexto: '',
+  })
+  const [motivosHistorico, setMotivosHistorico] = useState<TicketClassificacao.Motivo[]>([])
   const [redesList, setRedesList] = useState<Redes.Rede[]>([])
   const [empresasModalList, setEmpresasModalList] = useState<Empresas.EmpresaListaItem[]>([])
   const [saving, setSaving] = useState(false)
@@ -193,7 +234,7 @@ export function TicketDetalhe() {
   const [modalFecharAberto, setModalFecharAberto] = useState(false)
   /** Qual bloco do modal recebe destaque ao abrir (chips no cabeçalho). */
   const [modalGerirFoco, setModalGerirFoco] = useState<
-    'geral' | 'setor' | 'status' | 'atendente' | 'hierarquia' | 'relacionados'
+    'geral' | 'setor' | 'status' | 'atendente' | 'hierarquia' | 'relacionados' | 'classificacao'
   >('geral')
   const [historicoAberto, setHistoricoAberto] = useState(false)
 
@@ -365,8 +406,21 @@ export function TicketDetalhe() {
     if (ticket?.empresa_nome && ticket.empresa_id != null) {
       empresa.set(ticket.empresa_id, ticket.empresa_nome)
     }
-    return { status, setor, atendente, empresa }
-  }, [statusList, setoresList, atendentesList, empresasModalList, ticket])
+    const motivo = new Map<number, string>()
+    motivosHistorico.forEach((m) => motivo.set(m.id, m.nome))
+    if (ticket?.motivo_nome && ticket.motivo_id != null) {
+      motivo.set(ticket.motivo_id, ticket.motivo_nome)
+    }
+    return { status, setor, atendente, empresa, motivo }
+  }, [statusList, setoresList, atendentesList, empresasModalList, motivosHistorico, ticket])
+
+  useEffect(() => {
+    coletarTodasPaginas<TicketClassificacao.Motivo>((o, l) =>
+      ticketClassificacao.listMotivos({ incluir_inativos: true, offset: o, limit: l }),
+    )
+      .then(setMotivosHistorico)
+      .catch(() => setMotivosHistorico([]))
+  }, [])
 
   useEffect(() => {
     coletarTodasPaginas<StatusTicket.Status>((o, l) =>
@@ -478,6 +532,11 @@ export function TicketDetalhe() {
         setEditSetor(t.setor_id)
         setEditStatus(t.status_id)
         setEditAtendente(t.atendente_id ?? '')
+        setEditPrioridade((t.prioridade as PrioridadeTicket) ?? 'normal')
+        const classificacao = classificacaoFromTicket(t)
+        setEditClassificacao(classificacao)
+        setFecharClassificacao(classificacao)
+        setVinculoClassificacao(classificacao)
         void notificacoes
           .marcarVisto(numId)
           .then(() => refetchPendenciasResumo())
@@ -643,7 +702,7 @@ export function TicketDetalhe() {
   }, [modalGerirAberto, editSetor, editAtendente, atendentesList, setoresList])
 
   function abrirModalGerir(
-    foco: 'geral' | 'setor' | 'status' | 'atendente' | 'hierarquia' | 'relacionados' = 'geral',
+    foco: 'geral' | 'setor' | 'status' | 'atendente' | 'hierarquia' | 'relacionados' | 'classificacao' = 'geral',
   ) {
     if (!ticket) return
     setEditSetor(ticket.setor_id)
@@ -651,6 +710,8 @@ export function TicketDetalhe() {
     setEditAtendente(ticket.atendente_id ?? '')
     setEditRede(ticket.rede_id ?? '')
     setEditEmpresa(ticket.empresa_id ?? '')
+    setEditPrioridade((ticket.prioridade as PrioridadeTicket) ?? 'normal')
+    setEditClassificacao(classificacaoFromTicket(ticket))
     setModalGerirFoco(foco)
     setModalGerirAberto(true)
   }
@@ -700,7 +761,10 @@ export function TicketDetalhe() {
   }, [modalGerirAberto, editRede, editEmpresa, empresasVinculoSugeridas.length])
 
   const modalApenasUmCampo =
-    modalGerirFoco !== 'geral' && modalGerirFoco !== 'hierarquia' && modalGerirFoco !== 'relacionados'
+    modalGerirFoco !== 'geral' &&
+    modalGerirFoco !== 'hierarquia' &&
+    modalGerirFoco !== 'relacionados' &&
+    modalGerirFoco !== 'classificacao'
 
   async function handleSalvar() {
     if (!ticket) return
@@ -713,6 +777,23 @@ export function TicketDetalhe() {
     if (modalGerirFoco === 'geral' && editEmpresa !== '') {
       const novoEmpresa = Number(editEmpresa)
       if (novoEmpresa !== ticket.empresa_id) patch.empresa_id = novoEmpresa
+    }
+    if (
+      (modalGerirFoco === 'geral' || modalGerirFoco === 'classificacao') &&
+      editPrioridade !== (ticket.prioridade ?? 'normal')
+    ) {
+      patch.prioridade = editPrioridade
+    }
+    if (modalGerirFoco === 'geral' || modalGerirFoco === 'classificacao') {
+      const classPatch = patchClassificacaoFromForm(editClassificacao)
+      const atualMotivo = ticket.motivo_id ?? null
+      const novoMotivo = classPatch?.motivo_id ?? null
+      const outroAtual = ticket.motivo_outro_texto ?? ''
+      const outroNovo = classPatch?.motivo_outro_texto ?? ''
+      if (classPatch && (novoMotivo !== atualMotivo || outroNovo !== outroAtual)) {
+        patch.motivo_id = classPatch.motivo_id
+        patch.motivo_outro_texto = classPatch.motivo_outro_texto ?? null
+      }
     }
 
     if (Object.keys(patch).length === 0) {
@@ -748,9 +829,17 @@ export function TicketDetalhe() {
       toast.showWarning('Não existe um status com slug "fechado". Cadastre/ajuste em Status de ticket.')
       return
     }
+    const classPatch = patchClassificacaoFromForm(fecharClassificacao)
+    if (!classPatch && !ticket.motivo_id) {
+      toast.showWarning('Informe natureza e motivo para encerrar o ticket.')
+      return
+    }
     setFechando(true)
     try {
-      const updated = await tickets.update(ticket.id, { status_id: statusFechado.id })
+      const updated = await tickets.update(ticket.id, {
+        status_id: statusFechado.id,
+        ...(classPatch ?? {}),
+      })
       setTicket(updated)
       setEditStatus(updated.status_id)
       setEditAtendente(updated.atendente_id ?? '')
@@ -836,10 +925,17 @@ export function TicketDetalhe() {
     try {
       const fechar =
         tipoVinculoRelacionado === 'duplicado_de' ? fecharComoDuplicado : false
+      const classPatch =
+        fechar && !ticket.fechado_em ? patchClassificacaoFromForm(vinculoClassificacao) : null
+      if (fechar && !ticket.fechado_em && !classPatch && !ticket.motivo_id) {
+        toast.showWarning('Informe natureza e motivo para encerrar o ticket duplicado.')
+        return
+      }
       const resultado = await tickets.addVinculo(ticket.id, {
         related_ticket_id: alvo.id,
         tipo: tipoVinculoRelacionado,
         fechar_como_duplicado: fechar,
+        ...(classPatch ?? {}),
       })
       const [atualizado, mensagensAtualizadas, historicoAtualizado] = await Promise.all([
         tickets.get(ticket.id),
@@ -1298,6 +1394,20 @@ export function TicketDetalhe() {
                   label="Hier."
                   value={rotuloChipHierarquia}
                   onClick={() => tentarEditarTicket(() => abrirModalGerir('hierarquia'))}
+                />
+                <TicketMetaChip
+                  label="Prior."
+                  value={rotuloPrioridade(ticket.prioridade)}
+                  onClick={() => tentarEditarTicket(() => abrirModalGerir('classificacao'))}
+                />
+                <TicketMetaChip
+                  label="Motivo"
+                  value={
+                    ticket.motivo_nome
+                      ? `${ticket.natureza_nome ? `${ticket.natureza_nome} · ` : ''}${ticket.motivo_nome}`
+                      : '—'
+                  }
+                  onClick={() => tentarEditarTicket(() => abrirModalGerir('classificacao'))}
                 />
                 <TicketMetaChip
                   label="Relacionados"
@@ -2036,6 +2146,13 @@ export function TicketDetalhe() {
                           >
                             Fechar este ticket e registrar mensagem pública apontando para o original
                           </CheckboxField>
+                          {fecharComoDuplicado && !ticket.fechado_em ? (
+                            <TicketClassificacaoFields
+                              value={vinculoClassificacao}
+                              onChange={setVinculoClassificacao}
+                              disabled={vinculandoRelacionado}
+                            />
+                          ) : null}
                           {ticket.fechado_em ? (
                             <p className="text-xs text-amber-700 dark:text-amber-400">
                               Este ticket já está fechado — apenas o vínculo será registrado.
@@ -2175,6 +2292,22 @@ export function TicketDetalhe() {
                     )}
                   </div>
                 )}
+                {(modalGerirFoco === 'geral' || modalGerirFoco === 'classificacao') && (
+                  <>
+                    <Select
+                      label="Prioridade"
+                      value={editPrioridade}
+                      onChange={(v) => setEditPrioridade(v as PrioridadeTicket)}
+                      options={PRIORIDADE_OPCOES.map((o) => ({ value: o.value, label: o.label }))}
+                      disabled={Boolean(ticket?.fechado_em) && !isAdmin}
+                    />
+                    <TicketClassificacaoFields
+                      value={editClassificacao}
+                      onChange={setEditClassificacao}
+                      disabled={Boolean(ticket?.fechado_em) && !isAdmin}
+                    />
+                  </>
+                )}
               </div>
             )}
 
@@ -2245,8 +2378,16 @@ export function TicketDetalhe() {
               Fechar ticket
             </h2>
             <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-              Ao fechar, o ticket sairá da lista de abertos e não permitirá novas mensagens.
+              Ao fechar, o ticket sairá da lista de abertos e não permitirá novas mensagens. Informe a classificação do
+              atendimento.
             </p>
+            <div className="mt-4">
+              <TicketClassificacaoFields
+                value={fecharClassificacao}
+                onChange={setFecharClassificacao}
+                disabled={fechando}
+              />
+            </div>
             {filhosAbertosCount > 0 && (
               <p className="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950 dark:border-amber-800/50 dark:bg-amber-950/30 dark:text-amber-100">
                 Este ticket tem {filhosAbertosCount} filho(s) direto(s) ainda em aberto. O sistema bloqueia o fecho até

--- a/frontend/src/pages/TicketNaturezaMotivo.tsx
+++ b/frontend/src/pages/TicketNaturezaMotivo.tsx
@@ -1,0 +1,391 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ApiError, ticketClassificacao, type TicketClassificacao } from '../api/client'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { Input } from '../components/ui/Input'
+import { Select } from '../components/ui/Select'
+import { Switch } from '../components/ui/Switch'
+import { FiltroInativos } from '../components/ui/FiltroInativos'
+import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
+import { IconPencil } from '../components/ui/IconPencil'
+import { useToast } from '../components/ui/Toast'
+import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { MODAL_PANEL_COMPACT } from '../lib/modalPanel'
+import { ConfigListPageShell } from '../components/config/ConfigListPageShell'
+
+type Aba = 'naturezas' | 'motivos'
+
+type NaturezaForm = TicketClassificacao.NaturezaCreate
+type MotivoForm = TicketClassificacao.MotivoCreate
+
+const emptyNatureza = (): NaturezaForm => ({ nome: '', slug: '', ordem: 0, ativo: true })
+const emptyMotivo = (naturezaId: number): MotivoForm => ({
+  natureza_id: naturezaId,
+  nome: '',
+  slug: '',
+  ordem: 0,
+  ativo: true,
+})
+
+export function TicketNaturezaMotivoPage({ embedded = false }: { embedded?: boolean }) {
+  const toast = useToast()
+  const [forbidden, setForbidden] = useState(false)
+  const [aba, setAba] = useState<Aba>('naturezas')
+
+  const [naturezas, setNaturezas] = useState<TicketClassificacao.Natureza[]>([])
+  const [motivos, setMotivos] = useState<TicketClassificacao.Motivo[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [busca, setBusca] = useState('')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+  const [incluirInativos, setIncluirInativos] = useState(false)
+  const [filtroNaturezaId, setFiltroNaturezaId] = useState<number | ''>('')
+  const [loading, setLoading] = useState(true)
+
+  const [modalOpen, setModalOpen] = useState(false)
+  const [editId, setEditId] = useState<number | null>(null)
+  const [formNatureza, setFormNatureza] = useState<NaturezaForm>(emptyNatureza())
+  const [formMotivo, setFormMotivo] = useState<MotivoForm>(emptyMotivo(0))
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
+    return () => clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    setPage(1)
+  }, [debouncedBusca, incluirInativos, aba, filtroNaturezaId])
+
+  const loadNaturezasCatalogo = useCallback(() => {
+    ticketClassificacao
+      .listNaturezas({ limit: 100, incluir_inativos: true })
+      .then(({ items }) => setNaturezas(items))
+      .catch(() => setNaturezas([]))
+  }, [])
+
+  useEffect(() => {
+    loadNaturezasCatalogo()
+  }, [loadNaturezasCatalogo])
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    const params = {
+      incluir_inativos: incluirInativos,
+      busca: debouncedBusca || undefined,
+      offset: (page - 1) * PAGE_SIZE_PADRAO,
+      limit: PAGE_SIZE_PADRAO,
+    }
+    const req =
+      aba === 'naturezas'
+        ? ticketClassificacao.listNaturezas(params)
+        : ticketClassificacao.listMotivos({
+            ...params,
+            natureza_id: filtroNaturezaId === '' ? undefined : Number(filtroNaturezaId),
+          })
+    req
+      .then(({ items, total: t }) => {
+        if (aba === 'naturezas') {
+          setNaturezas(items as TicketClassificacao.Natureza[])
+          setMotivos([])
+        } else {
+          setMotivos(items as TicketClassificacao.Motivo[])
+        }
+        setTotal(t)
+      })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setTotal(0)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar o catálogo.'))
+        setTotal(0)
+      })
+      .finally(() => setLoading(false))
+  }, [aba, debouncedBusca, filtroNaturezaId, incluirInativos, page, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  function abrirNovo() {
+    setEditId(null)
+    if (aba === 'naturezas') {
+      setFormNatureza(emptyNatureza())
+    } else {
+      const nid = filtroNaturezaId === '' ? naturezas[0]?.id ?? 0 : Number(filtroNaturezaId)
+      setFormMotivo(emptyMotivo(nid))
+    }
+    setModalOpen(true)
+  }
+
+  function abrirEditarNatureza(item: TicketClassificacao.Natureza) {
+    setEditId(item.id)
+    setFormNatureza({ nome: item.nome, slug: item.slug, ordem: item.ordem, ativo: item.ativo })
+    setModalOpen(true)
+  }
+
+  function abrirEditarMotivo(item: TicketClassificacao.Motivo) {
+    setEditId(item.id)
+    setFormMotivo({
+      natureza_id: item.natureza_id,
+      nome: item.nome,
+      slug: item.slug,
+      ordem: item.ordem,
+      ativo: item.ativo,
+    })
+    setModalOpen(true)
+  }
+
+  function fecharModal() {
+    setModalOpen(false)
+    setEditId(null)
+  }
+
+  async function salvar() {
+    setSaving(true)
+    try {
+      if (aba === 'naturezas') {
+        const nome = formNatureza.nome.trim()
+        const slug = formNatureza.slug.trim().toLowerCase()
+        if (!nome || !slug) {
+          toast.showWarning('Informe nome e slug da natureza.')
+          return
+        }
+        const payload = { ...formNatureza, nome, slug, ordem: Number(formNatureza.ordem) || 0 }
+        if (editId != null) {
+          await ticketClassificacao.updateNatureza(editId, payload)
+        } else {
+          await ticketClassificacao.createNatureza(payload)
+        }
+      } else {
+        const nome = formMotivo.nome.trim()
+        const slug = formMotivo.slug.trim().toLowerCase()
+        if (!formMotivo.natureza_id || !nome || !slug) {
+          toast.showWarning('Informe natureza, nome e slug do motivo.')
+          return
+        }
+        const payload = { ...formMotivo, nome, slug, ordem: Number(formMotivo.ordem) || 0 }
+        if (editId != null) {
+          await ticketClassificacao.updateMotivo(editId, payload)
+        } else {
+          await ticketClassificacao.createMotivo(payload)
+        }
+      }
+      toast.showSuccess('Salvo com sucesso.')
+      fecharModal()
+      loadNaturezasCatalogo()
+      load()
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const denied = (
+    <SemPermissao
+      title="Apenas administradores podem gerir naturezas e motivos."
+      voltarPara="/configuracoes/atendimento/natureza-motivo"
+      voltarLabel="Voltar"
+    />
+  )
+
+  const tabBtn = (id: Aba, rotulo: string) => (
+    <button
+      type="button"
+      onClick={() => setAba(id)}
+      aria-current={aba === id ? 'page' : undefined}
+      className={
+        aba === id
+          ? 'border-b-2 border-sky-500 px-3 py-2.5 text-sm font-semibold text-slate-900 dark:border-sky-400 dark:text-white'
+          : 'border-b-2 border-transparent px-3 py-2.5 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200'
+      }
+    >
+      {rotulo}
+    </button>
+  )
+
+  return (
+    <ConfigListPageShell
+      embedded={embedded}
+      forbidden={forbidden}
+      denied={denied}
+      title="Natureza e motivo"
+      actions={
+        <Button type="button" onClick={abrirNovo}>
+          {aba === 'naturezas' ? 'Nova natureza' : 'Novo motivo'}
+        </Button>
+      }
+    >
+      <div className="border-b border-slate-200 dark:border-slate-700">
+        <nav className="-mb-px flex gap-1" aria-label="Catálogo de classificação">
+          {tabBtn('naturezas', 'Naturezas')}
+          {tabBtn('motivos', 'Motivos')}
+        </nav>
+      </div>
+
+      <Card>
+        <BarraBuscaPaginacao
+          busca={busca}
+          onBuscaChange={setBusca}
+          placeholder={aba === 'naturezas' ? 'Buscar natureza…' : 'Buscar motivo…'}
+          page={page}
+          total={total}
+          onPageChange={setPage}
+          disabled={loading}
+          extra={
+            <div className="flex flex-wrap items-center gap-3">
+              {aba === 'motivos' ? (
+                <Select
+                  value={filtroNaturezaId}
+                  onChange={(v) => setFiltroNaturezaId(v === '' ? '' : Number(v))}
+                  options={naturezas.map((n) => ({ value: n.id, label: n.nome }))}
+                  includeEmpty
+                  emptyLabel="Todas as naturezas"
+                  aria-label="Filtrar por natureza"
+                />
+              ) : null}
+              <FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />
+            </div>
+          }
+        />
+
+        {loading ? (
+          <p className="py-8 text-center text-sm text-slate-500 dark:text-slate-400">Carregando…</p>
+        ) : aba === 'naturezas' ? (
+          naturezas.length === 0 ? (
+            <p className="py-10 text-center text-sm text-slate-500">Nenhuma natureza cadastrada.</p>
+          ) : (
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-slate-100 bg-slate-50/60 text-xs font-semibold uppercase text-slate-500 dark:border-slate-800 dark:bg-slate-800/40">
+                  <th className="px-4 py-3 sm:px-6">Nome</th>
+                  <th className="px-4 py-3 sm:px-6">Slug</th>
+                  <th className="px-4 py-3 text-center sm:px-6">Ordem</th>
+                  <th className="px-4 py-3 sm:px-6">Situação</th>
+                  <th className="w-px px-4 py-3 sm:px-6" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                {naturezas.map((item) => (
+                  <tr key={item.id} className="hover:bg-slate-50/80 dark:hover:bg-slate-800/40">
+                    <td className="px-4 py-3.5 font-medium sm:px-6">{item.nome}</td>
+                    <td className="px-4 py-3.5 font-mono text-xs text-slate-500 sm:px-6">{item.slug}</td>
+                    <td className="px-4 py-3.5 text-center tabular-nums sm:px-6">{item.ordem}</td>
+                    <td className="px-4 py-3.5 sm:px-6">{item.ativo ? 'Ativo' : 'Inativo'}</td>
+                    <td className="px-4 py-3.5 text-right sm:px-6">
+                      <button type="button" onClick={() => abrirEditarNatureza(item)} aria-label={`Editar ${item.nome}`}>
+                        <IconPencil />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )
+        ) : motivos.length === 0 ? (
+          <p className="py-10 text-center text-sm text-slate-500">Nenhum motivo cadastrado.</p>
+        ) : (
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b border-slate-100 bg-slate-50/60 text-xs font-semibold uppercase text-slate-500 dark:border-slate-800 dark:bg-slate-800/40">
+                <th className="px-4 py-3 sm:px-6">Natureza</th>
+                <th className="px-4 py-3 sm:px-6">Motivo</th>
+                <th className="px-4 py-3 sm:px-6">Slug</th>
+                <th className="px-4 py-3 text-center sm:px-6">Ordem</th>
+                <th className="px-4 py-3 sm:px-6">Situação</th>
+                <th className="w-px px-4 py-3 sm:px-6" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+              {motivos.map((item) => (
+                <tr key={item.id} className="hover:bg-slate-50/80 dark:hover:bg-slate-800/40">
+                  <td className="px-4 py-3.5 text-slate-600 sm:px-6">{item.natureza_nome ?? item.natureza_id}</td>
+                  <td className="px-4 py-3.5 font-medium sm:px-6">{item.nome}</td>
+                  <td className="px-4 py-3.5 font-mono text-xs text-slate-500 sm:px-6">{item.slug}</td>
+                  <td className="px-4 py-3.5 text-center tabular-nums sm:px-6">{item.ordem}</td>
+                  <td className="px-4 py-3.5 sm:px-6">{item.ativo ? 'Ativo' : 'Inativo'}</td>
+                  <td className="px-4 py-3.5 text-right sm:px-6">
+                    <button type="button" onClick={() => abrirEditarMotivo(item)} aria-label={`Editar ${item.nome}`}>
+                      <IconPencil />
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Card>
+
+      {modalOpen && (
+        <div className="fixed inset-0 z-[520] flex items-center justify-center bg-slate-950/60 p-4 backdrop-blur-[2px]">
+          <div role="dialog" aria-modal="true" className={MODAL_PANEL_COMPACT} onClick={(e) => e.stopPropagation()}>
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              {editId != null ? 'Editar' : 'Novo'} {aba === 'naturezas' ? 'natureza' : 'motivo'}
+            </h2>
+            <div className="mt-4 space-y-3">
+              {aba === 'motivos' ? (
+                <Select
+                  label="Natureza"
+                  value={formMotivo.natureza_id || ''}
+                  onChange={(v) => setFormMotivo((f) => ({ ...f, natureza_id: Number(v) }))}
+                  options={naturezas.map((n) => ({ value: n.id, label: n.nome }))}
+                  disabled={editId != null}
+                />
+              ) : null}
+              <Input
+                label="Nome"
+                value={aba === 'naturezas' ? formNatureza.nome : formMotivo.nome}
+                onChange={(e) =>
+                  aba === 'naturezas'
+                    ? setFormNatureza((f) => ({ ...f, nome: e.target.value }))
+                    : setFormMotivo((f) => ({ ...f, nome: e.target.value }))
+                }
+              />
+              <Input
+                label="Slug"
+                value={aba === 'naturezas' ? formNatureza.slug : formMotivo.slug}
+                onChange={(e) =>
+                  aba === 'naturezas'
+                    ? setFormNatureza((f) => ({ ...f, slug: e.target.value }))
+                    : setFormMotivo((f) => ({ ...f, slug: e.target.value }))
+                }
+              />
+              <Input
+                label="Ordem"
+                type="number"
+                value={String(aba === 'naturezas' ? formNatureza.ordem : formMotivo.ordem)}
+                onChange={(e) => {
+                  const ordem = Number(e.target.value) || 0
+                  if (aba === 'naturezas') setFormNatureza((f) => ({ ...f, ordem }))
+                  else setFormMotivo((f) => ({ ...f, ordem }))
+                }}
+              />
+              <Switch
+                label="Ativo"
+                checked={aba === 'naturezas' ? formNatureza.ativo ?? true : formMotivo.ativo ?? true}
+                onCheckedChange={(ativo) =>
+                  aba === 'naturezas'
+                    ? setFormNatureza((f) => ({ ...f, ativo }))
+                    : setFormMotivo((f) => ({ ...f, ativo }))
+                }
+              />
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <Button type="button" variant="secondary" onClick={fecharModal} disabled={saving}>
+                Cancelar
+              </Button>
+              <Button type="button" onClick={() => void salvar()} loading={saving}>
+                Salvar
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </ConfigListPageShell>
+  )
+}

--- a/frontend/src/pages/TicketNovo.tsx
+++ b/frontend/src/pages/TicketNovo.tsx
@@ -14,6 +14,7 @@ import { FormSection } from '../components/ui/FormSection'
 import { CheckboxField } from '../components/ui/CheckboxField'
 import { SemPermissao } from './SemPermissao'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { PRIORIDADE_OPCOES, type PrioridadeTicket } from '../lib/ticketPrioridade'
 const MAX_ANEXO_BYTES = 25 * 1024 * 1024
 const MAX_ANEXOS_COUNT = 10
 
@@ -36,6 +37,7 @@ export function TicketNovo() {
   const [setorId, setSetorId] = useState<number | ''>('')
   const [assunto, setAssunto] = useState('')
   const [descricao, setDescricao] = useState('')
+  const [prioridade, setPrioridade] = useState<PrioridadeTicket>('normal')
   const [anexosSelecionados, setAnexosSelecionados] = useState<File[]>([])
   const [loading, setLoading] = useState(false)
   const anexosInputRef = useRef<HTMLInputElement>(null)
@@ -198,6 +200,7 @@ export function TicketNovo() {
         setor_id: Number(setorId),
         assunto: assunto.trim(),
         descricao: descricao.trim(),
+        prioridade,
         ...(paiResumo ? { parent_ticket_id: paiResumo.id } : {}),
       }
       if (modoCoordenacao) {
@@ -369,6 +372,13 @@ export function TicketNovo() {
             </FormSection>
 
             <FormSection title="Solicitação">
+              <Select
+                label="Prioridade"
+                value={prioridade}
+                onChange={(v) => setPrioridade(v as PrioridadeTicket)}
+                options={PRIORIDADE_OPCOES.map((o) => ({ value: o.value, label: o.label }))}
+                disabled={formDesabilitado}
+              />
               <Input
                 label="Assunto (resumo) *"
                 value={assunto}

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -25,6 +25,7 @@ import { useAlertaFilaSemResponsavel } from '../hooks/useAlertaFilaSemResponsave
 import { SemPermissao } from './SemPermissao'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { exibirProtocolo } from '../lib/exibirProtocolo'
+import { rotuloPrioridade, classeBadgePrioridade } from '../lib/ticketPrioridade'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 
 type ColunaOrdenacao =
@@ -610,6 +611,16 @@ export function Tickets() {
                         <span className="font-medium text-slate-600 dark:text-slate-300">Resp.:</span>{' '}
                         {t.atendente_nome ?? 'Na fila'}
                       </span>
+                      <span className="truncate">
+                        <span className="font-medium text-slate-600 dark:text-slate-300">Prior.:</span>{' '}
+                        {rotuloPrioridade(t.prioridade)}
+                      </span>
+                      {t.motivo_nome ? (
+                        <span className="truncate">
+                          <span className="font-medium text-slate-600 dark:text-slate-300">Motivo:</span>{' '}
+                          {t.motivo_nome}
+                        </span>
+                      ) : null}
                       {situacao === 'fechados' && (
                         <span className="truncate">
                           <span className="font-medium text-slate-600 dark:text-slate-300">Fechado em:</span>{' '}
@@ -682,6 +693,8 @@ export function Tickets() {
                     }}
                     className="hidden px-4 py-3 md:table-cell sm:px-6"
                   />
+                  <th className="hidden px-4 py-3 md:table-cell sm:px-6">Prioridade</th>
+                  <th className="hidden px-4 py-3 lg:table-cell sm:px-6">Motivo</th>
                   {situacao === 'fechados' ? (
                     <CabecalhoOrdenavel
                       coluna="fechado_em"
@@ -766,6 +779,26 @@ export function Tickets() {
                     </td>
                     <td className="hidden px-4 py-3.5 align-top font-medium text-slate-900 md:table-cell sm:px-6 dark:text-slate-100" title={t.assunto}>
                       <span className="block break-words whitespace-normal leading-snug">{t.assunto}</span>
+                    </td>
+                    <td className="hidden px-4 py-3.5 align-top md:table-cell sm:px-6">
+                      <span
+                        className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${classeBadgePrioridade(t.prioridade)}`}
+                      >
+                        {rotuloPrioridade(t.prioridade)}
+                      </span>
+                    </td>
+                    <td
+                      className="hidden px-4 py-3.5 align-top text-slate-600 lg:table-cell sm:px-6 dark:text-slate-400"
+                      title={t.motivo_outro_texto ?? undefined}
+                    >
+                      <span className="block break-words whitespace-normal leading-snug">
+                        {t.motivo_nome ?? '—'}
+                        {t.motivo_outro_texto ? (
+                          <span className="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">
+                            {t.motivo_outro_texto}
+                          </span>
+                        ) : null}
+                      </span>
                     </td>
                     {situacao === 'fechados' ? (
                       <td className="whitespace-nowrap px-4 py-3.5 align-top text-slate-600 sm:px-6 dark:text-slate-400">

--- a/frontend/src/pages/config/ConfigAtendimentoLayout.tsx
+++ b/frontend/src/pages/config/ConfigAtendimentoLayout.tsx
@@ -6,6 +6,7 @@ const TABS = [
   { to: '/configuracoes/atendimento/setores', label: 'Setores' },
   { to: '/configuracoes/atendimento/atendentes', label: 'Atendentes' },
   { to: '/configuracoes/atendimento/status-ticket', label: 'Status de ticket' },
+  { to: '/configuracoes/atendimento/natureza-motivo', label: 'Natureza e motivo' },
   { to: '/configuracoes/atendimento/respostas-prontas', label: 'Respostas prontas' },
 ] as const
 
@@ -13,6 +14,7 @@ const TAB_HINTS: Record<string, string> = {
   setores: 'Áreas de atuação dos atendentes (suporte, financeiro, comercial…).',
   atendentes: 'Usuários internos que operam tickets e o chat.',
   'status-ticket': 'Etapas do fluxo de chamados (aberto, em atendimento, encerrado…).',
+  'natureza-motivo': 'Categorias (natureza) e itens específicos (motivo) usados ao encerrar tickets.',
   'respostas-prontas': 'Macros reutilizáveis ao responder tickets — globais ou por setor.',
 }
 
@@ -29,7 +31,7 @@ export function ConfigAtendimentoLayout() {
     <PageContainer>
       <PageHeader
         title="Atendimento"
-        subtitle="Setores, equipe, status de ticket e respostas prontas."
+        subtitle="Setores, equipe, status, classificação e respostas prontas."
       />
       <ConfigSectionTabs tabs={[...TABS]} ariaLabel="Seções de atendimento" />
       {hint ? <p className="text-sm text-slate-600 dark:text-slate-400">{hint}</p> : null}


### PR DESCRIPTION
## Summary
- Implementa catálogo configurável de natureza/motivo e prioridade na abertura de tickets (#107/#108), com classificação obrigatória ao fechar, edição restrita a admin em tickets encerrados e telas de config, criação, detalhe e lista.
- Corrige flyout do menu lateral recolhido (#222): submenu em overlay via portal, sem barra de rolagem horizontal e com itens clicáveis.

## Test plan
- [ ] Rodar migration `036_ticket_classificacao_prioridade` e seed
- [ ] Config → Atendimento → Natureza e motivo (CRUD)
- [ ] Criar ticket com prioridade baixa/normal/alta/urgente
- [ ] Fechar ticket exigindo natureza/motivo; validar motivo Outros com texto
- [ ] Lista e detalhe exibem prioridade e motivo; admin altera classificação em ticket fechado
- [ ] Recolher sidebar e abrir submenus (Chat, Clientes, Configurações): sem scrollbar horizontal e navegação funcional
- [ ] `pytest tests/test_ticket_classificacao.py tests/test_ticket_vinculos.py`
- [ ] `python backend/scripts/simular_classificacao_local.py`