### PR TITLE
feat(observabilidade): health, retry, webhook e logs (#119)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+  workflow_dispatch:
 
 jobs:
   backend:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -52,7 +52,12 @@ LOG_LEVEL=INFO
 #
 # Ficheiros de mídia WhatsApp (path relativo ao cwd ou absoluto). Em Docker o cwd é /app — use volume em ./backend/data.
 # WHATSAPP_MEDIA_DIR=data/whatsapp_media
-# WHATSAPP_MEDIA_MAX_BYTES=26214400
+# EVOLUTION_HTTP_MAX_ATTEMPTS=3
+#
+# --- Webhook de saída (ticket fechado, #119) ---
+# TICKET_CLOSED_WEBHOOK_URL=https://integracao.exemplo.com/dx/ticket-closed
+# TICKET_CLOSED_WEBHOOK_SECRET=segredo-compartilhado-para-hmac
+# WEBHOOK_OUTBOX_WORKER_INTERVAL_SECONDS=15
 
 # Cache IBGE (municípios): intervalo entre syncs em segundos e idade máxima (horas) antes de re-sync.
 # IBGE_MUNICIPIOS_SYNC_INTERVAL_SECONDS=86400

--- a/backend/alembic/versions/043_ticket_msg_email_retry.py
+++ b/backend/alembic/versions/043_ticket_msg_email_retry.py
@@ -1,0 +1,27 @@
+"""ticket_mensagens: tentativas e último erro na fila de e-mail (#119).
+
+Revision ID: 043_ticket_msg_email_retry
+Revises: 042_atendente_notificacao
+Create Date: 2026-06-12
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "043_ticket_msg_email_retry"
+down_revision = "042_atendente_notificacao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ticket_mensagens",
+        sa.Column("email_send_attempts", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column("ticket_mensagens", sa.Column("email_last_error", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("ticket_mensagens", "email_last_error")
+    op.drop_column("ticket_mensagens", "email_send_attempts")

--- a/backend/alembic/versions/044_webhook_outbox.py
+++ b/backend/alembic/versions/044_webhook_outbox.py
@@ -1,0 +1,45 @@
+"""Fila de webhooks de saída (ticket fechado, etc.) (#119).
+
+Revision ID: 044_webhook_outbox
+Revises: 043_ticket_msg_email_retry
+Create Date: 2026-06-12
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "044_webhook_outbox"
+down_revision = "043_ticket_msg_email_retry"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "webhook_outbox",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("dedup_key", sa.String(length=255), nullable=False),
+        sa.Column("target_url", sa.String(length=2048), nullable=False),
+        sa.Column("payload_json", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False, server_default="pendente"),
+        sa.Column("tentativas", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("scheduled_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_webhook_outbox_dedup_key", "webhook_outbox", ["dedup_key"], unique=False)
+    op.create_index(
+        "ix_webhook_outbox_status_scheduled",
+        "webhook_outbox",
+        ["status", "scheduled_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_webhook_outbox_status_scheduled", table_name="webhook_outbox")
+    op.drop_index("ix_webhook_outbox_dedup_key", table_name="webhook_outbox")
+    op.drop_table("webhook_outbox")

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -52,7 +52,8 @@ from app.core.setor_scope import (
     responsavel_elegivel_para_setor_do_ticket,
 )
 from app.services import ticket_anexo_storage
-from app.services.ticket_csat import csat_brief_para_ticket, criar_convite_csat, processar_convite_csat_ao_fechar
+from app.services.ticket_csat import csat_brief_para_ticket, criar_convite_csat
+from app.services.ticket_close_hooks import processar_hooks_ao_fechar_ticket
 from app.services.notificacao_atendente_email import notificar_nova_mensagem_ticket, notificar_ticket_atribuido
 from app.schemas.ticket_csat import TicketCsatDevLinkRead
 from app.services.ticket_vinculos import (
@@ -802,7 +803,8 @@ def criar_vinculo(
     )
     db.commit()
     if duplicado_fechado:
-        processar_convite_csat_ao_fechar(db, ticket.id)
+        processar_hooks_ao_fechar_ticket(db, ticket.id)
+        db.commit()
     db.refresh(v)
     return _vinculo_para_read(v, ticket.id, db, duplicado_fechado=duplicado_fechado)
 
@@ -1561,7 +1563,8 @@ def atualizar(
 
     db.commit()
     if acabou_de_fechar:
-        processar_convite_csat_ao_fechar(db, ticket_id)
+        processar_hooks_ao_fechar_ticket(db, ticket_id)
+        db.commit()
     if atribuicao_notificar_id is not None:
         t_notify = db.query(Ticket).filter(Ticket.id == ticket_id).first()
         if t_notify:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -59,6 +59,12 @@ class Settings(BaseSettings):
     TICKET_MENSAGEM_EMAIL_WORKER_INTERVAL_SECONDS: int = 5
     NOTIFICACAO_EMAIL_DEBOUNCE_MINUTES: int = 5
     NOTIFICACAO_EMAIL_WORKER_INTERVAL_SECONDS: int = 10
+    WEBHOOK_OUTBOX_WORKER_INTERVAL_SECONDS: int = 15
+    # Webhook de saída ao fechar ticket (#119). URL vazia = desligado.
+    TICKET_CLOSED_WEBHOOK_URL: str | None = None
+    TICKET_CLOSED_WEBHOOK_SECRET: str | None = None
+    # Tentativas HTTP para Evolution API (falhas transitórias).
+    EVOLUTION_HTTP_MAX_ATTEMPTS: int = 3
     WHATSAPP_INACTIVITY_WORKER_INTERVAL_SECONDS: int = 60
 
     # Modo legado: vários clientes no mesmo Postgres (subdomínio numérico + coluna tenant_id).

--- a/backend/app/core/structured_log.py
+++ b/backend/app/core/structured_log.py
@@ -1,0 +1,16 @@
+"""Logs estruturados (JSON em uma linha) para auditoria operacional (#119)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+
+def log_event(logger: logging.Logger, event: str, *, level: int = logging.INFO, **fields: Any) -> None:
+    payload = {"event": event, **fields}
+    try:
+        line = json.dumps(payload, ensure_ascii=False, default=str)
+    except (TypeError, ValueError):
+        line = json.dumps({"event": event, "serialization_error": True}, ensure_ascii=False)
+    logger.log(level, line)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,11 +4,13 @@ import threading
 import time
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
 from starlette.middleware.trustedhost import TrustedHostMiddleware
+
+from app.database import get_db
 
 from app.api import (
     auth,
@@ -174,10 +176,7 @@ async def lifespan(app: FastAPI):
             db = SessionLocal()
             try:
                 n = process_pending_ticket_mensagem_emails(db, limit=30)
-                if n:
-                    db.commit()
-                else:
-                    db.rollback()
+                db.commit()
             except Exception as e:
                 logger.warning("Worker e-mail de mensagens de ticket: %s", e)
                 db.rollback()
@@ -273,7 +272,14 @@ if _th != ["*"]:
 async def tenant_context_middleware(request: Request, call_next):
     """Define ``request.state.tenant_id``. Webhooks e health ficam isentos."""
     path = request.url.path
-    if path.startswith("/v1/webhooks/") or path in ("/", "/health", "/docs", "/redoc", "/openapi.json"):
+    if path.startswith("/v1/webhooks/") or path in (
+        "/",
+        "/health",
+        "/health/ready",
+        "/docs",
+        "/redoc",
+        "/openapi.json",
+    ):
         return await call_next(request)
     try:
         tid = resolve_tenant_id(request)
@@ -353,10 +359,14 @@ def _app_capabilities() -> dict[str, bool]:
 
 @app.get("/health")
 def health():
-    import os
+    from app.services.health_checks import build_health_payload
 
-    return {
-        "status": "ok",
-        "git_sha": (os.environ.get("DX_CONNECT_GIT_SHA") or "").strip() or None,
-        "capabilities": _app_capabilities(),
-    }
+    return build_health_payload(capabilities=_app_capabilities())
+
+
+@app.get("/health/ready")
+def health_ready(db: Session = Depends(get_db)):
+    from app.services.health_checks import build_readiness_payload
+
+    body, status_code = build_readiness_payload(db=db, capabilities=_app_capabilities())
+    return JSONResponse(content=body, status_code=status_code)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -213,6 +213,29 @@ async def lifespan(app: FastAPI):
         name="notificacao-email-outbox",
     ).start()
 
+    def webhook_outbox_loop() -> None:
+        from app.database import SessionLocal
+        from app.services.ticket_closed_webhook import process_pending_webhooks
+
+        interval = max(5, settings.WEBHOOK_OUTBOX_WORKER_INTERVAL_SECONDS)
+        while True:
+            db = SessionLocal()
+            try:
+                process_pending_webhooks(db, limit=30)
+                db.commit()
+            except Exception as e:
+                logger.warning("Worker webhook outbox: %s", e)
+                db.rollback()
+            finally:
+                db.close()
+            time.sleep(interval)
+
+    threading.Thread(
+        target=webhook_outbox_loop,
+        daemon=True,
+        name="webhook-outbox",
+    ).start()
+
     def whatsapp_inactivity_loop() -> None:
         from app.database import SessionLocal
         from app.services.whatsapp_inactivity_worker import process_whatsapp_inactivity_closures

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -26,6 +26,7 @@ from app.models.ticket_vinculo import TicketVinculo
 from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
 from app.models.ticket_avaliacao import TicketAvaliacao, TicketCsatInvite
 from app.models.atendente_notificacao import AtendenteNotificacaoPreferencias, NotificacaoEmailOutbox
+from app.models.webhook_outbox import WebhookOutbox
 from app.models.empresa_pdv import EmpresaPdv, PdvRotulo, PdvTipoAcessoRemoto
 
 __all__ = [
@@ -67,6 +68,7 @@ __all__ = [
     "TicketCsatInvite",
     "AtendenteNotificacaoPreferencias",
     "NotificacaoEmailOutbox",
+    "WebhookOutbox",
     "PdvRotulo",
     "PdvTipoAcessoRemoto",
     "EmpresaPdv",

--- a/backend/app/models/ticket.py
+++ b/backend/app/models/ticket.py
@@ -87,6 +87,8 @@ class TicketMensagem(Base):
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
     edit_lock_token = Column(String(64), nullable=True)
     edit_lock_expires_at = Column(DateTime(timezone=True), nullable=True)
+    email_send_attempts = Column(Integer, nullable=False, default=0, server_default="0")
+    email_last_error = Column(Text, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     ticket = relationship("Ticket", back_populates="mensagens")

--- a/backend/app/models/webhook_outbox.py
+++ b/backend/app/models/webhook_outbox.py
@@ -1,0 +1,22 @@
+from sqlalchemy import Column, DateTime, Integer, String, Text
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class WebhookOutbox(Base):
+    """Fila de POSTs HTTP para integrações externas (#119)."""
+
+    __tablename__ = "webhook_outbox"
+
+    id = Column(Integer, primary_key=True, index=True)
+    event_type = Column(String(64), nullable=False, index=True)
+    dedup_key = Column(String(255), nullable=False, index=True)
+    target_url = Column(String(2048), nullable=False)
+    payload_json = Column(Text, nullable=False)
+    status = Column(String(32), nullable=False, default="pendente", index=True)
+    tentativas = Column(Integer, nullable=False, default=0, server_default="0")
+    last_error = Column(Text, nullable=True)
+    scheduled_at = Column(DateTime(timezone=True), nullable=False, index=True)
+    sent_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/services/email_outbox_policy.py
+++ b/backend/app/services/email_outbox_policy.py
@@ -1,0 +1,11 @@
+"""Política compartilhada de retry para filas de e-mail (#119)."""
+
+from __future__ import annotations
+
+MAX_EMAIL_SEND_ATTEMPTS = 5
+
+
+def retry_delay_seconds(attempt: int) -> int:
+    """Backoff exponencial a partir da 1ª falha (60s, 120s, 240s… máx. 15 min)."""
+    n = max(1, int(attempt))
+    return min(900, 60 * (2 ** (n - 1)))

--- a/backend/app/services/email_outbox_policy.py
+++ b/backend/app/services/email_outbox_policy.py
@@ -1,4 +1,4 @@
-"""Política compartilhada de retry para filas de e-mail (#119)."""
+"""Política compartilhada de retry para filas de e-mail e HTTP (#119)."""
 
 from __future__ import annotations
 
@@ -9,3 +9,12 @@ def retry_delay_seconds(attempt: int) -> int:
     """Backoff exponencial a partir da 1ª falha (60s, 120s, 240s… máx. 15 min)."""
     n = max(1, int(attempt))
     return min(900, 60 * (2 ** (n - 1)))
+
+
+def http_retry_delay_seconds(attempt: int) -> float:
+    """Backoff curto para chamadas HTTP síncronas (2s, 4s, 8s… máx. 30s)."""
+    n = max(1, int(attempt))
+    return min(30.0, 2.0 * (2 ** (n - 1)))
+
+
+TRANSIENT_HTTP_CODES = frozenset({0, 429, 502, 503, 504})

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -3,10 +3,18 @@
 from __future__ import annotations
 
 import json
+import logging
 import ssl
+import time
 import urllib.error
 import urllib.request
 from typing import Any
+
+from app.config import settings
+from app.core.structured_log import log_event
+from app.services.email_outbox_policy import TRANSIENT_HTTP_CODES, http_retry_delay_seconds
+
+logger = logging.getLogger(__name__)
 
 
 def _request_json(
@@ -35,6 +43,55 @@ def _request_json(
         return e.code, None, err_body or str(e.reason)
     except Exception as e:
         return 0, None, str(e)
+
+
+def _request_json_with_retry(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str],
+    body: dict[str, Any] | None = None,
+    timeout: int = 20,
+    max_attempts: int | None = None,
+) -> tuple[int, Any | None, str | None]:
+    attempts = max(1, int(max_attempts or settings.EVOLUTION_HTTP_MAX_ATTEMPTS))
+    last: tuple[int, Any | None, str | None] = (0, None, "sem resposta")
+    for attempt in range(1, attempts + 1):
+        code, data, err = _request_json(method, url, headers=headers, body=body, timeout=timeout)
+        last = (code, data, err)
+        if code in (200, 201) or code not in TRANSIENT_HTTP_CODES:
+            if attempt > 1 and code in (200, 201):
+                log_event(
+                    logger,
+                    "evolution_http_send_ok_after_retry",
+                    url=url.split("?")[0][-120:],
+                    attempts=attempt,
+                    http_status=code,
+                )
+            return code, data, err
+        if attempt < attempts:
+            delay = http_retry_delay_seconds(attempt)
+            log_event(
+                logger,
+                "evolution_http_retry",
+                level=logging.WARNING,
+                url=url.split("?")[0][-120:],
+                attempt=attempt,
+                http_status=code,
+                retry_in_seconds=delay,
+                error=(err or f"HTTP {code}")[:500],
+            )
+            time.sleep(delay)
+    log_event(
+        logger,
+        "evolution_http_failed_permanent",
+        level=logging.ERROR,
+        url=url.split("?")[0][-120:],
+        attempts=attempts,
+        http_status=last[0],
+        error=(last[2] or f"HTTP {last[0]}")[:500],
+    )
+    return last
 
 
 def evolution_connection_state(base_url: str, instance: str, api_key: str) -> tuple[bool, str | None]:
@@ -116,7 +173,7 @@ def evolution_send_text(
     body: dict[str, Any] = {"number": number_digits, "text": text}
     if quoted:
         body["quoted"] = quoted
-    code, data, err = _request_json(
+    code, data, err = _request_json_with_retry(
         "POST",
         url,
         headers=headers,
@@ -156,7 +213,7 @@ def evolution_send_media(
     }
     if quoted:
         body["quoted"] = quoted
-    code, data, err = _request_json("POST", url, headers=headers, body=body, timeout=120)
+    code, data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=120)
     if code in (200, 201):
         return True, None, _extract_wa_message_id(data)
     if err:
@@ -198,7 +255,7 @@ def evolution_get_base64_from_media_message(
     url = f"{base}/chat/getBase64FromMediaMessage/{instance}"
     headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
     body: dict[str, Any] = {"message": message_envelope, "convertToMp4": convert_to_mp4}
-    code, data, err = _request_json("POST", url, headers=headers, body=body, timeout=timeout)
+    code, data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=timeout)
     if code in (200, 201):
         b64 = _extrair_base64_resposta(data)
         if b64:

--- a/backend/app/services/health_checks.py
+++ b/backend/app/services/health_checks.py
@@ -1,0 +1,71 @@
+"""Health e readiness para operação (#119)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.config import settings
+
+
+def _git_sha() -> str | None:
+    return (os.environ.get("DX_CONNECT_GIT_SHA") or "").strip() or None
+
+
+def check_database(db: Session) -> dict[str, Any]:
+    try:
+        db.execute(text("SELECT 1"))
+        return {"status": "ok"}
+    except Exception as e:
+        return {"status": "error", "detail": str(e)[:500]}
+
+
+def integrations_status() -> dict[str, Any]:
+    """Sinais de configuração (não testa conectividade externa)."""
+    resend_key = bool((settings.RESEND_API_KEY or "").strip())
+    transactional_from = bool((settings.TRANSACTIONAL_FROM_EMAIL or "").strip())
+    inbound_webhook = bool((settings.EMAIL_INBOUND_WEBHOOK_SECRET or "").strip())
+    resend_inbound = bool((settings.RESEND_WEBHOOK_SECRET or "").strip())
+    evolution = settings.evolution_embutida_disponivel
+
+    email_outbound = "configured" if resend_key and transactional_from else "missing" if not resend_key else "partial"
+    email_inbound = "configured" if resend_inbound or inbound_webhook else "missing"
+
+    return {
+        "email_outbound": email_outbound,
+        "email_inbound": email_inbound,
+        "evolution_whatsapp": "configured" if evolution else "missing",
+    }
+
+
+def build_health_payload(*, capabilities: dict[str, bool]) -> dict[str, Any]:
+    """Liveness: processo de pé; não exige BD."""
+    return {
+        "status": "ok",
+        "git_sha": _git_sha(),
+        "environment": settings.ENVIRONMENT,
+        "capabilities": capabilities,
+        "integrations": integrations_status(),
+    }
+
+
+def build_readiness_payload(*, db: Session, capabilities: dict[str, bool]) -> tuple[dict[str, Any], int]:
+    """Readiness: inclui checagem de BD; HTTP 503 se não estiver pronto."""
+    base = build_health_payload(capabilities=capabilities)
+    db_check = check_database(db)
+    checks = {"database": db_check}
+    base["checks"] = checks
+
+    if db_check["status"] != "ok":
+        base["status"] = "unavailable"
+        return base, 503
+
+    integrations = base.get("integrations") or {}
+    if any(v in ("missing", "partial") for v in integrations.values()):
+        base["status"] = "degraded"
+    else:
+        base["status"] = "ok"
+    return base, 200

--- a/backend/app/services/health_checks.py
+++ b/backend/app/services/health_checks.py
@@ -38,6 +38,7 @@ def integrations_status() -> dict[str, Any]:
         "email_outbound": email_outbound,
         "email_inbound": email_inbound,
         "evolution_whatsapp": "configured" if evolution else "missing",
+        "ticket_closed_webhook": "configured" if bool((settings.TICKET_CLOSED_WEBHOOK_URL or "").strip()) else "missing",
     }
 
 

--- a/backend/app/services/notificacao_atendente_email.py
+++ b/backend/app/services/notificacao_atendente_email.py
@@ -8,10 +8,11 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy.orm import Session
 
 from app.config import settings
-from app.config import settings
+from app.core.structured_log import log_event
 from app.models.atendente import Atendente
 from app.models.atendente_notificacao import AtendenteNotificacaoPreferencias, NotificacaoEmailOutbox
 from app.models.ticket import Ticket, TicketMensagem
+from app.services.email_outbox_policy import MAX_EMAIL_SEND_ATTEMPTS
 from app.services.email_send_sistema import enviar_mensagem_texto_sistema
 from app.services.password_reset import _public_app_origin
 
@@ -24,7 +25,7 @@ STATUS_FALHA = "falha"
 TIPO_TICKET_ATRIBUIDO = "ticket_atribuido"
 TIPO_NOVA_MENSAGEM = "nova_mensagem"
 
-MAX_TENTATIVAS = 5
+MAX_TENTATIVAS = MAX_EMAIL_SEND_ATTEMPTS
 
 
 def _utcnow() -> datetime:
@@ -277,26 +278,69 @@ def process_pending_notificacao_emails(db: Session, *, limit: int = 20) -> int:
             row.last_error = None
             row.dedup_key = f"{row.dedup_key}:sent:{row.id}"
             sent += 1
+            log_event(
+                logger,
+                "notificacao_email_send_ok",
+                outbox_id=row.id,
+                tipo=row.tipo,
+                ticket_id=row.ticket_id,
+                atendente_id=row.atendente_id,
+            )
         except ValueError as e:
             row.last_error = str(e)[:2000]
             if settings.ENVIRONMENT == "development":
-                logger.info(
-                    "DEV notificação e-mail (simulado) id=%s → %s | %s",
-                    row.id,
-                    row.to_email,
-                    row.subject,
+                log_event(
+                    logger,
+                    "notificacao_email_send_simulated_dev",
+                    outbox_id=row.id,
+                    to_email=row.to_email,
+                    subject=row.subject,
+                    tipo=row.tipo,
+                    ticket_id=row.ticket_id,
                 )
-                logger.debug("DEV notificação corpo:\n%s", row.body)
                 row.status = STATUS_ENVIADA
                 row.sent_at = now
                 row.dedup_key = f"{row.dedup_key}:sent:{row.id}"
                 sent += 1
             elif row.tentativas >= MAX_TENTATIVAS:
                 row.status = STATUS_FALHA
-            logger.info("Notificação e-mail %s não enviada: %s", row.id, e)
+                log_event(
+                    logger,
+                    "notificacao_email_send_failed_permanent",
+                    level=logging.ERROR,
+                    outbox_id=row.id,
+                    tentativas=row.tentativas,
+                    error=str(e)[:500],
+                )
+            else:
+                log_event(
+                    logger,
+                    "notificacao_email_send_retry",
+                    level=logging.WARNING,
+                    outbox_id=row.id,
+                    tentativas=row.tentativas,
+                    error=str(e)[:500],
+                )
         except Exception as e:
             row.last_error = str(e)[:2000]
             if row.tentativas >= MAX_TENTATIVAS:
                 row.status = STATUS_FALHA
+                log_event(
+                    logger,
+                    "notificacao_email_send_failed_permanent",
+                    level=logging.ERROR,
+                    outbox_id=row.id,
+                    tentativas=row.tentativas,
+                    error=str(e)[:500],
+                )
+            else:
+                log_event(
+                    logger,
+                    "notificacao_email_send_retry",
+                    level=logging.WARNING,
+                    outbox_id=row.id,
+                    tentativas=row.tentativas,
+                    error=str(e)[:500],
+                )
             logger.exception("Falha ao enviar notificação e-mail %s", row.id)
     return sent

--- a/backend/app/services/ticket_close_hooks.py
+++ b/backend/app/services/ticket_close_hooks.py
@@ -1,0 +1,13 @@
+"""Hooks executados quando um ticket é fechado (CSAT, webhook externo, …)."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.services.ticket_closed_webhook import enfileirar_webhook_ticket_fechado
+from app.services.ticket_csat import processar_convite_csat_ao_fechar
+
+
+def processar_hooks_ao_fechar_ticket(db: Session, ticket_id: int) -> None:
+    processar_convite_csat_ao_fechar(db, ticket_id)
+    enfileirar_webhook_ticket_fechado(db, ticket_id)

--- a/backend/app/services/ticket_closed_webhook.py
+++ b/backend/app/services/ticket_closed_webhook.py
@@ -1,0 +1,186 @@
+"""Webhook de saída: ticket fechado (#119)."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import ssl
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.core.structured_log import log_event
+from app.models.ticket import Ticket
+from app.models.webhook_outbox import WebhookOutbox
+from app.services.email_outbox_policy import MAX_EMAIL_SEND_ATTEMPTS, retry_delay_seconds
+
+logger = logging.getLogger(__name__)
+
+EVENT_TICKET_CLOSED = "ticket.closed"
+STATUS_PENDENTE = "pendente"
+STATUS_ENVIADA = "enviada"
+STATUS_FALHA = "falha"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def webhook_ticket_fechado_configurado() -> bool:
+    return bool((settings.TICKET_CLOSED_WEBHOOK_URL or "").strip())
+
+
+def _payload_ticket_fechado(ticket: Ticket) -> dict:
+    return {
+        "event": EVENT_TICKET_CLOSED,
+        "ticket_id": ticket.id,
+        "protocolo": ticket.protocolo,
+        "empresa_id": ticket.empresa_id,
+        "setor_id": ticket.setor_id,
+        "atendente_id": ticket.atendente_id,
+        "assunto": ticket.assunto,
+        "fechado_em": ticket.fechado_em.isoformat() if ticket.fechado_em else None,
+    }
+
+
+def _dedup_ja_processado(db: Session, dedup_key: str) -> bool:
+    row = (
+        db.query(WebhookOutbox.id)
+        .filter(
+            WebhookOutbox.dedup_key == dedup_key,
+            WebhookOutbox.status.in_([STATUS_PENDENTE, STATUS_ENVIADA]),
+        )
+        .first()
+    )
+    if row:
+        return True
+    falha = (
+        db.query(WebhookOutbox.id)
+        .filter(
+            WebhookOutbox.dedup_key == dedup_key,
+            WebhookOutbox.status == STATUS_FALHA,
+            WebhookOutbox.tentativas >= MAX_EMAIL_SEND_ATTEMPTS,
+        )
+        .first()
+    )
+    return falha is not None
+
+
+def enfileirar_webhook_ticket_fechado(db: Session, ticket_id: int) -> None:
+    url = (settings.TICKET_CLOSED_WEBHOOK_URL or "").strip()
+    if not url:
+        return
+
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket or ticket.fechado_em is None:
+        return
+
+    dedup_key = f"{EVENT_TICKET_CLOSED}:{ticket_id}"
+    if _dedup_ja_processado(db, dedup_key):
+        return
+
+    payload = _payload_ticket_fechado(ticket)
+    now = _utcnow()
+    db.add(
+        WebhookOutbox(
+            event_type=EVENT_TICKET_CLOSED,
+            dedup_key=dedup_key,
+            target_url=url,
+            payload_json=json.dumps(payload, ensure_ascii=False),
+            status=STATUS_PENDENTE,
+            scheduled_at=now,
+        )
+    )
+    db.flush()
+    log_event(logger, "webhook_outbox_enqueued", event_type=EVENT_TICKET_CLOSED, ticket_id=ticket_id)
+
+
+def _sign_payload(body: bytes, secret: str) -> str:
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _post_webhook(*, url: str, body: bytes, event_type: str, secret: str | None) -> tuple[int, str | None]:
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "User-Agent": "DX-Connect-Webhook/1.0",
+        "X-DX-Webhook-Event": event_type,
+    }
+    if secret:
+        headers["X-DX-Webhook-Signature"] = _sign_payload(body, secret)
+    req = urllib.request.Request(url, data=body, headers=headers, method="POST")
+    ctx = ssl.create_default_context()
+    try:
+        with urllib.request.urlopen(req, timeout=20, context=ctx) as resp:
+            return resp.getcode(), None
+    except urllib.error.HTTPError as e:
+        err_body = e.read().decode("utf-8", errors="replace") if e.fp else ""
+        return e.code, (err_body or str(e.reason))[:2000]
+    except Exception as e:
+        return 0, str(e)[:2000]
+
+
+def process_pending_webhooks(db: Session, *, limit: int = 20) -> int:
+    now = _utcnow()
+    secret = (settings.TICKET_CLOSED_WEBHOOK_SECRET or "").strip() or None
+    rows = (
+        db.query(WebhookOutbox)
+        .filter(WebhookOutbox.status == STATUS_PENDENTE, WebhookOutbox.scheduled_at <= now)
+        .order_by(WebhookOutbox.scheduled_at.asc())
+        .limit(limit)
+        .all()
+    )
+    sent = 0
+    for row in rows:
+        row.tentativas = int(row.tentativas or 0) + 1
+        body = row.payload_json.encode("utf-8")
+        code, err = _post_webhook(url=row.target_url, body=body, event_type=row.event_type, secret=secret)
+        if 200 <= code < 300:
+            row.status = STATUS_ENVIADA
+            row.sent_at = now
+            row.last_error = None
+            row.dedup_key = f"{row.dedup_key}:sent:{row.id}"
+            sent += 1
+            log_event(
+                logger,
+                "webhook_outbox_send_ok",
+                outbox_id=row.id,
+                event_type=row.event_type,
+                http_status=code,
+            )
+            continue
+
+        row.last_error = err or f"HTTP {code}"
+        if row.tentativas >= MAX_EMAIL_SEND_ATTEMPTS:
+            row.status = STATUS_FALHA
+            log_event(
+                logger,
+                "webhook_outbox_send_failed_permanent",
+                level=logging.ERROR,
+                outbox_id=row.id,
+                event_type=row.event_type,
+                tentativas=row.tentativas,
+                http_status=code,
+                error=row.last_error[:500],
+            )
+        else:
+            delay = retry_delay_seconds(row.tentativas)
+            row.scheduled_at = now + timedelta(seconds=delay)
+            log_event(
+                logger,
+                "webhook_outbox_send_retry",
+                level=logging.WARNING,
+                outbox_id=row.id,
+                event_type=row.event_type,
+                tentativas=row.tentativas,
+                retry_in_seconds=delay,
+                http_status=code,
+                error=row.last_error[:500],
+            )
+    return sent

--- a/backend/app/services/ticket_mensagem_email_outbox.py
+++ b/backend/app/services/ticket_mensagem_email_outbox.py
@@ -11,7 +11,9 @@ from datetime import datetime, timedelta, timezone
 from sqlalchemy.orm import Session
 
 from app.config import settings
+from app.core.structured_log import log_event
 from app.models.ticket import Ticket, TicketMensagem
+from app.services.email_outbox_policy import MAX_EMAIL_SEND_ATTEMPTS, retry_delay_seconds
 from app.services.ticket_email_grace_config import resolver_grace_seconds
 from app.services.ticket_client_email import enviar_resposta_equipa_por_email, ultima_mensagem_inbound
 from app.services.ticket_email_index import registar_message_id_para_ticket
@@ -23,6 +25,7 @@ EMAIL_STATUS_EM_EDICAO = "em_edicao"
 EMAIL_STATUS_ENVIANDO = "enviando"
 EMAIL_STATUS_ENVIADA = "enviada"
 EMAIL_STATUS_CANCELADA = "cancelada"
+EMAIL_STATUS_FALHA = "falha_envio"
 
 _STATUSES_EDITAVEIS = frozenset({EMAIL_STATUS_PENDENTE, EMAIL_STATUS_EM_EDICAO})
 
@@ -84,6 +87,8 @@ def agendar_envio_email(m: TicketMensagem, db: Session, *, ref: datetime | None 
     m.email_status = EMAIL_STATUS_PENDENTE
     m.scheduled_at = now if secs == 0 else now + timedelta(seconds=secs)
     m.sent_at = None
+    m.email_send_attempts = 0
+    m.email_last_error = None
     m.edit_lock_token = None
     m.edit_lock_expires_at = None
     m.updated_at = now
@@ -135,7 +140,6 @@ def _enviar_uma(db: Session, m: TicketMensagem, ticket: Ticket) -> bool:
         out_mid = enviar_resposta_equipa_por_email(db, ticket=ticket, corpo=m.corpo)
     except Exception:
         m.email_status = EMAIL_STATUS_PENDENTE
-        m.scheduled_at = now + timedelta(seconds=60)
         m.updated_at = now
         raise
 
@@ -143,10 +147,45 @@ def _enviar_uma(db: Session, m: TicketMensagem, ticket: Ticket) -> bool:
     m.email_status = EMAIL_STATUS_ENVIADA
     m.sent_at = now
     m.scheduled_at = None
+    m.email_send_attempts = 0
+    m.email_last_error = None
     m.edit_lock_token = None
     m.edit_lock_expires_at = None
     m.updated_at = now
     return True
+
+
+def _registrar_falha_envio(m: TicketMensagem, error: Exception, *, now: datetime) -> None:
+    tentativa = int(m.email_send_attempts or 0) + 1
+    m.email_send_attempts = tentativa
+    m.email_last_error = str(error)[:2000]
+    if tentativa >= MAX_EMAIL_SEND_ATTEMPTS:
+        m.email_status = EMAIL_STATUS_FALHA
+        m.scheduled_at = None
+        log_event(
+            logger,
+            "ticket_email_send_failed_permanent",
+            level=logging.ERROR,
+            mensagem_id=m.id,
+            ticket_id=m.ticket_id,
+            tentativas=tentativa,
+            error=str(error)[:500],
+        )
+    else:
+        delay = retry_delay_seconds(tentativa)
+        m.email_status = EMAIL_STATUS_PENDENTE
+        m.scheduled_at = now + timedelta(seconds=delay)
+        log_event(
+            logger,
+            "ticket_email_send_retry",
+            level=logging.WARNING,
+            mensagem_id=m.id,
+            ticket_id=m.ticket_id,
+            tentativas=tentativa,
+            retry_in_seconds=delay,
+            error=str(error)[:500],
+        )
+    m.updated_at = now
 
 
 def process_pending_ticket_mensagem_emails(db: Session, *, limit: int = 20) -> int:
@@ -181,13 +220,14 @@ def process_pending_ticket_mensagem_emails(db: Session, *, limit: int = 20) -> i
         try:
             if _enviar_uma(db, m, ticket):
                 enviadas += 1
+                log_event(
+                    logger,
+                    "ticket_email_send_ok",
+                    mensagem_id=m.id,
+                    ticket_id=m.ticket_id,
+                )
         except Exception as e:
-            logger.warning(
-                "Falha ao enviar e-mail da mensagem %s (ticket %s): %s",
-                m.id,
-                m.ticket_id,
-                e,
-            )
+            _registrar_falha_envio(m, e, now=now)
     return enviadas
 
 

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -4,3 +4,4 @@ def test_health_ok(client):
     body = r.json()
     assert body.get("status") == "ok"
     assert "capabilities" in body
+    assert "integrations" in body

--- a/backend/tests/test_observabilidade.py
+++ b/backend/tests/test_observabilidade.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+
+from app.services.email_outbox_policy import MAX_EMAIL_SEND_ATTEMPTS, retry_delay_seconds
+
+
+def test_max_attempts():
+    assert MAX_EMAIL_SEND_ATTEMPTS == 5
+
+
+def test_retry_delay_backoff():
+    assert retry_delay_seconds(1) == 60
+    assert retry_delay_seconds(2) == 120
+    assert retry_delay_seconds(3) == 240
+    assert retry_delay_seconds(10) == 900
+
+
+def test_health_liveness(client):
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("status") == "ok"
+    assert "capabilities" in body
+    assert "integrations" in body
+    assert "environment" in body
+
+
+def test_health_ready_ok(client, db_session):
+    r = client.get("/health/ready")
+    assert r.status_code == 200
+    body = r.json()
+    assert body.get("checks", {}).get("database", {}).get("status") == "ok"
+    assert body.get("status") in ("ok", "degraded")
+
+
+def test_health_ready_db_failure(client, monkeypatch):
+    def fail_db(*args, **kwargs):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr("app.services.health_checks.check_database", lambda db: {"status": "error", "detail": "db down"})
+
+    r = client.get("/health/ready")
+    assert r.status_code == 503
+    body = r.json()
+    assert body.get("status") == "unavailable"
+
+
+def test_structured_log(caplog):
+    import logging
+
+    from app.core.structured_log import log_event
+
+    log = logging.getLogger("test.structured")
+    with caplog.at_level(logging.INFO):
+        log_event(log, "test_event", foo=1, bar="x")
+    assert caplog.records
+    payload = json.loads(caplog.records[-1].message)
+    assert payload["event"] == "test_event"
+    assert payload["foo"] == 1
+
+
+def test_ticket_mensagem_email_retry_ate_falha_permanente(client, seed_base, auth_headers, monkeypatch, db_session):
+    from app.models.ticket import TicketMensagem
+    from app.services.ticket_mensagem_email_outbox import EMAIL_STATUS_FALHA, process_pending_ticket_mensagem_emails
+    from app.services.system_email_config import TransactionalEmailConfig
+    from tests.test_ticket_reply_email import _headers, _minimal_rfc822
+
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_WEBHOOK_SECRET", "e165")
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_EMPRESA_ID", seed_base["empresa"].id)
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_SETOR_ID", seed_base["setor1"].id)
+
+    mid_in = "<inbound-retry@dx.test>"
+    r0 = client.post(
+        "/v1/webhooks/email-inbound",
+        headers=_headers("e165"),
+        json={"rfc822": _minimal_rfc822(mid_in)},
+    )
+    assert r0.status_code == 200
+    tid = r0.json()["ticket_id"]
+
+    _cfg = TransactionalEmailConfig(
+        api_key="re_test",
+        from_email="noreply@test.local",
+        from_name="Suporte",
+    )
+    for mod in ("app.services.ticket_client_email", "app.services.system_email_config"):
+        monkeypatch.setattr(f"{mod}.get_singleton_email_settings", lambda db: object())
+        monkeypatch.setattr(f"{mod}.transactional_config_from_row", lambda row: _cfg)
+
+    def fail_send(*a, **k):
+        raise ValueError("Resend indisponível")
+
+    monkeypatch.setattr("app.services.ticket_client_email.enviar_mensagem_texto_sistema", fail_send)
+    monkeypatch.setattr("app.config.settings.TICKET_MENSAGEM_EMAIL_GRACE_SECONDS", 0)
+    monkeypatch.setattr("app.services.ticket_mensagem_email_outbox.retry_delay_seconds", lambda n: 0)
+
+    r1 = client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["admin"],
+        json={
+            "corpo": "Tentativa de envio.",
+            "tipo": "publico",
+            "notificar_cliente_por_email": True,
+        },
+    )
+    assert r1.status_code == 201
+    msg_id = r1.json()["id"]
+
+    for _ in range(5):
+        process_pending_ticket_mensagem_emails(db_session, limit=10)
+        db_session.commit()
+
+    msg = db_session.query(TicketMensagem).filter(TicketMensagem.id == msg_id).first()
+    assert msg is not None
+    assert msg.email_status == EMAIL_STATUS_FALHA
+    assert msg.email_send_attempts == 5
+    assert msg.email_last_error

--- a/backend/tests/test_observabilidade.py
+++ b/backend/tests/test_observabilidade.py
@@ -60,6 +60,42 @@ def test_structured_log(caplog):
     assert payload["foo"] == 1
 
 
+def test_http_retry_delay():
+    from app.services.email_outbox_policy import http_retry_delay_seconds
+
+    assert http_retry_delay_seconds(1) == 2.0
+    assert http_retry_delay_seconds(2) == 4.0
+    assert http_retry_delay_seconds(10) == 30.0
+
+
+def test_evolution_send_text_retenta_falha_transiente(monkeypatch):
+    from app.services import evolution_api
+
+    calls = {"n": 0}
+
+    def fake_request(method, url, *, headers, body=None, timeout=20):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return 503, None, "unavailable"
+        return 201, {"key": {"id": "wa-msg-1"}}, None
+
+    monkeypatch.setattr(evolution_api, "_request_json", fake_request)
+    monkeypatch.setattr(evolution_api.settings, "EVOLUTION_HTTP_MAX_ATTEMPTS", 3)
+    monkeypatch.setattr(evolution_api.time, "sleep", lambda s: None)
+
+    ok, err, mid = evolution_api.evolution_send_text(
+        "http://evo.local",
+        "inst",
+        "key",
+        "5511999999999",
+        "oi",
+    )
+    assert ok is True
+    assert err is None
+    assert mid == "wa-msg-1"
+    assert calls["n"] == 3
+
+
 def test_ticket_mensagem_email_retry_ate_falha_permanente(client, seed_base, auth_headers, monkeypatch, db_session):
     from app.models.ticket import TicketMensagem
     from app.services.ticket_mensagem_email_outbox import EMAIL_STATUS_FALHA, process_pending_ticket_mensagem_emails

--- a/backend/tests/test_ticket_closed_webhook.py
+++ b/backend/tests/test_ticket_closed_webhook.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from app.models.status_ticket import StatusTicket
+from app.models.webhook_outbox import WebhookOutbox
+from app.services.ticket_closed_webhook import (
+    EVENT_TICKET_CLOSED,
+    STATUS_ENVIADA,
+    enfileirar_webhook_ticket_fechado,
+    process_pending_webhooks,
+)
+
+
+def _status_fechado(db_session):
+    st = db_session.query(StatusTicket).filter(StatusTicket.slug == "fechado").first()
+    if st:
+        return st
+    st = StatusTicket(nome="Fechado", slug="fechado", ordem=99, ativo=True)
+    db_session.add(st)
+    db_session.commit()
+    return st
+
+
+def test_enfileira_webhook_ao_fechar(seed_base, db_session, monkeypatch):
+    from app.models.ticket import Ticket
+    from app.services.protocolo_mensal import gerar_protocolo_ticket
+
+    monkeypatch.setattr("app.config.settings.TICKET_CLOSED_WEBHOOK_URL", "https://hooks.example.com/ticket-closed")
+    monkeypatch.setattr("app.config.settings.TICKET_CLOSED_WEBHOOK_SECRET", "segredo-teste")
+
+    st = _status_fechado(db_session)
+    ticket = Ticket(
+        tenant_id=seed_base["tenant"].id,
+        protocolo=gerar_protocolo_ticket(db_session),
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=st.id,
+        assunto="Webhook close test",
+        descricao="Corpo",
+        fechado_em=datetime.now(timezone.utc),
+    )
+    db_session.add(ticket)
+    db_session.commit()
+
+    enfileirar_webhook_ticket_fechado(db_session, ticket.id)
+    db_session.commit()
+
+    row = (
+        db_session.query(WebhookOutbox)
+        .filter(
+            WebhookOutbox.event_type == EVENT_TICKET_CLOSED,
+            WebhookOutbox.dedup_key == f"{EVENT_TICKET_CLOSED}:{ticket.id}",
+        )
+        .first()
+    )
+    assert row is not None
+    payload = json.loads(row.payload_json)
+    assert payload["ticket_id"] == ticket.id
+    assert payload["event"] == EVENT_TICKET_CLOSED
+
+
+def test_process_pending_webhook_envia_com_assinatura(db_session, monkeypatch):
+    monkeypatch.setattr("app.config.settings.TICKET_CLOSED_WEBHOOK_SECRET", "segredo-teste")
+    sent = []
+
+    def fake_post(*, url, body, event_type, secret):
+        sent.append({"url": url, "body": body, "event_type": event_type, "secret": secret})
+        return 200, None
+
+    monkeypatch.setattr("app.services.ticket_closed_webhook._post_webhook", fake_post)
+
+    now = datetime.now(timezone.utc)
+    db_session.add(
+        WebhookOutbox(
+            event_type=EVENT_TICKET_CLOSED,
+            dedup_key=f"{EVENT_TICKET_CLOSED}:99",
+            target_url="https://hooks.example.com/x",
+            payload_json=json.dumps({"event": EVENT_TICKET_CLOSED, "ticket_id": 99}),
+            status="pendente",
+            scheduled_at=now,
+        )
+    )
+    db_session.commit()
+
+    n = process_pending_webhooks(db_session, limit=5)
+    db_session.commit()
+    assert n == 1
+    assert len(sent) == 1
+    assert sent[0]["secret"] == "segredo-teste"
+    row = db_session.query(WebhookOutbox).filter(WebhookOutbox.dedup_key.like(f"{EVENT_TICKET_CLOSED}:99%")).first()
+    assert row is not None
+    assert row.status == STATUS_ENVIADA
+
+
+def test_enfileirar_ignora_sem_url(db_session, monkeypatch):
+    from app.models.ticket import Ticket
+    from app.services.protocolo_mensal import gerar_protocolo_ticket
+
+    monkeypatch.setattr("app.config.settings.TICKET_CLOSED_WEBHOOK_URL", None)
+    st = _status_fechado(db_session)
+    ticket = Ticket(
+        tenant_id=1,
+        protocolo=gerar_protocolo_ticket(db_session),
+        empresa_id=None,
+        setor_id=1,
+        status_id=st.id,
+        assunto="Sem webhook",
+        descricao="x",
+        fechado_em=datetime.now(timezone.utc),
+    )
+    db_session.add(ticket)
+    db_session.commit()
+    enfileirar_webhook_ticket_fechado(db_session, ticket.id)
+    db_session.commit()
+    assert db_session.query(WebhookOutbox).count() == 0

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -20,7 +20,8 @@ Guia para quem opera o DX Connect em staging/produção: healthchecks, filas de 
   "integrations": {
     "email_outbound": "configured",
     "email_inbound": "configured",
-    "evolution_whatsapp": "missing"
+    "evolution_whatsapp": "missing",
+    "ticket_closed_webhook": "missing"
   }
 }
 ```
@@ -33,7 +34,7 @@ Guia para quem opera o DX Connect em staging/produção: healthchecks, filas de 
 
 1. Uptime em `GET /health` (intervalo 1–5 min).
 2. Alerta se `GET /health/ready` retorna **503** por > 2 min.
-3. Logs com `"event": "notificacao_email_send_failed_permanent"` ou `"ticket_email_send_failed_permanent"`.
+3. Logs com `"event": "notificacao_email_send_failed_permanent"`, `"ticket_email_send_failed_permanent"` ou `"webhook_outbox_send_failed_permanent"`.
 
 ## Workers em background
 
@@ -41,11 +42,44 @@ Guia para quem opera o DX Connect em staging/produção: healthchecks, filas de 
 |--------|-----------------|--------|
 | `notificacao-email-outbox` | `NOTIFICACAO_EMAIL_WORKER_INTERVAL_SECONDS` (10s) | E-mails de notificação a atendentes |
 | `ticket-mensagem-email-outbox` | `TICKET_MENSAGEM_EMAIL_WORKER_INTERVAL_SECONDS` (5s) | Respostas públicas ao cliente por e-mail |
-| `ticket-mensagem-email-outbox` | idem | Janela de graça antes do envio (#140) |
+| `webhook-outbox` | `WEBHOOK_OUTBOX_WORKER_INTERVAL_SECONDS` (15s) | POST HTTP ao fechar ticket (#119) |
 
-Ambos fazem **commit** após cada ciclo (mesmo com 0 envios), para persistir tentativas e retries.
+Todos fazem **commit** após cada ciclo (mesmo com 0 envios), para persistir tentativas e retries.
 
-## Política de retry (e-mail)
+## Webhook de saída — ticket fechado
+
+Variáveis (`.env`):
+
+- `TICKET_CLOSED_WEBHOOK_URL` — destino do POST (vazio = desligado)
+- `TICKET_CLOSED_WEBHOOK_SECRET` — HMAC SHA-256 no header `X-DX-Webhook-Signature: sha256=...`
+
+Payload mínimo:
+
+```json
+{
+  "event": "ticket.closed",
+  "ticket_id": 206,
+  "protocolo": "#T202605-0206",
+  "empresa_id": 1,
+  "setor_id": 2,
+  "atendente_id": 3,
+  "assunto": "...",
+  "fechado_em": "2026-06-12T21:00:00+00:00"
+}
+```
+
+Fila: tabela `webhook_outbox` (mesma política de 5 tentativas que e-mail).
+
+## Retry Evolution API (WhatsApp)
+
+Envio de texto/mídia via Evolution usa retry **síncrono** em falhas transitórias (rede, HTTP 429/502/503/504):
+
+- `EVOLUTION_HTTP_MAX_ATTEMPTS` (padrão **3**)
+- Backoff curto: 2s → 4s → 8s (máx. 30s)
+
+Logs: `evolution_http_retry`, `evolution_http_failed_permanent`.
+
+## Política de retry (e-mail e webhooks)
 
 - **Máximo:** 5 tentativas (`MAX_EMAIL_SEND_ATTEMPTS`).
 - **Backoff:** 60s → 120s → 240s → … (máx. 15 min entre tentativas).
@@ -68,6 +102,11 @@ Eventos relevantes (JSON em uma linha):
 | `ticket_email_send_ok` | Resposta ao cliente enviada |
 | `ticket_email_send_retry` | Retry da mensagem pública |
 | `ticket_email_send_failed_permanent` | Mensagem presa em `falha_envio` |
+| `webhook_outbox_send_ok` | Webhook entregue |
+| `webhook_outbox_send_retry` | Retry do webhook |
+| `webhook_outbox_send_failed_permanent` | Webhook esgotou tentativas |
+| `evolution_http_retry` | Retry HTTP Evolution |
+| `evolution_http_failed_permanent` | Evolution falhou após tentativas |
 
 Filtrar no agregador de logs: `grep '"event":"notificacao_email_send_failed_permanent"'`.
 
@@ -85,6 +124,13 @@ LIMIT 20;
 SELECT id, ticket_id, email_send_attempts, email_last_error, updated_at
 FROM ticket_mensagens
 WHERE email_status = 'falha_envio'
+ORDER BY id DESC
+LIMIT 20;
+
+-- Webhooks com falha permanente
+SELECT id, event_type, target_url, tentativas, last_error, created_at
+FROM webhook_outbox
+WHERE status = 'falha'
 ORDER BY id DESC
 LIMIT 20;
 ```

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,96 @@
+# Operação e observabilidade (#119)
+
+Guia para quem opera o DX Connect em staging/produção: healthchecks, filas de e-mail e o que monitorizar.
+
+## Healthchecks
+
+| Endpoint | Uso | Falha HTTP |
+|----------|-----|------------|
+| `GET /health` | **Liveness** — processo de pé | Só se o app não responder |
+| `GET /health/ready` | **Readiness** — pronto para tráfego (inclui PostgreSQL) | **503** se o banco estiver inacessível |
+
+### Campos úteis
+
+```json
+{
+  "status": "ok",
+  "git_sha": "3aaff44",
+  "environment": "production",
+  "capabilities": { "settings_email": true, ... },
+  "integrations": {
+    "email_outbound": "configured",
+    "email_inbound": "configured",
+    "evolution_whatsapp": "missing"
+  }
+}
+```
+
+- **`git_sha`**: definir `DX_CONNECT_GIT_SHA` no deploy (commit em execução).
+- **`integrations`**: indica **configuração** (env/BD), não testa conectividade com Resend/Evolution.
+- **`/health/ready`**: inclui `"checks": { "database": { "status": "ok" } }`. Se `status` for `unavailable`, o orchestrator/load balancer não deve enviar tráfego.
+
+### Monitorização mínima
+
+1. Uptime em `GET /health` (intervalo 1–5 min).
+2. Alerta se `GET /health/ready` retorna **503** por > 2 min.
+3. Logs com `"event": "notificacao_email_send_failed_permanent"` ou `"ticket_email_send_failed_permanent"`.
+
+## Workers em background
+
+| Worker | Intervalo (env) | Função |
+|--------|-----------------|--------|
+| `notificacao-email-outbox` | `NOTIFICACAO_EMAIL_WORKER_INTERVAL_SECONDS` (10s) | E-mails de notificação a atendentes |
+| `ticket-mensagem-email-outbox` | `TICKET_MENSAGEM_EMAIL_WORKER_INTERVAL_SECONDS` (5s) | Respostas públicas ao cliente por e-mail |
+| `ticket-mensagem-email-outbox` | idem | Janela de graça antes do envio (#140) |
+
+Ambos fazem **commit** após cada ciclo (mesmo com 0 envios), para persistir tentativas e retries.
+
+## Política de retry (e-mail)
+
+- **Máximo:** 5 tentativas (`MAX_EMAIL_SEND_ATTEMPTS`).
+- **Backoff:** 60s → 120s → 240s → … (máx. 15 min entre tentativas).
+- **Notificações atendentes:** tabela `notificacao_email_outbox` — `status`: `pendente` | `enviada` | `falha`.
+- **Mensagem ao cliente:** colunas `email_status`, `email_send_attempts`, `email_last_error` em `ticket_mensagens` — `falha_envio` após esgotar tentativas.
+
+### Dev sem Resend
+
+Com `ENVIRONMENT=development` e envio não configurado, notificações a atendentes são **simuladas** (`status=enviada` + log estruturado `notificacao_email_send_simulated_dev`).
+
+## Logs estruturados
+
+Eventos relevantes (JSON em uma linha):
+
+| event | Significado |
+|-------|-------------|
+| `notificacao_email_send_ok` | Notificação enviada |
+| `notificacao_email_send_retry` | Falha transitória; nova tentativa agendada |
+| `notificacao_email_send_failed_permanent` | 5 falhas — investigar Resend/SMTP |
+| `ticket_email_send_ok` | Resposta ao cliente enviada |
+| `ticket_email_send_retry` | Retry da mensagem pública |
+| `ticket_email_send_failed_permanent` | Mensagem presa em `falha_envio` |
+
+Filtrar no agregador de logs: `grep '"event":"notificacao_email_send_failed_permanent"'`.
+
+## Consultas úteis (PostgreSQL)
+
+```sql
+-- Fila de notificações com falha permanente
+SELECT id, tipo, ticket_id, atendente_id, tentativas, last_error, created_at
+FROM notificacao_email_outbox
+WHERE status = 'falha'
+ORDER BY id DESC
+LIMIT 20;
+
+-- Mensagens ao cliente que falharam
+SELECT id, ticket_id, email_send_attempts, email_last_error, updated_at
+FROM ticket_mensagens
+WHERE email_status = 'falha_envio'
+ORDER BY id DESC
+LIMIT 20;
+```
+
+## Relacionado
+
+- Checklist de deploy: [`PRE_DEPLOY_CHECKLIST.md`](PRE_DEPLOY_CHECKLIST.md)
+- Arquitetura multi-cliente: [`DEPLOYMENT_ARCHITECTURE.md`](DEPLOYMENT_ARCHITECTURE.md)
+- Runbook e-mail inbound: issue **#167** (SPF/DKIM)

--- a/docs/PRE_DEPLOY_CHECKLIST.md
+++ b/docs/PRE_DEPLOY_CHECKLIST.md
@@ -65,6 +65,7 @@ Legenda: **OK** atendido no repositório | **Você** validação manual no servi
 | Telas só admin no frontend | **OK** — `AdminRoute` exibe página 403 para não-admin (defesa em profundidade além da API). |
 | XSS / dependências JS | **Você** — `npm audit` no frontend; CSP no Nginx; token em storage continua sensível a XSS até eventual refresh em cookie httpOnly. |
 | CI + Dependabot no GitHub | **OK** — `.github/workflows/ci.yml` e `.github/dependabot.yml` (se usar outro Git, replique os passos manualmente). |
+| Runbook operacional (health, filas, logs) | **OK** — [`docs/OPERATIONS.md`](OPERATIONS.md) (#119). |
 
 ---
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,11 +33,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -46,7 +48,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -54,20 +58,22 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -84,12 +90,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -99,12 +107,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -114,7 +124,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -122,25 +134,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -150,7 +166,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -158,7 +176,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -166,7 +186,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -174,23 +196,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -200,29 +226,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -230,12 +260,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -483,7 +515,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.132.0",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -491,9 +525,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -508,9 +542,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -525,9 +559,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -542,9 +576,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -559,9 +593,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -576,9 +610,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -593,9 +627,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -610,9 +644,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -627,9 +661,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -644,9 +678,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
-      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -661,9 +695,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -678,9 +712,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -695,9 +729,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -714,9 +748,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -731,7 +765,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1352,7 +1388,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.32",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1374,7 +1412,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -1393,11 +1433,11 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1407,7 +1447,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -1489,7 +1531,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.362",
+      "version": "1.5.374",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.374.tgz",
+      "integrity": "sha512-HCF5i7izveksHSGqa7mhDh6tr3Uz9Dar2RAjwuh69bw3QGPVObjQIgLwQWeO/Rxp9/r0KdboKy9RbpQDl97fjg==",
       "dev": true,
       "license": "ISC"
     },
@@ -1507,6 +1551,8 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1874,11 +1920,15 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2207,6 +2257,8 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2263,9 +2315,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2450,11 +2507,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.2",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.132.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -2464,21 +2523,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.2",
-        "@rolldown/binding-darwin-arm64": "1.0.2",
-        "@rolldown/binding-darwin-x64": "1.0.2",
-        "@rolldown/binding-freebsd-x64": "1.0.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
-        "@rolldown/binding-linux-arm64-musl": "1.0.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-musl": "1.0.2",
-        "@rolldown/binding-openharmony-arm64": "1.0.2",
-        "@rolldown/binding-wasm32-wasi": "1.0.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
-        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/scheduler": {
@@ -2487,6 +2546,8 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2542,7 +2603,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2625,6 +2688,8 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -2661,7 +2726,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.14",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -2669,8 +2736,8 @@
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.15",
-        "rolldown": "1.0.2",
-        "tinyglobby": "^0.2.16"
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2761,6 +2828,8 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,6 @@
     "tailwindcss": "^4.2.2",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.60.0",
-    "vite": "^8.0.14"
+    "vite": "^8.0.16"
   }
 }


### PR DESCRIPTION
## Summary

- **#119:** Health estendido (/health, /health/ready com checagem de BD), logs estruturados JSON nos workers de e-mail, runbook docs/OPERATIONS.md.
- Pol?tica unificada de retry (5 tentativas, backoff) nas filas de notifica??o, mensagens ao cliente e webhooks; migration **043** (email_send_attempts em 	icket_mensagens).
- Webhook de sa?da ao fechar ticket (TICKET_CLOSED_WEBHOOK_URL + HMAC), fila webhook_outbox, worker em background; migration **044**.
- Retry HTTP transit?rio na Evolution API (EVOLUTION_HTTP_MAX_ATTEMPTS) para envio WhatsApp.

## Test plan

- [ ] pytest (182 testes, incl. 	est_observabilidade.py e 	est_ticket_closed_webhook.py)
- [ ] GET /health e GET /health/ready (503 se BD indispon?vel)
- [ ] Fechar ticket com TICKET_CLOSED_WEBHOOK_URL configurado ? POST na URL destino
- [ ] Mensagem p?blica com e-mail: retry at? alha_envio ap?s 5 falhas
- [ ] Ap?s merge: PR main ? staging e lembic upgrade head (043 + 044)
