### PR TITLE
docs: processo de follow-ups ao fechar issues

### DIFF
--- a/.cursor/rules/issue-closure-backlog.mdc
+++ b/.cursor/rules/issue-closure-backlog.mdc
@@ -1,0 +1,41 @@
+---
+description: Ao fechar issues — registrar follow-ups em novas issues e manter escopo alinhado
+alwaysApply: true
+---
+
+# Encerramento de issues e backlog de follow-ups
+
+## Regra
+
+Ao **fechar** uma issue ou épico (merge do PR + fechamento no GitHub):
+
+1. **Escopo da issue atual** — só o que estava nos critérios de aceite; não expandir no mesmo PR.
+2. **Identificar lacunas** — stubs, «fora de escopo v1», melhorias descobertas na implementação, débito explícito.
+3. **Abrir issues novas** — uma issue por follow-up, com corpo em `.github/planning-issue-bodies/followups/` quando fizer sentido.
+4. **Referenciar origem** — seção «Origem» no corpo: issue/épico que motivou o follow-up.
+5. **Comentário ao fechar** — no PR ou na issue fechada, listar links `#NNN` dos follow-ups criados.
+
+## Checklist (obrigatório antes de fechar)
+
+- [ ] Critérios de aceite da issue **atendidos** ou explicitamente adiados com nova issue
+- [ ] Itens **fora de escopo** têm issue de backlog (não ficam só no chat ou no épico)
+- [ ] Stubs/campos nullable têm issue para implementação futura
+- [ ] Issues **obsoletas** substituídas por épico filho são **fechadas** com comentário (ex.: #101 → #277–#281)
+- [ ] Épico pai: checklist de filhas atualizado; follow-ups linkados no comentário final
+
+## Modelo de issue follow-up
+
+```markdown
+## Origem
+Identificado ao fechar #XXX — fora do escopo / stub / melhoria.
+
+## Dependências
+- Requer: #YYY (concluída)
+
+## Critérios de aceite
+- [ ] ...
+```
+
+## Referência
+
+Guia completo: `docs/ISSUE_CLOSURE.md`

--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -13,7 +13,7 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | RT | [#256](https://github.com/lgustavoss/dx-connect/issues/256) | #264–#269 |
 | T | [#257](https://github.com/lgustavoss/dx-connect/issues/257) | #270–#273 |
 | R | [#258](https://github.com/lgustavoss/dx-connect/issues/258) | #274–#276 |
-| S | [#259](https://github.com/lgustavoss/dx-connect/issues/259) | #277–#281 |
+| S | [#259](https://github.com/lgustavoss/dx-connect/issues/259) | #277–#281 (follow-ups: [#416](https://github.com/lgustavoss/dx-connect/issues/416)–[#419](https://github.com/lgustavoss/dx-connect/issues/419)) |
 | D | [#260](https://github.com/lgustavoss/dx-connect/issues/260) | #282–#289 |
 | A | [#261](https://github.com/lgustavoss/dx-connect/issues/261) | #290–#292 |
 | KB | [#262](https://github.com/lgustavoss/dx-connect/issues/262) | #293–#299 |

--- a/.github/planning-issue-bodies/followups/416-dashboard-sla-violacoes.md
+++ b/.github/planning-issue-bodies/followups/416-dashboard-sla-violacoes.md
@@ -1,0 +1,26 @@
+## Contexto
+
+Follow-up do épico SLA (#259) e dashboard (#260 / #282).
+
+O campo `sla_violacoes_abertas` em `GET /v1/dashboard/geral` foi criado em #282 como **nullable** até o SLA existir. Com #277–#278 mergeados, o campo ainda retorna `null` (stub em `dashboard_geral.py`).
+
+## Proposta
+
+- Contar tickets abertos com `sla_violado=true` (escopo RBAC setor, como demais métricas)
+- Exibir no dashboard geral (frontend) com link/filtro para listagem de tickets violados
+- Testes agregados (sem N+1)
+
+## Critérios de aceite
+
+- [ ] API retorna inteiro ≥ 0 em produção com SLA configurado
+- [ ] UI mostra card/alerta operacional
+- [ ] Admin global; atendente vê setores vinculados
+
+## Dependências
+
+- Requer: #277, #278 (concluídos)
+- Épico pai: #260
+
+## Origem
+
+Identificado ao fechar épico #259 — escopo fora de #277–#281.

--- a/.github/planning-issue-bodies/followups/417-sla-ui-calendarios.md
+++ b/.github/planning-issue-bodies/followups/417-sla-ui-calendarios.md
@@ -1,0 +1,28 @@
+## Contexto
+
+Follow-up pós-épico SLA (#259).
+
+#277 entregou CRUD de calendários comerciais na **API**. #280 entregou seleção e listagem read-only na tela de policies. Não há editor visual para criar/editar calendários (horário semanal, feriados, timezone).
+
+## Proposta
+
+Em Configurações → Atendimento → SLA (ou subseção Calendários):
+
+- Listar calendários comerciais
+- Criar/editar/desativar (consome `/v1/sla/calendars`)
+- Formulário de horário semanal (reutilizar padrão visual do WhatsApp se possível)
+- Opção usar feriados nacionais
+
+## Critérios de aceite
+
+- [ ] CRUD completo via UI (admin-only)
+- [ ] Validação de horários
+- [ ] Calendário inativo não aparece em novos vínculos de policy
+
+## Dependências
+
+- Requer: #277 (API)
+
+## Origem
+
+Fora do escopo explícito de #280 (link/seleção apenas). Backlog v2 SLA.

--- a/.github/planning-issue-bodies/followups/418-sla-pausa-aguardando-cliente.md
+++ b/.github/planning-issue-bodies/followups/418-sla-pausa-aguardando-cliente.md
@@ -1,0 +1,26 @@
+## Contexto
+
+Follow-up pós-épico SLA (#259).
+
+O épico #259 documentou **fora de escopo v1**: pausa automática do relógio SLA quando ticket está em status tipo «aguardando cliente». #278 implementa pausa por **horário comercial** (fim de semana/feriados), não pausa por status.
+
+## Proposta
+
+- Flag em `StatusTicket` (ex.: `pausa_sla`) ou regra por status slug `aguardando_cliente`
+- Motor de cálculo SLA deixa de contar minutos decorridos enquanto pausado
+- Retomada ao sair do status
+- Testes: pausa + retomada + violação após retomada
+
+## Critérios de aceite
+
+- [ ] Admin configura quais status pausam SLA (ou flag fixa no status)
+- [ ] `GET /tickets/{id}/sla` reflete pausa
+- [ ] Worker/alertas respeitam pausa
+
+## Dependências
+
+- Requer: #277, #278
+
+## Origem
+
+Explicitamente «issue futura» no corpo do épico #259.

--- a/.github/planning-issue-bodies/followups/419-sla-whatsapp-futuro.md
+++ b/.github/planning-issue-bodies/followups/419-sla-whatsapp-futuro.md
@@ -1,0 +1,20 @@
+## Contexto
+
+Follow-up pós-épico SLA (#259).
+
+O épico #259 definiu **fora de escopo v1**: SLA formal em chats WhatsApp (permanece alerta sonoro/fila operacional). Decisão de produto documentada em `.github/planning-issue-bodies/analises/filas-tickets-vs-chats.md`.
+
+## Proposta (quando priorizado)
+
+- Definir se SLA de chat reutiliza policies de ticket ou regras próprias
+- Metas TMA/primeira resposta no chat
+- UI e alertas alinhados ao módulo WhatsApp
+
+## Critérios de aceite
+
+- [ ] Spike/decisão de produto registrada
+- [ ] Implementação só após aprovação explícita
+
+## Origem
+
+Fora de escopo v1 #259 — issue de backlog para não perder rastreio.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,11 @@
 ## Test plan
 
 - [ ] 
+
+## Follow-ups / backlog (obrigatório ao fechar issue ou épico)
+
+- [ ] Revisei itens **fora do escopo** desta issue — cada um virou issue `#___` ou está documentado como wontfix
+- [ ] Stubs/campos nullable têm issue de conclusão, se aplicável
+- [ ] Comentário na issue fechada ou no PR lista links dos follow-ups criados
+
+> Guia: [docs/ISSUE_CLOSURE.md](../docs/ISSUE_CLOSURE.md)

--- a/docs/ISSUE_CLOSURE.md
+++ b/docs/ISSUE_CLOSURE.md
@@ -1,0 +1,48 @@
+# Encerramento de issues e follow-ups
+
+Métrica padrão do time: **nenhuma entrega fecha sem rastrear o que ficou de fora**.
+
+## Fluxo
+
+```
+Implementar (escopo da issue) → PR → merge → follow-ups? → fechar issue
+                                      │
+                                      └─ Sim: criar issues #NNN + linkar no comentário
+```
+
+## O que abrir como nova issue
+
+| Situação | Ação |
+|----------|------|
+| Descoberta na implementação, fora do escopo atual | Nova issue + «Origem: #XXX» |
+| Stub / campo nullable «até feature Y existir» e Y já mergeou | Nova issue para completar |
+| Épico diz «issue futura» sem número | Criar issue antes de fechar o épico |
+| Issue antiga substituída por épico filho | Fechar antiga com comentário (ex. superseded) |
+
+## O que **não** misturar na issue atual
+
+- Melhorias adjacentes «já que estamos aqui»
+- UI completa quando a issue pedia só API
+- Dashboard quando a issue era só backend de tickets
+
+## Onde documentar
+
+| Artefato | Uso |
+|----------|-----|
+| `.github/planning-issue-bodies/followups/` | Rascunho do corpo das issues follow-up |
+| Comentário ao fechar issue/PR | Lista `Closes #X` + «Follow-ups: #416, #417» |
+| `CHANGELOG.md` | Só o que **entrou** nesta release; follow-ups não entram até mergearem |
+
+## Exemplo (épico SLA #259)
+
+| Follow-up | Issue | Motivo |
+|-----------|-------|--------|
+| Métrica dashboard `sla_violacoes_abertas` | [#416](https://github.com/lgustavoss/dx-connect/issues/416) | Stub #282; SLA já existe |
+| UI calendários comerciais | [#417](https://github.com/lgustavoss/dx-connect/issues/417) | #280 = policies; API #277 |
+| Pausa SLA «aguardando cliente» | [#418](https://github.com/lgustavoss/dx-connect/issues/418) | Fora de escopo v1 #259 |
+| SLA em WhatsApp | [#419](https://github.com/lgustavoss/dx-connect/issues/419) | Decisão de produto futura |
+| Issue umbrella obsoleta | [#101](https://github.com/lgustavoss/dx-connect/issues/101) fechada | Substituída por #277–#281 |
+
+## Checklist no PR (template)
+
+Ver seção **Follow-ups / backlog** em `.github/pull_request_template.md`.


### PR DESCRIPTION
## Summary
- `docs/ISSUE_CLOSURE.md` — metrica padrao ao fechar issues/epicos
- Regra Cursor `issue-closure-backlog.mdc`
- Secao Follow-ups no template de PR
- Rascunhos follow-ups SLA #416-#419

Pre-requisito para PR main -> staging com processo documentado.

## Test plan
- [x] Arquivos revisados
- [ ] Merge antes do PR main -> staging

Made with [Cursor](https://cursor.com)