### PR TITLE
fix(whatsapp): cadastro funcionário sem e-mail #444

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais
 - WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível
 - WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional
 - WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile

--- a/backend/alembic/versions/055_funcionario_rede_email_nullable.py
+++ b/backend/alembic/versions/055_funcionario_rede_email_nullable.py
@@ -1,0 +1,32 @@
+"""funcionarios_rede.email opcional (#444).
+
+Revision ID: 055_funcionario_rede_email_nullable
+Revises: 054_kb_interno_only
+Create Date: 2026-06-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "055_funcionario_rede_email_nullable"
+down_revision = "054_kb_interno_only"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "funcionarios_rede",
+        "email",
+        existing_type=sa.String(length=255),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "funcionarios_rede",
+        "email",
+        existing_type=sa.String(length=255),
+        nullable=False,
+    )

--- a/backend/app/api/funcionarios_rede.py
+++ b/backend/app/api/funcionarios_rede.py
@@ -177,13 +177,15 @@ def criar(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe a rede.")
     if rede_id_final is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="rede_id não definido para o vínculo.")
-    try:
-        assert_email_unico_por_rede(db, email=str(data.email), rede_id=int(rede_id_final))
-    except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    email_eff = data.email
+    if email_eff:
+        try:
+            assert_email_unico_por_rede(db, email=str(email_eff), rede_id=int(rede_id_final))
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     f = FuncionarioRede(
         nome=data.nome,
-        email=data.email,
+        email=email_eff,
         tipo=data.tipo,
         escopo_empresas=escopo,
         ativo=data.ativo,
@@ -202,7 +204,8 @@ def criar(
     )
     db.commit()
     db.refresh(f)
-    reconciliar_tickets_pendentes_por_email(db, f.email)
+    if f.email:
+        reconciliar_tickets_pendentes_por_email(db, f.email)
     db.commit()
     return _para_read(f)
 
@@ -267,7 +270,7 @@ def atualizar(
         rede_id=int(rede_id),
         empresa_ids=ids if escopo == "selected" else None,
     )
-    if f.rede_id is not None:
+    if f.rede_id is not None and f.email:
         try:
             assert_email_unico_por_rede(
                 db,
@@ -280,7 +283,8 @@ def atualizar(
     registrar_audit(db, "funcionario_rede", funcionario_id, "update", atendente.id)
     db.commit()
     db.refresh(f)
-    reconciliar_tickets_pendentes_por_email(db, f.email)
+    if f.email:
+        reconciliar_tickets_pendentes_por_email(db, f.email)
     db.commit()
     return _para_read(f)
 

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -371,7 +371,7 @@ def _criar_funcionario_rede(
     atendente: Atendente,
     *,
     nome: str,
-    email: str,
+    email: str | None,
     tipo: str,
     escopo_empresas: str,
     rede_id: int,
@@ -402,16 +402,18 @@ def _criar_funcionario_rede(
         emps = db.query(Empresa).filter(Empresa.id.in_(ids)).all()
         if any(int(e.tenant_id) != int(atendente.tenant_id) for e in emps):
             raise HTTPException(status_code=400, detail="Empresa inválida para este tenant")
-    try:
-        assert_email_unico_por_rede(db, email=email.strip(), rede_id=int(rede_id))
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    email_norm = (email or "").strip() or None
+    if email_norm:
+        try:
+            assert_email_unico_por_rede(db, email=email_norm, rede_id=int(rede_id))
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
     emp_colab_id: int | None = None
     if escopo == "selected" and tipo_eff == "colaborador" and len(ids) == 1:
         emp_colab_id = ids[0]
     f = FuncionarioRede(
         nome=nome.strip(),
-        email=email.strip(),
+        email=email_norm,
         tipo=tipo_eff,
         escopo_empresas=escopo,
         ativo=True,

--- a/backend/app/models/funcionario_rede.py
+++ b/backend/app/models/funcionario_rede.py
@@ -19,7 +19,7 @@ class FuncionarioRede(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     nome = Column(String(255), nullable=False)
-    email = Column(String(255), nullable=False, index=True)  # único por contexto (rede/empresa)
+    email = Column(String(255), nullable=True, index=True)  # opcional (#444); único por rede quando preenchido
     tipo = Column(String(20), nullable=False)  # socio | supervisor | colaborador
     escopo_empresas = Column(String(20), nullable=False, default="selected")  # all | selected
     ativo = Column(Boolean, default=True)

--- a/backend/app/schemas/funcionario_rede.py
+++ b/backend/app/schemas/funcionario_rede.py
@@ -1,13 +1,24 @@
-from pydantic import BaseModel, ConfigDict, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, field_validator
 from datetime import datetime
+
+
+def _email_vazio_para_none(v: object) -> object:
+    if v is None or (isinstance(v, str) and not v.strip()):
+        return None
+    return v
 
 
 class FuncionarioRedeBase(BaseModel):
     nome: str
-    email: EmailStr
+    email: EmailStr | None = None
     tipo: str  # socio | supervisor | colaborador
     escopo_empresas: str = "selected"  # all | selected
     ativo: bool = True
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def email_opcional(cls, v: object) -> object:
+        return _email_vazio_para_none(v)
 
 
 class FuncionarioRedeCreate(FuncionarioRedeBase):
@@ -25,6 +36,11 @@ class FuncionarioRedeUpdate(BaseModel):
     rede_id: int | None = None
     empresa_id: int | None = None
     empresa_ids: list[int] | None = None
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def email_opcional(cls, v: object) -> object:
+        return _email_vazio_para_none(v)
 
 
 class FuncionarioRedeRead(FuncionarioRedeBase):

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class WhatsappMensagemRead(BaseModel):
@@ -105,7 +105,7 @@ class WhatsappVincularFuncionarioBody(BaseModel):
 
 class WhatsappCadastrarFuncionarioBody(BaseModel):
     nome: str = Field(..., min_length=1, max_length=255)
-    email: str = Field(..., min_length=3, max_length=255)
+    email: str | None = Field(default=None, max_length=255)
     rede_id: int
     tipo: str = Field(default="colaborador", description="colaborador | supervisor")
     escopo_empresas: str = Field(default="selected", description="all | selected")
@@ -114,6 +114,13 @@ class WhatsappCadastrarFuncionarioBody(BaseModel):
         None,
         description="Empresa exibida no chat quando o funcionário tem várias empresas.",
     )
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def email_opcional(cls, v: object) -> str | None:
+        if v is None or (isinstance(v, str) and not v.strip()):
+            return None
+        return str(v).strip()
 
 
 class WhatsappAbrirTicketBody(BaseModel):

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -474,6 +474,28 @@ def test_cadastrar_funcionario_no_chat(client, seed_base, auth_headers, db_sessi
     assert any(re["id"] == seed_base["rede"].id for re in catalogo.json()["redes"])
 
 
+def test_cadastrar_funcionario_no_chat_sem_email(client, seed_base, auth_headers):
+    """#444 — cadastro pelo WhatsApp sem e-mail vincula o contacto."""
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999112244", msg_id="func-sem-email")
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/cadastrar-funcionario",
+        json={
+            "nome": "Contacto Só WhatsApp",
+            "rede_id": seed_base["rede"].id,
+            "tipo": "colaborador",
+            "escopo_empresas": "selected",
+            "empresa_ids": [seed_base["empresa"].id],
+        },
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["funcionario_nome"] == "Contacto Só WhatsApp"
+    assert body["funcionario_email"] is None
+    assert body["funcionario_rede_id"] is not None
+    assert body["empresa_id"] == seed_base["empresa"].id
+
+
 def test_admin_nao_envia_ao_cliente_usa_comentario_interno(client, seed_base, auth_headers, monkeypatch):
     """#403 — admin acompanha chat alheio; mensagem ao cliente bloqueada; comentário interno permitido."""
     sent = {"n": 0, "seq": 0}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -983,7 +983,7 @@ export const whatsappChats = {
     id: number,
     data: {
       nome: string
-      email: string
+      email?: string | null
       rede_id: number
       tipo?: 'colaborador' | 'supervisor'
       escopo_empresas?: 'all' | 'selected'
@@ -1671,7 +1671,7 @@ export namespace FuncionariosRede {
   export interface Funcionario {
     id: number;
     nome: string;
-    email: string;
+    email: string | null;
     tipo: string;
     escopo_empresas: EscopoEmpresas;
     ativo: boolean;
@@ -1683,7 +1683,7 @@ export namespace FuncionariosRede {
   }
   export interface Create {
     nome: string;
-    email: string;
+    email?: string | null;
     tipo: string;
     escopo_empresas?: EscopoEmpresas;
     ativo?: boolean;
@@ -1693,7 +1693,7 @@ export namespace FuncionariosRede {
   }
   export interface Update {
     nome?: string;
-    email?: string;
+    email?: string | null;
     tipo?: string;
     escopo_empresas?: EscopoEmpresas;
     ativo?: boolean;

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -61,7 +61,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={value}>
       {children}
-      <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+      <div className="pointer-events-none fixed bottom-4 right-4 z-[200] flex flex-col gap-2">
         {toasts.map((toast) => {
           let styles =
             'bg-slate-800 text-white dark:bg-slate-800 dark:text-slate-100 dark:ring-1 dark:ring-slate-600/60'

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -97,7 +97,7 @@ export function FuncionarioRedeForm() {
       .then((item) => {
         if (cancelled) return
         setNome(item.nome)
-        setEmail(item.email)
+        setEmail(item.email || '')
         setTipo(item.tipo as Tipo)
         setEscopoEmpresas((item.escopo_empresas as Escopo) || (item.tipo === 'socio' ? 'all' : 'selected'))
         setAtivo(item.ativo)
@@ -170,12 +170,13 @@ export function FuncionarioRedeForm() {
       }
     }
     setSaving(true)
+    const emailPayload = email.trim() || null
     try {
       let saved: FuncionariosRede.Funcionario
       if (isEdit && !Number.isNaN(funcionarioId)) {
         const payload: FuncionariosRede.Update = {
           nome: nome.trim(),
-          email,
+          email: emailPayload,
           tipo,
           escopo_empresas: escopo,
           ativo,
@@ -188,7 +189,7 @@ export function FuncionarioRedeForm() {
       } else {
         const payload: FuncionariosRede.Create = {
           nome: nome.trim(),
-          email,
+          email: emailPayload,
           tipo,
           escopo_empresas: escopo,
           ativo,
@@ -257,7 +258,15 @@ export function FuncionarioRedeForm() {
           <div className="space-y-6">
             <FormSection title="Dados do funcionário">
               <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-              <Input label="E-mail" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+              <Input
+                label="E-mail (opcional)"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+              <p className="text-xs text-slate-500">
+                Usado para identificar remetente em tickets por e-mail. Contactos só WhatsApp podem ficar em branco.
+              </p>
               <Select
                 label="Tipo"
                 value={tipo}

--- a/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
@@ -45,6 +45,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
   const [empresaIdCadastro, setEmpresaIdCadastro] = useState<number | ''>('')
   const [empresaIdsCadastro, setEmpresaIdsCadastro] = useState<number[]>([])
   const [empresaContextoId, setEmpresaContextoId] = useState<number | ''>('')
+  const [erroFormulario, setErroFormulario] = useState<string | null>(null)
 
   const empresaItemsVincular = useMemo(
     () => (selecionado?.empresas ?? []).map((e) => ({ id: e.id, label: e.nome })),
@@ -90,6 +91,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
     setEmpresaIdCadastro('')
     setEmpresaIdsCadastro([])
     setEmpresaContextoId('')
+    setErroFormulario(null)
     setCatalogoLoading(true)
     whatsappChats
       .catalogoFuncionarios()
@@ -155,13 +157,14 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
 
   async function confirmarVinculo() {
     if (!selecionado) {
-      toast.showWarning('Selecione um funcionário.')
+      setErroFormulario('Selecione um funcionário.')
       return
     }
     if (selecionado.empresas.length > 1 && empresaVinculoId === '') {
-      toast.showWarning('Selecione a empresa do funcionário.')
+      setErroFormulario('Selecione a empresa do funcionário.')
       return
     }
+    setErroFormulario(null)
     setSalvando(true)
     try {
       const atualizado = await whatsappChats.vincularFuncionario(chat.id, {
@@ -172,7 +175,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
       onSuccess(atualizado)
       onClose()
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível vincular o funcionário.'))
+      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível vincular o funcionário.'))
     } finally {
       setSalvando(false)
     }
@@ -180,41 +183,39 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
 
   async function confirmarCadastro() {
     if (!nomeCadastro.trim()) {
-      toast.showWarning('Informe o nome do funcionário.')
-      return
-    }
-    if (!emailCadastro.trim()) {
-      toast.showWarning('Informe o e-mail do funcionário.')
+      setErroFormulario('Informe o nome do funcionário.')
       return
     }
     if (redeIdCadastro === '') {
-      toast.showWarning('Selecione a rede.')
+      setErroFormulario('Selecione a rede.')
       return
     }
     let empresaIds: number[] = []
     if (escopoCadastro === 'selected') {
       if (tipoCadastro === 'colaborador') {
         if (empresaIdCadastro === '') {
-          toast.showWarning('Selecione a empresa.')
+          setErroFormulario('Selecione a empresa.')
           return
         }
         empresaIds = [Number(empresaIdCadastro)]
       } else if (empresaIdsCadastro.length === 0) {
-        toast.showWarning('Marque ao menos uma empresa.')
+        setErroFormulario('Marque ao menos uma empresa.')
         return
       } else {
         empresaIds = [...empresaIdsCadastro]
       }
     }
     if (empresasContextoOpcoes.length > 1 && empresaContextoId === '') {
-      toast.showWarning('Selecione a empresa exibida no chat.')
+      setErroFormulario('Selecione a empresa exibida no chat.')
       return
     }
+    setErroFormulario(null)
     setSalvando(true)
     try {
+      const emailTrim = emailCadastro.trim()
       const atualizado = await whatsappChats.cadastrarFuncionario(chat.id, {
         nome: nomeCadastro.trim(),
-        email: emailCadastro.trim(),
+        email: emailTrim || null,
         rede_id: Number(redeIdCadastro),
         tipo: tipoCadastro,
         escopo_empresas: escopoCadastro,
@@ -225,7 +226,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
       onSuccess(atualizado)
       onClose()
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível cadastrar o funcionário.'))
+      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível cadastrar o funcionário.'))
     } finally {
       setSalvando(false)
     }
@@ -299,7 +300,10 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                 ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-white'
                 : 'text-slate-500 hover:text-slate-800 dark:hover:text-slate-200'
             }`}
-            onClick={() => setModo('vincular')}
+            onClick={() => {
+              setModo('vincular')
+              setErroFormulario(null)
+            }}
           >
             Vincular existente
           </button>
@@ -310,11 +314,23 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                 ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-white'
                 : 'text-slate-500 hover:text-slate-800 dark:hover:text-slate-200'
             }`}
-            onClick={() => setModo('cadastrar')}
+            onClick={() => {
+              setModo('cadastrar')
+              setErroFormulario(null)
+            }}
           >
             Cadastrar novo
           </button>
         </div>
+
+        {erroFormulario && (
+          <div
+            role="alert"
+            className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-100"
+          >
+            {erroFormulario}
+          </div>
+        )}
 
         {modo === 'vincular' ? (
           <div className="mt-4 space-y-4">
@@ -343,7 +359,9 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                       <div className="flex items-center justify-between gap-3">
                         <div>
                           <p className="font-semibold text-slate-900 dark:text-slate-100">{funcionario.nome}</p>
-                          <p className="text-xs text-slate-500 dark:text-slate-400">{funcionario.email}</p>
+                          <p className="text-xs text-slate-500 dark:text-slate-400">
+                            {funcionario.email || 'Sem e-mail'}
+                          </p>
                         </div>
                         <span className="text-xs uppercase tracking-wide text-slate-400">{funcionario.tipo}</span>
                       </div>
@@ -381,12 +399,17 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                   required
                 />
                 <Input
-                  label="E-mail"
+                  label="E-mail (opcional)"
                   type="email"
                   value={emailCadastro}
-                  onChange={(e) => setEmailCadastro(e.target.value)}
-                  required
+                  onChange={(e) => {
+                    setEmailCadastro(e.target.value)
+                    setErroFormulario(null)
+                  }}
                 />
+                <p className="text-xs text-slate-500">
+                  Usado para tickets por e-mail; contactos só WhatsApp podem deixar em branco.
+                </p>
                 <p className="text-xs text-slate-500">
                   WhatsApp do contato: <span className="font-mono">{chat.wa_id}</span>
                 </p>


### PR DESCRIPTION
## Summary
- **#444:** e-mail opcional ao cadastrar funcionário pelo chat WhatsApp (migration 055).
- Erros de validação e falhas de API aparecem **dentro do modal** (banner inline), não atrás do overlay.
- Toasts globais elevados para \z-[200]\; formulário geral \/funcionarios-rede\ alinhado.

## Test plan
- [ ] Cadastrar contacto só WhatsApp sem e-mail → vincula ao chat
- [ ] Erro «Selecione a rede» legível com modal aberto
- [ ] \pytest tests/test_whatsapp_chats.py::test_cadastrar_funcionario_no_chat_sem_email\`n- [ ] Migration \