### PR TITLE
feat(auditoria): trail expandido, consulta e export (#290-292)

### DIFF
--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -66,7 +66,7 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | Issue | Título |
 |-------|--------|
 | [#400](https://github.com/lgustavoss/dx-connect/issues/400) | **[Épico] Versionamento e release notes** |
-| [#426](https://github.com/lgustavoss/dx-connect/issues/426) | Centralizar badge "Melhorias" no card (`/sobre`) |
+| [#426](https://github.com/lgustavoss/dx-connect/issues/426) | Centralizar badge "Melhorias" no card (`/sobre`) | Em andamento |
 
 ---
 

--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -13,7 +13,7 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | RT | [#256](https://github.com/lgustavoss/dx-connect/issues/256) | #264–#269 |
 | T | [#257](https://github.com/lgustavoss/dx-connect/issues/257) | #270–#273 |
 | R | [#258](https://github.com/lgustavoss/dx-connect/issues/258) | #274–#276 |
-| S | [#259](https://github.com/lgustavoss/dx-connect/issues/259) | #277–#281 (follow-ups: [#416](https://github.com/lgustavoss/dx-connect/issues/416)–[#419](https://github.com/lgustavoss/dx-connect/issues/419)) |
+| S | [#259](https://github.com/lgustavoss/dx-connect/issues/259) | #277–#281 · follow-ups [#416](https://github.com/lgustavoss/dx-connect/issues/416)–[#418](https://github.com/lgustavoss/dx-connect/issues/418) fechados · [#419](https://github.com/lgustavoss/dx-connect/issues/419) backlog |
 | D | [#260](https://github.com/lgustavoss/dx-connect/issues/260) | #282–#289 |
 | A | [#261](https://github.com/lgustavoss/dx-connect/issues/261) | #290–#292 |
 | KB | [#262](https://github.com/lgustavoss/dx-connect/issues/262) | #293–#299 |
@@ -50,6 +50,14 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | [#102](https://github.com/lgustavoss/dx-connect/issues/102) | SLA UI → #277–#281, #416 |
 | [#111](https://github.com/lgustavoss/dx-connect/issues/111), [#112](https://github.com/lgustavoss/dx-connect/issues/112) | Portal → #263 |
 | [#122](https://github.com/lgustavoss/dx-connect/issues/122) | Decisão produto → README |
+
+## WhatsApp / chat operacional (2026-06-23)
+
+| Issue | Título | Estado |
+|-------|--------|--------|
+| [#403](https://github.com/lgustavoss/dx-connect/issues/403) | Admin só comentário interno em chat alheio | Fechada · PR [#427](https://github.com/lgustavoss/dx-connect/pull/427) |
+| [#418](https://github.com/lgustavoss/dx-connect/issues/418) | Pausa SLA por status do ticket | Fechada · PR [#427](https://github.com/lgustavoss/dx-connect/pull/427) |
+| [#423](https://github.com/lgustavoss/dx-connect/issues/423) | Demandas resolvidas na sessão | Fechada · PR [#427](https://github.com/lgustavoss/dx-connect/pull/427) |
 
 ---
 

--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -15,7 +15,7 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | R | [#258](https://github.com/lgustavoss/dx-connect/issues/258) | #274–#276 |
 | S | [#259](https://github.com/lgustavoss/dx-connect/issues/259) | #277–#281 · follow-ups [#416](https://github.com/lgustavoss/dx-connect/issues/416)–[#418](https://github.com/lgustavoss/dx-connect/issues/418) fechados · [#419](https://github.com/lgustavoss/dx-connect/issues/419) backlog |
 | D | [#260](https://github.com/lgustavoss/dx-connect/issues/260) | #282–#289 |
-| A | [#261](https://github.com/lgustavoss/dx-connect/issues/261) | #290–#292 |
+| A | [#261](https://github.com/lgustavoss/dx-connect/issues/261) | #290–#292 · em andamento |
 | KB | [#262](https://github.com/lgustavoss/dx-connect/issues/262) | #293–#299 |
 | P | [#263](https://github.com/lgustavoss/dx-connect/issues/263) | #300–#308 |
 
@@ -61,11 +61,21 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 
 ---
 
+## Auditoria (#261) — em andamento
+
+| Issue | Título | Estado |
+|-------|--------|--------|
+| [#290](https://github.com/lgustavoss/dx-connect/issues/290) | Trail expandido (backend) | Em andamento |
+| [#291](https://github.com/lgustavoss/dx-connect/issues/291) | Filtros e export CSV | Em andamento |
+| [#292](https://github.com/lgustavoss/dx-connect/issues/292) | UI consulta | Em andamento |
+
+---
+
 ## Release notes / UX (2026-06-23)
 
-| Issue | Título |
-|-------|--------|
-| [#400](https://github.com/lgustavoss/dx-connect/issues/400) | **[Épico] Versionamento e release notes** |
+| Issue | Título | Estado |
+|-------|--------|--------|
+| [#400](https://github.com/lgustavoss/dx-connect/issues/400) | **[Épico] Versionamento e release notes** | Fechada |
 | [#426](https://github.com/lgustavoss/dx-connect/issues/426) | Centralizar badge "Melhorias" no card (`/sobre`) | Em andamento |
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Auditoria (#290–#292): trail expandido com payload, IP, request-id e user-agent; registro de atribuição, transferência, fechamento e reabertura de tickets, ações em chats WhatsApp, envio de e-mail ao cliente, visualização de credencial PDV e exportação de relatórios
+- Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id
 - Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)
 - Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável
 - Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)
 - Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável
 - Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats
 - SLA (#418): pausa automática da contagem quando o ticket está em status configurado (flag `pausa_sla`; «Aguardando cliente» ativado por padrão)

--- a/backend/alembic/versions/052_audit_log_expandido.py
+++ b/backend/alembic/versions/052_audit_log_expandido.py
@@ -1,0 +1,46 @@
+"""Auditoria expandida: payload, IP, user-agent e request_id (#290).
+
+Revision ID: 052_audit_log_expandido
+Revises: 051_sla_policy_natureza
+Create Date: 2026-06-24
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "052_audit_log_expandido"
+down_revision = "051_sla_policy_natureza"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "audit_log",
+        "action",
+        existing_type=sa.String(length=20),
+        type_=sa.String(length=40),
+        existing_nullable=False,
+    )
+    op.add_column("audit_log", sa.Column("payload_json", sa.JSON(), nullable=True))
+    op.add_column("audit_log", sa.Column("ip_address", sa.String(length=45), nullable=True))
+    op.add_column("audit_log", sa.Column("user_agent", sa.String(length=512), nullable=True))
+    op.add_column("audit_log", sa.Column("request_id", sa.String(length=64), nullable=True))
+    op.create_index(op.f("ix_audit_log_request_id"), "audit_log", ["request_id"], unique=False)
+    op.create_index(op.f("ix_audit_log_action"), "audit_log", ["action"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_audit_log_action"), table_name="audit_log")
+    op.drop_index(op.f("ix_audit_log_request_id"), table_name="audit_log")
+    op.drop_column("audit_log", "request_id")
+    op.drop_column("audit_log", "user_agent")
+    op.drop_column("audit_log", "ip_address")
+    op.drop_column("audit_log", "payload_json")
+    op.alter_column(
+        "audit_log",
+        "action",
+        existing_type=sa.String(length=40),
+        type_=sa.String(length=20),
+        existing_nullable=False,
+    )

--- a/backend/app/api/audit.py
+++ b/backend/app/api/audit.py
@@ -1,6 +1,8 @@
+from datetime import date
 from enum import Enum
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import PlainTextResponse
 from sqlalchemy import or_, nullslast
 from sqlalchemy.orm import Session, joinedload
 
@@ -11,6 +13,8 @@ from app.core.ordenacao_lista import OrdemLista, expr_ordem
 from app.schemas.audit_log import AuditLogRead
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import exigir_admin
+from app.services.audit_export import exportar_audit_csv
+from app.services.ticket_dashboard_filters import period_bounds, resolve_period
 
 router = APIRouter(prefix="/audit", tags=["audit"])
 
@@ -26,11 +30,32 @@ class OrdenarAuditPor(str, Enum):
     atendente = "atendente"
 
 
+def _audit_para_read(r: AuditLog) -> AuditLogRead:
+    return AuditLogRead(
+        id=r.id,
+        entity_type=r.entity_type,
+        entity_id=r.entity_id,
+        action=r.action,
+        atendente_id=r.atendente_id,
+        atendente_nome=r.atendente.nome if r.atendente else None,
+        payload_json=r.payload_json,
+        ip_address=r.ip_address,
+        user_agent=r.user_agent,
+        request_id=r.request_id,
+        created_at=r.created_at,
+    )
+
+
 @router.get("", response_model=ListaPaginada[AuditLogRead])
 def listar_audit(
-    entity_type: str | None = Query(None, description="Filtrar por tipo: rede, empresa, setor, atendente, funcionario_rede, status_ticket"),
+    entity_type: str | None = Query(None, description="Filtrar por tipo de entidade"),
     entity_id: int | None = Query(None, description="Filtrar por ID do registro"),
-    busca: str | None = Query(None, description="Tipo de entidade ou nome do atendente"),
+    action: str | None = Query(None, description="Filtrar por ação (assign, transfer, close, …)"),
+    atendente_id: int | None = Query(None, ge=1, description="Filtrar por atendente autor"),
+    de: date | None = Query(None, description="Data inicial (inclusiva)"),
+    ate: date | None = Query(None, description="Data final (inclusiva)"),
+    busca: str | None = Query(None, description="Tipo, ação, request_id ou nome do atendente"),
+    format: str | None = Query(None, alias="format"),
     offset: int = Query(0, ge=0),
     limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
     ordenar_por: OrdenarAuditPor | None = Query(None),
@@ -38,15 +63,55 @@ def listar_audit(
     db: Session = Depends(get_db),
     _: Atendente = Depends(exigir_admin),
 ):
+    de_dt = ate_dt = None
+    if de is not None or ate is not None:
+        inicio, fim = resolve_period(de, ate)
+        de_dt, ate_dt = period_bounds(inicio, fim)
+
+    if format == "csv":
+        conteudo = exportar_audit_csv(
+            db,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            action=action,
+            atendente_id=atendente_id,
+            busca=busca,
+            de_dt=de_dt,
+            ate_dt=ate_dt,
+        )
+        nome = f"auditoria-{date.today().isoformat()}.csv"
+        return PlainTextResponse(
+            content=conteudo,
+            media_type="text/csv; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{nome}"'},
+        )
+    if format is not None:
+        raise HTTPException(status_code=422, detail="format suportado: csv")
+
     q = db.query(AuditLog).options(joinedload(AuditLog.atendente))
     if entity_type:
         q = q.filter(AuditLog.entity_type == entity_type)
     if entity_id is not None:
         q = q.filter(AuditLog.entity_id == entity_id)
+    if action:
+        q = q.filter(AuditLog.action == action)
+    if atendente_id is not None:
+        q = q.filter(AuditLog.atendente_id == atendente_id)
+    if de_dt is not None:
+        q = q.filter(AuditLog.created_at >= de_dt)
+    if ate_dt is not None:
+        q = q.filter(AuditLog.created_at < ate_dt)
     if busca and busca.strip():
         term = f"%{busca.strip()}%"
         atendente_ids = db.query(Atendente.id).filter(Atendente.nome.ilike(term))
-        q = q.filter(or_(AuditLog.entity_type.ilike(term), AuditLog.atendente_id.in_(atendente_ids)))
+        q = q.filter(
+            or_(
+                AuditLog.entity_type.ilike(term),
+                AuditLog.action.ilike(term),
+                AuditLog.request_id.ilike(term),
+                AuditLog.atendente_id.in_(atendente_ids),
+            )
+        )
     total = q.count()
     if ordenar_por is None:
         order_cols = [AuditLog.created_at.desc(), AuditLog.id.desc()]
@@ -64,16 +129,4 @@ def listar_audit(
             primary = expr_ordem(AuditLog.action, ordem)
         order_cols = [primary, expr_ordem(AuditLog.id, ordem)]
     rows = q.order_by(*order_cols).offset(offset).limit(limit).all()
-    items = [
-        AuditLogRead(
-            id=r.id,
-            entity_type=r.entity_type,
-            entity_id=r.entity_id,
-            action=r.action,
-            atendente_id=r.atendente_id,
-            atendente_nome=r.atendente.nome if r.atendente else None,
-            created_at=r.created_at,
-        )
-        for r in rows
-    ]
-    return ListaPaginada(items=items, total=total)
+    return ListaPaginada(items=[_audit_para_read(r) for r in rows], total=total)

--- a/backend/app/api/empresa_pdvs.py
+++ b/backend/app/api/empresa_pdvs.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session, joinedload
 
+from app.services.audit_operacional import audit_view_credential
 from app.core.audit import registrar_audit
 from app.core.auth import exigir_admin, obter_atendente_atual
 from app.database import get_db
@@ -179,6 +180,6 @@ def revelar_credencial(
         senha = decrypt_str(row.acesso_remoto_senha_cifrada)
     except Exception as e:
         raise HTTPException(status_code=500, detail="Não foi possível decifrar a credencial.") from e
-    registrar_audit(db, "empresa_pdv", row.id, "reveal_credential", atendente.id)
+    audit_view_credential(db, pdv_id=row.id, empresa_id=empresa_id, atendente_id=atendente.id)
     db.commit()
     return EmpresaPdvCredencialRead(acesso_remoto_senha=senha)

--- a/backend/app/api/relatorios.py
+++ b/backend/app/api/relatorios.py
@@ -18,6 +18,7 @@ from app.services.relatorio_tickets import (
     exportar_relatorio_tickets_csv,
     listar_relatorio_tickets,
 )
+from app.services.audit_operacional import audit_export_relatorio
 from app.services.ticket_dashboard_filters import normalizar_prioridade
 
 router = APIRouter(prefix="/relatorios", tags=["relatorios"])
@@ -61,6 +62,19 @@ def relatorio_tickets(
             setor_id=setor_id,
             prioridade=prio,
         )
+        audit_export_relatorio(
+            db,
+            tipo="tickets",
+            atendente_id=atendente.id,
+            filtros={
+                "de": de.isoformat() if de else None,
+                "ate": ate.isoformat() if ate else None,
+                "rede_id": rede_id,
+                "setor_id": setor_id,
+                "prioridade": prio,
+            },
+        )
+        db.commit()
         nome = f"relatorio-tickets-{date.today().isoformat()}.csv"
         return PlainTextResponse(
             content=conteudo,
@@ -108,6 +122,18 @@ def relatorio_chats(
             setor_id=setor_id,
             atendente_filtro_id=atendente_filtro_id,
         )
+        audit_export_relatorio(
+            db,
+            tipo="chats",
+            atendente_id=atendente.id,
+            filtros={
+                "de": de.isoformat() if de else None,
+                "ate": ate.isoformat() if ate else None,
+                "setor_id": setor_id,
+                "atendente_filtro_id": atendente_filtro_id,
+            },
+        )
+        db.commit()
         nome = f"relatorio-chats-{date.today().isoformat()}.csv"
         return PlainTextResponse(
             content=conteudo,

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -1341,6 +1341,16 @@ def criar_mensagem(
         agendar_envio_email(m, db)
     db.add(m)
     db.flush()
+    if data.notificar_cliente_por_email:
+        from app.services.audit_operacional import audit_ticket_send_email
+
+        audit_ticket_send_email(
+            db,
+            ticket_id=ticket_id,
+            mensagem_id=m.id,
+            atendente_id=atendente.id,
+            origem="agendar",
+        )
     from app.services.sla_calculo import mensagem_conta_primeira_resposta, registrar_primeira_resposta_se_necessario
 
     if mensagem_conta_primeira_resposta(m):
@@ -1469,6 +1479,15 @@ def enviar_mensagem_email_agora(
         forcar_envio_agora(m)
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    from app.services.audit_operacional import audit_ticket_send_email
+
+    audit_ticket_send_email(
+        db,
+        ticket_id=ticket_id,
+        mensagem_id=mensagem_id,
+        atendente_id=atendente.id,
+        origem="send_now",
+    )
     db.commit()
     process_pending_ticket_mensagem_emails(db, limit=5)
     db.commit()
@@ -1662,6 +1681,15 @@ def reabrir(
 
     ticket.fechado_em = None
     ticket.status_id = novo_status.id
+    from app.services.audit_operacional import audit_ticket_reopen
+
+    audit_ticket_reopen(
+        db,
+        ticket_id=ticket.id,
+        atendente_id=atendente.id,
+        status_id=novo_status.id,
+        protocolo=ticket.protocolo,
+    )
     db.commit()
     db.refresh(ticket)
     return _ticket_para_read(ticket, db)
@@ -1841,6 +1869,53 @@ def atualizar(
         antigo_o = ticket.motivo_outro_texto or ""
         novo_o = update["motivo_outro_texto"] or ""
         _registrar_historico(db, ticket.id, atendente.id, "motivo_outro_texto", antigo_o, novo_o)
+
+    from app.services.audit_operacional import (
+        audit_ticket_assign,
+        audit_ticket_close,
+        audit_ticket_status_change,
+        audit_ticket_transfer,
+    )
+
+    proto = ticket.protocolo
+    if "atendente_id" in update and update["atendente_id"] != ticket.atendente_id:
+        audit_ticket_assign(
+            db,
+            ticket_id=ticket.id,
+            atendente_id=atendente.id,
+            de_atendente_id=ticket.atendente_id,
+            para_atendente_id=update["atendente_id"],
+            protocolo=proto,
+        )
+    if "setor_id" in update and update["setor_id"] != ticket.setor_id:
+        audit_ticket_transfer(
+            db,
+            ticket_id=ticket.id,
+            atendente_id=atendente.id,
+            de_setor_id=ticket.setor_id,
+            para_setor_id=int(update["setor_id"]),
+            protocolo=proto,
+        )
+    if "status_id" in update and update["status_id"] != ticket.status_id:
+        st_novo_audit = db.query(StatusTicket).filter(StatusTicket.id == update["status_id"]).first()
+        slug_audit = (st_novo_audit.slug or "").lower() if st_novo_audit else ""
+        if slug_audit == "fechado":
+            audit_ticket_close(
+                db,
+                ticket_id=ticket.id,
+                atendente_id=atendente.id,
+                status_id=int(update["status_id"]),
+                protocolo=proto,
+            )
+        else:
+            audit_ticket_status_change(
+                db,
+                ticket_id=ticket.id,
+                atendente_id=atendente.id,
+                de_status_id=ticket.status_id,
+                para_status_id=int(update["status_id"]),
+                protocolo=proto,
+            )
 
     reset_fila = False
     if "setor_id" in update and update["setor_id"] != ticket.setor_id:

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -904,6 +904,15 @@ def assumir(
     c.estado = "em_atendimento"
     c.atendente_id = atendente.id
     c.atendimento_inicio_at = datetime.now(timezone.utc)
+    from app.services.audit_operacional import audit_whatsapp_chat
+
+    audit_whatsapp_chat(
+        db,
+        chat_id=c.id,
+        action="assign",
+        atendente_id=atendente.id,
+        payload={"de_estado": estado_anterior, "protocolo": c.protocolo},
+    )
     db.commit()
     db.refresh(c)
     emit_chat_fila_from_model(db, c, estado_anterior=estado_anterior)
@@ -954,6 +963,15 @@ def encerrar(
     from app.services.whatsapp_avaliacao import finalizar_atendimento_whatsapp
 
     try:
+        from app.services.audit_operacional import audit_whatsapp_chat
+
+        audit_whatsapp_chat(
+            db,
+            chat_id=c.id,
+            action="close",
+            atendente_id=atendente.id,
+            payload={"protocolo": c.protocolo},
+        )
         finalizar_atendimento_whatsapp(db, c, st_auto, evento_encerrado="auto_encerrado")
         db.commit()
     except Exception as exc:
@@ -1408,6 +1426,8 @@ def transferir(
                 raise HTTPException(status_code=400, detail="Atendente selecionado não pertence ao setor escolhido")
 
     estado_anterior = c.estado
+    de_setor_id = c.setor_id
+    de_atendente_id = c.atendente_id
     c.setor_id = data.setor_id
     c.atendente_id = destino.id if destino else None
     if destino:
@@ -1436,6 +1456,21 @@ def transferir(
             atendente_id=atendente.id,
             evento_sistema="transferencia",
         )
+    )
+    from app.services.audit_operacional import audit_whatsapp_chat
+
+    audit_whatsapp_chat(
+        db,
+        chat_id=c.id,
+        action="transfer",
+        atendente_id=atendente.id,
+        payload={
+            "protocolo": c.protocolo,
+            "de_setor_id": de_setor_id,
+            "para_setor_id": data.setor_id,
+            "de_atendente_id": de_atendente_id,
+            "para_atendente_id": destino.id if destino else None,
+        },
     )
     db.commit()
     db.refresh(c)

--- a/backend/app/core/audit.py
+++ b/backend/app/core/audit.py
@@ -1,8 +1,59 @@
-"""Registro de auditoria: quem fez e quando."""
+"""Registro de auditoria: quem fez, quando e contexto da requisição."""
+
+from __future__ import annotations
+
+import contextvars
+import re
+from typing import Any
 
 from sqlalchemy.orm import Session
 
 from app.models import AuditLog
+
+_REDACT_KEY = re.compile(
+    r"(password|senha|token|secret|api[_-]?key|credential|cifrada)",
+    re.IGNORECASE,
+)
+
+_audit_request_ctx: contextvars.ContextVar[dict[str, str | None] | None] = contextvars.ContextVar(
+    "audit_request_ctx",
+    default=None,
+)
+
+
+def set_audit_request_context(
+    *,
+    ip_address: str | None = None,
+    user_agent: str | None = None,
+    request_id: str | None = None,
+) -> None:
+    _audit_request_ctx.set(
+        {
+            "ip_address": ip_address,
+            "user_agent": (user_agent[:512] if user_agent else None),
+            "request_id": (request_id[:64] if request_id else None),
+        }
+    )
+
+
+def clear_audit_request_context() -> None:
+    _audit_request_ctx.set(None)
+
+
+def _sanitize_value(key: str, value: Any) -> Any:
+    if _REDACT_KEY.search(key):
+        return "[redacted]"
+    if isinstance(value, dict):
+        return {k: _sanitize_value(str(k), v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_value(key, item) for item in value]
+    return value
+
+
+def sanitize_payload(payload: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not payload:
+        return None
+    return {str(k): _sanitize_value(str(k), v) for k, v in payload.items()}
 
 
 def registrar_audit(
@@ -11,12 +62,48 @@ def registrar_audit(
     entity_id: int,
     action: str,
     atendente_id: int | None,
+    *,
+    payload: dict[str, Any] | None = None,
 ) -> None:
+    """Registra auditoria com payload opcional e metadados da requisição HTTP (quando disponíveis)."""
+    ctx = _audit_request_ctx.get() or {}
     db.add(
         AuditLog(
             entity_type=entity_type,
             entity_id=entity_id,
             action=action,
             atendente_id=atendente_id,
+            payload_json=sanitize_payload(payload),
+            ip_address=ctx.get("ip_address"),
+            user_agent=ctx.get("user_agent"),
+            request_id=ctx.get("request_id"),
+        )
+    )
+
+
+def registrar_audit_v2(
+    db: Session,
+    entity_type: str,
+    entity_id: int,
+    action: str,
+    atendente_id: int | None,
+    *,
+    payload: dict[str, Any] | None = None,
+    ip_address: str | None = None,
+    user_agent: str | None = None,
+    request_id: str | None = None,
+) -> None:
+    """Alias explícito com override de contexto HTTP (testes ou jobs)."""
+    ctx = _audit_request_ctx.get() or {}
+    db.add(
+        AuditLog(
+            entity_type=entity_type,
+            entity_id=entity_id,
+            action=action,
+            atendente_id=atendente_id,
+            payload_json=sanitize_payload(payload),
+            ip_address=ip_address if ip_address is not None else ctx.get("ip_address"),
+            user_agent=(user_agent[:512] if user_agent else ctx.get("user_agent")),
+            request_id=(request_id[:64] if request_id else ctx.get("request_id")),
         )
     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,6 +2,7 @@ import logging
 import sys
 import threading
 import time
+import uuid
 from contextlib import asynccontextmanager
 
 from fastapi import Depends, FastAPI, HTTPException, Request
@@ -45,6 +46,7 @@ from app.api import (
     sla,
 )
 from app.config import settings
+from app.core.audit import clear_audit_request_context, set_audit_request_context
 from app.core.tenant_context import resolve_tenant_id, set_request_tenant_id
 from app.core.lifecycle import dev_create_all_tables, production_require_alembic
 from app.database import Base, engine
@@ -373,6 +375,29 @@ async def tenant_context_middleware(request: Request, call_next):
         return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
     set_request_tenant_id(request, tid)
     return await call_next(request)
+
+
+@app.middleware("http")
+async def audit_request_context_middleware(request: Request, call_next):
+    """Propaga IP, user-agent e request_id para registros de auditoria."""
+    rid = request.headers.get("x-request-id") or request.headers.get("x-correlation-id")
+    if not rid:
+        rid = str(uuid.uuid4())
+    forwarded = request.headers.get("x-forwarded-for", "")
+    ip = forwarded.split(",")[0].strip() if forwarded else None
+    if not ip and request.client:
+        ip = request.client.host
+    set_audit_request_context(
+        ip_address=ip,
+        user_agent=request.headers.get("user-agent"),
+        request_id=rid,
+    )
+    try:
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = rid
+        return response
+    finally:
+        clear_audit_request_context()
 
 
 @app.middleware("http")

--- a/backend/app/models/audit_log.py
+++ b/backend/app/models/audit_log.py
@@ -1,6 +1,6 @@
 """Registro de quem fez e quando em cadastros e alterações."""
 
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey, JSON
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -11,10 +11,14 @@ class AuditLog(Base):
     __tablename__ = "audit_log"
 
     id = Column(Integer, primary_key=True, index=True)
-    entity_type = Column(String(50), nullable=False, index=True)  # rede, empresa, setor, atendente, funcionario_rede, status_ticket
+    entity_type = Column(String(50), nullable=False, index=True)
     entity_id = Column(Integer, nullable=False, index=True)
-    action = Column(String(20), nullable=False)  # create, update
+    action = Column(String(40), nullable=False, index=True)
     atendente_id = Column(Integer, ForeignKey("atendentes.id"), nullable=True)
+    payload_json = Column(JSON, nullable=True)
+    ip_address = Column(String(45), nullable=True)
+    user_agent = Column(String(512), nullable=True)
+    request_id = Column(String(64), nullable=True, index=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     atendente = relationship("Atendente", backref="audit_logs")

--- a/backend/app/schemas/audit_log.py
+++ b/backend/app/schemas/audit_log.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, ConfigDict
 from datetime import datetime
+from typing import Any
 
 
 class AuditLogRead(BaseModel):
@@ -9,6 +10,10 @@ class AuditLogRead(BaseModel):
     action: str
     atendente_id: int | None
     atendente_nome: str | None = None
+    payload_json: dict[str, Any] | None = None
+    ip_address: str | None = None
+    user_agent: str | None = None
+    request_id: str | None = None
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/audit_export.py
+++ b/backend/app/services/audit_export.py
@@ -1,0 +1,115 @@
+"""Exportação CSV da trilha de auditoria."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from datetime import date, datetime
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, joinedload
+
+from app.models import AuditLog
+from app.models.atendente import Atendente
+
+MAX_EXPORT_ROWS = 50_000
+
+_CSV_HEADERS = [
+    "id",
+    "created_at",
+    "entity_type",
+    "entity_id",
+    "action",
+    "atendente_id",
+    "atendente_nome",
+    "ip_address",
+    "request_id",
+    "payload_json",
+]
+
+
+def _apply_audit_filters(
+    q,
+    db: Session,
+    *,
+    entity_type: str | None,
+    entity_id: int | None,
+    action: str | None,
+    atendente_id: int | None,
+    busca: str | None,
+    de_dt: datetime | None,
+    ate_dt: datetime | None,
+):
+    if entity_type:
+        q = q.filter(AuditLog.entity_type == entity_type)
+    if entity_id is not None:
+        q = q.filter(AuditLog.entity_id == entity_id)
+    if action:
+        q = q.filter(AuditLog.action == action)
+    if atendente_id is not None:
+        q = q.filter(AuditLog.atendente_id == atendente_id)
+    if de_dt is not None:
+        q = q.filter(AuditLog.created_at >= de_dt)
+    if ate_dt is not None:
+        q = q.filter(AuditLog.created_at < ate_dt)
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        atendente_ids = db.query(Atendente.id).filter(Atendente.nome.ilike(term))
+        q = q.filter(
+            or_(
+                AuditLog.entity_type.ilike(term),
+                AuditLog.action.ilike(term),
+                AuditLog.request_id.ilike(term),
+                AuditLog.atendente_id.in_(atendente_ids),
+            )
+        )
+    return q
+
+
+def exportar_audit_csv(
+    db: Session,
+    *,
+    entity_type: str | None = None,
+    entity_id: int | None = None,
+    action: str | None = None,
+    atendente_id: int | None = None,
+    busca: str | None = None,
+    de_dt: datetime | None = None,
+    ate_dt: datetime | None = None,
+) -> str:
+    q = db.query(AuditLog).options(joinedload(AuditLog.atendente))
+    q = _apply_audit_filters(
+        q,
+        db,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        action=action,
+        atendente_id=atendente_id,
+        busca=busca,
+        de_dt=de_dt,
+        ate_dt=ate_dt,
+    )
+    rows = q.order_by(AuditLog.created_at.desc(), AuditLog.id.desc()).limit(MAX_EXPORT_ROWS).all()
+
+    buffer = io.StringIO()
+    buffer.write("\ufeff")
+    writer = csv.writer(buffer, lineterminator="\r\n")
+    writer.writerow(_CSV_HEADERS)
+    for r in rows:
+        payload = json.dumps(r.payload_json, ensure_ascii=False) if r.payload_json else ""
+        writer.writerow(
+            [
+                r.id,
+                r.created_at.isoformat() if r.created_at else "",
+                r.entity_type,
+                r.entity_id,
+                r.action,
+                r.atendente_id if r.atendente_id is not None else "",
+                r.atendente.nome if r.atendente else "",
+                r.ip_address or "",
+                r.request_id or "",
+                payload,
+            ]
+        )
+    return buffer.getvalue()

--- a/backend/app/services/audit_operacional.py
+++ b/backend/app/services/audit_operacional.py
@@ -1,0 +1,176 @@
+"""Hooks de auditoria para tickets, chats e exportações sensíveis."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+
+
+def audit_ticket_assign(
+    db: Session,
+    *,
+    ticket_id: int,
+    atendente_id: int | None,
+    de_atendente_id: int | None,
+    para_atendente_id: int | None,
+    protocolo: str | None = None,
+) -> None:
+    registrar_audit(
+        db,
+        "ticket",
+        ticket_id,
+        "assign",
+        atendente_id,
+        payload={
+            "protocolo": protocolo,
+            "de_atendente_id": de_atendente_id,
+            "para_atendente_id": para_atendente_id,
+        },
+    )
+
+
+def audit_ticket_transfer(
+    db: Session,
+    *,
+    ticket_id: int,
+    atendente_id: int | None,
+    de_setor_id: int,
+    para_setor_id: int,
+    protocolo: str | None = None,
+) -> None:
+    registrar_audit(
+        db,
+        "ticket",
+        ticket_id,
+        "transfer",
+        atendente_id,
+        payload={
+            "protocolo": protocolo,
+            "de_setor_id": de_setor_id,
+            "para_setor_id": para_setor_id,
+        },
+    )
+
+
+def audit_ticket_status_change(
+    db: Session,
+    *,
+    ticket_id: int,
+    atendente_id: int | None,
+    de_status_id: int,
+    para_status_id: int,
+    protocolo: str | None = None,
+) -> None:
+    registrar_audit(
+        db,
+        "ticket",
+        ticket_id,
+        "status_change",
+        atendente_id,
+        payload={
+            "protocolo": protocolo,
+            "de_status_id": de_status_id,
+            "para_status_id": para_status_id,
+        },
+    )
+
+
+def audit_ticket_close(
+    db: Session,
+    *,
+    ticket_id: int,
+    atendente_id: int | None,
+    status_id: int,
+    protocolo: str | None = None,
+) -> None:
+    registrar_audit(
+        db,
+        "ticket",
+        ticket_id,
+        "close",
+        atendente_id,
+        payload={"protocolo": protocolo, "status_id": status_id},
+    )
+
+
+def audit_ticket_reopen(
+    db: Session,
+    *,
+    ticket_id: int,
+    atendente_id: int | None,
+    status_id: int,
+    protocolo: str | None = None,
+) -> None:
+    registrar_audit(
+        db,
+        "ticket",
+        ticket_id,
+        "reopen",
+        atendente_id,
+        payload={"protocolo": protocolo, "status_id": status_id},
+    )
+
+
+def audit_ticket_send_email(
+    db: Session,
+    *,
+    ticket_id: int,
+    mensagem_id: int,
+    atendente_id: int | None,
+    origem: str,
+) -> None:
+    registrar_audit(
+        db,
+        "ticket_mensagem",
+        mensagem_id,
+        "send_email",
+        atendente_id,
+        payload={"ticket_id": ticket_id, "origem": origem},
+    )
+
+
+def audit_view_credential(
+    db: Session,
+    *,
+    pdv_id: int,
+    empresa_id: int,
+    atendente_id: int | None,
+    campo: str = "acesso_remoto_senha",
+) -> None:
+    registrar_audit(
+        db,
+        "empresa_pdv",
+        pdv_id,
+        "view_credential",
+        atendente_id,
+        payload={"empresa_id": empresa_id, "campo": campo},
+    )
+
+
+def audit_whatsapp_chat(
+    db: Session,
+    *,
+    chat_id: int,
+    action: str,
+    atendente_id: int | None,
+    payload: dict | None = None,
+) -> None:
+    registrar_audit(db, "whatsapp_chat", chat_id, action, atendente_id, payload=payload)
+
+
+def audit_export_relatorio(
+    db: Session,
+    *,
+    tipo: str,
+    atendente_id: int | None,
+    filtros: dict | None = None,
+) -> None:
+    registrar_audit(
+        db,
+        "export_relatorio",
+        0,
+        "export",
+        atendente_id,
+        payload={"tipo": tipo, "filtros": filtros or {}},
+    )

--- a/backend/tests/test_audit_expandido.py
+++ b/backend/tests/test_audit_expandido.py
@@ -1,0 +1,94 @@
+"""Auditoria expandida (#290–#292)."""
+
+from __future__ import annotations
+
+from app.core.audit import registrar_audit, registrar_audit_v2, sanitize_payload
+from app.models import AuditLog
+
+
+def _criar_ticket(client, auth_headers, seed_base, **extra):
+    body = {
+        "empresa_id": seed_base["empresa"].id,
+        "setor_id": seed_base["setor1"].id,
+        "assunto": "Teste auditoria",
+        "descricao": "Corpo",
+        **extra,
+    }
+    r = client.post("/v1/tickets", headers=auth_headers["admin"], json=body)
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def test_sanitize_payload_redact_secrets():
+    out = sanitize_payload({"campo": "ok", "senha": "123", "nested": {"api_key": "x"}})
+    assert out["campo"] == "ok"
+    assert out["senha"] == "[redacted]"
+    assert out["nested"]["api_key"] == "[redacted]"
+
+
+def test_ticket_assign_gera_audit(client, auth_headers, seed_base, db_session):
+    t = _criar_ticket(client, auth_headers, seed_base)
+    r = client.patch(
+        f"/v1/tickets/{t['id']}",
+        headers=auth_headers["admin"],
+        json={"atendente_id": seed_base["a1"].id},
+    )
+    assert r.status_code == 200, r.text
+    row = (
+        db_session.query(AuditLog)
+        .filter(AuditLog.entity_type == "ticket", AuditLog.entity_id == t["id"], AuditLog.action == "assign")
+        .first()
+    )
+    assert row is not None
+    assert row.payload_json is not None
+    assert row.payload_json.get("para_atendente_id") == seed_base["a1"].id
+
+
+def test_audit_filtro_action_e_csv(client, auth_headers, seed_base, db_session):
+    t = _criar_ticket(client, auth_headers, seed_base)
+    registrar_audit(
+        db_session,
+        "ticket",
+        t["id"],
+        "status_change",
+        seed_base["admin"].id,
+        payload={"de_status_id": 1, "para_status_id": 2},
+    )
+    db_session.commit()
+
+    r = client.get("/v1/audit", headers=auth_headers["admin"], params={"action": "status_change"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] >= 1
+    assert all(item["action"] == "status_change" for item in data["items"])
+
+    r_csv = client.get(
+        "/v1/audit",
+        headers={**auth_headers["admin"], "Accept": "text/csv"},
+        params={"format": "csv", "action": "status_change"},
+    )
+    assert r_csv.status_code == 200
+    assert "text/csv" in r_csv.headers.get("content-type", "")
+    assert "status_change" in r_csv.text
+
+
+def test_audit_campos_expandidos_na_api(client, auth_headers, db_session):
+    registrar_audit_v2(
+        db_session,
+        "settings",
+        1,
+        "update",
+        None,
+        payload={"chave": "valor"},
+        ip_address="127.0.0.1",
+        user_agent="pytest",
+        request_id="req-test-1",
+    )
+    db_session.commit()
+
+    r = client.get("/v1/audit", headers=auth_headers["admin"], params={"busca": "req-test-1"})
+    assert r.status_code == 200
+    item = r.json()["items"][0]
+    assert item["ip_address"] == "127.0.0.1"
+    assert item["request_id"] == "req-test-1"
+    assert item["payload_json"] == {"chave": "valor"}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -489,12 +489,43 @@ export const audit = {
   list: (params?: {
     entity_type?: string;
     entity_id?: number;
+    action?: string;
+    atendente_id?: number;
+    de?: string;
+    ate?: string;
     busca?: string;
     ordenar_por?: 'created_at' | 'entity_type' | 'entity_id' | 'action' | 'atendente';
     ordem?: 'asc' | 'desc';
     offset?: number;
     limit?: number;
   }) => listPaginated<Audit.AuditLogEntry>('/audit', params),
+  exportCsv: async (params?: {
+    entity_type?: string;
+    entity_id?: number;
+    action?: string;
+    atendente_id?: number;
+    de?: string;
+    ate?: string;
+    busca?: string;
+  }) => {
+    const token = getAuthToken();
+    const headers: Record<string, string> = {};
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname());
+    }
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const url = `${BASE}${API_VERSION_PREFIX}${withParams('/audit', { ...params, format: 'csv' })}`;
+    const res = await fetch(url, { headers });
+    if (res.status === 401) {
+      invalidateSessionAndRedirectToLogin();
+      throw new ApiError('Sessão expirada ou inválida.', 401, {});
+    }
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}));
+      throw new ApiError(mensagemErroApi(errBody, res.status), res.status, errBody);
+    }
+    return res.blob();
+  },
 };
 
 export namespace WhatsappSettings {
@@ -2229,6 +2260,10 @@ export namespace Audit {
     action: string;
     atendente_id: number | null;
     atendente_nome: string | null;
+    payload_json: Record<string, unknown> | null;
+    ip_address: string | null;
+    user_agent: string | null;
+    request_id: string | null;
     created_at: string;
   }
 }

--- a/frontend/src/pages/Auditoria.tsx
+++ b/frontend/src/pages/Auditoria.tsx
@@ -5,6 +5,8 @@ import { ApiError, audit, type Audit } from '../api/client'
 import { Card } from '../components/ui/Card'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
 import { Select } from '../components/ui/Select'
+import { Input } from '../components/ui/Input'
+import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
 import { ConfigListPageShell } from '../components/config/ConfigListPageShell'
 import { SemPermissao } from './SemPermissao'
@@ -17,14 +19,52 @@ const entityTypeLabel: Record<string, string> = {
   atendente: 'Atendente',
   funcionario_rede: 'Funcionário da rede',
   status_ticket: 'Status de ticket',
+  ticket: 'Ticket',
+  ticket_mensagem: 'Mensagem de ticket',
+  whatsapp_chat: 'Chat WhatsApp',
+  empresa_pdv: 'PDV',
+  export_relatorio: 'Exportação de relatório',
+  routing_rule: 'Regra de roteamento',
+  sla_policy: 'Política SLA',
+  business_calendar: 'Calendário comercial',
+  resposta_pronta: 'Resposta pronta',
+  ticket_natureza: 'Natureza de ticket',
+  ticket_motivo: 'Motivo de ticket',
+  pdv_rotulo: 'Rótulo PDV',
+  pdv_tipo_acesso_remoto: 'Tipo acesso remoto PDV',
+  tipo_negocio: 'Tipo de negócio',
 }
 
 const actionLabel: Record<string, string> = {
   create: 'Cadastro',
   update: 'Alteração',
+  delete: 'Exclusão',
+  assign: 'Atribuição',
+  transfer: 'Transferência',
+  close: 'Fechamento',
+  reopen: 'Reabertura',
+  status_change: 'Mudança de status',
+  send_email: 'Envio de e-mail',
+  view_credential: 'Visualização de credencial',
+  reveal_credential: 'Visualização de credencial',
+  export: 'Exportação',
+  apply: 'Aplicação (roteamento)',
+  reorder: 'Reordenação',
+  distribuicao_update: 'Distribuição na fila',
 }
 
+const ACTION_OPTIONS = Object.entries(actionLabel).map(([value, label]) => ({ value, label }))
+
 type ColunaAudit = 'created_at' | 'entity_type' | 'entity_id' | 'action' | 'atendente'
+
+function formatPayload(payload: Record<string, unknown> | null): string {
+  if (!payload || Object.keys(payload).length === 0) return '—'
+  try {
+    return JSON.stringify(payload, null, 0)
+  } catch {
+    return '—'
+  }
+}
 
 export function Auditoria({ embedded = false }: { embedded?: boolean }) {
   const toast = useToast()
@@ -35,21 +75,33 @@ export function Auditoria({ embedded = false }: { embedded?: boolean }) {
   const [busca, setBusca] = useState('')
   const [debouncedBusca, setDebouncedBusca] = useState('')
   const [loading, setLoading] = useState(true)
+  const [exportando, setExportando] = useState(false)
   const [filtroTipo, setFiltroTipo] = useState<string>('')
+  const [filtroAcao, setFiltroAcao] = useState<string>('')
+  const [de, setDe] = useState('')
+  const [ate, setAte] = useState('')
   const [forbidden, setForbidden] = useState(false)
+  const [detalhe, setDetalhe] = useState<Audit.AuditLogEntry | null>(null)
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
     return () => clearTimeout(t)
   }, [busca])
 
+  const filtrosApi = {
+    entity_type: filtroTipo || undefined,
+    action: filtroAcao || undefined,
+    busca: debouncedBusca || undefined,
+    de: de || undefined,
+    ate: ate || undefined,
+  }
+
   const load = useCallback(() => {
     setLoading(true)
     setForbidden(false)
     audit
       .list({
-        entity_type: filtroTipo || undefined,
-        busca: debouncedBusca || undefined,
+        ...filtrosApi,
         ...sortParams,
         offset: (page - 1) * PAGE_SIZE_PADRAO,
         limit: PAGE_SIZE_PADRAO,
@@ -68,11 +120,29 @@ export function Auditoria({ embedded = false }: { embedded?: boolean }) {
         toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos registros de auditoria.'))
       })
       .finally(() => setLoading(false))
-  }, [debouncedBusca, filtroTipo, page, sortParams, toast])
+  }, [debouncedBusca, filtroTipo, filtroAcao, de, ate, page, sortParams, toast])
 
   useEffect(() => {
     load()
   }, [load])
+
+  const exportarCsv = async () => {
+    setExportando(true)
+    try {
+      const blob = await audit.exportCsv(filtrosApi)
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `auditoria-${ate || de || 'periodo'}.csv`
+      a.click()
+      URL.revokeObjectURL(url)
+      toast.showSuccess('CSV exportado com sucesso.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao exportar CSV.'))
+    } finally {
+      setExportando(false)
+    }
+  }
 
   const denied = (
     <SemPermissao
@@ -89,7 +159,12 @@ export function Auditoria({ embedded = false }: { embedded?: boolean }) {
       forbidden={forbidden}
       denied={denied}
       title="Auditoria"
-      subtitle="Registro de cadastros e alterações: quem fez e quando."
+      subtitle="Trilha de ações sensíveis, cadastros e exportações — quem fez, quando e contexto."
+      actions={
+        <Button type="button" variant="secondary" loading={exportando} onClick={exportarCsv}>
+          Exportar CSV
+        </Button>
+      }
     >
       <Card>
         <BarraBuscaPaginacao
@@ -98,24 +173,60 @@ export function Auditoria({ embedded = false }: { embedded?: boolean }) {
             setBusca(v)
             setPage(1)
           }}
-          placeholder="Buscar por tipo ou nome do atendente"
+          placeholder="Buscar por tipo, ação, request_id ou atendente"
           page={page}
           total={total}
           onPageChange={setPage}
           disabled={loading}
           extra={
-            <div className="w-full min-w-0 sm:w-auto sm:min-w-[220px]">
-              <Select
-                label="Tipo"
-                value={filtroTipo}
-                onChange={(v) => {
-                  setFiltroTipo(typeof v === 'string' ? v : String(v))
+            <div className="flex w-full min-w-0 flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+              <div className="w-full min-w-0 sm:w-auto sm:min-w-[200px]">
+                <Select
+                  label="Tipo"
+                  value={filtroTipo}
+                  onChange={(v) => {
+                    setFiltroTipo(typeof v === 'string' ? v : String(v))
+                    setPage(1)
+                  }}
+                  options={Object.entries(entityTypeLabel).map(([k, v]) => ({ value: k, label: v }))}
+                  includeEmpty
+                  emptyLabel="Todos"
+                  placeholder="Todos"
+                />
+              </div>
+              <div className="w-full min-w-0 sm:w-auto sm:min-w-[200px]">
+                <Select
+                  label="Ação"
+                  value={filtroAcao}
+                  onChange={(v) => {
+                    setFiltroAcao(typeof v === 'string' ? v : String(v))
+                    setPage(1)
+                  }}
+                  options={ACTION_OPTIONS}
+                  includeEmpty
+                  emptyLabel="Todas"
+                  placeholder="Todas"
+                />
+              </div>
+              <Input
+                label="De"
+                type="date"
+                value={de}
+                onChange={(e) => {
+                  setDe(e.target.value)
                   setPage(1)
                 }}
-                options={Object.entries(entityTypeLabel).map(([k, v]) => ({ value: k, label: v }))}
-                includeEmpty
-                emptyLabel="Todos"
-                placeholder="Todos"
+                className="w-full sm:w-auto"
+              />
+              <Input
+                label="Até"
+                type="date"
+                value={ate}
+                onChange={(e) => {
+                  setAte(e.target.value)
+                  setPage(1)
+                }}
+                className="w-full sm:w-auto"
               />
             </div>
           }
@@ -184,6 +295,7 @@ export function Auditoria({ embedded = false }: { embedded?: boolean }) {
                     }}
                     className="pb-2 pr-4 font-medium normal-case"
                   />
+                  <th className="pb-2 pr-4 font-medium">Detalhes</th>
                 </tr>
               </thead>
               <tbody>
@@ -195,7 +307,20 @@ export function Auditoria({ embedded = false }: { embedded?: boolean }) {
                     <td className="py-2 pr-4">{entityTypeLabel[r.entity_type] ?? r.entity_type}</td>
                     <td className="py-2 pr-4 font-mono text-slate-600 dark:text-slate-400">{r.entity_id}</td>
                     <td className="py-2 pr-4">{actionLabel[r.action] ?? r.action}</td>
-                    <td className="py-2">{r.atendente_nome ?? '—'}</td>
+                    <td className="py-2 pr-4">{r.atendente_nome ?? '—'}</td>
+                    <td className="py-2">
+                      {(r.payload_json && Object.keys(r.payload_json).length > 0) || r.request_id || r.ip_address ? (
+                        <button
+                          type="button"
+                          className="text-cyan-700 hover:underline dark:text-cyan-300"
+                          onClick={() => setDetalhe(r)}
+                        >
+                          Ver
+                        </button>
+                      ) : (
+                        '—'
+                      )}
+                    </td>
                   </tr>
                 ))}
               </tbody>
@@ -203,6 +328,48 @@ export function Auditoria({ embedded = false }: { embedded?: boolean }) {
           </div>
         )}
       </Card>
+
+      {detalhe ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="audit-detail-title"
+        >
+          <Card className="max-h-[85vh] w-full max-w-lg overflow-y-auto p-5">
+            <h2 id="audit-detail-title" className="text-lg font-semibold text-slate-900 dark:text-slate-50">
+              Registro #{detalhe.id}
+            </h2>
+            <dl className="mt-4 space-y-2 text-sm">
+              {detalhe.request_id ? (
+                <div>
+                  <dt className="text-slate-500 dark:text-slate-400">Request ID</dt>
+                  <dd className="font-mono text-slate-800 dark:text-slate-100">{detalhe.request_id}</dd>
+                </div>
+              ) : null}
+              {detalhe.ip_address ? (
+                <div>
+                  <dt className="text-slate-500 dark:text-slate-400">IP</dt>
+                  <dd className="text-slate-800 dark:text-slate-100">{detalhe.ip_address}</dd>
+                </div>
+              ) : null}
+              {detalhe.payload_json && Object.keys(detalhe.payload_json).length > 0 ? (
+                <div>
+                  <dt className="text-slate-500 dark:text-slate-400">Payload</dt>
+                  <dd className="mt-1 overflow-x-auto rounded-md bg-slate-50 p-2 font-mono text-xs text-slate-800 dark:bg-slate-900/60 dark:text-slate-100">
+                    {formatPayload(detalhe.payload_json)}
+                  </dd>
+                </div>
+              ) : null}
+            </dl>
+            <div className="mt-5 flex justify-end">
+              <Button type="button" variant="secondary" onClick={() => setDetalhe(null)}>
+                Fechar
+              </Button>
+            </div>
+          </Card>
+        </div>
+      ) : null}
     </ConfigListPageShell>
   )
 }

--- a/frontend/src/pages/Sobre.tsx
+++ b/frontend/src/pages/Sobre.tsx
@@ -35,9 +35,9 @@ function ChangeList({ items }: { items: System.ReleaseChange[] }) {
   return (
     <ul className="space-y-3">
       {items.map((item, idx) => (
-        <li key={`${item.category}-${idx}`} className="flex gap-3 text-sm leading-relaxed">
+        <li key={`${item.category}-${idx}`} className="flex items-start gap-3 text-sm leading-relaxed">
           <span
-            className={`mt-0.5 inline-flex shrink-0 rounded-md px-2 py-0.5 text-xs font-medium ring-1 ring-inset ${categoryClass(item.category)}`}
+            className={`inline-flex min-w-[5.5rem] shrink-0 items-center justify-center self-start rounded-md px-2.5 py-1 text-center text-xs font-medium leading-none ring-1 ring-inset ${categoryClass(item.category)}`}
           >
             {CATEGORY_LABEL[item.category] ?? item.category}
           </span>


### PR DESCRIPTION
## Summary
- Auditoria expandida (#290): payload JSON, IP, user-agent e request-id; hooks em tickets, chats WhatsApp, credencial PDV e export de relatorios
- API (#291): filtros por acao, periodo e atendente; exportacao CSV em GET /audit?format=csv
- UI (#292): painel com filtros, export CSV e modal de detalhes (payload / request-id)
- Polish (#426): badges centralizados na pagina Sobre
- Indice ISSUES_CRIADAS atualizado

Closes #290
Closes #291
Closes #292
Closes #426

## Test plan
- [ ] Atribuir, transferir, fechar e reabrir ticket e verificar registros em Configuracoes > Sistema > Auditoria
- [ ] Assumir, transferir e encerrar chat WhatsApp
- [ ] Exportar relatorio de tickets/chats CSV e verificar registro export_relatorio
- [ ] Filtrar auditoria por acao e periodo; exportar CSV
- [ ] Pagina /sobre: badges Melhorias/Correcoes centralizados
- [ ] Deploy: alembic upgrade head (migration 052)