### PR TITLE
fix(atendimento): trilha A - WhatsApp, solicitante e triagem inbound

### DIFF
--- a/backend/app/api/funcionarios_rede.py
+++ b/backend/app/api/funcionarios_rede.py
@@ -20,6 +20,7 @@ from app.services.funcionario_escopo import (
     sincronizar_vinculos_empresas,
     validar_empresa_ids_na_rede,
 )
+from app.services.inbound_ticket_reconcile import reconciliar_tickets_pendentes_por_email
 from app.services.funcionario_rede_resolver import assert_email_unico_por_rede, resolver_remetente_por_email
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import exigir_admin
@@ -201,6 +202,8 @@ def criar(
     )
     db.commit()
     db.refresh(f)
+    reconciliar_tickets_pendentes_por_email(db, f.email)
+    db.commit()
     return _para_read(f)
 
 
@@ -277,6 +280,8 @@ def atualizar(
     registrar_audit(db, "funcionario_rede", funcionario_id, "update", atendente.id)
     db.commit()
     db.refresh(f)
+    reconciliar_tickets_pendentes_por_email(db, f.email)
+    db.commit()
     return _para_read(f)
 
 

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -24,6 +24,7 @@ from app.schemas.ticket import (
     TicketMensagemUpdate,
     TicketParentBrief,
     TicketRead,
+    TicketSolicitanteBrief,
     TicketTriagemInbound,
     TicketUpdate,
     TicketVinculoCreate,
@@ -71,7 +72,7 @@ from app.services.ticket_escopo import (
     validar_escopo_criacao_manual,
 )
 from app.services.funcionario_rede_resolver import resolver_remetente_por_email
-from app.services.ticket_client_email import extrair_email_de_from_address
+from app.services.ticket_client_email import extrair_email_de_from_address, extrair_nome_de_from_address
 from app.services.protocolo_mensal import gerar_protocolo_ticket
 from app.services.realtime_emit import emit_ticket_fila, emit_ticket_mensagem_from_model, emit_notificacao_after_counter_change
 from app.services.ticket_distribuicao import (
@@ -214,12 +215,68 @@ def _triagem_inbound_para_ticket(db: Session, t: Ticket) -> TicketTriagemInbound
             empresas.append(EmpresaVinculoSugerida(id=emp.id, nome=emp.nome))
     if not rem.requer_cadastro and not empresas and t.empresa_id is not None:
         return None
+    rede_nome_inferida = None
+    if rem.rede_id is not None:
+        r = db.query(Rede).filter(Rede.id == rem.rede_id).first()
+        rede_nome_inferida = r.nome if r else None
     return TicketTriagemInbound(
         requer_cadastro_funcionario=rem.requer_cadastro,
         remetente_email=rem.email or email,
         conflito_multiplas_redes=rem.conflito_multiplas_redes,
         empresas_vinculo_sugeridas=empresas,
+        rede_id_inferida=rem.rede_id,
+        rede_nome_inferida=rede_nome_inferida,
     )
+
+
+def _email_remetente_inbound(db: Session, t: Ticket) -> str | None:
+    if t.aberto_por_id:
+        f = db.query(FuncionarioRede).filter(FuncionarioRede.id == t.aberto_por_id).first()
+        email = (f.email or "").strip() if f else None
+        if email:
+            return email
+    row = (
+        db.query(EmailInboundReceived)
+        .filter(EmailInboundReceived.ticket_id == t.id)
+        .order_by(EmailInboundReceived.id.desc())
+        .first()
+    )
+    if row:
+        return extrair_email_de_from_address(row.from_address)
+    return None
+
+
+def _solicitante_para_read(
+    db: Session,
+    t: Ticket,
+    triagem: TicketTriagemInbound | None,
+) -> TicketSolicitanteBrief | None:
+    if t.aberto_por_id:
+        f = db.query(FuncionarioRede).filter(FuncionarioRede.id == t.aberto_por_id).first()
+        if f:
+            return TicketSolicitanteBrief(
+                id=f.id,
+                nome=f.nome,
+                email=f.email,
+                cadastrado=True,
+            )
+    row = (
+        db.query(EmailInboundReceived)
+        .filter(EmailInboundReceived.ticket_id == t.id)
+        .order_by(EmailInboundReceived.id.desc())
+        .first()
+    )
+    if row or triagem:
+        nome = extrair_nome_de_from_address(row.from_address) if row else None
+        email = triagem.remetente_email if triagem else extrair_email_de_from_address(row.from_address if row else None)
+        if email or nome:
+            return TicketSolicitanteBrief(
+                id=None,
+                nome=nome,
+                email=email,
+                cadastrado=not (triagem.requer_cadastro_funcionario if triagem else True),
+            )
+    return None
 
 
 def _ticket_vinculo_brief(t: Ticket) -> TicketVinculoOutroBrief:
@@ -334,6 +391,7 @@ def _ticket_para_read(t: Ticket, db: Session | None = None) -> TicketRead:
         children=children_out,
         vinculos=_vinculos_para_read(db, t) if db is not None else [],
         triagem_inbound=triagem,
+        solicitante=_solicitante_para_read(db, t, triagem) if db is not None else None,
         **csat,
         **fila,
     )
@@ -1542,25 +1600,20 @@ def atualizar(
             )
             if not empresa:
                 raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Empresa não encontrada")
-            email_rem = None
-            if ticket.aberto_por_id:
-                f_ab = db.query(FuncionarioRede).filter(FuncionarioRede.id == ticket.aberto_por_id).first()
-                email_rem = (f_ab.email or "").strip() if f_ab else None
-            if not email_rem:
-                row_in = (
-                    db.query(EmailInboundReceived)
-                    .filter(EmailInboundReceived.ticket_id == ticket.id)
-                    .order_by(EmailInboundReceived.id.desc())
-                    .first()
-                )
-                if row_in:
-                    email_rem = extrair_email_de_from_address(row_in.from_address)
-            rem = resolver_remetente_por_email(db, email_rem)
-            if rem.empresa_ids_opcao and int(novo_eid) not in rem.empresa_ids_opcao:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Esta empresa não está vinculada ao funcionário remetente do e-mail.",
-                )
+            email_rem = _email_remetente_inbound(db, ticket)
+            if email_rem:
+                rem = resolver_remetente_por_email(db, email_rem)
+                if not rem.requer_cadastro:
+                    if rem.rede_id is not None and int(empresa.rede_id) != int(rem.rede_id):
+                        raise HTTPException(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="Esta empresa não pertence à rede do remetente do e-mail.",
+                        )
+                    if rem.empresa_ids_opcao and int(novo_eid) not in rem.empresa_ids_opcao:
+                        raise HTTPException(
+                            status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="Esta empresa não está vinculada ao funcionário remetente do e-mail.",
+                        )
             ticket.rede_id = empresa.rede_id
         antigo = str(ticket.empresa_id) if ticket.empresa_id is not None else ""
         novo = str(novo_eid) if novo_eid is not None else ""

--- a/backend/app/schemas/ticket.py
+++ b/backend/app/schemas/ticket.py
@@ -134,6 +134,15 @@ class TicketTriagemInbound(BaseModel):
     remetente_email: str | None = None
     conflito_multiplas_redes: bool = False
     empresas_vinculo_sugeridas: list[EmpresaVinculoSugerida] = []
+    rede_id_inferida: int | None = None
+    rede_nome_inferida: str | None = None
+
+
+class TicketSolicitanteBrief(BaseModel):
+    id: int | None = None
+    nome: str | None = None
+    email: str | None = None
+    cadastrado: bool = True
 
 
 class TicketRead(BaseModel):
@@ -168,6 +177,7 @@ class TicketRead(BaseModel):
     children: list[TicketChildBrief] = Field(default_factory=list)
     vinculos: list[TicketVinculoRead] = Field(default_factory=list)
     triagem_inbound: TicketTriagemInbound | None = None
+    solicitante: TicketSolicitanteBrief | None = None
     avaliacao_nota: int | None = None
     avaliacao_comentario: str | None = None
     avaliacao_respondida_em: datetime | None = None

--- a/backend/app/services/inbound_ticket_reconcile.py
+++ b/backend/app/services/inbound_ticket_reconcile.py
@@ -1,0 +1,61 @@
+"""Reconcilia tickets inbound após cadastro do remetente (#388)."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.email_inbound_received import EmailInboundReceived
+from app.models.ticket import Ticket
+from app.services.funcionario_rede_resolver import RemetenteFuncionarioResolve, resolver_remetente_por_email
+from app.services.ticket_client_email import extrair_email_de_from_address
+
+
+def aplicar_reconciliacao_remetente(
+    db: Session,
+    ticket: Ticket,
+    rem: RemetenteFuncionarioResolve,
+) -> bool:
+    if rem.requer_cadastro or rem.funcionario_id is None:
+        return False
+    changed = False
+    if ticket.aberto_por_id is None:
+        ticket.aberto_por_id = rem.funcionario_id
+        changed = True
+    if rem.rede_id is not None and ticket.rede_id is None:
+        ticket.rede_id = rem.rede_id
+        changed = True
+    if rem.empresa_id is not None and ticket.empresa_id is None:
+        ticket.empresa_id = rem.empresa_id
+        changed = True
+    return changed
+
+
+def reconciliar_tickets_pendentes_por_email(db: Session, email_raw: str | None) -> int:
+    email = (email_raw or "").strip().lower()
+    if not email:
+        return 0
+    rem = resolver_remetente_por_email(db, email)
+    if rem.requer_cadastro:
+        return 0
+
+    rows = (
+        db.query(EmailInboundReceived)
+        .join(Ticket, Ticket.id == EmailInboundReceived.ticket_id)
+        .filter(Ticket.empresa_id.is_(None))
+        .all()
+    )
+    alterados = 0
+    vistos: set[int] = set()
+    for row in rows:
+        row_email = extrair_email_de_from_address(row.from_address)
+        if row_email != email:
+            continue
+        ticket = row.ticket
+        if ticket.id in vistos:
+            continue
+        vistos.add(ticket.id)
+        if aplicar_reconciliacao_remetente(db, ticket, rem):
+            alterados += 1
+    if alterados:
+        db.flush()
+    return alterados

--- a/backend/app/services/ticket_client_email.py
+++ b/backend/app/services/ticket_client_email.py
@@ -38,6 +38,18 @@ def extrair_email_de_from_address(raw: str | None) -> str | None:
     return None
 
 
+def extrair_nome_de_from_address(raw: str | None) -> str | None:
+    """Extrai nome legível antes do endereço em formato ``Nome <email@dominio>``."""
+    if not raw or not str(raw).strip():
+        return None
+    s = str(raw).strip()
+    m = _ANGLE_EMAIL.search(s)
+    if not m:
+        return None
+    nome = s[: m.start()].strip().strip('"').strip("'")
+    return nome or None
+
+
 def ultima_mensagem_inbound(db: Session, ticket_id: int) -> EmailInboundReceived | None:
     return (
         db.query(EmailInboundReceived)

--- a/backend/tests/test_inbound_ticket_reconcile.py
+++ b/backend/tests/test_inbound_ticket_reconcile.py
@@ -1,0 +1,110 @@
+"""Testes de reconciliação de tickets inbound (#388)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.models import Ticket
+from app.models.email_inbound_received import EmailInboundReceived
+from app.models.funcionario_rede import FuncionarioRede
+from app.services.inbound_ticket_reconcile import reconciliar_tickets_pendentes_por_email
+
+
+def _criar_ticket_inbound_pendente(db_session, seed_base, *, email: str):
+    t = Ticket(
+        tenant_id=1,
+        protocolo=f"IN{datetime.now().timestamp()}",
+        empresa_id=None,
+        rede_id=None,
+        setor_id=seed_base["setor1"].id,
+        status_id=seed_base["status"].id,
+        assunto="Triagem inbound teste",
+        aberto_por_id=None,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(t)
+    db_session.flush()
+    db_session.add(
+        EmailInboundReceived(
+            message_id_normalized=f"inbound-{datetime.now().timestamp()}@test",
+            ticket_id=t.id,
+            from_address=f"Cliente Teste <{email}>",
+        )
+    )
+    db_session.commit()
+    db_session.refresh(t)
+    return t
+
+
+def test_reconciliar_apos_cadastro_funcionario(db_session, seed_base):
+    email = "novo.cliente@empresa.test"
+    ticket = _criar_ticket_inbound_pendente(db_session, seed_base, email=email)
+    emp = seed_base["empresa"]
+
+    f = FuncionarioRede(
+        nome="Cliente Teste",
+        email=email,
+        tipo="colaborador",
+        ativo=True,
+        rede_id=emp.rede_id,
+        empresa_id=emp.id,
+    )
+    db_session.add(f)
+    db_session.commit()
+
+    alterados = reconciliar_tickets_pendentes_por_email(db_session, email)
+    db_session.commit()
+    db_session.refresh(ticket)
+
+    assert alterados == 1
+    assert ticket.aberto_por_id == f.id
+    assert ticket.rede_id == emp.rede_id
+    assert ticket.empresa_id == emp.id
+
+
+def test_patch_empresa_outra_rede_rejeitado(client, seed_base, auth_headers, db_session):
+    from app.models.empresa import Empresa
+    from app.models.rede import Rede
+
+    email = "outro.cliente@empresa.test"
+    ticket = _criar_ticket_inbound_pendente(db_session, seed_base, email=email)
+    emp = seed_base["empresa"]
+
+    f = FuncionarioRede(
+        nome="Cliente Outro",
+        email=email,
+        tipo="colaborador",
+        ativo=True,
+        rede_id=emp.rede_id,
+        empresa_id=emp.id,
+    )
+    db_session.add(f)
+    db_session.commit()
+    reconciliar_tickets_pendentes_por_email(db_session, email)
+    db_session.commit()
+
+    rede2 = Rede(tenant_id=1, nome="Rede B", ativo=True)
+    db_session.add(rede2)
+    db_session.flush()
+    empresa2 = Empresa(tenant_id=1, rede_id=rede2.id, nome="Empresa B", ativo=True)
+    db_session.add(empresa2)
+    db_session.commit()
+
+    r = client.patch(
+        f"/v1/tickets/{ticket.id}",
+        headers=auth_headers["admin"],
+        json={"empresa_id": empresa2.id},
+    )
+    assert r.status_code == 400
+
+
+def test_ticket_expoe_solicitante(client, seed_base, auth_headers, db_session):
+    email = "solicitante@empresa.test"
+    ticket = _criar_ticket_inbound_pendente(db_session, seed_base, email=email)
+
+    r = client.get(f"/v1/tickets/{ticket.id}", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["solicitante"] is not None
+    assert body["solicitante"]["email"] == email
+    assert body["solicitante"]["cadastrado"] is False

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1781,6 +1781,14 @@ export namespace Tickets {
     remetente_email?: string | null;
     conflito_multiplas_redes?: boolean;
     empresas_vinculo_sugeridas?: EmpresaVinculoSugerida[];
+    rede_id_inferida?: number | null;
+    rede_nome_inferida?: string | null;
+  }
+  export interface SolicitanteBrief {
+    id?: number | null;
+    nome?: string | null;
+    email?: string | null;
+    cadastrado: boolean;
   }
   export interface Ticket {
     id: number;
@@ -1813,6 +1821,7 @@ export namespace Tickets {
     children?: TicketChildBrief[];
     vinculos?: TicketVinculo[];
     triagem_inbound?: TriagemInbound | null;
+    solicitante?: SolicitanteBrief | null;
     avaliacao_nota?: number | null;
     avaliacao_comentario?: string | null;
     avaliacao_respondida_em?: string | null;

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -757,7 +757,7 @@ export function TicketDetalhe() {
     setEditSetor(ticket.setor_id)
     setEditStatus(ticket.status_id)
     setEditAtendente(ticket.atendente_id ?? '')
-    setEditRede(ticket.rede_id ?? '')
+    setEditRede(ticket.rede_id ?? ticket.triagem_inbound?.rede_id_inferida ?? '')
     setEditEmpresa(ticket.empresa_id ?? '')
     setEditPrioridade((ticket.prioridade as PrioridadeTicket) ?? 'normal')
     setEditClassificacao(classificacaoFromTicket(ticket))
@@ -775,7 +775,23 @@ export function TicketDetalhe() {
   const triagemInbound = ticket?.triagem_inbound
   const empresasVinculoSugeridas = triagemInbound?.empresas_vinculo_sugeridas ?? []
   const requerCadastroFuncionario = triagemInbound?.requer_cadastro_funcionario === true
-  const redeTriagemFixa = empresasVinculoSugeridas.length > 0 && ticket?.rede_id != null
+  const redeIdTriagem = ticket?.rede_id ?? triagemInbound?.rede_id_inferida ?? null
+  const redeTriagemFixa =
+    redeIdTriagem != null &&
+    (empresasVinculoSugeridas.length > 0 || (triagemInbound != null && !requerCadastroFuncionario))
+
+  const redesOpcoesModal = useMemo(() => {
+    if (!redeTriagemFixa || redeIdTriagem == null) return redesList
+    const found = redesList.find((r) => r.id === redeIdTriagem)
+    if (found) return [found]
+    return [
+      {
+        id: redeIdTriagem,
+        nome: triagemInbound?.rede_nome_inferida ?? `Rede #${redeIdTriagem}`,
+        ativo: true,
+      },
+    ]
+  }, [redesList, redeTriagemFixa, redeIdTriagem, triagemInbound?.rede_nome_inferida])
 
   const empresasOpcoesModal = useMemo(() => {
     if (empresasVinculoSugeridas.length > 0) {
@@ -1455,6 +1471,24 @@ export function TicketDetalhe() {
                   value={ticket.atendente_nome ?? '—'}
                   onClick={() => tentarEditarTicket(() => abrirModalGerir('atendente'))}
                 />
+                {ticket.solicitante && (ticket.solicitante.nome || ticket.solicitante.email) ? (
+                  <TicketMetaChip
+                    label="Solic."
+                    value={ticket.solicitante.nome ?? ticket.solicitante.email ?? '—'}
+                    onClick={() => {
+                      if (ticket.solicitante?.id) {
+                        navigate(`/funcionarios-rede/${ticket.solicitante.id}`)
+                        return
+                      }
+                      if (!ticket.solicitante?.cadastrado && isAdmin) {
+                        navigate(linkCadastroFuncionario)
+                      }
+                    }}
+                    disabled={
+                      !ticket.solicitante.id && (ticket.solicitante.cadastrado || !isAdmin)
+                    }
+                  />
+                ) : null}
                 <TicketMetaChip
                   label="Hier."
                   value={rotuloChipHierarquia}
@@ -2337,7 +2371,7 @@ export function TicketDetalhe() {
                         setEditRede(v === '' ? '' : Number(v))
                         setEditEmpresa('')
                       }}
-                      options={redesList.map((r) => ({
+                      options={redesOpcoesModal.map((r) => ({
                         value: r.id,
                         label: `${r.nome}${!r.ativo ? ' (inativa)' : ''}`,
                       }))}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -344,16 +344,23 @@ export function WhatsappConversa() {
       })
     })
     const unsubFila = subscribe('chat.fila', (payload) => {
-      if (Number(payload.chat_id) !== chatId) return
+      const payloadChatId = Number(payload.chat_id)
       const chatData = payload.chat as WhatsappChats.Chat | undefined
-      if (chatData) setChat(chatData)
-      else void carregar().catch(() => {})
+      if (payloadChatId === chatId) {
+        if (chatData) setChat(chatData)
+        else void carregar().catch(() => {})
+      }
+      if (chatData && chatData.estado !== 'em_atendimento') {
+        setMeusChats((prev) => prev.filter((c) => c.id !== payloadChatId))
+      } else {
+        void carregarSidebar()
+      }
     })
     return () => {
       unsubMsg()
       unsubFila()
     }
-  }, [id, subscribe, carregar])
+  }, [id, subscribe, carregar, carregarSidebar])
 
   // Polling legado quando SSE indisponível
   useEffect(() => {
@@ -550,7 +557,7 @@ useEffect(() => {
 
       const atualizado = await whatsappChats.encerrar(chat.id)
 
-      await carregar()
+      await Promise.all([carregar(), carregarSidebar()])
 
       toast.showSuccess(
         atualizado.estado === 'aguardando_avaliacao'


### PR DESCRIPTION
## Summary
- **#320**: chat encerrado sai imediatamente de Meus Chats (encerrar + SSE)
- **#389**: exibe solicitante no detalhe do ticket (chip Solic. + API `solicitante`)
- **#388**: reconcilia tickets inbound apos cadastro do remetente; bloqueia empresa de outra rede; rede inferida no modal Gerir ticket

## Test plan
- [ ] Encerrar chat WhatsApp e confirmar remocao da sidebar Meus Chats
- [ ] Ticket inbound sem cadastro: cadastrar funcionario e verificar rede/empresa/aberto_por preenchidos
- [ ] Tentar vincular empresa de outra rede no ticket inbound (deve falhar)
- [ ] Detalhe do ticket exibe chip Solic. com link
- [ ] `pytest tests/test_inbound_ticket_reconcile.py`
