### PR TITLE
feat(relatorios): exportacao de chats WhatsApp e abas na UI (D-F4)

### DIFF
--- a/backend/app/api/relatorios.py
+++ b/backend/app/api/relatorios.py
@@ -8,6 +8,11 @@ from app.core.auth import exigir_admin
 from app.database import get_db
 from app.models.atendente import Atendente
 from app.schemas.relatorio import RelatorioTicketsResponse
+from app.services.relatorio_chats import (
+    PREVIEW_LIMIT as PREVIEW_LIMIT_CHATS,
+    exportar_relatorio_chats_csv,
+    listar_relatorio_chats,
+)
 from app.services.relatorio_tickets import (
     PREVIEW_LIMIT,
     exportar_relatorio_tickets_csv,
@@ -72,6 +77,52 @@ def relatorio_tickets(
         rede_id=rede_id,
         setor_id=setor_id,
         prioridade=prio,
+        offset=offset,
+        limit=limit,
+    )
+
+
+@router.get(
+    "/chats",
+    summary="Relatório tabular de chats WhatsApp (pré-visualização ou CSV)",
+    description="Lista paginada de chats no período (mesmos filtros do dashboard). "
+    "Admin-only. Use `format=csv` para exportação (UTF-8 BOM, até 50k linhas).",
+)
+def relatorio_chats(
+    de: date | None = Query(None),
+    ate: date | None = Query(None),
+    setor_id: int | None = Query(None, ge=1),
+    atendente_filtro_id: int | None = Query(None, ge=1),
+    format: str | None = Query(None, alias="format"),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(PREVIEW_LIMIT_CHATS, ge=1, le=PREVIEW_LIMIT_CHATS),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    if format == "csv":
+        conteudo = exportar_relatorio_chats_csv(
+            db,
+            atendente,
+            de=de,
+            ate=ate,
+            setor_id=setor_id,
+            atendente_filtro_id=atendente_filtro_id,
+        )
+        nome = f"relatorio-chats-{date.today().isoformat()}.csv"
+        return PlainTextResponse(
+            content=conteudo,
+            media_type="text/csv; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{nome}"'},
+        )
+    if format is not None:
+        raise HTTPException(status_code=422, detail="format suportado: csv")
+    return listar_relatorio_chats(
+        db,
+        atendente,
+        de=de,
+        ate=ate,
+        setor_id=setor_id,
+        atendente_filtro_id=atendente_filtro_id,
         offset=offset,
         limit=limit,
     )

--- a/backend/app/schemas/relatorio.py
+++ b/backend/app/schemas/relatorio.py
@@ -24,3 +24,27 @@ class RelatorioTicketsResponse(BaseModel):
     offset: int = Field(ge=0)
     limit: int = Field(ge=1)
     itens: list[RelatorioTicketLinha]
+
+
+class RelatorioChatLinha(BaseModel):
+    protocolo: str
+    cliente_nome: str | None = None
+    wa_id: str
+    estado: str
+    estado_rotulo: str
+    setor_nome: str
+    atendente_nome: str
+    empresa_nome: str
+    aberto_em: datetime | None = None
+    inicio_atendimento: datetime | None = None
+    encerrado_em: datetime | None = None
+    avaliacao_nota: int | None = None
+
+
+class RelatorioChatsResponse(BaseModel):
+    de: date
+    ate: date
+    total: int = Field(ge=0)
+    offset: int = Field(ge=0)
+    limit: int = Field(ge=1)
+    itens: list[RelatorioChatLinha]

--- a/backend/app/services/relatorio_chats.py
+++ b/backend/app/services/relatorio_chats.py
@@ -1,0 +1,171 @@
+"""Relatório tabular de chats WhatsApp (#285 / D-F4)."""
+
+from __future__ import annotations
+
+import csv
+import io
+from datetime import date
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.atendente import Atendente
+from app.models.whatsapp_chat import WhatsappChat
+from app.schemas.relatorio import RelatorioChatLinha, RelatorioChatsResponse
+from app.services.chat_dashboard_filters import (
+    apply_chat_dashboard_filters,
+    period_bounds,
+    resolve_period,
+)
+
+MAX_EXPORT_ROWS = 50_000
+PREVIEW_LIMIT = 50
+
+_CSV_HEADERS = (
+    "protocolo",
+    "cliente_nome",
+    "wa_id",
+    "estado",
+    "setor",
+    "atendente",
+    "empresa",
+    "aberto_em",
+    "inicio_atendimento",
+    "encerrado_em",
+    "avaliacao_nota",
+)
+
+_ESTADO_ROTULOS = {
+    "aguardando_atendente": "Aguardando atendente",
+    "em_atendimento": "Em atendimento",
+    "aguardando_avaliacao": "Aguardando avaliação",
+    "encerrado": "Encerrado",
+}
+
+
+def _estado_rotulo(estado: str) -> str:
+    return _ESTADO_ROTULOS.get(estado, estado.replace("_", " ").title())
+
+
+def _chat_para_linha(chat: WhatsappChat) -> RelatorioChatLinha:
+    return RelatorioChatLinha(
+        protocolo=chat.protocolo,
+        cliente_nome=chat.cliente_nome,
+        wa_id=chat.wa_id,
+        estado=chat.estado,
+        estado_rotulo=_estado_rotulo(chat.estado),
+        setor_nome=chat.setor.nome if chat.setor else "",
+        atendente_nome=chat.atendente.nome if chat.atendente else "",
+        empresa_nome=chat.empresa.nome if chat.empresa else "",
+        aberto_em=chat.created_at,
+        inicio_atendimento=chat.atendimento_inicio_at,
+        encerrado_em=chat.encerramento_at,
+        avaliacao_nota=chat.avaliacao_nota,
+    )
+
+
+def _load_options(stmt):
+    return stmt.options(
+        joinedload(WhatsappChat.setor),
+        joinedload(WhatsappChat.atendente),
+        joinedload(WhatsappChat.empresa),
+    )
+
+
+def listar_relatorio_chats(
+    db: Session,
+    atendente: Atendente,
+    *,
+    de: date | None = None,
+    ate: date | None = None,
+    setor_id: int | None = None,
+    atendente_filtro_id: int | None = None,
+    offset: int = 0,
+    limit: int = PREVIEW_LIMIT,
+) -> RelatorioChatsResponse:
+    inicio, fim = resolve_period(de, ate)
+    de_dt, ate_dt = period_bounds(inicio, fim)
+    filtros = {
+        "setor_id": setor_id,
+        "atendente_id": atendente_filtro_id,
+    }
+
+    count_stmt = select(func.count()).select_from(WhatsappChat).where(
+        WhatsappChat.created_at >= de_dt,
+        WhatsappChat.created_at < ate_dt,
+    )
+    count_stmt = apply_chat_dashboard_filters(count_stmt, db, atendente, **filtros)
+    total = int(db.execute(count_stmt).scalar_one())
+
+    stmt = (
+        select(WhatsappChat)
+        .where(WhatsappChat.created_at >= de_dt, WhatsappChat.created_at < ate_dt)
+        .order_by(WhatsappChat.created_at.desc(), WhatsappChat.id.desc())
+    )
+    stmt = apply_chat_dashboard_filters(stmt, db, atendente, **filtros)
+    rows = (
+        db.execute(
+            _load_options(stmt)
+            .offset(max(0, offset))
+            .limit(min(max(1, limit), PREVIEW_LIMIT))
+        )
+        .unique()
+        .scalars()
+        .all()
+    )
+    return RelatorioChatsResponse(
+        de=inicio,
+        ate=fim,
+        total=total,
+        offset=max(0, offset),
+        limit=min(max(1, limit), PREVIEW_LIMIT),
+        itens=[_chat_para_linha(c) for c in rows],
+    )
+
+
+def exportar_relatorio_chats_csv(
+    db: Session,
+    atendente: Atendente,
+    *,
+    de: date | None = None,
+    ate: date | None = None,
+    setor_id: int | None = None,
+    atendente_filtro_id: int | None = None,
+) -> str:
+    inicio, fim = resolve_period(de, ate)
+    de_dt, ate_dt = period_bounds(inicio, fim)
+    filtros = {
+        "setor_id": setor_id,
+        "atendente_id": atendente_filtro_id,
+    }
+    stmt = (
+        select(WhatsappChat)
+        .where(WhatsappChat.created_at >= de_dt, WhatsappChat.created_at < ate_dt)
+        .order_by(WhatsappChat.created_at.desc(), WhatsappChat.id.desc())
+        .limit(MAX_EXPORT_ROWS)
+    )
+    stmt = apply_chat_dashboard_filters(stmt, db, atendente, **filtros)
+    chats = db.execute(_load_options(stmt)).unique().scalars().all()
+
+    buffer = io.StringIO()
+    buffer.write("\ufeff")
+    writer = csv.writer(buffer, lineterminator="\r\n")
+    writer.writerow(_CSV_HEADERS)
+    for chat in chats:
+        linha = _chat_para_linha(chat)
+        writer.writerow(
+            [
+                linha.protocolo,
+                linha.cliente_nome or "",
+                linha.wa_id,
+                linha.estado_rotulo,
+                linha.setor_nome,
+                linha.atendente_nome,
+                linha.empresa_nome,
+                linha.aberto_em.isoformat() if linha.aberto_em else "",
+                linha.inicio_atendimento.isoformat() if linha.inicio_atendimento else "",
+                linha.encerrado_em.isoformat() if linha.encerrado_em else "",
+                linha.avaliacao_nota if linha.avaliacao_nota is not None else "",
+            ]
+        )
+    return buffer.getvalue()

--- a/backend/tests/test_relatorio_chats.py
+++ b/backend/tests/test_relatorio_chats.py
@@ -1,0 +1,60 @@
+"""Testes do relatório de chats WhatsApp (#285 / D-F4)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.models.whatsapp_chat import WhatsappChat
+
+
+def _criar_chat(db_session, seed_base):
+    agora = datetime.now(timezone.utc)
+    suf = datetime.now().timestamp()
+    c = WhatsappChat(
+        protocolo=f"RC{suf}",
+        wa_id=f"5511888{suf}",
+        cliente_nome="Cliente relatório",
+        estado="encerrado",
+        setor_id=seed_base["setor1"].id,
+        atendente_id=seed_base["admin"].id,
+        created_at=agora - timedelta(hours=2),
+        atendimento_inicio_at=agora - timedelta(hours=1),
+        encerramento_at=agora,
+        avaliacao_nota=5,
+        avaliacao_respondida_at=agora,
+    )
+    db_session.add(c)
+    db_session.commit()
+    return c
+
+
+def test_relatorio_chats_admin_json(client, seed_base, auth_headers, db_session):
+    _criar_chat(db_session, seed_base)
+    r = client.get("/v1/relatorios/chats", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] >= 1
+    assert len(body["itens"]) >= 1
+    assert body["itens"][0]["protocolo"]
+    assert body["itens"][0]["cliente_nome"] == "Cliente relatório"
+
+
+def test_relatorio_chats_atendente_403(client, seed_base, auth_headers, db_session):
+    _criar_chat(db_session, seed_base)
+    r = client.get("/v1/relatorios/chats", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_relatorio_chats_export_csv(client, seed_base, auth_headers, db_session):
+    _criar_chat(db_session, seed_base)
+    r = client.get(
+        "/v1/relatorios/chats",
+        headers=auth_headers["admin"],
+        params={"format": "csv"},
+    )
+    assert r.status_code == 200
+    assert "text/csv" in r.headers.get("content-type", "")
+    text = r.text
+    assert text.startswith("\ufeff")
+    assert "protocolo" in text
+    assert "Cliente relatório" in text

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { Dashboard } from './pages/Dashboard'
 import { DashboardTickets } from './pages/DashboardTickets'
 import { DashboardChats } from './pages/DashboardChats'
 import { RelatoriosTickets } from './pages/RelatoriosTickets'
+import { RelatoriosChats } from './pages/RelatoriosChats'
 import { Tickets } from './pages/Tickets'
 import { TicketNovo } from './pages/TicketNovo'
 import { TicketDetalhe } from './pages/TicketDetalhe'
@@ -105,6 +106,14 @@ function AppRoutes() {
           element={
             <AdminRoute>
               <RelatoriosTickets />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="relatorios/chats"
+          element={
+            <AdminRoute>
+              <RelatoriosChats />
             </AdminRoute>
           }
         />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1004,6 +1004,38 @@ export const relatorios = {
     }
     return res.blob();
   },
+  chats: (params?: {
+    de?: string;
+    ate?: string;
+    setor_id?: number;
+    atendente_filtro_id?: number;
+    offset?: number;
+    limit?: number;
+  }) => api<Relatorios.ChatsResponse>(withParams('/relatorios/chats', params)),
+  exportChatsCsv: async (params?: {
+    de?: string;
+    ate?: string;
+    setor_id?: number;
+    atendente_filtro_id?: number;
+  }) => {
+    const token = getAuthToken();
+    const headers: Record<string, string> = {};
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname());
+    }
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const url = `${BASE}${API_VERSION_PREFIX}${withParams('/relatorios/chats', { ...params, format: 'csv' })}`;
+    const res = await fetch(url, { headers });
+    if (res.status === 401) {
+      invalidateSessionAndRedirectToLogin();
+      throw new ApiError('Sessão expirada ou inválida.', 401, {});
+    }
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}));
+      throw new ApiError(mensagemErroApi(errBody, res.status), res.status, errBody);
+    }
+    return res.blob();
+  },
 };
 
 export namespace Notificacoes {
@@ -1192,6 +1224,28 @@ export namespace Relatorios {
     offset: number;
     limit: number;
     itens: TicketLinha[];
+  }
+  export interface ChatLinha {
+    protocolo: string;
+    cliente_nome: string | null;
+    wa_id: string;
+    estado: string;
+    estado_rotulo: string;
+    setor_nome: string;
+    atendente_nome: string;
+    empresa_nome: string;
+    aberto_em: string | null;
+    inicio_atendimento: string | null;
+    encerrado_em: string | null;
+    avaliacao_nota: number | null;
+  }
+  export interface ChatsResponse {
+    de: string;
+    ate: string;
+    total: number;
+    offset: number;
+    limit: number;
+    itens: ChatLinha[];
   }
 }
 

--- a/frontend/src/components/relatorios/RelatoriosNav.tsx
+++ b/frontend/src/components/relatorios/RelatoriosNav.tsx
@@ -1,0 +1,34 @@
+import { NavLink } from 'react-router-dom'
+
+const VIEWS = [
+  { id: 'tickets', to: '/relatorios/tickets', label: 'Tickets' },
+  { id: 'chats', to: '/relatorios/chats', label: 'Chats' },
+] as const
+
+const TAB_CLASS =
+  'inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:ring-offset-2 dark:focus:ring-offset-slate-950'
+
+export function RelatoriosNav() {
+  return (
+    <nav
+      className="mb-6 inline-flex flex-wrap gap-1 rounded-xl border border-slate-200 bg-slate-50 p-1 dark:border-slate-700 dark:bg-slate-800/50"
+      aria-label="Navegação entre relatórios"
+    >
+      {VIEWS.map((view) => (
+        <NavLink
+          key={view.id}
+          to={view.to}
+          className={({ isActive }) =>
+            `${TAB_CLASS} ${
+              isActive
+                ? 'bg-gradient-to-r from-cyan-500 to-blue-600 text-slate-950 shadow-sm'
+                : 'text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800'
+            }`
+          }
+        >
+          {view.label}
+        </NavLink>
+      ))}
+    </nav>
+  )
+}

--- a/frontend/src/pages/DashboardChats.tsx
+++ b/frontend/src/pages/DashboardChats.tsx
@@ -72,6 +72,15 @@ export function DashboardChats() {
   const drill = useDashboardDrilldown()
   const [reloadKey, setReloadKey] = useState(0)
 
+  const relatorioHref = useMemo(() => {
+    const params = new URLSearchParams()
+    if (de) params.set('de', de)
+    if (ate) params.set('ate', ate)
+    if (setorId !== '') params.set('setor_id', String(setorId))
+    const qs = params.toString()
+    return qs ? `/relatorios/chats?${qs}` : '/relatorios/chats'
+  }, [de, ate, setorId])
+
   const aplicarPreset = useCallback((p: Exclude<PresetPeriodo, 'custom'>) => {
     setPreset(p)
     const fim = new Date()
@@ -199,6 +208,11 @@ export function DashboardChats() {
             <Link to="/whatsapp/avaliacoes">
               <Button variant="secondary">Ver avaliações</Button>
             </Link>
+            {user?.role === 'admin' ? (
+              <Link to={relatorioHref}>
+                <Button variant="secondary">Exportar planilha</Button>
+              </Link>
+            ) : null}
           </>
         }
       />

--- a/frontend/src/pages/RelatoriosChats.tsx
+++ b/frontend/src/pages/RelatoriosChats.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
-import { ApiError, redes, relatorios, setores, type Redes, type Relatorios, type Setores } from '../api/client'
+import {
+  ApiError,
+  atendentes,
+  relatorios,
+  setores,
+  type Atendentes,
+  type Relatorios,
+  type Setores,
+} from '../api/client'
 import { RelatoriosNav } from '../components/relatorios/RelatoriosNav'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
@@ -8,14 +16,6 @@ import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { useToast } from '../components/ui/Toast'
 import { SemPermissao } from './SemPermissao'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
-
-const PRIORIDADES = [
-  { value: '', label: 'Todas' },
-  { value: 'baixa', label: 'Baixa' },
-  { value: 'normal', label: 'Normal' },
-  { value: 'alta', label: 'Alta' },
-  { value: 'urgente', label: 'Urgente' },
-]
 
 function formatarData(iso: string | null | undefined): string {
   if (!iso) return '—'
@@ -26,23 +26,22 @@ function formatarData(iso: string | null | undefined): string {
   }
 }
 
-export function RelatoriosTickets() {
+export function RelatoriosChats() {
   const toast = useToast()
   const [searchParams, setSearchParams] = useSearchParams()
   const [de, setDe] = useState(searchParams.get('de') ?? '')
   const [ate, setAte] = useState(searchParams.get('ate') ?? '')
-  const [redeId, setRedeId] = useState<number | ''>(() => {
-    const v = searchParams.get('rede_id')
-    return v ? Number(v) : ''
-  })
   const [setorId, setSetorId] = useState<number | ''>(() => {
     const v = searchParams.get('setor_id')
     return v ? Number(v) : ''
   })
-  const [prioridade, setPrioridade] = useState(searchParams.get('prioridade') ?? '')
-  const [data, setData] = useState<Relatorios.TicketsResponse | null>(null)
-  const [redesLista, setRedesLista] = useState<Redes.Rede[]>([])
+  const [atendenteId, setAtendenteId] = useState<number | ''>(() => {
+    const v = searchParams.get('atendente_filtro_id')
+    return v ? Number(v) : ''
+  })
+  const [data, setData] = useState<Relatorios.ChatsResponse | null>(null)
   const [setoresLista, setSetoresLista] = useState<Setores.Setor[]>([])
+  const [atendentesLista, setAtendentesLista] = useState<Atendentes.Atendente[]>([])
   const [loading, setLoading] = useState(true)
   const [exportando, setExportando] = useState(false)
   const [semPermissao, setSemPermissao] = useState(false)
@@ -52,21 +51,20 @@ export function RelatoriosTickets() {
     () => ({
       de: de || undefined,
       ate: ate || undefined,
-      rede_id: redeId === '' ? undefined : redeId,
       setor_id: setorId === '' ? undefined : setorId,
-      prioridade: prioridade || undefined,
+      atendente_filtro_id: atendenteId === '' ? undefined : atendenteId,
     }),
-    [de, ate, redeId, setorId, prioridade],
+    [de, ate, setorId, atendenteId],
   )
 
   useEffect(() => {
     Promise.all([
-      redes.list({ limit: 100, ordenar_por: 'nome', ordem: 'asc' }),
       setores.list({ limit: 100, ordenar_por: 'nome', ordem: 'asc' }),
+      atendentes.list({ limit: 100, ordenar_por: 'nome', ordem: 'asc' }),
     ])
-      .then(([r, s]) => {
-        setRedesLista(r.items)
+      .then(([s, a]) => {
         setSetoresLista(s.items)
+        setAtendentesLista(a.items)
       })
       .catch(() => undefined)
   }, [])
@@ -76,7 +74,7 @@ export function RelatoriosTickets() {
     setError(null)
     setSemPermissao(false)
     relatorios
-      .tickets(filtrosApi)
+      .chats(filtrosApi)
       .then(setData)
       .catch((err) => {
         if (err instanceof ApiError && err.status === 403) {
@@ -98,9 +96,8 @@ export function RelatoriosTickets() {
     const params = new URLSearchParams()
     if (de) params.set('de', de)
     if (ate) params.set('ate', ate)
-    if (redeId !== '') params.set('rede_id', String(redeId))
     if (setorId !== '') params.set('setor_id', String(setorId))
-    if (prioridade) params.set('prioridade', prioridade)
+    if (atendenteId !== '') params.set('atendente_filtro_id', String(atendenteId))
     setSearchParams(params, { replace: true })
     carregar()
   }
@@ -108,11 +105,11 @@ export function RelatoriosTickets() {
   const exportarCsv = async () => {
     setExportando(true)
     try {
-      const blob = await relatorios.exportTicketsCsv(filtrosApi)
+      const blob = await relatorios.exportChatsCsv(filtrosApi)
       const url = URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
-      a.download = `relatorio-tickets-${ate || 'periodo'}.csv`
+      a.download = `relatorio-chats-${ate || 'periodo'}.csv`
       a.click()
       URL.revokeObjectURL(url)
       toast.showSuccess('CSV exportado com sucesso.')
@@ -128,9 +125,9 @@ export function RelatoriosTickets() {
     return (
       <PageContainer>
         <SemPermissao
-          title="Relatórios de tickets são exclusivos para administradores."
-          voltarPara="/dashboard/tickets"
-          voltarLabel="Voltar ao dashboard de tickets"
+          title="Relatórios de chats são exclusivos para administradores."
+          voltarPara="/dashboard/chats"
+          voltarLabel="Voltar ao dashboard de WhatsApp"
         />
       </PageContainer>
     )
@@ -143,8 +140,8 @@ export function RelatoriosTickets() {
         subtitle="Pré-visualização e exportação CSV (admin)"
         actions={
           <div className="flex flex-wrap gap-2">
-            <Link to="/dashboard/tickets">
-              <Button variant="secondary">Dashboard tickets</Button>
+            <Link to="/dashboard/chats">
+              <Button variant="secondary">Dashboard WhatsApp</Button>
             </Link>
             <Button type="button" loading={exportando} onClick={exportarCsv}>
               Exportar CSV
@@ -176,21 +173,6 @@ export function RelatoriosTickets() {
             />
           </label>
           <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
-            Rede
-            <select
-              value={redeId}
-              onChange={(e) => setRedeId(e.target.value ? Number(e.target.value) : '')}
-              className="min-w-[10rem] rounded-lg border border-slate-300 bg-white px-3 py-2 dark:border-slate-600 dark:bg-slate-800"
-            >
-              <option value="">Todas</option>
-              {redesLista.map((r) => (
-                <option key={r.id} value={r.id}>
-                  {r.nome}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
             Setor
             <select
               value={setorId}
@@ -206,15 +188,16 @@ export function RelatoriosTickets() {
             </select>
           </label>
           <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
-            Prioridade
+            Atendente
             <select
-              value={prioridade}
-              onChange={(e) => setPrioridade(e.target.value)}
+              value={atendenteId}
+              onChange={(e) => setAtendenteId(e.target.value ? Number(e.target.value) : '')}
               className="min-w-[10rem] rounded-lg border border-slate-300 bg-white px-3 py-2 dark:border-slate-600 dark:bg-slate-800"
             >
-              {PRIORIDADES.map((p) => (
-                <option key={p.value || 'todas'} value={p.value}>
-                  {p.label}
+              <option value="">Todos</option>
+              {atendentesLista.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.nome}
                 </option>
               ))}
             </select>
@@ -234,37 +217,37 @@ export function RelatoriosTickets() {
           <p className="text-slate-600 dark:text-slate-300">{error}</p>
         </Card>
       ) : data ? (
-        <Card title={`Pré-visualização (${data.itens.length} de ${data.total} tickets)`}>
+        <Card title={`Pré-visualização (${data.itens.length} de ${data.total} chats)`}>
           {data.itens.length === 0 ? (
-            <p className="text-slate-500 dark:text-slate-400">Nenhum ticket no período/filtros selecionados.</p>
+            <p className="text-slate-500 dark:text-slate-400">Nenhum chat no período/filtros selecionados.</p>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full min-w-[960px] text-left text-sm">
                 <thead>
                   <tr className="border-b border-slate-200 text-slate-500 dark:border-slate-700 dark:text-slate-400">
                     <th className="px-2 py-2">Protocolo</th>
-                    <th className="px-2 py-2">Assunto</th>
-                    <th className="px-2 py-2">Status</th>
-                    <th className="px-2 py-2">Prioridade</th>
-                    <th className="px-2 py-2">Rede</th>
-                    <th className="px-2 py-2">Empresa</th>
+                    <th className="px-2 py-2">Cliente</th>
+                    <th className="px-2 py-2">Estado</th>
                     <th className="px-2 py-2">Setor</th>
+                    <th className="px-2 py-2">Atendente</th>
+                    <th className="px-2 py-2">Empresa</th>
                     <th className="px-2 py-2">Aberto</th>
-                    <th className="px-2 py-2">Canal</th>
+                    <th className="px-2 py-2">Encerrado</th>
+                    <th className="px-2 py-2">Nota</th>
                   </tr>
                 </thead>
                 <tbody>
                   {data.itens.map((row) => (
                     <tr key={row.protocolo} className="border-b border-slate-100 dark:border-slate-800">
                       <td className="px-2 py-2 font-medium">{row.protocolo}</td>
-                      <td className="max-w-xs truncate px-2 py-2">{row.assunto}</td>
-                      <td className="px-2 py-2">{row.status_nome}</td>
-                      <td className="px-2 py-2 capitalize">{row.prioridade}</td>
-                      <td className="px-2 py-2">{row.rede_nome || '—'}</td>
+                      <td className="max-w-xs truncate px-2 py-2">{row.cliente_nome || row.wa_id}</td>
+                      <td className="px-2 py-2">{row.estado_rotulo}</td>
+                      <td className="px-2 py-2">{row.setor_nome || '—'}</td>
+                      <td className="px-2 py-2">{row.atendente_nome || '—'}</td>
                       <td className="px-2 py-2">{row.empresa_nome || '—'}</td>
-                      <td className="px-2 py-2">{row.setor_nome}</td>
                       <td className="whitespace-nowrap px-2 py-2">{formatarData(row.aberto_em)}</td>
-                      <td className="px-2 py-2">{row.canal}</td>
+                      <td className="whitespace-nowrap px-2 py-2">{formatarData(row.encerrado_em)}</td>
+                      <td className="px-2 py-2">{row.avaliacao_nota ?? '—'}</td>
                     </tr>
                   ))}
                 </tbody>


### PR DESCRIPTION
## Summary
- Adiciona `GET /v1/relatorios/chats` com pre-visualizacao paginada e export CSV (admin-only)
- UI em `/relatorios/chats` com abas Tickets | Chats, filtros alinhados ao dashboard WhatsApp
- Atalho Exportar planilha no dashboard de chats para admins
- Fecha D-F4 (#285, #289) e conclui epico #260

## Test plan
- [ ] Login admin -> /relatorios/chats -> aplicar filtros e conferir tabela
- [ ] Exportar CSV de chats e abrir no Excel (UTF-8 BOM)
- [ ] Alternar abas Tickets | Chats
- [ ] Dashboard WhatsApp -> Exportar planilha com filtros do periodo
- [ ] Atendente recebe 403 em /relatorios/chats
- [ ] pytest tests/test_relatorio_chats.py

Made with [Cursor](https://cursor.com)