### PR TITLE
fix(notificacoes): som de ticket na fila toca apenas uma vez (#406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ## [Unreleased]
 
+### Correções
+
+- Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)
+
 ### Melhorias
 
 - Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -750,16 +750,25 @@ def criar(
         .order_by(TicketMensagem.id.desc())
         .first()
     )
-    if msg_abertura:
-        emit_ticket_mensagem_from_model(db, ticket, msg_abertura, exclude_atendente_id=atendente.id)
+    contagem_ja_emitida = False
     if ticket.atendente_id is None:
         sincronizar_fila_desde_at(ticket)
         db.commit()
         if tentar_distribuicao_imediata(db, ticket):
             db.commit()
             emit_notificacao_after_counter_change(db)
+            contagem_ja_emitida = True
         else:
             emit_ticket_fila(db, ticket)
+            contagem_ja_emitida = True
+    if msg_abertura:
+        emit_ticket_mensagem_from_model(
+            db,
+            ticket,
+            msg_abertura,
+            exclude_atendente_id=atendente.id,
+            emit_notificacao=not contagem_ja_emitida,
+        )
     ticket_out = (
         db.query(Ticket)
         .options(*_opcoes_carregamento_ticket_detalhe())

--- a/backend/app/services/realtime_emit.py
+++ b/backend/app/services/realtime_emit.py
@@ -204,13 +204,15 @@ def emit_ticket_mensagem(
     mensagem_payload: dict[str, Any],
     *,
     exclude_atendente_id: int | None = None,
+    emit_notificacao: bool = True,
 ) -> None:
     recipients = ids_atendentes_ticket_mensagem(
         db, ticket, exclude_atendente_id=exclude_atendente_id
     )
     payload = {"ticket_id": ticket.id, "mensagem": mensagem_payload}
     _publish_to_atendentes(recipients, "ticket.mensagem", payload)
-    _emit_notificacao_after_counter_change(db)
+    if emit_notificacao:
+        _emit_notificacao_after_counter_change(db)
 
 
 def emit_ticket_fila(db: Session, ticket: Ticket) -> None:
@@ -265,6 +267,7 @@ def emit_ticket_mensagem_from_model(
     mensagem: Any,
     *,
     exclude_atendente_id: int | None = None,
+    emit_notificacao: bool = True,
 ) -> None:
     from app.api.tickets import _mensagem_para_read
 
@@ -273,4 +276,5 @@ def emit_ticket_mensagem_from_model(
         ticket,
         _mensagem_para_read(mensagem).model_dump(mode="json"),
         exclude_atendente_id=exclude_atendente_id,
+        emit_notificacao=emit_notificacao,
     )

--- a/backend/tests/test_realtime_notificacao.py
+++ b/backend/tests/test_realtime_notificacao.py
@@ -64,3 +64,30 @@ def test_marcar_visto_emite_contagem(client, seed_base, auth_headers, db_session
     r = client.post(f"/v1/notificacoes/tickets/{ticket.id}/visto", headers=auth_headers["a1"])
     assert r.status_code == 204
     assert seed_base["a1"].id in calls
+
+
+def test_criar_ticket_fila_emite_contagem_unica(client, seed_base, auth_headers, monkeypatch):
+    """#406: criação manual não deve disparar notificacao.contagem mais de uma vez."""
+    contagem_calls: list[int] = []
+
+    def count_emit(db) -> None:
+        contagem_calls.append(1)
+
+    monkeypatch.setattr(
+        "app.services.realtime_emit._emit_notificacao_after_counter_change",
+        count_emit,
+    )
+
+    r = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Fila som único",
+            "descricao": "Teste #406",
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["atendente_id"] is None
+    assert len(contagem_calls) == 1

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -9,6 +9,10 @@ const LS_KEY_LAST_WPP_RESP = 'dxconnect.notificacoes.last_wpp_resp'
 const POLL_MS = 10_000
 /** Fallback de segurança quando SSE está ativo (#266). */
 const POLL_SSE_SAFETY_MS = 60_000
+/** Evita som duplicado quando poll retorna contagem obsoleta após SSE (#406). */
+const POLL_STALE_GUARD_MS = 3000
+/** Dedup de transição idêntica (SSE duplicado / múltiplos listeners). */
+const ALERT_DEDUP_MS = 2000
 
 /** Tickets na fila sem responsável */
 const SOUND_TICKET_FILA = '/sons/alerta.mp3'
@@ -46,6 +50,10 @@ let wppFilaLoopInterval: number | null = null
 let wppFilaLoopAudio: HTMLAudioElement | null = null
 let pollTimerId: number | null = null
 let sseSlowPollMode = false
+let sseListenerCount = 0
+let sseUnsubscribe: (() => void) | null = null
+let lastSemIncreaseAt = 0
+const recentAlertKeys = new Map<string, number>()
 
 const audioByKey = new Map<string, HTMLAudioElement>()
 const alertQueue: AlertKind[] = []
@@ -200,6 +208,26 @@ function enqueueAlert(kind: AlertKind) {
   void drainAlertQueue()
 }
 
+function shouldEnqueueCounterAlert(kind: AlertKind, prev: number | null, next: number): boolean {
+  if (prev == null || next <= prev) return false
+  const key = `${kind}:${prev}->${next}`
+  const now = Date.now()
+  const last = recentAlertKeys.get(key)
+  if (last != null && now - last < ALERT_DEDUP_MS) return false
+  recentAlertKeys.set(key, now)
+  return true
+}
+
+function isStalePollResumo(r: Notificacoes.Resumo): boolean {
+  if (Date.now() - lastSemIncreaseAt >= POLL_STALE_GUARD_MS) return false
+  return (
+    r.sem_responsavel_count < currentResumo.sem_responsavel_count ||
+    r.nao_lidas_count < currentResumo.nao_lidas_count ||
+    r.wpp_fila_count < currentResumo.wpp_fila_count ||
+    r.wpp_respostas_count < currentResumo.wpp_respostas_count
+  )
+}
+
 async function drainAlertQueue() {
   if (drainingAlerts) return
   drainingAlerts = true
@@ -276,7 +304,9 @@ function persistPrevCounters(r: Notificacoes.Resumo) {
   setStoredNumber(LS_KEY_LAST_WPP_RESP, r.wpp_respostas_count)
 }
 
-function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean) {
+function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean, source: 'sse' | 'poll' | 'refetch' = 'poll') {
+  if (source === 'poll' && isStalePollResumo(r)) return
+
   currentResumo = r
   const sem = r.sem_responsavel_count
   currentCount = sem
@@ -291,19 +321,21 @@ function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean) {
     const prevWR = prevWppResp
     const prevWppFilaValue = prevWppFila
 
-    if (prevSem != null && r.sem_responsavel_count > prevSem) {
-      enqueueAlert('ticket_fila')
+    if (shouldEnqueueCounterAlert('ticket_fila', prevSem, r.sem_responsavel_count)) {
+      lastSemIncreaseAt = Date.now()
+      const delta = r.sem_responsavel_count - (prevSem ?? r.sem_responsavel_count)
+      for (let i = 0; i < delta; i++) enqueueAlert('ticket_fila')
     }
 
-    if (prevWppFilaValue != null && r.wpp_fila_count > prevWppFilaValue) {
+    if (shouldEnqueueCounterAlert('wpp_fila_pulse', prevWppFilaValue, r.wpp_fila_count)) {
       enqueueAlert('wpp_fila_pulse')
     }
 
-    if (prevNao != null && r.nao_lidas_count > prevNao) {
+    if (shouldEnqueueCounterAlert('ticket_mensagem', prevNao, r.nao_lidas_count)) {
       enqueueAlert('ticket_mensagem')
     }
 
-    if (prevWR != null && r.wpp_respostas_count > prevWR) {
+    if (shouldEnqueueCounterAlert('wpp_mensagem', prevWR, r.wpp_respostas_count)) {
       enqueueAlert('wpp_mensagem')
     }
   }
@@ -331,7 +363,7 @@ function isNotificacaoResumo(payload: Record<string, unknown>): boolean {
 /** Atualiza contadores a partir de evento SSE `notificacao.contagem`. */
 export function applyNotificacaoResumoSse(payload: Record<string, unknown>) {
   if (!isNotificacaoResumo(payload)) return
-  applyResumo(payload as unknown as Notificacoes.Resumo, true)
+  applyResumo(payload as unknown as Notificacoes.Resumo, true, 'sse')
 }
 
 function restartPollTimer() {
@@ -353,7 +385,7 @@ async function poll() {
   inFlight = true
   try {
     const r = await notificacoes.resumo()
-    applyResumo(r, true)
+    applyResumo(r, true, 'poll')
   } catch {
     // ignore
   } finally {
@@ -367,7 +399,7 @@ export async function refetchPendenciasResumo(atualizarSom = false) {
   inFlight = true
   try {
     const r = await notificacoes.resumo()
-    applyResumo(r, atualizarSom)
+    applyResumo(r, atualizarSom, 'refetch')
   } catch {
     // ignore
   } finally {
@@ -437,9 +469,20 @@ export function useAlertaFilaSemResponsavel(enabled: boolean) {
 
   useEffect(() => {
     if (!enabled) return
-    return subscribe('notificacao.contagem', (payload) => {
-      applyNotificacaoResumoSse(payload)
-    })
+    ensureStarted()
+    sseListenerCount++
+    if (sseListenerCount === 1) {
+      sseUnsubscribe = subscribe('notificacao.contagem', (payload) => {
+        applyNotificacaoResumoSse(payload)
+      })
+    }
+    return () => {
+      sseListenerCount = Math.max(0, sseListenerCount - 1)
+      if (sseListenerCount === 0) {
+        sseUnsubscribe?.()
+        sseUnsubscribe = null
+      }
+    }
   }, [enabled, subscribe])
 
   useEffect(() => {

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -21,7 +21,6 @@ import { useToast } from '../components/ui/Toast'
 import { CabecalhoOrdenavel } from '../components/ui/CabecalhoOrdenavel'
 import { useOrdenacaoLista } from '../hooks/useOrdenacaoLista'
 import { useAuth } from '../contexts/AuthContext'
-import { useAlertaFilaSemResponsavel } from '../hooks/useAlertaFilaSemResponsavel'
 import { SemPermissao } from './SemPermissao'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { exibirProtocolo } from '../lib/exibirProtocolo'
@@ -110,8 +109,7 @@ export function Tickets() {
   const navigate = useNavigate()
   const [searchParams, setSearchParams] = useSearchParams()
   const toast = useToast()
-  const { isAdmin, user } = useAuth()
-  useAlertaFilaSemResponsavel(Boolean(user))
+  const { isAdmin } = useAuth()
   const [forbidden, setForbidden] = useState(false)
 
   const situacao = useMemo<'abertos' | 'fechados'>(() => {


### PR DESCRIPTION
## Summary
- Remove hook duplicado de alertas em `Tickets.tsx` (mantido apenas no `Layout`)
- Assinatura SSE `notificacao.contagem` unica com refcount, dedup de transicao e protecao contra poll obsoleto
- Backend: criação manual emite contagem uma vez (fila antes da mensagem de abertura, `emit_notificacao=False` na mensagem quando fila ja emitiu)

## Test plan
- [ ] Criar ticket sem responsavel: som toca 1x
- [ ] Criar 2 tickets distintos: 2 alertas enfileirados
- [ ] Navegar para /tickets e criar ticket: som continua 1x (sem hook duplicado)
- [ ] `pytest tests/test_realtime_notificacao.py::test_criar_ticket_fila_emite_contagem_unica`