### PR TITLE
feat(dashboard): dashboards analiticos tickets e WhatsApp (D-F2 + D-F3)

### DIFF
--- a/backend/app/api/dashboard.py
+++ b/backend/app/api/dashboard.py
@@ -1,14 +1,28 @@
 from datetime import date
 
-from fastapi import APIRouter, Depends
-from sqlalchemy import func, cast, Date
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, cast, Date, or_, select
 from sqlalchemy.orm import Session, joinedload
 
 from app.database import get_db
 from app.models import Ticket, StatusTicket, Empresa
 from app.models.atendente import Atendente
-from app.schemas.dashboard import DashboardGeralResponse, DashboardResponse, DashboardResumo, StatusCount
+from app.models.whatsapp_chat import WhatsappChat
+from app.schemas.dashboard import (
+    ChatEstadoCount,
+    ChatRecenteResumo,
+    DashboardChatsResumo,
+    DashboardGeralResponse,
+    DashboardResponse,
+    DashboardResumo,
+    DashboardTicketsResponse,
+    DashboardChatsResponse,
+    StatusCount,
+)
 from app.services.dashboard_geral import obter_dashboard_geral as montar_dashboard_geral
+from app.services.dashboard_tickets import obter_dashboard_tickets as montar_dashboard_tickets
+from app.services.dashboard_chats import obter_dashboard_chats as montar_dashboard_chats
+from app.services.ticket_dashboard_filters import normalizar_prioridade
 from app.schemas.ticket import TicketRead
 from app.core.auth import obter_atendente_atual
 from app.api.tickets import _ticket_para_read
@@ -22,6 +36,21 @@ def _filtro_setor_atendente(db: Session, q, atendente: Atendente):
         vis = ids_setores_visiveis_atendente(db, atendente)
         return q.filter(Ticket.setor_id.in_(vis))
     return q
+
+
+def _filtro_whatsapp_scope(db: Session, q, atendente: Atendente):
+    if atendente.role != "admin":
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        return q.filter(or_(WhatsappChat.setor_id.is_(None), WhatsappChat.setor_id.in_(vis)))
+    return q
+
+
+_CHAT_ESTADO_ROTULO = {
+    "aguardando_atendente": "Aguardando atendente",
+    "em_atendimento": "Em atendimento",
+    "aguardando_avaliacao": "Aguardando avaliação",
+    "encerrado": "Encerrado",
+}
 
 
 @router.get("", response_model=DashboardResponse)
@@ -64,6 +93,40 @@ def obter_dashboard(
         por_status=por_status,
     )
 
+    q_chats_total = db.query(func.count(WhatsappChat.id)).select_from(WhatsappChat)
+    q_chats_total = _filtro_whatsapp_scope(db, q_chats_total, atendente)
+    total_chats = q_chats_total.scalar() or 0
+
+    q_chats_hoje = (
+        db.query(func.count(WhatsappChat.id))
+        .select_from(WhatsappChat)
+        .filter(cast(WhatsappChat.created_at, Date) == hoje)
+    )
+    q_chats_hoje = _filtro_whatsapp_scope(db, q_chats_hoje, atendente)
+    chats_hoje = q_chats_hoje.scalar() or 0
+
+    q_estados = (
+        db.query(WhatsappChat.estado, func.count(WhatsappChat.id))
+        .select_from(WhatsappChat)
+        .group_by(WhatsappChat.estado)
+    )
+    q_estados = _filtro_whatsapp_scope(db, q_estados, atendente)
+    por_estado = [
+        ChatEstadoCount(
+            estado=estado,
+            rotulo=_CHAT_ESTADO_ROTULO.get(estado, estado),
+            total=int(total),
+        )
+        for estado, total in q_estados.all()
+        if estado in _CHAT_ESTADO_ROTULO
+    ]
+
+    resumo_chats = DashboardChatsResumo(
+        total_chats=total_chats,
+        iniciados_hoje=chats_hoje,
+        por_estado=por_estado,
+    )
+
     # Últimos tickets
     q_ultimos = (
         db.query(Ticket)
@@ -86,7 +149,26 @@ def obter_dashboard(
     )
     ultimos_tickets = [_ticket_para_read(t) for t in ultimos]
 
-    return DashboardResponse(resumo=resumo, ultimos_tickets=ultimos_tickets)
+    q_ultimos_chats = db.query(WhatsappChat)
+    q_ultimos_chats = _filtro_whatsapp_scope(db, q_ultimos_chats, atendente)
+    ultimos_chats_rows = q_ultimos_chats.order_by(WhatsappChat.created_at.desc()).limit(10).all()
+    ultimos_chats = [
+        ChatRecenteResumo(
+            id=c.id,
+            protocolo=c.protocolo,
+            cliente_nome=c.cliente_nome,
+            estado=c.estado,
+            created_at=c.created_at,
+        )
+        for c in ultimos_chats_rows
+    ]
+
+    return DashboardResponse(
+        resumo=resumo,
+        resumo_chats=resumo_chats,
+        ultimos_tickets=ultimos_tickets,
+        ultimos_chats=ultimos_chats,
+    )
 
 
 @router.get("/geral", response_model=DashboardGeralResponse)
@@ -95,3 +177,74 @@ def obter_dashboard_geral(
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
     return montar_dashboard_geral(db, atendente)
+
+
+@router.get(
+    "/tickets",
+    response_model=DashboardTicketsResponse,
+    summary="Dashboard analítico de tickets",
+    description="Métricas consolidadas do canal ticket no período informado (default: últimos 30 dias). "
+    "Atendentes veem apenas setores vinculados.",
+)
+def obter_dashboard_tickets(
+    de: date | None = Query(None, description="Início do período (default: 30 dias antes de ate)"),
+    ate: date | None = Query(None, description="Fim do período (default: hoje)"),
+    rede_id: int | None = Query(None, ge=1),
+    setor_id: int | None = Query(None, ge=1),
+    prioridade: str | None = Query(
+        None,
+        description="Filtrar por prioridade: baixa, normal, alta, urgente",
+    ),
+    atendente_filtro_id: int | None = Query(None, ge=1, description="Drill-down por atendente responsável (legado)"),
+    drill_tipo: str | None = Query(None, description="Tipo do drill-down cross-filter (ex.: empresa, atendente)"),
+    drill_valor: str | None = Query(None, description="Valor do drill-down (id ou código conforme o tipo)"),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    prio = None
+    if prioridade is not None:
+        try:
+            prio = normalizar_prioridade(prioridade)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return montar_dashboard_tickets(
+        db,
+        atendente,
+        de=de,
+        ate=ate,
+        rede_id=rede_id,
+        setor_id=setor_id,
+        prioridade=prio,
+        drill_tipo=drill_tipo,
+        drill_valor=drill_valor,
+        atendente_filtro_id=atendente_filtro_id,
+    )
+
+
+@router.get(
+    "/chats",
+    response_model=DashboardChatsResponse,
+    summary="Dashboard analítico de chats WhatsApp",
+    description="Métricas consolidadas do canal WhatsApp no período informado (default: últimos 30 dias). "
+    "Atendentes veem apenas setores vinculados.",
+)
+def obter_dashboard_chats(
+    de: date | None = Query(None, description="Início do período (default: 30 dias antes de ate)"),
+    ate: date | None = Query(None, description="Fim do período (default: hoje)"),
+    setor_id: int | None = Query(None, ge=1),
+    atendente_filtro_id: int | None = Query(None, ge=1, description="Drill-down por atendente responsável (legado)"),
+    drill_tipo: str | None = Query(None, description="Tipo do drill-down cross-filter (ex.: estado, atendente)"),
+    drill_valor: str | None = Query(None, description="Valor do drill-down (id ou código conforme o tipo)"),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return montar_dashboard_chats(
+        db,
+        atendente,
+        de=de,
+        ate=ate,
+        setor_id=setor_id,
+        drill_tipo=drill_tipo,
+        drill_valor=drill_valor,
+        atendente_filtro_id=atendente_filtro_id,
+    )

--- a/backend/app/api/relatorios.py
+++ b/backend/app/api/relatorios.py
@@ -1,0 +1,77 @@
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import PlainTextResponse
+from sqlalchemy.orm import Session
+
+from app.core.auth import exigir_admin
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.schemas.relatorio import RelatorioTicketsResponse
+from app.services.relatorio_tickets import (
+    PREVIEW_LIMIT,
+    exportar_relatorio_tickets_csv,
+    listar_relatorio_tickets,
+)
+from app.services.ticket_dashboard_filters import normalizar_prioridade
+
+router = APIRouter(prefix="/relatorios", tags=["relatorios"])
+
+
+def _parse_prioridade(prioridade: str | None) -> str | None:
+    if prioridade is None:
+        return None
+    try:
+        return normalizar_prioridade(prioridade)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.get(
+    "/tickets",
+    summary="Relatório tabular de tickets (pré-visualização ou CSV)",
+    description="Lista paginada de tickets no período (mesmos filtros do dashboard). "
+    "Admin-only. Use `format=csv` para exportação (UTF-8 BOM, até 50k linhas).",
+)
+def relatorio_tickets(
+    de: date | None = Query(None),
+    ate: date | None = Query(None),
+    rede_id: int | None = Query(None, ge=1),
+    setor_id: int | None = Query(None, ge=1),
+    prioridade: str | None = Query(None),
+    format: str | None = Query(None, alias="format"),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(PREVIEW_LIMIT, ge=1, le=PREVIEW_LIMIT),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    prio = _parse_prioridade(prioridade)
+    if format == "csv":
+        conteudo = exportar_relatorio_tickets_csv(
+            db,
+            atendente,
+            de=de,
+            ate=ate,
+            rede_id=rede_id,
+            setor_id=setor_id,
+            prioridade=prio,
+        )
+        nome = f"relatorio-tickets-{date.today().isoformat()}.csv"
+        return PlainTextResponse(
+            content=conteudo,
+            media_type="text/csv; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{nome}"'},
+        )
+    if format is not None:
+        raise HTTPException(status_code=422, detail="format suportado: csv")
+    return listar_relatorio_tickets(
+        db,
+        atendente,
+        de=de,
+        ate=ate,
+        rede_id=rede_id,
+        setor_id=setor_id,
+        prioridade=prio,
+        offset=offset,
+        limit=limit,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -22,6 +22,7 @@ from app.api import (
     status_ticket,
     tickets,
     dashboard,
+    relatorios,
     audit,
     tipo_negocio,
     cadastro_aux,
@@ -380,6 +381,7 @@ app.include_router(funcionarios_rede.router, prefix=API_V1_PREFIX)
 app.include_router(status_ticket.router, prefix=API_V1_PREFIX)
 app.include_router(tickets.router, prefix=API_V1_PREFIX)
 app.include_router(dashboard.router, prefix=API_V1_PREFIX)
+app.include_router(relatorios.router, prefix=API_V1_PREFIX)
 app.include_router(audit.router, prefix=API_V1_PREFIX)
 app.include_router(tipo_negocio.router, prefix=API_V1_PREFIX)
 app.include_router(cadastro_aux.router, prefix=API_V1_PREFIX)

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 
 from pydantic import BaseModel, Field
 
@@ -17,9 +17,31 @@ class DashboardResumo(BaseModel):
     por_status: list[StatusCount]
 
 
+class ChatEstadoCount(BaseModel):
+    estado: str
+    rotulo: str
+    total: int = Field(ge=0)
+
+
+class DashboardChatsResumo(BaseModel):
+    total_chats: int = Field(ge=0)
+    iniciados_hoje: int = Field(ge=0)
+    por_estado: list[ChatEstadoCount]
+
+
+class ChatRecenteResumo(BaseModel):
+    id: int
+    protocolo: str
+    cliente_nome: str | None = None
+    estado: str
+    created_at: datetime
+
+
 class DashboardResponse(BaseModel):
     resumo: DashboardResumo
+    resumo_chats: DashboardChatsResumo
     ultimos_tickets: list[TicketRead]
+    ultimos_chats: list[ChatRecenteResumo]
 
 
 class CsAtMediaResumo(BaseModel):
@@ -36,5 +58,87 @@ class DashboardGeralResponse(BaseModel):
     csat_tickets: CsAtMediaResumo
     csat_chats: CsAtMediaResumo
     sla_violacoes_abertas: int | None = None
+    gerado_em: datetime
+    cache_ttl_segundos: int = Field(ge=0)
+
+
+class SerieVolumeDia(BaseModel):
+    dia: date
+    abertos: int = Field(ge=0)
+    fechados: int = Field(ge=0)
+
+
+class ContagemIdNome(BaseModel):
+    id: int
+    nome: str
+    total: int = Field(ge=0)
+
+
+class ContagemPrioridade(BaseModel):
+    prioridade: str
+    total: int = Field(ge=0)
+
+
+class ContagemRotulo(BaseModel):
+    chave: str | None = None
+    rotulo: str
+    total: int = Field(ge=0)
+
+
+class ContagemCanal(BaseModel):
+    canal: str
+    rotulo: str
+    total: int = Field(ge=0)
+
+
+class CsatDistribuicaoTickets(BaseModel):
+    media: float | None = None
+    total_avaliacoes: int = Field(ge=0)
+    por_nota: dict[int, int] = Field(default_factory=dict)
+
+
+class DashboardTicketsResponse(BaseModel):
+    de: date
+    ate: date
+    volume_por_dia: list[SerieVolumeDia]
+    por_status: list[ContagemIdNome]
+    por_prioridade: list[ContagemPrioridade]
+    por_motivo: list[ContagemIdNome]
+    por_rede: list[ContagemIdNome]
+    por_empresa: list[ContagemIdNome]
+    mttr_horas: float | None = None
+    fila_tempo_medio_horas: float | None = None
+    csat: CsatDistribuicaoTickets
+    por_canal: list[ContagemCanal]
+    por_atendente: list[ContagemIdNome]
+    gerado_em: datetime
+    cache_ttl_segundos: int = Field(ge=0)
+
+
+class ContagemEncerramentoChat(BaseModel):
+    tipo: str
+    rotulo: str
+    total: int = Field(ge=0)
+
+
+class SnapshotCanais(BaseModel):
+    tickets_abertos: int = Field(ge=0)
+    tickets_sem_responsavel: int = Field(ge=0)
+    chats_aguardando: int = Field(ge=0)
+    chats_em_atendimento: int = Field(ge=0)
+
+
+class DashboardChatsResponse(BaseModel):
+    de: date
+    ate: date
+    volume_por_dia: list[SerieVolumeDia]
+    tempo_espera_medio_horas: float | None = None
+    tempo_atendimento_medio_horas: float | None = None
+    avaliacoes: CsatDistribuicaoTickets
+    encerramentos: list[ContagemEncerramentoChat]
+    pct_com_ticket_vinculado: float | None = None
+    por_atendente: list[ContagemIdNome]
+    por_estado_atual: list[ContagemRotulo]
+    snapshot: SnapshotCanais
     gerado_em: datetime
     cache_ttl_segundos: int = Field(ge=0)

--- a/backend/app/schemas/relatorio.py
+++ b/backend/app/schemas/relatorio.py
@@ -1,0 +1,26 @@
+from datetime import date, datetime
+
+from pydantic import BaseModel, Field
+
+
+class RelatorioTicketLinha(BaseModel):
+    protocolo: str
+    assunto: str
+    status_nome: str
+    prioridade: str
+    rede_nome: str
+    empresa_nome: str
+    setor_nome: str
+    aberto_em: datetime | None = None
+    fechado_em: datetime | None = None
+    responsavel_nome: str
+    canal: str
+
+
+class RelatorioTicketsResponse(BaseModel):
+    de: date
+    ate: date
+    total: int = Field(ge=0)
+    offset: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    itens: list[RelatorioTicketLinha]

--- a/backend/app/services/chat_dashboard_filters.py
+++ b/backend/app/services/chat_dashboard_filters.py
@@ -1,0 +1,54 @@
+"""Filtros compartilhados do dashboard analítico de chats WhatsApp."""
+
+from __future__ import annotations
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from app.core.setor_scope import ids_setores_visiveis_atendente
+from app.models.atendente import Atendente
+from app.models.whatsapp_chat import WhatsappChat
+
+from app.services.ticket_dashboard_filters import (
+    DEFAULT_PERIOD_DAYS,
+    MAX_PERIOD_DAYS,
+    period_bounds,
+    resolve_period,
+)
+
+__all__ = [
+    "DEFAULT_PERIOD_DAYS",
+    "MAX_PERIOD_DAYS",
+    "apply_chat_dashboard_filters",
+    "period_bounds",
+    "resolve_period",
+]
+
+
+def apply_chat_dashboard_filters(
+    stmt,
+    db: Session,
+    atendente: Atendente,
+    *,
+    setor_id: int | None = None,
+    atendente_id: int | None = None,
+):
+    if atendente.role != "admin":
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        stmt = stmt.where(or_(WhatsappChat.setor_id.is_(None), WhatsappChat.setor_id.in_(vis)))
+    if setor_id is not None:
+        if atendente.role != "admin":
+            vis = ids_setores_visiveis_atendente(db, atendente)
+            if setor_id not in vis:
+                return stmt.where(WhatsappChat.id == -1)
+        stmt = stmt.where(WhatsappChat.setor_id == setor_id)
+    if atendente_id is not None:
+        stmt = stmt.where(WhatsappChat.atendente_id == atendente_id)
+    return stmt
+
+
+def apply_chat_drill_to_stmt(stmt, drill, *, exclude: str | None = None):
+    from app.services.dashboard_drilldown import ChatDrillDown, apply_chat_drill_down
+
+    active = drill.without(exclude) if isinstance(drill, ChatDrillDown) and exclude else drill
+    return apply_chat_drill_down(stmt, active)

--- a/backend/app/services/dashboard_chats.py
+++ b/backend/app/services/dashboard_chats.py
@@ -1,0 +1,394 @@
+"""Métricas analíticas do canal WhatsApp (#284 / D-03)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+from sqlalchemy import exists, func, select
+from sqlalchemy.orm import Session
+
+from app.models.atendente import Atendente
+from app.models.whatsapp_chat import WhatsappChat, WhatsappChatTicket, WhatsappMensagem
+from app.schemas.dashboard import (
+    ContagemEncerramentoChat,
+    ContagemIdNome,
+    ContagemRotulo,
+    CsatDistribuicaoTickets,
+    DashboardChatsResponse,
+    SerieVolumeDia,
+    SnapshotCanais,
+)
+from app.services.chat_dashboard_filters import apply_chat_dashboard_filters, period_bounds, resolve_period
+from app.services.dashboard_drilldown import ChatDrillDown, apply_chat_drill_down
+
+CACHE_TTL_SECONDS = 60
+
+_cache: dict[tuple, tuple[datetime, DashboardChatsResponse]] = {}
+
+
+def clear_dashboard_chats_cache() -> None:
+    _cache.clear()
+
+
+def _as_date(value) -> date:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    return date.fromisoformat(str(value))
+
+
+def _filtrar(db: Session, atendente: Atendente, setor_id: int | None, drill: ChatDrillDown):
+    def apply(stmt, exclude: str | None = None):
+        stmt = apply_chat_dashboard_filters(stmt, db, atendente, setor_id=setor_id)
+        active = drill.without(exclude) if exclude else drill
+        return apply_chat_drill_down(stmt, active)
+
+    return apply
+
+
+def _volume_por_dia(
+    db: Session,
+    atendente: Atendente,
+    de: date,
+    ate: date,
+    setor_id: int | None,
+    drill: ChatDrillDown,
+) -> list[SerieVolumeDia]:
+    de_dt, ate_dt = period_bounds(de, ate)
+    abertos: dict[date, int] = {}
+    encerrados: dict[date, int] = {}
+    filtrar = _filtrar(db, atendente, setor_id, drill)
+
+    stmt_a = (
+        select(func.date(WhatsappChat.created_at).label("dia"), func.count())
+        .select_from(WhatsappChat)
+        .where(WhatsappChat.created_at >= de_dt, WhatsappChat.created_at < ate_dt)
+        .group_by(func.date(WhatsappChat.created_at))
+    )
+    for dia, total in db.execute(filtrar(stmt_a)):
+        abertos[_as_date(dia)] = int(total)
+
+    stmt_e = (
+        select(func.date(WhatsappChat.encerramento_at).label("dia"), func.count())
+        .select_from(WhatsappChat)
+        .where(
+            WhatsappChat.encerramento_at.isnot(None),
+            WhatsappChat.encerramento_at >= de_dt,
+            WhatsappChat.encerramento_at < ate_dt,
+        )
+        .group_by(func.date(WhatsappChat.encerramento_at))
+    )
+    for dia, total in db.execute(filtrar(stmt_e)):
+        encerrados[_as_date(dia)] = int(total)
+
+    serie: list[SerieVolumeDia] = []
+    cursor = de
+    while cursor <= ate:
+        serie.append(
+            SerieVolumeDia(
+                dia=cursor,
+                abertos=abertos.get(cursor, 0),
+                fechados=encerrados.get(cursor, 0),
+            )
+        )
+        cursor += timedelta(days=1)
+    return serie
+
+
+def _tempo_espera_medio_horas(
+    db: Session,
+    atendente: Atendente,
+    de_dt: datetime,
+    ate_dt: datetime,
+    setor_id: int | None,
+    drill: ChatDrillDown,
+) -> float | None:
+    filtrar = _filtrar(db, atendente, setor_id, drill)
+    duracao = func.extract(
+        "epoch",
+        WhatsappChat.atendimento_inicio_at - WhatsappChat.created_at,
+    )
+    stmt = (
+        select(func.avg(duracao))
+        .select_from(WhatsappChat)
+        .where(
+            WhatsappChat.atendimento_inicio_at.isnot(None),
+            WhatsappChat.atendimento_inicio_at >= de_dt,
+            WhatsappChat.atendimento_inicio_at < ate_dt,
+        )
+    )
+    media_seg = db.execute(filtrar(stmt)).scalar_one_or_none()
+    if media_seg is None:
+        return None
+    return round(float(media_seg) / 3600.0, 2)
+
+
+def _tempo_atendimento_medio_horas(
+    db: Session,
+    atendente: Atendente,
+    de_dt: datetime,
+    ate_dt: datetime,
+    setor_id: int | None,
+    drill: ChatDrillDown,
+) -> float | None:
+    filtrar = _filtrar(db, atendente, setor_id, drill)
+    duracao = func.extract(
+        "epoch",
+        WhatsappChat.encerramento_at - WhatsappChat.atendimento_inicio_at,
+    )
+    stmt = (
+        select(func.avg(duracao))
+        .select_from(WhatsappChat)
+        .where(
+            WhatsappChat.atendimento_inicio_at.isnot(None),
+            WhatsappChat.encerramento_at.isnot(None),
+            WhatsappChat.encerramento_at >= de_dt,
+            WhatsappChat.encerramento_at < ate_dt,
+        )
+    )
+    media_seg = db.execute(filtrar(stmt)).scalar_one_or_none()
+    if media_seg is None:
+        return None
+    return round(float(media_seg) / 3600.0, 2)
+
+
+def _avaliacoes(
+    db: Session,
+    atendente: Atendente,
+    de_dt: datetime,
+    ate_dt: datetime,
+    setor_id: int | None,
+    drill: ChatDrillDown,
+) -> CsatDistribuicaoTickets:
+    filtrar = _filtrar(db, atendente, setor_id, drill)
+    stmt = (
+        select(WhatsappChat.avaliacao_nota, func.count())
+        .select_from(WhatsappChat)
+        .where(
+            WhatsappChat.avaliacao_nota.isnot(None),
+            WhatsappChat.avaliacao_respondida_at.isnot(None),
+            WhatsappChat.avaliacao_respondida_at >= de_dt,
+            WhatsappChat.avaliacao_respondida_at < ate_dt,
+        )
+        .group_by(WhatsappChat.avaliacao_nota)
+    )
+    por_nota = {i: 0 for i in range(1, 6)}
+    total = 0
+    soma = 0
+    for nota, qtd in db.execute(filtrar(stmt, "nota")):
+        n = int(nota)
+        c = int(qtd)
+        if 1 <= n <= 5:
+            por_nota[n] = c
+            total += c
+            soma += n * c
+    media = round(soma / total, 2) if total > 0 else None
+    return CsatDistribuicaoTickets(
+        media=media,
+        total_avaliacoes=total,
+        por_nota=por_nota,
+    )
+
+
+def _encerramentos(
+    db: Session,
+    atendente: Atendente,
+    de_dt: datetime,
+    ate_dt: datetime,
+    setor_id: int | None,
+    drill: ChatDrillDown,
+) -> list[ContagemEncerramentoChat]:
+    filtrar = _filtrar(db, atendente, setor_id, drill)
+    base = (
+        select(WhatsappChat.id)
+        .select_from(WhatsappChat)
+        .where(
+            WhatsappChat.encerramento_at.isnot(None),
+            WhatsappChat.encerramento_at >= de_dt,
+            WhatsappChat.encerramento_at < ate_dt,
+        )
+    )
+    base = filtrar(base, "encerramento")
+    ids_encerrados = [row[0] for row in db.execute(base)]
+    if not ids_encerrados:
+        return [
+            ContagemEncerramentoChat(tipo="manual", rotulo="Encerrado pelo atendente", total=0),
+            ContagemEncerramentoChat(tipo="inatividade", rotulo="Encerrado por inatividade", total=0),
+        ]
+
+    stmt_inat = (
+        select(func.count(func.distinct(WhatsappMensagem.chat_id)))
+        .select_from(WhatsappMensagem)
+        .where(
+            WhatsappMensagem.chat_id.in_(ids_encerrados),
+            WhatsappMensagem.evento_sistema == "auto_encerrado_inatividade",
+        )
+    )
+    inat_total = int(db.execute(stmt_inat).scalar_one() or 0)
+    manual_total = max(len(ids_encerrados) - inat_total, 0)
+    return [
+        ContagemEncerramentoChat(tipo="manual", rotulo="Encerrado pelo atendente", total=manual_total),
+        ContagemEncerramentoChat(tipo="inatividade", rotulo="Encerrado por inatividade", total=inat_total),
+    ]
+
+
+def _pct_com_ticket_vinculado(
+    db: Session,
+    atendente: Atendente,
+    de_dt: datetime,
+    ate_dt: datetime,
+    setor_id: int | None,
+    drill: ChatDrillDown,
+) -> float | None:
+    filtrar = _filtrar(db, atendente, setor_id, drill)
+    stmt_total = (
+        select(func.count())
+        .select_from(WhatsappChat)
+        .where(WhatsappChat.created_at >= de_dt, WhatsappChat.created_at < ate_dt)
+    )
+    total = int(db.execute(filtrar(stmt_total)).scalar_one() or 0)
+    if total == 0:
+        return None
+    vinculado = exists(
+        select(WhatsappChatTicket.id).where(WhatsappChatTicket.chat_id == WhatsappChat.id)
+    )
+    stmt_v = (
+        select(func.count())
+        .select_from(WhatsappChat)
+        .where(
+            WhatsappChat.created_at >= de_dt,
+            WhatsappChat.created_at < ate_dt,
+            vinculado,
+        )
+    )
+    com_ticket = int(db.execute(filtrar(stmt_v)).scalar_one() or 0)
+    return round(com_ticket * 100.0 / total, 1)
+
+
+def _por_atendente(
+    db: Session,
+    atendente: Atendente,
+    de_dt: datetime,
+    ate_dt: datetime,
+    setor_id: int | None,
+    drill: ChatDrillDown,
+) -> list[ContagemIdNome]:
+    if atendente.role != "admin":
+        return []
+    filtrar = _filtrar(db, atendente, setor_id, drill)
+    stmt = (
+        select(
+            Atendente.id,
+            Atendente.nome,
+            func.count(),
+        )
+        .select_from(WhatsappChat)
+        .join(Atendente, Atendente.id == WhatsappChat.atendente_id)
+        .where(
+            WhatsappChat.atendimento_inicio_at.isnot(None),
+            WhatsappChat.atendimento_inicio_at >= de_dt,
+            WhatsappChat.atendimento_inicio_at < ate_dt,
+        )
+        .group_by(Atendente.id, Atendente.nome)
+        .order_by(func.count().desc())
+        .limit(15)
+    )
+    return [
+        ContagemIdNome(id=int(aid), nome=str(nome), total=int(total))
+        for aid, nome, total in db.execute(filtrar(stmt, "atendente"))
+    ]
+
+
+def _por_estado_atual(
+    db: Session,
+    atendente: Atendente,
+    setor_id: int | None,
+    drill: ChatDrillDown,
+) -> list[ContagemRotulo]:
+    filtrar = _filtrar(db, atendente, setor_id, drill)
+    labels = {
+        "aguardando_atendente": "Aguardando atendente",
+        "em_atendimento": "Em atendimento",
+        "aguardando_avaliacao": "Aguardando avaliação",
+    }
+    stmt = (
+        select(WhatsappChat.estado, func.count())
+        .select_from(WhatsappChat)
+        .where(WhatsappChat.estado.in_(list(labels.keys())))
+        .group_by(WhatsappChat.estado)
+    )
+    counts = {estado: int(total) for estado, total in db.execute(filtrar(stmt, "estado"))}
+    return [
+        ContagemRotulo(chave=estado, rotulo=labels[estado], total=counts.get(estado, 0))
+        for estado in labels
+    ]
+
+
+def _snapshot_canais(db: Session, atendente: Atendente) -> SnapshotCanais:
+    from app.services.dashboard_geral import _count_chats_por_estado, _count_tickets_abertos, _count_tickets_sem_responsavel
+
+    return SnapshotCanais(
+        tickets_abertos=_count_tickets_abertos(db, atendente),
+        tickets_sem_responsavel=_count_tickets_sem_responsavel(db, atendente),
+        chats_aguardando=_count_chats_por_estado(db, atendente, "aguardando_atendente"),
+        chats_em_atendimento=_count_chats_por_estado(db, atendente, "em_atendimento"),
+    )
+
+
+def _compute(
+    db: Session,
+    atendente: Atendente,
+    de: date,
+    ate: date,
+    setor_id: int | None,
+    drill: ChatDrillDown,
+) -> DashboardChatsResponse:
+    de_dt, ate_dt = period_bounds(de, ate)
+    agora = datetime.now(timezone.utc)
+    return DashboardChatsResponse(
+        de=de,
+        ate=ate,
+        volume_por_dia=_volume_por_dia(db, atendente, de, ate, setor_id, drill),
+        tempo_espera_medio_horas=_tempo_espera_medio_horas(db, atendente, de_dt, ate_dt, setor_id, drill),
+        tempo_atendimento_medio_horas=_tempo_atendimento_medio_horas(
+            db, atendente, de_dt, ate_dt, setor_id, drill
+        ),
+        avaliacoes=_avaliacoes(db, atendente, de_dt, ate_dt, setor_id, drill),
+        encerramentos=_encerramentos(db, atendente, de_dt, ate_dt, setor_id, drill),
+        pct_com_ticket_vinculado=_pct_com_ticket_vinculado(db, atendente, de_dt, ate_dt, setor_id, drill),
+        por_atendente=_por_atendente(db, atendente, de_dt, ate_dt, setor_id, drill),
+        por_estado_atual=_por_estado_atual(db, atendente, setor_id, drill),
+        snapshot=_snapshot_canais(db, atendente),
+        gerado_em=agora,
+        cache_ttl_segundos=CACHE_TTL_SECONDS,
+    )
+
+
+def obter_dashboard_chats(
+    db: Session,
+    atendente: Atendente,
+    *,
+    de: date | None = None,
+    ate: date | None = None,
+    setor_id: int | None = None,
+    drill_tipo: str | None = None,
+    drill_valor: str | None = None,
+    atendente_filtro_id: int | None = None,
+) -> DashboardChatsResponse:
+    inicio, fim = resolve_period(de, ate)
+    drill = ChatDrillDown.parse(
+        drill_tipo=drill_tipo,
+        drill_valor=drill_valor,
+        atendente_filtro_id=atendente_filtro_id,
+    )
+    chave = (atendente.id, atendente.role, inicio, fim, setor_id, drill.tipo, drill.valor)
+    agora = datetime.now(timezone.utc)
+    em_cache = _cache.get(chave)
+    if em_cache is not None:
+        gerado_em, resposta = em_cache
+        if (agora - gerado_em).total_seconds() < CACHE_TTL_SECONDS:
+            return resposta
+    resposta = _compute(db, atendente, inicio, fim, setor_id, drill)
+    _cache[chave] = (agora, resposta)
+    return resposta

--- a/backend/app/services/dashboard_drilldown.py
+++ b/backend/app/services/dashboard_drilldown.py
@@ -1,0 +1,163 @@
+"""Drill-down cross-filter dos dashboards analíticos."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import exists, select
+
+from app.models import Ticket
+from app.models.ticket_avaliacao import TicketAvaliacao
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
+
+TICKET_DRILL_TIPOS = frozenset(
+    {"atendente", "empresa", "rede", "motivo", "status", "prioridade", "canal", "nota"}
+)
+CHAT_DRILL_TIPOS = frozenset({"atendente", "estado", "encerramento", "nota"})
+
+
+@dataclass(frozen=True)
+class TicketDrillDown:
+    tipo: str | None = None
+    valor: str | None = None
+
+    @classmethod
+    def parse(
+        cls,
+        *,
+        drill_tipo: str | None = None,
+        drill_valor: str | None = None,
+        atendente_filtro_id: int | None = None,
+    ) -> TicketDrillDown:
+        if drill_tipo and drill_valor:
+            tipo = drill_tipo.strip().lower()
+            if tipo in TICKET_DRILL_TIPOS:
+                return cls(tipo=tipo, valor=drill_valor.strip())
+        if atendente_filtro_id is not None:
+            return cls(tipo="atendente", valor=str(atendente_filtro_id))
+        return cls()
+
+    def without(self, dimension: str) -> TicketDrillDown:
+        if self.tipo == dimension:
+            return TicketDrillDown()
+        return self
+
+    @property
+    def ativo(self) -> bool:
+        return bool(self.tipo and self.valor)
+
+
+@dataclass(frozen=True)
+class ChatDrillDown:
+    tipo: str | None = None
+    valor: str | None = None
+
+    @classmethod
+    def parse(
+        cls,
+        *,
+        drill_tipo: str | None = None,
+        drill_valor: str | None = None,
+        atendente_filtro_id: int | None = None,
+    ) -> ChatDrillDown:
+        if drill_tipo and drill_valor:
+            tipo = drill_tipo.strip().lower()
+            if tipo in CHAT_DRILL_TIPOS:
+                return cls(tipo=tipo, valor=drill_valor.strip())
+        if atendente_filtro_id is not None:
+            return cls(tipo="atendente", valor=str(atendente_filtro_id))
+        return cls()
+
+    def without(self, dimension: str) -> ChatDrillDown:
+        if self.tipo == dimension:
+            return ChatDrillDown()
+        return self
+
+    @property
+    def ativo(self) -> bool:
+        return bool(self.tipo and self.valor)
+
+
+def apply_ticket_drill_down(stmt, drill: TicketDrillDown, *, canal_expr=None):
+    if not drill.ativo:
+        return stmt
+    tipo, valor = drill.tipo, drill.valor
+    assert tipo is not None and valor is not None
+
+    if tipo == "atendente":
+        return stmt.where(Ticket.atendente_id == int(valor))
+    if tipo == "empresa":
+        eid = int(valor)
+        if eid == 0:
+            return stmt.where(Ticket.empresa_id.is_(None))
+        return stmt.where(Ticket.empresa_id == eid)
+    if tipo == "rede":
+        rid = int(valor)
+        if rid == 0:
+            return stmt.where(Ticket.rede_id.is_(None))
+        return stmt.where(Ticket.rede_id == rid)
+    if tipo == "motivo":
+        mid = int(valor)
+        if mid == 0:
+            return stmt.where(Ticket.motivo_id.is_(None))
+        return stmt.where(Ticket.motivo_id == mid)
+    if tipo == "status":
+        return stmt.where(Ticket.status_id == int(valor))
+    if tipo == "prioridade":
+        return stmt.where(Ticket.prioridade == valor)
+    if tipo == "canal":
+        if canal_expr is None:
+            raise ValueError("canal_expr obrigatório para drill de canal")
+        return stmt.where(canal_expr == valor)
+    if tipo == "nota":
+        nota = int(valor)
+        avaliacao = (
+            select(TicketAvaliacao.id)
+            .where(
+                TicketAvaliacao.ticket_id == Ticket.id,
+                TicketAvaliacao.nota == nota,
+            )
+            .correlate(Ticket)
+            .exists()
+        )
+        return stmt.where(avaliacao)
+    return stmt
+
+
+def apply_chat_drill_down(stmt, drill: ChatDrillDown):
+    if not drill.ativo:
+        return stmt
+    tipo, valor = drill.tipo, drill.valor
+    assert tipo is not None and valor is not None
+
+    if tipo == "atendente":
+        return stmt.where(WhatsappChat.atendente_id == int(valor))
+    if tipo == "estado":
+        return stmt.where(WhatsappChat.estado == valor)
+    if tipo == "nota":
+        return stmt.where(WhatsappChat.avaliacao_nota == int(valor))
+    if tipo == "encerramento":
+        encerrados = WhatsappChat.encerramento_at.isnot(None)
+        if valor == "manual":
+            inatividade = (
+                select(WhatsappMensagem.id)
+                .where(
+                    WhatsappMensagem.chat_id == WhatsappChat.id,
+                    WhatsappMensagem.evento_sistema == "auto_encerrado_inatividade",
+                )
+                .correlate(WhatsappChat)
+                .exists()
+            )
+            return stmt.where(encerrados, ~inatividade)
+        if valor == "inatividade":
+            inatividade = (
+                select(WhatsappMensagem.id)
+                .where(
+                    WhatsappMensagem.chat_id == WhatsappChat.id,
+                    WhatsappMensagem.evento_sistema == "auto_encerrado_inatividade",
+                )
+                .correlate(WhatsappChat)
+                .exists()
+            )
+            return stmt.where(encerrados, inatividade)
+    return stmt

--- a/backend/app/services/dashboard_tickets.py
+++ b/backend/app/services/dashboard_tickets.py
@@ -1,0 +1,484 @@
+"""Métricas analíticas do canal tickets (#283)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta, timezone
+
+from sqlalchemy import case, func, or_, select
+from sqlalchemy.orm import Session
+
+from app.core.ticket_prioridade import PrioridadeTicket
+from app.models import Empresa, Rede, StatusTicket, Ticket
+from app.models.atendente import Atendente
+from app.models.ticket_avaliacao import TicketAvaliacao
+from app.models.ticket_classificacao import TicketMotivo
+from app.models.ticket import TicketHistorico, TicketMensagem
+from app.schemas.dashboard import (
+    ContagemCanal,
+    ContagemIdNome,
+    ContagemPrioridade,
+    CsatDistribuicaoTickets,
+    DashboardTicketsResponse,
+    SerieVolumeDia,
+)
+from app.services.dashboard_drilldown import TicketDrillDown, apply_ticket_drill_down
+from app.services.ticket_dashboard_filters import (
+    apply_ticket_dashboard_filters,
+    period_bounds,
+    resolve_period,
+)
+
+CACHE_TTL_SECONDS = 60
+
+_cache: dict[tuple, tuple[datetime, DashboardTicketsResponse]] = {}
+
+
+def clear_dashboard_tickets_cache() -> None:
+    _cache.clear()
+
+
+def _canal_expr():
+    email_exists = (
+        select(TicketMensagem.id)
+        .where(
+            TicketMensagem.ticket_id == Ticket.id,
+            TicketMensagem.tipo == "email_cliente",
+        )
+        .correlate(Ticket)
+        .exists()
+    )
+    return case(
+        (Ticket.parent_ticket_id.isnot(None), "filho_massa"),
+        (email_exists, "email"),
+        else_="manual",
+    )
+
+
+def _as_date(value) -> date:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    return date.fromisoformat(str(value))
+
+
+def _filtros(
+    db: Session,
+    atendente: Atendente,
+    rede_id: int | None,
+    setor_id: int | None,
+    prioridade: str | None,
+    drill: TicketDrillDown,
+):
+    canal = _canal_expr()
+
+    def apply(stmt, exclude: str | None = None):
+        stmt = apply_ticket_dashboard_filters(
+            stmt,
+            db,
+            atendente,
+            rede_id=rede_id,
+            setor_id=setor_id,
+            prioridade=prioridade,
+        )
+        active = drill.without(exclude) if exclude else drill
+        return apply_ticket_drill_down(stmt, active, canal_expr=canal)
+
+    return apply
+
+
+def _volume_por_dia(
+    db: Session,
+    atendente: Atendente,
+    de: date,
+    ate: date,
+    rede_id: int | None,
+    setor_id: int | None,
+    prioridade: str | None,
+    drill: TicketDrillDown,
+) -> list[SerieVolumeDia]:
+    de_dt, ate_dt = period_bounds(de, ate)
+    abertos: dict[date, int] = {}
+    fechados: dict[date, int] = {}
+    filtrar = _filtros(db, atendente, rede_id, setor_id, prioridade, drill)
+
+    stmt_a = (
+        select(func.date(Ticket.created_at).label("dia"), func.count())
+        .select_from(Ticket)
+        .where(Ticket.created_at >= de_dt, Ticket.created_at < ate_dt)
+        .group_by(func.date(Ticket.created_at))
+    )
+    for dia, total in db.execute(filtrar(stmt_a)):
+        abertos[_as_date(dia)] = int(total)
+
+    stmt_f = (
+        select(func.date(Ticket.fechado_em).label("dia"), func.count())
+        .select_from(Ticket)
+        .where(
+            Ticket.fechado_em.isnot(None),
+            Ticket.fechado_em >= de_dt,
+            Ticket.fechado_em < ate_dt,
+        )
+        .group_by(func.date(Ticket.fechado_em))
+    )
+    for dia, total in db.execute(filtrar(stmt_f)):
+        fechados[_as_date(dia)] = int(total)
+
+    serie: list[SerieVolumeDia] = []
+    cursor = de
+    while cursor <= ate:
+        serie.append(
+            SerieVolumeDia(
+                dia=cursor,
+                abertos=abertos.get(cursor, 0),
+                fechados=fechados.get(cursor, 0),
+            )
+        )
+        cursor += timedelta(days=1)
+    return serie
+
+
+def _por_status(
+    db: Session,
+    atendente: Atendente,
+    rede_id: int | None,
+    setor_id: int | None,
+    prioridade: str | None,
+    drill: TicketDrillDown,
+) -> list[ContagemIdNome]:
+    filtrar = _filtros(db, atendente, rede_id, setor_id, prioridade, drill)
+    stmt = (
+        select(Ticket.status_id, StatusTicket.nome, func.count())
+        .select_from(Ticket)
+        .join(StatusTicket, StatusTicket.id == Ticket.status_id)
+        .where(Ticket.fechado_em.is_(None))
+        .group_by(Ticket.status_id, StatusTicket.nome)
+        .order_by(func.count().desc())
+    )
+    return [
+        ContagemIdNome(id=int(sid), nome=nome, total=int(total))
+        for sid, nome, total in db.execute(filtrar(stmt, "status"))
+    ]
+
+
+def _por_prioridade(
+    db: Session,
+    atendente: Atendente,
+    rede_id: int | None,
+    setor_id: int | None,
+    prioridade: str | None,
+    drill: TicketDrillDown,
+) -> list[ContagemPrioridade]:
+    filtrar = _filtros(db, atendente, rede_id, setor_id, prioridade, drill)
+    stmt = (
+        select(Ticket.prioridade, func.count())
+        .select_from(Ticket)
+        .where(Ticket.fechado_em.is_(None))
+        .group_by(Ticket.prioridade)
+    )
+    counts = {
+        (p.value if hasattr(p, "value") else str(p)): int(n)
+        for p, n in db.execute(filtrar(stmt, "prioridade"))
+    }
+    ordem = [p.value for p in PrioridadeTicket]
+    if prioridade is not None:
+        ordem = [prioridade]
+    return [ContagemPrioridade(prioridade=p, total=counts.get(p, 0)) for p in ordem]
+
+
+def _top_por_campo(
+    db: Session,
+    atendente: Atendente,
+    de_dt: datetime,
+    ate_dt: datetime,
+    rede_id: int | None,
+    setor_id: int | None,
+    prioridade: str | None,
+    drill: TicketDrillDown,
+    *,
+    exclude_dim: str,
+    id_col,
+    nome_expr,
+    join_target,
+) -> list[ContagemIdNome]:
+    filtrar = _filtros(db, atendente, rede_id, setor_id, prioridade, drill)
+    stmt = (
+        select(id_col, nome_expr, func.count())
+        .select_from(Ticket)
+        .outerjoin(join_target, join_target.id == id_col)
+        .where(Ticket.created_at >= de_dt, Ticket.created_at < ate_dt)
+        .group_by(id_col, nome_expr)
+        .order_by(func.count().desc())
+        .limit(10)
+    )
+    return [
+        ContagemIdNome(
+            id=int(rid) if rid is not None else 0,
+            nome=str(nome),
+            total=int(total),
+        )
+        for rid, nome, total in db.execute(filtrar(stmt, exclude_dim))
+    ]
+
+
+def _por_motivo(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill: TicketDrillDown):
+    filtrar = _filtros(db, atendente, rede_id, setor_id, prioridade, drill)
+    stmt = (
+        select(Ticket.motivo_id, func.coalesce(TicketMotivo.nome, "Sem motivo"), func.count())
+        .select_from(Ticket)
+        .outerjoin(TicketMotivo, TicketMotivo.id == Ticket.motivo_id)
+        .where(Ticket.created_at >= de_dt, Ticket.created_at < ate_dt)
+        .group_by(Ticket.motivo_id, TicketMotivo.nome)
+        .order_by(func.count().desc())
+        .limit(10)
+    )
+    return [
+        ContagemIdNome(
+            id=int(motivo_id) if motivo_id is not None else 0,
+            nome=str(nome),
+            total=int(total),
+        )
+        for motivo_id, nome, total in db.execute(filtrar(stmt, "motivo"))
+    ]
+
+
+def _por_rede(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill: TicketDrillDown):
+    return _top_por_campo(
+        db,
+        atendente,
+        de_dt,
+        ate_dt,
+        rede_id,
+        setor_id,
+        prioridade,
+        drill,
+        exclude_dim="rede",
+        id_col=Ticket.rede_id,
+        nome_expr=func.coalesce(Rede.nome, "Sem rede"),
+        join_target=Rede,
+    )
+
+
+def _por_empresa(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill: TicketDrillDown):
+    return _top_por_campo(
+        db,
+        atendente,
+        de_dt,
+        ate_dt,
+        rede_id,
+        setor_id,
+        prioridade,
+        drill,
+        exclude_dim="empresa",
+        id_col=Ticket.empresa_id,
+        nome_expr=func.coalesce(Empresa.nome, "Sem empresa"),
+        join_target=Empresa,
+    )
+
+
+def _mttr_horas(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill: TicketDrillDown):
+    filtrar = _filtros(db, atendente, rede_id, setor_id, prioridade, drill)
+    duracao = func.extract("epoch", Ticket.fechado_em - Ticket.created_at)
+    stmt = (
+        select(func.avg(duracao))
+        .select_from(Ticket)
+        .where(
+            Ticket.fechado_em.isnot(None),
+            Ticket.fechado_em >= de_dt,
+            Ticket.fechado_em < ate_dt,
+        )
+    )
+    media_seg = db.execute(filtrar(stmt)).scalar_one_or_none()
+    if media_seg is None:
+        return None
+    return round(float(media_seg) / 3600.0, 2)
+
+
+def _fila_tempo_medio_horas(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill: TicketDrillDown):
+    filtrar = _filtros(db, atendente, rede_id, setor_id, prioridade, drill)
+    first_assign = (
+        select(func.min(TicketHistorico.created_at))
+        .where(
+            TicketHistorico.ticket_id == Ticket.id,
+            TicketHistorico.campo == "atendente_id",
+            or_(
+                TicketHistorico.valor_antigo.is_(None),
+                TicketHistorico.valor_antigo == "",
+            ),
+        )
+        .correlate(Ticket)
+        .scalar_subquery()
+    )
+    inicio_fila = func.coalesce(Ticket.fila_desde_at, Ticket.created_at)
+    duracao = func.extract("epoch", first_assign - inicio_fila)
+    stmt = (
+        select(func.avg(duracao))
+        .select_from(Ticket)
+        .where(
+            Ticket.atendente_id.isnot(None),
+            Ticket.created_at >= de_dt,
+            Ticket.created_at < ate_dt,
+            first_assign.isnot(None),
+        )
+    )
+    media_seg = db.execute(filtrar(stmt)).scalar_one_or_none()
+    if media_seg is None:
+        return None
+    return round(float(media_seg) / 3600.0, 2)
+
+
+def _csat(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill: TicketDrillDown):
+    filtrar = _filtros(db, atendente, rede_id, setor_id, prioridade, drill)
+    stmt = (
+        select(TicketAvaliacao.nota, func.count())
+        .select_from(TicketAvaliacao)
+        .join(Ticket, Ticket.id == TicketAvaliacao.ticket_id)
+        .where(
+            TicketAvaliacao.respondida_em >= de_dt,
+            TicketAvaliacao.respondida_em < ate_dt,
+        )
+        .group_by(TicketAvaliacao.nota)
+    )
+    por_nota = {i: 0 for i in range(1, 6)}
+    total = 0
+    soma = 0
+    for nota, qtd in db.execute(filtrar(stmt, "nota")):
+        n = int(nota)
+        c = int(qtd)
+        if 1 <= n <= 5:
+            por_nota[n] = c
+            total += c
+            soma += n * c
+    media = round(soma / total, 2) if total > 0 else None
+    return CsatDistribuicaoTickets(
+        media=media,
+        total_avaliacoes=total,
+        por_nota=por_nota,
+    )
+
+
+def _por_canal(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill: TicketDrillDown):
+    filtrar = _filtros(db, atendente, rede_id, setor_id, prioridade, drill)
+    canal = _canal_expr().label("canal")
+    stmt = (
+        select(canal, func.count())
+        .select_from(Ticket)
+        .where(Ticket.created_at >= de_dt, Ticket.created_at < ate_dt)
+        .group_by(canal)
+        .order_by(func.count().desc())
+    )
+    labels = {
+        "manual": "Manual",
+        "email": "E-mail",
+        "filho_massa": "Filho em massa",
+    }
+    return [
+        ContagemCanal(canal=str(c), rotulo=labels.get(str(c), str(c)), total=int(total))
+        for c, total in db.execute(filtrar(stmt, "canal"))
+    ]
+
+
+def _por_atendente(
+    db: Session,
+    atendente: Atendente,
+    de_dt: datetime,
+    ate_dt: datetime,
+    rede_id: int | None,
+    setor_id: int | None,
+    prioridade: str | None,
+    drill: TicketDrillDown,
+):
+    if atendente.role != "admin":
+        return []
+    filtrar = _filtros(db, atendente, rede_id, setor_id, prioridade, drill)
+    stmt = (
+        select(Atendente.id, Atendente.nome, func.count())
+        .select_from(Ticket)
+        .join(Atendente, Atendente.id == Ticket.atendente_id)
+        .where(
+            Ticket.atendente_id.isnot(None),
+            Ticket.created_at >= de_dt,
+            Ticket.created_at < ate_dt,
+        )
+        .group_by(Atendente.id, Atendente.nome)
+        .order_by(func.count().desc())
+        .limit(15)
+    )
+    return [
+        ContagemIdNome(id=int(aid), nome=str(nome), total=int(total))
+        for aid, nome, total in db.execute(filtrar(stmt, "atendente"))
+    ]
+
+
+def _compute(
+    db: Session,
+    atendente: Atendente,
+    de: date,
+    ate: date,
+    rede_id: int | None,
+    setor_id: int | None,
+    prioridade: str | None,
+    drill: TicketDrillDown,
+) -> DashboardTicketsResponse:
+    de_dt, ate_dt = period_bounds(de, ate)
+    agora = datetime.now(timezone.utc)
+    return DashboardTicketsResponse(
+        de=de,
+        ate=ate,
+        volume_por_dia=_volume_por_dia(db, atendente, de, ate, rede_id, setor_id, prioridade, drill),
+        por_status=_por_status(db, atendente, rede_id, setor_id, prioridade, drill),
+        por_prioridade=_por_prioridade(db, atendente, rede_id, setor_id, prioridade, drill),
+        por_motivo=_por_motivo(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill),
+        por_rede=_por_rede(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill),
+        por_empresa=_por_empresa(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill),
+        mttr_horas=_mttr_horas(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill),
+        fila_tempo_medio_horas=_fila_tempo_medio_horas(
+            db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill
+        ),
+        csat=_csat(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill),
+        por_canal=_por_canal(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill),
+        por_atendente=_por_atendente(db, atendente, de_dt, ate_dt, rede_id, setor_id, prioridade, drill),
+        gerado_em=agora,
+        cache_ttl_segundos=CACHE_TTL_SECONDS,
+    )
+
+
+def obter_dashboard_tickets(
+    db: Session,
+    atendente: Atendente,
+    *,
+    de: date | None = None,
+    ate: date | None = None,
+    rede_id: int | None = None,
+    setor_id: int | None = None,
+    prioridade: str | None = None,
+    drill_tipo: str | None = None,
+    drill_valor: str | None = None,
+    atendente_filtro_id: int | None = None,
+) -> DashboardTicketsResponse:
+    inicio, fim = resolve_period(de, ate)
+    drill = TicketDrillDown.parse(
+        drill_tipo=drill_tipo,
+        drill_valor=drill_valor,
+        atendente_filtro_id=atendente_filtro_id,
+    )
+    chave = (
+        atendente.id,
+        atendente.role,
+        inicio,
+        fim,
+        rede_id,
+        setor_id,
+        prioridade,
+        drill.tipo,
+        drill.valor,
+    )
+    agora = datetime.now(timezone.utc)
+    em_cache = _cache.get(chave)
+    if em_cache is not None:
+        gerado_em, resposta = em_cache
+        if (agora - gerado_em).total_seconds() < CACHE_TTL_SECONDS:
+            return resposta
+    resposta = _compute(db, atendente, inicio, fim, rede_id, setor_id, prioridade, drill)
+    _cache[chave] = (agora, resposta)
+    return resposta

--- a/backend/app/services/relatorio_tickets.py
+++ b/backend/app/services/relatorio_tickets.py
@@ -1,0 +1,174 @@
+"""Relatório tabular de tickets — export CSV (#287 → D-08, base para #285)."""
+
+from __future__ import annotations
+
+import csv
+import io
+from datetime import date, datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, joinedload
+
+from app.models import Ticket
+from app.models.atendente import Atendente
+from app.schemas.relatorio import RelatorioTicketLinha, RelatorioTicketsResponse
+from app.services.ticket_dashboard_filters import (
+    apply_ticket_dashboard_filters,
+    period_bounds,
+    resolve_period,
+)
+
+MAX_EXPORT_ROWS = 50_000
+PREVIEW_LIMIT = 50
+
+_CSV_HEADERS = (
+    "protocolo",
+    "assunto",
+    "status",
+    "prioridade",
+    "rede",
+    "empresa",
+    "setor",
+    "aberto_em",
+    "fechado_em",
+    "responsavel",
+    "canal",
+)
+
+
+def _canal_rotulo(ticket: Ticket) -> str:
+    if ticket.parent_ticket_id is not None:
+        return "Filho em massa"
+    if any(getattr(m, "tipo", None) == "email_cliente" for m in (ticket.mensagens or [])):
+        return "E-mail"
+    return "Manual"
+
+
+def _ticket_para_linha(ticket: Ticket) -> RelatorioTicketLinha:
+    return RelatorioTicketLinha(
+        protocolo=ticket.protocolo,
+        assunto=ticket.assunto,
+        status_nome=ticket.status.nome if ticket.status else "",
+        prioridade=str(ticket.prioridade),
+        rede_nome=ticket.rede.nome if ticket.rede else "",
+        empresa_nome=ticket.empresa.nome if ticket.empresa else "",
+        setor_nome=ticket.setor.nome if ticket.setor else "",
+        aberto_em=ticket.created_at,
+        fechado_em=ticket.fechado_em,
+        responsavel_nome=ticket.atendente.nome if ticket.atendente else "",
+        canal=_canal_rotulo(ticket),
+    )
+
+
+def _load_options(stmt):
+    return stmt.options(
+        joinedload(Ticket.status),
+        joinedload(Ticket.rede),
+        joinedload(Ticket.empresa),
+        joinedload(Ticket.setor),
+        joinedload(Ticket.atendente),
+        joinedload(Ticket.mensagens),
+    )
+
+
+def listar_relatorio_tickets(
+    db: Session,
+    atendente: Atendente,
+    *,
+    de: date | None = None,
+    ate: date | None = None,
+    rede_id: int | None = None,
+    setor_id: int | None = None,
+    prioridade: str | None = None,
+    offset: int = 0,
+    limit: int = PREVIEW_LIMIT,
+) -> RelatorioTicketsResponse:
+    inicio, fim = resolve_period(de, ate)
+    de_dt, ate_dt = period_bounds(inicio, fim)
+    filtros = {
+        "rede_id": rede_id,
+        "setor_id": setor_id,
+        "prioridade": prioridade,
+    }
+
+    count_stmt = select(func.count()).select_from(Ticket).where(
+        Ticket.created_at >= de_dt,
+        Ticket.created_at < ate_dt,
+    )
+    count_stmt = apply_ticket_dashboard_filters(count_stmt, db, atendente, **filtros)
+    total = int(db.execute(count_stmt).scalar_one())
+
+    stmt = (
+        select(Ticket)
+        .where(Ticket.created_at >= de_dt, Ticket.created_at < ate_dt)
+        .order_by(Ticket.created_at.desc(), Ticket.id.desc())
+    )
+    stmt = apply_ticket_dashboard_filters(stmt, db, atendente, **filtros)
+    rows = (
+        db.execute(
+            _load_options(stmt)
+            .offset(max(0, offset))
+            .limit(min(max(1, limit), PREVIEW_LIMIT))
+        )
+        .unique()
+        .scalars()
+        .all()
+    )
+    return RelatorioTicketsResponse(
+        de=inicio,
+        ate=fim,
+        total=total,
+        offset=max(0, offset),
+        limit=min(max(1, limit), PREVIEW_LIMIT),
+        itens=[_ticket_para_linha(t) for t in rows],
+    )
+
+
+def exportar_relatorio_tickets_csv(
+    db: Session,
+    atendente: Atendente,
+    *,
+    de: date | None = None,
+    ate: date | None = None,
+    rede_id: int | None = None,
+    setor_id: int | None = None,
+    prioridade: str | None = None,
+) -> str:
+    inicio, fim = resolve_period(de, ate)
+    de_dt, ate_dt = period_bounds(inicio, fim)
+    filtros = {
+        "rede_id": rede_id,
+        "setor_id": setor_id,
+        "prioridade": prioridade,
+    }
+    stmt = (
+        select(Ticket)
+        .where(Ticket.created_at >= de_dt, Ticket.created_at < ate_dt)
+        .order_by(Ticket.created_at.desc(), Ticket.id.desc())
+        .limit(MAX_EXPORT_ROWS)
+    )
+    stmt = apply_ticket_dashboard_filters(stmt, db, atendente, **filtros)
+    tickets = db.execute(_load_options(stmt)).unique().scalars().all()
+
+    buffer = io.StringIO()
+    buffer.write("\ufeff")
+    writer = csv.writer(buffer, lineterminator="\r\n")
+    writer.writerow(_CSV_HEADERS)
+    for ticket in tickets:
+        linha = _ticket_para_linha(ticket)
+        writer.writerow(
+            [
+                linha.protocolo,
+                linha.assunto,
+                linha.status_nome,
+                linha.prioridade,
+                linha.rede_nome,
+                linha.empresa_nome,
+                linha.setor_nome,
+                linha.aberto_em.isoformat() if linha.aberto_em else "",
+                linha.fechado_em.isoformat() if linha.fechado_em else "",
+                linha.responsavel_nome,
+                linha.canal,
+            ]
+        )
+    return buffer.getvalue()

--- a/backend/app/services/ticket_dashboard_filters.py
+++ b/backend/app/services/ticket_dashboard_filters.py
@@ -1,0 +1,75 @@
+"""Filtros compartilhados entre dashboard e relatórios de tickets."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.core.setor_scope import ids_setores_visiveis_atendente
+from app.core.ticket_prioridade import PrioridadeTicket
+from app.models import Ticket
+from app.models.atendente import Atendente
+
+DEFAULT_PERIOD_DAYS = 30
+MAX_PERIOD_DAYS = 366
+
+
+def period_bounds(de: date, ate: date) -> tuple[datetime, datetime]:
+    de_dt = datetime.combine(de, time.min, tzinfo=timezone.utc)
+    ate_dt = datetime.combine(ate + timedelta(days=1), time.min, tzinfo=timezone.utc)
+    return de_dt, ate_dt
+
+
+def resolve_period(de: date | None, ate: date | None) -> tuple[date, date]:
+    fim = ate or date.today()
+    inicio = de or (fim - timedelta(days=DEFAULT_PERIOD_DAYS))
+    if inicio > fim:
+        inicio, fim = fim, inicio
+    if (fim - inicio).days > MAX_PERIOD_DAYS:
+        inicio = fim - timedelta(days=MAX_PERIOD_DAYS)
+    return inicio, fim
+
+
+def normalizar_prioridade(prioridade: str | None) -> str | None:
+    if prioridade is None or prioridade == "":
+        return None
+    valor = prioridade.strip().lower()
+    if valor not in {p.value for p in PrioridadeTicket}:
+        raise ValueError(f"prioridade inválida: {prioridade}")
+    return valor
+
+
+def apply_ticket_dashboard_filters(
+    stmt,
+    db: Session,
+    atendente: Atendente,
+    *,
+    rede_id: int | None = None,
+    setor_id: int | None = None,
+    prioridade: str | None = None,
+    atendente_id: int | None = None,
+):
+    if atendente.role != "admin":
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        stmt = stmt.where(Ticket.setor_id.in_(vis))
+    if rede_id is not None:
+        stmt = stmt.where(Ticket.rede_id == rede_id)
+    if setor_id is not None:
+        if atendente.role != "admin":
+            vis = ids_setores_visiveis_atendente(db, atendente)
+            if setor_id not in vis:
+                return stmt.where(Ticket.id == -1)
+        stmt = stmt.where(Ticket.setor_id == setor_id)
+    if prioridade is not None:
+        stmt = stmt.where(Ticket.prioridade == prioridade)
+    if atendente_id is not None:
+        stmt = stmt.where(Ticket.atendente_id == atendente_id)
+    return stmt
+
+
+def apply_ticket_drill_to_stmt(stmt, drill, *, canal_expr=None, exclude: str | None = None):
+    from app.services.dashboard_drilldown import TicketDrillDown, apply_ticket_drill_down
+
+    active = drill.without(exclude) if isinstance(drill, TicketDrillDown) and exclude else drill
+    return apply_ticket_drill_down(stmt, active, canal_expr=canal_expr)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,7 +8,7 @@ sqlalchemy==2.0.50
 psycopg2-binary==2.9.12
 alembic==1.14.0
 pydantic[email]==2.13.4
-pydantic-settings==2.14.1
+pydantic-settings==2.14.2
 PyJWT[crypto]==2.13.0
 cryptography>=49.0.0
 bcrypt>=5.0.0,<6

--- a/backend/tests/test_dashboard_chats.py
+++ b/backend/tests/test_dashboard_chats.py
@@ -1,0 +1,119 @@
+"""Testes do dashboard chats (#284 / D-03)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models import Ticket
+from app.models.whatsapp_chat import WhatsappChat, WhatsappChatTicket, WhatsappMensagem
+from app.services.dashboard_chats import CACHE_TTL_SECONDS, clear_dashboard_chats_cache
+
+
+@pytest.fixture(autouse=True)
+def _limpar_cache_dashboard_chats():
+    clear_dashboard_chats_cache()
+    yield
+    clear_dashboard_chats_cache()
+
+
+def _criar_chat(
+    db_session,
+    seed_base,
+    *,
+    setor_id=None,
+    estado="encerrado",
+    created_at=None,
+    atendimento_inicio_at=None,
+    encerramento_at=None,
+    nota=None,
+):
+    agora = datetime.now(timezone.utc)
+    suf = datetime.now().timestamp()
+    c = WhatsappChat(
+        protocolo=f"WD{suf}",
+        wa_id=f"5511999{suf}",
+        estado=estado,
+        setor_id=setor_id or seed_base["setor1"].id,
+        atendente_id=seed_base["admin"].id,
+        created_at=created_at or agora - timedelta(hours=3),
+        atendimento_inicio_at=atendimento_inicio_at or agora - timedelta(hours=2),
+        encerramento_at=encerramento_at or (agora if estado == "encerrado" else None),
+        avaliacao_nota=nota,
+        avaliacao_respondida_at=agora if nota is not None else None,
+    )
+    db_session.add(c)
+    db_session.commit()
+    db_session.refresh(c)
+    return c
+
+
+def test_dashboard_chats_volume_e_tempos(client, seed_base, auth_headers, db_session):
+    ontem = datetime.now(timezone.utc) - timedelta(days=1)
+    _criar_chat(
+        db_session,
+        seed_base,
+        created_at=ontem,
+        atendimento_inicio_at=ontem + timedelta(minutes=10),
+        encerramento_at=ontem + timedelta(hours=1),
+    )
+
+    r = client.get("/v1/dashboard/chats", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["cache_ttl_segundos"] == CACHE_TTL_SECONDS
+    assert sum(d["abertos"] for d in body["volume_por_dia"]) >= 1
+    assert body["tempo_espera_medio_horas"] is not None
+    assert body["tempo_atendimento_medio_horas"] is not None
+    assert body["snapshot"]["chats_aguardando"] >= 0
+
+
+def test_dashboard_chats_atendente_escopo_setor(client, seed_base, auth_headers, db_session):
+    _criar_chat(db_session, seed_base, setor_id=seed_base["setor1"].id, estado="aguardando_atendente")
+    _criar_chat(db_session, seed_base, setor_id=seed_base["setor2"].id, estado="aguardando_atendente")
+
+    r = client.get("/v1/dashboard/chats", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    assert sum(x["total"] for x in r.json()["por_estado_atual"]) == 1
+
+
+def test_dashboard_chats_encerramento_e_vinculo_ticket(client, seed_base, auth_headers, db_session):
+    ontem = datetime.now(timezone.utc) - timedelta(days=1)
+    chat = _criar_chat(
+        db_session,
+        seed_base,
+        created_at=ontem,
+        atendimento_inicio_at=ontem + timedelta(minutes=5),
+        encerramento_at=ontem + timedelta(hours=1),
+        nota=5,
+    )
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="Encerrado por inatividade",
+            evento_sistema="auto_encerrado_inatividade",
+        )
+    )
+    ticket = Ticket(
+        tenant_id=1,
+        protocolo=f"TV-{datetime.now().timestamp()}",
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=seed_base["status"].id,
+        assunto="Vinculo chat",
+    )
+    db_session.add(ticket)
+    db_session.commit()
+    db_session.add(WhatsappChatTicket(chat_id=chat.id, ticket_id=ticket.id, atendente_id=seed_base["admin"].id))
+    db_session.commit()
+
+    r = client.get("/v1/dashboard/chats", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["avaliacoes"]["total_avaliacoes"] >= 1
+    assert body["pct_com_ticket_vinculado"] == 100.0
+    inat = next(x for x in body["encerramentos"] if x["tipo"] == "inatividade")
+    assert inat["total"] >= 1
+    assert len(body["por_atendente"]) >= 1

--- a/backend/tests/test_dashboard_tickets.py
+++ b/backend/tests/test_dashboard_tickets.py
@@ -1,0 +1,198 @@
+"""Testes do dashboard tickets (#283)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.models import Ticket
+from app.models.ticket_avaliacao import TicketAvaliacao
+from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+from app.models.ticket import TicketHistorico, TicketMensagem
+from app.services.dashboard_tickets import CACHE_TTL_SECONDS, clear_dashboard_tickets_cache
+
+
+@pytest.fixture(autouse=True)
+def _limpar_cache_dashboard_tickets():
+    clear_dashboard_tickets_cache()
+    yield
+    clear_dashboard_tickets_cache()
+
+
+def _criar_ticket(
+    db_session,
+    seed_base,
+    *,
+    setor_id,
+    atendente_id=None,
+    fechado=False,
+    created_at=None,
+    fechado_em=None,
+    parent_ticket_id=None,
+    motivo_id=None,
+    prioridade="normal",
+    rede_id=None,
+):
+    agora = datetime.now(timezone.utc)
+    t = Ticket(
+        tenant_id=1,
+        protocolo=f"T{setor_id}-{datetime.now().timestamp()}",
+        empresa_id=seed_base["empresa"].id,
+        rede_id=rede_id or seed_base["rede"].id,
+        setor_id=setor_id,
+        status_id=seed_base["status"].id,
+        atendente_id=atendente_id,
+        parent_ticket_id=parent_ticket_id,
+        motivo_id=motivo_id,
+        prioridade=prioridade,
+        assunto="Teste dashboard tickets",
+        fechado_em=fechado_em or (agora if fechado else None),
+        created_at=created_at or agora,
+    )
+    db_session.add(t)
+    db_session.commit()
+    db_session.refresh(t)
+    return t
+
+
+def test_dashboard_tickets_periodo_default_e_volume(client, seed_base, auth_headers, db_session):
+    ontem = datetime.now(timezone.utc) - timedelta(days=1)
+    _criar_ticket(db_session, seed_base, setor_id=seed_base["setor1"].id, created_at=ontem)
+    _criar_ticket(
+        db_session,
+        seed_base,
+        setor_id=seed_base["setor1"].id,
+        fechado=True,
+        created_at=ontem,
+        fechado_em=ontem + timedelta(hours=2),
+    )
+
+    r = client.get("/v1/dashboard/tickets", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["cache_ttl_segundos"] == CACHE_TTL_SECONDS
+    assert len(body["volume_por_dia"]) >= 2
+    assert sum(d["abertos"] for d in body["volume_por_dia"]) >= 2
+    assert sum(d["fechados"] for d in body["volume_por_dia"]) >= 1
+    assert body["mttr_horas"] is not None
+
+
+def test_dashboard_tickets_atendente_escopo_setor(client, seed_base, auth_headers, db_session):
+    _criar_ticket(db_session, seed_base, setor_id=seed_base["setor1"].id)
+    _criar_ticket(db_session, seed_base, setor_id=seed_base["setor2"].id)
+
+    r = client.get("/v1/dashboard/tickets", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    assert sum(d["abertos"] for d in r.json()["volume_por_dia"]) == 1
+
+    r2 = client.get(
+        "/v1/dashboard/tickets",
+        headers=auth_headers["a1"],
+        params={"setor_id": seed_base["setor2"].id},
+    )
+    assert r2.status_code == 200
+    assert sum(d["abertos"] for d in r2.json()["volume_por_dia"]) == 0
+
+
+def test_dashboard_tickets_motivo_canal_csat(client, seed_base, auth_headers, db_session):
+    nat = TicketNatureza(nome="Operação", slug="operacao", ordem=1, ativo=True)
+    db_session.add(nat)
+    db_session.flush()
+    motivo = TicketMotivo(natureza_id=nat.id, nome="Falha PDV", slug="falha_pdv", ordem=1, ativo=True)
+    db_session.add(motivo)
+    db_session.flush()
+
+    parent = _criar_ticket(db_session, seed_base, setor_id=seed_base["setor1"].id)
+    filho = _criar_ticket(
+        db_session,
+        seed_base,
+        setor_id=seed_base["setor1"].id,
+        parent_ticket_id=parent.id,
+    )
+    email_t = _criar_ticket(db_session, seed_base, setor_id=seed_base["setor1"].id, motivo_id=motivo.id)
+    db_session.add(
+        TicketMensagem(
+            ticket_id=email_t.id,
+            atendente_id=None,
+            tipo="email_cliente",
+            corpo="Corpo e-mail",
+        )
+    )
+    fechado = _criar_ticket(
+        db_session,
+        seed_base,
+        setor_id=seed_base["setor1"].id,
+        fechado=True,
+        atendente_id=seed_base["admin"].id,
+    )
+    db_session.add(
+        TicketAvaliacao(
+            ticket_id=fechado.id,
+            atendente_id=seed_base["admin"].id,
+            nota=4,
+            respondida_em=datetime.now(timezone.utc),
+        )
+    )
+    db_session.add(
+        TicketHistorico(
+            ticket_id=fechado.id,
+            atendente_id=seed_base["admin"].id,
+            campo="atendente_id",
+            valor_antigo=None,
+            valor_novo=str(seed_base["admin"].id),
+            created_at=fechado.created_at + timedelta(minutes=30),
+        )
+    )
+    db_session.commit()
+
+    r = client.get("/v1/dashboard/tickets", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    body = r.json()
+    canais = {c["canal"]: c["total"] for c in body["por_canal"]}
+    assert canais.get("filho_massa", 0) >= 1
+    assert canais.get("email", 0) >= 1
+    assert any(m["nome"] == "Falha PDV" for m in body["por_motivo"])
+    assert body["csat"]["total_avaliacoes"] >= 1
+    assert body["csat"]["media"] == 4.0
+    assert body["fila_tempo_medio_horas"] is not None
+    assert filho.id  # evita lint unused
+
+
+def test_dashboard_tickets_requer_autenticacao(client):
+    r = client.get("/v1/dashboard/tickets")
+    assert r.status_code == 401
+
+
+def test_dashboard_tickets_filtro_prioridade(client, seed_base, auth_headers, db_session):
+    _criar_ticket(
+        db_session,
+        seed_base,
+        setor_id=seed_base["setor1"].id,
+        prioridade="urgente",
+    )
+    _criar_ticket(
+        db_session,
+        seed_base,
+        setor_id=seed_base["setor1"].id,
+        prioridade="baixa",
+    )
+
+    r = client.get(
+        "/v1/dashboard/tickets",
+        headers=auth_headers["admin"],
+        params={"prioridade": "urgente"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert sum(d["abertos"] for d in body["volume_por_dia"]) == 1
+    assert body["por_prioridade"] == [{"prioridade": "urgente", "total": 1}]
+
+
+def test_dashboard_tickets_top_empresa(client, seed_base, auth_headers, db_session):
+    _criar_ticket(db_session, seed_base, setor_id=seed_base["setor1"].id)
+    r = client.get("/v1/dashboard/tickets", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    body = r.json()
+    assert len(body["por_empresa"]) >= 1
+    assert body["por_empresa"][0]["nome"] == "Empresa Teste"

--- a/backend/tests/test_relatorio_tickets.py
+++ b/backend/tests/test_relatorio_tickets.py
@@ -1,0 +1,54 @@
+"""Testes do relatório de tickets (D-08 / export CSV)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.models import Ticket
+
+
+def _criar_ticket(db_session, seed_base):
+    t = Ticket(
+        tenant_id=1,
+        protocolo=f"R{datetime.now().timestamp()}",
+        empresa_id=seed_base["empresa"].id,
+        rede_id=seed_base["rede"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=seed_base["status"].id,
+        assunto="Relatório teste",
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(t)
+    db_session.commit()
+    return t
+
+
+def test_relatorio_tickets_admin_json(client, seed_base, auth_headers, db_session):
+    _criar_ticket(db_session, seed_base)
+    r = client.get("/v1/relatorios/tickets", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] >= 1
+    assert len(body["itens"]) >= 1
+    assert body["itens"][0]["protocolo"]
+
+
+def test_relatorio_tickets_atendente_403(client, seed_base, auth_headers, db_session):
+    _criar_ticket(db_session, seed_base)
+    r = client.get("/v1/relatorios/tickets", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_relatorio_tickets_export_csv(client, seed_base, auth_headers, db_session):
+    _criar_ticket(db_session, seed_base)
+    r = client.get(
+        "/v1/relatorios/tickets",
+        headers=auth_headers["admin"],
+        params={"format": "csv"},
+    )
+    assert r.status_code == 200
+    assert "text/csv" in r.headers.get("content-type", "")
+    text = r.text
+    assert text.startswith("\ufeff")
+    assert "protocolo" in text
+    assert "Relatório teste" in text

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,8 @@
         "qrcode.react": "^4.2.0",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "react-router-dom": "^7.17.0"
+        "react-router-dom": "^7.17.0",
+        "recharts": "^2.15.4"
       },
       "devDependencies": {
         "@emnapi/core": "^1.11.1",
@@ -63,7 +64,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -225,6 +225,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -279,7 +288,6 @@
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -291,7 +299,6 @@
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1152,6 +1159,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "dev": true,
@@ -1171,7 +1241,6 @@
       "version": "25.9.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
       }
@@ -1180,7 +1249,6 @@
       "version": "19.2.17",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1238,7 +1306,6 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -1465,7 +1532,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1548,7 +1614,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1584,6 +1649,15 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "dev": true,
@@ -1615,8 +1689,128 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1634,6 +1828,12 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
@@ -1645,6 +1845,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1695,7 +1905,6 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -1857,10 +2066,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2012,6 +2236,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
@@ -2050,7 +2283,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -2383,6 +2615,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2454,6 +2704,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "dev": true,
@@ -2523,7 +2782,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2566,6 +2824,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "dev": true,
@@ -2584,7 +2859,6 @@
     "node_modules/react": {
       "version": "19.2.7",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2594,13 +2868,18 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.7"
       }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/react-router": {
       "version": "7.17.0",
@@ -2634,6 +2913,70 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "deprecated": "1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
       }
     },
     "node_modules/rolldown": {
@@ -2736,6 +3079,12 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -2786,7 +3135,6 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2863,13 +3211,34 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
     "node_modules/vite": {
       "version": "8.0.16",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2986,7 +3355,6 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,8 @@
     "qrcode.react": "^4.2.0",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "react-router-dom": "^7.17.0"
+    "react-router-dom": "^7.17.0",
+    "recharts": "^2.15.4"
   },
   "devDependencies": {
     "@emnapi/core": "^1.11.1",
@@ -31,5 +32,6 @@
     "tailwindcss": "^4.2.2",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.61.0",
-    "vite": "^8.0.16"  }
+    "vite": "^8.0.16"
+  }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,9 @@ import { EsqueciSenha } from './pages/EsqueciSenha'
 import { RedefinirSenha } from './pages/RedefinirSenha'
 import { AvaliarTicket } from './pages/AvaliarTicket'
 import { Dashboard } from './pages/Dashboard'
+import { DashboardTickets } from './pages/DashboardTickets'
+import { DashboardChats } from './pages/DashboardChats'
+import { RelatoriosTickets } from './pages/RelatoriosTickets'
 import { Tickets } from './pages/Tickets'
 import { TicketNovo } from './pages/TicketNovo'
 import { TicketDetalhe } from './pages/TicketDetalhe'
@@ -95,6 +98,16 @@ function AppRoutes() {
         }
       >
         <Route index element={<Dashboard />} />
+        <Route path="dashboard/tickets" element={<DashboardTickets />} />
+        <Route path="dashboard/chats" element={<DashboardChats />} />
+        <Route
+          path="relatorios/tickets"
+          element={
+            <AdminRoute>
+              <RelatoriosTickets />
+            </AdminRoute>
+          }
+        />
         <Route path="alterar-senha" element={<AlterarSenha />} />
         <Route path="notificacoes/preferencias" element={<NotificacoesPreferencias />} />
         <Route path="tickets" element={<Tickets />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -949,6 +949,61 @@ export const tickets = {
 export const dashboard = {
   get: () => api<Dashboard.Response>('/dashboard'),
   getGeral: () => api<Dashboard.GeralResponse>('/dashboard/geral'),
+  getTickets: (params?: {
+    de?: string;
+    ate?: string;
+    rede_id?: number;
+    setor_id?: number;
+    prioridade?: string;
+    atendente_filtro_id?: number;
+    drill_tipo?: string;
+    drill_valor?: string;
+  }) => api<Dashboard.TicketsResponse>(withParams('/dashboard/tickets', params)),
+  getChats: (params?: {
+    de?: string;
+    ate?: string;
+    setor_id?: number;
+    atendente_filtro_id?: number;
+    drill_tipo?: string;
+    drill_valor?: string;
+  }) => api<Dashboard.ChatsResponse>(withParams('/dashboard/chats', params)),
+};
+
+export const relatorios = {
+  tickets: (params?: {
+    de?: string;
+    ate?: string;
+    rede_id?: number;
+    setor_id?: number;
+    prioridade?: string;
+    offset?: number;
+    limit?: number;
+  }) => api<Relatorios.TicketsResponse>(withParams('/relatorios/tickets', params)),
+  exportTicketsCsv: async (params?: {
+    de?: string;
+    ate?: string;
+    rede_id?: number;
+    setor_id?: number;
+    prioridade?: string;
+  }) => {
+    const token = getAuthToken();
+    const headers: Record<string, string> = {};
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname());
+    }
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const url = `${BASE}${API_VERSION_PREFIX}${withParams('/relatorios/tickets', { ...params, format: 'csv' })}`;
+    const res = await fetch(url, { headers });
+    if (res.status === 401) {
+      invalidateSessionAndRedirectToLogin();
+      throw new ApiError('Sessão expirada ou inválida.', 401, {});
+    }
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}));
+      throw new ApiError(mensagemErroApi(errBody, res.status), res.status, errBody);
+    }
+    return res.blob();
+  },
 };
 
 export namespace Notificacoes {
@@ -1003,9 +1058,28 @@ export namespace Dashboard {
     abertos_hoje: number;
     por_status: StatusCount[];
   }
+  export interface ChatEstadoCount {
+    estado: string;
+    rotulo: string;
+    total: number;
+  }
+  export interface ChatsResumo {
+    total_chats: number;
+    iniciados_hoje: number;
+    por_estado: ChatEstadoCount[];
+  }
+  export interface ChatRecente {
+    id: number;
+    protocolo: string;
+    cliente_nome: string | null;
+    estado: string;
+    created_at: string;
+  }
   export interface Response {
     resumo: Resumo;
+    resumo_chats: ChatsResumo;
     ultimos_tickets: Tickets.Ticket[];
+    ultimos_chats: ChatRecente[];
   }
   export interface CsatResumo {
     media: number | null;
@@ -1022,6 +1096,102 @@ export namespace Dashboard {
     sla_violacoes_abertas: number | null;
     gerado_em: string;
     cache_ttl_segundos: number;
+  }
+  export interface SerieVolumeDia {
+    dia: string;
+    abertos: number;
+    fechados: number;
+  }
+  export interface ContagemIdNome {
+    id: number;
+    nome: string;
+    total: number;
+  }
+  export interface ContagemPrioridade {
+    prioridade: string;
+    total: number;
+  }
+  export interface ContagemCanal {
+    canal: string;
+    rotulo: string;
+    total: number;
+  }
+  export interface CsatDistribuicao {
+    media: number | null;
+    total_avaliacoes: number;
+    por_nota: Record<string, number>;
+  }
+  export interface TicketsResponse {
+    de: string;
+    ate: string;
+    volume_por_dia: SerieVolumeDia[];
+    por_status: ContagemIdNome[];
+    por_prioridade: ContagemPrioridade[];
+    por_motivo: ContagemIdNome[];
+    por_rede: ContagemIdNome[];
+    por_empresa: ContagemIdNome[];
+    mttr_horas: number | null;
+    fila_tempo_medio_horas: number | null;
+    csat: CsatDistribuicao;
+    por_canal: ContagemCanal[];
+    por_atendente: ContagemIdNome[];
+    gerado_em: string;
+    cache_ttl_segundos: number;
+  }
+  export interface SnapshotCanais {
+    tickets_abertos: number;
+    tickets_sem_responsavel: number;
+    chats_aguardando: number;
+    chats_em_atendimento: number;
+  }
+  export interface ContagemRotulo {
+    chave?: string | null;
+    rotulo: string;
+    total: number;
+  }
+  export interface ContagemEncerramentoChat {
+    tipo: string;
+    rotulo: string;
+    total: number;
+  }
+  export interface ChatsResponse {
+    de: string;
+    ate: string;
+    volume_por_dia: SerieVolumeDia[];
+    tempo_espera_medio_horas: number | null;
+    tempo_atendimento_medio_horas: number | null;
+    avaliacoes: CsatDistribuicao;
+    encerramentos: ContagemEncerramentoChat[];
+    pct_com_ticket_vinculado: number | null;
+    por_atendente: ContagemIdNome[];
+    por_estado_atual: ContagemRotulo[];
+    snapshot: SnapshotCanais;
+    gerado_em: string;
+    cache_ttl_segundos: number;
+  }
+}
+
+export namespace Relatorios {
+  export interface TicketLinha {
+    protocolo: string;
+    assunto: string;
+    status_nome: string;
+    prioridade: string;
+    rede_nome: string;
+    empresa_nome: string;
+    setor_nome: string;
+    aberto_em: string | null;
+    fechado_em: string | null;
+    responsavel_nome: string;
+    canal: string;
+  }
+  export interface TicketsResponse {
+    de: string;
+    ate: string;
+    total: number;
+    offset: number;
+    limit: number;
+    itens: TicketLinha[];
   }
 }
 

--- a/frontend/src/components/dashboard/DashboardCanalComparativo.tsx
+++ b/frontend/src/components/dashboard/DashboardCanalComparativo.tsx
@@ -1,0 +1,76 @@
+import { Link } from 'react-router-dom'
+import { Card } from '../ui/Card'
+import type { Dashboard } from '../../api/client'
+
+type Props = {
+  snapshot: Dashboard.SnapshotCanais
+}
+
+function ComparativoItem({
+  label,
+  value,
+  href,
+  hrefLabel,
+}: {
+  label: string
+  value: number
+  href: string
+  hrefLabel: string
+}) {
+  return (
+    <div className="flex min-w-[9rem] flex-1 flex-col gap-1 rounded-lg border border-slate-200 bg-white px-4 py-3 dark:border-slate-700 dark:bg-slate-900/40">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</p>
+      <p className="text-2xl font-bold text-slate-800 dark:text-slate-100">{value}</p>
+      <Link to={href} className="text-xs font-medium text-cyan-700 hover:text-cyan-800 dark:text-cyan-400">
+        {hrefLabel} →
+      </Link>
+    </div>
+  )
+}
+
+/** Comparativo rápido entre filas de tickets e WhatsApp (situação atual). */
+export function DashboardCanalComparativo({ snapshot }: Props) {
+  return (
+    <Card
+      title="Comparativo entre canais"
+      description="Situação atual — use para equilibrar atendimento entre tickets e WhatsApp"
+      className="mb-6"
+    >
+      <div className="flex flex-wrap gap-3">
+        <ComparativoItem
+          label="Tickets abertos"
+          value={snapshot.tickets_abertos}
+          href="/tickets?situacao=abertos"
+          hrefLabel="Ver tickets"
+        />
+        <ComparativoItem
+          label="Tickets na fila"
+          value={snapshot.tickets_sem_responsavel}
+          href="/tickets?sem_responsavel=1"
+          hrefLabel="Ver fila"
+        />
+        <ComparativoItem
+          label="WhatsApp aguardando"
+          value={snapshot.chats_aguardando}
+          href="/whatsapp/atendendo"
+          hrefLabel="Ir para fila"
+        />
+        <ComparativoItem
+          label="WhatsApp em atendimento"
+          value={snapshot.chats_em_atendimento}
+          href="/whatsapp/atendendo"
+          hrefLabel="Ver central"
+        />
+      </div>
+    </Card>
+  )
+}
+
+export function snapshotFromGeral(geral: Dashboard.GeralResponse): Dashboard.SnapshotCanais {
+  return {
+    tickets_abertos: geral.tickets_abertos,
+    tickets_sem_responsavel: geral.tickets_sem_responsavel,
+    chats_aguardando: geral.chats_aguardando_atendente,
+    chats_em_atendimento: geral.chats_em_atendimento,
+  }
+}

--- a/frontend/src/components/dashboard/DashboardFiltroAtivo.tsx
+++ b/frontend/src/components/dashboard/DashboardFiltroAtivo.tsx
@@ -1,0 +1,19 @@
+import { Button } from '../ui/Button'
+
+type Props = {
+  rotulo: string
+  onLimpar: () => void
+}
+
+export function DashboardFiltroAtivo({ rotulo, onLimpar }: Props) {
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-3 rounded-lg border border-cyan-200 bg-cyan-50 px-4 py-3 dark:border-cyan-800/60 dark:bg-cyan-950/30">
+      <p className="text-sm text-slate-700 dark:text-slate-200">
+        Filtrando por: <span className="font-semibold">{rotulo}</span>
+      </p>
+      <Button type="button" variant="ghost" className="text-sm" onClick={onLimpar}>
+        Limpar filtro
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/DashboardNav.tsx
+++ b/frontend/src/components/dashboard/DashboardNav.tsx
@@ -1,0 +1,52 @@
+import { NavLink } from 'react-router-dom'
+import type { ReactNode } from 'react'
+
+const VIEWS = [
+  { id: 'geral', to: '/', label: 'Visão geral', end: true },
+  { id: 'tickets', to: '/dashboard/tickets', label: 'Tickets', end: false },
+  { id: 'chats', to: '/dashboard/chats', label: 'WhatsApp', end: false },
+] as const
+
+export type DashboardViewId = (typeof VIEWS)[number]['id']
+
+const TAB_CLASS =
+  'inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:ring-offset-2 dark:focus:ring-offset-slate-950'
+
+type DashboardNavProps = {
+  actions?: ReactNode
+}
+
+export function dashboardViewFromPath(pathname: string): DashboardViewId {
+  if (pathname.startsWith('/dashboard/tickets')) return 'tickets'
+  if (pathname.startsWith('/dashboard/chats')) return 'chats'
+  return 'geral'
+}
+
+export function DashboardNav({ actions }: DashboardNavProps) {
+  return (
+    <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <nav
+        className="inline-flex flex-wrap gap-1 rounded-xl border border-slate-200 bg-slate-50 p-1 dark:border-slate-700 dark:bg-slate-800/50"
+        aria-label="Navegação entre dashboards"
+      >
+        {VIEWS.map((view) => (
+          <NavLink
+            key={view.id}
+            to={view.to}
+            end={view.end}
+            className={({ isActive }) =>
+              `${TAB_CLASS} ${
+                isActive
+                  ? 'bg-gradient-to-r from-cyan-500 to-blue-600 text-slate-950 shadow-sm'
+                  : 'text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800'
+              }`
+            }
+          >
+            {view.label}
+          </NavLink>
+        ))}
+      </nav>
+      {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/dashboardChartUtils.ts
+++ b/frontend/src/components/dashboard/dashboardChartUtils.ts
@@ -1,0 +1,17 @@
+/** Estilo do tooltip Recharts compatível com tema escuro, sem faixa clara no hover. */
+export const chartTooltipProps = {
+  contentStyle: {
+    backgroundColor: 'rgb(15 23 42)',
+    border: '1px solid rgb(51 65 85)',
+    borderRadius: '8px',
+    fontSize: '12px',
+    boxShadow: '0 4px 12px rgb(0 0 0 / 0.35)',
+  },
+  labelStyle: { color: 'rgb(148 163 184)' },
+  itemStyle: { color: 'rgb(226 232 240)' },
+  cursor: { fill: 'transparent' },
+} as const
+
+export const barClickableProps = {
+  cursor: 'pointer' as const,
+}

--- a/frontend/src/components/dashboard/dashboardMetrics.tsx
+++ b/frontend/src/components/dashboard/dashboardMetrics.tsx
@@ -1,0 +1,87 @@
+import type { ReactNode } from 'react'
+import { Card } from '../ui/Card'
+
+export function DicaMetrica({ texto }: { texto: string }) {
+  return (
+    <span
+      className="ml-1.5 inline-flex h-4 w-4 shrink-0 cursor-help items-center justify-center rounded-full bg-slate-200 text-[10px] font-bold leading-none text-slate-600 dark:bg-slate-700 dark:text-slate-300"
+      title={texto}
+      aria-label={texto}
+    >
+      ?
+    </span>
+  )
+}
+
+export function MetricCard({
+  label,
+  dica,
+  value,
+  hint,
+  borderClass,
+  children,
+}: {
+  label: string
+  dica?: string
+  value?: string
+  hint?: string
+  borderClass: string
+  children?: ReactNode
+}) {
+  return (
+    <Card className={`flex flex-col ${borderClass}`}>
+      <p className="text-sm font-medium text-slate-500 dark:text-slate-400">
+        {label}
+        {dica ? <DicaMetrica texto={dica} /> : null}
+      </p>
+      {value != null ? (
+        <p className="mt-1 text-2xl font-bold text-slate-800 dark:text-slate-100">{value}</p>
+      ) : null}
+      {children}
+      {hint ? (
+        <p className={`text-xs text-slate-500 dark:text-slate-400 ${value != null || children ? 'mt-1' : 'mt-2'}`}>
+          {hint}
+        </p>
+      ) : null}
+    </Card>
+  )
+}
+
+export function formatarHoras(valor: number | null): string {
+  if (valor == null) return '—'
+  if (valor < 1) return `${Math.round(valor * 60)} min`
+  return `${valor.toFixed(1).replace('.', ',')} h`
+}
+
+export function formatarDiaCurto(iso: string): string {
+  const [, m, day] = iso.split('-')
+  return `${day}/${m}`
+}
+
+export function formatarCsatMedia(media: number | null): string {
+  if (media == null) return '—'
+  return `${media.toFixed(1).replace('.', ',')} ★`
+}
+
+export function formatarPct(valor: number | null): string {
+  if (valor == null) return '—'
+  return `${valor.toFixed(1).replace('.', ',')}%`
+}
+
+export type PresetPeriodo = '7' | '30' | '90' | 'custom'
+
+export const PRESET_DIAS: Record<Exclude<PresetPeriodo, 'custom'>, number> = {
+  '7': 7,
+  '30': 30,
+  '90': 90,
+}
+
+export function isoDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+export function addDays(base: Date, dias: number): Date {
+  const d = new Date(base)
+  d.setDate(d.getDate() + dias)
+  return d
+}

--- a/frontend/src/components/dashboard/useDashboardDrilldown.ts
+++ b/frontend/src/components/dashboard/useDashboardDrilldown.ts
@@ -1,0 +1,70 @@
+import { useCallback, useMemo, useState } from 'react'
+
+export type DashboardDrill = {
+  tipo: string
+  valor: string
+  rotulo: string
+} | null
+
+const ROTULOS_TIPO: Record<string, string> = {
+  atendente: 'Atendente',
+  empresa: 'Empresa',
+  rede: 'Rede',
+  motivo: 'Motivo',
+  status: 'Status',
+  prioridade: 'Prioridade',
+  canal: 'Canal',
+  nota: 'Nota',
+  estado: 'Situação',
+  encerramento: 'Encerramento',
+}
+
+export function useDashboardDrilldown() {
+  const [drill, setDrill] = useState<DashboardDrill>(null)
+
+  const toggle = useCallback((tipo: string, valor: string, rotulo: string) => {
+    setDrill((prev) =>
+      prev?.tipo === tipo && prev?.valor === valor ? null : { tipo, valor, rotulo },
+    )
+  }, [])
+
+  const limpar = useCallback(() => setDrill(null), [])
+
+  const isSelected = useCallback(
+    (tipo: string, valor: string) => drill?.tipo === tipo && drill?.valor === valor,
+    [drill],
+  )
+
+  const apiParams = useMemo(
+    () =>
+      drill
+        ? { drill_tipo: drill.tipo, drill_valor: drill.valor }
+        : ({} as { drill_tipo?: string; drill_valor?: string }),
+    [drill],
+  )
+
+  const rotuloFiltro = drill
+    ? `${ROTULOS_TIPO[drill.tipo] ?? drill.tipo}: ${drill.rotulo}`
+    : null
+
+  const hasSelection = drill != null
+
+  return useMemo(
+    () => ({
+      drill,
+      toggle,
+      limpar,
+      isSelected,
+      hasSelection,
+      apiParams,
+      rotuloFiltro,
+    }),
+    [drill, toggle, limpar, isSelected, hasSelection, apiParams, rotuloFiltro],
+  )
+}
+
+/** Destaca a barra selecionada e atenua as demais quando há filtro ativo. */
+export function corDrill(base: string, selected: boolean, hasSelection: boolean): string {
+  if (!hasSelection) return base
+  return selected ? base : '#334155'
+}

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -2,9 +2,10 @@ import { type HTMLAttributes } from 'react'
 
 interface CardProps extends HTMLAttributes<HTMLDivElement> {
   title?: string
+  description?: string
 }
 
-export function Card({ title, className = '', children, ...props }: CardProps) {
+export function Card({ title, description, className = '', children, ...props }: CardProps) {
   return (
     <div
       className={`rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-700/80 dark:bg-slate-900/70 dark:shadow-none dark:ring-1 dark:ring-white/5 ${className}`}
@@ -13,6 +14,9 @@ export function Card({ title, className = '', children, ...props }: CardProps) {
       {title && (
         <div className="border-b border-slate-200 px-6 py-4 dark:border-slate-700/80">
           <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">{title}</h2>
+          {description ? (
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{description}</p>
+          ) : null}
         </div>
       )}
       <div className="p-6">{children}</div>

--- a/frontend/src/components/ui/NotaEstrelasMedia.tsx
+++ b/frontend/src/components/ui/NotaEstrelasMedia.tsx
@@ -1,0 +1,87 @@
+const STAR_PATH =
+  'M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z'
+
+type Size = 'sm' | 'md' | 'lg'
+
+const DIM: Record<Size, number> = { sm: 14, md: 18, lg: 22 }
+
+function EstrelaVazia({ size }: { size: Size }) {
+  const dim = DIM[size]
+  return (
+    <svg width={dim} height={dim} viewBox="0 0 24 24" aria-hidden className="text-slate-300 dark:text-slate-600">
+      <path fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinejoin="round" d={STAR_PATH} />
+    </svg>
+  )
+}
+
+function EstrelaParcial({ fill, size }: { fill: number; size: Size }) {
+  const dim = DIM[size]
+  const pct = `${Math.max(0, Math.min(1, fill)) * 100}%`
+  return (
+    <span className="relative inline-block" style={{ width: dim, height: dim }}>
+      <EstrelaVazia size={size} />
+      <span className="absolute inset-0 overflow-hidden" style={{ width: pct }}>
+        <svg width={dim} height={dim} viewBox="0 0 24 24" aria-hidden className="text-amber-400">
+          <path fill="currentColor" d={STAR_PATH} />
+        </svg>
+      </span>
+    </span>
+  )
+}
+
+type NotaEstrelasMediaProps = {
+  media: number | null
+  size?: Size
+  className?: string
+  mostrarNumero?: boolean
+}
+
+/** Exibe 5 estrelas com preenchimento parcial conforme a média (ex.: 4,3 → 4 cheias + 1 parcial). */
+export function NotaEstrelasMedia({
+  media,
+  size = 'md',
+  className = '',
+  mostrarNumero = true,
+}: NotaEstrelasMediaProps) {
+  if (media == null) {
+    return <span className={`text-2xl font-bold text-slate-400 ${className}`}>—</span>
+  }
+
+  const clamped = Math.max(0, Math.min(5, media))
+  const estrelas = Array.from({ length: 5 }, (_, i) => {
+    const fill = Math.max(0, Math.min(1, clamped - i))
+    return fill >= 1 ? 1 : fill
+  })
+
+  const label = `${media.toFixed(1).replace('.', ',')} de 5 estrelas`
+
+  return (
+    <div className={`flex flex-wrap items-center gap-2 ${className}`}>
+      <span className="inline-flex items-center gap-0.5" title={label} aria-label={label}>
+        {estrelas.map((fill, i) =>
+          fill >= 1 ? (
+            <svg
+              key={i}
+              width={DIM[size]}
+              height={DIM[size]}
+              viewBox="0 0 24 24"
+              aria-hidden
+              className="text-amber-400"
+            >
+              <path fill="currentColor" d={STAR_PATH} />
+            </svg>
+          ) : fill > 0 ? (
+            <EstrelaParcial key={i} fill={fill} size={size} />
+          ) : (
+            <EstrelaVazia key={i} size={size} />
+          ),
+        )}
+      </span>
+      {mostrarNumero ? (
+        <span className="text-lg font-semibold text-slate-700 dark:text-slate-200">
+          {media.toFixed(1).replace('.', ',')}
+        </span>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -31,4 +31,10 @@
   }
 }
 
+/* Recharts: remove faixa clara no hover (incompatível com tema escuro) */
+.recharts-tooltip-cursor,
+.recharts-active-bar,
+.recharts-active-shape {
+  fill: transparent !important;
+}
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useEffect, useMemo, type ReactNode } from 'react'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { Link } from 'react-router-dom'
@@ -11,6 +11,9 @@ import { SemPermissao } from './SemPermissao'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { exibirProtocolo } from '../lib/exibirProtocolo'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
+import { DashboardCanalComparativo, snapshotFromGeral } from '../components/dashboard/DashboardCanalComparativo'
+import { DashboardNav } from '../components/dashboard/DashboardNav'
+import { NotaEstrelasMedia } from '../components/ui/NotaEstrelasMedia'
 
 type ColunaUltimos = 'protocolo' | 'empresa' | 'assunto' | 'status'
 
@@ -31,15 +34,14 @@ function DashboardSkeleton() {
   )
 }
 
-function formatarCsat(csat: Dashboard.CsatResumo): string {
-  if (csat.media == null) return '—'
-  return `${csat.media.toFixed(1).replace('.', ',')} ★`
-}
-
-function subtituloCsat(csat: Dashboard.CsatResumo): string {
-  const n = csat.total_avaliacoes
-  const aval = n === 1 ? 'avaliação' : 'avaliações'
-  return `últimos ${csat.periodo_dias} dias · ${n} ${aval}`
+function rotuloEstadoChat(estado: string): string {
+  const map: Record<string, string> = {
+    aguardando_atendente: 'Aguardando',
+    em_atendimento: 'Em atendimento',
+    aguardando_avaliacao: 'Aguard. avaliação',
+    encerrado: 'Encerrado',
+  }
+  return map[estado] ?? estado
 }
 
 function MetricCard({
@@ -49,18 +51,22 @@ function MetricCard({
   borderClass,
   href,
   hrefLabel,
+  children,
 }: {
   label: string
-  value: string | number
+  value?: string | number
   hint?: string
   borderClass: string
   href?: string
   hrefLabel?: string
+  children?: ReactNode
 }) {
   return (
     <Card className={`flex flex-col ${borderClass}`}>
       <p className="text-sm font-medium text-slate-500 dark:text-slate-400">{label}</p>
-      <p className="mt-1 text-3xl font-bold text-slate-800 dark:text-slate-100">{value}</p>
+      {children ?? (
+        <p className="mt-1 text-3xl font-bold text-slate-800 dark:text-slate-100">{value}</p>
+      )}
       {hint ? <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{hint}</p> : null}
       {href && hrefLabel ? (
         <Link to={href} className="mt-3 text-sm font-medium text-cyan-700 hover:text-cyan-800 dark:text-cyan-400 dark:hover:text-cyan-300">
@@ -154,18 +160,26 @@ export function Dashboard() {
     )
   }
 
-  const { resumo } = data
+  const { resumo, resumo_chats } = data
 
   return (
     <PageContainer>
-      <PageHeader
-        title="Dashboard"
+      <PageHeader title="Dashboard" />
+
+      <DashboardNav
         actions={
-          <Link to="/tickets/novo">
-            <Button>Novo ticket</Button>
-          </Link>
+          <>
+            <Link to="/tickets/novo">
+              <Button variant="secondary">Novo ticket</Button>
+            </Link>
+            <Link to="/whatsapp/atendendo">
+              <Button variant="secondary">Ir para WhatsApp</Button>
+            </Link>
+          </>
         }
       />
+
+      {geral ? <DashboardCanalComparativo snapshot={snapshotFromGeral(geral)} /> : null}
 
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
         <MetricCard
@@ -197,46 +211,85 @@ export function Dashboard() {
           hrefLabel="Ver central de atendimento"
         />
         <MetricCard
-          label="CSAT tickets"
-          value={formatarCsat(geral.csat_tickets)}
-          hint={subtituloCsat(geral.csat_tickets)}
+          label="Satisfação — tickets"
           borderClass="border-l-4 border-l-violet-400"
-        />
+          hint={`últimos ${geral.csat_tickets.periodo_dias} dias · ${geral.csat_tickets.total_avaliacoes} avaliações`}
+        >
+          <div className="mt-2">
+            <NotaEstrelasMedia media={geral.csat_tickets.media} size="lg" />
+          </div>
+        </MetricCard>
         <MetricCard
-          label="CSAT WhatsApp"
-          value={formatarCsat(geral.csat_chats)}
-          hint={subtituloCsat(geral.csat_chats)}
+          label="Satisfação — WhatsApp"
           borderClass="border-l-4 border-l-pink-400"
-        />
+          hint={`últimos ${geral.csat_chats.periodo_dias} dias · ${geral.csat_chats.total_avaliacoes} avaliações`}
+        >
+          <div className="mt-2">
+            <NotaEstrelasMedia media={geral.csat_chats.media} size="lg" />
+          </div>
+        </MetricCard>
       </div>
 
-      <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        <Card className="border-l-4 border-l-slate-300">
-          <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Total de tickets</p>
-          <p className="mt-1 text-3xl font-bold text-slate-800 dark:text-slate-100">{resumo.total_tickets}</p>
-        </Card>
-        <Card className="border-l-4 border-l-amber-300">
-          <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Abertos hoje</p>
-          <p className="mt-1 text-3xl font-bold text-slate-800 dark:text-slate-100">{resumo.abertos_hoje}</p>
-        </Card>
-        <Card className="border-l-4 border-l-emerald-300 sm:col-span-2 lg:col-span-1">
-          <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Por status</p>
-          <ul className="mt-2 space-y-1">
-            {resumo.por_status.length === 0 ? (
-              <li className="text-slate-500 dark:text-slate-400">Nenhum ticket</li>
-            ) : (
-              resumo.por_status.map((s) => (
-                <li key={s.status_id} className="flex justify-between text-sm">
-                  <span className="text-slate-600 dark:text-slate-400">{s.status_nome}</span>
-                  <span className="font-medium text-slate-800 dark:text-slate-100">{s.total}</span>
-                </li>
-              ))
-            )}
-          </ul>
-        </Card>
+      <div className="mt-8 grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">Tickets</h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <Card className="border-l-4 border-l-slate-300">
+              <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Total de tickets</p>
+              <p className="mt-1 text-3xl font-bold text-slate-800 dark:text-slate-100">{resumo.total_tickets}</p>
+            </Card>
+            <Card className="border-l-4 border-l-amber-300">
+              <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Abertos hoje</p>
+              <p className="mt-1 text-3xl font-bold text-slate-800 dark:text-slate-100">{resumo.abertos_hoje}</p>
+            </Card>
+          </div>
+          <Card title="Por status">
+            <ul className="space-y-1">
+              {resumo.por_status.length === 0 ? (
+                <li className="text-slate-500 dark:text-slate-400">Nenhum ticket</li>
+              ) : (
+                resumo.por_status.map((s) => (
+                  <li key={s.status_id} className="flex justify-between text-sm">
+                    <span className="text-slate-600 dark:text-slate-400">{s.status_nome}</span>
+                    <span className="font-medium text-slate-800 dark:text-slate-100">{s.total}</span>
+                  </li>
+                ))
+              )}
+            </ul>
+          </Card>
+        </div>
+
+        <div className="space-y-4">
+          <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">WhatsApp</h2>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <Card className="border-l-4 border-l-emerald-300">
+              <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Total de conversas</p>
+              <p className="mt-1 text-3xl font-bold text-slate-800 dark:text-slate-100">{resumo_chats.total_chats}</p>
+            </Card>
+            <Card className="border-l-4 border-l-teal-300">
+              <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Iniciadas hoje</p>
+              <p className="mt-1 text-3xl font-bold text-slate-800 dark:text-slate-100">{resumo_chats.iniciados_hoje}</p>
+            </Card>
+          </div>
+          <Card title="Por situação">
+            <ul className="space-y-1">
+              {resumo_chats.por_estado.length === 0 ? (
+                <li className="text-slate-500 dark:text-slate-400">Nenhuma conversa</li>
+              ) : (
+                resumo_chats.por_estado.map((e) => (
+                  <li key={e.estado} className="flex justify-between text-sm">
+                    <span className="text-slate-600 dark:text-slate-400">{e.rotulo}</span>
+                    <span className="font-medium text-slate-800 dark:text-slate-100">{e.total}</span>
+                  </li>
+                ))
+              )}
+            </ul>
+          </Card>
+        </div>
       </div>
 
-      <Card title="Últimos tickets" className="mt-8">
+      <div className="mt-8 grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <Card title="Últimos tickets">
         {ultimos_tickets.length === 0 ? (
           <p className="text-slate-500 dark:text-slate-400">Nenhum ticket ainda.</p>
         ) : (
@@ -321,6 +374,47 @@ export function Dashboard() {
           </Link>
         </div>
       </Card>
+
+        <Card title="Últimas conversas WhatsApp">
+          {data.ultimos_chats.length === 0 ? (
+            <p className="text-slate-500 dark:text-slate-400">Nenhuma conversa ainda.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-left text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 dark:border-slate-700/80 text-slate-600 dark:text-slate-400">
+                    <th className="pb-2 pr-4 font-medium">Protocolo</th>
+                    <th className="pb-2 pr-4 font-medium">Cliente</th>
+                    <th className="pb-2 pr-4 font-medium">Situação</th>
+                    <th className="pb-2 font-medium">Ações</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.ultimos_chats.map((c) => (
+                    <tr key={c.id} className="border-b border-slate-100 dark:border-slate-700/60">
+                      <td className="py-3 pr-4 font-mono text-slate-800 dark:text-slate-100">{c.protocolo}</td>
+                      <td className="py-3 pr-4">{c.cliente_nome ?? '—'}</td>
+                      <td className="py-3 pr-4">{rotuloEstadoChat(c.estado)}</td>
+                      <td className="py-3">
+                        <Link to={`/whatsapp/c/${c.id}`}>
+                          <Button type="button" variant="ghost" className="text-sm">
+                            Abrir
+                          </Button>
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          <div className="mt-4">
+            <Link to="/whatsapp/atendendo">
+              <Button variant="secondary">Ir para WhatsApp</Button>
+            </Link>
+          </div>
+        </Card>
+      </div>
     </PageContainer>
   )
 }

--- a/frontend/src/pages/DashboardChats.tsx
+++ b/frontend/src/pages/DashboardChats.tsx
@@ -1,0 +1,497 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { ApiError, dashboard, setores, type Dashboard, type Setores } from '../api/client'
+import { useAuth } from '../contexts/AuthContext'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { PageContainer, PageHeader } from '../components/ui/PageContainer'
+import { useToast } from '../components/ui/Toast'
+import { SemPermissao } from './SemPermissao'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
+import { DashboardCanalComparativo } from '../components/dashboard/DashboardCanalComparativo'
+import { DashboardFiltroAtivo } from '../components/dashboard/DashboardFiltroAtivo'
+import { DashboardNav } from '../components/dashboard/DashboardNav'
+import { barClickableProps, chartTooltipProps } from '../components/dashboard/dashboardChartUtils'
+import { corDrill, useDashboardDrilldown } from '../components/dashboard/useDashboardDrilldown'
+import { NotaEstrelasMedia } from '../components/ui/NotaEstrelasMedia'
+import {
+  MetricCard,
+  PRESET_DIAS,
+  addDays,
+  formatarDiaCurto,
+  formatarHoras,
+  formatarPct,
+  isoDate,
+  type PresetPeriodo,
+} from '../components/dashboard/dashboardMetrics'
+
+const CORES_ENCERRAMENTO = ['#06b6d4', '#94a3b8']
+
+function DashboardChatsSkeleton() {
+  return (
+    <PageContainer>
+      <div className="mb-6 h-9 w-64 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+      <div className="mb-6 h-12 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-72 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+        ))}
+      </div>
+    </PageContainer>
+  )
+}
+
+export function DashboardChats() {
+  const toast = useToast()
+  const { user } = useAuth()
+  const hoje = useMemo(() => new Date(), [])
+  const [preset, setPreset] = useState<PresetPeriodo>('30')
+  const [de, setDe] = useState(() => isoDate(addDays(hoje, -30)))
+  const [ate, setAte] = useState(() => isoDate(hoje))
+  const [setorId, setSetorId] = useState<number | ''>('')
+  const [data, setData] = useState<Dashboard.ChatsResponse | null>(null)
+  const [setoresLista, setSetoresLista] = useState<Setores.Setor[]>([])
+  const [loading, setLoading] = useState(true)
+  const [semPermissao, setSemPermissao] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const drill = useDashboardDrilldown()
+  const [reloadKey, setReloadKey] = useState(0)
+
+  const aplicarPreset = useCallback((p: Exclude<PresetPeriodo, 'custom'>) => {
+    setPreset(p)
+    const fim = new Date()
+    setAte(isoDate(fim))
+    setDe(isoDate(addDays(fim, -PRESET_DIAS[p])))
+  }, [])
+
+  useEffect(() => {
+    setores
+      .list({ limit: 100, ordenar_por: 'nome', ordem: 'asc' })
+      .then((s) => setSetoresLista(s.items))
+      .catch(() => undefined)
+  }, [])
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    setSemPermissao(false)
+    dashboard
+      .getChats({
+        de,
+        ate,
+        setor_id: setorId === '' ? undefined : setorId,
+        ...drill.apiParams,
+      })
+      .then(setData)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setSemPermissao(true)
+          toast.showWarning(err.message || 'Você não tem permissão para ver este dashboard.')
+          return
+        }
+        const m = interpretarFalhaCarregamento(err, 'Não encontramos os dados do dashboard de WhatsApp.')
+        setError(m.titulo)
+        toast.showError(mensagemFalhaParaToast(m))
+      })
+      .finally(() => setLoading(false))
+  }, [de, ate, setorId, drill.apiParams, reloadKey, toast])
+
+  const atendentesChart = useMemo(
+    () => (data?.por_atendente ?? []).map((a) => ({ id: a.id, nome: a.nome, total: a.total })),
+    [data],
+  )
+
+  const volumeChart = useMemo(
+    () =>
+      (data?.volume_por_dia ?? []).map((d) => ({
+        ...d,
+        label: formatarDiaCurto(d.dia),
+      })),
+    [data],
+  )
+
+  const avaliacoesChart = useMemo(() => {
+    if (!data?.avaliacoes.por_nota) return []
+    return [1, 2, 3, 4, 5].map((n) => ({
+      nota: `${n}★`,
+      notaValor: String(n),
+      total: data.avaliacoes.por_nota[String(n)] ?? 0,
+    }))
+  }, [data])
+
+  const encerramentosChart = useMemo(
+    () => (data?.encerramentos ?? []).map((e) => ({ nome: e.rotulo, tipo: e.tipo, total: e.total })),
+    [data],
+  )
+
+  const estadoChart = useMemo(
+    () =>
+      (data?.por_estado_atual ?? []).map((e) => ({
+        nome: e.rotulo,
+        chave: e.chave ?? e.rotulo,
+        total: e.total,
+      })),
+    [data],
+  )
+
+  const semDados =
+    data != null &&
+    data.volume_por_dia.every((d) => d.abertos === 0 && d.fechados === 0) &&
+    data.por_estado_atual.every((e) => e.total === 0)
+
+  if (loading && !data) {
+    return <DashboardChatsSkeleton />
+  }
+
+  if (semPermissao) {
+    return (
+      <PageContainer>
+        <SemPermissao
+          title="Você não tem permissão para acessar o dashboard de WhatsApp."
+          voltarPara="/"
+          voltarLabel="Voltar ao dashboard"
+        />
+      </PageContainer>
+    )
+  }
+
+  if (error && !data) {
+    return (
+      <PageContainer className="flex flex-col items-center gap-4 py-16 text-center">
+        <p className="text-slate-600 dark:text-slate-300">{error}</p>
+        <Button type="button" onClick={() => setReloadKey((k) => k + 1)}>
+          Tentar novamente
+        </Button>
+      </PageContainer>
+    )
+  }
+
+  if (!data) return null
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Dashboard — WhatsApp"
+        subtitle={`Indicadores de atendimento · ${formatarDiaCurto(data.de)} a ${formatarDiaCurto(data.ate)}`}
+      />
+
+      <DashboardNav
+        actions={
+          <>
+            <Link to="/whatsapp/atendendo">
+              <Button>Ir para atendimento</Button>
+            </Link>
+            <Link to="/whatsapp/avaliacoes">
+              <Button variant="secondary">Ver avaliações</Button>
+            </Link>
+          </>
+        }
+      />
+
+      <DashboardCanalComparativo snapshot={data.snapshot} />
+
+      {drill.rotuloFiltro ? (
+        <DashboardFiltroAtivo rotulo={drill.rotuloFiltro} onLimpar={drill.limpar} />
+      ) : null}
+
+      <Card className="mb-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap lg:items-end">
+          <div className="flex flex-wrap gap-2">
+            {(['7', '30', '90'] as const).map((p) => (
+              <Button
+                key={p}
+                type="button"
+                variant={preset === p ? 'primary' : 'secondary'}
+                onClick={() => aplicarPreset(p)}
+              >
+                {p} dias
+              </Button>
+            ))}
+            <Button
+              type="button"
+              variant={preset === 'custom' ? 'primary' : 'secondary'}
+              onClick={() => setPreset('custom')}
+            >
+              Personalizado
+            </Button>
+          </div>
+          {preset === 'custom' ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+                De
+                <input
+                  type="date"
+                  value={de}
+                  onChange={(e) => setDe(e.target.value)}
+                  className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+                Até
+                <input
+                  type="date"
+                  value={ate}
+                  onChange={(e) => setAte(e.target.value)}
+                  className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+                />
+              </label>
+            </div>
+          ) : null}
+          <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+            Setor
+            <select
+              value={setorId}
+              onChange={(e) => setSetorId(e.target.value ? Number(e.target.value) : '')}
+              className="min-w-[10rem] rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+            >
+              <option value="">Todos</option>
+              {setoresLista.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.nome}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </Card>
+
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <MetricCard
+          label="Espera na fila"
+          dica="Tempo médio entre a primeira mensagem do cliente e o momento em que um atendente assume o chat."
+          value={formatarHoras(data.tempo_espera_medio_horas)}
+          hint="Até o atendente assumir"
+          borderClass="border-l-4 border-l-amber-400"
+        />
+        <MetricCard
+          label="Duração do atendimento"
+          dica="Tempo médio com o chat em atendimento, da assunção até o encerramento."
+          value={formatarHoras(data.tempo_atendimento_medio_horas)}
+          hint="Da assunção ao encerramento"
+          borderClass="border-l-4 border-l-cyan-500"
+        />
+        <MetricCard
+          label="Satisfação do cliente"
+          dica="Nota média de 1 a 5 estrelas após conversas no WhatsApp."
+          hint={
+            data.avaliacoes.total_avaliacoes === 0
+              ? 'Nenhuma avaliação no período'
+              : `${data.avaliacoes.total_avaliacoes} ${data.avaliacoes.total_avaliacoes === 1 ? 'avaliação' : 'avaliações'}`
+          }
+          borderClass="border-l-4 border-l-violet-400"
+        >
+          <div className="mt-2">
+            <NotaEstrelasMedia media={data.avaliacoes.media} size="md" />
+          </div>
+        </MetricCard>
+        <MetricCard
+          label="Chats com ticket vinculado"
+          dica="Percentual de conversas abertas no período que geraram ou foram ligadas a um ticket."
+          value={formatarPct(data.pct_com_ticket_vinculado)}
+          hint="Integração ticket ↔ WhatsApp"
+          borderClass="border-l-4 border-l-emerald-400"
+        />
+      </div>
+
+      {semDados ? (
+        <Card>
+          <p className="text-center text-slate-500 dark:text-slate-400">
+            Nenhum chat no período selecionado. Ajuste os filtros ou aguarde novas conversas.
+          </p>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+          <Card
+            title="Conversas por dia"
+            description="Chats iniciados e encerrados em cada dia do período"
+          >
+            <div className="h-72">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={volumeChart}>
+                  <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                  <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+                  <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                  <Tooltip {...chartTooltipProps} />
+                  <Legend />
+                  <Line type="monotone" dataKey="abertos" name="Iniciados" stroke="#10b981" strokeWidth={2} dot={false} />
+                  <Line type="monotone" dataKey="fechados" name="Encerrados" stroke="#64748b" strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </Card>
+
+          <Card
+            title="Chats abertos agora"
+            description="Clique em uma situação para filtrar os demais gráficos e indicadores"
+          >
+            <div className="h-72">
+              {estadoChart.every((e) => e.total === 0) ? (
+                <p className="text-slate-500 dark:text-slate-400">Nenhum chat aberto no momento.</p>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={estadoChart}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                    <XAxis dataKey="nome" tick={{ fontSize: 11 }} />
+                    <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                    <Tooltip {...chartTooltipProps} />
+                    <Bar
+                      dataKey="total"
+                      name="Chats"
+                      radius={[4, 4, 0, 0]}
+                      {...barClickableProps}
+                      onClick={(bar) => {
+                        const p = bar?.payload as { chave?: string; nome?: string }
+                        if (p?.chave && p.nome) drill.toggle('estado', p.chave, p.nome)
+                      }}
+                    >
+                      {estadoChart.map((entry) => (
+                        <Cell
+                          key={entry.chave}
+                          fill={corDrill('#10b981', drill.isSelected('estado', entry.chave), drill.hasSelection)}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+          </Card>
+
+          <Card
+            title="Como os chats foram encerrados"
+            description="Clique em um tipo de encerramento para filtrar os demais gráficos e indicadores"
+          >
+            <div className="h-72">
+              {encerramentosChart.every((e) => e.total === 0) ? (
+                <p className="text-slate-500 dark:text-slate-400">Nenhum encerramento no período.</p>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie
+                      data={encerramentosChart}
+                      dataKey="total"
+                      nameKey="nome"
+                      cx="50%"
+                      cy="50%"
+                      outerRadius={90}
+                      label={({ nome, total }) => `${nome}: ${total}`}
+                      {...barClickableProps}
+                      onClick={(entry) => {
+                        const p = entry as { tipo?: string; nome?: string }
+                        if (p.tipo && p.nome) drill.toggle('encerramento', p.tipo, p.nome)
+                      }}
+                    >
+                      {encerramentosChart.map((entry, i) => (
+                        <Cell
+                          key={entry.tipo}
+                          fill={corDrill(
+                            CORES_ENCERRAMENTO[i % CORES_ENCERRAMENTO.length],
+                            drill.isSelected('encerramento', entry.tipo),
+                            drill.hasSelection,
+                          )}
+                        />
+                      ))}
+                    </Pie>
+                    <Tooltip {...chartTooltipProps} />
+                  </PieChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+          </Card>
+
+          <Card
+            title="Distribuição das avaliações"
+            description="Clique em uma nota para filtrar os demais gráficos e indicadores"
+          >
+            <div className="h-72">
+              {data.avaliacoes.total_avaliacoes === 0 ? (
+                <p className="text-slate-500 dark:text-slate-400">Sem avaliações no período.</p>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={avaliacoesChart}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                    <XAxis dataKey="nota" tick={{ fontSize: 11 }} />
+                    <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                    <Tooltip {...chartTooltipProps} />
+                    <Bar
+                      dataKey="total"
+                      name="Avaliações"
+                      radius={[4, 4, 0, 0]}
+                      {...barClickableProps}
+                      onClick={(bar) => {
+                        const p = bar?.payload as { notaValor?: string; nota?: string }
+                        if (p?.notaValor && p.nota) drill.toggle('nota', p.notaValor, p.nota)
+                      }}
+                    >
+                      {avaliacoesChart.map((entry) => (
+                        <Cell
+                          key={entry.notaValor}
+                          fill={corDrill('#ec4899', drill.isSelected('nota', entry.notaValor), drill.hasSelection)}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+          </Card>
+
+          {user?.role === 'admin' && atendentesChart.length > 0 ? (
+            <Card
+              title="Atendentes com mais chats assumidos"
+              description="Clique em um atendente para filtrar os demais gráficos e indicadores"
+              className="xl:col-span-2"
+            >
+              <div className="h-80">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={atendentesChart} layout="vertical" margin={{ left: 8 }}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                    <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} />
+                    <YAxis type="category" dataKey="nome" width={140} tick={{ fontSize: 11 }} />
+                    <Tooltip {...chartTooltipProps} />
+                    <Bar
+                      dataKey="total"
+                      name="Chats assumidos"
+                      radius={[0, 4, 4, 0]}
+                      {...barClickableProps}
+                      onClick={(bar) => {
+                        const p = bar?.payload as { id?: number; nome?: string }
+                        if (p?.id != null && p.nome) drill.toggle('atendente', String(p.id), p.nome)
+                      }}
+                    >
+                      {atendentesChart.map((entry) => (
+                        <Cell
+                          key={entry.id}
+                          fill={corDrill(
+                            '#0ea5e9',
+                            drill.isSelected('atendente', String(entry.id)),
+                            drill.hasSelection,
+                          )}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
+          ) : null}
+        </div>
+      )}
+    </PageContainer>
+  )
+}

--- a/frontend/src/pages/DashboardTickets.tsx
+++ b/frontend/src/pages/DashboardTickets.tsx
@@ -1,0 +1,751 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import {
+  ApiError,
+  dashboard,
+  redes,
+  setores,
+  type Dashboard,
+  type Redes,
+  type Setores,
+} from '../api/client'
+import { useAuth } from '../contexts/AuthContext'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { PageContainer, PageHeader } from '../components/ui/PageContainer'
+import { useToast } from '../components/ui/Toast'
+import { SemPermissao } from './SemPermissao'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
+import { DashboardCanalComparativo, snapshotFromGeral } from '../components/dashboard/DashboardCanalComparativo'
+import { DashboardFiltroAtivo } from '../components/dashboard/DashboardFiltroAtivo'
+import { DashboardNav } from '../components/dashboard/DashboardNav'
+import { barClickableProps, chartTooltipProps } from '../components/dashboard/dashboardChartUtils'
+import { corDrill, useDashboardDrilldown } from '../components/dashboard/useDashboardDrilldown'
+import { NotaEstrelasMedia } from '../components/ui/NotaEstrelasMedia'
+import {
+  MetricCard,
+  PRESET_DIAS,
+  addDays,
+  formatarDiaCurto,
+  formatarHoras,
+  isoDate,
+  type PresetPeriodo,
+} from '../components/dashboard/dashboardMetrics'
+
+const CORES_PRIORIDADE: Record<string, string> = {
+  baixa: '#94a3b8',
+  normal: '#06b6d4',
+  alta: '#f59e0b',
+  urgente: '#ef4444',
+}
+
+function labelPrioridade(p: string): string {
+  const map: Record<string, string> = {
+    baixa: 'Baixa',
+    normal: 'Normal',
+    alta: 'Alta',
+    urgente: 'Urgente',
+  }
+  return map[p] ?? p
+}
+
+const PRIORIDADES = [
+  { value: '', label: 'Todas' },
+  { value: 'baixa', label: 'Baixa' },
+  { value: 'normal', label: 'Normal' },
+  { value: 'alta', label: 'Alta' },
+  { value: 'urgente', label: 'Urgente' },
+]
+
+function DashboardTicketsSkeleton() {
+  return (
+    <PageContainer>
+      <div className="mb-6 h-9 w-64 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
+      <div className="mb-6 h-12 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="h-72 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+        ))}
+      </div>
+    </PageContainer>
+  )
+}
+
+export function DashboardTickets() {
+  const toast = useToast()
+  const { user } = useAuth()
+  const hoje = useMemo(() => new Date(), [])
+  const [preset, setPreset] = useState<PresetPeriodo>('30')
+  const [de, setDe] = useState(() => isoDate(addDays(hoje, -30)))
+  const [ate, setAte] = useState(() => isoDate(hoje))
+  const [redeId, setRedeId] = useState<number | ''>('')
+  const [setorId, setSetorId] = useState<number | ''>('')
+  const [prioridade, setPrioridade] = useState('')
+  const [data, setData] = useState<Dashboard.TicketsResponse | null>(null)
+  const [snapshot, setSnapshot] = useState<Dashboard.SnapshotCanais | null>(null)
+  const [redesLista, setRedesLista] = useState<Redes.Rede[]>([])
+  const [setoresLista, setSetoresLista] = useState<Setores.Setor[]>([])
+  const [loading, setLoading] = useState(true)
+  const [semPermissao, setSemPermissao] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const drill = useDashboardDrilldown()
+  const [reloadKey, setReloadKey] = useState(0)
+
+  const aplicarPreset = useCallback(
+    (p: Exclude<PresetPeriodo, 'custom'>) => {
+      setPreset(p)
+      const fim = new Date()
+      setAte(isoDate(fim))
+      setDe(isoDate(addDays(fim, -PRESET_DIAS[p])))
+    },
+    [],
+  )
+
+  useEffect(() => {
+    Promise.all([
+      redes.list({ limit: 100, ordenar_por: 'nome', ordem: 'asc' }),
+      setores.list({ limit: 100, ordenar_por: 'nome', ordem: 'asc' }),
+    ])
+      .then(([r, s]) => {
+        setRedesLista(r.items)
+        setSetoresLista(s.items)
+      })
+      .catch(() => {
+        /* filtros opcionais */
+      })
+  }, [])
+
+  useEffect(() => {
+    dashboard.getGeral().then((g) => setSnapshot(snapshotFromGeral(g))).catch(() => undefined)
+  }, [reloadKey])
+
+  useEffect(() => {
+    setLoading(true)
+    setError(null)
+    setSemPermissao(false)
+    dashboard
+      .getTickets({
+        de,
+        ate,
+        rede_id: redeId === '' ? undefined : redeId,
+        setor_id: setorId === '' ? undefined : setorId,
+        prioridade: prioridade || undefined,
+        ...drill.apiParams,
+      })
+      .then(setData)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setSemPermissao(true)
+          toast.showWarning(err.message || 'Você não tem permissão para ver este dashboard.')
+          return
+        }
+        const m = interpretarFalhaCarregamento(err, 'Não encontramos os dados do dashboard de tickets.')
+        setError(m.titulo)
+        toast.showError(mensagemFalhaParaToast(m))
+      })
+      .finally(() => setLoading(false))
+  }, [de, ate, redeId, setorId, prioridade, drill.apiParams, reloadKey, toast])
+
+  const atendentesChart = useMemo(
+    () => (data?.por_atendente ?? []).map((a) => ({ id: a.id, nome: a.nome, total: a.total })),
+    [data],
+  )
+
+  const relatorioHref = useMemo(() => {
+    const params = new URLSearchParams()
+    if (de) params.set('de', de)
+    if (ate) params.set('ate', ate)
+    if (redeId !== '') params.set('rede_id', String(redeId))
+    if (setorId !== '') params.set('setor_id', String(setorId))
+    if (prioridade) params.set('prioridade', prioridade)
+    const qs = params.toString()
+    return qs ? `/relatorios/tickets?${qs}` : '/relatorios/tickets'
+  }, [de, ate, redeId, setorId, prioridade])
+
+  const volumeChart = useMemo(
+    () =>
+      (data?.volume_por_dia ?? []).map((d) => ({
+        ...d,
+        label: formatarDiaCurto(d.dia),
+      })),
+    [data],
+  )
+
+  const prioridadeChart = useMemo(
+    () =>
+      (data?.por_prioridade ?? [])
+        .filter((p) => p.total > 0)
+        .map((p) => ({
+          nome: labelPrioridade(p.prioridade),
+          prioridade: p.prioridade,
+          total: p.total,
+          fill: CORES_PRIORIDADE[p.prioridade] ?? '#64748b',
+        })),
+    [data],
+  )
+
+  const statusChart = useMemo(
+    () => (data?.por_status ?? []).map((s) => ({ id: s.id, nome: s.nome, total: s.total })),
+    [data],
+  )
+
+  const motivoChart = useMemo(
+    () => (data?.por_motivo ?? []).map((m) => ({ id: m.id, nome: m.nome, total: m.total })),
+    [data],
+  )
+
+  const redeChart = useMemo(
+    () => (data?.por_rede ?? []).map((r) => ({ id: r.id, nome: r.nome, total: r.total })),
+    [data],
+  )
+
+  const empresaChart = useMemo(
+    () => (data?.por_empresa ?? []).map((e) => ({ id: e.id, nome: e.nome, total: e.total })),
+    [data],
+  )
+
+  const canalChart = useMemo(
+    () => (data?.por_canal ?? []).map((c) => ({ nome: c.rotulo, canal: c.canal, total: c.total })),
+    [data],
+  )
+
+  const csatChart = useMemo(() => {
+    if (!data?.csat.por_nota) return []
+    return [1, 2, 3, 4, 5].map((n) => ({
+      nota: `${n}★`,
+      notaValor: String(n),
+      total: data.csat.por_nota[String(n)] ?? 0,
+    }))
+  }, [data])
+
+  const semDados =
+    data != null &&
+    data.volume_por_dia.every((d) => d.abertos === 0 && d.fechados === 0) &&
+    data.por_status.length === 0
+
+  if (loading && !data) {
+    return <DashboardTicketsSkeleton />
+  }
+
+  if (semPermissao) {
+    return (
+      <PageContainer>
+        <SemPermissao
+          title="Você não tem permissão para acessar o dashboard de tickets."
+          voltarPara="/"
+          voltarLabel="Voltar ao dashboard"
+        />
+      </PageContainer>
+    )
+  }
+
+  if (error && !data) {
+    return (
+      <PageContainer className="flex flex-col items-center gap-4 py-16 text-center">
+        <p className="text-slate-600 dark:text-slate-300">{error}</p>
+        <Button type="button" onClick={() => setReloadKey((k) => k + 1)}>
+          Tentar novamente
+        </Button>
+      </PageContainer>
+    )
+  }
+
+  if (!data) return null
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Dashboard — Tickets"
+        subtitle={`Indicadores de atendimento · ${formatarDiaCurto(data.de)} a ${formatarDiaCurto(data.ate)}`}
+      />
+
+      <DashboardNav
+        actions={
+          <>
+            <Link to="/tickets/novo">
+              <Button>Novo ticket</Button>
+            </Link>
+            {user?.role === 'admin' ? (
+              <Link to={relatorioHref}>
+                <Button variant="secondary">Exportar planilha</Button>
+              </Link>
+            ) : null}
+          </>
+        }
+      />
+
+      {snapshot ? <DashboardCanalComparativo snapshot={snapshot} /> : null}
+
+      {drill.rotuloFiltro ? (
+        <DashboardFiltroAtivo rotulo={drill.rotuloFiltro} onLimpar={drill.limpar} />
+      ) : null}
+
+      <Card className="mb-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap lg:items-end">
+          <div className="flex flex-wrap gap-2">
+            {(['7', '30', '90'] as const).map((p) => (
+              <Button
+                key={p}
+                type="button"
+                variant={preset === p ? 'primary' : 'secondary'}
+                onClick={() => aplicarPreset(p)}
+              >
+                {p} dias
+              </Button>
+            ))}
+            <Button
+              type="button"
+              variant={preset === 'custom' ? 'primary' : 'secondary'}
+              onClick={() => setPreset('custom')}
+            >
+              Personalizado
+            </Button>
+          </div>
+          {preset === 'custom' ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+                De
+                <input
+                  type="date"
+                  value={de}
+                  onChange={(e) => setDe(e.target.value)}
+                  className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+                Até
+                <input
+                  type="date"
+                  value={ate}
+                  onChange={(e) => setAte(e.target.value)}
+                  className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+                />
+              </label>
+            </div>
+          ) : null}
+          <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+            Rede
+            <select
+              value={redeId}
+              onChange={(e) => setRedeId(e.target.value ? Number(e.target.value) : '')}
+              className="min-w-[10rem] rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+            >
+              <option value="">Todas</option>
+              {redesLista.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.nome}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+            Setor
+            <select
+              value={setorId}
+              onChange={(e) => setSetorId(e.target.value ? Number(e.target.value) : '')}
+              className="min-w-[10rem] rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+            >
+              <option value="">Todos</option>
+              {setoresLista.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.nome}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+            Prioridade
+            <select
+              value={prioridade}
+              onChange={(e) => setPrioridade(e.target.value)}
+              className="min-w-[10rem] rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+            >
+              {PRIORIDADES.map((p) => (
+                <option key={p.value || 'todas'} value={p.value}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </Card>
+
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <MetricCard
+          label="Tempo médio de resolução"
+          dica="Quanto tempo, em média, leva para encerrar um ticket — da abertura até o fechamento. Considera apenas tickets encerrados no período selecionado."
+          value={formatarHoras(data.mttr_horas)}
+          hint="Da abertura até o encerramento"
+          borderClass="border-l-4 border-l-cyan-500"
+        />
+        <MetricCard
+          label="Espera na fila"
+          dica="Tempo médio que o ticket ficou aguardando até receber o primeiro atendente responsável."
+          value={formatarHoras(data.fila_tempo_medio_horas)}
+          hint="Até o primeiro responsável"
+          borderClass="border-l-4 border-l-amber-400"
+        />
+        <MetricCard
+          label="Satisfação do cliente"
+          dica="Nota média de 1 a 5 estrelas que os clientes deram após o atendimento do ticket (CSAT)."
+          hint={
+            data.csat.total_avaliacoes === 0
+              ? 'Nenhuma avaliação no período'
+              : `${data.csat.total_avaliacoes} ${data.csat.total_avaliacoes === 1 ? 'avaliação' : 'avaliações'} no período`
+          }
+          borderClass="border-l-4 border-l-violet-400"
+        >
+          <div className="mt-2">
+            <NotaEstrelasMedia media={data.csat.media} size="md" />
+          </div>
+        </MetricCard>
+      </div>
+
+      {semDados ? (
+        <Card>
+          <p className="text-center text-slate-500 dark:text-slate-400">
+            Nenhum ticket no período selecionado. Ajuste os filtros ou abra tickets para ver métricas aqui.
+          </p>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+          <Card
+            title="Volume por dia"
+            description="Quantidade de tickets abertos e encerrados em cada dia do período"
+          >
+            <div className="h-72">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={volumeChart}>
+                  <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                  <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+                  <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                  <Tooltip {...chartTooltipProps} />
+                  <Legend />
+                  <Line type="monotone" dataKey="abertos" name="Abertos" stroke="#06b6d4" strokeWidth={2} dot={false} />
+                  <Line type="monotone" dataKey="fechados" name="Fechados" stroke="#64748b" strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          </Card>
+
+          <Card
+            title="Tickets abertos por status"
+            description="Clique em um status para filtrar os demais gráficos e indicadores"
+          >
+            <div className="h-72">
+              {statusChart.length === 0 ? (
+                <p className="text-slate-500 dark:text-slate-400">Nenhum ticket aberto.</p>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={statusChart} layout="vertical" margin={{ left: 8 }}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                    <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} />
+                    <YAxis type="category" dataKey="nome" width={120} tick={{ fontSize: 11 }} />
+                    <Tooltip {...chartTooltipProps} />
+                    <Bar
+                      dataKey="total"
+                      name="Tickets"
+                      radius={[0, 4, 4, 0]}
+                      {...barClickableProps}
+                      onClick={(bar) => {
+                        const p = bar?.payload as { id?: number; nome?: string }
+                        if (p?.id != null && p.nome) drill.toggle('status', String(p.id), p.nome)
+                      }}
+                    >
+                      {statusChart.map((entry) => (
+                        <Cell
+                          key={entry.id}
+                          fill={corDrill('#06b6d4', drill.isSelected('status', String(entry.id)), drill.hasSelection)}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+          </Card>
+
+          <Card
+            title="Tickets abertos por prioridade"
+            description="Clique em uma prioridade para filtrar os demais gráficos e indicadores"
+          >
+            <div className="h-72">
+              {prioridadeChart.length === 0 ? (
+                <p className="text-slate-500 dark:text-slate-400">Nenhum ticket aberto.</p>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={prioridadeChart}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                    <XAxis dataKey="nome" tick={{ fontSize: 11 }} />
+                    <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                    <Tooltip {...chartTooltipProps} />
+                    <Bar
+                      dataKey="total"
+                      name="Tickets"
+                      radius={[4, 4, 0, 0]}
+                      {...barClickableProps}
+                      onClick={(bar) => {
+                        const p = bar?.payload as { prioridade?: string; nome?: string }
+                        if (p?.prioridade && p.nome) drill.toggle('prioridade', p.prioridade, p.nome)
+                      }}
+                    >
+                      {prioridadeChart.map((entry) => (
+                        <Cell
+                          key={entry.prioridade}
+                          fill={corDrill(
+                            entry.fill,
+                            drill.isSelected('prioridade', entry.prioridade),
+                            drill.hasSelection,
+                          )}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+          </Card>
+
+          <Card
+            title="Motivos mais frequentes"
+            description="Clique em um motivo para filtrar os demais gráficos e indicadores"
+          >
+            <div className="h-72">
+              {motivoChart.length === 0 ? (
+                <p className="text-slate-500 dark:text-slate-400">Sem dados de motivo.</p>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={motivoChart} layout="vertical" margin={{ left: 8 }}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                    <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} />
+                    <YAxis type="category" dataKey="nome" width={120} tick={{ fontSize: 11 }} />
+                    <Tooltip {...chartTooltipProps} />
+                    <Bar
+                      dataKey="total"
+                      name="Tickets"
+                      radius={[0, 4, 4, 0]}
+                      {...barClickableProps}
+                      onClick={(bar) => {
+                        const p = bar?.payload as { id?: number; nome?: string }
+                        if (p?.id != null && p.nome) drill.toggle('motivo', String(p.id), p.nome)
+                      }}
+                    >
+                      {motivoChart.map((entry) => (
+                        <Cell
+                          key={entry.id}
+                          fill={corDrill('#8b5cf6', drill.isSelected('motivo', String(entry.id)), drill.hasSelection)}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+          </Card>
+
+          <Card
+            title="Redes com mais tickets"
+            description="Clique em uma rede para filtrar os demais gráficos e indicadores"
+          >
+            <div className="h-72">
+              {redeChart.length === 0 ? (
+                <p className="text-slate-500 dark:text-slate-400">Sem dados de rede.</p>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={redeChart} layout="vertical" margin={{ left: 8 }}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                    <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} />
+                    <YAxis type="category" dataKey="nome" width={120} tick={{ fontSize: 11 }} />
+                    <Tooltip {...chartTooltipProps} />
+                    <Bar
+                      dataKey="total"
+                      name="Tickets"
+                      radius={[0, 4, 4, 0]}
+                      {...barClickableProps}
+                      onClick={(bar) => {
+                        const p = bar?.payload as { id?: number; nome?: string }
+                        if (p?.id != null && p.nome) drill.toggle('rede', String(p.id), p.nome)
+                      }}
+                    >
+                      {redeChart.map((entry) => (
+                        <Cell
+                          key={entry.id}
+                          fill={corDrill('#0ea5e9', drill.isSelected('rede', String(entry.id)), drill.hasSelection)}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+          </Card>
+
+          <Card
+            title="Empresas com mais tickets"
+            description="Clique em uma empresa para filtrar os demais gráficos e indicadores"
+          >
+            <div className="h-72">
+              {empresaChart.length === 0 ? (
+                <p className="text-slate-500 dark:text-slate-400">Sem dados de empresa.</p>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={empresaChart} layout="vertical" margin={{ left: 8 }}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                    <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} />
+                    <YAxis type="category" dataKey="nome" width={120} tick={{ fontSize: 11 }} />
+                    <Tooltip {...chartTooltipProps} />
+                    <Bar
+                      dataKey="total"
+                      name="Tickets"
+                      radius={[0, 4, 4, 0]}
+                      {...barClickableProps}
+                      onClick={(bar) => {
+                        const p = bar?.payload as { id?: number; nome?: string }
+                        if (p?.id != null && p.nome) drill.toggle('empresa', String(p.id), p.nome)
+                      }}
+                    >
+                      {empresaChart.map((entry) => (
+                        <Cell
+                          key={entry.id}
+                          fill={corDrill('#6366f1', drill.isSelected('empresa', String(entry.id)), drill.hasSelection)}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+          </Card>
+
+          <Card
+            title="Como o ticket foi aberto"
+            description="Clique em uma origem para filtrar os demais gráficos e indicadores"
+          >
+            <div className="h-72">
+              {canalChart.length === 0 ? (
+                <p className="text-slate-500 dark:text-slate-400">Sem dados.</p>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={canalChart}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                    <XAxis dataKey="nome" tick={{ fontSize: 11 }} />
+                    <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                    <Tooltip {...chartTooltipProps} />
+                    <Bar
+                      dataKey="total"
+                      name="Tickets"
+                      radius={[4, 4, 0, 0]}
+                      fill="#10b981"
+                      {...barClickableProps}
+                      onClick={(bar) => {
+                        const p = bar?.payload as { canal?: string; nome?: string }
+                        if (p?.canal && p.nome) drill.toggle('canal', p.canal, p.nome)
+                      }}
+                    >
+                      {canalChart.map((entry) => (
+                        <Cell
+                          key={entry.canal}
+                          fill={corDrill('#10b981', drill.isSelected('canal', entry.canal), drill.hasSelection)}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+          </Card>
+
+          <Card
+            title="Distribuição das avaliações"
+            description="Clique em uma nota para filtrar os demais gráficos e indicadores"
+          >
+            <div className="h-72">
+              {data.csat.total_avaliacoes === 0 ? (
+                <p className="text-slate-500 dark:text-slate-400">Sem avaliações no período.</p>
+              ) : (
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={csatChart}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                    <XAxis dataKey="nota" tick={{ fontSize: 11 }} />
+                    <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                    <Tooltip {...chartTooltipProps} />
+                    <Bar
+                      dataKey="total"
+                      name="Avaliações"
+                      radius={[4, 4, 0, 0]}
+                      {...barClickableProps}
+                      onClick={(bar) => {
+                        const p = bar?.payload as { notaValor?: string; nota?: string }
+                        if (p?.notaValor && p.nota) drill.toggle('nota', p.notaValor, p.nota)
+                      }}
+                    >
+                      {csatChart.map((entry) => (
+                        <Cell
+                          key={entry.notaValor}
+                          fill={corDrill('#ec4899', drill.isSelected('nota', entry.notaValor), drill.hasSelection)}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              )}
+            </div>
+          </Card>
+
+          {user?.role === 'admin' && atendentesChart.length > 0 ? (
+            <Card
+              title="Atendentes com mais tickets"
+              description="Clique em um atendente para filtrar os demais gráficos e indicadores"
+              className="xl:col-span-2"
+            >
+              <div className="h-80">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={atendentesChart} layout="vertical" margin={{ left: 8 }}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                    <XAxis type="number" allowDecimals={false} tick={{ fontSize: 11 }} />
+                    <YAxis type="category" dataKey="nome" width={140} tick={{ fontSize: 11 }} />
+                    <Tooltip {...chartTooltipProps} />
+                    <Bar
+                      dataKey="total"
+                      name="Tickets"
+                      radius={[0, 4, 4, 0]}
+                      {...barClickableProps}
+                      onClick={(bar) => {
+                        const p = bar?.payload as { id?: number; nome?: string }
+                        if (p?.id != null && p.nome) drill.toggle('atendente', String(p.id), p.nome)
+                      }}
+                    >
+                      {atendentesChart.map((entry) => (
+                        <Cell
+                          key={entry.id}
+                          fill={corDrill(
+                            '#06b6d4',
+                            drill.isSelected('atendente', String(entry.id)),
+                            drill.hasSelection,
+                          )}
+                        />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
+          ) : null}
+        </div>
+      )}
+    </PageContainer>
+  )
+}

--- a/frontend/src/pages/RelatoriosTickets.tsx
+++ b/frontend/src/pages/RelatoriosTickets.tsx
@@ -1,0 +1,275 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { ApiError, redes, relatorios, setores, type Redes, type Relatorios, type Setores } from '../api/client'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { PageContainer, PageHeader } from '../components/ui/PageContainer'
+import { useToast } from '../components/ui/Toast'
+import { SemPermissao } from './SemPermissao'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
+
+const PRIORIDADES = [
+  { value: '', label: 'Todas' },
+  { value: 'baixa', label: 'Baixa' },
+  { value: 'normal', label: 'Normal' },
+  { value: 'alta', label: 'Alta' },
+  { value: 'urgente', label: 'Urgente' },
+]
+
+function formatarData(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleString('pt-BR')
+  } catch {
+    return iso
+  }
+}
+
+export function RelatoriosTickets() {
+  const toast = useToast()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const [de, setDe] = useState(searchParams.get('de') ?? '')
+  const [ate, setAte] = useState(searchParams.get('ate') ?? '')
+  const [redeId, setRedeId] = useState<number | ''>(() => {
+    const v = searchParams.get('rede_id')
+    return v ? Number(v) : ''
+  })
+  const [setorId, setSetorId] = useState<number | ''>(() => {
+    const v = searchParams.get('setor_id')
+    return v ? Number(v) : ''
+  })
+  const [prioridade, setPrioridade] = useState(searchParams.get('prioridade') ?? '')
+  const [data, setData] = useState<Relatorios.TicketsResponse | null>(null)
+  const [redesLista, setRedesLista] = useState<Redes.Rede[]>([])
+  const [setoresLista, setSetoresLista] = useState<Setores.Setor[]>([])
+  const [loading, setLoading] = useState(true)
+  const [exportando, setExportando] = useState(false)
+  const [semPermissao, setSemPermissao] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const filtrosApi = useMemo(
+    () => ({
+      de: de || undefined,
+      ate: ate || undefined,
+      rede_id: redeId === '' ? undefined : redeId,
+      setor_id: setorId === '' ? undefined : setorId,
+      prioridade: prioridade || undefined,
+    }),
+    [de, ate, redeId, setorId, prioridade],
+  )
+
+  useEffect(() => {
+    Promise.all([
+      redes.list({ limit: 200, ordenar_por: 'nome', ordem: 'asc' }),
+      setores.list({ limit: 200, ordenar_por: 'nome', ordem: 'asc' }),
+    ])
+      .then(([r, s]) => {
+        setRedesLista(r.items)
+        setSetoresLista(s.items)
+      })
+      .catch(() => undefined)
+  }, [])
+
+  const carregar = useCallback(() => {
+    setLoading(true)
+    setError(null)
+    setSemPermissao(false)
+    relatorios
+      .tickets(filtrosApi)
+      .then(setData)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setSemPermissao(true)
+          return
+        }
+        const m = interpretarFalhaCarregamento(err, 'Não foi possível carregar o relatório.')
+        setError(m.titulo)
+        toast.showError(mensagemFalhaParaToast(m))
+      })
+      .finally(() => setLoading(false))
+  }, [filtrosApi, toast])
+
+  useEffect(() => {
+    carregar()
+  }, [carregar])
+
+  const aplicarFiltros = () => {
+    const params = new URLSearchParams()
+    if (de) params.set('de', de)
+    if (ate) params.set('ate', ate)
+    if (redeId !== '') params.set('rede_id', String(redeId))
+    if (setorId !== '') params.set('setor_id', String(setorId))
+    if (prioridade) params.set('prioridade', prioridade)
+    setSearchParams(params, { replace: true })
+    carregar()
+  }
+
+  const exportarCsv = async () => {
+    setExportando(true)
+    try {
+      const blob = await relatorios.exportTicketsCsv(filtrosApi)
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `relatorio-tickets-${ate || 'periodo'}.csv`
+      a.click()
+      URL.revokeObjectURL(url)
+      toast.showSuccess('CSV exportado com sucesso.')
+    } catch (err) {
+      const m = interpretarFalhaCarregamento(err, 'Falha ao exportar CSV.')
+      toast.showError(mensagemFalhaParaToast(m))
+    } finally {
+      setExportando(false)
+    }
+  }
+
+  if (semPermissao) {
+    return (
+      <PageContainer>
+        <SemPermissao
+          title="Relatórios de tickets são exclusivos para administradores."
+          voltarPara="/dashboard/tickets"
+          voltarLabel="Voltar ao dashboard de tickets"
+        />
+      </PageContainer>
+    )
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Relatório — Tickets"
+        subtitle="Pré-visualização e exportação CSV (admin)"
+        actions={
+          <div className="flex flex-wrap gap-2">
+            <Link to="/dashboard/tickets">
+              <Button variant="secondary">Dashboard tickets</Button>
+            </Link>
+            <Button type="button" loading={exportando} onClick={exportarCsv}>
+              Exportar CSV
+            </Button>
+          </div>
+        }
+      />
+
+      <Card className="mb-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap lg:items-end">
+          <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+            De
+            <input
+              type="date"
+              value={de}
+              onChange={(e) => setDe(e.target.value)}
+              className="rounded-lg border border-slate-300 bg-white px-3 py-2 dark:border-slate-600 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+            Até
+            <input
+              type="date"
+              value={ate}
+              onChange={(e) => setAte(e.target.value)}
+              className="rounded-lg border border-slate-300 bg-white px-3 py-2 dark:border-slate-600 dark:bg-slate-800"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+            Rede
+            <select
+              value={redeId}
+              onChange={(e) => setRedeId(e.target.value ? Number(e.target.value) : '')}
+              className="min-w-[10rem] rounded-lg border border-slate-300 bg-white px-3 py-2 dark:border-slate-600 dark:bg-slate-800"
+            >
+              <option value="">Todas</option>
+              {redesLista.map((r) => (
+                <option key={r.id} value={r.id}>
+                  {r.nome}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+            Setor
+            <select
+              value={setorId}
+              onChange={(e) => setSetorId(e.target.value ? Number(e.target.value) : '')}
+              className="min-w-[10rem] rounded-lg border border-slate-300 bg-white px-3 py-2 dark:border-slate-600 dark:bg-slate-800"
+            >
+              <option value="">Todos</option>
+              {setoresLista.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.nome}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+            Prioridade
+            <select
+              value={prioridade}
+              onChange={(e) => setPrioridade(e.target.value)}
+              className="min-w-[10rem] rounded-lg border border-slate-300 bg-white px-3 py-2 dark:border-slate-600 dark:bg-slate-800"
+            >
+              {PRIORIDADES.map((p) => (
+                <option key={p.value || 'todas'} value={p.value}>
+                  {p.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <Button type="button" onClick={aplicarFiltros}>
+            Aplicar filtros
+          </Button>
+        </div>
+      </Card>
+
+      {loading ? (
+        <Card>
+          <p className="text-slate-500 dark:text-slate-400">Carregando…</p>
+        </Card>
+      ) : error ? (
+        <Card>
+          <p className="text-slate-600 dark:text-slate-300">{error}</p>
+        </Card>
+      ) : data ? (
+        <Card title={`Pré-visualização (${data.itens.length} de ${data.total} tickets)`}>
+          {data.itens.length === 0 ? (
+            <p className="text-slate-500 dark:text-slate-400">Nenhum ticket no período/filtros selecionados.</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[960px] text-left text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                    <th className="px-2 py-2">Protocolo</th>
+                    <th className="px-2 py-2">Assunto</th>
+                    <th className="px-2 py-2">Status</th>
+                    <th className="px-2 py-2">Prioridade</th>
+                    <th className="px-2 py-2">Rede</th>
+                    <th className="px-2 py-2">Empresa</th>
+                    <th className="px-2 py-2">Setor</th>
+                    <th className="px-2 py-2">Aberto</th>
+                    <th className="px-2 py-2">Canal</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.itens.map((row) => (
+                    <tr key={row.protocolo} className="border-b border-slate-100 dark:border-slate-800">
+                      <td className="px-2 py-2 font-medium">{row.protocolo}</td>
+                      <td className="max-w-xs truncate px-2 py-2">{row.assunto}</td>
+                      <td className="px-2 py-2">{row.status_nome}</td>
+                      <td className="px-2 py-2 capitalize">{row.prioridade}</td>
+                      <td className="px-2 py-2">{row.rede_nome || '—'}</td>
+                      <td className="px-2 py-2">{row.empresa_nome || '—'}</td>
+                      <td className="px-2 py-2">{row.setor_nome}</td>
+                      <td className="whitespace-nowrap px-2 py-2">{formatarData(row.aberto_em)}</td>
+                      <td className="px-2 py-2">{row.canal}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
+      ) : null}
+    </PageContainer>
+  )
+}


### PR DESCRIPTION
## Summary

- **D-F2 (#283 / #287):** API `GET /dashboard/tickets` e `GET /relatorios/tickets` (JSON + CSV admin), pagina `/dashboard/tickets` com graficos Recharts, filtros de periodo/rede/setor/prioridade e exportacao de planilha.
- **D-F3 (#284 / #288):** API `GET /dashboard/chats`, pagina `/dashboard/chats` com metricas de fila, duracao, CSAT e encerramentos.
- **Visao geral:** dashboard `/` equilibrado entre tickets e WhatsApp (cards, breakdowns e ultimas conversas), navegacao unificada, comparativo de canais, estrelas de satisfacao parciais e cross-filter interativo entre todos os graficos.

Closes #283, #287, #284, #288

## Test plan

- [ ] Subir stack (`docker compose up`) e validar `/dashboard`, `/dashboard/tickets`, `/dashboard/chats`
- [ ] Clicar em barras dos graficos e confirmar cross-filter e banner de filtro ativo
- [ ] Admin: exportar CSV em `/relatorios/tickets` e botao no header do dashboard tickets
- [ ] Rodar `pytest tests/test_dashboard_tickets.py tests/test_dashboard_chats.py tests/test_relatorio_tickets.py`
- [ ] Verificar CI verde apos merge

## Fora de escopo neste PR

- D-F4 (#285 / #289) — dashboard de produtividade por atendente permanece pendente no epico #260
