### PR TITLE
feat(tickets): distribuicao automatica na fila — epico #257

### DIFF
--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -107,6 +107,7 @@ class OrdenarTicketsPor(str, Enum):
     status = "status"
     responsavel = "responsavel"
     fechado_em = "fechado_em"
+    fila_desde_at = "fila_desde_at"
 
 class SituacaoTicket(str, Enum):
     abertos = "abertos"
@@ -535,6 +536,9 @@ def listar(
         # Em finalizados, o mais útil é ordenar por data de fechamento (mais recentes primeiro).
         if situacao == SituacaoTicket.fechados:
             order_cols = [Ticket.fechado_em.desc().nullslast(), Ticket.id.desc()]
+        elif sem_responsavel and situacao == SituacaoTicket.abertos:
+            # Fila sem responsável: mais antigos primeiro (prioridade operacional).
+            order_cols = [nullslast(Ticket.fila_desde_at.asc()), Ticket.id.asc()]
         else:
             order_cols = [Ticket.created_at.desc(), Ticket.id.desc()]
     else:
@@ -557,6 +561,8 @@ def listar(
             primary = expr_ordem(StatusTicket.nome, ordem)
         elif ordenar_por == OrdenarTicketsPor.fechado_em:
             primary = nullslast(expr_ordem(Ticket.fechado_em, ordem))
+        elif ordenar_por == OrdenarTicketsPor.fila_desde_at:
+            primary = nullslast(expr_ordem(Ticket.fila_desde_at, ordem))
         else:
             primary = nullslast(expr_ordem(Atendente.nome, ordem))
         tie = expr_ordem(Ticket.id, ordem)

--- a/backend/app/core/distribuicao_ticket.py
+++ b/backend/app/core/distribuicao_ticket.py
@@ -12,3 +12,4 @@ class DistribuicaoModo(str, Enum):
 class DistribuicaoEstrategia(str, Enum):
     round_robin = "round_robin"
     menor_carga_abertos = "menor_carga_abertos"
+    menor_carga_setor = "menor_carga_setor"

--- a/backend/app/services/ticket_distribuicao.py
+++ b/backend/app/services/ticket_distribuicao.py
@@ -18,6 +18,9 @@ from app.services.realtime_emit import emit_notificacao_after_counter_change, em
 
 logger = logging.getLogger(__name__)
 
+CAMPO_HISTORICO_DISTRIBUICAO_AUTOMATICA = "distribuicao_automatica"
+TEXTO_HISTORICO_DISTRIBUICAO_AUTOMATICA = "Atribuído automaticamente"
+
 
 def setor_para_distribuicao_read(setor: Setor):
     from app.schemas.setor_distribuicao import SetorDistribuicaoRead
@@ -68,6 +71,18 @@ def _registrar_historico_atribuicao(
     )
 
 
+def _registrar_historico_distribuicao_automatica(db: Session, ticket_id: int) -> None:
+    db.add(
+        TicketHistorico(
+            ticket_id=ticket_id,
+            atendente_id=None,
+            campo=CAMPO_HISTORICO_DISTRIBUICAO_AUTOMATICA,
+            valor_antigo=None,
+            valor_novo=TEXTO_HISTORICO_DISTRIBUICAO_AUTOMATICA,
+        )
+    )
+
+
 def listar_atendentes_elegiveis_distribuicao(db: Session, setor: Setor) -> list[Atendente]:
     """Atendentes ativos do setor (homônimos), excluindo admin."""
     ids_setor = ids_setores_mesmo_nome(db, setor.id)
@@ -88,19 +103,24 @@ def listar_atendentes_elegiveis_distribuicao(db: Session, setor: Setor) -> list[
     return sorted(q.all(), key=lambda a: (a.nome.lower(), a.id))
 
 
-def _contar_tickets_abertos_por_atendente(db: Session, atendente_ids: list[int], setor_ids: set[int]) -> dict[int, int]:
+def _contar_tickets_abertos_por_atendente(
+    db: Session,
+    atendente_ids: list[int],
+    *,
+    tenant_id: int,
+    setor_ids: set[int] | None = None,
+) -> dict[int, int]:
+    """Conta tickets abertos por atendente. ``setor_ids=None`` = carga total no tenant."""
     if not atendente_ids:
         return {}
-    rows = (
-        db.query(Ticket.atendente_id, func.count(Ticket.id))
-        .filter(
-            Ticket.atendente_id.in_(atendente_ids),
-            Ticket.setor_id.in_(setor_ids),
-            Ticket.fechado_em.is_(None),
-        )
-        .group_by(Ticket.atendente_id)
-        .all()
+    q = db.query(Ticket.atendente_id, func.count(Ticket.id)).filter(
+        Ticket.tenant_id == tenant_id,
+        Ticket.atendente_id.in_(atendente_ids),
+        Ticket.fechado_em.is_(None),
     )
+    if setor_ids is not None:
+        q = q.filter(Ticket.setor_id.in_(setor_ids))
+    rows = q.group_by(Ticket.atendente_id).all()
     out = {aid: 0 for aid in atendente_ids}
     for aid, cnt in rows:
         if aid is not None:
@@ -108,11 +128,22 @@ def _contar_tickets_abertos_por_atendente(db: Session, atendente_ids: list[int],
     return out
 
 
-def _escolher_menor_carga(db: Session, setor: Setor, candidatos: list[Atendente]) -> Atendente | None:
+def _escolher_menor_carga(
+    db: Session,
+    setor: Setor,
+    candidatos: list[Atendente],
+    *,
+    escopo_setor: bool,
+) -> Atendente | None:
     if not candidatos:
         return None
-    ids_setor = ids_setores_mesmo_nome(db, setor.id)
-    cargas = _contar_tickets_abertos_por_atendente(db, [c.id for c in candidatos], ids_setor)
+    setor_ids = {setor.id} if escopo_setor else None
+    cargas = _contar_tickets_abertos_por_atendente(
+        db,
+        [c.id for c in candidatos],
+        tenant_id=setor.tenant_id,
+        setor_ids=setor_ids,
+    )
     return min(candidatos, key=lambda a: (cargas.get(a.id, 0), a.nome.lower(), a.id))
 
 
@@ -144,7 +175,9 @@ def _escolher_round_robin(db: Session, setor_id: int, candidatos: list[Atendente
 def _escolher_atendente(db: Session, setor: Setor, candidatos: list[Atendente]) -> Atendente | None:
     estrategia = setor.distribuicao_estrategia or DistribuicaoEstrategia.round_robin.value
     if estrategia == DistribuicaoEstrategia.menor_carga_abertos.value:
-        return _escolher_menor_carga(db, setor, candidatos)
+        return _escolher_menor_carga(db, setor, candidatos, escopo_setor=False)
+    if estrategia == DistribuicaoEstrategia.menor_carga_setor.value:
+        return _escolher_menor_carga(db, setor, candidatos, escopo_setor=True)
     return _escolher_round_robin(db, setor.id, candidatos)
 
 
@@ -167,6 +200,7 @@ def atribuir_ticket_automaticamente(
     ticket.atendente_id = escolhido.id
     ticket.fila_desde_at = None
     _registrar_historico_atribuicao(db, ticket.id, antigo or None, str(escolhido.id))
+    _registrar_historico_distribuicao_automatica(db, ticket.id)
     db.flush()
     notificar_ticket_atribuido(
         db,

--- a/backend/tests/test_ticket_distribuicao.py
+++ b/backend/tests/test_ticket_distribuicao.py
@@ -8,6 +8,8 @@ from app.models import Setor, Ticket, TicketHistorico
 from app.models.atendente_notificacao import NotificacaoEmailOutbox
 from app.models.setor_distribuicao_round_robin import SetorDistribuicaoRoundRobin
 from app.services.ticket_distribuicao import (
+    CAMPO_HISTORICO_DISTRIBUICAO_AUTOMATICA,
+    TEXTO_HISTORICO_DISTRIBUICAO_AUTOMATICA,
     atribuir_ticket_automaticamente,
     processar_distribuicao_timeout,
     tentar_distribuicao_imediata,
@@ -29,6 +31,29 @@ def _criar_ticket_fila(db, seed_base, *, setor_id=None, fila_desde_at=None):
     db.add(t)
     db.flush()
     return t
+
+
+def _criar_ticket_aberto_atribuido(db, seed_base, atendente_id, *, setor_id=None):
+    setor_id = setor_id or seed_base["setor1"].id
+    t = Ticket(
+        tenant_id=1,
+        protocolo=f"T-LOAD-{db.query(Ticket).count() + 1}",
+        empresa_id=seed_base["empresa"].id,
+        rede_id=seed_base["rede"].id,
+        setor_id=setor_id,
+        status_id=seed_base["status"].id,
+        assunto="Carga",
+        atendente_id=atendente_id,
+    )
+    db.add(t)
+    db.flush()
+    return t
+
+
+def _vincular_ao_setor(db, atendente, setor):
+    if setor not in atendente.setores:
+        atendente.setores.append(setor)
+        db.flush()
 
 
 def test_put_distribuicao_setor(client, seed_base, auth_headers, db_session):
@@ -160,3 +185,129 @@ def test_criar_ticket_auto_imediato_via_api(client, seed_base, auth_headers, db_
     assert r.status_code == 201, r.text
     body = r.json()
     assert body["atendente_id"] == seed_base["a1"].id
+
+
+def test_listagem_sem_responsavel_ordenada_por_fila(client, seed_base, auth_headers, db_session):
+    """#273: fila sem responsável — mais antigos na fila primeiro."""
+    agora = datetime.now(timezone.utc)
+    t_antigo = _criar_ticket_fila(
+        db_session,
+        seed_base,
+        fila_desde_at=agora - timedelta(hours=2),
+    )
+    t_recente = _criar_ticket_fila(
+        db_session,
+        seed_base,
+        fila_desde_at=agora - timedelta(minutes=10),
+    )
+    db_session.commit()
+
+    r = client.get(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        params={"sem_responsavel": True, "situacao": "abertos", "limit": 50},
+    )
+    assert r.status_code == 200, r.text
+    ids = [x["id"] for x in r.json()["items"] if x["id"] in (t_antigo.id, t_recente.id)]
+    assert ids == [t_antigo.id, t_recente.id]
+
+
+def test_listagem_ordenar_por_fila_desde_at(client, seed_base, auth_headers, db_session):
+    agora = datetime.now(timezone.utc)
+    t1 = _criar_ticket_fila(db_session, seed_base, fila_desde_at=agora - timedelta(hours=1))
+    t2 = _criar_ticket_fila(db_session, seed_base, fila_desde_at=agora - timedelta(hours=3))
+    db_session.commit()
+
+    r = client.get(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        params={
+            "sem_responsavel": True,
+            "situacao": "abertos",
+            "ordenar_por": "fila_desde_at",
+            "ordem": "desc",
+            "limit": 50,
+        },
+    )
+    assert r.status_code == 200, r.text
+    ids = [x["id"] for x in r.json()["items"] if x["id"] in (t1.id, t2.id)]
+    assert ids == [t1.id, t2.id]
+
+
+def test_distribuicao_menor_carga_abertos(db_session, seed_base):
+    setor = seed_base["setor1"]
+    a1, a2 = seed_base["a1"], seed_base["a2"]
+    _vincular_ao_setor(db_session, a2, setor)
+    setor.distribuicao_modo = "auto_imediato"
+    setor.distribuicao_estrategia = "menor_carga_abertos"
+    db_session.commit()
+
+    for _ in range(3):
+        _criar_ticket_aberto_atribuido(db_session, seed_base, a1.id, setor_id=setor.id)
+    _criar_ticket_aberto_atribuido(db_session, seed_base, a1.id, setor_id=seed_base["setor2"].id)
+    db_session.commit()
+
+    novo = _criar_ticket_fila(db_session, seed_base, setor_id=setor.id)
+    db_session.commit()
+    assert tentar_distribuicao_imediata(db_session, novo) is True
+    db_session.commit()
+    assert novo.atendente_id == a2.id
+
+
+def test_distribuicao_menor_carga_setor(db_session, seed_base):
+    setor = seed_base["setor1"]
+    a1, a2 = seed_base["a1"], seed_base["a2"]
+    _vincular_ao_setor(db_session, a2, setor)
+    setor.distribuicao_modo = "auto_imediato"
+    setor.distribuicao_estrategia = "menor_carga_setor"
+    db_session.commit()
+
+    for _ in range(2):
+        _criar_ticket_aberto_atribuido(db_session, seed_base, a1.id, setor_id=setor.id)
+    for _ in range(4):
+        _criar_ticket_aberto_atribuido(db_session, seed_base, a2.id, setor_id=seed_base["setor2"].id)
+    db_session.commit()
+
+    novo = _criar_ticket_fila(db_session, seed_base, setor_id=setor.id)
+    db_session.commit()
+    assert tentar_distribuicao_imediata(db_session, novo) is True
+    db_session.commit()
+    assert novo.atendente_id == a2.id
+
+
+def test_historico_atribuicao_automatica(db_session, seed_base):
+    setor = seed_base["setor1"]
+    setor.distribuicao_modo = "auto_imediato"
+    db_session.commit()
+
+    ticket = _criar_ticket_fila(db_session, seed_base)
+    db_session.commit()
+    atribuir_ticket_automaticamente(db_session, ticket, setor)
+    db_session.commit()
+
+    hist = (
+        db_session.query(TicketHistorico)
+        .filter(TicketHistorico.ticket_id == ticket.id)
+        .order_by(TicketHistorico.id.asc())
+        .all()
+    )
+    campos = [h.campo for h in hist]
+    assert "atendente_id" in campos
+    assert CAMPO_HISTORICO_DISTRIBUICAO_AUTOMATICA in campos
+    auto = next(h for h in hist if h.campo == CAMPO_HISTORICO_DISTRIBUICAO_AUTOMATICA)
+    assert auto.valor_novo == TEXTO_HISTORICO_DISTRIBUICAO_AUTOMATICA
+
+
+def test_distribuicao_exclui_atendente_inativo(db_session, seed_base):
+    setor = seed_base["setor1"]
+    a1, a2 = seed_base["a1"], seed_base["a2"]
+    _vincular_ao_setor(db_session, a2, setor)
+    a1.ativo = False
+    setor.distribuicao_modo = "auto_imediato"
+    db_session.commit()
+
+    ticket = _criar_ticket_fila(db_session, seed_base)
+    db_session.commit()
+    assert atribuir_ticket_automaticamente(db_session, ticket, setor) == a2.id
+    db_session.commit()
+    assert ticket.atendente_id == a2.id

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -899,7 +899,7 @@ export const tickets = {
     meus?: boolean;
     atendente_id?: number;
     /** Coluna para ordenar (omitir = mais recentes primeiro). */
-    ordenar_por?: 'protocolo' | 'rede' | 'empresa' | 'setor' | 'assunto' | 'status' | 'responsavel' | 'fechado_em';
+    ordenar_por?: 'protocolo' | 'rede' | 'empresa' | 'setor' | 'assunto' | 'status' | 'responsavel' | 'fechado_em' | 'fila_desde_at';
     ordem?: 'asc' | 'desc';
     offset?: number;
     limit?: number;
@@ -1430,7 +1430,7 @@ export namespace TiposNegocio {
 
 export namespace Setores {
   export type DistribuicaoModo = 'manual' | 'auto_apos_timeout' | 'auto_imediato'
-  export type DistribuicaoEstrategia = 'round_robin' | 'menor_carga_abertos'
+  export type DistribuicaoEstrategia = 'round_robin' | 'menor_carga_abertos' | 'menor_carga_setor'
 
   export interface Distribuicao {
     modo: DistribuicaoModo

--- a/frontend/src/pages/SetorDetalhe.tsx
+++ b/frontend/src/pages/SetorDetalhe.tsx
@@ -22,7 +22,8 @@ const MODO_OPCOES: { value: Setores.DistribuicaoModo; label: string }[] = [
 
 const ESTRATEGIA_OPCOES: { value: Setores.DistribuicaoEstrategia; label: string }[] = [
   { value: 'round_robin', label: 'Round-robin (revezamento)' },
-  { value: 'menor_carga_abertos', label: 'Menor carga (tickets abertos)' },
+  { value: 'menor_carga_abertos', label: 'Menor carga (todos os tickets abertos do atendente)' },
+  { value: 'menor_carga_setor', label: 'Menor carga (tickets abertos neste setor)' },
 ]
 
 /** Mesmo nome de setor = mesmo “setor lógico” (vários IDs no banco). */
@@ -304,7 +305,7 @@ export function SetorDetalhe() {
         <div className="space-y-4">
           <p className="text-sm text-slate-600 dark:text-slate-400">
             Define como tickets sem responsável neste setor são atribuídos. Administradores nunca recebem atribuição
-            automática.
+            automática. Chats WhatsApp não são afetados — apenas tickets.
           </p>
 
           <Select

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -69,6 +69,7 @@ const ROTULO_CAMPO: Record<string, string> = {
   prioridade: 'Prioridade',
   motivo_id: 'Motivo',
   motivo_outro_texto: 'Detalhe do motivo',
+  distribuicao_automatica: 'Distribuição automática',
 }
 
 function resolverValorHistorico(
@@ -83,6 +84,7 @@ function resolverValorHistorico(
   },
 ): string {
   if (valor == null || valor === '') return '—'
+  if (campo === 'distribuicao_automatica') return valor
   if (campo === 'prioridade') return rotuloPrioridade(valor)
   if (campo === 'motivo_outro_texto') {
     const t = (valor || '').trim()
@@ -2019,11 +2021,17 @@ export function TicketDetalhe() {
                     {ROTULO_CAMPO[h.campo] ?? h.campo}
                   </div>
                   <div className="mt-1 text-slate-600 dark:text-slate-300">
-                    <span className="text-slate-500 dark:text-slate-400">
-                      {resolverValorHistorico(h.campo, h.valor_antigo, mapsHistorico)}
-                    </span>
-                    <span className="mx-2 text-slate-400 dark:text-slate-500">→</span>
-                    <span>{resolverValorHistorico(h.campo, h.valor_novo, mapsHistorico)}</span>
+                    {h.campo === 'distribuicao_automatica' ? (
+                      <span>{resolverValorHistorico(h.campo, h.valor_novo, mapsHistorico)}</span>
+                    ) : (
+                      <>
+                        <span className="text-slate-500 dark:text-slate-400">
+                          {resolverValorHistorico(h.campo, h.valor_antigo, mapsHistorico)}
+                        </span>
+                        <span className="mx-2 text-slate-400 dark:text-slate-500">→</span>
+                        <span>{resolverValorHistorico(h.campo, h.valor_novo, mapsHistorico)}</span>
+                      </>
+                    )}
                   </div>
                   <div className="mt-1 text-xs text-slate-500 dark:text-slate-400">
                     {new Date(h.created_at).toLocaleString('pt-BR')}

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -37,6 +37,10 @@ type ColunaOrdenacao =
   | 'status'
   | 'responsavel'
   | 'fechado_em'
+  | 'fila_desde_at'
+
+/** Minutos restantes para auto-atribuição abaixo disto → destaque na listagem. */
+const MINUTOS_DESTAQUE_PROXIMO_AUTO = 5
 
 const searchIcon = (
   <svg className="size-4 text-slate-400 dark:text-slate-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
@@ -53,11 +57,26 @@ function formatarTempoNaFila(filaDesdeAt: string | undefined | null): string {
   return m > 0 ? `${h}h ${m}min` : `${h}h`
 }
 
+function ticketProximoAutoAtribuicao(ticket: Tickets.Ticket): boolean {
+  return (
+    ticket.distribuicao_modo_setor === 'auto_apos_timeout' &&
+    ticket.distribuicao_auto_em_minutos != null &&
+    ticket.distribuicao_auto_em_minutos <= MINUTOS_DESTAQUE_PROXIMO_AUTO
+  )
+}
+
 function BadgeAutoDistribuicao({ ticket }: { ticket: Tickets.Ticket }) {
+  const urgente = ticketProximoAutoAtribuicao(ticket)
   if (ticket.distribuicao_modo_setor === 'auto_apos_timeout' && ticket.distribuicao_auto_em_minutos != null) {
     return (
-      <span className="inline-flex rounded-full bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800 dark:bg-amber-950/40 dark:text-amber-200">
-        Auto em {ticket.distribuicao_auto_em_minutos} min
+      <span
+        className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+          urgente
+            ? 'bg-red-50 text-red-800 ring-1 ring-inset ring-red-200 dark:bg-red-950/40 dark:text-red-200 dark:ring-red-800/60'
+            : 'bg-amber-50 text-amber-800 dark:bg-amber-950/40 dark:text-amber-200'
+        }`}
+      >
+        {urgente ? 'Auto iminente' : `Auto em ${ticket.distribuicao_auto_em_minutos} min`}
       </span>
     )
   }
@@ -122,6 +141,14 @@ export function Tickets() {
   const [maisFiltrosAberto, setMaisFiltrosAberto] = useState(false)
   const painelFiltrosId = useId()
   const { ordenarPor, ordem, aoOrdenarColuna, sortParams } = useOrdenacaoLista<ColunaOrdenacao>()
+
+  const sortParamsEfetivos = useMemo(() => {
+    if (sortParams.ordenar_por) return sortParams
+    if (situacao === 'abertos' && filtroFila === 'sem_responsavel') {
+      return { ordenar_por: 'fila_desde_at' as const, ordem: 'asc' as const }
+    }
+    return {}
+  }, [sortParams, situacao, filtroFila])
 
   const resetarPagina = useCallback(() => setPage(1), [])
 
@@ -258,7 +285,7 @@ export function Tickets() {
           filtroAtendente !== ''
             ? Number(filtroAtendente)
             : undefined,
-        ...sortParams,
+        ...sortParamsEfetivos,
         offset: (page - 1) * PAGE_SIZE_PADRAO,
         limit: PAGE_SIZE_PADRAO,
       })
@@ -291,7 +318,7 @@ export function Tickets() {
     isAdmin,
     ordenarPor,
     ordem,
-    sortParams,
+    sortParamsEfetivos,
     toast,
   ])
 
@@ -621,12 +648,17 @@ export function Tickets() {
             <div className="divide-y divide-slate-100 dark:divide-slate-800 sm:hidden">
               {list.map((t) => {
                 const fechadoFmt = t.fechado_em ? new Date(t.fechado_em).toLocaleString('pt-BR') : null
+                const proximoAuto = mostrarColunasFila && !t.atendente_id && ticketProximoAutoAtribuicao(t)
                 return (
                   <button
                     key={t.id}
                     type="button"
                     onClick={() => navigate(`/tickets/${t.id}`)}
-                    className="w-full px-4 py-4 text-left transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-slate-800/40 dark:focus-visible:bg-slate-800/60"
+                    className={`w-full px-4 py-4 text-left transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-slate-800/40 dark:focus-visible:bg-slate-800/60 ${
+                      proximoAuto
+                        ? 'bg-amber-50/70 ring-1 ring-inset ring-amber-200/70 dark:bg-amber-950/25 dark:ring-amber-800/40'
+                        : ''
+                    }`}
                   >
                     <div className="flex items-start justify-between gap-3">
                       <div className="min-w-0">
@@ -798,7 +830,17 @@ export function Tickets() {
                     className="hidden px-4 py-3 lg:table-cell sm:px-6"
                   />
                   {mostrarColunasFila && (
-                    <th className="hidden whitespace-nowrap px-4 py-3 lg:table-cell sm:px-6">Na fila há</th>
+                    <CabecalhoOrdenavel
+                      coluna="fila_desde_at"
+                      rotulo="Na fila há"
+                      ordenarPor={ordenarPor ?? (filtroFila === 'sem_responsavel' ? 'fila_desde_at' : null)}
+                      ordem={ordenarPor ? ordem : 'asc'}
+                      aoOrdenar={(c) => {
+                        resetarPagina()
+                        aoOrdenarColuna(c)
+                      }}
+                      className="hidden whitespace-nowrap px-4 py-3 lg:table-cell sm:px-6"
+                    />
                   )}
                   {mostrarColunasFila && (
                     <th className="hidden whitespace-nowrap px-4 py-3 lg:table-cell sm:px-6">Distribuição</th>
@@ -806,7 +848,9 @@ export function Tickets() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
-                {list.map((t) => (
+                {list.map((t) => {
+                  const proximoAuto = mostrarColunasFila && !t.atendente_id && ticketProximoAutoAtribuicao(t)
+                  return (
                   <tr
                     key={t.id}
                     role="button"
@@ -818,7 +862,11 @@ export function Tickets() {
                         navigate(`/tickets/${t.id}`)
                       }
                     }}
-                    className="cursor-pointer transition-colors hover:bg-slate-50/90 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-slate-800/50 dark:focus-visible:bg-slate-800/60"
+                    className={`cursor-pointer transition-colors hover:bg-slate-50/90 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-slate-800/50 dark:focus-visible:bg-slate-800/60 ${
+                      proximoAuto
+                        ? 'bg-amber-50/70 ring-1 ring-inset ring-amber-200/70 dark:bg-amber-950/25 dark:ring-amber-800/40'
+                        : ''
+                    }`}
                   >
                     <td
                       className="max-w-[10rem] truncate px-4 py-3.5 align-top font-mono text-sm text-slate-900 sm:max-w-[12rem] sm:px-6 dark:text-slate-100"
@@ -908,7 +956,8 @@ export function Tickets() {
                       </td>
                     )}
                   </tr>
-                ))}
+                  )
+                })}
               </tbody>
             </table>
             </div>

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -143,12 +143,12 @@ export function Tickets() {
   const { ordenarPor, ordem, aoOrdenarColuna, sortParams } = useOrdenacaoLista<ColunaOrdenacao>()
 
   const sortParamsEfetivos = useMemo(() => {
-    if (sortParams.ordenar_por) return sortParams
+    if (ordenarPor) return sortParams
     if (situacao === 'abertos' && filtroFila === 'sem_responsavel') {
       return { ordenar_por: 'fila_desde_at' as const, ordem: 'asc' as const }
     }
     return {}
-  }, [sortParams, situacao, filtroFila])
+  }, [ordenarPor, sortParams, situacao, filtroFila])
 
   const resetarPagina = useCallback(() => setPage(1), [])
 


### PR DESCRIPTION
## Summary
- Completa o epico #257: indicadores de fila (#273), ordenacao por `fila_desde_at`, destaque visual proximo ao timeout e default na fila sem responsavel.
- Estrategia `menor_carga_setor` e ajuste de `menor_carga_abertos` (carga total vs. so no setor).
- Historico «Atribuido automaticamente» e UI de estrategias no setor (#272).
- Testes: menor carga, historico automatico, atendente inativo, listagem ordenada.

## Test plan
- [ ] Merge na main (deploy staging/producao aguarda lote de melhorias)
- [ ] Configurar setor com auto_imediato / auto_apos_timeout e validar atribuicao
- [ ] Filtro Na fila: ordenacao, badge Auto em X min e destaque iminente
- [ ] Historico do ticket mostra Atribuido automaticamente apos worker
- [ ] Estrategias menor carga abertos vs. setor escolhem atendente correto

Closes #271, #272, #273