### PR TITLE
feat(whatsapp): abrir e vincular ticket no chat (#98)

### DIFF
--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -269,6 +269,42 @@ def test_abrir_ticket_vincula(client, seed_base, auth_headers):
     assert r.json()["ticket_ids"]
 
 
+def test_vincular_ticket_existente(client, seed_base, auth_headers):
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "vinc"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "vinc"}
+    client.post("/v1/webhooks/evolution", json=_webhook_body(wa_id="5511999778899", msg_id="vinc-1"), headers=h)
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+
+    ticket = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Ticket para vincular",
+            "descricao": "Teste",
+        },
+    )
+    assert ticket.status_code == 201
+    tid = ticket.json()["id"]
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/vincular-ticket",
+        json={"ticket_id": tid},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    assert tid in r.json()["ticket_ids"]
+
+    por_ticket = client.get(f"/v1/whatsapp/chats/por-ticket/{tid}", headers=auth_headers["admin"]).json()
+    assert any(c["id"] == cid for c in por_ticket)
+
+
 def test_transferir_registra_mensagem_interna(client, seed_base, auth_headers):
     client.patch(
         "/v1/settings/whatsapp",

--- a/frontend/src/components/TicketBuscaPicker.tsx
+++ b/frontend/src/components/TicketBuscaPicker.tsx
@@ -6,8 +6,8 @@ import { Input } from './ui/Input'
 import { useToast } from './ui/Toast'
 
 type Props = {
-  /** Ticket atual — nunca aparece na lista. */
-  ticketAtualId: number
+  /** Ticket atual — nunca aparece na lista (omitir em vínculo a partir do chat). */
+  ticketAtualId?: number
   /** IDs adicionais a omitir (já vinculados, filhos, etc.). */
   excluirIds?: number[]
   /** Restringe a listagem (ex.: duplicado = mesma rede e empresa). */
@@ -38,7 +38,7 @@ export function TicketBuscaPicker({
   const [loading, setLoading] = useState(false)
 
   const omitir = useCallback(
-    (id: number) => id === ticketAtualId || excluirIds.includes(id),
+    (id: number) => (ticketAtualId != null && id === ticketAtualId) || excluirIds.includes(id),
     [excluirIds, ticketAtualId],
   )
 

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -1430,7 +1430,9 @@ export function TicketDetalhe() {
             </p>
 
             {chatsWhatsapp.length > 0 && (
-              <div className="mt-2 flex flex-wrap gap-2">
+              <div className="mt-2">
+                <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">Conversas vinculadas</p>
+                <div className="mt-1 flex flex-wrap gap-2">
                 {chatsWhatsapp.map((c) => (
                   <Link
                     key={c.id}
@@ -1440,6 +1442,7 @@ export function TicketDetalhe() {
                     WA {exibirProtocolo(c.protocolo)}
                   </Link>
                 ))}
+                </div>
               </div>
             )}
 

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -6,8 +6,7 @@ import {
 
 
   atendentes,
-
-
+  tickets,
   whatsappChats,
 
   funcionariosRede,
@@ -20,6 +19,7 @@ import {
   type Atendentes,
   type FuncionariosRede,
 
+  type Tickets,
   type WhatsappChats,
 
 } from '../../api/client'
@@ -46,8 +46,7 @@ import {
   rotuloEstadoChat,
   rotuloResponsavelChat,
 } from '../../lib/whatsappChatMeta'
-
-
+import { WhatsappTicketsModal } from './WhatsappTicketsModal'
 
 const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha)\]$/
 
@@ -248,9 +247,8 @@ export function WhatsappConversa() {
 
   // Modais (Vincular/Transferir/Abrir)
 
-  const [modalVinc, setModalVinc] = useState(false)
-
-  const [ticketVincId, setTicketVincId] = useState('')
+  const [modalTickets, setModalTickets] = useState(false)
+  const [ticketsVinculados, setTicketsVinculados] = useState<Tickets.Ticket[]>([])
   const navigate = useNavigate()
 
 
@@ -350,6 +348,24 @@ export function WhatsappConversa() {
     return () => clearInterval(t)
 
   }, [chat, carregar])
+
+  useEffect(() => {
+    if (!chat?.ticket_ids?.length) {
+      setTicketsVinculados([])
+      return
+    }
+    let cancelled = false
+    Promise.all(chat.ticket_ids.map((tid) => tickets.get(tid)))
+      .then((rows) => {
+        if (!cancelled) setTicketsVinculados(rows)
+      })
+      .catch(() => {
+        if (!cancelled) setTicketsVinculados([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [chat?.ticket_ids])
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedBuscaFuncionario(buscaFuncionario.trim()), 400)
@@ -728,6 +744,21 @@ useEffect(() => {
 
               </div>
 
+              {ticketsVinculados.length > 0 && (
+                <div className="mt-1.5 flex flex-wrap gap-1.5">
+                  {ticketsVinculados.map((t) => (
+                    <Link
+                      key={t.id}
+                      to={`/tickets/${t.id}`}
+                      className="inline-flex rounded-full border border-cyan-200/80 bg-cyan-50 px-2 py-0.5 text-[10px] font-medium text-cyan-800 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-300"
+                      title={t.assunto}
+                    >
+                      {exibirProtocolo(t.protocolo)}
+                    </Link>
+                  ))}
+                </div>
+              )}
+
             </div>
 
           </div>
@@ -757,7 +788,9 @@ useEffect(() => {
                 Vincular funcionário
               </Button>
 
-                <Button variant="ghost" className="hidden sm:inline-flex text-xs h-8" onClick={() => setModalVinc(true)}>Tickets</Button>
+                <Button variant="ghost" className="hidden sm:inline-flex text-xs h-8" onClick={() => setModalTickets(true)}>
+                  Tickets{ticketsVinculados.length > 0 ? ` (${ticketsVinculados.length})` : ''}
+                </Button>
 
                 {podeEnviar && (
 
@@ -1177,28 +1210,13 @@ useEffect(() => {
           </div>
         )}
 
-      {modalVinc && (
-
-        <div className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-900/50 backdrop-blur-sm">
-
-           <Card className="w-full max-w-lg p-6 animate-in zoom-in-95">
-
-              <h3 className="text-lg font-bold">Vincular Ticket</h3>
-
-              <Input className="mt-4" type="number" value={ticketVincId} onChange={(e) => setTicketVincId(e.target.value)} placeholder="Número do Ticket" />
-
-              <div className="mt-6 flex justify-end gap-2">
-
-                <Button variant="secondary" onClick={() => setModalVinc(false)}>Cancelar</Button>
-
-                <Button onClick={() => {/* lógica vincular */ setModalVinc(false)}}>Vincular</Button>
-
-              </div>
-
-           </Card>
-
-        </div>
-
+      {chat && (
+        <WhatsappTicketsModal
+          chat={chat}
+          open={modalTickets}
+          onClose={() => setModalTickets(false)}
+          onSuccess={(atualizado) => setChat(atualizado)}
+        />
       )}
 
       {/* Modal Zoom de Imagem */}

--- a/frontend/src/pages/whatsapp/WhatsappTicketsModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappTicketsModal.tsx
@@ -1,0 +1,259 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  empresas,
+  setores,
+  whatsappChats,
+  type Empresas,
+  type Setores,
+  type WhatsappChats,
+} from '../../api/client'
+import { coletarTodasPaginas } from '../../api/collectPages'
+import { TicketBuscaPicker } from '../../components/TicketBuscaPicker'
+import { Card } from '../../components/ui/Card'
+import { Button } from '../../components/ui/Button'
+import { Input } from '../../components/ui/Input'
+import { Select } from '../../components/ui/Select'
+import { SelectComPesquisa } from '../../components/ui/SelectComPesquisa'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { exibirProtocolo } from '../../lib/exibirProtocolo'
+
+type Modo = 'vincular' | 'abrir'
+
+type Props = {
+  chat: WhatsappChats.Chat
+  open: boolean
+  onClose: () => void
+  onSuccess: (chat: WhatsappChats.Chat) => void
+}
+
+export function WhatsappTicketsModal({ chat, open, onClose, onSuccess }: Props) {
+  const toast = useToast()
+  const [modo, setModo] = useState<Modo>('vincular')
+  const [salvando, setSalvando] = useState(false)
+
+  const [empresasList, setEmpresasList] = useState<Empresas.EmpresaListaItem[]>([])
+  const [setoresList, setSetoresList] = useState<Setores.Setor[]>([])
+  const [catalogoLoading, setCatalogoLoading] = useState(false)
+
+  const [empresaId, setEmpresaId] = useState<number | ''>('')
+  const [setorId, setSetorId] = useState<number | ''>(chat.setor_id ?? '')
+  const [assunto, setAssunto] = useState('')
+  const [descricao, setDescricao] = useState('')
+
+  const empresaItems = useMemo(
+    () => empresasList.map((e) => ({ id: e.id, label: e.nome })),
+    [empresasList],
+  )
+
+  const setoresAtivos = useMemo(
+    () => [...setoresList.filter((s) => s.ativo)].sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR')),
+    [setoresList],
+  )
+
+  useEffect(() => {
+    if (!open) return
+    setModo('vincular')
+    setAssunto(`Atendimento WhatsApp — ${chat.cliente_nome?.trim() || chat.wa_id}`)
+    setDescricao('')
+    setSetorId(chat.setor_id ?? '')
+    setEmpresaId('')
+    setCatalogoLoading(true)
+    Promise.all([
+      coletarTodasPaginas<Empresas.EmpresaListaItem>((o, l) => empresas.list({ offset: o, limit: l })),
+      coletarTodasPaginas<Setores.Setor>((o, l) => setores.list({ incluir_inativos: true, offset: o, limit: l })),
+    ])
+      .then(([emps, sets]) => {
+        setEmpresasList(emps)
+        setSetoresList(sets)
+      })
+      .catch((err) => {
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar empresas e setores.'))
+      })
+      .finally(() => setCatalogoLoading(false))
+  }, [chat.cliente_nome, chat.setor_id, chat.wa_id, open, toast])
+
+  if (!open) return null
+
+  async function vincular(ticketId: number) {
+    setSalvando(true)
+    try {
+      const atualizado = await whatsappChats.vincularTicket(chat.id, ticketId)
+      toast.showSuccess('Ticket vinculado ao chat.')
+      onSuccess(atualizado)
+      onClose()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível vincular o ticket.'))
+    } finally {
+      setSalvando(false)
+    }
+  }
+
+  async function abrir() {
+    if (empresaId === '' || setorId === '' || !assunto.trim()) {
+      toast.showWarning('Preencha empresa, setor e assunto.')
+      return
+    }
+    setSalvando(true)
+    try {
+      const atualizado = await whatsappChats.abrirTicket(chat.id, {
+        empresa_id: Number(empresaId),
+        setor_id: Number(setorId),
+        assunto: assunto.trim(),
+        descricao: descricao.trim() || null,
+      })
+      const novoId = atualizado.ticket_ids.find((tid) => !chat.ticket_ids.includes(tid))
+      toast.showSuccess(
+        novoId
+          ? `Ticket criado e vinculado.`
+          : 'Ticket criado e vinculado ao chat.',
+      )
+      onSuccess(atualizado)
+      onClose()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível abrir o ticket.'))
+    } finally {
+      setSalvando(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-900/50 p-4 backdrop-blur-sm">
+      <Card className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden p-0 animate-in zoom-in-95">
+        <div className="border-b border-slate-100 px-6 py-4 dark:border-slate-800">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100">Tickets</h3>
+              <p className="mt-1 text-sm text-slate-500">
+                Chat {exibirProtocolo(chat.protocolo)} · vincule ou abra um chamado
+              </p>
+            </div>
+            <button
+              type="button"
+              className="text-2xl leading-none text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+              onClick={onClose}
+              aria-label="Fechar"
+            >
+              &times;
+            </button>
+          </div>
+
+          {chat.ticket_ids.length > 0 && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {chat.ticket_ids.map((tid) => (
+                <Link
+                  key={tid}
+                  to={`/tickets/${tid}`}
+                  className="inline-flex rounded-full border border-cyan-200 bg-cyan-50 px-2.5 py-0.5 text-xs font-medium text-cyan-800 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-300"
+                  onClick={onClose}
+                >
+                  Ticket #{tid}
+                </Link>
+              ))}
+            </div>
+          )}
+
+          <div
+            className="mt-4 inline-flex w-full rounded-xl bg-slate-100/90 p-1 ring-1 ring-slate-200/60 dark:bg-slate-800/60 dark:ring-slate-700/80"
+            role="group"
+            aria-label="Ação de ticket"
+          >
+            {(
+              [
+                { id: 'vincular' as const, label: 'Vincular existente' },
+                { id: 'abrir' as const, label: 'Abrir novo' },
+              ] as const
+            ).map(({ id, label }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => setModo(id)}
+                className={`min-h-[2.25rem] flex-1 rounded-lg px-3 py-2 text-center text-xs font-medium transition-all sm:text-sm ${
+                  modo === id
+                    ? 'bg-white text-slate-900 shadow-sm ring-1 ring-slate-200/80 dark:bg-slate-700 dark:text-slate-50'
+                    : 'text-slate-500 hover:text-slate-800 dark:text-slate-400'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="overflow-y-auto px-6 py-4">
+          {modo === 'vincular' ? (
+            <TicketBuscaPicker
+              excluirIds={chat.ticket_ids}
+              label="Buscar ticket em aberto"
+              hint="Selecione um ticket para vincular a este chat. Protocolos de chat e ticket permanecem distintos."
+              disabled={salvando}
+              loadingExterno={salvando}
+              onSelecionar={(t) => void vincular(t.id)}
+            />
+          ) : catalogoLoading ? (
+            <p className="py-8 text-center text-sm text-slate-500">Carregando formulário…</p>
+          ) : (
+            <div className="space-y-4">
+              <SelectComPesquisa
+                label="Empresa"
+                value={empresaId}
+                onChange={(id) => setEmpresaId(id)}
+                items={empresaItems}
+                placeholder="Selecione a empresa"
+                disabled={salvando}
+                required
+              />
+              <Select
+                label="Setor"
+                value={setorId}
+                onChange={(v) => setSetorId(v === '' ? '' : Number(v))}
+                options={setoresAtivos.map((s) => ({ value: s.id, label: s.nome }))}
+                placeholder="Selecione o setor"
+                includeEmpty
+                emptyLabel="Selecione o setor"
+                disabled={salvando}
+              />
+              <Input
+                label="Assunto"
+                value={assunto}
+                onChange={(e) => setAssunto(e.target.value)}
+                disabled={salvando}
+              />
+              <label className="block">
+                <span className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">Descrição</span>
+                <textarea
+                  value={descricao}
+                  onChange={(e) => setDescricao(e.target.value)}
+                  rows={4}
+                  disabled={salvando}
+                  placeholder="Detalhes do problema (opcional). O vínculo com o chat será registrado automaticamente."
+                  className="w-full rounded-xl border-0 bg-white px-3 py-2 text-sm shadow-sm ring-1 ring-slate-200/90 focus:outline-none focus:ring-2 focus:ring-slate-400/35 dark:bg-slate-900/80 dark:text-slate-100 dark:ring-slate-600/90"
+                />
+              </label>
+            </div>
+          )}
+        </div>
+
+        {modo === 'abrir' && !catalogoLoading && (
+          <div className="flex justify-end gap-2 border-t border-slate-100 px-6 py-4 dark:border-slate-800">
+            <Button type="button" variant="secondary" onClick={onClose} disabled={salvando}>
+              Cancelar
+            </Button>
+            <Button type="button" onClick={() => void abrir()} loading={salvando}>
+              Abrir ticket
+            </Button>
+          </div>
+        )}
+
+        {modo === 'vincular' && (
+          <div className="border-t border-slate-100 px-6 py-3 dark:border-slate-800">
+            <Button type="button" variant="secondary" className="w-full sm:w-auto" onClick={onClose} disabled={salvando}>
+              Fechar
+            </Button>
+          </div>
+        )}
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Modal Tickets no chat: vincular ticket existente (busca por protocolo/assunto) ou abrir novo chamado.
- Badges com protocolo do ticket no cabeçalho do chat; seção Conversas vinculadas no detalhe do ticket.
- TicketBuscaPicker com ticketAtualId opcional; teste test_vincular_ticket_existente.

Fecha #98.

## Test plan

- [ ] pytest tests/test_whatsapp_chats.py::test_vincular_ticket_existente -q
- [ ] Chat em atendimento: Tickets > Vincular existente
- [ ] Chat em atendimento: Tickets > Abrir novo
- [ ] Protocolos de chat e ticket distintos e visíveis
- [ ] Detalhe do ticket mostra conversas vinculadas com link

Made with [Cursor](https://cursor.com)