### PR TITLE
docs(planning): rascunhos de issues para roadmap interno e portal

### DIFF
--- a/.github/planning-issue-bodies/A-01-backend-audit-trail-expandido.md
+++ b/.github/planning-issue-bodies/A-01-backend-audit-trail-expandido.md
@@ -1,0 +1,34 @@
+# Auditoria — trail expandido (backend)
+
+## Contexto
+
+Épico: **Auditoria estruturada**.
+
+Parte de: **A-F1**
+
+## Proposta
+
+Estender `AuditLog`:
+
+- `payload_json` (diff resumido ou snapshot)
+- `ip_address`, `user_agent` (opcional)
+- `request_id` correlacionável
+- Novas entidades: `ticket`, `ticket_mensagem`, `whatsapp_chat`, `whatsapp_mensagem`, `settings`, `export_relatorio`
+- Novas actions: `assign`, `transfer`, `close`, `reopen`, `send_email`, `view_credential`
+
+Helper `registrar_audit_v2(...)` mantendo compat com chamadas antigas.
+
+## Critérios de aceite
+
+- [ ] Migração nullable para logs antigos
+- [ ] Tickets: log assume, transfer, status change
+- [ ] PDV reveal_credential enriquecido
+- [ ] Não logar senhas/tokens em payload
+
+## Dependências
+
+- Bloqueia: A-02, A-03
+
+## Labels
+
+`backend`, `auditoria`, `fase-interna`

--- a/.github/planning-issue-bodies/A-02-backend-consulta-export-auditoria.md
+++ b/.github/planning-issue-bodies/A-02-backend-consulta-export-auditoria.md
@@ -1,0 +1,31 @@
+# Auditoria — filtros avançados e export (backend)
+
+## Contexto
+
+Épico: **Auditoria estruturada**.
+
+Parte de: **A-F2**
+
+## Proposta
+
+Evoluir `GET /v1/audit`:
+
+- Filtros: período, atendente, entity_type, action, entity_id, busca texto payload
+- Paginação cursor-based
+- `GET /v1/audit/export?format=csv` admin-only
+- Retenção: config `AUDIT_RETENTION_DAYS` (job purge opcional v1)
+
+## Critérios de aceite
+
+- [ ] Performance índice `(created_at, entity_type)`
+- [ ] Export auditado (meta-audit)
+- [ ] Testes filtros
+
+## Dependências
+
+- Requer: A-01
+- Bloqueia: A-03
+
+## Labels
+
+`backend`, `auditoria`, `fase-interna`

--- a/.github/planning-issue-bodies/A-03-frontend-auditoria-ui.md
+++ b/.github/planning-issue-bodies/A-03-frontend-auditoria-ui.md
@@ -1,0 +1,31 @@
+# Auditoria — UI com filtros, detalhe e paginação (frontend)
+
+## Contexto
+
+Épico: **Auditoria estruturada**.
+
+Parte de: **A-F3**
+
+## Proposta
+
+Evoluir página `Auditoria` em Config Sistema:
+
+- Filtros avançados (período, usuário, entidade, ação)
+- Tabela paginada com colunas legíveis (nome atendente, label entidade)
+- Drawer detalhe com JSON payload formatado
+- Botão export CSV
+- Link «Ver ticket #123» quando entity_type=ticket
+
+## Critérios de aceite
+
+- [ ] Consome A-02
+- [ ] Admin-only
+- [ ] Mobile usable
+
+## Dependências
+
+- Requer: A-02
+
+## Labels
+
+`frontend`, `auditoria`, `fase-interna`

--- a/.github/planning-issue-bodies/A-epic-auditoria.md
+++ b/.github/planning-issue-bodies/A-epic-auditoria.md
@@ -1,0 +1,24 @@
+# [Épico] Auditoria estruturada e rastreável
+
+## Contexto
+
+Auditoria atual (`registrar_audit`) grava apenas `entity_type`, `entity_id`, `action`, `atendente_id` — sem payload, IP, ou cobertura de tickets/chats/mensagens sensíveis.
+
+## Objetivo
+
+- Trail completo para compliance e suporte interno
+- UI consultável com filtros
+- Export para análise
+- Registro de ações sensíveis (credenciais PDV, export relatórios)
+
+## Fases
+
+| Fase | Issues |
+|------|--------|
+| A-F1 | A-01 — Trail expandido |
+| A-F2 | A-02 — Consulta/export |
+| A-F3 | A-03 — UI |
+
+## Labels
+
+`epic`, `auditoria`, `fase-interna`

--- a/.github/planning-issue-bodies/D-01-backend-metricas-dashboard-geral.md
+++ b/.github/planning-issue-bodies/D-01-backend-metricas-dashboard-geral.md
@@ -1,0 +1,36 @@
+# Dashboard geral — endpoints de métricas consolidadas (backend)
+
+## Contexto
+
+Épico: **Dashboards e relatórios**. Evoluir além de `dashboard.py` atual.
+
+Parte de: **D-F1**
+
+## Proposta
+
+Novo ou estendido `GET /v1/dashboard/geral`:
+
+- Tickets abertos / sem responsável (escopo setor)
+- Chats `aguardando_atendente` / `em_atendimento`
+- CSAT médio tickets (7 dias) se existir avaliação
+- CSAT médio chats (7 dias)
+- Violações SLA abertas (quando épico S existir — campo nullable até lá)
+- Última atualização / cache curto (60s)
+
+Respeitar RBAC setor (#38).
+
+## Critérios de aceite
+
+- [ ] Admin vê global; atendente vê setores vinculados
+- [ ] Resposta tipada Pydantic `DashboardGeralResponse`
+- [ ] Testes com fixtures multi-setor
+- [ ] Performance: queries agregadas, sem N+1
+
+## Dependências
+
+- Paralelo: D-05
+- Opcional futuro: S-02 (SLA)
+
+## Labels
+
+`backend`, `dashboard`, `fase-interna`

--- a/.github/planning-issue-bodies/D-02-backend-metricas-dashboard-tickets.md
+++ b/.github/planning-issue-bodies/D-02-backend-metricas-dashboard-tickets.md
@@ -1,0 +1,38 @@
+# Dashboard tickets — endpoints de métricas (backend)
+
+## Contexto
+
+Épico: **Dashboards e relatórios**. Visão analítica do canal ticket.
+
+Parte de: **D-F2**
+
+## Proposta
+
+`GET /v1/dashboard/tickets?de=&ate=&rede_id=&setor_id=`:
+
+| Métrica | Descrição |
+|---------|-----------|
+| Volume por dia | Série temporal aberturas/fechamentos |
+| Por status | Snapshot atual |
+| Por prioridade | Distribuição |
+| Por natureza/motivo | Top 10 |
+| Por rede/empresa | Top redes |
+| MTTR | Média tempo abertura → encerramento (tickets fechados no período) |
+| Fila | Tempo médio aguardando primeiro responsável |
+| CSAT | Média e distribuição 1–5 (tickets com avaliação) |
+| Canal origem | Manual, e-mail, filho massa, etc. |
+
+## Critérios de aceite
+
+- [ ] Filtro de período obrigatório (default 30 dias)
+- [ ] Escopo setor para atendentes
+- [ ] Documentação OpenAPI
+- [ ] Testes unitários das agregações
+
+## Dependências
+
+- Paralelo: D-06
+
+## Labels
+
+`backend`, `dashboard`, `fase-interna`, `tickets`

--- a/.github/planning-issue-bodies/D-03-backend-metricas-dashboard-chats.md
+++ b/.github/planning-issue-bodies/D-03-backend-metricas-dashboard-chats.md
@@ -1,0 +1,35 @@
+# Dashboard chats — endpoints de métricas WhatsApp (backend)
+
+## Contexto
+
+Épico: **Dashboards e relatórios**. Visão analítica do canal WhatsApp.
+
+Parte de: **D-F3**
+
+## Proposta
+
+`GET /v1/dashboard/chats?de=&ate=`:
+
+| Métrica | Descrição |
+|---------|-----------|
+| Chats por dia | Abertos, encerrados |
+| Tempo médio de espera | `aguardando_atendente` → assume |
+| Tempo médio de atendimento | assume → encerra |
+| Avaliações | Média 1–5, distribuição |
+| Encerramentos por inatividade vs manual |
+| Chats com ticket vinculado | % |
+| Por atendente | Volume assumido (admin) |
+
+## Critérios de aceite
+
+- [ ] Usa timestamps existentes (`atendimento_inicio_at`, `encerramento_at`)
+- [ ] Atendente vê métricas dos próprios chats + fila setor (definir política)
+- [ ] Admin vê global
+
+## Dependências
+
+- Paralelo: D-07
+
+## Labels
+
+`backend`, `dashboard`, `fase-interna`, `whatsapp`

--- a/.github/planning-issue-bodies/D-04-backend-relatorios-export.md
+++ b/.github/planning-issue-bodies/D-04-backend-relatorios-export.md
@@ -1,0 +1,33 @@
+# Relatórios — consultas paginadas e export CSV (backend)
+
+## Contexto
+
+Épico: **Dashboards e relatórios**. Dados tabulares para gestão.
+
+Parte de: **D-F4**
+
+## Proposta
+
+`GET /v1/relatorios/tickets` e `GET /v1/relatorios/chats`:
+
+- Mesmos filtros dos dashboards + paginação
+- `Accept: text/csv` ou `?format=csv` para export
+- Colunas configuráveis via query `fields=`
+- Limite export: ex. 50k linhas (admin)
+
+Admin-only ou atendente com permissão futura.
+
+## Critérios de aceite
+
+- [ ] CSV UTF-8 com BOM para Excel
+- [ ] Rate limit export
+- [ ] Audit log ao exportar (#A quando pronto)
+
+## Dependências
+
+- Requer: D-02, D-03 (reutilizar queries)
+- Bloqueia: D-08
+
+## Labels
+
+`backend`, `dashboard`, `fase-interna`, `relatorios`

--- a/.github/planning-issue-bodies/D-05-frontend-dashboard-geral.md
+++ b/.github/planning-issue-bodies/D-05-frontend-dashboard-geral.md
@@ -1,0 +1,28 @@
+# Dashboard geral — visão executiva (frontend)
+
+## Contexto
+
+Épico: **Dashboards e relatórios**. Substituir/evoluir `Dashboard.tsx` atual.
+
+Parte de: **D-F1**
+
+## Proposta
+
+- Cards: tickets abertos, fila sem responsável, chats aguardando, CSAT resumido
+- Atalhos: «Ir para fila WhatsApp», «Ver tickets sem responsável»
+- Gráfico sparkline 7 dias (opcional v1)
+- Tabs ou sub-rotas futuras: `/`, `/dashboard/tickets`, `/dashboard/chats`
+
+## Critérios de aceite
+
+- [ ] Consome D-01
+- [ ] Loading skeleton
+- [ ] Responsivo mobile
+
+## Dependências
+
+- Requer: D-01
+
+## Labels
+
+`frontend`, `dashboard`, `fase-interna`

--- a/.github/planning-issue-bodies/D-06-frontend-dashboard-tickets.md
+++ b/.github/planning-issue-bodies/D-06-frontend-dashboard-tickets.md
@@ -1,0 +1,30 @@
+# Dashboard tickets — gráficos e filtros (frontend)
+
+## Contexto
+
+Épico: **Dashboards e relatórios**.
+
+Parte de: **D-F2**
+
+## Proposta
+
+Rota `/dashboard/tickets`:
+
+- Seletor período (7/30/90/custom)
+- Filtros rede, setor, prioridade
+- Gráficos: linha volume, barras motivo/status, card MTTR e CSAT
+- Biblioteca: Recharts ou similar (avaliar bundle)
+
+## Critérios de aceite
+
+- [ ] Consome D-02
+- [ ] Empty state período sem dados
+- [ ] Link «Exportar CSV» → D-08
+
+## Dependências
+
+- Requer: D-02
+
+## Labels
+
+`frontend`, `dashboard`, `fase-interna`, `tickets`

--- a/.github/planning-issue-bodies/D-07-frontend-dashboard-chats.md
+++ b/.github/planning-issue-bodies/D-07-frontend-dashboard-chats.md
@@ -1,0 +1,29 @@
+# Dashboard chats — métricas WhatsApp (frontend)
+
+## Contexto
+
+Épico: **Dashboards e relatórios**.
+
+Parte de: **D-F3**
+
+## Proposta
+
+Rota `/dashboard/chats`:
+
+- TMA, tempo de espera, avaliações
+- Gráfico encerramentos/dia
+- Tabela top atendentes (admin)
+- Link para `/whatsapp/avaliacoes` existente
+
+## Critérios de aceite
+
+- [ ] Consome D-03
+- [ ] Admin vs atendente (ocultar colunas sensíveis)
+
+## Dependências
+
+- Requer: D-03
+
+## Labels
+
+`frontend`, `dashboard`, `fase-interna`, `whatsapp`

--- a/.github/planning-issue-bodies/D-08-frontend-relatorios-ui.md
+++ b/.github/planning-issue-bodies/D-08-frontend-relatorios-ui.md
@@ -1,0 +1,30 @@
+# Relatórios — telas de consulta e download (frontend)
+
+## Contexto
+
+Épico: **Dashboards e relatórios**.
+
+Parte de: **D-F4**
+
+## Proposta
+
+Rota admin `/configuracoes/sistema/relatorios` ou `/relatorios`:
+
+- Abas Tickets | Chats
+- Filtros espelhando dashboards
+- Pré-visualização paginada (50 linhas)
+- Botão «Exportar CSV»
+
+## Critérios de aceite
+
+- [ ] Admin-only
+- [ ] Download via blob + nome arquivo com data
+- [ ] Feedback durante export grande
+
+## Dependências
+
+- Requer: D-04
+
+## Labels
+
+`frontend`, `dashboard`, `fase-interna`, `relatorios`

--- a/.github/planning-issue-bodies/D-epic-dashboards-relatorios.md
+++ b/.github/planning-issue-bodies/D-epic-dashboards-relatorios.md
@@ -1,0 +1,32 @@
+# [Épico] Dashboards e relatórios operacionais
+
+## Contexto
+
+O dashboard atual (`GET /v1/dashboard`) expõe apenas totais básicos. A operação precisa de **visões separadas** por canal e **relatórios exportáveis** para gestão de redes de postos.
+
+## Objetivo
+
+| Área | Público | Métricas principais |
+|------|---------|---------------------|
+| **Dashboard geral** | Admin + atendentes | Resumo cross-canal, alertas operacionais |
+| **Dashboard tickets** | Admin + atendentes (setor) | Volume, fila, MTTR, CSAT, por motivo/rede |
+| **Dashboard chats** | Admin + atendentes | Fila WhatsApp, TMA, avaliações, encerramentos |
+| **Relatórios** | Admin | Export CSV, filtros por período/rede/setor |
+
+## Fases
+
+| Fase | Issues |
+|------|--------|
+| D-F1 | D-01, D-05 — Geral |
+| D-F2 | D-02, D-06 — Tickets |
+| D-F3 | D-03, D-07 — Chats |
+| D-F4 | D-04, D-08 — Relatórios |
+
+## Fora de escopo v1
+
+- BI externo (Power BI)
+- Relatórios agendados por e-mail (issue futura)
+
+## Labels
+
+`epic`, `dashboard`, `fase-interna`

--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -1,0 +1,16 @@
+# Issues criadas no GitHub (2026-06-14)
+
+Geradas automaticamente via `scripts/create_planning_issues.py`.
+
+| Prefixo | Épico | Issues filhas |
+|---------|-------|---------------|
+| RT | [#256](https://github.com/lgustavoss/dx-connect/issues/256) | #264–#269 |
+| T | [#257](https://github.com/lgustavoss/dx-connect/issues/257) | #270–#273 |
+| R | [#258](https://github.com/lgustavoss/dx-connect/issues/258) | #274–#276 |
+| S | [#259](https://github.com/lgustavoss/dx-connect/issues/259) | #277–#281 |
+| D | [#260](https://github.com/lgustavoss/dx-connect/issues/260) | #282–#289 |
+| A | [#261](https://github.com/lgustavoss/dx-connect/issues/261) | #290–#292 |
+| KB | [#262](https://github.com/lgustavoss/dx-connect/issues/262) | #293–#299 |
+| P | [#263](https://github.com/lgustavoss/dx-connect/issues/263) | #300–#308 |
+
+Meta-issue: [#16](https://github.com/lgustavoss/dx-connect/issues/16)

--- a/.github/planning-issue-bodies/KB-01-backend-modelo-artigos-categorias.md
+++ b/.github/planning-issue-bodies/KB-01-backend-modelo-artigos-categorias.md
@@ -1,0 +1,31 @@
+# KB — categorias, artigos, versões e publicação (backend)
+
+## Contexto
+
+Épico: **Base de conhecimento**.
+
+Parte de: **KB-F1**
+
+## Proposta
+
+### Tabelas
+
+- `kb_categories`: nome, slug, ordem, parent_id nullable
+- `kb_articles`: titulo, slug, category_id, status (`rascunho`|`publicado`|`arquivado`), conteudo_html ou markdown, autor_atendente_id, published_at
+- `kb_article_versions` (opcional v1): snapshot em cada save
+
+Slugs únicos globalmente.
+
+## Critérios de aceite
+
+- [ ] Migração Alembic
+- [ ] Índice full-text titulo+conteudo (Postgres `tsvector` ou ILIKE v1)
+- [ ] Soft delete / arquivar
+
+## Dependências
+
+- Bloqueia: KB-02, KB-03, KB-06
+
+## Labels
+
+`backend`, `base-conhecimento`, `fase-interna`

--- a/.github/planning-issue-bodies/KB-02-backend-api-admin-artigos.md
+++ b/.github/planning-issue-bodies/KB-02-backend-api-admin-artigos.md
@@ -1,0 +1,33 @@
+# KB — API admin CRUD artigos (backend)
+
+## Contexto
+
+Épico: **Base de conhecimento**.
+
+Parte de: **KB-F2**
+
+## Proposta
+
+Admin/atendente autorizado:
+
+- `GET/POST/PUT /v1/kb/articles`
+- `POST /v1/kb/articles/{id}/publish`
+- `POST /v1/kb/articles/{id}/archive`
+- Upload imagens inline (storage ticket-like)
+
+Permissão: admin ou flag `pode_editar_kb` no atendente (v1: admin-only).
+
+## Critérios de aceite
+
+- [ ] Rascunho não visível API pública
+- [ ] Audit log publish/update
+- [ ] Testes CRUD + publish
+
+## Dependências
+
+- Requer: KB-01
+- Bloqueia: KB-05
+
+## Labels
+
+`backend`, `base-conhecimento`, `fase-interna`

--- a/.github/planning-issue-bodies/KB-03-backend-api-publica-artigos.md
+++ b/.github/planning-issue-bodies/KB-03-backend-api-publica-artigos.md
@@ -1,0 +1,32 @@
+# KB — API pública de leitura (backend)
+
+## Contexto
+
+Épico: **Base de conhecimento**. Consumo externo (portal) e interno.
+
+Parte de: **KB-F4**
+
+## Proposta
+
+- `GET /v1/kb/public/categories`
+- `GET /v1/kb/public/articles?categoria=&q=`
+- `GET /v1/kb/public/articles/{slug}`
+
+Sem auth ou auth portal opcional (artigos podem ser `interno_only=false`).
+
+Rate limit básico.
+
+## Critérios de aceite
+
+- [ ] Só artigos publicados
+- [ ] Busca por termo
+- [ ] Cache-Control curto
+
+## Dependências
+
+- Requer: KB-01
+- Bloqueia: P-09, KB-07
+
+## Labels
+
+`backend`, `base-conhecimento`, `fase-interna`, `fase-portal`

--- a/.github/planning-issue-bodies/KB-04-backend-vinculo-motivo-artigos.md
+++ b/.github/planning-issue-bodies/KB-04-backend-vinculo-motivo-artigos.md
@@ -1,0 +1,26 @@
+# KB — sugestão de artigos por natureza/motivo (backend)
+
+## Contexto
+
+Épico: **Base de conhecimento**.
+
+Parte de: **KB-F4**
+
+## Proposta
+
+- Tabela `kb_article_motivo_links`: article_id, motivo_id (nullable natureza_id)
+- `GET /v1/kb/suggestions?motivo_id=&natureza_id=` — artigos publicados linked
+- Usado na abertura ticket (interno + portal)
+
+## Critérios de aceite
+
+- [ ] Admin vincula artigo a motivo no CRUD
+- [ ] Máx 5 sugestões ordenadas
+
+## Dependências
+
+- Requer: KB-01, KB-03
+
+## Labels
+
+`backend`, `base-conhecimento`, `fase-interna`

--- a/.github/planning-issue-bodies/KB-05-frontend-editor-artigos-admin.md
+++ b/.github/planning-issue-bodies/KB-05-frontend-editor-artigos-admin.md
@@ -1,0 +1,30 @@
+# KB — editor de manuais (frontend)
+
+## Contexto
+
+Épico: **Base de conhecimento**.
+
+Parte de: **KB-F2**
+
+## Proposta
+
+**Configurações → Atendimento → Base de conhecimento**:
+
+- Lista artigos (status, categoria, autor, data)
+- Editor rich text (TipTap, Lexical ou textarea markdown v1)
+- Preview antes publicar
+- Botões Salvar rascunho / Publicar / Arquivar
+
+## Critérios de aceite
+
+- [ ] Consome KB-02
+- [ ] Valida título e slug
+- [ ] Confirmação ao arquivar
+
+## Dependências
+
+- Requer: KB-02, KB-06
+
+## Labels
+
+`frontend`, `base-conhecimento`, `fase-interna`

--- a/.github/planning-issue-bodies/KB-06-frontend-gestao-categorias-admin.md
+++ b/.github/planning-issue-bodies/KB-06-frontend-gestao-categorias-admin.md
@@ -1,0 +1,28 @@
+# KB — gestão de categorias (frontend)
+
+## Contexto
+
+Épico: **Base de conhecimento**.
+
+Parte de: **KB-F1**
+
+## Proposta
+
+- CRUD categorias (nome, ordem)
+- Drag reorder
+- Contagem artigos por categoria
+
+Endpoint categorias pode estar em KB-02 ou dedicado.
+
+## Critérios de aceite
+
+- [ ] Não apagar categoria com artigos (ou mover para «Sem categoria»)
+- [ ] Admin-only
+
+## Dependências
+
+- Requer: KB-01
+
+## Labels
+
+`frontend`, `base-conhecimento`, `fase-interna`

--- a/.github/planning-issue-bodies/KB-07-frontend-leitura-artigos-interno.md
+++ b/.github/planning-issue-bodies/KB-07-frontend-leitura-artigos-interno.md
@@ -1,0 +1,29 @@
+# KB — consulta rápida no painel interno (frontend)
+
+## Contexto
+
+Épico: **Base de conhecimento**.
+
+Parte de: **KB-F3**
+
+## Proposta
+
+- Item sidebar «Ajuda» ou botão no detalhe ticket/chat «Consultar base»
+- Modal/drawer: busca + categorias + visualização artigo
+- Botão «Inserir link no ticket» (mensagem pública com URL artigo)
+- Sugestões automáticas se ticket tem motivo (KB-04)
+
+## Critérios de aceite
+
+- [ ] Busca debounced
+- [ ] Funciona offline cache últimos 10 artigos (opcional)
+- [ ] Atendentes leem; só admin edita
+
+## Dependências
+
+- Requer: KB-03
+- Opcional: KB-04
+
+## Labels
+
+`frontend`, `base-conhecimento`, `fase-interna`

--- a/.github/planning-issue-bodies/KB-epic-base-conhecimento.md
+++ b/.github/planning-issue-bodies/KB-epic-base-conhecimento.md
@@ -1,0 +1,28 @@
+# [Épico] Base de conhecimento (interno + público)
+
+## Contexto
+
+Atendentes precisam **criar manuais** no DX Connect que possam ser **publicados** para funcionários (portal futuro) e consultados durante atendimento.
+
+Diferente de **respostas prontas** (#113): artigos longos, categorizados, versionados, com busca.
+
+## Objetivo
+
+| Camada | Uso |
+|--------|-----|
+| **Admin/atendente** | Editor, rascunho, publicar, categorias |
+| **Painel interno** | Consulta rápida durante ticket/chat |
+| **Portal cliente** | Ajuda self-service (P-09) |
+
+## Fases
+
+| Fase | Issues |
+|------|--------|
+| KB-F1 | KB-01, KB-06 — Modelo + categorias |
+| KB-F2 | KB-02, KB-05 — Editor admin |
+| KB-F3 | KB-07 — Leitura interna |
+| KB-F4 | KB-03, KB-04, P-09 — Público + sugestões |
+
+## Labels
+
+`epic`, `base-conhecimento`, `fase-interna`

--- a/.github/planning-issue-bodies/P-01-backend-auth-portal-funcionario.md
+++ b/.github/planning-issue-bodies/P-01-backend-auth-portal-funcionario.md
@@ -1,0 +1,47 @@
+# Portal do cliente — autenticação e escopo (backend)
+
+## Contexto
+
+Épico: **Portal do cliente** (fase futura). Primeira entrega backend: autenticação de **funcionário da rede** com JWT e escopo de dados.
+
+Parte de: **P-F1**
+
+## Problema atual
+
+- Apenas atendentes internos (`Atendente`) autenticam no sistema
+- `FuncionarioRede` existe no cadastro mas não tem fluxo de login
+
+## Proposta
+
+1. **Login portal:** e-mail + senha (ou magic link em fase posterior) vinculado a `FuncionarioRede` ativo
+2. **JWT distinto** ou claim `aud=portal` para separar rotas internas vs portal
+3. **Escopo automático:**
+   - Colaborador → uma `empresa_id`
+   - Supervisor → `empresa_ids` vinculadas
+   - Sócio → todas empresas da `rede_id`
+4. Endpoints `GET /v1/portal/me` com perfil e empresas visíveis
+5. Primeiro acesso / reset de senha (reutilizar padrão #105 adaptado)
+
+## Critérios de aceite
+
+- [ ] Funcionário ativo consegue login; inativo recebe 403
+- [ ] Token portal não acessa rotas admin internas
+- [ ] Escopo de empresas respeita tipo (sócio/supervisor/colaborador)
+- [ ] Testes pytest cobrindo os três perfis de funcionário
+- [ ] Migração: campos `password_hash`, `must_change_password` em `funcionarios_rede` (ou tabela auth dedicada)
+
+## Escopo técnico
+
+- `backend/app/api/portal_auth.py` (novo router prefix `/portal`)
+- `backend/app/core/portal_scope.py`
+- Schemas Pydantic `PortalLogin`, `PortalMe`
+- Alembic migration
+
+## Dependências
+
+- Bloqueia: P-02, P-03, P-04
+- Paralelo possível com: P-05 (mock API)
+
+## Labels
+
+`backend`, `fase-portal`, `portal-cliente`

--- a/.github/planning-issue-bodies/P-02-backend-api-tickets-portal.md
+++ b/.github/planning-issue-bodies/P-02-backend-api-tickets-portal.md
@@ -1,0 +1,41 @@
+# Portal do cliente — API tickets listagem, detalhe e abertura (backend)
+
+## Contexto
+
+Épico: **Portal do cliente**. Expor tickets no escopo do funcionário autenticado.
+
+Parte de: **P-F2**
+
+## Proposta
+
+### Endpoints
+
+- `GET /v1/portal/tickets` — paginado, filtros: status, protocolo, data
+- `GET /v1/portal/tickets/{id}` — detalhe se ticket pertence ao escopo
+- `POST /v1/portal/tickets` — abertura com:
+  - `empresa_id` (obrigatório se colaborador; validar escopo)
+  - `setor_id` ou roteamento default
+  - `assunto`, `descricao`, classificação opcional
+  - `aberto_por_id` = funcionário logado (automático)
+
+### Regras
+
+- Funcionário **não** vê mensagens `interno`
+- **Não** altera status/atendente (somente leitura operacional + nova mensagem pública se permitido)
+- Empresa fora do escopo → 404 (não revelar existência)
+
+## Critérios de aceite
+
+- [ ] Listagem filtrada por escopo rede/empresa
+- [ ] Abertura preenche `aberto_por_id` e respeita RBAC
+- [ ] Detalhe omite campos internos (notas internas, atendente interno opcional)
+- [ ] Testes de autorização cross-empresa
+
+## Dependências
+
+- Requer: P-01
+- Bloqueia: P-06, P-07, P-08
+
+## Labels
+
+`backend`, `fase-portal`, `portal-cliente`, `tickets`

--- a/.github/planning-issue-bodies/P-03-backend-mensagens-anexos-portal.md
+++ b/.github/planning-issue-bodies/P-03-backend-mensagens-anexos-portal.md
@@ -1,0 +1,30 @@
+# Portal do cliente — mensagens públicas e anexos (backend)
+
+## Contexto
+
+Épico: **Portal do cliente**. Permitir que o solicitante acompanhe e responda no fio público.
+
+Parte de: **P-F3**
+
+## Proposta
+
+- `GET /v1/portal/tickets/{id}/mensagens` — apenas `tipo=publico`
+- `POST /v1/portal/tickets/{id}/mensagens` — texto + anexos (limites de tamanho/count)
+- Upload anexo reutilizando storage de tickets com prefixo/quota portal
+- Disparar notificação interna (#109) ao atendente responsável ou setor
+
+## Critérios de aceite
+
+- [ ] Mensagens internas nunca expostas
+- [ ] Anexos respeitam limites configuráveis
+- [ ] Nova mensagem do cliente notifica atendente (in-app; e-mail se P-04 pronto)
+- [ ] Ticket encerrado: mensagem pode reabrir ou criar novo (definir regra — sugerido: mensagem pública em encerrado abre triagem / novo ticket, alinhado e-mail)
+
+## Dependências
+
+- Requer: P-02
+- Bloqueia: P-08
+
+## Labels
+
+`backend`, `fase-portal`, `portal-cliente`, `tickets`

--- a/.github/planning-issue-bodies/P-04-backend-notificacoes-portal.md
+++ b/.github/planning-issue-bodies/P-04-backend-notificacoes-portal.md
@@ -1,0 +1,35 @@
+# Portal do cliente — notificações por e-mail ao funcionário (backend)
+
+## Contexto
+
+Épico: **Portal do cliente**. Funcionário deve ser avisado quando há resposta no ticket.
+
+Parte de: **P-F4**
+
+## Proposta
+
+Eventos que disparam e-mail ao `FuncionarioRede.email`:
+
+- Nova mensagem **pública** da equipa no ticket
+- Mudança de status relevante (ex.: encerrado, aguardando cliente)
+- Link deep link para `/portal/tickets/{id}`
+
+Reutilizar `email_send_sistema.py` / Resend transacional.
+
+Preferências opt-out simples (fase 1: tudo ou nada por funcionário).
+
+## Critérios de aceite
+
+- [ ] E-mail enviado com protocolo e link correto
+- [ ] Não envia para mensagens internas
+- [ ] Idempotência básica (não spammar reenvios)
+- [ ] Teste unitário com mock Resend
+
+## Dependências
+
+- Requer: P-02 (idealmente P-03)
+- Paralelo: P-08 frontend
+
+## Labels
+
+`backend`, `fase-portal`, `portal-cliente`, `notificacoes`

--- a/.github/planning-issue-bodies/P-05-frontend-shell-portal.md
+++ b/.github/planning-issue-bodies/P-05-frontend-shell-portal.md
@@ -1,0 +1,31 @@
+# Portal do cliente — layout, rotas e login (frontend)
+
+## Contexto
+
+Épico: **Portal do cliente**. Shell da aplicação externa (subdomínio ou `/portal`).
+
+Parte de: **P-F1**
+
+## Proposta
+
+- Rotas: `/portal/login`, `/portal/tickets`, `/portal/tickets/novo`, `/portal/tickets/:id`
+- Layout distinto do painel interno (marca empresa sistema + rede)
+- Auth context separado (`PortalAuthProvider`) ou app Vite separado (decisão implementação)
+- Guard: redireciona não autenticado para login
+- Tema claro/escuro opcional (reutilizar ThemeContext se mesmo bundle)
+
+## Critérios de aceite
+
+- [ ] Login consome P-01 e persiste token
+- [ ] Logout limpa sessão
+- [ ] Mobile-first (funcionários de posto)
+- [ ] Sem links para áreas admin internas
+
+## Dependências
+
+- Requer: P-01 (ou mock)
+- Bloqueia: P-06, P-07, P-08
+
+## Labels
+
+`frontend`, `fase-portal`, `portal-cliente`

--- a/.github/planning-issue-bodies/P-06-frontend-listagem-tickets-portal.md
+++ b/.github/planning-issue-bodies/P-06-frontend-listagem-tickets-portal.md
@@ -1,0 +1,28 @@
+# Portal do cliente — listagem de tickets (frontend)
+
+## Contexto
+
+Épico: **Portal do cliente**. Tela principal pós-login.
+
+Parte de: **P-F2**
+
+## Proposta
+
+- Tabela/cards: protocolo, assunto, status, última atualização
+- Filtros: abertos/fechados, busca por protocolo
+- Empty state orientando abrir primeiro ticket
+- Paginação ou infinite scroll
+
+## Critérios de aceite
+
+- [ ] Consome `GET /v1/portal/tickets`
+- [ ] Estados loading/erro/vazio
+- [ ] Clique navega para detalhe
+
+## Dependências
+
+- Requer: P-05, P-02
+
+## Labels
+
+`frontend`, `fase-portal`, `portal-cliente`, `tickets`

--- a/.github/planning-issue-bodies/P-07-frontend-abertura-ticket-portal.md
+++ b/.github/planning-issue-bodies/P-07-frontend-abertura-ticket-portal.md
@@ -1,0 +1,29 @@
+# Portal do cliente — abertura de ticket (frontend)
+
+## Contexto
+
+Épico: **Portal do cliente**. Formulário de nova solicitação.
+
+Parte de: **P-F2**
+
+## Proposta
+
+- Empresa pré-selecionada se colaborador (única); select se supervisor/sócio
+- PDV opcional (lista PDVs da empresa, se cadastrados)
+- Setor: select ou default configurável
+- Classificação natureza/motivo (reutilizar componentes adaptados de `TicketClassificacaoFields`)
+- Anexos na abertura (opcional v1)
+
+## Critérios de aceite
+
+- [ ] Validação de campos obrigatórios
+- [ ] Sucesso redireciona para detalhe com toast
+- [ ] Empresa fora do escopo impossível de selecionar
+
+## Dependências
+
+- Requer: P-05, P-02
+
+## Labels
+
+`frontend`, `fase-portal`, `portal-cliente`, `tickets`

--- a/.github/planning-issue-bodies/P-08-frontend-detalhe-ticket-portal.md
+++ b/.github/planning-issue-bodies/P-08-frontend-detalhe-ticket-portal.md
@@ -1,0 +1,29 @@
+# Portal do cliente — detalhe e timeline (frontend)
+
+## Contexto
+
+Épico: **Portal do cliente**. Acompanhamento da solicitação.
+
+Parte de: **P-F3**
+
+## Proposta
+
+- Cabeçalho: protocolo, status, assunto, empresa
+- Timeline só mensagens públicas
+- Composer para nova mensagem + anexos (P-03)
+- Banner CSAT se ticket encerrado e pesquisa pendente (link `/avaliar-ticket`)
+- Sem ações de atendente (assumir, transferir, nota interna)
+
+## Critérios de aceite
+
+- [ ] Timeline atualiza após envio
+- [ ] Anexos visualizáveis/download
+- [ ] Ticket encerrado: UX clara (nova mensagem vs novo ticket conforme regra backend)
+
+## Dependências
+
+- Requer: P-05, P-02, P-03
+
+## Labels
+
+`frontend`, `fase-portal`, `portal-cliente`, `tickets`

--- a/.github/planning-issue-bodies/P-09-frontend-kb-portal-cliente.md
+++ b/.github/planning-issue-bodies/P-09-frontend-kb-portal-cliente.md
@@ -1,0 +1,29 @@
+# Portal do cliente — base de conhecimento (frontend)
+
+## Contexto
+
+Épico: **Portal do cliente** + **Base de conhecimento**. Artigos publicados visíveis ao funcionário antes/durante abertura de ticket.
+
+Parte de: **P-F5**
+
+## Proposta
+
+- Rota `/portal/ajuda` com categorias e busca
+- Artigo individual `/portal/ajuda/:slug`
+- Widget «Artigos sugeridos» na abertura de ticket (KB-04)
+- Feedback «Este artigo ajudou?» (opcional v1)
+
+## Critérios de aceite
+
+- [ ] Consome API pública KB-03
+- [ ] Apenas artigos `publicado=true`
+- [ ] Mobile-friendly
+
+## Dependências
+
+- Requer: P-05, KB-03
+- Relacionado: KB-07 (leitura interna)
+
+## Labels
+
+`frontend`, `fase-portal`, `portal-cliente`, `base-conhecimento`

--- a/.github/planning-issue-bodies/P-epic-portal-cliente.md
+++ b/.github/planning-issue-bodies/P-epic-portal-cliente.md
@@ -1,0 +1,47 @@
+# [Épico] Portal do cliente — visão e fases
+
+## Contexto
+
+Desde o início do DX Connect, a visão inclui um **portal externo** para funcionários da rede (sócio, supervisor, colaborador) abrirem e acompanharem tickets. O modelo de dados já prevê `aberto_por_id` em tickets.
+
+**Decisão atual:** priorizar o **produto interno** (atendentes) até consolidação; o portal é **fase posterior**, mas as issues ficam abertas para planejamento incremental.
+
+## Objetivo do épico
+
+Entregar um portal web autenticado onde o funcionário:
+
+- Veja apenas tickets da sua **rede/empresa** (escopo RBAC distinto do painel interno)
+- Abra tickets com empresa e PDV pré-preenchidos quando aplicável
+- Acompanhe mensagens **públicas** e responda quando permitido
+- Avalie atendimento (CSAT) via fluxo existente
+
+## Fases de entrega
+
+| Fase | Issues | Entrega |
+|------|--------|---------|
+| **P-F1** | P-01, P-05 | Auth + shell do portal |
+| **P-F2** | P-02, P-06, P-07 | Listagem e abertura |
+| **P-F3** | P-03, P-08 | Detalhe, mensagens, anexos |
+| **P-F4** | P-04 | Notificações por e-mail |
+| **P-F5** | P-09 (+ KB-03) | Base de conhecimento no portal |
+
+## Fora de escopo (v1 portal)
+
+- Chat WhatsApp no portal (permanece canal separado)
+- Gestão de cadastros (redes/empresas) pelo cliente
+- App mobile (equipe separada)
+
+## Issues filhas
+
+- Backend: P-01 → P-04
+- Frontend: P-05 → P-09
+
+## Relacionado
+
+- Modelo: `backend/app/models/ticket.py` (`aberto_por_id`)
+- CSAT público: `public_csat.py` (reutilizar padrão)
+- Épico KB: KB-03, KB-07, P-09
+
+## Labels
+
+`epic`, `fase-portal`, `portal-cliente`

--- a/.github/planning-issue-bodies/R-01-backend-modelo-regras-roteamento.md
+++ b/.github/planning-issue-bodies/R-01-backend-modelo-regras-roteamento.md
@@ -1,0 +1,35 @@
+# Roteamento — modelo e CRUD de regras (backend)
+
+## Contexto
+
+Épico: **Roteamento automático**.
+
+Parte de: **R-F1**
+
+## Proposta
+
+### Tabela `routing_rules`
+
+- `nome`, `ativo`, `ordem` (precedência)
+- `condicoes` JSON: `{ "campo": "email_from"|"email_to"|"assunto"|"canal", "operador": "contains"|"equals"|"regex", "valor": "..." }`
+- `acoes` JSON: `{ "setor_id", "prioridade", "natureza_id", "motivo_id" }`
+- `escopo`: global ou `rede_id`
+
+### API admin
+
+- `GET/POST/PUT/DELETE /v1/routing/rules`
+- Reordenar: `PUT /v1/routing/rules/reorder`
+
+## Critérios de aceite
+
+- [ ] Validação JSON schema condições/ações
+- [ ] Audit log create/update
+- [ ] Testes CRUD
+
+## Dependências
+
+- Bloqueia: R-02, R-03
+
+## Labels
+
+`backend`, `roteamento`, `fase-interna`

--- a/.github/planning-issue-bodies/R-02-backend-motor-aplicacao-roteamento.md
+++ b/.github/planning-issue-bodies/R-02-backend-motor-aplicacao-roteamento.md
@@ -1,0 +1,35 @@
+# Roteamento — avaliação de regras (backend)
+
+## Contexto
+
+Épico: **Roteamento automático**.
+
+Parte de: **R-F2**
+
+## Proposta
+
+Serviço `evaluate_routing(context) -> RoutingResult`:
+
+1. Carrega regras ativas ordenadas
+2. Primeira match ganha
+3. Integração:
+   - `email_inbound_dispatch.py` — após parse MIME
+   - `POST /v1/tickets` — se setor não informado ou flag `aplicar_roteamento=true`
+4. Log qual regra aplicou (debug + audit)
+
+Fallback: comportamento atual (default setor env).
+
+## Critérios de aceite
+
+- [ ] E-mail financeiro roteado conforme regra teste
+- [ ] Ticket manual sem setor recebe setor da regra
+- [ ] Setor explícito manual **não** sobrescrito (a menos que admin force)
+- [ ] Testes unitários operadores contains/regex
+
+## Dependências
+
+- Requer: R-01
+
+## Labels
+
+`backend`, `roteamento`, `fase-interna`, `tickets`, `email`

--- a/.github/planning-issue-bodies/R-03-frontend-crud-regras-roteamento.md
+++ b/.github/planning-issue-bodies/R-03-frontend-crud-regras-roteamento.md
@@ -1,0 +1,32 @@
+# Roteamento — UI admin de regras (frontend)
+
+## Contexto
+
+Épico: **Roteamento automático**.
+
+Parte de: **R-F1**
+
+## Proposta
+
+**Configurações → Atendimento → Roteamento**:
+
+- Lista regras drag-and-drop ordem
+- Form builder condição: campo + operador + valor
+- Form ação: selects setor, prioridade, natureza/motivo
+- Toggle ativo/inativo
+- Teste seco: «Simular com e-mail X / assunto Y» (chama endpoint debug)
+
+## Critérios de aceite
+
+- [ ] CRUD completo
+- [ ] Validação client-side
+- [ ] Admin-only
+
+## Dependências
+
+- Requer: R-01
+- Simulador opcional depende R-02
+
+## Labels
+
+`frontend`, `roteamento`, `fase-interna`

--- a/.github/planning-issue-bodies/R-epic-roteamento.md
+++ b/.github/planning-issue-bodies/R-epic-roteamento.md
@@ -1,0 +1,34 @@
+# [Épico] Motor de roteamento automático
+
+## Contexto
+
+Hoje e-mail inbound usa setor/empresa default via env ou tabela encaminhamento. Tickets manuais exigem escolha manual. **Regras configuráveis** reduzem triagem errada.
+
+## Objetivo
+
+Motor que, dado um contexto (e-mail, ticket manual), define:
+
+- `setor_id`
+- `prioridade` (opcional)
+- `atendente_id` (opcional, raro v1)
+- `natureza_id` / `motivo_id` (sugestão)
+
+## Fases
+
+| Fase | Issues |
+|------|--------|
+| R-F1 | R-01, R-03 — Modelo + UI |
+| R-F2 | R-02 — Aplicação inbound + manual |
+
+## Exemplos de regras
+
+| Condição | Ação |
+|----------|------|
+| Remetente domínio `@financeiro.` | Setor Financeiro |
+| Assunto contém «NF» | Motivo Entrada NF + prioridade normal |
+| Destino `financeiro.t1@notify...` | Setor Financeiro |
+| Rede X + motivo PDV | Prioridade alta |
+
+## Labels
+
+`epic`, `roteamento`, `fase-interna`

--- a/.github/planning-issue-bodies/README.md
+++ b/.github/planning-issue-bodies/README.md
@@ -1,0 +1,148 @@
+# Rascunhos de issues — planejamento DX Connect
+
+Corpos de issue prontos para colar no GitHub. Cada arquivo segue o template do projeto (contexto, proposta, critérios de aceite, escopo técnico, dependências).
+
+**Como usar:** abra uma issue no repositório, copie o conteúdo do `.md` correspondente e vincule ao épico pai indicado no cabeçalho do arquivo.
+
+**Convenção de labels sugeridas:** `backend` | `frontend` | `epic` | `fase-interna` | `fase-portal` | `dashboard` | `sla` | `auditoria` | `tempo-real` | `roteamento` | `base-conhecimento`
+
+---
+
+## Ordem sugerida de implementação (uso interno primeiro)
+
+| Fase | Épico | Prioridade | Observação |
+|------|--------|------------|------------|
+| 1 | [Tempo real (SSE)](#épico-rt--tempo-real) | Alta | Melhora chat e notificações sem unificar filas |
+| 2 | [Distribuição automática de tickets](#épico-t--distribuição-automática-de-tickets) | Alta | Complementa fila receptiva; chats permanecem manuais |
+| 3 | [Roteamento automático](#épico-r--roteamento-automático) | Alta | E-mail e abertura manual |
+| 4 | [SLA](#épico-s--sla) | Média-alta | Depende de métricas de tempo (parcialmente dashboard) |
+| 5 | [Dashboards e relatórios](#épico-d--dashboards-e-relatórios) | Média-alta | Pode iniciar em paralelo com SLA |
+| 6 | [Auditoria estruturada](#épico-a--auditoria) | Média | Independente |
+| 7 | [Base de conhecimento](#épico-kb--base-de-conhecimento) | Média | Editor interno primeiro; portal público no épico Portal |
+| 8 | [Portal do cliente](#épico-p--portal-do-cliente-fase-futura) | Após consolidação interna | Issues abertas para planejamento |
+
+**Fora de escopo por agora (decisão do time):** inbox omnichannel unificada, templates WhatsApp proativos, API pública/webhooks externos.
+
+**Análises de viabilidade:** [`analises/integracao-retaguarda.md`](analises/integracao-retaguarda.md) · [`analises/filas-tickets-vs-chats.md`](analises/filas-tickets-vs-chats.md)
+
+---
+
+## Épico P — Portal do cliente (fase futura)
+
+Meta: permitir que **funcionários da rede** abram e acompanhem tickets após o produto interno estar consolidado. Reutiliza `aberto_por_id`, CSAT e classificação existentes.
+
+| Arquivo | Título sugerido | Camada |
+|---------|-----------------|--------|
+| [`P-epic-portal-cliente.md`](P-epic-portal-cliente.md) | **[Épico] Portal do cliente — visão e fases** | epic |
+| [`P-01-backend-auth-portal-funcionario.md`](P-01-backend-auth-portal-funcionario.md) | Portal: autenticação e escopo por funcionário/rede/empresa | backend |
+| [`P-02-backend-api-tickets-portal.md`](P-02-backend-api-tickets-portal.md) | Portal: API de listagem, detalhe e abertura de tickets | backend |
+| [`P-03-backend-mensagens-anexos-portal.md`](P-03-backend-mensagens-anexos-portal.md) | Portal: mensagens públicas e anexos do solicitante | backend |
+| [`P-04-backend-notificacoes-portal.md`](P-04-backend-notificacoes-portal.md) | Portal: notificações ao funcionário (e-mail) | backend |
+| [`P-05-frontend-shell-portal.md`](P-05-frontend-shell-portal.md) | Portal: layout, rotas e login (app separado ou subpath) | frontend |
+| [`P-06-frontend-listagem-tickets-portal.md`](P-06-frontend-listagem-tickets-portal.md) | Portal: listagem e filtros de tickets do funcionário | frontend |
+| [`P-07-frontend-abertura-ticket-portal.md`](P-07-frontend-abertura-ticket-portal.md) | Portal: formulário de abertura com empresa/PDV | frontend |
+| [`P-08-frontend-detalhe-ticket-portal.md`](P-08-frontend-detalhe-ticket-portal.md) | Portal: detalhe, timeline e CSAT | frontend |
+
+---
+
+## Épico D — Dashboards e relatórios
+
+| Arquivo | Título sugerido | Camada |
+|---------|-----------------|--------|
+| [`D-epic-dashboards-relatorios.md`](D-epic-dashboards-relatorios.md) | **[Épico] Dashboards e relatórios operacionais** | epic |
+| [`D-01-backend-metricas-dashboard-geral.md`](D-01-backend-metricas-dashboard-geral.md) | Dashboard geral: endpoints de métricas consolidadas | backend |
+| [`D-02-backend-metricas-dashboard-tickets.md`](D-02-backend-metricas-dashboard-tickets.md) | Dashboard tickets: volume, MTTR, fila, CSAT | backend |
+| [`D-03-backend-metricas-dashboard-chats.md`](D-03-backend-metricas-dashboard-chats.md) | Dashboard chats: fila, TMA, avaliações, encerramentos | backend |
+| [`D-04-backend-relatorios-export.md`](D-04-backend-relatorios-export.md) | Relatórios: consultas paginadas e export CSV | backend |
+| [`D-05-frontend-dashboard-geral.md`](D-05-frontend-dashboard-geral.md) | Dashboard geral: visão executiva e atalhos | frontend |
+| [`D-06-frontend-dashboard-tickets.md`](D-06-frontend-dashboard-tickets.md) | Dashboard tickets: gráficos e filtros por período | frontend |
+| [`D-07-frontend-dashboard-chats.md`](D-07-frontend-dashboard-chats.md) | Dashboard chats: métricas WhatsApp | frontend |
+| [`D-08-frontend-relatorios-ui.md`](D-08-frontend-relatorios-ui.md) | Relatórios: telas de consulta e download | frontend |
+
+---
+
+## Épico S — SLA
+
+| Arquivo | Título sugerido | Camada |
+|---------|-----------------|--------|
+| [`S-epic-sla.md`](S-epic-sla.md) | **[Épico] SLA configurável por setor e prioridade** | epic |
+| [`S-01-backend-modelo-config-sla.md`](S-01-backend-modelo-config-sla.md) | SLA: modelo de metas e calendário comercial | backend |
+| [`S-02-backend-calculo-violacoes-sla.md`](S-02-backend-calculo-violacoes-sla.md) | SLA: cálculo de prazos, pausas e violações | backend |
+| [`S-03-backend-notificacoes-sla.md`](S-03-backend-notificacoes-sla.md) | SLA: alertas in-app e e-mail ao estourar prazo | backend |
+| [`S-04-frontend-config-sla-admin.md`](S-04-frontend-config-sla-admin.md) | SLA: painel admin de configuração por setor | frontend |
+| [`S-05-frontend-indicadores-sla-tickets.md`](S-05-frontend-indicadores-sla-tickets.md) | SLA: badges e filtros na listagem/detalhe de tickets | frontend |
+
+---
+
+## Épico R — Roteamento automático
+
+| Arquivo | Título sugerido | Camada |
+|---------|-----------------|--------|
+| [`R-epic-roteamento.md`](R-epic-roteamento.md) | **[Épico] Motor de roteamento automático** | epic |
+| [`R-01-backend-modelo-regras-roteamento.md`](R-01-backend-modelo-regras-roteamento.md) | Roteamento: modelo e CRUD de regras | backend |
+| [`R-02-backend-motor-aplicacao-roteamento.md`](R-02-backend-motor-aplicacao-roteamento.md) | Roteamento: avaliação de regras (e-mail e ticket manual) | backend |
+| [`R-03-frontend-crud-regras-roteamento.md`](R-03-frontend-crud-regras-roteamento.md) | Roteamento: UI admin de regras | frontend |
+
+---
+
+## Épico RT — Tempo real
+
+| Arquivo | Título sugerido | Camada |
+|---------|-----------------|--------|
+| [`RT-epic-tempo-real.md`](RT-epic-tempo-real.md) | **[Épico] Eventos em tempo real (SSE)** | epic |
+| [`RT-01-backend-infra-sse.md`](RT-01-backend-infra-sse.md) | Tempo real: infraestrutura SSE e autenticação | backend |
+| [`RT-02-backend-eventos-tickets-chats.md`](RT-02-backend-eventos-tickets-chats.md) | Tempo real: eventos de tickets e chats WhatsApp | backend |
+| [`RT-03-backend-eventos-notificacoes.md`](RT-03-backend-eventos-notificacoes.md) | Tempo real: eventos do sino de notificações | backend |
+| [`RT-04-frontend-cliente-sse.md`](RT-04-frontend-cliente-sse.md) | Tempo real: hook/cliente SSE com fallback polling | frontend |
+| [`RT-05-frontend-integracao-chat-sse.md`](RT-05-frontend-integracao-chat-sse.md) | Tempo real: conversa WhatsApp sem polling agressivo | frontend |
+| [`RT-06-frontend-integracao-tickets-notificacoes-sse.md`](RT-06-frontend-integracao-tickets-notificacoes-sse.md) | Tempo real: detalhe ticket e NavbarNotificacoes | frontend |
+
+---
+
+## Épico KB — Base de conhecimento
+
+| Arquivo | Título sugerido | Camada |
+|---------|-----------------|--------|
+| [`KB-epic-base-conhecimento.md`](KB-epic-base-conhecimento.md) | **[Épico] Base de conhecimento (interno + público)** | epic |
+| [`KB-01-backend-modelo-artigos-categorias.md`](KB-01-backend-modelo-artigos-categorias.md) | KB: categorias, artigos, versões e publicação | backend |
+| [`KB-02-backend-api-admin-artigos.md`](KB-02-backend-api-admin-artigos.md) | KB: API admin (CRUD, rascunho, publicar) | backend |
+| [`KB-03-backend-api-publica-artigos.md`](KB-03-backend-api-publica-artigos.md) | KB: API pública de leitura (portal / link) | backend |
+| [`KB-04-backend-vinculo-motivo-artigos.md`](KB-04-backend-vinculo-motivo-artigos.md) | KB: sugestão de artigos por natureza/motivo | backend |
+| [`KB-05-frontend-editor-artigos-admin.md`](KB-05-frontend-editor-artigos-admin.md) | KB: editor de manuais para atendentes/admin | frontend |
+| [`KB-06-frontend-gestao-categorias-admin.md`](KB-06-frontend-gestao-categorias-admin.md) | KB: gestão de categorias e ordem | frontend |
+| [`KB-07-frontend-leitura-artigos-interno.md`](KB-07-frontend-leitura-artigos-interno.md) | KB: consulta rápida no painel interno (sidebar/modal) | frontend |
+
+*Publicação no portal do cliente: issue [`P-09-frontend-kb-portal-cliente.md`](P-09-frontend-kb-portal-cliente.md) (depende do épico Portal).*
+
+---
+
+## Épico T — Distribuição automática de tickets
+
+| Arquivo | Título sugerido | Camada |
+|---------|-----------------|--------|
+| [`T-epic-distribuicao-tickets.md`](T-epic-distribuicao-tickets.md) | **[Épico] Distribuição automática de tickets na fila** | epic |
+| [`T-01-backend-config-setor-distribuicao.md`](T-01-backend-config-setor-distribuicao.md) | Distribuição: config por setor (modo, timeout, estratégia) | backend |
+| [`T-02-backend-worker-atribuicao-automatica.md`](T-02-backend-worker-atribuicao-automatica.md) | Distribuição: worker de atribuição após timeout | backend |
+| [`T-03-frontend-config-distribuicao-setor.md`](T-03-frontend-config-distribuicao-setor.md) | Distribuição: UI em configurações do setor | frontend |
+| [`T-04-frontend-indicadores-fila-tickets.md`](T-04-frontend-indicadores-fila-tickets.md) | Distribuição: indicadores de tempo na fila sem responsável | frontend |
+
+---
+
+## Épico A — Auditoria
+
+| Arquivo | Título sugerido | Camada |
+|---------|-----------------|--------|
+| [`A-epic-auditoria.md`](A-epic-auditoria.md) | **[Épico] Auditoria estruturada e rastreável** | epic |
+| [`A-01-backend-audit-trail-expandido.md`](A-01-backend-audit-trail-expandido.md) | Auditoria: trail expandido (payload, IP, tickets/chats) | backend |
+| [`A-02-backend-consulta-export-auditoria.md`](A-02-backend-consulta-export-auditoria.md) | Auditoria: filtros avançados e export | backend |
+| [`A-03-frontend-auditoria-ui.md`](A-03-frontend-auditoria-ui.md) | Auditoria: UI com filtros, detalhe e paginação | frontend |
+
+---
+
+## Relacionamento com épicos existentes
+
+| Épico existente | Issues desta pasta |
+|-----------------|-------------------|
+| [#16](https://github.com/lgustavoss/dx-connect/issues/16) melhorias operacionais | D, S, R, T, RT, A |
+| [#162](https://github.com/lgustavoss/dx-connect/issues/162) e-mail SaaS | R (roteamento inbound complementa) |
+| Portal futuro | P, KB-03, KB-07, P-09 |

--- a/.github/planning-issue-bodies/RT-01-backend-infra-sse.md
+++ b/.github/planning-issue-bodies/RT-01-backend-infra-sse.md
@@ -1,0 +1,36 @@
+# Tempo real — infraestrutura SSE e autenticação (backend)
+
+## Contexto
+
+Épico: **Tempo real (SSE)**.
+
+Parte de: **RT-F1**
+
+## Proposta
+
+- `GET /v1/events/stream` — `text/event-stream`
+- Auth: JWT query param **ou** cookie HttpOnly (preferir header se EventSource permitir proxy)
+- Heartbeat 30s
+- Canal por atendente: `atendente:{id}`
+- Pub/sub in-process (asyncio Queue) v1; Redis opcional v2 multi-worker
+
+Event envelope:
+
+```json
+{ "type": "ping|ticket.mensagem|chat.mensagem|notificacao", "payload": {} }
+```
+
+## Critérios de aceite
+
+- [ ] Conexão autenticada; 401 sem token
+- [ ] Desconexão limpa
+- [ ] Teste integração com cliente SSE
+- [ ] Documentar limite conexões Gunicorn
+
+## Dependências
+
+- Bloqueia: RT-02, RT-03, RT-04
+
+## Labels
+
+`backend`, `tempo-real`, `fase-interna`

--- a/.github/planning-issue-bodies/RT-02-backend-eventos-tickets-chats.md
+++ b/.github/planning-issue-bodies/RT-02-backend-eventos-tickets-chats.md
@@ -1,0 +1,35 @@
+# Tempo real — eventos tickets e chats (backend)
+
+## Contexto
+
+Épico: **Tempo real (SSE)**.
+
+Parte de: **RT-F2**
+
+## Proposta
+
+Emitir eventos após commit DB:
+
+| Evento | Quando | Destinatários |
+|--------|--------|---------------|
+| `chat.mensagem` | Nova msg inbound/outbound | Atendentes com acesso ao chat |
+| `chat.fila` | Chat entra/sai fila | Setor/admins |
+| `ticket.mensagem` | Nova mensagem ticket | Responsável + setor |
+| `ticket.fila` | Ticket sem responsável | Setor |
+
+Hook em services existentes (`evolution_inbound`, `tickets.py` mensagens).
+
+## Critérios de aceite
+
+- [ ] Evento só após commit
+- [ ] RBAC: atendente não recebe chat de outro setor
+- [ ] Testes emit mock
+
+## Dependências
+
+- Requer: RT-01
+- Bloqueia: RT-05, RT-06
+
+## Labels
+
+`backend`, `tempo-real`, `fase-interna`, `whatsapp`, `tickets`

--- a/.github/planning-issue-bodies/RT-03-backend-eventos-notificacoes.md
+++ b/.github/planning-issue-bodies/RT-03-backend-eventos-notificacoes.md
@@ -1,0 +1,27 @@
+# Tempo real — eventos notificações (backend)
+
+## Contexto
+
+Épico: **Tempo real (SSE)**.
+
+Parte de: **RT-F3**
+
+## Proposta
+
+- `notificacao.contagem` — payload `{ tickets_fila, chats_fila, ... }`
+- Emitir quando fila notificação/atualização contadores muda
+- Integrar após assume chat, nova msg, ticket atribuído
+
+## Critérios de aceite
+
+- [ ] Navbar pode substituir polling por SSE + fallback 60s
+- [ ] Payload compatível com API atual notificações
+
+## Dependências
+
+- Requer: RT-01
+- Paralelo: RT-02
+
+## Labels
+
+`backend`, `tempo-real`, `fase-interna`, `notificacoes`

--- a/.github/planning-issue-bodies/RT-04-frontend-cliente-sse.md
+++ b/.github/planning-issue-bodies/RT-04-frontend-cliente-sse.md
@@ -1,0 +1,31 @@
+# Tempo real — hook cliente SSE com fallback (frontend)
+
+## Contexto
+
+Épico: **Tempo real (SSE)**.
+
+Parte de: **RT-F1**
+
+## Proposta
+
+- `useEventStream()` hook:
+  - Conecta SSE autenticado
+  - Reconnect exponential backoff
+  - Fallback polling se 3 falhas
+  - Dispatch por `type` para listeners registrados
+- Provider global no `Layout`
+
+## Critérios de aceite
+
+- [ ] Reconexão transparente
+- [ ] Cleanup on unmount/logout
+- [ ] Log dev-only erros conexão
+
+## Dependências
+
+- Requer: RT-01
+- Bloqueia: RT-05, RT-06
+
+## Labels
+
+`frontend`, `tempo-real`, `fase-interna`

--- a/.github/planning-issue-bodies/RT-05-frontend-integracao-chat-sse.md
+++ b/.github/planning-issue-bodies/RT-05-frontend-integracao-chat-sse.md
@@ -1,0 +1,32 @@
+# Tempo real — conversa WhatsApp (frontend)
+
+## Contexto
+
+Épico: **Tempo real (SSE)**.
+
+Parte de: **RT-F2**
+
+## Proposta
+
+Em `WhatsappConversa.tsx`:
+
+- Subscrever `chat.mensagem` para `chatId` atual
+- Append mensagem na timeline
+- Reduzir intervalo polling (ou remover quando SSE ok)
+- Manter scroll behavior existente
+
+Lista `WhatsappAtendendo`: refresh fila on `chat.fila`.
+
+## Critérios de aceite
+
+- [ ] Mensagem inbound aparece <2s (rede local)
+- [ ] Sem duplicata (dedupe por wa_message_id)
+- [ ] Funciona com SSE off (polling legacy)
+
+## Dependências
+
+- Requer: RT-04, RT-02
+
+## Labels
+
+`frontend`, `tempo-real`, `fase-interna`, `whatsapp`

--- a/.github/planning-issue-bodies/RT-06-frontend-integracao-tickets-notificacoes-sse.md
+++ b/.github/planning-issue-bodies/RT-06-frontend-integracao-tickets-notificacoes-sse.md
@@ -1,0 +1,26 @@
+# Tempo real — tickets e NavbarNotificacoes (frontend)
+
+## Contexto
+
+Épico: **Tempo real (SSE)**.
+
+Parte de: **RT-F3**
+
+## Proposta
+
+- `TicketDetalhe`: subscrever `ticket.mensagem`
+- `NavbarNotificacoes`: subscrever `notificacao.contagem`
+- Opcional: badge fila tickets lista on `ticket.fila`
+
+## Critérios de aceite
+
+- [ ] Contadores atualizam sem refresh página
+- [ ] Detalhe ticket mostra msg sem F5
+
+## Dependências
+
+- Requer: RT-04, RT-02, RT-03
+
+## Labels
+
+`frontend`, `tempo-real`, `fase-interna`, `tickets`, `notificacoes`

--- a/.github/planning-issue-bodies/RT-epic-tempo-real.md
+++ b/.github/planning-issue-bodies/RT-epic-tempo-real.md
@@ -1,0 +1,31 @@
+# [Épico] Eventos em tempo real (SSE)
+
+## Contexto
+
+Chat WhatsApp e notificações usam **polling**, causando atraso e carga. **Server-Sent Events (SSE)** é suficiente para push unidirecional servidor→cliente (FastAPI friendly).
+
+**Importante:** tempo real **não** unifica filas tickets/chats — apenas atualiza cada tela mais rápido.
+
+## Objetivo
+
+- Nova mensagem chat aparece sem refresh manual
+- Contadores `NavbarNotificacoes` atualizam ao vivo
+- Detalhe ticket: nova mensagem/anexo em tempo real
+- Fallback automático para polling se SSE cair
+
+## Fases
+
+| Fase | Issues |
+|------|--------|
+| RT-F1 | RT-01, RT-04 — Infra |
+| RT-F2 | RT-02, RT-05 — Chats |
+| RT-F3 | RT-03, RT-06 — Tickets + notificações |
+
+## Fora de escopo v1
+
+- WebSocket bidirecional
+- Typing indicators WhatsApp
+
+## Labels
+
+`epic`, `tempo-real`, `fase-interna`

--- a/.github/planning-issue-bodies/S-01-backend-modelo-config-sla.md
+++ b/.github/planning-issue-bodies/S-01-backend-modelo-config-sla.md
@@ -1,0 +1,36 @@
+# SLA — modelo de metas e calendário comercial (backend)
+
+## Contexto
+
+Épico: **SLA**. Fundação de dados.
+
+Parte de: **S-F1**
+
+## Proposta
+
+### Tabelas
+
+- `sla_policies`: setor_id, prioridade (nullable = default setor), meta_primeira_resposta_min, meta_resolucao_min, ativo
+- Reutilizar `whatsapp_business_hours` / feriados ou extrair `business_calendars` compartilhado
+
+### Campos em `tickets`
+
+- `sla_primeira_resposta_vence_em` (nullable, calculado)
+- `sla_resolucao_vence_em`
+- `sla_primeira_resposta_em` (timestamp cumprido)
+- `sla_violado` (bool ou enum)
+
+## Critérios de aceite
+
+- [ ] CRUD admin `POST/GET/PUT /v1/sla/policies`
+- [ ] Migração Alembic
+- [ ] Ao criar ticket: snapshot das metas aplicáveis
+- [ ] Testes criação policy
+
+## Dependências
+
+- Bloqueia: S-02, S-04
+
+## Labels
+
+`backend`, `sla`, `fase-interna`

--- a/.github/planning-issue-bodies/S-02-backend-calculo-violacoes-sla.md
+++ b/.github/planning-issue-bodies/S-02-backend-calculo-violacoes-sla.md
@@ -1,0 +1,32 @@
+# SLA — cálculo de prazos, pausas e violações (backend)
+
+## Contexto
+
+Épico: **SLA**. Motor de cálculo.
+
+Parte de: **S-F2**
+
+## Proposta
+
+1. **Job periódico** (60s) ou trigger em eventos:
+   - Nova mensagem pública equipa → marca primeira resposta
+   - Mudança status → verifica resolução
+2. **Horário comercial:** incrementar relógio SLA só dentro do calendário do setor
+3. **Estados:** `dentro`, `em_risco` (ex.: 80% tempo), `violado`
+4. Endpoint `GET /v1/tickets/{id}/sla` para detalhe
+
+## Critérios de aceite
+
+- [ ] Ticket criado sexta 18h → relógio pausa até segunda
+- [ ] Prioridade alta usa policy correta
+- [ ] Testes unitários calendário + edge cases
+- [ ] Não recalcular retroativo policies alteradas (snapshot na criação)
+
+## Dependências
+
+- Requer: S-01
+- Bloqueia: S-03, S-05, D-01 (campo violações)
+
+## Labels
+
+`backend`, `sla`, `fase-interna`

--- a/.github/planning-issue-bodies/S-03-backend-notificacoes-sla.md
+++ b/.github/planning-issue-bodies/S-03-backend-notificacoes-sla.md
@@ -1,0 +1,35 @@
+# SLA — alertas in-app e e-mail (backend)
+
+## Contexto
+
+Épico: **SLA**. Notificar antes e após violação.
+
+Parte de: **S-F3**
+
+## Proposta
+
+Eventos:
+
+- `sla_em_risco` — ex.: 80% do prazo
+- `sla_violado` — prazo estourado
+
+Destinatários:
+
+- Atendente responsável (se houver)
+- Admins do setor ou lista configurável
+
+Integrar com notificações existentes (#109) + novo tipo preferência.
+
+## Critérios de aceite
+
+- [ ] Não duplicar alerta (debounce por ticket/meta)
+- [ ] Preferência opt-in/out por tipo
+- [ ] Testes mock fila e-mail
+
+## Dependências
+
+- Requer: S-02
+
+## Labels
+
+`backend`, `sla`, `fase-interna`, `notificacoes`

--- a/.github/planning-issue-bodies/S-04-frontend-config-sla-admin.md
+++ b/.github/planning-issue-bodies/S-04-frontend-config-sla-admin.md
@@ -1,0 +1,30 @@
+# SLA — painel admin de configuração (frontend)
+
+## Contexto
+
+Épico: **SLA**.
+
+Parte de: **S-F1**
+
+## Proposta
+
+Em **Configurações → Atendimento → SLA** (ou dentro de Setor):
+
+- Tabela policies por setor/prioridade
+- Form: minutos primeira resposta / resolução
+- Link para calendário comercial (WhatsApp hours ou compartilhado)
+- Preview exemplo: «Prioridade alta = 2h / 8h úteis»
+
+## Critérios de aceite
+
+- [ ] CRUD consome S-01
+- [ ] Validação minutos > 0
+- [ ] Admin-only
+
+## Dependências
+
+- Requer: S-01
+
+## Labels
+
+`frontend`, `sla`, `fase-interna`

--- a/.github/planning-issue-bodies/S-05-frontend-indicadores-sla-tickets.md
+++ b/.github/planning-issue-bodies/S-05-frontend-indicadores-sla-tickets.md
@@ -1,0 +1,27 @@
+# SLA — badges e filtros em tickets (frontend)
+
+## Contexto
+
+Épico: **SLA**.
+
+Parte de: **S-F2**
+
+## Proposta
+
+- Badge na listagem: verde/amarelo/vermelho (dentro/risco/violado)
+- Filtro «SLA violado» / «Em risco»
+- Detalhe ticket: card com countdown ou «Violado há X»
+- Tooltip explicando meta aplicada
+
+## Critérios de aceite
+
+- [ ] Consome campos S-02 ou endpoint `/sla`
+- [ ] Performance listagem (não N+1)
+
+## Dependências
+
+- Requer: S-02
+
+## Labels
+
+`frontend`, `sla`, `fase-interna`, `tickets`

--- a/.github/planning-issue-bodies/S-epic-sla.md
+++ b/.github/planning-issue-bodies/S-epic-sla.md
@@ -1,0 +1,36 @@
+# [Épico] SLA configurável por setor e prioridade
+
+## Contexto
+
+Tickets têm **prioridade** (#107/#108) mas não há metas de tempo nem alertas. Chats WhatsApp têm urgência operacional via alerta sonoro — SLA formal aplica-se principalmente a **tickets** (e-mail e assíncronos).
+
+## Objetivo
+
+- Definir metas por setor + prioridade (e opcionalmente por natureza)
+- Calcular prazos em **horário comercial** (reutilizar lógica WhatsApp business hours)
+- Alertar atendente/supervisor ao aproximar ou violar SLA
+- Exibir status visual na UI
+
+## Métricas sugeridas (v1)
+
+| Meta | Início | Fim |
+|------|--------|-----|
+| **Primeira resposta** | Criação ticket | Primeira mensagem pública da equipa |
+| **Resolução** | Criação ticket | Status terminal (fechado/resolvido) |
+
+## Fases
+
+| Fase | Issues |
+|------|--------|
+| S-F1 | S-01, S-04 — Config |
+| S-F2 | S-02, S-05 — Cálculo e UI |
+| S-F3 | S-03 — Notificações |
+
+## Fora de escopo v1
+
+- SLA em chats WhatsApp (permanece alerta contínuo na fila)
+- Pausa automática SLA quando «aguardando cliente» (issue futura)
+
+## Labels
+
+`epic`, `sla`, `fase-interna`

--- a/.github/planning-issue-bodies/T-01-backend-config-setor-distribuicao.md
+++ b/.github/planning-issue-bodies/T-01-backend-config-setor-distribuicao.md
@@ -1,0 +1,32 @@
+# Distribuição tickets — config por setor (backend)
+
+## Contexto
+
+Épico: **Distribuição automática de tickets**.
+
+Parte de: **T-F1**
+
+## Proposta
+
+Campos em `setores` ou tabela `setor_distribuicao_config`:
+
+- `modo`: `manual` | `auto_apos_timeout` | `auto_imediato`
+- `timeout_minutos`: int (só auto_apos_timeout)
+- `estrategia`: `round_robin` | `menor_carga_abertos`
+- `atendentes_elegiveis`: null = todos do setor (+ homônimos #38)
+
+API admin: `PUT /v1/setores/{id}/distribuicao`
+
+## Critérios de aceite
+
+- [ ] Default `manual` preserva comportamento atual
+- [ ] Validação timeout >= 1 quando modo timeout
+- [ ] Audit log alteração config
+
+## Dependências
+
+- Bloqueia: T-02, T-03
+
+## Labels
+
+`backend`, `tickets`, `fase-interna`, `distribuicao`

--- a/.github/planning-issue-bodies/T-02-backend-worker-atribuicao-automatica.md
+++ b/.github/planning-issue-bodies/T-02-backend-worker-atribuicao-automatica.md
@@ -1,0 +1,35 @@
+# Distribuição tickets — worker de atribuição automática (backend)
+
+## Contexto
+
+Épico: **Distribuição automática de tickets**.
+
+Parte de: **T-F2**
+
+## Proposta
+
+Worker periódico (30–60s) + hook pós-criação ticket:
+
+1. Lista tickets `atendente_id IS NULL` em setores com auto
+2. Filtra elegíveis (status aberto, não encerrado)
+3. Para `auto_apos_timeout`: `created_at + timeout < now`
+4. Seleciona atendente via estratégia (round-robin persistido em `setor_distribuicao_state`)
+5. Atribui + histórico status opcional «Atribuído automaticamente»
+6. Notifica atendente (#109)
+
+**Concorrência:** lock ticket row FOR UPDATE.
+
+## Critérios de aceite
+
+- [ ] Dois workers não atribuem mesmo ticket
+- [ ] Atendente inativo excluído
+- [ ] Admin sempre elegível se vinculado? (definir: sugerido **não** auto-atribuir admin)
+- [ ] Testes estratégias round-robin e carga
+
+## Dependências
+
+- Requer: T-01
+
+## Labels
+
+`backend`, `tickets`, `fase-interna`, `distribuicao`

--- a/.github/planning-issue-bodies/T-03-frontend-config-distribuicao-setor.md
+++ b/.github/planning-issue-bodies/T-03-frontend-config-distribuicao-setor.md
@@ -1,0 +1,30 @@
+# Distribuição tickets — UI configuração no setor (frontend)
+
+## Contexto
+
+Épico: **Distribuição automática de tickets**.
+
+Parte de: **T-F1**
+
+## Proposta
+
+Em **Setor detalhe** ou **Configurações → Setores → Distribuição**:
+
+- Select modo (manual / após timeout / imediato)
+- Input minutos timeout (condicional)
+- Select estratégia
+- Texto explicativo: «Chats WhatsApp não são afetados»
+
+## Critérios de aceite
+
+- [ ] Consome T-01
+- [ ] Admin-only
+- [ ] Confirmação ao mudar para auto_imediato
+
+## Dependências
+
+- Requer: T-01
+
+## Labels
+
+`frontend`, `tickets`, `fase-interna`, `distribuicao`

--- a/.github/planning-issue-bodies/T-04-frontend-indicadores-fila-tickets.md
+++ b/.github/planning-issue-bodies/T-04-frontend-indicadores-fila-tickets.md
@@ -1,0 +1,29 @@
+# Distribuição tickets — indicadores tempo na fila (frontend)
+
+## Contexto
+
+Épico: **Distribuição automática de tickets**.
+
+Parte de: **T-F2**
+
+## Proposta
+
+Na listagem tickets (filtro sem responsável):
+
+- Coluna «Na fila há» (tempo relativo)
+- Badge «Auto em X min» se setor `auto_apos_timeout`
+- Destaque visual tickets próximos do timeout
+
+## Critérios de aceite
+
+- [ ] Cálculo client-side from `created_at` + config setor (endpoint ticket inclui `distribuicao_preview` opcional)
+- [ ] Ordenação por tempo na fila
+
+## Dependências
+
+- Requer: T-01
+- Ideal com: T-02
+
+## Labels
+
+`frontend`, `tickets`, `fase-interna`, `distribuicao`

--- a/.github/planning-issue-bodies/T-epic-distribuicao-tickets.md
+++ b/.github/planning-issue-bodies/T-epic-distribuicao-tickets.md
@@ -1,0 +1,38 @@
+# [Épico] Distribuição automática de tickets na fila
+
+## Contexto
+
+Modelo operacional **receptivo**:
+
+- **Chats:** alerta contínuo até atendente **assumir manualmente** — sem fila automática (decisão do time).
+- **Tickets:** podem ficar «sem responsável»; após **timeout configurável**, atribuir automaticamente ou permanecer em fila conforme configuração do **setor**.
+
+> **Nota:** Isto **não** é escala de plantão/turnos (sugestão original #9). É **atribuição automática opcional** de tickets órfãos na fila.
+
+## Objetivo
+
+Por setor, configurar:
+
+| Modo | Comportamento |
+|------|---------------|
+| `manual` | Só assume manualmente (default atual) |
+| `auto_apos_timeout` | Após X minutos sem responsável, atribui automaticamente |
+| `auto_imediato` | Atribui na criação (round-robin ou menor carga) |
+
+Estratégias: `round_robin`, `menor_carga_abertos`, `menor_carga_setor`.
+
+## Fases
+
+| Fase | Issues |
+|------|--------|
+| T-F1 | T-01, T-03 — Config |
+| T-F2 | T-02, T-04 — Worker + UI fila |
+
+## Fora de escopo
+
+- Distribuição automática de **chats** WhatsApp
+- Escalas de horário de atendentes (turnos)
+
+## Labels
+
+`epic`, `tickets`, `fase-interna`, `distribuicao`

--- a/.github/planning-issue-bodies/analises/filas-tickets-vs-chats.md
+++ b/.github/planning-issue-bodies/analises/filas-tickets-vs-chats.md
@@ -1,0 +1,37 @@
+# Análise: filas separadas (tickets vs chats) vs inbox unificada
+
+## Decisão do time (registrar)
+
+O DX Connect **mantém filas separadas**:
+
+- **Chats WhatsApp** — prioridade operacional; alerta contínuo até um atendente assumir; atendimento síncrono.
+- **Tickets** — demanda assíncrona; o atendente resolve quando não está em chat.
+
+**Não implementar** inbox omnichannel unificada no curto/médio prazo.
+
+## Por que a sugestão de unificação apareceu
+
+Em helpdesks genéricos (Zendesk, Intercom), uma única fila reduz troca de contexto. No DX Connect, o WhatsApp já tem UX e SLA operacional distintos (som, fila `aguardando_atendente`, assume/encerra). Unificar poderia:
+
+- Diluir a prioridade do chat
+- Misturar métricas incompatíveis (TMA de chat vs MTTR de ticket)
+- Complicar RBAC (setor de ticket vs fila global de chat)
+
+## Alternativa recomendada (sem unificar)
+
+Melhorar a **coordenação entre filas**, não fundi-las:
+
+| Melhoria | Issue relacionada |
+|----------|-------------------|
+| Tempo real no chat e notificações | RT-* |
+| Badge global no header (já existe parcialmente) | RT-06 |
+| Atalho «Abrir ticket a partir do chat» (já existe #98) | — |
+| Dashboard separado por canal | D-* |
+| Distribuição automática **só tickets** | T-* |
+
+## Quando reavaliar unificação
+
+- Se atendentes reportarem perda sistemática de chats por excesso de navegação entre telas
+- Se surgir canal adicional (ex.: chat web no portal) com mesma semântica de chat WhatsApp
+
+Até lá: **duas filas, uma prioridade clara (chat > ticket quando em plantão)**.

--- a/.github/planning-issue-bodies/analises/integracao-retaguarda.md
+++ b/.github/planning-issue-bodies/analises/integracao-retaguarda.md
@@ -1,0 +1,91 @@
+# Análise de viabilidade: integração com retaguarda / ERP
+
+## O que foi sugerido originalmente
+
+Hoje o DX Connect guarda **metadados** sobre sistemas de retaguarda (ex.: campo `login_retaguarda` na rede, credenciais de acesso remoto no cadastro de PDV), mas **não há troca automática de dados** com o software de retaguarda do posto (PDV, NF, estoque, etc.).
+
+A sugestão era criar uma **ponte bidirecional**:
+
+1. **Retaguarda → DX Connect:** quando o sistema detecta falha (ex.: PDV offline, erro de sincronização NF), abrir ou atualizar um ticket automaticamente.
+2. **DX Connect → Retaguarda:** consultar status do PDV/loja ao atender um chamado, evitando pedir informação que já existe no ERP.
+3. **Sincronização de cadastro:** lista de PDVs/empresas alinhada entre os dois sistemas.
+
+## Por que isso surgiu no contexto de postos
+
+Redes de postos costumam ter:
+
+- **Retaguarda proprietária** (ex.: produtos Duplexsoft) ou ERP de terceiros
+- Chamados recorrentes do tipo «PDV travou», «NF não entrou», «preço não atualizou»
+- Atendentes que alternam entre Connect e retaguarda para diagnosticar
+
+Integrar reduziria retrabalho e permitiria **abertura proativa** de tickets antes do cliente ligar.
+
+## O que já existe no código (base parcial)
+
+| Recurso | Onde | Uso atual |
+|---------|------|-----------|
+| `login_retaguarda` | Model Rede | Metadado informativo |
+| PDVs por empresa | `empresa_pdvs` | Código PDV, tipo acesso remoto, credenciais |
+| Classificação motivo | `ticket_catalogos` | Motivos como «Falha no PDV», «Entrada de NF» |
+| Tickets filhos em massa | #117 | Comunicados para toda a rede |
+
+Nada disso **chama API externa** hoje.
+
+## Níveis de integração (do mais simples ao mais complexo)
+
+### Nível 1 — Link contextual (baixo esforço, alto valor imediato)
+
+- No detalhe do ticket/chat, botão «Abrir retaguarda» com URL/login da rede
+- Exibir código PDV e credenciais (já auditadas em `reveal_credential`)
+- **Viabilidade:** alta; só frontend + dados já cadastrados
+- **Recomendação:** pode virar issue pequena se desejado (não incluída neste lote)
+
+### Nível 2 — Webhook unidirecional retaguarda → Connect (médio esforço)
+
+- Endpoint autenticado: `POST /v1/integrations/retaguarda/evento`
+- Payload: `{ rede_id, empresa_id, pdv_codigo, tipo_evento, descricao }`
+- Connect abre ticket com classificação sugerida
+- **Viabilidade:** média; depende de **contrato de API** com equipe retaguarda
+- **Risco:** cada cliente pode ter retaguarda diferente → começar só com **produto próprio Duplexsoft**
+
+### Nível 3 — Consulta status PDV (médio-alto esforço)
+
+- Connect consulta API retaguarda: «PDV 03 online? última sync?»
+- Exibe painel lateral no ticket
+- **Viabilidade:** média; exige API estável e latência aceitável
+- **Risco:** credenciais e permissões por rede
+
+### Nivel 4 — Sincronização contínua de cadastro (alto esforço)
+
+- Master data: empresas/PDVs sempre alinhados
+- **Viabilidade:** baixa no curto prazo; conflito com cadastro manual atual
+- **Recomendação:** adiar até produto interno maduro
+
+## Recomendação alinhada ao roadmap atual
+
+| Momento | Ação |
+|---------|------|
+| **Agora (uso interno)** | Não abrir épico de integração ERP; foco em tickets, chat, SLA, dashboards |
+| **Curto prazo opcional** | Nível 1 (deep links + exibição contextual) se operação pedir |
+| **Médio prazo** | Nível 2 **apenas** se equipe mobile/retaguarda definir contrato API com Duplexsoft |
+| **App mobile** | Pode ser o **primeiro consumidor** de API Connect (não retaguarda direta) |
+
+## Dependências para viabilizar Nível 2+
+
+1. Documentação OpenAPI da retaguarda (eventos, autenticação)
+2. Ambiente de homologação compartilhado
+3. Mapeamento evento retaguarda → natureza/motivo ticket
+4. Política de idempotência (mesmo evento não abre 10 tickets)
+5. Acordo comercial sobre quais clientes usam integração
+
+## Conclusão
+
+A integração retaguarda **faz sentido estrategicamente** para redes de postos, mas **não é prioridade** enquanto o produto interno não estiver consolidado — alinhado à decisão do time sobre API pública (#12).
+
+**Registrar como ideia futura** (issue tipo *research/spike*) somente quando:
+
+- Produto interno estável
+- Equipe retaguarda disponível para definir contrato
+- Pelo menos um cliente piloto confirmado
+
+Até lá, os metadados de PDV e classificação por motivo já cobrem boa parte do fluxo **manual** de suporte.

--- a/docs/EMAIL_SETTINGS.md
+++ b/docs/EMAIL_SETTINGS.md
@@ -177,4 +177,4 @@ Ao carregar a configuração, o frontend tenta classificar o provedor se os host
 
 Meta-issue relacionada: [#16 — melhorias operacionais](https://github.com/lgustavoss/dx-connect/issues/16). Ingestão **IMAP legado / BYO** em [#20](https://github.com/lgustavoss/dx-connect/issues/20).
 
-Rascunhos de texto usados na criação destas issues: pasta [`.github/planning-issue-bodies/`](https://github.com/lgustavoss/dx-connect/tree/main/.github/planning-issue-bodies).
+Rascunhos de issues de planejamento (portal, dashboards, SLA, roteamento, tempo real, KB, distribuição, auditoria): [`.github/planning-issue-bodies/`](../.github/planning-issue-bodies/README.md).

--- a/docs/MOBILE_APP_BRIEF.md
+++ b/docs/MOBILE_APP_BRIEF.md
@@ -1,0 +1,415 @@
+# DX Connect — Brief para app mobile (Android / iOS)
+
+Documento para equipes/ferramentas que **não têm acesso ao GitHub**. Descreve stack, APIs, telas e MVP sugerido.
+
+---
+
+## 1. Correção importante sobre o backend
+
+| Item | Valor |
+|------|--------|
+| **Framework** | **FastAPI** (Python) — **não é Django / DRF** |
+| **Validação** | Pydantic (schemas JSON) |
+| **Banco** | PostgreSQL |
+| **Auth** | JWT Bearer (`access_token` + `refresh_token`) |
+| **Prefixo API** | `/v1` |
+| **Docs interativas** | `{API_URL}/docs` (Swagger) |
+
+**Frontend web existente:** React 18 + Vite + TypeScript + Tailwind (referência de telas e chamadas em `frontend/src/`).
+
+**Público do app mobile (v1):** **atendentes internos** (suporte/financeiro) — mesmo perfil do painel web. Portal para funcionários de postos é **futuro** (issues #263+).
+
+---
+
+## 2. URL base e autenticação
+
+### Base URL
+
+- **Desenvolvimento:** `http://localhost:8000/v1`
+- **Produção:** configurar por build (ex.: `https://api.connect.duplexsoft.com.br/v1`)
+
+### Login
+
+```http
+POST /v1/auth/login
+Content-Type: application/json
+
+{"email": "admin@email.com", "senha": "admin123"}
+```
+
+**Resposta 200:**
+
+```json
+{
+  "access_token": "eyJ...",
+  "refresh_token": "eyJ...",
+  "token_type": "bearer",
+  "must_change_password": false
+}
+```
+
+### Refresh
+
+```http
+POST /v1/auth/login
+POST /v1/auth/refresh
+{"refresh_token": "..."}
+```
+
+### Requisições autenticadas
+
+```http
+Authorization: Bearer {access_token}
+Content-Type: application/json
+```
+
+### Usuário logado
+
+```http
+GET /v1/atendentes/me
+```
+
+**Resposta 200:**
+
+```json
+{
+  "id": 1,
+  "email": "admin@email.com",
+  "nome": "Administrador",
+  "role": "admin",
+  "ativo": true,
+  "setor_ids": [1, 2],
+  "must_change_password": false,
+  "created_at": "2026-01-01T12:00:00",
+  "updated_at": null
+}
+```
+
+**Perfis:** `admin` | `atendente`. Atendentes veem dados filtrados por **setor** (#38).
+
+### Erros
+
+```json
+{"detail": "E-mail ou senha inválidos"}
+```
+
+HTTP comuns: `401` (renovar token ou login), `403` (sem permissão), `422` (validação).
+
+---
+
+## 3. Paginação padrão
+
+Listagens retornam:
+
+```json
+{
+  "items": [ ... ],
+  "total": 42
+}
+```
+
+Query params: `offset`, `limit` (default ~20).
+
+---
+
+## 4. Domínio do produto
+
+Sistema de **helpdesk** para **redes de postos/empresas**:
+
+- **Rede** → várias **Empresas** (postos)
+- **Tickets** — demanda assíncrona (e-mail, manual)
+- **WhatsApp** — atendimento **síncrono prioritário** (Evolution API)
+- **Atendentes** — usuários internos com JWT
+
+**Regra operacional:** chat WhatsApp tem **prioridade** sobre tickets; filas **separadas** (não unificar inbox).
+
+---
+
+## 5. MVP mobile recomendado (fases)
+
+### Fase 1 — Core
+
+| Tela | Rotas API |
+|------|-----------|
+| Login | `POST /auth/login` |
+| Trocar senha (se `must_change_password`) | `POST /atendentes/me/trocar-senha` |
+| Dashboard resumo | `GET /dashboard` |
+| Notificações (badge + lista) | `GET /notificacoes/resumo`, `GET /notificacoes/itens` |
+
+### Fase 2 — WhatsApp (prioridade operacional)
+
+| Tela | Rotas API |
+|------|-----------|
+| Fila aguardando | `GET /whatsapp/chats/fila` |
+| Meus chats | `GET /whatsapp/chats/meus` |
+| Conversa | `GET /whatsapp/chats/{id}`, `GET .../mensagens` |
+| Assumir / Encerrar | `POST .../assumir`, `POST .../encerrar` |
+| Enviar texto | `POST .../mensagens` `{"texto":"..."}` |
+| Enviar mídia | `POST .../mensagens/midia` (multipart) |
+| Abrir ticket do chat | `POST .../abrir-ticket` |
+
+Estados do chat: `aguardando_atendente` | `em_atendimento` | `encerrado`
+
+### Fase 3 — Tickets
+
+| Tela | Rotas API |
+|------|-----------|
+| Lista (filtros) | `GET /tickets?situacao=abertos&meus=true` |
+| Fila sem responsável | `GET /tickets?sem_responsavel=true` |
+| Detalhe | `GET /tickets/{id}` |
+| Mensagens | `GET /tickets/{id}/mensagens` |
+| Nova mensagem | `POST /tickets/{id}/mensagens` |
+| Assumir (PATCH) | `PATCH /tickets/{id}` `{"atendente_id": ME}` |
+| Catálogos | `GET /status-ticket`, `GET /setores`, `GET /ticket-naturezas`, `GET /ticket-motivos` |
+
+### Fora do MVP mobile v1
+
+- Cadastros admin (redes, empresas, atendentes, config WhatsApp)
+- Relatórios/dashboards avançados (#260)
+- Portal do cliente (#263)
+
+---
+
+## 6. Exemplos JSON — endpoints principais
+
+### Dashboard — `GET /v1/dashboard`
+
+```json
+{
+  "resumo": {
+    "total_tickets": 150,
+    "abertos_hoje": 5,
+    "por_status": [
+      {"status_id": 1, "status_nome": "Aberto", "total": 12},
+      {"status_id": 2, "status_nome": "Em atendimento", "total": 8}
+    ]
+  },
+  "ultimos_tickets": [
+    {
+      "id": 99,
+      "protocolo": "#T202606-0042",
+      "empresa_id": 3,
+      "empresa_nome": "Posto Exemplo",
+      "setor_id": 1,
+      "setor_nome": "Suporte",
+      "status_id": 1,
+      "status_nome": "Aberto",
+      "atendente_id": null,
+      "assunto": "Falha no PDV",
+      "prioridade": "alta",
+      "fechado_em": null,
+      "created_at": "2026-06-14T10:00:00"
+    }
+  ]
+}
+```
+
+### Notificações — `GET /v1/notificacoes/resumo`
+
+```json
+{
+  "sem_responsavel_count": 3,
+  "nao_lidas_count": 2,
+  "wpp_fila_count": 1,
+  "wpp_respostas_count": 4,
+  "total_pendencias": 7
+}
+```
+
+### Tickets lista — `GET /v1/tickets?situacao=abertos&limit=10`
+
+```json
+{
+  "items": [
+    {
+      "id": 99,
+      "protocolo": "#T202606-0042",
+      "assunto": "Falha no PDV",
+      "empresa_nome": "Posto Exemplo",
+      "setor_nome": "Suporte",
+      "status_nome": "Aberto",
+      "atendente_nome": null,
+      "prioridade": "alta",
+      "motivo_nome": "PDV travado",
+      "natureza_nome": "Suporte técnico",
+      "fechado_em": null,
+      "created_at": "2026-06-14T10:00:00"
+    }
+  ],
+  "total": 1
+}
+```
+
+**Filtros úteis:** `meus`, `sem_responsavel`, `com_responsavel`, `busca`, `protocolo`, `setor_id`, `situacao=abertos|fechados|todos`
+
+**Prioridades:** `baixa` | `normal` | `alta` | `urgente`
+
+### Ticket mensagem — `POST /v1/tickets/{id}/mensagens`
+
+```json
+{
+  "corpo": "Olá, estamos verificando.",
+  "tipo": "publico",
+  "notificar_cliente_por_email": false
+}
+```
+
+Tipos: `publico` (cliente vê) | `interno` (só equipe).
+
+### WhatsApp fila — `GET /v1/whatsapp/chats/fila`
+
+```json
+[
+  {
+    "id": 12,
+    "protocolo": "#C202606-0003",
+    "wa_id": "5511999999999",
+    "cliente_nome": "João",
+    "estado": "aguardando_atendente",
+    "setor_nome": "Suporte",
+    "atendente_id": null,
+    "empresa_nome": "Posto Centro",
+    "created_at": "2026-06-14T09:55:00"
+  }
+]
+```
+
+### WhatsApp mensagens — `GET /v1/whatsapp/chats/{id}/mensagens`
+
+```json
+[
+  {
+    "id": 501,
+    "chat_id": 12,
+    "direcao": "inbound",
+    "corpo": "Bom dia, PDV não abre",
+    "tipo_midia": null,
+    "midia_disponivel": false,
+    "atendente_nome": null,
+    "created_at": "2026-06-14T09:56:00"
+  },
+  {
+    "id": 502,
+    "chat_id": 12,
+    "direcao": "outbound",
+    "corpo": "Olá, sou Maria. Vou ajudar.",
+    "atendente_nome": "Maria",
+    "created_at": "2026-06-14T10:01:00"
+  }
+]
+```
+
+`direcao`: `inbound` | `outbound`. Mídia: `GET /v1/whatsapp/chats/{id}/mensagens/{msg_id}/midia`
+
+### Assumir chat — `POST /v1/whatsapp/chats/{id}/assumir`
+
+Retorna objeto `WhatsappChatRead` atualizado (`estado`: `em_atendimento`).
+
+---
+
+## 7. Mapa de rotas API (referência)
+
+| Módulo | Prefixo | Autenticação |
+|--------|---------|--------------|
+| Auth | `/v1/auth/*` | Público |
+| Atendentes | `/v1/atendentes/*` | JWT |
+| Dashboard | `/v1/dashboard` | JWT |
+| Notificações | `/v1/notificacoes/*` | JWT |
+| Tickets | `/v1/tickets/*` | JWT |
+| WhatsApp chats | `/v1/whatsapp/chats/*` | JWT |
+| Setores | `/v1/setores` | JWT (lista filtrada) |
+| Status ticket | `/v1/status-ticket` | JWT |
+| Catálogos ticket | `/v1/ticket-naturezas`, `/v1/ticket-motivos` | JWT |
+| Respostas prontas | `/v1/respostas-prontas/disponiveis` | JWT |
+| Redes/Empresas/Admin | `/v1/redes`, `/v1/empresas`, … | JWT **admin** |
+
+OpenAPI completo: `{API_URL}/docs`
+
+---
+
+## 8. Navegação sugerida (mobile)
+
+```
+[Login]
+   ↓
+[Home / Dashboard] ← badge notificações
+   ├── [WhatsApp]
+   │     ├── Fila (aguardando) ← prioridade, alerta
+   │     ├── Meus chats
+   │     └── Conversa → Assumir | Enviar | Encerrar | Abrir ticket
+   └── [Tickets]
+         ├── Abertos / Meus / Fila
+         └── Detalhe → Mensagens | Status | Assumir
+```
+
+**Bottom navigation sugerida:** Início | WhatsApp | Tickets | Perfil
+
+---
+
+## 9. Abordagem técnica mobile (resposta à AI Studio)
+
+O projeto web já é **React + TypeScript**. Opções:
+
+| Abordagem | Prós |
+|-----------|------|
+| **PWA / SPA mobile-first + Capacitor** | Reutiliza mental model React; empacota `.apk`/`.ipa`; API idêntica |
+| **React Native (Expo)** | UX nativa; lógica de serviços/state portável do web |
+| **Flutter / nativo** | Consome mesma REST API documentada acima |
+
+**Recomendação do time:** React Native ou Capacitor consumindo **REST JSON** (Fetch/Axios), **não** GraphQL.
+
+### Cliente HTTP (pseudocódigo)
+
+```typescript
+const API = 'https://api.exemplo.com/v1';
+
+async function api(path: string, options: RequestInit = {}) {
+  const token = await SecureStore.getItem('access_token');
+  const res = await fetch(`${API}${path}`, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...options.headers,
+    },
+  });
+  if (res.status === 401) { /* refresh ou logout */ }
+  if (!res.ok) throw await res.json();
+  return res.json();
+}
+```
+
+### Polling vs tempo real
+
+Hoje o web usa **polling** para chat/notificações. Roadmap: **SSE** (#256) — mobile pode começar com polling (15–30s) e evoluir.
+
+---
+
+## 10. Credenciais de desenvolvimento
+
+Somente ambiente local (nunca produção):
+
+- E-mail: `admin@email.com`
+- Senha: `admin123`
+
+---
+
+## 11. Repositório (para humanos)
+
+- GitHub: `lgustavoss/dx-connect` (privado)
+- Cliente HTTP tipado: `frontend/src/api/client.ts`
+- Rotas web: `frontend/src/App.tsx`
+- RBAC: `docs/BACKEND_RBAC.md`
+
+---
+
+## 12. Resposta pronta para colar na AI Studio
+
+> **Projeto:** DX Connect — helpdesk para redes de postos.  
+> **Backend:** FastAPI + JWT em `/v1` (não Django).  
+> **Mobile v1:** app para **atendentes** (login, dashboard, notificações, **WhatsApp prioritário**, tickets).  
+> **Começar por:** Login → Dashboard → Fila WhatsApp → Conversa (assumir/enviar/encerrar).  
+> **Auth:** `POST /v1/auth/login` → Bearer token → `GET /v1/atendentes/me`.  
+> **APIs principais:** `/dashboard`, `/notificacoes/resumo`, `/whatsapp/chats/fila`, `/whatsapp/chats/{id}/mensagens`, `/tickets`.  
+> **Stack sugerida:** React Native ou Capacitor + TypeScript, Fetch/Axios, design mobile-first com bottom nav.  
+> **Ver exemplos JSON completos** neste documento (secção 6).

--- a/scripts/create_planning_issues.py
+++ b/scripts/create_planning_issues.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Cria épicos e issues filhas a partir de .github/planning-issue-bodies/."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = "lgustavoss/dx-connect"
+META_ISSUE = 16
+PLANNING_DIR = Path(__file__).resolve().parents[1] / ".github/planning-issue-bodies"
+
+EPICS = [
+    ("RT", "RT-epic-tempo-real.md"),
+    ("T", "T-epic-distribuicao-tickets.md"),
+    ("R", "R-epic-roteamento.md"),
+    ("S", "S-epic-sla.md"),
+    ("D", "D-epic-dashboards-relatorios.md"),
+    ("A", "A-epic-auditoria.md"),
+    ("KB", "KB-epic-base-conhecimento.md"),
+    ("P", "P-epic-portal-cliente.md"),
+]
+
+CHILDREN: dict[str, list[str]] = {
+    "RT": [
+        "RT-01-backend-infra-sse.md",
+        "RT-02-backend-eventos-tickets-chats.md",
+        "RT-03-backend-eventos-notificacoes.md",
+        "RT-04-frontend-cliente-sse.md",
+        "RT-05-frontend-integracao-chat-sse.md",
+        "RT-06-frontend-integracao-tickets-notificacoes-sse.md",
+    ],
+    "T": [
+        "T-01-backend-config-setor-distribuicao.md",
+        "T-02-backend-worker-atribuicao-automatica.md",
+        "T-03-frontend-config-distribuicao-setor.md",
+        "T-04-frontend-indicadores-fila-tickets.md",
+    ],
+    "R": [
+        "R-01-backend-modelo-regras-roteamento.md",
+        "R-02-backend-motor-aplicacao-roteamento.md",
+        "R-03-frontend-crud-regras-roteamento.md",
+    ],
+    "S": [
+        "S-01-backend-modelo-config-sla.md",
+        "S-02-backend-calculo-violacoes-sla.md",
+        "S-03-backend-notificacoes-sla.md",
+        "S-04-frontend-config-sla-admin.md",
+        "S-05-frontend-indicadores-sla-tickets.md",
+    ],
+    "D": [
+        "D-01-backend-metricas-dashboard-geral.md",
+        "D-02-backend-metricas-dashboard-tickets.md",
+        "D-03-backend-metricas-dashboard-chats.md",
+        "D-04-backend-relatorios-export.md",
+        "D-05-frontend-dashboard-geral.md",
+        "D-06-frontend-dashboard-tickets.md",
+        "D-07-frontend-dashboard-chats.md",
+        "D-08-frontend-relatorios-ui.md",
+    ],
+    "A": [
+        "A-01-backend-audit-trail-expandido.md",
+        "A-02-backend-consulta-export-auditoria.md",
+        "A-03-frontend-auditoria-ui.md",
+    ],
+    "KB": [
+        "KB-01-backend-modelo-artigos-categorias.md",
+        "KB-02-backend-api-admin-artigos.md",
+        "KB-03-backend-api-publica-artigos.md",
+        "KB-04-backend-vinculo-motivo-artigos.md",
+        "KB-05-frontend-editor-artigos-admin.md",
+        "KB-06-frontend-gestao-categorias-admin.md",
+        "KB-07-frontend-leitura-artigos-interno.md",
+    ],
+    "P": [
+        "P-01-backend-auth-portal-funcionario.md",
+        "P-02-backend-api-tickets-portal.md",
+        "P-03-backend-mensagens-anexos-portal.md",
+        "P-04-backend-notificacoes-portal.md",
+        "P-05-frontend-shell-portal.md",
+        "P-06-frontend-listagem-tickets-portal.md",
+        "P-07-frontend-abertura-ticket-portal.md",
+        "P-08-frontend-detalhe-ticket-portal.md",
+        "P-09-frontend-kb-portal-cliente.md",
+    ],
+}
+
+
+def read_md(filename: str) -> tuple[str, str]:
+    path = PLANNING_DIR / filename
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    if not lines or not lines[0].startswith("# "):
+        raise ValueError(f"Título inválido em {filename}")
+    title = lines[0][2:].strip()
+    body = "\n".join(lines[1:]).strip()
+    return title, body
+
+
+def labels_for(filename: str, is_epic: bool) -> list[str]:
+    if is_epic:
+        return ["epic", "documentation", "enhancement"]
+    labels = ["enhancement"]
+    if "backend" in filename:
+        labels.extend(["backend", "python"])
+    elif "frontend" in filename:
+        labels.extend(["frontend", "ux"])
+    if filename.startswith("P-"):
+        labels.append("documentation")
+    return labels
+
+
+def gh_issue_create(title: str, body: str, labels: list[str]) -> int:
+    cmd = [
+        "gh",
+        "issue",
+        "create",
+        "--repo",
+        REPO,
+        "--title",
+        title,
+        "--body",
+        body,
+    ]
+    for label in labels:
+        cmd.extend(["--label", label])
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    url = result.stdout.strip()
+    m = re.search(r"/issues/(\d+)", url)
+    if not m:
+        raise RuntimeError(f"URL inesperada: {url}")
+    return int(m.group(1))
+
+
+def append_footer(body: str, filename: str, epic_num: int | None) -> str:
+    lines = [
+        "",
+        "---",
+        f"**Rascunho:** `.github/planning-issue-bodies/{filename}`",
+        f"**Meta-issue:** #{META_ISSUE}",
+    ]
+    if epic_num is not None:
+        lines.append(f"**Épico pai:** #{epic_num}")
+    return body + "\n".join(lines)
+
+
+def main() -> int:
+    epic_numbers: dict[str, int] = {}
+    child_map: dict[str, list[int]] = {k: [] for k in CHILDREN}
+
+    print("=== Criando épicos ===")
+    for prefix, epic_file in EPICS:
+        title, body = read_md(epic_file)
+        body = append_footer(
+            body
+            + f"\n\n---\n\n**Relacionado:** meta-issue #{META_ISSUE} (melhorias operacionais).\n",
+            epic_file,
+            None,
+        )
+        num = gh_issue_create(title, body, labels_for(epic_file, True))
+        epic_numbers[prefix] = num
+        print(f"  #{num} {title}")
+        time.sleep(0.5)
+
+    print("\n=== Criando issues filhas ===")
+    total_children = 0
+    for prefix, files in CHILDREN.items():
+        epic_num = epic_numbers[prefix]
+        for child_file in files:
+            title, body = read_md(child_file)
+            body = append_footer(body, child_file, epic_num)
+            num = gh_issue_create(title, body, labels_for(child_file, False))
+            child_map[prefix].append(num)
+            total_children += 1
+            print(f"  #{num} [{prefix}] {title}")
+            time.sleep(0.4)
+
+    print("\n=== Atualizando épicos com checklist ===")
+    for prefix, epic_file in EPICS:
+        epic_num = epic_numbers[prefix]
+        title, body = read_md(epic_file)
+        checklist = "\n".join(f"- [ ] #{n}" for n in child_map[prefix])
+        new_body = (
+            append_footer(body, epic_file, None)
+            + f"\n\n## Issues filhas (GitHub)\n\n{checklist}\n"
+        )
+        subprocess.run(
+            [
+                "gh",
+                "issue",
+                "edit",
+                str(epic_num),
+                "--repo",
+                REPO,
+                "--body",
+                new_body,
+            ],
+            check=True,
+        )
+        print(f"  #{epic_num} checklist ({len(child_map[prefix])} filhas)")
+        time.sleep(0.3)
+
+    print(f"\nConcluído: {len(EPICS)} épicos, {total_children} filhas.")
+    print("Épicos:", ", ".join(f"{p}=#{n}" for p, n in epic_numbers.items()))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumo

Adiciona a pasta `.github/planning-issue-bodies/` com **56 arquivos** de planejamento: épicos, issues filhas (backend/frontend separados) e análises de viabilidade.

## Épicos documentados

| Épico | Issues | Fase |
|-------|--------|------|
| **Portal do cliente** | P-01…P-09 | Futura (pós consolidação interna) |
| **Dashboards e relatórios** | D-01…D-08 | Interna |
| **SLA** | S-01…S-05 | Interna |
| **Roteamento automático** | R-01…R-03 | Interna |
| **Tempo real (SSE)** | RT-01…RT-06 | Interna |
| **Base de conhecimento** | KB-01…KB-07 | Interna (+ portal) |
| **Distribuição automática de tickets** | T-01…T-04 | Interna |
| **Auditoria estruturada** | A-01…A-03 | Interna |

## Análises incluídas

- `analises/filas-tickets-vs-chats.md` — registra decisão de **não** unificar inbox; chats prioritários
- `analises/integracao-retaguarda.md` — viabilidade integração ERP (adiada)

## Como usar

1. Abrir issues no GitHub copiando o conteúdo de cada `.md`
2. Vincular ao épico pai e à meta-issue #16 quando aplicável
3. Seguir ordem sugerida no `README.md` (tempo real → distribuição → roteamento → SLA → dashboards…)

## Fora de escopo (decisão do time)

- Inbox omnichannel unificada
- Templates WhatsApp proativos
- API pública / webhooks externos (por enquanto)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95f36cf5-88d0-4e92-8246-09956e485c68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95f36cf5-88d0-4e92-8246-09956e485c68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

