### PR TITLE
feat(dashboard): popular sla_violacoes_abertas (#416)

### DIFF
--- a/.cursor/rules/main-pr-batch-delivery.mdc
+++ b/.cursor/rules/main-pr-batch-delivery.mdc
@@ -1,0 +1,54 @@
+---
+description: PRs para main em lotes coesos — evitar merges frequentes de issues isoladas
+alwaysApply: true
+---
+
+# Entrega na main — lotes, não micro-PRs
+
+## Contexto
+
+Outros devs criam branch a partir da **`main`**. Merges frequentes e pequenos na `main` dificultam rebase/sync para quem trabalha em paralelo. **Issue no GitHub = rastreio; PR na `main` = unidade de entrega.**
+
+## Regra (agente + Luis)
+
+Antes de abrir ou mergear PR **`→ main`**:
+
+1. **Agrupar por lote lógico** — mesmo épico, tema ou mini-release (ex.: `feat/sla-v1.1` com #416 + #417; `feat/chat-operacional` com #403 + #423).
+2. **Não abrir PR separado por issue** se o trabalho é claramente relacionado e pode ir na mesma branch em sequência.
+3. **Continuar na branch do lote** — implementar issues relacionadas no mesmo branch; **um PR** quando o lote estiver testável e com CHANGELOG atualizado.
+4. **Cadência orientativa** — preferir **1–2 merges na `main` por semana** (ou quando o lote fechar), não vários PRs no mesmo dia por padrão.
+5. **Exceção: hotfix** — correção urgente (produção/deploy quebrado) pode ir em PR isolado; avisar no corpo do PR.
+
+## Fluxo do repositório
+
+```
+feature/feat/<lote>  →  PR  →  main  →  (acumular)  →  PR main → staging  →  deploy
+```
+
+- **`main → staging`**: só quando houver **release** para produção (várias melhorias no `[Unreleased]`), não a cada merge na `main`.
+- **Nunca** commit direto na `main`.
+
+## Nomenclatura de branch
+
+- Lote: `feat/sla-v1.1`, `feat/chat-operacional`, `fix/alembic-045` (hotfix)
+- Evitar: uma branch por issue de poucas linhas se faz parte do mesmo lote
+
+## Checklist antes de `gh pr create --base main`
+
+- [ ] Este PR fecha um **lote coeso** (ou é hotfix documentado)?
+- [ ] Issues relacionadas pendentes **não** foram deixadas de fora sem motivo?
+- [ ] `CHANGELOG.md` → `[Unreleased]` com bullets para o **lote** (linguagem para usuário final)
+- [ ] Corpo do PR lista issues fechadas (`Closes #NNN`) e test plan do lote
+
+## Exemplos
+
+| Situação | Fazer | Evitar |
+|----------|-------|--------|
+| #416 pronta, #417 é próximo passo SLA | Segurar merge; implementar #417 na mesma branch; **1 PR** | 2 PRs na `main` no mesmo dia |
+| Alembic quebrou deploy | PR hotfix isolado | Esperar lote |
+| #403 e #423 (chat) | Branch `feat/chat-operacional`, 1 PR quando ambas prontas | PR só por issue pequena |
+
+## Referências
+
+- Encerramento de issues: `.cursor/rules/issue-closure-backlog.mdc`, `docs/ISSUE_CLOSURE.md`
+- Deploy: PR `main → staging`; ver `docs/RELEASES.md` se existir

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta
 - SLA (#280): painel admin em Configurações → Atendimento → SLA para CRUD de políticas por setor/prioridade
 - SLA (#281): badges e filtros na listagem de tickets e card de SLA no detalhe com countdown
+- Dashboard geral: card com quantidade de tickets abertos em violação de SLA, com atalho para a listagem filtrada (#416)
 - Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets
 - Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime
 - `aplicar_roteamento` restrito a administradores para sobrescrever setor explícito

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -57,7 +57,7 @@ class DashboardGeralResponse(BaseModel):
     chats_em_atendimento: int = Field(ge=0)
     csat_tickets: CsAtMediaResumo
     csat_chats: CsAtMediaResumo
-    sla_violacoes_abertas: int | None = None
+    sla_violacoes_abertas: int = Field(ge=0)
     gerado_em: datetime
     cache_ttl_segundos: int = Field(ge=0)
 

--- a/backend/app/services/dashboard_geral.py
+++ b/backend/app/services/dashboard_geral.py
@@ -57,6 +57,19 @@ def _count_tickets_sem_responsavel(db: Session, atendente: Atendente) -> int:
     return int(db.execute(stmt).scalar_one())
 
 
+def _count_sla_violacoes_abertas(db: Session, atendente: Atendente) -> int:
+    stmt = (
+        select(func.count())
+        .select_from(Ticket)
+        .where(
+            Ticket.fechado_em.is_(None),
+            Ticket.sla_violado.is_(True),
+        )
+    )
+    stmt = _ticket_scope(stmt, db, atendente)
+    return int(db.execute(stmt).scalar_one())
+
+
 def _count_chats_por_estado(db: Session, atendente: Atendente, estado: str) -> int:
     stmt = select(func.count()).select_from(WhatsappChat).where(WhatsappChat.estado == estado)
     stmt = _whatsapp_scope(stmt, db, atendente)
@@ -116,7 +129,7 @@ def _compute_dashboard_geral(db: Session, atendente: Atendente) -> DashboardGera
         chats_em_atendimento=_count_chats_por_estado(db, atendente, "em_atendimento"),
         csat_tickets=_csat_tickets(db, atendente, desde),
         csat_chats=_csat_chats(db, atendente, desde),
-        sla_violacoes_abertas=None,
+        sla_violacoes_abertas=_count_sla_violacoes_abertas(db, atendente),
         gerado_em=agora,
         cache_ttl_segundos=CACHE_TTL_SECONDS,
     )

--- a/backend/tests/test_dashboard_geral.py
+++ b/backend/tests/test_dashboard_geral.py
@@ -64,7 +64,7 @@ def test_dashboard_geral_admin_ve_global(client, seed_base, auth_headers, db_ses
     assert body["tickets_sem_responsavel"] == 2
     assert body["chats_aguardando_atendente"] == 1
     assert body["chats_em_atendimento"] == 1
-    assert body["sla_violacoes_abertas"] is None
+    assert body["sla_violacoes_abertas"] == 0
     assert body["cache_ttl_segundos"] == CACHE_TTL_SECONDS
     assert body["csat_tickets"]["total_avaliacoes"] == 0
     assert body["csat_tickets"]["media"] is None
@@ -114,3 +114,24 @@ def test_dashboard_geral_csat_7_dias(client, seed_base, auth_headers, db_session
 def test_dashboard_geral_requer_autenticacao(client):
     r = client.get("/v1/dashboard/geral")
     assert r.status_code == 401
+
+
+def test_dashboard_geral_sla_violacoes_abertas(client, seed_base, auth_headers, db_session):
+    _criar_ticket(db_session, seed_base, setor_id=seed_base["setor1"].id)
+    violado_s1 = _criar_ticket(db_session, seed_base, setor_id=seed_base["setor1"].id)
+    violado_s2 = _criar_ticket(db_session, seed_base, setor_id=seed_base["setor2"].id)
+    fechado_violado = _criar_ticket(
+        db_session, seed_base, setor_id=seed_base["setor1"].id, fechado=True
+    )
+    violado_s1.sla_violado = True
+    violado_s2.sla_violado = True
+    fechado_violado.sla_violado = True
+    db_session.commit()
+
+    r_admin = client.get("/v1/dashboard/geral", headers=auth_headers["admin"])
+    assert r_admin.status_code == 200
+    assert r_admin.json()["sla_violacoes_abertas"] == 2
+
+    r_a1 = client.get("/v1/dashboard/geral", headers=auth_headers["a1"])
+    assert r_a1.status_code == 200
+    assert r_a1.json()["sla_violacoes_abertas"] == 1

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1165,7 +1165,7 @@ export namespace Dashboard {
     chats_em_atendimento: number;
     csat_tickets: CsatResumo;
     csat_chats: CsatResumo;
-    sla_violacoes_abertas: number | null;
+    sla_violacoes_abertas: number;
     gerado_em: string;
     cache_ttl_segundos: number;
   }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -197,6 +197,14 @@ export function Dashboard() {
           hrefLabel="Ver tickets sem responsável"
         />
         <MetricCard
+          label="SLA violado (abertos)"
+          value={geral.sla_violacoes_abertas}
+          borderClass="border-l-4 border-l-red-500"
+          hint="Tickets abertos com meta de SLA estourada"
+          href="/tickets?situacao=abertos&sla_violado=1"
+          hrefLabel="Ver tickets com SLA violado"
+        />
+        <MetricCard
           label="WhatsApp aguardando"
           value={geral.chats_aguardando_atendente}
           borderClass="border-l-4 border-l-emerald-400"

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -137,7 +137,10 @@ export function Tickets() {
     return sr === '1' || sr === 'true' ? 'sem_responsavel' : ''
   })
   const [filtroAtendente, setFiltroAtendente] = useState<number | ''>('')
-  const [filtroSla, setFiltroSla] = useState<'' | 'violado' | 'em_risco'>('')
+  const [filtroSla, setFiltroSla] = useState<'' | 'violado' | 'em_risco'>(() => {
+    const sv = searchParams.get('sla_violado')
+    return sv === '1' || sv === 'true' ? 'violado' : ''
+  })
   const [maisFiltrosAberto, setMaisFiltrosAberto] = useState(false)
   const painelFiltrosId = useId()
   const { ordenarPor, ordem, aoOrdenarColuna, sortParams } = useOrdenacaoLista<ColunaOrdenacao>()
@@ -225,6 +228,21 @@ export function Tickets() {
         (prev) => {
           const next = new URLSearchParams(prev)
           next.delete('sem_responsavel')
+          return next
+        },
+        { replace: true },
+      )
+    }
+  }, [searchParams, setSearchParams])
+
+  useEffect(() => {
+    const sv = searchParams.get('sla_violado')
+    if (sv === '1' || sv === 'true') {
+      setFiltroSla('violado')
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev)
+          next.delete('sla_violado')
           return next
         },
         { replace: true },


### PR DESCRIPTION
## Summary

- Implementa contagem de tickets abertos com `sla_violado=true` em `GET /v1/dashboard/geral` (escopo RBAC por setor, agregação única)
- Card **SLA violado (abertos)** no dashboard geral com link para `/tickets?situacao=abertos&sla_violado=1`
- Suporte ao parâmetro `sla_violado=1` na URL da listagem de tickets

Fecha follow-up #416 (stub desde #282).

## Test plan

- [ ] CI verde (backend + frontend)
- [ ] Dashboard: card exibe contagem ≥ 0
- [ ] Link abre tickets abertos filtrados por SLA violado
- [ ] Atendente vê apenas violações dos setores vinculados

Closes #416
