### PR TITLE
fix(deploy): valida git_sha contra HEAD do ref no re-run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Resolver SHA esperado no ref deployado
+        run: |
+          REF="${EVENT_REF:-${DEPLOY_GIT_REF:-staging}}"
+          git fetch origin "${REF}"
+          SHA="$(git rev-parse --short "origin/${REF}")"
+          echo "EXPECTED_DEPLOY_SHA=${SHA}" >> "$GITHUB_ENV"
+          echo "SHA esperado em producao (origin/${REF}): ${SHA}"
+
       - name: Preparar release (CalVer + release notes)
         run: |
           python3 scripts/prepare_release.py --deploy --write-env >> "$GITHUB_ENV"
@@ -305,7 +313,7 @@ jobs:
                   file=sys.stderr,
               )
               sys.exit(1)
-          expected_sha = os.environ.get("GITHUB_SHA", "")[:7]
+          expected_sha = os.environ.get("EXPECTED_DEPLOY_SHA", "") or os.environ.get("GITHUB_SHA", "")[:7]
           actual_sha = (body.get("git_sha") or "") or ""
           if expected_sha and actual_sha and actual_sha != expected_sha:
               print(
@@ -314,7 +322,7 @@ jobs:
                   file=sys.stderr,
               )
               sys.exit(1)
-          print("OK: capabilities", caps, "git_sha", body.get("git_sha"))
+          print("OK: capabilities", caps, "git_sha", body.get("git_sha"), "expected", expected_sha)
           PY
 
       - name: Persistir manifest e CHANGELOG em staging


### PR DESCRIPTION
## Summary

Corrige falha no deploy apos re-run: o health check comparava git_sha da API com GITHUB_SHA do commit que disparou o workflow, mas o VPS faz git pull do HEAD atual de staging (commit diferente apos merges).

Agora usa origin/\$REF\ no momento do deploy.

## Test plan

- [ ] Re-run do Deploy em staging conclui com health OK