### PR TITLE
release(staging): WhatsApp inatividade, avaliação 1–5 e painel admin

### DIFF
--- a/backend/alembic/versions/037_wpp_inatividade_encerramento.py
+++ b/backend/alembic/versions/037_wpp_inatividade_encerramento.py
@@ -1,0 +1,47 @@
+"""WhatsApp: encerramento automático por inatividade do cliente.
+
+Revision ID: 037_wpp_inatividade
+Revises: 036_ticket_classificacao
+Create Date: 2026-06-09
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "037_wpp_inatividade"
+down_revision = "036_ticket_classificacao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "whatsapp_settings",
+        sa.Column("inativ_encerramento_ativa", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "whatsapp_settings",
+        sa.Column("inativ_aviso_minutos", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "whatsapp_settings",
+        sa.Column("inativ_encerramento_apos_aviso_minutos", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "whatsapp_settings",
+        sa.Column("auto_msg_inativ_aviso_ativa", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.add_column(
+        "whatsapp_settings",
+        sa.Column("auto_msg_inativ_aviso_texto", sa.Text(), nullable=True),
+    )
+    op.alter_column("whatsapp_settings", "inativ_encerramento_ativa", server_default=None)
+    op.alter_column("whatsapp_settings", "auto_msg_inativ_aviso_ativa", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("whatsapp_settings", "auto_msg_inativ_aviso_texto")
+    op.drop_column("whatsapp_settings", "auto_msg_inativ_aviso_ativa")
+    op.drop_column("whatsapp_settings", "inativ_encerramento_apos_aviso_minutos")
+    op.drop_column("whatsapp_settings", "inativ_aviso_minutos")
+    op.drop_column("whatsapp_settings", "inativ_encerramento_ativa")

--- a/backend/alembic/versions/038_wpp_avaliacao_atendimento.py
+++ b/backend/alembic/versions/038_wpp_avaliacao_atendimento.py
@@ -1,0 +1,40 @@
+"""WhatsApp: avaliação 1–5 ao encerrar atendimento.
+
+Revision ID: 038_wpp_avaliacao
+Revises: 037_wpp_inatividade
+Create Date: 2026-06-09
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "038_wpp_avaliacao"
+down_revision = "037_wpp_inatividade"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "whatsapp_settings",
+        sa.Column("avaliacao_ativa", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.add_column(
+        "whatsapp_settings",
+        sa.Column("auto_msg_avaliacao_ativa", sa.Boolean(), nullable=False, server_default=sa.true()),
+    )
+    op.add_column("whatsapp_settings", sa.Column("auto_msg_avaliacao_texto", sa.Text(), nullable=True))
+    op.add_column("whatsapp_settings", sa.Column("auto_msg_avaliacao_obrigado_texto", sa.Text(), nullable=True))
+    op.add_column("whatsapp_chats", sa.Column("avaliacao_nota", sa.Integer(), nullable=True))
+    op.add_column("whatsapp_chats", sa.Column("avaliacao_respondida_at", sa.DateTime(timezone=True), nullable=True))
+    op.alter_column("whatsapp_settings", "avaliacao_ativa", server_default=None)
+    op.alter_column("whatsapp_settings", "auto_msg_avaliacao_ativa", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("whatsapp_chats", "avaliacao_respondida_at")
+    op.drop_column("whatsapp_chats", "avaliacao_nota")
+    op.drop_column("whatsapp_settings", "auto_msg_avaliacao_obrigado_texto")
+    op.drop_column("whatsapp_settings", "auto_msg_avaliacao_texto")
+    op.drop_column("whatsapp_settings", "auto_msg_avaliacao_ativa")
+    op.drop_column("whatsapp_settings", "avaliacao_ativa")

--- a/backend/alembic/versions/039_wpp_avaliacao_solicitada.py
+++ b/backend/alembic/versions/039_wpp_avaliacao_solicitada.py
@@ -1,0 +1,26 @@
+"""WhatsApp: flag avaliacao_solicitada no chat.
+
+Revision ID: 039_wpp_avaliacao_solicitada
+Revises: 038_wpp_avaliacao
+Create Date: 2026-06-09
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "039_wpp_avaliacao_solicitada"
+down_revision = "038_wpp_avaliacao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "whatsapp_chats",
+        sa.Column("avaliacao_solicitada", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.alter_column("whatsapp_chats", "avaliacao_solicitada", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("whatsapp_chats", "avaliacao_solicitada")

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -15,10 +15,11 @@ from app.models.status_ticket import StatusTicket
 from app.models.empresa import Empresa
 from app.models.setor import Setor
 from app.models.whatsapp_chat import WhatsappChat, WhatsappChatTicket, WhatsappMensagem, WhatsappSettings
-from app.models.whatsapp_chat_read import WhatsappChatRead
+from app.models.whatsapp_chat_read import WhatsappChatRead as WhatsappChatReadModel
 from app.schemas.lista_paginada import ListaPaginada
 from app.schemas.whatsapp_chat import (
     WhatsappAbrirTicketBody,
+    WhatsappAvaliacaoRead,
     WhatsappChatComentarioInternoCreate,
     WhatsappChatMensagemCreate,
     WhatsappChatRead,
@@ -26,7 +27,7 @@ from app.schemas.whatsapp_chat import (
     WhatsappTransferirChatBody,
     WhatsappVincularTicketBody,
 )
-from app.core.auth import obter_atendente_atual
+from app.core.auth import exigir_admin, obter_atendente_atual
 from app.api.tickets import _gerar_protocolo, _pode_ver_ticket
 from app.core.setor_scope import ids_setores_visiveis_atendente
 from app.config import settings
@@ -36,6 +37,7 @@ from app.services.whatsapp_auto_messages import (
     DEFAULT_AUTO_MSG_ENCERRADO,
     resolver_nome_empresa_para_template,
 )
+from app.services.whatsapp_avaliacao import mensagem_oculta_na_conversa
 from app.services.whatsapp_media_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
 
 router = APIRouter(prefix="/whatsapp/chats", tags=["whatsapp-chats"])
@@ -270,7 +272,10 @@ def _ticket_ids(db: Session, chat_id: int) -> list[int]:
     return [x[0] for x in db.query(WhatsappChatTicket.ticket_id).filter(WhatsappChatTicket.chat_id == chat_id).all()]
 
 
-def _chat_read(db: Session, c: WhatsappChat) -> WhatsappChatRead:
+def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False) -> WhatsappChatRead:
+    nota = getattr(c, "avaliacao_nota", None) if revelar_avaliacao else None
+    respondida = getattr(c, "avaliacao_respondida_at", None) if revelar_avaliacao else None
+    solicitada = bool(getattr(c, "avaliacao_solicitada", False)) if revelar_avaliacao else False
     return WhatsappChatRead(
         id=c.id,
         protocolo=c.protocolo,
@@ -284,7 +289,29 @@ def _chat_read(db: Session, c: WhatsappChat) -> WhatsappChatRead:
         created_at=c.created_at,
         atendimento_inicio_at=c.atendimento_inicio_at,
         encerramento_at=c.encerramento_at,
+        avaliacao_nota=nota,
+        avaliacao_respondida_at=respondida,
+        avaliacao_solicitada=solicitada,
         ticket_ids=_ticket_ids(db, c.id),
+    )
+
+
+def _avaliacao_read(c: WhatsappChat) -> WhatsappAvaliacaoRead:
+    nota = getattr(c, "avaliacao_nota", None)
+    solicitada = bool(getattr(c, "avaliacao_solicitada", False))
+    return WhatsappAvaliacaoRead(
+        chat_id=c.id,
+        protocolo=c.protocolo,
+        wa_id=c.wa_id,
+        cliente_nome=c.cliente_nome,
+        atendente_id=c.atendente_id,
+        atendente_nome=c.atendente.nome if c.atendente else None,
+        setor_id=getattr(c, "setor_id", None),
+        setor_nome=c.setor.nome if getattr(c, "setor", None) else None,
+        nota=nota,
+        avaliacao_respondida_at=getattr(c, "avaliacao_respondida_at", None),
+        encerramento_at=c.encerramento_at,
+        sem_avaliacao=solicitada and nota is None,
     )
 
 
@@ -300,7 +327,7 @@ def _pode_ver_chat(db: Session, atendente: Atendente, c: WhatsappChat) -> bool:
     # require either being the attendant or having the setor visible.
     if c.setor_id is None:
         return c.estado == "aguardando_atendente"
-    if c.estado in ("aguardando_atendente", "encerrado"):
+    if c.estado in ("aguardando_atendente", "encerrado", "aguardando_avaliacao"):
         return c.setor_id in vis
     return False
 
@@ -394,7 +421,49 @@ def listar_encerrados(
         q = q.filter(or_(WhatsappChat.atendente_id == atendente.id, WhatsappChat.setor_id.in_(vis)))
     total = q.count()
     rows = q.order_by(desc(WhatsappChat.encerramento_at), desc(WhatsappChat.id)).offset(offset).limit(limit).all()
-    return ListaPaginada(items=[_chat_read(db, c) for c in rows], total=total)
+    return ListaPaginada(items=[_chat_read(db, c, revelar_avaliacao=True) for c in rows], total=total)
+
+
+@router.get("/avaliacoes", response_model=ListaPaginada[WhatsappAvaliacaoRead])
+def listar_avaliacoes(
+    busca: str | None = Query(None, description="Busca por protocolo, telefone ou contato"),
+    atendente_id: int | None = Query(None, ge=1),
+    nota_min: int | None = Query(None, ge=1, le=5),
+    nota_max: int | None = Query(None, ge=1, le=5),
+    encerramento_inicio: datetime | None = Query(None),
+    encerramento_fim: datetime | None = Query(None),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_admin),
+):
+    q = (
+        db.query(WhatsappChat)
+        .options(joinedload(WhatsappChat.atendente), joinedload(WhatsappChat.setor))
+        .filter(WhatsappChat.avaliacao_solicitada.is_(True))
+    )
+    if busca:
+        term = f"%{busca.strip()}%"
+        q = q.filter(
+            or_(
+                WhatsappChat.protocolo.ilike(term),
+                WhatsappChat.wa_id.ilike(term),
+                WhatsappChat.cliente_nome.ilike(term),
+            )
+        )
+    if atendente_id:
+        q = q.filter(WhatsappChat.atendente_id == atendente_id)
+    if nota_min is not None:
+        q = q.filter(WhatsappChat.avaliacao_nota >= nota_min)
+    if nota_max is not None:
+        q = q.filter(WhatsappChat.avaliacao_nota <= nota_max)
+    if encerramento_inicio:
+        q = q.filter(WhatsappChat.encerramento_at >= encerramento_inicio)
+    if encerramento_fim:
+        q = q.filter(WhatsappChat.encerramento_at <= encerramento_fim)
+    total = q.count()
+    rows = q.order_by(desc(WhatsappChat.encerramento_at), desc(WhatsappChat.id)).offset(offset).limit(limit).all()
+    return ListaPaginada(items=[_avaliacao_read(c) for c in rows], total=total)
 
 
 @router.get("/por-ticket/{ticket_id}", response_model=list[WhatsappChatRead])
@@ -485,7 +554,8 @@ def listar_mensagens(
         .order_by(WhatsappMensagem.created_at.asc())
         .all()
     )
-    return [_mensagem_read(m) for m in rows]
+    visiveis = [m for m in rows if not mensagem_oculta_na_conversa(getattr(m, "evento_sistema", None))]
+    return [_mensagem_read(m) for m in visiveis]
 
 
 @router.post("/{chat_id}/assumir", response_model=WhatsappChatRead)
@@ -545,30 +615,22 @@ def encerrar(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
     if c.estado == "encerrado":
         return _chat_read(db, c)
+    if c.estado == "aguardando_avaliacao":
+        return _chat_read(db, c)
     if c.estado != "em_atendimento":
         raise HTTPException(status_code=400, detail="Encerre apenas chats em atendimento")
     if atendente.role != "admin" and c.atendente_id != atendente.id:
         raise HTTPException(status_code=403, detail="Apenas o atendente responsável pode encerrar este chat")
-    c.estado = "encerrado"
-    c.encerramento_at = datetime.now(timezone.utc)
-    db.commit()
-    db.refresh(c)
     st_auto = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
-    if st_auto and bool(getattr(st_auto, "auto_msg_encerrado_ativa", True)) and _evolution_configurada(st_auto):
-        raw = (getattr(st_auto, "auto_msg_encerrado_texto", "") or "").strip() or DEFAULT_AUTO_MSG_ENCERRADO
-        txt = _render_template(
-            raw,
-            db=db,
-            chat=c,
-            atendente=atendente,
-            st=st_auto,
-            atendente_nome="BOT",
-        )
-        if txt:
-            try:
-                _enviar_texto_whatsapp(db, chat=c, texto=txt, atendente=atendente, evento_sistema="auto_encerrado")
-            except HTTPException as exc:
-                logger.warning("Auto-msg encerrado falhou (chat=%s): %s", c.protocolo, exc.detail)
+    from app.services.whatsapp_avaliacao import finalizar_atendimento_whatsapp
+
+    try:
+        finalizar_atendimento_whatsapp(db, c, st_auto, evento_encerrado="auto_encerrado")
+        db.commit()
+    except Exception as exc:
+        db.rollback()
+        logger.warning("Encerramento WhatsApp falhou (chat=%s): %s", c.protocolo, exc)
+        raise HTTPException(status_code=502, detail="Falha ao encerrar o atendimento no WhatsApp") from exc
     c = db.query(WhatsappChat).options(joinedload(WhatsappChat.atendente)).filter(WhatsappChat.id == chat_id).first()
     assert c is not None
     return _chat_read(db, c)
@@ -719,7 +781,7 @@ def comentar_interno(
         vis = ids_setores_visiveis_atendente(db, atendente)
         if c.setor_id not in vis:
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
-    if c.estado == "encerrado":
+    if c.estado in ("encerrado", "aguardando_avaliacao"):
         raise HTTPException(status_code=400, detail="Chat encerrado (somente leitura)")
     texto = data.texto.strip()
     if not texto:
@@ -765,14 +827,14 @@ def marcar_chat_visto(
 
     now = datetime.now(timezone.utc)
     row = (
-        db.query(WhatsappChatRead)
-        .filter(WhatsappChatRead.chat_id == chat_id, WhatsappChatRead.atendente_id == atendente.id)
+        db.query(WhatsappChatReadModel)
+        .filter(WhatsappChatReadModel.chat_id == chat_id, WhatsappChatReadModel.atendente_id == atendente.id)
         .first()
     )
     if row:
         row.last_seen_at = now
     else:
-        db.add(WhatsappChatRead(chat_id=chat_id, atendente_id=atendente.id, last_seen_at=now))
+        db.add(WhatsappChatReadModel(chat_id=chat_id, atendente_id=atendente.id, last_seen_at=now))
     db.commit()
     return None
 
@@ -873,7 +935,7 @@ def transferir(
     )
     if not c:
         raise HTTPException(status_code=404, detail="Chat não encontrado")
-    if c.estado == "encerrado":
+    if c.estado in ("encerrado", "aguardando_avaliacao"):
         raise HTTPException(status_code=400, detail="Chat encerrado não pode ser transferido")
     # Permissão: admin ou atendente responsável atual
     if atendente.role != "admin" and c.atendente_id not in (None, atendente.id):

--- a/backend/app/api/whatsapp_settings.py
+++ b/backend/app/api/whatsapp_settings.py
@@ -45,6 +45,15 @@ def _read_out(row: WhatsappSettings | None) -> WhatsappSettingsRead:
             horario_semana=None,
             usar_feriados_nacionais=False,
             nome_empresa_exibicao=None,
+            inativ_encerramento_ativa=False,
+            inativ_aviso_minutos=None,
+            inativ_encerramento_apos_aviso_minutos=None,
+            auto_msg_inativ_aviso_ativa=True,
+            auto_msg_inativ_aviso_texto=None,
+            avaliacao_ativa=False,
+            auto_msg_avaliacao_ativa=True,
+            auto_msg_avaliacao_texto=None,
+            auto_msg_avaliacao_obrigado_texto=None,
         )
     horario_semana = None
     raw = getattr(row, "horario_semana_json", None)
@@ -73,6 +82,15 @@ def _read_out(row: WhatsappSettings | None) -> WhatsappSettingsRead:
         horario_semana=horario_semana if isinstance(horario_semana, dict) else None,
         usar_feriados_nacionais=bool(getattr(row, "usar_feriados_nacionais", False)),
         nome_empresa_exibicao=getattr(row, "nome_empresa_exibicao", None),
+        inativ_encerramento_ativa=bool(getattr(row, "inativ_encerramento_ativa", False)),
+        inativ_aviso_minutos=getattr(row, "inativ_aviso_minutos", None),
+        inativ_encerramento_apos_aviso_minutos=getattr(row, "inativ_encerramento_apos_aviso_minutos", None),
+        auto_msg_inativ_aviso_ativa=bool(getattr(row, "auto_msg_inativ_aviso_ativa", True)),
+        auto_msg_inativ_aviso_texto=getattr(row, "auto_msg_inativ_aviso_texto", None),
+        avaliacao_ativa=bool(getattr(row, "avaliacao_ativa", False)),
+        auto_msg_avaliacao_ativa=bool(getattr(row, "auto_msg_avaliacao_ativa", True)),
+        auto_msg_avaliacao_texto=getattr(row, "auto_msg_avaliacao_texto", None),
+        auto_msg_avaliacao_obrigado_texto=getattr(row, "auto_msg_avaliacao_obrigado_texto", None),
     )
 
 
@@ -133,14 +151,32 @@ def atualizar(
         "auto_msg_encerrado_texto",
         "auto_msg_fora_horario_ativa",
         "auto_msg_fora_horario_texto",
+        "auto_msg_inativ_aviso_ativa",
+        "auto_msg_inativ_aviso_texto",
         "horario_inicio",
         "horario_fim",
         "horario_timezone",
         "usar_feriados_nacionais",
         "nome_empresa_exibicao",
+        "inativ_encerramento_ativa",
+        "inativ_aviso_minutos",
+        "inativ_encerramento_apos_aviso_minutos",
+        "avaliacao_ativa",
+        "auto_msg_avaliacao_ativa",
+        "auto_msg_avaliacao_texto",
+        "auto_msg_avaliacao_obrigado_texto",
     ):
         if k in payload:
             setattr(row, k, payload[k])
+    ativa = bool(getattr(row, "inativ_encerramento_ativa", False))
+    if ativa:
+        aviso = getattr(row, "inativ_aviso_minutos", None)
+        pos = getattr(row, "inativ_encerramento_apos_aviso_minutos", None)
+        if not aviso or aviso < 1 or not pos or pos < 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Informe minutos válidos para aviso e encerramento após o aviso.",
+            )
     if "horario_semana" in payload:
         hs = payload["horario_semana"]
         if hs is None:

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -349,6 +349,42 @@ def evolution_webhook(
         mimetype_val = item.get("mimetype")
         midia_nome: str | None = None
 
+        chat = _chat_aberto_por_wa_id(db, wa_id)
+        if chat and chat.estado == "aguardando_avaliacao":
+            q_prev = item.get("quoted_corpo_preview")
+            if q_prev is not None and len(str(q_prev)) > 500:
+                q_prev = str(q_prev)[:500]
+            msg = WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="inbound",
+                corpo=corpo,
+                tipo_midia=tipo_midia,
+                mimetype=mimetype_val,
+                midia_nome_arquivo=midia_nome,
+                wa_message_id=wa_mid,
+                quoted_wa_message_id=item.get("quoted_wa_message_id"),
+                quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
+                atendente_id=None,
+            )
+            db.add(msg)
+            if push and not chat.cliente_nome:
+                chat.cliente_nome = push
+            try:
+                from app.services.whatsapp_avaliacao import processar_resposta_avaliacao
+
+                processar_resposta_avaliacao(
+                    db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
+                )
+                db.commit()
+                processados += 1
+            except IntegrityError:
+                db.rollback()
+                logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
+            except Exception:
+                db.rollback()
+                raise
+            continue
+
         if tipo != "texto":
             raw_env = item.get("raw_envelope")
             if (

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -57,6 +57,7 @@ class Settings(BaseSettings):
     TICKET_MENSAGEM_EMAIL_GRACE_SECONDS: int = 120
     TICKET_MENSAGEM_EDIT_LOCK_TTL_SECONDS: int = 300
     TICKET_MENSAGEM_EMAIL_WORKER_INTERVAL_SECONDS: int = 5
+    WHATSAPP_INACTIVITY_WORKER_INTERVAL_SECONDS: int = 60
 
     # Modo legado: vários clientes no mesmo Postgres (subdomínio numérico + coluna tenant_id).
     # Produção comercial: manter False (um Postgres por cliente / deploy).

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -190,6 +190,32 @@ async def lifespan(app: FastAPI):
         name="ticket-mensagem-email-outbox",
     ).start()
 
+    def whatsapp_inactivity_loop() -> None:
+        from app.database import SessionLocal
+        from app.services.whatsapp_inactivity_worker import process_whatsapp_inactivity_closures
+
+        interval = max(15, settings.WHATSAPP_INACTIVITY_WORKER_INTERVAL_SECONDS)
+        while True:
+            db = SessionLocal()
+            try:
+                n = process_whatsapp_inactivity_closures(db, limit=200)
+                if n:
+                    db.commit()
+                else:
+                    db.rollback()
+            except Exception as e:
+                logger.warning("Worker inatividade WhatsApp: %s", e)
+                db.rollback()
+            finally:
+                db.close()
+            time.sleep(interval)
+
+    threading.Thread(
+        target=whatsapp_inactivity_loop,
+        daemon=True,
+        name="whatsapp-inactivity",
+    ).start()
+
     yield
 
 

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -35,6 +35,16 @@ class WhatsappSettings(Base):
     usar_feriados_nacionais = Column(Boolean, nullable=False, default=False)
     # Nome amigável da empresa para templates (ex.: "DX Connect" ou nome do cliente/negócio).
     nome_empresa_exibicao = Column(String(255), nullable=True)
+    # Encerramento automático por inatividade do cliente (chat em atendimento).
+    inativ_encerramento_ativa = Column(Boolean, nullable=False, default=False)
+    inativ_aviso_minutos = Column(Integer, nullable=True)
+    inativ_encerramento_apos_aviso_minutos = Column(Integer, nullable=True)
+    auto_msg_inativ_aviso_ativa = Column(Boolean, nullable=False, default=True)
+    auto_msg_inativ_aviso_texto = Column(Text, nullable=True)
+    avaliacao_ativa = Column(Boolean, nullable=False, default=False)
+    auto_msg_avaliacao_ativa = Column(Boolean, nullable=False, default=True)
+    auto_msg_avaliacao_texto = Column(Text, nullable=True)
+    auto_msg_avaliacao_obrigado_texto = Column(Text, nullable=True)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
 
 
@@ -51,6 +61,9 @@ class WhatsappChat(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     atendimento_inicio_at = Column(DateTime(timezone=True), nullable=True)
     encerramento_at = Column(DateTime(timezone=True), nullable=True)
+    avaliacao_nota = Column(Integer, nullable=True)
+    avaliacao_respondida_at = Column(DateTime(timezone=True), nullable=True)
+    avaliacao_solicitada = Column(Boolean, nullable=False, default=False)
 
     atendente = relationship("Atendente", backref="whatsapp_chats_atendidos")
     setor = relationship("Setor", backref="whatsapp_chats")

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -35,6 +35,9 @@ class WhatsappChatRead(BaseModel):
     created_at: datetime | None = None
     atendimento_inicio_at: datetime | None = None
     encerramento_at: datetime | None = None
+    avaliacao_nota: int | None = None
+    avaliacao_respondida_at: datetime | None = None
+    avaliacao_solicitada: bool = False
     ticket_ids: list[int] = Field(default_factory=list)
 
     model_config = {"from_attributes": True}
@@ -67,3 +70,18 @@ class WhatsappAbrirTicketBody(BaseModel):
 class WhatsappTransferirChatBody(BaseModel):
     setor_id: int
     atendente_id: int | None = None
+
+
+class WhatsappAvaliacaoRead(BaseModel):
+    chat_id: int
+    protocolo: str
+    wa_id: str
+    cliente_nome: str | None = None
+    atendente_id: int | None = None
+    atendente_nome: str | None = None
+    setor_id: int | None = None
+    setor_nome: str | None = None
+    nota: int | None = None
+    avaliacao_respondida_at: datetime | None = None
+    encerramento_at: datetime | None = None
+    sem_avaliacao: bool = False

--- a/backend/app/schemas/whatsapp_settings.py
+++ b/backend/app/schemas/whatsapp_settings.py
@@ -23,6 +23,15 @@ class WhatsappSettingsRead(BaseModel):
     horario_semana: dict[str, Any] | None = None
     usar_feriados_nacionais: bool = False
     nome_empresa_exibicao: str | None = None
+    inativ_encerramento_ativa: bool = False
+    inativ_aviso_minutos: int | None = None
+    inativ_encerramento_apos_aviso_minutos: int | None = None
+    auto_msg_inativ_aviso_ativa: bool = True
+    auto_msg_inativ_aviso_texto: str | None = None
+    avaliacao_ativa: bool = False
+    auto_msg_avaliacao_ativa: bool = True
+    auto_msg_avaliacao_texto: str | None = None
+    auto_msg_avaliacao_obrigado_texto: str | None = None
 
     model_config = {"from_attributes": True}
 
@@ -46,6 +55,15 @@ class WhatsappSettingsUpdate(BaseModel):
     horario_semana: dict[str, Any] | None = None
     usar_feriados_nacionais: bool | None = None
     nome_empresa_exibicao: str | None = None
+    inativ_encerramento_ativa: bool | None = None
+    inativ_aviso_minutos: int | None = Field(None, ge=1, le=24 * 60)
+    inativ_encerramento_apos_aviso_minutos: int | None = Field(None, ge=1, le=24 * 60)
+    auto_msg_inativ_aviso_ativa: bool | None = None
+    auto_msg_inativ_aviso_texto: str | None = None
+    avaliacao_ativa: bool | None = None
+    auto_msg_avaliacao_ativa: bool | None = None
+    auto_msg_avaliacao_texto: str | None = None
+    auto_msg_avaliacao_obrigado_texto: str | None = None
 
     @field_validator("evolution_base_url", mode="before")
     @classmethod

--- a/backend/app/services/whatsapp_auto_messages.py
+++ b/backend/app/services/whatsapp_auto_messages.py
@@ -20,6 +20,34 @@ DEFAULT_AUTO_MSG_FORA_HORARIO = (
     "Olá, {nome}! No momento estamos fora do horário de atendimento. "
     "Assim que voltarmos, responderemos por aqui."
 )
+DEFAULT_AUTO_MSG_INATIV_AVISO = (
+    "Olá, {{nome_cliente}}! Você está há um tempo sem responder. "
+    "Se não houver retorno, encerraremos este atendimento em breve. "
+    "Responda aqui se ainda precisar de ajuda."
+)
+DEFAULT_AUTO_MSG_AVALIACAO = (
+    "Como você avalia o atendimento?\n\n"
+    "Responda com uma nota de *1* a *5*:\n"
+    "1 — Péssimo\n2 — Ruim\n3 — Regular\n4 — Bom\n5 — Excelente"
+)
+DEFAULT_AUTO_MSG_AVALIACAO_OBRIGADO = (
+    "Obrigado pela sua avaliação! Atendimento encerrado."
+)
+DEFAULT_AUTO_MSG_AVALIACAO_SEM_NOTA = (
+    "Não foi possível registrar sua avaliação. O atendimento foi encerrado. "
+    "Se precisar de algo mais, envie uma nova mensagem por aqui."
+)
+
+# Mensagens desta fase não aparecem na conversa do atendente (só no WhatsApp do cliente).
+EVENTOS_MENSAGEM_OCULTA_CONVERSA = frozenset(
+    {
+        "auto_avaliacao_solicitacao",
+        "auto_avaliacao_obrigado",
+        "auto_avaliacao_sem_nota",
+        "avaliacao_cliente_nota",
+        "avaliacao_cliente_invalida",
+    }
+)
 
 
 def resolver_nome_empresa_para_template(db: Session) -> str:

--- a/backend/app/services/whatsapp_avaliacao.py
+++ b/backend/app/services/whatsapp_avaliacao.py
@@ -1,0 +1,226 @@
+"""Avaliação 1–5 do atendimento WhatsApp ao encerrar o chat."""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem, WhatsappSettings
+from app.services import evolution_api
+from app.services.whatsapp_auto_messages import (
+    DEFAULT_AUTO_MSG_AVALIACAO,
+    DEFAULT_AUTO_MSG_AVALIACAO_OBRIGADO,
+    DEFAULT_AUTO_MSG_AVALIACAO_SEM_NOTA,
+    DEFAULT_AUTO_MSG_ENCERRADO,
+    EVENTOS_MENSAGEM_OCULTA_CONVERSA,
+)
+
+logger = logging.getLogger(__name__)
+
+_NOTA_RE = re.compile(r"^[1-5]$")
+
+
+def parse_nota_avaliacao(texto: str) -> int | None:
+    s = (texto or "").strip()
+    if _NOTA_RE.match(s):
+        return int(s)
+    return None
+
+
+def avaliacao_habilitada(st: WhatsappSettings | None) -> bool:
+    return bool(st and getattr(st, "avaliacao_ativa", False))
+
+
+def mensagem_oculta_na_conversa(evento_sistema: str | None) -> bool:
+    return (evento_sistema or "") in EVENTOS_MENSAGEM_OCULTA_CONVERSA
+
+
+def _evolution_configurada(st: WhatsappSettings | None) -> bool:
+    return bool(
+        st
+        and st.evolution_base_url
+        and st.evolution_instance_name
+        and st.evolution_api_key
+    )
+
+
+def _render_template(template: str, *, db: Session, chat: WhatsappChat, st: WhatsappSettings | None) -> str:
+    from app.api.whatsapp_webhook import _render_template as render_webhook
+
+    return render_webhook(template, db=db, chat=chat, st=st, atendente_nome="BOT")
+
+
+def _prefixo_bot(texto: str) -> str:
+    t = (texto or "").strip()
+    if not t:
+        return ""
+    if not t.startswith("["):
+        return f"[ BOT ]: {t}"
+    return t
+
+
+def _enviar_texto_sistema(
+    db: Session,
+    *,
+    chat: WhatsappChat,
+    st: WhatsappSettings,
+    texto: str,
+    evento_sistema: str | None,
+) -> bool:
+    txt = _prefixo_bot(texto)
+    if not txt:
+        return False
+    ok, err, sent_wa_id = evolution_api.evolution_send_text(
+        st.evolution_base_url,
+        st.evolution_instance_name,
+        st.evolution_api_key,
+        chat.wa_id,
+        txt,
+    )
+    if not ok:
+        logger.warning("Auto-msg avaliação falhou (chat=%s): %s", chat.protocolo, err)
+        return False
+    db.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo=txt,
+            tipo_midia="texto",
+            mimetype=None,
+            midia_nome_arquivo=None,
+            wa_message_id=sent_wa_id,
+            atendente_id=None,
+            evento_sistema=evento_sistema,
+        )
+    )
+    return True
+
+
+def _enviar_encerrado(
+    db: Session,
+    chat: WhatsappChat,
+    st: WhatsappSettings,
+    *,
+    evento_sistema: str,
+) -> None:
+    if not bool(getattr(st, "auto_msg_encerrado_ativa", True)):
+        return
+    raw = (getattr(st, "auto_msg_encerrado_texto", "") or "").strip() or DEFAULT_AUTO_MSG_ENCERRADO
+    txt = _render_template(raw, db=db, chat=chat, st=st)
+    if txt:
+        _enviar_texto_sistema(db, chat=chat, st=st, texto=txt, evento_sistema=evento_sistema)
+
+
+def _encerrar_sem_avaliacao(
+    db: Session,
+    chat: WhatsappChat,
+    st: WhatsappSettings,
+    *,
+    msg_inbound: WhatsappMensagem | None = None,
+) -> None:
+    if msg_inbound is not None:
+        msg_inbound.evento_sistema = "avaliacao_cliente_invalida"
+    chat.estado = "encerrado"
+    chat.avaliacao_nota = None
+    chat.avaliacao_respondida_at = None
+    db.flush()
+    raw = DEFAULT_AUTO_MSG_AVALIACAO_SEM_NOTA
+    txt = _render_template(raw, db=db, chat=chat, st=st)
+    if txt:
+        _enviar_texto_sistema(
+            db,
+            chat=chat,
+            st=st,
+            texto=txt,
+            evento_sistema="auto_avaliacao_sem_nota",
+        )
+
+
+def finalizar_atendimento_whatsapp(
+    db: Session,
+    chat: WhatsappChat,
+    st: WhatsappSettings | None,
+    *,
+    evento_encerrado: str = "auto_encerrado",
+) -> None:
+    """
+    Encerra o atendimento para o atendente.
+    Com avaliação ativa: passa a aguardar nota 1–5 do cliente antes do encerramento final.
+    """
+    chat.encerramento_at = datetime.now(timezone.utc)
+    db.flush()
+
+    if not st or not _evolution_configurada(st):
+        chat.estado = "encerrado"
+        return
+
+    if avaliacao_habilitada(st):
+        chat.estado = "aguardando_avaliacao"
+        chat.avaliacao_solicitada = True
+        chat.avaliacao_nota = None
+        chat.avaliacao_respondida_at = None
+        db.flush()
+        if bool(getattr(st, "auto_msg_avaliacao_ativa", True)):
+            raw = (getattr(st, "auto_msg_avaliacao_texto", "") or "").strip() or DEFAULT_AUTO_MSG_AVALIACAO
+            txt = _render_template(raw, db=db, chat=chat, st=st)
+            if txt:
+                _enviar_texto_sistema(
+                    db,
+                    chat=chat,
+                    st=st,
+                    texto=txt,
+                    evento_sistema="auto_avaliacao_solicitacao",
+                )
+        return
+
+    chat.estado = "encerrado"
+    _enviar_encerrado(db, chat, st, evento_sistema=evento_encerrado)
+
+
+def processar_resposta_avaliacao(
+    db: Session,
+    chat: WhatsappChat,
+    st: WhatsappSettings | None,
+    texto: str,
+    *,
+    tipo_midia: str = "texto",
+    msg_inbound: WhatsappMensagem | None = None,
+) -> None:
+    """Processa mensagem inbound em chat aguardando_avaliacao."""
+    if chat.estado != "aguardando_avaliacao" or not st or not _evolution_configurada(st):
+        return
+
+    if (tipo_midia or "texto").strip().lower() != "texto":
+        _encerrar_sem_avaliacao(db, chat, st, msg_inbound=msg_inbound)
+        return
+
+    nota = parse_nota_avaliacao(texto)
+    if nota is None:
+        _encerrar_sem_avaliacao(db, chat, st, msg_inbound=msg_inbound)
+        return
+
+    if msg_inbound is not None:
+        msg_inbound.evento_sistema = "avaliacao_cliente_nota"
+
+    chat.avaliacao_nota = nota
+    chat.avaliacao_respondida_at = datetime.now(timezone.utc)
+    chat.estado = "encerrado"
+    db.flush()
+
+    if bool(getattr(st, "auto_msg_avaliacao_ativa", True)):
+        raw = (
+            (getattr(st, "auto_msg_avaliacao_obrigado_texto", "") or "").strip()
+            or DEFAULT_AUTO_MSG_AVALIACAO_OBRIGADO
+        )
+        txt = _render_template(raw, db=db, chat=chat, st=st)
+        if txt:
+            _enviar_texto_sistema(
+                db,
+                chat=chat,
+                st=st,
+                texto=txt,
+                evento_sistema="auto_avaliacao_obrigado",
+            )

--- a/backend/app/services/whatsapp_inactivity_worker.py
+++ b/backend/app/services/whatsapp_inactivity_worker.py
@@ -1,0 +1,216 @@
+"""Encerramento automático de chats WhatsApp por inatividade do cliente."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy import desc, or_
+from sqlalchemy.orm import Session
+
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem, WhatsappSettings
+from app.services import evolution_api
+from app.services.whatsapp_auto_messages import (
+    DEFAULT_AUTO_MSG_INATIV_AVISO,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _evolution_configurada(st: WhatsappSettings | None) -> bool:
+    return bool(
+        st
+        and st.evolution_base_url
+        and st.evolution_instance_name
+        and st.evolution_api_key
+    )
+
+
+def _render_template(template: str, *, db: Session, chat: WhatsappChat, st: WhatsappSettings | None) -> str:
+    from app.api.whatsapp_webhook import _render_template as render_webhook
+
+    return render_webhook(template, db=db, chat=chat, st=st, atendente_nome="BOT")
+
+
+def _mensagens_relevantes_q(db: Session, chat_id: int):
+    return db.query(WhatsappMensagem).filter(
+        WhatsappMensagem.chat_id == chat_id,
+        or_(
+            WhatsappMensagem.evento_sistema.is_(None),
+            WhatsappMensagem.evento_sistema != "comentario_interno",
+        ),
+    )
+
+
+def _ultima_mensagem_relevante(db: Session, chat_id: int) -> WhatsappMensagem | None:
+    return (
+        _mensagens_relevantes_q(db, chat_id)
+        .order_by(desc(WhatsappMensagem.created_at), desc(WhatsappMensagem.id))
+        .first()
+    )
+
+
+def _referencia_inatividade_cliente(db: Session, chat: WhatsappChat) -> datetime | None:
+    """
+    Momento a partir do qual o cliente está inativo.
+
+    Conta desde a última mensagem **do cliente** quando o atendente já respondeu depois
+    (cliente sumiu). Novas mensagens do atendente não reiniciam o timer — evita que
+    o atendente "fale sozinho" e impeça o encerramento.
+    """
+    last_in = (
+        _mensagens_relevantes_q(db, chat.id)
+        .filter(WhatsappMensagem.direcao == "inbound")
+        .order_by(desc(WhatsappMensagem.created_at), desc(WhatsappMensagem.id))
+        .first()
+    )
+    last_out = (
+        _mensagens_relevantes_q(db, chat.id)
+        .filter(WhatsappMensagem.direcao == "outbound")
+        .order_by(desc(WhatsappMensagem.created_at), desc(WhatsappMensagem.id))
+        .first()
+    )
+    if not last_out:
+        return None
+    if last_in is None:
+        return last_out.created_at or chat.atendimento_inicio_at
+    out_at = last_out.created_at
+    in_at = last_in.created_at
+    if out_at is None or in_at is None:
+        return None
+    if out_at <= in_at:
+        # Cliente falou por último ou atendente ainda não respondeu — não encerra.
+        return None
+    return in_at
+
+
+def _minutos_desde(ref: datetime | None, now: datetime) -> float:
+    if ref is None:
+        return 0.0
+    if ref.tzinfo is None:
+        ref = ref.replace(tzinfo=timezone.utc)
+    return max(0.0, (now - ref).total_seconds() / 60.0)
+
+
+def _prefixo_bot(texto: str) -> str:
+    t = (texto or "").strip()
+    if not t:
+        return ""
+    if not t.startswith("["):
+        return f"[ BOT ]: {t}"
+    return t
+
+
+def _enviar_texto_sistema(
+    db: Session,
+    *,
+    chat: WhatsappChat,
+    st: WhatsappSettings,
+    texto: str,
+    evento_sistema: str,
+) -> bool:
+    txt = _prefixo_bot(texto)
+    if not txt:
+        return False
+    ok, err, sent_wa_id = evolution_api.evolution_send_text(
+        st.evolution_base_url,
+        st.evolution_instance_name,
+        st.evolution_api_key,
+        chat.wa_id,
+        txt,
+    )
+    if not ok:
+        logger.warning("Auto-msg %s falhou (chat=%s): %s", evento_sistema, chat.protocolo, err)
+        return False
+    db.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo=txt,
+            tipo_midia="texto",
+            mimetype=None,
+            midia_nome_arquivo=None,
+            wa_message_id=sent_wa_id,
+            atendente_id=None,
+            evento_sistema=evento_sistema,
+        )
+    )
+    return True
+
+
+def _encerrar_por_inatividade(db: Session, chat: WhatsappChat, st: WhatsappSettings) -> None:
+    from app.services.whatsapp_avaliacao import finalizar_atendimento_whatsapp
+
+    finalizar_atendimento_whatsapp(db, chat, st, evento_encerrado="auto_encerrado_inatividade")
+
+
+def _processar_chat_inatividade(
+    db: Session,
+    chat: WhatsappChat,
+    st: WhatsappSettings,
+    now: datetime,
+) -> bool:
+    """Retorna True se alterou algo no chat (mensagem ou encerramento)."""
+    if chat.estado != "em_atendimento":
+        return False
+
+    aviso_min = int(getattr(st, "inativ_aviso_minutos", 0) or 0)
+    pos_aviso_min = int(getattr(st, "inativ_encerramento_apos_aviso_minutos", 0) or 0)
+    if aviso_min < 1 or pos_aviso_min < 1:
+        return False
+
+    last = _ultima_mensagem_relevante(db, chat.id)
+    if last and last.evento_sistema == "auto_inativ_aviso":
+        if _minutos_desde(last.created_at, now) >= pos_aviso_min:
+            _encerrar_por_inatividade(db, chat, st)
+            return True
+        return False
+
+    referencia = _referencia_inatividade_cliente(db, chat)
+    if referencia is None:
+        return False
+
+    if _minutos_desde(referencia, now) < aviso_min:
+        return False
+
+    if not bool(getattr(st, "auto_msg_inativ_aviso_ativa", True)):
+        _encerrar_por_inatividade(db, chat, st)
+        return True
+
+    if not _evolution_configurada(st):
+        return False
+
+    raw = (getattr(st, "auto_msg_inativ_aviso_texto", "") or "").strip() or DEFAULT_AUTO_MSG_INATIV_AVISO
+    txt = _render_template(raw, db=db, chat=chat, st=st)
+    if not txt:
+        return False
+    return _enviar_texto_sistema(db, chat=chat, st=st, texto=txt, evento_sistema="auto_inativ_aviso")
+
+
+def process_whatsapp_inactivity_closures(db: Session, *, limit: int = 200) -> int:
+    """
+    Verifica chats em atendimento e envia aviso ou encerra por inatividade do cliente.
+    Retorna quantidade de chats alterados.
+    """
+    st = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
+    if not st or not bool(getattr(st, "inativ_encerramento_ativa", False)):
+        return 0
+    if not _evolution_configurada(st):
+        return 0
+
+    now = datetime.now(timezone.utc)
+    chats = (
+        db.query(WhatsappChat)
+        .filter(WhatsappChat.estado == "em_atendimento")
+        .order_by(WhatsappChat.id.asc())
+        .limit(limit)
+        .all()
+    )
+    alterados = 0
+    for chat in chats:
+        try:
+            if _processar_chat_inatividade(db, chat, st, now):
+                alterados += 1
+        except Exception as exc:
+            logger.warning("Inatividade WhatsApp (chat=%s): %s", chat.protocolo, exc)
+    return alterados

--- a/backend/tests/test_whatsapp_avaliacao.py
+++ b/backend/tests/test_whatsapp_avaliacao.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem, WhatsappSettings
+from app.services.whatsapp_avaliacao import (
+    mensagem_oculta_na_conversa,
+    parse_nota_avaliacao,
+    processar_resposta_avaliacao,
+)
+
+
+def test_parse_nota_avaliacao():
+    assert parse_nota_avaliacao("5") == 5
+    assert parse_nota_avaliacao(" 3 ") == 3
+    assert parse_nota_avaliacao("0") is None
+    assert parse_nota_avaliacao("6") is None
+    assert parse_nota_avaliacao("ótimo") is None
+
+
+def test_mensagens_avaliacao_ocultas_na_conversa():
+    assert mensagem_oculta_na_conversa("auto_avaliacao_solicitacao")
+    assert mensagem_oculta_na_conversa("avaliacao_cliente_nota")
+    assert not mensagem_oculta_na_conversa("auto_encerrado")
+    assert not mensagem_oculta_na_conversa(None)
+
+
+def _configurar(db_session, *, avaliacao_ativa: bool = True):
+    st = WhatsappSettings(
+        evolution_base_url="http://evolution.test",
+        evolution_instance_name="inst",
+        evolution_api_key="key",
+        avaliacao_ativa=avaliacao_ativa,
+        auto_msg_avaliacao_ativa=True,
+        auto_msg_encerrado_ativa=True,
+    )
+    db_session.add(st)
+    db_session.commit()
+    return st
+
+
+def test_encerrar_com_avaliacao_ativa_vai_para_aguardando_avaliacao(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    _configurar(db_session)
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "avaliacao-1"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "avaliacao-1"}
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {"remoteJid": "5511888777666@s.whatsapp.net", "fromMe": False, "id": "m-av-1"},
+                    "message": {"conversation": "Oi"},
+                }
+            ]
+        },
+    }
+    client.post("/v1/webhooks/evolution", json=body, headers=h)
+    fila = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()
+    cid = fila[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+
+    enviados: list[str] = []
+
+    def fake_send(base, inst, key, wa, text):
+        enviados.append(text)
+        return True, None, "wa-out-av"
+
+    monkeypatch.setattr("app.services.whatsapp_avaliacao.evolution_api.evolution_send_text", fake_send)
+
+    r = client.post(f"/v1/whatsapp/chats/{cid}/encerrar", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    data = r.json()
+    assert data["estado"] == "aguardando_avaliacao"
+    assert data["encerramento_at"] is not None
+    assert data.get("avaliacao_nota") is None
+    assert len(enviados) >= 1
+    assert "1" in enviados[0] and "5" in enviados[0]
+
+
+def test_resposta_nota_encerra_chat(client, seed_base, auth_headers, db_session, monkeypatch):
+    st = _configurar(db_session)
+    chat = WhatsappChat(
+        protocolo="WPP-AV-1",
+        wa_id="5511999112233",
+        cliente_nome="Cliente",
+        estado="aguardando_avaliacao",
+        atendente_id=1,
+        avaliacao_solicitada=True,
+    )
+    db_session.add(chat)
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_avaliacao.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-thx"),
+    )
+
+    msg = WhatsappMensagem(
+        chat_id=chat.id,
+        direcao="inbound",
+        corpo="4",
+        tipo_midia="texto",
+    )
+    db_session.add(msg)
+    processar_resposta_avaliacao(db_session, chat, st, "4", msg_inbound=msg)
+    db_session.commit()
+    db_session.refresh(chat)
+
+    assert chat.estado == "encerrado"
+    assert chat.avaliacao_nota == 4
+    assert chat.avaliacao_respondida_at is not None
+    assert msg.evento_sistema == "avaliacao_cliente_nota"
+
+
+def test_resposta_invalida_encerra_sem_avaliacao(client, seed_base, auth_headers, db_session, monkeypatch):
+    st = _configurar(db_session)
+    chat = WhatsappChat(
+        protocolo="WPP-AV-2",
+        wa_id="5511999223344",
+        cliente_nome="Cliente",
+        estado="aguardando_avaliacao",
+        atendente_id=1,
+        avaliacao_solicitada=True,
+    )
+    db_session.add(chat)
+    db_session.commit()
+
+    enviados: list[str] = []
+
+    def fake_send(base, inst, key, wa, text):
+        enviados.append(text)
+        return True, None, "wa-out-x"
+
+    monkeypatch.setattr("app.services.whatsapp_avaliacao.evolution_api.evolution_send_text", fake_send)
+
+    msg = WhatsappMensagem(chat_id=chat.id, direcao="inbound", corpo="ótimo", tipo_midia="texto")
+    db_session.add(msg)
+    processar_resposta_avaliacao(db_session, chat, st, "ótimo", msg_inbound=msg)
+    db_session.commit()
+    db_session.refresh(chat)
+
+    assert chat.estado == "encerrado"
+    assert chat.avaliacao_nota is None
+    assert msg.evento_sistema == "avaliacao_cliente_invalida"
+    assert enviados
+    assert "sem avaliação" in enviados[0].lower() or "encerrado" in enviados[0].lower()
+
+
+def test_mensagens_avaliacao_nao_aparecem_na_conversa(client, seed_base, auth_headers, db_session):
+    _configurar(db_session)
+    aid = seed_base["a1"].id
+    chat = WhatsappChat(
+        protocolo="WPP-AV-3",
+        wa_id="5511999334455",
+        cliente_nome="Cliente",
+        estado="encerrado",
+        atendente_id=aid,
+        avaliacao_solicitada=True,
+        avaliacao_nota=5,
+    )
+    db_session.add(chat)
+    db_session.flush()
+    db_session.add_all(
+        [
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="outbound",
+                corpo="[ BOT ]: Avalie",
+                tipo_midia="texto",
+                evento_sistema="auto_avaliacao_solicitacao",
+            ),
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="inbound",
+                corpo="5",
+                tipo_midia="texto",
+                evento_sistema="avaliacao_cliente_nota",
+            ),
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="outbound",
+                corpo="[ Atendente ]: Olá",
+                tipo_midia="texto",
+                atendente_id=aid,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    r = client.get(f"/v1/whatsapp/chats/{chat.id}/mensagens", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    corpos = [m["corpo"] for m in r.json()]
+    assert len(corpos) == 1
+    assert "Olá" in corpos[0]
+
+
+def test_listar_avaliacoes_admin(client, seed_base, auth_headers, db_session):
+    _configurar(db_session)
+    chat = WhatsappChat(
+        protocolo="WPP-AV-4",
+        wa_id="5511999445566",
+        cliente_nome="Cliente",
+        estado="encerrado",
+        atendente_id=1,
+        avaliacao_solicitada=True,
+        avaliacao_nota=3,
+    )
+    db_session.add(chat)
+    db_session.commit()
+
+    r = client.get("/v1/whatsapp/chats/avaliacoes", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] >= 1
+    assert body["items"][0]["nota"] == 3
+
+    r403 = client.get("/v1/whatsapp/chats/avaliacoes", headers=auth_headers["a1"])
+    assert r403.status_code == 403

--- a/backend/tests/test_whatsapp_inatividade_encerramento.py
+++ b/backend/tests/test_whatsapp_inatividade_encerramento.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem, WhatsappSettings
+from app.services.whatsapp_inactivity_worker import process_whatsapp_inactivity_closures
+
+
+def _configurar_evolution(db_session):
+    st = WhatsappSettings(
+        evolution_base_url="http://evolution.test",
+        evolution_instance_name="inst",
+        evolution_api_key="key",
+        webhook_secret="sec",
+        inativ_encerramento_ativa=True,
+        inativ_aviso_minutos=10,
+        inativ_encerramento_apos_aviso_minutos=5,
+        auto_msg_inativ_aviso_ativa=True,
+        auto_msg_encerrado_ativa=True,
+    )
+    db_session.add(st)
+    db_session.commit()
+
+
+def _chat_em_atendimento(db_session, *, wa_id: str = "5511999887766") -> WhatsappChat:
+    chat = WhatsappChat(
+        protocolo="WPP-TEST-1",
+        wa_id=wa_id,
+        cliente_nome="Cliente Teste",
+        estado="em_atendimento",
+        atendente_id=1,
+    )
+    db_session.add(chat)
+    db_session.flush()
+    return chat
+
+
+def test_settings_exige_minutos_quando_inatividade_ativa(client, seed_base, auth_headers):
+    r = client.patch(
+        "/v1/settings/whatsapp",
+        json={"inativ_encerramento_ativa": True, "inativ_aviso_minutos": 10},
+        headers=auth_headers["admin"],
+    )
+    assert r.status_code == 400
+
+
+def test_worker_envia_aviso_apos_inatividade(client, seed_base, auth_headers, db_session, monkeypatch):
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session)
+    antiga_cliente = datetime.now(timezone.utc) - timedelta(minutes=20)
+    antiga_atendente = datetime.now(timezone.utc) - timedelta(minutes=15)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="inbound",
+            corpo="Preciso de ajuda",
+            tipo_midia="texto",
+            created_at=antiga_cliente,
+        )
+    )
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Alguma dúvida?",
+            tipo_midia="texto",
+            atendente_id=1,
+            created_at=antiga_atendente,
+        )
+    )
+    db_session.commit()
+
+    enviados: list[str] = []
+
+    def fake_send(base, inst, key, wa, text):
+        enviados.append(text)
+        return True, None, "wa-out-1"
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        fake_send,
+    )
+
+    n = process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+
+    assert n == 1
+    assert len(enviados) == 1
+    assert "sem responder" in enviados[0].lower() or "encerr" in enviados[0].lower()
+    aviso = (
+        db_session.query(WhatsappMensagem)
+        .filter(WhatsappMensagem.chat_id == chat.id, WhatsappMensagem.evento_sistema == "auto_inativ_aviso")
+        .first()
+    )
+    assert aviso is not None
+    assert chat.estado == "em_atendimento"
+
+
+def test_worker_encerra_apos_aviso(client, seed_base, auth_headers, db_session, monkeypatch):
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session, wa_id="5511999776655")
+    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso de encerramento",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=antiga_aviso,
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-2"),
+    )
+
+    n = process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+
+    assert n == 1
+    assert chat.estado == "encerrado"
+    assert chat.encerramento_at is not None
+
+
+def test_worker_nao_age_quando_cliente_respondeu_por_ultimo(client, seed_base, auth_headers, db_session, monkeypatch):
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session, wa_id="5511999665544")
+    antiga = datetime.now(timezone.utc) - timedelta(minutes=20)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Pergunta?",
+            tipo_midia="texto",
+            atendente_id=1,
+            created_at=antiga,
+        )
+    )
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="inbound",
+            corpo="Resposta do cliente",
+            tipo_midia="texto",
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-3"),
+    )
+
+    n = process_whatsapp_inactivity_closures(db_session)
+    assert n == 0
+
+
+def test_worker_aviso_mesmo_com_atendente_enviando_varias_vezes(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session, wa_id="5511999554433")
+    t_cliente = datetime.now(timezone.utc) - timedelta(minutes=25)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="inbound",
+            corpo="Oi",
+            tipo_midia="texto",
+            created_at=t_cliente,
+        )
+    )
+    for i, delta in enumerate((20, 10, 2)):
+        db_session.add(
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="outbound",
+                corpo=f"[ Atendente ]: Lembrete {i}",
+                tipo_midia="texto",
+                atendente_id=1,
+                created_at=datetime.now(timezone.utc) - timedelta(minutes=delta),
+            )
+        )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-4"),
+    )
+
+    n = process_whatsapp_inactivity_closures(db_session)
+    assert n == 1

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,6 +44,7 @@ import { ConfigSistemaLayout } from './pages/config/ConfigSistemaLayout'
 import { WhatsappLayout } from './pages/whatsapp/WhatsappLayout'
 import { WhatsappAtendendo } from './pages/whatsapp/WhatsappAtendendo'
 import { WhatsappHistorico } from './pages/whatsapp/WhatsappHistorico'
+import { WhatsappAvaliacoes } from './pages/whatsapp/WhatsappAvaliacoes'
 import { WhatsappConversa } from './pages/whatsapp/WhatsappConversa'
 import { AlterarSenha } from './pages/AlterarSenha'
 import { AcessoNegado } from './pages/AcessoNegado'
@@ -99,6 +100,14 @@ function AppRoutes() {
           <Route index element={<Navigate to="atendendo" replace />} />
           <Route path="atendendo" element={<WhatsappAtendendo />} />
           <Route path="historico" element={<WhatsappHistorico />} />
+          <Route
+            path="avaliacoes"
+            element={
+              <AdminRoute>
+                <WhatsappAvaliacoes />
+              </AdminRoute>
+            }
+          />
           <Route path="fila" element={<Navigate to="/whatsapp/atendendo" replace />} />
           <Route path="meus" element={<Navigate to="/whatsapp/atendendo" replace />} />
           <Route path="c/:chatId" element={<WhatsappConversa />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -440,6 +440,15 @@ export namespace WhatsappSettings {
     horario_semana?: Record<string, { ativo?: boolean; inicio?: string; fim?: string }> | null
     usar_feriados_nacionais?: boolean
     nome_empresa_exibicao?: string | null
+    inativ_encerramento_ativa?: boolean
+    inativ_aviso_minutos?: number | null
+    inativ_encerramento_apos_aviso_minutos?: number | null
+    auto_msg_inativ_aviso_ativa?: boolean
+    auto_msg_inativ_aviso_texto?: string | null
+    avaliacao_ativa?: boolean
+    auto_msg_avaliacao_ativa?: boolean
+    auto_msg_avaliacao_texto?: string | null
+    auto_msg_avaliacao_obrigado_texto?: string | null
   }
   export interface ProvisionEmbutidoResult {
     instance: string
@@ -467,6 +476,15 @@ export namespace WhatsappSettings {
     horario_semana?: Record<string, { ativo?: boolean; inicio?: string; fim?: string }> | null
     usar_feriados_nacionais?: boolean | null
     nome_empresa_exibicao?: string | null
+    inativ_encerramento_ativa?: boolean | null
+    inativ_aviso_minutos?: number | null
+    inativ_encerramento_apos_aviso_minutos?: number | null
+    auto_msg_inativ_aviso_ativa?: boolean | null
+    auto_msg_inativ_aviso_texto?: string | null
+    avaliacao_ativa?: boolean | null
+    auto_msg_avaliacao_ativa?: boolean | null
+    auto_msg_avaliacao_texto?: string | null
+    auto_msg_avaliacao_obrigado_texto?: string | null
   }
   export interface TesteResult {
     ok: boolean
@@ -635,7 +653,24 @@ export namespace WhatsappChats {
     created_at?: string | null
     atendimento_inicio_at?: string | null
     encerramento_at?: string | null
+    avaliacao_nota?: number | null
+    avaliacao_respondida_at?: string | null
+    avaliacao_solicitada?: boolean
     ticket_ids: number[]
+  }
+  export interface Avaliacao {
+    chat_id: number
+    protocolo: string
+    wa_id: string
+    cliente_nome?: string | null
+    atendente_id?: number | null
+    atendente_nome?: string | null
+    setor_id?: number | null
+    setor_nome?: string | null
+    nota?: number | null
+    avaliacao_respondida_at?: string | null
+    encerramento_at?: string | null
+    sem_avaliacao: boolean
   }
   export interface Mensagem {
     id: number
@@ -697,8 +732,10 @@ export async function fetchTicketAnexoBlob(ticketId: number, anexoId: number): P
 export const whatsappChats = {
   fila: () => api<WhatsappChats.Chat[]>('/whatsapp/chats/fila'),
   meus: () => api<WhatsappChats.Chat[]>('/whatsapp/chats/meus'),
-  encerrados: (params?: { offset?: number; limit?: number }) =>
+  encerrados: (params?: Record<string, string | number | undefined>) =>
     listPaginated<WhatsappChats.Chat>('/whatsapp/chats/encerrados', params),
+  avaliacoes: (params?: Record<string, string | number | undefined>) =>
+    listPaginated<WhatsappChats.Avaliacao>('/whatsapp/chats/avaliacoes', params),
   get: (id: number) => api<WhatsappChats.Chat>(`/whatsapp/chats/${id}`),
   mensagens: (id: number) => api<WhatsappChats.Mensagem[]>(`/whatsapp/chats/${id}/mensagens`),
   assumir: (id: number) => api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/assumir`, { method: 'POST' }),

--- a/frontend/src/lib/whatsappChatMeta.ts
+++ b/frontend/src/lib/whatsappChatMeta.ts
@@ -8,6 +8,7 @@ type ChatResumo = Pick<
 export function rotuloEstadoChat(estado: string): string {
   if (estado === 'em_atendimento') return 'Em atendimento'
   if (estado === 'aguardando_atendente') return 'Aguardando atendimento'
+  if (estado === 'aguardando_avaliacao') return 'Aguardando avaliação'
   if (estado === 'encerrado') return 'Encerrado'
   return estado.replace(/_/g, ' ')
 }
@@ -19,11 +20,26 @@ export function rotuloResponsavelChat(chat: ChatResumo, usuarioId?: number | nul
   if (chat.estado === 'encerrado') {
     return chat.atendente_nome ? `Encerrado por ${chat.atendente_nome}` : 'Encerrado'
   }
+  if (chat.estado === 'aguardando_avaliacao') {
+    return chat.atendente_nome ? `Aguardando avaliação • ${chat.atendente_nome}` : 'Aguardando avaliação'
+  }
   if (!chat.atendente_id) {
     return chat.setor_nome ? `Sem responsável • ${chat.setor_nome}` : 'Sem responsável'
   }
   if (usuarioId != null && chat.atendente_id === usuarioId) return 'Você'
   return chat.atendente_nome || `Atendente #${chat.atendente_id}`
+}
+
+export function rotuloAvaliacaoChat(chat: {
+  avaliacao_nota?: number | null
+  avaliacao_solicitada?: boolean
+  sem_avaliacao?: boolean
+  nota?: number | null
+}): string {
+  const nota = chat.avaliacao_nota ?? chat.nota
+  if (nota != null) return `${nota}/5`
+  if (chat.sem_avaliacao || (chat.avaliacao_solicitada && nota == null)) return 'Sem avaliação'
+  return '—'
 }
 
 export function mensagemTransferenciaSucesso(chat: ChatResumo): string {

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -14,7 +14,15 @@ type EstadoEvolution = {
   erro?: string | null
 }
 
-type Aba = 'conexao' | 'mensagens' | 'horarios'
+type Aba = 'conexao' | 'mensagens' | 'inatividade' | 'avaliacao' | 'horarios'
+
+const ABAS: Array<{ id: Aba; label: string }> = [
+  { id: 'conexao', label: 'Conexão' },
+  { id: 'mensagens', label: 'Mensagens automáticas' },
+  { id: 'inatividade', label: 'Inatividade' },
+  { id: 'avaliacao', label: 'Avaliação' },
+  { id: 'horarios', label: 'Horários' },
+]
 
 type DiaKey = 'seg' | 'ter' | 'qua' | 'qui' | 'sex' | 'sab' | 'dom'
 type HorarioDia = { ativo: boolean; inicio: string; fim: string }
@@ -86,6 +94,11 @@ const DEFAULT_MSG_ENCERRADO =
   'Atendimento encerrado. Se precisar de algo mais, é só enviar uma nova mensagem por aqui.'
 const DEFAULT_MSG_FORA_HORARIO =
   'Olá, {nome}! No momento estamos fora do horário de atendimento. Assim que voltarmos, responderemos por aqui.'
+const DEFAULT_MSG_INATIV_AVISO =
+  'Olá, {{nome_cliente}}! Você está há um tempo sem responder. Se não houver retorno, encerraremos este atendimento em breve. Responda aqui se ainda precisar de ajuda.'
+const DEFAULT_MSG_AVALIACAO =
+  'Como você avalia o atendimento?\n\nResponda com uma nota de *1* a *5*:\n1 — Péssimo\n2 — Ruim\n3 — Regular\n4 — Bom\n5 — Excelente'
+const DEFAULT_MSG_AVALIACAO_OBRIGADO = 'Obrigado pela sua avaliação! Atendimento encerrado.'
 
 function renderQrPayload(data: Record<string, unknown> | null | undefined) {
   if (!data || typeof data !== 'object') return null
@@ -138,6 +151,8 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
   const [qrPayload, setQrPayload] = useState<Record<string, unknown> | null>(null)
   const [provisionando, setProvisionando] = useState(false)
   const [salvandoMsgs, setSalvandoMsgs] = useState(false)
+  const [salvandoInatividade, setSalvandoInatividade] = useState(false)
+  const [salvandoAvaliacao, setSalvandoAvaliacao] = useState(false)
 
   const [msgEsperaAtiva, setMsgEsperaAtiva] = useState(true)
   const [msgEsperaTexto, setMsgEsperaTexto] = useState(DEFAULT_MSG_ESPERA)
@@ -147,6 +162,15 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
   const [msgEncerradoTexto, setMsgEncerradoTexto] = useState(DEFAULT_MSG_ENCERRADO)
   const [msgForaHorarioAtiva, setMsgForaHorarioAtiva] = useState(true)
   const [msgForaHorarioTexto, setMsgForaHorarioTexto] = useState(DEFAULT_MSG_FORA_HORARIO)
+  const [inativEncerramentoAtiva, setInativEncerramentoAtiva] = useState(false)
+  const [inativAvisoMinutos, setInativAvisoMinutos] = useState('15')
+  const [inativEncerramentoAposAvisoMinutos, setInativEncerramentoAposAvisoMinutos] = useState('5')
+  const [msgInativAvisoAtiva, setMsgInativAvisoAtiva] = useState(true)
+  const [msgInativAvisoTexto, setMsgInativAvisoTexto] = useState(DEFAULT_MSG_INATIV_AVISO)
+  const [avaliacaoAtiva, setAvaliacaoAtiva] = useState(false)
+  const [msgAvaliacaoAtiva, setMsgAvaliacaoAtiva] = useState(true)
+  const [msgAvaliacaoTexto, setMsgAvaliacaoTexto] = useState(DEFAULT_MSG_AVALIACAO)
+  const [msgAvaliacaoObrigadoTexto, setMsgAvaliacaoObrigadoTexto] = useState(DEFAULT_MSG_AVALIACAO_OBRIGADO)
   const [nomeEmpresaExibicao, setNomeEmpresaExibicao] = useState('')
   const [horarioTimezone, setHorarioTimezone] = useState<string>('America/Sao_Paulo')
   const [usarFeriadosNacionais, setUsarFeriadosNacionais] = useState(false)
@@ -169,6 +193,20 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
       setMsgForaHorarioAtiva(Boolean(r.auto_msg_fora_horario_ativa))
       setMsgForaHorarioTexto(
         (r.auto_msg_fora_horario_texto ?? DEFAULT_MSG_FORA_HORARIO).trim() || DEFAULT_MSG_FORA_HORARIO,
+      )
+      setInativEncerramentoAtiva(Boolean(r.inativ_encerramento_ativa))
+      setInativAvisoMinutos(String(r.inativ_aviso_minutos ?? 15))
+      setInativEncerramentoAposAvisoMinutos(String(r.inativ_encerramento_apos_aviso_minutos ?? 5))
+      setMsgInativAvisoAtiva(Boolean(r.auto_msg_inativ_aviso_ativa ?? true))
+      setMsgInativAvisoTexto(
+        (r.auto_msg_inativ_aviso_texto ?? DEFAULT_MSG_INATIV_AVISO).trim() || DEFAULT_MSG_INATIV_AVISO,
+      )
+      setAvaliacaoAtiva(Boolean(r.avaliacao_ativa))
+      setMsgAvaliacaoAtiva(Boolean(r.auto_msg_avaliacao_ativa ?? true))
+      setMsgAvaliacaoTexto((r.auto_msg_avaliacao_texto ?? DEFAULT_MSG_AVALIACAO).trim() || DEFAULT_MSG_AVALIACAO)
+      setMsgAvaliacaoObrigadoTexto(
+        (r.auto_msg_avaliacao_obrigado_texto ?? DEFAULT_MSG_AVALIACAO_OBRIGADO).trim() ||
+          DEFAULT_MSG_AVALIACAO_OBRIGADO,
       )
       setHorarioTimezone((r.horario_timezone ?? 'America/Sao_Paulo').trim() || 'America/Sao_Paulo')
       const identidadeSalva = (r.nome_empresa_exibicao ?? '').trim()
@@ -282,48 +320,27 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
     <Card title={embedded ? undefined : 'WhatsApp (Evolution)'}>
       {!embedded ? (
         <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-          Conecte um número via QR Code e configure mensagens automáticas para padronizar a experiência do cliente.
+          Conecte um número via QR Code e configure mensagens, inatividade, avaliação e horários de atendimento.
         </p>
       ) : null}
 
       <div className={embedded ? 'border-b border-slate-200 dark:border-slate-700/80' : 'mt-5 border-b border-slate-200 dark:border-slate-700/80'}>
-          <nav className="flex gap-1 sm:gap-2" aria-label="Seções do WhatsApp">
-            <button
-              type="button"
-              onClick={() => setAba('conexao')}
-              aria-current={aba === 'conexao' ? 'page' : undefined}
-              className={
-                aba === 'conexao'
-                  ? 'border-b-2 border-sky-500 px-3 py-2 text-sm font-semibold text-slate-900 dark:border-sky-400 dark:bg-slate-800/50 dark:text-white'
-                  : 'border-b-2 border-transparent px-3 py-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800/30 dark:hover:text-slate-200'
-              }
-            >
-              Conexão
-            </button>
-            <button
-              type="button"
-              onClick={() => setAba('mensagens')}
-              aria-current={aba === 'mensagens' ? 'page' : undefined}
-              className={
-                aba === 'mensagens'
-                  ? 'border-b-2 border-sky-500 px-3 py-2 text-sm font-semibold text-slate-900 dark:border-sky-400 dark:bg-slate-800/50 dark:text-white'
-                  : 'border-b-2 border-transparent px-3 py-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800/30 dark:hover:bg-slate-800/30 dark:hover:text-slate-200'
-              }
-            >
-              Mensagens automáticas
-            </button>
-            <button
-              type="button"
-              onClick={() => setAba('horarios')}
-              aria-current={aba === 'horarios' ? 'page' : undefined}
-              className={
-                aba === 'horarios'
-                  ? 'border-b-2 border-sky-500 px-3 py-2 text-sm font-semibold text-slate-900 dark:border-sky-400 dark:bg-slate-800/50 dark:text-white'
-                  : 'border-b-2 border-transparent px-3 py-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800/30 dark:hover:text-slate-200'
-              }
-            >
-              Horários
-            </button>
+          <nav className="-mb-px flex gap-1 overflow-x-auto sm:gap-2" aria-label="Seções do WhatsApp">
+            {ABAS.map(({ id, label }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setAba(id)}
+                aria-current={aba === id ? 'page' : undefined}
+                className={
+                  aba === id
+                    ? 'shrink-0 border-b-2 border-sky-500 px-3 py-2 text-sm font-semibold text-slate-900 dark:border-sky-400 dark:bg-slate-800/50 dark:text-white'
+                    : 'shrink-0 border-b-2 border-transparent px-3 py-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800/30 dark:hover:text-slate-200'
+                }
+              >
+                {label}
+              </button>
+            ))}
           </nav>
         </div>
 
@@ -462,7 +479,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               checked={msgEncerradoAtiva}
               onCheckedChange={setMsgEncerradoAtiva}
               label="Mensagem quando o chat é encerrado"
-              description="Enviada automaticamente quando o atendente encerra o chat."
+              description="Enviada ao finalizar o atendimento quando a avaliação (aba Avaliação) estiver desativada."
               showStatusPill
               statusOnText="Enviar"
               statusOffText="Não enviar"
@@ -514,6 +531,174 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
                 }}
               >
                 Salvar mensagens
+              </Button>
+            </div>
+          </div>
+        ) : aba === 'inatividade' ? (
+          <div className="mt-6 space-y-5">
+            <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 dark:border-slate-700/80 dark:bg-slate-800/20 dark:text-slate-200">
+              <p className="font-medium">Encerramento por inatividade</p>
+              <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
+                Encerra chats em atendimento quando o cliente para de responder. O tempo conta desde a última mensagem
+                do cliente, depois que o atendente já respondeu.
+              </p>
+            </div>
+
+            <Switch
+              checked={inativEncerramentoAtiva}
+              onCheckedChange={setInativEncerramentoAtiva}
+              label="Encerramento automático por inatividade do cliente"
+              description="Novas mensagens do atendente não reiniciam o timer."
+              showStatusPill
+              statusOnText="Ativo"
+              statusOffText="Inativo"
+            />
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <div>
+                <label className="text-xs font-medium text-slate-600 dark:text-slate-400">
+                  Minutos sem resposta para enviar o aviso
+                </label>
+                <input
+                  type="number"
+                  min={1}
+                  max={1440}
+                  disabled={!inativEncerramentoAtiva}
+                  value={inativAvisoMinutos}
+                  onChange={(e) => setInativAvisoMinutos(e.target.value)}
+                  className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-medium text-slate-600 dark:text-slate-400">
+                  Minutos após o aviso para encerrar o chat
+                </label>
+                <input
+                  type="number"
+                  min={1}
+                  max={1440}
+                  disabled={!inativEncerramentoAtiva}
+                  value={inativEncerramentoAposAvisoMinutos}
+                  onChange={(e) => setInativEncerramentoAposAvisoMinutos(e.target.value)}
+                  className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+                />
+              </div>
+            </div>
+            <Switch
+              checked={msgInativAvisoAtiva}
+              onCheckedChange={setMsgInativAvisoAtiva}
+              label="Mensagem de aviso antes do encerramento"
+              description="Enviada ao cliente quando o tempo de inatividade é atingido."
+              showStatusPill
+              statusOnText="Enviar"
+              statusOffText="Encerrar direto"
+            />
+            <textarea
+              value={msgInativAvisoTexto}
+              onChange={(e) => setMsgInativAvisoTexto(e.target.value)}
+              rows={4}
+              disabled={!inativEncerramentoAtiva || !msgInativAvisoAtiva}
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+            />
+
+            <div className="flex justify-end pt-2">
+              <Button
+                type="button"
+                loading={salvandoInatividade}
+                onClick={() => {
+                  const avisoMin = Number.parseInt(inativAvisoMinutos, 10)
+                  const posMin = Number.parseInt(inativEncerramentoAposAvisoMinutos, 10)
+                  if (
+                    inativEncerramentoAtiva &&
+                    (!Number.isFinite(avisoMin) || avisoMin < 1 || !Number.isFinite(posMin) || posMin < 1)
+                  ) {
+                    toast.showError('Informe minutos válidos para aviso e encerramento após o aviso.')
+                    return
+                  }
+                  setSalvandoInatividade(true)
+                  whatsappSettings
+                    .patch({
+                      inativ_encerramento_ativa: inativEncerramentoAtiva,
+                      inativ_aviso_minutos: inativEncerramentoAtiva ? avisoMin : null,
+                      inativ_encerramento_apos_aviso_minutos: inativEncerramentoAtiva ? posMin : null,
+                      auto_msg_inativ_aviso_ativa: msgInativAvisoAtiva,
+                      auto_msg_inativ_aviso_texto: msgInativAvisoTexto,
+                    })
+                    .then(() => toast.showSuccess('Configurações de inatividade atualizadas.'))
+                    .catch((err) => toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.')))
+                    .finally(() => setSalvandoInatividade(false))
+                }}
+              >
+                Salvar inatividade
+              </Button>
+            </div>
+          </div>
+        ) : aba === 'avaliacao' ? (
+          <div className="mt-6 space-y-5">
+            <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 dark:border-slate-700/80 dark:bg-slate-800/20 dark:text-slate-200">
+              <p className="font-medium">Avaliação do atendimento</p>
+              <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
+                Ao encerrar o chat, o cliente recebe uma solicitação de nota de 1 a 5 antes do atendimento ser
+                finalizado. As notas aparecem no histórico de conversas.
+              </p>
+            </div>
+
+            <Switch
+              checked={avaliacaoAtiva}
+              onCheckedChange={setAvaliacaoAtiva}
+              label="Solicitar avaliação ao encerrar (notas 1 a 5)"
+              showStatusPill
+              statusOnText="Ativo"
+              statusOffText="Inativo"
+            />
+            <Switch
+              checked={msgAvaliacaoAtiva}
+              onCheckedChange={setMsgAvaliacaoAtiva}
+              label="Enviar mensagens de avaliação"
+              description="Solicitação da nota e agradecimento após a resposta."
+              showStatusPill
+              statusOnText="Enviar"
+              statusOffText="Encerrar direto"
+            />
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-400">
+              Mensagem solicitando a nota (1 a 5)
+            </label>
+            <textarea
+              value={msgAvaliacaoTexto}
+              onChange={(e) => setMsgAvaliacaoTexto(e.target.value)}
+              rows={4}
+              disabled={!avaliacaoAtiva || !msgAvaliacaoAtiva}
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+            />
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-400">
+              Mensagem de agradecimento após a nota
+            </label>
+            <textarea
+              value={msgAvaliacaoObrigadoTexto}
+              onChange={(e) => setMsgAvaliacaoObrigadoTexto(e.target.value)}
+              rows={2}
+              disabled={!avaliacaoAtiva || !msgAvaliacaoAtiva}
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+            />
+
+            <div className="flex justify-end pt-2">
+              <Button
+                type="button"
+                loading={salvandoAvaliacao}
+                onClick={() => {
+                  setSalvandoAvaliacao(true)
+                  whatsappSettings
+                    .patch({
+                      avaliacao_ativa: avaliacaoAtiva,
+                      auto_msg_avaliacao_ativa: msgAvaliacaoAtiva,
+                      auto_msg_avaliacao_texto: msgAvaliacaoTexto,
+                      auto_msg_avaliacao_obrigado_texto: msgAvaliacaoObrigadoTexto,
+                    })
+                    .then(() => toast.showSuccess('Configurações de avaliação atualizadas.'))
+                    .catch((err) => toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.')))
+                    .finally(() => setSalvandoAvaliacao(false))
+                }}
+              >
+                Salvar avaliação
               </Button>
             </div>
           </div>

--- a/frontend/src/pages/config/ConfigSistemaLayout.tsx
+++ b/frontend/src/pages/config/ConfigSistemaLayout.tsx
@@ -12,7 +12,7 @@ const TABS = [
 const TAB_HINTS: Record<string, string> = {
   empresa: 'Dados institucionais da instalação — CNPJ, logo e endereço.',
   email: 'Encaminhamento por setor e envio de respostas aos clientes.',
-  whatsapp: 'Conexão Evolution API, mensagens automáticas e horários de atendimento.',
+  whatsapp: 'Conexão, mensagens automáticas, inatividade, avaliação e horários de atendimento.',
   auditoria: 'Histórico de alterações em cadastros e configurações.',
 }
 

--- a/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
@@ -1,0 +1,178 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { atendentes, whatsappChats, type WhatsappChats, type Atendentes } from '../../api/client'
+import { Card } from '../../components/ui/Card'
+import { Button } from '../../components/ui/Button'
+import { Input } from '../../components/ui/Input'
+import { Select } from '../../components/ui/Select'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { exibirProtocolo } from '../../lib/exibirProtocolo'
+import { rotuloAvaliacaoChat } from '../../lib/whatsappChatMeta'
+
+const PAGE_SIZE = 15
+
+export function WhatsappAvaliacoes() {
+  const toast = useToast()
+  const [items, setItems] = useState<WhatsappChats.Avaliacao[]>([])
+  const [total, setTotal] = useState(0)
+  const [offset, setOffset] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [busca, setBusca] = useState('')
+  const [atendentesList, setAtendentesList] = useState<Atendentes.Atendente[]>([])
+  const [atendenteId, setAtendenteId] = useState<number | ''>('')
+  const [notaMin, setNotaMin] = useState<number | ''>('')
+  const [desde, setDesde] = useState('')
+  const [ate, setAte] = useState('')
+
+  const load = useCallback(
+    async (from: number) => {
+      setLoading(true)
+      try {
+        const params: Record<string, string | number | undefined> = {
+          offset: from,
+          limit: PAGE_SIZE,
+        }
+        if (busca.trim()) params.busca = busca.trim()
+        if (atendenteId !== '') params.atendente_id = atendenteId
+        if (notaMin !== '') {
+          params.nota_min = notaMin
+          params.nota_max = notaMin
+        }
+        if (desde) params.encerramento_inicio = `${desde}T00:00:00`
+        if (ate) params.encerramento_fim = `${ate}T23:59:59`
+        const { items: rows, total: t } = await whatsappChats.avaliacoes(params)
+        setItems(rows)
+        setTotal(t)
+        setOffset(from)
+      } catch (err) {
+        toast.showError(mensagemFalhaParaToast(err, 'Falha ao carregar avaliações.'))
+      } finally {
+        setLoading(false)
+      }
+    },
+    [atendenteId, ate, busca, desde, notaMin, toast],
+  )
+
+  useEffect(() => {
+    void load(0)
+  }, [load])
+
+  useEffect(() => {
+    void atendentes
+      .list({ incluir_inativos: true, offset: 0, limit: 100 })
+      .then((result) => setAtendentesList(result.items))
+      .catch(() => setAtendentesList([]))
+  }, [])
+
+  const mediaNotas =
+    items.filter((i) => i.nota != null).length > 0
+      ? (
+          items.filter((i) => i.nota != null).reduce((s, i) => s + (i.nota ?? 0), 0) /
+          items.filter((i) => i.nota != null).length
+        ).toFixed(1)
+      : null
+
+  const paginaAtual = Math.floor(offset / PAGE_SIZE) + 1
+  const totalPaginas = Math.ceil(total / PAGE_SIZE)
+
+  return (
+    <div className="space-y-6">
+      <Card className="border-none p-4 shadow-sm ring-1 ring-slate-200 dark:ring-slate-800">
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <Input label="Busca" value={busca} onChange={(e) => setBusca(e.target.value)} placeholder="Protocolo, telefone…" />
+          <Select
+            label="Atendente"
+            value={atendenteId}
+            onChange={(value) => setAtendenteId(value === '' ? '' : Number(value))}
+            options={atendentesList.map((a) => ({ value: a.id, label: a.nome }))}
+            placeholder="Todos"
+            includeEmpty
+            emptyLabel="Todos"
+          />
+          <Select
+            label="Nota"
+            value={notaMin}
+            onChange={(value) => setNotaMin(value === '' ? '' : Number(value))}
+            options={[5, 4, 3, 2, 1].map((n) => ({ value: n, label: String(n) }))}
+            placeholder="Todas"
+            includeEmpty
+            emptyLabel="Todas"
+          />
+          <div className="grid grid-cols-2 gap-2">
+            <Input label="De" type="date" value={desde} onChange={(e) => setDesde(e.target.value)} />
+            <Input label="Até" type="date" value={ate} onChange={(e) => setAte(e.target.value)} />
+          </div>
+        </div>
+        <div className="mt-4 flex justify-end">
+          <Button type="button" onClick={() => void load(0)}>
+            Filtrar
+          </Button>
+        </div>
+      </Card>
+
+      {mediaNotas && (
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Média nesta página: <span className="font-semibold text-slate-900 dark:text-slate-100">{mediaNotas}</span>
+        </p>
+      )}
+
+      {loading ? (
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-16 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <Card className="py-12 text-center text-sm text-slate-500">Nenhuma avaliação encontrada.</Card>
+      ) : (
+        <div className="grid gap-3">
+          {items.map((a) => (
+            <Card key={a.chat_id} className="border-none p-4 shadow-sm ring-1 ring-slate-200 dark:ring-slate-800">
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                  <p className="font-semibold text-slate-900 dark:text-slate-100">{a.cliente_nome || 'Cliente'}</p>
+                  <p className="font-mono text-xs text-cyan-600 dark:text-cyan-400">{exibirProtocolo(a.protocolo)}</p>
+                  <p className="text-xs text-slate-500">{a.atendente_nome || '—'} · {a.setor_nome || 'Sem setor'}</p>
+                </div>
+                <div className="text-right">
+                  <p className="text-lg font-bold text-slate-900 dark:text-slate-100">{rotuloAvaliacaoChat(a)}</p>
+                  <p className="text-xs text-slate-500">
+                    {a.encerramento_at
+                      ? new Date(a.encerramento_at).toLocaleString('pt-BR')
+                      : '—'}
+                  </p>
+                  <Link
+                    to={`/whatsapp/c/${a.chat_id}`}
+                    className="mt-1 inline-block text-xs font-medium text-cyan-600 hover:underline dark:text-cyan-400"
+                  >
+                    Ver conversa
+                  </Link>
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {totalPaginas > 1 && (
+        <footer className="flex items-center justify-between border-t pt-4 dark:border-slate-800">
+          <Button type="button" variant="secondary" disabled={offset === 0} onClick={() => void load(offset - PAGE_SIZE)}>
+            Anterior
+          </Button>
+          <span className="text-sm text-slate-500">
+            Página {paginaAtual} de {totalPaginas}
+          </span>
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={offset + PAGE_SIZE >= total}
+            onClick={() => void load(offset + PAGE_SIZE)}
+          >
+            Próxima
+          </Button>
+        </footer>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -343,7 +343,7 @@ export function WhatsappConversa() {
 
   useEffect(() => {
 
-    if (!chat || chat.estado === 'encerrado') return
+    if (!chat || chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao') return
 
     const t = setInterval(() => void carregar().catch(() => {}), 5000)
 
@@ -545,11 +545,15 @@ useEffect(() => {
 
     try {
 
-      await whatsappChats.encerrar(chat.id)
+      const atualizado = await whatsappChats.encerrar(chat.id)
 
       await carregar()
 
-      toast.showSuccess('Atendimento encerrado.')
+      toast.showSuccess(
+        atualizado.estado === 'aguardando_avaliacao'
+          ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
+          : 'Atendimento encerrado.',
+      )
 
     } finally { setEncerrando(false) }
 
@@ -573,7 +577,7 @@ useEffect(() => {
 
 
 
-  const encerrado = chat?.estado === 'encerrado'
+  const encerrado = chat?.estado === 'encerrado' || chat?.estado === 'aguardando_avaliacao'
 
   const isResponsavel = user?.role === 'admin' || (chat?.atendente_id === user?.id)
 

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -8,6 +8,7 @@ import { Select } from '../../components/ui/Select'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
+import { rotuloAvaliacaoChat } from '../../lib/whatsappChatMeta'
 
 const PAGE_SIZE = 15 // Reduzi para 15 para melhorar o fôlego da página em listas longas
 
@@ -186,6 +187,12 @@ export function WhatsappHistorico() {
                       <div>
                         <p className="text-[10px] font-bold uppercase tracking-tight text-slate-400">Duração</p>
                         <p className="text-xs font-medium text-slate-700 dark:text-slate-300">{formatDuration(c)}</p>
+                      </div>
+                      <div>
+                        <p className="text-[10px] font-bold uppercase tracking-tight text-slate-400">Avaliação</p>
+                        <p className="text-xs font-medium text-slate-700 dark:text-slate-300">
+                          {rotuloAvaliacaoChat(c)}
+                        </p>
                       </div>
                     </div>
 

--- a/frontend/src/pages/whatsapp/WhatsappLayout.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappLayout.tsx
@@ -1,9 +1,10 @@
 import { Outlet, useLocation, Link } from 'react-router-dom'
+import { useAuth } from '../../contexts/AuthContext'
 
 export function WhatsappLayout() {
   const loc = useLocation()
-  
-  // Foco total: Se estiver dentro de um chat específico, removemos a moldura do layout
+  const { user } = useAuth()
+
   if (/\/whatsapp\/c\//.test(loc.pathname)) {
     return (
       <div className="h-full w-full animate-in fade-in duration-300">
@@ -13,11 +14,18 @@ export function WhatsappLayout() {
   }
 
   const isHistorico = loc.pathname.includes('/whatsapp/historico')
+  const isAvaliacoes = loc.pathname.includes('/whatsapp/avaliacoes')
+  const isAtendendo = !isHistorico && !isAvaliacoes
+
+  const tabClass = (active: boolean) =>
+    `flex items-center gap-2 rounded-lg px-5 py-2.5 text-sm font-bold transition-all sm:px-6 ${
+      active
+        ? 'bg-white text-cyan-600 shadow-sm dark:bg-slate-700 dark:text-cyan-400'
+        : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
+    }`
 
   return (
     <div className="mx-auto max-w-6xl space-y-8 pb-10 pt-4 animate-in fade-in slide-in-from-top-1 duration-500">
-      
-      {/* Header e Navegação */}
       <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <div className="flex items-center gap-3">
@@ -25,51 +33,39 @@ export function WhatsappLayout() {
               <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
             </div>
             <div>
-              <h1 className="text-3xl font-extrabold tracking-tight text-slate-900 dark:text-white">
-                WhatsApp
-              </h1>
+              <h1 className="text-3xl font-extrabold tracking-tight text-slate-900 dark:text-white">WhatsApp</h1>
               <p className="text-sm font-medium text-slate-500">
-                {isHistorico ? 'Revisão de atendimentos passados' : 'Operação em tempo real'}
+                {isAvaliacoes
+                  ? 'Avaliações dos clientes (notas não aparecem na conversa)'
+                  : isHistorico
+                    ? 'Revisão de atendimentos passados'
+                    : 'Operação em tempo real'}
               </p>
             </div>
           </div>
         </div>
 
-        {/* Tabs de Navegação Estilo Segmented Control */}
-        <nav className="inline-flex items-center rounded-xl bg-slate-100 p-1.5 dark:bg-slate-800/60 ring-1 ring-slate-200 dark:ring-slate-800">
-          <Link
-            to="/whatsapp/atendendo"
-            className={`relative flex items-center gap-2 rounded-lg px-6 py-2.5 text-sm font-bold transition-all ${
-              !isHistorico
-                ? 'bg-white text-cyan-600 shadow-sm dark:bg-slate-700 dark:text-cyan-400'
-                : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
-            }`}
-          >
-            {!isHistorico && (
+        <nav className="inline-flex max-w-full items-center overflow-x-auto rounded-xl bg-slate-100 p-1.5 dark:bg-slate-800/60 ring-1 ring-slate-200 dark:ring-slate-800">
+          <Link to="/whatsapp/atendendo" className={tabClass(isAtendendo)}>
+            {isAtendendo && (
               <span className="absolute -top-1 -right-1 flex h-2 w-2">
-                <span className="absolute h-full w-full animate-ping rounded-full bg-cyan-400 opacity-75"></span>
-                <span className="relative h-2 w-2 rounded-full bg-cyan-500"></span>
+                <span className="absolute h-full w-full animate-ping rounded-full bg-cyan-400 opacity-75" />
+                <span className="relative h-2 w-2 rounded-full bg-cyan-500" />
               </span>
             )}
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M14 9a2 2 0 0 1-2 2H6l-4 4V5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2z"/><path d="M18 9h2a2 2 0 0 1 2 2v11l-4-4h-6a2 2 0 0 1-2-2v-1"/></svg>
             Atendimento
           </Link>
-
-          <Link
-            to="/whatsapp/historico"
-            className={`flex items-center gap-2 rounded-lg px-6 py-2.5 text-sm font-bold transition-all ${
-              isHistorico
-                ? 'bg-white text-cyan-600 shadow-sm dark:bg-slate-700 dark:text-cyan-400'
-                : 'text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200'
-            }`}
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+          <Link to="/whatsapp/historico" className={tabClass(isHistorico)}>
             Histórico
           </Link>
+          {user?.role === 'admin' && (
+            <Link to="/whatsapp/avaliacoes" className={tabClass(isAvaliacoes)}>
+              Avaliações
+            </Link>
+          )}
         </nav>
       </div>
 
-      {/* Conteúdo Renderizado */}
       <main className="relative min-h-[500px]">
         <Outlet />
       </main>


### PR DESCRIPTION
## Summary

- Sincroniza `staging` com `main` após merge do PR #231.
- Encerramento automático por inatividade do cliente (configurável).
- Avaliação 1–5 ao encerrar atendimento, com mensagens ocultas na conversa do atendente.
- Resposta inválida encerra sem avaliação; histórico e tela admin (`/whatsapp/avaliacoes`) exibem notas.
- Migrations **037–039** — aplicar com `alembic upgrade head` no deploy.

## Test plan

- [ ] Deploy em staging concluído sem erro
- [ ] `alembic upgrade head` aplicado no banco de produção/staging
- [ ] Config WhatsApp: abas Inatividade e Avaliação funcionando
- [ ] Fluxo de encerramento + avaliação testado com WhatsApp real
- [ ] Tela `/whatsapp/avaliacoes` acessível para admin
- [ ] Histórico de encerrados exibe coluna Avaliação
