### PR TITLE
feat(notificacoes): e-mail para atendentes com preferencias (#109, #110)

### DIFF
--- a/backend/alembic/versions/042_atendente_notificacao.py
+++ b/backend/alembic/versions/042_atendente_notificacao.py
@@ -1,0 +1,58 @@
+"""Preferências de notificação por atendente e fila de e-mail.
+
+Revision ID: 042_atendente_notificacao
+Revises: 041_ticket_csat
+Create Date: 2026-06-12
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "042_atendente_notificacao"
+down_revision = "041_ticket_csat"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "atendente_notificacao_preferencias",
+        sa.Column("atendente_id", sa.Integer(), nullable=False),
+        sa.Column("email_habilitado", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("email_ticket_atribuido", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("email_nova_mensagem", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["atendente_id"], ["atendentes.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("atendente_id"),
+    )
+
+    op.create_table(
+        "notificacao_email_outbox",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("atendente_id", sa.Integer(), nullable=False),
+        sa.Column("ticket_id", sa.Integer(), nullable=True),
+        sa.Column("tipo", sa.String(length=40), nullable=False),
+        sa.Column("dedup_key", sa.String(length=120), nullable=False),
+        sa.Column("to_email", sa.String(length=255), nullable=False),
+        sa.Column("subject", sa.String(length=998), nullable=False),
+        sa.Column("body", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="pendente"),
+        sa.Column("tentativas", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("scheduled_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["atendente_id"], ["atendentes.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["ticket_id"], ["tickets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_notificacao_email_outbox_status_scheduled", "notificacao_email_outbox", ["status", "scheduled_at"])
+    op.create_index("ix_notificacao_email_outbox_dedup_key", "notificacao_email_outbox", ["dedup_key"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_notificacao_email_outbox_dedup_key", table_name="notificacao_email_outbox")
+    op.drop_index("ix_notificacao_email_outbox_status_scheduled", table_name="notificacao_email_outbox")
+    op.drop_table("notificacao_email_outbox")
+    op.drop_table("atendente_notificacao_preferencias")

--- a/backend/app/api/notificacoes.py
+++ b/backend/app/api/notificacoes.py
@@ -12,7 +12,13 @@ from app.models.ticket_read import TicketRead
 from app.models.whatsapp_chat_read import WhatsappChatRead
 from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
 from app.schemas.notificacoes import NotificacaoResumo, NotificacaoItem, NotificacaoItensResponse
+from app.schemas.atendente_notificacao import NotificacaoPreferenciasRead, NotificacaoPreferenciasUpdate
 from app.core.auth import obter_atendente_atual
+from app.services.notificacao_atendente_email import (
+    atualizar_preferencias,
+    obter_ou_criar_preferencias,
+    preferencias_para_dict,
+)
 from app.core.setor_scope import ids_setores_visiveis_atendente
 from app.api.tickets import _pode_ver_ticket
 
@@ -324,3 +330,28 @@ def marcar_visto(
         )
     db.commit()
     return None
+
+
+@router.get("/preferencias", response_model=NotificacaoPreferenciasRead)
+def obter_preferencias(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    prefs = obter_ou_criar_preferencias(db, atendente.id)
+    db.commit()
+    return NotificacaoPreferenciasRead(**preferencias_para_dict(prefs))
+
+
+@router.patch("/preferencias", response_model=NotificacaoPreferenciasRead)
+def atualizar_preferencias_endpoint(
+    data: NotificacaoPreferenciasUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    payload = data.model_dump(exclude_unset=True)
+    if not payload:
+        prefs = obter_ou_criar_preferencias(db, atendente.id)
+        db.commit()
+        return NotificacaoPreferenciasRead(**preferencias_para_dict(prefs))
+    prefs = atualizar_preferencias(db, atendente.id, payload)
+    return NotificacaoPreferenciasRead(**preferencias_para_dict(prefs))

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -53,6 +53,7 @@ from app.core.setor_scope import (
 )
 from app.services import ticket_anexo_storage
 from app.services.ticket_csat import csat_brief_para_ticket, criar_convite_csat, processar_convite_csat_ao_fechar
+from app.services.notificacao_atendente_email import notificar_nova_mensagem_ticket, notificar_ticket_atribuido
 from app.schemas.ticket_csat import TicketCsatDevLinkRead
 from app.services.ticket_vinculos import (
     criar_vinculo as criar_vinculo_ticket,
@@ -1036,6 +1037,7 @@ def criar_mensagem(
         agendar_envio_email(m, db)
     db.add(m)
     db.flush()
+    notificar_nova_mensagem_ticket(db, ticket=ticket, mensagem=m, autor_atendente_id=atendente.id)
     db.commit()
     db.refresh(m)
     m = (
@@ -1536,6 +1538,13 @@ def atualizar(
         novo_o = update["motivo_outro_texto"] or ""
         _registrar_historico(db, ticket.id, atendente.id, "motivo_outro_texto", antigo_o, novo_o)
 
+    atribuicao_notificar_id: int | None = None
+    if "atendente_id" in update:
+        antigo_at = ticket.atendente_id
+        novo_at = update["atendente_id"]
+        if novo_at is not None and novo_at != antigo_at:
+            atribuicao_notificar_id = int(novo_at)
+
     for k, v in update.items():
         setattr(ticket, k, v)
 
@@ -1553,6 +1562,16 @@ def atualizar(
     db.commit()
     if acabou_de_fechar:
         processar_convite_csat_ao_fechar(db, ticket_id)
+    if atribuicao_notificar_id is not None:
+        t_notify = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+        if t_notify:
+            notificar_ticket_atribuido(
+                db,
+                ticket=t_notify,
+                novo_atendente_id=atribuicao_notificar_id,
+                actor_id=atendente.id,
+            )
+            db.commit()
     ticket_out = (
         db.query(Ticket)
         .options(*_opcoes_carregamento_ticket_detalhe())

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -57,6 +57,8 @@ class Settings(BaseSettings):
     TICKET_MENSAGEM_EMAIL_GRACE_SECONDS: int = 120
     TICKET_MENSAGEM_EDIT_LOCK_TTL_SECONDS: int = 300
     TICKET_MENSAGEM_EMAIL_WORKER_INTERVAL_SECONDS: int = 5
+    NOTIFICACAO_EMAIL_DEBOUNCE_MINUTES: int = 5
+    NOTIFICACAO_EMAIL_WORKER_INTERVAL_SECONDS: int = 10
     WHATSAPP_INACTIVITY_WORKER_INTERVAL_SECONDS: int = 60
 
     # Modo legado: vários clientes no mesmo Postgres (subdomínio numérico + coluna tenant_id).

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -191,6 +191,29 @@ async def lifespan(app: FastAPI):
         name="ticket-mensagem-email-outbox",
     ).start()
 
+    def notificacao_email_outbox_loop() -> None:
+        from app.database import SessionLocal
+        from app.services.notificacao_atendente_email import process_pending_notificacao_emails
+
+        interval = max(5, settings.NOTIFICACAO_EMAIL_WORKER_INTERVAL_SECONDS)
+        while True:
+            db = SessionLocal()
+            try:
+                n = process_pending_notificacao_emails(db, limit=30)
+                db.commit()
+            except Exception as e:
+                logger.warning("Worker e-mail de notificações: %s", e)
+                db.rollback()
+            finally:
+                db.close()
+            time.sleep(interval)
+
+    threading.Thread(
+        target=notificacao_email_outbox_loop,
+        daemon=True,
+        name="notificacao-email-outbox",
+    ).start()
+
     def whatsapp_inactivity_loop() -> None:
         from app.database import SessionLocal
         from app.services.whatsapp_inactivity_worker import process_whatsapp_inactivity_closures

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -25,6 +25,7 @@ from app.models.resposta_pronta import RespostaPronta
 from app.models.ticket_vinculo import TicketVinculo
 from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
 from app.models.ticket_avaliacao import TicketAvaliacao, TicketCsatInvite
+from app.models.atendente_notificacao import AtendenteNotificacaoPreferencias, NotificacaoEmailOutbox
 from app.models.empresa_pdv import EmpresaPdv, PdvRotulo, PdvTipoAcessoRemoto
 
 __all__ = [
@@ -64,6 +65,8 @@ __all__ = [
     "TicketMotivo",
     "TicketAvaliacao",
     "TicketCsatInvite",
+    "AtendenteNotificacaoPreferencias",
+    "NotificacaoEmailOutbox",
     "PdvRotulo",
     "PdvTipoAcessoRemoto",
     "EmpresaPdv",

--- a/backend/app/models/atendente_notificacao.py
+++ b/backend/app/models/atendente_notificacao.py
@@ -1,0 +1,40 @@
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class AtendenteNotificacaoPreferencias(Base):
+    __tablename__ = "atendente_notificacao_preferencias"
+
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), primary_key=True)
+    email_habilitado = Column(Boolean, nullable=False, default=True)
+    email_ticket_atribuido = Column(Boolean, nullable=False, default=True)
+    email_nova_mensagem = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
+
+    atendente = relationship("Atendente", backref="notificacao_preferencias", uselist=False)
+
+
+class NotificacaoEmailOutbox(Base):
+    __tablename__ = "notificacao_email_outbox"
+
+    id = Column(Integer, primary_key=True, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    ticket_id = Column(Integer, ForeignKey("tickets.id", ondelete="CASCADE"), nullable=True, index=True)
+    tipo = Column(String(40), nullable=False)
+    dedup_key = Column(String(120), nullable=False, unique=True, index=True)
+    to_email = Column(String(255), nullable=False)
+    subject = Column(String(998), nullable=False)
+    body = Column(Text, nullable=False)
+    status = Column(String(20), nullable=False, default="pendente", index=True)
+    tentativas = Column(Integer, nullable=False, default=0)
+    scheduled_at = Column(DateTime(timezone=True), nullable=False, index=True)
+    sent_at = Column(DateTime(timezone=True), nullable=True)
+    last_error = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    atendente = relationship("Atendente", backref="notificacoes_email_outbox")
+    ticket = relationship("Ticket", backref="notificacoes_email_outbox")

--- a/backend/app/schemas/atendente_notificacao.py
+++ b/backend/app/schemas/atendente_notificacao.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel, Field
+
+
+class NotificacaoPreferenciasRead(BaseModel):
+    email_habilitado: bool = True
+    email_ticket_atribuido: bool = True
+    email_nova_mensagem: bool = True
+
+
+class NotificacaoPreferenciasUpdate(BaseModel):
+    email_habilitado: bool | None = None
+    email_ticket_atribuido: bool | None = None
+    email_nova_mensagem: bool | None = None

--- a/backend/app/services/notificacao_atendente_email.py
+++ b/backend/app/services/notificacao_atendente_email.py
@@ -1,0 +1,302 @@
+"""Notificações por e-mail para atendentes (#109): preferências, fila e disparos."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.config import settings
+from app.models.atendente import Atendente
+from app.models.atendente_notificacao import AtendenteNotificacaoPreferencias, NotificacaoEmailOutbox
+from app.models.ticket import Ticket, TicketMensagem
+from app.services.email_send_sistema import enviar_mensagem_texto_sistema
+from app.services.password_reset import _public_app_origin
+
+logger = logging.getLogger(__name__)
+
+STATUS_PENDENTE = "pendente"
+STATUS_ENVIADA = "enviada"
+STATUS_FALHA = "falha"
+
+TIPO_TICKET_ATRIBUIDO = "ticket_atribuido"
+TIPO_NOVA_MENSAGEM = "nova_mensagem"
+
+MAX_TENTATIVAS = 5
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _debounce_minutes() -> int:
+    return max(1, int(settings.NOTIFICACAO_EMAIL_DEBOUNCE_MINUTES))
+
+
+def _ticket_link(ticket_id: int) -> str:
+    origin = _public_app_origin().rstrip("/")
+    return f"{origin}/tickets/{ticket_id}"
+
+
+def obter_ou_criar_preferencias(db: Session, atendente_id: int) -> AtendenteNotificacaoPreferencias:
+    row = (
+        db.query(AtendenteNotificacaoPreferencias)
+        .filter(AtendenteNotificacaoPreferencias.atendente_id == atendente_id)
+        .first()
+    )
+    if row:
+        return row
+    row = AtendenteNotificacaoPreferencias(atendente_id=atendente_id)
+    db.add(row)
+    db.flush()
+    return row
+
+
+def preferencias_para_dict(p: AtendenteNotificacaoPreferencias) -> dict:
+    return {
+        "email_habilitado": bool(p.email_habilitado),
+        "email_ticket_atribuido": bool(p.email_ticket_atribuido),
+        "email_nova_mensagem": bool(p.email_nova_mensagem),
+    }
+
+
+def atualizar_preferencias(db: Session, atendente_id: int, data: dict) -> AtendenteNotificacaoPreferencias:
+    row = obter_ou_criar_preferencias(db, atendente_id)
+    for k, v in data.items():
+        if v is not None:
+            setattr(row, k, v)
+    row.updated_at = _utcnow()
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def _deve_notificar(prefs: AtendenteNotificacaoPreferencias, *, tipo: str) -> bool:
+    if not prefs.email_habilitado:
+        return False
+    if tipo == TIPO_TICKET_ATRIBUIDO:
+        return bool(prefs.email_ticket_atribuido)
+    if tipo == TIPO_NOVA_MENSAGEM:
+        return bool(prefs.email_nova_mensagem)
+    return False
+
+
+def _enqueue_email(
+    db: Session,
+    *,
+    atendente: Atendente,
+    ticket: Ticket | None,
+    tipo: str,
+    dedup_key: str,
+    subject: str,
+    body: str,
+    debounce: bool = False,
+) -> None:
+    if not (atendente.email or "").strip() or not atendente.ativo:
+        return
+    prefs = obter_ou_criar_preferencias(db, atendente.id)
+    if not _deve_notificar(prefs, tipo=tipo):
+        return
+
+    now = _utcnow()
+    scheduled = now
+    if debounce:
+        scheduled = now + timedelta(minutes=_debounce_minutes())
+
+    existing = (
+        db.query(NotificacaoEmailOutbox)
+        .filter(
+            NotificacaoEmailOutbox.dedup_key == dedup_key,
+            NotificacaoEmailOutbox.status == STATUS_PENDENTE,
+        )
+        .first()
+    )
+    if existing:
+        if debounce:
+            existing.scheduled_at = scheduled
+            existing.subject = subject[:998]
+            existing.body = body
+            existing.to_email = atendente.email.strip().lower()
+            return
+        existing.subject = subject[:998]
+        existing.body = body
+        existing.to_email = atendente.email.strip().lower()
+        existing.scheduled_at = scheduled
+        existing.last_error = None
+        return
+
+    failed = (
+        db.query(NotificacaoEmailOutbox)
+        .filter(
+            NotificacaoEmailOutbox.dedup_key == dedup_key,
+            NotificacaoEmailOutbox.status == STATUS_FALHA,
+            NotificacaoEmailOutbox.tentativas >= MAX_TENTATIVAS,
+        )
+        .first()
+    )
+    if failed:
+        return
+
+    db.add(
+        NotificacaoEmailOutbox(
+            atendente_id=atendente.id,
+            ticket_id=ticket.id if ticket else None,
+            tipo=tipo,
+            dedup_key=dedup_key,
+            to_email=atendente.email.strip().lower(),
+            subject=subject[:998],
+            body=body,
+            status=STATUS_PENDENTE,
+            scheduled_at=scheduled,
+        )
+    )
+
+
+def notificar_ticket_atribuido(
+    db: Session,
+    *,
+    ticket: Ticket,
+    novo_atendente_id: int,
+    actor_id: int | None = None,
+) -> None:
+    if ticket.fechado_em is not None:
+        return
+    if novo_atendente_id == actor_id:
+        return
+    atendente = db.query(Atendente).filter(Atendente.id == novo_atendente_id, Atendente.ativo.is_(True)).first()
+    if not atendente:
+        return
+    proto = ticket.protocolo or str(ticket.id)
+    link = _ticket_link(ticket.id)
+    subject = f"Chamado atribuído a você — {proto}"
+    body = (
+        f"Olá {atendente.nome},\n\n"
+        f"O chamado {proto} foi atribuído a você.\n"
+        f"Assunto: {ticket.assunto or '—'}\n\n"
+        f"Acesse: {link}\n"
+    )
+    dedup = f"atribuido:{novo_atendente_id}:{ticket.id}"
+    try:
+        _enqueue_email(
+            db,
+            atendente=atendente,
+            ticket=ticket,
+            tipo=TIPO_TICKET_ATRIBUIDO,
+            dedup_key=dedup,
+            subject=subject,
+            body=body,
+            debounce=False,
+        )
+    except Exception:
+        logger.exception("Falha ao enfileirar notificação de atribuição (ticket %s)", ticket.id)
+
+
+def notificar_nova_mensagem_ticket(
+    db: Session,
+    *,
+    ticket: Ticket,
+    mensagem: TicketMensagem,
+    autor_atendente_id: int | None,
+) -> None:
+    if ticket.fechado_em is not None or ticket.atendente_id is None:
+        return
+    if mensagem.tipo not in ("publico", "email_cliente"):
+        return
+    if autor_atendente_id is not None and autor_atendente_id == ticket.atendente_id:
+        return
+
+    atendente = (
+        db.query(Atendente)
+        .filter(Atendente.id == ticket.atendente_id, Atendente.ativo.is_(True))
+        .first()
+    )
+    if not atendente:
+        return
+
+    proto = ticket.protocolo or str(ticket.id)
+    link = _ticket_link(ticket.id)
+    preview = (mensagem.corpo or "").strip().replace("\n", " ")[:200]
+    if len((mensagem.corpo or "").strip()) > 200:
+        preview += "…"
+    origem = (mensagem.autor_externo or "").strip() or "Cliente"
+    if mensagem.tipo == "publico" and mensagem.atendente_id:
+        autor = db.query(Atendente).filter(Atendente.id == mensagem.atendente_id).first()
+        if autor:
+            origem = autor.nome
+
+    subject = f"Nova mensagem — {proto}"
+    body = (
+        f"Olá {atendente.nome},\n\n"
+        f"Há uma nova mensagem no chamado {proto}.\n"
+        f"De: {origem}\n"
+        f"Prévia: {preview or '—'}\n\n"
+        f"Acesse: {link}\n"
+    )
+    dedup = f"nova_msg:{ticket.atendente_id}:{ticket.id}"
+    try:
+        _enqueue_email(
+            db,
+            atendente=atendente,
+            ticket=ticket,
+            tipo=TIPO_NOVA_MENSAGEM,
+            dedup_key=dedup,
+            subject=subject,
+            body=body,
+            debounce=True,
+        )
+    except Exception:
+        logger.exception("Falha ao enfileirar notificação de mensagem (ticket %s)", ticket.id)
+
+
+def process_pending_notificacao_emails(db: Session, *, limit: int = 20) -> int:
+    now = _utcnow()
+    rows = (
+        db.query(NotificacaoEmailOutbox)
+        .filter(
+            NotificacaoEmailOutbox.status == STATUS_PENDENTE,
+            NotificacaoEmailOutbox.scheduled_at <= now,
+        )
+        .order_by(NotificacaoEmailOutbox.scheduled_at.asc())
+        .limit(limit)
+        .all()
+    )
+    sent = 0
+    for row in rows:
+        row.tentativas = int(row.tentativas or 0) + 1
+        try:
+            enviar_mensagem_texto_sistema(
+                db,
+                to_addr=row.to_email,
+                subject=row.subject,
+                body=row.body,
+            )
+            row.status = STATUS_ENVIADA
+            row.sent_at = now
+            row.last_error = None
+            row.dedup_key = f"{row.dedup_key}:sent:{row.id}"
+            sent += 1
+        except ValueError as e:
+            row.last_error = str(e)[:2000]
+            if settings.ENVIRONMENT == "development":
+                logger.info(
+                    "DEV notificação e-mail (simulado) id=%s → %s | %s",
+                    row.id,
+                    row.to_email,
+                    row.subject,
+                )
+                logger.debug("DEV notificação corpo:\n%s", row.body)
+                row.status = STATUS_ENVIADA
+                row.sent_at = now
+                row.dedup_key = f"{row.dedup_key}:sent:{row.id}"
+                sent += 1
+            elif row.tentativas >= MAX_TENTATIVAS:
+                row.status = STATUS_FALHA
+            logger.info("Notificação e-mail %s não enviada: %s", row.id, e)
+        except Exception as e:
+            row.last_error = str(e)[:2000]
+            if row.tentativas >= MAX_TENTATIVAS:
+                row.status = STATUS_FALHA
+            logger.exception("Falha ao enviar notificação e-mail %s", row.id)
+    return sent

--- a/backend/app/services/ticket_from_inbound_email.py
+++ b/backend/app/services/ticket_from_inbound_email.py
@@ -219,6 +219,22 @@ def processar_email_inbound(
                 autor_externo=(parsed.from_display or parsed.from_email or "")[:512] or None,
             )
         )
+        db.flush()
+        from app.services.notificacao_atendente_email import notificar_nova_mensagem_ticket
+
+        msg_row = (
+            db.query(TicketMensagem)
+            .filter(TicketMensagem.ticket_id == existing_ticket.id)
+            .order_by(TicketMensagem.id.desc())
+            .first()
+        )
+        if msg_row:
+            notificar_nova_mensagem_ticket(
+                db,
+                ticket=existing_ticket,
+                mensagem=msg_row,
+                autor_atendente_id=None,
+            )
         db.add(
             EmailInboundReceived(
                 message_id_normalized=mid,

--- a/backend/scripts/testar_notificacoes_local.py
+++ b/backend/scripts/testar_notificacoes_local.py
@@ -1,0 +1,93 @@
+"""Testa fluxo local de notificações (#109/#110) contra API em execução."""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+
+BASE = "http://localhost:8000/v1"
+EMAIL = "admin@email.com"
+SENHA = "admin123"
+
+
+def req(method: str, path: str, *, token: str | None = None, body: dict | None = None) -> dict:
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    data = json.dumps(body).encode() if body is not None else None
+    r = urllib.request.Request(f"{BASE}{path}", data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(r, timeout=30) as resp:
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        raise RuntimeError(f"{method} {path} -> {e.code}: {e.read().decode()}") from e
+
+
+def main() -> int:
+    print("1. Health…")
+    with urllib.request.urlopen("http://localhost:8000/health", timeout=10) as h:
+        assert h.status == 200
+
+    print("2. Login…")
+    tok = req("POST", "/auth/login", body={"email": EMAIL, "senha": SENHA})["access_token"]
+
+    print("3. Preferências (GET/PATCH)…")
+    prefs = req("GET", "/notificacoes/preferencias", token=tok)
+    assert prefs.get("email_habilitado") is True, prefs
+    prefs2 = req(
+        "PATCH",
+        "/notificacoes/preferencias",
+        token=tok,
+        body={"email_nova_mensagem": True, "email_ticket_atribuido": True},
+    )
+    assert prefs2["email_ticket_atribuido"] is True
+
+    print("4. Resumo e itens in-app…")
+    resumo = req("GET", "/notificacoes/resumo", token=tok)
+    assert "total_pendencias" in resumo, resumo
+    itens = req("GET", "/notificacoes/itens?limit=5", token=tok)
+    assert "itens" in itens
+
+    print("5. Atribuir ticket e verificar fila (via listagem indireta)…")
+    tickets = req("GET", "/tickets?situacao=abertos&limit=1", token=tok)
+    items = tickets.get("items") or []
+    if not items:
+        setores = req("GET", "/setores?limit=1", token=tok)["items"]
+        empresas = req("GET", "/empresas?limit=1", token=tok)["items"]
+        created = req(
+            "POST",
+            "/tickets",
+            token=tok,
+            body={
+                "empresa_id": empresas[0]["id"],
+                "setor_id": setores[0]["id"],
+                "assunto": "Teste notificação local",
+                "descricao": "Script testar_notificacoes_local.py",
+            },
+        )
+        tid = created["id"]
+    else:
+        tid = items[0]["id"]
+
+    me = req("GET", "/atendentes/me", token=tok)
+    req("PATCH", f"/tickets/{tid}", token=tok, body={"atendente_id": me["id"]})
+
+    print("6. Nova mensagem pública (outro user simulado: admin em ticket do admin — sem fila nova_msg)…")
+    # Mensagem do próprio responsável não deve gerar nova_msg para si
+    r = req("POST", f"/tickets/{tid}/mensagens", token=tok, body={"corpo": "Teste msg", "tipo": "publico"})
+    assert r.get("id"), r
+
+    print("OK — API de notificações respondendo; atribuição e preferências funcionais.")
+    print(f"   Ticket usado: #{tid}")
+    print("   Em dev sem Resend, o worker simula envio (status enviada + log no backend).")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as e:
+        print(f"FALHA: {e}", file=sys.stderr)
+        raise SystemExit(1)

--- a/backend/tests/test_notificacoes_atendente.py
+++ b/backend/tests/test_notificacoes_atendente.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from app.models.atendente_notificacao import NotificacaoEmailOutbox
+
+
+def _criar_ticket(client, seed_base, auth_headers, *, atendente_id=None):
+    payload = {
+        "empresa_id": seed_base["empresa"].id,
+        "setor_id": seed_base["setor1"].id,
+        "assunto": "Ticket notificação teste",
+        "descricao": "Teste",
+    }
+    if atendente_id is not None:
+        payload["atendente_id"] = atendente_id
+    r = client.post("/v1/tickets", headers=auth_headers["admin"], json=payload)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def test_preferencias_padrao_e_atualizacao(client, seed_base, auth_headers):
+    r = client.get("/v1/notificacoes/preferencias", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["email_habilitado"] is True
+    assert body["email_ticket_atribuido"] is True
+    assert body["email_nova_mensagem"] is True
+
+    r2 = client.patch(
+        "/v1/notificacoes/preferencias",
+        headers=auth_headers["a1"],
+        json={"email_nova_mensagem": False},
+    )
+    assert r2.status_code == 200
+    assert r2.json()["email_nova_mensagem"] is False
+    assert r2.json()["email_ticket_atribuido"] is True
+
+
+def test_atribuicao_enfileira_email(client, seed_base, auth_headers, db_session):
+    t = _criar_ticket(client, seed_base, auth_headers)
+    r = client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"atendente_id": seed_base["a1"].id},
+    )
+    assert r.status_code == 200, r.text
+
+    row = (
+        db_session.query(NotificacaoEmailOutbox)
+        .filter(
+            NotificacaoEmailOutbox.ticket_id == t["id"],
+            NotificacaoEmailOutbox.tipo == "ticket_atribuido",
+        )
+        .first()
+    )
+    assert row is not None
+    assert row.atendente_id == seed_base["a1"].id
+    assert row.status == "pendente"
+
+
+def test_atribuicao_respeita_preferencias(client, seed_base, auth_headers, db_session):
+    client.patch(
+        "/v1/notificacoes/preferencias",
+        headers=auth_headers["a1"],
+        json={"email_habilitado": False},
+    )
+    t = _criar_ticket(client, seed_base, auth_headers)
+    client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"atendente_id": seed_base["a1"].id},
+    )
+    row = db_session.query(NotificacaoEmailOutbox).filter(NotificacaoEmailOutbox.ticket_id == t["id"]).first()
+    assert row is None
+
+
+def test_nova_mensagem_enfileira_para_responsavel(client, seed_base, auth_headers, db_session):
+    t = _criar_ticket(client, seed_base, auth_headers)
+    client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"atendente_id": seed_base["a1"].id},
+    )
+    r = client.post(
+        f"/v1/tickets/{t['id']}/mensagens",
+        headers=auth_headers["admin"],
+        json={"corpo": "Atualização da equipe", "tipo": "publico"},
+    )
+    assert r.status_code == 201, r.text
+
+    row = (
+        db_session.query(NotificacaoEmailOutbox)
+        .filter(
+            NotificacaoEmailOutbox.ticket_id == t["id"],
+            NotificacaoEmailOutbox.tipo == "nova_mensagem",
+        )
+        .first()
+    )
+    assert row is not None
+    assert row.atendente_id == seed_base["a1"].id
+
+
+def test_process_pending_simula_envio_em_dev_sem_smtp(client, seed_base, auth_headers, db_session, monkeypatch):
+    def fail_send(*args, **kwargs):
+        raise ValueError("Envio de e-mail não configurado na plataforma.")
+
+    monkeypatch.setattr("app.services.notificacao_atendente_email.enviar_mensagem_texto_sistema", fail_send)
+
+    t = _criar_ticket(client, seed_base, auth_headers)
+    client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"atendente_id": seed_base["a1"].id},
+    )
+
+    from app.services.notificacao_atendente_email import process_pending_notificacao_emails
+
+    n = process_pending_notificacao_emails(db_session, limit=10)
+    db_session.commit()
+    assert n == 1
+    row = db_session.query(NotificacaoEmailOutbox).filter(NotificacaoEmailOutbox.ticket_id == t["id"]).first()
+    assert row is not None
+    assert row.status == "enviada"
+
+
+def test_mensagem_email_cliente_enfileira_notificacao(client, seed_base, auth_headers, db_session):
+    from app.models.ticket import Ticket, TicketMensagem
+
+    t = _criar_ticket(client, seed_base, auth_headers)
+    client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"atendente_id": seed_base["a1"].id},
+    )
+    ticket = db_session.query(Ticket).filter(Ticket.id == t["id"]).first()
+    msg = TicketMensagem(
+        ticket_id=ticket.id,
+        atendente_id=None,
+        tipo="email_cliente",
+        corpo="Resposta do cliente por e-mail",
+        autor_externo="cliente@test.local",
+    )
+    db_session.add(msg)
+    db_session.flush()
+
+    from app.services.notificacao_atendente_email import notificar_nova_mensagem_ticket
+
+    notificar_nova_mensagem_ticket(db_session, ticket=ticket, mensagem=msg, autor_atendente_id=None)
+    db_session.commit()
+
+    row = (
+        db_session.query(NotificacaoEmailOutbox)
+        .filter(
+            NotificacaoEmailOutbox.ticket_id == t["id"],
+            NotificacaoEmailOutbox.tipo == "nova_mensagem",
+        )
+        .first()
+    )
+    assert row is not None
+    assert row.atendente_id == seed_base["a1"].id
+
+
+def test_process_pending_envia_email(client, seed_base, auth_headers, db_session, monkeypatch):
+    sent = []
+
+    def fake_send(db, *, to_addr, subject, body, in_reply_to=None, references=None):
+        sent.append({"to": to_addr, "subject": subject})
+        return "<mid@test>"
+
+    monkeypatch.setattr("app.services.notificacao_atendente_email.enviar_mensagem_texto_sistema", fake_send)
+
+    t = _criar_ticket(client, seed_base, auth_headers)
+    client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"atendente_id": seed_base["a1"].id},
+    )
+
+    from app.services.notificacao_atendente_email import process_pending_notificacao_emails
+
+    n = process_pending_notificacao_emails(db_session, limit=10)
+    db_session.commit()
+    assert n == 1
+    assert len(sent) == 1
+    assert seed_base["a1"].email in sent[0]["to"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -48,6 +48,7 @@ import { WhatsappHistorico } from './pages/whatsapp/WhatsappHistorico'
 import { WhatsappAvaliacoes } from './pages/whatsapp/WhatsappAvaliacoes'
 import { WhatsappConversa } from './pages/whatsapp/WhatsappConversa'
 import { AlterarSenha } from './pages/AlterarSenha'
+import { NotificacoesPreferencias } from './pages/NotificacoesPreferencias'
 import { AcessoNegado } from './pages/AcessoNegado'
 import { ToastProvider } from './components/ui/Toast'
 import { ErrorBoundary } from './components/ErrorBoundary'
@@ -95,6 +96,7 @@ function AppRoutes() {
       >
         <Route index element={<Dashboard />} />
         <Route path="alterar-senha" element={<AlterarSenha />} />
+        <Route path="notificacoes/preferencias" element={<NotificacoesPreferencias />} />
         <Route path="tickets" element={<Tickets />} />
         <Route path="tickets/novo" element={<TicketNovo />} />
         <Route path="tickets/:id" element={<TicketDetalhe />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -968,6 +968,11 @@ export namespace Notificacoes {
   export interface ItensResponse {
     itens: Item[];
   }
+  export interface Preferencias {
+    email_habilitado: boolean;
+    email_ticket_atribuido: boolean;
+    email_nova_mensagem: boolean;
+  }
 }
 
 export const notificacoes = {
@@ -976,6 +981,12 @@ export const notificacoes = {
     api<Notificacoes.ItensResponse>(withParams('/notificacoes/itens', params)),
   marcarVisto: (ticketId: number) =>
     api<void>(`/notificacoes/tickets/${ticketId}/visto`, { method: 'POST' }),
+  preferenciasGet: () => api<Notificacoes.Preferencias>('/notificacoes/preferencias'),
+  preferenciasUpdate: (data: Partial<Notificacoes.Preferencias>) =>
+    api<Notificacoes.Preferencias>('/notificacoes/preferencias', {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
 };
 
 export namespace Dashboard {

--- a/frontend/src/components/NavbarNotificacoes.tsx
+++ b/frontend/src/components/NavbarNotificacoes.tsx
@@ -182,6 +182,15 @@ export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
                 <span className="font-medium">Não lidas:</span> {resumo.nao_lidas_count}
               </div>
             )}
+            <div className="shrink-0 border-t border-slate-200/90 bg-white px-4 py-3 dark:border-slate-800/90 dark:bg-slate-950">
+              <Link
+                to="/notificacoes/preferencias"
+                className="text-xs font-medium text-cyan-700 hover:underline dark:text-cyan-400"
+                onClick={() => setAberto(false)}
+              >
+                Preferências de e-mail
+              </Link>
+            </div>
           </div>,
           document.body
         )}
@@ -232,6 +241,15 @@ export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
               Fila: {resumo.sem_responsavel_count} · Não lidas: {resumo.nao_lidas_count}
             </div>
           )}
+          <div className="border-t border-slate-100 px-3 py-2 dark:border-slate-800">
+            <Link
+              to="/notificacoes/preferencias"
+              className="text-xs font-medium text-cyan-700 hover:underline dark:text-cyan-400"
+              onClick={() => setAberto(false)}
+            >
+              Preferências de e-mail
+            </Link>
+          </div>
         </div>
       ) : null}
     </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -119,6 +119,16 @@ const icons: Record<string, React.ReactNode> = {
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
     </svg>
   ),
+  notificacoes: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.75}
+        d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+      />
+    </svg>
+  ),
   menu: (
     <svg className="size-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
@@ -497,6 +507,25 @@ export function Sidebar({
             <p className="truncate text-xs text-slate-500 dark:text-slate-400">{userRole}</p>
           </div>
         </div>
+        <Link
+          to="/notificacoes/preferencias"
+          onClick={onMobileClose}
+          title="Notificações por e-mail"
+          className={`mt-2 flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium text-slate-600 hover:bg-slate-100 active:bg-slate-200 touch-manipulation min-h-[44px] dark:text-slate-400 dark:hover:bg-slate-800 dark:active:bg-slate-700 ${
+            expanded ? '' : 'md:justify-center md:px-2'
+          }`}
+        >
+          {icons.notificacoes}
+          <span
+            className={
+              expanded
+                ? 'min-w-0 truncate transition-all duration-200'
+                : 'min-w-0 truncate transition-all duration-200 md:hidden'
+            }
+          >
+            Notificações e-mail
+          </span>
+        </Link>
         <button
           type="button"
           onClick={() => {

--- a/frontend/src/pages/NotificacoesPreferencias.tsx
+++ b/frontend/src/pages/NotificacoesPreferencias.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { notificacoes, type Notificacoes } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { Switch } from '../components/ui/Switch'
+import { useToast } from '../components/ui/Toast'
+
+export function NotificacoesPreferencias() {
+  const toast = useToast()
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [prefs, setPrefs] = useState<Notificacoes.Preferencias>({
+    email_habilitado: true,
+    email_ticket_atribuido: true,
+    email_nova_mensagem: true,
+  })
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    notificacoes
+      .preferenciasGet()
+      .then((p) => {
+        if (!cancelled) setPrefs(p)
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar as preferências.'))
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [toast])
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    try {
+      const updated = await notificacoes.preferenciasUpdate(prefs)
+      setPrefs(updated)
+      toast.showSuccess('Preferências salvas.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-2xl">
+        <div className="h-48 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6 pb-10">
+      <div>
+        <Link
+          to="/"
+          className="inline-flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100"
+        >
+          <span aria-hidden>←</span> Voltar
+        </Link>
+        <h1 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">
+          Notificações por e-mail
+        </h1>
+        <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+          Escolha quando deseja receber e-mails sobre atividade nos seus chamados. Os alertas in-app (sino no topo)
+          continuam independentes — fila, mensagens não lidas e WhatsApp.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-sky-200/80 bg-sky-50/80 px-4 py-3 text-sm text-sky-950 dark:border-sky-900/50 dark:bg-sky-950/30 dark:text-sky-100">
+        <p className="font-medium">Como funciona</p>
+        <ul className="mt-2 list-inside list-disc space-y-1 text-xs leading-relaxed text-sky-900/90 dark:text-sky-200/90">
+          <li>
+            <strong>Atribuído a mim</strong> — quando outro atendente ou admin atribui o chamado a você (não dispara se
+            você mesmo usar «Atribuir a mim»).
+          </li>
+          <li>
+            <strong>Nova mensagem</strong> — e-mail do cliente ou mensagem pública de colega; agrupamos avisos do mesmo
+            chamado em intervalos de alguns minutos.
+          </li>
+          <li>
+            Em desenvolvimento, sem SMTP configurado, o sistema simula o envio e registra no log do backend.
+          </li>
+        </ul>
+      </div>
+
+      <Card title="Preferências">
+        <form onSubmit={handleSave} className="space-y-5">
+          <Switch
+            checked={prefs.email_habilitado}
+            onCheckedChange={(v) => setPrefs((p) => ({ ...p, email_habilitado: v }))}
+            label="Receber notificações por e-mail"
+            description="Desliga todos os e-mails abaixo."
+            showStatusPill
+            statusOnText="Ativo"
+            statusOffText="Inativo"
+          />
+
+          <div className="space-y-4 border-t border-slate-200 pt-4 dark:border-slate-700">
+            <Switch
+              checked={prefs.email_ticket_atribuido}
+              onCheckedChange={(v) => setPrefs((p) => ({ ...p, email_ticket_atribuido: v }))}
+              label="Chamado atribuído a mim"
+              disabled={!prefs.email_habilitado}
+              showStatusPill
+              statusOnText="Sim"
+              statusOffText="Não"
+            />
+            <Switch
+              checked={prefs.email_nova_mensagem}
+              onCheckedChange={(v) => setPrefs((p) => ({ ...p, email_nova_mensagem: v }))}
+              label="Nova mensagem em chamado sob minha responsabilidade"
+              description="Mensagens do cliente ou de colegas (agrupadas em intervalos de alguns minutos)."
+              disabled={!prefs.email_habilitado}
+              showStatusPill
+              statusOnText="Sim"
+              statusOffText="Não"
+            />
+          </div>
+
+          <div className="flex justify-end border-t border-slate-200 pt-4 dark:border-slate-700">
+            <Button type="submit" disabled={saving}>
+              {saving ? 'Salvando…' : 'Salvar preferências'}
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **#109 (backend):** Prefer?ncias de e-mail por atendente, fila 
otificacao_email_outbox com debounce, hooks em atribui??o de ticket, mensagem p?blica e e-mail inbound do cliente; worker em background; simula??o de envio em dev sem SMTP; migration **042**.
- **#110 (frontend):** P?gina /notificacoes/preferencias com toggles, links no sino de notifica??es e no sidebar, bloco explicativo ?Como funciona?.

## Test plan

- [ ] pytest tests/test_notificacoes_atendente.py (7 testes)
- [ ] Atribuir ticket a outro atendente ? item 	icket_atribuido na fila
- [ ] Mensagem p?blica / e-mail cliente ? item 
ova_mensagem com debounce
- [ ] PATCH /notificacoes/preferencias desliga envios conforme toggles
- [ ] UI: salvar prefer?ncias, links no navbar e sidebar
- [ ] Dev sem Resend: worker marca enviada e loga no backend
- [ ] Ap?s merge em main: PR main ? staging e lembic upgrade head (042)
