### PR TITLE
fix(whatsapp): mídia inbound, anexos e triagem de vínculo (#431–#433)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível
+- WhatsApp (#432): envio de anexos com menu explícito (imagem, vídeo, áudio, documento), legenda opcional e aviso quando o chat ainda não foi assumido
+- WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile
 - Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)
 
 ### Melhorias

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 ### Correções
 
 - WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível
-- WhatsApp (#432): envio de anexos com menu explícito (imagem, vídeo, áudio, documento), legenda opcional e aviso quando o chat ainda não foi assumido
+- WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional
 - WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile
+- WhatsApp: mensagens de contacto e localização recebidas passam a aparecer como texto legível no chat
 - Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)
 
 ### Melhorias

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -9,6 +9,7 @@ from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem, WhatsappSet
 from app.services import evolution_api
 from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.evolution_inbound import iter_inbound_whatsapp_messages
+from app.services.whatsapp_media_storage import gravar_base64_em_disco
 from app.services.whatsapp_auto_messages import (
     DEFAULT_AUTO_MSG_ESPERA,
     DEFAULT_AUTO_MSG_FORA_HORARIO,
@@ -37,6 +38,54 @@ def _webhook_autorizado(request: Request, secret: str | None) -> bool:
 
 def _get_settings(db: Session) -> WhatsappSettings | None:
     return db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
+
+
+def _baixar_midia_inbound(
+    *,
+    item: dict,
+    st_media: WhatsappSettings | None,
+    tipo: str,
+    wa_id: str,
+    wa_mid: str | None,
+) -> str | None:
+    """Obtém base64 na Evolution e grava em disco. Devolve basename ou None."""
+    if tipo == "texto":
+        return None
+    raw_env = item.get("raw_envelope")
+    if not (
+        isinstance(raw_env, dict)
+        and st_media
+        and st_media.evolution_base_url
+        and st_media.evolution_instance_name
+        and st_media.evolution_api_key
+    ):
+        logger.warning(
+            "Webhook Evolution: integração incompleta para obter mídia (wa_id=%s wa_message_id=%s tipo=%s)",
+            wa_id,
+            wa_mid,
+            tipo,
+        )
+        return None
+    mimetype_val = item.get("mimetype")
+    ok, b64, err = evolution_api.evolution_get_base64_from_media_message(
+        st_media.evolution_base_url,
+        st_media.evolution_instance_name,
+        st_media.evolution_api_key,
+        raw_env,
+        convert_to_mp4=(tipo in ("video", "audio")),
+    )
+    if ok and b64:
+        nome = gravar_base64_em_disco(b64, mimetype_val)
+        if nome:
+            return nome
+    logger.warning(
+        "Webhook Evolution: mídia não gravada (wa_id=%s wa_message_id=%s tipo=%s): %s",
+        wa_id,
+        wa_mid,
+        tipo,
+        err or "sem ficheiro",
+    )
+    return None
 
 
 def _chat_aberto_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
@@ -304,7 +353,13 @@ def evolution_webhook(
 
         tipo_midia = tipo
         mimetype_val = item.get("mimetype")
-        midia_nome: str | None = None
+        midia_nome = _baixar_midia_inbound(
+            item=item,
+            st_media=st_media,
+            tipo=tipo,
+            wa_id=wa_id,
+            wa_mid=wa_mid,
+        )
 
         chat = _chat_aberto_por_wa_id(db, wa_id)
         if chat and chat.estado == "aguardando_avaliacao":
@@ -342,42 +397,11 @@ def evolution_webhook(
                 raise
             continue
 
-        if tipo != "texto":
-            raw_env = item.get("raw_envelope")
-            if (
-                isinstance(raw_env, dict)
-                and st_media
-                and st_media.evolution_base_url
-                and st_media.evolution_instance_name
-                and st_media.evolution_api_key
-            ):
-                ok, b64, err = evolution_api.evolution_get_base64_from_media_message(
-                    st_media.evolution_base_url,
-                    st_media.evolution_instance_name,
-                    st_media.evolution_api_key,
-                    raw_env,
-                    convert_to_mp4=(tipo == "video"),
-                )
-                if ok and b64:
-                    midia_nome = gravar_base64_em_disco(b64, mimetype_val)
-                if not midia_nome:
-                    logger.warning(
-                        "Webhook Evolution: mídia não gravada (wa_id=%s tipo=%s): %s",
-                        wa_id,
-                        tipo,
-                        err or "sem ficheiro",
-                    )
-            elif tipo != "texto":
-                logger.warning(
-                    "Webhook Evolution: integração incompleta para obter mídia (wa_id=%s tipo=%s)",
-                    wa_id,
-                    tipo,
-                )
-        else:
+        if tipo == "texto":
             tipo_midia = "texto"
             mimetype_val = None
+            midia_nome = None
 
-        chat = _chat_aberto_por_wa_id(db, wa_id)
         chat_novo = False
         if not chat:
             chat_novo = True

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -226,7 +226,7 @@ def _extrair_base64_resposta(data: Any) -> str | None:
         return data.strip()
     if not isinstance(data, dict):
         return None
-    for k in ("base64", "Base64"):
+    for k in ("base64", "Base64", "buffer", "Buffer"):
         v = data.get(k)
         if isinstance(v, str) and v.strip():
             return v.strip()
@@ -236,6 +236,43 @@ def _extrair_base64_resposta(data: Any) -> str | None:
         if got:
             return got
     return None
+
+
+def _payloads_get_base64_from_envelope(message_envelope: dict[str, Any]) -> list[dict[str, Any]]:
+    """Variantes aceites pela Evolution v2 (envelope completo ou só key.id)."""
+    payloads: list[dict[str, Any]] = [message_envelope]
+    key = message_envelope.get("key") or message_envelope.get("Key")
+    if isinstance(key, dict):
+        slim_key: dict[str, Any] = {}
+        mid = key.get("id") or key.get("Id")
+        if mid:
+            slim_key["id"] = str(mid).strip()
+        rj = key.get("remoteJid") or key.get("RemoteJid")
+        if rj:
+            slim_key["remoteJid"] = rj
+        if "fromMe" in key:
+            slim_key["fromMe"] = key["fromMe"]
+        elif "FromMe" in key:
+            slim_key["fromMe"] = key["FromMe"]
+        if slim_key.get("id"):
+            payloads.append({"key": slim_key})
+            payloads.append({"key": {"id": slim_key["id"]}})
+    # dedupe mantendo ordem
+    seen: set[str] = set()
+    out: list[dict[str, Any]] = []
+    for p in payloads:
+        sig = json.dumps(p, sort_keys=True, default=str)
+        if sig not in seen:
+            seen.add(sig)
+            out.append(p)
+    return out
+
+
+def _erro_indica_mensagem_nao_encontrada(err: str | None) -> bool:
+    if not err:
+        return False
+    low = err.lower()
+    return "message not found" in low or "mensagem não encontrada" in low or "mensagem nao encontrada" in low
 
 
 def evolution_get_base64_from_media_message(
@@ -250,17 +287,26 @@ def evolution_get_base64_from_media_message(
     """
     POST /chat/getBase64FromMediaMessage/{instance}
     `message_envelope` costuma ser o objeto completo da mensagem no webhook (key, message, …).
+    Tenta envelope completo e fallback com key mínima; repete uma vez se a Evolution ainda
+    não persistiu a mensagem (erro «Message not found»).
     """
     base = base_url.rstrip("/")
     url = f"{base}/chat/getBase64FromMediaMessage/{instance}"
     headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
-    body: dict[str, Any] = {"message": message_envelope, "convertToMp4": convert_to_mp4}
-    code, data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=timeout)
-    if code in (200, 201):
-        b64 = _extrair_base64_resposta(data)
-        if b64:
-            return True, b64, None
-        return False, None, "Evolution não devolveu base64 no formato esperado"
-    if err:
-        return False, None, err[:1200]
-    return False, None, f"HTTP {code}"
+    last_err: str | None = None
+    for attempt in range(2):
+        for msg_payload in _payloads_get_base64_from_envelope(message_envelope):
+            body: dict[str, Any] = {"message": msg_payload, "convertToMp4": convert_to_mp4}
+            code, data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=timeout)
+            if code in (200, 201):
+                b64 = _extrair_base64_resposta(data)
+                if b64:
+                    return True, b64, None
+                last_err = "Evolution não devolveu base64 no formato esperado"
+            else:
+                last_err = (err[:1200] if err else f"HTTP {code}") or last_err
+        if attempt == 0 and _erro_indica_mensagem_nao_encontrada(last_err):
+            time.sleep(1.5)
+            continue
+        break
+    return False, None, last_err or "Falha ao obter mídia da Evolution"

--- a/backend/app/services/evolution_inbound.py
+++ b/backend/app/services/evolution_inbound.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Iterator
+from typing import Any, Callable, Iterator
 
 _MEDIA_KEYS: list[tuple[str, str]] = [
     ("imageMessage", "imagem"),
@@ -133,6 +133,45 @@ def _caption_de_obj_midia(obj: dict[str, Any]) -> str | None:
     return None
 
 
+def _telefone_de_vcard(vcard: str | None) -> str | None:
+    if not vcard:
+        return None
+    for line in str(vcard).splitlines():
+        s = line.strip()
+        if s.upper().startswith("TEL"):
+            part = s.split(":", 1)
+            if len(part) == 2 and part[1].strip():
+                return re.sub(r"\D", "", part[1]) or part[1].strip()
+    return None
+
+
+def _corpo_contacto(obj: dict[str, Any]) -> str:
+    nome = str(obj.get("displayName") or obj.get("DisplayName") or "Contacto").strip()
+    tel = _telefone_de_vcard(obj.get("vcard") or obj.get("Vcard"))
+    if tel:
+        return f"[Contacto] {nome} — {tel}"
+    return f"[Contacto] {nome}"
+
+
+def _corpo_localizacao(obj: dict[str, Any]) -> str:
+    nome = str(obj.get("name") or obj.get("Name") or obj.get("address") or obj.get("Address") or "Localização").strip()
+    lat = obj.get("degreesLatitude") if obj.get("degreesLatitude") is not None else obj.get("DegreesLatitude")
+    lng = obj.get("degreesLongitude") if obj.get("degreesLongitude") is not None else obj.get("DegreesLongitude")
+    if lat is not None and lng is not None:
+        return f"[Localização] {nome}\nhttps://maps.google.com/?q={lat},{lng}"
+    return f"[Localização] {nome}"
+
+
+_ESPECIAL_TEXTO: list[tuple[str, Callable[[dict[str, Any]], str]]] = [
+    ("contactMessage", _corpo_contacto),
+    ("ContactMessage", _corpo_contacto),
+    ("locationMessage", _corpo_localizacao),
+    ("LocationMessage", _corpo_localizacao),
+    ("liveLocationMessage", _corpo_localizacao),
+    ("LiveLocationMessage", _corpo_localizacao),
+]
+
+
 def _iter_message_dicts(data: Any) -> Iterator[dict[str, Any]]:
     if isinstance(data, list):
         for item in data:
@@ -206,6 +245,28 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
                 "corpo": corpo,
                 "mimetype": mime,
                 "raw_envelope": m,
+                "quoted_wa_message_id": q_wid,
+                "quoted_corpo_preview": q_prev,
+            }
+            continue
+
+        corpo_especial: str | None = None
+        for key, formatter in _ESPECIAL_TEXTO:
+            obj = inner.get(key)
+            if isinstance(obj, dict):
+                corpo_fmt = formatter(obj).strip()
+                if corpo_fmt:
+                    corpo_especial = corpo_fmt
+                    break
+        if corpo_especial:
+            yield {
+                "wa_id": wa_id,
+                "wa_message_id": wa_message_id,
+                "push_name": push_name,
+                "tipo": "texto",
+                "corpo": corpo_especial,
+                "mimetype": None,
+                "raw_envelope": None,
                 "quoted_wa_message_id": q_wid,
                 "quoted_corpo_preview": q_prev,
             }

--- a/backend/app/services/whatsapp_media_storage.py
+++ b/backend/app/services/whatsapp_media_storage.py
@@ -15,6 +15,7 @@ _MIME_EXT: dict[str, str] = {
     "image/png": ".png",
     "image/webp": ".webp",
     "audio/ogg": ".ogg",
+    "audio/webm": ".webm",
     "audio/mpeg": ".mp3",
     "audio/mp4": ".m4a",
     "video/mp4": ".mp4",

--- a/backend/tests/test_evolution_get_base64.py
+++ b/backend/tests/test_evolution_get_base64.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+
+from app.services import evolution_api
+
+
+def test_payloads_get_base64_inclui_envelope_e_key_minima():
+    envelope = {
+        "key": {
+            "remoteJid": "5511999999999@s.whatsapp.net",
+            "fromMe": False,
+            "id": "MSG-IMG-1",
+        },
+        "message": {"imageMessage": {"mimetype": "image/jpeg"}},
+    }
+    payloads = evolution_api._payloads_get_base64_from_envelope(envelope)
+    assert payloads[0] is envelope
+    assert {"key": {"id": "MSG-IMG-1"}} in payloads
+    assert any(p.get("key", {}).get("remoteJid") for p in payloads)
+
+
+def test_get_base64_tenta_fallback_quando_envelope_completo_falha(monkeypatch):
+    envelope = {
+        "key": {"id": "MID-2", "remoteJid": "5511888777666@s.whatsapp.net", "fromMe": False},
+        "message": {"audioMessage": {"mimetype": "audio/ogg"}},
+    }
+    calls: list[dict] = []
+
+    def fake_request(method, url, *, headers, body=None, timeout=20):
+        calls.append(body or {})
+        key = (body or {}).get("message", {}).get("key", {})
+        if key == {"id": "MID-2"}:
+            return 200, {"base64": "ZGF0YQ=="}, None
+        return 400, None, '{"message":["Message not found"]}'
+
+    monkeypatch.setattr(evolution_api, "_request_json_with_retry", fake_request)
+    monkeypatch.setattr(evolution_api.time, "sleep", lambda _s: None)
+
+    ok, b64, err = evolution_api.evolution_get_base64_from_media_message(
+        "http://evo.test",
+        "inst",
+        "key",
+        envelope,
+    )
+    assert ok is True
+    assert b64 == "ZGF0YQ=="
+    assert err is None
+    assert len(calls) >= 2
+    assert json.dumps({"message": {"key": {"id": "MID-2"}}, "convertToMp4": False}, sort_keys=True) in {
+        json.dumps(c, sort_keys=True) for c in calls
+    }

--- a/backend/tests/test_evolution_inbound_especiais.py
+++ b/backend/tests/test_evolution_inbound_especiais.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from app.services.evolution_inbound import iter_inbound_whatsapp_messages
+
+
+def _one(body: dict) -> dict:
+    return next(iter_inbound_whatsapp_messages(body))
+
+
+def test_inbound_contacto():
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "key": {"remoteJid": "5511999999999@s.whatsapp.net", "fromMe": False, "id": "c1"},
+            "message": {
+                "contactMessage": {
+                    "displayName": "Maria Silva",
+                    "vcard": "BEGIN:VCARD\nVERSION:3.0\nFN:Maria Silva\nTEL;type=CELL:+5511987654321\nEND:VCARD",
+                }
+            },
+        },
+    }
+    item = _one(body)
+    assert item["tipo"] == "texto"
+    assert "Maria Silva" in item["corpo"]
+    assert "5511987654321" in item["corpo"]
+
+
+def test_inbound_localizacao():
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "key": {"remoteJid": "5511888777666@s.whatsapp.net", "fromMe": False, "id": "loc1"},
+            "message": {
+                "locationMessage": {
+                    "name": "Escritório",
+                    "degreesLatitude": -23.5505,
+                    "degreesLongitude": -46.6333,
+                }
+            },
+        },
+    }
+    item = _one(body)
+    assert item["tipo"] == "texto"
+    assert "[Localização]" in item["corpo"]
+    assert "maps.google.com" in item["corpo"]

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -532,3 +532,66 @@ def test_admin_nao_envia_ao_cliente_usa_comentario_interno(client, seed_base, au
     assert allowed.status_code == 201
     assert sent["n"] == enviados_antes + 1
 
+
+def test_webhook_inbound_midia_grava_ficheiro(client, seed_base, auth_headers, monkeypatch, tmp_path):
+    """Mídia inbound: obtém base64 da Evolution e persiste em disco (#431)."""
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "midia-in",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    monkeypatch.setattr("app.config.settings.WHATSAPP_MEDIA_DIR", str(tmp_path))
+
+    png_b64 = (
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+    )
+
+    def fake_get_base64(_base, _inst, _key, envelope, *, convert_to_mp4=False, timeout=90):
+        assert envelope.get("key", {}).get("id") == "img-in-1"
+        return True, png_b64, None
+
+    monkeypatch.setattr(
+        "app.api.whatsapp_webhook.evolution_api.evolution_get_base64_from_media_message",
+        fake_get_base64,
+    )
+
+    h = {"X-Dx-Webhook-Secret": "midia-in"}
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "key": {
+                "remoteJid": "5511666555444@s.whatsapp.net",
+                "fromMe": False,
+                "id": "img-in-1",
+            },
+            "message": {
+                "imageMessage": {
+                    "mimetype": "image/jpeg",
+                    "caption": "Foto teste",
+                }
+            },
+        },
+    }
+    r = client.post("/v1/webhooks/evolution", json=body, headers=h)
+    assert r.status_code == 200
+    assert r.json().get("processados") == 1
+
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    rows = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    last = rows[-1]
+    assert last["tipo_midia"] == "imagem"
+    assert last["midia_disponivel"] is True
+    assert last["corpo"] == "Foto teste"
+
+    r_mid = client.get(
+        f"/v1/whatsapp/chats/{cid}/mensagens/{last['id']}/midia",
+        headers=auth_headers["a1"],
+    )
+    assert r_mid.status_code == 200
+    assert r_mid.headers.get("content-type", "").startswith("image/")
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,9 @@ services:
       AUTHENTICATION_EXPOSE_IN_FETCH_INSTANCES: "true"
       DATABASE_PROVIDER: postgresql
       DATABASE_CONNECTION_URI: postgresql://evolution:evolution_e2e_secret@evolution-db:5432/evolution?schema=public
+      DATABASE_ENABLED: "true"
+      DATABASE_SAVE_DATA_INSTANCE: "true"
+      DATABASE_SAVE_DATA_NEW_MESSAGE: "true"
       CACHE_REDIS_ENABLED: "true"
       CACHE_REDIS_URI: redis://evolution-redis:6379/0
       CACHE_REDIS_PREFIX_KEY: evo_dx

--- a/docs/WHATSAPP_EVOLUTION.md
+++ b/docs/WHATSAPP_EVOLUTION.md
@@ -74,7 +74,9 @@ Campos persistidos em `whatsapp_settings` (via **Configurações → WhatsApp**,
 - Comportamento e payloads podem variar entre **versões** da Evolution; ajustar o parser em `app/services/evolution_inbound.py` ou a chamada a `getBase64FromMediaMessage` se necessário.
 - Políticas e limitações do **WhatsApp** aplicam-se ao número conectado na Evolution.
 - **Localização** e **templates** não são tratados nesta versão.
-- Ficheiros muito grandes respeitam `WHATSAPP_MEDIA_MAX_BYTES` (por defeito 25 MB); mensagens de contacto / localização não são mapeadas.
+- Ficheiros muito grandes respeitam `WHATSAPP_MEDIA_MAX_BYTES` (por defeito 25 MB).
+- **Contacto** e **localização** inbound aparecem como texto legível (`[Contacto]`, `[Localização]` + link Google Maps).
+- Grupos (`@g.us`) continuam ignorados.
 
 ## Referências úteis
 

--- a/docs/WHATSAPP_EVOLUTION.md
+++ b/docs/WHATSAPP_EVOLUTION.md
@@ -47,6 +47,16 @@ Campos persistidos em `whatsapp_settings` (via **Configurações → WhatsApp**,
 
 4. **Segurança:** se `webhook_secret` estiver preenchido nas settings, o pedido deve enviar o mesmo valor em `X-Dx-Webhook-Secret` ou `apikey` (útil se a Evolution só permitir o header `apikey`). Se o segredo estiver vazio (ex.: dev), o webhook aceita sem validação — **não usar assim em produção**.
 
+5. **Mídia inbound (Evolution):** o download via `getBase64FromMediaMessage` exige que a Evolution **persista mensagens** na base de dados. Defina pelo menos:
+
+   ```env
+   DATABASE_ENABLED=true
+   DATABASE_SAVE_DATA_INSTANCE=true
+   DATABASE_SAVE_DATA_NEW_MESSAGE=true
+   ```
+
+   Sem isto, o webhook recebe o evento mas a Evolution responde «Message not found» ao pedir o base64. Garanta também volume/gravação em `WHATSAPP_MEDIA_DIR` no backend e que URL/API key da instância estão corretos no painel.
+
 ## Envio (DX Connect → Evolution)
 
 - Endpoint típico Evolution v2: `POST {base}/message/sendText/{instance}` com JSON `{ "number": "<DDI+DDD+número>", "text": "..." }` e header `apikey`.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1018,9 +1018,10 @@ export const whatsappChats = {
 
     // Infere o tipo de mídia
     let mediatipo = 'documento'
+    const nome = file.name.toLowerCase()
     if (file.type.startsWith('image/')) {
       mediatipo = 'imagem'
-    } else if (file.type.startsWith('audio/')) {
+    } else if (file.type.startsWith('audio/') || nome.endsWith('.webm') || nome.endsWith('.ogg') || nome.endsWith('.m4a')) {
       mediatipo = 'audio'
     } else if (file.type.startsWith('video/')) {
       mediatipo = 'video'

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -153,6 +153,11 @@ export function WhatsappAtendendo() {
                             {exibirProtocolo(c.protocolo)}
                           </span>
                           <TempoEspera data={c.created_at} />
+                          {!c.funcionario_rede_id && (
+                            <span className="shrink-0 rounded-full bg-violet-100 px-2 py-0.5 text-[9px] font-medium text-violet-700 dark:bg-violet-950/50 dark:text-violet-300">
+                              Sem vínculo
+                            </span>
+                          )}
                         </div>
                         <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</h3>
                         <p className="font-mono text-xs text-slate-500">{c.wa_id}</p>
@@ -219,6 +224,11 @@ export function WhatsappAtendendo() {
                         <h3 className="font-bold text-slate-900 dark:text-slate-100 group-hover:text-cyan-600 transition-colors">
                           {c.cliente_nome || 'Cliente'}
                         </h3>
+                        {!c.funcionario_rede_id && (
+                          <span className="mt-1 inline-flex rounded-full bg-violet-100 px-2 py-0.5 text-[9px] font-medium text-violet-700 dark:bg-violet-950/50 dark:text-violet-300">
+                            Sem vínculo
+                          </span>
+                        )}
                         <p className="text-xs text-slate-400 font-mono mt-1">{c.wa_id}</p>
                         <p className="mt-2 text-[10px] font-medium text-slate-500 dark:text-slate-400">
                           {rotuloResponsavelChat(c)}

--- a/frontend/src/pages/whatsapp/WhatsappBarraAnexos.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappBarraAnexos.tsx
@@ -1,0 +1,51 @@
+export type TipoAnexoPicker = 'imagem' | 'video' | 'audio' | 'documento'
+
+const ACOES: { tipo: TipoAnexoPicker | 'gravar'; rotulo: string; icone: string }[] = [
+  { tipo: 'imagem', rotulo: 'Imagem', icone: '🖼️' },
+  { tipo: 'video', rotulo: 'Vídeo', icone: '🎬' },
+  { tipo: 'audio', rotulo: 'Áudio', icone: '🎵' },
+  { tipo: 'documento', rotulo: 'Documento', icone: '📄' },
+  { tipo: 'gravar', rotulo: 'Gravar', icone: '🎙️' },
+]
+
+type Props = {
+  disabled: boolean
+  motivoDesabilitado?: string
+  onEscolher: (tipo: TipoAnexoPicker) => void
+  onGravarAudio: () => void
+}
+
+export function WhatsappBarraAnexos({ disabled, motivoDesabilitado, onEscolher, onGravarAudio }: Props) {
+  return (
+    <div className="mb-2">
+      {disabled && motivoDesabilitado && (
+        <p className="mb-1.5 text-[11px] text-amber-800 dark:text-amber-200">{motivoDesabilitado}</p>
+      )}
+      <div className="flex flex-wrap gap-1 sm:gap-1.5">
+        {ACOES.map((a) => (
+          <button
+            key={a.tipo}
+            type="button"
+            disabled={disabled}
+            title={disabled ? motivoDesabilitado : a.rotulo}
+            onClick={() => (a.tipo === 'gravar' ? onGravarAudio() : onEscolher(a.tipo))}
+            className="flex min-w-[3.5rem] flex-col items-center gap-0.5 rounded-xl border border-slate-200 bg-white px-2 py-1.5 text-[10px] font-semibold text-slate-700 shadow-sm transition hover:border-cyan-300 hover:bg-cyan-50 disabled:cursor-not-allowed disabled:opacity-40 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:border-cyan-700 dark:hover:bg-cyan-950/30"
+          >
+            <span className="text-base leading-none" aria-hidden>
+              {a.icone}
+            </span>
+            <span>{a.rotulo}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export const ACCEPT_ANEXO: Record<TipoAnexoPicker, string> = {
+  imagem: 'image/*',
+  video: 'video/*',
+  audio: 'audio/*',
+  documento:
+    '.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.zip,.rar,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -46,29 +46,38 @@ import {
 import { WhatsappTicketsModal } from './WhatsappTicketsModal'
 import { WhatsappVincFuncionarioModal } from './WhatsappVincFuncionarioModal'
 import { WhatsappDemandasPanel } from './WhatsappDemandasPanel'
+import { WhatsappBarraAnexos, ACCEPT_ANEXO, type TipoAnexoPicker } from './WhatsappBarraAnexos'
+import { WhatsappGravadorAudio } from './WhatsappGravadorAudio'
+import { WhatsappPreviaAnexo } from './WhatsappPreviaAnexo'
 
-const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha)\]$/
-
-type TipoAnexoPicker = 'imagem' | 'video' | 'audio' | 'documento'
-
-const ACCEPT_ANEXO: Record<TipoAnexoPicker, string> = {
-  imagem: 'image/*',
-  video: 'video/*',
-  audio: 'audio/*',
-  documento:
-    '.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.zip,.rar,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-}
-
-const ROTULO_TIPO_ANEXO: Record<TipoAnexoPicker, string> = {
-  imagem: 'Imagem',
-  video: 'Vídeo',
-  audio: 'Áudio',
-  documento: 'Documento',
-}
+const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)\]$/
 
 
 
 // --- Subcomponente de Renderização de Mídia ---
+
+function TextoComLinks({ texto }: { texto: string }) {
+  const partes = texto.split(/(https?:\/\/\S+)/g)
+  return (
+    <p className="whitespace-pre-wrap">
+      {partes.map((parte, i) =>
+        /^https?:\/\//.test(parte) ? (
+          <a
+            key={i}
+            href={parte}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="break-all underline opacity-90 hover:opacity-100"
+          >
+            {parte}
+          </a>
+        ) : (
+          <span key={i}>{parte}</span>
+        ),
+      )}
+    </p>
+  )
+}
 
 function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number; m: WhatsappChats.Mensagem; onImageClick: (url: string, caption: string | null) => void }) {
 
@@ -132,7 +141,7 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 
 
 
-  if (tipo === 'texto' || !m.tipo_midia) return <p className="whitespace-pre-wrap">{m.corpo}</p>
+  if (tipo === 'texto' || !m.tipo_midia) return <TextoComLinks texto={m.corpo} />
 
   if (!m.midia_disponivel) {
     return (
@@ -224,10 +233,9 @@ export function WhatsappConversa() {
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const anexoMenuRef = useRef<HTMLDivElement>(null)
 
   const [pickerAnexo, setPickerAnexo] = useState<TipoAnexoPicker>('imagem')
-  const [menuAnexoAberto, setMenuAnexoAberto] = useState(false)
+  const [mostrarGravador, setMostrarGravador] = useState(false)
   const [arquivoPendente, setArquivoPendente] = useState<File | null>(null)
   const [legendaMidia, setLegendaMidia] = useState('')
 
@@ -354,17 +362,6 @@ export function WhatsappConversa() {
   }, [id, carregar])
 
 
-
-  useEffect(() => {
-    if (!menuAnexoAberto) return
-    function fechar(ev: MouseEvent) {
-      if (anexoMenuRef.current && !anexoMenuRef.current.contains(ev.target as Node)) {
-        setMenuAnexoAberto(false)
-      }
-    }
-    document.addEventListener('mousedown', fechar)
-    return () => document.removeEventListener('mousedown', fechar)
-  }, [menuAnexoAberto])
 
   useEffect(() => {
     if (!chat) return
@@ -558,9 +555,15 @@ useEffect(() => {
 }
 
   function abrirPickerAnexo(tipo: TipoAnexoPicker) {
+    setMostrarGravador(false)
     setPickerAnexo(tipo)
-    setMenuAnexoAberto(false)
     window.setTimeout(() => fileInputRef.current?.click(), 0)
+  }
+
+  function handleGravacaoConcluida(file: File) {
+    setMostrarGravador(false)
+    setArquivoPendente(file)
+    setLegendaMidia('')
   }
 
   function handleFileSelecionado(e: React.ChangeEvent<HTMLInputElement>) {
@@ -648,6 +651,15 @@ useEffect(() => {
   const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && (isResponsavel || isAdmin)
 
   const podeDigitarMensagem = !encerrado && (modoInterno || podeEnviar)
+
+  const motivoAnexoDesabilitado =
+    encerrado
+      ? undefined
+      : chat?.estado === 'aguardando_atendente'
+        ? 'Assuma este chat para enviar anexos ao cliente.'
+        : !podeEnviar && chat?.estado === 'em_atendimento'
+          ? `Este chat está com ${chat.atendente_nome || 'outro atendente'}.`
+          : undefined
 
   return (
 
@@ -1074,16 +1086,32 @@ useEffect(() => {
             </p>
           )}
 
-          {!encerrado && !modoInterno && chat?.estado === 'aguardando_atendente' && (
-            <p className="mb-2 text-xs text-amber-800 dark:text-amber-200">
-              Assuma este chat para enviar mensagens e anexos ao cliente.
-            </p>
+          {!encerrado && !modoInterno && podeEnviar && !arquivoPendente && !mostrarGravador && (
+            <WhatsappBarraAnexos
+              disabled={enviando}
+              onEscolher={abrirPickerAnexo}
+              onGravarAudio={() => {
+                setArquivoPendente(null)
+                setMostrarGravador(true)
+              }}
+            />
           )}
 
-          {!encerrado && !modoInterno && chat?.estado === 'em_atendimento' && !podeEnviar && (
-            <p className="mb-2 text-xs text-amber-800 dark:text-amber-200">
-              Este chat está com <strong>{chat.atendente_nome || 'outro atendente'}</strong>. Assuma o atendimento ou use comentário interno.
-            </p>
+          {!encerrado && !modoInterno && !podeEnviar && (
+            <WhatsappBarraAnexos
+              disabled
+              motivoDesabilitado={motivoAnexoDesabilitado}
+              onEscolher={() => {}}
+              onGravarAudio={() => {}}
+            />
+          )}
+
+          {mostrarGravador && podeEnviar && !encerrado && (
+            <WhatsappGravadorAudio
+              disabled={enviando}
+              onConcluido={handleGravacaoConcluida}
+              onCancelar={() => setMostrarGravador(false)}
+            />
           )}
 
           {arquivoPendente && (
@@ -1092,6 +1120,7 @@ useEffect(() => {
                 <div className="min-w-0 flex-1">
                   <p className="text-xs font-bold text-cyan-800 dark:text-cyan-300">Anexo selecionado</p>
                   <p className="truncate text-sm text-slate-700 dark:text-slate-200">{arquivoPendente.name}</p>
+                  <WhatsappPreviaAnexo file={arquivoPendente} />
                 </div>
                 <button
                   type="button"
@@ -1105,13 +1134,15 @@ useEffect(() => {
                   &times;
                 </button>
               </div>
-              <input
-                type="text"
-                value={legendaMidia}
-                onChange={(e) => setLegendaMidia(e.target.value)}
-                placeholder="Legenda opcional (visível no WhatsApp)"
-                className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900"
-              />
+              {!arquivoPendente.type.startsWith('audio/') && (
+                <input
+                  type="text"
+                  value={legendaMidia}
+                  onChange={(e) => setLegendaMidia(e.target.value)}
+                  placeholder="Legenda opcional (visível no WhatsApp)"
+                  className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900"
+                />
+              )}
               <div className="mt-2 flex justify-end gap-2">
                 <Button variant="ghost" className="h-8 text-xs" onClick={() => setArquivoPendente(null)}>
                   Cancelar
@@ -1137,38 +1168,6 @@ useEffect(() => {
               disabled={encerrado}
               onInserirReferencia={podeDigitarMensagem ? inserirReferenciaKb : undefined}
             />
-
-            <div className="relative shrink-0" ref={anexoMenuRef}>
-              <Button
-                variant="ghost"
-                type="button"
-                title={
-                  !podeEnviar && !encerrado
-                    ? 'Assuma o chat para enviar anexos'
-                    : 'Anexar imagem, vídeo, áudio ou documento'
-                }
-                onClick={() => setMenuAnexoAberto((v) => !v)}
-                disabled={enviando || encerrado || !podeEnviar || !!arquivoPendente}
-                className="h-10 min-w-[2.5rem] shrink-0 rounded-xl px-2 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
-              >
-                <span className="text-lg leading-none" aria-hidden>📎</span>
-                <span className="ml-1 hidden text-xs font-semibold sm:inline">Anexar</span>
-              </Button>
-              {menuAnexoAberto && (
-                <div className="absolute bottom-full left-0 z-20 mb-2 w-44 overflow-hidden rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900">
-                  {(Object.keys(ROTULO_TIPO_ANEXO) as TipoAnexoPicker[]).map((tipo) => (
-                    <button
-                      key={tipo}
-                      type="button"
-                      className="flex w-full px-3 py-2 text-left text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
-                      onClick={() => abrirPickerAnexo(tipo)}
-                    >
-                      {ROTULO_TIPO_ANEXO[tipo]}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
 
 
 

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -49,6 +49,23 @@ import { WhatsappDemandasPanel } from './WhatsappDemandasPanel'
 
 const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha)\]$/
 
+type TipoAnexoPicker = 'imagem' | 'video' | 'audio' | 'documento'
+
+const ACCEPT_ANEXO: Record<TipoAnexoPicker, string> = {
+  imagem: 'image/*',
+  video: 'video/*',
+  audio: 'audio/*',
+  documento:
+    '.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.zip,.rar,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+}
+
+const ROTULO_TIPO_ANEXO: Record<TipoAnexoPicker, string> = {
+  imagem: 'Imagem',
+  video: 'Vídeo',
+  audio: 'Áudio',
+  documento: 'Documento',
+}
+
 
 
 // --- Subcomponente de Renderização de Mídia ---
@@ -116,6 +133,14 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 
 
   if (tipo === 'texto' || !m.tipo_midia) return <p className="whitespace-pre-wrap">{m.corpo}</p>
+
+  if (!m.midia_disponivel) {
+    return (
+      <p className="text-xs italic opacity-70" title="O ficheiro não foi obtido da Evolution API">
+        {m.corpo || 'Mídia não disponível'}
+      </p>
+    )
+  }
 
   if (loading || !url) return <p className="text-[10px] animate-pulse opacity-50">Carregando mídia...</p>
 
@@ -199,6 +224,12 @@ export function WhatsappConversa() {
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const anexoMenuRef = useRef<HTMLDivElement>(null)
+
+  const [pickerAnexo, setPickerAnexo] = useState<TipoAnexoPicker>('imagem')
+  const [menuAnexoAberto, setMenuAnexoAberto] = useState(false)
+  const [arquivoPendente, setArquivoPendente] = useState<File | null>(null)
+  const [legendaMidia, setLegendaMidia] = useState('')
 
 
 
@@ -323,6 +354,17 @@ export function WhatsappConversa() {
   }, [id, carregar])
 
 
+
+  useEffect(() => {
+    if (!menuAnexoAberto) return
+    function fechar(ev: MouseEvent) {
+      if (anexoMenuRef.current && !anexoMenuRef.current.contains(ev.target as Node)) {
+        setMenuAnexoAberto(false)
+      }
+    }
+    document.addEventListener('mousedown', fechar)
+    return () => document.removeEventListener('mousedown', fechar)
+  }, [menuAnexoAberto])
 
   useEffect(() => {
     if (!chat) return
@@ -515,38 +557,43 @@ useEffect(() => {
   }
 }
 
-  async function handleFileUpload(e: React.ChangeEvent<HTMLInputElement>) {
+  function abrirPickerAnexo(tipo: TipoAnexoPicker) {
+    setPickerAnexo(tipo)
+    setMenuAnexoAberto(false)
+    window.setTimeout(() => fileInputRef.current?.click(), 0)
+  }
 
+  function handleFileSelecionado(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0]
-
-    if (!file || !chat || !podeEnviar) return
-
-   
-
-    setEnviando(true)
-
-    try {
-
-      await whatsappChats.enviarMidia(chat.id, file, '', msgRespondida?.wa_message_id || null)
-
-      setMsgRespondida(null)
-
-      toast.showSuccess('Arquivo enviado!')
-
-      await carregar()
-
-    } catch (err) {
-
-      toast.showError(mensagemFalhaParaToast(err, 'Falha no envio do arquivo'))
-
-    } finally {
-
-      setEnviando(false)
-
+    if (!file || !chat || !podeEnviar) {
       if (fileInputRef.current) fileInputRef.current.value = ''
-
+      return
     }
+    setArquivoPendente(file)
+    setLegendaMidia('')
+    if (fileInputRef.current) fileInputRef.current.value = ''
+  }
 
+  async function confirmarEnvioMidia() {
+    if (!arquivoPendente || !chat || !podeEnviar) return
+    setEnviando(true)
+    try {
+      await whatsappChats.enviarMidia(
+        chat.id,
+        arquivoPendente,
+        legendaMidia.trim(),
+        msgRespondida?.wa_message_id || null,
+      )
+      setMsgRespondida(null)
+      setArquivoPendente(null)
+      setLegendaMidia('')
+      toast.showSuccess('Anexo enviado!')
+      await carregar()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha no envio do anexo'))
+    } finally {
+      setEnviando(false)
+    }
   }
 
 
@@ -672,6 +719,11 @@ useEffect(() => {
                     <p className="truncate text-sm font-bold text-slate-800 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</p>
 
                     {c.estado === 'aguardando_atendente' && <span className="h-2 w-2 rounded-full bg-amber-500 animate-pulse" />}
+                    {!c.funcionario_rede_id && (
+                      <span className="shrink-0 rounded-full bg-violet-100 px-1.5 py-0.5 text-[9px] font-medium text-violet-700 dark:bg-violet-950/50 dark:text-violet-300">
+                        Sem vínculo
+                      </span>
+                    )}
 
                   </div>
 
@@ -799,10 +851,11 @@ useEffect(() => {
               )}
               <Button
                 variant="ghost"
-                className="hidden sm:inline-flex text-xs h-8"
+                className="inline-flex text-xs h-8"
                 onClick={() => setModalVincFuncionario(true)}
               >
-                Vincular funcionário
+                <span className="sm:hidden">Vincular</span>
+                <span className="hidden sm:inline">Vincular funcionário</span>
               </Button>
 
                 <Button variant="ghost" className="hidden sm:inline-flex text-xs h-8" onClick={() => setModalTickets(true)}>
@@ -822,6 +875,17 @@ useEffect(() => {
           </div>
 
         </header>
+
+        {!encerrado && chat && !chat.funcionario_rede_id && (
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-violet-200 bg-violet-50 px-4 py-3 text-sm text-violet-950 dark:border-violet-900/40 dark:bg-violet-950/30 dark:text-violet-100">
+            <p>
+              <strong>Contacto não vinculado</strong> a nenhuma empresa ou funcionário cadastrado.
+            </p>
+            <Button variant="primary" className="h-8 shrink-0 text-xs" onClick={() => setModalVincFuncionario(true)}>
+              Vincular a empresa
+            </Button>
+          </div>
+        )}
 
         {!encerrado && chat?.estado === 'em_atendimento' && !isResponsavel && (
           <div className="border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100">
@@ -1010,41 +1074,101 @@ useEffect(() => {
             </p>
           )}
 
+          {!encerrado && !modoInterno && chat?.estado === 'aguardando_atendente' && (
+            <p className="mb-2 text-xs text-amber-800 dark:text-amber-200">
+              Assuma este chat para enviar mensagens e anexos ao cliente.
+            </p>
+          )}
+
+          {!encerrado && !modoInterno && chat?.estado === 'em_atendimento' && !podeEnviar && (
+            <p className="mb-2 text-xs text-amber-800 dark:text-amber-200">
+              Este chat está com <strong>{chat.atendente_nome || 'outro atendente'}</strong>. Assuma o atendimento ou use comentário interno.
+            </p>
+          )}
+
+          {arquivoPendente && (
+            <div className="mb-2 rounded-xl border border-cyan-200 bg-cyan-50/80 p-3 dark:border-cyan-900/40 dark:bg-cyan-950/20">
+              <div className="flex flex-wrap items-start justify-between gap-2">
+                <div className="min-w-0 flex-1">
+                  <p className="text-xs font-bold text-cyan-800 dark:text-cyan-300">Anexo selecionado</p>
+                  <p className="truncate text-sm text-slate-700 dark:text-slate-200">{arquivoPendente.name}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setArquivoPendente(null)
+                    setLegendaMidia('')
+                  }}
+                  className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200"
+                  aria-label="Remover anexo"
+                >
+                  &times;
+                </button>
+              </div>
+              <input
+                type="text"
+                value={legendaMidia}
+                onChange={(e) => setLegendaMidia(e.target.value)}
+                placeholder="Legenda opcional (visível no WhatsApp)"
+                className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900"
+              />
+              <div className="mt-2 flex justify-end gap-2">
+                <Button variant="ghost" className="h-8 text-xs" onClick={() => setArquivoPendente(null)}>
+                  Cancelar
+                </Button>
+                <Button className="h-8 text-xs" loading={enviando} onClick={() => void confirmarEnvioMidia()}>
+                  Enviar anexo
+                </Button>
+              </div>
+            </div>
+          )}
+
           <div className="flex items-end gap-2 bg-slate-100 dark:bg-slate-900 p-2 rounded-2xl shadow-inner">
 
-           
-
-            {/* Input de arquivo invisível */}
-
             <input
-
               type="file"
-
               ref={fileInputRef}
-
-              onChange={handleFileUpload}
-
+              onChange={handleFileSelecionado}
               className="hidden"
-
-              accept="image/*,video/*,application/pdf"
-
+              accept={ACCEPT_ANEXO[pickerAnexo]}
             />
-
-
 
             <KbConsultaButton
               disabled={encerrado}
               onInserirReferencia={podeDigitarMensagem ? inserirReferenciaKb : undefined}
             />
 
-            <Button
-              variant="ghost"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={enviando || encerrado || !podeEnviar}
-              className="h-10 w-10 shrink-0 rounded-xl hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
-            >
-              📎
-            </Button>
+            <div className="relative shrink-0" ref={anexoMenuRef}>
+              <Button
+                variant="ghost"
+                type="button"
+                title={
+                  !podeEnviar && !encerrado
+                    ? 'Assuma o chat para enviar anexos'
+                    : 'Anexar imagem, vídeo, áudio ou documento'
+                }
+                onClick={() => setMenuAnexoAberto((v) => !v)}
+                disabled={enviando || encerrado || !podeEnviar || !!arquivoPendente}
+                className="h-10 min-w-[2.5rem] shrink-0 rounded-xl px-2 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
+              >
+                <span className="text-lg leading-none" aria-hidden>📎</span>
+                <span className="ml-1 hidden text-xs font-semibold sm:inline">Anexar</span>
+              </Button>
+              {menuAnexoAberto && (
+                <div className="absolute bottom-full left-0 z-20 mb-2 w-44 overflow-hidden rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900">
+                  {(Object.keys(ROTULO_TIPO_ANEXO) as TipoAnexoPicker[]).map((tipo) => (
+                    <button
+                      key={tipo}
+                      type="button"
+                      className="flex w-full px-3 py-2 text-left text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
+                      onClick={() => abrirPickerAnexo(tipo)}
+                    >
+                      {ROTULO_TIPO_ANEXO[tipo]}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
 
 
 

--- a/frontend/src/pages/whatsapp/WhatsappGravadorAudio.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappGravadorAudio.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { Button } from '../../components/ui/Button'
+
+type Props = {
+  disabled?: boolean
+  onConcluido: (file: File) => void
+  onCancelar: () => void
+}
+
+export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Props) {
+  const [gravando, setGravando] = useState(false)
+  const [segundos, setSegundos] = useState(0)
+  const [erro, setErro] = useState<string | null>(null)
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+  const timerRef = useRef<number | null>(null)
+
+  const pararStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach((t) => t.stop())
+    streamRef.current = null
+    if (timerRef.current != null) {
+      window.clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => () => pararStream(), [pararStream])
+
+  async function iniciar() {
+    if (disabled || gravando) return
+    setErro(null)
+    chunksRef.current = []
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      streamRef.current = stream
+      const mime =
+        MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+          ? 'audio/webm;codecs=opus'
+          : MediaRecorder.isTypeSupported('audio/webm')
+            ? 'audio/webm'
+            : ''
+      const recorder = mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream)
+      recorderRef.current = recorder
+      recorder.ondataavailable = (ev) => {
+        if (ev.data.size > 0) chunksRef.current.push(ev.data)
+      }
+      recorder.onstop = () => {
+        pararStream()
+        const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' })
+        if (blob.size === 0) {
+          setErro('Gravação vazia. Tente novamente.')
+          setGravando(false)
+          setSegundos(0)
+          return
+        }
+        const ext = blob.type.includes('ogg') ? 'ogg' : 'webm'
+        const file = new File([blob], `audio-${Date.now()}.${ext}`, { type: blob.type || 'audio/webm' })
+        setGravando(false)
+        setSegundos(0)
+        onConcluido(file)
+      }
+      recorder.start(250)
+      setGravando(true)
+      setSegundos(0)
+      timerRef.current = window.setInterval(() => setSegundos((s) => s + 1), 1000)
+    } catch {
+      pararStream()
+      setErro('Não foi possível aceder ao microfone. Verifique as permissões do browser.')
+    }
+  }
+
+  function parar() {
+    const rec = recorderRef.current
+    if (rec && rec.state !== 'inactive') rec.stop()
+    recorderRef.current = null
+  }
+
+  function cancelar() {
+    if (gravando) {
+      recorderRef.current?.stop()
+      recorderRef.current = null
+      chunksRef.current = []
+      pararStream()
+      setGravando(false)
+      setSegundos(0)
+    }
+    onCancelar()
+  }
+
+  const mm = String(Math.floor(segundos / 60)).padStart(2, '0')
+  const ss = String(segundos % 60).padStart(2, '0')
+
+  return (
+    <div className="mb-2 rounded-xl border border-rose-200 bg-rose-50/90 p-3 dark:border-rose-900/40 dark:bg-rose-950/20">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="text-xs font-bold text-rose-800 dark:text-rose-200">Gravar áudio</p>
+          <p className="text-[11px] text-slate-600 dark:text-slate-400">
+            {gravando ? `A gravar… ${mm}:${ss}` : 'Toque em gravar e fale ao microfone'}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="ghost" className="h-8 text-xs" onClick={cancelar}>
+            Cancelar
+          </Button>
+          {!gravando ? (
+            <Button className="h-8 text-xs" disabled={disabled} onClick={() => void iniciar()}>
+              ● Gravar
+            </Button>
+          ) : (
+            <Button variant="danger" className="h-8 text-xs" onClick={parar}>
+              ■ Parar
+            </Button>
+          )}
+        </div>
+      </div>
+      {gravando && (
+        <div className="mt-2 flex items-center gap-2">
+          <span className="h-2 w-2 animate-pulse rounded-full bg-rose-500" />
+          <span className="text-[10px] text-rose-700 dark:text-rose-300">Microfone activo</span>
+        </div>
+      )}
+      {erro && <p className="mt-2 text-xs text-rose-700 dark:text-rose-300">{erro}</p>}
+    </div>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappPreviaAnexo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappPreviaAnexo.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react'
+
+type Props = {
+  file: File
+}
+
+export function WhatsappPreviaAnexo({ file }: Props) {
+  const [url, setUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    const u = URL.createObjectURL(file)
+    setUrl(u)
+    return () => URL.revokeObjectURL(u)
+  }, [file])
+
+  if (!url) return null
+
+  if (file.type.startsWith('image/')) {
+    return (
+      <img
+        src={url}
+        alt=""
+        className="mt-2 max-h-40 max-w-full rounded-lg border border-slate-200 object-contain dark:border-slate-700"
+      />
+    )
+  }
+
+  if (file.type.startsWith('video/')) {
+    return <video controls src={url} className="mt-2 max-h-40 max-w-full rounded-lg border border-slate-200 dark:border-slate-700" />
+  }
+
+  if (file.type.startsWith('audio/')) {
+    return <audio controls src={url} className="mt-2 w-full max-w-sm" />
+  }
+
+  return (
+    <p className="mt-2 text-[11px] text-slate-500 dark:text-slate-400">
+      {(file.size / 1024).toFixed(0)} KB • {file.type || 'ficheiro'}
+    </p>
+  )
+}


### PR DESCRIPTION
## Summary
- **#431:** Corrige gravação de mídia inbound (import em falta, fallback/retry na Evolution API, logs com \wa_message_id\, estado claro na UI quando o ficheiro não está disponível)
- **#432:** Menu **Anexar** com tipos explícitos (imagem, vídeo, áudio, documento), legenda opcional antes do envio e avisos quando o chat não foi assumido
- **#433:** Banner «Contacto não vinculado», badge «Sem vínculo» na fila/listagens e botão vincular visível em mobile
- Docker local: \DATABASE_SAVE_DATA_NEW_MESSAGE\ na Evolution; documentação em \docs/WHATSAPP_EVOLUTION.md\

## Test plan
- [ ] Cliente envia imagem, áudio, vídeo, documento e figurinha → aparecem no chat
- [ ] Evolution de produção com \DATABASE_ENABLED=true\, \DATABASE_SAVE_DATA_INSTANCE=true\, \DATABASE_SAVE_DATA_NEW_MESSAGE=true\
- [ ] Atendente assume chat → menu Anexar → envia cada tipo com legenda
- [ ] Chat sem \uncionario_rede_id\ → banner + badge; após vincular, banner some
- [ ] Mobile: botão Vincular e Anexar acessíveis
- [ ] \pytest tests/test_evolution_get_base64.py tests/test_whatsapp_chats.py::test_webhook_inbound_midia_grava_ficheiro\