### PR TITLE
fix(tickets): corrige envio de e-mail de resposta ao cliente no Postgres

### DIFF
--- a/backend/app/services/ticket_mensagem_email_outbox.py
+++ b/backend/app/services/ticket_mensagem_email_outbox.py
@@ -42,6 +42,13 @@ def _as_utc(dt: datetime | None) -> datetime | None:
     return dt.astimezone(timezone.utc)
 
 
+def _naive_utc(dt: datetime | None) -> datetime | None:
+    """UTC sem tzinfo — alinha leituras do Postgres (TIMESTAMPTZ) com ``_dt_for_db()``."""
+    if dt is None:
+        return None
+    return _as_utc(dt).replace(tzinfo=None)
+
+
 def _dt_for_db(dt: datetime | None = None) -> datetime:
     """Persistência em UTC naive (compatível SQLite/Postgres)."""
     return _as_utc(dt or _utcnow()).replace(tzinfo=None)  # type: ignore[return-value]
@@ -111,8 +118,8 @@ def liberar_locks_expirados(db: Session, *, ref: datetime | None = None) -> int:
     )
     liberados = 0
     for m in rows:
-        exp = _as_utc(m.edit_lock_expires_at)
-        if exp is None or exp.replace(tzinfo=None) >= now:
+        exp = _naive_utc(m.edit_lock_expires_at)
+        if exp is None or exp >= now:
             continue
         m.email_status = EMAIL_STATUS_PENDENTE
         m.edit_lock_token = None
@@ -200,6 +207,7 @@ def process_pending_ticket_mensagem_emails(db: Session, *, limit: int = 20) -> i
         .filter(
             TicketMensagem.email_status == EMAIL_STATUS_PENDENTE,
             TicketMensagem.scheduled_at.isnot(None),
+            TicketMensagem.scheduled_at <= now,
         )
         .order_by(TicketMensagem.scheduled_at.asc())
         .limit(limit)
@@ -212,7 +220,8 @@ def process_pending_ticket_mensagem_emails(db: Session, *, limit: int = 20) -> i
     rows = q.all()
     enviadas = 0
     for m in rows:
-        if m.scheduled_at is None or m.scheduled_at > now:
+        sched = _naive_utc(m.scheduled_at)
+        if sched is None or sched > now:
             continue
         ticket = db.query(Ticket).filter(Ticket.id == m.ticket_id).first()
         if not ticket:
@@ -256,8 +265,8 @@ def validar_lock(m: TicketMensagem, token: str) -> None:
         raise ValueError("A mensagem não está em edição.")
     if not m.edit_lock_token or m.edit_lock_token != token:
         raise ValueError("Token de edição inválido.")
-    exp = _as_utc(m.edit_lock_expires_at)
-    if exp and exp.replace(tzinfo=None) < _dt_for_db():
+    exp = _naive_utc(m.edit_lock_expires_at)
+    if exp and exp < _dt_for_db():
         raise ValueError("O lock de edição expirou. Inicie a edição novamente.")
 
 

--- a/backend/tests/test_ticket_mensagem_email_outbox.py
+++ b/backend/tests/test_ticket_mensagem_email_outbox.py
@@ -11,12 +11,14 @@ from app.services.system_email_config import TransactionalEmailConfig
 from app.services.ticket_mensagem_email_outbox import (
     EMAIL_STATUS_CANCELADA,
     EMAIL_STATUS_EM_EDICAO,
+    EMAIL_STATUS_ENVIADA,
     EMAIL_STATUS_PENDENTE,
     _dt_for_db,
     agendar_envio_email,
     cancelar_envio,
     iniciar_edicao,
     liberar_locks_expirados,
+    process_pending_ticket_mensagem_emails,
     salvar_edicao,
     validar_lock,
 )
@@ -169,3 +171,42 @@ def test_cancelar_envio(db_session):
     agendar_envio_email(m, db_session)
     cancelar_envio(m)
     assert m.email_status == EMAIL_STATUS_CANCELADA
+
+
+def test_process_pending_com_scheduled_at_timezone_aware(
+    client, seed_base, auth_headers, monkeypatch, db_session
+):
+    """Postgres devolve TIMESTAMPTZ como datetime aware; comparação naive não pode falhar."""
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_WEBHOOK_SECRET", "ob140tz")
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_EMPRESA_ID", seed_base["empresa"].id)
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_SETOR_ID", seed_base["setor1"].id)
+    monkeypatch.setattr("app.config.settings.TICKET_MENSAGEM_EMAIL_GRACE_SECONDS", 0)
+    _mock_resend(monkeypatch)
+    monkeypatch.setattr(
+        "app.services.ticket_client_email.enviar_mensagem_texto_sistema",
+        lambda *a, **k: "outbound-tz-aware@dx.test",
+    )
+
+    r0 = client.post(
+        "/v1/webhooks/email-inbound",
+        headers={"X-Dx-Email-Webhook-Secret": "ob140tz"},
+        json={"rfc822": _minimal_rfc822("<ob140tz@dx.local>")},
+    )
+    tid = r0.json()["ticket_id"]
+
+    r1 = client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["admin"],
+        json={"corpo": "Resposta", "tipo": "publico", "notificar_cliente_por_email": True},
+    )
+    mid = r1.json()["id"]
+    m = db_session.query(TicketMensagem).filter(TicketMensagem.id == mid).first()
+    assert m is not None
+    # Simula TIMESTAMPTZ do Postgres (aware) na instância que o worker vai ler.
+    m.scheduled_at = datetime.now(timezone.utc) - timedelta(seconds=30)
+
+    n = process_pending_ticket_mensagem_emails(db_session, limit=10)
+    assert n == 1
+    db_session.commit()
+    db_session.refresh(m)
+    assert m.email_status == EMAIL_STATUS_ENVIADA


### PR DESCRIPTION
## Summary
- Corrige comparacao de `scheduled_at` (TIMESTAMPTZ aware do Postgres vs datetime naive UTC) no worker de outbox de mensagens de ticket.
- Adiciona filtro SQL `scheduled_at <= now` e helper `_naive_utc()` para evitar `TypeError` silencioso no worker.
- Teste de regressao simulando leitura timezone-aware do Postgres.

## Test plan
- [ ] Merge e deploy em staging/producao
- [ ] Responder ticket com checkbox de e-mail marcado; status deve ir para enviada sem clicar em Enviar agora
- [ ] Mensagens presas em pendente_envio devem ser processadas pelo worker apos deploy
- [ ] (Opcional) `docker logs` no container da API sem erros de Worker e-mail de mensagens de ticket