### PR TITLE
feat(tempo-real): eventos SSE chats/tickets RT-F2 (#265, #268)

### DIFF
--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -1,0 +1,50 @@
+"""
+SSE — tempo real (#264).
+
+GET /v1/events/stream — `text/event-stream`, autenticado por JWT (Bearer ou query `token`).
+
+**Gunicorn / produção:** cada worker mantém filas in-process (v1). Com `--workers N`,
+conexões SSE e pub/sub ficam isoladas por processo — ver `docs/REALTIME_SSE.md`.
+"""
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import StreamingResponse
+
+from app.core.auth import obter_atendente_sse
+from app.models.atendente import Atendente
+from app.services.realtime_hub import channel_atendente, stream_channel_events
+
+router = APIRouter(prefix="/events", tags=["events"])
+
+
+@router.get("/stream")
+async def events_stream(
+    request: Request,
+    atendente: Atendente = Depends(obter_atendente_sse),
+):
+    channel = channel_atendente(atendente.id)
+    initial = {
+        "type": "connected",
+        "payload": {
+            "atendente_id": atendente.id,
+            "canal": channel,
+        },
+    }
+
+    async def generate():
+        async for chunk in stream_channel_events(
+            channel,
+            initial_payload=initial,
+            disconnect_check=request.is_disconnected,
+        ):
+            yield chunk
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -72,6 +72,7 @@ from app.services.ticket_escopo import (
 from app.services.funcionario_rede_resolver import resolver_remetente_por_email
 from app.services.ticket_client_email import extrair_email_de_from_address
 from app.services.protocolo_mensal import gerar_protocolo_ticket
+from app.services.realtime_emit import emit_ticket_fila, emit_ticket_mensagem_from_model
 from app.services.ticket_mensagem_email_outbox import (
     EMAIL_STATUS_ENVIADA,
     agendar_envio_email,
@@ -604,6 +605,17 @@ def criar(
         )
     )
     db.commit()
+    msg_abertura = (
+        db.query(TicketMensagem)
+        .options(joinedload(TicketMensagem.atendente))
+        .filter(TicketMensagem.ticket_id == ticket.id, TicketMensagem.tipo == "abertura")
+        .order_by(TicketMensagem.id.desc())
+        .first()
+    )
+    if msg_abertura:
+        emit_ticket_mensagem_from_model(db, ticket, msg_abertura, exclude_atendente_id=atendente.id)
+    if ticket.atendente_id is None:
+        emit_ticket_fila(db, ticket)
     ticket_out = (
         db.query(Ticket)
         .options(*_opcoes_carregamento_ticket_detalhe())
@@ -1047,6 +1059,7 @@ def criar_mensagem(
         .first()
     )
     assert m is not None
+    emit_ticket_mensagem_from_model(db, ticket, m, exclude_atendente_id=atendente.id)
     return _mensagem_para_read(m)
 
 
@@ -1578,4 +1591,7 @@ def atualizar(
         .filter(Ticket.id == ticket_id)
         .first()
     )
+    if ticket_out and ticket_out.atendente_id is None and ticket_out.fechado_em is None:
+        if "atendente_id" in update or "setor_id" in update:
+            emit_ticket_fila(db, ticket_out)
     return _ticket_para_read(ticket_out or ticket, db)

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -51,6 +51,7 @@ from app.services.whatsapp_auto_messages import (
 )
 from app.services.whatsapp_avaliacao import mensagem_oculta_na_conversa
 from app.services.whatsapp_media_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
+from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
 
 router = APIRouter(prefix="/whatsapp/chats", tags=["whatsapp-chats"])
 
@@ -284,6 +285,7 @@ def _enviar_texto_whatsapp(
     db.add(m)
     db.commit()
     db.refresh(m)
+    emit_chat_mensagem_from_models(db, chat, m, exclude_atendente_id=atendente.id if atendente else None)
     return m
 
 
@@ -813,11 +815,13 @@ def assumir(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
     if c.estado != "aguardando_atendente":
         raise HTTPException(status_code=400, detail="Só é possível assumir chats na fila de espera")
+    estado_anterior = c.estado
     c.estado = "em_atendimento"
     c.atendente_id = atendente.id
     c.atendimento_inicio_at = datetime.now(timezone.utc)
     db.commit()
     db.refresh(c)
+    emit_chat_fila_from_model(db, c, estado_anterior=estado_anterior)
     st_auto = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
     if st_auto and bool(getattr(st_auto, "auto_msg_assumido_ativa", True)) and _evolution_configurada(st_auto):
         raw = (getattr(st_auto, "auto_msg_assumido_texto", "") or "").strip() or DEFAULT_AUTO_MSG_ASSUMIDO
@@ -873,6 +877,7 @@ def encerrar(
         raise HTTPException(status_code=502, detail="Falha ao encerrar o atendimento no WhatsApp") from exc
     c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     assert c is not None
+    emit_chat_fila_from_model(db, c, estado_anterior="em_atendimento")
     return _chat_read(db, c)
 
 
@@ -1004,6 +1009,7 @@ async def enviar_mensagem_midia(
         .first()
     )
     assert m2 is not None
+    emit_chat_mensagem_from_models(db, c, m2, exclude_atendente_id=atendente.id)
     return _mensagem_read(m2)
 
 
@@ -1290,6 +1296,7 @@ def transferir(
             if data.setor_id not in setor_ids:
                 raise HTTPException(status_code=400, detail="Atendente selecionado não pertence ao setor escolhido")
 
+    estado_anterior = c.estado
     c.setor_id = data.setor_id
     c.atendente_id = destino.id if destino else None
     if destino:
@@ -1328,4 +1335,17 @@ def transferir(
         .first()
     )
     assert c2 is not None
+    transfer_msg = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.atendente))
+        .filter(
+            WhatsappMensagem.chat_id == chat_id,
+            WhatsappMensagem.evento_sistema == "transferencia",
+        )
+        .order_by(WhatsappMensagem.id.desc())
+        .first()
+    )
+    emit_chat_fila_from_model(db, c2, estado_anterior=estado_anterior)
+    if transfer_msg:
+        emit_chat_mensagem_from_models(db, c2, transfer_msg, exclude_atendente_id=atendente.id)
     return _chat_read(db, c2)

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -421,7 +421,9 @@ def evolution_webhook(
             mimetype_val = None
 
         chat = _chat_aberto_por_wa_id(db, wa_id)
+        chat_novo = False
         if not chat:
+            chat_novo = True
             chat = WhatsappChat(
                 protocolo=gerar_protocolo_chat(db),
                 wa_id=wa_id,
@@ -470,6 +472,18 @@ def evolution_webhook(
         try:
             db.commit()
             processados += 1
+            chat_emit = db.query(WhatsappChat).filter(WhatsappChat.id == chat.id).first()
+            msg_emit = (
+                db.query(WhatsappMensagem)
+                .filter(WhatsappMensagem.chat_id == chat.id, WhatsappMensagem.wa_message_id == wa_mid)
+                .first()
+            )
+            if chat_emit and msg_emit:
+                from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
+
+                emit_chat_mensagem_from_models(db, chat_emit, msg_emit)
+                if chat_novo:
+                    emit_chat_fila_from_model(db, chat_emit, estado_anterior=None)
         except IntegrityError:
             db.rollback()
             logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, HTTPException, Request, status
+from fastapi import Depends, HTTPException, Query, Request, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from sqlalchemy.orm import Session
 
@@ -14,18 +14,13 @@ from app.core.tenant_context import (
 
 security = HTTPBearer(auto_error=False)
 
-def obter_atendente_atual(
+
+def _carregar_atendente_por_token(
     request: Request,
-    credentials: HTTPAuthorizationCredentials | None = Depends(security),
-    db: Session = Depends(get_db),
+    token: str,
+    db: Session,
 ) -> Atendente:
-    if not credentials:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Token não informado",
-            headers={"WWW-Authenticate": "Bearer"},
-        )
-    payload = decodificar_token(credentials.credentials)
+    payload = decodificar_token(token)
     if not payload or "sub" not in payload:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -66,6 +61,36 @@ def obter_atendente_atual(
                 detail="Altere sua senha antes de usar o sistema.",
             )
     return atendente
+
+
+def obter_atendente_atual(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+    db: Session = Depends(get_db),
+) -> Atendente:
+    if not credentials:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token não informado",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return _carregar_atendente_por_token(request, credentials.credentials, db)
+
+
+def obter_atendente_sse(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+    token: str | None = Query(None, description="JWT access token (alternativa ao header Bearer)"),
+    db: Session = Depends(get_db),
+) -> Atendente:
+    raw = credentials.credentials if credentials else token
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token não informado",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return _carregar_atendente_por_token(request, raw, db)
 
 
 def exigir_admin(atendente: Atendente = Depends(obter_atendente_atual)) -> Atendente:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -64,8 +64,14 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Testes (pytest): schema mínimo sem seed, backfill nem thread IBGE — ver tests/conftest.py (#46).
+    import asyncio
     import os
+
+    from app.services.realtime_emit import register_realtime_loop
+
+    register_realtime_loop(asyncio.get_running_loop())
+
+    # Testes (pytest): schema mínimo sem seed, backfill nem thread IBGE — ver tests/conftest.py (#46).
 
     if os.environ.get("DX_CONNECT_TESTING") == "1":
         dev_create_all_tables(engine, Base.metadata)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -24,6 +24,7 @@ from app.api import (
     tipo_negocio,
     cadastro_aux,
     notificacoes,
+    events,
     whatsapp_settings,
     whatsapp_chats,
     whatsapp_webhook,
@@ -322,6 +323,7 @@ app.include_router(audit.router, prefix=API_V1_PREFIX)
 app.include_router(tipo_negocio.router, prefix=API_V1_PREFIX)
 app.include_router(cadastro_aux.router, prefix=API_V1_PREFIX)
 app.include_router(notificacoes.router, prefix=API_V1_PREFIX)
+app.include_router(events.router, prefix=API_V1_PREFIX)
 app.include_router(whatsapp_settings.router, prefix=API_V1_PREFIX)
 app.include_router(whatsapp_chats.router, prefix=API_V1_PREFIX)
 app.include_router(whatsapp_webhook.router, prefix=API_V1_PREFIX)

--- a/backend/app/schemas/realtime.py
+++ b/backend/app/schemas/realtime.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class RealtimeEventEnvelope(BaseModel):
+    type: str
+    payload: dict[str, Any] = Field(default_factory=dict)

--- a/backend/app/services/realtime_emit.py
+++ b/backend/app/services/realtime_emit.py
@@ -1,0 +1,238 @@
+"""Emissão SSE após commit — tickets e chats (#265)."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Iterable
+
+from sqlalchemy.orm import Session
+
+from app.core.setor_scope import ids_setores_mesmo_nome, ids_setores_visiveis_atendente
+from app.core.tenant_context import effective_tenant_id
+from app.models.atendente import Atendente
+from app.models.setor import Setor
+from app.models.ticket import Ticket
+from app.models.whatsapp_chat import WhatsappChat
+from app.services.realtime_hub import publish_to_atendente
+
+logger = logging.getLogger(__name__)
+
+_main_loop: asyncio.AbstractEventLoop | None = None
+
+
+def register_realtime_loop(loop: asyncio.AbstractEventLoop) -> None:
+    global _main_loop
+    _main_loop = loop
+
+
+def _schedule(coro) -> None:
+    loop = _main_loop
+    if loop is None or not loop.is_running():
+        try:
+            asyncio.run(coro)
+        except RuntimeError:
+            logger.debug("SSE: loop principal indisponível; evento descartado")
+        return
+    asyncio.run_coroutine_threadsafe(coro, loop)
+
+
+async def _publish_many(atendente_ids: Iterable[int], event_type: str, payload: dict[str, Any]) -> None:
+    seen: set[int] = set()
+    for aid in atendente_ids:
+        if aid in seen:
+            continue
+        seen.add(aid)
+        await publish_to_atendente(aid, event_type, payload)
+
+
+def _publish_to_atendentes(atendente_ids: Iterable[int], event_type: str, payload: dict[str, Any]) -> None:
+    ids = list(atendente_ids)
+    if not ids:
+        return
+    _schedule(_publish_many(ids, event_type, payload))
+
+
+def _pode_ver_chat(db: Session, atendente: Atendente, chat: WhatsappChat) -> bool:
+    if atendente.role == "admin":
+        return True
+    if chat.atendente_id == atendente.id:
+        return True
+    vis = ids_setores_visiveis_atendente(db, atendente)
+    if chat.setor_id is None:
+        return chat.estado == "aguardando_atendente"
+    if chat.estado in ("aguardando_atendente", "encerrado", "aguardando_avaliacao"):
+        return chat.setor_id in vis
+    return False
+
+
+def _pode_ver_ticket(db: Session, atendente: Atendente, ticket: Ticket) -> bool:
+    if atendente.role == "admin":
+        return True
+    vis = ids_setores_visiveis_atendente(db, atendente)
+    return ticket.setor_id in vis
+
+
+def _ids_atendentes_ativos(db: Session) -> list[Atendente]:
+    tenant_id = effective_tenant_id()
+    return (
+        db.query(Atendente)
+        .filter(Atendente.ativo.is_(True), Atendente.tenant_id == tenant_id)
+        .all()
+    )
+
+
+def _ids_atendentes_por_setor(db: Session, setor_id: int) -> set[int]:
+    alvo_ids = list(ids_setores_mesmo_nome(db, setor_id))
+    q = (
+        db.query(Atendente)
+        .join(Atendente.setores)
+        .filter(Setor.id.in_(alvo_ids), Atendente.ativo.is_(True))
+        .distinct()
+    )
+    ids = {a.id for a in q.all()}
+    admins = (
+        db.query(Atendente)
+        .filter(Atendente.role == "admin", Atendente.ativo.is_(True))
+        .all()
+    )
+    ids.update(a.id for a in admins)
+    return ids
+
+
+def ids_atendentes_acesso_chat(db: Session, chat: WhatsappChat) -> set[int]:
+    return {a.id for a in _ids_atendentes_ativos(db) if _pode_ver_chat(db, a, chat)}
+
+
+def ids_atendentes_chat_fila(db: Session, chat: WhatsappChat) -> set[int]:
+    if chat.setor_id is None:
+        return {a.id for a in _ids_atendentes_ativos(db)}
+    return _ids_atendentes_por_setor(db, chat.setor_id)
+
+
+def ids_atendentes_ticket_mensagem(
+    db: Session,
+    ticket: Ticket,
+    *,
+    exclude_atendente_id: int | None = None,
+) -> set[int]:
+    ids = {a.id for a in _ids_atendentes_ativos(db) if _pode_ver_ticket(db, a, ticket)}
+    if exclude_atendente_id is not None:
+        ids.discard(exclude_atendente_id)
+    return ids
+
+
+def ids_atendentes_ticket_fila(db: Session, ticket: Ticket) -> set[int]:
+    if ticket.atendente_id is not None or ticket.fechado_em is not None:
+        return set()
+    return _ids_atendentes_por_setor(db, ticket.setor_id)
+
+
+def emit_chat_mensagem(
+    db: Session,
+    chat: WhatsappChat,
+    mensagem_payload: dict[str, Any],
+    *,
+    exclude_atendente_id: int | None = None,
+) -> None:
+    recipients = ids_atendentes_acesso_chat(db, chat)
+    if exclude_atendente_id is not None:
+        recipients.discard(exclude_atendente_id)
+    payload = {"chat_id": chat.id, "mensagem": mensagem_payload}
+    _publish_to_atendentes(recipients, "chat.mensagem", payload)
+
+
+def emit_chat_fila(
+    db: Session,
+    chat: WhatsappChat,
+    *,
+    chat_payload: dict[str, Any] | None = None,
+    estado_anterior: str | None = None,
+) -> None:
+    recipients = ids_atendentes_chat_fila(db, chat)
+    if chat.atendente_id is not None:
+        recipients.add(chat.atendente_id)
+    payload: dict[str, Any] = {
+        "chat_id": chat.id,
+        "estado": chat.estado,
+        "estado_anterior": estado_anterior,
+    }
+    if chat_payload is not None:
+        payload["chat"] = chat_payload
+    _publish_to_atendentes(recipients, "chat.fila", payload)
+
+
+def emit_ticket_mensagem(
+    db: Session,
+    ticket: Ticket,
+    mensagem_payload: dict[str, Any],
+    *,
+    exclude_atendente_id: int | None = None,
+) -> None:
+    recipients = ids_atendentes_ticket_mensagem(
+        db, ticket, exclude_atendente_id=exclude_atendente_id
+    )
+    payload = {"ticket_id": ticket.id, "mensagem": mensagem_payload}
+    _publish_to_atendentes(recipients, "ticket.mensagem", payload)
+
+
+def emit_ticket_fila(db: Session, ticket: Ticket) -> None:
+    recipients = ids_atendentes_ticket_fila(db, ticket)
+    if not recipients:
+        return
+    payload = {
+        "ticket_id": ticket.id,
+        "setor_id": ticket.setor_id,
+        "protocolo": ticket.protocolo,
+    }
+    _publish_to_atendentes(recipients, "ticket.fila", payload)
+
+
+def emit_chat_mensagem_from_models(
+    db: Session,
+    chat: WhatsappChat,
+    mensagem: Any,
+    *,
+    exclude_atendente_id: int | None = None,
+) -> None:
+    from app.api.whatsapp_chats import _mensagem_read
+
+    emit_chat_mensagem(
+        db,
+        chat,
+        _mensagem_read(mensagem).model_dump(mode="json"),
+        exclude_atendente_id=exclude_atendente_id,
+    )
+
+
+def emit_chat_fila_from_model(
+    db: Session,
+    chat: WhatsappChat,
+    *,
+    estado_anterior: str | None = None,
+) -> None:
+    from app.api.whatsapp_chats import _chat_read
+
+    emit_chat_fila(
+        db,
+        chat,
+        chat_payload=_chat_read(db, chat).model_dump(mode="json"),
+        estado_anterior=estado_anterior,
+    )
+
+
+def emit_ticket_mensagem_from_model(
+    db: Session,
+    ticket: Ticket,
+    mensagem: Any,
+    *,
+    exclude_atendente_id: int | None = None,
+) -> None:
+    from app.api.tickets import _mensagem_para_read
+
+    emit_ticket_mensagem(
+        db,
+        ticket,
+        _mensagem_para_read(mensagem).model_dump(mode="json"),
+        exclude_atendente_id=exclude_atendente_id,
+    )

--- a/backend/app/services/realtime_hub.py
+++ b/backend/app/services/realtime_hub.py
@@ -1,0 +1,105 @@
+"""Pub/sub in-process para SSE (v1). Redis opcional em v2 para multi-worker Gunicorn."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections import defaultdict
+from typing import Any, AsyncIterator
+
+logger = logging.getLogger(__name__)
+
+HEARTBEAT_INTERVAL_SEC = 30
+_DISCONNECT_POLL_SEC = 1.0
+
+
+def channel_atendente(atendente_id: int) -> str:
+    return f"atendente:{atendente_id}"
+
+
+class RealtimeHub:
+    """Hub in-memory: um canal por atendente, filas asyncio por conexão SSE."""
+
+    def __init__(self) -> None:
+        self._queues: dict[str, set[asyncio.Queue]] = defaultdict(set)
+        self._lock = asyncio.Lock()
+
+    async def subscribe(self, channel: str) -> asyncio.Queue:
+        queue: asyncio.Queue = asyncio.Queue(maxsize=256)
+        async with self._lock:
+            self._queues[channel].add(queue)
+        return queue
+
+    async def unsubscribe(self, channel: str, queue: asyncio.Queue) -> None:
+        async with self._lock:
+            subs = self._queues.get(channel)
+            if not subs:
+                return
+            subs.discard(queue)
+            if not subs:
+                del self._queues[channel]
+
+    async def publish(
+        self,
+        channel: str,
+        event_type: str,
+        payload: dict[str, Any] | None = None,
+    ) -> None:
+        envelope = {"type": event_type, "payload": payload or {}}
+        async with self._lock:
+            subs = list(self._queues.get(channel, ()))
+        for queue in subs:
+            try:
+                queue.put_nowait(envelope)
+            except asyncio.QueueFull:
+                logger.warning(
+                    "Fila SSE cheia no canal %s; evento %s descartado",
+                    channel,
+                    event_type,
+                )
+
+
+hub = RealtimeHub()
+
+
+def format_sse(data: dict[str, Any]) -> str:
+    body = json.dumps(data, ensure_ascii=False)
+    return f"event: message\ndata: {body}\n\n"
+
+
+async def stream_channel_events(
+    channel: str,
+    *,
+    initial_payload: dict[str, Any] | None = None,
+    disconnect_check: Any | None = None,
+) -> AsyncIterator[str]:
+    """Gera linhas SSE para um canal, com heartbeat e desconexão limpa."""
+    queue = await hub.subscribe(channel)
+    try:
+        if initial_payload is not None:
+            yield format_sse(initial_payload)
+        elapsed = 0.0
+        while True:
+            if disconnect_check is not None and await disconnect_check():
+                break
+            try:
+                envelope = await asyncio.wait_for(queue.get(), timeout=_DISCONNECT_POLL_SEC)
+                yield format_sse(envelope)
+                elapsed = 0.0
+            except asyncio.TimeoutError:
+                elapsed += _DISCONNECT_POLL_SEC
+                if elapsed >= HEARTBEAT_INTERVAL_SEC:
+                    yield format_sse({"type": "ping", "payload": {}})
+                    elapsed = 0.0
+    finally:
+        await hub.unsubscribe(channel, queue)
+
+
+async def publish_to_atendente(
+    atendente_id: int,
+    event_type: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    """Publica evento no canal do atendente (RT-F2/F3)."""
+    await hub.publish(channel_atendente(atendente_id), event_type, payload)

--- a/backend/tests/test_events_stream.py
+++ b/backend/tests/test_events_stream.py
@@ -1,0 +1,64 @@
+"""Testes SSE — infraestrutura tempo real (#264)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from app.core.security import criar_access_token
+from app.services.realtime_hub import RealtimeHub, channel_atendente, format_sse
+
+
+async def _short_stream(channel, *, initial_payload=None, disconnect_check=None):
+    """Generator finito para TestClient (evita conexão longa em testes)."""
+    if initial_payload is not None:
+        yield format_sse(initial_payload)
+
+
+def test_events_stream_401_sem_token(client):
+    r = client.get("/v1/events/stream")
+    assert r.status_code == 401
+
+
+def test_events_stream_conectado_com_bearer(client, seed_base, auth_headers, monkeypatch):
+    monkeypatch.setattr("app.api.events.stream_channel_events", _short_stream)
+    r = client.get("/v1/events/stream", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/event-stream")
+    assert "connected" in r.text
+    payload = json.loads(r.text.split("data: ", 1)[1].strip())
+    assert payload["type"] == "connected"
+    assert payload["payload"]["atendente_id"] == seed_base["a1"].id
+    assert payload["payload"]["canal"] == channel_atendente(seed_base["a1"].id)
+
+
+def test_events_stream_conectado_com_query_token(client, seed_base, monkeypatch):
+    monkeypatch.setattr("app.api.events.stream_channel_events", _short_stream)
+    token = criar_access_token({"sub": seed_base["a1"].email, "tid": 1})
+    r = client.get(
+        f"/v1/events/stream?token={token}",
+        headers={"X-Dx-Tenant-Id": "1"},
+    )
+    assert r.status_code == 200
+    assert "connected" in r.text
+
+
+def test_hub_publish_subscribe():
+    async def _run() -> None:
+        hub = RealtimeHub()
+        channel = channel_atendente(99)
+        queue = await hub.subscribe(channel)
+        await hub.publish(channel, "ticket.mensagem", {"ticket_id": 1})
+        envelope = await asyncio.wait_for(queue.get(), timeout=1)
+        assert envelope["type"] == "ticket.mensagem"
+        assert envelope["payload"]["ticket_id"] == 1
+        await hub.unsubscribe(channel, queue)
+
+    asyncio.run(_run())
+
+
+def test_format_sse():
+    line = format_sse({"type": "ping", "payload": {}})
+    assert line.startswith("event: message\n")
+    assert "data: " in line
+    assert line.endswith("\n\n")

--- a/backend/tests/test_realtime_emit.py
+++ b/backend/tests/test_realtime_emit.py
@@ -1,0 +1,130 @@
+"""Testes emissão SSE — tickets e chats (#265)."""
+
+from __future__ import annotations
+
+from app.services.realtime_emit import (
+    emit_chat_mensagem,
+    ids_atendentes_acesso_chat,
+    ids_atendentes_chat_fila,
+    ids_atendentes_ticket_fila,
+    ids_atendentes_ticket_mensagem,
+)
+
+
+def test_ids_atendentes_chat_fila_setor(client, seed_base, db_session):
+    from app.models.whatsapp_chat import WhatsappChat
+
+    chat = WhatsappChat(
+        protocolo="WCH-TEST-1",
+        wa_id="5511999990001",
+        cliente_nome="Cliente",
+        estado="aguardando_atendente",
+        setor_id=seed_base["setor1"].id,
+    )
+    db_session.add(chat)
+    db_session.commit()
+
+    ids = ids_atendentes_chat_fila(db_session, chat)
+    assert seed_base["a1"].id in ids
+    assert seed_base["a2"].id not in ids
+    assert seed_base["admin"].id in ids
+
+
+def test_ids_atendentes_ticket_fila(client, seed_base, db_session):
+    from app.models.ticket import Ticket
+    from app.models.status_ticket import StatusTicket
+
+    st = db_session.query(StatusTicket).first()
+    ticket = Ticket(
+        tenant_id=1,
+        protocolo="#T202606-0001",
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=st.id,
+        assunto="Teste fila",
+        descricao="x",
+        atendente_id=None,
+    )
+    db_session.add(ticket)
+    db_session.commit()
+
+    ids = ids_atendentes_ticket_fila(db_session, ticket)
+    assert seed_base["a1"].id in ids
+    assert seed_base["a2"].id not in ids
+
+
+def test_emit_chat_mensagem_rbac(client, seed_base, db_session, monkeypatch):
+    from app.models.whatsapp_chat import WhatsappChat
+
+    chat = WhatsappChat(
+        protocolo="WCH-TEST-2",
+        wa_id="5511999990002",
+        cliente_nome="Cliente",
+        estado="em_atendimento",
+        setor_id=seed_base["setor1"].id,
+        atendente_id=seed_base["a1"].id,
+    )
+    db_session.add(chat)
+    db_session.commit()
+
+    publicados: list[int] = []
+
+    def fake_publish(atendente_ids, event_type, payload):
+        publicados.extend(atendente_ids)
+        assert event_type == "chat.mensagem"
+        assert payload["chat_id"] == chat.id
+
+    monkeypatch.setattr("app.services.realtime_emit._publish_to_atendentes", fake_publish)
+
+    emit_chat_mensagem(
+        db_session,
+        chat,
+        {"id": 1, "chat_id": chat.id, "corpo": "oi"},
+    )
+    assert seed_base["a1"].id in publicados
+    assert seed_base["admin"].id in publicados
+    assert seed_base["a2"].id not in publicados
+
+
+def test_ids_atendentes_acesso_chat_em_atendimento(client, seed_base, db_session):
+    from app.models.whatsapp_chat import WhatsappChat
+
+    chat = WhatsappChat(
+        protocolo="WCH-TEST-3",
+        wa_id="5511999990003",
+        cliente_nome="Cliente",
+        estado="em_atendimento",
+        setor_id=seed_base["setor2"].id,
+        atendente_id=seed_base["a2"].id,
+    )
+    db_session.add(chat)
+    db_session.commit()
+
+    ids = ids_atendentes_acesso_chat(db_session, chat)
+    assert seed_base["a2"].id in ids
+    assert seed_base["admin"].id in ids
+    assert seed_base["a1"].id not in ids
+
+
+def test_ids_atendentes_ticket_mensagem_por_setor(client, seed_base, db_session):
+    from app.models.ticket import Ticket
+    from app.models.status_ticket import StatusTicket
+
+    st = db_session.query(StatusTicket).first()
+    ticket = Ticket(
+        tenant_id=1,
+        protocolo="#T202606-0002",
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=st.id,
+        assunto="Msg",
+        descricao="x",
+        atendente_id=seed_base["a1"].id,
+    )
+    db_session.add(ticket)
+    db_session.commit()
+
+    ids = ids_atendentes_ticket_mensagem(db_session, ticket)
+    assert seed_base["a1"].id in ids
+    assert seed_base["admin"].id in ids
+    assert seed_base["a2"].id not in ids

--- a/docs/REALTIME_SSE.md
+++ b/docs/REALTIME_SSE.md
@@ -1,0 +1,48 @@
+# Tempo real (SSE) — RT-F1
+
+Infraestrutura de eventos servidor→cliente para substituir polling no painel interno.
+
+## Endpoint
+
+- `GET /v1/events/stream` — `text/event-stream`
+- Autenticação: header `Authorization: Bearer <access_token>` (preferido) ou query `?token=<access_token>`
+- Heartbeat: evento `ping` a cada **30 s** sem outro evento
+- Envelope: `{ "type": "<tipo>", "payload": { ... } }`
+- Canal por atendente: `atendente:{id}`
+
+Evento inicial ao conectar:
+
+```json
+{ "type": "connected", "payload": { "atendente_id": 1, "canal": "atendente:1" } }
+```
+
+## Frontend
+
+- Cliente fetch-based (suporta Bearer; `EventSource` nativo não envia header)
+- Hook `useEventStream()` + `EventStreamProvider` no `Layout`
+- Reconexão com backoff exponencial; após **3 falhas** consecutivas, `useFallback === true` (consumidores RT-F2 mantêm polling)
+
+## Gunicorn e multi-worker
+
+O hub v1 é **in-process** (`asyncio.Queue` por conexão). Implicações:
+
+| Config | Comportamento |
+|--------|----------------|
+| `--workers 1` | Pub/sub e SSE no mesmo processo — adequado para v1 interno |
+| `--workers N>1` | Cada worker tem filas isoladas; um evento publicado no worker A **não** chega a SSE conectada no worker B |
+
+**Recomendação v1 (uso interno):** `--workers 1` ou sticky sessions no Nginx (`ip_hash` / `hash $cookie_...`) se precisar de N>1 por CPU.
+
+**v2 (futuro):** Redis Pub/Sub ou similar para fan-out entre workers.
+
+### Limites práticos
+
+- Cada atendente autenticado = **1 conexão HTTP longa** por aba do painel
+- Gunicorn `worker_connections` (gevent/eventlet) ou limite de file descriptors do SO aplicam-se
+- Nginx: desativar buffering (`X-Accel-Buffering: no` já enviado pela API); `proxy_read_timeout` ≥ 3600 s para SSE
+
+## Issues
+
+- Épico: [#256](https://github.com/lgustavoss/dx-connect/issues/256)
+- RT-F1 backend: [#264](https://github.com/lgustavoss/dx-connect/issues/264)
+- RT-F1 frontend: [#267](https://github.com/lgustavoss/dx-connect/issues/267)

--- a/docs/REALTIME_SSE.md
+++ b/docs/REALTIME_SSE.md
@@ -16,6 +16,18 @@ Evento inicial ao conectar:
 { "type": "connected", "payload": { "atendente_id": 1, "canal": "atendente:1" } }
 ```
 
+## Eventos (RT-F2+)
+
+| Tipo | Quando | Payload principal |
+|------|--------|-------------------|
+| `chat.mensagem` | Nova mensagem WhatsApp | `{ chat_id, mensagem }` |
+| `chat.fila` | Chat entra/sai da fila ou muda estado | `{ chat_id, estado, chat? }` |
+| `ticket.mensagem` | Nova mensagem em ticket | `{ ticket_id, mensagem }` |
+| `ticket.fila` | Ticket aberto sem responsável | `{ ticket_id, setor_id, protocolo }` |
+| `notificacao.contagem` | RT-F3 — contadores navbar | `{ ... }` (compatível com `/notificacoes/resumo`) |
+
+Destinatários filtrados por RBAC (setor homônimo + admin).
+
 ## Frontend
 
 - Cliente fetch-based (suporta Bearer; `EventSource` nativo não envia header)

--- a/frontend/src/api/eventStream.ts
+++ b/frontend/src/api/eventStream.ts
@@ -1,0 +1,191 @@
+import {
+  API_VERSION_PREFIX,
+  getAuthToken,
+  invalidateSessionAndRedirectToLogin,
+  resolvedApiBaseUrl,
+} from './client'
+import { isMultiTenantMode, resolveTenantIdFromHostname } from '../lib/tenant'
+
+export interface RealtimeEnvelope {
+  type: string
+  payload: Record<string, unknown>
+}
+
+export type RealtimeEventHandler = (payload: Record<string, unknown>, envelope: RealtimeEnvelope) => void
+
+const TOKEN_KEY = 'token'
+const REFRESH_TOKEN_KEY = 'refresh_token'
+
+function getRefreshToken(): string | null {
+  return sessionStorage.getItem(REFRESH_TOKEN_KEY) || localStorage.getItem(REFRESH_TOKEN_KEY)
+}
+
+function setAccessToken(accessToken: string): void {
+  if (localStorage.getItem(REFRESH_TOKEN_KEY)) {
+    localStorage.setItem(TOKEN_KEY, accessToken)
+    return
+  }
+  sessionStorage.setItem(TOKEN_KEY, accessToken)
+}
+
+async function refreshAccessTokenForStream(): Promise<string | null> {
+  const refresh_token = getRefreshToken()
+  if (!refresh_token) return null
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (isMultiTenantMode()) {
+    headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+  }
+  const res = await fetch(`${resolvedApiBaseUrl()}${API_VERSION_PREFIX}/auth/refresh`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ refresh_token }),
+  })
+  if (!res.ok) return null
+  const body = (await res.json()) as { access_token?: string }
+  if (!body.access_token) return null
+  setAccessToken(body.access_token)
+  return body.access_token
+}
+
+export function buildEventStreamUrl(): string {
+  return `${resolvedApiBaseUrl()}${API_VERSION_PREFIX}/events/stream`
+}
+
+function authHeaders(token: string): Record<string, string> {
+  const headers: Record<string, string> = { Authorization: `Bearer ${token}` }
+  if (isMultiTenantMode()) {
+    headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+  }
+  return headers
+}
+
+function parseSseBlocks(buffer: string): { events: RealtimeEnvelope[]; rest: string } {
+  const events: RealtimeEnvelope[] = []
+  let rest = buffer
+  while (true) {
+    const idx = rest.indexOf('\n\n')
+    if (idx === -1) break
+    const block = rest.slice(0, idx)
+    rest = rest.slice(idx + 2)
+    const dataLine = block.split('\n').find((line) => line.startsWith('data: '))
+    if (!dataLine) continue
+    try {
+      events.push(JSON.parse(dataLine.slice(6)) as RealtimeEnvelope)
+    } catch {
+      if (import.meta.env.DEV) {
+        console.warn('[SSE] JSON inválido:', dataLine)
+      }
+    }
+  }
+  return { events, rest }
+}
+
+async function openAuthenticatedStream(
+  signal: AbortSignal,
+  retried401: boolean,
+): Promise<Response> {
+  let token = getAuthToken()
+  if (!token) {
+    throw new Error('Token não informado')
+  }
+  const res = await fetch(buildEventStreamUrl(), {
+    headers: authHeaders(token),
+    signal,
+  })
+  if (res.status === 401 && !retried401) {
+    const refreshed = await refreshAccessTokenForStream()
+    if (refreshed) {
+      return openAuthenticatedStream(signal, true)
+    }
+    invalidateSessionAndRedirectToLogin()
+    throw new Error('Sessão expirada')
+  }
+  if (res.status === 401) {
+    invalidateSessionAndRedirectToLogin()
+    throw new Error('Sessão expirada')
+  }
+  if (!res.ok) {
+    throw new Error(`SSE HTTP ${res.status}`)
+  }
+  if (!res.body) {
+    throw new Error('SSE sem body')
+  }
+  return res
+}
+
+export type EventStreamRunOptions = {
+  signal: AbortSignal
+  onEvent: (event: RealtimeEnvelope) => void
+  onConnected?: () => void
+  onError?: (err: Error) => void
+}
+
+/** Lê o stream até abort ou erro de rede. */
+export async function runEventStreamLoop(options: EventStreamRunOptions): Promise<void> {
+  const { signal, onEvent, onConnected, onError } = options
+  let response: Response
+  try {
+    response = await openAuthenticatedStream(signal, false)
+  } catch (err) {
+    onError?.(err instanceof Error ? err : new Error(String(err)))
+    throw err
+  }
+
+  const reader = response.body!.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  try {
+    while (!signal.aborted) {
+      const { done, value } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      const parsed = parseSseBlocks(buffer)
+      buffer = parsed.rest
+      for (const event of parsed.events) {
+        if (event.type === 'connected') {
+          onConnected?.()
+        }
+        onEvent(event)
+      }
+    }
+  } catch (err) {
+    if (!signal.aborted) {
+      onError?.(err instanceof Error ? err : new Error(String(err)))
+      throw err
+    }
+  } finally {
+    try {
+      await reader.cancel()
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+export const EVENT_STREAM_MAX_FAILURES = 3
+export const EVENT_STREAM_BASE_RECONNECT_MS = 1000
+export const EVENT_STREAM_MAX_RECONNECT_MS = 30000
+
+export function nextReconnectDelayMs(failureCount: number): number {
+  const exp = EVENT_STREAM_BASE_RECONNECT_MS * 2 ** Math.max(0, failureCount - 1)
+  return Math.min(exp, EVENT_STREAM_MAX_RECONNECT_MS)
+}
+
+export function sleepMs(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'))
+      return
+    }
+    const timer = window.setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      window.clearTimeout(timer)
+      reject(new DOMException('Aborted', 'AbortError'))
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from './Sidebar'
 import { ThemeToggle } from './ThemeToggle'
 import { NavbarNotificacoes } from './NavbarNotificacoes'
 import { useAlertaFilaSemResponsavel } from '../hooks/useAlertaFilaSemResponsavel'
+import { EventStreamProvider } from '../contexts/EventStreamContext'
 
 function perfilExibicao(role: string | undefined): string {
   if (role === 'admin') return 'Administrador'
@@ -36,6 +37,7 @@ export function Layout() {
     /^\/tickets\/\d+\/?$/.test(location.pathname) || location.pathname === '/tickets/novo'
 
   return (
+    <EventStreamProvider enabled={notificacoesEnabled}>
     <div
       className="flex h-dvh max-h-dvh min-h-0 overflow-hidden bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95 md:grid md:grid-cols-[var(--sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
       style={
@@ -110,5 +112,6 @@ export function Layout() {
           </main>
       </div>
     </div>
+    </EventStreamProvider>
   )
 }

--- a/frontend/src/contexts/EventStreamContext.tsx
+++ b/frontend/src/contexts/EventStreamContext.tsx
@@ -1,0 +1,167 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import {
+  EVENT_STREAM_MAX_FAILURES,
+  nextReconnectDelayMs,
+  runEventStreamLoop,
+  sleepMs,
+  type RealtimeEnvelope,
+  type RealtimeEventHandler,
+} from '../api/eventStream'
+
+type ListenerMap = Map<string, Set<RealtimeEventHandler>>
+
+interface EventStreamContextValue {
+  connected: boolean
+  useFallback: boolean
+  subscribe: (type: string, handler: RealtimeEventHandler) => () => void
+}
+
+const EventStreamContext = createContext<EventStreamContextValue | null>(null)
+
+export function EventStreamProvider({
+  enabled,
+  children,
+}: {
+  enabled: boolean
+  children: ReactNode
+}) {
+  const listenersRef = useRef<ListenerMap>(new Map())
+  const [connected, setConnected] = useState(false)
+  const [useFallback, setUseFallback] = useState(false)
+
+  const dispatch = useCallback((event: RealtimeEnvelope) => {
+    const handlers = listenersRef.current.get(event.type)
+    handlers?.forEach((handler) => {
+      try {
+        handler(event.payload, event)
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.warn('[SSE] Erro em listener', event.type, err)
+        }
+      }
+    })
+    if (event.type !== 'ping') {
+      const wildcard = listenersRef.current.get('*')
+      wildcard?.forEach((handler) => {
+        try {
+          handler(event.payload, event)
+        } catch {
+          /* ignore */
+        }
+      })
+    }
+  }, [])
+
+  const subscribe = useCallback((type: string, handler: RealtimeEventHandler) => {
+    const map = listenersRef.current
+    let set = map.get(type)
+    if (!set) {
+      set = new Set()
+      map.set(type, set)
+    }
+    set.add(handler)
+    return () => {
+      set?.delete(handler)
+      if (set && set.size === 0) {
+        map.delete(type)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!enabled) {
+      setConnected(false)
+      setUseFallback(false)
+      return
+    }
+
+    const abort = new AbortController()
+    let failureCount = 0
+    let disposed = false
+
+    const connectLoop = async () => {
+      while (!disposed && !abort.signal.aborted) {
+        try {
+          await runEventStreamLoop({
+            signal: abort.signal,
+            onEvent: dispatch,
+            onConnected: () => {
+              failureCount = 0
+              setConnected(true)
+              setUseFallback(false)
+            },
+            onError: (err) => {
+              if (import.meta.env.DEV) {
+                console.warn('[SSE] Erro de conexão:', err.message)
+              }
+            },
+          })
+          if (disposed || abort.signal.aborted) break
+          failureCount += 1
+        } catch (err) {
+          if (disposed || abort.signal.aborted) break
+          if (err instanceof DOMException && err.name === 'AbortError') break
+          failureCount += 1
+          if (import.meta.env.DEV) {
+            const msg = err instanceof Error ? err.message : String(err)
+            console.warn('[SSE] Falha', failureCount, msg)
+          }
+        }
+
+        setConnected(false)
+
+        if (failureCount >= EVENT_STREAM_MAX_FAILURES) {
+          setUseFallback(true)
+          if (import.meta.env.DEV) {
+            console.warn('[SSE] Fallback para polling após', failureCount, 'falhas')
+          }
+          break
+        }
+
+        try {
+          await sleepMs(nextReconnectDelayMs(failureCount), abort.signal)
+        } catch {
+          break
+        }
+      }
+    }
+
+    void connectLoop()
+
+    return () => {
+      disposed = true
+      abort.abort()
+      setConnected(false)
+    }
+  }, [enabled, dispatch])
+
+  const value = useMemo(
+    () => ({ connected, useFallback, subscribe }),
+    [connected, useFallback, subscribe],
+  )
+
+  return <EventStreamContext.Provider value={value}>{children}</EventStreamContext.Provider>
+}
+
+/** Consome o stream SSE global (Provider no Layout). */
+export function useEventStream(): EventStreamContextValue {
+  const ctx = useContext(EventStreamContext)
+  if (!ctx) {
+    throw new Error('useEventStream deve ser usado dentro de EventStreamProvider')
+  }
+  return ctx
+}
+
+/** Opcional: retorna null se Provider não estiver montado (telas públicas). */
+export function useEventStreamOptional(): EventStreamContextValue | null {
+  return useContext(EventStreamContext)
+}

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { ApiError, whatsappChats, type WhatsappChats } from '../../api/client'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
+import { useEventStream } from '../../contexts/EventStreamContext'
 import { Card } from '../../components/ui/Card'
 import { Button } from '../../components/ui/Button'
 import { useToast } from '../../components/ui/Toast'
@@ -35,6 +36,7 @@ function TempoEspera({ data }: { data?: string | null }) {
 
 export function WhatsappAtendendo() {
   const toast = useToast()
+  const { subscribe, useFallback } = useEventStream()
   const [fila, setFila] = useState<WhatsappChats.Chat[]>([])
   const [meus, setMeus] = useState<WhatsappChats.Chat[]>([])
   const [loading, setLoading] = useState(true)
@@ -58,12 +60,23 @@ export function WhatsappAtendendo() {
     }
   }, [toast])
 
-  // Refresh automático a cada 10 segundos
   useEffect(() => {
-    void load() 
+    const refresh = () => void load(true)
+    const unsubFila = subscribe('chat.fila', refresh)
+    const unsubMsg = subscribe('chat.mensagem', refresh)
+    return () => {
+      unsubFila()
+      unsubMsg()
+    }
+  }, [subscribe, load])
+
+  // Refresh inicial + polling legado quando SSE indisponível
+  useEffect(() => {
+    void load()
+    if (!useFallback) return
     const timer = setInterval(() => void load(true), 10000)
     return () => clearInterval(timer)
-  }, [load])
+  }, [load, useFallback])
 
   useEffect(() => {
     if (fila.length > prevFilaCount.current) {

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -34,6 +34,7 @@ import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 
 import { useAuth } from '../../contexts/AuthContext'
+import { useEventStream } from '../../contexts/EventStreamContext'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
 import { CustomAudioPlayer } from '../../components/CustomAudioPlayer'
 import {
@@ -187,6 +188,7 @@ export function WhatsappConversa() {
   const toast = useToast()
 
   const { user } = useAuth()
+  const { subscribe, useFallback } = useEventStream()
 
  
 
@@ -328,17 +330,38 @@ export function WhatsappConversa() {
     }
   }, [chat, user?.role, user?.id])
 
-  // Polling para novas mensagens (a cada 5s)
-
   useEffect(() => {
+    if (!id) return
+    const chatId = Number(id)
+    const unsubMsg = subscribe('chat.mensagem', (payload) => {
+      if (Number(payload.chat_id) !== chatId) return
+      const msg = payload.mensagem as WhatsappChats.Mensagem | undefined
+      if (!msg) return
+      setMsgs((prev) => {
+        if (prev.some((m) => m.id === msg.id)) return prev
+        if (msg.wa_message_id && prev.some((m) => m.wa_message_id === msg.wa_message_id)) return prev
+        return [...prev, msg]
+      })
+    })
+    const unsubFila = subscribe('chat.fila', (payload) => {
+      if (Number(payload.chat_id) !== chatId) return
+      const chatData = payload.chat as WhatsappChats.Chat | undefined
+      if (chatData) setChat(chatData)
+      else void carregar().catch(() => {})
+    })
+    return () => {
+      unsubMsg()
+      unsubFila()
+    }
+  }, [id, subscribe, carregar])
 
+  // Polling legado quando SSE indisponível
+  useEffect(() => {
+    if (!useFallback) return
     if (!chat || chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao') return
-
     const t = setInterval(() => void carregar().catch(() => {}), 5000)
-
     return () => clearInterval(t)
-
-  }, [chat, carregar])
+  }, [useFallback, chat, carregar])
 
   useEffect(() => {
     if (!chat?.ticket_ids?.length) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumo

Implementa **RT-F2** do épico tempo real (#256): emissão de eventos SSE para chats e tickets no backend (#265) e integração no frontend WhatsApp (#268).

Depende da infra RT-F1 (#264/#267 — PR #309).

## Backend (#265)

Eventos emitidos **após commit**, com destinatários filtrados por RBAC (setor homônimo + admin):

| Evento | Gatilhos |
|--------|----------|
| `chat.mensagem` | Webhook inbound, envio texto/mídia, transferência |
| `chat.fila` | Novo chat, assumir, transferir, encerrar |
| `ticket.mensagem` | Criar mensagem, abertura de ticket |
| `ticket.fila` | Ticket sem responsável (criação, transferência setor) |

Novo serviço `realtime_emit.py` + registro do event loop no `lifespan` para publicar a partir de rotas síncronas.

## Frontend (#268)

- **`WhatsappConversa`**: subscreve `chat.mensagem` (append com dedupe por `id`/`wa_message_id`) e `chat.fila` (atualiza cabeçalho)
- **`WhatsappAtendendo`**: refresh da fila/meus em `chat.fila` e `chat.mensagem`
- Polling legado (5s/10s) **somente** quando `useFallback === true`

## Testes

- `test_realtime_emit.py` — RBAC de destinatários
- 30 testes relacionados passando

## Próximo passo (RT-F3)

- #266 — `notificacao.contagem` no backend
- #269 — NavbarNotificacoes + TicketDetalhe no frontend

## Issues

- Closes #265
- Closes #268
- Épico: #256
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-433597c5-e949-4afc-9a44-e6b31b45b2f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-433597c5-e949-4afc-9a44-e6b31b45b2f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

