### PR TITLE
feat(tickets): distribuição automática por setor (#257)

### DIFF
--- a/backend/alembic/versions/043_setor_distribuicao_tickets.py
+++ b/backend/alembic/versions/043_setor_distribuicao_tickets.py
@@ -1,0 +1,62 @@
+"""Configuração de distribuição automática de tickets por setor.
+
+Revision ID: 043_setor_distribuicao
+Revises: 042_atendente_notificacao
+Create Date: 2026-06-14
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "043_setor_distribuicao"
+down_revision = "042_atendente_notificacao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "setores",
+        sa.Column("distribuicao_modo", sa.String(length=30), nullable=False, server_default="manual"),
+    )
+    op.add_column(
+        "setores",
+        sa.Column("distribuicao_timeout_minutos", sa.Integer(), nullable=False, server_default="30"),
+    )
+    op.add_column(
+        "setores",
+        sa.Column("distribuicao_estrategia", sa.String(length=30), nullable=False, server_default="round_robin"),
+    )
+    op.add_column(
+        "setores",
+        sa.Column("distribuicao_atendentes_elegiveis", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "tickets",
+        sa.Column("fila_desde_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_table(
+        "setor_distribuicao_round_robin",
+        sa.Column("setor_id", sa.Integer(), nullable=False),
+        sa.Column("last_atendente_id", sa.Integer(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["last_atendente_id"], ["atendentes.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["setor_id"], ["setores.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("setor_id"),
+    )
+    op.execute(
+        """
+        UPDATE tickets
+        SET fila_desde_at = created_at
+        WHERE atendente_id IS NULL AND fechado_em IS NULL AND fila_desde_at IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("setor_distribuicao_round_robin")
+    op.drop_column("tickets", "fila_desde_at")
+    op.drop_column("setores", "distribuicao_atendentes_elegiveis")
+    op.drop_column("setores", "distribuicao_estrategia")
+    op.drop_column("setores", "distribuicao_timeout_minutos")
+    op.drop_column("setores", "distribuicao_modo")

--- a/backend/app/api/setores.py
+++ b/backend/app/api/setores.py
@@ -8,15 +8,22 @@ from app.core.ordenacao_lista import OrdemLista, expr_ordem
 from app.models import Setor
 from app.models.atendente import Atendente
 from app.schemas.setor import SetorCreate, SetorUpdate, SetorRead
+from app.schemas.setor_distribuicao import SetorDistribuicaoRead, SetorDistribuicaoUpdate
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import obter_atendente_atual, exigir_admin
 from app.core.audit import registrar_audit
 from app.core.setor_scope import ids_setores_visiveis_atendente
+from app.services.ticket_distribuicao import setor_para_distribuicao_read, validar_atendentes_elegiveis
 
 router = APIRouter(prefix="/setores", tags=["setores"])
 
 _MAX_PAGE = 100
 _DEFAULT_PAGE = 20
+
+
+def _setor_para_read(setor: Setor) -> SetorRead:
+    base = SetorRead.model_validate(setor)
+    return base.model_copy(update={"distribuicao": setor_para_distribuicao_read(setor)})
 
 
 class OrdenarSetoresPor(str, Enum):
@@ -55,7 +62,7 @@ def listar_setores(
     else:
         order_cols = [expr_ordem(Setor.ativo, ordem), expr_ordem(Setor.id, ordem)]
     items = q.order_by(*order_cols).offset(offset).limit(limit).all()
-    return ListaPaginada(items=items, total=total)
+    return ListaPaginada(items=[_setor_para_read(s) for s in items], total=total)
 
 
 @router.post("", response_model=SetorRead, status_code=201)
@@ -76,7 +83,7 @@ def criar_setor(
     registrar_audit(db, "setor", setor.id, "create", atendente.id)
     db.commit()
     db.refresh(setor)
-    return setor
+    return _setor_para_read(setor)
 
 
 @router.get("/{setor_id}", response_model=SetorRead)
@@ -88,7 +95,7 @@ def obter_setor(
     setor = db.query(Setor).filter(Setor.id == setor_id).first()
     if not setor:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Setor não encontrado")
-    return setor
+    return _setor_para_read(setor)
 
 
 @router.patch("/{setor_id}", response_model=SetorRead)
@@ -106,7 +113,32 @@ def atualizar_setor(
     registrar_audit(db, "setor", setor_id, "update", atendente.id)
     db.commit()
     db.refresh(setor)
-    return setor
+    return _setor_para_read(setor)
+
+
+@router.put("/{setor_id}/distribuicao", response_model=SetorDistribuicaoRead)
+def atualizar_distribuicao_setor(
+    setor_id: int,
+    data: SetorDistribuicaoUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    setor = db.query(Setor).filter(Setor.id == setor_id, Setor.tenant_id == atendente.tenant_id).first()
+    if not setor:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Setor não encontrado")
+    try:
+        elegiveis = validar_atendentes_elegiveis(db, setor, data.atendentes_elegiveis)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+    setor.distribuicao_modo = data.modo.value
+    setor.distribuicao_timeout_minutos = data.timeout_minutos
+    setor.distribuicao_estrategia = data.estrategia.value
+    setor.distribuicao_atendentes_elegiveis = elegiveis
+    registrar_audit(db, "setor", setor_id, "distribuicao_update", atendente.id)
+    db.commit()
+    db.refresh(setor)
+    return setor_para_distribuicao_read(setor)
 
 
 @router.delete("/{setor_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -73,6 +73,11 @@ from app.services.funcionario_rede_resolver import resolver_remetente_por_email
 from app.services.ticket_client_email import extrair_email_de_from_address
 from app.services.protocolo_mensal import gerar_protocolo_ticket
 from app.services.realtime_emit import emit_ticket_fila, emit_ticket_mensagem_from_model, emit_notificacao_after_counter_change
+from app.services.ticket_distribuicao import (
+    fila_info_para_ticket,
+    sincronizar_fila_desde_at,
+    tentar_distribuicao_imediata,
+)
 from app.services.ticket_mensagem_email_outbox import (
     EMAIL_STATUS_ENVIADA,
     agendar_envio_email,
@@ -293,6 +298,10 @@ def _ticket_para_read(t: Ticket, db: Session | None = None) -> TicketRead:
             r = db.query(Rede).filter(Rede.id == f.rede_id).first()
             rede_nome_out = r.nome if r else rede_nome_out
     csat = csat_brief_para_ticket(db, t.id) if db is not None else {}
+    setor_obj = t.setor if _attr_relacionamento_carregado(t, "setor") else None
+    if setor_obj is None and db is not None:
+        setor_obj = db.query(Setor).filter(Setor.id == t.setor_id).first()
+    fila = fila_info_para_ticket(t, setor_obj)
     return TicketRead(
         id=t.id,
         protocolo=t.protocolo,
@@ -325,6 +334,7 @@ def _ticket_para_read(t: Ticket, db: Session | None = None) -> TicketRead:
         vinculos=_vinculos_para_read(db, t) if db is not None else [],
         triagem_inbound=triagem,
         **csat,
+        **fila,
     )
 
 
@@ -615,7 +625,13 @@ def criar(
     if msg_abertura:
         emit_ticket_mensagem_from_model(db, ticket, msg_abertura, exclude_atendente_id=atendente.id)
     if ticket.atendente_id is None:
-        emit_ticket_fila(db, ticket)
+        sincronizar_fila_desde_at(ticket)
+        db.commit()
+        if tentar_distribuicao_imediata(db, ticket):
+            db.commit()
+            emit_notificacao_after_counter_change(db)
+        else:
+            emit_ticket_fila(db, ticket)
     ticket_out = (
         db.query(Ticket)
         .options(*_opcoes_carregamento_ticket_detalhe())
@@ -935,7 +951,17 @@ def criar_filhos_em_massa_endpoint(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
 
     _registrar_historico(db, ticket.id, atendente.id, "filhos_em_massa", "", str(len(criados)))
+    for filho in criados:
+        if filho.atendente_id is None:
+            sincronizar_fila_desde_at(filho)
     db.commit()
+    for filho in criados:
+        if filho.atendente_id is None:
+            if tentar_distribuicao_imediata(db, filho):
+                db.commit()
+                emit_notificacao_after_counter_change(db)
+            else:
+                emit_ticket_fila(db, filho)
 
     empresa_nomes = {
         e.id: e.nome
@@ -1551,6 +1577,10 @@ def atualizar(
         novo_o = update["motivo_outro_texto"] or ""
         _registrar_historico(db, ticket.id, atendente.id, "motivo_outro_texto", antigo_o, novo_o)
 
+    reset_fila = False
+    if "setor_id" in update and update["setor_id"] != ticket.setor_id:
+        reset_fila = True
+
     atribuicao_notificar_id: int | None = None
     if "atendente_id" in update:
         antigo_at = ticket.atendente_id
@@ -1571,6 +1601,13 @@ def atualizar(
             ticket.fechado_em = datetime.now(timezone.utc)
         else:
             ticket.fechado_em = None
+
+    if ticket.fechado_em is not None:
+        ticket.fila_desde_at = None
+    elif ticket.atendente_id is None:
+        sincronizar_fila_desde_at(ticket, reset=reset_fila or "atendente_id" in update)
+    else:
+        ticket.fila_desde_at = None
 
     db.commit()
     if acabou_de_fechar:
@@ -1593,7 +1630,11 @@ def atualizar(
     )
     if ticket_out and ticket_out.atendente_id is None and ticket_out.fechado_em is None:
         if "atendente_id" in update or "setor_id" in update:
-            emit_ticket_fila(db, ticket_out)
+            if tentar_distribuicao_imediata(db, ticket_out):
+                db.commit()
+                emit_notificacao_after_counter_change(db)
+            else:
+                emit_ticket_fila(db, ticket_out)
     elif atribuicao_notificar_id is not None or "atendente_id" in update or "setor_id" in update:
         emit_notificacao_after_counter_change(db)
     return _ticket_para_read(ticket_out or ticket, db)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -60,6 +60,7 @@ class Settings(BaseSettings):
     NOTIFICACAO_EMAIL_DEBOUNCE_MINUTES: int = 5
     NOTIFICACAO_EMAIL_WORKER_INTERVAL_SECONDS: int = 10
     WHATSAPP_INACTIVITY_WORKER_INTERVAL_SECONDS: int = 60
+    TICKET_DISTRIBUICAO_WORKER_INTERVAL_SECONDS: int = 45
 
     # Modo legado: vários clientes no mesmo Postgres (subdomínio numérico + coluna tenant_id).
     # Produção comercial: manter False (um Postgres por cliente / deploy).

--- a/backend/app/core/distribuicao_ticket.py
+++ b/backend/app/core/distribuicao_ticket.py
@@ -1,0 +1,14 @@
+"""Enums e helpers de distribuição automática de tickets."""
+
+from enum import Enum
+
+
+class DistribuicaoModo(str, Enum):
+    manual = "manual"
+    auto_apos_timeout = "auto_apos_timeout"
+    auto_imediato = "auto_imediato"
+
+
+class DistribuicaoEstrategia(str, Enum):
+    round_robin = "round_robin"
+    menor_carga_abertos = "menor_carga_abertos"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -247,6 +247,32 @@ async def lifespan(app: FastAPI):
         name="whatsapp-inactivity",
     ).start()
 
+    def ticket_distribuicao_loop() -> None:
+        from app.database import SessionLocal
+        from app.services.ticket_distribuicao import processar_distribuicao_timeout
+
+        interval = max(30, settings.TICKET_DISTRIBUICAO_WORKER_INTERVAL_SECONDS)
+        while True:
+            db = SessionLocal()
+            try:
+                n = processar_distribuicao_timeout(db, limit=50)
+                if n:
+                    db.commit()
+                else:
+                    db.rollback()
+            except Exception as e:
+                logger.warning("Worker distribuição de tickets: %s", e)
+                db.rollback()
+            finally:
+                db.close()
+            time.sleep(interval)
+
+    threading.Thread(
+        target=ticket_distribuicao_loop,
+        daemon=True,
+        name="ticket-distribuicao",
+    ).start()
+
     yield
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,6 +3,7 @@ from app.models.empresa import Empresa
 from app.models.tipo_negocio import TipoNegocio
 from app.models.atendente import Atendente, AtendenteSetor
 from app.models.setor import Setor
+from app.models.setor_distribuicao_round_robin import SetorDistribuicaoRoundRobin
 from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
 from app.models.status_ticket import StatusTicket
 from app.models.ticket import Ticket, TicketHistorico, TicketMensagem
@@ -33,6 +34,7 @@ __all__ = [
     "Empresa",
     "TipoNegocio",
     "Setor",
+    "SetorDistribuicaoRoundRobin",
     "Atendente",
     "AtendenteSetor",
     "FuncionarioRede",

--- a/backend/app/models/setor.py
+++ b/backend/app/models/setor.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey, UniqueConstraint, JSON
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -16,6 +16,10 @@ class Setor(Base):
     nome = Column(String(100), nullable=False)
     slug = Column(String(50), nullable=False, index=True)
     ativo = Column(Boolean, default=True)
+    distribuicao_modo = Column(String(30), nullable=False, default="manual", server_default="manual")
+    distribuicao_timeout_minutos = Column(Integer, nullable=False, default=30, server_default="30")
+    distribuicao_estrategia = Column(String(30), nullable=False, default="round_robin", server_default="round_robin")
+    distribuicao_atendentes_elegiveis = Column(JSON, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/app/models/setor_distribuicao_round_robin.py
+++ b/backend/app/models/setor_distribuicao_round_robin.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Integer
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class SetorDistribuicaoRoundRobin(Base):
+    """Estado persistido do round-robin por setor."""
+
+    __tablename__ = "setor_distribuicao_round_robin"
+
+    setor_id = Column(Integer, ForeignKey("setores.id", ondelete="CASCADE"), primary_key=True)
+    last_atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/app/models/ticket.py
+++ b/backend/app/models/ticket.py
@@ -29,6 +29,7 @@ class Ticket(Base):
     assunto = Column(String(500), nullable=False)
     descricao = Column(Text, nullable=True)
     fechado_em = Column(DateTime(timezone=True), nullable=True)
+    fila_desde_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/app/schemas/setor.py
+++ b/backend/app/schemas/setor.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel, ConfigDict
 from datetime import datetime
 
+from app.schemas.setor_distribuicao import SetorDistribuicaoRead
+
 
 class SetorBase(BaseModel):
     nome: str
@@ -22,5 +24,6 @@ class SetorRead(SetorBase):
     id: int
     created_at: datetime | None = None
     updated_at: datetime | None = None
+    distribuicao: SetorDistribuicaoRead | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/setor_distribuicao.py
+++ b/backend/app/schemas/setor_distribuicao.py
@@ -1,0 +1,32 @@
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.core.distribuicao_ticket import DistribuicaoEstrategia, DistribuicaoModo
+
+
+class SetorDistribuicaoRead(BaseModel):
+    modo: DistribuicaoModo = DistribuicaoModo.manual
+    timeout_minutos: int = 30
+    estrategia: DistribuicaoEstrategia = DistribuicaoEstrategia.round_robin
+    atendentes_elegiveis: list[int] | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SetorDistribuicaoUpdate(BaseModel):
+    modo: DistribuicaoModo
+    timeout_minutos: int = Field(default=30, ge=1, le=24 * 60)
+    estrategia: DistribuicaoEstrategia = DistribuicaoEstrategia.round_robin
+    atendentes_elegiveis: list[int] | None = None
+
+    @field_validator("atendentes_elegiveis")
+    @classmethod
+    def deduplicar_elegiveis(cls, v: list[int] | None) -> list[int] | None:
+        if v is None:
+            return None
+        seen: set[int] = set()
+        out: list[int] = []
+        for i in v:
+            if i not in seen:
+                seen.add(i)
+                out.append(i)
+        return out

--- a/backend/app/schemas/ticket.py
+++ b/backend/app/schemas/ticket.py
@@ -172,6 +172,9 @@ class TicketRead(BaseModel):
     avaliacao_comentario: str | None = None
     avaliacao_respondida_em: datetime | None = None
     csat_pendente: bool = False
+    fila_desde_at: datetime | None = None
+    distribuicao_modo_setor: str | None = None
+    distribuicao_auto_em_minutos: int | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/ticket_distribuicao.py
+++ b/backend/app/services/ticket_distribuicao.py
@@ -1,0 +1,306 @@
+"""Distribuição automática de tickets na fila por setor."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.distribuicao_ticket import DistribuicaoModo, DistribuicaoEstrategia
+from app.core.setor_scope import ids_setores_mesmo_nome
+from app.models import Setor, Ticket, TicketHistorico
+from app.models.atendente import Atendente, atendente_setor
+from app.models.setor_distribuicao_round_robin import SetorDistribuicaoRoundRobin
+from app.services.notificacao_atendente_email import notificar_ticket_atribuido
+from app.services.realtime_emit import emit_notificacao_after_counter_change, emit_ticket_fila
+
+logger = logging.getLogger(__name__)
+
+
+def setor_para_distribuicao_read(setor: Setor):
+    from app.schemas.setor_distribuicao import SetorDistribuicaoRead
+
+    return SetorDistribuicaoRead(
+        modo=setor.distribuicao_modo or DistribuicaoModo.manual.value,
+        timeout_minutos=int(setor.distribuicao_timeout_minutos or 30),
+        estrategia=setor.distribuicao_estrategia or DistribuicaoEstrategia.round_robin.value,
+        atendentes_elegiveis=setor.distribuicao_atendentes_elegiveis,
+    )
+
+
+def _agora_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _as_utc(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def sincronizar_fila_desde_at(ticket: Ticket, *, reset: bool = False) -> None:
+    """Atualiza ``fila_desde_at`` conforme o ticket está ou não na fila."""
+    if ticket.atendente_id is None and ticket.fechado_em is None:
+        if reset or ticket.fila_desde_at is None:
+            ticket.fila_desde_at = _agora_utc()
+    else:
+        ticket.fila_desde_at = None
+
+
+def _registrar_historico_atribuicao(
+    db: Session,
+    ticket_id: int,
+    valor_antigo: str | None,
+    valor_novo: str,
+) -> None:
+    db.add(
+        TicketHistorico(
+            ticket_id=ticket_id,
+            atendente_id=None,
+            campo="atendente_id",
+            valor_antigo=valor_antigo,
+            valor_novo=valor_novo,
+        )
+    )
+
+
+def listar_atendentes_elegiveis_distribuicao(db: Session, setor: Setor) -> list[Atendente]:
+    """Atendentes ativos do setor (homônimos), excluindo admin."""
+    ids_setor = ids_setores_mesmo_nome(db, setor.id)
+    q = (
+        db.query(Atendente)
+        .join(atendente_setor, atendente_setor.c.atendente_id == Atendente.id)
+        .filter(
+            Atendente.tenant_id == setor.tenant_id,
+            Atendente.ativo.is_(True),
+            Atendente.role != "admin",
+            atendente_setor.c.setor_id.in_(ids_setor),
+        )
+        .distinct()
+    )
+    elegiveis = setor.distribuicao_atendentes_elegiveis
+    if elegiveis is not None:
+        q = q.filter(Atendente.id.in_(elegiveis))
+    return sorted(q.all(), key=lambda a: (a.nome.lower(), a.id))
+
+
+def _contar_tickets_abertos_por_atendente(db: Session, atendente_ids: list[int], setor_ids: set[int]) -> dict[int, int]:
+    if not atendente_ids:
+        return {}
+    rows = (
+        db.query(Ticket.atendente_id, func.count(Ticket.id))
+        .filter(
+            Ticket.atendente_id.in_(atendente_ids),
+            Ticket.setor_id.in_(setor_ids),
+            Ticket.fechado_em.is_(None),
+        )
+        .group_by(Ticket.atendente_id)
+        .all()
+    )
+    out = {aid: 0 for aid in atendente_ids}
+    for aid, cnt in rows:
+        if aid is not None:
+            out[aid] = int(cnt)
+    return out
+
+
+def _escolher_menor_carga(db: Session, setor: Setor, candidatos: list[Atendente]) -> Atendente | None:
+    if not candidatos:
+        return None
+    ids_setor = ids_setores_mesmo_nome(db, setor.id)
+    cargas = _contar_tickets_abertos_por_atendente(db, [c.id for c in candidatos], ids_setor)
+    return min(candidatos, key=lambda a: (cargas.get(a.id, 0), a.nome.lower(), a.id))
+
+
+def _escolher_round_robin(db: Session, setor_id: int, candidatos: list[Atendente]) -> Atendente | None:
+    if not candidatos:
+        return None
+    state = (
+        db.query(SetorDistribuicaoRoundRobin)
+        .filter(SetorDistribuicaoRoundRobin.setor_id == setor_id)
+        .with_for_update()
+        .first()
+    )
+    if not state:
+        state = SetorDistribuicaoRoundRobin(setor_id=setor_id)
+        db.add(state)
+        db.flush()
+
+    ids_candidatos = [c.id for c in candidatos]
+    last = state.last_atendente_id
+    if last is None or last not in ids_candidatos:
+        escolhido = candidatos[0]
+    else:
+        idx = ids_candidatos.index(last)
+        escolhido = candidatos[(idx + 1) % len(candidatos)]
+    state.last_atendente_id = escolhido.id
+    return escolhido
+
+
+def _escolher_atendente(db: Session, setor: Setor, candidatos: list[Atendente]) -> Atendente | None:
+    estrategia = setor.distribuicao_estrategia or DistribuicaoEstrategia.round_robin.value
+    if estrategia == DistribuicaoEstrategia.menor_carga_abertos.value:
+        return _escolher_menor_carga(db, setor, candidatos)
+    return _escolher_round_robin(db, setor.id, candidatos)
+
+
+def atribuir_ticket_automaticamente(
+    db: Session,
+    ticket: Ticket,
+    setor: Setor,
+    *,
+    actor_id: int | None = None,
+) -> int | None:
+    """Atribui responsável automaticamente. Retorna o id do atendente ou None."""
+    if ticket.atendente_id is not None or ticket.fechado_em is not None:
+        return None
+    candidatos = listar_atendentes_elegiveis_distribuicao(db, setor)
+    escolhido = _escolher_atendente(db, setor, candidatos)
+    if not escolhido:
+        return None
+
+    antigo = str(ticket.atendente_id) if ticket.atendente_id else ""
+    ticket.atendente_id = escolhido.id
+    ticket.fila_desde_at = None
+    _registrar_historico_atribuicao(db, ticket.id, antigo or None, str(escolhido.id))
+    db.flush()
+    notificar_ticket_atribuido(
+        db,
+        ticket=ticket,
+        novo_atendente_id=escolhido.id,
+        actor_id=actor_id,
+    )
+    return escolhido.id
+
+
+def tentar_distribuicao_imediata(db: Session, ticket: Ticket, *, actor_id: int | None = None) -> bool:
+    """Tenta atribuição imediata se o setor estiver em ``auto_imediato``."""
+    setor = db.query(Setor).filter(Setor.id == ticket.setor_id).first()
+    if not setor or not setor.ativo:
+        return False
+    modo = setor.distribuicao_modo or DistribuicaoModo.manual.value
+    if modo != DistribuicaoModo.auto_imediato.value:
+        return False
+    novo = atribuir_ticket_automaticamente(db, ticket, setor, actor_id=actor_id)
+    return novo is not None
+
+
+def pos_entrada_fila(db: Session, ticket: Ticket, *, reset_fila: bool = False) -> None:
+    """Chamado quando o ticket entra (ou retorna) à fila sem responsável."""
+    sincronizar_fila_desde_at(ticket, reset=reset_fila)
+    db.flush()
+    if tentar_distribuicao_imediata(db, ticket):
+        emit_notificacao_after_counter_change(db)
+    elif ticket.atendente_id is None and ticket.fechado_em is None:
+        emit_ticket_fila(db, ticket)
+
+
+def fila_info_para_ticket(ticket: Ticket, setor: Setor | None) -> dict:
+    if ticket.atendente_id is not None or ticket.fechado_em is not None or setor is None:
+        return {
+            "fila_desde_at": None,
+            "distribuicao_modo_setor": None,
+            "distribuicao_auto_em_minutos": None,
+        }
+    fila_desde = _as_utc(ticket.fila_desde_at or ticket.created_at)
+    modo = setor.distribuicao_modo or DistribuicaoModo.manual.value
+    minutos_restantes: int | None = None
+    if modo == DistribuicaoModo.auto_apos_timeout.value and fila_desde is not None:
+        timeout = int(setor.distribuicao_timeout_minutos or 30)
+        decorridos = int((_agora_utc() - fila_desde).total_seconds() // 60)
+        minutos_restantes = max(0, timeout - decorridos)
+    return {
+        "fila_desde_at": fila_desde,
+        "distribuicao_modo_setor": modo,
+        "distribuicao_auto_em_minutos": minutos_restantes,
+    }
+
+
+def processar_distribuicao_timeout(db: Session, *, limit: int = 50) -> int:
+    """Worker: atribui tickets que excederam o timeout de fila."""
+    agora = _agora_utc()
+    atribuidos = 0
+    setores = (
+        db.query(Setor)
+        .filter(
+            Setor.ativo.is_(True),
+            Setor.distribuicao_modo == DistribuicaoModo.auto_apos_timeout.value,
+        )
+        .all()
+    )
+    for setor in setores:
+        timeout = max(1, int(setor.distribuicao_timeout_minutos or 30))
+        cutoff = agora - timedelta(minutes=timeout)
+        q = (
+            db.query(Ticket)
+            .filter(
+                Ticket.setor_id == setor.id,
+                Ticket.atendente_id.is_(None),
+                Ticket.fechado_em.is_(None),
+                Ticket.fila_desde_at.isnot(None),
+                Ticket.fila_desde_at <= cutoff,
+            )
+            .order_by(Ticket.fila_desde_at.asc(), Ticket.id.asc())
+            .limit(limit)
+        )
+        try:
+            tickets = q.with_for_update(skip_locked=True).all()
+        except Exception:
+            tickets = q.all()
+
+        for ticket in tickets:
+            if atribuidos >= limit:
+                return atribuidos
+            novo = atribuir_ticket_automaticamente(db, ticket, setor)
+            if novo is not None:
+                atribuidos += 1
+
+    if atribuidos:
+        emit_notificacao_after_counter_change(db)
+    return atribuidos
+
+
+def validar_atendentes_elegiveis(
+    db: Session,
+    setor: Setor,
+    atendentes_elegiveis: list[int] | None,
+) -> list[int] | None:
+    if atendentes_elegiveis is None:
+        return None
+    if not atendentes_elegiveis:
+        raise ValueError("Informe ao menos um atendente elegível ou deixe vazio para todos do setor.")
+    ids_setor = ids_setores_mesmo_nome(db, setor.id)
+    vinculados = {
+        r[0]
+        for r in db.query(Atendente.id)
+        .join(atendente_setor, atendente_setor.c.atendente_id == Atendente.id)
+        .filter(
+            Atendente.tenant_id == setor.tenant_id,
+            Atendente.ativo.is_(True),
+            Atendente.role != "admin",
+            atendente_setor.c.setor_id.in_(ids_setor),
+            Atendente.id.in_(atendentes_elegiveis),
+        )
+        .all()
+    }
+    invalidos = [i for i in atendentes_elegiveis if i not in vinculados]
+    if invalidos:
+        raise ValueError(f"Atendentes não elegíveis para o setor: {invalidos}")
+    return atendentes_elegiveis
+
+
+def pos_criar_ticket_na_fila(db: Session, ticket: Ticket) -> None:
+    """Hook pós-criação: sincroniza fila e tenta distribuição imediata."""
+    if ticket.atendente_id is not None or ticket.fechado_em is not None:
+        return
+    sincronizar_fila_desde_at(ticket)
+    db.commit()
+    if tentar_distribuicao_imediata(db, ticket):
+        db.commit()
+        emit_notificacao_after_counter_change(db)
+    else:
+        emit_ticket_fila(db, ticket)

--- a/backend/app/services/ticket_from_inbound_email.py
+++ b/backend/app/services/ticket_from_inbound_email.py
@@ -201,6 +201,9 @@ def processar_email_inbound(
                 registar_message_id_para_ticket(db, ticket_id=ticket.id, message_id=out_mid, source="outbound")
             db.commit()
             db.refresh(ticket)
+            from app.services.ticket_distribuicao import pos_criar_ticket_na_fila
+
+            pos_criar_ticket_na_fila(db, ticket)
             return EmailInboundProcessResult(
                 ticket=ticket,
                 duplicate=False,
@@ -286,6 +289,9 @@ def processar_email_inbound(
     registar_message_id_para_ticket(db, ticket_id=ticket.id, message_id=mid, source="inbound")
     db.commit()
     db.refresh(ticket)
+    from app.services.ticket_distribuicao import pos_criar_ticket_na_fila
+
+    pos_criar_ticket_na_fila(db, ticket)
     return EmailInboundProcessResult(ticket=ticket, duplicate=False)
 
 

--- a/backend/tests/test_ticket_distribuicao.py
+++ b/backend/tests/test_ticket_distribuicao.py
@@ -1,0 +1,162 @@
+"""Testes de distribuição automática de tickets (#257)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.models import Setor, Ticket, TicketHistorico
+from app.models.atendente_notificacao import NotificacaoEmailOutbox
+from app.models.setor_distribuicao_round_robin import SetorDistribuicaoRoundRobin
+from app.services.ticket_distribuicao import (
+    atribuir_ticket_automaticamente,
+    processar_distribuicao_timeout,
+    tentar_distribuicao_imediata,
+)
+
+
+def _criar_ticket_fila(db, seed_base, *, setor_id=None, fila_desde_at=None):
+    setor_id = setor_id or seed_base["setor1"].id
+    t = Ticket(
+        tenant_id=1,
+        protocolo=f"T-TEST-{db.query(Ticket).count() + 1}",
+        empresa_id=seed_base["empresa"].id,
+        rede_id=seed_base["rede"].id,
+        setor_id=setor_id,
+        status_id=seed_base["status"].id,
+        assunto="Teste fila",
+        fila_desde_at=fila_desde_at or datetime.now(timezone.utc),
+    )
+    db.add(t)
+    db.flush()
+    return t
+
+
+def test_put_distribuicao_setor(client, seed_base, auth_headers, db_session):
+    setor_id = seed_base["setor1"].id
+    r = client.put(
+        f"/v1/setores/{setor_id}/distribuicao",
+        headers=auth_headers["admin"],
+        json={
+            "modo": "auto_apos_timeout",
+            "timeout_minutos": 15,
+            "estrategia": "round_robin",
+            "atendentes_elegiveis": None,
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["modo"] == "auto_apos_timeout"
+    assert body["timeout_minutos"] == 15
+
+    s = db_session.query(Setor).filter(Setor.id == setor_id).first()
+    db_session.refresh(s)
+    assert s.distribuicao_modo == "auto_apos_timeout"
+    assert s.distribuicao_timeout_minutos == 15
+
+
+def test_distribuicao_imediata_round_robin(client, seed_base, auth_headers, db_session):
+    setor = seed_base["setor1"]
+    setor.distribuicao_modo = "auto_imediato"
+    setor.distribuicao_estrategia = "round_robin"
+    db_session.commit()
+
+    t1 = _criar_ticket_fila(db_session, seed_base)
+    t2 = _criar_ticket_fila(db_session, seed_base)
+    db_session.commit()
+
+    assert tentar_distribuicao_imediata(db_session, t1) is True
+    db_session.commit()
+    assert t1.atendente_id == seed_base["a1"].id
+
+    assert tentar_distribuicao_imediata(db_session, t2) is True
+    db_session.commit()
+    assert t2.atendente_id == seed_base["a1"].id
+
+    state = db_session.query(SetorDistribuicaoRoundRobin).filter(SetorDistribuicaoRoundRobin.setor_id == setor.id).first()
+    assert state is not None
+    assert state.last_atendente_id == seed_base["a1"].id
+
+
+def test_distribuicao_nao_atribui_admin(db_session, seed_base):
+    setor = seed_base["setor1"]
+    setor.distribuicao_modo = "auto_imediato"
+    db_session.commit()
+
+    admin = seed_base["admin"]
+    admin.setores.append(setor)
+    db_session.commit()
+
+    ticket = _criar_ticket_fila(db_session, seed_base)
+    db_session.commit()
+
+    ok = atribuir_ticket_automaticamente(db_session, ticket, setor)
+    db_session.commit()
+    assert ok == seed_base["a1"].id
+    assert ticket.atendente_id != admin.id
+
+
+def test_worker_timeout_atribui(client, seed_base, db_session):
+    setor = seed_base["setor1"]
+    setor.distribuicao_modo = "auto_apos_timeout"
+    setor.distribuicao_timeout_minutos = 5
+    db_session.commit()
+
+    antigo = datetime.now(timezone.utc) - timedelta(minutes=10)
+    ticket = _criar_ticket_fila(db_session, seed_base, fila_desde_at=antigo)
+    db_session.commit()
+
+    n = processar_distribuicao_timeout(db_session, limit=10)
+    db_session.commit()
+    assert n == 1
+    db_session.refresh(ticket)
+    assert ticket.atendente_id == seed_base["a1"].id
+
+    hist = (
+        db_session.query(TicketHistorico)
+        .filter(TicketHistorico.ticket_id == ticket.id, TicketHistorico.campo == "atendente_id")
+        .first()
+    )
+    assert hist is not None
+    assert hist.valor_novo == str(seed_base["a1"].id)
+
+
+def test_atribuicao_automatica_notifica(client, seed_base, db_session):
+    setor = seed_base["setor1"]
+    setor.distribuicao_modo = "auto_imediato"
+    db_session.commit()
+
+    ticket = _criar_ticket_fila(db_session, seed_base)
+    db_session.commit()
+
+    atribuir_ticket_automaticamente(db_session, ticket, setor)
+    db_session.commit()
+
+    outbox = (
+        db_session.query(NotificacaoEmailOutbox)
+        .filter(
+            NotificacaoEmailOutbox.ticket_id == ticket.id,
+            NotificacaoEmailOutbox.tipo == "ticket_atribuido",
+        )
+        .first()
+    )
+    assert outbox is not None
+
+
+def test_criar_ticket_auto_imediato_via_api(client, seed_base, auth_headers, db_session):
+    setor = seed_base["setor1"]
+    setor.distribuicao_modo = "auto_imediato"
+    db_session.commit()
+
+    r = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": setor.id,
+            "assunto": "Novo com auto",
+            "descricao": "Corpo",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["atendente_id"] == seed_base["a1"].id

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -360,6 +360,8 @@ export const setores = {
   get: (id: number) => api<Setores.Setor>(`/setores/${id}`),
   create: (data: Setores.Create) => api<Setores.Setor>('/setores', { method: 'POST', body: JSON.stringify(data) }),
   update: (id: number, data: Setores.Update) => api<Setores.Setor>(`/setores/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  updateDistribuicao: (id: number, data: Setores.DistribuicaoUpdate) =>
+    api<Setores.Distribuicao>(`/setores/${id}/distribuicao`, { method: 'PUT', body: JSON.stringify(data) }),
   delete: (id: number) => api<void>(`/setores/${id}`, { method: 'DELETE' }),
 };
 
@@ -1186,11 +1188,22 @@ export namespace TiposNegocio {
 }
 
 export namespace Setores {
+  export type DistribuicaoModo = 'manual' | 'auto_apos_timeout' | 'auto_imediato'
+  export type DistribuicaoEstrategia = 'round_robin' | 'menor_carga_abertos'
+
+  export interface Distribuicao {
+    modo: DistribuicaoModo
+    timeout_minutos: number
+    estrategia: DistribuicaoEstrategia
+    atendentes_elegiveis: number[] | null
+  }
+
   export interface Setor {
     id: number;
     nome: string;
     slug: string;
     ativo: boolean;
+    distribuicao?: Distribuicao | null;
   }
   export interface Create {
     nome: string;
@@ -1201,6 +1214,12 @@ export namespace Setores {
     nome?: string;
     slug?: string;
     ativo?: boolean;
+  }
+  export interface DistribuicaoUpdate {
+    modo: DistribuicaoModo;
+    timeout_minutos: number;
+    estrategia: DistribuicaoEstrategia;
+    atendentes_elegiveis?: number[] | null;
   }
 }
 
@@ -1557,6 +1576,9 @@ export namespace Tickets {
     avaliacao_comentario?: string | null;
     avaliacao_respondida_em?: string | null;
     csat_pendente?: boolean;
+    fila_desde_at?: string | null;
+    distribuicao_modo_setor?: string | null;
+    distribuicao_auto_em_minutos?: number | null;
   }
   export type TicketVinculoTipo = 'duplicado_de' | 'relacionado_a';
   export interface TicketVinculoOutro {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -19,7 +19,7 @@ const menuIcon = (
   </svg>
 )
 
-export function Layout() {
+function LayoutInner() {
   const { user, logout, isAdmin } = useAuth()
   const location = useLocation()
   const [sidebarExpanded, setSidebarExpanded] = useState(true)
@@ -37,7 +37,6 @@ export function Layout() {
     /^\/tickets\/\d+\/?$/.test(location.pathname) || location.pathname === '/tickets/novo'
 
   return (
-    <EventStreamProvider enabled={notificacoesEnabled}>
     <div
       className="flex h-dvh max-h-dvh min-h-0 overflow-hidden bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95 md:grid md:grid-cols-[var(--sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
       style={
@@ -112,6 +111,16 @@ export function Layout() {
           </main>
       </div>
     </div>
+  )
+}
+
+export function Layout() {
+  const { user } = useAuth()
+  const notificacoesEnabled = Boolean(user && !user.must_change_password)
+
+  return (
+    <EventStreamProvider enabled={notificacoesEnabled}>
+      <LayoutInner />
     </EventStreamProvider>
   )
 }

--- a/frontend/src/pages/SetorDetalhe.tsx
+++ b/frontend/src/pages/SetorDetalhe.tsx
@@ -7,11 +7,23 @@ import { Button } from '../components/ui/Button'
 import { DetailRow } from '../components/ui/DetailRow'
 import { BadgeAtivo } from '../components/ui/BadgeAtivo'
 import { SelectComPesquisa } from '../components/ui/SelectComPesquisa'
+import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { SemPermissao } from './SemPermissao'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+
+const MODO_OPCOES: { value: Setores.DistribuicaoModo; label: string }[] = [
+  { value: 'manual', label: 'Manual — fila sem atribuição automática' },
+  { value: 'auto_apos_timeout', label: 'Automático após tempo na fila' },
+  { value: 'auto_imediato', label: 'Automático imediato ao entrar na fila' },
+]
+
+const ESTRATEGIA_OPCOES: { value: Setores.DistribuicaoEstrategia; label: string }[] = [
+  { value: 'round_robin', label: 'Round-robin (revezamento)' },
+  { value: 'menor_carga_abertos', label: 'Menor carga (tickets abertos)' },
+]
 
 /** Mesmo nome de setor = mesmo “setor lógico” (vários IDs no banco). */
 function idsSetoresMesmoNome(setoresList: Setores.Setor[], setorId: number): Set<number> {
@@ -39,6 +51,13 @@ export function SetorDetalhe() {
   const [addingId, setAddingId] = useState<number | ''>('')
   const [saving, setSaving] = useState(false)
 
+  const [distModo, setDistModo] = useState<Setores.DistribuicaoModo>('manual')
+  const [distTimeout, setDistTimeout] = useState(30)
+  const [distEstrategia, setDistEstrategia] = useState<Setores.DistribuicaoEstrategia>('round_robin')
+  const [distElegiveisIds, setDistElegiveisIds] = useState<number[]>([])
+  const [distUsarTodos, setDistUsarTodos] = useState(true)
+  const [savingDist, setSavingDist] = useState(false)
+
   const grupoSetorIds = useMemo(() => {
     if (!Number.isFinite(setorId) || setorId <= 0 || setoresList.length === 0) return new Set<number>()
     return idsSetoresMesmoNome(setoresList, setorId)
@@ -59,6 +78,21 @@ export function SetorDetalhe() {
       })),
     [candidatosParaAdicionar],
   )
+
+  const vinculadosOperacionais = useMemo(
+    () => vinculados.filter((a) => a.ativo && a.role !== 'admin').sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR')),
+    [vinculados],
+  )
+
+  function aplicarDistribuicaoDoSetor(s: Setores.Setor) {
+    const d = s.distribuicao
+    setDistModo(d?.modo ?? 'manual')
+    setDistTimeout(d?.timeout_minutos ?? 30)
+    setDistEstrategia(d?.estrategia ?? 'round_robin')
+    const eleg = d?.atendentes_elegiveis ?? null
+    setDistUsarTodos(eleg === null || eleg === undefined)
+    setDistElegiveisIds(eleg ?? [])
+  }
 
   async function reload() {
     if (!Number.isFinite(setorId) || setorId <= 0) {
@@ -83,6 +117,7 @@ export function SetorDetalhe() {
         ),
       ])
       setSetor(s)
+      aplicarDistribuicaoDoSetor(s)
       setSetoresList(setoresAll)
       setTodosAtendentes(todos)
 
@@ -138,7 +173,6 @@ export function SetorDetalhe() {
     setSaving(true)
     try {
       const atual = new Set(atendente.setor_ids ?? [])
-      // remove do “setor lógico” (todas duplicatas de mesmo nome)
       for (const sid of grupoSetorIds) atual.delete(sid)
       await updateVinculo(atendente, Array.from(atual))
       toast.showSuccess('Vínculo removido.')
@@ -147,6 +181,46 @@ export function SetorDetalhe() {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível remover o vínculo.'))
     } finally {
       setSaving(false)
+    }
+  }
+
+  function toggleElegivel(atendenteId: number) {
+    setDistElegiveisIds((prev) => {
+      const s = new Set(prev)
+      if (s.has(atendenteId)) s.delete(atendenteId)
+      else s.add(atendenteId)
+      return Array.from(s).sort((a, b) => a - b)
+    })
+  }
+
+  async function handleSalvarDistribuicao() {
+    if (savingDist || !setor) return
+    if (distModo === 'auto_imediato') {
+      const ok = confirm(
+        'Tickets novos ou devolvidos à fila serão atribuídos automaticamente assim que entrarem. Deseja continuar?',
+      )
+      if (!ok) return
+    }
+    if (!distUsarTodos && distElegiveisIds.length === 0) {
+      toast.showError('Selecione ao menos um atendente elegível ou marque «todos do setor».')
+      return
+    }
+    setSavingDist(true)
+    try {
+      const body: Setores.DistribuicaoUpdate = {
+        modo: distModo,
+        timeout_minutos: Math.max(1, distTimeout),
+        estrategia: distEstrategia,
+        atendentes_elegiveis: distUsarTodos ? null : distElegiveisIds,
+      }
+      const atualizado = await setores.updateDistribuicao(setor.id, body)
+      setSetor((prev) => (prev ? { ...prev, distribuicao: atualizado } : prev))
+      aplicarDistribuicaoDoSetor({ ...setor, distribuicao: atualizado })
+      toast.showSuccess('Distribuição automática atualizada.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a distribuição.'))
+    } finally {
+      setSavingDist(false)
     }
   }
 
@@ -226,6 +300,91 @@ export function SetorDetalhe() {
         </dl>
       </Card>
 
+      <Card title="Distribuição automática de tickets">
+        <div className="space-y-4">
+          <p className="text-sm text-slate-600 dark:text-slate-400">
+            Define como tickets sem responsável neste setor são atribuídos. Administradores nunca recebem atribuição
+            automática.
+          </p>
+
+          <Select
+            label="Modo"
+            value={distModo}
+            onChange={(v) => setDistModo(v as Setores.DistribuicaoModo)}
+            options={MODO_OPCOES.map((o) => ({ value: o.value, label: o.label }))}
+          />
+
+          {distModo === 'auto_apos_timeout' && (
+            <div className="max-w-xs">
+              <label htmlFor="dist-timeout" className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
+                Tempo na fila antes de atribuir (minutos)
+              </label>
+              <input
+                id="dist-timeout"
+                type="number"
+                min={1}
+                max={1440}
+                value={distTimeout}
+                onChange={(e) => setDistTimeout(Number(e.target.value) || 1)}
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              />
+            </div>
+          )}
+
+          {distModo !== 'manual' && (
+            <>
+              <Select
+                label="Estratégia"
+                value={distEstrategia}
+                onChange={(v) => setDistEstrategia(v as Setores.DistribuicaoEstrategia)}
+                options={ESTRATEGIA_OPCOES.map((o) => ({ value: o.value, label: o.label }))}
+              />
+
+              <div className="space-y-2">
+                <label className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+                  <input
+                    type="checkbox"
+                    checked={distUsarTodos}
+                    onChange={(e) => setDistUsarTodos(e.target.checked)}
+                    className="size-4 rounded border-slate-300 text-sky-600 focus:ring-sky-500"
+                  />
+                  Todos os atendentes vinculados ao setor
+                </label>
+                {!distUsarTodos && (
+                  <div className="rounded-lg border border-slate-200 p-3 dark:border-slate-700">
+                    {vinculadosOperacionais.length === 0 ? (
+                      <p className="text-sm text-slate-500 dark:text-slate-400">Nenhum atendente operacional vinculado.</p>
+                    ) : (
+                      <ul className="space-y-2">
+                        {vinculadosOperacionais.map((a) => (
+                          <li key={a.id}>
+                            <label className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+                              <input
+                                type="checkbox"
+                                checked={distElegiveisIds.includes(a.id)}
+                                onChange={() => toggleElegivel(a.id)}
+                                className="size-4 rounded border-slate-300 text-sky-600 focus:ring-sky-500"
+                              />
+                              {a.nome}
+                            </label>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
+          <div>
+            <Button onClick={handleSalvarDistribuicao} loading={savingDist}>
+              Salvar distribuição
+            </Button>
+          </div>
+        </div>
+      </Card>
+
       <Card title="Atendentes vinculados">
         <div className="space-y-4">
           <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
@@ -295,4 +454,3 @@ export function SetorDetalhe() {
     </div>
   )
 }
-

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -44,6 +44,15 @@ const searchIcon = (
   </svg>
 )
 
+function formatarTempoNaFila(filaDesdeAt: string | undefined | null): string {
+  if (!filaDesdeAt) return '—'
+  const min = Math.max(0, Math.floor((Date.now() - new Date(filaDesdeAt).getTime()) / 60000))
+  if (min < 60) return `${min} min`
+  const h = Math.floor(min / 60)
+  const m = min % 60
+  return m > 0 ? `${h}h ${m}min` : `${h}h`
+}
+
 export function Tickets() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -110,6 +119,8 @@ export function Tickets() {
     const ativos = atendentesOpt.filter((a) => a.ativo)
     return [...ativos].sort((a, b) => a.nome.localeCompare(b.nome, 'pt-BR')).map((a) => ({ value: a.id, label: a.nome }))
   }, [atendentesOpt])
+
+  const mostrarColunasFila = situacao === 'abertos' && filtroFila === 'sem_responsavel'
 
   const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE_PADRAO))
   const inicio = total === 0 ? 0 : (page - 1) * PAGE_SIZE_PADRAO + 1
@@ -621,6 +632,17 @@ export function Tickets() {
                         <span className="font-medium text-slate-600 dark:text-slate-300">Resp.:</span>{' '}
                         {t.atendente_nome ?? 'Na fila'}
                       </span>
+                      {mostrarColunasFila && (
+                        <span className="truncate">
+                          <span className="font-medium text-slate-600 dark:text-slate-300">Na fila há:</span>{' '}
+                          {formatarTempoNaFila(t.fila_desde_at)}
+                        </span>
+                      )}
+                      {mostrarColunasFila && t.distribuicao_modo_setor === 'auto_apos_timeout' && t.distribuicao_auto_em_minutos != null && (
+                        <span className="inline-flex rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
+                          Auto em {t.distribuicao_auto_em_minutos} min
+                        </span>
+                      )}
                       {situacao === 'abertos' && (
                         <span className="truncate">
                           <span className="font-medium text-slate-600 dark:text-slate-300">Prior.:</span>{' '}
@@ -747,6 +769,12 @@ export function Tickets() {
                     }}
                     className="hidden px-4 py-3 lg:table-cell sm:px-6"
                   />
+                  {mostrarColunasFila && (
+                    <th className="hidden whitespace-nowrap px-4 py-3 lg:table-cell sm:px-6">Na fila há</th>
+                  )}
+                  {mostrarColunasFila && (
+                    <th className="hidden whitespace-nowrap px-4 py-3 xl:table-cell sm:px-6">Distribuição</th>
+                  )}
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -836,6 +864,22 @@ export function Tickets() {
                         {t.atendente_nome ?? 'Na fila'}
                       </span>
                     </td>
+                    {mostrarColunasFila && (
+                      <td className="hidden whitespace-nowrap px-4 py-3.5 align-top text-slate-600 lg:table-cell sm:px-6 dark:text-slate-400">
+                        {formatarTempoNaFila(t.fila_desde_at)}
+                      </td>
+                    )}
+                    {mostrarColunasFila && (
+                      <td className="hidden px-4 py-3.5 align-top xl:table-cell sm:px-6">
+                        {t.distribuicao_modo_setor === 'auto_apos_timeout' && t.distribuicao_auto_em_minutos != null ? (
+                          <span className="inline-flex rounded-full bg-amber-50 px-2.5 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
+                            Auto em {t.distribuicao_auto_em_minutos} min
+                          </span>
+                        ) : (
+                          <span className="text-slate-400">—</span>
+                        )}
+                      </td>
+                    )}
                   </tr>
                 ))}
               </tbody>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumo

Implementa o épico **#257 — Distribuição automática de tickets** (T-F1 + T-F2), cobrindo as issues #270, #271, #272 e #273.

Tickets sem responsável podem ser atribuídos automaticamente conforme a configuração de cada setor.

## Backend

### T-F1 — Configuração (#270)
- Migration `043_setor_distribuicao_tickets`: colunas em `setores`, `fila_desde_at` em `tickets`, tabela `setor_distribuicao_round_robin`
- `PUT /v1/setores/{id}/distribuicao` — modo (`manual` | `auto_apos_timeout` | `auto_imediato`), timeout, estratégia, atendentes elegíveis
- Defaults: manual, timeout 30 min, round-robin; audit log `distribuicao_update`
- Campos de distribuição expostos em `SetorRead.distribuicao`

### T-F2 — Worker e atribuição (#271)
- Serviço `ticket_distribuicao.py`: elegíveis (exclui admin), round-robin com estado persistido, menor carga (tickets abertos)
- Worker em thread no lifespan (intervalo configurável, default 45s) para `auto_apos_timeout`
- Hook pós-criação/atualização para `auto_imediato` (API tickets, e-mail inbound, filhos em massa)
- Notificação de atribuição (#109) via outbox existente; emissão SSE de contadores quando aplicável
- `TicketRead` enriquecido com `fila_desde_at`, `distribuicao_modo_setor`, `distribuicao_auto_em_minutos`

## Frontend

### T-F1 UI (#272)
- `SetorDetalhe`: card «Distribuição automática» — modo, timeout, estratégia, elegíveis; confirmação para `auto_imediato`

### T-F2 UI (#273)
- `Tickets`: com filtro «sem responsável», colunas «Na fila há» e badge «Auto em X min»

## Testes

- 6 testes novos em `test_ticket_distribuicao.py`
- Suite completa: **189 passed**

## Validação manual sugerida

1. Rodar migration `043` no ambiente local
2. Em Setores → detalhe, configurar `auto_imediato` e criar ticket no setor
3. Configurar `auto_apos_timeout` (ex.: 2 min), aguardar worker, verificar atribuição
4. Listar tickets «sem responsável» e conferir colunas de fila

Closes #270, #271, #272, #273
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-433597c5-e949-4afc-9a44-e6b31b45b2f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-433597c5-e949-4afc-9a44-e6b31b45b2f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

