### PR TITLE
release(staging): WhatsApp nome empresa, saudação do atendente e alertas sonoros

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@
 #   VITE_API_URL          — URL HTTPS da API (sem barra final)
 # Opcional:
 #   DEPLOY_SSH_PORT       — porta SSH (padrão 22)
-#   DEPLOY_GIT_REF        — branch no VPS (padrão staging; só usado se o workflow não tiver github.ref_name)
+#   DEPLOY_GIT_REF        — branch no VPS (padrão main; só usado se o workflow não tiver github.ref_name)
 #
 # Opcional: crie um Environment "production" com estes secrets e descomente "environment: production" abaixo.
 
@@ -24,7 +24,7 @@ on:
         default: false
         type: boolean
   push:
-    branches: [staging]
+    branches: [main]
     paths:
       - "backend/**"
       - "frontend/**"
@@ -95,7 +95,7 @@ jobs:
 
       - name: Git pull + Alembic + Docker Compose
         run: |
-          REF="${EVENT_REF:-${DEPLOY_GIT_REF:-staging}}"
+          REF="${EVENT_REF:-${DEPLOY_GIT_REF:-main}}"
           echo "Deploy ref no VPS: ${REF}"
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new -p "${SSH_PORT}" \
             "${DEPLOY_USER}@${DEPLOY_HOST}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@
 #   VITE_API_URL          — URL HTTPS da API (sem barra final)
 # Opcional:
 #   DEPLOY_SSH_PORT       — porta SSH (padrão 22)
-#   DEPLOY_GIT_REF        — branch no VPS (padrão main; só usado se o workflow não tiver github.ref_name)
+#   DEPLOY_GIT_REF        — branch no VPS (padrão staging; só usado se o workflow não tiver github.ref_name)
 #
 # Opcional: crie um Environment "production" com estes secrets e descomente "environment: production" abaixo.
 
@@ -24,7 +24,7 @@ on:
         default: false
         type: boolean
   push:
-    branches: [main]
+    branches: [staging]
     paths:
       - "backend/**"
       - "frontend/**"
@@ -95,7 +95,7 @@ jobs:
 
       - name: Git pull + Alembic + Docker Compose
         run: |
-          REF="${EVENT_REF:-${DEPLOY_GIT_REF:-main}}"
+          REF="${EVENT_REF:-${DEPLOY_GIT_REF:-staging}}"
           echo "Deploy ref no VPS: ${REF}"
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new -p "${SSH_PORT}" \
             "${DEPLOY_USER}@${DEPLOY_HOST}" \

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -34,6 +34,7 @@ from app.services import evolution_api
 from app.services.whatsapp_auto_messages import (
     DEFAULT_AUTO_MSG_ASSUMIDO,
     DEFAULT_AUTO_MSG_ENCERRADO,
+    resolver_nome_empresa_para_template,
 )
 from app.services.whatsapp_media_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
 
@@ -168,6 +169,7 @@ def _sanitizar_nome_ficheiro(name: str | None, fallback: str) -> str:
 def _render_template(
     template: str,
     *,
+    db: Session,
     chat: WhatsappChat,
     atendente: Atendente | None = None,
     st: WhatsappSettings | None = None,
@@ -178,7 +180,7 @@ def _render_template(
         return ""
     nome = (chat.cliente_nome or "").strip() or "Cliente"
     nome_atendente = (atendente_nome or "").strip() or (atendente.nome if atendente else "").strip() or "BOT"
-    nome_empresa = ((getattr(st, "nome_empresa_exibicao", None) or "").strip() if st else "") or "nossa empresa"
+    nome_empresa = resolver_nome_empresa_para_template(db)
     return (
         t.replace("{nome}", nome)
         .replace("{atendente}", nome_atendente)
@@ -206,13 +208,12 @@ def _enviar_texto_whatsapp(
         raise HTTPException(status_code=400, detail="Mensagem vazia")
     # Quando o atendente envia manualmente pelo DX Connect, prefixa o nome no texto
     # para ficar visível no WhatsApp do cliente (padrão: "[ Nome ]: mensagem").
-    # Mensagens automáticas (evento_sistema != None) não recebem este prefixo.
-    if atendente is not None and evento_sistema is None:
+    # A saudação ao assumir o chat usa o mesmo prefixo do atendente (não BOT).
+    if atendente is not None and evento_sistema in (None, "auto_assumido"):
         nome = (atendente.nome or "").strip()
-        if nome:
+        if nome and not texto_eff.startswith("["):
             texto_eff = f"[ {nome} ]: {texto_eff}"
-    # Mensagens automáticas devem deixar claro que são do BOT.
-    if evento_sistema is not None:
+    elif evento_sistema is not None:
         if not texto_eff.startswith("["):
             texto_eff = f"[ BOT ]: {texto_eff}"
     if evento_sistema:
@@ -512,10 +513,11 @@ def assumir(
         raw = (getattr(st_auto, "auto_msg_assumido_texto", "") or "").strip() or DEFAULT_AUTO_MSG_ASSUMIDO
         txt = _render_template(
             raw,
+            db=db,
             chat=c,
             atendente=atendente,
             st=st_auto,
-            # Mensagem é automática (prefixo [ BOT ]), mas o conteúdo pode citar o atendente real.
+            # Conteúdo automático, mas assinatura no WhatsApp como o atendente responsável.
             atendente_nome=(atendente.nome or "").strip() or "BOT",
         )
         if txt:
@@ -556,6 +558,7 @@ def encerrar(
         raw = (getattr(st_auto, "auto_msg_encerrado_texto", "") or "").strip() or DEFAULT_AUTO_MSG_ENCERRADO
         txt = _render_template(
             raw,
+            db=db,
             chat=c,
             atendente=atendente,
             st=st_auto,

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -12,6 +12,7 @@ from app.services.evolution_inbound import iter_inbound_whatsapp_messages
 from app.services.whatsapp_auto_messages import (
     DEFAULT_AUTO_MSG_ESPERA,
     DEFAULT_AUTO_MSG_FORA_HORARIO,
+    resolver_nome_empresa_para_template,
 )
 from app.services.whatsapp_media_storage import gravar_base64_em_disco
 from datetime import date, datetime, timedelta
@@ -57,14 +58,21 @@ def _fmt_data_abertura(dt: datetime | None, tz: ZoneInfo) -> str:
     return local.strftime("%d/%m/%Y %H:%M")
 
 
-def _render_template(template: str, *, chat: WhatsappChat, st: WhatsappSettings | None, atendente_nome: str | None = None) -> str:
+def _render_template(
+    template: str,
+    *,
+    db: Session,
+    chat: WhatsappChat,
+    st: WhatsappSettings | None,
+    atendente_nome: str | None = None,
+) -> str:
     t = (template or "").strip()
     if not t:
         return ""
     nome = (chat.cliente_nome or "").strip() or "Cliente"
     # Para mensagens automáticas (webhook), por padrão assina como BOT
     nome_atendente = (atendente_nome or "").strip() or "BOT"
-    nome_empresa = ((getattr(st, "nome_empresa_exibicao", None) or "").strip() if st else "") or "nossa empresa"
+    nome_empresa = resolver_nome_empresa_para_template(db)
     tzname = (getattr(st, "horario_timezone", None) or "America/Sao_Paulo").strip() or "America/Sao_Paulo"
     try:
         tz = ZoneInfo(tzname)
@@ -94,6 +102,7 @@ def _try_auto_msg_espera(db: Session, st: WhatsappSettings | None, chat: Whatsap
         return
     txt = _render_template(
         (getattr(st, "auto_msg_espera_texto", "") or "").strip() or DEFAULT_AUTO_MSG_ESPERA,
+        db=db,
         chat=chat,
         st=st,
     )
@@ -269,6 +278,7 @@ def _try_auto_msg_fora_horario(db: Session, st: WhatsappSettings | None, chat: W
         return
     txt = _render_template(
         (getattr(st, "auto_msg_fora_horario_texto", "") or "").strip() or DEFAULT_AUTO_MSG_FORA_HORARIO,
+        db=db,
         chat=chat,
         st=st,
     )

--- a/backend/app/services/whatsapp_auto_messages.py
+++ b/backend/app/services/whatsapp_auto_messages.py
@@ -1,5 +1,10 @@
 """Textos padrão das mensagens automáticas WhatsApp (espelham o frontend ConfigWhatsapp)."""
 
+from sqlalchemy.orm import Session
+
+from app.models.empresa_sistema import EmpresaSistema
+from app.models.whatsapp_chat import WhatsappSettings
+
 DEFAULT_AUTO_MSG_ESPERA = (
     "Olá, {{nome_cliente}}, Seja Bem-Vindo(a) a {{nome_empresa}}.\n\n"
     "✅protocolo de atendimento: *{{protocolo}}*\n\n"
@@ -15,3 +20,24 @@ DEFAULT_AUTO_MSG_FORA_HORARIO = (
     "Olá, {nome}! No momento estamos fora do horário de atendimento. "
     "Assim que voltarmos, responderemos por aqui."
 )
+
+
+def resolver_nome_empresa_para_template(db: Session) -> str:
+    """
+    Nome da empresa para templates WhatsApp ({{nome_empresa}}).
+
+    Prioridade: override em whatsapp_settings → nome fantasia → razão social → nome (empresa_sistema).
+    Sempre relê whatsapp_settings do banco (evita objeto stale na sessão do webhook).
+    """
+    st = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
+    if st:
+        override = (getattr(st, "nome_empresa_exibicao", None) or "").strip()
+        if override:
+            return override
+    row = db.query(EmpresaSistema).order_by(EmpresaSistema.id.asc()).first()
+    if row:
+        for attr in ("nome_fantasia", "razao_social", "nome"):
+            val = (getattr(row, attr, None) or "").strip()
+            if val:
+                return val
+    return "nossa empresa"

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -172,6 +172,50 @@ def test_webhook_guarda_citacao_em_mensagem(client, seed_base, auth_headers):
     assert "original" in (last.get("quoted_corpo_preview") or "").lower()
 
 
+def test_webhook_boas_vindas_usa_nome_empresa_exibicao(client, seed_base, auth_headers, monkeypatch):
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "emp-wpp",
+            "nome_empresa_exibicao": "DX Connect",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+
+    sent: list[str] = []
+
+    def fake_send(_base, _inst, _key, number_digits, text, **_kw):
+        sent.append(text)
+        return True, None, "out-welcome-1"
+
+    monkeypatch.setattr("app.api.whatsapp_webhook.evolution_api.evolution_send_text", fake_send)
+
+    h = {"X-Dx-Webhook-Secret": "emp-wpp"}
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {
+                        "remoteJid": "5511777888999@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": "welcome-emp-1",
+                    },
+                    "message": {"conversation": "Oi"},
+                }
+            ]
+        },
+    }
+    r = client.post("/v1/webhooks/evolution", json=body, headers=h)
+    assert r.status_code == 200
+    assert sent, "deveria enviar boas-vindas"
+    assert "DX Connect" in sent[0]
+    assert "nossa empresa" not in sent[0]
+
+
 def test_webhook_guarda_citacao_formato_evolution(client, seed_base, auth_headers):
     """Evolution prepareMessage coloca contextInfo no envelope, não dentro de extendedTextMessage."""
     client.patch(

--- a/backend/tests/test_whatsapp_nome_empresa_template.py
+++ b/backend/tests/test_whatsapp_nome_empresa_template.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from app.models.empresa_sistema import EmpresaSistema
+from app.services.whatsapp_auto_messages import resolver_nome_empresa_para_template
+
+
+def test_nome_empresa_usa_fantasia_da_empresa_sistema(db_session):
+    db_session.add(
+        EmpresaSistema(
+            cnpj="63.420.877/0001-51",
+            razao_social="DUPLEX SISTEMAS E AUTOMACAO LTDA",
+            nome_fantasia="DUPLEX SOFT",
+        )
+    )
+    db_session.commit()
+    assert resolver_nome_empresa_para_template(db_session) == "DUPLEX SOFT"
+
+
+def test_nome_empresa_prioriza_override_whatsapp(db_session):
+    from app.models.whatsapp_chat import WhatsappSettings
+
+    db_session.add(EmpresaSistema(nome_fantasia="DUPLEX SOFT"))
+    db_session.add(WhatsappSettings(nome_empresa_exibicao="DX Connect"))
+    db_session.commit()
+    assert resolver_nome_empresa_para_template(db_session) == "DX Connect"
+
+
+def test_nome_empresa_cai_para_razao_social_sem_fantasia(db_session):
+    db_session.add(EmpresaSistema(razao_social="Razão Teste Ltda", nome_fantasia=None))
+    db_session.commit()
+    assert resolver_nome_empresa_para_template(db_session) == "Razão Teste Ltda"

--- a/deploy/github-actions.md
+++ b/deploy/github-actions.md
@@ -6,9 +6,15 @@ O workflow [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml) faz
 2. **`rsync`** da pasta `frontend/dist/` para o caminho no VPS (`DEPLOY_FRONTEND_DIST`).
 3. **SSH** no servidor: `git pull`, `alembic upgrade head`, `docker compose -f docker-compose.prod.yml up -d --build`.
 
-Disparo automático em **push** para **`staging`** quando mudam `backend/`, `frontend/`, `docker-compose.prod.yml` ou o próprio workflow. A branch **`main`** não dispara deploy (integração/testes); use merge ou push em **`staging`** para produção. Também pode rodar manualmente em **Actions → Deploy → Run workflow**.
+Disparo automático em **push** para **`main`** quando mudam `backend/`, `frontend/`, `docker-compose.prod.yml` ou o próprio workflow. Após merge de um PR em **`main`**, o deploy roda sozinho (se os paths acima mudaram). Também pode rodar manualmente em **Actions → Deploy → Run workflow**.
 
-**Importante:** não defina `DEPLOY_GIT_REF=main` nos secrets se o ambiente de produção simulada segue a branch **`staging`** — isso fazia o frontend atualizar e o backend continuar na `main` (rotas novas como `/v1/settings/empresa-sistema` respondiam 404).
+### Por que não usar mais a branch `staging` no GitHub?
+
+Antes o fluxo era merge em `main` → PR `main → staging` → push em `staging` → deploy. Cada push em `staging` fazia o GitHub exibir o banner amarelo **“staging had recent pushes — Compare & pull request”** na aba Pull requests. Isso é comportamento nativo do GitHub (sugere abrir PR a partir da branch que recebeu push); **não há como desligar**. O botão apontava para `staging → main`, direção oposta ao release.
+
+Com deploy na **`main`**, esse passo extra e o banner deixam de ser necessários. A branch `staging` no remoto pode ser apagada quando quiser (opcional); no VPS o workflow faz `git checkout main` e `git reset --hard origin/main`.
+
+**Importante:** não defina `DEPLOY_GIT_REF` com uma branch diferente da que disparou o workflow — isso fazia o frontend atualizar e o backend continuar num commit antigo (rotas novas respondiam 404).
 
 ## Secrets no GitHub
 
@@ -93,5 +99,5 @@ Em cada deploy o workflow executa `alembic upgrade head` antes do `up --build`. 
 - **`rsync` falha**: permissões em `DEPLOY_FRONTEND_DIST` e caminho absoluto correto.
 - **`docker: permission denied`**: usuário no grupo `docker` ou reiniciar sessão SSH após `usermod`.
 - **Build do frontend errado**: `VITE_API_URL` nos secrets deve ser a URL **pública** que o browser usa para chamar a API.
-- **404 em `/v1/settings/*` ou `/v1/tenant/*` com frontend novo**: o SPA foi atualizado mas o **container da API** ainda está na `main` antiga. Remova o secret `DEPLOY_GIT_REF=main` (deixe o workflow usar a branch do push, ex. `staging`). No VPS: `bash deploy/scripts/redeploy-staging-backend.sh`. Confirme: `curl -s https://SUA-API/health` deve incluir `"capabilities":{"settings_empresa_sistema":true,...}`.
+- **404 em `/v1/settings/*` ou `/v1/tenant/*` com frontend novo**: o SPA foi atualizado mas o **container da API** ainda está num commit antigo. Remova qualquer secret `DEPLOY_GIT_REF` que aponte para outra branch. No VPS: `bash deploy/scripts/redeploy-staging-backend.sh` (aceita branch como 2º argumento, padrão `staging`; use `main` se o clone já seguir `main`). Confirme: `curl -s https://SUA-API/health` deve incluir `"capabilities":{"settings_empresa_sistema":true,...}`.
 - **Deploy SSH “passa” mas `/health` continua com `git_sha` antigo**: o `docker compose run` no script remoto (`bash -s` + heredoc) pode **consumir o stdin** e impedir o restart do backend. O workflow usa `run --rm -T ... < /dev/null` para evitar isso.

--- a/deploy/github-actions.md
+++ b/deploy/github-actions.md
@@ -6,15 +6,13 @@ O workflow [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml) faz
 2. **`rsync`** da pasta `frontend/dist/` para o caminho no VPS (`DEPLOY_FRONTEND_DIST`).
 3. **SSH** no servidor: `git pull`, `alembic upgrade head`, `docker compose -f docker-compose.prod.yml up -d --build`.
 
-Disparo automático em **push** para **`main`** quando mudam `backend/`, `frontend/`, `docker-compose.prod.yml` ou o próprio workflow. Após merge de um PR em **`main`**, o deploy roda sozinho (se os paths acima mudaram). Também pode rodar manualmente em **Actions → Deploy → Run workflow**.
+Disparo automático em **push** para **`staging`** quando mudam `backend/`, `frontend/`, `docker-compose.prod.yml` ou o próprio workflow. A branch **`main`** não dispara deploy (último estágio de testes/integração); após validar em `main`, abra PR **`main → staging`**, merge e o deploy roda no VPS. Também pode rodar manualmente em **Actions → Deploy → Run workflow**.
 
-### Por que não usar mais a branch `staging` no GitHub?
+**Importante:** não defina `DEPLOY_GIT_REF=main` nos secrets se o ambiente de produção segue a branch **`staging`** — isso fazia o frontend atualizar e o backend continuar na `main` (rotas novas como `/v1/settings/empresa-sistema` respondiam 404).
 
-Antes o fluxo era merge em `main` → PR `main → staging` → push em `staging` → deploy. Cada push em `staging` fazia o GitHub exibir o banner amarelo **“staging had recent pushes — Compare & pull request”** na aba Pull requests. Isso é comportamento nativo do GitHub (sugere abrir PR a partir da branch que recebeu push); **não há como desligar**. O botão apontava para `staging → main`, direção oposta ao release.
+### Banner “staging had recent pushes” na aba Pull requests
 
-Com deploy na **`main`**, esse passo extra e o banner deixam de ser necessários. A branch `staging` no remoto pode ser apagada quando quiser (opcional); no VPS o workflow faz `git checkout main` e `git reset --hard origin/main`.
-
-**Importante:** não defina `DEPLOY_GIT_REF` com uma branch diferente da que disparou o workflow — isso fazia o frontend atualizar e o backend continuar num commit antigo (rotas novas respondiam 404).
+Depois de mergear um release **`main → staging`**, o GitHub exibe um aviso amarelo sugerindo **Compare & pull request**. Isso é **comportamento nativo** (a branch `staging` acabou de receber push) e **não indica erro**. **Ignore o botão** — ele abriria PR na direção **`staging → main`**, oposta ao fluxo correto. Não há configuração no GitHub para desligar esse aviso enquanto o deploy continuar em push para `staging`.
 
 ## Secrets no GitHub
 
@@ -99,5 +97,5 @@ Em cada deploy o workflow executa `alembic upgrade head` antes do `up --build`. 
 - **`rsync` falha**: permissões em `DEPLOY_FRONTEND_DIST` e caminho absoluto correto.
 - **`docker: permission denied`**: usuário no grupo `docker` ou reiniciar sessão SSH após `usermod`.
 - **Build do frontend errado**: `VITE_API_URL` nos secrets deve ser a URL **pública** que o browser usa para chamar a API.
-- **404 em `/v1/settings/*` ou `/v1/tenant/*` com frontend novo**: o SPA foi atualizado mas o **container da API** ainda está num commit antigo. Remova qualquer secret `DEPLOY_GIT_REF` que aponte para outra branch. No VPS: `bash deploy/scripts/redeploy-staging-backend.sh` (aceita branch como 2º argumento, padrão `staging`; use `main` se o clone já seguir `main`). Confirme: `curl -s https://SUA-API/health` deve incluir `"capabilities":{"settings_empresa_sistema":true,...}`.
+- **404 em `/v1/settings/*` ou `/v1/tenant/*` com frontend novo**: o SPA foi atualizado mas o **container da API** ainda está na `main` antiga. Remova o secret `DEPLOY_GIT_REF=main` (deixe o workflow usar a branch do push, ex. `staging`). No VPS: `bash deploy/scripts/redeploy-staging-backend.sh`. Confirme: `curl -s https://SUA-API/health` deve incluir `"capabilities":{"settings_empresa_sistema":true,...}`.
 - **Deploy SSH “passa” mas `/health` continua com `git_sha` antigo**: o `docker compose run` no script remoto (`bash -s` + heredoc) pode **consumir o stdin** e impedir o restart do backend. O workflow usa `run --rm -T ... < /dev/null` para evitar isso.

--- a/frontend/public/sons/LEIA-ME.txt
+++ b/frontend/public/sons/LEIA-ME.txt
@@ -1,2 +1,15 @@
-Coloque o arquivo "alerta.mp3" nesta pasta para personalizar o som de alerta dos chamados abertos na fila.
-O sistema tentará carregar "/sons/alerta.mp3" e, se o arquivo não existir ou se a reprodução automática for bloqueada pelo navegador, haverá um fallback automático para o beep sintetizado original.
+Sons de alerta do DX Connect (pasta public/sons).
+
+Cada evento usa um arquivo distinto para não se misturar na reprodução:
+
+  alerta.mp3           — ticket novo na fila (sem responsável)
+  ticket-mensagem.mp3  — nova mensagem em ticket já atribuído
+                         (fallback: notification.mp3, se existir)
+  wpp-fila.mp3         — cliente aguardando na fila WhatsApp (loop enquanto houver fila)
+  wpp-mensagem.mp3     — nova mensagem do cliente em chat WhatsApp em atendimento
+
+Se um arquivo não existir ou o navegador bloquear autoplay, o sistema usa um beep
+sintetizado diferente por tipo de alerta (frequências distintas).
+
+Alertas pontuais são enfileirados: se vários eventos ocorrerem juntos, tocam em sequência
+com pequena pausa, sem sobrepor um ao outro.

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -1,12 +1,23 @@
 import { useEffect, useState } from 'react'
 import { notificacoes, type Notificacoes } from '../api/client'
 
+const LS_KEY_LAST_SEM_RESP = 'dxconnect.notificacoes.last_sem_responsavel'
 const LS_KEY_LAST_NAO_LIDAS = 'dxconnect.notificacoes.last_nao_lidas'
 const LS_KEY_LAST_WPP_FILA = 'dxconnect.notificacoes.last_wpp_fila'
 const LS_KEY_LAST_WPP_RESP = 'dxconnect.notificacoes.last_wpp_resp'
-const POLL_MS = 30_000
-const SOUND_NOTIFICATION = '/sons/notification.mp3'
-const SOUND_OPEN_TICKET_ALERT = '/sons/alerta.mp3'
+const POLL_MS = 10_000
+
+/** Tickets na fila sem responsável */
+const SOUND_TICKET_FILA = '/sons/alerta.mp3'
+/** Nova mensagem em ticket já atribuído */
+const SOUND_TICKET_MENSAGEM = '/sons/ticket-mensagem.mp3'
+const SOUND_TICKET_MENSAGEM_FALLBACK = '/sons/notification.mp3'
+/** Cliente aguardando na fila WhatsApp (alerta contínuo) */
+const SOUND_WPP_FILA = '/sons/wpp-fila.mp3'
+/** Nova mensagem do cliente em chat WhatsApp em atendimento */
+const SOUND_WPP_MENSAGEM = '/sons/wpp-mensagem.mp3'
+
+type AlertKind = 'ticket_fila' | 'ticket_mensagem' | 'wpp_fila_pulse' | 'wpp_mensagem'
 
 type ListenerFila = (state: { count: number }) => void
 type ListenerResumo = (state: Notificacoes.Resumo) => void
@@ -21,13 +32,20 @@ let currentResumo: Notificacoes.Resumo = {
   wpp_respostas_count: 0,
   total_pendencias: 0,
 }
+let prevSemResponsavel: number | null = null
 let prevNaoLidas: number | null = null
 let prevWppResp: number | null = null
 let prevWppFila: number | null = null
 const listenersFila = new Set<ListenerFila>()
 const listenersResumo = new Set<ListenerResumo>()
 
-let wppBeepInterval: number | null = null
+let wppFilaLoopInterval: number | null = null
+let wppFilaLoopAudio: HTMLAudioElement | null = null
+
+const audioByKey = new Map<string, HTMLAudioElement>()
+const alertQueue: AlertKind[] = []
+let drainingAlerts = false
+let oneShotPlaying = false
 
 function getStoredNumber(key: string): number | null {
   try {
@@ -48,35 +66,34 @@ function setStoredNumber(key: string, n: number) {
   }
 }
 
-const audioBySrc = new Map<string, HTMLAudioElement>()
+function audioKey(kind: AlertKind | 'wpp_fila_loop', src: string) {
+  return `${kind}:${src}`
+}
 
-function playAudio(src: string, volume = 0.45) {
-  try {
-    let audio = audioBySrc.get(src)
-    if (!audio) {
-      audio = new Audio(src)
-      audio.preload = 'auto'
-      audioBySrc.set(src, audio)
-    }
-    audio.currentTime = 0
-    audio.volume = volume
-    audio.play().catch(() => {
-      playSynthBeep()
-    })
-  } catch {
-    playSynthBeep()
+function getAudioElement(key: string, src: string): HTMLAudioElement {
+  let audio = audioByKey.get(key)
+  if (!audio) {
+    audio = new Audio(src)
+    audio.preload = 'auto'
+    audioByKey.set(key, audio)
+  }
+  return audio
+}
+
+function srcForKind(kind: AlertKind): string {
+  switch (kind) {
+    case 'ticket_fila':
+      return SOUND_TICKET_FILA
+    case 'ticket_mensagem':
+      return SOUND_TICKET_MENSAGEM
+    case 'wpp_fila_pulse':
+      return SOUND_WPP_FILA
+    case 'wpp_mensagem':
+      return SOUND_WPP_MENSAGEM
   }
 }
 
-function playSystemNotification() {
-  playAudio(SOUND_NOTIFICATION, 0.42)
-}
-
-function playOpenTicketAlert() {
-  playAudio(SOUND_OPEN_TICKET_ALERT, 0.45)
-}
-
-function playSynthBeep() {
+function playSynthPattern(notes: Array<{ freq: number; ms: number; gap?: number }>) {
   try {
     const Ctx = window.AudioContext || (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
     if (!Ctx) return
@@ -85,46 +102,149 @@ function playSynthBeep() {
     g.gain.value = 0.09
     g.connect(ctx.destination)
 
-    const o1 = ctx.createOscillator()
-    o1.type = 'sine'
-    o1.frequency.value = 880
-    o1.connect(g)
+    let t = ctx.currentTime
+    const oscillators: OscillatorNode[] = []
+    for (const note of notes) {
+      const o = ctx.createOscillator()
+      o.type = 'sine'
+      o.frequency.value = note.freq
+      o.connect(g)
+      o.start(t)
+      o.stop(t + note.ms / 1000)
+      oscillators.push(o)
+      t += note.ms / 1000 + (note.gap ?? 0.05)
+    }
 
-    const o2 = ctx.createOscillator()
-    o2.type = 'sine'
-    o2.frequency.value = 660
-    o2.connect(g)
-
-    o1.start()
-    setTimeout(() => {
-      o2.start()
-    }, 140)
-
-    setTimeout(() => {
-      o1.stop()
-      o2.stop()
+    window.setTimeout(() => {
       ctx.close().catch(() => {})
-    }, 380)
+    }, Math.ceil((t - ctx.currentTime) * 1000) + 40)
   } catch {
     // ignore
   }
 }
 
-function stopWppContinuousBeep() {
-  if (wppBeepInterval != null) {
-    window.clearInterval(wppBeepInterval)
-    wppBeepInterval = null
+function synthForKind(kind: AlertKind) {
+  switch (kind) {
+    case 'ticket_fila':
+      playSynthPattern([
+        { freq: 520, ms: 180 },
+        { freq: 660, ms: 220 },
+      ])
+      break
+    case 'ticket_mensagem':
+      playSynthPattern([{ freq: 740, ms: 300 }])
+      break
+    case 'wpp_fila_pulse':
+      playSynthPattern([
+        { freq: 980, ms: 110, gap: 0.04 },
+        { freq: 880, ms: 110, gap: 0.04 },
+        { freq: 980, ms: 130 },
+      ])
+      break
+    case 'wpp_mensagem':
+      playSynthPattern([
+        { freq: 620, ms: 160 },
+        { freq: 780, ms: 200 },
+      ])
+      break
   }
 }
 
-function ensureWppContinuousBeep() {
-  if (wppBeepInterval != null) return
-  // Beep curto e contínuo até a fila de WhatsApp zerar.
-  wppBeepInterval = window.setInterval(() => {
-    playSystemNotification()
-  }, 4500)
-  // dispara um logo no início
-  playSystemNotification()
+function playSrcOnce(src: string, key: string, volume: number): Promise<void> {
+  return new Promise((resolve) => {
+    const audio = getAudioElement(key, src)
+    let settled = false
+    const finish = () => {
+      if (settled) return
+      settled = true
+      audio.removeEventListener('ended', onEnded)
+      audio.removeEventListener('error', onError)
+      resolve()
+    }
+    const onEnded = () => finish()
+    const onError = () => {
+      if (key.startsWith('ticket_mensagem:') && src === SOUND_TICKET_MENSAGEM) {
+        void playSrcOnce(SOUND_TICKET_MENSAGEM_FALLBACK, `${key}:fallback`, volume).then(finish)
+        return
+      }
+      const kind = key.split(':')[0] as AlertKind
+      synthForKind(kind)
+      finish()
+    }
+
+    audio.addEventListener('ended', onEnded)
+    audio.addEventListener('error', onError, { once: true })
+    audio.pause()
+    audio.currentTime = 0
+    audio.volume = volume
+    audio.play().catch(onError)
+  })
+}
+
+async function playAlertKind(kind: AlertKind) {
+  oneShotPlaying = true
+  try {
+    await playSrcOnce(srcForKind(kind), audioKey(kind, srcForKind(kind)), 0.44)
+  } finally {
+    oneShotPlaying = false
+  }
+}
+
+function enqueueAlert(kind: AlertKind) {
+  alertQueue.push(kind)
+  void drainAlertQueue()
+}
+
+async function drainAlertQueue() {
+  if (drainingAlerts) return
+  drainingAlerts = true
+  while (alertQueue.length > 0) {
+    const kind = alertQueue.shift()
+    if (!kind) continue
+    await playAlertKind(kind)
+    await new Promise((r) => window.setTimeout(r, 180))
+  }
+  drainingAlerts = false
+}
+
+function playWppFilaLoopPulse() {
+  if (oneShotPlaying) return
+
+  const src = SOUND_WPP_FILA
+  if (!wppFilaLoopAudio) {
+    wppFilaLoopAudio = getAudioElement(audioKey('wpp_fila_loop', src), src)
+  }
+  const audio = wppFilaLoopAudio
+  audio.pause()
+  audio.currentTime = 0
+  audio.volume = 0.38
+  audio.play().catch(() => {
+    if (!oneShotPlaying) synthForKind('wpp_fila_pulse')
+  })
+}
+
+function stopWppFilaLoop() {
+  if (wppFilaLoopInterval != null) {
+    window.clearInterval(wppFilaLoopInterval)
+    wppFilaLoopInterval = null
+  }
+  wppFilaLoopAudio?.pause()
+}
+
+function ensureWppFilaLoop() {
+  if (wppFilaLoopInterval != null) return
+  playWppFilaLoopPulse()
+  wppFilaLoopInterval = window.setInterval(() => {
+    playWppFilaLoopPulse()
+  }, 5200)
+}
+
+function syncWppFilaBeep(wppFilaCount: number) {
+  if (wppFilaCount > 0) {
+    ensureWppFilaLoop()
+  } else {
+    stopWppFilaLoop()
+  }
 }
 
 async function trySetAppBadge(count: number) {
@@ -140,6 +260,17 @@ async function trySetAppBadge(count: number) {
   }
 }
 
+function persistPrevCounters(r: Notificacoes.Resumo) {
+  prevSemResponsavel = r.sem_responsavel_count
+  prevNaoLidas = r.nao_lidas_count
+  prevWppResp = r.wpp_respostas_count
+  prevWppFila = r.wpp_fila_count
+  setStoredNumber(LS_KEY_LAST_SEM_RESP, r.sem_responsavel_count)
+  setStoredNumber(LS_KEY_LAST_NAO_LIDAS, r.nao_lidas_count)
+  setStoredNumber(LS_KEY_LAST_WPP_FILA, r.wpp_fila_count)
+  setStoredNumber(LS_KEY_LAST_WPP_RESP, r.wpp_respostas_count)
+}
+
 function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean) {
   currentResumo = r
   const sem = r.sem_responsavel_count
@@ -147,42 +278,32 @@ function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean) {
   for (const l of listenersFila) l({ count: sem })
   for (const l of listenersResumo) l(r)
 
+  syncWppFilaBeep(r.wpp_fila_count)
+
   if (atualizarSom) {
+    const prevSem = prevSemResponsavel
     const prevNao = prevNaoLidas
     const prevWR = prevWppResp
     const prevWppFilaValue = prevWppFila
 
-    prevNaoLidas = r.nao_lidas_count
-    prevWppResp = r.wpp_respostas_count
-    prevWppFila = r.wpp_fila_count
-
-    setStoredNumber(LS_KEY_LAST_NAO_LIDAS, r.nao_lidas_count)
-    setStoredNumber(LS_KEY_LAST_WPP_FILA, r.wpp_fila_count)
-    setStoredNumber(LS_KEY_LAST_WPP_RESP, r.wpp_respostas_count)
-
-    // Som: chats na fila de WhatsApp => 1 beep quando a fila aumentar.
-    const wppFilaIncreased = prevWppFilaValue != null ? r.wpp_fila_count > prevWppFilaValue : false
-    if (wppFilaIncreased) {
-      playOpenTicketAlert()
+    if (prevSem != null && r.sem_responsavel_count > prevSem) {
+      enqueueAlert('ticket_fila')
     }
 
-    // Som padrao do sistema: novas mensagens/novidades em tickets ja atribuidos.
+    if (prevWppFilaValue != null && r.wpp_fila_count > prevWppFilaValue) {
+      enqueueAlert('wpp_fila_pulse')
+    }
+
     if (prevNao != null && r.nao_lidas_count > prevNao) {
-      playSystemNotification()
+      enqueueAlert('ticket_mensagem')
     }
 
-    // Som: chats na fila => beep contínuo enquanto houver chats na fila.
-    if (r.wpp_fila_count > 0) {
-      ensureWppContinuousBeep()
-    } else {
-      stopWppContinuousBeep()
-    }
-
-    // Resposta em chat do atendente => 1 beep quando aumentar.
     if (prevWR != null && r.wpp_respostas_count > prevWR) {
-      playSystemNotification()
+      enqueueAlert('wpp_mensagem')
     }
   }
+
+  persistPrevCounters(r)
 
   const total = r.total_pendencias
   const base = (typeof document !== 'undefined' ? document.title : 'DX Connect').replace(/^\(\d+\)\s+/, '')
@@ -205,13 +326,13 @@ async function poll() {
   }
 }
 
-/** Atualiza contadores na UI (ex.: após marcar ticket como visto). Não dispara som de fila. */
-export async function refetchPendenciasResumo() {
+/** Atualiza contadores na UI. `atualizarSom=false` evita beeps pontuais, mas sincroniza o loop da fila WPP. */
+export async function refetchPendenciasResumo(atualizarSom = false) {
   if (inFlight) return
   inFlight = true
   try {
     const r = await notificacoes.resumo()
-    applyResumo(r, false)
+    applyResumo(r, atualizarSom)
   } catch {
     // ignore
   } finally {
@@ -219,17 +340,38 @@ export async function refetchPendenciasResumo() {
   }
 }
 
+function preloadSounds() {
+  const sources = [
+    SOUND_TICKET_FILA,
+    SOUND_TICKET_MENSAGEM,
+    SOUND_TICKET_MENSAGEM_FALLBACK,
+    SOUND_WPP_FILA,
+    SOUND_WPP_MENSAGEM,
+  ]
+  for (const src of sources) {
+    getAudioElement(`preload:${src}`, src)
+  }
+}
+
 function ensureStarted() {
   if (started) return
   started = true
+  prevSemResponsavel = getStoredNumber(LS_KEY_LAST_SEM_RESP)
   prevNaoLidas = getStoredNumber(LS_KEY_LAST_NAO_LIDAS)
-  // Carregamos o último valor conhecido da fila de WPP para detectar aumentos originados
-  // por chats (para tocar `alerta.mp3` apenas nesses casos).
   prevWppFila = getStoredNumber(LS_KEY_LAST_WPP_FILA)
   prevWppResp = getStoredNumber(LS_KEY_LAST_WPP_RESP)
 
+  preloadSounds()
+
   void poll()
   window.setInterval(() => void poll(), POLL_MS)
+
+  const onFocusOrVisible = () => {
+    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return
+    void poll()
+  }
+  window.addEventListener('focus', onFocusOrVisible)
+  document.addEventListener('visibilitychange', onFocusOrVisible)
 }
 
 export function usePendenciasResumo(enabled: boolean): Notificacoes.Resumo {

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { QRCodeSVG } from 'qrcode.react'
-import { whatsappSettings } from '../api/client'
+import { systemSettings, whatsappSettings } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { PageContainer } from '../components/ui/PageContainer'
 import { Button } from '../components/ui/Button'
@@ -63,6 +63,19 @@ function rotuloEstadoConexao(estadoRaw: string | null): {
   if (s === 'connecting' || s === 'qr' || s === 'qrcode') return { label: 'Aguardando pareamento', tone: 'warn' }
   if (s === 'close' || s === 'closed' || s === 'disconnected') return { label: 'Desconectado', tone: 'warn' }
   return { label: `Em processamento (${s})`, tone: 'warn' }
+}
+
+function nomeEmpresaSistemaPadrao(emp: {
+  nome_fantasia?: string | null
+  razao_social?: string | null
+  nome?: string | null
+} | null | undefined): string {
+  if (!emp) return ''
+  return (
+    (emp.nome_fantasia ?? '').trim() ||
+    (emp.razao_social ?? '').trim() ||
+    (emp.nome ?? '').trim()
+  )
 }
 
 const DEFAULT_MSG_ESPERA =
@@ -134,7 +147,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
   const [msgEncerradoTexto, setMsgEncerradoTexto] = useState(DEFAULT_MSG_ENCERRADO)
   const [msgForaHorarioAtiva, setMsgForaHorarioAtiva] = useState(true)
   const [msgForaHorarioTexto, setMsgForaHorarioTexto] = useState(DEFAULT_MSG_FORA_HORARIO)
-  const [nomeEmpresaExibicao, setNomeEmpresaExibicao] = useState('DX Connect')
+  const [nomeEmpresaExibicao, setNomeEmpresaExibicao] = useState('')
   const [horarioTimezone, setHorarioTimezone] = useState<string>('America/Sao_Paulo')
   const [usarFeriadosNacionais, setUsarFeriadosNacionais] = useState(false)
   const [horarioSemana, setHorarioSemana] = useState<HorarioSemana>(horarioSemanaPadrao())
@@ -143,7 +156,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
   const carregar = useCallback(async () => {
     setLoading(true)
     try {
-      const r = await whatsappSettings.get()
+      const [r, emp] = await Promise.all([whatsappSettings.get(), systemSettings.getEmpresaSistema()])
       setFlags({
         evolution_embutida_disponivel: Boolean(r.evolution_embutida_disponivel),
       })
@@ -158,9 +171,10 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
         (r.auto_msg_fora_horario_texto ?? DEFAULT_MSG_FORA_HORARIO).trim() || DEFAULT_MSG_FORA_HORARIO,
       )
       setHorarioTimezone((r.horario_timezone ?? 'America/Sao_Paulo').trim() || 'America/Sao_Paulo')
-      setNomeEmpresaExibicao((String((r as any).nome_empresa_exibicao ?? 'DX Connect')).trim() || 'DX Connect')
-      setUsarFeriadosNacionais(Boolean((r as any).usar_feriados_nacionais))
-      const hs = (r as any).horario_semana as Record<string, any> | null | undefined
+      const identidadeSalva = (r.nome_empresa_exibicao ?? '').trim()
+      setNomeEmpresaExibicao(identidadeSalva || nomeEmpresaSistemaPadrao(emp))
+      setUsarFeriadosNacionais(Boolean(r.usar_feriados_nacionais))
+      const hs = r.horario_semana as Record<string, { ativo?: boolean; inicio?: string; fim?: string }> | null | undefined
       if (hs && typeof hs === 'object') {
         const base = horarioSemanaPadrao()
         for (const d of DIAS) {
@@ -386,8 +400,13 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
             <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 dark:border-slate-700/80 dark:bg-slate-800/20 dark:text-slate-200">
               <p className="font-medium">Como funciona</p>
               <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
-                As mensagens abaixo são enviadas automaticamente em eventos do chat. Variáveis disponíveis: <span className="font-mono">{'{nome}'}</span>,{' '}
-                <span className="font-mono">{'{atendente}'}</span>, <span className="font-mono">{'{protocolo}'}</span>,{' '}
+                As mensagens abaixo são enviadas automaticamente em eventos do chat. Variáveis:{' '}
+                <span className="font-mono">{'{{nome_cliente}}'}</span>,{' '}
+                <span className="font-mono">{'{{nome_empresa}}'}</span>,{' '}
+                <span className="font-mono">{'{{protocolo}}'}</span>,{' '}
+                <span className="font-mono">{'{{data_abertura}}'}</span>,{' '}
+                <span className="font-mono">{'{nome}'}</span>,{' '}
+                <span className="font-mono">{'{atendente}'}</span>,{' '}
                 <span className="font-mono">{'{telefone}'}</span>.
               </p>
             </div>
@@ -395,13 +414,14 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
             <div className="rounded-lg border border-slate-200 bg-white p-4 dark:border-slate-700/80 dark:bg-slate-900/30">
               <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">Identidade</p>
               <p className="mt-1 text-xs text-slate-600 dark:text-slate-400">
-                Usado em templates como <span className="font-mono">{'{{nome_empresa}}'}</span>.
+                Usado em templates como <span className="font-mono">{'{{nome_empresa}}'}</span>. Se vazio ao salvar,
+                usa o nome fantasia de Configurações → Sistema → Empresa.
               </p>
               <input
                 type="text"
                 value={nomeEmpresaExibicao}
                 onChange={(e) => setNomeEmpresaExibicao(e.target.value)}
-                placeholder="Ex.: DX Connect"
+                placeholder="Ex.: nome fantasia da empresa"
                 className="mt-3 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
               />
             </div>

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -39,6 +39,7 @@ export function WhatsappAtendendo() {
   const [meus, setMeus] = useState<WhatsappChats.Chat[]>([])
   const [loading, setLoading] = useState(true)
   const isFirstLoad = useRef(true)
+  const prevFilaCount = useRef(0)
 
   const load = useCallback(async (silent = false) => {
     if (!silent) setLoading(true)
@@ -63,6 +64,15 @@ export function WhatsappAtendendo() {
     const timer = setInterval(() => void load(true), 10000)
     return () => clearInterval(timer)
   }, [load])
+
+  useEffect(() => {
+    if (fila.length > prevFilaCount.current) {
+      void refetchPendenciasResumo(true)
+    } else if (fila.length < prevFilaCount.current) {
+      void refetchPendenciasResumo()
+    }
+    prevFilaCount.current = fila.length
+  }, [fila.length])
 
   async function assumir(id: number) {
     try {


### PR DESCRIPTION
## Summary

- **`{{nome_empresa}}`** nas mensagens automáticas: prioriza identidade WhatsApp (`nome_empresa_exibicao`) e nome fantasia da empresa do sistema
- **Saudação ao assumir chat**: assinatura com nome do atendente em vez de `[ BOT ]:`
- **Alertas sonoros**: poll mais rápido, fila WPP para ao assumir, sons distintos por tipo (ticket mensagem, WPP fila, WPP mensagem)
- **Config WhatsApp**: identidade carrega valor salvo; documentação dos MP3s em `frontend/public/sons/`
- **Docs deploy**: explica banner amarelo do GitHub após push em `staging` (ignorar botão `staging → main`)

Inclui sync prévio (#229) e correção do revert de deploy (#228 — deploy permanece só em `staging`).

## Test plan

- [ ] Após merge, confirmar workflow **Deploy** concluído com sucesso
- [ ] `GET /health` no VPS com `git_sha` do commit deployado
- [ ] WhatsApp: mensagem automática usa nome da empresa configurado
- [ ] Assumir chat: saudação com nome do atendente
- [ ] Alertas sonoros distintos; fila para ao assumir conversa
- [ ] Colocar MP3s no servidor se ainda não existirem (`wpp-fila.mp3`, `wpp-mensagem.mp3`, etc.)