### PR TITLE
fix(deploy): prioriza backend e retenta SSH em timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,19 +86,39 @@ jobs:
           P="${SSH_PORT:-22}"
           ssh-keyscan -p "$P" -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
           echo "SSH_PORT=${P}" >> "$GITHUB_ENV"
-
-      - name: Rsync — frontend dist → VPS
-        run: |
-          rsync -avz --delete \
-            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new -p ${SSH_PORT}" \
-            frontend/dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_FRONTEND_DIST}/"
+          {
+            echo 'SSH_COMMON_OPTS=-i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new'
+            echo 'SSH_CONNECT_OPTS=-o ConnectTimeout=30 -o ServerAliveInterval=15 -o ServerAliveCountMax=3'
+            echo 'SSH_MUX_OPTS=-o ControlMaster=auto -o ControlPath=~/.ssh/cm-%r@%h:%p -o ControlPersist=120'
+          } >> "$GITHUB_ENV"
 
       - name: Git pull + Alembic + Docker Compose
         run: |
           REF="${EVENT_REF:-${DEPLOY_GIT_REF:-staging}}"
           echo "Deploy ref no VPS: ${REF}"
-          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new -p "${SSH_PORT}" \
-            "${DEPLOY_USER}@${DEPLOY_HOST}" \
+
+          retry() {
+            local attempt=1 max=3 delay=20
+            while true; do
+              if "$@"; then return 0; fi
+              if [ "$attempt" -ge "$max" ]; then
+                echo "::error::Comando falhou após ${max} tentativas: $*"
+                return 1
+              fi
+              echo "Tentativa ${attempt}/${max} falhou; nova em ${delay}s..."
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          ssh_cmd() {
+            # shellcheck disable=SC2086
+            ssh ${SSH_COMMON_OPTS} ${SSH_CONNECT_OPTS} ${SSH_MUX_OPTS} -p "${SSH_PORT}" \
+              "${DEPLOY_USER}@${DEPLOY_HOST}" "$@"
+          }
+
+          retry ssh_cmd \
             "REF='${REF}' DEPLOY_PATH='${DEPLOY_PATH}' SKIP_MIGRATIONS='${SKIP_MIGRATIONS}' WEBHOOK_BASE_URL='${VITE_API_URL}' bash -s" << 'REMOTE_SCRIPT'
           set -ex
           cd "$DEPLOY_PATH"
@@ -141,6 +161,27 @@ jobs:
           done
           curl -sf "http://127.0.0.1:8080" >/dev/null || echo "Evolution API: aguardar ou conferir logs (docker logs dx-connect-evolution-api)"
           REMOTE_SCRIPT
+
+      - name: Rsync — frontend dist → VPS
+        run: |
+          retry() {
+            local attempt=1 max=3 delay=20
+            while true; do
+              if "$@"; then return 0; fi
+              if [ "$attempt" -ge "$max" ]; then
+                echo "::error::Comando falhou após ${max} tentativas: $*"
+                return 1
+              fi
+              echo "Tentativa ${attempt}/${max} falhou; nova em ${delay}s..."
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          retry rsync -avz --delete \
+            -e "ssh ${SSH_COMMON_OPTS} ${SSH_CONNECT_OPTS} ${SSH_MUX_OPTS} -p ${SSH_PORT}" \
+            frontend/dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_FRONTEND_DIST}/"
 
       - name: Verificar rotas da API (health)
         run: |

--- a/deploy/github-actions.md
+++ b/deploy/github-actions.md
@@ -3,8 +3,8 @@
 O workflow [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml) faz:
 
 1. **Build do frontend** no runner (usa `VITE_API_URL` dos secrets).
-2. **`rsync`** da pasta `frontend/dist/` para o caminho no VPS (`DEPLOY_FRONTEND_DIST`).
-3. **SSH** no servidor: `git pull`, `alembic upgrade head`, `docker compose -f docker-compose.prod.yml up -d --build`.
+2. **SSH** no servidor: `git pull`, `alembic upgrade head`, `docker compose -f docker-compose.prod.yml up -d --build` (com até 3 tentativas em falha de conexão).
+3. **`rsync`** da pasta `frontend/dist/` para o caminho no VPS (`DEPLOY_FRONTEND_DIST`), reutilizando a mesma sessão SSH quando possível.
 
 Disparo automático em **push** para **`staging`** quando mudam `backend/`, `frontend/`, `docker-compose.prod.yml` ou o próprio workflow. A branch **`main`** não dispara deploy (último estágio de testes/integração); após validar em `main`, abra PR **`main → staging`**, merge e o deploy roda no VPS. Também pode rodar manualmente em **Actions → Deploy → Run workflow**.
 
@@ -93,6 +93,7 @@ Em cada deploy o workflow executa `alembic upgrade head` antes do `up --build`. 
 
 ## Troubleshooting
 
+- **`Connection timed out` (SSH/rsync)**: conexão intermitente entre o runner do GitHub e o VPS. O workflow tenta até 3 vezes e prioriza backend/migrations antes do rsync do frontend. Se persistir, confira firewall (porta SSH), se o VPS está online e se `DEPLOY_HOST`/`DEPLOY_SSH_PORT` estão corretos. Pode reexecutar em **Actions → Deploy → Run workflow**.
 - **`Permission denied (publickey)`**: confira `DEPLOY_SSH_KEY`, usuário e `authorized_keys` no VPS.
 - **`rsync` falha**: permissões em `DEPLOY_FRONTEND_DIST` e caminho absoluto correto.
 - **`docker: permission denied`**: usuário no grupo `docker` ou reiniciar sessão SSH após `usermod`.


### PR DESCRIPTION
## Summary

- Executa git pull, alembic e restart do backend antes do rsync do frontend
- Adiciona ate 3 tentativas com backoff em falhas de conexao SSH
- Reutiliza sessao SSH (ControlMaster) entre os passos

## Contexto

O merge do PR #317 falhou com timeout SSH no rsync, antes de chegar no Alembic. Um re-run manual concluiu com sucesso (staging em 21ddc2c, migration 045 aplicada).

## Test plan

- [ ] Merge em staging dispara Deploy sem timeout SSH
- [ ] Backend atualiza mesmo se rsync falhar na primeira tentativa
- [ ] Health retorna git_sha do commit deployado