### PR TITLE
feat(tickets): CSAT por e-mail — avaliacao do cliente (#117, #118)

### DIFF
--- a/backend/alembic/versions/041_ticket_csat.py
+++ b/backend/alembic/versions/041_ticket_csat.py
@@ -1,0 +1,57 @@
+"""Tickets: CSAT por e-mail (convite + avaliação do cliente).
+
+Revision ID: 041_ticket_csat
+Revises: 040_wpp_chat_funcionario
+Create Date: 2026-06-11
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "041_ticket_csat"
+down_revision = "040_wpp_chat_funcionario"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ticket_csat_invites",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("ticket_id", sa.Integer(), nullable=False),
+        sa.Column("atendente_id", sa.Integer(), nullable=True),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["atendente_id"], ["atendentes.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["ticket_id"], ["tickets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_ticket_csat_invites_ticket_id", "ticket_csat_invites", ["ticket_id"])
+    op.create_index("ix_ticket_csat_invites_token_hash", "ticket_csat_invites", ["token_hash"], unique=True)
+
+    op.create_table(
+        "ticket_avaliacoes",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("ticket_id", sa.Integer(), nullable=False),
+        sa.Column("atendente_id", sa.Integer(), nullable=True),
+        sa.Column("nota", sa.Integer(), nullable=False),
+        sa.Column("comentario", sa.Text(), nullable=True),
+        sa.Column("respondida_em", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("invite_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(["atendente_id"], ["atendentes.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["invite_id"], ["ticket_csat_invites.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["ticket_id"], ["tickets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("ticket_id", name="uq_ticket_avaliacoes_ticket_id"),
+    )
+    op.create_index("ix_ticket_avaliacoes_atendente_id", "ticket_avaliacoes", ["atendente_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ticket_avaliacoes_atendente_id", table_name="ticket_avaliacoes")
+    op.drop_table("ticket_avaliacoes")
+    op.drop_index("ix_ticket_csat_invites_token_hash", table_name="ticket_csat_invites")
+    op.drop_index("ix_ticket_csat_invites_ticket_id", table_name="ticket_csat_invites")
+    op.drop_table("ticket_csat_invites")

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -8,8 +8,10 @@ from app.database import get_db
 from app.core.ordenacao_lista import OrdemLista, expr_ordem
 from app.models import Atendente, Setor
 from app.schemas.atendente import AtendenteCreate, AtendenteRead, AtendenteUpdate, TrocaSenhaPropria
+from app.schemas.ticket_csat import AtendenteAvaliacoesRead, AvaliacaoResumoRead
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import exigir_admin, obter_atendente_atual
+from app.services.atendente_avaliacoes import calcular_avaliacoes_atendente
 from app.core.setor_scope import ids_setores_mesmo_nome, ids_setores_visiveis_atendente
 from app.core.security import hash_senha, verificar_senha
 from app.core.audit import registrar_audit
@@ -173,6 +175,23 @@ def listar_atendentes_por_setor(
             by_id[a.id] = a
     merged = sorted(by_id.values(), key=lambda x: ((x.nome or "").lower(), x.id))
     return [_atendente_para_read(a) for a in merged]
+
+
+@router.get("/{atendente_id}/avaliacoes", response_model=AtendenteAvaliacoesRead)
+def obter_avaliacoes_atendente(
+    atendente_id: int,
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_admin),
+):
+    atendente = db.query(Atendente).filter(Atendente.id == atendente_id).first()
+    if not atendente:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Atendente não encontrado")
+    data = calcular_avaliacoes_atendente(db, atendente_id)
+    return AtendenteAvaliacoesRead(
+        geral=AvaliacaoResumoRead(**data["geral"]),
+        whatsapp=AvaliacaoResumoRead(**data["whatsapp"]),
+        tickets=AvaliacaoResumoRead(**data["tickets"]),
+    )
 
 
 @router.get("/{atendente_id}", response_model=AtendenteRead)

--- a/backend/app/api/public_csat.py
+++ b/backend/app/api/public_csat.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.schemas.ticket_csat import TicketCsatPublicRead, TicketCsatSubmitBody
+from app.services.ticket_csat import MSG_TOKEN_INVALIDO, consultar_csat_publico, registrar_csat_publico
+
+router = APIRouter(prefix="/public/csat", tags=["public-csat"])
+
+
+@router.get("/tickets/{token}", response_model=TicketCsatPublicRead)
+def obter_csat_ticket(token: str, db: Session = Depends(get_db)):
+    data = consultar_csat_publico(db, token)
+    return TicketCsatPublicRead(**data)
+
+
+@router.post("/tickets/{token}", response_model=TicketCsatPublicRead)
+def enviar_csat_ticket(token: str, body: TicketCsatSubmitBody, db: Session = Depends(get_db)):
+    try:
+        registrar_csat_publico(db, token, nota=body.nota, comentario=body.comentario)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    data = consultar_csat_publico(db, token)
+    if data.get("status") == "invalido":
+        raise HTTPException(status_code=400, detail=MSG_TOKEN_INVALIDO)
+    return TicketCsatPublicRead(**data)

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -37,7 +37,8 @@ from app.schemas.ticket import (
 )
 from app.schemas.ticket_anexo import TicketAnexoCreateResponse, TicketAnexoRead
 from app.schemas.lista_paginada import ListaPaginada
-from app.core.auth import obter_atendente_atual
+from app.core.auth import obter_atendente_atual, exigir_admin
+from app.config import settings
 from app.core.ticket_prioridade import PrioridadeTicket
 from app.services.ticket_classificacao_rules import (
     motivo_efetivo_no_ticket,
@@ -51,7 +52,8 @@ from app.core.setor_scope import (
     responsavel_elegivel_para_setor_do_ticket,
 )
 from app.services import ticket_anexo_storage
-from app.services.protocolo_mensal import gerar_protocolo_ticket
+from app.services.ticket_csat import csat_brief_para_ticket, criar_convite_csat, processar_convite_csat_ao_fechar
+from app.schemas.ticket_csat import TicketCsatDevLinkRead
 from app.services.ticket_vinculos import (
     criar_vinculo as criar_vinculo_ticket,
     fechar_ticket_como_duplicado,
@@ -68,6 +70,7 @@ from app.services.ticket_escopo import (
 )
 from app.services.funcionario_rede_resolver import resolver_remetente_por_email
 from app.services.ticket_client_email import extrair_email_de_from_address
+from app.services.protocolo_mensal import gerar_protocolo_ticket
 from app.services.ticket_mensagem_email_outbox import (
     EMAIL_STATUS_ENVIADA,
     agendar_envio_email,
@@ -287,6 +290,7 @@ def _ticket_para_read(t: Ticket, db: Session | None = None) -> TicketRead:
             rede_id_out = f.rede_id
             r = db.query(Rede).filter(Rede.id == f.rede_id).first()
             rede_nome_out = r.nome if r else rede_nome_out
+    csat = csat_brief_para_ticket(db, t.id) if db is not None else {}
     return TicketRead(
         id=t.id,
         protocolo=t.protocolo,
@@ -318,6 +322,7 @@ def _ticket_para_read(t: Ticket, db: Session | None = None) -> TicketRead:
         children=children_out,
         vinculos=_vinculos_para_read(db, t) if db is not None else [],
         triagem_inbound=triagem,
+        **csat,
     )
 
 
@@ -635,6 +640,39 @@ def obter(
     return _ticket_para_read(ticket, db)
 
 
+@router.post("/{ticket_id}/csat/link-dev", response_model=TicketCsatDevLinkRead)
+def gerar_link_csat_dev(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_admin),
+):
+    """Desenvolvimento: gera link de avaliação sem enviar e-mail (não disponível em produção)."""
+    if settings.ENVIRONMENT != "development":
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Não encontrado")
+
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if ticket.fechado_em is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="O ticket precisa estar fechado para gerar o link de avaliação.",
+        )
+
+    result = criar_convite_csat(
+        db,
+        ticket_id,
+        enviar_email=False,
+        exigir_email_cliente=False,
+    )
+    if not result:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Não foi possível gerar o link (ticket já avaliado ou inválido).",
+        )
+    return TicketCsatDevLinkRead(**result)
+
+
 @router.get("/{ticket_id}/historico", response_model=list[TicketHistoricoRead])
 def historico(
     ticket_id: int,
@@ -762,6 +800,8 @@ def criar_vinculo(
         f"{data.tipo}:{related.id}",
     )
     db.commit()
+    if duplicado_fechado:
+        processar_convite_csat_ao_fechar(db, ticket.id)
     db.refresh(v)
     return _vinculo_para_read(v, ticket.id, db, duplicado_fechado=duplicado_fechado)
 
@@ -1499,15 +1539,20 @@ def atualizar(
     for k, v in update.items():
         setattr(ticket, k, v)
 
+    acabou_de_fechar = False
     if "status_id" in update:
         st = db.query(StatusTicket).filter(StatusTicket.id == ticket.status_id).first()
         slug = (st.slug or "").lower() if st else ""
         if slug == "fechado":
+            if ticket.fechado_em is None:
+                acabou_de_fechar = True
             ticket.fechado_em = datetime.now(timezone.utc)
         else:
             ticket.fechado_em = None
 
     db.commit()
+    if acabou_de_fechar:
+        processar_convite_csat_ao_fechar(db, ticket_id)
     ticket_out = (
         db.query(Ticket)
         .options(*_opcoes_carregamento_ticket_detalhe())

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -35,6 +35,7 @@ from app.api import (
     empresa_pdvs,
     system_settings,
     tenant,
+    public_csat,
 )
 from app.config import settings
 from app.core.tenant_context import resolve_tenant_id, set_request_tenant_id
@@ -309,6 +310,7 @@ app.include_router(ticket_catalogos.router, prefix=API_V1_PREFIX)
 app.include_router(empresa_pdvs.router, prefix=API_V1_PREFIX)
 app.include_router(system_settings.router, prefix=API_V1_PREFIX)
 app.include_router(tenant.router, prefix=API_V1_PREFIX)
+app.include_router(public_csat.router, prefix=API_V1_PREFIX)
 
 
 def _app_capabilities() -> dict[str, bool]:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -24,6 +24,7 @@ from app.models.password_reset_token import PasswordResetToken
 from app.models.resposta_pronta import RespostaPronta
 from app.models.ticket_vinculo import TicketVinculo
 from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+from app.models.ticket_avaliacao import TicketAvaliacao, TicketCsatInvite
 from app.models.empresa_pdv import EmpresaPdv, PdvRotulo, PdvTipoAcessoRemoto
 
 __all__ = [
@@ -61,6 +62,8 @@ __all__ = [
     "TicketVinculo",
     "TicketNatureza",
     "TicketMotivo",
+    "TicketAvaliacao",
+    "TicketCsatInvite",
     "PdvRotulo",
     "PdvTipoAcessoRemoto",
     "EmpresaPdv",

--- a/backend/app/models/ticket_avaliacao.py
+++ b/backend/app/models/ticket_avaliacao.py
@@ -1,0 +1,38 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class TicketCsatInvite(Base):
+    __tablename__ = "ticket_csat_invites"
+
+    id = Column(Integer, primary_key=True, index=True)
+    ticket_id = Column(Integer, ForeignKey("tickets.id", ondelete="CASCADE"), nullable=False, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    token_hash = Column(String(64), nullable=False, unique=True, index=True)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    used_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    ticket = relationship("Ticket", backref="csat_invites")
+    atendente = relationship("Atendente", backref="ticket_csat_invites")
+
+
+class TicketAvaliacao(Base):
+    __tablename__ = "ticket_avaliacoes"
+
+    id = Column(Integer, primary_key=True, index=True)
+    ticket_id = Column(Integer, ForeignKey("tickets.id", ondelete="CASCADE"), nullable=False, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True, index=True)
+    nota = Column(Integer, nullable=False)
+    comentario = Column(Text, nullable=True)
+    respondida_em = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    invite_id = Column(Integer, ForeignKey("ticket_csat_invites.id", ondelete="SET NULL"), nullable=True)
+
+    ticket = relationship("Ticket", backref="avaliacao", uselist=False)
+    atendente = relationship("Atendente", backref="ticket_avaliacoes")
+    invite = relationship("TicketCsatInvite", backref="avaliacao", uselist=False)
+
+    __table_args__ = (UniqueConstraint("ticket_id", name="uq_ticket_avaliacoes_ticket_id"),)

--- a/backend/app/schemas/ticket.py
+++ b/backend/app/schemas/ticket.py
@@ -168,6 +168,10 @@ class TicketRead(BaseModel):
     children: list[TicketChildBrief] = Field(default_factory=list)
     vinculos: list[TicketVinculoRead] = Field(default_factory=list)
     triagem_inbound: TicketTriagemInbound | None = None
+    avaliacao_nota: int | None = None
+    avaliacao_comentario: str | None = None
+    avaliacao_respondida_em: datetime | None = None
+    csat_pendente: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/schemas/ticket_csat.py
+++ b/backend/app/schemas/ticket_csat.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class TicketCsatSubmitBody(BaseModel):
+    nota: int = Field(..., ge=1, le=5)
+    comentario: str | None = Field(None, max_length=2000)
+
+
+class TicketCsatPublicRead(BaseModel):
+    status: str
+    protocolo: str | None = None
+    assunto: str | None = None
+    nota: int | None = None
+    comentario: str | None = None
+    respondida_em: datetime | None = None
+
+
+class AvaliacaoResumoRead(BaseModel):
+    media: float | None = None
+    total: int = 0
+
+
+class AtendenteAvaliacoesRead(BaseModel):
+    geral: AvaliacaoResumoRead
+    whatsapp: AvaliacaoResumoRead
+    tickets: AvaliacaoResumoRead
+
+
+class TicketAvaliacaoBrief(BaseModel):
+    nota: int
+    comentario: str | None = None
+    respondida_em: datetime | None = None
+    csat_pendente: bool = False
+
+
+class TicketCsatDevLinkRead(BaseModel):
+    link: str
+    expires_at: datetime

--- a/backend/app/services/atendente_avaliacoes.py
+++ b/backend/app/services/atendente_avaliacoes.py
@@ -1,0 +1,46 @@
+"""Métricas de avaliação (CSAT) por atendente."""
+
+from __future__ import annotations
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.models.ticket_avaliacao import TicketAvaliacao
+from app.models.whatsapp_chat import WhatsappChat
+
+
+def calcular_avaliacoes_atendente(db: Session, atendente_id: int) -> dict:
+    wpp_row = (
+        db.query(func.avg(WhatsappChat.avaliacao_nota), func.count(WhatsappChat.id))
+        .filter(
+            WhatsappChat.atendente_id == atendente_id,
+            WhatsappChat.avaliacao_nota.isnot(None),
+        )
+        .one()
+    )
+    tkt_row = (
+        db.query(func.avg(TicketAvaliacao.nota), func.count(TicketAvaliacao.id))
+        .filter(TicketAvaliacao.atendente_id == atendente_id)
+        .one()
+    )
+    wpp_media, wpp_total = wpp_row[0], int(wpp_row[1] or 0)
+    tkt_media, tkt_total = tkt_row[0], int(tkt_row[1] or 0)
+
+    soma = 0.0
+    total_geral = 0
+    if wpp_total and wpp_media is not None:
+        soma += float(wpp_media) * wpp_total
+        total_geral += wpp_total
+    if tkt_total and tkt_media is not None:
+        soma += float(tkt_media) * tkt_total
+        total_geral += tkt_total
+    geral_media = round(soma / total_geral, 2) if total_geral else None
+
+    def pack(media, total: int) -> dict:
+        return {"media": round(float(media), 2) if media is not None and total else None, "total": total}
+
+    return {
+        "geral": pack(geral_media, total_geral),
+        "whatsapp": pack(wpp_media, wpp_total),
+        "tickets": pack(tkt_media, tkt_total),
+    }

--- a/backend/app/services/ticket_client_email.py
+++ b/backend/app/services/ticket_client_email.py
@@ -47,6 +47,14 @@ def ultima_mensagem_inbound(db: Session, ticket_id: int) -> EmailInboundReceived
     )
 
 
+def resolver_email_cliente_ticket(db: Session, ticket_id: int) -> str | None:
+    """Endereço do cliente a partir do último e-mail recebido na thread do ticket."""
+    row = ultima_mensagem_inbound(db, ticket_id)
+    if not row:
+        return None
+    return extrair_email_de_from_address(row.from_address)
+
+
 def enviar_resposta_equipa_por_email(db: Session, *, ticket: Ticket, corpo: str) -> str:
     """
     Envia e-mail ao último remetente conhecido (ingestão) e devolve o **Message-ID** normalizado do envio.

--- a/backend/app/services/ticket_csat.py
+++ b/backend/app/services/ticket_csat.py
@@ -1,0 +1,212 @@
+"""CSAT de tickets: convite por e-mail (24h) e métricas por atendente."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.ticket import Ticket
+from app.models.ticket_avaliacao import TicketAvaliacao, TicketCsatInvite
+from app.services.email_send_sistema import enviar_mensagem_texto_sistema
+from app.services.ticket_client_email import resolver_email_cliente_ticket, ultima_mensagem_inbound
+from app.services.password_reset import _public_app_origin  # reuse origin builder
+
+logger = logging.getLogger(__name__)
+
+CSAT_EXPIRE_HOURS = 24
+MSG_TOKEN_INVALIDO = "Link inválido ou expirado."
+
+
+def _as_utc_aware(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _hash_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def build_csat_link(raw_token: str) -> str:
+    origin = _public_app_origin().rstrip("/")
+    return f"{origin}/avaliar-ticket?token={raw_token}"
+
+
+def _invalidate_pending_invites(db: Session, ticket_id: int) -> None:
+    now = datetime.now(timezone.utc)
+    rows = (
+        db.query(TicketCsatInvite)
+        .filter(
+            TicketCsatInvite.ticket_id == ticket_id,
+            TicketCsatInvite.used_at.is_(None),
+        )
+        .all()
+    )
+    for row in rows:
+        if _as_utc_aware(row.expires_at) > now:
+            row.used_at = now
+
+
+def _convite_ativo(db: Session, ticket_id: int) -> TicketCsatInvite | None:
+    now = datetime.now(timezone.utc)
+    return (
+        db.query(TicketCsatInvite)
+        .filter(
+            TicketCsatInvite.ticket_id == ticket_id,
+            TicketCsatInvite.used_at.is_(None),
+            TicketCsatInvite.expires_at > now,
+        )
+        .order_by(TicketCsatInvite.id.desc())
+        .first()
+    )
+
+
+def csat_brief_para_ticket(db: Session, ticket_id: int) -> dict:
+    aval = db.query(TicketAvaliacao).filter(TicketAvaliacao.ticket_id == ticket_id).first()
+    if aval:
+        return {
+            "avaliacao_nota": aval.nota,
+            "avaliacao_comentario": aval.comentario,
+            "avaliacao_respondida_em": aval.respondida_em,
+            "csat_pendente": False,
+        }
+    pendente = _convite_ativo(db, ticket_id) is not None
+    return {
+        "avaliacao_nota": None,
+        "avaliacao_comentario": None,
+        "avaliacao_respondida_em": None,
+        "csat_pendente": pendente,
+    }
+
+
+def criar_convite_csat(
+    db: Session,
+    ticket_id: int,
+    *,
+    enviar_email: bool = True,
+    exigir_email_cliente: bool = True,
+) -> dict | None:
+    """
+    Cria convite CSAT para ticket fechado. Retorna ``{link, expires_at}`` ou None se não aplicável.
+
+    ``exigir_email_cliente=False`` permite convite em dev sem histórico inbound (sem enviar e-mail).
+    """
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket or ticket.fechado_em is None:
+        return None
+    if db.query(TicketAvaliacao).filter(TicketAvaliacao.ticket_id == ticket_id).first():
+        return None
+
+    to_addr = resolver_email_cliente_ticket(db, ticket_id)
+    if exigir_email_cliente and not to_addr:
+        return None
+
+    raw = secrets.token_urlsafe(32)
+    expires = datetime.now(timezone.utc) + timedelta(hours=CSAT_EXPIRE_HOURS)
+    _invalidate_pending_invites(db, ticket_id)
+    invite = TicketCsatInvite(
+        ticket_id=ticket_id,
+        atendente_id=ticket.atendente_id,
+        token_hash=_hash_token(raw),
+        expires_at=expires,
+    )
+    db.add(invite)
+    db.commit()
+
+    link = build_csat_link(raw)
+    if enviar_email and to_addr:
+        proto = ticket.protocolo or str(ticket.id)
+        subject = f"Avalie o atendimento — chamado {proto}"
+        body = (
+            "Olá,\n\n"
+            f"Seu chamado {proto} foi encerrado.\n"
+            "Gostaríamos de saber como foi sua experiência (nota de 1 a 5 estrelas).\n\n"
+            f"Acesse o link abaixo (válido por {CSAT_EXPIRE_HOURS} horas):\n"
+            f"{link}\n\n"
+            "Obrigado,\n"
+            "Equipe de atendimento"
+        )
+        try:
+            inbound = ultima_mensagem_inbound(db, ticket_id)
+            in_reply_to = (inbound.message_id_normalized or "").strip() if inbound else None
+            enviar_mensagem_texto_sistema(
+                db,
+                to_addr=to_addr,
+                subject=subject[:998],
+                body=body,
+                in_reply_to=in_reply_to or None,
+            )
+        except ValueError as e:
+            logger.info("CSAT ticket %s: e-mail não enviado (%s)", ticket_id, e)
+        except Exception:
+            logger.exception("CSAT ticket %s: falha ao enviar e-mail", ticket_id)
+
+    return {"link": link, "expires_at": expires}
+
+
+def processar_convite_csat_ao_fechar(db: Session, ticket_id: int) -> None:
+    """Após fecho do ticket: cria convite e envia e-mail se o cliente tiver endereço."""
+    criar_convite_csat(db, ticket_id, enviar_email=True, exigir_email_cliente=True)
+
+
+def _invite_por_token(db: Session, raw_token: str) -> TicketCsatInvite | None:
+    token = (raw_token or "").strip()
+    if not token:
+        return None
+    return db.query(TicketCsatInvite).filter(TicketCsatInvite.token_hash == _hash_token(token)).first()
+
+
+def consultar_csat_publico(db: Session, raw_token: str) -> dict:
+    invite = _invite_por_token(db, raw_token)
+    if not invite:
+        return {"status": "invalido"}
+    ticket = db.query(Ticket).filter(Ticket.id == invite.ticket_id).first()
+    aval = db.query(TicketAvaliacao).filter(TicketAvaliacao.ticket_id == invite.ticket_id).first()
+    if aval:
+        return {
+            "status": "respondido",
+            "protocolo": ticket.protocolo if ticket else None,
+            "assunto": ticket.assunto if ticket else None,
+            "nota": aval.nota,
+            "comentario": aval.comentario,
+            "respondida_em": aval.respondida_em,
+        }
+    now = datetime.now(timezone.utc)
+    if invite.used_at is not None or _as_utc_aware(invite.expires_at) <= now:
+        return {
+            "status": "expirado",
+            "protocolo": ticket.protocolo if ticket else None,
+            "assunto": ticket.assunto if ticket else None,
+        }
+    return {
+        "status": "pendente",
+        "protocolo": ticket.protocolo if ticket else None,
+        "assunto": ticket.assunto if ticket else None,
+    }
+
+
+def registrar_csat_publico(db: Session, raw_token: str, *, nota: int, comentario: str | None) -> None:
+    invite = _invite_por_token(db, raw_token)
+    if not invite:
+        raise ValueError(MSG_TOKEN_INVALIDO)
+    now = datetime.now(timezone.utc)
+    if invite.used_at is not None or _as_utc_aware(invite.expires_at) <= now:
+        raise ValueError(MSG_TOKEN_INVALIDO)
+    if db.query(TicketAvaliacao).filter(TicketAvaliacao.ticket_id == invite.ticket_id).first():
+        raise ValueError("Este chamado já foi avaliado.")
+
+    comentario_eff = (comentario or "").strip() or None
+    aval = TicketAvaliacao(
+        ticket_id=invite.ticket_id,
+        atendente_id=invite.atendente_id,
+        nota=int(nota),
+        comentario=comentario_eff,
+        invite_id=invite.id,
+    )
+    invite.used_at = now
+    db.add(aval)
+    db.commit()

--- a/backend/scripts/testar_csat_local.py
+++ b/backend/scripts/testar_csat_local.py
@@ -1,0 +1,104 @@
+"""Testa fluxo CSAT local sem envio de e-mail (endpoint link-dev)."""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+
+BASE = "http://localhost:8000/v1"
+EMAIL = "admin@email.com"
+SENHA = "admin123"
+
+
+def req(method: str, path: str, *, token: str | None = None, body: dict | None = None) -> dict:
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    data = json.dumps(body).encode() if body is not None else None
+    r = urllib.request.Request(f"{BASE}{path}", data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(r, timeout=30) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        err = e.read().decode()
+        raise RuntimeError(f"{method} {path} -> {e.code}: {err}") from e
+
+
+def main() -> int:
+    print("1. Login…")
+    tok = req("POST", "/auth/login", body={"email": EMAIL, "senha": SENHA})["access_token"]
+
+    print("2. Listar tickets fechados…")
+    tickets = req("GET", "/tickets?situacao=fechados&limit=5", token=tok)
+    items = tickets.get("items") or []
+    ticket = items[0] if items else None
+
+    if not ticket:
+        print("   Nenhum ticket fechado — criando e fechando um…")
+        setores = req("GET", "/setores?limit=1", token=tok)["items"]
+        empresas = req("GET", "/empresas?limit=1", token=tok)["items"]
+        status_list = req("GET", "/status-ticket?limit=50", token=tok)["items"]
+        fechado = next((s for s in status_list if (s.get("slug") or "").lower() == "fechado"), None)
+        if not fechado:
+            print("ERRO: cadastre status slug 'fechado'", file=sys.stderr)
+            return 1
+        motivos = req("GET", "/ticket-classificacao/motivos?limit=50", token=tok)
+        motivo_items = motivos if isinstance(motivos, list) else motivos.get("items") or []
+        motivo = motivo_items[0] if motivo_items else None
+        if not motivo:
+            print("ERRO: cadastre ao menos um motivo de ticket", file=sys.stderr)
+            return 1
+        created = req(
+            "POST",
+            "/tickets",
+            token=tok,
+            body={
+                "empresa_id": empresas[0]["id"],
+                "setor_id": setores[0]["id"],
+                "assunto": "Teste CSAT local",
+                "descricao": "Gerado por scripts/testar_csat_local.py",
+            },
+        )
+        ticket = req(
+            "PATCH",
+            f"/tickets/{created['id']}",
+            token=tok,
+            body={"status_id": fechado["id"], "motivo_id": motivo["id"]},
+        )
+        print(f"   Ticket #{ticket['id']} fechado.")
+
+    tid = ticket["id"]
+    if ticket.get("avaliacao_nota") is not None:
+        print(f"   Ticket {tid} já avaliado — usando mesmo ticket para novo convite dev.")
+
+    print(f"3. Gerar link dev (ticket {tid})…")
+    link_resp = req("POST", f"/tickets/{tid}/csat/link-dev", token=tok)
+    link = link_resp["link"]
+    print(f"   Link: {link}")
+
+    token_raw = link.split("token=")[-1]
+    print("4. GET página pública (pendente)…")
+    pub = req("GET", f"/public/csat/tickets/{token_raw}")
+    assert pub["status"] == "pendente", pub
+    print(f"   OK — protocolo {pub.get('protocolo')}")
+
+    print("5. POST avaliação (nota 4)…")
+    pub2 = req("POST", f"/public/csat/tickets/{token_raw}", body={"nota": 4, "comentario": "Teste local OK"})
+    assert pub2["status"] == "respondido" and pub2["nota"] == 4, pub2
+    print("   Avaliação registrada.")
+
+    print("6. Verificar ticket…")
+    t2 = req("GET", f"/tickets/{tid}", token=tok)
+    assert t2.get("avaliacao_nota") == 4, t2
+    print(f"   Ticket exibe nota {t2['avaliacao_nota']} — fluxo completo OK.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as e:
+        print(f"FALHA: {e}", file=sys.stderr)
+        raise SystemExit(1)

--- a/backend/tests/test_ticket_csat.py
+++ b/backend/tests/test_ticket_csat.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from app.models.email_inbound_received import EmailInboundReceived
+from app.models import StatusTicket
+from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+from app.models.ticket import Ticket
+from app.models.ticket_avaliacao import TicketAvaliacao, TicketCsatInvite
+from app.models.whatsapp_chat import WhatsappChat
+
+
+def _status_fechado(db_session) -> StatusTicket:
+    st = db_session.query(StatusTicket).filter(StatusTicket.slug == "fechado").first()
+    if st:
+        return st
+    st = StatusTicket(nome="Fechado", slug="fechado", ordem=99, ativo=True)
+    db_session.add(st)
+    db_session.commit()
+    db_session.refresh(st)
+    return st
+
+
+def _seed_motivo(db_session) -> TicketMotivo:
+    n = TicketNatureza(nome="Erro CSAT", slug="erro-csat", ordem=10, ativo=True)
+    db_session.add(n)
+    db_session.flush()
+    m = TicketMotivo(natureza_id=n.id, nome="Teste CSAT", slug="teste-csat", ordem=10, ativo=True)
+    db_session.add(m)
+    db_session.commit()
+    db_session.refresh(m)
+    return m
+
+
+def _fechar_ticket(client, auth_headers, tid: int, status_fechado: StatusTicket, motivo: TicketMotivo):
+    r = client.patch(
+        f"/v1/tickets/{tid}",
+        headers=auth_headers["admin"],
+        json={"status_id": status_fechado.id, "motivo_id": motivo.id},
+    )
+    assert r.status_code == 200, r.text
+    return r
+
+
+def _criar_ticket(client, seed_base, auth_headers):
+    ticket = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Ticket CSAT teste",
+            "descricao": "Teste",
+        },
+    )
+    assert ticket.status_code == 201
+    return ticket.json()["id"]
+
+
+def test_csat_convite_ao_fechar_ticket_com_email(client, seed_base, auth_headers, db_session, monkeypatch):
+    sent = []
+
+    def fake_send(db, *, to_addr, subject, body, in_reply_to=None):
+        sent.append({"to": to_addr, "subject": subject, "body": body})
+        return "<out-mid@test>"
+
+    monkeypatch.setattr("app.services.ticket_csat.enviar_mensagem_texto_sistema", fake_send)
+
+    tid = _criar_ticket(client, seed_base, auth_headers)
+    db_session.add(
+        EmailInboundReceived(
+            message_id_normalized="csat-inbound-1",
+            ticket_id=tid,
+            from_address="Cliente Teste <cliente.csat@test.local>",
+            subject="Ticket CSAT teste",
+        )
+    )
+    db_session.commit()
+
+    status_fechado = _status_fechado(db_session)
+    motivo = _seed_motivo(db_session)
+    _fechar_ticket(client, auth_headers, tid, status_fechado, motivo)
+
+    invite = db_session.query(TicketCsatInvite).filter(TicketCsatInvite.ticket_id == tid).first()
+    assert invite is not None
+    assert len(sent) == 1
+    assert "cliente.csat@test.local" in sent[0]["to"]
+
+
+def test_csat_sem_email_nao_cria_convite(client, seed_base, auth_headers, db_session):
+    tid = _criar_ticket(client, seed_base, auth_headers)
+    status_fechado = _status_fechado(db_session)
+    motivo = _seed_motivo(db_session)
+    _fechar_ticket(client, auth_headers, tid, status_fechado, motivo)
+    invite = db_session.query(TicketCsatInvite).filter(TicketCsatInvite.ticket_id == tid).first()
+    assert invite is None
+
+
+def test_csat_publico_registrar_nota(client, seed_base, auth_headers, db_session):
+    tid = _criar_ticket(client, seed_base, auth_headers)
+    db_session.add(
+        EmailInboundReceived(
+            message_id_normalized="csat-pub-in",
+            ticket_id=tid,
+            from_address="cliente.pub@test.local",
+            subject="Assunto",
+        )
+    )
+    ticket = db_session.query(Ticket).filter(Ticket.id == tid).first()
+    ticket.fechado_em = datetime.now(timezone.utc)
+    db_session.commit()
+
+    raw = secrets.token_urlsafe(32)
+    invite = TicketCsatInvite(
+        ticket_id=tid,
+        atendente_id=seed_base["a1"].id,
+        token_hash=hashlib.sha256(raw.encode()).hexdigest(),
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=24),
+    )
+    db_session.add(invite)
+    db_session.commit()
+
+    get_r = client.get(f"/v1/public/csat/tickets/{raw}")
+    assert get_r.status_code == 200
+    assert get_r.json()["status"] == "pendente"
+
+    post_r = client.post(
+        f"/v1/public/csat/tickets/{raw}",
+        json={"nota": 5, "comentario": "Ótimo atendimento"},
+    )
+    assert post_r.status_code == 200
+    assert post_r.json()["status"] == "respondido"
+    assert post_r.json()["nota"] == 5
+
+    aval = db_session.query(TicketAvaliacao).filter(TicketAvaliacao.ticket_id == tid).first()
+    assert aval is not None
+    assert aval.nota == 5
+
+
+def test_csat_link_dev_sem_email(client, seed_base, auth_headers, db_session):
+    tid = _criar_ticket(client, seed_base, auth_headers)
+    status_fechado = _status_fechado(db_session)
+    motivo = _seed_motivo(db_session)
+    _fechar_ticket(client, auth_headers, tid, status_fechado, motivo)
+
+    r = client.post(f"/v1/tickets/{tid}/csat/link-dev", headers=auth_headers["admin"])
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["link"].startswith("http")
+    assert "token=" in body["link"]
+
+    token = body["link"].split("token=")[-1]
+    post_r = client.post(f"/v1/public/csat/tickets/{token}", json={"nota": 3})
+    assert post_r.status_code == 200
+    assert post_r.json()["nota"] == 3
+
+
+def test_metricas_avaliacoes_atendente(client, seed_base, auth_headers, db_session):
+    a1 = seed_base["a1"]
+    tid = _criar_ticket(client, seed_base, auth_headers)
+    db_session.add(
+        WhatsappChat(
+            protocolo="WPP-CSAT-1",
+            wa_id="5511999000001",
+            estado="encerrado",
+            atendente_id=a1.id,
+            avaliacao_nota=5,
+        )
+    )
+    db_session.add(
+        TicketAvaliacao(
+            ticket_id=tid,
+            atendente_id=a1.id,
+            nota=3,
+        )
+    )
+    db_session.commit()
+
+    r = client.get(f"/v1/atendentes/{a1.id}/avaliacoes", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["whatsapp"]["total"] == 1
+    assert body["tickets"]["total"] == 1
+    assert body["geral"]["total"] == 2

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { Layout } from './components/Layout'
 import { Login } from './pages/Login'
 import { EsqueciSenha } from './pages/EsqueciSenha'
 import { RedefinirSenha } from './pages/RedefinirSenha'
+import { AvaliarTicket } from './pages/AvaliarTicket'
 import { Dashboard } from './pages/Dashboard'
 import { Tickets } from './pages/Tickets'
 import { TicketNovo } from './pages/TicketNovo'
@@ -83,6 +84,7 @@ function AppRoutes() {
       <Route path="/login" element={<Login />} />
       <Route path="/esqueci-senha" element={<EsqueciSenha />} />
       <Route path="/redefinir-senha" element={<RedefinirSenha />} />
+      <Route path="/avaliar-ticket" element={<AvaliarTicket />} />
       <Route
         path="/"
         element={

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -154,6 +154,41 @@ export async function api<T>(
   return res.json();
 }
 
+/** Chamadas públicas (sem token nem redirect em 401). */
+async function publicApi<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+    ...(options.headers as object),
+  };
+  const res = await fetch(`${BASE}${API_VERSION_PREFIX}${path}`, { ...options, headers });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new ApiError(mensagemErroApi(err, res.status), res.status, err);
+  }
+  return res.json();
+}
+
+export const publicCsat = {
+  get: (token: string) =>
+    publicApi<PublicCsat.TicketCsat>(`/public/csat/tickets/${encodeURIComponent(token)}`),
+  submit: (token: string, data: { nota: number; comentario?: string | null }) =>
+    publicApi<PublicCsat.TicketCsat>(`/public/csat/tickets/${encodeURIComponent(token)}`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+};
+
+export namespace PublicCsat {
+  export interface TicketCsat {
+    status: 'pendente' | 'respondido' | 'expirado' | 'invalido';
+    protocolo?: string | null;
+    assunto?: string | null;
+    nota?: number | null;
+    comentario?: string | null;
+    respondida_em?: string | null;
+  }
+}
+
 export const auth = {
   login: (email: string, senha: string) =>
     api<{ access_token: string; refresh_token?: string | null; must_change_password?: boolean }>('/auth/login', {
@@ -347,6 +382,7 @@ export const atendentes = {
     api<Atendentes.Atendente[]>(withParams(`/atendentes/por-setor/${setorId}`, params)),
   me: () => api<Atendentes.Atendente>('/atendentes/me'),
   get: (id: number) => api<Atendentes.Atendente>(`/atendentes/${id}`),
+  avaliacoes: (id: number) => api<Atendentes.AvaliacoesResumo>(`/atendentes/${id}/avaliacoes`),
   create: (data: Atendentes.Create) => api<Atendentes.Atendente>('/atendentes', { method: 'POST', body: JSON.stringify(data) }),
   update: (id: number, data: Atendentes.Update) => api<Atendentes.Atendente>(`/atendentes/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
   delete: (id: number) => api<void>(`/atendentes/${id}`, { method: 'DELETE' }),
@@ -883,6 +919,9 @@ export const tickets = {
   sendNowMensagemEmail: (ticketId: number, mensagemId: number) =>
     api<Tickets.Mensagem>(`/tickets/${ticketId}/mensagens/${mensagemId}/send-now`, { method: 'POST' }),
   reabrir: (id: number) => api<Tickets.Ticket>(`/tickets/${id}/reabrir`, { method: 'POST' }),
+  /** Apenas desenvolvimento: gera link CSAT sem enviar e-mail. */
+  csatLinkDev: (id: number) =>
+    api<{ link: string; expires_at: string }>(`/tickets/${id}/csat/link-dev`, { method: 'POST' }),
   create: (data: Tickets.Create) => api<Tickets.Ticket>('/tickets', { method: 'POST', body: JSON.stringify(data) }),
   update: (id: number, data: Tickets.Update) => api<Tickets.Ticket>(`/tickets/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
   addVinculo: (ticketId: number, data: Tickets.VinculoCreate) =>
@@ -1179,6 +1218,15 @@ export namespace Atendentes {
     role?: string;
     ativo?: boolean;
     setor_ids?: number[];
+  }
+  export interface AvaliacaoResumo {
+    media: number | null;
+    total: number;
+  }
+  export interface AvaliacoesResumo {
+    geral: AvaliacaoResumo;
+    whatsapp: AvaliacaoResumo;
+    tickets: AvaliacaoResumo;
   }
 }
 
@@ -1494,6 +1542,10 @@ export namespace Tickets {
     children?: TicketChildBrief[];
     vinculos?: TicketVinculo[];
     triagem_inbound?: TriagemInbound | null;
+    avaliacao_nota?: number | null;
+    avaliacao_comentario?: string | null;
+    avaliacao_respondida_em?: string | null;
+    csat_pendente?: boolean;
   }
   export type TicketVinculoTipo = 'duplicado_de' | 'relacionado_a';
   export interface TicketVinculoOutro {

--- a/frontend/src/pages/AtendenteDetalhe.tsx
+++ b/frontend/src/pages/AtendenteDetalhe.tsx
@@ -13,6 +13,11 @@ import { interpretarFalhaCarregamento } from '../api/errorMessage'
 
 const roleLabel: Record<string, string> = { admin: 'Administrador', atendente: 'Atendente' }
 
+function fmtMediaAvaliacao(media: number | null): string {
+  if (media == null) return '—'
+  return media.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+
 export function AtendenteDetalhe() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
@@ -23,6 +28,7 @@ export function AtendenteDetalhe() {
   const [forbidden, setForbidden] = useState(false)
   const [falha, setFalha] = useState<{ titulo: string; detalhe?: string } | null>(null)
   const [atendente, setAtendente] = useState<Atendentes.Atendente | null>(null)
+  const [avaliacoes, setAvaliacoes] = useState<Atendentes.AvaliacoesResumo | null>(null)
   const [setoresList, setSetoresList] = useState<Setores.Setor[]>([])
 
   useEffect(() => {
@@ -37,11 +43,13 @@ export function AtendenteDetalhe() {
     setFalha(null)
     Promise.all([
       atendentes.get(atendenteId),
+      atendentes.avaliacoes(atendenteId),
       coletarTodasPaginas<Setores.Setor>((o, l) => setores.list({ incluir_inativos: true, offset: o, limit: l })),
     ])
-      .then(([a, setoresAll]) => {
+      .then(([a, av, setoresAll]) => {
         if (cancelled) return
         setAtendente(a)
+        setAvaliacoes(av)
         setSetoresList(setoresAll)
       })
       .catch((err) => {
@@ -125,6 +133,37 @@ export function AtendenteDetalhe() {
           ) : null}
         </dl>
       </Card>
+
+      {avaliacoes ? (
+        <Card title="Avaliações (CSAT)">
+          <dl className="grid gap-4 sm:grid-cols-3">
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Geral</dt>
+              <dd className="mt-1 text-lg font-semibold text-slate-900 dark:text-slate-50">
+                {fmtMediaAvaliacao(avaliacoes.geral.media)}
+              </dd>
+              <dd className="text-xs text-slate-500 dark:text-slate-400">{avaliacoes.geral.total} avaliação(ões)</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">WhatsApp</dt>
+              <dd className="mt-1 text-lg font-semibold text-slate-900 dark:text-slate-50">
+                {fmtMediaAvaliacao(avaliacoes.whatsapp.media)}
+              </dd>
+              <dd className="text-xs text-slate-500 dark:text-slate-400">{avaliacoes.whatsapp.total} avaliação(ões)</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Tickets</dt>
+              <dd className="mt-1 text-lg font-semibold text-slate-900 dark:text-slate-50">
+                {fmtMediaAvaliacao(avaliacoes.tickets.media)}
+              </dd>
+              <dd className="text-xs text-slate-500 dark:text-slate-400">{avaliacoes.tickets.total} avaliação(ões)</dd>
+            </div>
+          </dl>
+          <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
+            Média geral ponderada por quantidade de respostas (WhatsApp + tickets por e-mail).
+          </p>
+        </Card>
+      ) : null}
     </div>
   )
 }

--- a/frontend/src/pages/AvaliarTicket.tsx
+++ b/frontend/src/pages/AvaliarTicket.tsx
@@ -1,0 +1,234 @@
+import { useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { publicCsat, type PublicCsat } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Button } from '../components/ui/Button'
+import { useToast } from '../components/ui/Toast'
+
+const STAR_PATH =
+  'M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z'
+
+const fieldClass =
+  'w-full rounded-xl border border-white/10 bg-white/[0.06] px-3.5 py-3 text-[0.9375rem] text-slate-100 placeholder:text-slate-500 shadow-inner shadow-black/20 backdrop-blur-sm transition-colors focus:border-cyan-400/50 focus:outline-none focus:ring-2 focus:ring-cyan-400/25'
+
+function EstrelaBtn({
+  indice,
+  nota,
+  hover,
+  onClick,
+  onHover,
+}: {
+  indice: number
+  nota: number
+  hover: number
+  onClick: () => void
+  onHover: (n: number) => void
+}) {
+  const preenchida = indice <= (hover || nota)
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onMouseEnter={() => onHover(indice)}
+      onMouseLeave={() => onHover(0)}
+      className="rounded p-1 transition-transform hover:scale-110 focus:outline-none focus:ring-2 focus:ring-cyan-400/40"
+      aria-label={`${indice} estrela${indice > 1 ? 's' : ''}`}
+    >
+      <svg width={36} height={36} viewBox="0 0 24 24" aria-hidden className={preenchida ? 'text-amber-400' : 'text-slate-600'}>
+        {preenchida ? (
+          <path fill="currentColor" d={STAR_PATH} />
+        ) : (
+          <path fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinejoin="round" d={STAR_PATH} />
+        )}
+      </svg>
+    </button>
+  )
+}
+
+function EstrelasFixas({ nota }: { nota: number }) {
+  return (
+    <span className="inline-flex items-center gap-0.5" aria-label={`Avaliação: ${nota} de 5`}>
+      {Array.from({ length: 5 }, (_, i) => (
+        <svg
+          key={i}
+          width={22}
+          height={22}
+          viewBox="0 0 24 24"
+          aria-hidden
+          className={i < nota ? 'text-amber-400' : 'text-slate-600'}
+        >
+          {i < nota ? (
+            <path fill="currentColor" d={STAR_PATH} />
+          ) : (
+            <path fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinejoin="round" d={STAR_PATH} />
+          )}
+        </svg>
+      ))}
+    </span>
+  )
+}
+
+export function AvaliarTicket() {
+  const [searchParams] = useSearchParams()
+  const token = searchParams.get('token')?.trim() ?? ''
+  const [dados, setDados] = useState<PublicCsat.TicketCsat | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [nota, setNota] = useState(0)
+  const [hover, setHover] = useState(0)
+  const [comentario, setComentario] = useState('')
+  const [enviando, setEnviando] = useState(false)
+  const { showError, showSuccess } = useToast()
+
+  useEffect(() => {
+    if (!token) {
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    publicCsat
+      .get(token)
+      .then((res) => {
+        if (!cancelled) setDados(res)
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          showError(mensagemFalhaParaToast(err, 'Não foi possível carregar a pesquisa.'))
+          setDados({ status: 'invalido' })
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [token, showError])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!token || nota < 1) {
+      showError('Selecione uma nota de 1 a 5 estrelas.')
+      return
+    }
+    setEnviando(true)
+    try {
+      const res = await publicCsat.submit(token, {
+        nota,
+        comentario: comentario.trim() || null,
+      })
+      setDados(res)
+      showSuccess('Obrigado pela sua avaliação!')
+    } catch (err) {
+      showError(mensagemFalhaParaToast(err, 'Não foi possível enviar a avaliação.'))
+    } finally {
+      setEnviando(false)
+    }
+  }
+
+  const shell = (children: React.ReactNode) => (
+    <div className="relative flex min-h-dvh flex-col items-center justify-center overflow-y-auto bg-[#050810] px-4 py-10 font-[family-name:'Plus_Jakarta_Sans',system-ui,sans-serif] text-slate-100 antialiased">
+      <div className="mx-auto w-full max-w-[440px] space-y-6">{children}</div>
+    </div>
+  )
+
+  if (!token) {
+    return shell(
+      <div className="text-center">
+        <h1 className="text-xl font-semibold text-white">Link inválido</h1>
+        <p className="mt-2 text-sm text-slate-400">O link de avaliação está incompleto ou expirou.</p>
+      </div>,
+    )
+  }
+
+  if (loading) {
+    return shell(<p className="text-center text-sm text-slate-400">Carregando…</p>)
+  }
+
+  if (!dados || dados.status === 'invalido') {
+    return shell(
+      <div className="text-center">
+        <h1 className="text-xl font-semibold text-white">Link inválido ou expirado</h1>
+        <p className="mt-2 text-sm text-slate-400">Solicite um novo link ao suporte, se necessário.</p>
+      </div>,
+    )
+  }
+
+  if (dados.status === 'expirado') {
+    return shell(
+      <div className="text-center">
+        <h1 className="text-xl font-semibold text-white">Prazo encerrado</h1>
+        <p className="mt-2 text-sm text-slate-400">
+          O link para avaliar o chamado {dados.protocolo ? `#${dados.protocolo}` : ''} expirou (24 horas).
+        </p>
+      </div>,
+    )
+  }
+
+  if (dados.status === 'respondido' && dados.nota != null) {
+    return shell(
+      <div className="rounded-2xl border border-white/[0.08] bg-white/[0.03] p-6 text-center shadow-2xl shadow-black/40 backdrop-blur-md">
+        <h1 className="text-xl font-semibold text-white">Avaliação registrada</h1>
+        {dados.protocolo ? (
+          <p className="mt-2 text-sm text-slate-400">Chamado {dados.protocolo}</p>
+        ) : null}
+        <div className="mt-4 flex justify-center">
+          <EstrelasFixas nota={dados.nota} />
+        </div>
+        {dados.comentario ? (
+          <p className="mt-4 rounded-lg bg-white/[0.04] px-3 py-2 text-left text-sm text-slate-300">{dados.comentario}</p>
+        ) : null}
+        <p className="mt-4 text-xs text-slate-500">Obrigado pelo seu feedback.</p>
+      </div>,
+    )
+  }
+
+  return shell(
+    <>
+      <header className="text-center">
+        <h1 className="text-2xl font-semibold text-white">Como foi o atendimento?</h1>
+        <p className="mt-2 text-sm text-slate-400">
+          {dados.protocolo ? `Chamado ${dados.protocolo}` : 'Avalie sua experiência'}
+          {dados.assunto ? ` — ${dados.assunto}` : ''}
+        </p>
+      </header>
+
+      <div className="rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 shadow-2xl shadow-black/40 backdrop-blur-md sm:p-6">
+        <form onSubmit={handleSubmit} className="space-y-5" noValidate>
+          <div className="flex justify-center gap-1">
+            {[1, 2, 3, 4, 5].map((n) => (
+              <EstrelaBtn
+                key={n}
+                indice={n}
+                nota={nota}
+                hover={hover}
+                onClick={() => setNota(n)}
+                onHover={setHover}
+              />
+            ))}
+          </div>
+          <p className="text-center text-xs text-slate-500">1 = muito insatisfeito · 5 = excelente</p>
+
+          <div>
+            <label htmlFor="csat-comentario" className="mb-1.5 block text-sm font-medium text-slate-300">
+              Comentário (opcional)
+            </label>
+            <textarea
+              id="csat-comentario"
+              rows={3}
+              maxLength={2000}
+              value={comentario}
+              onChange={(e) => setComentario(e.target.value)}
+              className={fieldClass}
+              placeholder="Conte-nos mais sobre sua experiência…"
+            />
+          </div>
+
+          <Button type="submit" className="w-full" disabled={enviando || nota < 1}>
+            {enviando ? 'Enviando…' : 'Enviar avaliação'}
+          </Button>
+        </form>
+      </div>
+    </>,
+  )
+}

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -166,6 +166,33 @@ function dedupeAtendentesMesmoNome(
   return [...m.values()].sort((x, y) => x.nome.localeCompare(y.nome, 'pt-BR'))
 }
 
+const CSAT_STAR_PATH =
+  'M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z'
+
+function TicketCsatEstrelas({ nota }: { nota: number }) {
+  return (
+    <span className="inline-flex items-center gap-0.5" aria-label={`${nota} de 5 estrelas`}>
+      {Array.from({ length: 5 }, (_, i) => (
+        <svg
+          key={i}
+          width={14}
+          height={14}
+          viewBox="0 0 24 24"
+          aria-hidden
+          className={i < nota ? 'text-amber-500' : 'text-slate-300 dark:text-slate-600'}
+        >
+          {i < nota ? (
+            <path fill="currentColor" d={CSAT_STAR_PATH} />
+          ) : (
+            <path fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinejoin="round" d={CSAT_STAR_PATH} />
+          )}
+        </svg>
+      ))}
+      <span className="ml-1 font-medium text-slate-700 dark:text-slate-200">{nota}/5</span>
+    </span>
+  )
+}
+
 export function TicketDetalhe() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
@@ -174,6 +201,8 @@ export function TicketDetalhe() {
   const { isAdmin, user } = useAuth()
   const [atribuindo, setAtribuindo] = useState(false)
   const [fechando, setFechando] = useState(false)
+  const [gerandoCsatLink, setGerandoCsatLink] = useState(false)
+  const [csatDevLink, setCsatDevLink] = useState<string | null>(null)
 
   const [loading, setLoading] = useState(true)
   const [carregamentoFalhou, setCarregamentoFalhou] = useState<{ titulo: string; detalhe?: string } | null>(null)
@@ -855,6 +884,22 @@ export function TicketDetalhe() {
     }
   }
 
+  async function gerarLinkCsatDev() {
+    if (!ticket) return
+    setGerandoCsatLink(true)
+    try {
+      const res = await tickets.csatLinkDev(ticket.id)
+      setCsatDevLink(res.link)
+      const refreshed = await tickets.get(ticket.id)
+      setTicket(refreshed)
+      toast.showSuccess('Link de avaliação gerado (sem e-mail).')
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível gerar o link.'))
+    } finally {
+      setGerandoCsatLink(false)
+    }
+  }
+
   async function handleVincularFilhoExistente(alvo: Tickets.Ticket) {
     if (!ticket || alvo.id === ticket.id) return
     setVinculandoFilho(true)
@@ -1428,6 +1473,68 @@ export function TicketDetalhe() {
                 </span>
               ) : null}
             </p>
+
+            {ticket.fechado_em ? (
+              <div className="mt-2 rounded-lg border border-slate-200/80 bg-slate-50/80 px-2.5 py-2 text-[11px] sm:px-3 sm:text-xs dark:border-slate-700/70 dark:bg-slate-900/40">
+                <p className="font-semibold text-slate-700 dark:text-slate-200">Avaliação do cliente</p>
+                {ticket.avaliacao_nota != null ? (
+                  <div className="mt-1 space-y-1">
+                    <TicketCsatEstrelas nota={ticket.avaliacao_nota} />
+                    {ticket.avaliacao_comentario ? (
+                      <p className="text-slate-600 dark:text-slate-400">{ticket.avaliacao_comentario}</p>
+                    ) : null}
+                    {ticket.avaliacao_respondida_em ? (
+                      <p className="text-[10px] text-slate-500 dark:text-slate-500">
+                        Respondida em {new Date(ticket.avaliacao_respondida_em).toLocaleString('pt-BR')}
+                      </p>
+                    ) : null}
+                  </div>
+                ) : ticket.csat_pendente ? (
+                  <p className="mt-1 text-slate-600 dark:text-slate-400">
+                    Aguardando resposta — link enviado por e-mail (válido por 24 horas).
+                  </p>
+                ) : (
+                  <p className="mt-1 text-slate-500 dark:text-slate-500">Sem avaliação (cliente sem e-mail na thread).</p>
+                )}
+                {import.meta.env.DEV && isAdmin && ticket.avaliacao_nota == null ? (
+                  <div className="mt-2 space-y-2 border-t border-slate-200/60 pt-2 dark:border-slate-700/60">
+                    <p className="text-[10px] font-medium uppercase tracking-wide text-amber-700 dark:text-amber-400">
+                      Dev — testar sem e-mail
+                    </p>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      disabled={gerandoCsatLink}
+                      onClick={() => void gerarLinkCsatDev()}
+                    >
+                      {gerandoCsatLink ? 'Gerando…' : 'Gerar link de avaliação'}
+                    </Button>
+                    {csatDevLink ? (
+                      <div className="space-y-1">
+                        <a
+                          href={csatDevLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="break-all text-cyan-700 underline underline-offset-2 dark:text-cyan-400"
+                        >
+                          {csatDevLink}
+                        </a>
+                        <button
+                          type="button"
+                          className="text-[10px] font-medium text-slate-600 underline dark:text-slate-400"
+                          onClick={() => {
+                            void navigator.clipboard.writeText(csatDevLink)
+                            toast.showSuccess('Link copiado.')
+                          }}
+                        >
+                          Copiar link
+                        </button>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
 
             {chatsWhatsapp.length > 0 && (
               <div className="mt-2">


### PR DESCRIPTION
## Summary
- CSAT de tickets: ao fechar, envia link por e-mail (24h, escala 1–5) para o ultimo remetente inbound; sem e-mail na thread, nao cria convite.
- Pagina publica `/avaliar-ticket`, API publica GET/POST, exibicao no TicketDetalhe e metricas (geral/WhatsApp/tickets) no AtendenteDetalhe.
- Migration 041 (`ticket_csat_invites`, `ticket_avaliacoes`); endpoint dev `POST /tickets/{id}/csat/link-dev` para testar sem SMTP.

## Test plan
- [x] `pytest` backend (163 testes, incl. `test_ticket_csat.py`)
- [x] `tsc --noEmit` frontend
- [x] Fluxo local: fechar ticket → gerar link dev → avaliar na pagina publica → nota no ticket
- [ ] CI GitHub Actions
- [ ] Apos merge: PR main → staging (migration 041 no deploy)

Closes #117, #118