### PR TITLE
fix(notificacoes): paridade badge e dropdown (#391)

### DIFF
--- a/backend/app/api/notificacoes.py
+++ b/backend/app/api/notificacoes.py
@@ -56,6 +56,7 @@ def _count_sem_responsavel(db: Session, atendente: Atendente) -> int:
         select(func.count())
         .select_from(Ticket)
         .where(
+            Ticket.tenant_id == atendente.tenant_id,
             Ticket.fechado_em.is_(None),
             Ticket.atendente_id.is_(None),
         )
@@ -66,15 +67,22 @@ def _count_sem_responsavel(db: Session, atendente: Atendente) -> int:
     return int(db.execute(stmt).scalar_one())
 
 
-def _count_tickets_com_nao_lidas(db: Session, atendente: Atendente) -> int:
-    stmt = select(func.count()).select_from(Ticket).where(
+def _apply_escopo_tickets_nao_lidos(stmt, db: Session, atendente: Atendente):
+    """Tickets abertos atribuídos ao atendente com mensagens não lidas (mesmo escopo em resumo e itens)."""
+    stmt = stmt.where(
+        Ticket.tenant_id == atendente.tenant_id,
         Ticket.fechado_em.is_(None),
-        Ticket.atendente_id.isnot(None),
+        Ticket.atendente_id == atendente.id,
         _exists_mensagem_nao_lida(atendente.id),
     )
     if atendente.role != "admin":
         vis = ids_setores_visiveis_atendente(db, atendente)
-        stmt = stmt.where(Ticket.setor_id.in_(vis), Ticket.atendente_id == atendente.id)
+        stmt = stmt.where(Ticket.setor_id.in_(vis))
+    return stmt
+
+
+def _count_tickets_com_nao_lidas(db: Session, atendente: Atendente) -> int:
+    stmt = _apply_escopo_tickets_nao_lidos(select(func.count()).select_from(Ticket), db, atendente)
     return int(db.execute(stmt).scalar_one())
 
 
@@ -169,35 +177,49 @@ def _wpp_unread_count_for_chat(db: Session, chat_id: int, atendente_id: int) -> 
     return int(n or 0)
 
 
-def build_notificacao_resumo(db: Session, atendente: Atendente) -> NotificacaoResumo:
-    """Contadores de pendências para um atendente (reutilizado por API e SSE)."""
-    sem = _count_sem_responsavel(db, atendente)
-    nao = _count_tickets_com_nao_lidas(db, atendente)
-    wpp_fila = _count_wpp_fila(db, atendente)
-    wpp_resp = _count_wpp_respostas_pendentes(db, atendente)
-    return NotificacaoResumo(
-        sem_responsavel_count=sem,
-        nao_lidas_count=nao,
-        wpp_fila_count=wpp_fila,
-        wpp_respostas_count=wpp_resp,
-        total_pendencias=sem + nao + wpp_fila + wpp_resp,
-    )
+def _append_fallback_itens(
+    out: list[NotificacaoItem],
+    *,
+    nao_lidas: int,
+    wpp_resp: int,
+) -> None:
+    """Garante item navegável quando o contador do resumo indica pendências mas a listagem ficou vazia."""
+    has_ticket = any(i.tipo == "mensagens_nao_lidas" for i in out)
+    if nao_lidas > 0 and not has_ticket:
+        out.append(
+            NotificacaoItem(
+                tipo="mensagens_nao_lidas",
+                ticket_id=None,
+                titulo=f"{nao_lidas} ticket(s) com mensagens não lidas",
+                descricao="Abrir tickets em aberto",
+                count=nao_lidas,
+                href="/tickets?situacao=abertos",
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+
+    has_wpp_resp = any(i.tipo == "wpp_chats_com_resposta" for i in out)
+    if wpp_resp > 0 and not has_wpp_resp:
+        out.append(
+            NotificacaoItem(
+                tipo="wpp_chats_com_resposta",
+                ticket_id=None,
+                titulo=f"{wpp_resp} chat(s) com resposta pendente",
+                descricao="WhatsApp — ver meus atendimentos",
+                count=wpp_resp,
+                href="/whatsapp/atendendo",
+                created_at=datetime.now(timezone.utc),
+            )
+        )
 
 
-@router.get("/resumo", response_model=NotificacaoResumo)
-def resumo(
-    db: Session = Depends(get_db),
-    atendente: Atendente = Depends(obter_atendente_atual),
-):
-    return build_notificacao_resumo(db, atendente)
-
-
-@router.get("/itens", response_model=NotificacaoItensResponse)
-def itens(
-    limit: int = Query(15, ge=1, le=50),
-    db: Session = Depends(get_db),
-    atendente: Atendente = Depends(obter_atendente_atual),
-):
+def build_notificacao_itens(
+    db: Session,
+    atendente: Atendente,
+    *,
+    limit: int = 15,
+) -> list[NotificacaoItem]:
+    """Lista de pendências navegáveis (paridade com build_notificacao_resumo)."""
     out: list[NotificacaoItem] = []
 
     sem = _count_sem_responsavel(db, atendente)
@@ -228,8 +250,6 @@ def itens(
             )
         )
 
-    # Itens de WhatsApp com resposta: listar chats (até `limit`) com contagem por chat.
-    # Isso dá clareza ao atendente e permite navegar direto para o chat.
     stmt_wpp = (
         select(WhatsappChat)
         .where(
@@ -260,24 +280,17 @@ def itens(
             )
         )
 
-    stmt = (
+    stmt = _apply_escopo_tickets_nao_lidos(
         select(Ticket)
-        .where(
-            Ticket.fechado_em.is_(None),
-            Ticket.atendente_id.isnot(None),
-            _exists_mensagem_nao_lida(atendente.id),
-        )
         .options(
             joinedload(Ticket.empresa),
             joinedload(Ticket.setor),
         )
         .order_by(Ticket.updated_at.desc().nulls_last(), Ticket.id.desc())
-        .limit(limit)
+        .limit(limit),
+        db,
+        atendente,
     )
-    if atendente.role != "admin":
-        vis = ids_setores_visiveis_atendente(db, atendente)
-        stmt = stmt.where(Ticket.setor_id.in_(vis), Ticket.atendente_id == atendente.id)
-
     rows = db.execute(stmt).unique().scalars().all()
 
     for t in rows:
@@ -286,11 +299,12 @@ def itens(
             continue
         emp = t.empresa.nome if t.empresa else "—"
         setor = t.setor.nome if t.setor else "—"
+        assunto = (t.assunto or "").strip() or "—"
         out.append(
             NotificacaoItem(
                 tipo="mensagens_nao_lidas",
                 ticket_id=t.id,
-                titulo=f"{t.protocolo} — {t.assunto[:80]}{'…' if len(t.assunto) > 80 else ''}",
+                titulo=f"{t.protocolo} — {assunto[:80]}{'…' if len(assunto) > 80 else ''}",
                 descricao=f"{emp} · {setor}",
                 count=uc,
                 href=f"/tickets/{t.id}",
@@ -298,7 +312,42 @@ def itens(
             )
         )
 
-    return NotificacaoItensResponse(itens=out)
+    nao = _count_tickets_com_nao_lidas(db, atendente)
+    wpp_resp = _count_wpp_respostas_pendentes(db, atendente)
+    _append_fallback_itens(out, nao_lidas=nao, wpp_resp=wpp_resp)
+    return out
+
+
+def build_notificacao_resumo(db: Session, atendente: Atendente) -> NotificacaoResumo:
+    """Contadores de pendências para um atendente (reutilizado por API e SSE)."""
+    sem = _count_sem_responsavel(db, atendente)
+    nao = _count_tickets_com_nao_lidas(db, atendente)
+    wpp_fila = _count_wpp_fila(db, atendente)
+    wpp_resp = _count_wpp_respostas_pendentes(db, atendente)
+    return NotificacaoResumo(
+        sem_responsavel_count=sem,
+        nao_lidas_count=nao,
+        wpp_fila_count=wpp_fila,
+        wpp_respostas_count=wpp_resp,
+        total_pendencias=sem + nao + wpp_fila + wpp_resp,
+    )
+
+
+@router.get("/resumo", response_model=NotificacaoResumo)
+def resumo(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return build_notificacao_resumo(db, atendente)
+
+
+@router.get("/itens", response_model=NotificacaoItensResponse)
+def itens(
+    limit: int = Query(15, ge=1, le=50),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return NotificacaoItensResponse(itens=build_notificacao_itens(db, atendente, limit=limit))
 
 
 @router.post("/tickets/{ticket_id}/visto", status_code=204)

--- a/backend/tests/test_notificacoes_itens.py
+++ b/backend/tests/test_notificacoes_itens.py
@@ -1,0 +1,119 @@
+"""Paridade entre /notificacoes/resumo e /notificacoes/itens (#391)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.api.notificacoes import build_notificacao_itens, build_notificacao_resumo
+from app.models.ticket import Ticket, TicketMensagem
+from app.models.ticket_read import TicketRead
+
+
+def _criar_ticket_com_mensagem(db_session, seed_base, *, atendente_id: int, assunto: str = "Teste notif"):
+    from app.models.status_ticket import StatusTicket
+
+    st = db_session.query(StatusTicket).first()
+    ticket = Ticket(
+        tenant_id=1,
+        protocolo=f"#T-NOTIF-{assunto[:8]}",
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=st.id,
+        assunto=assunto,
+        descricao="x",
+        atendente_id=atendente_id,
+    )
+    db_session.add(ticket)
+    db_session.flush()
+    db_session.add(
+        TicketMensagem(
+            ticket_id=ticket.id,
+            atendente_id=None,
+            tipo="publico",
+            corpo="Mensagem do cliente",
+            created_at=datetime.now(timezone.utc),
+        )
+    )
+    db_session.commit()
+    return ticket
+
+
+def test_resumo_e_itens_parity_atendente(client, seed_base, auth_headers, db_session):
+    _criar_ticket_com_mensagem(db_session, seed_base, atendente_id=seed_base["a1"].id)
+
+    r_resumo = client.get("/v1/notificacoes/resumo", headers=auth_headers["a1"])
+    assert r_resumo.status_code == 200
+    resumo = r_resumo.json()
+
+    r_itens = client.get("/v1/notificacoes/itens", headers=auth_headers["a1"])
+    assert r_itens.status_code == 200
+    itens = r_itens.json()["itens"]
+
+    assert resumo["nao_lidas_count"] >= 1
+    assert any(i["tipo"] == "mensagens_nao_lidas" for i in itens)
+
+
+def test_admin_nao_conta_nao_lidas_de_outro_responsavel(client, seed_base, auth_headers, db_session):
+    """Badge pessoal: admin não acumula não-lidas de tickets de outros atendentes."""
+    _criar_ticket_com_mensagem(db_session, seed_base, atendente_id=seed_base["a1"].id, assunto="Do A1")
+
+    resumo_admin = build_notificacao_resumo(db_session, seed_base["admin"])
+    assert resumo_admin.nao_lidas_count == 0
+
+    resumo_a1 = build_notificacao_resumo(db_session, seed_base["a1"])
+    assert resumo_a1.nao_lidas_count >= 1
+
+
+def test_itens_fallback_quando_contador_positivo(client, seed_base, auth_headers, db_session, monkeypatch):
+    _criar_ticket_com_mensagem(db_session, seed_base, atendente_id=seed_base["a1"].id)
+
+    def fake_unread(db, ticket, atendente_id):
+        return 0
+
+    monkeypatch.setattr("app.api.notificacoes._unread_count_for_ticket", fake_unread)
+
+    resumo = build_notificacao_resumo(db_session, seed_base["a1"])
+    itens = build_notificacao_itens(db_session, seed_base["a1"], limit=15)
+
+    assert resumo.nao_lidas_count >= 1
+    assert any(i.tipo == "mensagens_nao_lidas" for i in itens)
+
+
+def test_mensagem_anterior_a_visto_nao_conta(db_session, seed_base):
+    from app.models.status_ticket import StatusTicket
+
+    st = db_session.query(StatusTicket).first()
+    ticket = Ticket(
+        tenant_id=1,
+        protocolo="#T-NOTIF-VISTO",
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=st.id,
+        assunto="Visto",
+        descricao="x",
+        atendente_id=seed_base["a1"].id,
+    )
+    db_session.add(ticket)
+    db_session.flush()
+
+    agora = datetime.now(timezone.utc)
+    db_session.add(
+        TicketMensagem(
+            ticket_id=ticket.id,
+            atendente_id=None,
+            tipo="publico",
+            corpo="Antiga",
+            created_at=agora - timedelta(hours=1),
+        )
+    )
+    db_session.add(
+        TicketRead(
+            atendente_id=seed_base["a1"].id,
+            ticket_id=ticket.id,
+            last_seen_at=agora,
+        )
+    )
+    db_session.commit()
+
+    resumo = build_notificacao_resumo(db_session, seed_base["a1"])
+    assert resumo.nao_lidas_count == 0

--- a/frontend/src/components/NavbarNotificacoes.tsx
+++ b/frontend/src/components/NavbarNotificacoes.tsx
@@ -25,6 +25,85 @@ function badgeText(n: number): string {
   return String(n)
 }
 
+function ResumoRodape({ resumo }: { resumo: Notificacoes.Resumo }) {
+  const partes: string[] = []
+  if (resumo.sem_responsavel_count > 0) partes.push(`Fila: ${resumo.sem_responsavel_count}`)
+  if (resumo.nao_lidas_count > 0) partes.push(`Não lidas: ${resumo.nao_lidas_count}`)
+  if (resumo.wpp_fila_count > 0) partes.push(`WPP fila: ${resumo.wpp_fila_count}`)
+  if (resumo.wpp_respostas_count > 0) partes.push(`WPP resposta: ${resumo.wpp_respostas_count}`)
+  if (partes.length === 0) return null
+  return (
+    <div className="shrink-0 border-t border-slate-200/90 bg-white px-4 py-3 text-xs text-slate-600 dark:border-slate-800/90 dark:bg-slate-950 dark:text-slate-300 sm:border-slate-100 sm:px-3 sm:pt-2 sm:text-[11px] sm:text-slate-400 dark:sm:border-slate-800 dark:sm:text-slate-500">
+      {partes.join(' · ')}
+    </div>
+  )
+}
+
+function ListaPendencias({
+  itens,
+  loadingItens,
+  erroItens,
+  totalPendencias,
+  onNavigate,
+}: {
+  itens: Notificacoes.Item[]
+  loadingItens: boolean
+  erroItens: boolean
+  totalPendencias: number
+  onNavigate: () => void
+}) {
+  if (loadingItens && itens.length === 0) {
+    return (
+      <p className="px-3 py-10 text-center text-sm text-slate-500 dark:text-slate-400 sm:py-6">
+        Carregando…
+      </p>
+    )
+  }
+  if (erroItens && itens.length === 0) {
+    return (
+      <p className="px-3 py-10 text-center text-sm text-rose-600 dark:text-rose-400 sm:py-6">
+        Não foi possível carregar as pendências.
+      </p>
+    )
+  }
+  if (itens.length === 0) {
+    return (
+      <p className="px-3 py-10 text-center text-sm text-slate-500 dark:text-slate-400 sm:py-6">
+        {totalPendencias > 0
+          ? 'Pendências no badge — abra novamente em instantes ou use a listagem de tickets.'
+          : 'Sem pendências'}
+      </p>
+    )
+  }
+  return (
+    <ul className="space-y-2 sm:space-y-0.5">
+      {itens.map((item, idx) => (
+        <li key={`${item.tipo}-${item.ticket_id ?? 'fila'}-${idx}`}>
+          <Link
+            role="menuitem"
+            to={item.href}
+            className="flex gap-3 rounded-2xl border border-slate-200/90 bg-white px-4 py-3 text-left text-sm shadow-sm transition-colors hover:bg-slate-50 dark:border-slate-800/80 dark:bg-slate-900/50 dark:hover:bg-slate-800/60 sm:gap-2 sm:rounded-lg sm:border-0 sm:bg-transparent sm:px-2 sm:py-2 sm:shadow-none sm:hover:bg-slate-50 dark:sm:hover:bg-slate-800/80"
+            onClick={onNavigate}
+          >
+            <div className="min-w-0 flex-1">
+              <p className="truncate font-medium text-slate-900 dark:text-slate-100">{item.titulo}</p>
+              <p className="mt-0.5 line-clamp-2 text-xs text-slate-500 dark:text-slate-400 sm:mt-0 sm:truncate sm:line-clamp-none">
+                {item.descricao}
+              </p>
+            </div>
+            <div className="flex shrink-0 flex-col items-end gap-1">
+              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
+                {item.count}
+              </span>
+              <span className="text-xs font-medium text-cyan-600 dark:text-cyan-400">Ver</span>
+            </div>
+          </Link>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
 export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
   const resumo = usePendenciasResumo(enabled)
   const { subscribe, useFallback } = useEventStream()
@@ -32,6 +111,7 @@ export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
   const [mobileVisible, setMobileVisible] = useState(false)
   const [itens, setItens] = useState<Notificacoes.Item[]>([])
   const [loadingItens, setLoadingItens] = useState(false)
+  const [erroItens, setErroItens] = useState(false)
   const wrapRef = useRef<HTMLDivElement>(null)
   const mobileDrawerRef = useRef<HTMLDivElement>(null)
   const menuId = useId()
@@ -39,11 +119,13 @@ export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
   const carregarItens = useCallback(async () => {
     if (!enabled) return
     setLoadingItens(true)
+    setErroItens(false)
     try {
       const { itens: list } = await notificacoes.itens({ limit: 15 })
       setItens(list)
     } catch {
       setItens([])
+      setErroItens(true)
     } finally {
       setLoadingItens(false)
     }
@@ -155,44 +237,16 @@ export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
             </div>
 
             <div className="flex-1 overflow-y-auto bg-white p-2 dark:bg-slate-950">
-              {loadingItens && itens.length === 0 ? (
-                <p className="px-3 py-10 text-center text-sm text-slate-500 dark:text-slate-400">Carregando…</p>
-              ) : itens.length === 0 ? (
-                <p className="px-3 py-10 text-center text-sm text-slate-500 dark:text-slate-400">Sem pendências</p>
-              ) : (
-                <ul className="space-y-2">
-                  {itens.map((item, idx) => (
-                    <li key={`${item.tipo}-${item.ticket_id ?? 'fila'}-${idx}`}>
-                      <Link
-                        role="menuitem"
-                        to={item.href}
-                        className="flex gap-3 rounded-2xl border border-slate-200/90 bg-white px-4 py-3 text-left text-sm shadow-sm transition-colors hover:bg-slate-50 dark:border-slate-800/80 dark:bg-slate-900/50 dark:hover:bg-slate-800/60"
-                        onClick={() => setAberto(false)}
-                      >
-                        <div className="min-w-0 flex-1">
-                          <p className="truncate font-medium text-slate-900 dark:text-slate-100">{item.titulo}</p>
-                          <p className="mt-0.5 line-clamp-2 text-xs text-slate-500 dark:text-slate-400">{item.descricao}</p>
-                        </div>
-                        <div className="flex shrink-0 flex-col items-end gap-1">
-                          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
-                            {item.count}
-                          </span>
-                          <span className="text-xs font-medium text-cyan-600 dark:text-cyan-400">Ver</span>
-                        </div>
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              )}
+              <ListaPendencias
+                itens={itens}
+                loadingItens={loadingItens}
+                erroItens={erroItens}
+                totalPendencias={total}
+                onNavigate={() => setAberto(false)}
+              />
             </div>
 
-            {(resumo.sem_responsavel_count > 0 || resumo.nao_lidas_count > 0) && (
-              <div className="shrink-0 border-t border-slate-200/90 bg-white px-4 py-3 text-xs text-slate-600 dark:border-slate-800/90 dark:bg-slate-950 dark:text-slate-300">
-                <span className="font-medium">Fila:</span> {resumo.sem_responsavel_count}
-                <span className="text-slate-400 dark:text-slate-600"> · </span>
-                <span className="font-medium">Não lidas:</span> {resumo.nao_lidas_count}
-              </div>
-            )}
+            <ResumoRodape resumo={resumo} />
             <div className="shrink-0 border-t border-slate-200/90 bg-white px-4 py-3 dark:border-slate-800/90 dark:bg-slate-950">
               <Link
                 to="/notificacoes/preferencias"
@@ -217,41 +271,15 @@ export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Pendências</p>
           </div>
           <div className="max-h-[min(70vh,24rem)] overflow-y-auto px-1 py-1">
-            {loadingItens && itens.length === 0 ? (
-              <p className="px-3 py-6 text-center text-sm text-slate-500 dark:text-slate-400">Carregando…</p>
-            ) : itens.length === 0 ? (
-              <p className="px-3 py-6 text-center text-sm text-slate-500 dark:text-slate-400">Sem pendências</p>
-            ) : (
-              <ul className="space-y-0.5">
-                {itens.map((item, idx) => (
-                  <li key={`${item.tipo}-${item.ticket_id ?? 'fila'}-${idx}`}>
-                    <Link
-                      role="menuitem"
-                      to={item.href}
-                      className="flex gap-2 rounded-lg px-2 py-2 text-left text-sm hover:bg-slate-50 dark:hover:bg-slate-800/80"
-                      onClick={() => setAberto(false)}
-                    >
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate font-medium text-slate-900 dark:text-slate-100">{item.titulo}</p>
-                        <p className="truncate text-xs text-slate-500 dark:text-slate-400">{item.descricao}</p>
-                      </div>
-                      <div className="flex shrink-0 flex-col items-end gap-1">
-                        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
-                          {item.count}
-                        </span>
-                        <span className="text-xs font-medium text-cyan-600 dark:text-cyan-400">Ver</span>
-                      </div>
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            )}
+            <ListaPendencias
+              itens={itens}
+              loadingItens={loadingItens}
+              erroItens={erroItens}
+              totalPendencias={total}
+              onNavigate={() => setAberto(false)}
+            />
           </div>
-          {(resumo.sem_responsavel_count > 0 || resumo.nao_lidas_count > 0) && (
-            <div className="border-t border-slate-100 px-3 pt-2 text-[11px] text-slate-400 dark:border-slate-800 dark:text-slate-500">
-              Fila: {resumo.sem_responsavel_count} · Não lidas: {resumo.nao_lidas_count}
-            </div>
-          )}
+          <ResumoRodape resumo={resumo} />
           <div className="border-t border-slate-100 px-3 py-2 dark:border-slate-800">
             <Link
               to="/notificacoes/preferencias"


### PR DESCRIPTION
## Summary
- Corrige inconsistência entre `GET /notificacoes/resumo` e `GET /notificacoes/itens` (#391).
- `nao_lidas` passa a considerar apenas tickets **atribuídos ao usuário logado** (incluindo admin); antes o admin acumulava não-lidas de tickets de outros atendentes no badge.
- Item agregado de fallback quando o contador indica pendências mas a listagem individual falha.
- Frontend: não exibe "Sem pendências" com badge > 0, mostra erro de carga e rodapé com contadores WPP.

## Test plan
- [ ] Login como admin com tickets atribuídos a outros: badge não deve inflar com não-lidas alheias.
- [ ] Login com tickets próprios não lidos: badge e dropdown listam os mesmos itens (ou link agregado).
- [ ] Simular falha de rede ao abrir o sino: mensagem de erro em vez de lista vazia.
- [x] `pytest tests/test_notificacoes_itens.py` (4 passed) + realtime (3 passed)

Closes #391
