### PR TITLE
feat(whatsapp): avaliação em estrelas no histórico

### DIFF
--- a/frontend/src/components/ui/AvaliacaoEstrelas.tsx
+++ b/frontend/src/components/ui/AvaliacaoEstrelas.tsx
@@ -1,0 +1,69 @@
+import { resolveAvaliacaoChat } from '../../lib/whatsappChatMeta'
+
+type AvaliacaoChat = Parameters<typeof resolveAvaliacaoChat>[0]
+
+type AvaliacaoEstrelasProps = {
+  chat: AvaliacaoChat
+  size?: 'sm' | 'md'
+  className?: string
+}
+
+const STAR_PATH =
+  'M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z'
+
+function Estrela({ preenchida, size }: { preenchida: boolean; size: 'sm' | 'md' }) {
+  const dim = size === 'sm' ? 14 : 18
+  return (
+    <svg
+      width={dim}
+      height={dim}
+      viewBox="0 0 24 24"
+      aria-hidden
+      className={preenchida ? 'text-amber-400' : 'text-slate-300 dark:text-slate-600'}
+    >
+      {preenchida ? (
+        <path fill="currentColor" d={STAR_PATH} />
+      ) : (
+        <path
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={1.5}
+          strokeLinejoin="round"
+          d={STAR_PATH}
+        />
+      )}
+    </svg>
+  )
+}
+
+export function AvaliacaoEstrelas({ chat, size = 'sm', className = '' }: AvaliacaoEstrelasProps) {
+  const resolvida = resolveAvaliacaoChat(chat)
+
+  if (resolvida.kind === 'sem_avaliacao') {
+    return (
+      <span className={`text-xs font-medium text-slate-500 dark:text-slate-400 ${className}`}>
+        Sem avaliação
+      </span>
+    )
+  }
+
+  if (resolvida.kind === 'nao_solicitada') {
+    return (
+      <span className={`text-xs font-medium text-slate-400 dark:text-slate-500 ${className}`}>—</span>
+    )
+  }
+
+  const { nota } = resolvida
+
+  return (
+    <span
+      className={`inline-flex items-center gap-0.5 ${className}`}
+      title={`${nota} de 5 estrelas`}
+      aria-label={`Avaliação: ${nota} de 5 estrelas`}
+    >
+      {Array.from({ length: 5 }, (_, i) => (
+        <Estrela key={i} preenchida={i < nota} size={size} />
+      ))}
+    </span>
+  )
+}

--- a/frontend/src/lib/whatsappChatMeta.ts
+++ b/frontend/src/lib/whatsappChatMeta.ts
@@ -30,15 +30,32 @@ export function rotuloResponsavelChat(chat: ChatResumo, usuarioId?: number | nul
   return chat.atendente_nome || `Atendente #${chat.atendente_id}`
 }
 
+export type AvaliacaoChatResolvida =
+  | { kind: 'nota'; nota: number }
+  | { kind: 'sem_avaliacao' }
+  | { kind: 'nao_solicitada' }
+
+export function resolveAvaliacaoChat(chat: {
+  avaliacao_nota?: number | null
+  avaliacao_solicitada?: boolean
+  sem_avaliacao?: boolean
+  nota?: number | null
+}): AvaliacaoChatResolvida {
+  const nota = chat.avaliacao_nota ?? chat.nota
+  if (nota != null) return { kind: 'nota', nota }
+  if (chat.sem_avaliacao || (chat.avaliacao_solicitada && nota == null)) return { kind: 'sem_avaliacao' }
+  return { kind: 'nao_solicitada' }
+}
+
 export function rotuloAvaliacaoChat(chat: {
   avaliacao_nota?: number | null
   avaliacao_solicitada?: boolean
   sem_avaliacao?: boolean
   nota?: number | null
 }): string {
-  const nota = chat.avaliacao_nota ?? chat.nota
-  if (nota != null) return `${nota}/5`
-  if (chat.sem_avaliacao || (chat.avaliacao_solicitada && nota == null)) return 'Sem avaliação'
+  const resolvida = resolveAvaliacaoChat(chat)
+  if (resolvida.kind === 'nota') return `${resolvida.nota}/5`
+  if (resolvida.kind === 'sem_avaliacao') return 'Sem avaliação'
   return '—'
 }
 

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -8,7 +8,7 @@ import { Select } from '../../components/ui/Select'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
-import { rotuloAvaliacaoChat } from '../../lib/whatsappChatMeta'
+import { AvaliacaoEstrelas } from '../../components/ui/AvaliacaoEstrelas'
 
 const PAGE_SIZE = 15 // Reduzi para 15 para melhorar o fôlego da página em listas longas
 
@@ -190,9 +190,9 @@ export function WhatsappHistorico() {
                       </div>
                       <div>
                         <p className="text-[10px] font-bold uppercase tracking-tight text-slate-400">Avaliação</p>
-                        <p className="text-xs font-medium text-slate-700 dark:text-slate-300">
-                          {rotuloAvaliacaoChat(c)}
-                        </p>
+                        <div className="flex justify-end">
+                          <AvaliacaoEstrelas chat={c} size="sm" />
+                        </div>
                       </div>
                     </div>
 


### PR DESCRIPTION
## Summary

- Exibe a avaliação do cliente em **estrelas** (1–5) na listagem de chats encerrados (`WhatsappHistorico`).
- Mantém texto para casos sem nota (`Sem avaliação`) ou quando a avaliação não foi solicitada.
- Novo componente reutilizável `AvaliacaoEstrelas`.

## Test plan

- [ ] Abrir WhatsApp → Histórico com chats encerrados que tenham nota
- [ ] Confirmar exibição de estrelas preenchidas conforme a nota (ex.: nota 4 = 4 estrelas âmbar + 1 vazia)
- [ ] Confirmar tooltip ao passar o mouse (`X de 5 estrelas`)
- [ ] Chats sem avaliação exibem "Sem avaliação" ou traço conforme o caso
