### PR TITLE
fix(whatsapp): tempo real #442 e áudio outbound #441

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker
+- WhatsApp (#441): áudio gravado pelo atendente enviado como nota de voz via `sendWhatsAppAudio` (encoding Evolution); falha explícita se a API não confirmar entrega
 - WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível
 - WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional
 - WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -1073,20 +1073,35 @@ async def enviar_mensagem_midia(
         )
         q_prev = _preview_citacao(ref) if ref else None
 
-    ok, err, sent_wa_id = evolution_api.evolution_send_media(
-        st.evolution_base_url,
-        st.evolution_instance_name,
-        st.evolution_api_key,
-        c.wa_id,
-        mediatype=ev_mt,
-        mimetype=mime,
-        caption=legenda_whatsapp,
-        media_base64=b64,
-        file_name=fname,
-        quoted=quoted_payload,
-    )
+    if tipo_db == "audio":
+        ok, err, sent_wa_id = evolution_api.evolution_send_whatsapp_audio(
+            st.evolution_base_url,
+            st.evolution_instance_name,
+            st.evolution_api_key,
+            c.wa_id,
+            audio_base64=b64,
+            quoted=quoted_payload,
+        )
+    else:
+        ok, err, sent_wa_id = evolution_api.evolution_send_media(
+            st.evolution_base_url,
+            st.evolution_instance_name,
+            st.evolution_api_key,
+            c.wa_id,
+            mediatype=ev_mt,
+            mimetype=mime,
+            caption=legenda_whatsapp,
+            media_base64=b64,
+            file_name=fname,
+            quoted=quoted_payload,
+        )
     if not ok:
         raise HTTPException(status_code=502, detail=err or "Falha ao enviar mídia pela Evolution API")
+    if tipo_db == "audio" and not sent_wa_id:
+        raise HTTPException(
+            status_code=502,
+            detail="Evolution API não confirmou entrega do áudio (wa_message_id ausente).",
+        )
 
     m = WhatsappMensagem(
         chat_id=c.id,

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -186,6 +186,34 @@ def evolution_send_text(
     return False, f"HTTP {code}", None
 
 
+def evolution_send_whatsapp_audio(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    number_digits: str,
+    *,
+    audio_base64: str,
+    quoted: dict[str, Any] | None = None,
+) -> tuple[bool, str | None, str | None]:
+    """POST /message/sendWhatsAppAudio/{instance} — nota de voz (PTT) com encoding automático."""
+    base = base_url.rstrip("/")
+    url = f"{base}/message/sendWhatsAppAudio/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body: dict[str, Any] = {
+        "number": number_digits,
+        "audio": audio_base64,
+        "encoding": True,
+    }
+    if quoted:
+        body["quoted"] = quoted
+    code, data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=120)
+    if code in (200, 201):
+        return True, None, _extract_wa_message_id(data)
+    if err:
+        return False, err[:1200], None
+    return False, f"HTTP {code}", None
+
+
 def evolution_send_media(
     base_url: str,
     instance: str,

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -595,3 +595,73 @@ def test_webhook_inbound_midia_grava_ficheiro(client, seed_base, auth_headers, m
     assert r_mid.status_code == 200
     assert r_mid.headers.get("content-type", "").startswith("image/")
 
+
+def test_enviar_audio_usa_sendWhatsAppAudio(client, seed_base, auth_headers, monkeypatch):
+    """#441 — áudio outbound via sendWhatsAppAudio com encoding, não sendMedia."""
+    calls: list[str] = []
+
+    def fake_audio(*_a, **_k):
+        calls.append("audio")
+        return True, None, "wa-audio-1"
+
+    def fake_media(*_a, **_k):
+        calls.append("media")
+        return True, None, "wa-media-1"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_whatsapp_audio", fake_audio)
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_media", fake_media)
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "aud-out",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999445566", msg_id="aud-out-1")
+
+    webm_bytes = b"\x1a\x45\xdf\xa3" + b"\x00" * 64
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens/midia",
+        data={"mediatipo": "audio", "caption": ""},
+        files={"file": ("gravacao.webm", webm_bytes, "audio/webm")},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["tipo_midia"] == "audio"
+    assert body["wa_message_id"] == "wa-audio-1"
+    assert calls == ["audio"]
+
+
+def test_enviar_audio_falha_sem_wa_message_id(client, seed_base, auth_headers, monkeypatch):
+    """#441 — não persiste áudio se Evolution não devolver wa_message_id."""
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_whatsapp_audio",
+        lambda *_a, **_k: (True, None, None),
+    )
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "aud-fail",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999556677", msg_id="aud-fail-1")
+    webm_bytes = b"\x1a\x45\xdf\xa3" + b"\x00" * 64
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens/midia",
+        data={"mediatipo": "audio", "caption": ""},
+        files={"file": ("gravacao.webm", webm_bytes, "audio/webm")},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 502
+    rows = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    assert all(m.get("tipo_midia") != "audio" or m.get("direcao") != "outbound" for m in rows)
+

--- a/docs/REALTIME_SSE.md
+++ b/docs/REALTIME_SSE.md
@@ -32,7 +32,8 @@ Destinatários filtrados por RBAC (setor homônimo + admin).
 
 - Cliente fetch-based (suporta Bearer; `EventSource` nativo não envia header)
 - Hook `useEventStream()` + `EventStreamProvider` no `Layout`
-- Reconexão com backoff exponencial; após **3 falhas** consecutivas, `useFallback === true` (consumidores RT-F2 mantêm polling)
+- Reconexão com backoff exponencial; após **3 falhas** consecutivas, `useFallback === true` (intervalos de polling mais frequentes)
+- **Polling de segurança (#442):** WhatsApp (`WhatsappConversa`, `WhatsappAtendendo`) faz refresh periódico **mesmo com SSE conectado** (4–8 s), porque o hub v1 não propaga eventos entre workers Gunicorn
 
 ## Gunicorn e multi-worker
 

--- a/docs/WHATSAPP_EVOLUTION.md
+++ b/docs/WHATSAPP_EVOLUTION.md
@@ -60,6 +60,7 @@ Campos persistidos em `whatsapp_settings` (via **Configurações → WhatsApp**,
 ## Envio (DX Connect → Evolution)
 
 - Endpoint típico Evolution v2: `POST {base}/message/sendText/{instance}` com JSON `{ "number": "<DDI+DDD+número>", "text": "..." }` e header `apikey`.
+- **Áudio outbound (#441):** notas de voz usam `POST {base}/message/sendWhatsAppAudio/{instance}` com `{ "number", "audio": "<base64>", "encoding": true }` — a Evolution converte para Ogg Opus compatível com WhatsApp (não usar `sendMedia` com `audio/webm` do browser).
 - O número do cliente é normalizado a dígitos (ex.: `5511999999999`).
 
 ## Ciclo de vida do chat

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -70,11 +70,11 @@ export function WhatsappAtendendo() {
     }
   }, [subscribe, load])
 
-  // Refresh inicial + polling legado quando SSE indisponível
+  // Refresh inicial + polling de segurança (#442)
   useEffect(() => {
     void load()
-    if (!useFallback) return
-    const timer = setInterval(() => void load(true), 10000)
+    const intervalMs = useFallback ? 10000 : 8000
+    const timer = setInterval(() => void load(true), intervalMs)
     return () => clearInterval(timer)
   }, [load, useFallback])
 

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -413,11 +413,11 @@ export function WhatsappConversa() {
     }
   }, [id, subscribe, carregar, carregarSidebar])
 
-  // Polling legado quando SSE indisponível
+  // Polling de segurança (#442): complementa SSE quando Gunicorn usa N workers in-process
   useEffect(() => {
-    if (!useFallback) return
     if (!chat || chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao') return
-    const t = setInterval(() => void carregar().catch(() => {}), 5000)
+    const intervalMs = useFallback ? 5000 : 4000
+    const t = setInterval(() => void carregar().catch(() => {}), intervalMs)
     return () => clearInterval(t)
   }, [useFallback, chat, carregar])
 


### PR DESCRIPTION
## Summary
- **#442:** polling de segurança (4–8 s) em \WhatsappConversa\ e \WhatsappAtendendo\, mesmo com SSE conectado — cobre deploy Gunicorn multi-worker onde eventos não cruzam workers.
- **#441:** áudio gravado/enviado pelo atendente passa por \POST /message/sendWhatsAppAudio\ com \encoding: true\ (nota de voz WhatsApp); erro 502 se Evolution não devolver \wa_message_id\.

## Test plan
- [ ] Cliente envia mensagem com conversa aberta → aparece em ≤5 s sem F5
- [ ] Gravar áudio no painel → cliente recebe nota de voz no WhatsApp
- [ ] \pytest tests/test_whatsapp_chats.py::test_enviar_audio_*\

Made with [Cursor](https://cursor.com)