### PR TITLE
feat(sla): painel admin + indicadores em tickets (#280, #281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket
 - SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta
 - SLA (#280): painel admin em Configurações → Atendimento → SLA para CRUD de políticas por setor/prioridade
+- SLA (#281): badges e filtros na listagem de tickets e card de SLA no detalhe com countdown
 - Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets
 - Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime
 - `aplicar_roteamento` restrito a administradores para sobrescrever setor explícito

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets
 - SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket
 - SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta
+- SLA (#280): painel admin em Configurações → Atendimento → SLA para CRUD de políticas por setor/prioridade
 - Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets
 - Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime
 - `aplicar_roteamento` restrito a administradores para sobrescrever setor explícito

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -321,7 +321,7 @@ def _vinculos_para_read(db: Session, t: Ticket) -> list[TicketVinculoRead]:
     return [_vinculo_para_read(v, t.id, db) for v in listar_vinculos(db, t.id)]
 
 
-def _ticket_para_read(t: Ticket, db: Session | None = None) -> TicketRead:
+def _ticket_para_read(t: Ticket, db: Session | None = None, *, sla_estado: str | None = None) -> TicketRead:
     parent_brief = None
     if t.parent_ticket_id and _attr_relacionamento_carregado(t, "parent") and t.parent is not None:
         p = t.parent
@@ -403,6 +403,7 @@ def _ticket_para_read(t: Ticket, db: Session | None = None) -> TicketRead:
         sla_resolucao_vence_em=t.sla_resolucao_vence_em,
         sla_primeira_resposta_em=t.sla_primeira_resposta_em,
         sla_violado=bool(t.sla_violado),
+        sla_estado=sla_estado,
     )
 
 
@@ -478,6 +479,14 @@ def listar(
         SituacaoTicket.abertos,
         description="abertos = fechado_em vazio; fechados = fechado_em preenchido; todos = sem filtro",
     ),
+    sla_violado: bool | None = Query(
+        None,
+        description="True = somente tickets com SLA violado",
+    ),
+    sla_em_risco: bool | None = Query(
+        None,
+        description="True = somente tickets com SLA em risco (≥80% do prazo)",
+    ),
     offset: int = Query(0, ge=0),
     limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
     ordenar_por: OrdenarTicketsPor | None = Query(
@@ -527,6 +536,12 @@ def listar(
         q = q.filter(Ticket.fechado_em.is_(None))
     elif situacao == SituacaoTicket.fechados:
         q = q.filter(Ticket.fechado_em.is_not(None))
+    if sla_violado is True:
+        q = q.filter(Ticket.sla_violado.is_(True))
+    if sla_em_risco is True:
+        from app.services.sla_calculo import filtro_sql_sla_em_risco
+
+        q = q.filter(filtro_sql_sla_em_risco())
     if protocolo and protocolo.strip():
         q = q.filter(Ticket.protocolo.ilike(f"%{protocolo.strip()}%"))
     if busca and busca.strip():
@@ -590,7 +605,25 @@ def listar(
         .limit(limit)
         .all()
     )
-    return ListaPaginada(items=[_ticket_para_read(t, db) for t in rows], total=total)
+    from datetime import datetime, timezone
+
+    from app.services.sla_calculo import preload_sla_calendars, sla_estado_resumido
+
+    now = datetime.now(timezone.utc)
+    cal_map = preload_sla_calendars(db, rows)
+    items = [
+        _ticket_para_read(
+            t,
+            db,
+            sla_estado=sla_estado_resumido(
+                t,
+                now=now,
+                calendar=cal_map.get(t.sla_policy_id) if t.sla_policy_id else None,
+            ),
+        )
+        for t in rows
+    ]
+    return ListaPaginada(items=items, total=total)
 
 
 @router.post("", response_model=TicketRead, status_code=201)
@@ -819,7 +852,17 @@ def obter(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
     if not _pode_ver_ticket(db, atendente, ticket):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
-    return _ticket_para_read(ticket, db)
+    from datetime import datetime, timezone
+
+    from app.services.sla_calculo import preload_sla_calendars, sla_estado_resumido
+
+    cal_map = preload_sla_calendars(db, [ticket])
+    estado = sla_estado_resumido(
+        ticket,
+        now=datetime.now(timezone.utc),
+        calendar=cal_map.get(ticket.sla_policy_id) if ticket.sla_policy_id else None,
+    )
+    return _ticket_para_read(ticket, db, sla_estado=estado)
 
 
 @router.get("/{ticket_id}/sla", response_model=TicketSlaRead)

--- a/backend/app/schemas/ticket.py
+++ b/backend/app/schemas/ticket.py
@@ -193,6 +193,10 @@ class TicketRead(BaseModel):
     sla_resolucao_vence_em: datetime | None = None
     sla_primeira_resposta_em: datetime | None = None
     sla_violado: bool = False
+    sla_estado: str | None = Field(
+        default=None,
+        description="Pior estado SLA resumido: dentro, em_risco, violado ou cumprido.",
+    )
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/sla_calculo.py
+++ b/backend/app/services/sla_calculo.py
@@ -161,6 +161,111 @@ def build_ticket_sla_read(db: Session, ticket: Ticket, *, now: datetime | None =
     }
 
 
+def sla_estado_resumido(
+    ticket: Ticket,
+    *,
+    now: datetime | None = None,
+    calendar: CalendarConfig | None = None,
+) -> str | None:
+    """Pior estado SLA entre primeira resposta e resolução (para listagem, sem query extra)."""
+    if not ticket.sla_policy_id:
+        return None
+    now_u = ensure_utc(now or datetime.now(timezone.utc))
+    inicio = ensure_utc(ticket.created_at or now_u)
+    estados: list[SlaMetaEstado] = []
+    if ticket.sla_meta_primeira_resposta_min:
+        estado, _ = avaliar_meta(
+            inicio=inicio,
+            vence_em=ticket.sla_primeira_resposta_vence_em,
+            cumprido_em=ticket.sla_primeira_resposta_em,
+            meta_min=ticket.sla_meta_primeira_resposta_min,
+            now=now_u,
+            calendar=calendar,
+        )
+        estados.append(estado)
+    if ticket.sla_meta_resolucao_min:
+        estado, _ = avaliar_meta(
+            inicio=inicio,
+            vence_em=ticket.sla_resolucao_vence_em,
+            cumprido_em=ticket.fechado_em,
+            meta_min=ticket.sla_meta_resolucao_min,
+            now=now_u,
+            calendar=calendar,
+        )
+        estados.append(estado)
+    if not estados:
+        return None
+    prioridade = {
+        SlaMetaEstado.violado: 5,
+        SlaMetaEstado.em_risco: 4,
+        SlaMetaEstado.dentro: 3,
+        SlaMetaEstado.cumprido: 2,
+        SlaMetaEstado.sem_meta: 1,
+    }
+    pior = max(estados, key=lambda e: prioridade.get(e, 0))
+    if pior in (SlaMetaEstado.sem_meta, SlaMetaEstado.cumprido) and ticket.fechado_em is not None:
+        return pior.value
+    if pior == SlaMetaEstado.sem_meta:
+        return None
+    if ticket.fechado_em is not None and pior == SlaMetaEstado.cumprido:
+        return "cumprido"
+    if ticket.fechado_em is not None and pior == SlaMetaEstado.violado:
+        return "violado"
+    if ticket.fechado_em is not None:
+        return None
+    return pior.value
+
+
+def preload_sla_calendars(db: Session, tickets: list[Ticket]) -> dict[int, CalendarConfig | None]:
+    """Mapa sla_policy_id → calendário (uma query por lote, evita N+1 na listagem)."""
+    policy_ids = {t.sla_policy_id for t in tickets if t.sla_policy_id}
+    if not policy_ids:
+        return {}
+    policies = db.query(SlaPolicy).filter(SlaPolicy.id.in_(policy_ids)).all()
+    cal_ids = {p.business_calendar_id for p in policies if p.business_calendar_id}
+    cal_by_id: dict[int, CalendarConfig] = {}
+    if cal_ids:
+        from app.models.business_calendar import BusinessCalendar
+
+        for row in db.query(BusinessCalendar).filter(BusinessCalendar.id.in_(cal_ids)).all():
+            cfg = calendar_config_from_model(row)
+            if cfg:
+                cal_by_id[row.id] = cfg
+    out: dict[int, CalendarConfig | None] = {}
+    for p in policies:
+        out[p.id] = cal_by_id.get(p.business_calendar_id) if p.business_calendar_id else None
+    return out
+
+
+def filtro_sql_sla_em_risco():
+    """Expressão SQL para tickets com alguma meta em risco (aprox. relógio contínuo)."""
+    from sqlalchemy import and_, func, or_
+
+    elapsed_min = (func.extract("epoch", func.now()) - func.extract("epoch", Ticket.created_at)) / 60.0
+    primeira = and_(
+        Ticket.sla_primeira_resposta_em.is_(None),
+        Ticket.sla_meta_primeira_resposta_min.isnot(None),
+        Ticket.sla_meta_primeira_resposta_min > 0,
+        Ticket.sla_primeira_resposta_vence_em.isnot(None),
+        Ticket.sla_primeira_resposta_vence_em > func.now(),
+        elapsed_min >= Ticket.sla_meta_primeira_resposta_min * (SLA_RISCO_PERCENT / 100.0),
+    )
+    resolucao = and_(
+        Ticket.fechado_em.is_(None),
+        Ticket.sla_meta_resolucao_min.isnot(None),
+        Ticket.sla_meta_resolucao_min > 0,
+        Ticket.sla_resolucao_vence_em.isnot(None),
+        Ticket.sla_resolucao_vence_em > func.now(),
+        elapsed_min >= Ticket.sla_meta_resolucao_min * (SLA_RISCO_PERCENT / 100.0),
+    )
+    return and_(
+        Ticket.sla_policy_id.isnot(None),
+        Ticket.sla_violado.is_(False),
+        Ticket.fechado_em.is_(None),
+        or_(primeira, resolucao),
+    )
+
+
 def sincronizar_sla_violado(db: Session, ticket: Ticket, *, now: datetime | None = None) -> None:
     dados = build_ticket_sla_read(db, ticket, now=now)
     violado = (

--- a/backend/tests/test_tickets_sla_list.py
+++ b/backend/tests/test_tickets_sla_list.py
@@ -1,0 +1,69 @@
+"""Listagem de tickets com SLA resumido e filtros (#281)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.models.sla_policy import SlaPolicy
+from app.models.status_ticket import StatusTicket
+from app.models.ticket import Ticket
+from app.services.sla_calculo import sla_estado_resumido
+
+
+def _ticket_com_sla(db_session, seed_base, *, minutos_decorridos: int, violado: bool = False, sufixo: str = "1"):
+    policy = SlaPolicy(
+        tenant_id=1,
+        setor_id=seed_base["setor1"].id,
+        meta_primeira_resposta_min=100,
+        meta_resolucao_min=480,
+        ativo=True,
+    )
+    db_session.add(policy)
+    db_session.flush()
+    st = db_session.query(StatusTicket).first()
+    now = datetime.now(timezone.utc)
+    inicio = now - timedelta(minutes=minutos_decorridos)
+    ticket = Ticket(
+        tenant_id=1,
+        protocolo=f"#T202606-SLA-LIST-{sufixo}",
+        empresa_id=seed_base["empresa"].id,
+        setor_id=seed_base["setor1"].id,
+        status_id=st.id,
+        assunto="SLA listagem",
+        sla_policy_id=policy.id,
+        sla_meta_primeira_resposta_min=100,
+        sla_primeira_resposta_vence_em=inicio + timedelta(minutes=100),
+        sla_meta_resolucao_min=480,
+        sla_resolucao_vence_em=inicio + timedelta(minutes=480),
+        sla_violado=violado,
+        created_at=inicio,
+    )
+    db_session.add(ticket)
+    db_session.commit()
+    return ticket
+
+
+def test_sla_estado_resumido_em_risco(db_session, seed_base):
+    ticket = _ticket_com_sla(db_session, seed_base, minutos_decorridos=85)
+    assert sla_estado_resumido(ticket) == "em_risco"
+
+
+def test_lista_expoe_sla_estado(client, seed_base, auth_headers, db_session):
+    ticket = _ticket_com_sla(db_session, seed_base, minutos_decorridos=85)
+    r = client.get("/v1/tickets", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    row = next(i for i in r.json()["items"] if i["id"] == ticket.id)
+    assert row["sla_estado"] == "em_risco"
+
+
+def test_filtro_sla_violado(client, seed_base, auth_headers, db_session):
+    ok = _ticket_com_sla(db_session, seed_base, minutos_decorridos=30, violado=False, sufixo="ok")
+    bad = _ticket_com_sla(db_session, seed_base, minutos_decorridos=120, violado=True, sufixo="bad")
+    bad.sla_violado = True
+    db_session.commit()
+
+    r = client.get("/v1/tickets", headers=auth_headers["admin"], params={"sla_violado": True})
+    assert r.status_code == 200
+    ids = {i["id"] for i in r.json()["items"]}
+    assert bad.id in ids
+    assert ok.id not in ids

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import { StatusTicketForm } from './pages/StatusTicketForm'
 import { StatusTicketDetalhe } from './pages/StatusTicketDetalhe'
 import { RespostasProntasPage } from './pages/RespostasProntas'
 import { RoteamentoRegrasPage } from './pages/RoteamentoRegras'
+import { SlaPoliticasPage } from './pages/SlaPoliticas'
 import { RespostaProntaForm } from './pages/RespostaProntaForm'
 import { RespostaProntaDetalhe } from './pages/RespostaProntaDetalhe'
 import { Auditoria } from './pages/Auditoria'
@@ -378,6 +379,7 @@ function AppRoutes() {
           <Route path="natureza-motivo" element={<TicketNaturezaMotivoPage embedded />} />
           <Route path="respostas-prontas" element={<RespostasProntasPage embedded />} />
           <Route path="roteamento" element={<RoteamentoRegrasPage embedded />} />
+          <Route path="sla" element={<SlaPoliticasPage embedded />} />
         </Route>
         <Route
           path="configuracoes/cadastros"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -463,6 +463,23 @@ export const routingRules = {
     api<RoutingRules.Resultado>('/routing/rules/simulate', { method: 'POST', body: JSON.stringify(data) }),
 };
 
+export const sla = {
+  prioridades: () => api<Sla.PrioridadesDisponiveis>('/sla/prioridades'),
+  policies: {
+    list: (params?: { setor_id?: number; incluir_inativos?: boolean }) =>
+      api<Sla.Policy[]>(withParams('/sla/policies', params)),
+    get: (id: number) => api<Sla.Policy>(`/sla/policies/${id}`),
+    create: (data: Sla.PolicyCreate) =>
+      api<Sla.Policy>('/sla/policies', { method: 'POST', body: JSON.stringify(data) }),
+    update: (id: number, data: Sla.PolicyUpdate) =>
+      api<Sla.Policy>(`/sla/policies/${id}`, { method: 'PUT', body: JSON.stringify(data) }),
+  },
+  calendars: {
+    list: (params?: { setor_id?: number; incluir_inativos?: boolean }) =>
+      api<Sla.BusinessCalendar[]>(withParams('/sla/calendars', params)),
+  },
+};
+
 export const audit = {
   list: (params?: {
     entity_type?: string;
@@ -1747,6 +1764,58 @@ export namespace StatusTicket {
     slug?: string;
     ordem?: number;
     ativo?: boolean;
+  }
+}
+
+export namespace Sla {
+  export type Prioridade = 'baixa' | 'normal' | 'alta' | 'urgente';
+
+  export interface PrioridadesDisponiveis {
+    prioridades: Prioridade[];
+  }
+
+  export interface Policy {
+    id: number;
+    setor_id: number;
+    setor_nome?: string | null;
+    prioridade: Prioridade | null;
+    business_calendar_id: number | null;
+    business_calendar_nome?: string | null;
+    meta_primeira_resposta_min: number | null;
+    meta_resolucao_min: number | null;
+    ativo: boolean;
+    created_at?: string | null;
+    updated_at?: string | null;
+  }
+
+  export interface PolicyCreate {
+    setor_id: number;
+    prioridade?: Prioridade | null;
+    business_calendar_id?: number | null;
+    meta_primeira_resposta_min?: number | null;
+    meta_resolucao_min?: number | null;
+    ativo?: boolean;
+  }
+
+  export interface PolicyUpdate {
+    setor_id?: number;
+    prioridade?: Prioridade | null;
+    business_calendar_id?: number | null;
+    meta_primeira_resposta_min?: number | null;
+    meta_resolucao_min?: number | null;
+    ativo?: boolean;
+  }
+
+  export interface BusinessCalendar {
+    id: number;
+    nome: string;
+    setor_id: number | null;
+    horario_timezone: string;
+    horario_inicio: string | null;
+    horario_fim: string | null;
+    horario_semana?: Record<string, { ativo?: boolean; inicio?: string; fim?: string }> | null;
+    usar_feriados_nacionais: boolean;
+    ativo: boolean;
   }
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -936,10 +936,13 @@ export const tickets = {
     /** Coluna para ordenar (omitir = mais recentes primeiro). */
     ordenar_por?: 'protocolo' | 'rede' | 'empresa' | 'setor' | 'assunto' | 'status' | 'responsavel' | 'fechado_em' | 'fila_desde_at';
     ordem?: 'asc' | 'desc';
+    sla_violado?: boolean;
+    sla_em_risco?: boolean;
     offset?: number;
     limit?: number;
   }) => listPaginated<Tickets.Ticket>('/tickets', params),
   get: (id: number) => api<Tickets.Ticket>(`/tickets/${id}`),
+  getSla: (id: number) => api<Tickets.TicketSla>(`/tickets/${id}/sla`),
   getHistorico: (id: number) => api<Tickets.Historico[]>(`/tickets/${id}/historico`),
   listMensagens: (id: number) => api<Tickets.Mensagem[]>(`/tickets/${id}/mensagens`),
   addMensagem: (id: number, data: Tickets.MensagemCreate) =>
@@ -1986,6 +1989,25 @@ export namespace Tickets {
     fila_desde_at?: string | null;
     distribuicao_modo_setor?: string | null;
     distribuicao_auto_em_minutos?: number | null;
+    sla_policy_id?: number | null;
+    sla_violado?: boolean;
+    sla_estado?: 'dentro' | 'em_risco' | 'violado' | 'cumprido' | null;
+  }
+  export interface SlaMetaDetalhe {
+    meta_minutos: number | null;
+    vence_em: string | null;
+    cumprido_em: string | null;
+    estado: string;
+    percentual_decorrido: number | null;
+  }
+  export interface TicketSla {
+    ticket_id: number;
+    sla_policy_id: number | null;
+    sla_violado: boolean;
+    inicio_em: string;
+    usa_horario_comercial: boolean;
+    primeira_resposta: SlaMetaDetalhe;
+    resolucao: SlaMetaDetalhe;
   }
   export type TicketVinculoTipo = 'duplicado_de' | 'relacionado_a';
   export interface TicketVinculoOutro {

--- a/frontend/src/components/tickets/SlaBadge.tsx
+++ b/frontend/src/components/tickets/SlaBadge.tsx
@@ -1,0 +1,20 @@
+import { classeBadgeSla, rotuloSlaEstado } from '../../lib/slaTicket'
+
+export function SlaBadge({
+  estado,
+  className = '',
+}: {
+  estado: string | null | undefined
+  className?: string
+}) {
+  const rotulo = rotuloSlaEstado(estado)
+  if (!rotulo) return null
+  return (
+    <span
+      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${classeBadgeSla(estado)} ${className}`}
+      title={rotulo}
+    >
+      {rotulo}
+    </span>
+  )
+}

--- a/frontend/src/components/tickets/TicketSlaCard.tsx
+++ b/frontend/src/components/tickets/TicketSlaCard.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import { tickets, type Tickets } from '../../api/client'
+import { Card } from '../ui/Card'
+import { SlaBadge } from './SlaBadge'
+import { formatMinutosSla, textoCountdownSla, tooltipSlaMeta } from '../../lib/slaTicket'
+
+export function TicketSlaCard({ ticketId, fechado }: { ticketId: number; fechado: boolean }) {
+  const [sla, setSla] = useState<Tickets.TicketSla | null>(null)
+  const [erro, setErro] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    tickets
+      .getSla(ticketId)
+      .then((d) => {
+        if (!cancelled) setSla(d)
+      })
+      .catch(() => {
+        if (!cancelled) setErro(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [ticketId])
+
+  if (erro || !sla?.sla_policy_id) return null
+
+  const comercial = sla.usa_horario_comercial
+  const pior =
+    sla.primeira_resposta.estado === 'violado' || sla.resolucao.estado === 'violado'
+      ? 'violado'
+      : sla.primeira_resposta.estado === 'em_risco' || sla.resolucao.estado === 'em_risco'
+        ? 'em_risco'
+        : sla.primeira_resposta.estado === 'cumprido' && sla.resolucao.estado === 'cumprido'
+          ? 'cumprido'
+          : 'dentro'
+
+  return (
+    <Card className="mb-4 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">SLA</h3>
+        <SlaBadge estado={fechado && pior === 'dentro' ? 'cumprido' : pior} />
+      </div>
+      <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+        {comercial ? 'Contagem em horário comercial' : 'Contagem contínua (24×7)'}
+      </p>
+      <dl className="mt-3 grid gap-3 sm:grid-cols-2">
+        {(['primeira_resposta', 'resolucao'] as const).map((chave) => {
+          const meta = sla[chave]
+          const nome = chave === 'primeira_resposta' ? 'Primeira resposta' : 'Resolução'
+          return (
+            <div
+              key={chave}
+              className="rounded-lg border border-slate-200/80 bg-slate-50/80 px-3 py-2 dark:border-slate-700/70 dark:bg-slate-900/40"
+              title={tooltipSlaMeta(nome, meta, comercial)}
+            >
+              <dt className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                {nome}
+              </dt>
+              <dd className="mt-1 text-sm font-medium text-slate-800 dark:text-slate-100">
+                {textoCountdownSla(meta, comercial)}
+              </dd>
+              <dd className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+                Meta: {formatMinutosSla(meta.meta_minutos, comercial)}
+              </dd>
+            </div>
+          )
+        })}
+      </dl>
+    </Card>
+  )
+}

--- a/frontend/src/lib/slaTicket.ts
+++ b/frontend/src/lib/slaTicket.ts
@@ -1,0 +1,93 @@
+export type SlaEstadoResumido = 'dentro' | 'em_risco' | 'violado' | 'cumprido'
+
+export interface SlaMetaDetalhe {
+  meta_minutos: number | null
+  vence_em: string | null
+  cumprido_em: string | null
+  estado: string
+  percentual_decorrido: number | null
+}
+
+export interface TicketSlaDetalhe {
+  ticket_id: number
+  sla_policy_id: number | null
+  sla_violado: boolean
+  inicio_em: string
+  usa_horario_comercial: boolean
+  primeira_resposta: SlaMetaDetalhe
+  resolucao: SlaMetaDetalhe
+}
+
+const ROTULOS: Record<string, string> = {
+  dentro: 'Dentro do SLA',
+  em_risco: 'SLA em risco',
+  violado: 'SLA violado',
+  cumprido: 'SLA cumprido',
+  sem_meta: 'Sem meta',
+}
+
+export function rotuloSlaEstado(estado: string | null | undefined): string | null {
+  if (!estado) return null
+  return ROTULOS[estado] ?? estado
+}
+
+export function classeBadgeSla(estado: string | null | undefined): string {
+  switch (estado) {
+    case 'violado':
+      return 'bg-red-50 text-red-800 ring-1 ring-inset ring-red-200 dark:bg-red-950/40 dark:text-red-200 dark:ring-red-800/60'
+    case 'em_risco':
+      return 'bg-amber-50 text-amber-800 ring-1 ring-inset ring-amber-200 dark:bg-amber-950/40 dark:text-amber-200 dark:ring-amber-800/50'
+    case 'cumprido':
+      return 'bg-emerald-50 text-emerald-800 ring-1 ring-inset ring-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-200 dark:ring-emerald-800/50'
+    case 'dentro':
+      return 'bg-emerald-50/70 text-emerald-900 ring-1 ring-inset ring-emerald-200/80 dark:bg-emerald-950/30 dark:text-emerald-100 dark:ring-emerald-800/40'
+    default:
+      return 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300'
+  }
+}
+
+export function formatMinutosSla(min: number | null | undefined, comercial: boolean): string {
+  if (min == null || min <= 0) return '—'
+  const suf = comercial ? ' úteis' : ''
+  if (min < 60) return `${min} min${suf}`
+  const h = Math.floor(min / 60)
+  const rest = min % 60
+  if (rest === 0) return `${h}h${suf}`
+  return `${h}h ${rest}min${suf}`
+}
+
+function diffMinutos(iso: string | null | undefined, agora = Date.now()): number | null {
+  if (!iso) return null
+  const t = new Date(iso).getTime()
+  if (Number.isNaN(t)) return null
+  return Math.round((t - agora) / 60000)
+}
+
+export function textoCountdownSla(meta: SlaMetaDetalhe, comercial: boolean): string {
+  if (meta.estado === 'cumprido') return 'Cumprido'
+  if (meta.estado === 'violado') {
+    const atraso = diffMinutos(meta.vence_em)
+    if (atraso != null && atraso < 0) {
+      const min = Math.abs(atraso)
+      if (min < 60) return `Violado há ${min} min`
+      const h = Math.floor(min / 60)
+      const m = min % 60
+      return m > 0 ? `Violado há ${h}h ${m}min` : `Violado há ${h}h`
+    }
+    return 'Violado'
+  }
+  const rest = diffMinutos(meta.vence_em)
+  if (rest == null) return '—'
+  if (rest <= 0) return 'Prazo esgotado'
+  const tipo = comercial ? 'úteis' : 'restantes'
+  if (rest < 60) return `${rest} min ${tipo}`
+  const h = Math.floor(rest / 60)
+  const m = rest % 60
+  return m > 0 ? `${h}h ${m}min ${tipo}` : `${h}h ${tipo}`
+}
+
+export function tooltipSlaMeta(nome: string, meta: SlaMetaDetalhe, comercial: boolean): string {
+  const metaTxt = formatMinutosSla(meta.meta_minutos, comercial)
+  const estado = rotuloSlaEstado(meta.estado) ?? meta.estado
+  return `${nome}: meta ${metaTxt} · ${estado}`
+}

--- a/frontend/src/pages/SlaPoliticas.tsx
+++ b/frontend/src/pages/SlaPoliticas.tsx
@@ -1,0 +1,426 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ApiError, setores, sla, type Sla } from '../api/client'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { ConfigListPageShell } from '../components/config/ConfigListPageShell'
+import { FiltroInativos } from '../components/ui/FiltroInativos'
+import { useToast } from '../components/ui/Toast'
+import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+
+const PRIORIDADE_LABELS: Record<Sla.Prioridade, string> = {
+  baixa: 'Baixa',
+  normal: 'Normal',
+  alta: 'Alta',
+  urgente: 'Urgente',
+}
+
+function formatMinutosSla(min: number | null | undefined, comercial: boolean): string {
+  if (min == null || min <= 0) return '—'
+  const suf = comercial ? ' úteis' : ''
+  if (min < 60) return `${min} min${suf}`
+  const h = Math.floor(min / 60)
+  const rest = min % 60
+  if (rest === 0) return `${h}h${suf}`
+  return `${h}h ${rest}min${suf}`
+}
+
+function formVazio(): Sla.PolicyCreate {
+  return {
+    setor_id: 0,
+    prioridade: null,
+    business_calendar_id: null,
+    meta_primeira_resposta_min: 60,
+    meta_resolucao_min: 480,
+    ativo: true,
+  }
+}
+
+function buildPreview(
+  form: Sla.PolicyCreate,
+  prioridade: Sla.Prioridade | null | undefined,
+): string {
+  const prioLabel = prioridade ? PRIORIDADE_LABELS[prioridade] : 'padrão'
+  const comercial = !!form.business_calendar_id
+  const p1 = formatMinutosSla(form.meta_primeira_resposta_min, comercial)
+  const p2 = formatMinutosSla(form.meta_resolucao_min, comercial)
+  return `Exemplo: Prioridade ${prioLabel} = ${p1} primeira resposta / ${p2} resolução`
+}
+
+export function SlaPoliticasPage({ embedded = false }: { embedded?: boolean }) {
+  const toast = useToast()
+  const [list, setList] = useState<Sla.Policy[]>([])
+  const [calendars, setCalendars] = useState<Sla.BusinessCalendar[]>([])
+  const [prioridades, setPrioridades] = useState<Sla.Prioridade[]>([])
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [incluirInativos, setIncluirInativos] = useState(false)
+  const [filtroSetor, setFiltroSetor] = useState<number | ''>('')
+  const [setorOpts, setSetorOpts] = useState<{ id: number; nome: string }[]>([])
+
+  const [editId, setEditId] = useState<number | null>(null)
+  const [formOpen, setFormOpen] = useState(false)
+  const [form, setForm] = useState<Sla.PolicyCreate>(formVazio())
+  const [saving, setSaving] = useState(false)
+
+  const preview = useMemo(() => buildPreview(form, form.prioridade), [form])
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    sla.policies
+      .list({
+        incluir_inativos: incluirInativos,
+        setor_id: filtroSetor === '' ? undefined : filtroSetor,
+      })
+      .then(setList)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar as políticas SLA.'))
+      })
+      .finally(() => setLoading(false))
+  }, [filtroSetor, incluirInativos, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  useEffect(() => {
+    setores.list({ limit: 100 }).then(({ items }) => {
+      const opts = items.map((s) => ({ id: s.id, nome: s.nome }))
+      setSetorOpts(opts)
+      setForm((f) => (f.setor_id ? f : { ...f, setor_id: opts[0]?.id ?? 0 }))
+    })
+    sla.prioridades().then((r) => setPrioridades(r.prioridades))
+    sla.calendars.list({ incluir_inativos: true }).then(setCalendars).catch(() => setCalendars([]))
+  }, [])
+
+  function iniciarNova() {
+    setEditId(null)
+    setForm({
+      ...formVazio(),
+      setor_id: setorOpts[0]?.id ?? 0,
+    })
+    setFormOpen(true)
+  }
+
+  function iniciarEdicao(policy: Sla.Policy) {
+    setEditId(policy.id)
+    setForm({
+      setor_id: policy.setor_id,
+      prioridade: policy.prioridade,
+      business_calendar_id: policy.business_calendar_id,
+      meta_primeira_resposta_min: policy.meta_primeira_resposta_min,
+      meta_resolucao_min: policy.meta_resolucao_min,
+      ativo: policy.ativo,
+    })
+    setFormOpen(true)
+  }
+
+  function cancelarForm() {
+    setEditId(null)
+    setFormOpen(false)
+    setForm(formVazio())
+  }
+
+  async function salvar() {
+    if (!form.setor_id) {
+      toast.showWarning('Selecione o setor.')
+      return
+    }
+    const primeira = form.meta_primeira_resposta_min
+    const resolucao = form.meta_resolucao_min
+    if ((!primeira || primeira <= 0) && (!resolucao || resolucao <= 0)) {
+      toast.showWarning('Informe ao menos uma meta com minutos maior que zero.')
+      return
+    }
+    if (primeira != null && primeira <= 0) {
+      toast.showWarning('Minutos de primeira resposta devem ser maiores que zero.')
+      return
+    }
+    if (resolucao != null && resolucao <= 0) {
+      toast.showWarning('Minutos de resolução devem ser maiores que zero.')
+      return
+    }
+
+    setSaving(true)
+    try {
+      const payload = {
+        ...form,
+        prioridade: form.prioridade || null,
+        business_calendar_id: form.business_calendar_id || null,
+        meta_primeira_resposta_min: primeira && primeira > 0 ? primeira : null,
+        meta_resolucao_min: resolucao && resolucao > 0 ? resolucao : null,
+      }
+      if (editId) {
+        await sla.policies.update(editId, payload)
+        toast.showSuccess('Política atualizada.')
+      } else {
+        await sla.policies.create(payload)
+        toast.showSuccess('Política criada.')
+      }
+      cancelarForm()
+      load()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a política.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function desativar(policy: Sla.Policy) {
+    if (!window.confirm(`Desativar a política SLA do setor ${policy.setor_nome ?? policy.setor_id}?`)) return
+    try {
+      await sla.policies.update(policy.id, { ativo: false })
+      toast.showSuccess('Política desativada.')
+      if (editId === policy.id) cancelarForm()
+      load()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível desativar.'))
+    }
+  }
+
+  const denied = (
+    <SemPermissao
+      title="Você não tem permissão para gerenciar SLA."
+      voltarPara="/"
+      voltarLabel="Voltar para o Dashboard"
+    />
+  )
+
+  return (
+    <ConfigListPageShell
+      embedded={embedded}
+      forbidden={forbidden}
+      denied={denied}
+      title="SLA"
+      subtitle="Metas de primeira resposta e resolução por setor e prioridade."
+      actions={<Button onClick={iniciarNova}>Nova política</Button>}
+    >
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        <FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />
+        <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400">
+          Setor
+          <select
+            className="rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5 text-sm"
+            value={filtroSetor}
+            onChange={(e) => setFiltroSetor(e.target.value ? Number(e.target.value) : '')}
+          >
+            <option value="">Todos</option>
+            {setorOpts.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.nome}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <Card className="mb-6 overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-slate-200 dark:border-slate-700 text-left">
+              <th className="p-2">Setor</th>
+              <th className="p-2">Prioridade</th>
+              <th className="p-2">Primeira resposta</th>
+              <th className="p-2">Resolução</th>
+              <th className="p-2">Calendário</th>
+              <th className="p-2 w-36" />
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr>
+                <td colSpan={6} className="p-4 text-slate-500">
+                  Carregando…
+                </td>
+              </tr>
+            ) : list.length === 0 ? (
+              <tr>
+                <td colSpan={6} className="p-4 text-slate-500">
+                  Nenhuma política cadastrada.
+                </td>
+              </tr>
+            ) : (
+              list.map((p) => {
+                const comercial = !!p.business_calendar_id
+                return (
+                  <tr key={p.id} className="border-b border-slate-100 dark:border-slate-800">
+                    <td className="p-2 font-medium">{p.setor_nome ?? `#${p.setor_id}`}</td>
+                    <td className="p-2">
+                      {p.prioridade ? PRIORIDADE_LABELS[p.prioridade] : 'Padrão'}
+                      {!p.ativo ? (
+                        <span className="ml-2 text-xs text-amber-600 dark:text-amber-400">inativa</span>
+                      ) : null}
+                    </td>
+                    <td className="p-2">{formatMinutosSla(p.meta_primeira_resposta_min, comercial)}</td>
+                    <td className="p-2">{formatMinutosSla(p.meta_resolucao_min, comercial)}</td>
+                    <td className="p-2 text-slate-600 dark:text-slate-400">
+                      {p.business_calendar_nome ?? (comercial ? '—' : '24×7')}
+                    </td>
+                    <td className="p-2">
+                      <Button type="button" variant="ghost" className="px-2 py-1" onClick={() => iniciarEdicao(p)}>
+                        Editar
+                      </Button>
+                      {p.ativo ? (
+                        <Button type="button" variant="ghost" className="px-2 py-1" onClick={() => desativar(p)}>
+                          Desativar
+                        </Button>
+                      ) : null}
+                    </td>
+                  </tr>
+                )
+              })
+            )}
+          </tbody>
+        </table>
+      </Card>
+
+      {formOpen ? (
+        <Card className="mb-6 p-4 space-y-4">
+          <h3 className="font-semibold">{editId ? 'Editar política' : 'Nova política'}</h3>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            <label className="block text-sm">
+              Setor
+              <select
+                className="mt-1 w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5"
+                value={form.setor_id || ''}
+                onChange={(e) => setForm((f) => ({ ...f, setor_id: Number(e.target.value) }))}
+              >
+                {setorOpts.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.nome}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-sm">
+              Prioridade
+              <select
+                className="mt-1 w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5"
+                value={form.prioridade ?? ''}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    prioridade: (e.target.value || null) as Sla.Prioridade | null,
+                  }))
+                }
+              >
+                <option value="">Padrão (qualquer prioridade sem regra específica)</option>
+                {prioridades.map((p) => (
+                  <option key={p} value={p}>
+                    {PRIORIDADE_LABELS[p]}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="block text-sm">
+              Primeira resposta (minutos)
+              <input
+                type="number"
+                min={1}
+                className="mt-1 w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5"
+                value={form.meta_primeira_resposta_min ?? ''}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    meta_primeira_resposta_min: e.target.value ? Number(e.target.value) : null,
+                  }))
+                }
+              />
+            </label>
+            <label className="block text-sm">
+              Resolução (minutos)
+              <input
+                type="number"
+                min={1}
+                className="mt-1 w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5"
+                value={form.meta_resolucao_min ?? ''}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    meta_resolucao_min: e.target.value ? Number(e.target.value) : null,
+                  }))
+                }
+              />
+            </label>
+            <label className="block text-sm md:col-span-2">
+              Calendário comercial
+              <select
+                className="mt-1 w-full rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 px-2 py-1.5"
+                value={form.business_calendar_id ?? ''}
+                onChange={(e) =>
+                  setForm((f) => ({
+                    ...f,
+                    business_calendar_id: e.target.value ? Number(e.target.value) : null,
+                  }))
+                }
+              >
+                <option value="">Sem calendário (contagem contínua 24×7)</option>
+                {calendars.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.nome}
+                    {!c.ativo ? ' (inativo)' : ''}
+                  </option>
+                ))}
+              </select>
+              <span className="mt-1 block text-xs text-slate-500 dark:text-slate-400">
+                Calendários compartilhados contam apenas horário útil. Para referência de horário do WhatsApp, veja{' '}
+                <Link to="/configuracoes/sistema/whatsapp" className="text-sky-600 hover:underline dark:text-sky-400">
+                  Configurações → Sistema → WhatsApp
+                </Link>
+                .
+              </span>
+            </label>
+          </div>
+
+          <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800/50 dark:text-slate-200">
+            {preview}
+          </div>
+
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={form.ativo !== false}
+              onChange={(e) => setForm((f) => ({ ...f, ativo: e.target.checked }))}
+            />
+            Política ativa
+          </label>
+
+          <div className="flex gap-2">
+            <Button onClick={salvar} disabled={saving}>
+              {saving ? 'Salvando…' : 'Salvar'}
+            </Button>
+            <Button type="button" variant="ghost" onClick={cancelarForm}>
+              Cancelar
+            </Button>
+          </div>
+        </Card>
+      ) : null}
+
+      {calendars.length > 0 ? (
+        <Card className="p-4">
+          <h3 className="font-semibold mb-2">Calendários comerciais</h3>
+          <p className="text-sm text-slate-600 dark:text-slate-400 mb-3">
+            Calendários cadastrados no tenant. Vincule um deles à política para contar apenas minutos úteis.
+          </p>
+          <ul className="text-sm space-y-1">
+            {calendars.map((c) => (
+              <li key={c.id} className="flex flex-wrap gap-x-2 text-slate-700 dark:text-slate-300">
+                <span className="font-medium">{c.nome}</span>
+                <span className="text-slate-500">({c.horario_timezone})</span>
+                {!c.ativo ? <span className="text-amber-600 dark:text-amber-400">inativo</span> : null}
+              </li>
+            ))}
+          </ul>
+        </Card>
+      ) : null}
+    </ConfigListPageShell>
+  )
+}

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -44,6 +44,7 @@ import { TicketBuscaPicker } from '../components/TicketBuscaPicker'
 import { TicketFilhosMassaPanel } from '../components/tickets/TicketFilhosMassaPanel'
 import { TicketMetaChip } from '../components/tickets/TicketMetaChip'
 import { TicketDetalheSkeleton } from '../components/tickets/TicketDetalheSkeleton'
+import { TicketSlaCard } from '../components/tickets/TicketSlaCard'
 import {
   TicketClassificacaoFields,
   classificacaoFromTicket,
@@ -1617,6 +1618,7 @@ export function TicketDetalhe() {
 
         <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
           <div className="mx-auto max-w-6xl space-y-4 px-3 pb-8 pt-3 sm:space-y-6 sm:px-5 sm:pb-10 sm:pt-4 md:px-6">
+        {!ticket.fechado_em ? <TicketSlaCard ticketId={ticket.id} fechado={false} /> : null}
         {temVinculosHierarquia && (
           <div className="rounded-xl border border-slate-200/90 bg-slate-50/50 px-3 py-2.5 text-sm dark:border-slate-700/80 dark:bg-slate-900/35">
             <div className="flex flex-wrap items-start justify-between gap-3">

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -26,6 +26,7 @@ import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { exibirProtocolo } from '../lib/exibirProtocolo'
 import { rotuloPrioridade, classeBadgePrioridade } from '../lib/ticketPrioridade'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
+import { SlaBadge } from '../components/tickets/SlaBadge'
 
 type ColunaOrdenacao =
   | 'protocolo'
@@ -136,6 +137,7 @@ export function Tickets() {
     return sr === '1' || sr === 'true' ? 'sem_responsavel' : ''
   })
   const [filtroAtendente, setFiltroAtendente] = useState<number | ''>('')
+  const [filtroSla, setFiltroSla] = useState<'' | 'violado' | 'em_risco'>('')
   const [maisFiltrosAberto, setMaisFiltrosAberto] = useState(false)
   const painelFiltrosId = useId()
   const { ordenarPor, ordem, aoOrdenarColuna, sortParams } = useOrdenacaoLista<ColunaOrdenacao>()
@@ -191,13 +193,19 @@ export function Tickets() {
     filtroSetor !== '' ||
     (situacao === 'abertos' && filtroStatus !== '') ||
     filtroFila !== '' ||
+    filtroSla !== '' ||
     (isAdmin && filtroAtendente !== '')
 
   const qtdFiltrosRefinamento =
     (filtroEmpresa !== '' ? 1 : 0) +
     (filtroSetor !== '' ? 1 : 0) +
     (situacao === 'abertos' && filtroStatus !== '' ? 1 : 0) +
+    (situacao === 'abertos' && filtroSla !== '' ? 1 : 0) +
     (isAdmin && filtroAtendente !== '' ? 1 : 0)
+
+  useEffect(() => {
+    if (situacao !== 'abertos' && filtroSla !== '') setFiltroSla('')
+  }, [situacao, filtroSla])
 
   useEffect(() => {
     if (situacao !== 'fechados') return
@@ -283,6 +291,8 @@ export function Tickets() {
           filtroAtendente !== ''
             ? Number(filtroAtendente)
             : undefined,
+        sla_violado: filtroSla === 'violado' ? true : undefined,
+        sla_em_risco: filtroSla === 'em_risco' ? true : undefined,
         ...sortParamsEfetivos,
         offset: (page - 1) * PAGE_SIZE_PADRAO,
         limit: PAGE_SIZE_PADRAO,
@@ -313,6 +323,7 @@ export function Tickets() {
     filtroSetor,
     filtroFila,
     filtroAtendente,
+    filtroSla,
     isAdmin,
     ordenarPor,
     ordem,
@@ -341,6 +352,7 @@ export function Tickets() {
     setFiltroStatus('')
     setFiltroFila('')
     setFiltroAtendente('')
+    setFiltroSla('')
     setPage(1)
   }
 
@@ -497,6 +509,46 @@ export function Tickets() {
               <span className="font-medium text-slate-600 dark:text-slate-300">Em atendimento</span> — já com responsável atribuído.
               {isAdmin && ' Use «Mais filtros» para filtrar por atendente da equipe.'}
             </p>
+            </div>
+          )}
+
+          {situacao === 'abertos' && (
+            <div className="mt-4">
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                SLA
+              </p>
+              <div
+                className="mt-2 inline-flex w-full flex-wrap rounded-2xl bg-slate-100/90 p-1 ring-1 ring-slate-200/60 dark:bg-slate-800/60 dark:ring-slate-700/80 sm:w-auto"
+                role="group"
+                aria-label="Filtrar por estado SLA"
+              >
+                {(
+                  [
+                    { id: '' as const, label: 'Todos' },
+                    { id: 'em_risco' as const, label: 'Em risco' },
+                    { id: 'violado' as const, label: 'Violado' },
+                  ] as const
+                ).map(({ id, label }) => {
+                  const ativo = filtroSla === id
+                  return (
+                    <button
+                      key={id || 'todos-sla'}
+                      type="button"
+                      onClick={() => {
+                        setFiltroSla(id)
+                        resetarPagina()
+                      }}
+                      className={`min-h-[2.25rem] flex-1 rounded-xl px-3 py-2 text-center text-xs font-medium transition-all duration-200 sm:flex-none sm:px-4 sm:text-sm ${
+                        ativo
+                          ? 'bg-white text-slate-900 shadow-sm ring-1 ring-slate-200/80 dark:bg-slate-700 dark:text-slate-50 dark:ring-slate-600/50'
+                          : 'text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200'
+                      }`}
+                    >
+                      {label}
+                    </button>
+                  )
+                })}
+              </div>
             </div>
           )}
 
@@ -684,6 +736,11 @@ export function Tickets() {
                             {t.status_nome ?? t.status_id}
                           </span>
                         )}
+                        {situacao === 'abertos' && t.sla_estado ? (
+                          <div className="mt-2">
+                            <SlaBadge estado={t.sla_estado} />
+                          </div>
+                        ) : null}
                       </div>
                     </div>
 
@@ -843,6 +900,9 @@ export function Tickets() {
                   {mostrarColunasFila && (
                     <th className="hidden whitespace-nowrap px-4 py-3 lg:table-cell sm:px-6">Distribuição</th>
                   )}
+                  {situacao === 'abertos' && (
+                    <th className="hidden whitespace-nowrap px-4 py-3 lg:table-cell sm:px-6">SLA</th>
+                  )}
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
@@ -931,6 +991,11 @@ export function Tickets() {
                         <span className="inline-flex rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200">
                           {t.status_nome ?? t.status_id}
                         </span>
+                      </td>
+                    )}
+                    {situacao === 'abertos' && (
+                      <td className="hidden px-4 py-3.5 align-top lg:table-cell sm:px-6">
+                        <SlaBadge estado={t.sla_estado} />
                       </td>
                     )}
                     <td className="hidden px-4 py-3.5 align-top text-slate-600 md:table-cell sm:px-6 dark:text-slate-400">

--- a/frontend/src/pages/config/ConfigAtendimentoLayout.tsx
+++ b/frontend/src/pages/config/ConfigAtendimentoLayout.tsx
@@ -9,6 +9,7 @@ const TABS = [
   { to: '/configuracoes/atendimento/natureza-motivo', label: 'Natureza e motivo' },
   { to: '/configuracoes/atendimento/respostas-prontas', label: 'Respostas prontas' },
   { to: '/configuracoes/atendimento/roteamento', label: 'Roteamento' },
+  { to: '/configuracoes/atendimento/sla', label: 'SLA' },
 ] as const
 
 const TAB_HINTS: Record<string, string> = {
@@ -18,6 +19,7 @@ const TAB_HINTS: Record<string, string> = {
   'natureza-motivo': 'Categorias (natureza) e itens específicos (motivo) usados ao encerrar tickets.',
   'respostas-prontas': 'Macros reutilizáveis ao responder tickets — globais ou por setor.',
   roteamento: 'Regras automáticas de setor e prioridade na criação de tickets (e-mail e manual).',
+  sla: 'Metas de primeira resposta e resolução por setor e prioridade, com calendário comercial opcional.',
 }
 
 function abaAtiva(pathname: string): string {


### PR DESCRIPTION
## Summary
Entrega consolidada do frontend SLA (S-F1 + S-F2):

### #280 — Config admin
- Aba **Configuracoes -> Atendimento -> SLA** com CRUD de politicas
- Preview de metas, calendario comercial, validacao minutos > 0, admin-only

### #281 — Indicadores em tickets
- Campo `sla_estado` na listagem (sem N+1 — preload de calendarios)
- Filtros `sla_violado` e `sla_em_risco` em `GET /v1/tickets`
- Badges verde/amarelo/vermelho na listagem
- Card SLA no detalhe com countdown / violado ha X e tooltips

Closes #280
Closes #281

## Test plan
- [x] `tsc -b`
- [x] `pytest tests/test_tickets_sla_list.py` (3 testes)
- [x] `pytest tests/test_sla_policies.py` (regressao)
- [ ] Admin: criar politica em Config -> Atendimento -> SLA
- [ ] Listagem: filtros Em risco / Violado e badges
- [ ] Detalhe: card SLA com metas e countdown
- [ ] Atendente nao-admin: 403 no painel SLA