### PR TITLE
feat(sla): alertas em risco e violado por e-mail e SSE (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 - SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets
 - SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket
+- SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta
 - Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets
 - Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime
 - `aplicar_roteamento` restrito a administradores para sobrescrever setor explícito

--- a/backend/alembic/versions/048_sla_alertas.py
+++ b/backend/alembic/versions/048_sla_alertas.py
@@ -1,0 +1,49 @@
+"""SLA: preferências de alerta e registro de emissões (#279).
+
+Revision ID: 048_sla_alertas
+Revises: 047_sla_policies
+Create Date: 2026-06-23
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "048_sla_alertas"
+down_revision = "047_sla_policies"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "atendente_notificacao_preferencias",
+        sa.Column("email_sla_em_risco", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+    )
+    op.add_column(
+        "atendente_notificacao_preferencias",
+        sa.Column("email_sla_violado", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+    )
+    op.alter_column("atendente_notificacao_preferencias", "email_sla_em_risco", server_default=None)
+    op.alter_column("atendente_notificacao_preferencias", "email_sla_violado", server_default=None)
+
+    op.create_table(
+        "sla_alerta_emitidos",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("ticket_id", sa.Integer(), nullable=False),
+        sa.Column("meta", sa.String(length=30), nullable=False),
+        sa.Column("evento", sa.String(length=20), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["ticket_id"], ["tickets.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("ticket_id", "meta", "evento", name="uq_sla_alerta_emitidos_ticket_meta_evento"),
+    )
+    op.create_index(op.f("ix_sla_alerta_emitidos_id"), "sla_alerta_emitidos", ["id"], unique=False)
+    op.create_index(op.f("ix_sla_alerta_emitidos_ticket_id"), "sla_alerta_emitidos", ["ticket_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_sla_alerta_emitidos_ticket_id"), table_name="sla_alerta_emitidos")
+    op.drop_index(op.f("ix_sla_alerta_emitidos_id"), table_name="sla_alerta_emitidos")
+    op.drop_table("sla_alerta_emitidos")
+    op.drop_column("atendente_notificacao_preferencias", "email_sla_violado")
+    op.drop_column("atendente_notificacao_preferencias", "email_sla_em_risco")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -301,13 +301,13 @@ async def lifespan(app: FastAPI):
 
     def sla_violacao_loop() -> None:
         from app.database import SessionLocal
-        from app.services.sla_calculo import processar_sla_tickets_abertos
+        from app.services.sla_notificacao import processar_alertas_sla
 
         interval = max(30, settings.SLA_WORKER_INTERVAL_SECONDS)
         while True:
             db = SessionLocal()
             try:
-                n = processar_sla_tickets_abertos(db, limit=200)
+                n = processar_alertas_sla(db, limit=200)
                 if n:
                     db.commit()
                 else:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -31,6 +31,7 @@ from app.models.webhook_outbox import WebhookOutbox
 from app.models.routing_rule import RoutingRule
 from app.models.business_calendar import BusinessCalendar
 from app.models.sla_policy import SlaPolicy
+from app.models.sla_alerta_emitido import SlaAlertaEmitido
 from app.models.empresa_pdv import EmpresaPdv, PdvRotulo, PdvTipoAcessoRemoto
 
 __all__ = [
@@ -77,6 +78,7 @@ __all__ = [
     "RoutingRule",
     "BusinessCalendar",
     "SlaPolicy",
+    "SlaAlertaEmitido",
     "PdvRotulo",
     "PdvTipoAcessoRemoto",
     "EmpresaPdv",

--- a/backend/app/models/atendente_notificacao.py
+++ b/backend/app/models/atendente_notificacao.py
@@ -12,6 +12,8 @@ class AtendenteNotificacaoPreferencias(Base):
     email_habilitado = Column(Boolean, nullable=False, default=True)
     email_ticket_atribuido = Column(Boolean, nullable=False, default=True)
     email_nova_mensagem = Column(Boolean, nullable=False, default=True)
+    email_sla_em_risco = Column(Boolean, nullable=False, default=True)
+    email_sla_violado = Column(Boolean, nullable=False, default=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
 

--- a/backend/app/models/sla_alerta_emitido.py
+++ b/backend/app/models/sla_alerta_emitido.py
@@ -1,0 +1,22 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class SlaAlertaEmitido(Base):
+    """Registro de alerta SLA já disparado (debounce por ticket/meta/evento)."""
+
+    __tablename__ = "sla_alerta_emitidos"
+    __table_args__ = (
+        UniqueConstraint("ticket_id", "meta", "evento", name="uq_sla_alerta_emitidos_ticket_meta_evento"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    ticket_id = Column(Integer, ForeignKey("tickets.id", ondelete="CASCADE"), nullable=False, index=True)
+    meta = Column(String(30), nullable=False)
+    evento = Column(String(20), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    ticket = relationship("Ticket", backref="sla_alertas_emitidos")

--- a/backend/app/schemas/atendente_notificacao.py
+++ b/backend/app/schemas/atendente_notificacao.py
@@ -5,9 +5,13 @@ class NotificacaoPreferenciasRead(BaseModel):
     email_habilitado: bool = True
     email_ticket_atribuido: bool = True
     email_nova_mensagem: bool = True
+    email_sla_em_risco: bool = True
+    email_sla_violado: bool = True
 
 
 class NotificacaoPreferenciasUpdate(BaseModel):
     email_habilitado: bool | None = None
     email_ticket_atribuido: bool | None = None
     email_nova_mensagem: bool | None = None
+    email_sla_em_risco: bool | None = None
+    email_sla_violado: bool | None = None

--- a/backend/app/services/notificacao_atendente_email.py
+++ b/backend/app/services/notificacao_atendente_email.py
@@ -24,6 +24,8 @@ STATUS_FALHA = "falha"
 
 TIPO_TICKET_ATRIBUIDO = "ticket_atribuido"
 TIPO_NOVA_MENSAGEM = "nova_mensagem"
+TIPO_SLA_EM_RISCO = "sla_em_risco"
+TIPO_SLA_VIOLADO = "sla_violado"
 
 MAX_TENTATIVAS = MAX_EMAIL_SEND_ATTEMPTS
 
@@ -60,6 +62,8 @@ def preferencias_para_dict(p: AtendenteNotificacaoPreferencias) -> dict:
         "email_habilitado": bool(p.email_habilitado),
         "email_ticket_atribuido": bool(p.email_ticket_atribuido),
         "email_nova_mensagem": bool(p.email_nova_mensagem),
+        "email_sla_em_risco": bool(getattr(p, "email_sla_em_risco", True)),
+        "email_sla_violado": bool(getattr(p, "email_sla_violado", True)),
     }
 
 
@@ -81,6 +85,10 @@ def _deve_notificar(prefs: AtendenteNotificacaoPreferencias, *, tipo: str) -> bo
         return bool(prefs.email_ticket_atribuido)
     if tipo == TIPO_NOVA_MENSAGEM:
         return bool(prefs.email_nova_mensagem)
+    if tipo == TIPO_SLA_EM_RISCO:
+        return bool(getattr(prefs, "email_sla_em_risco", True))
+    if tipo == TIPO_SLA_VIOLADO:
+        return bool(getattr(prefs, "email_sla_violado", True))
     return False
 
 
@@ -249,6 +257,41 @@ def notificar_nova_mensagem_ticket(
         )
     except Exception:
         logger.exception("Falha ao enfileirar notificação de mensagem (ticket %s)", ticket.id)
+
+
+def notificar_sla_alerta_email(
+    db: Session,
+    *,
+    atendente: Atendente,
+    ticket: Ticket,
+    meta: str,
+    evento: str,
+    meta_label: str,
+    evento_label: str,
+) -> None:
+    if ticket.fechado_em is not None:
+        return
+    proto = ticket.protocolo or str(ticket.id)
+    link = _ticket_link(ticket.id)
+    tipo = TIPO_SLA_EM_RISCO if evento == "em_risco" else TIPO_SLA_VIOLADO
+    subject = f"SLA {evento_label} — {proto} ({meta_label})"
+    body = (
+        f"Olá {atendente.nome},\n\n"
+        f"O chamado {proto} está com SLA de {meta_label.lower()} {evento_label}.\n"
+        f"Assunto: {ticket.assunto or '—'}\n\n"
+        f"Acesse: {link}\n"
+    )
+    dedup = f"sla:{evento}:{meta}:{ticket.id}:{atendente.id}"
+    _enqueue_email(
+        db,
+        atendente=atendente,
+        ticket=ticket,
+        tipo=tipo,
+        dedup_key=dedup,
+        subject=subject,
+        body=body,
+        debounce=False,
+    )
 
 
 def process_pending_notificacao_emails(db: Session, *, limit: int = 20) -> int:

--- a/backend/app/services/realtime_emit.py
+++ b/backend/app/services/realtime_emit.py
@@ -128,6 +128,37 @@ def ids_atendentes_ticket_fila(db: Session, ticket: Ticket) -> set[int]:
     return _ids_atendentes_por_setor(db, ticket.setor_id)
 
 
+def ids_atendentes_sla_ticket(db: Session, ticket: Ticket) -> set[int]:
+    """Responsável + atendentes/admins do setor para alertas SLA."""
+    ids = _ids_atendentes_por_setor(db, ticket.setor_id)
+    if ticket.atendente_id is not None:
+        ids.add(ticket.atendente_id)
+    return ids
+
+
+def emit_ticket_sla_alerta(
+    db: Session,
+    ticket: Ticket,
+    *,
+    meta: str,
+    evento: str,
+    meta_label: str,
+    evento_label: str,
+    atendente_ids: set[int],
+) -> None:
+    payload = {
+        "ticket_id": ticket.id,
+        "protocolo": ticket.protocolo,
+        "assunto": ticket.assunto,
+        "meta": meta,
+        "evento": evento,
+        "meta_label": meta_label,
+        "evento_label": evento_label,
+    }
+    _publish_to_atendentes(atendente_ids, "ticket.sla_alerta", payload)
+    _emit_notificacao_after_counter_change(db)
+
+
 def emit_notificacao_contagem(db: Session, atendente_ids: Iterable[int]) -> None:
     """Publica contadores personalizados por atendente (#266)."""
     from app.api.notificacoes import build_notificacao_resumo

--- a/backend/app/services/sla_notificacao.py
+++ b/backend/app/services/sla_notificacao.py
@@ -1,0 +1,131 @@
+"""Alertas SLA in-app (SSE) e e-mail (#279)."""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from app.models.atendente import Atendente
+from app.models.sla_alerta_emitido import SlaAlertaEmitido
+from app.models.ticket import Ticket
+from app.services.realtime_emit import emit_ticket_sla_alerta, ids_atendentes_sla_ticket
+from app.services.sla_calculo import SlaMetaEstado, build_ticket_sla_read
+from app.services.notificacao_atendente_email import notificar_sla_alerta_email
+
+logger = logging.getLogger(__name__)
+
+META_PRIMEIRA = "primeira_resposta"
+META_RESOLUCAO = "resolucao"
+EVENTO_EM_RISCO = "em_risco"
+EVENTO_VIOLADO = "violado"
+
+_META_LABELS = {
+    META_PRIMEIRA: "Primeira resposta",
+    META_RESOLUCAO: "Resolução",
+}
+
+
+def _ja_emitido(db: Session, *, ticket_id: int, meta: str, evento: str) -> bool:
+    return (
+        db.query(SlaAlertaEmitido.id)
+        .filter(
+            SlaAlertaEmitido.ticket_id == ticket_id,
+            SlaAlertaEmitido.meta == meta,
+            SlaAlertaEmitido.evento == evento,
+        )
+        .first()
+        is not None
+    )
+
+
+def _marcar_emitido(db: Session, *, ticket_id: int, meta: str, evento: str) -> None:
+    if _ja_emitido(db, ticket_id=ticket_id, meta=meta, evento=evento):
+        return
+    db.add(SlaAlertaEmitido(ticket_id=ticket_id, meta=meta, evento=evento))
+    db.flush()
+
+
+def _disparar_alerta(
+    db: Session,
+    *,
+    ticket: Ticket,
+    meta: str,
+    evento: str,
+) -> None:
+    recipients = ids_atendentes_sla_ticket(db, ticket)
+    if not recipients:
+        return
+
+    meta_label = _META_LABELS.get(meta, meta)
+    evento_label = "em risco" if evento == EVENTO_EM_RISCO else "violado"
+
+    for aid in recipients:
+        atendente = db.query(Atendente).filter(Atendente.id == aid, Atendente.ativo.is_(True)).first()
+        if not atendente:
+            continue
+        try:
+            notificar_sla_alerta_email(
+                db,
+                atendente=atendente,
+                ticket=ticket,
+                meta=meta,
+                evento=evento,
+                meta_label=meta_label,
+                evento_label=evento_label,
+            )
+        except Exception:
+            logger.exception("Falha ao enfileirar e-mail SLA (ticket %s)", ticket.id)
+
+    try:
+        emit_ticket_sla_alerta(
+            db,
+            ticket,
+            meta=meta,
+            evento=evento,
+            meta_label=meta_label,
+            evento_label=evento_label,
+            atendente_ids=recipients,
+        )
+    except Exception:
+        logger.exception("Falha ao emitir SSE SLA (ticket %s)", ticket.id)
+
+    _marcar_emitido(db, ticket_id=ticket.id, meta=meta, evento=evento)
+
+
+def processar_alertas_sla(db: Session, *, limit: int = 200) -> int:
+    """Avalia tickets abertos com SLA e dispara alertas ``em_risco`` / ``violado`` (uma vez cada)."""
+    from datetime import datetime, timezone
+
+    from app.services.sla_calculo import processar_sla_tickets_abertos
+
+    processar_sla_tickets_abertos(db, limit=limit)
+
+    now = datetime.now(timezone.utc)
+    tickets = (
+        db.query(Ticket)
+        .filter(
+            Ticket.fechado_em.is_(None),
+            Ticket.sla_policy_id.isnot(None),
+        )
+        .order_by(Ticket.id.asc())
+        .limit(limit)
+        .all()
+    )
+    disparados = 0
+    for ticket in tickets:
+        dados = build_ticket_sla_read(db, ticket, now=now)
+        pares = (
+            (META_PRIMEIRA, dados["primeira_resposta"]["estado"]),
+            (META_RESOLUCAO, dados["resolucao"]["estado"]),
+        )
+        for meta, estado in pares:
+            if estado == SlaMetaEstado.em_risco.value:
+                if not _ja_emitido(db, ticket_id=ticket.id, meta=meta, evento=EVENTO_EM_RISCO):
+                    _disparar_alerta(db, ticket=ticket, meta=meta, evento=EVENTO_EM_RISCO)
+                    disparados += 1
+            elif estado == SlaMetaEstado.violado.value:
+                if not _ja_emitido(db, ticket_id=ticket.id, meta=meta, evento=EVENTO_VIOLADO):
+                    _disparar_alerta(db, ticket=ticket, meta=meta, evento=EVENTO_VIOLADO)
+                    disparados += 1
+    return disparados

--- a/backend/tests/test_notificacoes_atendente.py
+++ b/backend/tests/test_notificacoes_atendente.py
@@ -24,6 +24,8 @@ def test_preferencias_padrao_e_atualizacao(client, seed_base, auth_headers):
     assert body["email_habilitado"] is True
     assert body["email_ticket_atribuido"] is True
     assert body["email_nova_mensagem"] is True
+    assert body["email_sla_em_risco"] is True
+    assert body["email_sla_violado"] is True
 
     r2 = client.patch(
         "/v1/notificacoes/preferencias",

--- a/backend/tests/test_sla_notificacao.py
+++ b/backend/tests/test_sla_notificacao.py
@@ -1,0 +1,136 @@
+"""Alertas SLA in-app e e-mail (#279)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.models.atendente_notificacao import NotificacaoEmailOutbox
+from app.models.sla_alerta_emitido import SlaAlertaEmitido
+from app.models.sla_policy import SlaPolicy
+from app.models.status_ticket import StatusTicket
+from app.models.ticket import Ticket
+from app.services.sla_notificacao import EVENTO_EM_RISCO, EVENTO_VIOLADO, META_PRIMEIRA, processar_alertas_sla
+
+
+def _criar_ticket_sla(
+    db_session,
+    seed_base,
+    *,
+    meta_min: int = 100,
+    minutos_decorridos: int,
+    atendente_id: int | None = None,
+) -> Ticket:
+    policy = SlaPolicy(
+        tenant_id=1,
+        setor_id=seed_base["setor1"].id,
+        prioridade=None,
+        meta_primeira_resposta_min=meta_min,
+        meta_resolucao_min=480,
+        ativo=True,
+    )
+    db_session.add(policy)
+    db_session.flush()
+    st = db_session.query(StatusTicket).first()
+    now = datetime.now(timezone.utc)
+    inicio = now - timedelta(minutes=minutos_decorridos)
+    ticket = Ticket(
+        tenant_id=1,
+        protocolo="#T202606-SLA-ALERT",
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=st.id,
+        assunto="SLA alerta",
+        prioridade="normal",
+        atendente_id=atendente_id or seed_base["a1"].id,
+        sla_policy_id=policy.id,
+        sla_meta_primeira_resposta_min=meta_min,
+        sla_primeira_resposta_vence_em=inicio + timedelta(minutes=meta_min),
+        sla_meta_resolucao_min=480,
+        sla_resolucao_vence_em=inicio + timedelta(minutes=480),
+        created_at=inicio,
+    )
+    db_session.add(ticket)
+    db_session.commit()
+    return ticket
+
+
+def test_alerta_em_risco_enfileira_email_e_registra_emitido(db_session, seed_base):
+    ticket = _criar_ticket_sla(db_session, seed_base, minutos_decorridos=85)
+
+    n = processar_alertas_sla(db_session)
+    db_session.commit()
+
+    assert n >= 1
+    emitido = (
+        db_session.query(SlaAlertaEmitido)
+        .filter(
+            SlaAlertaEmitido.ticket_id == ticket.id,
+            SlaAlertaEmitido.meta == META_PRIMEIRA,
+            SlaAlertaEmitido.evento == EVENTO_EM_RISCO,
+        )
+        .first()
+    )
+    assert emitido is not None
+
+    rows = (
+        db_session.query(NotificacaoEmailOutbox)
+        .filter(
+            NotificacaoEmailOutbox.ticket_id == ticket.id,
+            NotificacaoEmailOutbox.tipo == "sla_em_risco",
+        )
+        .all()
+    )
+    assert len(rows) >= 1
+    assert seed_base["a1"].id in {r.atendente_id for r in rows}
+
+
+def test_alerta_violado_debounce_nao_repete(db_session, seed_base):
+    ticket = _criar_ticket_sla(db_session, seed_base, minutos_decorridos=120)
+
+    n1 = processar_alertas_sla(db_session)
+    db_session.commit()
+    assert n1 >= 1
+
+    n2 = processar_alertas_sla(db_session)
+    db_session.commit()
+    assert n2 == 0
+
+    count = (
+        db_session.query(SlaAlertaEmitido)
+        .filter(
+            SlaAlertaEmitido.ticket_id == ticket.id,
+            SlaAlertaEmitido.meta == META_PRIMEIRA,
+            SlaAlertaEmitido.evento == EVENTO_VIOLADO,
+        )
+        .count()
+    )
+    assert count == 1
+
+
+def test_preferencias_sla_desligam_email(client, seed_base, auth_headers, db_session):
+    client.patch(
+        "/v1/notificacoes/preferencias",
+        headers=auth_headers["a1"],
+        json={"email_sla_em_risco": False, "email_sla_violado": False},
+    )
+    ticket = _criar_ticket_sla(db_session, seed_base, minutos_decorridos=85)
+
+    processar_alertas_sla(db_session)
+    db_session.commit()
+
+    rows = (
+        db_session.query(NotificacaoEmailOutbox)
+        .filter(
+            NotificacaoEmailOutbox.ticket_id == ticket.id,
+            NotificacaoEmailOutbox.tipo.in_(["sla_em_risco", "sla_violado"]),
+        )
+        .all()
+    )
+    assert all(r.atendente_id != seed_base["a1"].id for r in rows)
+
+    emitido = (
+        db_session.query(SlaAlertaEmitido)
+        .filter(SlaAlertaEmitido.ticket_id == ticket.id)
+        .first()
+    )
+    assert emitido is not None

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1080,6 +1080,8 @@ export namespace Notificacoes {
     email_habilitado: boolean;
     email_ticket_atribuido: boolean;
     email_nova_mensagem: boolean;
+    email_sla_em_risco: boolean;
+    email_sla_violado: boolean;
   }
 }
 

--- a/frontend/src/pages/NotificacoesPreferencias.tsx
+++ b/frontend/src/pages/NotificacoesPreferencias.tsx
@@ -15,6 +15,8 @@ export function NotificacoesPreferencias() {
     email_habilitado: true,
     email_ticket_atribuido: true,
     email_nova_mensagem: true,
+    email_sla_em_risco: true,
+    email_sla_violado: true,
   })
 
   useEffect(() => {
@@ -90,6 +92,10 @@ export function NotificacoesPreferencias() {
             chamado em intervalos de alguns minutos.
           </li>
           <li>
+            <strong>SLA em risco / violado</strong> — quando um chamado sob sua responsabilidade (ou do seu setor)
+            atinge 80% do prazo ou estoura a meta de primeira resposta ou resolução.
+          </li>
+          <li>
             Em desenvolvimento, sem SMTP configurado, o sistema simula o envio e registra no log do backend.
           </li>
         </ul>
@@ -122,6 +128,26 @@ export function NotificacoesPreferencias() {
               onCheckedChange={(v) => setPrefs((p) => ({ ...p, email_nova_mensagem: v }))}
               label="Nova mensagem em chamado sob minha responsabilidade"
               description="Mensagens do cliente ou de colegas (agrupadas em intervalos de alguns minutos)."
+              disabled={!prefs.email_habilitado}
+              showStatusPill
+              statusOnText="Sim"
+              statusOffText="Não"
+            />
+            <Switch
+              checked={prefs.email_sla_em_risco}
+              onCheckedChange={(v) => setPrefs((p) => ({ ...p, email_sla_em_risco: v }))}
+              label="SLA em risco (80% do prazo)"
+              description="Primeira resposta ou resolução próximas do limite."
+              disabled={!prefs.email_habilitado}
+              showStatusPill
+              statusOnText="Sim"
+              statusOffText="Não"
+            />
+            <Switch
+              checked={prefs.email_sla_violado}
+              onCheckedChange={(v) => setPrefs((p) => ({ ...p, email_sla_violado: v }))}
+              label="SLA violado"
+              description="Meta de primeira resposta ou resolução estourada."
               disabled={!prefs.email_habilitado}
               showStatusPill
               statusOnText="Sim"


### PR DESCRIPTION
## Summary
- Worker SLA passa a chamar `processar_alertas_sla` (calculo + disparo unico por ticket/meta/evento)
- E-mail com preferencias `email_sla_em_risco` / `email_sla_violado` e SSE `ticket.sla_alerta` para responsavel + setor
- Migration 048, toggles na pagina de preferencias de notificacoes e 3 testes novos

Closes #279

## Test plan
- [x] `pytest tests/test_sla_notificacao.py` (3 testes)
- [x] `pytest tests/test_sla_policies.py tests/test_sla_calculo.py` (regressao SLA)
- [ ] Aplicar migration 048 em staging
- [ ] Validar SSE `ticket.sla_alerta` no frontend (consumo em #281)