### PR TITLE
fix(whatsapp): correções produção #441–#449

### DIFF
--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -59,6 +59,26 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | [#418](https://github.com/lgustavoss/dx-connect/issues/418) | Pausa SLA por status do ticket | Fechada · PR [#427](https://github.com/lgustavoss/dx-connect/pull/427) |
 | [#423](https://github.com/lgustavoss/dx-connect/issues/423) | Demandas resolvidas na sessão | Fechada · PR [#427](https://github.com/lgustavoss/dx-connect/pull/427) |
 
+### Feedback produção — WhatsApp, UX, notificações (2026-06)
+
+| Issue | Título | Estado |
+|-------|--------|--------|
+| [#431](https://github.com/lgustavoss/dx-connect/issues/431) | Mídia inbound webhook + UI | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
+| [#432](https://github.com/lgustavoss/dx-connect/issues/432) | Barra de anexos e pré-visualização | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
+| [#433](https://github.com/lgustavoss/dx-connect/issues/433) | Banner «Sem vínculo» | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
+| [#441](https://github.com/lgustavoss/dx-connect/issues/441) | Áudio outbound nota de voz | Fechada · PR `fix/whatsapp-correcoes` |
+| [#442](https://github.com/lgustavoss/dx-connect/issues/442) | Tempo real / polling | Fechada · PR `fix/whatsapp-correcoes` |
+| [#444](https://github.com/lgustavoss/dx-connect/issues/444) | E-mail opcional no cadastro | Fechada · PR `fix/whatsapp-correcoes` |
+| [#445](https://github.com/lgustavoss/dx-connect/issues/445) | Modal encerramento + demandas | Fechada · PR `fix/whatsapp-correcoes` |
+| [#448](https://github.com/lgustavoss/dx-connect/issues/448) | Histórico e Avaliações | Fechada · PR `fix/whatsapp-correcoes` |
+| [#449](https://github.com/lgustavoss/dx-connect/issues/449) | Botão Voltar na conversa | Fechada · PR `fix/whatsapp-correcoes` |
+| [#446](https://github.com/lgustavoss/dx-connect/issues/446) | Marco timeline demanda (SSE/backend) | Aberta · parcial em `fix/whatsapp-correcoes` |
+| [#443](https://github.com/lgustavoss/dx-connect/issues/443) | Composer estilo WhatsApp Web | Aberta |
+| [#447](https://github.com/lgustavoss/dx-connect/issues/447) | Terminologia contato vs atendente | Aberta |
+| [#452](https://github.com/lgustavoss/dx-connect/issues/452) | Notificações: link directo ao ticket | Aberta · #391 |
+| [#453](https://github.com/lgustavoss/dx-connect/issues/453) | Ícones por tipo de ficheiro | Aberta |
+| [#455](https://github.com/lgustavoss/dx-connect/issues/455) | Chats activos no Histórico (colaboração) | Aberta |
+
 ---
 
 ## Base de conhecimento (#262) — v1 interno fechado

--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -66,12 +66,12 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | [#431](https://github.com/lgustavoss/dx-connect/issues/431) | Mídia inbound webhook + UI | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
 | [#432](https://github.com/lgustavoss/dx-connect/issues/432) | Barra de anexos e pré-visualização | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
 | [#433](https://github.com/lgustavoss/dx-connect/issues/433) | Banner «Sem vínculo» | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
-| [#441](https://github.com/lgustavoss/dx-connect/issues/441) | Áudio outbound nota de voz | Fechada · PR `fix/whatsapp-correcoes` |
-| [#442](https://github.com/lgustavoss/dx-connect/issues/442) | Tempo real / polling | Fechada · PR `fix/whatsapp-correcoes` |
-| [#444](https://github.com/lgustavoss/dx-connect/issues/444) | E-mail opcional no cadastro | Fechada · PR `fix/whatsapp-correcoes` |
-| [#445](https://github.com/lgustavoss/dx-connect/issues/445) | Modal encerramento + demandas | Fechada · PR `fix/whatsapp-correcoes` |
-| [#448](https://github.com/lgustavoss/dx-connect/issues/448) | Histórico e Avaliações | Fechada · PR `fix/whatsapp-correcoes` |
-| [#449](https://github.com/lgustavoss/dx-connect/issues/449) | Botão Voltar na conversa | Fechada · PR `fix/whatsapp-correcoes` |
+| [#441](https://github.com/lgustavoss/dx-connect/issues/441) | Áudio outbound nota de voz | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#442](https://github.com/lgustavoss/dx-connect/issues/442) | Tempo real / polling | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#444](https://github.com/lgustavoss/dx-connect/issues/444) | E-mail opcional no cadastro | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#445](https://github.com/lgustavoss/dx-connect/issues/445) | Modal encerramento + demandas | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#448](https://github.com/lgustavoss/dx-connect/issues/448) | Histórico e Avaliações | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#449](https://github.com/lgustavoss/dx-connect/issues/449) | Botão Voltar na conversa | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
 | [#446](https://github.com/lgustavoss/dx-connect/issues/446) | Marco timeline demanda (SSE/backend) | Aberta · parcial em `fix/whatsapp-correcoes` |
 | [#443](https://github.com/lgustavoss/dx-connect/issues/443) | Composer estilo WhatsApp Web | Aberta |
 | [#447](https://github.com/lgustavoss/dx-connect/issues/447) | Terminologia contato vs atendente | Aberta |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape
 - WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)
 - WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais
 - WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker
+- WhatsApp (#441): áudio gravado pelo atendente enviado como nota de voz via `sendWhatsAppAudio` (encoding Evolution); falha explícita se a API não confirmar entrega
 - WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível
 - WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional
 - WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#445): modal de encerramento substitui `confirm()` nativo — registo/edição de demandas, aviso quando houve conversa após última demanda, marco na timeline e `ConfirmDialog` reutilizável
 - WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape
 - WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)
 - WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais
@@ -25,7 +26,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id
 - Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)
 - Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável
-- Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats
+- Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats; edição via `PATCH`, marco na timeline e fluxo completo no modal de encerramento (#445)
 - SLA (#418): pausa automática da contagem quando o ticket está em status configurado (flag `pausa_sla`; «Aguardando cliente» ativado por padrão)
 - SLA: políticas opcionais por natureza do ticket; filtro «em risco» e dashboard usam o motor completo (calendário + pausa); prazo efetivo no card SLA
 - SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais
 - WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível
 - WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional
 - WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)
 - WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais
+- WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker
+- WhatsApp (#441): áudio gravado pelo atendente enviado como nota de voz via `sendWhatsAppAudio` (encoding Evolution); falha explícita se a API não confirmar entrega
 - WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível
 - WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional
 - WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile

--- a/backend/alembic/versions/055_funcionario_rede_email_nullable.py
+++ b/backend/alembic/versions/055_funcionario_rede_email_nullable.py
@@ -1,0 +1,32 @@
+"""funcionarios_rede.email opcional (#444).
+
+Revision ID: 055_funcionario_rede_email_nullable
+Revises: 054_kb_interno_only
+Create Date: 2026-06-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "055_funcionario_rede_email_nullable"
+down_revision = "054_kb_interno_only"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "funcionarios_rede",
+        "email",
+        existing_type=sa.String(length=255),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "funcionarios_rede",
+        "email",
+        existing_type=sa.String(length=255),
+        nullable=False,
+    )

--- a/backend/app/api/funcionarios_rede.py
+++ b/backend/app/api/funcionarios_rede.py
@@ -177,13 +177,15 @@ def criar(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe a rede.")
     if rede_id_final is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="rede_id não definido para o vínculo.")
-    try:
-        assert_email_unico_por_rede(db, email=str(data.email), rede_id=int(rede_id_final))
-    except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    email_eff = data.email
+    if email_eff:
+        try:
+            assert_email_unico_por_rede(db, email=str(email_eff), rede_id=int(rede_id_final))
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     f = FuncionarioRede(
         nome=data.nome,
-        email=data.email,
+        email=email_eff,
         tipo=data.tipo,
         escopo_empresas=escopo,
         ativo=data.ativo,
@@ -202,7 +204,8 @@ def criar(
     )
     db.commit()
     db.refresh(f)
-    reconciliar_tickets_pendentes_por_email(db, f.email)
+    if f.email:
+        reconciliar_tickets_pendentes_por_email(db, f.email)
     db.commit()
     return _para_read(f)
 
@@ -267,7 +270,7 @@ def atualizar(
         rede_id=int(rede_id),
         empresa_ids=ids if escopo == "selected" else None,
     )
-    if f.rede_id is not None:
+    if f.rede_id is not None and f.email:
         try:
             assert_email_unico_por_rede(
                 db,
@@ -280,7 +283,8 @@ def atualizar(
     registrar_audit(db, "funcionario_rede", funcionario_id, "update", atendente.id)
     db.commit()
     db.refresh(f)
-    reconciliar_tickets_pendentes_por_email(db, f.email)
+    if f.email:
+        reconciliar_tickets_pendentes_por_email(db, f.email)
     db.commit()
     return _para_read(f)
 

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -63,6 +63,26 @@ logger = logging.getLogger(__name__)
 _MAX_PAGE = 100
 _DEFAULT_PAGE = 20
 
+_ESTADOS_HISTORICO_FINALIZADOS = ("encerrado", "aguardando_avaliacao")
+_ESTADOS_HISTORICO_ATIVOS = ("em_atendimento", "aguardando_atendente")
+
+
+def _estados_historico_filtro(estado: str | None) -> list[str]:
+    s = (estado or "finalizados").strip().lower()
+    if s in ("finalizados", "default"):
+        return list(_ESTADOS_HISTORICO_FINALIZADOS)
+    if s == "encerrado":
+        return ["encerrado"]
+    if s == "aguardando_avaliacao":
+        return ["aguardando_avaliacao"]
+    if s == "em_atendimento":
+        return ["em_atendimento"]
+    if s == "aguardando_atendente":
+        return ["aguardando_atendente"]
+    if s == "todos":
+        return list(_ESTADOS_HISTORICO_FINALIZADOS + _ESTADOS_HISTORICO_ATIVOS)
+    raise HTTPException(status_code=400, detail="Parâmetro estado inválido para histórico.")
+
 _CHAT_LOAD_OPTIONS = (
     joinedload(WhatsappChat.atendente),
     joinedload(WhatsappChat.setor),
@@ -580,12 +600,17 @@ def listar_encerrados(
     atendente_id: int | None = Query(None, ge=1, description="Filtro por atendente que encerrou"),
     encerramento_inicio: datetime | None = Query(None, description="Filtro por data de encerramento a partir de"),
     encerramento_fim: datetime | None = Query(None, description="Filtro por data de encerramento até"),
+    estado: str | None = Query(
+        None,
+        description="finalizados (padrão) | encerrado | aguardando_avaliacao | em_atendimento | aguardando_atendente | todos",
+    ),
     offset: int = Query(0, ge=0),
     limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    q = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.estado == "encerrado")
+    estados = _estados_historico_filtro(estado)
+    q = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.estado.in_(estados))
     if protocolo:
         q = q.filter(WhatsappChat.protocolo.ilike(f"%{protocolo}%"))
     if wa_id:
@@ -621,16 +646,20 @@ def listar_avaliacoes(
     nota_max: int | None = Query(None, ge=1, le=5),
     encerramento_inicio: datetime | None = Query(None),
     encerramento_fim: datetime | None = Query(None),
+    incluir_sem_resposta: bool = Query(
+        False,
+        description="Incluir chats com avaliação solicitada mas sem nota (auditoria)",
+    ),
     offset: int = Query(0, ge=0),
     limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
     db: Session = Depends(get_db),
     _: Atendente = Depends(exigir_admin),
 ):
-    q = (
-        db.query(WhatsappChat)
-        .options(*_CHAT_LOAD_OPTIONS)
-        .filter(WhatsappChat.avaliacao_solicitada.is_(True))
-    )
+    q = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS)
+    if incluir_sem_resposta:
+        q = q.filter(WhatsappChat.avaliacao_solicitada.is_(True))
+    else:
+        q = q.filter(WhatsappChat.avaliacao_nota.isnot(None))
     if busca:
         term = f"%{busca.strip()}%"
         q = q.filter(
@@ -1075,20 +1104,35 @@ async def enviar_mensagem_midia(
         )
         q_prev = _preview_citacao(ref) if ref else None
 
-    ok, err, sent_wa_id = evolution_api.evolution_send_media(
-        st.evolution_base_url,
-        st.evolution_instance_name,
-        st.evolution_api_key,
-        c.wa_id,
-        mediatype=ev_mt,
-        mimetype=mime,
-        caption=legenda_whatsapp,
-        media_base64=b64,
-        file_name=fname,
-        quoted=quoted_payload,
-    )
+    if tipo_db == "audio":
+        ok, err, sent_wa_id = evolution_api.evolution_send_whatsapp_audio(
+            st.evolution_base_url,
+            st.evolution_instance_name,
+            st.evolution_api_key,
+            c.wa_id,
+            audio_base64=b64,
+            quoted=quoted_payload,
+        )
+    else:
+        ok, err, sent_wa_id = evolution_api.evolution_send_media(
+            st.evolution_base_url,
+            st.evolution_instance_name,
+            st.evolution_api_key,
+            c.wa_id,
+            mediatype=ev_mt,
+            mimetype=mime,
+            caption=legenda_whatsapp,
+            media_base64=b64,
+            file_name=fname,
+            quoted=quoted_payload,
+        )
     if not ok:
         raise HTTPException(status_code=502, detail=err or "Falha ao enviar mídia pela Evolution API")
+    if tipo_db == "audio" and not sent_wa_id:
+        raise HTTPException(
+            status_code=502,
+            detail="Evolution API não confirmou entrega do áudio (wa_message_id ausente).",
+        )
 
     m = WhatsappMensagem(
         chat_id=c.id,

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -1073,20 +1073,35 @@ async def enviar_mensagem_midia(
         )
         q_prev = _preview_citacao(ref) if ref else None
 
-    ok, err, sent_wa_id = evolution_api.evolution_send_media(
-        st.evolution_base_url,
-        st.evolution_instance_name,
-        st.evolution_api_key,
-        c.wa_id,
-        mediatype=ev_mt,
-        mimetype=mime,
-        caption=legenda_whatsapp,
-        media_base64=b64,
-        file_name=fname,
-        quoted=quoted_payload,
-    )
+    if tipo_db == "audio":
+        ok, err, sent_wa_id = evolution_api.evolution_send_whatsapp_audio(
+            st.evolution_base_url,
+            st.evolution_instance_name,
+            st.evolution_api_key,
+            c.wa_id,
+            audio_base64=b64,
+            quoted=quoted_payload,
+        )
+    else:
+        ok, err, sent_wa_id = evolution_api.evolution_send_media(
+            st.evolution_base_url,
+            st.evolution_instance_name,
+            st.evolution_api_key,
+            c.wa_id,
+            mediatype=ev_mt,
+            mimetype=mime,
+            caption=legenda_whatsapp,
+            media_base64=b64,
+            file_name=fname,
+            quoted=quoted_payload,
+        )
     if not ok:
         raise HTTPException(status_code=502, detail=err or "Falha ao enviar mídia pela Evolution API")
+    if tipo_db == "audio" and not sent_wa_id:
+        raise HTTPException(
+            status_code=502,
+            detail="Evolution API não confirmou entrega do áudio (wa_message_id ausente).",
+        )
 
     m = WhatsappMensagem(
         chat_id=c.id,

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -371,7 +371,7 @@ def _criar_funcionario_rede(
     atendente: Atendente,
     *,
     nome: str,
-    email: str,
+    email: str | None,
     tipo: str,
     escopo_empresas: str,
     rede_id: int,
@@ -402,16 +402,18 @@ def _criar_funcionario_rede(
         emps = db.query(Empresa).filter(Empresa.id.in_(ids)).all()
         if any(int(e.tenant_id) != int(atendente.tenant_id) for e in emps):
             raise HTTPException(status_code=400, detail="Empresa inválida para este tenant")
-    try:
-        assert_email_unico_por_rede(db, email=email.strip(), rede_id=int(rede_id))
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    email_norm = (email or "").strip() or None
+    if email_norm:
+        try:
+            assert_email_unico_por_rede(db, email=email_norm, rede_id=int(rede_id))
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
     emp_colab_id: int | None = None
     if escopo == "selected" and tipo_eff == "colaborador" and len(ids) == 1:
         emp_colab_id = ids[0]
     f = FuncionarioRede(
         nome=nome.strip(),
-        email=email.strip(),
+        email=email_norm,
         tipo=tipo_eff,
         escopo_empresas=escopo,
         ativo=True,

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -25,6 +25,7 @@ from app.schemas.whatsapp_chat import (
     WhatsappChatComentarioInternoCreate,
     WhatsappChatDemandaCreate,
     WhatsappChatDemandaRead,
+    WhatsappChatDemandaUpdate,
     WhatsappChatMensagemCreate,
     WhatsappChatRead,
     WhatsappMensagemRead,
@@ -887,6 +888,36 @@ def registrar_demanda(
     db.commit()
     assert row is not None
     return demanda_para_read(row)
+
+
+@router.patch("/{chat_id}/demandas/{demanda_id}", response_model=WhatsappChatDemandaRead)
+def atualizar_demanda(
+    chat_id: int,
+    demanda_id: int,
+    data: WhatsappChatDemandaUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
+    from app.services.whatsapp_chat_demandas import atualizar_demanda_chat, demanda_para_read
+
+    c = db.query(WhatsappChat).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_registrar_demanda(db, atendente, c):
+        raise HTTPException(status_code=403, detail="Sem permissão para alterar demandas neste chat")
+    row = (
+        db.query(WhatsappChatDemanda)
+        .filter(WhatsappChatDemanda.id == demanda_id, WhatsappChatDemanda.chat_id == chat_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Demanda não encontrada")
+    if not data.model_dump(exclude_unset=True):
+        raise HTTPException(status_code=400, detail="Nenhum campo para atualizar")
+    updated = atualizar_demanda_chat(db, c, row, data, atendente=atendente)
+    db.commit()
+    return demanda_para_read(updated)
 
 
 @router.delete("/{chat_id}/demandas/{demanda_id}", status_code=204)

--- a/backend/app/models/funcionario_rede.py
+++ b/backend/app/models/funcionario_rede.py
@@ -19,7 +19,7 @@ class FuncionarioRede(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     nome = Column(String(255), nullable=False)
-    email = Column(String(255), nullable=False, index=True)  # único por contexto (rede/empresa)
+    email = Column(String(255), nullable=True, index=True)  # opcional (#444); único por rede quando preenchido
     tipo = Column(String(20), nullable=False)  # socio | supervisor | colaborador
     escopo_empresas = Column(String(20), nullable=False, default="selected")  # all | selected
     ativo = Column(Boolean, default=True)

--- a/backend/app/schemas/funcionario_rede.py
+++ b/backend/app/schemas/funcionario_rede.py
@@ -1,13 +1,24 @@
-from pydantic import BaseModel, ConfigDict, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, field_validator
 from datetime import datetime
+
+
+def _email_vazio_para_none(v: object) -> object:
+    if v is None or (isinstance(v, str) and not v.strip()):
+        return None
+    return v
 
 
 class FuncionarioRedeBase(BaseModel):
     nome: str
-    email: EmailStr
+    email: EmailStr | None = None
     tipo: str  # socio | supervisor | colaborador
     escopo_empresas: str = "selected"  # all | selected
     ativo: bool = True
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def email_opcional(cls, v: object) -> object:
+        return _email_vazio_para_none(v)
 
 
 class FuncionarioRedeCreate(FuncionarioRedeBase):
@@ -25,6 +36,11 @@ class FuncionarioRedeUpdate(BaseModel):
     rede_id: int | None = None
     empresa_id: int | None = None
     empresa_ids: list[int] | None = None
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def email_opcional(cls, v: object) -> object:
+        return _email_vazio_para_none(v)
 
 
 class FuncionarioRedeRead(FuncionarioRedeBase):

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -138,6 +138,12 @@ class WhatsappChatDemandaCreate(BaseModel):
     descricao_curta: str | None = Field(None, max_length=500)
 
 
+class WhatsappChatDemandaUpdate(BaseModel):
+    natureza_id: int | None = None
+    motivo_id: int | None = None
+    descricao_curta: str | None = Field(None, max_length=500)
+
+
 class WhatsappChatDemandaRead(BaseModel):
     id: int
     chat_id: int

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class WhatsappMensagemRead(BaseModel):
@@ -105,7 +105,7 @@ class WhatsappVincularFuncionarioBody(BaseModel):
 
 class WhatsappCadastrarFuncionarioBody(BaseModel):
     nome: str = Field(..., min_length=1, max_length=255)
-    email: str = Field(..., min_length=3, max_length=255)
+    email: str | None = Field(default=None, max_length=255)
     rede_id: int
     tipo: str = Field(default="colaborador", description="colaborador | supervisor")
     escopo_empresas: str = Field(default="selected", description="all | selected")
@@ -114,6 +114,13 @@ class WhatsappCadastrarFuncionarioBody(BaseModel):
         None,
         description="Empresa exibida no chat quando o funcionário tem várias empresas.",
     )
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def email_opcional(cls, v: object) -> str | None:
+        if v is None or (isinstance(v, str) and not v.strip()):
+            return None
+        return str(v).strip()
 
 
 class WhatsappAbrirTicketBody(BaseModel):

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -186,6 +186,34 @@ def evolution_send_text(
     return False, f"HTTP {code}", None
 
 
+def evolution_send_whatsapp_audio(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    number_digits: str,
+    *,
+    audio_base64: str,
+    quoted: dict[str, Any] | None = None,
+) -> tuple[bool, str | None, str | None]:
+    """POST /message/sendWhatsAppAudio/{instance} — nota de voz (PTT) com encoding automático."""
+    base = base_url.rstrip("/")
+    url = f"{base}/message/sendWhatsAppAudio/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body: dict[str, Any] = {
+        "number": number_digits,
+        "audio": audio_base64,
+        "encoding": True,
+    }
+    if quoted:
+        body["quoted"] = quoted
+    code, data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=120)
+    if code in (200, 201):
+        return True, None, _extract_wa_message_id(data)
+    if err:
+        return False, err[:1200], None
+    return False, f"HTTP {code}", None
+
+
 def evolution_send_media(
     base_url: str,
     instance: str,

--- a/backend/app/services/whatsapp_chat_demandas.py
+++ b/backend/app/services/whatsapp_chat_demandas.py
@@ -14,7 +14,7 @@ from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
 from app.models.whatsapp_chat import WhatsappChat
 from app.models.whatsapp_chat_demanda import DESFECHOS_DEMANDA, WhatsappChatDemanda
 from app.schemas.dashboard import ContagemIdNome
-from app.schemas.whatsapp_chat import WhatsappChatDemandaCreate, WhatsappChatDemandaRead
+from app.schemas.whatsapp_chat import WhatsappChatDemandaCreate, WhatsappChatDemandaRead, WhatsappChatDemandaUpdate
 from app.services.chat_dashboard_filters import apply_chat_dashboard_filters, period_bounds
 
 
@@ -114,6 +114,50 @@ def listar_demandas_chat(db: Session, chat_id: int) -> list[WhatsappChatDemandaR
         .all()
     )
     return [demanda_para_read(r) for r in rows]
+
+
+def atualizar_demanda_chat(
+    db: Session,
+    chat: WhatsappChat,
+    row: WhatsappChatDemanda,
+    data: WhatsappChatDemandaUpdate,
+    *,
+    atendente: Atendente,
+) -> WhatsappChatDemanda:
+    if chat.estado != "em_atendimento":
+        raise HTTPException(status_code=400, detail="Edite demandas apenas em chats em atendimento")
+    if row.desfecho != "resolvido_sessao":
+        raise HTTPException(status_code=400, detail="Demandas escaladas para ticket não podem ser editadas")
+    if atendente.role != "admin" and row.atendente_id != atendente.id:
+        raise HTTPException(status_code=403, detail="Somente quem registrou ou admin pode editar")
+    update = data.model_dump(exclude_unset=True)
+    natureza_id = update.get("natureza_id", row.natureza_id)
+    motivo_id = update.get("motivo_id", row.motivo_id)
+    if "motivo_id" in update and update["motivo_id"] is None:
+        motivo_id = None
+    _validar_natureza_motivo(db, natureza_id=int(natureza_id), motivo_id=motivo_id)
+    if "natureza_id" in update:
+        row.natureza_id = int(natureza_id)
+    if "motivo_id" in update or "natureza_id" in update:
+        row.motivo_id = motivo_id
+    if "descricao_curta" in update:
+        desc = (update["descricao_curta"] or "").strip() or None
+        if desc and len(desc) > 500:
+            raise HTTPException(status_code=400, detail="Descrição curta excede 500 caracteres")
+        row.descricao_curta = desc
+    db.flush()
+    refreshed = (
+        db.query(WhatsappChatDemanda)
+        .options(
+            joinedload(WhatsappChatDemanda.natureza),
+            joinedload(WhatsappChatDemanda.motivo),
+            joinedload(WhatsappChatDemanda.atendente),
+        )
+        .filter(WhatsappChatDemanda.id == row.id)
+        .first()
+    )
+    assert refreshed is not None
+    return refreshed
 
 
 def agregar_demandas_por_natureza(

--- a/backend/tests/test_whatsapp_avaliacao.py
+++ b/backend/tests/test_whatsapp_avaliacao.py
@@ -220,3 +220,82 @@ def test_listar_avaliacoes_admin(client, seed_base, auth_headers, db_session):
 
     r403 = client.get("/v1/whatsapp/chats/avaliacoes", headers=auth_headers["a1"])
     assert r403.status_code == 403
+
+
+def test_historico_inclui_aguardando_avaliacao(client, seed_base, auth_headers, db_session, monkeypatch):
+    """#448 — sessão aguardando avaliação aparece no histórico (filtro padrão)."""
+    _configurar(db_session)
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "hist-av"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "hist-av"}
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {"remoteJid": "5511777666555@s.whatsapp.net", "fromMe": False, "id": "hist-av-1"},
+                    "message": {"conversation": "Oi"},
+                }
+            ]
+        },
+    }
+    client.post("/v1/webhooks/evolution", json=body, headers=h)
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    monkeypatch.setattr(
+        "app.services.whatsapp_avaliacao.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-hist"),
+    )
+    enc = client.post(f"/v1/whatsapp/chats/{cid}/encerrar", headers=auth_headers["a1"])
+    assert enc.json()["estado"] == "aguardando_avaliacao"
+
+    hist = client.get("/v1/whatsapp/chats/encerrados", headers=auth_headers["admin"]).json()
+    assert any(item["id"] == cid for item in hist["items"])
+    assert any(item["estado"] == "aguardando_avaliacao" for item in hist["items"] if item["id"] == cid)
+
+    so_encerrado = client.get("/v1/whatsapp/chats/encerrados?estado=encerrado", headers=auth_headers["admin"]).json()
+    assert not any(item["id"] == cid for item in so_encerrado["items"])
+
+
+def test_avaliacoes_exclui_sem_nota_por_defeito(client, seed_base, auth_headers, db_session):
+    """#448 — aba Avaliações lista só chats com nota respondida."""
+    _configurar(db_session)
+    db_session.add(
+        WhatsappChat(
+            protocolo="WPP-AV-SEM",
+            wa_id="5511999000011",
+            cliente_nome="Sem nota",
+            estado="aguardando_avaliacao",
+            atendente_id=1,
+            avaliacao_solicitada=True,
+            avaliacao_nota=None,
+        )
+    )
+    db_session.add(
+        WhatsappChat(
+            protocolo="WPP-AV-COM",
+            wa_id="5511999000022",
+            cliente_nome="Com nota",
+            estado="encerrado",
+            atendente_id=1,
+            avaliacao_solicitada=True,
+            avaliacao_nota=5,
+        )
+    )
+    db_session.commit()
+
+    body = client.get("/v1/whatsapp/chats/avaliacoes", headers=auth_headers["admin"]).json()
+    ids = [item["chat_id"] for item in body["items"]]
+    assert any(item["nota"] == 5 for item in body["items"])
+    assert all(item.get("nota") is not None for item in body["items"])
+    assert not any(item.get("sem_avaliacao") for item in body["items"])
+
+    audit = client.get(
+        "/v1/whatsapp/chats/avaliacoes?incluir_sem_resposta=true",
+        headers=auth_headers["admin"],
+    ).json()
+    assert any(item.get("sem_avaliacao") for item in audit["items"])
+

--- a/backend/tests/test_whatsapp_chat_demandas.py
+++ b/backend/tests/test_whatsapp_chat_demandas.py
@@ -102,3 +102,55 @@ def test_dashboard_agrega_demandas_por_natureza(client, seed_base, auth_headers,
     assert row is not None
     assert row["total"] >= 1
     assert row["nome"] == "Dúvida WPP"
+
+
+def test_atualizar_demanda_resolvido_sessao(client, seed_base, auth_headers, db_session):
+    from app.models.ticket_classificacao import TicketNatureza
+
+    nat, mot = _seed_natureza_motivo(db_session)
+    nat2 = TicketNatureza(nome="Outra WPP", slug="outra-wpp-test", ordem=2, ativo=True)
+    db_session.add(nat2)
+    db_session.commit()
+
+    cid = _chat_em_atendimento(client, auth_headers, wa_id="5511999005566", msg_id="dm-5")
+    created = client.post(
+        f"/v1/whatsapp/chats/{cid}/demandas",
+        json={"natureza_id": nat.id, "motivo_id": mot.id, "descricao_curta": "Antes"},
+        headers=auth_headers["a1"],
+    ).json()
+    did = created["id"]
+
+    r = client.patch(
+        f"/v1/whatsapp/chats/{cid}/demandas/{did}",
+        json={"natureza_id": nat2.id, "motivo_id": None, "descricao_curta": "Depois"},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["natureza_nome"] == "Outra WPP"
+    assert body["motivo_id"] is None
+    assert body["descricao_curta"] == "Depois"
+
+
+def test_nao_edita_demanda_escalada(client, seed_base, auth_headers, db_session):
+    nat, mot = _seed_natureza_motivo(db_session)
+    cid = _chat_em_atendimento(client, auth_headers, wa_id="5511999006677", msg_id="dm-6")
+    client.post(
+        f"/v1/whatsapp/chats/{cid}/abrir-ticket",
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Escalado",
+            "natureza_id": nat.id,
+            "motivo_id": mot.id,
+        },
+        headers=auth_headers["a1"],
+    )
+    demandas = client.get(f"/v1/whatsapp/chats/{cid}/demandas", headers=auth_headers["a1"]).json()
+    did = demandas[0]["id"]
+    denied = client.patch(
+        f"/v1/whatsapp/chats/{cid}/demandas/{did}",
+        json={"descricao_curta": "Tentativa"},
+        headers=auth_headers["a1"],
+    )
+    assert denied.status_code == 400

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -617,3 +617,73 @@ def test_webhook_inbound_midia_grava_ficheiro(client, seed_base, auth_headers, m
     assert r_mid.status_code == 200
     assert r_mid.headers.get("content-type", "").startswith("image/")
 
+
+def test_enviar_audio_usa_sendWhatsAppAudio(client, seed_base, auth_headers, monkeypatch):
+    """#441 — áudio outbound via sendWhatsAppAudio com encoding, não sendMedia."""
+    calls: list[str] = []
+
+    def fake_audio(*_a, **_k):
+        calls.append("audio")
+        return True, None, "wa-audio-1"
+
+    def fake_media(*_a, **_k):
+        calls.append("media")
+        return True, None, "wa-media-1"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_whatsapp_audio", fake_audio)
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_media", fake_media)
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "aud-out",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999445566", msg_id="aud-out-1")
+
+    webm_bytes = b"\x1a\x45\xdf\xa3" + b"\x00" * 64
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens/midia",
+        data={"mediatipo": "audio", "caption": ""},
+        files={"file": ("gravacao.webm", webm_bytes, "audio/webm")},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["tipo_midia"] == "audio"
+    assert body["wa_message_id"] == "wa-audio-1"
+    assert calls == ["audio"]
+
+
+def test_enviar_audio_falha_sem_wa_message_id(client, seed_base, auth_headers, monkeypatch):
+    """#441 — não persiste áudio se Evolution não devolver wa_message_id."""
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_whatsapp_audio",
+        lambda *_a, **_k: (True, None, None),
+    )
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "aud-fail",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999556677", msg_id="aud-fail-1")
+    webm_bytes = b"\x1a\x45\xdf\xa3" + b"\x00" * 64
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens/midia",
+        data={"mediatipo": "audio", "caption": ""},
+        files={"file": ("gravacao.webm", webm_bytes, "audio/webm")},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 502
+    rows = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    assert all(m.get("tipo_midia") != "audio" or m.get("direcao") != "outbound" for m in rows)
+

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -595,3 +595,73 @@ def test_webhook_inbound_midia_grava_ficheiro(client, seed_base, auth_headers, m
     assert r_mid.status_code == 200
     assert r_mid.headers.get("content-type", "").startswith("image/")
 
+
+def test_enviar_audio_usa_sendWhatsAppAudio(client, seed_base, auth_headers, monkeypatch):
+    """#441 — áudio outbound via sendWhatsAppAudio com encoding, não sendMedia."""
+    calls: list[str] = []
+
+    def fake_audio(*_a, **_k):
+        calls.append("audio")
+        return True, None, "wa-audio-1"
+
+    def fake_media(*_a, **_k):
+        calls.append("media")
+        return True, None, "wa-media-1"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_whatsapp_audio", fake_audio)
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_media", fake_media)
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "aud-out",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999445566", msg_id="aud-out-1")
+
+    webm_bytes = b"\x1a\x45\xdf\xa3" + b"\x00" * 64
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens/midia",
+        data={"mediatipo": "audio", "caption": ""},
+        files={"file": ("gravacao.webm", webm_bytes, "audio/webm")},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["tipo_midia"] == "audio"
+    assert body["wa_message_id"] == "wa-audio-1"
+    assert calls == ["audio"]
+
+
+def test_enviar_audio_falha_sem_wa_message_id(client, seed_base, auth_headers, monkeypatch):
+    """#441 — não persiste áudio se Evolution não devolver wa_message_id."""
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_whatsapp_audio",
+        lambda *_a, **_k: (True, None, None),
+    )
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "aud-fail",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999556677", msg_id="aud-fail-1")
+    webm_bytes = b"\x1a\x45\xdf\xa3" + b"\x00" * 64
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens/midia",
+        data={"mediatipo": "audio", "caption": ""},
+        files={"file": ("gravacao.webm", webm_bytes, "audio/webm")},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 502
+    rows = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    assert all(m.get("tipo_midia") != "audio" or m.get("direcao") != "outbound" for m in rows)
+

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -474,6 +474,28 @@ def test_cadastrar_funcionario_no_chat(client, seed_base, auth_headers, db_sessi
     assert any(re["id"] == seed_base["rede"].id for re in catalogo.json()["redes"])
 
 
+def test_cadastrar_funcionario_no_chat_sem_email(client, seed_base, auth_headers):
+    """#444 — cadastro pelo WhatsApp sem e-mail vincula o contacto."""
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999112244", msg_id="func-sem-email")
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/cadastrar-funcionario",
+        json={
+            "nome": "Contacto Só WhatsApp",
+            "rede_id": seed_base["rede"].id,
+            "tipo": "colaborador",
+            "escopo_empresas": "selected",
+            "empresa_ids": [seed_base["empresa"].id],
+        },
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["funcionario_nome"] == "Contacto Só WhatsApp"
+    assert body["funcionario_email"] is None
+    assert body["funcionario_rede_id"] is not None
+    assert body["empresa_id"] == seed_base["empresa"].id
+
+
 def test_admin_nao_envia_ao_cliente_usa_comentario_interno(client, seed_base, auth_headers, monkeypatch):
     """#403 — admin acompanha chat alheio; mensagem ao cliente bloqueada; comentário interno permitido."""
     sent = {"n": 0, "seq": 0}

--- a/docs/REALTIME_SSE.md
+++ b/docs/REALTIME_SSE.md
@@ -32,7 +32,8 @@ Destinatários filtrados por RBAC (setor homônimo + admin).
 
 - Cliente fetch-based (suporta Bearer; `EventSource` nativo não envia header)
 - Hook `useEventStream()` + `EventStreamProvider` no `Layout`
-- Reconexão com backoff exponencial; após **3 falhas** consecutivas, `useFallback === true` (consumidores RT-F2 mantêm polling)
+- Reconexão com backoff exponencial; após **3 falhas** consecutivas, `useFallback === true` (intervalos de polling mais frequentes)
+- **Polling de segurança (#442):** WhatsApp (`WhatsappConversa`, `WhatsappAtendendo`) faz refresh periódico **mesmo com SSE conectado** (4–8 s), porque o hub v1 não propaga eventos entre workers Gunicorn
 
 ## Gunicorn e multi-worker
 

--- a/docs/WHATSAPP_EVOLUTION.md
+++ b/docs/WHATSAPP_EVOLUTION.md
@@ -60,6 +60,7 @@ Campos persistidos em `whatsapp_settings` (via **Configurações → WhatsApp**,
 ## Envio (DX Connect → Evolution)
 
 - Endpoint típico Evolution v2: `POST {base}/message/sendText/{instance}` com JSON `{ "number": "<DDI+DDD+número>", "text": "..." }` e header `apikey`.
+- **Áudio outbound (#441):** notas de voz usam `POST {base}/message/sendWhatsAppAudio/{instance}` com `{ "number", "audio": "<base64>", "encoding": true }` — a Evolution converte para Ogg Opus compatível com WhatsApp (não usar `sendMedia` com `audio/webm` do browser).
 - O número do cliente é normalizado a dígitos (ex.: `5511999999999`).
 
 ## Ciclo de vida do chat

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -889,6 +889,11 @@ export namespace WhatsappChats {
     motivo_id?: number | null
     descricao_curta?: string | null
   }
+  export interface DemandaUpdate {
+    natureza_id?: number
+    motivo_id?: number | null
+    descricao_curta?: string | null
+  }
 }
 
 /** Obtém o binário de uma mensagem com mídia (requer JWT; não usar em `src` de img direto). */
@@ -947,6 +952,11 @@ export const whatsappChats = {
     }),
   excluirDemanda: (id: number, demandaId: number) =>
     api<void>(`/whatsapp/chats/${id}/demandas/${demandaId}`, { method: 'DELETE' }),
+  atualizarDemanda: (id: number, demandaId: number, data: WhatsappChats.DemandaUpdate) =>
+    api<WhatsappChats.Demanda>(`/whatsapp/chats/${id}/demandas/${demandaId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
   assumir: (id: number) => api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/assumir`, { method: 'POST' }),
   encerrar: (id: number) => api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/encerrar`, { method: 'POST' }),
   transferir: (id: number, data: { setor_id: number; atendente_id?: number | null }) =>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -983,7 +983,7 @@ export const whatsappChats = {
     id: number,
     data: {
       nome: string
-      email: string
+      email?: string | null
       rede_id: number
       tipo?: 'colaborador' | 'supervisor'
       escopo_empresas?: 'all' | 'selected'
@@ -1671,7 +1671,7 @@ export namespace FuncionariosRede {
   export interface Funcionario {
     id: number;
     nome: string;
-    email: string;
+    email: string | null;
     tipo: string;
     escopo_empresas: EscopoEmpresas;
     ativo: boolean;
@@ -1683,7 +1683,7 @@ export namespace FuncionariosRede {
   }
   export interface Create {
     nome: string;
-    email: string;
+    email?: string | null;
     tipo: string;
     escopo_empresas?: EscopoEmpresas;
     ativo?: boolean;
@@ -1693,7 +1693,7 @@ export namespace FuncionariosRede {
   }
   export interface Update {
     nome?: string;
-    email?: string;
+    email?: string | null;
     tipo?: string;
     escopo_empresas?: EscopoEmpresas;
     ativo?: boolean;

--- a/frontend/src/components/FuncionariosEmpresaLista.tsx
+++ b/frontend/src/components/FuncionariosEmpresaLista.tsx
@@ -59,7 +59,7 @@ export function FuncionariosEmpresaLista({
               </td>
               <td
                 className="max-w-[14rem] truncate px-4 py-3 text-slate-600 dark:text-slate-300 sm:px-6"
-                title={f.email}
+                title={f.email ?? undefined}
               >
                 {f.email}
               </td>

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useId, useRef, type ReactNode } from 'react'
+import { Card } from './Card'
+import { Button } from './Button'
+
+type Props = {
+  open: boolean
+  title: string
+  message?: string
+  confirmLabel?: string
+  cancelLabel?: string
+  variant?: 'danger' | 'primary'
+  loading?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+  children?: ReactNode
+  /** Oculta botões de acção (modal com acções customizadas no children). */
+  hideActions?: boolean
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = 'Confirmar',
+  cancelLabel = 'Cancelar',
+  variant = 'primary',
+  loading = false,
+  onConfirm,
+  onCancel,
+  children,
+  hideActions = false,
+}: Props) {
+  const titleId = useId()
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    dialogRef.current?.focus()
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onCancel()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onCancel])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-[110] flex items-center justify-center bg-slate-900/50 p-4 backdrop-blur-sm"
+      role="presentation"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onCancel()
+      }}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="w-full max-w-lg outline-none"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+      >
+        <Card className="animate-in zoom-in-95 border-none p-0 shadow-xl ring-1 ring-slate-200 dark:ring-slate-800">
+          <div className="p-6">
+            <div className="flex items-start justify-between gap-3">
+              <h3 id={titleId} className="text-lg font-bold text-slate-900 dark:text-white">
+                {title}
+              </h3>
+              <button
+                type="button"
+                className="text-slate-500 hover:text-slate-900 dark:hover:text-slate-100"
+                onClick={onCancel}
+                aria-label="Fechar"
+              >
+                &times;
+              </button>
+            </div>
+            {message && <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{message}</p>}
+            {children && <div className="mt-4">{children}</div>}
+            {!hideActions && (
+              <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <Button variant="secondary" onClick={onCancel} disabled={loading}>
+                  {cancelLabel}
+                </Button>
+                <Button
+                  variant={variant === 'danger' ? 'danger' : 'primary'}
+                  onClick={onConfirm}
+                  loading={loading}
+                >
+                  {confirmLabel}
+                </Button>
+              </div>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -61,7 +61,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={value}>
       {children}
-      <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+      <div className="pointer-events-none fixed bottom-4 right-4 z-[200] flex flex-col gap-2">
         {toasts.map((toast) => {
           let styles =
             'bg-slate-800 text-white dark:bg-slate-800 dark:text-slate-100 dark:ring-1 dark:ring-slate-600/60'

--- a/frontend/src/hooks/useWhatsappVoltarLista.ts
+++ b/frontend/src/hooks/useWhatsappVoltarLista.ts
@@ -1,0 +1,24 @@
+import { useCallback } from 'react'
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
+
+import { resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../lib/whatsappListReturn'
+
+/**
+ * Volta à lista WhatsApp de origem (#449): history.back() no SPA quando possível;
+ * senão state whatsappListReturn, query ?from= ou atendimento.
+ */
+export function useWhatsappVoltarLista(fallbackPath = WHATSAPP_LIST_PATHS.atendendo) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [searchParams] = useSearchParams()
+
+  return useCallback(() => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      navigate(-1)
+      return
+    }
+    navigate(
+      resolveWhatsappListFallback(location.state, searchParams.get('from'), fallbackPath),
+    )
+  }, [navigate, location.state, searchParams, fallbackPath])
+}

--- a/frontend/src/lib/whatsappDemandaUtils.ts
+++ b/frontend/src/lib/whatsappDemandaUtils.ts
@@ -1,0 +1,86 @@
+import type { WhatsappChats } from '../api/client'
+
+export type DemandaPosEncerramento = {
+  ultimaDemanda: WhatsappChats.Demanda
+  mensagensApos: number
+  ultimaMensagemAt: string | null
+}
+
+export function formatarHoraDemanda(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function rotuloDemanda(d: WhatsappChats.Demanda): string {
+  return d.motivo_nome ? `${d.natureza_nome} · ${d.motivo_nome}` : d.natureza_nome ?? 'Demanda'
+}
+
+/** Mensagens visíveis na conversa (exclui eventos ocultos de avaliação). */
+export function mensagensVisiveisConversa(msgs: WhatsappChats.Mensagem[]): WhatsappChats.Mensagem[] {
+  return msgs.filter(
+    (m) =>
+      m.evento_sistema !== 'auto_avaliacao_solicitacao' &&
+      m.evento_sistema !== 'avaliacao_cliente_nota',
+  )
+}
+
+export function analisarDemandaPosRegistro(
+  demandas: WhatsappChats.Demanda[],
+  msgs: WhatsappChats.Mensagem[],
+): DemandaPosEncerramento | null {
+  const editaveis = demandas.filter((d) => d.desfecho === 'resolvido_sessao')
+  if (editaveis.length === 0) return null
+  const ultimaDemanda = editaveis.reduce((a, b) => {
+    const ta = a.created_at ? new Date(a.created_at).getTime() : 0
+    const tb = b.created_at ? new Date(b.created_at).getTime() : 0
+    return tb >= ta ? b : a
+  })
+  const tDemanda = ultimaDemanda.created_at ? new Date(ultimaDemanda.created_at).getTime() : 0
+  const visiveis = mensagensVisiveisConversa(msgs)
+  const apos = visiveis.filter((m) => {
+    const t = m.created_at ? new Date(m.created_at).getTime() : 0
+    return t > tDemanda
+  })
+  if (apos.length === 0) return null
+  const ultima = apos.reduce((a, b) => {
+    const ta = a.created_at ? new Date(a.created_at).getTime() : 0
+    const tb = b.created_at ? new Date(b.created_at).getTime() : 0
+    return tb >= ta ? b : a
+  })
+  return {
+    ultimaDemanda,
+    mensagensApos: apos.length,
+    ultimaMensagemAt: ultima.created_at ?? null,
+  }
+}
+
+export type TimelineItem =
+  | { kind: 'mensagem'; ts: number; mensagem: WhatsappChats.Mensagem }
+  | { kind: 'demanda'; ts: number; demanda: WhatsappChats.Demanda }
+
+export function mergeTimelineChat(
+  msgs: WhatsappChats.Mensagem[],
+  demandas: WhatsappChats.Demanda[],
+): TimelineItem[] {
+  const items: TimelineItem[] = []
+  for (const m of mensagensVisiveisConversa(msgs)) {
+    items.push({
+      kind: 'mensagem',
+      ts: m.created_at ? new Date(m.created_at).getTime() : 0,
+      mensagem: m,
+    })
+  }
+  for (const d of demandas) {
+    items.push({
+      kind: 'demanda',
+      ts: d.created_at ? new Date(d.created_at).getTime() : 0,
+      demanda: d,
+    })
+  }
+  return items.sort((a, b) => a.ts - b.ts || (a.kind === 'demanda' ? 1 : 0) - (b.kind === 'demanda' ? 1 : 0))
+}

--- a/frontend/src/lib/whatsappListReturn.ts
+++ b/frontend/src/lib/whatsappListReturn.ts
@@ -1,0 +1,77 @@
+export const WHATSAPP_LIST_PATHS = {
+  atendendo: '/whatsapp/atendendo',
+  historico: '/whatsapp/historico',
+  avaliacoes: '/whatsapp/avaliacoes',
+} as const
+
+export type WhatsappListOrigin = keyof typeof WHATSAPP_LIST_PATHS
+
+export type WhatsappListReturnState = {
+  whatsappListReturn?: string
+}
+
+export function whatsappConversaState(returnPath: string): WhatsappListReturnState {
+  return { whatsappListReturn: returnPath }
+}
+
+export function whatsappConversaLink(chatId: number, returnPath: string, from?: WhatsappListOrigin) {
+  const search = from ? `?from=${from}` : ''
+  return {
+    pathname: `/whatsapp/c/${chatId}${search}`,
+    state: whatsappConversaState(returnPath),
+  }
+}
+
+export function resolveWhatsappListFallback(
+  state: unknown,
+  fromQuery: string | null,
+  fallback = WHATSAPP_LIST_PATHS.atendendo,
+): string {
+  const st = state as WhatsappListReturnState | null
+  if (st?.whatsappListReturn?.trim()) return st.whatsappListReturn.trim()
+  const from = fromQuery?.trim().toLowerCase()
+  if (from && from in WHATSAPP_LIST_PATHS) {
+    return WHATSAPP_LIST_PATHS[from as WhatsappListOrigin]
+  }
+  return fallback
+}
+
+export function buildHistoricoReturnPath(filters: {
+  busca: string
+  atendenteId: number | ''
+  desde: string
+  ate: string
+  estado: string
+  offset: number
+}): string {
+  const p = new URLSearchParams()
+  if (filters.busca.trim()) p.set('busca', filters.busca.trim())
+  if (filters.atendenteId !== '') p.set('atendente_id', String(filters.atendenteId))
+  if (filters.desde) p.set('desde', filters.desde)
+  if (filters.ate) p.set('ate', filters.ate)
+  if (filters.estado && filters.estado !== 'finalizados') p.set('estado', filters.estado)
+  if (filters.offset > 0) p.set('offset', String(filters.offset))
+  const qs = p.toString()
+  return qs ? `${WHATSAPP_LIST_PATHS.historico}?${qs}` : WHATSAPP_LIST_PATHS.historico
+}
+
+export function buildAvaliacoesReturnPath(filters: {
+  busca: string
+  atendenteId: number | ''
+  notaMin: number | ''
+  desde: string
+  ate: string
+  incluirSemResposta: boolean
+  offset: number
+}): string {
+  const p = new URLSearchParams()
+  if (filters.busca.trim()) p.set('busca', filters.busca.trim())
+  if (filters.atendenteId !== '') p.set('atendente_id', String(filters.atendenteId))
+  if (filters.notaMin !== '') p.set('nota', String(filters.notaMin))
+  if (filters.desde) p.set('desde', filters.desde)
+  if (filters.ate) p.set('ate', filters.ate)
+  if (filters.incluirSemResposta) p.set('incluir_sem_resposta', 'true')
+  if (filters.offset > 0) p.set('offset', String(filters.offset))
+  const qs = p.toString()
+  return qs ? `${WHATSAPP_LIST_PATHS.avaliacoes}?${qs}` : WHATSAPP_LIST_PATHS.avaliacoes
+}

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -97,7 +97,7 @@ export function FuncionarioRedeForm() {
       .then((item) => {
         if (cancelled) return
         setNome(item.nome)
-        setEmail(item.email)
+        setEmail(item.email || '')
         setTipo(item.tipo as Tipo)
         setEscopoEmpresas((item.escopo_empresas as Escopo) || (item.tipo === 'socio' ? 'all' : 'selected'))
         setAtivo(item.ativo)
@@ -170,12 +170,13 @@ export function FuncionarioRedeForm() {
       }
     }
     setSaving(true)
+    const emailPayload = email.trim() || null
     try {
       let saved: FuncionariosRede.Funcionario
       if (isEdit && !Number.isNaN(funcionarioId)) {
         const payload: FuncionariosRede.Update = {
           nome: nome.trim(),
-          email,
+          email: emailPayload,
           tipo,
           escopo_empresas: escopo,
           ativo,
@@ -188,7 +189,7 @@ export function FuncionarioRedeForm() {
       } else {
         const payload: FuncionariosRede.Create = {
           nome: nome.trim(),
-          email,
+          email: emailPayload,
           tipo,
           escopo_empresas: escopo,
           ativo,
@@ -257,7 +258,15 @@ export function FuncionarioRedeForm() {
           <div className="space-y-6">
             <FormSection title="Dados do funcionário">
               <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-              <Input label="E-mail" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+              <Input
+                label="E-mail (opcional)"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+              <p className="text-xs text-slate-500">
+                Usado para identificar remetente em tickets por e-mail. Contactos só WhatsApp podem ficar em branco.
+              </p>
               <Select
                 label="Tipo"
                 value={tipo}

--- a/frontend/src/pages/FuncionariosRede.tsx
+++ b/frontend/src/pages/FuncionariosRede.tsx
@@ -196,7 +196,7 @@ export function FuncionariosRede() {
                         )}
                       </div>
                     </td>
-                    <td className="max-w-[14rem] truncate px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400" title={f.email}>
+                    <td className="max-w-[14rem] truncate px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400" title={f.email ?? undefined}>
                       {f.email}
                     </td>
                     <td className="whitespace-nowrap px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400">

--- a/frontend/src/pages/RedeDetalhe.tsx
+++ b/frontend/src/pages/RedeDetalhe.tsx
@@ -626,7 +626,7 @@ export function RedeDetalhe() {
 
   function preencherFormFuncionario(f: FuncionarioListaItem) {
     setNomeFuncionario(f.nome)
-    setEmailFuncionario(f.email)
+    setEmailFuncionario(f.email ?? '')
     setTipoFuncionario((f.tipo as TipoFuncionario) || 'colaborador')
     setAtivoFuncionario(f.ativo)
     setEmpresaIdFuncionario(f.empresa_id ?? '')
@@ -1766,7 +1766,7 @@ export function RedeDetalhe() {
                       className="cursor-pointer transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/50"
                     >
                       <td className="px-4 py-3.5 font-medium text-slate-800 sm:px-6 dark:text-slate-100">{f.nome}</td>
-                      <td className="max-w-[12rem] truncate px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-300" title={f.email}>
+                      <td className="max-w-[12rem] truncate px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-300" title={f.email ?? undefined}>
                         {f.email}
                       </td>
                       <td className="whitespace-nowrap px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-300">

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -70,11 +70,11 @@ export function WhatsappAtendendo() {
     }
   }, [subscribe, load])
 
-  // Refresh inicial + polling legado quando SSE indisponível
+  // Refresh inicial + polling de segurança (#442)
   useEffect(() => {
     void load()
-    if (!useFallback) return
-    const timer = setInterval(() => void load(true), 10000)
+    const intervalMs = useFallback ? 10000 : 8000
+    const timer = setInterval(() => void load(true), intervalMs)
     return () => clearInterval(timer)
   }, [load, useFallback])
 

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { ApiError, whatsappChats, type WhatsappChats } from '../../api/client'
+import { whatsappConversaLink, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
 import { useEventStream } from '../../contexts/EventStreamContext'
 import { Card } from '../../components/ui/Card'
@@ -173,7 +174,7 @@ export function WhatsappAtendendo() {
                     {/* Grupo de Botões da Fila */}
                     <div className="flex items-center gap-2 border-t pt-3 dark:border-slate-800">
                       <Link 
-                        to={`/whatsapp/c/${c.id}`}
+                        to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
                         className="flex-1 text-center rounded-lg bg-slate-100 py-2 text-xs font-bold text-slate-600 hover:bg-slate-200 transition-colors dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
                       >
                         Visualizar
@@ -205,7 +206,7 @@ export function WhatsappAtendendo() {
               </div>
             ) : (
               meus.map((c) => (
-                <Link key={c.id} to={`/whatsapp/c/${c.id}`} className="group">
+                <Link key={c.id} to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')} className="group">
                   <Card className="h-full border-none p-5 shadow-sm ring-1 ring-slate-200 transition-all group-hover:ring-cyan-500 dark:ring-slate-800">
                     <div className="flex flex-col h-full justify-between gap-4">
                       <div>

--- a/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
 import { atendentes, whatsappChats, type WhatsappChats, type Atendentes } from '../../api/client'
 import { Card } from '../../components/ui/Card'
 import { Button } from '../../components/ui/Button'
@@ -9,23 +9,64 @@ import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { rotuloAvaliacaoChat } from '../../lib/whatsappChatMeta'
+import { buildAvaliacoesReturnPath, whatsappConversaLink } from '../../lib/whatsappListReturn'
 import { CheckboxField } from '../../components/ui/CheckboxField'
 
 const PAGE_SIZE = 15
 
 export function WhatsappAvaliacoes() {
   const toast = useToast()
+  const [searchParams, setSearchParams] = useSearchParams()
   const [items, setItems] = useState<WhatsappChats.Avaliacao[]>([])
   const [total, setTotal] = useState(0)
-  const [offset, setOffset] = useState(0)
+  const [offset, setOffset] = useState(() => Number(searchParams.get('offset') || 0))
   const [loading, setLoading] = useState(true)
-  const [busca, setBusca] = useState('')
+  const [busca, setBusca] = useState(() => searchParams.get('busca') ?? '')
   const [atendentesList, setAtendentesList] = useState<Atendentes.Atendente[]>([])
-  const [atendenteId, setAtendenteId] = useState<number | ''>('')
-  const [notaMin, setNotaMin] = useState<number | ''>('')
-  const [desde, setDesde] = useState('')
-  const [ate, setAte] = useState('')
-  const [incluirSemResposta, setIncluirSemResposta] = useState(false)
+  const [atendenteId, setAtendenteId] = useState<number | ''>(() => {
+    const v = searchParams.get('atendente_id')
+    return v ? Number(v) : ''
+  })
+  const [notaMin, setNotaMin] = useState<number | ''>(() => {
+    const v = searchParams.get('nota')
+    return v ? Number(v) : ''
+  })
+  const [desde, setDesde] = useState(() => searchParams.get('desde') ?? '')
+  const [ate, setAte] = useState(() => searchParams.get('ate') ?? '')
+  const [incluirSemResposta, setIncluirSemResposta] = useState(
+    () => searchParams.get('incluir_sem_resposta') === 'true',
+  )
+
+  const avaliacoesReturnPath = useMemo(
+    () =>
+      buildAvaliacoesReturnPath({
+        busca,
+        atendenteId,
+        notaMin,
+        desde,
+        ate,
+        incluirSemResposta,
+        offset,
+      }),
+    [ate, atendenteId, busca, desde, incluirSemResposta, notaMin, offset],
+  )
+
+  const syncUrl = useCallback(
+    (from: number) => {
+      const path = buildAvaliacoesReturnPath({
+        busca,
+        atendenteId,
+        notaMin,
+        desde,
+        ate,
+        incluirSemResposta,
+        offset: from,
+      })
+      const qs = path.includes('?') ? path.split('?')[1] : ''
+      setSearchParams(qs ? new URLSearchParams(qs) : new URLSearchParams(), { replace: true })
+    },
+    [ate, atendenteId, busca, desde, incluirSemResposta, notaMin, setSearchParams],
+  )
 
   const load = useCallback(
     async (from: number) => {
@@ -48,13 +89,14 @@ export function WhatsappAvaliacoes() {
         setItems(rows)
         setTotal(t)
         setOffset(from)
+        syncUrl(from)
       } catch (err) {
         toast.showError(mensagemFalhaParaToast(err, 'Falha ao carregar avaliações.'))
       } finally {
         setLoading(false)
       }
     },
-    [atendenteId, ate, busca, desde, incluirSemResposta, notaMin, toast],
+    [atendenteId, ate, busca, desde, incluirSemResposta, notaMin, syncUrl, toast],
   )
 
   useEffect(() => {
@@ -108,7 +150,10 @@ export function WhatsappAvaliacoes() {
           </div>
         </div>
         <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-          <CheckboxField checked={incluirSemResposta} onChange={setIncluirSemResposta}>
+          <CheckboxField
+            checked={incluirSemResposta}
+            onChange={(e) => setIncluirSemResposta(e.target.checked)}
+          >
             Incluir solicitações sem resposta (auditoria)
           </CheckboxField>
           <Button type="button" onClick={() => void load(0)}>
@@ -149,7 +194,7 @@ export function WhatsappAvaliacoes() {
                       : '—'}
                   </p>
                   <Link
-                    to={`/whatsapp/c/${a.chat_id}`}
+                    to={whatsappConversaLink(a.chat_id, avaliacoesReturnPath, 'avaliacoes')}
                     className="mt-1 inline-block text-xs font-medium text-cyan-600 hover:underline dark:text-cyan-400"
                   >
                     Ver conversa

--- a/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
@@ -9,6 +9,7 @@ import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { rotuloAvaliacaoChat } from '../../lib/whatsappChatMeta'
+import { CheckboxField } from '../../components/ui/CheckboxField'
 
 const PAGE_SIZE = 15
 
@@ -24,6 +25,7 @@ export function WhatsappAvaliacoes() {
   const [notaMin, setNotaMin] = useState<number | ''>('')
   const [desde, setDesde] = useState('')
   const [ate, setAte] = useState('')
+  const [incluirSemResposta, setIncluirSemResposta] = useState(false)
 
   const load = useCallback(
     async (from: number) => {
@@ -41,6 +43,7 @@ export function WhatsappAvaliacoes() {
         }
         if (desde) params.encerramento_inicio = `${desde}T00:00:00`
         if (ate) params.encerramento_fim = `${ate}T23:59:59`
+        if (incluirSemResposta) params.incluir_sem_resposta = 'true'
         const { items: rows, total: t } = await whatsappChats.avaliacoes(params)
         setItems(rows)
         setTotal(t)
@@ -51,7 +54,7 @@ export function WhatsappAvaliacoes() {
         setLoading(false)
       }
     },
-    [atendenteId, ate, busca, desde, notaMin, toast],
+    [atendenteId, ate, busca, desde, incluirSemResposta, notaMin, toast],
   )
 
   useEffect(() => {
@@ -104,7 +107,10 @@ export function WhatsappAvaliacoes() {
             <Input label="Até" type="date" value={ate} onChange={(e) => setAte(e.target.value)} />
           </div>
         </div>
-        <div className="mt-4 flex justify-end">
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+          <CheckboxField checked={incluirSemResposta} onChange={setIncluirSemResposta}>
+            Incluir solicitações sem resposta (auditoria)
+          </CheckboxField>
           <Button type="button" onClick={() => void load(0)}>
             Filtrar
           </Button>

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -46,11 +46,14 @@ import {
 import { WhatsappTicketsModal } from './WhatsappTicketsModal'
 import { WhatsappVincFuncionarioModal } from './WhatsappVincFuncionarioModal'
 import { WhatsappDemandasPanel } from './WhatsappDemandasPanel'
+import { WhatsappEncerrarModal } from './WhatsappEncerrarModal'
+import { WhatsappDemandaTimelineMarco } from './WhatsappDemandaTimelineMarco'
 import { WhatsappBarraAnexos, ACCEPT_ANEXO, type TipoAnexoPicker } from './WhatsappBarraAnexos'
 import { WhatsappGravadorAudio } from './WhatsappGravadorAudio'
 import { WhatsappPreviaAnexo } from './WhatsappPreviaAnexo'
 import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
 import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
+import { mergeTimelineChat } from '../../lib/whatsappDemandaUtils'
 
 const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)\]$/
 
@@ -270,7 +273,6 @@ export function WhatsappConversa() {
   const [texto, setTexto] = useState('')
 
   const [enviando, setEnviando] = useState(false)
-  const [encerrando, setEncerrando] = useState(false)
 
   // Estados de WhatsApp Clone (Citação e Zoom)
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
@@ -293,8 +295,9 @@ export function WhatsappConversa() {
 
   const [modalTickets, setModalTickets] = useState(false)
   const [ticketsVinculados, setTicketsVinculados] = useState<Tickets.Ticket[]>([])
-  const [demandasCount, setDemandasCount] = useState(0)
   const [demandasReloadKey, setDemandasReloadKey] = useState(0)
+  const [demandasTimeline, setDemandasTimeline] = useState<WhatsappChats.Demanda[]>([])
+  const [modalEncerrar, setModalEncerrar] = useState(false)
   const navigate = useNavigate()
   const location = useLocation()
   const [searchParams] = useSearchParams()
@@ -307,14 +310,22 @@ export function WhatsappConversa() {
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape' || e.defaultPrevented) return
+      if (e.key !== 'Escape' || e.defaultPrevented || modalEncerrar) return
       const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase()
       if (tag === 'input' || tag === 'textarea' || tag === 'select') return
       voltarLista()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [voltarLista])
+  }, [voltarLista, modalEncerrar])
+
+  useEffect(() => {
+    if (!id) return
+    whatsappChats
+      .demandas(id)
+      .then(setDemandasTimeline)
+      .catch(() => setDemandasTimeline([]))
+  }, [id, demandasReloadKey])
 
 
 
@@ -630,36 +641,15 @@ useEffect(() => {
 
 
 
-  async function encerrar() {
-
-    if (!chat || !confirm('Encerrar este atendimento?')) return
-
-    const podeRegistrarDemanda =
-      chat.estado === 'em_atendimento' &&
-      (chat.atendente_id === user?.id || user?.role === 'admin')
-    if (podeRegistrarDemanda && demandasCount === 0) {
-      const prosseguir = confirm(
-        'Nenhuma demanda foi registrada nesta sessão. Deseja encerrar mesmo assim?',
-      )
-      if (!prosseguir) return
-    }
-
-    setEncerrando(true)
-
-    try {
-
-      const atualizado = await whatsappChats.encerrar(chat.id)
-
-      await Promise.all([carregar(), carregarSidebar()])
-
-      toast.showSuccess(
-        atualizado.estado === 'aguardando_avaliacao'
-          ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
-          : 'Atendimento encerrado.',
-      )
-
-    } finally { setEncerrando(false) }
-
+  async function handleEncerrado(atualizado: WhatsappChats.Chat) {
+    setChat(atualizado)
+    await Promise.all([carregar(), carregarSidebar()])
+    setDemandasReloadKey((k) => k + 1)
+    toast.showSuccess(
+      atualizado.estado === 'aguardando_avaliacao'
+        ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
+        : 'Atendimento encerrado.',
+    )
   }
 
 
@@ -916,7 +906,9 @@ useEffect(() => {
 
                 {podeEncerrar && (
 
-                  <Button variant="danger" className="h-8 px-3 text-xs" onClick={() => void encerrar()} loading={encerrando}>Encerrar</Button>
+                  <Button variant="danger" className="h-8 px-3 text-xs" onClick={() => setModalEncerrar(true)}>
+                    Encerrar
+                  </Button>
 
                 )}
 
@@ -963,7 +955,7 @@ useEffect(() => {
             key={`${chat.id}-${demandasReloadKey}`}
             chatId={chat.id}
             podeRegistrar={isResponsavel || isAdmin}
-            onDemandasChange={setDemandasCount}
+            onDemandasChange={() => setDemandasReloadKey((k) => k + 1)}
           />
         )}
 
@@ -983,7 +975,12 @@ useEffect(() => {
 
         >
 
-          {msgs.map((m) => {
+          {mergeTimelineChat(msgs, demandasTimeline).map((item) => {
+            if (item.kind === 'demanda') {
+              return <WhatsappDemandaTimelineMarco key={`dem-${item.demanda.id}`} demanda={item.demanda} />
+            }
+
+            const m = item.mensagem
 
             const isInbound = m.direcao === 'inbound'
 
@@ -1357,6 +1354,17 @@ useEffect(() => {
             setChat(atualizado)
             setDemandasReloadKey((k) => k + 1)
           }}
+        />
+      )}
+
+      {chat && (
+        <WhatsappEncerrarModal
+          open={modalEncerrar}
+          chatId={chat.id}
+          msgs={msgs}
+          onClose={() => setModalEncerrar(false)}
+          onEncerrado={(atualizado) => void handleEncerrado(atualizado)}
+          onDemandasChange={() => setDemandasReloadKey((k) => k + 1)}
         />
       )}
 

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -413,11 +413,11 @@ export function WhatsappConversa() {
     }
   }, [id, subscribe, carregar, carregarSidebar])
 
-  // Polling legado quando SSE indisponível
+  // Polling de segurança (#442): complementa SSE quando Gunicorn usa N workers in-process
   useEffect(() => {
-    if (!useFallback) return
     if (!chat || chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao') return
-    const t = setInterval(() => void carregar().catch(() => {}), 5000)
+    const intervalMs = useFallback ? 5000 : 4000
+    const t = setInterval(() => void carregar().catch(() => {}), intervalMs)
     return () => clearInterval(t)
   }, [useFallback, chat, carregar])
 

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
 
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
 import {
 
@@ -49,6 +49,8 @@ import { WhatsappDemandasPanel } from './WhatsappDemandasPanel'
 import { WhatsappBarraAnexos, ACCEPT_ANEXO, type TipoAnexoPicker } from './WhatsappBarraAnexos'
 import { WhatsappGravadorAudio } from './WhatsappGravadorAudio'
 import { WhatsappPreviaAnexo } from './WhatsappPreviaAnexo'
+import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
+import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
 
 const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)\]$/
 
@@ -294,6 +296,25 @@ export function WhatsappConversa() {
   const [demandasCount, setDemandasCount] = useState(0)
   const [demandasReloadKey, setDemandasReloadKey] = useState(0)
   const navigate = useNavigate()
+  const location = useLocation()
+  const [searchParams] = useSearchParams()
+  const voltarLista = useWhatsappVoltarLista()
+  const listaRetorno = resolveWhatsappListFallback(
+    location.state,
+    searchParams.get('from'),
+    WHATSAPP_LIST_PATHS.atendendo,
+  )
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || e.defaultPrevented) return
+      const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase()
+      if (tag === 'input' || tag === 'textarea' || tag === 'select') return
+      voltarLista()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [voltarLista])
 
 
 
@@ -716,7 +737,7 @@ useEffect(() => {
 
               key={c.id}
 
-              to={`/whatsapp/c/${c.id}`}
+              to={whatsappConversaLink(c.id, listaRetorno)}
 
               className={`flex items-center p-4 gap-3 transition-colors ${c.id === id ? 'bg-white shadow-sm dark:bg-slate-800' : 'hover:bg-white/40 dark:hover:bg-slate-900/50'}`}
 
@@ -778,7 +799,18 @@ useEffect(() => {
 
         <header className="flex h-16 items-center justify-between border-b border-slate-100 px-4 dark:border-slate-800 shadow-sm z-10">
 
-          <div className="flex items-center gap-3 min-w-0">
+          <div className="flex items-center gap-2 min-w-0 sm:gap-3">
+
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-9 shrink-0 px-2 text-xs font-medium"
+              onClick={voltarLista}
+              aria-label="Voltar à lista"
+            >
+              <span aria-hidden>←</span>
+              <span className="hidden sm:inline"> Voltar</span>
+            </Button>
 
             <div className="min-w-0">
 

--- a/frontend/src/pages/whatsapp/WhatsappDemandaFormFields.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappDemandaFormFields.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react'
+import { ticketClassificacao, type TicketClassificacao } from '../../api/client'
+import { Input } from '../../components/ui/Input'
+import { Select } from '../../components/ui/Select'
+
+export type DemandaFormValues = {
+  naturezaId: number | ''
+  motivoId: number | ''
+  descricaoCurta: string
+}
+
+type Props = {
+  values: DemandaFormValues
+  onChange: (values: DemandaFormValues) => void
+  disabled?: boolean
+  idPrefix?: string
+}
+
+export function WhatsappDemandaFormFields({ values, onChange, disabled, idPrefix = 'dem' }: Props) {
+  const [naturezas, setNaturezas] = useState<TicketClassificacao.Natureza[]>([])
+  const [motivos, setMotivos] = useState<TicketClassificacao.Motivo[]>([])
+
+  useEffect(() => {
+    ticketClassificacao
+      .listNaturezas({ limit: 100 })
+      .then(({ items }) => setNaturezas(items))
+      .catch(() => setNaturezas([]))
+  }, [])
+
+  useEffect(() => {
+    if (values.naturezaId === '') {
+      setMotivos([])
+      return
+    }
+    ticketClassificacao
+      .listMotivos({ natureza_id: Number(values.naturezaId), limit: 100 })
+      .then(({ items }) => setMotivos(items))
+      .catch(() => setMotivos([]))
+  }, [values.naturezaId])
+
+  return (
+    <div className="space-y-3">
+      <Select
+        label="Natureza"
+        value={values.naturezaId}
+        onChange={(v) =>
+          onChange({
+            ...values,
+            naturezaId: v === '' ? '' : Number(v),
+            motivoId: '',
+          })
+        }
+        options={naturezas.map((n) => ({ value: n.id, label: n.nome }))}
+        includeEmpty
+        emptyLabel="Selecione a natureza"
+        disabled={disabled}
+      />
+      <Select
+        label="Motivo (opcional)"
+        value={values.motivoId}
+        onChange={(v) => onChange({ ...values, motivoId: v === '' ? '' : Number(v) })}
+        options={motivos.map((m) => ({ value: m.id, label: m.nome }))}
+        includeEmpty
+        emptyLabel={values.naturezaId === '' ? '—' : 'Opcional'}
+        disabled={disabled || values.naturezaId === ''}
+      />
+      <Input
+        label="Descrição curta (opcional)"
+        value={values.descricaoCurta}
+        onChange={(e) => onChange({ ...values, descricaoCurta: e.target.value })}
+        disabled={disabled}
+        id={`${idPrefix}-desc`}
+        placeholder="Resumo do que foi tratado"
+      />
+    </div>
+  )
+}
+
+export function demandaFormPayload(values: DemandaFormValues) {
+  return {
+    natureza_id: Number(values.naturezaId),
+    motivo_id: values.motivoId === '' ? null : Number(values.motivoId),
+    descricao_curta: values.descricaoCurta.trim() || null,
+  }
+}
+
+export function demandaFormFromDemanda(d: {
+  natureza_id: number
+  motivo_id?: number | null
+  descricao_curta?: string | null
+}): DemandaFormValues {
+  return {
+    naturezaId: d.natureza_id,
+    motivoId: d.motivo_id ?? '',
+    descricaoCurta: d.descricao_curta ?? '',
+  }
+}
+
+export const DEMANDA_FORM_VAZIO: DemandaFormValues = {
+  naturezaId: '',
+  motivoId: '',
+  descricaoCurta: '',
+}

--- a/frontend/src/pages/whatsapp/WhatsappDemandaTimelineMarco.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappDemandaTimelineMarco.tsx
@@ -1,0 +1,36 @@
+import type { WhatsappChats } from '../../api/client'
+import { rotuloDemanda, formatarHoraDemanda } from '../../lib/whatsappDemandaUtils'
+
+const DESFECHO: Record<string, string> = {
+  resolvido_sessao: 'Resolvido na sessão',
+  escalado_ticket: 'Escalado para ticket',
+}
+
+type Props = {
+  demanda: WhatsappChats.Demanda
+}
+
+export function WhatsappDemandaTimelineMarco({ demanda }: Props) {
+  return (
+    <div className="flex w-full justify-center py-2">
+      <div
+        className="max-w-md rounded-xl border border-violet-200 bg-violet-50/95 px-4 py-2 text-center text-xs shadow-sm dark:border-violet-900/50 dark:bg-violet-950/40"
+        title={demanda.descricao_curta ?? undefined}
+      >
+        <p className="font-bold uppercase tracking-wide text-violet-800 dark:text-violet-200">
+          Demanda registada
+        </p>
+        <p className="mt-0.5 font-medium text-violet-950 dark:text-violet-100">{rotuloDemanda(demanda)}</p>
+        <p className="mt-0.5 text-[10px] text-violet-700/80 dark:text-violet-300/80">
+          {DESFECHO[demanda.desfecho] ?? demanda.desfecho}
+          {demanda.atendente_nome ? ` · ${demanda.atendente_nome}` : ''}
+          {' · '}
+          {formatarHoraDemanda(demanda.created_at)}
+        </p>
+        {demanda.descricao_curta && (
+          <p className="mt-1 text-[11px] text-violet-800/90 dark:text-violet-200/90">{demanda.descricao_curta}</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappDemandasPanel.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappDemandasPanel.tsx
@@ -1,15 +1,18 @@
 import { useCallback, useEffect, useState } from 'react'
-import {
-  ticketClassificacao,
-  whatsappChats,
-  type TicketClassificacao,
-  type WhatsappChats,
-} from '../../api/client'
+import { whatsappChats, type WhatsappChats } from '../../api/client'
 import { Button } from '../../components/ui/Button'
-import { Select } from '../../components/ui/Select'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { useAuth } from '../../contexts/AuthContext'
+import { formatarHoraDemanda, rotuloDemanda } from '../../lib/whatsappDemandaUtils'
+import {
+  DEMANDA_FORM_VAZIO,
+  WhatsappDemandaFormFields,
+  demandaFormFromDemanda,
+  demandaFormPayload,
+  type DemandaFormValues,
+} from './WhatsappDemandaFormFields'
 
 type Props = {
   chatId: number
@@ -27,12 +30,11 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
   const { user } = useAuth()
   const [demandas, setDemandas] = useState<WhatsappChats.Demanda[]>([])
   const [loading, setLoading] = useState(true)
-  const [naturezaId, setNaturezaId] = useState<number | ''>('')
-  const [motivoId, setMotivoId] = useState<number | ''>('')
-  const [naturezas, setNaturezas] = useState<TicketClassificacao.Natureza[]>([])
-  const [motivos, setMotivos] = useState<TicketClassificacao.Motivo[]>([])
+  const [form, setForm] = useState<DemandaFormValues>(DEMANDA_FORM_VAZIO)
   const [salvando, setSalvando] = useState(false)
   const [expandido, setExpandido] = useState(false)
+  const [editandoId, setEditandoId] = useState<number | null>(null)
+  const [excluirId, setExcluirId] = useState<number | null>(null)
 
   const carregar = useCallback(async () => {
     try {
@@ -50,64 +52,62 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
     void carregar().finally(() => setLoading(false))
   }, [carregar])
 
-  useEffect(() => {
-    ticketClassificacao
-      .listNaturezas({ limit: 100 })
-      .then(({ items }) => setNaturezas(items))
-      .catch(() => setNaturezas([]))
-  }, [])
+  function resetFormulario() {
+    setForm(DEMANDA_FORM_VAZIO)
+    setEditandoId(null)
+    setExpandido(false)
+  }
 
-  useEffect(() => {
-    if (naturezaId === '') {
-      setMotivos([])
-      setMotivoId('')
-      return
-    }
-    ticketClassificacao
-      .listMotivos({ natureza_id: Number(naturezaId), limit: 100 })
-      .then(({ items }) => setMotivos(items))
-      .catch(() => setMotivos([]))
-  }, [naturezaId])
-
-  async function registrar() {
-    if (naturezaId === '') {
+  async function salvar() {
+    if (form.naturezaId === '') {
       toast.showWarning('Selecione a natureza da demanda.')
       return
     }
     setSalvando(true)
     try {
-      const row = await whatsappChats.registrarDemanda(chatId, {
-        natureza_id: Number(naturezaId),
-        motivo_id: motivoId === '' ? null : Number(motivoId),
-      })
-      setDemandas((prev) => {
-        const next = [...prev, row]
-        onDemandasChange?.(next.length)
-        return next
-      })
-      setNaturezaId('')
-      setMotivoId('')
-      setExpandido(false)
-      toast.showSuccess('Demanda registrada.')
+      const payload = demandaFormPayload(form)
+      if (editandoId != null) {
+        const row = await whatsappChats.atualizarDemanda(chatId, editandoId, payload)
+        setDemandas((prev) => prev.map((d) => (d.id === editandoId ? row : d)))
+        toast.showSuccess('Demanda atualizada.')
+      } else {
+        const row = await whatsappChats.registrarDemanda(chatId, payload)
+        setDemandas((prev) => {
+          const next = [...prev, row]
+          onDemandasChange?.(next.length)
+          return next
+        })
+        toast.showSuccess('Demanda registrada.')
+      }
+      resetFormulario()
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível registrar a demanda.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a demanda.'))
     } finally {
       setSalvando(false)
     }
   }
 
-  async function excluir(demandaId: number) {
-    if (!confirm('Remover este registro de demanda?')) return
+  async function confirmarExclusao() {
+    if (excluirId == null) return
     try {
-      await whatsappChats.excluirDemanda(chatId, demandaId)
+      await whatsappChats.excluirDemanda(chatId, excluirId)
       setDemandas((prev) => {
-        const next = prev.filter((d) => d.id !== demandaId)
+        const next = prev.filter((d) => d.id !== excluirId)
         onDemandasChange?.(next.length)
         return next
       })
+      if (editandoId === excluirId) resetFormulario()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível excluir a demanda.'))
+    } finally {
+      setExcluirId(null)
     }
+  }
+
+  function iniciarEdicao(d: WhatsappChats.Demanda) {
+    setEditandoId(d.id)
+    setForm(demandaFormFromDemanda(d))
+    setExpandido(true)
   }
 
   if (loading) {
@@ -119,105 +119,117 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
   }
 
   return (
-    <div className="border-b border-slate-100 bg-slate-50/80 px-4 py-2 dark:border-slate-800 dark:bg-slate-900/40">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
-            Demandas ({demandas.length})
-          </span>
-          {demandas.slice(0, 3).map((d) => (
-            <span
-              key={d.id}
-              className="inline-flex max-w-[12rem] truncate rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[10px] text-slate-700 dark:border-slate-800 dark:bg-slate-800 dark:text-slate-200"
-              title={d.motivo_nome ? `${d.natureza_nome} · ${d.motivo_nome}` : d.natureza_nome ?? undefined}
-            >
-              {d.natureza_nome}
-              {d.motivo_nome ? ` · ${d.motivo_nome}` : ''}
+    <>
+      <div className="border-b border-slate-100 bg-slate-50/80 px-4 py-2 dark:border-slate-800 dark:bg-slate-900/40">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
+              Demandas ({demandas.length})
             </span>
-          ))}
-          {demandas.length > 3 && (
-            <span className="text-[10px] text-slate-400">+{demandas.length - 3}</span>
+            {demandas.slice(0, 3).map((d) => (
+              <span
+                key={d.id}
+                className="inline-flex max-w-[12rem] truncate rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[10px] text-slate-700 dark:border-slate-800 dark:bg-slate-800 dark:text-slate-200"
+                title={d.descricao_curta ?? rotuloDemanda(d)}
+              >
+                {d.natureza_nome}
+                {d.motivo_nome ? ` · ${d.motivo_nome}` : ''}
+              </span>
+            ))}
+            {demandas.length > 3 && (
+              <span className="text-[10px] text-slate-400">+{demandas.length - 3}</span>
+            )}
+          </div>
+          {podeRegistrar && (
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-7 px-2 text-[10px]"
+              onClick={() => {
+                if (expandido && editandoId == null) {
+                  resetFormulario()
+                } else {
+                  setEditandoId(null)
+                  setForm(DEMANDA_FORM_VAZIO)
+                  setExpandido(true)
+                }
+              }}
+            >
+              {expandido ? 'Cancelar' : '+ Registrar demanda'}
+            </Button>
           )}
         </div>
-        {podeRegistrar && (
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-7 px-2 text-[10px]"
-            onClick={() => setExpandido((v) => !v)}
-          >
-            {expandido ? 'Cancelar' : '+ Registrar demanda'}
-          </Button>
+
+        {expandido && podeRegistrar && (
+          <div className="mt-2 space-y-3 rounded-xl border border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-900">
+            <p className="text-xs font-medium text-slate-600 dark:text-slate-300">
+              {editandoId != null ? 'Editar demanda' : 'Nova demanda'}
+            </p>
+            <WhatsappDemandaFormFields values={form} onChange={setForm} disabled={salvando} idPrefix="panel" />
+            <Button type="button" className="h-9 shrink-0" onClick={() => void salvar()} loading={salvando}>
+              {editandoId != null ? 'Guardar alterações' : 'Registrar'}
+            </Button>
+          </div>
+        )}
+
+        {demandas.length > 0 && (
+          <ul className="mt-2 space-y-1">
+            {demandas.map((d) => {
+              const podeAlterar =
+                podeRegistrar &&
+                d.desfecho === 'resolvido_sessao' &&
+                (user?.role === 'admin' || (user?.id != null && d.atendente_id === user.id))
+              return (
+                <li
+                  key={d.id}
+                  className="flex items-start justify-between gap-2 rounded-lg border border-slate-100 bg-white px-2 py-1.5 text-xs dark:border-slate-800 dark:bg-slate-950/50"
+                >
+                  <div className="min-w-0">
+                    <p className="font-medium text-slate-800 dark:text-slate-100">{rotuloDemanda(d)}</p>
+                    <p className="text-[10px] text-slate-500">
+                      {DESFECHO_ROTULO[d.desfecho] ?? d.desfecho}
+                      {d.atendente_nome ? ` · ${d.atendente_nome}` : ''}
+                      {' · '}
+                      {formatarHoraDemanda(d.created_at)}
+                    </p>
+                    {d.descricao_curta && (
+                      <p className="mt-0.5 text-[10px] text-slate-500">{d.descricao_curta}</p>
+                    )}
+                  </div>
+                  {podeAlterar && (
+                    <div className="flex shrink-0 gap-2">
+                      <button
+                        type="button"
+                        className="text-[10px] font-medium text-cyan-600 hover:underline dark:text-cyan-400"
+                        onClick={() => iniciarEdicao(d)}
+                      >
+                        Editar
+                      </button>
+                      <button
+                        type="button"
+                        className="text-[10px] font-medium text-red-500 hover:underline"
+                        onClick={() => setExcluirId(d.id)}
+                      >
+                        Remover
+                      </button>
+                    </div>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
         )}
       </div>
 
-      {expandido && podeRegistrar && (
-        <div className="mt-2 flex flex-wrap items-end gap-2 rounded-xl border border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-900">
-          <div className="min-w-[10rem] flex-1">
-            <Select
-              label="Natureza"
-              value={naturezaId}
-              onChange={(v) => {
-                setNaturezaId(v === '' ? '' : Number(v))
-                setMotivoId('')
-              }}
-              options={naturezas.map((n) => ({ value: n.id, label: n.nome }))}
-              includeEmpty
-              emptyLabel="Selecione"
-              disabled={salvando}
-            />
-          </div>
-          <div className="min-w-[10rem] flex-1">
-            <Select
-              label="Motivo (opcional)"
-              value={motivoId}
-              onChange={(v) => setMotivoId(v === '' ? '' : Number(v))}
-              options={motivos.map((m) => ({ value: m.id, label: m.nome }))}
-              includeEmpty
-              emptyLabel={naturezaId === '' ? '—' : 'Opcional'}
-              disabled={salvando || naturezaId === ''}
-            />
-          </div>
-          <Button type="button" className="h-9 shrink-0" onClick={() => void registrar()} loading={salvando}>
-            Registrar
-          </Button>
-        </div>
-      )}
-
-      {demandas.length > 0 && (
-        <ul className="mt-2 space-y-1">
-          {demandas.map((d) => {
-            const podeExcluir =
-              user?.role === 'admin' || (user?.id != null && d.atendente_id === user.id)
-            return (
-              <li
-                key={d.id}
-                className="flex items-start justify-between gap-2 rounded-lg border border-slate-100 bg-white px-2 py-1.5 text-xs dark:border-slate-800 dark:bg-slate-950/50"
-              >
-                <div className="min-w-0">
-                  <p className="font-medium text-slate-800 dark:text-slate-100">
-                    {d.natureza_nome}
-                    {d.motivo_nome ? ` · ${d.motivo_nome}` : ''}
-                  </p>
-                  <p className="text-[10px] text-slate-500">
-                    {DESFECHO_ROTULO[d.desfecho] ?? d.desfecho}
-                    {d.atendente_nome ? ` · ${d.atendente_nome}` : ''}
-                  </p>
-                </div>
-                {podeExcluir && d.desfecho === 'resolvido_sessao' && podeRegistrar && (
-                  <button
-                    type="button"
-                    className="shrink-0 text-[10px] text-red-500 hover:underline"
-                    onClick={() => void excluir(d.id)}
-                  >
-                    Remover
-                  </button>
-                )}
-              </li>
-            )
-          })}
-        </ul>
-      )}
-    </div>
+      <ConfirmDialog
+        open={excluirId != null}
+        title="Remover demanda?"
+        message="Este registro de demanda será eliminado desta sessão."
+        confirmLabel="Remover"
+        variant="danger"
+        onConfirm={() => void confirmarExclusao()}
+        onCancel={() => setExcluirId(null)}
+      />
+    </>
   )
 }

--- a/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { whatsappChats, type WhatsappChats } from '../../api/client'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import { Button } from '../../components/ui/Button'
+import { CheckboxField } from '../../components/ui/CheckboxField'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import {
+  analisarDemandaPosRegistro,
+  formatarHoraDemanda,
+  rotuloDemanda,
+} from '../../lib/whatsappDemandaUtils'
+import {
+  DEMANDA_FORM_VAZIO,
+  WhatsappDemandaFormFields,
+  demandaFormFromDemanda,
+  demandaFormPayload,
+  type DemandaFormValues,
+} from './WhatsappDemandaFormFields'
+
+type AcaoEncerramento = 'manter' | 'editar' | 'nova' | 'registrar' | 'sem_demanda'
+
+type Props = {
+  open: boolean
+  chatId: number
+  msgs: WhatsappChats.Mensagem[]
+  onClose: () => void
+  onEncerrado: (chat: WhatsappChats.Chat) => void
+  onDemandasChange?: () => void
+}
+
+export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado, onDemandasChange }: Props) {
+  const toast = useToast()
+  const [demandas, setDemandas] = useState<WhatsappChats.Demanda[]>([])
+  const [loadingDemandas, setLoadingDemandas] = useState(false)
+  const [salvando, setSalvando] = useState(false)
+  const [acao, setAcao] = useState<AcaoEncerramento>('manter')
+  const [form, setForm] = useState<DemandaFormValues>(DEMANDA_FORM_VAZIO)
+  const [confirmarSemDemanda, setConfirmarSemDemanda] = useState(false)
+
+  const posRegistro = useMemo(
+    () => analisarDemandaPosRegistro(demandas, msgs),
+    [demandas, msgs],
+  )
+
+  const semDemandas = demandas.length === 0
+  const demandasResolvidas = demandas.filter((d) => d.desfecho === 'resolvido_sessao')
+
+  const carregarDemandas = useCallback(async () => {
+    setLoadingDemandas(true)
+    try {
+      const rows = await whatsappChats.demandas(chatId)
+      setDemandas(rows)
+      return rows
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar demandas.'))
+      setDemandas([])
+      return []
+    } finally {
+      setLoadingDemandas(false)
+    }
+  }, [chatId, toast])
+
+  useEffect(() => {
+    if (!open) return
+    void carregarDemandas().then((rows) => {
+      const pos = analisarDemandaPosRegistro(rows, msgs)
+      if (rows.length === 0) {
+        setAcao('registrar')
+        setForm(DEMANDA_FORM_VAZIO)
+        setConfirmarSemDemanda(false)
+      } else if (pos) {
+        setAcao('nova')
+        setForm(DEMANDA_FORM_VAZIO)
+        setConfirmarSemDemanda(false)
+      } else {
+        setAcao('manter')
+        setForm(DEMANDA_FORM_VAZIO)
+        setConfirmarSemDemanda(false)
+      }
+    })
+  }, [open, carregarDemandas, msgs])
+
+  useEffect(() => {
+    if (acao === 'editar' && posRegistro) {
+      setForm(demandaFormFromDemanda(posRegistro.ultimaDemanda))
+    } else if (acao === 'nova' || acao === 'registrar') {
+      setForm(DEMANDA_FORM_VAZIO)
+    }
+  }, [acao, posRegistro])
+
+  async function executarEncerramento() {
+    setSalvando(true)
+    try {
+      if (acao === 'registrar') {
+        if (form.naturezaId === '') {
+          toast.showWarning('Selecione a natureza da demanda ou marque encerrar sem registar.')
+          return
+        }
+        await whatsappChats.registrarDemanda(chatId, demandaFormPayload(form))
+      } else if (acao === 'sem_demanda') {
+        if (!confirmarSemDemanda) {
+          toast.showWarning('Confirme que deseja encerrar sem registar demanda.')
+          return
+        }
+      } else if (acao === 'nova') {
+        if (form.naturezaId === '') {
+          toast.showWarning('Selecione a natureza da nova demanda.')
+          return
+        }
+        await whatsappChats.registrarDemanda(chatId, demandaFormPayload(form))
+      } else if (acao === 'editar' && posRegistro) {
+        await whatsappChats.atualizarDemanda(chatId, posRegistro.ultimaDemanda.id, demandaFormPayload(form))
+      }
+
+      const atualizado = await whatsappChats.encerrar(chatId)
+      onDemandasChange?.()
+      onEncerrado(atualizado)
+      onClose()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível encerrar o atendimento.'))
+    } finally {
+      setSalvando(false)
+    }
+  }
+
+  const titulo = 'Encerrar atendimento'
+
+  let mensagemIntro =
+    'Revise as demandas desta sessão antes de finalizar. O cliente poderá receber pedido de avaliação conforme configuração.'
+
+  if (semDemandas) {
+    mensagemIntro =
+      'Registe o motivo do atendimento antes de encerrar, ou confirme explicitamente o encerramento sem demanda.'
+  } else if (posRegistro) {
+    mensagemIntro =
+      'Houve conversa após o último registo de demanda. Escolha se mantém, corrige ou acrescenta outra demanda.'
+  }
+
+  const mostrarForm =
+    acao === 'registrar' || acao === 'nova' || (acao === 'editar' && posRegistro != null)
+
+  return (
+    <ConfirmDialog
+      open={open}
+      title={titulo}
+      message={loadingDemandas ? 'A carregar demandas…' : mensagemIntro}
+      hideActions
+      onConfirm={() => {}}
+      onCancel={onClose}
+    >
+      {!loadingDemandas && (
+        <div className="space-y-4">
+          {demandas.length > 0 && (
+            <div className="rounded-xl border border-slate-200 bg-slate-50/80 p-3 dark:border-slate-800 dark:bg-slate-900/40">
+              <p className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                Demandas desta sessão ({demandas.length})
+              </p>
+              <ul className="mt-2 space-y-2">
+                {demandas.map((d) => (
+                  <li key={d.id} className="text-xs text-slate-700 dark:text-slate-200">
+                    <span className="font-medium">{rotuloDemanda(d)}</span>
+                    <span className="text-slate-500"> · {formatarHoraDemanda(d.created_at)}</span>
+                    {d.desfecho === 'escalado_ticket' && (
+                      <span className="ml-1 text-amber-600 dark:text-amber-400">(ticket)</span>
+                    )}
+                    {d.descricao_curta && (
+                      <p className="mt-0.5 text-[11px] text-slate-500">{d.descricao_curta}</p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {posRegistro && (
+            <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-950 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-100">
+              <p className="font-semibold">Conversa continuou após a última demanda</p>
+              <p className="mt-1">
+                «{rotuloDemanda(posRegistro.ultimaDemanda)}» registada às{' '}
+                {formatarHoraDemanda(posRegistro.ultimaDemanda.created_at)}.
+              </p>
+              <p className="mt-1">
+                {posRegistro.mensagensApos} mensagem(ns) depois
+                {posRegistro.ultimaMensagemAt
+                  ? ` (última às ${formatarHoraDemanda(posRegistro.ultimaMensagemAt)})`
+                  : ''}
+                .
+              </p>
+            </div>
+          )}
+
+          {semDemandas ? (
+            <div className="space-y-3">
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'registrar'}
+                  onChange={() => setAcao('registrar')}
+                />
+                Registar demanda e encerrar
+              </label>
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'sem_demanda'}
+                  onChange={() => setAcao('sem_demanda')}
+                />
+                Encerrar sem registar demanda
+              </label>
+              {acao === 'sem_demanda' && (
+                <CheckboxField
+                  checked={confirmarSemDemanda}
+                  onChange={(e) => setConfirmarSemDemanda(e.target.checked)}
+                  variant="inline"
+                >
+                  Confirmo encerrar sem classificar esta sessão
+                </CheckboxField>
+              )}
+            </div>
+          ) : posRegistro ? (
+            <div className="space-y-2 text-sm">
+              <label className="flex cursor-pointer items-center gap-2">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'manter'}
+                  onChange={() => setAcao('manter')}
+                />
+                Manter demandas como estão
+              </label>
+              {demandasResolvidas.length > 0 && (
+                <label className="flex cursor-pointer items-center gap-2">
+                  <input
+                    type="radio"
+                    name="acao-encerrar"
+                    checked={acao === 'editar'}
+                    onChange={() => setAcao('editar')}
+                  />
+                  Editar última demanda «{rotuloDemanda(posRegistro.ultimaDemanda)}»
+                </label>
+              )}
+              <label className="flex cursor-pointer items-center gap-2">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'nova'}
+                  onChange={() => setAcao('nova')}
+                />
+                Registar nova demanda para o restante da conversa
+              </label>
+            </div>
+          ) : (
+            <p className="text-xs text-slate-500">
+              As demandas registadas cobrem esta sessão. Confirme para encerrar.
+            </p>
+          )}
+
+          {mostrarForm && (
+            <WhatsappDemandaFormFields values={form} onChange={setForm} disabled={salvando} idPrefix="enc" />
+          )}
+
+          <div className="flex flex-col-reverse gap-2 border-t border-slate-100 pt-4 dark:border-slate-800 sm:flex-row sm:justify-end">
+            <Button variant="secondary" onClick={onClose} disabled={salvando}>
+              Cancelar
+            </Button>
+            <Button variant="danger" onClick={() => void executarEncerramento()} loading={salvando}>
+              Encerrar atendimento
+            </Button>
+          </div>
+        </div>
+      )}
+    </ConfirmDialog>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, useCallback } from 'react'
-import { Link } from 'react-router-dom'
+import { useEffect, useState, useCallback, useMemo } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
 import { atendentes, whatsappChats, type WhatsappChats, type Atendentes } from '../../api/client'
 import { Card } from '../../components/ui/Card'
 import { Button } from '../../components/ui/Button'
@@ -10,6 +10,7 @@ import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { AvaliacaoEstrelas } from '../../components/ui/AvaliacaoEstrelas'
 import { rotuloEstadoChat } from '../../lib/whatsappChatMeta'
+import { buildHistoricoReturnPath, whatsappConversaLink } from '../../lib/whatsappListReturn'
 
 const PAGE_SIZE = 15
 
@@ -23,16 +24,52 @@ type FiltroEstadoHistorico =
 
 export function WhatsappHistorico() {
   const toast = useToast()
+  const [searchParams, setSearchParams] = useSearchParams()
   const [items, setItems] = useState<WhatsappChats.Chat[]>([])
   const [total, setTotal] = useState(0)
-  const [offset, setOffset] = useState(0)
+  const [offset, setOffset] = useState(() => Number(searchParams.get('offset') || 0))
   const [loading, setLoading] = useState(true)
-  const [busca, setBusca] = useState('')
+  const [busca, setBusca] = useState(() => searchParams.get('busca') ?? '')
   const [atendentesList, setAtendentesList] = useState<Atendentes.Atendente[]>([])
-  const [atendenteId, setAtendenteId] = useState<number | ''>('')
-  const [desde, setDesde] = useState('')
-  const [ate, setAte] = useState('')
-  const [estadoFiltro, setEstadoFiltro] = useState<FiltroEstadoHistorico>('finalizados')
+  const [atendenteId, setAtendenteId] = useState<number | ''>(() => {
+    const v = searchParams.get('atendente_id')
+    return v ? Number(v) : ''
+  })
+  const [desde, setDesde] = useState(() => searchParams.get('desde') ?? '')
+  const [ate, setAte] = useState(() => searchParams.get('ate') ?? '')
+  const [estadoFiltro, setEstadoFiltro] = useState<FiltroEstadoHistorico>(() => {
+    const v = searchParams.get('estado')
+    return (v as FiltroEstadoHistorico) || 'finalizados'
+  })
+
+  const historicoReturnPath = useMemo(
+    () =>
+      buildHistoricoReturnPath({
+        busca,
+        atendenteId,
+        desde,
+        ate,
+        estado: estadoFiltro,
+        offset,
+      }),
+    [ate, atendenteId, busca, desde, estadoFiltro, offset],
+  )
+
+  const syncUrl = useCallback(
+    (from: number) => {
+      const path = buildHistoricoReturnPath({
+        busca,
+        atendenteId,
+        desde,
+        ate,
+        estado: estadoFiltro,
+        offset: from,
+      })
+      const qs = path.includes('?') ? path.split('?')[1] : ''
+      setSearchParams(qs ? new URLSearchParams(qs) : new URLSearchParams(), { replace: true })
+    },
+    [ate, atendenteId, busca, desde, estadoFiltro, setSearchParams],
+  )
 
   const load = useCallback(async (from: number) => {
     setLoading(true)
@@ -50,12 +87,13 @@ export function WhatsappHistorico() {
       setItems(rows)
       setTotal(t)
       setOffset(from)
+      syncUrl(from)
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha ao carregar histórico.'))
     } finally {
       setLoading(false)
     }
-  }, [atendenteId, ate, busca, desde, estadoFiltro, toast])
+  }, [atendenteId, ate, busca, desde, estadoFiltro, syncUrl, toast])
 
   useEffect(() => {
     void load(0)
@@ -224,7 +262,7 @@ export function WhatsappHistorico() {
                     </div>
 
                     <Link
-                      to={`/whatsapp/c/${c.id}`}
+                      to={whatsappConversaLink(c.id, historicoReturnPath, 'historico')}
                       className="rounded-full bg-slate-100 p-2 text-slate-400 transition-all hover:bg-cyan-600 hover:text-white dark:bg-slate-800 dark:hover:bg-cyan-700"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -9,8 +9,17 @@ import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { AvaliacaoEstrelas } from '../../components/ui/AvaliacaoEstrelas'
+import { rotuloEstadoChat } from '../../lib/whatsappChatMeta'
 
-const PAGE_SIZE = 15 // Reduzi para 15 para melhorar o fôlego da página em listas longas
+const PAGE_SIZE = 15
+
+type FiltroEstadoHistorico =
+  | 'finalizados'
+  | 'encerrado'
+  | 'aguardando_avaliacao'
+  | 'em_atendimento'
+  | 'aguardando_atendente'
+  | 'todos'
 
 export function WhatsappHistorico() {
   const toast = useToast()
@@ -23,6 +32,7 @@ export function WhatsappHistorico() {
   const [atendenteId, setAtendenteId] = useState<number | ''>('')
   const [desde, setDesde] = useState('')
   const [ate, setAte] = useState('')
+  const [estadoFiltro, setEstadoFiltro] = useState<FiltroEstadoHistorico>('finalizados')
 
   const load = useCallback(async (from: number) => {
     setLoading(true)
@@ -35,6 +45,7 @@ export function WhatsappHistorico() {
       if (atendenteId !== '') params.atendente_id = atendenteId
       if (desde) params.encerramento_inicio = `${desde}T00:00:00`
       if (ate) params.encerramento_fim = `${ate}T23:59:59`
+      params.estado = estadoFiltro
       const { items: rows, total: t } = await whatsappChats.encerrados(params)
       setItems(rows)
       setTotal(t)
@@ -44,7 +55,7 @@ export function WhatsappHistorico() {
     } finally {
       setLoading(false)
     }
-  }, [atendenteId, ate, busca, desde, toast])
+  }, [atendenteId, ate, busca, desde, estadoFiltro, toast])
 
   useEffect(() => {
     void load(0)
@@ -80,7 +91,7 @@ export function WhatsappHistorico() {
       <header className="flex flex-col gap-6 border-b pb-6 dark:border-slate-800 md:flex-row md:items-end md:justify-between">
         <div className="space-y-1">
           <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Histórico de Mensagens</h1>
-          <p className="text-sm text-slate-500">Consulte atendimentos finalizados e protocolos antigos.</p>
+          <p className="text-sm text-slate-500">Consulte sessões finalizadas, aguardando avaliação e chats em aberto (conforme filtro).</p>
         </div>
 
         <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:justify-between flex-1">
@@ -95,7 +106,20 @@ export function WhatsappHistorico() {
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
             </span>
           </div>
-          <div className="grid w-full max-w-full grid-cols-1 gap-3 sm:max-w-xl sm:grid-cols-3">
+          <div className="grid w-full max-w-full grid-cols-1 gap-3 sm:max-w-2xl sm:grid-cols-2 lg:grid-cols-4">
+            <Select
+              label="Estado"
+              value={estadoFiltro}
+              onChange={(value) => setEstadoFiltro(value as FiltroEstadoHistorico)}
+              options={[
+                { value: 'finalizados', label: 'Finalizados (padrão)' },
+                { value: 'encerrado', label: 'Encerrados' },
+                { value: 'aguardando_avaliacao', label: 'Aguardando avaliação' },
+                { value: 'em_atendimento', label: 'Em atendimento' },
+                { value: 'aguardando_atendente', label: 'Aguardando atendente' },
+                { value: 'todos', label: 'Todos' },
+              ]}
+            />
             <Input
               type="date"
               label="De"
@@ -153,6 +177,9 @@ export function WhatsappHistorico() {
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</h3>
+                        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                          {rotuloEstadoChat(c.estado)}
+                        </span>
                         <span className="font-mono text-[10px] font-bold text-slate-400">{c.wa_id}</span>
                       </div>
                       <p

--- a/frontend/src/pages/whatsapp/WhatsappLayout.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappLayout.tsx
@@ -36,9 +36,9 @@ export function WhatsappLayout() {
               <h1 className="text-3xl font-extrabold tracking-tight text-slate-900 dark:text-white">WhatsApp</h1>
               <p className="text-sm font-medium text-slate-500">
                 {isAvaliacoes
-                  ? 'Avaliações dos clientes (notas não aparecem na conversa)'
+                  ? 'Chats com avaliação respondida pelos clientes'
                   : isHistorico
-                    ? 'Revisão de atendimentos passados'
+                    ? 'Consulta de sessões finalizadas e chats em aberto'
                     : 'Operação em tempo real'}
               </p>
             </div>

--- a/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
@@ -45,6 +45,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
   const [empresaIdCadastro, setEmpresaIdCadastro] = useState<number | ''>('')
   const [empresaIdsCadastro, setEmpresaIdsCadastro] = useState<number[]>([])
   const [empresaContextoId, setEmpresaContextoId] = useState<number | ''>('')
+  const [erroFormulario, setErroFormulario] = useState<string | null>(null)
 
   const empresaItemsVincular = useMemo(
     () => (selecionado?.empresas ?? []).map((e) => ({ id: e.id, label: e.nome })),
@@ -90,6 +91,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
     setEmpresaIdCadastro('')
     setEmpresaIdsCadastro([])
     setEmpresaContextoId('')
+    setErroFormulario(null)
     setCatalogoLoading(true)
     whatsappChats
       .catalogoFuncionarios()
@@ -155,13 +157,14 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
 
   async function confirmarVinculo() {
     if (!selecionado) {
-      toast.showWarning('Selecione um funcionário.')
+      setErroFormulario('Selecione um funcionário.')
       return
     }
     if (selecionado.empresas.length > 1 && empresaVinculoId === '') {
-      toast.showWarning('Selecione a empresa do funcionário.')
+      setErroFormulario('Selecione a empresa do funcionário.')
       return
     }
+    setErroFormulario(null)
     setSalvando(true)
     try {
       const atualizado = await whatsappChats.vincularFuncionario(chat.id, {
@@ -172,7 +175,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
       onSuccess(atualizado)
       onClose()
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível vincular o funcionário.'))
+      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível vincular o funcionário.'))
     } finally {
       setSalvando(false)
     }
@@ -180,41 +183,39 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
 
   async function confirmarCadastro() {
     if (!nomeCadastro.trim()) {
-      toast.showWarning('Informe o nome do funcionário.')
-      return
-    }
-    if (!emailCadastro.trim()) {
-      toast.showWarning('Informe o e-mail do funcionário.')
+      setErroFormulario('Informe o nome do funcionário.')
       return
     }
     if (redeIdCadastro === '') {
-      toast.showWarning('Selecione a rede.')
+      setErroFormulario('Selecione a rede.')
       return
     }
     let empresaIds: number[] = []
     if (escopoCadastro === 'selected') {
       if (tipoCadastro === 'colaborador') {
         if (empresaIdCadastro === '') {
-          toast.showWarning('Selecione a empresa.')
+          setErroFormulario('Selecione a empresa.')
           return
         }
         empresaIds = [Number(empresaIdCadastro)]
       } else if (empresaIdsCadastro.length === 0) {
-        toast.showWarning('Marque ao menos uma empresa.')
+        setErroFormulario('Marque ao menos uma empresa.')
         return
       } else {
         empresaIds = [...empresaIdsCadastro]
       }
     }
     if (empresasContextoOpcoes.length > 1 && empresaContextoId === '') {
-      toast.showWarning('Selecione a empresa exibida no chat.')
+      setErroFormulario('Selecione a empresa exibida no chat.')
       return
     }
+    setErroFormulario(null)
     setSalvando(true)
     try {
+      const emailTrim = emailCadastro.trim()
       const atualizado = await whatsappChats.cadastrarFuncionario(chat.id, {
         nome: nomeCadastro.trim(),
-        email: emailCadastro.trim(),
+        email: emailTrim || null,
         rede_id: Number(redeIdCadastro),
         tipo: tipoCadastro,
         escopo_empresas: escopoCadastro,
@@ -225,7 +226,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
       onSuccess(atualizado)
       onClose()
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível cadastrar o funcionário.'))
+      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível cadastrar o funcionário.'))
     } finally {
       setSalvando(false)
     }
@@ -299,7 +300,10 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                 ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-white'
                 : 'text-slate-500 hover:text-slate-800 dark:hover:text-slate-200'
             }`}
-            onClick={() => setModo('vincular')}
+            onClick={() => {
+              setModo('vincular')
+              setErroFormulario(null)
+            }}
           >
             Vincular existente
           </button>
@@ -310,11 +314,23 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                 ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-white'
                 : 'text-slate-500 hover:text-slate-800 dark:hover:text-slate-200'
             }`}
-            onClick={() => setModo('cadastrar')}
+            onClick={() => {
+              setModo('cadastrar')
+              setErroFormulario(null)
+            }}
           >
             Cadastrar novo
           </button>
         </div>
+
+        {erroFormulario && (
+          <div
+            role="alert"
+            className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-100"
+          >
+            {erroFormulario}
+          </div>
+        )}
 
         {modo === 'vincular' ? (
           <div className="mt-4 space-y-4">
@@ -343,7 +359,9 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                       <div className="flex items-center justify-between gap-3">
                         <div>
                           <p className="font-semibold text-slate-900 dark:text-slate-100">{funcionario.nome}</p>
-                          <p className="text-xs text-slate-500 dark:text-slate-400">{funcionario.email}</p>
+                          <p className="text-xs text-slate-500 dark:text-slate-400">
+                            {funcionario.email || 'Sem e-mail'}
+                          </p>
                         </div>
                         <span className="text-xs uppercase tracking-wide text-slate-400">{funcionario.tipo}</span>
                       </div>
@@ -381,12 +399,17 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                   required
                 />
                 <Input
-                  label="E-mail"
+                  label="E-mail (opcional)"
                   type="email"
                   value={emailCadastro}
-                  onChange={(e) => setEmailCadastro(e.target.value)}
-                  required
+                  onChange={(e) => {
+                    setEmailCadastro(e.target.value)
+                    setErroFormulario(null)
+                  }}
                 />
+                <p className="text-xs text-slate-500">
+                  Usado para tickets por e-mail; contactos só WhatsApp podem deixar em branco.
+                </p>
                 <p className="text-xs text-slate-500">
                   WhatsApp do contato: <span className="font-mono">{chat.wa_id}</span>
                 </p>


### PR DESCRIPTION
## Summary

Consolida correções e melhorias de WhatsApp reportadas em produção (jun/2026):

- **#441** — áudio do atendente enviado como nota de voz (`sendWhatsAppAudio`); falha explícita sem `wa_message_id`
- **#442** — polling de segurança na conversa e na fila (complementa SSE multi-worker)
- **#444** — e-mail opcional no cadastro de funcionário (migration `055`); erros inline no modal; toasts acima de overlays
- **#445** — modal de encerramento no design system; registo/edição de demandas; `ConfirmDialog`; marco na timeline
- **#448** — Histórico e Avaliações com filtros coerentes (`aguardando_avaliacao`, avaliações só com nota)
- **#449** — botão Voltar na conversa com filtros na URL e atalho Escape

Issues **#431–#433** já estavam em `main` (PR #439); este PR fecha-as no GitHub por hygiene.

## Test plan

- [ ] Migration `055` aplicada em staging antes do deploy
- [ ] Encerrar chat: modal customizado; registar demanda; encerrar sem demanda com checkbox
- [ ] Editar demanda após conversa posterior; remover demanda com `ConfirmDialog`
- [ ] Marco «Demanda registada» visível na timeline
- [ ] Áudio gravado chega ao cliente como nota de voz
- [ ] Mensagem inbound aparece sem reload (polling)
- [ ] Cadastro de funcionário sem e-mail; erros visíveis no modal
- [ ] Histórico: filtros finalizados / aguardando avaliação / em atendimento
- [ ] Avaliações: só chats com nota respondida
- [ ] Voltar na conversa regressa à lista com filtros preservados
- [ ] `pytest tests/test_whatsapp_chat_demandas.py tests/test_whatsapp_chats.py tests/test_whatsapp_avaliacao.py -q`

## Issues a encerrar

Closes #441, #442, #444, #445, #448, #449, #431, #432, #433

**Não incluídas** (escopo futuro): #443, #446 (parcial), #447, #453, #455
