### PR TITLE
feat(whatsapp): vincular e cadastrar funcionário no chat (#155, #156)

### DIFF
--- a/backend/alembic/versions/040_wpp_chat_funcionario.py
+++ b/backend/alembic/versions/040_wpp_chat_funcionario.py
@@ -1,0 +1,52 @@
+"""WhatsApp: vínculo chat ↔ funcionário da rede.
+
+Revision ID: 040_wpp_chat_funcionario
+Revises: 039_wpp_avaliacao_solicitada
+Create Date: 2026-06-11
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "040_wpp_chat_funcionario"
+down_revision = "039_wpp_avaliacao_solicitada"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "whatsapp_chats",
+        sa.Column("funcionario_rede_id", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "whatsapp_chats",
+        sa.Column("empresa_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_whatsapp_chats_funcionario_rede_id",
+        "whatsapp_chats",
+        "funcionarios_rede",
+        ["funcionario_rede_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_foreign_key(
+        "fk_whatsapp_chats_empresa_id",
+        "whatsapp_chats",
+        "empresas",
+        ["empresa_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index("ix_whatsapp_chats_funcionario_rede_id", "whatsapp_chats", ["funcionario_rede_id"])
+    op.create_index("ix_whatsapp_chats_empresa_id", "whatsapp_chats", ["empresa_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_whatsapp_chats_empresa_id", table_name="whatsapp_chats")
+    op.drop_index("ix_whatsapp_chats_funcionario_rede_id", table_name="whatsapp_chats")
+    op.drop_constraint("fk_whatsapp_chats_empresa_id", "whatsapp_chats", type_="foreignkey")
+    op.drop_constraint("fk_whatsapp_chats_funcionario_rede_id", "whatsapp_chats", type_="foreignkey")
+    op.drop_column("whatsapp_chats", "empresa_id")
+    op.drop_column("whatsapp_chats", "funcionario_rede_id")

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -14,6 +14,8 @@ from app.models.ticket import Ticket, TicketMensagem
 from app.models.status_ticket import StatusTicket
 from app.models.empresa import Empresa
 from app.models.setor import Setor
+from app.models.rede import Rede
+from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
 from app.models.whatsapp_chat import WhatsappChat, WhatsappChatTicket, WhatsappMensagem, WhatsappSettings
 from app.models.whatsapp_chat_read import WhatsappChatRead as WhatsappChatReadModel
 from app.schemas.lista_paginada import ListaPaginada
@@ -25,8 +27,18 @@ from app.schemas.whatsapp_chat import (
     WhatsappChatRead,
     WhatsappMensagemRead,
     WhatsappTransferirChatBody,
+    WhatsappVincularFuncionarioBody,
+    WhatsappCadastrarFuncionarioBody,
     WhatsappVincularTicketBody,
+    WhatsappEmpresaOpcaoRead,
+    WhatsappFuncionarioOpcaoRead,
+    WhatsappFuncionarioCatalogoRead,
+    WhatsappRedeCatalogoRead,
+    WhatsappEmpresaCatalogoRead,
 )
+from app.services.funcionario_escopo import empresa_ids_vinculados, rede_id_efetiva, sincronizar_vinculos_empresas, validar_empresa_ids_na_rede
+from app.services.funcionario_rede_resolver import assert_email_unico_por_rede
+from app.core.audit import registrar_audit
 from app.core.auth import exigir_admin, obter_atendente_atual
 from app.api.tickets import _gerar_protocolo, _pode_ver_ticket
 from app.core.setor_scope import ids_setores_visiveis_atendente
@@ -46,6 +58,13 @@ logger = logging.getLogger(__name__)
 
 _MAX_PAGE = 100
 _DEFAULT_PAGE = 20
+
+_CHAT_LOAD_OPTIONS = (
+    joinedload(WhatsappChat.atendente),
+    joinedload(WhatsappChat.setor),
+    joinedload(WhatsappChat.funcionario_rede),
+    joinedload(WhatsappChat.empresa),
+)
 
 
 @router.get("/transfer/setores", response_model=list[dict])
@@ -272,10 +291,148 @@ def _ticket_ids(db: Session, chat_id: int) -> list[int]:
     return [x[0] for x in db.query(WhatsappChatTicket.ticket_id).filter(WhatsappChatTicket.chat_id == chat_id).all()]
 
 
+def _empresa_nome_exibicao(emp: Empresa | None) -> str | None:
+    if not emp:
+        return None
+    for raw in (emp.nome_fantasia, emp.nome, emp.razao_social):
+        if raw and str(raw).strip():
+            return str(raw).strip()
+    return None
+
+
+def _funcionario_no_tenant(db: Session, atendente: Atendente, funcionario_id: int) -> FuncionarioRede | None:
+    func = db.query(FuncionarioRede).filter(FuncionarioRede.id == funcionario_id).first()
+    if not func or not func.ativo:
+        return None
+    rede_id = rede_id_efetiva(db, func)
+    if rede_id is not None:
+        rede = db.query(Rede).filter(Rede.id == rede_id, Rede.tenant_id == atendente.tenant_id).first()
+        if rede:
+            return func
+    if func.empresa_id is not None:
+        emp = (
+            db.query(Empresa)
+            .filter(Empresa.id == func.empresa_id, Empresa.tenant_id == atendente.tenant_id)
+            .first()
+        )
+        if emp:
+            return func
+    vinculo = (
+        db.query(FuncionarioRedeEmpresa)
+        .join(Empresa, Empresa.id == FuncionarioRedeEmpresa.empresa_id)
+        .filter(
+            FuncionarioRedeEmpresa.funcionario_id == func.id,
+            Empresa.tenant_id == atendente.tenant_id,
+        )
+        .first()
+    )
+    return func if vinculo else None
+
+
+def _empresas_funcionario(db: Session, func: FuncionarioRede) -> list[WhatsappEmpresaOpcaoRead]:
+    ids = empresa_ids_vinculados(db, func, apenas_ativas=True)
+    if not ids:
+        return []
+    rows = db.query(Empresa).filter(Empresa.id.in_(ids)).order_by(Empresa.nome.asc(), Empresa.id.asc()).all()
+    return [WhatsappEmpresaOpcaoRead(id=e.id, nome=_empresa_nome_exibicao(e) or e.nome) for e in rows]
+
+
+def _resolver_empresa_vinculo(
+    db: Session,
+    atendente: Atendente,
+    func: FuncionarioRede,
+    empresa_id: int | None,
+) -> Empresa:
+    emp_ids = empresa_ids_vinculados(db, func, apenas_ativas=True)
+    if not emp_ids:
+        raise HTTPException(status_code=400, detail="Funcionário sem empresas vinculadas")
+    escolhida: int
+    if len(emp_ids) == 1:
+        escolhida = next(iter(emp_ids))
+    elif empresa_id is None:
+        raise HTTPException(status_code=400, detail="Selecione a empresa do funcionário")
+    elif int(empresa_id) not in emp_ids:
+        raise HTTPException(status_code=400, detail="Empresa inválida para este funcionário")
+    else:
+        escolhida = int(empresa_id)
+    emp = db.query(Empresa).filter(Empresa.id == escolhida, Empresa.tenant_id == atendente.tenant_id).first()
+    if not emp:
+        raise HTTPException(status_code=404, detail="Empresa não encontrada")
+    return emp
+
+
+def _criar_funcionario_rede(
+    db: Session,
+    atendente: Atendente,
+    *,
+    nome: str,
+    email: str,
+    tipo: str,
+    escopo_empresas: str,
+    rede_id: int,
+    empresa_id: int | None,
+    empresa_ids: list[int],
+) -> FuncionarioRede:
+    tipo_eff = (tipo or "colaborador").strip().lower()
+    if tipo_eff not in ("colaborador", "supervisor", "socio"):
+        raise HTTPException(status_code=400, detail="Tipo de funcionário inválido")
+    escopo = (escopo_empresas or "selected").strip().lower()
+    if escopo not in ("all", "selected"):
+        raise HTTPException(status_code=400, detail="escopo_empresas deve ser all ou selected")
+    if tipo_eff == "socio" and escopo != "all":
+        escopo = "all"
+    ids = list(dict.fromkeys(empresa_ids or []))
+    if empresa_id and int(empresa_id) not in ids:
+        ids.insert(0, int(empresa_id))
+    rede = db.query(Rede).filter(Rede.id == rede_id, Rede.tenant_id == atendente.tenant_id).first()
+    if not rede:
+        raise HTTPException(status_code=404, detail="Rede não encontrada")
+    if escopo == "selected" and not ids:
+        raise HTTPException(status_code=400, detail="Selecione ao menos uma empresa da rede")
+    if escopo == "selected":
+        try:
+            validar_empresa_ids_na_rede(db, int(rede_id), ids)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        emps = db.query(Empresa).filter(Empresa.id.in_(ids)).all()
+        if any(int(e.tenant_id) != int(atendente.tenant_id) for e in emps):
+            raise HTTPException(status_code=400, detail="Empresa inválida para este tenant")
+    try:
+        assert_email_unico_por_rede(db, email=email.strip(), rede_id=int(rede_id))
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    emp_colab_id: int | None = None
+    if escopo == "selected" and tipo_eff == "colaborador" and len(ids) == 1:
+        emp_colab_id = ids[0]
+    f = FuncionarioRede(
+        nome=nome.strip(),
+        email=email.strip(),
+        tipo=tipo_eff,
+        escopo_empresas=escopo,
+        ativo=True,
+        rede_id=int(rede_id),
+        empresa_id=emp_colab_id,
+    )
+    db.add(f)
+    db.flush()
+    registrar_audit(db, "funcionario_rede", f.id, "create", atendente.id)
+    sincronizar_vinculos_empresas(
+        db,
+        f,
+        escopo=escopo,
+        rede_id=int(rede_id),
+        empresa_ids=ids if escopo == "selected" else None,
+    )
+    db.refresh(f)
+    return f
+
+
 def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False) -> WhatsappChatRead:
     nota = getattr(c, "avaliacao_nota", None) if revelar_avaliacao else None
     respondida = getattr(c, "avaliacao_respondida_at", None) if revelar_avaliacao else None
     solicitada = bool(getattr(c, "avaliacao_solicitada", False)) if revelar_avaliacao else False
+    func = getattr(c, "funcionario_rede", None)
+    emp = getattr(c, "empresa", None)
     return WhatsappChatRead(
         id=c.id,
         protocolo=c.protocolo,
@@ -293,6 +450,12 @@ def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False)
         avaliacao_respondida_at=respondida,
         avaliacao_solicitada=solicitada,
         ticket_ids=_ticket_ids(db, c.id),
+        funcionario_rede_id=getattr(c, "funcionario_rede_id", None),
+        funcionario_nome=func.nome if func else None,
+        funcionario_email=func.email if func else None,
+        funcionario_tipo=func.tipo if func else None,
+        empresa_id=getattr(c, "empresa_id", None),
+        empresa_nome=_empresa_nome_exibicao(emp),
     )
 
 
@@ -357,7 +520,7 @@ def listar_fila(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    q = db.query(WhatsappChat).options(joinedload(WhatsappChat.atendente), joinedload(WhatsappChat.setor)).filter(
+    q = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(
         WhatsappChat.estado == "aguardando_atendente"
     )
     if atendente.role != "admin":
@@ -374,7 +537,7 @@ def listar_meus_ativos(
 ):
     q = (
         db.query(WhatsappChat)
-        .options(joinedload(WhatsappChat.atendente), joinedload(WhatsappChat.setor))
+        .options(*_CHAT_LOAD_OPTIONS)
         .filter(WhatsappChat.estado == "em_atendimento")
     )
     if atendente.role != "admin":
@@ -396,7 +559,7 @@ def listar_encerrados(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    q = db.query(WhatsappChat).options(joinedload(WhatsappChat.atendente)).filter(WhatsappChat.estado == "encerrado")
+    q = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.estado == "encerrado")
     if protocolo:
         q = q.filter(WhatsappChat.protocolo.ilike(f"%{protocolo}%"))
     if wa_id:
@@ -439,7 +602,7 @@ def listar_avaliacoes(
 ):
     q = (
         db.query(WhatsappChat)
-        .options(joinedload(WhatsappChat.atendente), joinedload(WhatsappChat.setor))
+        .options(*_CHAT_LOAD_OPTIONS)
         .filter(WhatsappChat.avaliacao_solicitada.is_(True))
     )
     if busca:
@@ -482,12 +645,89 @@ def listar_por_ticket(
         return []
     rows = (
         db.query(WhatsappChat)
-        .options(joinedload(WhatsappChat.atendente))
+        .options(*_CHAT_LOAD_OPTIONS)
         .filter(WhatsappChat.id.in_(chat_ids))
         .order_by(desc(WhatsappChat.id))
         .all()
     )
     return [_chat_read(db, c) for c in rows]
+
+
+@router.get("/funcionarios", response_model=list[WhatsappFuncionarioOpcaoRead])
+def buscar_funcionarios(
+    busca: str = Query(..., min_length=1, description="Nome ou e-mail do funcionário"),
+    limit: int = Query(20, ge=1, le=_MAX_PAGE),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    term = f"%{busca.strip()}%"
+    rede_ids = [int(r[0]) for r in db.query(Rede.id).filter(Rede.tenant_id == atendente.tenant_id).all()]
+    empresa_ids = [int(r[0]) for r in db.query(Empresa.id).filter(Empresa.tenant_id == atendente.tenant_id).all()]
+    func_ids_junction = [
+        int(r[0])
+        for r in db.query(FuncionarioRedeEmpresa.funcionario_id)
+        .join(Empresa, Empresa.id == FuncionarioRedeEmpresa.empresa_id)
+        .filter(Empresa.tenant_id == atendente.tenant_id)
+        .distinct()
+        .all()
+    ]
+    filtros = []
+    if rede_ids:
+        filtros.append(FuncionarioRede.rede_id.in_(rede_ids))
+    if empresa_ids:
+        filtros.append(FuncionarioRede.empresa_id.in_(empresa_ids))
+    if func_ids_junction:
+        filtros.append(FuncionarioRede.id.in_(func_ids_junction))
+    if not filtros:
+        return []
+    q = (
+        db.query(FuncionarioRede)
+        .filter(
+            FuncionarioRede.ativo.is_(True),
+            or_(*filtros),
+            or_(FuncionarioRede.nome.ilike(term), FuncionarioRede.email.ilike(term)),
+        )
+        .order_by(FuncionarioRede.nome.asc(), FuncionarioRede.id.asc())
+        .limit(limit)
+    )
+    rows = q.all()
+    out: list[WhatsappFuncionarioOpcaoRead] = []
+    for func in rows:
+        if _funcionario_no_tenant(db, atendente, func.id) is None:
+            continue
+        out.append(
+            WhatsappFuncionarioOpcaoRead(
+                id=func.id,
+                nome=func.nome,
+                email=func.email,
+                tipo=func.tipo,
+                empresas=_empresas_funcionario(db, func),
+            )
+        )
+    return out
+
+
+@router.get("/funcionarios/catalogo", response_model=WhatsappFuncionarioCatalogoRead)
+def catalogo_funcionarios(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    redes = (
+        db.query(Rede)
+        .filter(Rede.tenant_id == atendente.tenant_id, Rede.ativo.is_(True))
+        .order_by(Rede.nome.asc(), Rede.id.asc())
+        .all()
+    )
+    empresas = (
+        db.query(Empresa)
+        .filter(Empresa.tenant_id == atendente.tenant_id, Empresa.ativo.is_(True))
+        .order_by(Empresa.nome.asc(), Empresa.id.asc())
+        .all()
+    )
+    return WhatsappFuncionarioCatalogoRead(
+        redes=[WhatsappRedeCatalogoRead(id=r.id, nome=r.nome) for r in redes],
+        empresas=[WhatsappEmpresaCatalogoRead(id=e.id, nome=_empresa_nome_exibicao(e) or e.nome, rede_id=int(e.rede_id)) for e in empresas],
+    )
 
 
 @router.get("/{chat_id}", response_model=WhatsappChatRead)
@@ -498,7 +738,7 @@ def obter(
 ):
     c = (
         db.query(WhatsappChat)
-        .options(joinedload(WhatsappChat.atendente), joinedload(WhatsappChat.setor))
+        .options(*_CHAT_LOAD_OPTIONS)
         .filter(WhatsappChat.id == chat_id)
         .first()
     )
@@ -564,7 +804,7 @@ def assumir(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    c = db.query(WhatsappChat).options(joinedload(WhatsappChat.atendente)).filter(WhatsappChat.id == chat_id).first()
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     if not c:
         raise HTTPException(status_code=404, detail="Chat não encontrado")
     if atendente.role != "admin" and c.setor_id is not None:
@@ -595,7 +835,7 @@ def assumir(
                 _enviar_texto_whatsapp(db, chat=c, texto=txt, atendente=atendente, evento_sistema="auto_assumido")
             except HTTPException as exc:
                 logger.warning("Auto-msg assumido falhou (chat=%s): %s", c.protocolo, exc.detail)
-    c = db.query(WhatsappChat).options(joinedload(WhatsappChat.atendente)).filter(WhatsappChat.id == chat_id).first()
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     assert c is not None
     return _chat_read(db, c)
 
@@ -606,7 +846,7 @@ def encerrar(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    c = db.query(WhatsappChat).options(joinedload(WhatsappChat.atendente)).filter(WhatsappChat.id == chat_id).first()
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     if not c:
         raise HTTPException(status_code=404, detail="Chat não encontrado")
     if atendente.role != "admin" and c.setor_id is not None:
@@ -631,7 +871,7 @@ def encerrar(
         db.rollback()
         logger.warning("Encerramento WhatsApp falhou (chat=%s): %s", c.protocolo, exc)
         raise HTTPException(status_code=502, detail="Falha ao encerrar o atendimento no WhatsApp") from exc
-    c = db.query(WhatsappChat).options(joinedload(WhatsappChat.atendente)).filter(WhatsappChat.id == chat_id).first()
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     assert c is not None
     return _chat_read(db, c)
 
@@ -846,7 +1086,7 @@ def vincular_ticket(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    c = db.query(WhatsappChat).options(joinedload(WhatsappChat.atendente)).filter(WhatsappChat.id == chat_id).first()
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     if not c:
         raise HTTPException(status_code=404, detail="Chat não encontrado")
     ticket = db.query(Ticket).filter(Ticket.id == data.ticket_id).first()
@@ -862,7 +1102,89 @@ def vincular_ticket(
     if not exist:
         db.add(WhatsappChatTicket(chat_id=chat_id, ticket_id=data.ticket_id, atendente_id=atendente.id))
         db.commit()
-    c2 = db.query(WhatsappChat).options(joinedload(WhatsappChat.atendente)).filter(WhatsappChat.id == chat_id).first()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    return _chat_read(db, c2)
+
+
+@router.post("/{chat_id}/vincular-funcionario", response_model=WhatsappChatRead)
+def vincular_funcionario(
+    chat_id: int,
+    data: WhatsappVincularFuncionarioBody,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=403, detail="Sem permissão para este chat")
+    func = _funcionario_no_tenant(db, atendente, data.funcionario_rede_id)
+    if not func:
+        raise HTTPException(status_code=404, detail="Funcionário não encontrado")
+    emp = _resolver_empresa_vinculo(db, atendente, func, data.empresa_id)
+    c.funcionario_rede_id = func.id
+    c.empresa_id = emp.id
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    return _chat_read(db, c2)
+
+
+@router.post("/{chat_id}/desvincular-funcionario", response_model=WhatsappChatRead)
+def desvincular_funcionario(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=403, detail="Sem permissão para este chat")
+    c.funcionario_rede_id = None
+    c.empresa_id = None
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    return _chat_read(db, c2)
+
+
+@router.post("/{chat_id}/cadastrar-funcionario", response_model=WhatsappChatRead)
+def cadastrar_funcionario(
+    chat_id: int,
+    data: WhatsappCadastrarFuncionarioBody,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=403, detail="Sem permissão para este chat")
+    tipo = (data.tipo or "colaborador").strip().lower()
+    if tipo not in ("colaborador", "supervisor"):
+        raise HTTPException(status_code=400, detail="No chat, cadastre como colaborador ou supervisor")
+    escopo = (data.escopo_empresas or "selected").strip().lower()
+    empresa_ids = list(dict.fromkeys(data.empresa_ids or []))
+    if data.empresa_id and int(data.empresa_id) not in empresa_ids:
+        empresa_ids.insert(0, int(data.empresa_id))
+    func = _criar_funcionario_rede(
+        db,
+        atendente,
+        nome=data.nome,
+        email=data.email,
+        tipo=tipo,
+        escopo_empresas=escopo,
+        rede_id=data.rede_id,
+        empresa_id=data.empresa_id,
+        empresa_ids=empresa_ids,
+    )
+    emp = _resolver_empresa_vinculo(db, atendente, func, data.empresa_id)
+    c.funcionario_rede_id = func.id
+    c.empresa_id = emp.id
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     assert c2 is not None
     return _chat_read(db, c2)
 
@@ -874,7 +1196,7 @@ def abrir_ticket(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    c = db.query(WhatsappChat).options(joinedload(WhatsappChat.atendente)).filter(WhatsappChat.id == chat_id).first()
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     if not c:
         raise HTTPException(status_code=404, detail="Chat não encontrado")
     if atendente.role != "admin":
@@ -915,7 +1237,7 @@ def abrir_ticket(
     )
     db.add(WhatsappChatTicket(chat_id=chat_id, ticket_id=ticket.id, atendente_id=atendente.id))
     db.commit()
-    c2 = db.query(WhatsappChat).options(joinedload(WhatsappChat.atendente)).filter(WhatsappChat.id == chat_id).first()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     assert c2 is not None
     return _chat_read(db, c2)
 
@@ -929,7 +1251,7 @@ def transferir(
 ):
     c = (
         db.query(WhatsappChat)
-        .options(joinedload(WhatsappChat.atendente), joinedload(WhatsappChat.setor))
+        .options(*_CHAT_LOAD_OPTIONS)
         .filter(WhatsappChat.id == chat_id)
         .first()
     )
@@ -1001,7 +1323,7 @@ def transferir(
     db.refresh(c)
     c2 = (
         db.query(WhatsappChat)
-        .options(joinedload(WhatsappChat.atendente), joinedload(WhatsappChat.setor))
+        .options(*_CHAT_LOAD_OPTIONS)
         .filter(WhatsappChat.id == chat_id)
         .first()
     )

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -64,9 +64,15 @@ class WhatsappChat(Base):
     avaliacao_nota = Column(Integer, nullable=True)
     avaliacao_respondida_at = Column(DateTime(timezone=True), nullable=True)
     avaliacao_solicitada = Column(Boolean, nullable=False, default=False)
+    funcionario_rede_id = Column(
+        Integer, ForeignKey("funcionarios_rede.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    empresa_id = Column(Integer, ForeignKey("empresas.id", ondelete="SET NULL"), nullable=True, index=True)
 
     atendente = relationship("Atendente", backref="whatsapp_chats_atendidos")
     setor = relationship("Setor", backref="whatsapp_chats")
+    funcionario_rede = relationship("FuncionarioRede", backref="whatsapp_chats")
+    empresa = relationship("Empresa", backref="whatsapp_chats")
     mensagens = relationship(
         "WhatsappMensagem",
         back_populates="chat",

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -39,8 +39,43 @@ class WhatsappChatRead(BaseModel):
     avaliacao_respondida_at: datetime | None = None
     avaliacao_solicitada: bool = False
     ticket_ids: list[int] = Field(default_factory=list)
+    funcionario_rede_id: int | None = None
+    funcionario_nome: str | None = None
+    funcionario_email: str | None = None
+    funcionario_tipo: str | None = None
+    empresa_id: int | None = None
+    empresa_nome: str | None = None
 
     model_config = {"from_attributes": True}
+
+
+class WhatsappEmpresaOpcaoRead(BaseModel):
+    id: int
+    nome: str
+
+
+class WhatsappEmpresaCatalogoRead(BaseModel):
+    id: int
+    nome: str
+    rede_id: int
+
+
+class WhatsappFuncionarioOpcaoRead(BaseModel):
+    id: int
+    nome: str
+    email: str
+    tipo: str
+    empresas: list[WhatsappEmpresaOpcaoRead] = Field(default_factory=list)
+
+
+class WhatsappRedeCatalogoRead(BaseModel):
+    id: int
+    nome: str
+
+
+class WhatsappFuncionarioCatalogoRead(BaseModel):
+    redes: list[WhatsappRedeCatalogoRead] = Field(default_factory=list)
+    empresas: list[WhatsappEmpresaCatalogoRead] = Field(default_factory=list)
 
 
 class WhatsappChatMensagemCreate(BaseModel):
@@ -58,6 +93,27 @@ class WhatsappChatComentarioInternoCreate(BaseModel):
 
 class WhatsappVincularTicketBody(BaseModel):
     ticket_id: int
+
+
+class WhatsappVincularFuncionarioBody(BaseModel):
+    funcionario_rede_id: int
+    empresa_id: int | None = Field(
+        None,
+        description="Obrigatório quando o funcionário está vinculado a mais de uma empresa.",
+    )
+
+
+class WhatsappCadastrarFuncionarioBody(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=255)
+    email: str = Field(..., min_length=3, max_length=255)
+    rede_id: int
+    tipo: str = Field(default="colaborador", description="colaborador | supervisor")
+    escopo_empresas: str = Field(default="selected", description="all | selected")
+    empresa_ids: list[int] = Field(default_factory=list)
+    empresa_id: int | None = Field(
+        None,
+        description="Empresa exibida no chat quando o funcionário tem várias empresas.",
+    )
 
 
 class WhatsappAbrirTicketBody(BaseModel):

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -330,3 +330,106 @@ def test_transferir_registra_mensagem_interna(client, seed_base, auth_headers):
     transfer_msgs = [m for m in msgs if m.get("evento_sistema") == "transferencia"]
     assert len(transfer_msgs) == 1
     assert "Financeiro" in transfer_msgs[0]["corpo"]
+
+
+def _criar_funcionario_colaborador(db_session, seed_base, *, nome="João Cliente", email="joao.cliente@test.local"):
+    from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
+
+    emp = seed_base["empresa"]
+    f = FuncionarioRede(
+        nome=nome,
+        email=email,
+        tipo="colaborador",
+        escopo_empresas="selected",
+        ativo=True,
+        rede_id=emp.rede_id,
+        empresa_id=emp.id,
+    )
+    db_session.add(f)
+    db_session.flush()
+    db_session.add(FuncionarioRedeEmpresa(funcionario_id=f.id, empresa_id=emp.id))
+    db_session.commit()
+    db_session.refresh(f)
+    return {"id": f.id, "nome": f.nome, "email": f.email}
+
+
+def _chat_ativo(client, seed_base, auth_headers, wa_id="5511999334455", msg_id="func-1"):
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "func-vinc"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "func-vinc"}
+    client.post("/v1/webhooks/evolution", json=_webhook_body(wa_id=wa_id, msg_id=msg_id), headers=h)
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    return cid
+
+
+def test_vincular_funcionario_no_chat(client, seed_base, auth_headers, db_session):
+    func = _criar_funcionario_colaborador(db_session, seed_base)
+    cid = _chat_ativo(client, seed_base, auth_headers)
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/vincular-funcionario",
+        json={"funcionario_rede_id": func["id"]},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["funcionario_rede_id"] == func["id"]
+    assert body["funcionario_nome"] == func["nome"]
+    assert body["empresa_id"] == seed_base["empresa"].id
+    assert body["empresa_nome"]
+
+    get_r = client.get(f"/v1/whatsapp/chats/{cid}", headers=auth_headers["a1"])
+    assert get_r.status_code == 200
+    assert get_r.json()["funcionario_rede_id"] == func["id"]
+
+
+def test_buscar_funcionarios_whatsapp(client, seed_base, auth_headers, db_session):
+    func = _criar_funcionario_colaborador(db_session, seed_base, nome="Maria Silva", email="maria@test.local")
+    r = client.get("/v1/whatsapp/chats/funcionarios?busca=Maria", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    ids = [x["id"] for x in r.json()]
+    assert func["id"] in ids
+
+
+def test_desvincular_funcionario_no_chat(client, seed_base, auth_headers, db_session):
+    func = _criar_funcionario_colaborador(db_session, seed_base, email="desv@test.local")
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999223344", msg_id="func-desv")
+    client.post(
+        f"/v1/whatsapp/chats/{cid}/vincular-funcionario",
+        json={"funcionario_rede_id": func["id"]},
+        headers=auth_headers["a1"],
+    )
+    r = client.post(f"/v1/whatsapp/chats/{cid}/desvincular-funcionario", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    assert r.json()["funcionario_rede_id"] is None
+    assert r.json()["empresa_id"] is None
+
+
+def test_cadastrar_funcionario_no_chat(client, seed_base, auth_headers, db_session):
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999112233", msg_id="func-cad")
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/cadastrar-funcionario",
+        json={
+            "nome": "Cliente Novo",
+            "email": "cliente.novo@test.local",
+            "rede_id": seed_base["rede"].id,
+            "tipo": "colaborador",
+            "escopo_empresas": "selected",
+            "empresa_ids": [seed_base["empresa"].id],
+        },
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["funcionario_nome"] == "Cliente Novo"
+    assert body["funcionario_email"] == "cliente.novo@test.local"
+    assert body["empresa_id"] == seed_base["empresa"].id
+
+    catalogo = client.get("/v1/whatsapp/chats/funcionarios/catalogo", headers=auth_headers["a1"])
+    assert catalogo.status_code == 200
+    assert any(re["id"] == seed_base["rede"].id for re in catalogo.json()["redes"])
+

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -657,6 +657,30 @@ export namespace WhatsappChats {
     avaliacao_respondida_at?: string | null
     avaliacao_solicitada?: boolean
     ticket_ids: number[]
+    funcionario_rede_id?: number | null
+    funcionario_nome?: string | null
+    funcionario_email?: string | null
+    funcionario_tipo?: string | null
+    empresa_id?: number | null
+    empresa_nome?: string | null
+  }
+  export interface EmpresaOpcao {
+    id: number
+    nome: string
+  }
+  export interface FuncionarioOpcao {
+    id: number
+    nome: string
+    email: string
+    tipo: string
+    empresas: EmpresaOpcao[]
+  }
+  export interface EmpresaCatalogo extends EmpresaOpcao {
+    rede_id: number
+  }
+  export interface FuncionarioCatalogo {
+    redes: Array<{ id: number; nome: string }>
+    empresas: EmpresaCatalogo[]
   }
   export interface Avaliacao {
     chat_id: number
@@ -757,6 +781,34 @@ export const whatsappChats = {
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/vincular-ticket`, {
       method: 'POST',
       body: JSON.stringify({ ticket_id: ticketId }),
+    }),
+  vincularFuncionario: (id: number, data: { funcionario_rede_id: number; empresa_id?: number | null }) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/vincular-funcionario`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  desvincularFuncionario: (id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/desvincular-funcionario`, { method: 'POST' }),
+  buscarFuncionarios: (busca: string, limit = 20) =>
+    api<WhatsappChats.FuncionarioOpcao[]>(
+      `/whatsapp/chats/funcionarios?${new URLSearchParams({ busca, limit: String(limit) }).toString()}`,
+    ),
+  catalogoFuncionarios: () => api<WhatsappChats.FuncionarioCatalogo>('/whatsapp/chats/funcionarios/catalogo'),
+  cadastrarFuncionario: (
+    id: number,
+    data: {
+      nome: string
+      email: string
+      rede_id: number
+      tipo?: 'colaborador' | 'supervisor'
+      escopo_empresas?: 'all' | 'selected'
+      empresa_ids?: number[]
+      empresa_id?: number | null
+    },
+  ) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/cadastrar-funcionario`, {
+      method: 'POST',
+      body: JSON.stringify(data),
     }),
   abrirTicket: (
     id: number,

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -9,15 +9,12 @@ import {
   tickets,
   whatsappChats,
 
-  funcionariosRede,
-
   fetchWhatsAppMidiaBlob,
 
 
   type Setores,
 
   type Atendentes,
-  type FuncionariosRede,
 
   type Tickets,
   type WhatsappChats,
@@ -47,6 +44,7 @@ import {
   rotuloResponsavelChat,
 } from '../../lib/whatsappChatMeta'
 import { WhatsappTicketsModal } from './WhatsappTicketsModal'
+import { WhatsappVincFuncionarioModal } from './WhatsappVincFuncionarioModal'
 
 const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha)\]$/
 
@@ -235,11 +233,6 @@ export function WhatsappConversa() {
   const [transferAtendenteId, setTransferAtendenteId] = useState<number | ''>('')
   const [transferindo, setTransferindo] = useState(false)
   const [modalVincFuncionario, setModalVincFuncionario] = useState(false)
-  const [buscaFuncionario, setBuscaFuncionario] = useState('')
-  const [debouncedBuscaFuncionario, setDebouncedBuscaFuncionario] = useState('')
-  const [funcionariosResultados, setFuncionariosResultados] = useState<FuncionariosRede.Funcionario[]>([])
-  const [funcionariosLoading, setFuncionariosLoading] = useState(false)
-  const [funcionariosError, setFuncionariosError] = useState<string | null>(null)
 
   const [setoresList, setSetoresList] = useState<Setores.Setor[]>([])
   const [atendentesDestino, setAtendentesDestino] = useState<Atendentes.Atendente[]>([])
@@ -366,33 +359,6 @@ export function WhatsappConversa() {
       cancelled = true
     }
   }, [chat?.ticket_ids])
-
-  useEffect(() => {
-    const timer = setTimeout(() => setDebouncedBuscaFuncionario(buscaFuncionario.trim()), 400)
-    return () => clearTimeout(timer)
-  }, [buscaFuncionario])
-
-  useEffect(() => {
-    if (!modalVincFuncionario) return
-    if (!debouncedBuscaFuncionario) {
-      setFuncionariosResultados([])
-      setFuncionariosError(null)
-      return
-    }
-
-    setFuncionariosLoading(true)
-    setFuncionariosError(null)
-    funcionariosRede
-      .list({ busca: debouncedBuscaFuncionario, incluir_inativos: true, limit: 20 })
-      .then((data) => {
-        setFuncionariosResultados(data.items)
-      })
-      .catch((err) => {
-        setFuncionariosResultados([])
-        setFuncionariosError(mensagemFalhaParaToast(err, 'Não foi possível buscar funcionários.'))
-      })
-      .finally(() => setFuncionariosLoading(false))
-  }, [modalVincFuncionario, debouncedBuscaFuncionario])
 
 //transferencia de atendente
 useEffect(() => {
@@ -575,18 +541,6 @@ useEffect(() => {
 
   }
 
-  function selecionarFuncionario(funcionario: FuncionariosRede.Funcionario) {
-    setModalVincFuncionario(false)
-    navigate(`/funcionarios-rede/${funcionario.id}`)
-  }
-
-  function criarFuncionarioNovo() {
-    setModalVincFuncionario(false)
-    const email = buscaFuncionario.trim()
-    const emailQuery = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? `?email=${encodeURIComponent(email)}` : ''
-    navigate(`/funcionarios-rede/novo${emailQuery}`)
-  }
-
 
 
   if (loading && !chat) return <div className="flex h-full items-center justify-center italic text-slate-400">Carregando workspace...</div>
@@ -756,6 +710,24 @@ useEffect(() => {
                       {exibirProtocolo(t.protocolo)}
                     </Link>
                   ))}
+                </div>
+              )}
+
+              {chat?.funcionario_rede_id && (
+                <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                  <Link
+                    to={`/funcionarios-rede/${chat.funcionario_rede_id}`}
+                    className="inline-flex rounded-full border border-violet-200/80 bg-violet-50 px-2 py-0.5 text-[10px] font-medium text-violet-800 dark:border-violet-800 dark:bg-violet-950/40 dark:text-violet-300"
+                    title={chat.funcionario_email ?? undefined}
+                  >
+                    {chat.funcionario_nome}
+                    {chat.funcionario_tipo ? ` · ${chat.funcionario_tipo}` : ''}
+                  </Link>
+                  {chat.empresa_nome && (
+                    <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300">
+                      {chat.empresa_nome}
+                    </span>
+                  )}
                 </div>
               )}
 
@@ -1140,74 +1112,13 @@ useEffect(() => {
   </div>
 )}
 
-        {modalVincFuncionario && (
-          <div className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-900/50 backdrop-blur-sm">
-            <Card className="w-full max-w-lg p-6 animate-in zoom-in-95">
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <h3 className="text-lg font-bold">Vincular funcionário</h3>
-                  <p className="mt-1 text-sm text-slate-500">Busque por nome ou e-mail e abra o cadastro do funcionário.</p>
-                </div>
-                <button
-                  type="button"
-                  className="text-slate-500 hover:text-slate-900 dark:hover:text-slate-100"
-                  onClick={() => setModalVincFuncionario(false)}
-                >
-                  &times;
-                </button>
-              </div>
-
-              <div className="mt-4 space-y-4">
-                <Input
-                  placeholder="Buscar funcionário por nome ou e-mail"
-                  value={buscaFuncionario}
-                  onChange={(e) => setBuscaFuncionario(e.target.value)}
-                />
-
-                {funcionariosError && (
-                  <p className="text-xs text-amber-500">{funcionariosError}</p>
-                )}
-
-                {funcionariosLoading ? (
-                  <p className="text-sm text-slate-500">Buscando...</p>
-                ) : debouncedBuscaFuncionario ? (
-                  funcionariosResultados.length > 0 ? (
-                    <div className="max-h-72 overflow-y-auto divide-y divide-slate-200 rounded-xl border border-slate-200 bg-slate-50 p-1 dark:divide-slate-700 dark:border-slate-700 dark:bg-slate-900">
-                      {funcionariosResultados.map((funcionario) => (
-                        <button
-                          key={funcionario.id}
-                          type="button"
-                          onClick={() => selecionarFuncionario(funcionario)}
-                          className="w-full text-left px-4 py-3 hover:bg-white dark:hover:bg-slate-800 transition-colors"
-                        >
-                          <div className="flex items-center justify-between gap-3">
-                            <div>
-                              <p className="font-semibold text-slate-900 dark:text-slate-100">{funcionario.nome}</p>
-                              <p className="text-xs text-slate-500 dark:text-slate-400">{funcionario.email}</p>
-                            </div>
-                            <span className="text-xs uppercase tracking-wide text-slate-400">{funcionario.tipo}</span>
-                          </div>
-                        </button>
-                      ))}
-                    </div>
-                  ) : (
-                    <p className="text-sm text-slate-500">Nenhum funcionário encontrado.</p>
-                  )
-                ) : (
-                  <p className="text-sm text-slate-500">Digite um termo para buscar funcionários.</p>
-                )}
-              </div>
-
-              <div className="mt-6 flex flex-col gap-2 sm:flex-row sm:justify-end">
-                <Button variant="secondary" onClick={() => setModalVincFuncionario(false)}>
-                  Cancelar
-                </Button>
-                <Button onClick={criarFuncionarioNovo}>
-                  Novo funcionário
-                </Button>
-              </div>
-            </Card>
-          </div>
+        {modalVincFuncionario && chat && (
+          <WhatsappVincFuncionarioModal
+            chat={chat}
+            open={modalVincFuncionario}
+            onClose={() => setModalVincFuncionario(false)}
+            onSuccess={(atualizado) => setChat(atualizado)}
+          />
         )}
 
       {chat && (

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -25,8 +25,6 @@ import { Card } from '../../components/ui/Card'
 
 import { Button } from '../../components/ui/Button'
 
-import { Input } from '../../components/ui/Input'
-
 import { Select } from '../../components/ui/Select'
 
 import { useToast } from '../../components/ui/Toast'

--- a/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
@@ -1,0 +1,496 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { whatsappChats, type WhatsappChats } from '../../api/client'
+import { Card } from '../../components/ui/Card'
+import { Button } from '../../components/ui/Button'
+import { Input } from '../../components/ui/Input'
+import { Select } from '../../components/ui/Select'
+import { SelectComPesquisa } from '../../components/ui/SelectComPesquisa'
+import { CheckboxField } from '../../components/ui/CheckboxField'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+
+type Modo = 'vincular' | 'cadastrar'
+type TipoCadastro = 'colaborador' | 'supervisor'
+type EscopoCadastro = 'all' | 'selected'
+
+type Props = {
+  chat: WhatsappChats.Chat
+  open: boolean
+  onClose: () => void
+  onSuccess: (chat: WhatsappChats.Chat) => void
+}
+
+export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }: Props) {
+  const toast = useToast()
+  const [modo, setModo] = useState<Modo>('vincular')
+  const [salvando, setSalvando] = useState(false)
+
+  const [busca, setBusca] = useState('')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+  const [resultados, setResultados] = useState<WhatsappChats.FuncionarioOpcao[]>([])
+  const [loadingBusca, setLoadingBusca] = useState(false)
+  const [erroBusca, setErroBusca] = useState<string | null>(null)
+  const [selecionado, setSelecionado] = useState<WhatsappChats.FuncionarioOpcao | null>(null)
+  const [empresaVinculoId, setEmpresaVinculoId] = useState<number | ''>('')
+
+  const [catalogo, setCatalogo] = useState<WhatsappChats.FuncionarioCatalogo | null>(null)
+  const [catalogoLoading, setCatalogoLoading] = useState(false)
+
+  const [nomeCadastro, setNomeCadastro] = useState('')
+  const [emailCadastro, setEmailCadastro] = useState('')
+  const [tipoCadastro, setTipoCadastro] = useState<TipoCadastro>('colaborador')
+  const [escopoCadastro, setEscopoCadastro] = useState<EscopoCadastro>('selected')
+  const [redeIdCadastro, setRedeIdCadastro] = useState<number | ''>('')
+  const [empresaIdCadastro, setEmpresaIdCadastro] = useState<number | ''>('')
+  const [empresaIdsCadastro, setEmpresaIdsCadastro] = useState<number[]>([])
+  const [empresaContextoId, setEmpresaContextoId] = useState<number | ''>('')
+
+  const empresaItemsVincular = useMemo(
+    () => (selecionado?.empresas ?? []).map((e) => ({ id: e.id, label: e.nome })),
+    [selecionado],
+  )
+
+  const empresasDaRede = useMemo(
+    () =>
+      (catalogo?.empresas ?? []).filter(
+        (e) => redeIdCadastro !== '' && e.rede_id === Number(redeIdCadastro),
+      ),
+    [catalogo, redeIdCadastro],
+  )
+
+  const empresasContextoOpcoes = useMemo(() => {
+    if (escopoCadastro === 'all') return empresasDaRede
+    if (tipoCadastro === 'colaborador' && empresaIdCadastro !== '') {
+      const emp = empresasDaRede.find((e) => e.id === Number(empresaIdCadastro))
+      return emp ? [emp] : []
+    }
+    return empresasDaRede.filter((e) => empresaIdsCadastro.includes(e.id))
+  }, [empresaIdCadastro, empresaIdsCadastro, empresasDaRede, escopoCadastro, tipoCadastro])
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
+    return () => clearTimeout(timer)
+  }, [busca])
+
+  useEffect(() => {
+    if (!open) return
+    setModo('vincular')
+    setBusca('')
+    setDebouncedBusca('')
+    setResultados([])
+    setErroBusca(null)
+    setSelecionado(null)
+    setEmpresaVinculoId('')
+    setNomeCadastro(chat.cliente_nome?.trim() || '')
+    setEmailCadastro('')
+    setTipoCadastro('colaborador')
+    setEscopoCadastro('selected')
+    setRedeIdCadastro('')
+    setEmpresaIdCadastro('')
+    setEmpresaIdsCadastro([])
+    setEmpresaContextoId('')
+    setCatalogoLoading(true)
+    whatsappChats
+      .catalogoFuncionarios()
+      .then((data) => {
+        setCatalogo(data)
+        if (data.redes.length === 1) setRedeIdCadastro(data.redes[0].id)
+      })
+      .catch((err) => {
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar redes e empresas.'))
+      })
+      .finally(() => setCatalogoLoading(false))
+  }, [chat.cliente_nome, chat.id, open, toast])
+
+  useEffect(() => {
+    if (!open || modo !== 'vincular' || !debouncedBusca) {
+      setResultados([])
+      setErroBusca(null)
+      return
+    }
+    setLoadingBusca(true)
+    setErroBusca(null)
+    whatsappChats
+      .buscarFuncionarios(debouncedBusca)
+      .then(setResultados)
+      .catch((err) => {
+        setResultados([])
+        setErroBusca(mensagemFalhaParaToast(err, 'Não foi possível buscar funcionários.'))
+      })
+      .finally(() => setLoadingBusca(false))
+  }, [debouncedBusca, modo, open])
+
+  useEffect(() => {
+    if (!selecionado) {
+      setEmpresaVinculoId('')
+      return
+    }
+    if (selecionado.empresas.length === 1) setEmpresaVinculoId(selecionado.empresas[0].id)
+    else setEmpresaVinculoId('')
+  }, [selecionado])
+
+  useEffect(() => {
+    setEmpresaIdCadastro('')
+    setEmpresaIdsCadastro([])
+    setEmpresaContextoId('')
+  }, [redeIdCadastro, tipoCadastro, escopoCadastro])
+
+  useEffect(() => {
+    if (empresasContextoOpcoes.length === 1) {
+      setEmpresaContextoId(empresasContextoOpcoes[0].id)
+    } else if (
+      empresaContextoId !== '' &&
+      !empresasContextoOpcoes.some((e) => e.id === Number(empresaContextoId))
+    ) {
+      setEmpresaContextoId('')
+    }
+  }, [empresaContextoId, empresasContextoOpcoes])
+
+  if (!open) return null
+
+  function toggleEmpresaCadastro(id: number) {
+    setEmpresaIdsCadastro((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+  }
+
+  async function confirmarVinculo() {
+    if (!selecionado) {
+      toast.showWarning('Selecione um funcionário.')
+      return
+    }
+    if (selecionado.empresas.length > 1 && empresaVinculoId === '') {
+      toast.showWarning('Selecione a empresa do funcionário.')
+      return
+    }
+    setSalvando(true)
+    try {
+      const atualizado = await whatsappChats.vincularFuncionario(chat.id, {
+        funcionario_rede_id: selecionado.id,
+        empresa_id: empresaVinculoId === '' ? null : Number(empresaVinculoId),
+      })
+      toast.showSuccess('Funcionário vinculado ao contato.')
+      onSuccess(atualizado)
+      onClose()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível vincular o funcionário.'))
+    } finally {
+      setSalvando(false)
+    }
+  }
+
+  async function confirmarCadastro() {
+    if (!nomeCadastro.trim()) {
+      toast.showWarning('Informe o nome do funcionário.')
+      return
+    }
+    if (!emailCadastro.trim()) {
+      toast.showWarning('Informe o e-mail do funcionário.')
+      return
+    }
+    if (redeIdCadastro === '') {
+      toast.showWarning('Selecione a rede.')
+      return
+    }
+    let empresaIds: number[] = []
+    if (escopoCadastro === 'selected') {
+      if (tipoCadastro === 'colaborador') {
+        if (empresaIdCadastro === '') {
+          toast.showWarning('Selecione a empresa.')
+          return
+        }
+        empresaIds = [Number(empresaIdCadastro)]
+      } else if (empresaIdsCadastro.length === 0) {
+        toast.showWarning('Marque ao menos uma empresa.')
+        return
+      } else {
+        empresaIds = [...empresaIdsCadastro]
+      }
+    }
+    if (empresasContextoOpcoes.length > 1 && empresaContextoId === '') {
+      toast.showWarning('Selecione a empresa exibida no chat.')
+      return
+    }
+    setSalvando(true)
+    try {
+      const atualizado = await whatsappChats.cadastrarFuncionario(chat.id, {
+        nome: nomeCadastro.trim(),
+        email: emailCadastro.trim(),
+        rede_id: Number(redeIdCadastro),
+        tipo: tipoCadastro,
+        escopo_empresas: escopoCadastro,
+        empresa_ids: empresaIds,
+        empresa_id: empresaContextoId === '' ? null : Number(empresaContextoId),
+      })
+      toast.showSuccess('Funcionário cadastrado e vinculado ao contato.')
+      onSuccess(atualizado)
+      onClose()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível cadastrar o funcionário.'))
+    } finally {
+      setSalvando(false)
+    }
+  }
+
+  async function desvincular() {
+    setSalvando(true)
+    try {
+      const atualizado = await whatsappChats.desvincularFuncionario(chat.id)
+      toast.showSuccess('Vínculo com funcionário removido.')
+      onSuccess(atualizado)
+      onClose()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível desvincular o funcionário.'))
+    } finally {
+      setSalvando(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-900/50 backdrop-blur-sm p-4">
+      <Card className="w-full max-w-lg max-h-[90vh] overflow-y-auto p-6 animate-in zoom-in-95">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h3 className="text-lg font-bold">Funcionário do contato</h3>
+            <p className="mt-1 text-sm text-slate-500">
+              Vincule um cadastro existente ou cadastre o contato como funcionário da rede.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="text-slate-500 hover:text-slate-900 dark:hover:text-slate-100"
+            onClick={onClose}
+          >
+            &times;
+          </button>
+        </div>
+
+        {chat.funcionario_rede_id && (
+          <div className="mt-4 rounded-xl border border-cyan-200 bg-cyan-50 px-4 py-3 text-sm dark:border-cyan-900/50 dark:bg-cyan-950/30">
+            <p className="font-semibold text-cyan-900 dark:text-cyan-100">
+              Vínculo atual: {chat.funcionario_nome}
+            </p>
+            {chat.empresa_nome && (
+              <p className="mt-0.5 text-xs text-cyan-800/80 dark:text-cyan-200/80">{chat.empresa_nome}</p>
+            )}
+            <div className="mt-2 flex flex-wrap gap-2">
+              <Link
+                to={`/funcionarios-rede/${chat.funcionario_rede_id}`}
+                className="text-xs font-medium text-cyan-700 underline dark:text-cyan-300"
+              >
+                Abrir cadastro
+              </Link>
+              <button
+                type="button"
+                className="text-xs font-medium text-red-600 underline"
+                onClick={() => void desvincular()}
+                disabled={salvando}
+              >
+                Remover vínculo
+              </button>
+            </div>
+          </div>
+        )}
+
+        <div className="mt-4 flex gap-2 rounded-xl bg-slate-100 p-1 dark:bg-slate-800">
+          <button
+            type="button"
+            className={`flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+              modo === 'vincular'
+                ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-white'
+                : 'text-slate-500 hover:text-slate-800 dark:hover:text-slate-200'
+            }`}
+            onClick={() => setModo('vincular')}
+          >
+            Vincular existente
+          </button>
+          <button
+            type="button"
+            className={`flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors ${
+              modo === 'cadastrar'
+                ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-white'
+                : 'text-slate-500 hover:text-slate-800 dark:hover:text-slate-200'
+            }`}
+            onClick={() => setModo('cadastrar')}
+          >
+            Cadastrar novo
+          </button>
+        </div>
+
+        {modo === 'vincular' ? (
+          <div className="mt-4 space-y-4">
+            <Input
+              placeholder="Buscar por nome ou e-mail"
+              value={busca}
+              onChange={(e) => setBusca(e.target.value)}
+            />
+            {erroBusca && <p className="text-xs text-amber-500">{erroBusca}</p>}
+            {loadingBusca ? (
+              <p className="text-sm text-slate-500">Buscando...</p>
+            ) : debouncedBusca ? (
+              resultados.length > 0 ? (
+                <div className="max-h-56 overflow-y-auto divide-y divide-slate-200 rounded-xl border border-slate-200 bg-slate-50 p-1 dark:divide-slate-700 dark:border-slate-700 dark:bg-slate-900">
+                  {resultados.map((funcionario) => (
+                    <button
+                      key={funcionario.id}
+                      type="button"
+                      onClick={() => setSelecionado(funcionario)}
+                      className={`w-full text-left px-4 py-3 transition-colors ${
+                        selecionado?.id === funcionario.id
+                          ? 'bg-cyan-100 dark:bg-cyan-950/50'
+                          : 'hover:bg-white dark:hover:bg-slate-800'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <div>
+                          <p className="font-semibold text-slate-900 dark:text-slate-100">{funcionario.nome}</p>
+                          <p className="text-xs text-slate-500 dark:text-slate-400">{funcionario.email}</p>
+                        </div>
+                        <span className="text-xs uppercase tracking-wide text-slate-400">{funcionario.tipo}</span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-sm text-slate-500">
+                  Nenhum funcionário encontrado. Use a aba <strong>Cadastrar novo</strong>.
+                </p>
+              )
+            ) : (
+              <p className="text-sm text-slate-500">Digite um termo para buscar funcionários.</p>
+            )}
+            {selecionado && selecionado.empresas.length > 1 && (
+              <SelectComPesquisa
+                label="Empresa no chat"
+                items={empresaItemsVincular}
+                value={empresaVinculoId}
+                onChange={(id) => setEmpresaVinculoId(id)}
+                placeholder="Selecione a empresa"
+              />
+            )}
+          </div>
+        ) : (
+          <div className="mt-4 space-y-4">
+            {catalogoLoading ? (
+              <p className="text-sm text-slate-500">Carregando redes e empresas...</p>
+            ) : (
+              <>
+                <Input
+                  label="Nome"
+                  value={nomeCadastro}
+                  onChange={(e) => setNomeCadastro(e.target.value)}
+                  required
+                />
+                <Input
+                  label="E-mail"
+                  type="email"
+                  value={emailCadastro}
+                  onChange={(e) => setEmailCadastro(e.target.value)}
+                  required
+                />
+                <p className="text-xs text-slate-500">
+                  WhatsApp do contato: <span className="font-mono">{chat.wa_id}</span>
+                </p>
+                <Select
+                  label="Tipo"
+                  value={tipoCadastro}
+                  onChange={(v) => {
+                    setTipoCadastro(v as TipoCadastro)
+                    setEscopoCadastro('selected')
+                  }}
+                  options={[
+                    { value: 'colaborador', label: 'Colaborador (uma empresa)' },
+                    { value: 'supervisor', label: 'Supervisor (várias empresas)' },
+                  ]}
+                />
+                <SelectComPesquisa
+                  label="Rede"
+                  value={redeIdCadastro}
+                  onChange={(id) => setRedeIdCadastro(id)}
+                  items={(catalogo?.redes ?? []).map((r) => ({ id: r.id, label: r.nome }))}
+                  placeholder="Selecione a rede"
+                  required
+                />
+                <div className="space-y-2">
+                  <p className="text-sm font-medium text-slate-700 dark:text-slate-200">Escopo de empresas</p>
+                  <label className="flex cursor-pointer items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      checked={escopoCadastro === 'selected'}
+                      onChange={() => setEscopoCadastro('selected')}
+                    />
+                    Selecionar empresa(s)
+                  </label>
+                  <label className="flex cursor-pointer items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      checked={escopoCadastro === 'all'}
+                      onChange={() => {
+                        setEscopoCadastro('all')
+                        setEmpresaIdCadastro('')
+                        setEmpresaIdsCadastro([])
+                      }}
+                    />
+                    Todas as empresas da rede
+                  </label>
+                </div>
+                {escopoCadastro === 'selected' && redeIdCadastro !== '' && (
+                  <>
+                    {tipoCadastro === 'colaborador' ? (
+                      <SelectComPesquisa
+                        label="Empresa"
+                        value={empresaIdCadastro}
+                        onChange={(id) => setEmpresaIdCadastro(id)}
+                        items={empresasDaRede.map((e) => ({ id: e.id, label: e.nome }))}
+                        placeholder="Selecione a empresa"
+                        required
+                      />
+                    ) : empresasDaRede.length > 0 ? (
+                      <div className="flex max-h-40 flex-wrap gap-2 overflow-auto rounded-xl border border-slate-200 bg-slate-50/40 p-3 dark:border-slate-700 dark:bg-slate-800/40">
+                        {empresasDaRede.map((e) => (
+                          <CheckboxField
+                            key={e.id}
+                            checked={empresaIdsCadastro.includes(e.id)}
+                            onChange={() => toggleEmpresaCadastro(e.id)}
+                          >
+                            {e.nome}
+                          </CheckboxField>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="text-sm text-slate-500">Nenhuma empresa ativa nesta rede.</p>
+                    )}
+                  </>
+                )}
+                {empresasContextoOpcoes.length > 1 && (
+                  <SelectComPesquisa
+                    label="Empresa exibida no chat"
+                    value={empresaContextoId}
+                    onChange={(id) => setEmpresaContextoId(id)}
+                    items={empresasContextoOpcoes.map((e) => ({ id: e.id, label: e.nome }))}
+                    placeholder="Selecione a empresa de contexto"
+                    required
+                  />
+                )}
+              </>
+            )}
+          </div>
+        )}
+
+        <div className="mt-6 flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <Button variant="secondary" onClick={onClose} disabled={salvando}>
+            Cancelar
+          </Button>
+          {modo === 'vincular' ? (
+            <Button onClick={() => void confirmarVinculo()} loading={salvando} disabled={!selecionado}>
+              Vincular
+            </Button>
+          ) : (
+            <Button onClick={() => void confirmarCadastro()} loading={salvando} disabled={catalogoLoading}>
+              Cadastrar e vincular
+            </Button>
+          )}
+        </div>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Vincula contato do chat WhatsApp a funcionário existente (busca, escolha de empresa e badge no header).
- Cadastra funcionário inline no modal (colaborador/supervisor, rede, uma ou mais empresas) e vincula ao chat na mesma ação.
- Migration 040, endpoints de catálogo/busca/vincular/cadastrar/desvincular e testes backend.

## Test plan
- [ ] \lembic upgrade head\ (migration 040)
- [ ] No chat ativo: aba **Vincular existente** — buscar, vincular e ver badges no header
- [ ] Aba **Cadastrar novo** — criar colaborador com uma empresa e confirmar vínculo persistente ao recarregar
- [ ] Supervisor com várias empresas — selecionar empresas e empresa exibida no chat
- [ ] Remover vínculo pelo modal
- [ ] \pytest tests/test_whatsapp_chats.py\

Made with [Cursor](https://cursor.com)