### PR TITLE
feat(roteamento): motor de regras configuravel — epico #258

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets
+- Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime
+- `aplicar_roteamento` restrito a administradores para sobrescrever setor explícito
+- UI em Configurações → Atendimento → Roteamento com simulador de teste seco
 - Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)
 - CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)
 

--- a/backend/alembic/versions/045_merge_distribuicao_webhook_heads.py
+++ b/backend/alembic/versions/045_merge_distribuicao_webhook_heads.py
@@ -1,0 +1,19 @@
+"""Unifica heads: distribuicao tickets + webhook outbox.
+
+Revision ID: 045_merge_distrib_webhook
+Revises: 043_setor_distribuicao, 044_webhook_outbox
+Create Date: 2026-06-17
+"""
+
+revision = "045_merge_distrib_webhook"
+down_revision = ("043_setor_distribuicao", "044_webhook_outbox")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/046_routing_rules.py
+++ b/backend/alembic/versions/046_routing_rules.py
@@ -1,0 +1,43 @@
+"""Tabela routing_rules (#258).
+
+Revision ID: 046_routing_rules
+Revises: 045_merge_distrib_webhook
+Create Date: 2026-06-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "046_routing_rules"
+down_revision = "045_merge_distrib_webhook"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "routing_rules",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sa.Integer(), nullable=False),
+        sa.Column("nome", sa.String(length=200), nullable=False),
+        sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("ordem", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("rede_id", sa.Integer(), nullable=True),
+        sa.Column("condicoes", sa.JSON(), nullable=False),
+        sa.Column("acoes", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["rede_id"], ["redes.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_routing_rules_id"), "routing_rules", ["id"], unique=False)
+    op.create_index(op.f("ix_routing_rules_tenant_id"), "routing_rules", ["tenant_id"], unique=False)
+    op.create_index(op.f("ix_routing_rules_rede_id"), "routing_rules", ["rede_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_routing_rules_rede_id"), table_name="routing_rules")
+    op.drop_index(op.f("ix_routing_rules_tenant_id"), table_name="routing_rules")
+    op.drop_index(op.f("ix_routing_rules_id"), table_name="routing_rules")
+    op.drop_table("routing_rules")

--- a/backend/app/api/routing.py
+++ b/backend/app/api/routing.py
@@ -1,0 +1,216 @@
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.core.auth import exigir_admin
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.models.rede import Rede
+from app.models.routing_rule import RoutingRule
+from app.models.setor import Setor
+from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+from app.schemas.routing import (
+    RoutingAction,
+    RoutingCondition,
+    RoutingResultRead,
+    RoutingRuleCreate,
+    RoutingRuleRead,
+    RoutingRuleReorder,
+    RoutingRuleUpdate,
+    RoutingSimulateRequest,
+)
+from app.services.routing_evaluate import RoutingContext, evaluate_routing, resultado_para_read_dict
+
+router = APIRouter(prefix="/routing", tags=["routing"])
+
+
+def _validar_acoes(db: Session, tenant_id: int, acoes: RoutingAction) -> None:
+    if acoes.setor_id is not None:
+        setor = db.query(Setor).filter(Setor.id == acoes.setor_id, Setor.tenant_id == tenant_id).first()
+        if not setor:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Setor da ação não encontrado")
+    if acoes.natureza_id is not None:
+        nat = db.query(TicketNatureza).filter(TicketNatureza.id == acoes.natureza_id).first()
+        if not nat:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Natureza não encontrada")
+    if acoes.motivo_id is not None:
+        mot = db.query(TicketMotivo).filter(TicketMotivo.id == acoes.motivo_id).first()
+        if not mot:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Motivo não encontrado")
+        if acoes.natureza_id is not None and mot.natureza_id != acoes.natureza_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Motivo não pertence à natureza informada",
+            )
+    if acoes.atendente_id is not None:
+        at = db.query(Atendente).filter(Atendente.id == acoes.atendente_id, Atendente.tenant_id == tenant_id).first()
+        if not at:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Atendente não encontrado")
+
+
+def _validar_rede(db: Session, tenant_id: int, rede_id: int | None) -> None:
+    if rede_id is None:
+        return
+    rede = db.query(Rede).filter(Rede.id == rede_id, Rede.tenant_id == tenant_id).first()
+    if not rede:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Rede não encontrada")
+
+
+def _row_para_read(rule: RoutingRule) -> RoutingRuleRead:
+    return RoutingRuleRead.from_orm_row(rule)
+
+
+@router.get("/rules", response_model=list[RoutingRuleRead])
+def listar_regras(
+    incluir_inativos: bool = Query(False),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    q = db.query(RoutingRule).filter(RoutingRule.tenant_id == atendente.tenant_id)
+    if not incluir_inativos:
+        q = q.filter(RoutingRule.ativo.is_(True))
+    rules = q.order_by(RoutingRule.ordem.asc(), RoutingRule.id.asc()).all()
+    return [_row_para_read(r) for r in rules]
+
+
+@router.post("/rules", response_model=RoutingRuleRead, status_code=201)
+def criar_regra(
+    data: RoutingRuleCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    _validar_rede(db, atendente.tenant_id, data.rede_id)
+    _validar_acoes(db, atendente.tenant_id, data.acoes)
+    max_ordem = (
+        db.query(RoutingRule.ordem)
+        .filter(RoutingRule.tenant_id == atendente.tenant_id)
+        .order_by(RoutingRule.ordem.desc())
+        .limit(1)
+        .scalar()
+    )
+    ordem = (max_ordem + 1) if max_ordem is not None else 0
+    rule = RoutingRule(
+        tenant_id=atendente.tenant_id,
+        nome=data.nome.strip(),
+        ativo=data.ativo,
+        ordem=ordem,
+        rede_id=data.rede_id,
+        condicoes=[c.model_dump(mode="json") for c in data.condicoes],
+        acoes=data.acoes.model_dump(mode="json", exclude_none=True),
+    )
+    db.add(rule)
+    db.flush()
+    registrar_audit(db, "routing_rule", rule.id, "create", atendente.id)
+    db.commit()
+    db.refresh(rule)
+    return _row_para_read(rule)
+
+
+@router.put("/rules/reorder", response_model=list[RoutingRuleRead])
+def reordenar_regras(
+    data: RoutingRuleReorder,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    ids = [item.id for item in data.items]
+    rules = (
+        db.query(RoutingRule)
+        .filter(RoutingRule.tenant_id == atendente.tenant_id, RoutingRule.id.in_(ids))
+        .all()
+    )
+    if len(rules) != len(ids):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Uma ou mais regras não encontradas")
+    ordem_por_id = {item.id: item.ordem for item in data.items}
+    for rule in rules:
+        rule.ordem = ordem_por_id[rule.id]
+    registrar_audit(db, "routing_rule", 0, "reorder", atendente.id)
+    db.commit()
+    rules = (
+        db.query(RoutingRule)
+        .filter(RoutingRule.tenant_id == atendente.tenant_id)
+        .order_by(RoutingRule.ordem.asc(), RoutingRule.id.asc())
+        .all()
+    )
+    return [_row_para_read(r) for r in rules]
+
+
+@router.post("/rules/simulate", response_model=RoutingResultRead)
+def simular_regra(
+    data: RoutingSimulateRequest,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    ctx = RoutingContext(
+        email_from=data.email_from,
+        email_to=data.email_to,
+        assunto=data.assunto,
+        canal=data.canal,
+        rede_id=data.rede_id,
+    )
+    resultado = evaluate_routing(db, tenant_id=atendente.tenant_id, context=ctx)
+    if resultado.matched and not data.aplicar_setor and data.setor_id_atual is not None:
+        resultado.setor_id = data.setor_id_atual
+    return RoutingResultRead.model_validate(resultado_para_read_dict(resultado))
+
+
+@router.get("/rules/{rule_id}", response_model=RoutingRuleRead)
+def obter_regra(
+    rule_id: int,
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_admin),
+):
+    rule = db.query(RoutingRule).filter(RoutingRule.id == rule_id).first()
+    if not rule:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Regra não encontrada")
+    return _row_para_read(rule)
+
+
+@router.put("/rules/{rule_id}", response_model=RoutingRuleRead)
+def atualizar_regra(
+    rule_id: int,
+    data: RoutingRuleUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    rule = db.query(RoutingRule).filter(
+        RoutingRule.id == rule_id, RoutingRule.tenant_id == atendente.tenant_id
+    ).first()
+    if not rule:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Regra não encontrada")
+
+    payload = data.model_dump(exclude_unset=True)
+    if "nome" in payload and payload["nome"] is not None:
+        rule.nome = payload["nome"].strip()
+    if "ativo" in payload:
+        rule.ativo = payload["ativo"]
+    if "rede_id" in payload:
+        _validar_rede(db, atendente.tenant_id, payload["rede_id"])
+        rule.rede_id = payload["rede_id"]
+    if "condicoes" in payload and payload["condicoes"] is not None:
+        conds = [RoutingCondition.model_validate(c) for c in payload["condicoes"]]
+        rule.condicoes = [c.model_dump(mode="json") for c in conds]
+    if "acoes" in payload and payload["acoes"] is not None:
+        acoes = RoutingAction.model_validate(payload["acoes"])
+        _validar_acoes(db, atendente.tenant_id, acoes)
+        rule.acoes = acoes.model_dump(mode="json", exclude_none=True)
+
+    registrar_audit(db, "routing_rule", rule.id, "update", atendente.id)
+    db.commit()
+    db.refresh(rule)
+    return _row_para_read(rule)
+
+
+@router.delete("/rules/{rule_id}", status_code=status.HTTP_204_NO_CONTENT)
+def excluir_regra(
+    rule_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    rule = db.query(RoutingRule).filter(
+        RoutingRule.id == rule_id, RoutingRule.tenant_id == atendente.tenant_id
+    ).first()
+    if not rule:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Regra não encontrada")
+    db.delete(rule)
+    registrar_audit(db, "routing_rule", rule_id, "delete", atendente.id)
+    db.commit()

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -591,11 +591,6 @@ def criar(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    # Atendente só pode abrir ticket em setor que ele atende
-    if atendente.role != "admin":
-        vis = ids_setores_visiveis_atendente(db, atendente)
-        if data.setor_id not in vis:
-            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este setor")
     try:
         modo = validar_escopo_criacao_manual(
             empresa_id=data.empresa_id,
@@ -604,14 +599,6 @@ def criar(
         )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
-
-    setor = (
-        db.query(Setor)
-        .filter(Setor.id == data.setor_id, Setor.tenant_id == atendente.tenant_id)
-        .first()
-    )
-    if not setor:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Setor não encontrado")
 
     ticket_empresa_id: int | None
     ticket_rede_id: int | None
@@ -648,26 +635,102 @@ def criar(
             filho_ticket_id=None,
             parent_id=data.parent_ticket_id,
         )
+
+    from app.core.routing import RoutingCanal
+    from app.services.routing_apply import acoes_efetivas_do_resultado, registrar_roteamento_aplicado
+    from app.services.routing_evaluate import (
+        RoutingContext,
+        aplicar_roteamento_setor,
+        evaluate_routing,
+    )
+
+    if data.aplicar_roteamento and atendente.role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Apenas administradores podem forçar roteamento sobre setor explícito.",
+        )
+
+    setor_id_efetivo = data.setor_id
+    prioridade_efetiva = data.prioridade
+    motivo_id_rota: int | None = None
+    atendente_id_rota: int | None = None
+    rota_resultado = evaluate_routing(
+        db,
+        tenant_id=atendente.tenant_id,
+        context=RoutingContext(
+            assunto=data.assunto,
+            canal=RoutingCanal.manual,
+            rede_id=ticket_rede_id,
+        ),
+    )
+    if rota_resultado.matched:
+        aplicar_setor = data.setor_id is None or data.aplicar_roteamento
+        setor_id_efetivo = aplicar_roteamento_setor(
+            setor_atual=data.setor_id,
+            resultado=rota_resultado,
+            aplicar_setor=aplicar_setor,
+        )
+        if rota_resultado.prioridade is not None:
+            prioridade_efetiva = rota_resultado.prioridade
+
+    if setor_id_efetivo is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Setor não informado e nenhuma regra de roteamento definiu setor.",
+        )
+
+    if rota_resultado.matched:
+        motivo_id_rota, atendente_id_rota = acoes_efetivas_do_resultado(
+            db,
+            tenant_id=atendente.tenant_id,
+            setor_id=setor_id_efetivo,
+            resultado=rota_resultado,
+        )
+
+    # Atendente só pode abrir ticket em setor que ele atende
+    if atendente.role != "admin":
+        vis = ids_setores_visiveis_atendente(db, atendente)
+        if setor_id_efetivo not in vis:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este setor")
+
+    setor = (
+        db.query(Setor)
+        .filter(Setor.id == setor_id_efetivo, Setor.tenant_id == atendente.tenant_id)
+        .first()
+    )
+    if not setor:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Setor não encontrado")
+
     # Status inicial: primeiro status ativo por ordem (ex.: «Aguardando atendimento» na fila do setor)
     status_inicial = db.query(StatusTicket).filter(StatusTicket.ativo.is_(True)).order_by(StatusTicket.ordem).first()
     if not status_inicial:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Cadastre ao menos um status de ticket")
     protocolo = _gerar_protocolo(db)
-    prioridade = validar_prioridade(data.prioridade)
+    prioridade = validar_prioridade(prioridade_efetiva)
     ticket = Ticket(
         tenant_id=atendente.tenant_id,
         protocolo=protocolo,
         empresa_id=ticket_empresa_id,
         rede_id=ticket_rede_id,
-        setor_id=data.setor_id,
+        setor_id=setor_id_efetivo,
         status_id=status_inicial.id,
         prioridade=prioridade,
         assunto=data.assunto,
         descricao=data.descricao,
         aberto_por_id=data.aberto_por_id,
         parent_ticket_id=data.parent_ticket_id,
+        motivo_id=motivo_id_rota,
+        atendente_id=atendente_id_rota,
     )
     db.add(ticket)
+    db.flush()
+    if rota_resultado.matched:
+        registrar_roteamento_aplicado(
+            db,
+            resultado=rota_resultado,
+            ticket_id=ticket.id,
+            atendente_audit_id=atendente.id,
+        )
     db.commit()
     db.refresh(ticket)
     corpo_abertura = (data.descricao or "").strip() or "—"

--- a/backend/app/core/routing.py
+++ b/backend/app/core/routing.py
@@ -1,0 +1,23 @@
+"""Enums e tipos do motor de roteamento (#258)."""
+
+from __future__ import annotations
+
+import enum
+
+
+class RoutingCampo(str, enum.Enum):
+    email_from = "email_from"
+    email_to = "email_to"
+    assunto = "assunto"
+    canal = "canal"
+
+
+class RoutingOperador(str, enum.Enum):
+    contains = "contains"
+    equals = "equals"
+    regex = "regex"
+
+
+class RoutingCanal(str, enum.Enum):
+    email = "email"
+    manual = "manual"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,6 +41,7 @@ from app.api import (
     tenant,
     public_csat,
     system,
+    routing,
 )
 from app.config import settings
 from app.core.tenant_context import resolve_tenant_id, set_request_tenant_id
@@ -401,6 +402,7 @@ app.include_router(system_settings.router, prefix=API_V1_PREFIX)
 app.include_router(tenant.router, prefix=API_V1_PREFIX)
 app.include_router(public_csat.router, prefix=API_V1_PREFIX)
 app.include_router(system.router, prefix=API_V1_PREFIX)
+app.include_router(routing.router, prefix=API_V1_PREFIX)
 
 
 def _app_route_paths() -> set[str]:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -28,6 +28,7 @@ from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
 from app.models.ticket_avaliacao import TicketAvaliacao, TicketCsatInvite
 from app.models.atendente_notificacao import AtendenteNotificacaoPreferencias, NotificacaoEmailOutbox
 from app.models.webhook_outbox import WebhookOutbox
+from app.models.routing_rule import RoutingRule
 from app.models.empresa_pdv import EmpresaPdv, PdvRotulo, PdvTipoAcessoRemoto
 
 __all__ = [
@@ -71,6 +72,7 @@ __all__ = [
     "AtendenteNotificacaoPreferencias",
     "NotificacaoEmailOutbox",
     "WebhookOutbox",
+    "RoutingRule",
     "PdvRotulo",
     "PdvTipoAcessoRemoto",
     "EmpresaPdv",

--- a/backend/app/models/routing_rule.py
+++ b/backend/app/models/routing_rule.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, JSON, String
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class RoutingRule(Base):
+    """Regra de roteamento configurável (primeira match ganha)."""
+
+    __tablename__ = "routing_rules"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    nome = Column(String(200), nullable=False)
+    ativo = Column(Boolean, default=True, nullable=False)
+    ordem = Column(Integer, default=0, nullable=False)
+    rede_id = Column(Integer, ForeignKey("redes.id", ondelete="CASCADE"), nullable=True, index=True)
+    condicoes = Column(JSON, nullable=False)
+    acoes = Column(JSON, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    rede = relationship("Rede", foreign_keys=[rede_id])

--- a/backend/app/schemas/routing.py
+++ b/backend/app/schemas/routing.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from app.core.routing import RoutingCampo, RoutingCanal, RoutingOperador
+from app.core.ticket_prioridade import PrioridadeTicket
+
+
+class RoutingCondition(BaseModel):
+    campo: RoutingCampo
+    operador: RoutingOperador
+    valor: str = Field(..., min_length=1, max_length=500)
+
+    @field_validator("valor")
+    @classmethod
+    def valor_nao_vazio(cls, v: str) -> str:
+        s = v.strip()
+        if not s:
+            raise ValueError("Valor da condição é obrigatório")
+        return s
+
+    @model_validator(mode="after")
+    def validar_regex(self):
+        if self.operador == RoutingOperador.regex:
+            try:
+                re.compile(self.valor)
+            except re.error as e:
+                raise ValueError(f"Expressão regular inválida: {e}") from e
+        return self
+
+
+class RoutingAction(BaseModel):
+    setor_id: int | None = None
+    prioridade: PrioridadeTicket | None = None
+    natureza_id: int | None = None
+    motivo_id: int | None = None
+    atendente_id: int | None = None
+
+    @model_validator(mode="after")
+    def ao_menos_uma_acao(self):
+        if not any(
+            v is not None
+            for v in (
+                self.setor_id,
+                self.prioridade,
+                self.natureza_id,
+                self.motivo_id,
+                self.atendente_id,
+            )
+        ):
+            raise ValueError("Informe ao menos uma ação (setor, prioridade, natureza, motivo ou atendente)")
+        return self
+
+
+class RoutingRuleBase(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=200)
+    ativo: bool = True
+    rede_id: int | None = Field(None, description="Null = escopo global do tenant")
+    condicoes: list[RoutingCondition] = Field(..., min_length=1)
+    acoes: RoutingAction
+
+
+class RoutingRuleCreate(RoutingRuleBase):
+    pass
+
+
+class RoutingRuleUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=200)
+    ativo: bool | None = None
+    rede_id: int | None = None
+    condicoes: list[RoutingCondition] | None = Field(None, min_length=1)
+    acoes: RoutingAction | None = None
+
+
+class RoutingRuleRead(RoutingRuleBase):
+    id: int
+    ordem: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @classmethod
+    def from_orm_row(cls, row: Any) -> RoutingRuleRead:
+        return cls(
+            id=row.id,
+            nome=row.nome,
+            ativo=row.ativo,
+            ordem=row.ordem,
+            rede_id=row.rede_id,
+            condicoes=[RoutingCondition.model_validate(c) for c in (row.condicoes or [])],
+            acoes=RoutingAction.model_validate(row.acoes or {}),
+        )
+
+
+class RoutingRuleReorderItem(BaseModel):
+    id: int
+    ordem: int = Field(..., ge=0)
+
+
+class RoutingRuleReorder(BaseModel):
+    items: list[RoutingRuleReorderItem] = Field(..., min_length=1)
+
+
+class RoutingSimulateRequest(BaseModel):
+    email_from: str | None = None
+    email_to: str | None = None
+    assunto: str | None = None
+    canal: RoutingCanal = RoutingCanal.email
+    rede_id: int | None = None
+    setor_id_atual: int | None = None
+    aplicar_setor: bool = True
+
+
+class RoutingResultRead(BaseModel):
+    matched: bool = False
+    rule_id: int | None = None
+    rule_nome: str | None = None
+    setor_id: int | None = None
+    prioridade: PrioridadeTicket | None = None
+    natureza_id: int | None = None
+    motivo_id: int | None = None
+    atendente_id: int | None = None

--- a/backend/app/schemas/ticket.py
+++ b/backend/app/schemas/ticket.py
@@ -9,12 +9,13 @@ from app.core.ticket_prioridade import PrioridadeTicket
 class TicketCreate(BaseModel):
     empresa_id: int | None = None
     rede_id: int | None = None
-    setor_id: int
+    setor_id: int | None = None
     assunto: str
     descricao: str | None = None
     aberto_por_id: int | None = None
     parent_ticket_id: int | None = None
     prioridade: PrioridadeTicket = PrioridadeTicket.normal
+    aplicar_roteamento: bool = False
 
     @model_validator(mode="after")
     def validar_escopo(self):

--- a/backend/app/services/email_inbound_dispatch.py
+++ b/backend/app/services/email_inbound_dispatch.py
@@ -5,9 +5,17 @@ from __future__ import annotations
 from sqlalchemy.orm import Session
 
 from app.config import settings
+from app.core.routing import RoutingCanal
 from app.models.tenant import Tenant
 from app.schemas.email_inbound import EmailInboundWebhookResponse
 from app.services.email_inbound_parse import ParsedInboundEmail
+from app.services.routing_evaluate import (
+    RoutingContext,
+    RoutingResult,
+    aplicar_roteamento_setor,
+    evaluate_routing,
+)
+from app.services.routing_apply import acoes_efetivas_do_resultado
 from app.services.tenant_inbound import resolve_routing_from_recipients
 from app.services.funcionario_rede_resolver import resolver_remetente_por_email
 from app.services.ticket_from_inbound_email import processar_email_inbound
@@ -67,13 +75,54 @@ def dispatch_parsed_inbound(db: Session, parsed: ParsedInboundEmail) -> EmailInb
 
     tenant_id, empresa_id_rota, setor_id = resolve_inbound_routing(db, parsed)
     empresa_id, aberto_por_id = _empresa_e_funcionario_do_remetente(db, parsed, empresa_id_rota)
+
+    rede_id_ctx = None
+    if empresa_id is not None:
+        from app.models.empresa import Empresa
+
+        emp = db.query(Empresa).filter(Empresa.id == empresa_id).first()
+        if emp:
+            rede_id_ctx = emp.rede_id
+
+    email_to = parsed.to_recipients[0] if parsed.to_recipients else None
+    rota = evaluate_routing(
+        db,
+        tenant_id=tenant_id,
+        context=RoutingContext(
+            email_from=parsed.from_email,
+            email_to=email_to,
+            assunto=parsed.subject,
+            canal=RoutingCanal.email,
+            rede_id=rede_id_ctx,
+        ),
+    )
+    setor_final = aplicar_roteamento_setor(
+        setor_atual=setor_id,
+        resultado=rota,
+        aplicar_setor=True,
+    )
+    if setor_final is None:
+        setor_final = setor_id
+
+    motivo_id, atendente_id = acoes_efetivas_do_resultado(
+        db,
+        tenant_id=tenant_id,
+        setor_id=setor_final,
+        resultado=rota,
+    )
+
     res = processar_email_inbound(
         db,
         empresa_id=empresa_id,
-        setor_id=setor_id,
+        setor_id=setor_final,
         parsed=parsed,
         tenant_id=tenant_id,
         aberto_por_id=aberto_por_id,
+        prioridade=rota.prioridade,
+        natureza_id=rota.natureza_id,
+        motivo_id=motivo_id,
+        atendente_id=atendente_id,
+        rota_aplicada=rota if rota.matched else None,
     )
     return EmailInboundWebhookResponse(
         ticket_id=res.ticket.id,

--- a/backend/app/services/routing_apply.py
+++ b/backend/app/services/routing_apply.py
@@ -1,0 +1,104 @@
+"""Aplicação de resultado de roteamento em tickets (#258)."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.models import TicketHistorico
+from app.models.atendente import Atendente
+from app.models.ticket_classificacao import TicketMotivo
+from app.services.routing_evaluate import RoutingResult
+
+CAMPO_HISTORICO_ROTEAMENTO = "roteamento_regra"
+
+
+def resolver_motivo_roteamento(
+    db: Session,
+    *,
+    natureza_id: int | None,
+    motivo_id: int | None,
+) -> int | None:
+    """Resolve motivo_id efetivo; natureza sozinha usa o primeiro motivo ativo da natureza."""
+    if motivo_id is not None:
+        mot = db.query(TicketMotivo).filter(TicketMotivo.id == motivo_id, TicketMotivo.ativo.is_(True)).first()
+        if not mot:
+            return None
+        if natureza_id is not None and mot.natureza_id != natureza_id:
+            return None
+        return motivo_id
+    if natureza_id is not None:
+        mot = (
+            db.query(TicketMotivo)
+            .filter(TicketMotivo.natureza_id == natureza_id, TicketMotivo.ativo.is_(True))
+            .order_by(TicketMotivo.ordem.asc(), TicketMotivo.id.asc())
+            .first()
+        )
+        return mot.id if mot else None
+    return None
+
+
+def resolver_atendente_roteamento(
+    db: Session,
+    *,
+    tenant_id: int,
+    setor_id: int,
+    atendente_id: int | None,
+) -> int | None:
+    if atendente_id is None:
+        return None
+    at = (
+        db.query(Atendente)
+        .filter(Atendente.id == atendente_id, Atendente.tenant_id == tenant_id, Atendente.ativo.is_(True))
+        .first()
+    )
+    if not at:
+        return None
+    ids_setor = {s.id for s in at.setores}
+    if setor_id not in ids_setor:
+        return None
+    return atendente_id
+
+
+def registrar_roteamento_aplicado(
+    db: Session,
+    *,
+    resultado: RoutingResult,
+    ticket_id: int | None = None,
+    atendente_audit_id: int | None = None,
+) -> None:
+    if not resultado.matched or resultado.rule_id is None:
+        return
+    registrar_audit(db, "routing_rule", resultado.rule_id, "apply", atendente_audit_id)
+    if ticket_id is not None:
+        db.add(
+            TicketHistorico(
+                ticket_id=ticket_id,
+                atendente_id=atendente_audit_id,
+                campo=CAMPO_HISTORICO_ROTEAMENTO,
+                valor_antigo="",
+                valor_novo=f"{resultado.rule_id}:{resultado.rule_nome or ''}",
+            )
+        )
+
+
+def acoes_efetivas_do_resultado(
+    db: Session,
+    *,
+    tenant_id: int,
+    setor_id: int,
+    resultado: RoutingResult,
+) -> tuple[int | None, int | None]:
+    """Retorna (motivo_id, atendente_id) resolvidos e validados."""
+    motivo_id = resolver_motivo_roteamento(
+        db,
+        natureza_id=resultado.natureza_id,
+        motivo_id=resultado.motivo_id,
+    )
+    atendente_id = resolver_atendente_roteamento(
+        db,
+        tenant_id=tenant_id,
+        setor_id=setor_id,
+        atendente_id=resultado.atendente_id,
+    )
+    return motivo_id, atendente_id

--- a/backend/app/services/routing_evaluate.py
+++ b/backend/app/services/routing_evaluate.py
@@ -1,0 +1,147 @@
+"""Motor de avaliação de regras de roteamento (#258)."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+
+from sqlalchemy.orm import Session
+
+from app.core.routing import RoutingCampo, RoutingCanal, RoutingOperador
+from app.core.ticket_prioridade import PrioridadeTicket
+from app.models.routing_rule import RoutingRule
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RoutingContext:
+    email_from: str | None = None
+    email_to: str | None = None
+    assunto: str | None = None
+    canal: RoutingCanal = RoutingCanal.email
+    rede_id: int | None = None
+
+
+@dataclass
+class RoutingResult:
+    matched: bool = False
+    rule_id: int | None = None
+    rule_nome: str | None = None
+    setor_id: int | None = None
+    prioridade: PrioridadeTicket | None = None
+    natureza_id: int | None = None
+    motivo_id: int | None = None
+    atendente_id: int | None = None
+    acoes_parciais: dict = field(default_factory=dict)
+
+
+def _valor_campo(ctx: RoutingContext, campo: RoutingCampo) -> str:
+    if campo == RoutingCampo.email_from:
+        return (ctx.email_from or "").strip().lower()
+    if campo == RoutingCampo.email_to:
+        return (ctx.email_to or "").strip().lower()
+    if campo == RoutingCampo.assunto:
+        return (ctx.assunto or "").strip()
+    if campo == RoutingCampo.canal:
+        return ctx.canal.value
+    return ""
+
+
+def _condicao_atende(ctx: RoutingContext, cond: dict) -> bool:
+    try:
+        campo = RoutingCampo(cond["campo"])
+        operador = RoutingOperador(cond["operador"])
+        valor_regra = str(cond.get("valor") or "").strip()
+    except (KeyError, ValueError):
+        return False
+
+    atual = _valor_campo(ctx, campo)
+    if operador == RoutingOperador.equals:
+        if campo == RoutingCampo.assunto:
+            return atual.lower() == valor_regra.lower()
+        return atual == valor_regra.lower()
+    if operador == RoutingOperador.contains:
+        if campo == RoutingCampo.assunto:
+            return valor_regra.lower() in atual.lower()
+        return valor_regra.lower() in atual
+    if operador == RoutingOperador.regex:
+        try:
+            return bool(re.search(valor_regra, atual, re.IGNORECASE))
+        except re.error:
+            return False
+    return False
+
+
+def _regra_no_escopo(rule: RoutingRule, rede_id: int | None) -> bool:
+    if rule.rede_id is None:
+        return True
+    return rede_id is not None and rule.rede_id == rede_id
+
+
+def _regra_atende(ctx: RoutingContext, rule: RoutingRule) -> bool:
+    if not _regra_no_escopo(rule, ctx.rede_id):
+        return False
+    condicoes = rule.condicoes or []
+    if not condicoes:
+        return False
+    return all(_condicao_atende(ctx, c) for c in condicoes)
+
+
+def _merge_acoes(resultado: RoutingResult, acoes: dict) -> None:
+    if not acoes:
+        return
+    if acoes.get("setor_id") is not None:
+        resultado.setor_id = int(acoes["setor_id"])
+    if acoes.get("prioridade") is not None:
+        resultado.prioridade = PrioridadeTicket(str(acoes["prioridade"]))
+    if acoes.get("natureza_id") is not None:
+        resultado.natureza_id = int(acoes["natureza_id"])
+    if acoes.get("motivo_id") is not None:
+        resultado.motivo_id = int(acoes["motivo_id"])
+    if acoes.get("atendente_id") is not None:
+        resultado.atendente_id = int(acoes["atendente_id"])
+
+
+def evaluate_routing(db: Session, *, tenant_id: int, context: RoutingContext) -> RoutingResult:
+    """Primeira regra ativa que casa (ordem ascendente) define o resultado."""
+    rules = (
+        db.query(RoutingRule)
+        .filter(RoutingRule.tenant_id == tenant_id, RoutingRule.ativo.is_(True))
+        .order_by(RoutingRule.ordem.asc(), RoutingRule.id.asc())
+        .all()
+    )
+    for rule in rules:
+        if not _regra_atende(context, rule):
+            continue
+        resultado = RoutingResult(matched=True, rule_id=rule.id, rule_nome=rule.nome)
+        _merge_acoes(resultado, rule.acoes or {})
+        logger.debug("Roteamento: regra #%s (%s) aplicada", rule.id, rule.nome)
+        return resultado
+    return RoutingResult()
+
+
+def aplicar_roteamento_setor(
+    *,
+    setor_atual: int | None,
+    resultado: RoutingResult,
+    aplicar_setor: bool,
+) -> int | None:
+    """Respeita setor explícito quando aplicar_setor=False."""
+    if aplicar_setor and resultado.setor_id is not None:
+        return resultado.setor_id
+    return setor_atual
+
+
+def resultado_para_read_dict(resultado: RoutingResult) -> dict:
+    return {
+        "matched": resultado.matched,
+        "rule_id": resultado.rule_id,
+        "rule_nome": resultado.rule_nome,
+        "setor_id": resultado.setor_id,
+        "prioridade": resultado.prioridade.value if resultado.prioridade else None,
+        "natureza_id": resultado.natureza_id,
+        "motivo_id": resultado.motivo_id,
+        "atendente_id": resultado.atendente_id,
+    }

--- a/backend/app/services/ticket_from_inbound_email.py
+++ b/backend/app/services/ticket_from_inbound_email.py
@@ -22,6 +22,9 @@ from app.services.protocolo_mensal import gerar_protocolo_ticket
 from app.services.ticket_escopo import rede_id_de_empresa
 from app.services.email_body_sanitize import sanitize_inbound_email_body
 from app.services.ticket_email_index import registar_message_id_para_ticket
+from app.core.ticket_prioridade import PrioridadeTicket
+from app.services.ticket_classificacao_rules import validar_prioridade
+from app.services.routing_evaluate import RoutingResult
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +156,11 @@ def processar_email_inbound(
     setor_id: int,
     parsed: ParsedInboundEmail,
     aberto_por_id: int | None = None,
+    prioridade=None,
+    natureza_id: int | None = None,
+    motivo_id: int | None = None,
+    atendente_id: int | None = None,
+    rota_aplicada: RoutingResult | None = None,
 ) -> EmailInboundProcessResult:
     """
     Idempotente por ``parsed.message_id``.
@@ -254,6 +262,7 @@ def processar_email_inbound(
     protocolo = gerar_protocolo_ticket(db)
     assunto = (parsed.subject or "(sem assunto)")[:500]
     corpo = _corpo_mensagem(parsed, mid)
+    prio = validar_prioridade(prioridade) if prioridade is not None else PrioridadeTicket.normal
 
     ticket = Ticket(
         tenant_id=tenant_id,
@@ -262,12 +271,20 @@ def processar_email_inbound(
         rede_id=rede_id_de_empresa(db, empresa_id, tenant_id=tenant_id) if empresa_id else None,
         setor_id=setor_id,
         status_id=status_inicial.id,
+        prioridade=prio,
         assunto=assunto,
         descricao=corpo,
         aberto_por_id=aberto_por_id,
+        motivo_id=motivo_id,
+        atendente_id=atendente_id,
     )
     db.add(ticket)
     db.flush()
+
+    if rota_aplicada is not None and rota_aplicada.matched:
+        from app.services.routing_apply import registrar_roteamento_aplicado
+
+        registrar_roteamento_aplicado(db, resultado=rota_aplicada, ticket_id=ticket.id, atendente_audit_id=None)
 
     db.add(
         TicketMensagem(

--- a/backend/tests/test_routing_rules.py
+++ b/backend/tests/test_routing_rules.py
@@ -1,0 +1,383 @@
+"""Testes do motor de roteamento (#258)."""
+
+from __future__ import annotations
+
+from app.core.routing import RoutingCanal
+from app.models import AuditLog, Ticket, TicketHistorico
+from app.models.routing_rule import RoutingRule
+from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+from app.services.routing_apply import CAMPO_HISTORICO_ROTEAMENTO, resolver_motivo_roteamento
+from app.services.routing_evaluate import RoutingContext, evaluate_routing
+
+
+def _criar_regra(db, seed_base, *, nome, condicoes, acoes, ordem=0, rede_id=None, ativo=True):
+    rule = RoutingRule(
+        tenant_id=1,
+        nome=nome,
+        ativo=ativo,
+        ordem=ordem,
+        rede_id=rede_id,
+        condicoes=condicoes,
+        acoes=acoes,
+    )
+    db.add(rule)
+    db.flush()
+    return rule
+
+
+def _seed_natureza_motivo(db_session):
+    nat = TicketNatureza(nome="Financeiro", slug="fin_test", ordem=1, ativo=True)
+    db_session.add(nat)
+    db_session.flush()
+    mot = TicketMotivo(natureza_id=nat.id, nome="Boleto", slug="boleto_test", ordem=1, ativo=True)
+    db_session.add(mot)
+    db_session.flush()
+    return nat, mot
+
+
+def test_evaluate_contains_assunto(db_session, seed_base):
+    _criar_regra(
+        db_session,
+        seed_base,
+        nome="NF financeiro",
+        condicoes=[{"campo": "assunto", "operador": "contains", "valor": "NF"}],
+        acoes={"setor_id": seed_base["setor2"].id, "prioridade": "alta"},
+    )
+    db_session.commit()
+
+    ctx = RoutingContext(assunto="Entrada de NF cliente X", canal=RoutingCanal.email)
+    r = evaluate_routing(db_session, tenant_id=1, context=ctx)
+    assert r.matched is True
+    assert r.setor_id == seed_base["setor2"].id
+    assert r.prioridade.value == "alta"
+
+
+def test_evaluate_regex_assunto(db_session, seed_base):
+    _criar_regra(
+        db_session,
+        seed_base,
+        nome="Protocolo numerico",
+        condicoes=[{"campo": "assunto", "operador": "regex", "valor": r"NF-\d{4}"}],
+        acoes={"setor_id": seed_base["setor2"].id},
+    )
+    db_session.commit()
+
+    ctx = RoutingContext(assunto="Entrada NF-2024 cliente", canal=RoutingCanal.email)
+    r = evaluate_routing(db_session, tenant_id=1, context=ctx)
+    assert r.matched is True
+    assert r.setor_id == seed_base["setor2"].id
+
+    ctx_fail = RoutingContext(assunto="Entrada NF cliente", canal=RoutingCanal.email)
+    assert evaluate_routing(db_session, tenant_id=1, context=ctx_fail).matched is False
+
+
+def test_evaluate_email_from_domain(db_session, seed_base):
+    _criar_regra(
+        db_session,
+        seed_base,
+        nome="Financeiro remetente",
+        condicoes=[{"campo": "email_from", "operador": "contains", "valor": "@financeiro."}],
+        acoes={"setor_id": seed_base["setor2"].id},
+        ordem=0,
+    )
+    db_session.commit()
+
+    ctx = RoutingContext(email_from="contato@financeiro.empresa.com", canal=RoutingCanal.email)
+    r = evaluate_routing(db_session, tenant_id=1, context=ctx)
+    assert r.matched is True
+    assert r.setor_id == seed_base["setor2"].id
+
+
+def test_primeira_regra_ganha(db_session, seed_base):
+    _criar_regra(
+        db_session,
+        seed_base,
+        nome="Geral",
+        ordem=0,
+        condicoes=[{"campo": "canal", "operador": "equals", "valor": "email"}],
+        acoes={"setor_id": seed_base["setor1"].id},
+    )
+    _criar_regra(
+        db_session,
+        seed_base,
+        nome="NF",
+        ordem=1,
+        condicoes=[{"campo": "assunto", "operador": "contains", "valor": "NF"}],
+        acoes={"setor_id": seed_base["setor2"].id},
+    )
+    db_session.commit()
+
+    ctx = RoutingContext(assunto="NF entrada", canal=RoutingCanal.email)
+    r = evaluate_routing(db_session, tenant_id=1, context=ctx)
+    assert r.rule_nome == "Geral"
+    assert r.setor_id == seed_base["setor1"].id
+
+
+def test_escopo_rede(db_session, seed_base):
+    _criar_regra(
+        db_session,
+        seed_base,
+        nome="Só rede",
+        rede_id=seed_base["rede"].id,
+        condicoes=[{"campo": "assunto", "operador": "contains", "valor": "PDV"}],
+        acoes={"setor_id": seed_base["setor2"].id},
+    )
+    db_session.commit()
+
+    ctx_ok = RoutingContext(assunto="PDV offline", rede_id=seed_base["rede"].id, canal=RoutingCanal.manual)
+    assert evaluate_routing(db_session, tenant_id=1, context=ctx_ok).matched is True
+
+    ctx_fail = RoutingContext(assunto="PDV offline", rede_id=999, canal=RoutingCanal.manual)
+    assert evaluate_routing(db_session, tenant_id=1, context=ctx_fail).matched is False
+
+
+def test_resolver_motivo_por_natureza(db_session):
+    nat, mot = _seed_natureza_motivo(db_session)
+    db_session.commit()
+    mid = resolver_motivo_roteamento(db_session, natureza_id=nat.id, motivo_id=None)
+    assert mid == mot.id
+
+
+def test_crud_routing_rules(client, seed_base, auth_headers, db_session):
+    r = client.post(
+        "/v1/routing/rules",
+        headers=auth_headers["admin"],
+        json={
+            "nome": "Regra teste",
+            "ativo": True,
+            "rede_id": None,
+            "condicoes": [{"campo": "assunto", "operador": "equals", "valor": "Urgente"}],
+            "acoes": {"setor_id": seed_base["setor1"].id},
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    rule_id = body["id"]
+    assert body["nome"] == "Regra teste"
+
+    r2 = client.get("/v1/routing/rules", headers=auth_headers["admin"])
+    assert r2.status_code == 200
+    assert len(r2.json()) >= 1
+
+    r3 = client.post(
+        "/v1/routing/rules/simulate",
+        headers=auth_headers["admin"],
+        json={"assunto": "Urgente", "canal": "manual"},
+    )
+    assert r3.status_code == 200
+    sim = r3.json()
+    assert sim["matched"] is True
+    assert sim["setor_id"] == seed_base["setor1"].id
+
+    r4 = client.delete(f"/v1/routing/rules/{rule_id}", headers=auth_headers["admin"])
+    assert r4.status_code == 204
+
+
+def test_routing_rules_admin_only(client, seed_base, auth_headers):
+    r = client.get("/v1/routing/rules", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_criar_ticket_com_roteamento(client, seed_base, auth_headers, db_session):
+    _criar_regra(
+        db_session,
+        seed_base,
+        nome="Assunto financeiro",
+        condicoes=[{"campo": "assunto", "operador": "contains", "valor": "boleto"}],
+        acoes={"setor_id": seed_base["setor2"].id},
+    )
+    db_session.commit()
+
+    r = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "assunto": "Cobrança boleto vencido",
+            "descricao": "Teste roteamento",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["setor_id"] == seed_base["setor2"].id
+
+    hist = (
+        db_session.query(TicketHistorico)
+        .filter(TicketHistorico.ticket_id == body["id"], TicketHistorico.campo == CAMPO_HISTORICO_ROTEAMENTO)
+        .first()
+    )
+    assert hist is not None
+    audit = (
+        db_session.query(AuditLog)
+        .filter(AuditLog.entity_type == "routing_rule", AuditLog.action == "apply")
+        .first()
+    )
+    assert audit is not None
+
+
+def test_criar_ticket_setor_explicito_nao_sobrescrito(client, seed_base, auth_headers, db_session):
+    _criar_regra(
+        db_session,
+        seed_base,
+        nome="Boleto financeiro",
+        condicoes=[{"campo": "assunto", "operador": "contains", "valor": "boleto"}],
+        acoes={"setor_id": seed_base["setor2"].id},
+    )
+    db_session.commit()
+
+    r = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Cobrança boleto",
+            "descricao": "Setor explícito",
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["setor_id"] == seed_base["setor1"].id
+
+
+def test_aplicar_roteamento_so_admin(client, seed_base, auth_headers, db_session):
+    _criar_regra(
+        db_session,
+        seed_base,
+        nome="Força financeiro",
+        condicoes=[{"campo": "assunto", "operador": "contains", "valor": "boleto"}],
+        acoes={"setor_id": seed_base["setor2"].id},
+    )
+    db_session.commit()
+
+    r = client.post(
+        "/v1/tickets",
+        headers=auth_headers["a1"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "boleto",
+            "descricao": "x",
+            "aplicar_roteamento": True,
+        },
+    )
+    assert r.status_code == 403
+
+
+def test_aplicar_roteamento_admin_sobrescreve_setor(client, seed_base, auth_headers, db_session):
+    _criar_regra(
+        db_session,
+        seed_base,
+        nome="Força financeiro admin",
+        condicoes=[{"campo": "assunto", "operador": "contains", "valor": "boleto"}],
+        acoes={"setor_id": seed_base["setor2"].id},
+    )
+    db_session.commit()
+
+    r = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "boleto",
+            "descricao": "x",
+            "aplicar_roteamento": True,
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["setor_id"] == seed_base["setor2"].id
+
+
+def test_roteamento_atribui_atendente(client, seed_base, auth_headers, db_session):
+    _criar_regra(
+        db_session,
+        seed_base,
+        nome="Atribui a1",
+        condicoes=[{"campo": "assunto", "operador": "equals", "valor": "VIP"}],
+        acoes={"setor_id": seed_base["setor1"].id, "atendente_id": seed_base["a1"].id},
+    )
+    db_session.commit()
+
+    r = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "assunto": "VIP",
+            "descricao": "x",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["atendente_id"] == seed_base["a1"].id
+
+
+def test_roteamento_natureza_define_motivo(client, seed_base, auth_headers, db_session):
+    nat, mot = _seed_natureza_motivo(db_session)
+    _criar_regra(
+        db_session,
+        seed_base,
+        nome="Classif financeiro",
+        condicoes=[{"campo": "assunto", "operador": "contains", "valor": "cobrança"}],
+        acoes={"setor_id": seed_base["setor1"].id, "natureza_id": nat.id},
+    )
+    db_session.commit()
+
+    r = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "assunto": "cobrança mensal",
+            "descricao": "x",
+        },
+    )
+    assert r.status_code == 201, r.text
+    t = db_session.query(Ticket).filter(Ticket.id == r.json()["id"]).first()
+    assert t.motivo_id == mot.id
+
+
+def _minimal_rfc822_nf(message_id: str = "<routing-nf@dx.test>") -> str:
+    return (
+        f"From: Cliente <cliente@example.com>\r\n"
+        f"To: suporte@dxconnect.local\r\n"
+        f"Subject: Entrada NF cliente\r\n"
+        f"Message-ID: {message_id}\r\n"
+        f"MIME-Version: 1.0\r\n"
+        f"Content-Type: text/plain; charset=utf-8\r\n"
+        f"\r\n"
+        f"Corpo NF.\r\n"
+    )
+
+
+def test_webhook_inbound_aplica_regra_roteamento(client, seed_base, monkeypatch, db_session):
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_WEBHOOK_SECRET", "segredo-routing")
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_EMPRESA_ID", seed_base["empresa"].id)
+    monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_SETOR_ID", seed_base["setor1"].id)
+
+    _criar_regra(
+        db_session,
+        seed_base,
+        nome="NF para financeiro",
+        condicoes=[{"campo": "assunto", "operador": "contains", "valor": "NF"}],
+        acoes={"setor_id": seed_base["setor2"].id},
+    )
+    db_session.commit()
+
+    mid = "<inbound-routing-nf@dx.test>"
+    r = client.post(
+        "/v1/webhooks/email-inbound",
+        headers={"X-Dx-Email-Webhook-Secret": "segredo-routing"},
+        json={"rfc822": _minimal_rfc822_nf(mid)},
+    )
+    assert r.status_code == 200, r.text
+    ticket_id = r.json()["ticket_id"]
+    t = db_session.query(Ticket).filter(Ticket.id == ticket_id).first()
+    assert t.setor_id == seed_base["setor2"].id
+
+    hist = (
+        db_session.query(TicketHistorico)
+        .filter(TicketHistorico.ticket_id == ticket_id, TicketHistorico.campo == CAMPO_HISTORICO_ROTEAMENTO)
+        .first()
+    )
+    assert hist is not None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ import { TicketNaturezaMotivoPage } from './pages/TicketNaturezaMotivo'
 import { StatusTicketForm } from './pages/StatusTicketForm'
 import { StatusTicketDetalhe } from './pages/StatusTicketDetalhe'
 import { RespostasProntasPage } from './pages/RespostasProntas'
+import { RoteamentoRegrasPage } from './pages/RoteamentoRegras'
 import { RespostaProntaForm } from './pages/RespostaProntaForm'
 import { RespostaProntaDetalhe } from './pages/RespostaProntaDetalhe'
 import { Auditoria } from './pages/Auditoria'
@@ -376,6 +377,7 @@ function AppRoutes() {
           <Route path="status-ticket" element={<StatusTicketPage embedded />} />
           <Route path="natureza-motivo" element={<TicketNaturezaMotivoPage embedded />} />
           <Route path="respostas-prontas" element={<RespostasProntasPage embedded />} />
+          <Route path="roteamento" element={<RoteamentoRegrasPage embedded />} />
         </Route>
         <Route
           path="configuracoes/cadastros"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -445,6 +445,24 @@ export const respostasProntas = {
     ),
 };
 
+export const routingRules = {
+  list: (params?: { incluir_inativos?: boolean }) =>
+    api<RoutingRules.Regra[]>(withParams('/routing/rules', params)),
+  get: (id: number) => api<RoutingRules.Regra>(`/routing/rules/${id}`),
+  create: (data: RoutingRules.Create) =>
+    api<RoutingRules.Regra>('/routing/rules', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id: number, data: RoutingRules.Update) =>
+    api<RoutingRules.Regra>(`/routing/rules/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  delete: (id: number) => api<void>(`/routing/rules/${id}`, { method: 'DELETE' }),
+  reorder: (items: { id: number; ordem: number }[]) =>
+    api<RoutingRules.Regra[]>('/routing/rules/reorder', {
+      method: 'PUT',
+      body: JSON.stringify({ items }),
+    }),
+  simulate: (data: RoutingRules.Simulate) =>
+    api<RoutingRules.Resultado>('/routing/rules/simulate', { method: 'POST', body: JSON.stringify(data) }),
+};
+
 export const audit = {
   list: (params?: {
     entity_type?: string;
@@ -1727,6 +1745,74 @@ export namespace StatusTicket {
     slug?: string;
     ordem?: number;
     ativo?: boolean;
+  }
+}
+
+export namespace RoutingRules {
+  export type Campo = 'email_from' | 'email_to' | 'assunto' | 'canal';
+  export type Operador = 'contains' | 'equals' | 'regex';
+  export type Canal = 'email' | 'manual';
+  export type Prioridade = 'baixa' | 'normal' | 'alta' | 'urgente';
+
+  export interface Condicao {
+    campo: Campo;
+    operador: Operador;
+    valor: string;
+  }
+
+  export interface Acoes {
+    setor_id?: number | null;
+    prioridade?: Prioridade | null;
+    natureza_id?: number | null;
+    motivo_id?: number | null;
+    atendente_id?: number | null;
+  }
+
+  export interface Regra {
+    id: number;
+    nome: string;
+    ativo: boolean;
+    ordem: number;
+    rede_id: number | null;
+    condicoes: Condicao[];
+    acoes: Acoes;
+  }
+
+  export interface Create {
+    nome: string;
+    ativo?: boolean;
+    rede_id?: number | null;
+    condicoes: Condicao[];
+    acoes: Acoes;
+  }
+
+  export interface Update {
+    nome?: string;
+    ativo?: boolean;
+    rede_id?: number | null;
+    condicoes?: Condicao[];
+    acoes?: Acoes;
+  }
+
+  export interface Simulate {
+    email_from?: string | null;
+    email_to?: string | null;
+    assunto?: string | null;
+    canal?: Canal;
+    rede_id?: number | null;
+    setor_id_atual?: number | null;
+    aplicar_setor?: boolean;
+  }
+
+  export interface Resultado {
+    matched: boolean;
+    rule_id?: number | null;
+    rule_nome?: string | null;
+    setor_id?: number | null;
+    prioridade?: Prioridade | null;
+    natureza_id?: number | null;
+    motivo_id?: number | null;
+    atendente_id?: number | null;
   }
 }
 

--- a/frontend/src/pages/RoteamentoRegras.tsx
+++ b/frontend/src/pages/RoteamentoRegras.tsx
@@ -1,0 +1,592 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ApiError,
+  atendentes,
+  redes,
+  routingRules,
+  setores,
+  ticketClassificacao,
+  type RoutingRules,
+} from '../api/client'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { ConfigListPageShell } from '../components/config/ConfigListPageShell'
+import { FiltroInativos } from '../components/ui/FiltroInativos'
+import { useToast } from '../components/ui/Toast'
+import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+
+const CAMPOS: { value: RoutingRules.Campo; label: string }[] = [
+  { value: 'email_from', label: 'Remetente (e-mail)' },
+  { value: 'email_to', label: 'Destinatário (e-mail)' },
+  { value: 'assunto', label: 'Assunto' },
+  { value: 'canal', label: 'Canal' },
+]
+
+const OPERADORES: { value: RoutingRules.Operador; label: string }[] = [
+  { value: 'contains', label: 'contém' },
+  { value: 'equals', label: 'é igual a' },
+  { value: 'regex', label: 'expressão regular' },
+]
+
+const PRIORIDADES: RoutingRules.Prioridade[] = ['baixa', 'normal', 'alta', 'urgente']
+
+function condicaoVazia(): RoutingRules.Condicao {
+  return { campo: 'assunto', operador: 'contains', valor: '' }
+}
+
+function formVazio(): RoutingRules.Create {
+  return {
+    nome: '',
+    ativo: true,
+    rede_id: null,
+    condicoes: [condicaoVazia()],
+    acoes: { setor_id: null },
+  }
+}
+
+export function RoteamentoRegrasPage({ embedded = false }: { embedded?: boolean }) {
+  const toast = useToast()
+  const [list, setList] = useState<RoutingRules.Regra[]>([])
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [incluirInativos, setIncluirInativos] = useState(false)
+  const [setorOpts, setSetorOpts] = useState<{ id: number; nome: string }[]>([])
+  const [redeOpts, setRedeOpts] = useState<{ id: number; nome: string }[]>([])
+  const [naturezaOpts, setNaturezaOpts] = useState<{ id: number; nome: string }[]>([])
+  const [motivoOpts, setMotivoOpts] = useState<{ id: number; nome: string; natureza_id: number }[]>([])
+  const [atendenteOpts, setAtendenteOpts] = useState<{ id: number; nome: string }[]>([])
+
+  const [editId, setEditId] = useState<number | null>(null)
+  const [form, setForm] = useState<RoutingRules.Create>(formVazio())
+  const [saving, setSaving] = useState(false)
+
+  const [simAssunto, setSimAssunto] = useState('')
+  const [simFrom, setSimFrom] = useState('')
+  const [simTo, setSimTo] = useState('')
+  const [simCanal, setSimCanal] = useState<RoutingRules.Canal>('email')
+  const [simResult, setSimResult] = useState<RoutingRules.Resultado | null>(null)
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    routingRules
+      .list({ incluir_inativos: incluirInativos })
+      .then(setList)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar as regras.'))
+      })
+      .finally(() => setLoading(false))
+  }, [incluirInativos, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  useEffect(() => {
+    setores.list({ limit: 100 }).then(({ items }) => setSetorOpts(items.map((s) => ({ id: s.id, nome: s.nome }))))
+    redes.list({ limit: 100 }).then(({ items }) => setRedeOpts(items.map((r) => ({ id: r.id, nome: r.nome }))))
+    ticketClassificacao.listNaturezas({ limit: 100 }).then(({ items }) =>
+      setNaturezaOpts(items.map((n) => ({ id: n.id, nome: n.nome }))),
+    )
+    ticketClassificacao.listMotivos({ limit: 300 }).then(({ items }) =>
+      setMotivoOpts(items.map((m) => ({ id: m.id, nome: m.nome, natureza_id: m.natureza_id }))),
+    )
+    atendentes.list({ limit: 100 }).then(({ items }) =>
+      setAtendenteOpts(items.map((a) => ({ id: a.id, nome: a.nome }))),
+    )
+  }, [])
+
+  const motivosFiltrados = form.acoes.natureza_id
+    ? motivoOpts.filter((m) => m.natureza_id === form.acoes.natureza_id)
+    : motivoOpts
+
+  function iniciarNova() {
+    setEditId(null)
+    setForm(formVazio())
+  }
+
+  function iniciarEdicao(regra: RoutingRules.Regra) {
+    setEditId(regra.id)
+    setForm({
+      nome: regra.nome,
+      ativo: regra.ativo,
+      rede_id: regra.rede_id,
+      condicoes: regra.condicoes.length ? regra.condicoes : [condicaoVazia()],
+      acoes: { ...regra.acoes },
+    })
+  }
+
+  async function salvar() {
+    if (!form.nome.trim()) {
+      toast.showWarning('Informe o nome da regra.')
+      return
+    }
+    if (!form.condicoes.every((c) => c.valor.trim())) {
+      toast.showWarning('Preencha o valor de todas as condições.')
+      return
+    }
+    if (
+      !form.acoes.setor_id &&
+      !form.acoes.prioridade &&
+      !form.acoes.motivo_id &&
+      !form.acoes.natureza_id &&
+      !form.acoes.atendente_id
+    ) {
+      toast.showWarning('Informe ao menos uma ação (setor, prioridade, natureza, motivo ou atendente).')
+      return
+    }
+    setSaving(true)
+    try {
+      if (editId) {
+        await routingRules.update(editId, form)
+        toast.showSuccess('Regra atualizada.')
+      } else {
+        await routingRules.create(form)
+        toast.showSuccess('Regra criada.')
+      }
+      setEditId(null)
+      setForm(formVazio())
+      load()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a regra.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function excluir(id: number) {
+    if (!window.confirm('Excluir esta regra de roteamento?')) return
+    try {
+      await routingRules.delete(id)
+      toast.showSuccess('Regra excluída.')
+      if (editId === id) iniciarNova()
+      load()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível excluir.'))
+    }
+  }
+
+  async function mover(idx: number, dir: -1 | 1) {
+    const nova = [...list]
+    const alvo = idx + dir
+    if (alvo < 0 || alvo >= nova.length) return
+    ;[nova[idx], nova[alvo]] = [nova[alvo], nova[idx]]
+    const items = nova.map((r, i) => ({ id: r.id, ordem: i }))
+    try {
+      const atualizado = await routingRules.reorder(items)
+      setList(atualizado)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível reordenar.'))
+    }
+  }
+
+  async function simular() {
+    try {
+      const res = await routingRules.simulate({
+        assunto: simAssunto || null,
+        email_from: simFrom || null,
+        email_to: simTo || null,
+        canal: simCanal,
+      })
+      setSimResult(res)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha na simulação.'))
+    }
+  }
+
+  const denied = (
+    <SemPermissao
+      title="Você não tem permissão para gerenciar roteamento."
+      voltarPara="/"
+      voltarLabel="Voltar para o Dashboard"
+    />
+  )
+
+  return (
+    <ConfigListPageShell
+      embedded={embedded}
+      forbidden={forbidden}
+      denied={denied}
+      title="Roteamento automático"
+      subtitle="Regras avaliadas em ordem — a primeira que casar define setor, prioridade ou classificação."
+      actions={<Button onClick={iniciarNova}>Nova regra</Button>}
+    >
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />
+      </div>
+
+      <Card className="mb-6 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-slate-200 dark:border-slate-700 text-left">
+              <th className="p-2 w-20">Ordem</th>
+              <th className="p-2">Nome</th>
+              <th className="p-2">Escopo</th>
+              <th className="p-2">Condições</th>
+              <th className="p-2">Ações</th>
+              <th className="p-2 w-32" />
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td colSpan={6} className="p-4 text-slate-500">
+                  Carregando…
+                </td>
+              </tr>
+            ) : list.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="p-4 text-slate-500">
+                  Nenhuma regra cadastrada.
+                </td>
+              </tr>
+            ) : (
+              list.map((r, idx) => (
+                <tr key={r.id} className="border-b border-slate-100 dark:border-slate-800">
+                  <td className="p-2">
+                    <div className="flex gap-1">
+                      <Button type="button" variant="ghost" className="px-2 py-1" onClick={() => mover(idx, -1)} disabled={idx === 0}>
+                        ↑
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className="px-2 py-1"
+                        onClick={() => mover(idx, 1)}
+                        disabled={idx === list.length - 1}
+                      >
+                        ↓
+                      </Button>
+                    </div>
+                  </td>
+                  <td className="p-2">
+                    <span className="font-medium">{r.nome}</span>
+                    {!r.ativo ? (
+                      <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">inativa</span>
+                    ) : null}
+                  </td>
+                  <td className="p-2">{r.rede_id ? `Rede #${r.rede_id}` : 'Global'}</td>
+                  <td className="p-2 text-slate-600 dark:text-slate-400">
+                    {r.condicoes.map((c, i) => (
+                      <span key={i}>
+                        {i > 0 ? ' e ' : ''}
+                        {c.campo} {c.operador} «{c.valor}»
+                      </span>
+                    ))}
+                  </td>
+                  <td className="p-2 text-slate-600 dark:text-slate-400">
+                    {r.acoes.setor_id ? `setor #${r.acoes.setor_id} ` : ''}
+                    {r.acoes.prioridade ? `prioridade ${r.acoes.prioridade} ` : ''}
+                    {r.acoes.natureza_id ? `natureza #${r.acoes.natureza_id} ` : ''}
+                    {r.acoes.motivo_id ? `motivo #${r.acoes.motivo_id} ` : ''}
+                    {r.acoes.atendente_id ? `atendente #${r.acoes.atendente_id}` : ''}
+                  </td>
+                  <td className="p-2">
+                    <Button type="button" variant="ghost" className="px-2 py-1" onClick={() => iniciarEdicao(r)}>
+                      Editar
+                    </Button>
+                    <Button type="button" variant="ghost" className="px-2 py-1" onClick={() => excluir(r.id)}>
+                      Excluir
+                    </Button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </Card>
+
+      {(editId !== null || form.nome || form.condicoes[0]?.valor) && (
+        <Card className="mb-6 p-4 space-y-4">
+          <h3 className="font-semibold">{editId ? 'Editar regra' : 'Nova regra'}</h3>
+          <div className="grid gap-3 md:grid-cols-2">
+            <label className="block text-sm">
+              Nome
+              <input
+                className="mt-1 w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5"
+                value={form.nome}
+                onChange={(e) => setForm((f) => ({ ...f, nome: e.target.value }))}
+              />
+            </label>
+            <label className="block text-sm">
+              Escopo (rede)
+              <select
+                className="mt-1 w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5"
+                value={form.rede_id ?? ''}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, rede_id: e.target.value ? Number(e.target.value) : null }))
+                }
+              >
+                <option value="">Global (todas as redes)</option>
+                {redeOpts.map((r) => (
+                  <option key={r.id} value={r.id}>
+                    {r.nome}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <div>
+            <p className="text-sm font-medium mb-2">Condições (todas devem casar)</p>
+            {form.condicoes.map((c, idx) => (
+              <div key={idx} className="flex flex-wrap gap-2 mb-2 items-end">
+                <select
+                  className="rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5 text-sm"
+                  value={c.campo}
+                  onChange={(e) => {
+                    const campo = e.target.value as RoutingRules.Campo
+                    setForm((f) => {
+                      const condicoes = [...f.condicoes]
+                      condicoes[idx] = { ...condicoes[idx], campo }
+                      return { ...f, condicoes }
+                    })
+                  }}
+                >
+                  {CAMPOS.map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  className="rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5 text-sm"
+                  value={c.operador}
+                  onChange={(e) => {
+                    const operador = e.target.value as RoutingRules.Operador
+                    setForm((f) => {
+                      const condicoes = [...f.condicoes]
+                      condicoes[idx] = { ...condicoes[idx], operador }
+                      return { ...f, condicoes }
+                    })
+                  }}
+                >
+                  {OPERADORES.map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+                <input
+                  className="flex-1 min-w-[120px] rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5 text-sm"
+                  placeholder="Valor"
+                  value={c.valor}
+                  onChange={(e) => {
+                    const valor = e.target.value
+                    setForm((f) => {
+                      const condicoes = [...f.condicoes]
+                      condicoes[idx] = { ...condicoes[idx], valor }
+                      return { ...f, condicoes }
+                    })
+                  }}
+                />
+                {form.condicoes.length > 1 ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="px-2 py-1"
+                    onClick={() =>
+                      setForm((f) => ({ ...f, condicoes: f.condicoes.filter((_, i) => i !== idx) }))
+                    }
+                  >
+                    Remover
+                  </Button>
+                ) : null}
+              </div>
+            ))}
+            <Button
+              type="button"
+              variant="ghost"
+              className="px-2 py-1"
+              onClick={() => setForm((f) => ({ ...f, condicoes: [...f.condicoes, condicaoVazia()] }))}
+            >
+              + Condição
+            </Button>
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+            <label className="block text-sm">
+              Setor destino
+              <select
+                className="mt-1 w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5"
+                value={form.acoes.setor_id ?? ''}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    acoes: { ...f.acoes, setor_id: e.target.value ? Number(e.target.value) : null },
+                  }))
+                }
+              >
+                <option value="">—</option>
+                {setorOpts.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.nome}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-sm">
+              Prioridade
+              <select
+                className="mt-1 w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5"
+                value={form.acoes.prioridade ?? ''}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    acoes: {
+                      ...f.acoes,
+                      prioridade: (e.target.value || null) as RoutingRules.Prioridade | null,
+                    },
+                  }))
+                }
+              >
+                <option value="">—</option>
+                {PRIORIDADES.map((p) => (
+                  <option key={p} value={p}>
+                    {p}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-sm">
+              Atendente responsável
+              <select
+                className="mt-1 w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5"
+                value={form.acoes.atendente_id ?? ''}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    acoes: { ...f.acoes, atendente_id: e.target.value ? Number(e.target.value) : null },
+                  }))
+                }
+              >
+                <option value="">—</option>
+                {atendenteOpts.map((a) => (
+                  <option key={a.id} value={a.id}>
+                    {a.nome}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-sm">
+              Natureza sugerida
+              <select
+                className="mt-1 w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5"
+                value={form.acoes.natureza_id ?? ''}
+                onChange={(e) => {
+                  const natureza_id = e.target.value ? Number(e.target.value) : null
+                  setForm((f) => ({
+                    ...f,
+                    acoes: {
+                      ...f.acoes,
+                      natureza_id,
+                      motivo_id:
+                        f.acoes.motivo_id &&
+                        motivoOpts.find((m) => m.id === f.acoes.motivo_id)?.natureza_id !== natureza_id
+                          ? null
+                          : f.acoes.motivo_id,
+                    },
+                  }))
+                }}
+              >
+                <option value="">—</option>
+                {naturezaOpts.map((n) => (
+                  <option key={n.id} value={n.id}>
+                    {n.nome}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-sm md:col-span-2">
+              Motivo sugerido
+              <select
+                className="mt-1 w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5"
+                value={form.acoes.motivo_id ?? ''}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    acoes: { ...f.acoes, motivo_id: e.target.value ? Number(e.target.value) : null },
+                  }))
+                }
+              >
+                <option value="">—</option>
+                {motivosFiltrados.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.nome}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={form.ativo !== false}
+              onChange={(e) => setForm((f) => ({ ...f, ativo: e.target.checked }))}
+            />
+            Regra ativa
+          </label>
+
+          <div className="flex gap-2">
+            <Button onClick={salvar} disabled={saving}>
+              {saving ? 'Salvando…' : 'Salvar'}
+            </Button>
+            <Button type="button" variant="ghost" onClick={iniciarNova}>
+              Cancelar
+            </Button>
+          </div>
+        </Card>
+      )}
+
+      <Card className="p-4 space-y-3">
+        <h3 className="font-semibold">Simular roteamento</h3>
+        <p className="text-sm text-slate-600 dark:text-slate-400">
+          Teste seco — não cria ticket. Chats WhatsApp não são afetados por estas regras.
+        </p>
+        <div className="grid gap-3 md:grid-cols-2">
+          <input
+            className="rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5 text-sm"
+            placeholder="Assunto"
+            value={simAssunto}
+            onChange={(e) => setSimAssunto(e.target.value)}
+          />
+          <input
+            className="rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5 text-sm"
+            placeholder="Remetente"
+            value={simFrom}
+            onChange={(e) => setSimFrom(e.target.value)}
+          />
+          <input
+            className="rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5 text-sm"
+            placeholder="Destinatário"
+            value={simTo}
+            onChange={(e) => setSimTo(e.target.value)}
+          />
+          <select
+            className="rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5 text-sm"
+            value={simCanal}
+            onChange={(e) => setSimCanal(e.target.value as RoutingRules.Canal)}
+          >
+            <option value="email">E-mail</option>
+            <option value="manual">Manual</option>
+          </select>
+        </div>
+        <Button type="button" onClick={simular}>
+          Simular
+        </Button>
+        {simResult ? (
+          <pre className="text-xs bg-slate-100 dark:bg-slate-800 p-3 rounded overflow-x-auto">
+            {JSON.stringify(simResult, null, 2)}
+          </pre>
+        ) : null}
+      </Card>
+    </ConfigListPageShell>
+  )
+}

--- a/frontend/src/pages/config/ConfigAtendimentoLayout.tsx
+++ b/frontend/src/pages/config/ConfigAtendimentoLayout.tsx
@@ -8,6 +8,7 @@ const TABS = [
   { to: '/configuracoes/atendimento/status-ticket', label: 'Status de ticket' },
   { to: '/configuracoes/atendimento/natureza-motivo', label: 'Natureza e motivo' },
   { to: '/configuracoes/atendimento/respostas-prontas', label: 'Respostas prontas' },
+  { to: '/configuracoes/atendimento/roteamento', label: 'Roteamento' },
 ] as const
 
 const TAB_HINTS: Record<string, string> = {
@@ -16,6 +17,7 @@ const TAB_HINTS: Record<string, string> = {
   'status-ticket': 'Etapas do fluxo de chamados (aberto, em atendimento, encerrado…).',
   'natureza-motivo': 'Categorias (natureza) e itens específicos (motivo) usados ao encerrar tickets.',
   'respostas-prontas': 'Macros reutilizáveis ao responder tickets — globais ou por setor.',
+  roteamento: 'Regras automáticas de setor e prioridade na criação de tickets (e-mail e manual).',
 }
 
 function abaAtiva(pathname: string): string {


### PR DESCRIPTION
## Summary
- Implementa o motor de roteamento automatico (#258): regras configuraveis por admin definem setor, prioridade, natureza/motivo e atendente na criacao de tickets.
- API `/v1/routing/rules` (CRUD, reordenar, simular), migrations `routing_rules`, integracao em e-mail inbound e `POST /v1/tickets` (setor opcional; `aplicar_roteamento` restrito a admin).
- UI em Configuracoes > Atendimento > Roteamento com simulador de teste seco; audit log e historico do ticket quando uma regra e aplicada em runtime.

Fecha #274, #275, #276.

## Test plan
- [ ] CI verde (backend + frontend + changelog)
- [ ] Admin: criar regra (assunto contem NF -> setor Financeiro) e simular no painel
- [ ] E-mail inbound com assunto NF roteia para o setor da regra
- [ ] Ticket manual sem setor recebe setor da regra; setor explicito nao e sobrescrito (exceto admin + aplicar_roteamento)
- [ ] Apos merge: PR main -> staging e validar em staging

Made with [Cursor](https://cursor.com)