### PR TITLE
feat(sla): modelo de metas, calendario comercial e snapshot na criacao (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets
 - Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets
 - Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime
 - `aplicar_roteamento` restrito a administradores para sobrescrever setor explícito

--- a/backend/alembic/versions/047_sla_policies.py
+++ b/backend/alembic/versions/047_sla_policies.py
@@ -1,0 +1,105 @@
+"""SLA: business_calendars, sla_policies e campos em tickets (#277).
+
+Revision ID: 047_sla_policies
+Revises: 046_routing_rules
+Create Date: 2026-06-23
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "047_sla_policies"
+down_revision = "046_routing_rules"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "business_calendars",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sa.Integer(), nullable=False),
+        sa.Column("setor_id", sa.Integer(), nullable=True),
+        sa.Column("nome", sa.String(length=120), nullable=False),
+        sa.Column("horario_timezone", sa.String(length=64), nullable=False, server_default="America/Sao_Paulo"),
+        sa.Column("horario_inicio", sa.String(length=5), nullable=True),
+        sa.Column("horario_fim", sa.String(length=5), nullable=True),
+        sa.Column("horario_semana_json", sa.Text(), nullable=True),
+        sa.Column("usar_feriados_nacionais", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["setor_id"], ["setores.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_business_calendars_id"), "business_calendars", ["id"], unique=False)
+    op.create_index(op.f("ix_business_calendars_tenant_id"), "business_calendars", ["tenant_id"], unique=False)
+    op.create_index(op.f("ix_business_calendars_setor_id"), "business_calendars", ["setor_id"], unique=False)
+
+    op.create_table(
+        "sla_policies",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sa.Integer(), nullable=False),
+        sa.Column("setor_id", sa.Integer(), nullable=False),
+        sa.Column("prioridade", sa.String(length=20), nullable=True),
+        sa.Column("business_calendar_id", sa.Integer(), nullable=True),
+        sa.Column("meta_primeira_resposta_min", sa.Integer(), nullable=True),
+        sa.Column("meta_resolucao_min", sa.Integer(), nullable=True),
+        sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["business_calendar_id"], ["business_calendars.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["setor_id"], ["setores.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("tenant_id", "setor_id", "prioridade", name="uq_sla_policies_setor_prioridade"),
+    )
+    op.create_index(op.f("ix_sla_policies_id"), "sla_policies", ["id"], unique=False)
+    op.create_index(op.f("ix_sla_policies_tenant_id"), "sla_policies", ["tenant_id"], unique=False)
+    op.create_index(op.f("ix_sla_policies_setor_id"), "sla_policies", ["setor_id"], unique=False)
+    op.create_index(op.f("ix_sla_policies_prioridade"), "sla_policies", ["prioridade"], unique=False)
+
+    op.add_column("tickets", sa.Column("sla_policy_id", sa.Integer(), nullable=True))
+    op.add_column("tickets", sa.Column("sla_meta_primeira_resposta_min", sa.Integer(), nullable=True))
+    op.add_column("tickets", sa.Column("sla_meta_resolucao_min", sa.Integer(), nullable=True))
+    op.add_column("tickets", sa.Column("sla_primeira_resposta_vence_em", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("tickets", sa.Column("sla_resolucao_vence_em", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("tickets", sa.Column("sla_primeira_resposta_em", sa.DateTime(timezone=True), nullable=True))
+    op.add_column(
+        "tickets",
+        sa.Column("sla_violado", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+    )
+    op.create_foreign_key(
+        "fk_tickets_sla_policy_id",
+        "tickets",
+        "sla_policies",
+        ["sla_policy_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(op.f("ix_tickets_sla_policy_id"), "tickets", ["sla_policy_id"], unique=False)
+    op.alter_column("tickets", "sla_violado", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_tickets_sla_policy_id"), table_name="tickets")
+    op.drop_constraint("fk_tickets_sla_policy_id", "tickets", type_="foreignkey")
+    op.drop_column("tickets", "sla_violado")
+    op.drop_column("tickets", "sla_primeira_resposta_em")
+    op.drop_column("tickets", "sla_resolucao_vence_em")
+    op.drop_column("tickets", "sla_primeira_resposta_vence_em")
+    op.drop_column("tickets", "sla_meta_resolucao_min")
+    op.drop_column("tickets", "sla_meta_primeira_resposta_min")
+    op.drop_column("tickets", "sla_policy_id")
+
+    op.drop_index(op.f("ix_sla_policies_prioridade"), table_name="sla_policies")
+    op.drop_index(op.f("ix_sla_policies_setor_id"), table_name="sla_policies")
+    op.drop_index(op.f("ix_sla_policies_tenant_id"), table_name="sla_policies")
+    op.drop_index(op.f("ix_sla_policies_id"), table_name="sla_policies")
+    op.drop_table("sla_policies")
+
+    op.drop_index(op.f("ix_business_calendars_setor_id"), table_name="business_calendars")
+    op.drop_index(op.f("ix_business_calendars_tenant_id"), table_name="business_calendars")
+    op.drop_index(op.f("ix_business_calendars_id"), table_name="business_calendars")
+    op.drop_table("business_calendars")

--- a/backend/app/api/sla.py
+++ b/backend/app/api/sla.py
@@ -1,0 +1,329 @@
+import json
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.core.auth import exigir_admin
+from app.core.ticket_prioridade import PrioridadeTicket
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.models.business_calendar import BusinessCalendar
+from app.models.setor import Setor
+from app.models.sla_policy import SlaPolicy
+from app.schemas.sla import (
+    BusinessCalendarCreate,
+    BusinessCalendarRead,
+    BusinessCalendarUpdate,
+    SlaPolicyCreate,
+    SlaPolicyRead,
+    SlaPolicyUpdate,
+    SlaPrioridadesDisponiveis,
+)
+from app.services.sla_policy import validar_metas_sla
+
+router = APIRouter(prefix="/sla", tags=["sla"])
+
+
+def _validar_setor(db: Session, tenant_id: int, setor_id: int) -> Setor:
+    setor = db.query(Setor).filter(Setor.id == setor_id, Setor.tenant_id == tenant_id).first()
+    if not setor:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Setor não encontrado")
+    return setor
+
+
+def _validar_calendario(db: Session, tenant_id: int, calendar_id: int | None) -> None:
+    if calendar_id is None:
+        return
+    cal = (
+        db.query(BusinessCalendar)
+        .filter(BusinessCalendar.id == calendar_id, BusinessCalendar.tenant_id == tenant_id)
+        .first()
+    )
+    if not cal:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Calendário comercial não encontrado")
+
+
+def _prioridade_db(prioridade: PrioridadeTicket | None) -> str | None:
+    if prioridade is None:
+        return None
+    return prioridade.value
+
+
+def _assert_policy_unica(
+    db: Session,
+    *,
+    tenant_id: int,
+    setor_id: int,
+    prioridade: PrioridadeTicket | None,
+    exclude_id: int | None = None,
+) -> None:
+    q = db.query(SlaPolicy).filter(SlaPolicy.tenant_id == tenant_id, SlaPolicy.setor_id == setor_id)
+    prio_db = _prioridade_db(prioridade)
+    if prio_db is None:
+        q = q.filter(SlaPolicy.prioridade.is_(None))
+    else:
+        q = q.filter(SlaPolicy.prioridade == prio_db)
+    if exclude_id is not None:
+        q = q.filter(SlaPolicy.id != exclude_id)
+    if q.first():
+        label = prio_db or "padrão"
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Já existe política SLA para este setor (prioridade {label}).",
+        )
+
+
+def _policy_para_read(db: Session, policy: SlaPolicy) -> SlaPolicyRead:
+    setor = db.query(Setor).filter(Setor.id == policy.setor_id).first()
+    cal_nome = None
+    if policy.business_calendar_id:
+        cal = db.query(BusinessCalendar).filter(BusinessCalendar.id == policy.business_calendar_id).first()
+        cal_nome = cal.nome if cal else None
+    return SlaPolicyRead.from_row(policy, setor_nome=setor.nome if setor else None, calendar_nome=cal_nome)
+
+
+def _calendar_para_read(row: BusinessCalendar) -> BusinessCalendarRead:
+    return BusinessCalendarRead.from_row(row)
+
+
+def _horario_semana_json(horario_semana: dict | None) -> str | None:
+    if horario_semana is None:
+        return None
+    return json.dumps(horario_semana, ensure_ascii=False)
+
+
+# --- Calendários comerciais (opcional #277) ---
+
+
+@router.get("/calendars", response_model=list[BusinessCalendarRead])
+def listar_calendarios(
+    setor_id: int | None = Query(None),
+    incluir_inativos: bool = Query(False),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    q = db.query(BusinessCalendar).filter(BusinessCalendar.tenant_id == atendente.tenant_id)
+    if setor_id is not None:
+        q = q.filter(BusinessCalendar.setor_id == setor_id)
+    if not incluir_inativos:
+        q = q.filter(BusinessCalendar.ativo.is_(True))
+    rows = q.order_by(BusinessCalendar.nome.asc(), BusinessCalendar.id.asc()).all()
+    return [_calendar_para_read(r) for r in rows]
+
+
+@router.post("/calendars", response_model=BusinessCalendarRead, status_code=201)
+def criar_calendario(
+    data: BusinessCalendarCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    if data.setor_id is not None:
+        _validar_setor(db, atendente.tenant_id, data.setor_id)
+    row = BusinessCalendar(
+        tenant_id=atendente.tenant_id,
+        setor_id=data.setor_id,
+        nome=data.nome.strip(),
+        horario_timezone=data.horario_timezone.strip() or "America/Sao_Paulo",
+        horario_inicio=data.horario_inicio,
+        horario_fim=data.horario_fim,
+        horario_semana_json=_horario_semana_json(data.horario_semana),
+        usar_feriados_nacionais=data.usar_feriados_nacionais,
+        ativo=data.ativo,
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(db, "business_calendar", row.id, "create", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return _calendar_para_read(row)
+
+
+@router.get("/calendars/{calendar_id}", response_model=BusinessCalendarRead)
+def obter_calendario(
+    calendar_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = (
+        db.query(BusinessCalendar)
+        .filter(BusinessCalendar.id == calendar_id, BusinessCalendar.tenant_id == atendente.tenant_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Calendário não encontrado")
+    return _calendar_para_read(row)
+
+
+@router.put("/calendars/{calendar_id}", response_model=BusinessCalendarRead)
+def atualizar_calendario(
+    calendar_id: int,
+    data: BusinessCalendarUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = (
+        db.query(BusinessCalendar)
+        .filter(BusinessCalendar.id == calendar_id, BusinessCalendar.tenant_id == atendente.tenant_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Calendário não encontrado")
+
+    payload = data.model_dump(exclude_unset=True)
+    if "nome" in payload and payload["nome"] is not None:
+        row.nome = payload["nome"].strip()
+    if "setor_id" in payload:
+        if payload["setor_id"] is not None:
+            _validar_setor(db, atendente.tenant_id, payload["setor_id"])
+        row.setor_id = payload["setor_id"]
+    if "horario_timezone" in payload and payload["horario_timezone"] is not None:
+        row.horario_timezone = payload["horario_timezone"].strip() or "America/Sao_Paulo"
+    if "horario_inicio" in payload:
+        row.horario_inicio = payload["horario_inicio"]
+    if "horario_fim" in payload:
+        row.horario_fim = payload["horario_fim"]
+    if "horario_semana" in payload:
+        row.horario_semana_json = _horario_semana_json(payload["horario_semana"])
+    if "usar_feriados_nacionais" in payload and payload["usar_feriados_nacionais"] is not None:
+        row.usar_feriados_nacionais = payload["usar_feriados_nacionais"]
+    if "ativo" in payload and payload["ativo"] is not None:
+        row.ativo = payload["ativo"]
+
+    registrar_audit(db, "business_calendar", row.id, "update", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return _calendar_para_read(row)
+
+
+# --- Políticas SLA ---
+
+
+@router.get("/prioridades", response_model=SlaPrioridadesDisponiveis)
+def listar_prioridades_sla(_: Atendente = Depends(exigir_admin)):
+    return SlaPrioridadesDisponiveis()
+
+
+@router.get("/policies", response_model=list[SlaPolicyRead])
+def listar_policies(
+    setor_id: int | None = Query(None),
+    incluir_inativos: bool = Query(False),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    q = db.query(SlaPolicy).filter(SlaPolicy.tenant_id == atendente.tenant_id)
+    if setor_id is not None:
+        q = q.filter(SlaPolicy.setor_id == setor_id)
+    if not incluir_inativos:
+        q = q.filter(SlaPolicy.ativo.is_(True))
+    rows = q.order_by(SlaPolicy.setor_id.asc(), SlaPolicy.prioridade.asc().nullsfirst(), SlaPolicy.id.asc()).all()
+    return [_policy_para_read(db, r) for r in rows]
+
+
+@router.post("/policies", response_model=SlaPolicyRead, status_code=201)
+def criar_policy(
+    data: SlaPolicyCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    try:
+        validar_metas_sla(
+            meta_primeira_resposta_min=data.meta_primeira_resposta_min,
+            meta_resolucao_min=data.meta_resolucao_min,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+    _validar_setor(db, atendente.tenant_id, data.setor_id)
+    _validar_calendario(db, atendente.tenant_id, data.business_calendar_id)
+    _assert_policy_unica(
+        db,
+        tenant_id=atendente.tenant_id,
+        setor_id=data.setor_id,
+        prioridade=data.prioridade,
+    )
+
+    policy = SlaPolicy(
+        tenant_id=atendente.tenant_id,
+        setor_id=data.setor_id,
+        prioridade=_prioridade_db(data.prioridade),
+        business_calendar_id=data.business_calendar_id,
+        meta_primeira_resposta_min=data.meta_primeira_resposta_min,
+        meta_resolucao_min=data.meta_resolucao_min,
+        ativo=data.ativo,
+    )
+    db.add(policy)
+    db.flush()
+    registrar_audit(db, "sla_policy", policy.id, "create", atendente.id)
+    db.commit()
+    db.refresh(policy)
+    return _policy_para_read(db, policy)
+
+
+@router.get("/policies/{policy_id}", response_model=SlaPolicyRead)
+def obter_policy(
+    policy_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    policy = (
+        db.query(SlaPolicy)
+        .filter(SlaPolicy.id == policy_id, SlaPolicy.tenant_id == atendente.tenant_id)
+        .first()
+    )
+    if not policy:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Política SLA não encontrada")
+    return _policy_para_read(db, policy)
+
+
+@router.put("/policies/{policy_id}", response_model=SlaPolicyRead)
+def atualizar_policy(
+    policy_id: int,
+    data: SlaPolicyUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    policy = (
+        db.query(SlaPolicy)
+        .filter(SlaPolicy.id == policy_id, SlaPolicy.tenant_id == atendente.tenant_id)
+        .first()
+    )
+    if not policy:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Política SLA não encontrada")
+
+    payload = data.model_dump(exclude_unset=True)
+    if "setor_id" in payload and payload["setor_id"] is not None:
+        _validar_setor(db, atendente.tenant_id, payload["setor_id"])
+        policy.setor_id = payload["setor_id"]
+    if "prioridade" in payload:
+        policy.prioridade = _prioridade_db(payload["prioridade"])
+    if "business_calendar_id" in payload:
+        _validar_calendario(db, atendente.tenant_id, payload["business_calendar_id"])
+        policy.business_calendar_id = payload["business_calendar_id"]
+    if "meta_primeira_resposta_min" in payload:
+        policy.meta_primeira_resposta_min = payload["meta_primeira_resposta_min"]
+    if "meta_resolucao_min" in payload:
+        policy.meta_resolucao_min = payload["meta_resolucao_min"]
+    if "ativo" in payload and payload["ativo"] is not None:
+        policy.ativo = payload["ativo"]
+
+    try:
+        validar_metas_sla(
+            meta_primeira_resposta_min=policy.meta_primeira_resposta_min,
+            meta_resolucao_min=policy.meta_resolucao_min,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+    _assert_policy_unica(
+        db,
+        tenant_id=atendente.tenant_id,
+        setor_id=policy.setor_id,
+        prioridade=PrioridadeTicket(policy.prioridade) if policy.prioridade else None,
+        exclude_id=policy.id,
+    )
+
+    registrar_audit(db, "sla_policy", policy.id, "update", atendente.id)
+    db.commit()
+    db.refresh(policy)
+    return _policy_para_read(db, policy)

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -395,6 +395,13 @@ def _ticket_para_read(t: Ticket, db: Session | None = None) -> TicketRead:
         solicitante=_solicitante_para_read(db, t, triagem) if db is not None else None,
         **csat,
         **fila,
+        sla_policy_id=t.sla_policy_id,
+        sla_meta_primeira_resposta_min=t.sla_meta_primeira_resposta_min,
+        sla_meta_resolucao_min=t.sla_meta_resolucao_min,
+        sla_primeira_resposta_vence_em=t.sla_primeira_resposta_vence_em,
+        sla_resolucao_vence_em=t.sla_resolucao_vence_em,
+        sla_primeira_resposta_em=t.sla_primeira_resposta_em,
+        sla_violado=bool(t.sla_violado),
     )
 
 
@@ -724,6 +731,9 @@ def criar(
     )
     db.add(ticket)
     db.flush()
+    from app.services.sla_policy import aplicar_sla_snapshot_ao_ticket
+
+    aplicar_sla_snapshot_ao_ticket(db, ticket)
     if rota_resultado.matched:
         registrar_roteamento_aplicado(
             db,

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -1236,6 +1236,9 @@ def abrir_ticket(
     )
     db.add(ticket)
     db.flush()
+    from app.services.sla_policy import aplicar_sla_snapshot_ao_ticket
+
+    aplicar_sla_snapshot_ao_ticket(db, ticket)
     corpo_abertura = desc or linha_chat
     db.add(
         TicketMensagem(

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -14,7 +14,7 @@ from app.services.whatsapp_auto_messages import (
     DEFAULT_AUTO_MSG_FORA_HORARIO,
     resolver_nome_empresa_para_template,
 )
-from app.services.whatsapp_media_storage import gravar_base64_em_disco
+from app.core.business_calendar import is_feriado_nacional_br as _is_feriado_nacional_br
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import json
@@ -164,49 +164,6 @@ def _parse_hhmm(v: str | None) -> tuple[int, int] | None:
         return hh, mm
     except Exception:
         return None
-
-
-def _easter_date_gregorian(year: int) -> date:
-    """Meeus/Jones/Butcher algorithm."""
-    a = year % 19
-    b = year // 100
-    c = year % 100
-    d = b // 4
-    e = b % 4
-    f = (b + 8) // 25
-    g = (b - f + 1) // 3
-    h = (19 * a + b - d - g + 15) % 30
-    i = c // 4
-    k = c % 4
-    l = (32 + 2 * e + 2 * i - h - k) % 7
-    m = (a + 11 * h + 22 * l) // 451
-    month = (h + l - 7 * m + 114) // 31
-    day = ((h + l - 7 * m + 114) % 31) + 1
-    return date(year, month, day)
-
-
-def _is_feriado_nacional_br(d: date) -> bool:
-    # Fixos (Brasil)
-    fixos = {
-        (1, 1),   # Confraternização
-        (4, 21),  # Tiradentes
-        (5, 1),   # Trabalho
-        (9, 7),   # Independência
-        (10, 12), # Nossa Senhora Aparecida
-        (11, 2),  # Finados
-        (11, 15), # Proclamação
-        (11, 20), # Consciência Negra (nacional)
-        (12, 25), # Natal
-    }
-    if (d.month, d.day) in fixos:
-        return True
-    # Móveis (base Páscoa)
-    easter = _easter_date_gregorian(d.year)
-    carnaval_seg = easter - timedelta(days=48)
-    carnaval_ter = easter - timedelta(days=47)
-    sexta_santa = easter - timedelta(days=2)
-    corpus_christi = easter + timedelta(days=60)
-    return d in (carnaval_seg, carnaval_ter, sexta_santa, corpus_christi)
 
 
 def _horario_semana(st: WhatsappSettings) -> dict[str, dict] | None:

--- a/backend/app/core/business_calendar.py
+++ b/backend/app/core/business_calendar.py
@@ -1,0 +1,129 @@
+"""Calendário comercial compartilhado (feriados BR + helpers de horário)."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+def easter_date_gregorian(year: int) -> date:
+    """Domingo de Páscoa (algoritmo de Meeus/Jones/Butcher)."""
+    a = year % 19
+    b = year // 100
+    c = year % 100
+    d = b // 4
+    e = b % 4
+    f = (b + 8) // 25
+    g = (b - f + 1) // 3
+    h = (19 * a + b - d - g + 15) % 30
+    i = c // 4
+    k = c % 4
+    l = (32 + 2 * e + 2 * i - h - k) % 7
+    m = (a + 11 * h + 22 * l) // 451
+    month = (h + l - 7 * m + 114) // 31
+    day = ((h + l - 7 * m + 114) % 31) + 1
+    return date(year, month, day)
+
+
+def is_feriado_nacional_br(d: date) -> bool:
+    fixos = {
+        (1, 1),
+        (4, 21),
+        (5, 1),
+        (9, 7),
+        (10, 12),
+        (11, 2),
+        (11, 15),
+        (11, 20),
+        (12, 25),
+    }
+    if (d.month, d.day) in fixos:
+        return True
+    easter = easter_date_gregorian(d.year)
+    carnaval_seg = easter - timedelta(days=48)
+    carnaval_ter = easter - timedelta(days=47)
+    sexta_santa = easter - timedelta(days=2)
+    corpus_christi = easter + timedelta(days=60)
+    return d in (carnaval_seg, carnaval_ter, sexta_santa, corpus_christi)
+
+
+def parse_hhmm(value: str | None) -> tuple[int, int] | None:
+    if not value or not str(value).strip():
+        return None
+    parts = str(value).strip().split(":")
+    if len(parts) != 2:
+        return None
+    try:
+        h, m = int(parts[0]), int(parts[1])
+    except ValueError:
+        return None
+    if not (0 <= h <= 23 and 0 <= m <= 59):
+        return None
+    return h, m
+
+
+def horario_semana_from_json(raw: str | None) -> dict[str, dict[str, Any]] | None:
+    if not raw or not str(raw).strip():
+        return None
+    try:
+        v = json.loads(str(raw))
+        return v if isinstance(v, dict) else None
+    except Exception:
+        return None
+
+
+def esta_em_horario_comercial(
+    *,
+    timezone_name: str,
+    horario_inicio: str | None,
+    horario_fim: str | None,
+    horario_semana_json: str | None,
+    usar_feriados_nacionais: bool,
+    moment: datetime | None = None,
+) -> bool:
+    tzname = (timezone_name or "America/Sao_Paulo").strip() or "America/Sao_Paulo"
+    try:
+        tz = ZoneInfo(tzname)
+    except ZoneInfoNotFoundError:
+        tz = ZoneInfo("America/Sao_Paulo")
+    now = moment.astimezone(tz) if moment is not None else datetime.now(tz)
+    today = now.date()
+
+    if usar_feriados_nacionais and is_feriado_nacional_br(today):
+        return False
+
+    hs = horario_semana_from_json(horario_semana_json)
+    if hs:
+        keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+        k = keys[now.weekday()]
+        cfg = hs.get(k) if isinstance(hs, dict) else None
+        if isinstance(cfg, dict):
+            if not bool(cfg.get("ativo", True)):
+                return False
+            ini = parse_hhmm(cfg.get("inicio"))
+            fim = parse_hhmm(cfg.get("fim"))
+            if not ini or not fim:
+                return True
+            m = now.hour * 60 + now.minute
+            a = ini[0] * 60 + ini[1]
+            b = fim[0] * 60 + fim[1]
+            if a == b:
+                return True
+            if a < b:
+                return a <= m < b
+            return m >= a or m < b
+
+    ini = parse_hhmm(horario_inicio)
+    fim = parse_hhmm(horario_fim)
+    if not ini or not fim:
+        return True
+    m = now.hour * 60 + now.minute
+    a = ini[0] * 60 + ini[1]
+    b = fim[0] * 60 + fim[1]
+    if a == b:
+        return True
+    if a < b:
+        return a <= m < b
+    return m >= a or m < b

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -42,6 +42,7 @@ from app.api import (
     public_csat,
     system,
     routing,
+    sla,
 )
 from app.config import settings
 from app.core.tenant_context import resolve_tenant_id, set_request_tenant_id
@@ -403,6 +404,7 @@ app.include_router(tenant.router, prefix=API_V1_PREFIX)
 app.include_router(public_csat.router, prefix=API_V1_PREFIX)
 app.include_router(system.router, prefix=API_V1_PREFIX)
 app.include_router(routing.router, prefix=API_V1_PREFIX)
+app.include_router(sla.router, prefix=API_V1_PREFIX)
 
 
 def _app_route_paths() -> set[str]:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -29,6 +29,8 @@ from app.models.ticket_avaliacao import TicketAvaliacao, TicketCsatInvite
 from app.models.atendente_notificacao import AtendenteNotificacaoPreferencias, NotificacaoEmailOutbox
 from app.models.webhook_outbox import WebhookOutbox
 from app.models.routing_rule import RoutingRule
+from app.models.business_calendar import BusinessCalendar
+from app.models.sla_policy import SlaPolicy
 from app.models.empresa_pdv import EmpresaPdv, PdvRotulo, PdvTipoAcessoRemoto
 
 __all__ = [
@@ -73,6 +75,8 @@ __all__ = [
     "NotificacaoEmailOutbox",
     "WebhookOutbox",
     "RoutingRule",
+    "BusinessCalendar",
+    "SlaPolicy",
     "PdvRotulo",
     "PdvTipoAcessoRemoto",
     "EmpresaPdv",

--- a/backend/app/models/business_calendar.py
+++ b/backend/app/models/business_calendar.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class BusinessCalendar(Base):
+    """Calendário comercial reutilizável (SLA, futuro: outros módulos)."""
+
+    __tablename__ = "business_calendars"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    setor_id = Column(Integer, ForeignKey("setores.id", ondelete="CASCADE"), nullable=True, index=True)
+    nome = Column(String(120), nullable=False)
+    horario_timezone = Column(String(64), nullable=False, default="America/Sao_Paulo", server_default="America/Sao_Paulo")
+    horario_inicio = Column(String(5), nullable=True)
+    horario_fim = Column(String(5), nullable=True)
+    horario_semana_json = Column(Text, nullable=True)
+    usar_feriados_nacionais = Column(Boolean, nullable=False, default=False, server_default="false")
+    ativo = Column(Boolean, nullable=False, default=True, server_default="true")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    setor = relationship("Setor", foreign_keys=[setor_id])
+    sla_policies = relationship("SlaPolicy", back_populates="business_calendar")

--- a/backend/app/models/sla_policy.py
+++ b/backend/app/models/sla_policy.py
@@ -1,0 +1,28 @@
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class SlaPolicy(Base):
+    """Meta de SLA por setor e prioridade (prioridade nula = default do setor)."""
+
+    __tablename__ = "sla_policies"
+    __table_args__ = (
+        UniqueConstraint("tenant_id", "setor_id", "prioridade", name="uq_sla_policies_setor_prioridade"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    setor_id = Column(Integer, ForeignKey("setores.id", ondelete="CASCADE"), nullable=False, index=True)
+    prioridade = Column(String(20), nullable=True, index=True)
+    business_calendar_id = Column(Integer, ForeignKey("business_calendars.id", ondelete="SET NULL"), nullable=True)
+    meta_primeira_resposta_min = Column(Integer, nullable=True)
+    meta_resolucao_min = Column(Integer, nullable=True)
+    ativo = Column(Boolean, nullable=False, default=True, server_default="true")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    setor = relationship("Setor", foreign_keys=[setor_id])
+    business_calendar = relationship("BusinessCalendar", back_populates="sla_policies")

--- a/backend/app/models/ticket.py
+++ b/backend/app/models/ticket.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, Enum as SAEnum
+from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, Enum as SAEnum, Boolean
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -30,6 +30,13 @@ class Ticket(Base):
     descricao = Column(Text, nullable=True)
     fechado_em = Column(DateTime(timezone=True), nullable=True)
     fila_desde_at = Column(DateTime(timezone=True), nullable=True)
+    sla_policy_id = Column(Integer, ForeignKey("sla_policies.id", ondelete="SET NULL"), nullable=True, index=True)
+    sla_meta_primeira_resposta_min = Column(Integer, nullable=True)
+    sla_meta_resolucao_min = Column(Integer, nullable=True)
+    sla_primeira_resposta_vence_em = Column(DateTime(timezone=True), nullable=True)
+    sla_resolucao_vence_em = Column(DateTime(timezone=True), nullable=True)
+    sla_primeira_resposta_em = Column(DateTime(timezone=True), nullable=True)
+    sla_violado = Column(Boolean, nullable=False, default=False, server_default="false")
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/app/schemas/sla.py
+++ b/backend/app/schemas/sla.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.core.ticket_prioridade import PRIORIDADES_TICKET, PrioridadeTicket
+
+
+class BusinessCalendarBase(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=120)
+    setor_id: int | None = None
+    horario_timezone: str = Field(default="America/Sao_Paulo", max_length=64)
+    horario_inicio: str | None = Field(default=None, max_length=5)
+    horario_fim: str | None = Field(default=None, max_length=5)
+    horario_semana: dict[str, Any] | None = None
+    usar_feriados_nacionais: bool = False
+    ativo: bool = True
+
+
+class BusinessCalendarCreate(BusinessCalendarBase):
+    pass
+
+
+class BusinessCalendarUpdate(BaseModel):
+    nome: str | None = Field(default=None, min_length=1, max_length=120)
+    setor_id: int | None = None
+    horario_timezone: str | None = Field(default=None, max_length=64)
+    horario_inicio: str | None = Field(default=None, max_length=5)
+    horario_fim: str | None = Field(default=None, max_length=5)
+    horario_semana: dict[str, Any] | None = None
+    usar_feriados_nacionais: bool | None = None
+    ativo: bool | None = None
+
+
+class BusinessCalendarRead(BusinessCalendarBase):
+    id: int
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @classmethod
+    def from_row(cls, row) -> "BusinessCalendarRead":
+        import json
+
+        horario_semana = None
+        raw = getattr(row, "horario_semana_json", None)
+        if raw:
+            try:
+                horario_semana = json.loads(str(raw))
+            except Exception:
+                horario_semana = None
+        return cls(
+            id=row.id,
+            nome=row.nome,
+            setor_id=row.setor_id,
+            horario_timezone=row.horario_timezone,
+            horario_inicio=row.horario_inicio,
+            horario_fim=row.horario_fim,
+            horario_semana=horario_semana,
+            usar_feriados_nacionais=row.usar_feriados_nacionais,
+            ativo=row.ativo,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
+
+
+class SlaPolicyBase(BaseModel):
+    setor_id: int
+    prioridade: PrioridadeTicket | None = Field(
+        default=None,
+        description="Nulo = política padrão do setor (qualquer prioridade sem regra específica).",
+    )
+    business_calendar_id: int | None = None
+    meta_primeira_resposta_min: int | None = Field(default=None, ge=1)
+    meta_resolucao_min: int | None = Field(default=None, ge=1)
+    ativo: bool = True
+
+    @field_validator("prioridade", mode="before")
+    @classmethod
+    def _empty_prioridade_none(cls, v):
+        if v == "" or v is None:
+            return None
+        return v
+
+
+class SlaPolicyCreate(SlaPolicyBase):
+    pass
+
+
+class SlaPolicyUpdate(BaseModel):
+    setor_id: int | None = None
+    prioridade: PrioridadeTicket | None = None
+    business_calendar_id: int | None = None
+    meta_primeira_resposta_min: int | None = Field(default=None, ge=1)
+    meta_resolucao_min: int | None = Field(default=None, ge=1)
+    ativo: bool | None = None
+
+    @field_validator("prioridade", mode="before")
+    @classmethod
+    def _empty_prioridade_none(cls, v):
+        if v == "":
+            return None
+        return v
+
+
+class SlaPolicyRead(SlaPolicyBase):
+    id: int
+    setor_nome: str | None = None
+    business_calendar_nome: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+    @classmethod
+    def from_row(cls, row, *, setor_nome: str | None = None, calendar_nome: str | None = None) -> "SlaPolicyRead":
+        prio = row.prioridade
+        prioridade = PrioridadeTicket(prio) if prio else None
+        return cls(
+            id=row.id,
+            setor_id=row.setor_id,
+            prioridade=prioridade,
+            business_calendar_id=row.business_calendar_id,
+            meta_primeira_resposta_min=row.meta_primeira_resposta_min,
+            meta_resolucao_min=row.meta_resolucao_min,
+            ativo=row.ativo,
+            setor_nome=setor_nome,
+            business_calendar_nome=calendar_nome,
+            created_at=row.created_at,
+            updated_at=row.updated_at,
+        )
+
+
+class SlaPrioridadesDisponiveis(BaseModel):
+    prioridades: list[str] = list(PRIORIDADES_TICKET)

--- a/backend/app/schemas/ticket.py
+++ b/backend/app/schemas/ticket.py
@@ -186,6 +186,13 @@ class TicketRead(BaseModel):
     fila_desde_at: datetime | None = None
     distribuicao_modo_setor: str | None = None
     distribuicao_auto_em_minutos: int | None = None
+    sla_policy_id: int | None = None
+    sla_meta_primeira_resposta_min: int | None = None
+    sla_meta_resolucao_min: int | None = None
+    sla_primeira_resposta_vence_em: datetime | None = None
+    sla_resolucao_vence_em: datetime | None = None
+    sla_primeira_resposta_em: datetime | None = None
+    sla_violado: bool = False
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/sla_policy.py
+++ b/backend/app/services/sla_policy.py
@@ -1,0 +1,117 @@
+"""Resolução de policy SLA e snapshot na criação do ticket (#277)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.core.ticket_prioridade import PrioridadeTicket
+from app.models.business_calendar import BusinessCalendar
+from app.models.sla_policy import SlaPolicy
+from app.models.ticket import Ticket
+
+
+def _prioridade_valor(prioridade) -> str:
+    if isinstance(prioridade, PrioridadeTicket):
+        return prioridade.value
+    return str(prioridade or PrioridadeTicket.normal.value)
+
+
+def resolve_sla_policy(
+    db: Session,
+    *,
+    tenant_id: int,
+    setor_id: int,
+    prioridade,
+) -> SlaPolicy | None:
+    prio_val = _prioridade_valor(prioridade)
+    base_q = db.query(SlaPolicy).filter(
+        SlaPolicy.tenant_id == tenant_id,
+        SlaPolicy.setor_id == setor_id,
+        SlaPolicy.ativo.is_(True),
+    )
+    specific = base_q.filter(SlaPolicy.prioridade == prio_val).first()
+    if specific:
+        return specific
+    return base_q.filter(SlaPolicy.prioridade.is_(None)).first()
+
+
+def _deadline_wall_clock(base: datetime, minutes: int) -> datetime:
+    if base.tzinfo is None:
+        base = base.replace(tzinfo=timezone.utc)
+    return base + timedelta(minutes=minutes)
+
+
+def aplicar_sla_snapshot_ao_ticket(
+    db: Session,
+    ticket: Ticket,
+    *,
+    base_time: datetime | None = None,
+) -> SlaPolicy | None:
+    """Grava metas e prazos iniciais no ticket (relógio corrido em S-01; calendário em S-02)."""
+    prioridade = ticket.prioridade
+    if prioridade is None:
+        prioridade = PrioridadeTicket.normal
+    policy = resolve_sla_policy(
+        db,
+        tenant_id=ticket.tenant_id,
+        setor_id=ticket.setor_id,
+        prioridade=prioridade,
+    )
+    if not policy:
+        return None
+
+    base = base_time or ticket.created_at or datetime.now(timezone.utc)
+
+    ticket.sla_policy_id = policy.id
+    ticket.sla_meta_primeira_resposta_min = policy.meta_primeira_resposta_min
+    ticket.sla_meta_resolucao_min = policy.meta_resolucao_min
+    ticket.sla_violado = False
+
+    if policy.meta_primeira_resposta_min and policy.meta_primeira_resposta_min > 0:
+        ticket.sla_primeira_resposta_vence_em = _deadline_wall_clock(
+            base, policy.meta_primeira_resposta_min
+        )
+    else:
+        ticket.sla_primeira_resposta_vence_em = None
+
+    if policy.meta_resolucao_min and policy.meta_resolucao_min > 0:
+        ticket.sla_resolucao_vence_em = _deadline_wall_clock(base, policy.meta_resolucao_min)
+    else:
+        ticket.sla_resolucao_vence_em = None
+
+    return policy
+
+
+def validar_metas_sla(
+    *,
+    meta_primeira_resposta_min: int | None,
+    meta_resolucao_min: int | None,
+) -> None:
+    primeira = meta_primeira_resposta_min
+    resolucao = meta_resolucao_min
+    if primeira is None and resolucao is None:
+        raise ValueError("Informe ao menos uma meta (primeira resposta ou resolução).")
+    for label, valor in (
+        ("meta_primeira_resposta_min", primeira),
+        ("meta_resolucao_min", resolucao),
+    ):
+        if valor is None:
+            continue
+        if valor <= 0:
+            raise ValueError(f"{label} deve ser maior que zero.")
+
+
+def carregar_calendario_policy(db: Session, policy: SlaPolicy) -> BusinessCalendar | None:
+    if not policy.business_calendar_id:
+        return None
+    return (
+        db.query(BusinessCalendar)
+        .filter(
+            BusinessCalendar.id == policy.business_calendar_id,
+            BusinessCalendar.tenant_id == policy.tenant_id,
+            BusinessCalendar.ativo.is_(True),
+        )
+        .first()
+    )

--- a/backend/app/services/ticket_filhos_massa.py
+++ b/backend/app/services/ticket_filhos_massa.py
@@ -127,6 +127,9 @@ def criar_filhos_em_massa(
         )
         db.add(ticket)
         db.flush()
+        from app.services.sla_policy import aplicar_sla_snapshot_ao_ticket
+
+        aplicar_sla_snapshot_ao_ticket(db, ticket)
         db.add(
             TicketMensagem(
                 ticket_id=ticket.id,

--- a/backend/app/services/ticket_from_inbound_email.py
+++ b/backend/app/services/ticket_from_inbound_email.py
@@ -126,6 +126,9 @@ def _criar_ticket_triagem_pos_fecho(
     )
     db.add(ticket)
     db.flush()
+    from app.services.sla_policy import aplicar_sla_snapshot_ao_ticket
+
+    aplicar_sla_snapshot_ao_ticket(db, ticket)
 
     db.add(
         TicketMensagem(
@@ -280,6 +283,10 @@ def processar_email_inbound(
     )
     db.add(ticket)
     db.flush()
+
+    from app.services.sla_policy import aplicar_sla_snapshot_ao_ticket
+
+    aplicar_sla_snapshot_ao_ticket(db, ticket)
 
     if rota_aplicada is not None and rota_aplicada.matched:
         from app.services.routing_apply import registrar_roteamento_aplicado

--- a/backend/tests/test_sla_policies.py
+++ b/backend/tests/test_sla_policies.py
@@ -1,0 +1,184 @@
+"""Testes SLA — modelo e políticas (#277)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.models.sla_policy import SlaPolicy
+from app.models.ticket import Ticket
+from app.services.sla_policy import aplicar_sla_snapshot_ao_ticket, resolve_sla_policy
+
+
+def _criar_policy(db, seed_base, *, prioridade=None, primeira=60, resolucao=480):
+    policy = SlaPolicy(
+        tenant_id=1,
+        setor_id=seed_base["setor1"].id,
+        prioridade=prioridade,
+        meta_primeira_resposta_min=primeira,
+        meta_resolucao_min=resolucao,
+        ativo=True,
+    )
+    db.add(policy)
+    db.flush()
+    return policy
+
+
+def test_criar_policy_via_api(client, seed_base, auth_headers):
+    r = client.post(
+        "/v1/sla/policies",
+        headers=auth_headers["admin"],
+        json={
+            "setor_id": seed_base["setor1"].id,
+            "prioridade": "alta",
+            "meta_primeira_resposta_min": 30,
+            "meta_resolucao_min": 240,
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["setor_id"] == seed_base["setor1"].id
+    assert body["prioridade"] == "alta"
+    assert body["meta_primeira_resposta_min"] == 30
+    assert body["meta_resolucao_min"] == 240
+
+
+def test_policy_duplicada_rejeitada(client, seed_base, auth_headers, db_session):
+    _criar_policy(db_session, seed_base, prioridade="normal")
+    db_session.commit()
+
+    r = client.post(
+        "/v1/sla/policies",
+        headers=auth_headers["admin"],
+        json={
+            "setor_id": seed_base["setor1"].id,
+            "prioridade": "normal",
+            "meta_primeira_resposta_min": 15,
+            "meta_resolucao_min": 120,
+        },
+    )
+    assert r.status_code == 400
+    assert "Já existe" in r.json()["detail"]
+
+
+def test_listar_e_atualizar_policy(client, seed_base, auth_headers, db_session):
+    policy = _criar_policy(db_session, seed_base, prioridade=None, primeira=45, resolucao=300)
+    db_session.commit()
+
+    r = client.get("/v1/sla/policies", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    ids = [p["id"] for p in r.json()]
+    assert policy.id in ids
+
+    r2 = client.put(
+        f"/v1/sla/policies/{policy.id}",
+        headers=auth_headers["admin"],
+        json={"meta_primeira_resposta_min": 50, "ativo": False},
+    )
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["meta_primeira_resposta_min"] == 50
+    assert r2.json()["ativo"] is False
+
+
+def test_resolve_prioridade_especifica_sobre_default(db_session, seed_base):
+    _criar_policy(db_session, seed_base, prioridade=None, primeira=120, resolucao=600)
+    especifica = _criar_policy(db_session, seed_base, prioridade="urgente", primeira=10, resolucao=60)
+    db_session.commit()
+
+    resolved = resolve_sla_policy(
+        db_session,
+        tenant_id=1,
+        setor_id=seed_base["setor1"].id,
+        prioridade="urgente",
+    )
+    assert resolved is not None
+    assert resolved.id == especifica.id
+
+
+def test_snapshot_na_criacao_ticket(client, seed_base, auth_headers, db_session):
+    _criar_policy(db_session, seed_base, prioridade=None, primeira=60, resolucao=480)
+    db_session.commit()
+
+    r = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Ticket com SLA",
+            "descricao": "Teste snapshot",
+            "prioridade": "normal",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["sla_policy_id"] is not None
+    assert body["sla_meta_primeira_resposta_min"] == 60
+    assert body["sla_meta_resolucao_min"] == 480
+    assert body["sla_primeira_resposta_vence_em"] is not None
+    assert body["sla_resolucao_vence_em"] is not None
+    assert body["sla_violado"] is False
+
+
+def test_aplicar_snapshot_em_ticket_existente(db_session, seed_base):
+    from app.models.status_ticket import StatusTicket
+
+    _criar_policy(db_session, seed_base, prioridade="alta", primeira=20, resolucao=100)
+    st = db_session.query(StatusTicket).first()
+    ticket = Ticket(
+        tenant_id=1,
+        protocolo="#T202606-SLA1",
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=st.id,
+        assunto="SLA unit",
+        prioridade="alta",
+    )
+    db_session.add(ticket)
+    db_session.flush()
+    base = datetime(2026, 6, 23, 10, 0, tzinfo=timezone.utc)
+    ticket.created_at = base
+    aplicar_sla_snapshot_ao_ticket(db_session, ticket, base_time=base)
+    assert ticket.sla_meta_primeira_resposta_min == 20
+    assert ticket.sla_primeira_resposta_vence_em == base + timedelta(minutes=20)
+
+
+def test_criar_calendario_comercial(client, seed_base, auth_headers):
+    r = client.post(
+        "/v1/sla/calendars",
+        headers=auth_headers["admin"],
+        json={
+            "nome": "Comercial setor 1",
+            "setor_id": seed_base["setor1"].id,
+            "horario_inicio": "09:00",
+            "horario_fim": "18:00",
+            "usar_feriados_nacionais": True,
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["nome"] == "Comercial setor 1"
+    assert body["horario_inicio"] == "09:00"
+
+
+def test_policy_com_calendario(client, seed_base, auth_headers):
+    cal = client.post(
+        "/v1/sla/calendars",
+        headers=auth_headers["admin"],
+        json={"nome": "Cal SLA", "horario_inicio": "08:00", "horario_fim": "17:00"},
+    )
+    assert cal.status_code == 201
+    calendar_id = cal.json()["id"]
+
+    r = client.post(
+        "/v1/sla/policies",
+        headers=auth_headers["admin"],
+        json={
+            "setor_id": seed_base["setor2"].id,
+            "business_calendar_id": calendar_id,
+            "meta_primeira_resposta_min": 45,
+            "meta_resolucao_min": 360,
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["business_calendar_id"] == calendar_id
+    assert r.json()["business_calendar_nome"] == "Cal SLA"


### PR DESCRIPTION
## Summary
- Tabelas `business_calendars` e `sla_policies` (migration 047) + campos SLA em `tickets`
- API admin: `GET/POST/PUT /v1/sla/policies` e `GET/POST/PUT /v1/sla/calendars`
- Snapshot de metas e prazos na criacao (manual, inbound, WhatsApp, filhos em massa)
- Modulo compartilhado `business_calendar` (feriados BR + horario comercial) reutilizado pelo WhatsApp

## Test plan
- [ ] `docker compose exec backend alembic upgrade head`
- [ ] Admin cria policy por setor/prioridade e calendario opcional
- [ ] Criar ticket aplica `sla_meta_*` e `sla_*_vence_em`
- [ ] `docker compose exec backend python -m pytest tests/test_sla_policies.py`