### PR TITLE
feat(tickets): filtro em atendimento e ajuste de colunas na listagem

### DIFF
--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -380,6 +380,10 @@ def listar(
         False,
         description="Somente tickets sem atendente atribuído (fila do setor)",
     ),
+    com_responsavel: bool = Query(
+        False,
+        description="Somente tickets com responsável atribuído (em atendimento)",
+    ),
     meus: bool = Query(False, description="Somente tickets em que você é o responsável"),
     atendente_id: int | None = Query(
         None,
@@ -429,7 +433,9 @@ def listar(
         q = q.filter(Ticket.atendente_id == atendente_id)
     elif meus:
         q = q.filter(Ticket.atendente_id == atendente.id)
-    if sem_responsavel:
+    elif com_responsavel:
+        q = q.filter(Ticket.atendente_id.isnot(None))
+    elif sem_responsavel:
         q = q.filter(Ticket.atendente_id.is_(None))
 
     if situacao == SituacaoTicket.abertos:

--- a/backend/tests/test_ticket_list_filtros.py
+++ b/backend/tests/test_ticket_list_filtros.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+
+def _create_ticket(client, headers: dict[str, str], empresa_id: int, setor_id: int, assunto: str):
+    r = client.post(
+        "/v1/tickets",
+        headers=headers,
+        json={"empresa_id": empresa_id, "setor_id": setor_id, "assunto": assunto, "descricao": "Teste"},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def test_listar_filtro_com_responsavel(client, seed_base, auth_headers):
+    empresa_id = seed_base["empresa"].id
+    setor_id = seed_base["setor1"].id
+
+    na_fila = _create_ticket(client, auth_headers["admin"], empresa_id, setor_id, "Na fila")
+    com_resp = _create_ticket(client, auth_headers["admin"], empresa_id, setor_id, "Com responsável")
+    r_patch = client.patch(
+        f"/v1/tickets/{com_resp['id']}",
+        headers=auth_headers["admin"],
+        json={"atendente_id": seed_base["a1"].id},
+    )
+    assert r_patch.status_code == 200, r_patch.text
+
+    r_fila = client.get(
+        "/v1/tickets",
+        params={"situacao": "abertos", "sem_responsavel": True},
+        headers=auth_headers["admin"],
+    )
+    assert r_fila.status_code == 200
+    ids_fila = {t["id"] for t in r_fila.json()["items"]}
+    assert na_fila["id"] in ids_fila
+    assert com_resp["id"] not in ids_fila
+
+    r_atend = client.get(
+        "/v1/tickets",
+        params={"situacao": "abertos", "com_responsavel": True},
+        headers=auth_headers["admin"],
+    )
+    assert r_atend.status_code == 200
+    ids_atend = {t["id"] for t in r_atend.json()["items"]}
+    assert com_resp["id"] in ids_atend
+    assert na_fila["id"] not in ids_atend

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -805,6 +805,7 @@ export const tickets = {
     protocolo?: string;
     busca?: string;
     sem_responsavel?: boolean;
+    com_responsavel?: boolean;
     meus?: boolean;
     atendente_id?: number;
     /** Coluna para ordenar (omitir = mais recentes primeiro). */

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -70,8 +70,8 @@ export function Tickets() {
   const [empresasOpt, setEmpresasOpt] = useState<Empresas.EmpresaListaItem[]>([])
   const [setoresOpt, setSetoresOpt] = useState<Setores.Setor[]>([])
   const [atendentesOpt, setAtendentesOpt] = useState<Atendentes.Atendente[]>([])
-  /** '' | 'sem_responsavel' | 'meus' — fila do setor vs. atribuídos a mim */
-  const [filtroFila, setFiltroFila] = useState<'' | 'sem_responsavel' | 'meus'>(() => {
+  /** '' | 'sem_responsavel' | 'com_responsavel' | 'meus */
+  const [filtroFila, setFiltroFila] = useState<'' | 'sem_responsavel' | 'com_responsavel' | 'meus'>(() => {
     const sr = searchParams.get('sem_responsavel')
     return sr === '1' || sr === 'true' ? 'sem_responsavel' : ''
   })
@@ -204,9 +204,15 @@ export function Tickets() {
         empresa_id: filtroEmpresa !== '' ? Number(filtroEmpresa) : undefined,
         setor_id: filtroSetor !== '' ? Number(filtroSetor) : undefined,
         sem_responsavel: filtroFila === 'sem_responsavel' ? true : undefined,
+        com_responsavel: filtroFila === 'com_responsavel' ? true : undefined,
         meus: filtroFila === 'meus' ? true : undefined,
         atendente_id:
-          isAdmin && filtroFila === '' && filtroAtendente !== '' ? Number(filtroAtendente) : undefined,
+          isAdmin &&
+          filtroFila !== 'sem_responsavel' &&
+          filtroFila !== 'meus' &&
+          filtroAtendente !== ''
+            ? Number(filtroAtendente)
+            : undefined,
         ...sortParams,
         offset: (page - 1) * PAGE_SIZE_PADRAO,
         limit: PAGE_SIZE_PADRAO,
@@ -391,6 +397,7 @@ export function Tickets() {
                 [
                   { id: '' as const, label: 'Todos' },
                   { id: 'sem_responsavel' as const, label: 'Na fila' },
+                  { id: 'com_responsavel' as const, label: 'Em atendimento' },
                   { id: 'meus' as const, label: 'Meus' },
                 ] as const
               ).map(({ id, label }) => {
@@ -416,8 +423,9 @@ export function Tickets() {
               })}
             </div>
             <p className="mt-2 max-w-xl text-xs text-slate-500 dark:text-slate-400">
-              <span className="font-medium text-slate-600 dark:text-slate-300">Na fila</span> mostra chamados sem responsável no setor.
-              {isAdmin && ' Use «Mais filtros» para ver tickets de um atendente.'}
+              <span className="font-medium text-slate-600 dark:text-slate-300">Na fila</span> — sem responsável.{' '}
+              <span className="font-medium text-slate-600 dark:text-slate-300">Em atendimento</span> — já com responsável atribuído.
+              {isAdmin && ' Use «Mais filtros» para filtrar por atendente da equipe.'}
             </p>
             </div>
           )}
@@ -496,7 +504,9 @@ export function Tickets() {
                   includeEmpty
                   emptyLabel="Qualquer"
                   placeholder="Qualquer"
-                  disabled={situacao === 'abertos' ? filtroFila !== '' : false}
+                  disabled={
+                    situacao === 'abertos' ? filtroFila === 'sem_responsavel' || filtroFila === 'meus' : false
+                  }
                 />
               )}
             </div>
@@ -611,11 +621,13 @@ export function Tickets() {
                         <span className="font-medium text-slate-600 dark:text-slate-300">Resp.:</span>{' '}
                         {t.atendente_nome ?? 'Na fila'}
                       </span>
-                      <span className="truncate">
-                        <span className="font-medium text-slate-600 dark:text-slate-300">Prior.:</span>{' '}
-                        {rotuloPrioridade(t.prioridade)}
-                      </span>
-                      {t.motivo_nome ? (
+                      {situacao === 'abertos' && (
+                        <span className="truncate">
+                          <span className="font-medium text-slate-600 dark:text-slate-300">Prior.:</span>{' '}
+                          {rotuloPrioridade(t.prioridade)}
+                        </span>
+                      )}
+                      {situacao === 'fechados' && t.motivo_nome ? (
                         <span className="truncate">
                           <span className="font-medium text-slate-600 dark:text-slate-300">Motivo:</span>{' '}
                           {t.motivo_nome}
@@ -693,8 +705,12 @@ export function Tickets() {
                     }}
                     className="hidden px-4 py-3 md:table-cell sm:px-6"
                   />
-                  <th className="hidden px-4 py-3 md:table-cell sm:px-6">Prioridade</th>
-                  <th className="hidden px-4 py-3 lg:table-cell sm:px-6">Motivo</th>
+                  {situacao === 'abertos' && (
+                    <th className="hidden px-4 py-3 md:table-cell sm:px-6">Prioridade</th>
+                  )}
+                  {situacao === 'fechados' && (
+                    <th className="hidden px-4 py-3 lg:table-cell sm:px-6">Motivo</th>
+                  )}
                   {situacao === 'fechados' ? (
                     <CabecalhoOrdenavel
                       coluna="fechado_em"
@@ -780,26 +796,30 @@ export function Tickets() {
                     <td className="hidden px-4 py-3.5 align-top font-medium text-slate-900 md:table-cell sm:px-6 dark:text-slate-100" title={t.assunto}>
                       <span className="block break-words whitespace-normal leading-snug">{t.assunto}</span>
                     </td>
-                    <td className="hidden px-4 py-3.5 align-top md:table-cell sm:px-6">
-                      <span
-                        className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${classeBadgePrioridade(t.prioridade)}`}
+                    {situacao === 'abertos' && (
+                      <td className="hidden px-4 py-3.5 align-top md:table-cell sm:px-6">
+                        <span
+                          className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${classeBadgePrioridade(t.prioridade)}`}
+                        >
+                          {rotuloPrioridade(t.prioridade)}
+                        </span>
+                      </td>
+                    )}
+                    {situacao === 'fechados' && (
+                      <td
+                        className="hidden px-4 py-3.5 align-top text-slate-600 lg:table-cell sm:px-6 dark:text-slate-400"
+                        title={t.motivo_outro_texto ?? undefined}
                       >
-                        {rotuloPrioridade(t.prioridade)}
-                      </span>
-                    </td>
-                    <td
-                      className="hidden px-4 py-3.5 align-top text-slate-600 lg:table-cell sm:px-6 dark:text-slate-400"
-                      title={t.motivo_outro_texto ?? undefined}
-                    >
-                      <span className="block break-words whitespace-normal leading-snug">
-                        {t.motivo_nome ?? '—'}
-                        {t.motivo_outro_texto ? (
-                          <span className="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">
-                            {t.motivo_outro_texto}
-                          </span>
-                        ) : null}
-                      </span>
-                    </td>
+                        <span className="block break-words whitespace-normal leading-snug">
+                          {t.motivo_nome ?? '—'}
+                          {t.motivo_outro_texto ? (
+                            <span className="mt-0.5 block text-xs text-slate-500 dark:text-slate-400">
+                              {t.motivo_outro_texto}
+                            </span>
+                          ) : null}
+                        </span>
+                      </td>
+                    )}
                     {situacao === 'fechados' ? (
                       <td className="whitespace-nowrap px-4 py-3.5 align-top text-slate-600 sm:px-6 dark:text-slate-400">
                         {t.fechado_em ? new Date(t.fechado_em).toLocaleString('pt-BR') : '—'}


### PR DESCRIPTION
## Summary

- Remove coluna **Motivo** na listagem de tickets **abertos** (preenchido só no fechamento).
- Remove coluna **Prioridade** na listagem de tickets **finalizados**.
- Novo filtro **Em atendimento** na fila de abertos: tickets com responsável atribuído (`com_responsavel` na API).
- Teste `test_ticket_list_filtros.py`.

Fecha feedback de UX da listagem de tickets (sem issue dedicada).

## Test plan

- [ ] `pytest tests/test_ticket_list_filtros.py -q`
- [ ] Tickets abertos: sem coluna Motivo; filtro Em atendimento lista só com responsável
- [ ] Tickets finalizados: sem coluna Prioridade; coluna Motivo mantida
- [ ] Filtros Na fila / Meus / Todos continuam funcionando
