### PR TITLE
fix(deploy): auto-retry quando SSH do runner falhar

### DIFF
--- a/.github/workflows/deploy-retry.yml
+++ b/.github/workflows/deploy-retry.yml
@@ -1,0 +1,38 @@
+# Reexecuta Deploy após falha em push para staging (SSH intermitente do runner GitHub).
+# Não dispara em workflow_dispatch, para evitar loop infinito.
+
+name: Deploy retry
+
+on:
+  workflow_run:
+    workflows: ["Deploy"]
+    types: [completed]
+    branches: [staging]
+
+jobs:
+  retry:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+
+    steps:
+      - name: Aguardar antes de nova tentativa
+        run: |
+          echo "Deploy por push falhou (run ${{ github.event.workflow_run.id }})."
+          echo "Nova tentativa manual via workflow_dispatch em 90s..."
+          sleep 90
+
+      - name: Reexecutar Deploy
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: "deploy.yml",
+              ref: "staging",
+            });

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,39 +86,43 @@ jobs:
           P="${SSH_PORT:-22}"
           ssh-keyscan -p "$P" -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
           echo "SSH_PORT=${P}" >> "$GITHUB_ENV"
-          {
-            echo 'SSH_COMMON_OPTS=-i ~/.ssh/deploy_key -o StrictHostKeyChecking=accept-new'
-            echo 'SSH_CONNECT_OPTS=-o ConnectTimeout=30 -o ServerAliveInterval=15 -o ServerAliveCountMax=3'
-            echo 'SSH_MUX_OPTS=-o ControlMaster=auto -o ControlPath=~/.ssh/cm-%r@%h:%p -o ControlPersist=120'
-          } >> "$GITHUB_ENV"
+          echo "DEPLOY_KEY_PATH=${HOME}/.ssh/deploy_key" >> "$GITHUB_ENV"
+          echo "SSH_MUX_PATH=${HOME}/.ssh/cm-%r@%h:%p" >> "$GITHUB_ENV"
 
       - name: Git pull + Alembic + Docker Compose
         run: |
           REF="${EVENT_REF:-${DEPLOY_GIT_REF:-staging}}"
           echo "Deploy ref no VPS: ${REF}"
 
-          retry() {
-            local attempt=1 max=3 delay=20
-            while true; do
-              if "$@"; then return 0; fi
-              if [ "$attempt" -ge "$max" ]; then
-                echo "::error::Comando falhou após ${max} tentativas: $*"
-                return 1
-              fi
-              echo "Tentativa ${attempt}/${max} falhou; nova em ${delay}s..."
-              sleep "$delay"
-              attempt=$((attempt + 1))
-              delay=$((delay * 2))
-            done
-          }
-
-          ssh_cmd() {
-            # shellcheck disable=SC2086
-            ssh ${SSH_COMMON_OPTS} ${SSH_CONNECT_OPTS} ${SSH_MUX_OPTS} -p "${SSH_PORT}" \
+          ssh_base() {
+            ssh -i "$DEPLOY_KEY_PATH" \
+              -o StrictHostKeyChecking=accept-new \
+              -o ConnectTimeout=20 \
+              -o ServerAliveInterval=15 \
+              -o ServerAliveCountMax=3 \
+              -o ControlMaster=auto \
+              -o "ControlPath=${SSH_MUX_PATH}" \
+              -o ControlPersist=120 \
+              -p "${SSH_PORT}" \
               "${DEPLOY_USER}@${DEPLOY_HOST}" "$@"
           }
 
-          retry ssh_cmd \
+          retry() {
+            local attempt=1 max=5 delay=15
+            while true; do
+              if "$@"; then return 0; fi
+              if [ "$attempt" -ge "$max" ]; then
+                echo "::error::Comando falhou após ${max} tentativas."
+                return 1
+              fi
+              echo "Tentativa ${attempt}/${max} falhou; nova em ${delay}s (runner GitHub → VPS)..."
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay + 15))
+            done
+          }
+
+          retry ssh_base \
             "REF='${REF}' DEPLOY_PATH='${DEPLOY_PATH}' SKIP_MIGRATIONS='${SKIP_MIGRATIONS}' WEBHOOK_BASE_URL='${VITE_API_URL}' bash -s" << 'REMOTE_SCRIPT'
           set -ex
           cd "$DEPLOY_PATH"
@@ -164,24 +168,28 @@ jobs:
 
       - name: Rsync — frontend dist → VPS
         run: |
+          ssh_rsync() {
+            rsync -avz --delete \
+              -e "ssh -i ${DEPLOY_KEY_PATH} -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20 -o ControlMaster=auto -o ControlPath=${SSH_MUX_PATH} -o ControlPersist=120 -p ${SSH_PORT}" \
+              frontend/dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_FRONTEND_DIST}/"
+          }
+
           retry() {
-            local attempt=1 max=3 delay=20
+            local attempt=1 max=5 delay=15
             while true; do
               if "$@"; then return 0; fi
               if [ "$attempt" -ge "$max" ]; then
-                echo "::error::Comando falhou após ${max} tentativas: $*"
+                echo "::error::Rsync falhou após ${max} tentativas."
                 return 1
               fi
               echo "Tentativa ${attempt}/${max} falhou; nova em ${delay}s..."
               sleep "$delay"
               attempt=$((attempt + 1))
-              delay=$((delay * 2))
+              delay=$((delay + 15))
             done
           }
 
-          retry rsync -avz --delete \
-            -e "ssh ${SSH_COMMON_OPTS} ${SSH_CONNECT_OPTS} ${SSH_MUX_OPTS} -p ${SSH_PORT}" \
-            frontend/dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_FRONTEND_DIST}/"
+          retry ssh_rsync
 
       - name: Verificar rotas da API (health)
         run: |

--- a/deploy/github-actions.md
+++ b/deploy/github-actions.md
@@ -93,7 +93,7 @@ Em cada deploy o workflow executa `alembic upgrade head` antes do `up --build`. 
 
 ## Troubleshooting
 
-- **`Connection timed out` (SSH/rsync)**: conexão intermitente entre o runner do GitHub e o VPS. O workflow tenta até 3 vezes e prioriza backend/migrations antes do rsync do frontend. Se persistir, confira firewall (porta SSH), se o VPS está online e se `DEPLOY_HOST`/`DEPLOY_SSH_PORT` estão corretos. Pode reexecutar em **Actions → Deploy → Run workflow**.
+- **`Connection timed out` (SSH/rsync)**: o runner do GitHub usa **IPs diferentes a cada execução** (pool Azure). O VPS pode aceitar uma tentativa e recusar outra no mesmo dia — não indica configuração SSH errada no servidor. O workflow tenta até 5 vezes; se o deploy por **push** falhar, o workflow **Deploy retry** reexecuta automaticamente após 90s. Também pode rodar manualmente em **Actions → Deploy → Run workflow**.
 - **`Permission denied (publickey)`**: confira `DEPLOY_SSH_KEY`, usuário e `authorized_keys` no VPS.
 - **`rsync` falha**: permissões em `DEPLOY_FRONTEND_DIST` e caminho absoluto correto.
 - **`docker: permission denied`**: usuário no grupo `docker` ou reiniciar sessão SSH após `usermod`.


### PR DESCRIPTION
## Summary

- Explica e mitiga falhas intermitentes de SSH (runner GitHub com IP diferente a cada execucao)
- Corrige paths SSH com HOME absoluto (tilde em variavel de ambiente nao expande)
- Aumenta tentativas para 5 com intervalo linear
- Novo workflow Deploy retry: reexecuta Deploy 90s apos falha em push para staging

## Test plan

- [ ] Merge dispara Deploy; se falhar por timeout, Deploy retry roda automaticamente
- [ ] workflow_dispatch manual continua funcionando como hoje