### PR TITLE
fix(alembic): revision 045 excedia varchar(32) no deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,22 @@ jobs:
             exit 1
           fi
 
+      - name: Verificar tamanho dos revision IDs (máx. 32)
+        run: |
+          python - <<'PY'
+          import pathlib, re, sys
+          bad = []
+          for path in pathlib.Path("alembic/versions").glob("*.py"):
+              text = path.read_text(encoding="utf-8")
+              m = re.search(r'^revision\s*=\s*["\']([^"\']+)["\']', text, re.M)
+              if m and len(m.group(1)) > 32:
+                  bad.append(f"{path.name}: {m.group(1)!r} ({len(m.group(1))} chars)")
+          if bad:
+              print("revision IDs excedem varchar(32) do alembic_version:", file=sys.stderr)
+              print("\n".join(bad), file=sys.stderr)
+              sys.exit(1)
+          PY
+
   frontend:
     runs-on: ubuntu-latest
     defaults:

--- a/backend/alembic/versions/045_merge_setor_distribuicao_webhook_heads.py
+++ b/backend/alembic/versions/045_merge_setor_distribuicao_webhook_heads.py
@@ -1,11 +1,11 @@
 """Unifica heads: distribuição por setor + outbox webhook/e-mail retry.
 
-Revision ID: 045_merge_setor_distribuicao_webhook
+Revision ID: 045_merge_setor_webhook
 Revises: 043_setor_distribuicao, 044_webhook_outbox
 Create Date: 2026-05-27
 """
 
-revision = "045_merge_setor_distribuicao_webhook"
+revision = "045_merge_setor_webhook"
 down_revision = ("043_setor_distribuicao", "044_webhook_outbox")
 branch_labels = None
 depends_on = None

--- a/docs/ALEMBIC_MIGRATIONS.md
+++ b/docs/ALEMBIC_MIGRATIONS.md
@@ -14,6 +14,7 @@ Quando esse encadeamento fica inconsistente, o comando `alembic upgrade head` fa
   - o `revision` gerado
   - o `down_revision` que ela referencia
   - se o `down_revision` bate com o `revision` real da migration anterior
+- **`revision` com no máximo 32 caracteres** — `alembic_version.version_num` é `varchar(32)`; IDs maiores falham no deploy com `StringDataRightTruncation`.
 - **Evite trocar o valor de `revision`** de uma migration que já pode ter sido aplicada em algum ambiente. Se precisar padronizar IDs antigos, prefira planejar isso como uma ação controlada (ex.: com `alembic stamp`) e documentar para todos os ambientes.
 
 ## Checagem rápida (local/CI)


### PR DESCRIPTION
## Summary
- Encurta revision de 045_merge_setor_distribuicao_webhook (36 chars) para 045_merge_setor_webhook (22 chars)
- O deploy #316 aplicou 043/044 no VPS mas falhou ao registrar a merge no alembic_version
- Adiciona validacao de tamanho maximo (32) no CI

## Contexto
- Run 27686527877: timeout SSH (transiente)
- Run 27686824004: alembic StringDataRightTruncation ao gravar revision 045

## Test plan
- [ ] CI passa
- [ ] Deploy em staging completa alembic upgrade head
- [ ] Health da API retorna git_sha atualizado