### PR TITLE
Release: main → staging (WhatsApp citações, mensagens automáticas e responsável no chat)

### DIFF
--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -1,4 +1,6 @@
 import base64
+import logging
+import re
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
@@ -29,9 +31,15 @@ from app.api.tickets import _gerar_protocolo, _pode_ver_ticket
 from app.core.setor_scope import ids_setores_visiveis_atendente
 from app.config import settings
 from app.services import evolution_api
+from app.services.whatsapp_auto_messages import (
+    DEFAULT_AUTO_MSG_ASSUMIDO,
+    DEFAULT_AUTO_MSG_ENCERRADO,
+)
 from app.services.whatsapp_media_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
 
 router = APIRouter(prefix="/whatsapp/chats", tags=["whatsapp-chats"])
+
+logger = logging.getLogger(__name__)
 
 _MAX_PAGE = 100
 _DEFAULT_PAGE = 20
@@ -57,13 +65,43 @@ def _settings_envio(db: Session) -> WhatsappSettings:
     return row
 
 
-def _quoted_evolution_payload(db: Session, chat_id: int, quoted_wa_message_id: str) -> dict:
+def _evolution_configurada(st: WhatsappSettings | None) -> bool:
+    return bool(
+        st
+        and st.evolution_base_url
+        and st.evolution_instance_name
+        and st.evolution_api_key
+    )
+
+
+def _remote_jid_from_wa_id(wa_id: str) -> str:
+    digits = re.sub(r"\D", "", wa_id or "")
+    return f"{digits}@s.whatsapp.net" if digits else ""
+
+
+def _quoted_message_body(ref: WhatsappMensagem) -> dict:
+    corpo = (ref.corpo or "").strip()
+    tipo = (ref.tipo_midia or "texto").strip().lower()
+    if tipo in ("", "texto"):
+        return {"conversation": corpo[:2000] or " "}
+    if tipo == "imagem":
+        return {"imageMessage": {"caption": corpo[:200]}} if corpo else {"conversation": "[Imagem]"}
+    if tipo == "video":
+        return {"videoMessage": {"caption": corpo[:200]}} if corpo else {"conversation": "[Vídeo]"}
+    if tipo == "audio":
+        return {"conversation": "[Áudio]"}
+    if tipo == "figurinha":
+        return {"conversation": "[Figurinha]"}
+    return {"conversation": corpo[:200] or "[Documento]"}
+
+
+def _quoted_evolution_payload(db: Session, chat: WhatsappChat, quoted_wa_message_id: str) -> dict:
     q = (quoted_wa_message_id or "").strip()
     if not q:
         raise HTTPException(status_code=400, detail="Citação inválida.")
     ref = (
         db.query(WhatsappMensagem)
-        .filter(WhatsappMensagem.chat_id == chat_id, WhatsappMensagem.wa_message_id == q)
+        .filter(WhatsappMensagem.chat_id == chat.id, WhatsappMensagem.wa_message_id == q)
         .first()
     )
     if not ref:
@@ -72,8 +110,16 @@ def _quoted_evolution_payload(db: Session, chat_id: int, quoted_wa_message_id: s
             detail="Mensagem citada não encontrada neste chat (use o id da mensagem no WhatsApp, "
             "campo wa_message_id na listagem de mensagens).",
         )
-    pv = ((ref.corpo or "").strip()[:2000] or " ")
-    return {"key": {"id": q}, "message": {"conversation": pv}}
+    remote_jid = _remote_jid_from_wa_id(chat.wa_id)
+    from_me = ref.direcao == "outbound"
+    return {
+        "key": {
+            "id": q,
+            "remoteJid": remote_jid,
+            "fromMe": from_me,
+        },
+        "message": _quoted_message_body(ref),
+    }
 
 
 def _preview_citacao(ref: WhatsappMensagem) -> str | None:
@@ -183,14 +229,14 @@ def _enviar_texto_whatsapp(
     q_prev: str | None = None
     if quoted_wa_message_id and str(quoted_wa_message_id).strip() and evento_sistema is None:
         q_wa = str(quoted_wa_message_id).strip()
-        quoted_payload = _quoted_evolution_payload(db, chat.id, q_wa)
+        quoted_payload = _quoted_evolution_payload(db, chat, q_wa)
         ref = (
             db.query(WhatsappMensagem)
             .filter(WhatsappMensagem.chat_id == chat.id, WhatsappMensagem.wa_message_id == q_wa)
             .first()
         )
         q_prev = _preview_citacao(ref) if ref else None
-    ok, err = evolution_api.evolution_send_text(
+    ok, err, sent_wa_id = evolution_api.evolution_send_text(
         st.evolution_base_url,
         st.evolution_instance_name,
         st.evolution_api_key,
@@ -207,7 +253,7 @@ def _enviar_texto_whatsapp(
         tipo_midia="texto",
         mimetype=None,
         midia_nome_arquivo=None,
-        wa_message_id=None,
+        wa_message_id=sent_wa_id,
         quoted_wa_message_id=q_wa,
         quoted_corpo_preview=q_prev,
         atendente_id=atendente.id if atendente else None,
@@ -462,9 +508,10 @@ def assumir(
     db.commit()
     db.refresh(c)
     st_auto = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
-    if st_auto and bool(getattr(st_auto, "auto_msg_assumido_ativa", True)):
+    if st_auto and bool(getattr(st_auto, "auto_msg_assumido_ativa", True)) and _evolution_configurada(st_auto):
+        raw = (getattr(st_auto, "auto_msg_assumido_texto", "") or "").strip() or DEFAULT_AUTO_MSG_ASSUMIDO
         txt = _render_template(
-            getattr(st_auto, "auto_msg_assumido_texto", "") or "",
+            raw,
             chat=c,
             atendente=atendente,
             st=st_auto,
@@ -472,7 +519,10 @@ def assumir(
             atendente_nome=(atendente.nome or "").strip() or "BOT",
         )
         if txt:
-            _enviar_texto_whatsapp(db, chat=c, texto=txt, atendente=atendente, evento_sistema="auto_assumido")
+            try:
+                _enviar_texto_whatsapp(db, chat=c, texto=txt, atendente=atendente, evento_sistema="auto_assumido")
+            except HTTPException as exc:
+                logger.warning("Auto-msg assumido falhou (chat=%s): %s", c.protocolo, exc.detail)
     c = db.query(WhatsappChat).options(joinedload(WhatsappChat.atendente)).filter(WhatsappChat.id == chat_id).first()
     assert c is not None
     return _chat_read(db, c)
@@ -502,16 +552,20 @@ def encerrar(
     db.commit()
     db.refresh(c)
     st_auto = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
-    if st_auto and bool(getattr(st_auto, "auto_msg_encerrado_ativa", True)):
+    if st_auto and bool(getattr(st_auto, "auto_msg_encerrado_ativa", True)) and _evolution_configurada(st_auto):
+        raw = (getattr(st_auto, "auto_msg_encerrado_texto", "") or "").strip() or DEFAULT_AUTO_MSG_ENCERRADO
         txt = _render_template(
-            getattr(st_auto, "auto_msg_encerrado_texto", "") or "",
+            raw,
             chat=c,
             atendente=atendente,
             st=st_auto,
             atendente_nome="BOT",
         )
         if txt:
-            _enviar_texto_whatsapp(db, chat=c, texto=txt, atendente=atendente, evento_sistema="auto_encerrado")
+            try:
+                _enviar_texto_whatsapp(db, chat=c, texto=txt, atendente=atendente, evento_sistema="auto_encerrado")
+            except HTTPException as exc:
+                logger.warning("Auto-msg encerrado falhou (chat=%s): %s", c.protocolo, exc.detail)
     c = db.query(WhatsappChat).options(joinedload(WhatsappChat.atendente)).filter(WhatsappChat.id == chat_id).first()
     assert c is not None
     return _chat_read(db, c)
@@ -600,7 +654,7 @@ async def enviar_mensagem_midia(
     q_prev: str | None = None
     if quoted_wa_message_id and str(quoted_wa_message_id).strip():
         q_wa = str(quoted_wa_message_id).strip()
-        quoted_payload = _quoted_evolution_payload(db, chat_id, q_wa)
+        quoted_payload = _quoted_evolution_payload(db, c, q_wa)
         ref = (
             db.query(WhatsappMensagem)
             .filter(WhatsappMensagem.chat_id == chat_id, WhatsappMensagem.wa_message_id == q_wa)
@@ -608,7 +662,7 @@ async def enviar_mensagem_midia(
         )
         q_prev = _preview_citacao(ref) if ref else None
 
-    ok, err = evolution_api.evolution_send_media(
+    ok, err, sent_wa_id = evolution_api.evolution_send_media(
         st.evolution_base_url,
         st.evolution_instance_name,
         st.evolution_api_key,
@@ -630,7 +684,7 @@ async def enviar_mensagem_midia(
         tipo_midia=tipo_db,
         mimetype=mime,
         midia_nome_arquivo=nome_guardado,
-        wa_message_id=None,
+        wa_message_id=sent_wa_id,
         quoted_wa_message_id=q_wa,
         quoted_corpo_preview=q_prev,
         atendente_id=atendente.id,
@@ -857,6 +911,27 @@ def transferir(
     else:
         c.estado = "aguardando_atendente"
         c.atendimento_inicio_at = None
+
+    nome_origem = (atendente.nome or "").strip() or "Equipe"
+    if destino:
+        texto_transfer = (
+            f"Chat transferido por {nome_origem} para {destino.nome} (setor {setor.nome})."
+        )
+    else:
+        texto_transfer = f"Chat transferido por {nome_origem} para a fila do setor {setor.nome}."
+    db.add(
+        WhatsappMensagem(
+            chat_id=c.id,
+            direcao="outbound",
+            corpo=f"[ TRANSFERÊNCIA / {nome_origem} ]: {texto_transfer}",
+            tipo_midia="texto",
+            mimetype=None,
+            midia_nome_arquivo=None,
+            wa_message_id=None,
+            atendente_id=atendente.id,
+            evento_sistema="transferencia",
+        )
+    )
     db.commit()
     db.refresh(c)
     c2 = (

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -9,6 +9,10 @@ from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem, WhatsappSet
 from app.services import evolution_api
 from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.evolution_inbound import iter_inbound_whatsapp_messages
+from app.services.whatsapp_auto_messages import (
+    DEFAULT_AUTO_MSG_ESPERA,
+    DEFAULT_AUTO_MSG_FORA_HORARIO,
+)
 from app.services.whatsapp_media_storage import gravar_base64_em_disco
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -88,7 +92,11 @@ def _try_auto_msg_espera(db: Session, st: WhatsappSettings | None, chat: Whatsap
         return
     if not bool(getattr(st, "auto_msg_espera_ativa", True)):
         return
-    txt = _render_template(getattr(st, "auto_msg_espera_texto", "") or "", chat=chat, st=st)
+    txt = _render_template(
+        (getattr(st, "auto_msg_espera_texto", "") or "").strip() or DEFAULT_AUTO_MSG_ESPERA,
+        chat=chat,
+        st=st,
+    )
     if not txt:
         return
     if not txt.startswith("["):
@@ -101,8 +109,9 @@ def _try_auto_msg_espera(db: Session, st: WhatsappSettings | None, chat: Whatsap
     if exist:
         return
     if not st.evolution_base_url or not st.evolution_instance_name or not st.evolution_api_key:
+        logger.warning("Auto-msg espera ignorada: integração Evolution incompleta (wa_id=%s)", chat.wa_id)
         return
-    ok, err = evolution_api.evolution_send_text(
+    ok, err, sent_wa_id = evolution_api.evolution_send_text(
         st.evolution_base_url,
         st.evolution_instance_name,
         st.evolution_api_key,
@@ -120,7 +129,7 @@ def _try_auto_msg_espera(db: Session, st: WhatsappSettings | None, chat: Whatsap
             tipo_midia="texto",
             mimetype=None,
             midia_nome_arquivo=None,
-            wa_message_id=None,
+            wa_message_id=sent_wa_id,
             atendente_id=None,
             evento_sistema="auto_espera",
         )
@@ -258,7 +267,11 @@ def _try_auto_msg_fora_horario(db: Session, st: WhatsappSettings | None, chat: W
         return
     if _esta_no_horario(st):
         return
-    txt = _render_template(getattr(st, "auto_msg_fora_horario_texto", "") or "", chat=chat, st=st)
+    txt = _render_template(
+        (getattr(st, "auto_msg_fora_horario_texto", "") or "").strip() or DEFAULT_AUTO_MSG_FORA_HORARIO,
+        chat=chat,
+        st=st,
+    )
     if not txt:
         return
     if not txt.startswith("["):
@@ -271,8 +284,9 @@ def _try_auto_msg_fora_horario(db: Session, st: WhatsappSettings | None, chat: W
     if exist:
         return
     if not st.evolution_base_url or not st.evolution_instance_name or not st.evolution_api_key:
+        logger.warning("Auto-msg fora do horário ignorada: integração Evolution incompleta (wa_id=%s)", chat.wa_id)
         return
-    ok, err = evolution_api.evolution_send_text(
+    ok, err, sent_wa_id = evolution_api.evolution_send_text(
         st.evolution_base_url,
         st.evolution_instance_name,
         st.evolution_api_key,
@@ -290,7 +304,7 @@ def _try_auto_msg_fora_horario(db: Session, st: WhatsappSettings | None, chat: W
             tipo_midia="texto",
             mimetype=None,
             midia_nome_arquivo=None,
-            wa_message_id=None,
+            wa_message_id=sent_wa_id,
             atendente_id=None,
             evento_sistema="auto_fora_horario",
         )

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -88,6 +88,18 @@ def evolution_connection_state_json(
     return _request_json("GET", url, headers=headers)
 
 
+def _extract_wa_message_id(data: Any) -> str | None:
+    if not isinstance(data, dict):
+        return None
+    key = data.get("key") or data.get("Key")
+    if isinstance(key, dict):
+        mid = key.get("id") or key.get("Id")
+        if mid:
+            s = str(mid).strip()
+            return s or None
+    return None
+
+
 def evolution_send_text(
     base_url: str,
     instance: str,
@@ -96,7 +108,7 @@ def evolution_send_text(
     text: str,
     *,
     quoted: dict[str, Any] | None = None,
-) -> tuple[bool, str | None]:
+) -> tuple[bool, str | None, str | None]:
     base = base_url.rstrip("/")
     path = f"/message/sendText/{instance}"
     url = base + path
@@ -104,17 +116,17 @@ def evolution_send_text(
     body: dict[str, Any] = {"number": number_digits, "text": text}
     if quoted:
         body["quoted"] = quoted
-    code, _data, err = _request_json(
+    code, data, err = _request_json(
         "POST",
         url,
         headers=headers,
         body=body,
     )
     if code in (200, 201):
-        return True, None
+        return True, None, _extract_wa_message_id(data)
     if err:
-        return False, err[:800]
-    return False, f"HTTP {code}"
+        return False, err[:800], None
+    return False, f"HTTP {code}", None
 
 
 def evolution_send_media(
@@ -129,7 +141,7 @@ def evolution_send_media(
     media_base64: str,
     file_name: str,
     quoted: dict[str, Any] | None = None,
-) -> tuple[bool, str | None]:
+) -> tuple[bool, str | None, str | None]:
     """POST /message/sendMedia/{instance} — mediatype típico: image | video | audio | document."""
     base = base_url.rstrip("/")
     url = f"{base}/message/sendMedia/{instance}"
@@ -144,12 +156,12 @@ def evolution_send_media(
     }
     if quoted:
         body["quoted"] = quoted
-    code, _data, err = _request_json("POST", url, headers=headers, body=body, timeout=120)
+    code, data, err = _request_json("POST", url, headers=headers, body=body, timeout=120)
     if code in (200, 201):
-        return True, None
+        return True, None, _extract_wa_message_id(data)
     if err:
-        return False, err[:1200]
-    return False, f"HTTP {code}"
+        return False, err[:1200], None
+    return False, f"HTTP {code}", None
 
 
 def _extrair_base64_resposta(data: Any) -> str | None:

--- a/backend/app/services/evolution_inbound.py
+++ b/backend/app/services/evolution_inbound.py
@@ -69,6 +69,40 @@ _SUBCOM_KEYS = (
 )
 
 
+def _quoted_from_context_info(ctx: dict[str, Any]) -> tuple[str | None, str | None]:
+    sid = ctx.get("stanzaId") or ctx.get("StanzaId")
+    if not sid:
+        return None, None
+    wid = str(sid).strip()
+    if not wid:
+        return None, None
+    preview: str | None = None
+    qm = ctx.get("quotedMessage") or ctx.get("QuotedMessage")
+    if isinstance(qm, dict):
+        preview = _text_from_inner(qm)
+        if not preview:
+            md = _detect_media(qm)
+            if md:
+                kind, _ = md
+                preview = _ROTULO_TIPO.get(kind, "[Mídia]")
+    return wid, preview
+
+
+def quoted_reply_from_envelope(envelope: dict[str, Any], inner: dict[str, Any]) -> tuple[str | None, str | None]:
+    """
+    Extrai citação do payload do webhook.
+
+    A Evolution API (prepareMessage) coloca contextInfo no envelope da mensagem,
+    não dentro de extendedTextMessage — formato diferente do Baileys bruto usado em testes.
+    """
+    ctx = envelope.get("contextInfo") or envelope.get("ContextInfo")
+    if isinstance(ctx, dict):
+        wid, prev = _quoted_from_context_info(ctx)
+        if wid:
+            return wid, prev
+    return quoted_reply_from_inner(inner)
+
+
 def quoted_reply_from_inner(inner: dict[str, Any]) -> tuple[str | None, str | None]:
     """Extrai resposta citada: id da mensagem original (stanzaId) e texto de pré-visualização."""
     for sub_key in _SUBCOM_KEYS:
@@ -76,24 +110,10 @@ def quoted_reply_from_inner(inner: dict[str, Any]) -> tuple[str | None, str | No
         if not isinstance(sub, dict):
             continue
         ctx = sub.get("contextInfo") or sub.get("ContextInfo")
-        if not isinstance(ctx, dict):
-            continue
-        sid = ctx.get("stanzaId") or ctx.get("StanzaId")
-        if not sid:
-            continue
-        wid = str(sid).strip()
-        if not wid:
-            continue
-        preview: str | None = None
-        qm = ctx.get("quotedMessage") or ctx.get("QuotedMessage")
-        if isinstance(qm, dict):
-            preview = _text_from_inner(qm)
-            if not preview:
-                md = _detect_media(qm)
-                if md:
-                    kind, _ = md
-                    preview = _ROTULO_TIPO.get(kind, "[Mídia]")
-        return wid, preview
+        if isinstance(ctx, dict):
+            wid, preview = _quoted_from_context_info(ctx)
+            if wid:
+                return wid, preview
     return None, None
 
 
@@ -168,7 +188,7 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
         if not isinstance(inner, dict):
             continue
 
-        q_wid, q_prev = quoted_reply_from_inner(inner)
+        q_wid, q_prev = quoted_reply_from_envelope(m, inner)
         if q_prev and len(q_prev) > 500:
             q_prev = q_prev[:500]
 

--- a/backend/app/services/whatsapp_auto_messages.py
+++ b/backend/app/services/whatsapp_auto_messages.py
@@ -1,0 +1,17 @@
+"""Textos padrão das mensagens automáticas WhatsApp (espelham o frontend ConfigWhatsapp)."""
+
+DEFAULT_AUTO_MSG_ESPERA = (
+    "Olá, {{nome_cliente}}, Seja Bem-Vindo(a) a {{nome_empresa}}.\n\n"
+    "✅protocolo de atendimento: *{{protocolo}}*\n\n"
+    "Abertura: *{{data_abertura}}*\n"
+)
+DEFAULT_AUTO_MSG_ASSUMIDO = (
+    "Olá, {nome}! Sou o {atendente} atendente responsável pelo seu atendimento. Como posso ajudar?"
+)
+DEFAULT_AUTO_MSG_ENCERRADO = (
+    "Atendimento encerrado. Se precisar de algo mais, é só enviar uma nova mensagem por aqui."
+)
+DEFAULT_AUTO_MSG_FORA_HORARIO = (
+    "Olá, {nome}! No momento estamos fora do horário de atendimento. "
+    "Assim que voltarmos, responderemos por aqui."
+)

--- a/backend/tests/test_evolution_inbound_quotes.py
+++ b/backend/tests/test_evolution_inbound_quotes.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from app.services.evolution_inbound import quoted_reply_from_envelope
+
+
+def test_quoted_reply_envelope_evolution():
+    envelope = {
+        "key": {"remoteJid": "5511999999999@s.whatsapp.net", "fromMe": False, "id": "r1"},
+        "message": {"conversation": "Resposta"},
+        "contextInfo": {
+            "stanzaId": "orig-1",
+            "quotedMessage": {"conversation": "Original"},
+        },
+    }
+    wid, prev = quoted_reply_from_envelope(envelope, envelope["message"])
+    assert wid == "orig-1"
+    assert prev == "Original"
+
+
+def test_quoted_reply_envelope_baileys_aninhado():
+    inner = {
+        "extendedTextMessage": {
+            "text": "Resposta",
+            "contextInfo": {
+                "stanzaId": "orig-2",
+                "quotedMessage": {"conversation": "Legado"},
+            },
+        }
+    }
+    envelope = {"message": inner}
+    wid, prev = quoted_reply_from_envelope(envelope, inner)
+    assert wid == "orig-2"
+    assert prev == "Legado"

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -172,6 +172,38 @@ def test_webhook_guarda_citacao_em_mensagem(client, seed_base, auth_headers):
     assert "original" in (last.get("quoted_corpo_preview") or "").lower()
 
 
+def test_webhook_guarda_citacao_formato_evolution(client, seed_base, auth_headers):
+    """Evolution prepareMessage coloca contextInfo no envelope, não dentro de extendedTextMessage."""
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "cit-ev"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "cit-ev"}
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "key": {
+                "remoteJid": "5511444555666@s.whatsapp.net",
+                "fromMe": False,
+                "id": "reply-msg-ev-1",
+            },
+            "message": {"conversation": "Resposta citando (Evolution)"},
+            "contextInfo": {
+                "stanzaId": "orig-msg-ev-1",
+                "quotedMessage": {"conversation": "Texto original Evolution"},
+            },
+        },
+    }
+    r = client.post("/v1/webhooks/evolution", json=body, headers=h)
+    assert r.status_code == 200
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    rows = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    last = rows[-1]
+    assert last.get("quoted_wa_message_id") == "orig-msg-ev-1"
+    assert "evolution" in (last.get("quoted_corpo_preview") or "").lower()
+
+
 def test_abrir_ticket_vincula(client, seed_base, auth_headers):
     client.patch(
         "/v1/settings/whatsapp",
@@ -191,3 +223,30 @@ def test_abrir_ticket_vincula(client, seed_base, auth_headers):
     )
     assert r.status_code == 200
     assert r.json()["ticket_ids"]
+
+
+def test_transferir_registra_mensagem_interna(client, seed_base, auth_headers):
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "tr-int"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "tr-int"}
+    client.post("/v1/webhooks/evolution", json=_webhook_body(wa_id="5511999445566", msg_id="tr-1"), headers=h)
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/transferir",
+        json={"setor_id": seed_base["setor2"].id, "atendente_id": None},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["estado"] == "aguardando_atendente"
+    assert body["setor_id"] == seed_base["setor2"].id
+
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["admin"]).json()
+    transfer_msgs = [m for m in msgs if m.get("evento_sistema") == "transferencia"]
+    assert len(transfer_msgs) == 1
+    assert "Financeiro" in transfer_msgs[0]["corpo"]

--- a/frontend/src/lib/whatsappChatMeta.ts
+++ b/frontend/src/lib/whatsappChatMeta.ts
@@ -1,0 +1,40 @@
+import type { WhatsappChats } from '../api/client'
+
+type ChatResumo = Pick<
+  WhatsappChats.Chat,
+  'estado' | 'atendente_id' | 'atendente_nome' | 'setor_nome'
+>
+
+export function rotuloEstadoChat(estado: string): string {
+  if (estado === 'em_atendimento') return 'Em atendimento'
+  if (estado === 'aguardando_atendente') return 'Aguardando atendimento'
+  if (estado === 'encerrado') return 'Encerrado'
+  return estado.replace(/_/g, ' ')
+}
+
+export function rotuloResponsavelChat(chat: ChatResumo, usuarioId?: number | null): string {
+  if (chat.estado === 'aguardando_atendente') {
+    return chat.setor_nome ? `Fila • ${chat.setor_nome}` : 'Na fila'
+  }
+  if (chat.estado === 'encerrado') {
+    return chat.atendente_nome ? `Encerrado por ${chat.atendente_nome}` : 'Encerrado'
+  }
+  if (!chat.atendente_id) {
+    return chat.setor_nome ? `Sem responsável • ${chat.setor_nome}` : 'Sem responsável'
+  }
+  if (usuarioId != null && chat.atendente_id === usuarioId) return 'Você'
+  return chat.atendente_nome || `Atendente #${chat.atendente_id}`
+}
+
+export function mensagemTransferenciaSucesso(chat: ChatResumo): string {
+  if (chat.estado === 'aguardando_atendente') {
+    return chat.setor_nome
+      ? `Chat enviado para a fila do setor ${chat.setor_nome}.`
+      : 'Chat enviado para a fila.'
+  }
+  if (chat.atendente_nome) {
+    const setor = chat.setor_nome ? ` (${chat.setor_nome})` : ''
+    return `Chat transferido para ${chat.atendente_nome}${setor}.`
+  }
+  return 'Chat transferido.'
+}

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -7,6 +7,7 @@ import { Button } from '../../components/ui/Button'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
+import { rotuloResponsavelChat } from '../../lib/whatsappChatMeta'
 
 // Componente para cálculo de tempo de espera
 function TempoEspera({ data }: { data?: string | null }) {
@@ -132,6 +133,11 @@ export function WhatsappAtendendo() {
                         </div>
                         <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</h3>
                         <p className="font-mono text-xs text-slate-500">{c.wa_id}</p>
+                        {c.setor_nome && (
+                          <p className="mt-1 text-[10px] font-medium text-slate-500 dark:text-slate-400">
+                            Setor {c.setor_nome}
+                          </p>
+                        )}
                       </div>
                       <div className="h-2 w-2 rounded-full bg-amber-400 shadow-[0_0_8px_rgba(251,191,36,0.5)]" />
                     </div>
@@ -191,6 +197,10 @@ export function WhatsappAtendendo() {
                           {c.cliente_nome || 'Cliente'}
                         </h3>
                         <p className="text-xs text-slate-400 font-mono mt-1">{c.wa_id}</p>
+                        <p className="mt-2 text-[10px] font-medium text-slate-500 dark:text-slate-400">
+                          {rotuloResponsavelChat(c)}
+                          {c.setor_nome ? ` • ${c.setor_nome}` : ''}
+                        </p>
                       </div>
                       
                       <div className="flex items-center justify-end border-t pt-3 dark:border-slate-800">

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -41,6 +41,11 @@ import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { useAuth } from '../../contexts/AuthContext'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
 import { CustomAudioPlayer } from '../../components/CustomAudioPlayer'
+import {
+  mensagemTransferenciaSucesso,
+  rotuloEstadoChat,
+  rotuloResponsavelChat,
+} from '../../lib/whatsappChatMeta'
 
 
 
@@ -377,6 +382,13 @@ export function WhatsappConversa() {
 useEffect(() => {
   if (!modalTransferir) return
 
+  if (chat?.setor_id) {
+    setTransferSetorId(chat.setor_id)
+  } else {
+    setTransferSetorId('')
+  }
+  setTransferAtendenteId('')
+
   whatsappChats
     .setoresParaTransferencia()
     .then((rows) =>
@@ -393,7 +405,7 @@ useEffect(() => {
 
   setAtendentesDestino([])
   setErroAtendentesDestino(null)
-}, [modalTransferir])
+}, [modalTransferir, chat?.id, chat?.setor_id])
 
 //transferencia de setor
 useEffect(() => {
@@ -460,7 +472,7 @@ useEffect(() => {
 
   setTransferindo(true)
   try {
-    await whatsappChats.transferir(chat.id, {
+    const atualizado = await whatsappChats.transferir(chat.id, {
       setor_id,
       atendente_id,
     })
@@ -469,10 +481,17 @@ useEffect(() => {
     setTransferSetorId('')
     setTransferAtendenteId('')
 
-    await carregar()
+    setChat(atualizado)
+    await Promise.all([carregar(), carregarSidebar()])
     void refetchPendenciasResumo()
 
-    toast.showSuccess('Chat transferido.')
+    toast.showSuccess(mensagemTransferenciaSucesso(atualizado))
+
+    const aindaResponsavel =
+      user?.role === 'admin' || atualizado.atendente_id === user?.id
+    if (!aindaResponsavel && atualizado.estado === 'em_atendimento') {
+      navigate('/whatsapp/atendendo')
+    }
   } catch (err) {
     toast.showWarning(
       mensagemFalhaParaToast(err, 'Não foi possível transferir o chat.')
@@ -558,6 +577,8 @@ useEffect(() => {
 
   const isResponsavel = user?.role === 'admin' || (chat?.atendente_id === user?.id)
 
+  const podeTransferir = !encerrado && isResponsavel
+
   const podeEnviar = chat?.estado === 'em_atendimento' && isResponsavel && !encerrado
 
 
@@ -638,6 +659,9 @@ useEffect(() => {
                   <p className="truncate text-[10px] font-mono text-slate-400" title={exibirProtocolo(c.protocolo)}>
                     {exibirProtocolo(c.protocolo)}
                   </p>
+                  <p className="truncate text-[10px] text-slate-500 dark:text-slate-400">
+                    {rotuloResponsavelChat(c, user?.id)}
+                  </p>
 
                 </div>
 
@@ -669,7 +693,7 @@ useEffect(() => {
 
               <h1 className="truncate font-bold text-slate-900 dark:text-white">{chat?.cliente_nome || 'Atendimento'}</h1>
 
-              <div className="flex items-center gap-2 text-[10px]">
+              <div className="flex flex-wrap items-center gap-2 text-[10px]">
 
                 <span className="min-w-0 truncate font-mono font-bold text-cyan-600" title={exibirProtocolo(chat?.protocolo)}>
                   {exibirProtocolo(chat?.protocolo)}
@@ -677,7 +701,26 @@ useEffect(() => {
 
                 <span className="text-slate-300">•</span>
 
-                <span className={`capitalize ${encerrado ? 'text-red-500' : 'text-emerald-500'}`}>{chat?.estado.replace(/_/g, ' ')}</span>
+                <span className={`capitalize ${encerrado ? 'text-red-500' : 'text-emerald-500'}`}>
+                  {chat ? rotuloEstadoChat(chat.estado) : '—'}
+                </span>
+
+                {chat && (
+                  <>
+                    <span className="text-slate-300">•</span>
+                    <span className="truncate text-slate-600 dark:text-slate-300">
+                      Responsável: {rotuloResponsavelChat(chat, user?.id)}
+                    </span>
+                    {chat.setor_nome && (
+                      <>
+                        <span className="hidden sm:inline text-slate-300">•</span>
+                        <span className="hidden sm:inline truncate text-slate-500 dark:text-slate-400">
+                          {chat.setor_nome}
+                        </span>
+                      </>
+                    )}
+                  </>
+                )}
 
               </div>
 
@@ -693,6 +736,7 @@ useEffect(() => {
 
               <>
 
+              {podeTransferir && (
               <Button
   variant="primary"
   className="hidden sm:inline-flex text-xs h-8"
@@ -700,6 +744,7 @@ useEffect(() => {
 >
   Transferir
 </Button>
+              )}
               <Button
                 variant="ghost"
                 className="hidden sm:inline-flex text-xs h-8"
@@ -724,6 +769,13 @@ useEffect(() => {
 
         </header>
 
+        {!encerrado && chat?.estado === 'em_atendimento' && !isResponsavel && (
+          <div className="border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100">
+            Este chat está com <strong>{chat.atendente_nome || 'outro atendente'}</strong>.
+            Você pode acompanhar em modo interno; mensagens ao cliente ficam bloqueadas.
+          </div>
+        )}
+
 
 
         {/* Mensagens (Feed) */}
@@ -744,7 +796,9 @@ useEffect(() => {
 
             const isInbound = m.direcao === 'inbound'
 
-            const isSystem = m.evento_sistema === 'comentario_interno'
+            const isSystem =
+              m.evento_sistema === 'comentario_interno' || m.evento_sistema === 'transferencia'
+            const isTransferencia = m.evento_sistema === 'transferencia'
 
            
 
@@ -767,7 +821,11 @@ useEffect(() => {
 
                 <div className={`max-w-[85%] sm:max-w-[70%] space-y-1 ${isInbound ? 'items-start' : 'items-end'}`}>
 
-                  {isSystem && <span className="text-[9px] font-bold text-amber-600 uppercase px-2">🔒 Interno</span>}
+                  {isSystem && (
+                    <span className="text-[9px] font-bold uppercase px-2 text-amber-600">
+                      {isTransferencia ? '↪ Transferência' : '🔒 Interno'}
+                    </span>
+                  )}
 
                  
 
@@ -985,6 +1043,12 @@ useEffect(() => {
   <div className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-900/50 backdrop-blur-sm">
     <Card className="w-full max-w-lg p-6">
       <h3 className="text-lg font-bold">Transferir Atendimento</h3>
+      {chat && (
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          Responsável atual: <strong>{rotuloResponsavelChat(chat, user?.id)}</strong>
+          {chat.setor_nome ? ` • Setor ${chat.setor_nome}` : ''}
+        </p>
+      )}
 
       <div className="mt-4 space-y-4">
 


### PR DESCRIPTION
## Summary
- Promove `main` para `staging` após merge do PR #226.
- WhatsApp: citações bidirecionais (Evolution `contextInfo`, payload `quoted` completo, `wa_message_id` no envio).
- Mensagens automáticas com textos padrão quando o toggle está ativo; falhas de envio não bloqueiam assumir/encerrar.
- UX do chat: responsável/setor na fila e conversa, banner para observação interna, transferência com mensagem de sistema.

## Test plan
- [ ] Deploy staging concluído (backend + frontend)
- [ ] Cliente cita mensagem no WhatsApp → preview visível no Connect
- [ ] Atendente responde citando no Connect → citação aparece no WhatsApp do cliente
- [ ] Novo chat dispara boas-vindas automáticas (Evolution conectada)
- [ ] Assumir/encerrar envia mensagens automáticas ao cliente
- [ ] Header/sidebar exibem responsável e setor; transferência registra badge interno
