### PR TITLE
feat(tempo-real): infraestrutura SSE RT-F1 (#264, #267)

### DIFF
--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -1,0 +1,50 @@
+"""
+SSE — tempo real (#264).
+
+GET /v1/events/stream — `text/event-stream`, autenticado por JWT (Bearer ou query `token`).
+
+**Gunicorn / produção:** cada worker mantém filas in-process (v1). Com `--workers N`,
+conexões SSE e pub/sub ficam isoladas por processo — ver `docs/REALTIME_SSE.md`.
+"""
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import StreamingResponse
+
+from app.core.auth import obter_atendente_sse
+from app.models.atendente import Atendente
+from app.services.realtime_hub import channel_atendente, stream_channel_events
+
+router = APIRouter(prefix="/events", tags=["events"])
+
+
+@router.get("/stream")
+async def events_stream(
+    request: Request,
+    atendente: Atendente = Depends(obter_atendente_sse),
+):
+    channel = channel_atendente(atendente.id)
+    initial = {
+        "type": "connected",
+        "payload": {
+            "atendente_id": atendente.id,
+            "canal": channel,
+        },
+    }
+
+    async def generate():
+        async for chunk in stream_channel_events(
+            channel,
+            initial_payload=initial,
+            disconnect_check=request.is_disconnected,
+        ):
+            yield chunk
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, HTTPException, Request, status
+from fastapi import Depends, HTTPException, Query, Request, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 
@@ -14,18 +14,13 @@ from app.core.tenant_context import (
 
 security = HTTPBearer(auto_error=False)
 
-def obter_atendente_atual(
+
+def _carregar_atendente_por_token(
     request: Request,
-    credentials: HTTPAuthorizationCredentials | None = Depends(security),
-    db: Session = Depends(get_db),
+    token: str,
+    db: Session,
 ) -> Atendente:
-    if not credentials:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token não informado",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    payload = decodificar_token(credentials.credentials)
+    payload = decodificar_token(token)
     if not payload or "sub" not in payload:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -66,6 +61,36 @@ def obter_atendente_atual(
                 detail="Altere sua senha antes de usar o sistema.",
             )
     return atendente
+
+
+def obter_atendente_atual(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+    db: Session = Depends(get_db),
+) -> Atendente:
+    if not credentials:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token não informado",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return _carregar_atendente_por_token(request, credentials.credentials, db)
+
+
+def obter_atendente_sse(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+    token: str | None = Query(None, description="JWT access token (alternativa ao header Bearer)"),
+    db: Session = Depends(get_db),
+) -> Atendente:
+    raw = credentials.credentials if credentials else token
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token não informado",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return _carregar_atendente_por_token(request, raw, db)
 
 
 def exigir_admin(atendente: Atendente = Depends(obter_atendente_atual)) -> Atendente:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.api import (
     tipo_negocio,
     cadastro_aux,
     notificacoes,
+    events,
     whatsapp_settings,
     whatsapp_chats,
     whatsapp_webhook,
@@ -322,6 +323,7 @@ app.include_router(audit.router, prefix=API_V1_PREFIX)
 app.include_router(tipo_negocio.router, prefix=API_V1_PREFIX)
 app.include_router(cadastro_aux.router, prefix=API_V1_PREFIX)
 app.include_router(notificacoes.router, prefix=API_V1_PREFIX)
+app.include_router(events.router, prefix=API_V1_PREFIX)
 app.include_router(whatsapp_settings.router, prefix=API_V1_PREFIX)
 app.include_router(whatsapp_chats.router, prefix=API_V1_PREFIX)
 app.include_router(whatsapp_webhook.router, prefix=API_V1_PREFIX)

--- a/backend/app/schemas/realtime.py
+++ b/backend/app/schemas/realtime.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class RealtimeEventEnvelope(BaseModel):
+    type: str
+    payload: dict[str, Any] = Field(default_factory=dict)

--- a/backend/app/services/realtime_hub.py
+++ b/backend/app/services/realtime_hub.py
@@ -1,0 +1,105 @@
+"""Pub/sub in-process para SSE (v1). Redis opcional em v2 para multi-worker Gunicorn."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections import defaultdict
+from typing import Any, AsyncIterator
+
+logger = logging.getLogger(__name__)
+
+HEARTBEAT_INTERVAL_SEC = 30
+_DISCONNECT_POLL_SEC = 1.0
+
+
+def channel_atendente(atendente_id: int) -> str:
+    return f"atendente:{atendente_id}"
+
+
+class RealtimeHub:
+    """Hub in-memory: um canal por atendente, filas asyncio por conexão SSE."""
+
+    def __init__(self) -> None:
+        self._queues: dict[str, set[asyncio.Queue]] = defaultdict(set)
+        self._lock = asyncio.Lock()
+
+    async def subscribe(self, channel: str) -> asyncio.Queue:
+        queue: asyncio.Queue = asyncio.Queue(maxsize=256)
+        async with self._lock:
+            self._queues[channel].add(queue)
+        return queue
+
+    async def unsubscribe(self, channel: str, queue: asyncio.Queue) -> None:
+        async with self._lock:
+            subs = self._queues.get(channel)
+            if not subs:
+                return
+            subs.discard(queue)
+            if not subs:
+                del self._queues[channel]
+
+    async def publish(
+        self,
+        channel: str,
+        event_type: str,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        envelope = {"type": event_type, "payload": payload or {}}
+        async with self._lock:
+            subs = list(self._queues.get(channel, ()))
+        for queue in subs:
+            try:
+                queue.put_nowait(envelope)
+            except asyncio.QueueFull:
+                logger.warning(
+                    "Fila SSE cheia no canal %s; evento %s descartado",
+                    channel,
+                    event_type,
+                )
+
+
+hub = RealtimeHub()
+
+
+def format_sse(data: dict[str, Any]) -> str:
+    body = json.dumps(data, ensure_ascii=False)
+    return f"event: message\ndata: {body}\n\n"
+
+
+async def stream_channel_events(
+    channel: str,
+    *,
+    initial_payload: dict[str, Any] | None = None,
+    disconnect_check: Any | None = None,
+) -> AsyncIterator[str]:
+    """Gera linhas SSE para um canal, com heartbeat e desconexão limpa."""
+    queue = await hub.subscribe(channel)
+    try:
+        if initial_payload is not None:
+            yield format_sse(initial_payload)
+        elapsed = 0.0
+        while True:
+            if disconnect_check is not None and await disconnect_check():
+                break
+            try:
+                envelope = await asyncio.wait_for(queue.get(), timeout=_DISCONNECT_POLL_SEC)
+                yield format_sse(envelope)
+                elapsed = 0.0
+            except asyncio.TimeoutError:
+                elapsed += _DISCONNECT_POLL_SEC
+                if elapsed >= HEARTBEAT_INTERVAL_SEC:
+                    yield format_sse({"type": "ping", "payload": {}})
+                    elapsed = 0.0
+    finally:
+        await hub.unsubscribe(channel, queue)
+
+
+async def publish_to_atendente(
+    atendente_id: int,
+    event_type: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    """Publica evento no canal do atendente (RT-F2/F3)."""
+    await hub.publish(channel_atendente(atendente_id), event_type, payload)

--- a/backend/tests/test_events_stream.py
+++ b/backend/tests/test_events_stream.py
@@ -1,0 +1,64 @@
+"""Testes SSE — infraestrutura tempo real (#264)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from app.core.security import criar_access_token
+from app.services.realtime_hub import RealtimeHub, channel_atendente, format_sse
+
+
+async def _short_stream(channel, *, initial_payload=None, disconnect_check=None):
+    """Generator finito para TestClient (evita conexão longa em testes)."""
+    if initial_payload is not None:
+        yield format_sse(initial_payload)
+
+
+def test_events_stream_401_sem_token(client):
+    r = client.get("/v1/events/stream")
+    assert r.status_code == 401
+
+
+def test_events_stream_conectado_com_bearer(client, seed_base, auth_headers, monkeypatch):
+    monkeypatch.setattr("app.api.events.stream_channel_events", _short_stream)
+    r = client.get("/v1/events/stream", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/event-stream")
+    assert "connected" in r.text
+    payload = json.loads(r.text.split("data: ", 1)[1].strip())
+    assert payload["type"] == "connected"
+    assert payload["payload"]["atendente_id"] == seed_base["a1"].id
+    assert payload["payload"]["canal"] == channel_atendente(seed_base["a1"].id)
+
+
+def test_events_stream_conectado_com_query_token(client, seed_base, monkeypatch):
+    monkeypatch.setattr("app.api.events.stream_channel_events", _short_stream)
+    token = criar_access_token({"sub": seed_base["a1"].email, "tid": 1})
+    r = client.get(
+        f"/v1/events/stream?token={token}",
+        headers={"X-Dx-Tenant-Id": "1"},
+    )
+    assert r.status_code == 200
+    assert "connected" in r.text
+
+
+def test_hub_publish_subscribe():
+    async def _run() -> None:
+        hub = RealtimeHub()
+        channel = channel_atendente(99)
+        queue = await hub.subscribe(channel)
+        await hub.publish(channel, "ticket.mensagem", {"ticket_id": 1})
+        envelope = await asyncio.wait_for(queue.get(), timeout=1)
+        assert envelope["type"] == "ticket.mensagem"
+        assert envelope["payload"]["ticket_id"] == 1
+        await hub.unsubscribe(channel, queue)
+
+    asyncio.run(_run())
+
+
+def test_format_sse():
+    line = format_sse({"type": "ping", "payload": {}})
+    assert line.startswith("event: message\n")
+    assert "data: " in line
+    assert line.endswith("\n\n")

--- a/docs/REALTIME_SSE.md
+++ b/docs/REALTIME_SSE.md
@@ -1,0 +1,48 @@
+# Tempo real (SSE) — RT-F1
+
+Infraestrutura de eventos servidor→cliente para substituir polling no painel interno.
+
+## Endpoint
+
+- `GET /v1/events/stream` — `text/event-stream`
+- Autenticação: header `Authorization: Bearer <access_token>` (preferido) ou query `?token=<access_token>`
+- Heartbeat: evento `ping` a cada **30 s** sem outro evento
+- Envelope: `{ "type": "<tipo>", "payload": { ... } }`
+- Canal por atendente: `atendente:{id}`
+
+Evento inicial ao conectar:
+
+```json
+{ "type": "connected", "payload": { "atendente_id": 1, "canal": "atendente:1" } }
+```
+
+## Frontend
+
+- Cliente fetch-based (suporta Bearer; `EventSource` nativo não envia header)
+- Hook `useEventStream()` + `EventStreamProvider` no `Layout`
+- Reconexão com backoff exponencial; após **3 falhas** consecutivas, `useFallback === true` (consumidores RT-F2 mantêm polling)
+
+## Gunicorn e multi-worker
+
+O hub v1 é **in-process** (`asyncio.Queue` por conexão). Implicações:
+
+| Config | Comportamento |
+|--------|----------------|
+| `--workers 1` | Pub/sub e SSE no mesmo processo — adequado para v1 interno |
+| `--workers N>1` | Cada worker tem filas isoladas; um evento publicado no worker A **não** chega a SSE conectada no worker B |
+
+**Recomendação v1 (uso interno):** `--workers 1` ou sticky sessions no Nginx (`ip_hash` / `hash $cookie_...`) se precisar de N>1 por CPU.
+
+**v2 (futuro):** Redis Pub/Sub ou similar para fan-out entre workers.
+
+### Limites práticos
+
+- Cada atendente autenticado = **1 conexão HTTP longa** por aba do painel
+- Gunicorn `worker_connections` (gevent/eventlet) ou limite de file descriptors do SO aplicam-se
+- Nginx: desativar buffering (`X-Accel-Buffering: no` já enviado pela API); `proxy_read_timeout` ≥ 3600 s para SSE
+
+## Issues
+
+- Épico: [#256](https://github.com/lgustavoss/dx-connect/issues/256)
+- RT-F1 backend: [#264](https://github.com/lgustavoss/dx-connect/issues/264)
+- RT-F1 frontend: [#267](https://github.com/lgustavoss/dx-connect/issues/267)

--- a/frontend/src/api/eventStream.ts
+++ b/frontend/src/api/eventStream.ts
@@ -1,0 +1,191 @@
+import {
+  API_VERSION_PREFIX,
+  getAuthToken,
+  invalidateSessionAndRedirectToLogin,
+  resolvedApiBaseUrl,
+} from './client'
+import { isMultiTenantMode, resolveTenantIdFromHostname } from '../lib/tenant'
+
+export interface RealtimeEnvelope {
+  type: string
+  payload: Record<string, unknown>
+}
+
+export type RealtimeEventHandler = (payload: Record<string, unknown>, envelope: RealtimeEnvelope) => void
+
+const TOKEN_KEY = 'token'
+const REFRESH_TOKEN_KEY = 'refresh_token'
+
+function getRefreshToken(): string | null {
+  return sessionStorage.getItem(REFRESH_TOKEN_KEY) || localStorage.getItem(REFRESH_TOKEN_KEY)
+}
+
+function setAccessToken(accessToken: string): void {
+  if (localStorage.getItem(REFRESH_TOKEN_KEY)) {
+    localStorage.setItem(TOKEN_KEY, accessToken)
+    return
+  }
+  sessionStorage.setItem(TOKEN_KEY, accessToken)
+}
+
+async function refreshAccessTokenForStream(): Promise<string | null> {
+  const refresh_token = getRefreshToken()
+  if (!refresh_token) return null
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (isMultiTenantMode()) {
+    headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+  }
+  const res = await fetch(`${resolvedApiBaseUrl()}${API_VERSION_PREFIX}/auth/refresh`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ refresh_token }),
+  })
+  if (!res.ok) return null
+  const body = (await res.json()) as { access_token?: string }
+  if (!body.access_token) return null
+  setAccessToken(body.access_token)
+  return body.access_token
+}
+
+export function buildEventStreamUrl(): string {
+  return `${resolvedApiBaseUrl()}${API_VERSION_PREFIX}/events/stream`
+}
+
+function authHeaders(token: string): Record<string, string> {
+  const headers: Record<string, string> = { Authorization: `Bearer ${token}` }
+  if (isMultiTenantMode()) {
+    headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+  }
+  return headers
+}
+
+function parseSseBlocks(buffer: string): { events: RealtimeEnvelope[]; rest: string } {
+  const events: RealtimeEnvelope[] = []
+  let rest = buffer
+  while (true) {
+    const idx = rest.indexOf('\n\n')
+    if (idx === -1) break
+    const block = rest.slice(0, idx)
+    rest = rest.slice(idx + 2)
+    const dataLine = block.split('\n').find((line) => line.startsWith('data: '))
+    if (!dataLine) continue
+    try {
+      events.push(JSON.parse(dataLine.slice(6)) as RealtimeEnvelope)
+    } catch {
+      if (import.meta.env.DEV) {
+        console.warn('[SSE] JSON inválido:', dataLine)
+      }
+    }
+  }
+  return { events, rest }
+}
+
+async function openAuthenticatedStream(
+  signal: AbortSignal,
+  retried401: boolean,
+): Promise<Response> {
+  let token = getAuthToken()
+  if (!token) {
+    throw new Error('Token não informado')
+  }
+  const res = await fetch(buildEventStreamUrl(), {
+    headers: authHeaders(token),
+    signal,
+  })
+  if (res.status === 401 && !retried401) {
+    const refreshed = await refreshAccessTokenForStream()
+    if (refreshed) {
+      return openAuthenticatedStream(signal, true)
+    }
+    invalidateSessionAndRedirectToLogin()
+    throw new Error('Sessão expirada')
+  }
+  if (res.status === 401) {
+    invalidateSessionAndRedirectToLogin()
+    throw new Error('Sessão expirada')
+  }
+  if (!res.ok) {
+    throw new Error(`SSE HTTP ${res.status}`)
+  }
+  if (!res.body) {
+    throw new Error('SSE sem body')
+  }
+  return res
+}
+
+export type EventStreamRunOptions = {
+  signal: AbortSignal
+  onEvent: (event: RealtimeEnvelope) => void
+  onConnected?: () => void
+  onError?: (err: Error) => void
+}
+
+/** Lê o stream até abort ou erro de rede. */
+export async function runEventStreamLoop(options: EventStreamRunOptions): Promise<void> {
+  const { signal, onEvent, onConnected, onError } = options
+  let response: Response
+  try {
+    response = await openAuthenticatedStream(signal, false)
+  } catch (err) {
+    onError?.(err instanceof Error ? err : new Error(String(err)))
+    throw err
+  }
+
+  const reader = response.body!.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  try {
+    while (!signal.aborted) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      const parsed = parseSseBlocks(buffer)
+      buffer = parsed.rest
+      for (const event of parsed.events) {
+        if (event.type === 'connected') {
+          onConnected?.()
+        }
+        onEvent(event)
+      }
+    }
+  } catch (err) {
+    if (!signal.aborted) {
+      onError?.(err instanceof Error ? err : new Error(String(err)))
+      throw err
+    }
+  } finally {
+    try {
+      await reader.cancel()
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+export const EVENT_STREAM_MAX_FAILURES = 3
+export const EVENT_STREAM_BASE_RECONNECT_MS = 1000
+export const EVENT_STREAM_MAX_RECONNECT_MS = 30000
+
+export function nextReconnectDelayMs(failureCount: number): number {
+  const exp = EVENT_STREAM_BASE_RECONNECT_MS * 2 ** Math.max(0, failureCount - 1)
+  return Math.min(exp, EVENT_STREAM_MAX_RECONNECT_MS)
+}
+
+export function sleepMs(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'))
+      return
+    }
+    const timer = window.setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      window.clearTimeout(timer)
+      reject(new DOMException('Aborted', 'AbortError'))
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from './Sidebar'
 import { ThemeToggle } from './ThemeToggle'
 import { NavbarNotificacoes } from './NavbarNotificacoes'
 import { useAlertaFilaSemResponsavel } from '../hooks/useAlertaFilaSemResponsavel'
+import { EventStreamProvider } from '../contexts/EventStreamContext'
 
 function perfilExibicao(role: string | undefined): string {
   if (role === 'admin') return 'Administrador'
@@ -36,6 +37,7 @@ export function Layout() {
     /^\/tickets\/\d+\/?$/.test(location.pathname) || location.pathname === '/tickets/novo'
 
   return (
+    <EventStreamProvider enabled={notificacoesEnabled}>
     <div
       className="flex h-dvh max-h-dvh min-h-0 overflow-hidden bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95 md:grid md:grid-cols-[var(--sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
       style={
@@ -110,5 +112,6 @@ export function Layout() {
           </main>
       </div>
     </div>
+    </EventStreamProvider>
   )
 }

--- a/frontend/src/contexts/EventStreamContext.tsx
+++ b/frontend/src/contexts/EventStreamContext.tsx
@@ -1,0 +1,167 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import {
+  EVENT_STREAM_MAX_FAILURES,
+  nextReconnectDelayMs,
+  runEventStreamLoop,
+  sleepMs,
+  type RealtimeEnvelope,
+  type RealtimeEventHandler,
+} from '../api/eventStream'
+
+type ListenerMap = Map<string, Set<RealtimeEventHandler>>
+
+interface EventStreamContextValue {
+  connected: boolean
+  useFallback: boolean
+  subscribe: (type: string, handler: RealtimeEventHandler) => () => void
+}
+
+const EventStreamContext = createContext<EventStreamContextValue | null>(null)
+
+export function EventStreamProvider({
+  enabled,
+  children,
+}: {
+  enabled: boolean
+  children: ReactNode
+}) {
+  const listenersRef = useRef<ListenerMap>(new Map())
+  const [connected, setConnected] = useState(false)
+  const [useFallback, setUseFallback] = useState(false)
+
+  const dispatch = useCallback((event: RealtimeEnvelope) => {
+    const handlers = listenersRef.current.get(event.type)
+    handlers?.forEach((handler) => {
+      try {
+        handler(event.payload, event)
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.warn('[SSE] Erro em listener', event.type, err)
+        }
+      }
+    })
+    if (event.type !== 'ping') {
+      const wildcard = listenersRef.current.get('*')
+      wildcard?.forEach((handler) => {
+        try {
+          handler(event.payload, event)
+        } catch {
+          /* ignore */
+        }
+      })
+    }
+  }, [])
+
+  const subscribe = useCallback((type: string, handler: RealtimeEventHandler) => {
+    const map = listenersRef.current
+    let set = map.get(type)
+    if (!set) {
+      set = new Set()
+      map.set(type, set)
+    }
+    set.add(handler)
+    return () => {
+      set?.delete(handler)
+      if (set && set.size === 0) {
+        map.delete(type)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!enabled) {
+      setConnected(false)
+      setUseFallback(false)
+      return
+    }
+
+    const abort = new AbortController()
+    let failureCount = 0
+    let disposed = false
+
+    const connectLoop = async () => {
+      while (!disposed && !abort.signal.aborted) {
+        try {
+          await runEventStreamLoop({
+            signal: abort.signal,
+            onEvent: dispatch,
+            onConnected: () => {
+              failureCount = 0
+              setConnected(true)
+              setUseFallback(false)
+            },
+            onError: (err) => {
+              if (import.meta.env.DEV) {
+                console.warn('[SSE] Erro de conexão:', err.message)
+              }
+            },
+          })
+          if (disposed || abort.signal.aborted) break
+          failureCount += 1
+        } catch (err) {
+          if (disposed || abort.signal.aborted) break
+          if (err instanceof DOMException && err.name === 'AbortError') break
+          failureCount += 1
+          if (import.meta.env.DEV) {
+            const msg = err instanceof Error ? err.message : String(err)
+            console.warn('[SSE] Falha', failureCount, msg)
+          }
+        }
+
+        setConnected(false)
+
+        if (failureCount >= EVENT_STREAM_MAX_FAILURES) {
+          setUseFallback(true)
+          if (import.meta.env.DEV) {
+            console.warn('[SSE] Fallback para polling após', failureCount, 'falhas')
+          }
+          break
+        }
+
+        try {
+          await sleepMs(nextReconnectDelayMs(failureCount), abort.signal)
+        } catch {
+          break
+        }
+      }
+    }
+
+    void connectLoop()
+
+    return () => {
+      disposed = true
+      abort.abort()
+      setConnected(false)
+    }
+  }, [enabled, dispatch])
+
+  const value = useMemo(
+    () => ({ connected, useFallback, subscribe }),
+    [connected, useFallback, subscribe],
+  )
+
+  return <EventStreamContext.Provider value={value}>{children}</EventStreamContext.Provider>
+}
+
+/** Consome o stream SSE global (Provider no Layout). */
+export function useEventStream(): EventStreamContextValue {
+  const ctx = useContext(EventStreamContext)
+  if (!ctx) {
+    throw new Error('useEventStream deve ser usado dentro de EventStreamProvider')
+  }
+  return ctx
+}
+
+/** Opcional: retorna null se Provider não estiver montado (telas públicas). */
+export function useEventStreamOptional(): EventStreamContextValue | null {
+  return useContext(EventStreamContext)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumo

Implementa a fase **RT-F1** do épico de tempo real (#256): infraestrutura SSE no backend (#264) e cliente/hook no frontend (#267).

## Backend (#264)

- `GET /v1/events/stream` — `text/event-stream`
- Autenticação JWT via header `Authorization: Bearer` ou query `?token=`
- Hub in-process (`asyncio.Queue`) por canal `atendente:{id}`
- Evento inicial `connected` + heartbeat `ping` a cada 30s
- Desconexão limpa com poll de 1s (`request.is_disconnected`)
- Helper `publish_to_atendente()` preparado para RT-F2/F3
- Refatoração de `obter_atendente_atual` → `_carregar_atendente_por_token` + `obter_atendente_sse`

## Frontend (#267)

- Cliente fetch-based (`eventStream.ts`) — suporta Bearer e refresh JWT (EventSource nativo não envia header)
- `EventStreamProvider` + hook `useEventStream()` montados no `Layout`
- Reconexão com backoff exponencial (1s → 30s)
- Após 3 falhas consecutivas: `useFallback === true` (consumidores RT-F2 mantêm polling existente)
- Dispatch por `type` via `subscribe(type, handler)`

## Documentação

- [`docs/REALTIME_SSE.md`](docs/REALTIME_SSE.md) — envelope, auth, limites Gunicorn multi-worker

## Testes

- `backend/tests/test_events_stream.py` — 401, connected (Bearer + query), hub pub/sub, format SSE
- Typecheck frontend: `tsc -b --noEmit` OK

## Próximo passo (RT-F2)

Conectar emissores de eventos (webhooks, tickets, notificações) e substituir polling em `useAlertaFilaSemResponsavel` / chat / detalhe ticket.

## Issues

- Closes #264
- Closes #267
- Épico pai: #256
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-433597c5-e949-4afc-9a44-e6b31b45b2f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-433597c5-e949-4afc-9a44-e6b31b45b2f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

