### PR TITLE
feat(sla): calculo com horario comercial, violacoes e endpoint (#278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 ### Melhorias
 
 - SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets
+- SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket
 - Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets
 - Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime
 - `aplicar_roteamento` restrito a administradores para sobrescrever setor explícito

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -57,6 +57,7 @@ from app.services.ticket_csat import csat_brief_para_ticket, criar_convite_csat
 from app.services.ticket_close_hooks import processar_hooks_ao_fechar_ticket
 from app.services.notificacao_atendente_email import notificar_nova_mensagem_ticket, notificar_ticket_atribuido
 from app.schemas.ticket_csat import TicketCsatDevLinkRead
+from app.schemas.sla import TicketSlaRead
 from app.services.ticket_vinculos import (
     criar_vinculo as criar_vinculo_ticket,
     fechar_ticket_como_duplicado,
@@ -772,6 +773,11 @@ def criar(
             emit_ticket_fila(db, ticket)
             contagem_ja_emitida = True
     if msg_abertura:
+        from app.services.sla_calculo import mensagem_conta_primeira_resposta, registrar_primeira_resposta_se_necessario
+
+        if mensagem_conta_primeira_resposta(msg_abertura):
+            registrar_primeira_resposta_se_necessario(db, ticket, momento=msg_abertura.created_at)
+            db.commit()
         emit_ticket_mensagem_from_model(
             db,
             ticket,
@@ -814,6 +820,33 @@ def obter(
     if not _pode_ver_ticket(db, atendente, ticket):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
     return _ticket_para_read(ticket, db)
+
+
+@router.get("/{ticket_id}/sla", response_model=TicketSlaRead)
+def obter_sla_ticket(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if not _pode_ver_ticket(db, atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+    from app.services.sla_calculo import build_ticket_sla_read
+
+    dados = build_ticket_sla_read(db, ticket)
+    from app.schemas.sla import SlaMetaDetalheRead
+
+    return TicketSlaRead(
+        ticket_id=dados["ticket_id"],
+        sla_policy_id=dados["sla_policy_id"],
+        sla_violado=dados["sla_violado"],
+        inicio_em=dados["inicio_em"],
+        usa_horario_comercial=dados["usa_horario_comercial"],
+        primeira_resposta=SlaMetaDetalheRead(**dados["primeira_resposta"]),
+        resolucao=SlaMetaDetalheRead(**dados["resolucao"]),
+    )
 
 
 @router.post("/{ticket_id}/csat/link-dev", response_model=TicketCsatDevLinkRead)
@@ -1223,6 +1256,10 @@ def criar_mensagem(
         agendar_envio_email(m, db)
     db.add(m)
     db.flush()
+    from app.services.sla_calculo import mensagem_conta_primeira_resposta, registrar_primeira_resposta_se_necessario
+
+    if mensagem_conta_primeira_resposta(m):
+        registrar_primeira_resposta_se_necessario(db, ticket, momento=m.created_at)
     notificar_nova_mensagem_ticket(db, ticket=ticket, mensagem=m, autor_atendente_id=atendente.id)
     db.commit()
     db.refresh(m)
@@ -1751,6 +1788,10 @@ def atualizar(
         sincronizar_fila_desde_at(ticket, reset=reset_fila or "atendente_id" in update)
     else:
         ticket.fila_desde_at = None
+
+    from app.services.sla_calculo import sincronizar_sla_violado
+
+    sincronizar_sla_violado(db, ticket)
 
     db.commit()
     if acabou_de_fechar:

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -1248,6 +1248,10 @@ def abrir_ticket(
             corpo=corpo_abertura,
         )
     )
+    db.flush()
+    from app.services.sla_calculo import registrar_primeira_resposta_se_necessario
+
+    registrar_primeira_resposta_se_necessario(db, ticket)
     db.add(WhatsappChatTicket(chat_id=chat_id, ticket_id=ticket.id, atendente_id=atendente.id))
     db.commit()
     db.refresh(ticket)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -67,6 +67,7 @@ class Settings(BaseSettings):
     EVOLUTION_HTTP_MAX_ATTEMPTS: int = 3
     WHATSAPP_INACTIVITY_WORKER_INTERVAL_SECONDS: int = 60
     TICKET_DISTRIBUICAO_WORKER_INTERVAL_SECONDS: int = 45
+    SLA_WORKER_INTERVAL_SECONDS: int = 60
 
     # Modo legado: vários clientes no mesmo Postgres (subdomínio numérico + coluna tenant_id).
     # Produção comercial: manter False (um Postgres por cliente / deploy).

--- a/backend/app/core/business_calendar.py
+++ b/backend/app/core/business_calendar.py
@@ -3,9 +3,45 @@
 from __future__ import annotations
 
 import json
-from datetime import date, datetime, timedelta
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+WEEKDAY_KEYS = ("seg", "ter", "qua", "qui", "sex", "sab", "dom")
+
+
+@dataclass(frozen=True)
+class CalendarConfig:
+    timezone_name: str = "America/Sao_Paulo"
+    horario_inicio: str | None = None
+    horario_fim: str | None = None
+    horario_semana_json: str | None = None
+    usar_feriados_nacionais: bool = False
+
+
+def calendar_config_from_model(cal) -> CalendarConfig:
+    return CalendarConfig(
+        timezone_name=cal.horario_timezone or "America/Sao_Paulo",
+        horario_inicio=cal.horario_inicio,
+        horario_fim=cal.horario_fim,
+        horario_semana_json=cal.horario_semana_json,
+        usar_feriados_nacionais=bool(cal.usar_feriados_nacionais),
+    )
+
+
+def resolve_timezone(config: CalendarConfig) -> ZoneInfo:
+    tzname = (config.timezone_name or "America/Sao_Paulo").strip() or "America/Sao_Paulo"
+    try:
+        return ZoneInfo(tzname)
+    except ZoneInfoNotFoundError:
+        return ZoneInfo("America/Sao_Paulo")
+
+
+def ensure_utc(moment: datetime) -> datetime:
+    if moment.tzinfo is None:
+        return moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc)
 
 
 def easter_date_gregorian(year: int) -> date:
@@ -127,3 +163,116 @@ def esta_em_horario_comercial(
     if a < b:
         return a <= m < b
     return m >= a or m < b
+
+
+def _day_schedule_for_date(d: date, config: CalendarConfig) -> tuple[tuple[int, int] | None, tuple[int, int] | None]:
+    """Retorna (inicio, fim) em minutos desde meia-noite ou (None, None) se dia fechado."""
+    if config.usar_feriados_nacionais and is_feriado_nacional_br(d):
+        return None, None
+
+    hs = horario_semana_from_json(config.horario_semana_json)
+    if hs:
+        k = WEEKDAY_KEYS[d.weekday()]
+        cfg = hs.get(k) if isinstance(hs, dict) else None
+        if isinstance(cfg, dict) and not bool(cfg.get("ativo", True)):
+            return None, None
+        ini = parse_hhmm(cfg.get("inicio") if isinstance(cfg, dict) else None)
+        fim = parse_hhmm(cfg.get("fim") if isinstance(cfg, dict) else None)
+        if ini is None:
+            ini = parse_hhmm(config.horario_inicio)
+        if fim is None:
+            fim = parse_hhmm(config.horario_fim)
+    else:
+        ini = parse_hhmm(config.horario_inicio)
+        fim = parse_hhmm(config.horario_fim)
+
+    if not ini or not fim:
+        return (0, 0), (23, 59)
+    return ini, fim
+
+
+def day_business_window(d: date, config: CalendarConfig, tz: ZoneInfo) -> tuple[datetime, datetime] | None:
+    ini, fim = _day_schedule_for_date(d, config)
+    if ini is None or fim is None:
+        return None
+    start = datetime.combine(d, time(ini[0], ini[1]), tzinfo=tz)
+    end = datetime.combine(d, time(fim[0], fim[1]), tzinfo=tz)
+    if end <= start:
+        end += timedelta(days=1)
+    return start, end
+
+
+def _start_of_next_business_moment(moment: datetime, config: CalendarConfig) -> datetime:
+    tz = resolve_timezone(config)
+    cur = moment.astimezone(tz)
+    for _ in range(370):
+        window = day_business_window(cur.date(), config, tz)
+        if window is None:
+            cur = datetime.combine(cur.date() + timedelta(days=1), time(0, 0), tzinfo=tz)
+            continue
+        day_open, day_close = window
+        if cur < day_open:
+            return day_open
+        if cur < day_close:
+            return cur
+        cur = datetime.combine(cur.date() + timedelta(days=1), time(0, 0), tzinfo=tz)
+    return moment
+
+
+def add_business_minutes(start: datetime, minutes: int, config: CalendarConfig) -> datetime:
+    if minutes <= 0:
+        return ensure_utc(start)
+    tz = resolve_timezone(config)
+    cur = _start_of_next_business_moment(ensure_utc(start), config)
+    remaining = minutes
+    for _ in range(60 * 24 * 400):
+        window = day_business_window(cur.date(), config, tz)
+        if window is None:
+            cur = datetime.combine(cur.date() + timedelta(days=1), time(0, 0), tzinfo=tz)
+            continue
+        day_open, day_close = window
+        if cur < day_open:
+            cur = day_open
+        if cur >= day_close:
+            cur = datetime.combine(cur.date() + timedelta(days=1), time(0, 0), tzinfo=tz)
+            continue
+        avail = max(0, int((day_close - cur).total_seconds() // 60))
+        if avail == 0:
+            cur = datetime.combine(cur.date() + timedelta(days=1), time(0, 0), tzinfo=tz)
+            continue
+        take = min(remaining, avail)
+        cur += timedelta(minutes=take)
+        remaining -= take
+        if remaining <= 0:
+            return ensure_utc(cur)
+    return ensure_utc(cur)
+
+
+def business_minutes_between(start: datetime, end: datetime, config: CalendarConfig) -> int:
+    start_u = ensure_utc(start)
+    end_u = ensure_utc(end)
+    if end_u <= start_u:
+        return 0
+    tz = resolve_timezone(config)
+    cur = _start_of_next_business_moment(start_u, config)
+    total = 0
+    for _ in range(60 * 24 * 400):
+        if cur >= end_u.astimezone(tz):
+            break
+        window = day_business_window(cur.date(), config, tz)
+        if window is None:
+            cur = datetime.combine(cur.date() + timedelta(days=1), time(0, 0), tzinfo=tz)
+            continue
+        day_open, day_close = window
+        if cur < day_open:
+            cur = day_open
+        segment_end = min(day_close, end_u.astimezone(tz))
+        if segment_end <= cur:
+            cur = datetime.combine(cur.date() + timedelta(days=1), time(0, 0), tzinfo=tz)
+            continue
+        total += max(0, int((segment_end - cur).total_seconds() // 60))
+        cur = day_close
+        if cur >= end_u.astimezone(tz):
+            break
+        cur = datetime.combine(cur.date() + timedelta(days=1), time(0, 0), tzinfo=tz)
+    return total

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -299,6 +299,32 @@ async def lifespan(app: FastAPI):
         name="ticket-distribuicao",
     ).start()
 
+    def sla_violacao_loop() -> None:
+        from app.database import SessionLocal
+        from app.services.sla_calculo import processar_sla_tickets_abertos
+
+        interval = max(30, settings.SLA_WORKER_INTERVAL_SECONDS)
+        while True:
+            db = SessionLocal()
+            try:
+                n = processar_sla_tickets_abertos(db, limit=200)
+                if n:
+                    db.commit()
+                else:
+                    db.rollback()
+            except Exception as e:
+                logger.warning("Worker SLA: %s", e)
+                db.rollback()
+            finally:
+                db.close()
+            time.sleep(interval)
+
+    threading.Thread(
+        target=sla_violacao_loop,
+        daemon=True,
+        name="sla-violacao",
+    ).start()
+
     yield
 
 

--- a/backend/app/schemas/sla.py
+++ b/backend/app/schemas/sla.py
@@ -136,3 +136,21 @@ class SlaPolicyRead(SlaPolicyBase):
 
 class SlaPrioridadesDisponiveis(BaseModel):
     prioridades: list[str] = list(PRIORIDADES_TICKET)
+
+
+class SlaMetaDetalheRead(BaseModel):
+    meta_minutos: int | None = None
+    vence_em: datetime | None = None
+    cumprido_em: datetime | None = None
+    estado: str
+    percentual_decorrido: float | None = None
+
+
+class TicketSlaRead(BaseModel):
+    ticket_id: int
+    sla_policy_id: int | None = None
+    sla_violado: bool = False
+    inicio_em: datetime
+    usa_horario_comercial: bool = False
+    primeira_resposta: SlaMetaDetalheRead
+    resolucao: SlaMetaDetalheRead

--- a/backend/app/services/sla_calculo.py
+++ b/backend/app/services/sla_calculo.py
@@ -1,0 +1,192 @@
+"""Motor de cálculo SLA: estados, violações e primeira resposta (#278)."""
+
+from __future__ import annotations
+
+import enum
+import logging
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.core.business_calendar import (
+    CalendarConfig,
+    add_business_minutes,
+    business_minutes_between,
+    calendar_config_from_model,
+    ensure_utc,
+)
+from app.models.sla_policy import SlaPolicy
+from app.models.ticket import Ticket, TicketMensagem
+from app.services.sla_policy import carregar_calendario_policy
+
+logger = logging.getLogger(__name__)
+
+SLA_RISCO_PERCENT = 80
+
+
+class SlaMetaEstado(str, enum.Enum):
+    sem_meta = "sem_meta"
+    dentro = "dentro"
+    em_risco = "em_risco"
+    violado = "violado"
+    cumprido = "cumprido"
+
+
+def calendar_config_para_ticket(db: Session, ticket: Ticket) -> CalendarConfig | None:
+    if not ticket.sla_policy_id:
+        return None
+    policy = db.query(SlaPolicy).filter(SlaPolicy.id == ticket.sla_policy_id).first()
+    if not policy:
+        return None
+    cal = carregar_calendario_policy(db, policy)
+    if not cal:
+        return None
+    return calendar_config_from_model(cal)
+
+
+def compute_deadline(
+    base: datetime,
+    minutes: int,
+    calendar: CalendarConfig | None,
+) -> datetime:
+    base_u = ensure_utc(base)
+    if calendar is None:
+        from datetime import timedelta
+
+        return base_u + timedelta(minutes=minutes)
+    return add_business_minutes(base_u, minutes, calendar)
+
+
+def elapsed_minutes(
+    inicio: datetime,
+    fim: datetime,
+    calendar: CalendarConfig | None,
+) -> int:
+    if calendar is None:
+        return max(0, int((ensure_utc(fim) - ensure_utc(inicio)).total_seconds() // 60))
+    return business_minutes_between(inicio, fim, calendar)
+
+
+def avaliar_meta(
+    *,
+    inicio: datetime,
+    vence_em: datetime | None,
+    cumprido_em: datetime | None,
+    meta_min: int | None,
+    now: datetime,
+    calendar: CalendarConfig | None,
+) -> tuple[SlaMetaEstado, float | None]:
+    if not meta_min or meta_min <= 0 or not vence_em:
+        return SlaMetaEstado.sem_meta, None
+
+    vence_u = ensure_utc(vence_em)
+    now_u = ensure_utc(now)
+
+    if cumprido_em is not None:
+        cumprido_u = ensure_utc(cumprido_em)
+        if cumprido_u <= vence_u:
+            return SlaMetaEstado.cumprido, 100.0
+        return SlaMetaEstado.violado, 100.0
+
+    if now_u > vence_u:
+        return SlaMetaEstado.violado, 100.0
+
+    decorridos = elapsed_minutes(inicio, now_u, calendar)
+    pct = min(99.9, (decorridos / meta_min) * 100) if meta_min > 0 else 0.0
+    if pct >= SLA_RISCO_PERCENT:
+        return SlaMetaEstado.em_risco, pct
+    return SlaMetaEstado.dentro, pct
+
+
+def mensagem_conta_primeira_resposta(mensagem: TicketMensagem) -> bool:
+    return mensagem.atendente_id is not None and mensagem.tipo in ("publico", "abertura")
+
+
+def registrar_primeira_resposta_se_necessario(
+    db: Session,
+    ticket: Ticket,
+    momento: datetime | None = None,
+) -> bool:
+    if ticket.sla_primeira_resposta_em is not None:
+        return False
+    if not ticket.sla_meta_primeira_resposta_min:
+        return False
+    ticket.sla_primeira_resposta_em = ensure_utc(momento or datetime.now(timezone.utc))
+    sincronizar_sla_violado(db, ticket)
+    return True
+
+
+def build_ticket_sla_read(db: Session, ticket: Ticket, *, now: datetime | None = None) -> dict:
+    now_u = ensure_utc(now or datetime.now(timezone.utc))
+    inicio = ensure_utc(ticket.created_at or now_u)
+    calendar = calendar_config_para_ticket(db, ticket)
+
+    estado_primeira, pct_primeira = avaliar_meta(
+        inicio=inicio,
+        vence_em=ticket.sla_primeira_resposta_vence_em,
+        cumprido_em=ticket.sla_primeira_resposta_em,
+        meta_min=ticket.sla_meta_primeira_resposta_min,
+        now=now_u,
+        calendar=calendar,
+    )
+    estado_resolucao, pct_resolucao = avaliar_meta(
+        inicio=inicio,
+        vence_em=ticket.sla_resolucao_vence_em,
+        cumprido_em=ticket.fechado_em,
+        meta_min=ticket.sla_meta_resolucao_min,
+        now=now_u,
+        calendar=calendar,
+    )
+
+    return {
+        "ticket_id": ticket.id,
+        "sla_policy_id": ticket.sla_policy_id,
+        "sla_violado": bool(ticket.sla_violado),
+        "inicio_em": inicio,
+        "usa_horario_comercial": calendar is not None,
+        "primeira_resposta": {
+            "meta_minutos": ticket.sla_meta_primeira_resposta_min,
+            "vence_em": ticket.sla_primeira_resposta_vence_em,
+            "cumprido_em": ticket.sla_primeira_resposta_em,
+            "estado": estado_primeira.value,
+            "percentual_decorrido": pct_primeira,
+        },
+        "resolucao": {
+            "meta_minutos": ticket.sla_meta_resolucao_min,
+            "vence_em": ticket.sla_resolucao_vence_em,
+            "cumprido_em": ticket.fechado_em,
+            "estado": estado_resolucao.value,
+            "percentual_decorrido": pct_resolucao,
+        },
+    }
+
+
+def sincronizar_sla_violado(db: Session, ticket: Ticket, *, now: datetime | None = None) -> None:
+    dados = build_ticket_sla_read(db, ticket, now=now)
+    violado = (
+        dados["primeira_resposta"]["estado"] == SlaMetaEstado.violado.value
+        or dados["resolucao"]["estado"] == SlaMetaEstado.violado.value
+    )
+    ticket.sla_violado = violado
+
+
+def processar_sla_tickets_abertos(db: Session, *, limit: int = 200) -> int:
+    """Worker periódico: atualiza flag ``sla_violado`` em tickets abertos com SLA."""
+    now = datetime.now(timezone.utc)
+    tickets = (
+        db.query(Ticket)
+        .filter(
+            Ticket.fechado_em.is_(None),
+            Ticket.sla_policy_id.isnot(None),
+        )
+        .order_by(Ticket.id.asc())
+        .limit(limit)
+        .all()
+    )
+    atualizados = 0
+    for ticket in tickets:
+        antes = bool(ticket.sla_violado)
+        sincronizar_sla_violado(db, ticket, now=now)
+        if bool(ticket.sla_violado) != antes:
+            atualizados += 1
+    return atualizados

--- a/backend/app/services/sla_policy.py
+++ b/backend/app/services/sla_policy.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.orm import Session
 
+from app.core.business_calendar import CalendarConfig, add_business_minutes, calendar_config_from_model, ensure_utc
 from app.core.ticket_prioridade import PrioridadeTicket
 from app.models.business_calendar import BusinessCalendar
 from app.models.sla_policy import SlaPolicy
@@ -37,10 +38,15 @@ def resolve_sla_policy(
     return base_q.filter(SlaPolicy.prioridade.is_(None)).first()
 
 
-def _deadline_wall_clock(base: datetime, minutes: int) -> datetime:
-    if base.tzinfo is None:
-        base = base.replace(tzinfo=timezone.utc)
-    return base + timedelta(minutes=minutes)
+def _deadline_for_ticket(
+    base: datetime,
+    minutes: int,
+    calendar: CalendarConfig | None,
+) -> datetime:
+    base_u = ensure_utc(base)
+    if calendar is None:
+        return base_u + timedelta(minutes=minutes)
+    return add_business_minutes(base_u, minutes, calendar)
 
 
 def aplicar_sla_snapshot_ao_ticket(
@@ -49,7 +55,7 @@ def aplicar_sla_snapshot_ao_ticket(
     *,
     base_time: datetime | None = None,
 ) -> SlaPolicy | None:
-    """Grava metas e prazos iniciais no ticket (relógio corrido em S-01; calendário em S-02)."""
+    """Grava metas e prazos iniciais no ticket (horário comercial quando há calendário)."""
     prioridade = ticket.prioridade
     if prioridade is None:
         prioridade = PrioridadeTicket.normal
@@ -62,7 +68,9 @@ def aplicar_sla_snapshot_ao_ticket(
     if not policy:
         return None
 
-    base = base_time or ticket.created_at or datetime.now(timezone.utc)
+    base = ensure_utc(base_time or ticket.created_at or datetime.now(timezone.utc))
+    cal_model = carregar_calendario_policy(db, policy)
+    calendar = calendar_config_from_model(cal_model) if cal_model else None
 
     ticket.sla_policy_id = policy.id
     ticket.sla_meta_primeira_resposta_min = policy.meta_primeira_resposta_min
@@ -70,14 +78,14 @@ def aplicar_sla_snapshot_ao_ticket(
     ticket.sla_violado = False
 
     if policy.meta_primeira_resposta_min and policy.meta_primeira_resposta_min > 0:
-        ticket.sla_primeira_resposta_vence_em = _deadline_wall_clock(
-            base, policy.meta_primeira_resposta_min
+        ticket.sla_primeira_resposta_vence_em = _deadline_for_ticket(
+            base, policy.meta_primeira_resposta_min, calendar
         )
     else:
         ticket.sla_primeira_resposta_vence_em = None
 
     if policy.meta_resolucao_min and policy.meta_resolucao_min > 0:
-        ticket.sla_resolucao_vence_em = _deadline_wall_clock(base, policy.meta_resolucao_min)
+        ticket.sla_resolucao_vence_em = _deadline_for_ticket(base, policy.meta_resolucao_min, calendar)
     else:
         ticket.sla_resolucao_vence_em = None
 

--- a/backend/app/services/ticket_filhos_massa.py
+++ b/backend/app/services/ticket_filhos_massa.py
@@ -130,6 +130,9 @@ def criar_filhos_em_massa(
         from app.services.sla_policy import aplicar_sla_snapshot_ao_ticket
 
         aplicar_sla_snapshot_ao_ticket(db, ticket)
+        from app.services.sla_calculo import registrar_primeira_resposta_se_necessario
+
+        registrar_primeira_resposta_se_necessario(db, ticket)
         db.add(
             TicketMensagem(
                 ticket_id=ticket.id,

--- a/backend/tests/test_sla_calculo.py
+++ b/backend/tests/test_sla_calculo.py
@@ -1,0 +1,283 @@
+"""Testes cálculo SLA e horário comercial (#278)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from app.core.business_calendar import CalendarConfig, add_business_minutes, business_minutes_between
+from app.models.business_calendar import BusinessCalendar
+from app.models.sla_policy import SlaPolicy
+from app.models.ticket import Ticket, TicketMensagem
+from app.services.sla_calculo import (
+    SlaMetaEstado,
+    avaliar_meta,
+    build_ticket_sla_read,
+    mensagem_conta_primeira_resposta,
+    processar_sla_tickets_abertos,
+    registrar_primeira_resposta_se_necessario,
+)
+from app.services.sla_policy import aplicar_sla_snapshot_ao_ticket
+
+
+def _horario_comercial_semana() -> str:
+    dia = {"ativo": True, "inicio": "09:00", "fim": "18:00"}
+    return json.dumps(
+        {
+            "seg": dia,
+            "ter": dia,
+            "qua": dia,
+            "qui": dia,
+            "sex": dia,
+            "sab": {"ativo": False},
+            "dom": {"ativo": False},
+        }
+    )
+
+
+def test_add_business_minutes_sexta_18h_pausa_ate_segunda():
+    config = CalendarConfig(
+        timezone_name="America/Sao_Paulo",
+        horario_semana_json=_horario_comercial_semana(),
+    )
+    tz = ZoneInfo("America/Sao_Paulo")
+    # 2026-06-19 é sexta-feira
+    start = datetime(2026, 6, 19, 18, 0, tzinfo=tz)
+    result = add_business_minutes(start, 60, config)
+    expected = datetime(2026, 6, 22, 10, 0, tzinfo=tz)
+    assert result.astimezone(tz) == expected
+
+
+def test_business_minutes_between_respeita_fim_de_semana():
+    config = CalendarConfig(
+        timezone_name="America/Sao_Paulo",
+        horario_semana_json=_horario_comercial_semana(),
+    )
+    tz = ZoneInfo("America/Sao_Paulo")
+    start = datetime(2026, 6, 19, 17, 0, tzinfo=tz)
+    end = datetime(2026, 6, 22, 10, 0, tzinfo=tz)
+    # 1h sexta (17-18) + 1h segunda (9-10)
+    assert business_minutes_between(start, end, config) == 120
+
+
+def test_snapshot_com_calendario_comercial(db_session, seed_base):
+    cal = BusinessCalendar(
+        tenant_id=1,
+        nome="Comercial",
+        horario_semana_json=_horario_comercial_semana(),
+        horario_timezone="America/Sao_Paulo",
+    )
+    db_session.add(cal)
+    db_session.flush()
+    policy = SlaPolicy(
+        tenant_id=1,
+        setor_id=seed_base["setor1"].id,
+        prioridade="alta",
+        business_calendar_id=cal.id,
+        meta_primeira_resposta_min=60,
+        meta_resolucao_min=480,
+        ativo=True,
+    )
+    db_session.add(policy)
+    db_session.flush()
+
+    from app.models.status_ticket import StatusTicket
+
+    st = db_session.query(StatusTicket).first()
+    tz = ZoneInfo("America/Sao_Paulo")
+    base = datetime(2026, 6, 19, 18, 0, tzinfo=tz)
+    ticket = Ticket(
+        tenant_id=1,
+        protocolo="#T202606-SLA2",
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=st.id,
+        assunto="SLA calendário",
+        prioridade="alta",
+        created_at=base.astimezone(timezone.utc),
+    )
+    db_session.add(ticket)
+    db_session.flush()
+    aplicar_sla_snapshot_ao_ticket(db_session, ticket, base_time=base.astimezone(timezone.utc))
+    assert ticket.sla_primeira_resposta_vence_em is not None
+    vence = ticket.sla_primeira_resposta_vence_em.astimezone(tz)
+    assert vence == datetime(2026, 6, 22, 10, 0, tzinfo=tz)
+
+
+def test_prioridade_alta_usa_policy_especifica(db_session, seed_base):
+    padrao = SlaPolicy(
+        tenant_id=1,
+        setor_id=seed_base["setor1"].id,
+        prioridade=None,
+        meta_primeira_resposta_min=120,
+        meta_resolucao_min=600,
+        ativo=True,
+    )
+    alta = SlaPolicy(
+        tenant_id=1,
+        setor_id=seed_base["setor1"].id,
+        prioridade="alta",
+        meta_primeira_resposta_min=15,
+        meta_resolucao_min=60,
+        ativo=True,
+    )
+    db_session.add_all([padrao, alta])
+    db_session.flush()
+
+    from app.models.status_ticket import StatusTicket
+
+    st = db_session.query(StatusTicket).first()
+    ticket = Ticket(
+        tenant_id=1,
+        protocolo="#T202606-SLA3",
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=st.id,
+        assunto="Prioridade alta",
+        prioridade="alta",
+    )
+    db_session.add(ticket)
+    db_session.flush()
+    aplicar_sla_snapshot_ao_ticket(db_session, ticket)
+    assert ticket.sla_meta_primeira_resposta_min == 15
+
+
+def test_avaliar_meta_em_risco_e_violado():
+    inicio = datetime(2026, 6, 23, 10, 0, tzinfo=timezone.utc)
+    vence = inicio + timedelta(minutes=100)
+    estado, pct = avaliar_meta(
+        inicio=inicio,
+        vence_em=vence,
+        cumprido_em=None,
+        meta_min=100,
+        now=inicio + timedelta(minutes=85),
+        calendar=None,
+    )
+    assert estado == SlaMetaEstado.em_risco
+    assert pct is not None and pct >= 80
+
+    estado2, _ = avaliar_meta(
+        inicio=inicio,
+        vence_em=vence,
+        cumprido_em=None,
+        meta_min=100,
+        now=inicio + timedelta(minutes=101),
+        calendar=None,
+    )
+    assert estado2 == SlaMetaEstado.violado
+
+
+def test_mensagem_publica_marca_primeira_resposta(client, seed_base, auth_headers, db_session):
+    from app.models.status_ticket import StatusTicket
+
+    policy = SlaPolicy(
+        tenant_id=1,
+        setor_id=seed_base["setor1"].id,
+        prioridade=None,
+        meta_primeira_resposta_min=60,
+        meta_resolucao_min=240,
+        ativo=True,
+    )
+    db_session.add(policy)
+    db_session.flush()
+    st = db_session.query(StatusTicket).first()
+    ticket = Ticket(
+        tenant_id=1,
+        protocolo="#T202606-SLA-MSG",
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=st.id,
+        assunto="Sem resposta ainda",
+        descricao="x",
+    )
+    db_session.add(ticket)
+    db_session.flush()
+    aplicar_sla_snapshot_ao_ticket(db_session, ticket)
+    db_session.commit()
+
+    r2 = client.post(
+        f"/v1/tickets/{ticket.id}/mensagens",
+        headers=auth_headers["admin"],
+        json={"corpo": "Olá, estamos analisando.", "tipo": "publico"},
+    )
+    assert r2.status_code == 201, r2.text
+
+    r3 = client.get(f"/v1/tickets/{ticket.id}/sla", headers=auth_headers["admin"])
+    assert r3.status_code == 200, r3.text
+    body = r3.json()
+    assert body["primeira_resposta"]["estado"] == "cumprido"
+    assert body["primeira_resposta"]["cumprido_em"] is not None
+
+
+def test_get_ticket_sla_endpoint(client, seed_base, auth_headers, db_session):
+    policy = SlaPolicy(
+        tenant_id=1,
+        setor_id=seed_base["setor1"].id,
+        prioridade=None,
+        meta_primeira_resposta_min=30,
+        meta_resolucao_min=120,
+        ativo=True,
+    )
+    db_session.add(policy)
+    db_session.commit()
+
+    r = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "SLA API",
+            "descricao": "x",
+        },
+    )
+    tid = r.json()["id"]
+    r_sla = client.get(f"/v1/tickets/{tid}/sla", headers=auth_headers["admin"])
+    assert r_sla.status_code == 200
+    assert r_sla.json()["ticket_id"] == tid
+    assert r_sla.json()["primeira_resposta"]["meta_minutos"] == 30
+
+
+def test_worker_marca_violado(db_session, seed_base):
+    from app.models.status_ticket import StatusTicket
+
+    policy = SlaPolicy(
+        tenant_id=1,
+        setor_id=seed_base["setor1"].id,
+        meta_primeira_resposta_min=30,
+        meta_resolucao_min=120,
+        ativo=True,
+    )
+    db_session.add(policy)
+    db_session.flush()
+    st = db_session.query(StatusTicket).first()
+    inicio = datetime.now(timezone.utc) - timedelta(hours=2)
+    ticket = Ticket(
+        tenant_id=1,
+        protocolo="#T202606-SLA4",
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=st.id,
+        assunto="Violado",
+        sla_policy_id=policy.id,
+        sla_meta_primeira_resposta_min=30,
+        sla_primeira_resposta_vence_em=inicio + timedelta(minutes=30),
+        sla_violado=False,
+        created_at=inicio,
+    )
+    db_session.add(ticket)
+    db_session.commit()
+
+    n = processar_sla_tickets_abertos(db_session)
+    db_session.commit()
+    db_session.refresh(ticket)
+    assert n >= 1
+    assert ticket.sla_violado is True
+
+
+def test_mensagem_conta_primeira_resposta():
+    m_pub = TicketMensagem(ticket_id=1, atendente_id=1, tipo="publico", corpo="x")
+    m_int = TicketMensagem(ticket_id=1, atendente_id=1, tipo="interno", corpo="x")
+    assert mensagem_conta_primeira_resposta(m_pub) is True
+    assert mensagem_conta_primeira_resposta(m_int) is False


### PR DESCRIPTION
## Summary
- Horario comercial: `add_business_minutes` / `business_minutes_between` (sexta 18h pausa ate segunda)
- Snapshot de prazos usa calendario da policy quando configurado
- Estados `dentro` / `em_risco` (80%) / `violado` / `cumprido` por meta
- `GET /v1/tickets/{id}/sla` com detalhe de primeira resposta e resolucao
- Worker a cada 60s atualiza `sla_violado`; hooks em mensagem publica/abertura e fechamento
- Depende de #277 (incluido nesta branch se #412 ainda nao estiver na main)

## Test plan
- [ ] `docker compose exec backend python -m pytest tests/test_sla_calculo.py tests/test_sla_policies.py`
- [ ] Ticket criado sexta 18h com calendario seg-sex 9-18: prazo 60min cai na segunda 10h
- [ ] Mensagem publica marca primeira resposta cumprida
- [ ] Ticket aberto apos prazo: `sla_violado=true`