### PR TITLE
WhatsApp UX lote 2 + notificações (#443–#447, #452–#455)

### DIFF
--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -72,12 +72,12 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | [#445](https://github.com/lgustavoss/dx-connect/issues/445) | Modal encerramento + demandas | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
 | [#448](https://github.com/lgustavoss/dx-connect/issues/448) | Histórico e Avaliações | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
 | [#449](https://github.com/lgustavoss/dx-connect/issues/449) | Botão Voltar na conversa | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
-| [#446](https://github.com/lgustavoss/dx-connect/issues/446) | Marco timeline demanda (SSE/backend) | Aberta · parcial em `fix/whatsapp-correcoes` |
-| [#443](https://github.com/lgustavoss/dx-connect/issues/443) | Composer estilo WhatsApp Web | Aberta |
-| [#447](https://github.com/lgustavoss/dx-connect/issues/447) | Terminologia contato vs atendente | Aberta |
-| [#452](https://github.com/lgustavoss/dx-connect/issues/452) | Notificações: link directo ao ticket | Aberta · #391 |
-| [#453](https://github.com/lgustavoss/dx-connect/issues/453) | Ícones por tipo de ficheiro | Aberta |
-| [#455](https://github.com/lgustavoss/dx-connect/issues/455) | Chats activos no Histórico (colaboração) | Aberta |
+| [#452](https://github.com/lgustavoss/dx-connect/issues/452) | Notificações: link directo ao ticket | PR pendente · branch `feat/whatsapp-ux-lote-2` |
+| [#446](https://github.com/lgustavoss/dx-connect/issues/446) | Marco timeline demanda (SSE/backend) | PR pendente · branch `feat/whatsapp-ux-lote-2` |
+| [#443](https://github.com/lgustavoss/dx-connect/issues/443) | Composer estilo WhatsApp Web | PR pendente · branch `feat/whatsapp-ux-lote-2` |
+| [#447](https://github.com/lgustavoss/dx-connect/issues/447) | Terminologia contato vs atendente | PR pendente · branch `feat/whatsapp-ux-lote-2` |
+| [#453](https://github.com/lgustavoss/dx-connect/issues/453) | Ícones por tipo de ficheiro | PR pendente · branch `feat/whatsapp-ux-lote-2` |
+| [#455](https://github.com/lgustavoss/dx-connect/issues/455) | Chats activos no Histórico (colaboração) | PR pendente · branch `feat/whatsapp-ux-lote-2` |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- Notificações (#452): pendências de mensagem não lida abrem o ticket ou chat concreto (`/tickets/{id}`, `/whatsapp/c/{id}`) — removido fallback genérico para listagens
+- WhatsApp (#447): terminologia «contato do cliente» no chat e tickets — distingue colaborador da rede de atendente interno
+- WhatsApp (#453): ícones por tipo de ficheiro (PDF, Word, Excel, etc.) nas mensagens de documento
+- WhatsApp (#446): marco «Demanda registada» na timeline via evento interno + SSE em tempo real; removido ao excluir demanda
+- WhatsApp (#455): Histórico lista chats em atendimento — colegas do setor consultam e comentam internamente; ordenação e filtros de data corrigidos
+- WhatsApp (#443): barra de composição estilo WhatsApp Web (+ anexos, figurinhas em breve, microfone à direita)
 - WhatsApp (#445): modal de encerramento substitui `confirm()` nativo — registo/edição de demandas, aviso quando houve conversa após última demanda, marco na timeline e `ConfirmDialog` reutilizável
 - WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape
 - WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)

--- a/backend/app/api/notificacoes.py
+++ b/backend/app/api/notificacoes.py
@@ -107,6 +107,68 @@ def _unread_count_for_ticket(db: Session, ticket: Ticket, atendente_id: int) -> 
     return int(n or 0)
 
 
+def _last_unread_message_at_subq(atendente_id: int):
+    eff = _effective_last_seen_expr(atendente_id)
+    return (
+        select(func.max(TicketMensagem.created_at))
+        .where(
+            TicketMensagem.ticket_id == Ticket.id,
+            TicketMensagem.created_at > eff,
+        )
+        .scalar_subquery()
+    )
+
+
+def _wpp_resposta_pendente_exprs(atendente_id: int):
+    seen_at = (
+        select(WhatsappChatRead.last_seen_at)
+        .where(
+            WhatsappChatRead.chat_id == WhatsappChat.id,
+            WhatsappChatRead.atendente_id == atendente_id,
+        )
+        .limit(1)
+        .scalar_subquery()
+    )
+    inbound_last = (
+        select(func.max(WhatsappMensagem.created_at))
+        .where(
+            WhatsappMensagem.chat_id == WhatsappChat.id,
+            WhatsappMensagem.direcao == "inbound",
+        )
+        .scalar_subquery()
+    )
+    eff_seen = func.coalesce(seen_at, WhatsappChat.atendimento_inicio_at, WhatsappChat.created_at)
+    return inbound_last, eff_seen
+
+
+def _preview_ultima_nao_lida(db: Session, ticket: Ticket, atendente_id: int) -> str | None:
+    ls = (
+        db.query(TicketRead.last_seen_at)
+        .filter(
+            TicketRead.ticket_id == ticket.id,
+            TicketRead.atendente_id == atendente_id,
+        )
+        .scalar()
+    )
+    eff = ls if ls is not None else ticket.created_at
+    corpo = (
+        db.query(TicketMensagem.corpo)
+        .filter(
+            TicketMensagem.ticket_id == ticket.id,
+            TicketMensagem.created_at > eff,
+        )
+        .order_by(TicketMensagem.created_at.desc())
+        .limit(1)
+        .scalar()
+    )
+    if not corpo:
+        return None
+    texto = corpo.strip()
+    if len(texto) > 60:
+        return texto[:60] + "…"
+    return texto
+
+
 def _count_wpp_fila(db: Session, atendente: Atendente) -> int:
     stmt = (
         select(func.count())
@@ -122,23 +184,7 @@ def _count_wpp_fila(db: Session, atendente: Atendente) -> int:
 
 
 def _count_wpp_respostas_pendentes(db: Session, atendente: Atendente) -> int:
-    seen_at = (
-        select(WhatsappChatRead.last_seen_at)
-        .where(
-            WhatsappChatRead.chat_id == WhatsappChat.id,
-            WhatsappChatRead.atendente_id == atendente.id,
-        )
-        .limit(1)
-        .scalar_subquery()
-    )
-    inbound_last = (
-        select(func.max(WhatsappMensagem.created_at))
-        .where(
-            WhatsappMensagem.chat_id == WhatsappChat.id,
-            WhatsappMensagem.direcao == "inbound",
-        )
-        .scalar_subquery()
-    )
+    inbound_last, eff_seen = _wpp_resposta_pendente_exprs(atendente.id)
     stmt = (
         select(func.count())
         .select_from(WhatsappChat)
@@ -146,7 +192,7 @@ def _count_wpp_respostas_pendentes(db: Session, atendente: Atendente) -> int:
             WhatsappChat.estado == "em_atendimento",
             WhatsappChat.atendente_id == atendente.id,
             inbound_last.isnot(None),
-            func.coalesce(seen_at, WhatsappChat.atendimento_inicio_at, WhatsappChat.created_at) < inbound_last,
+            eff_seen < inbound_last,
         )
     )
     if atendente.role != "admin":
@@ -175,42 +221,6 @@ def _wpp_unread_count_for_chat(db: Session, chat_id: int, atendente_id: int) -> 
         .scalar()
     )
     return int(n or 0)
-
-
-def _append_fallback_itens(
-    out: list[NotificacaoItem],
-    *,
-    nao_lidas: int,
-    wpp_resp: int,
-) -> None:
-    """Garante item navegável quando o contador do resumo indica pendências mas a listagem ficou vazia."""
-    has_ticket = any(i.tipo == "mensagens_nao_lidas" for i in out)
-    if nao_lidas > 0 and not has_ticket:
-        out.append(
-            NotificacaoItem(
-                tipo="mensagens_nao_lidas",
-                ticket_id=None,
-                titulo=f"{nao_lidas} ticket(s) com mensagens não lidas",
-                descricao="Abrir tickets em aberto",
-                count=nao_lidas,
-                href="/tickets?situacao=abertos",
-                created_at=datetime.now(timezone.utc),
-            )
-        )
-
-    has_wpp_resp = any(i.tipo == "wpp_chats_com_resposta" for i in out)
-    if wpp_resp > 0 and not has_wpp_resp:
-        out.append(
-            NotificacaoItem(
-                tipo="wpp_chats_com_resposta",
-                ticket_id=None,
-                titulo=f"{wpp_resp} chat(s) com resposta pendente",
-                descricao="WhatsApp — ver meus atendimentos",
-                count=wpp_resp,
-                href="/whatsapp/atendendo",
-                created_at=datetime.now(timezone.utc),
-            )
-        )
 
 
 def build_notificacao_itens(
@@ -250,13 +260,16 @@ def build_notificacao_itens(
             )
         )
 
+    inbound_last, eff_seen = _wpp_resposta_pendente_exprs(atendente.id)
     stmt_wpp = (
         select(WhatsappChat)
         .where(
             WhatsappChat.estado == "em_atendimento",
             WhatsappChat.atendente_id == atendente.id,
+            inbound_last.isnot(None),
+            eff_seen < inbound_last,
         )
-        .order_by(WhatsappChat.id.desc())
+        .order_by(inbound_last.desc(), WhatsappChat.id.desc())
         .limit(limit)
     )
     if atendente.role != "admin":
@@ -266,7 +279,7 @@ def build_notificacao_itens(
     for c in chats:
         uc = _wpp_unread_count_for_chat(db, c.id, atendente.id)
         if uc <= 0:
-            continue
+            uc = 1
         nome = (c.cliente_nome or "").strip() or c.wa_id
         out.append(
             NotificacaoItem(
@@ -280,13 +293,14 @@ def build_notificacao_itens(
             )
         )
 
+    last_unread_at = _last_unread_message_at_subq(atendente.id)
     stmt = _apply_escopo_tickets_nao_lidos(
         select(Ticket)
         .options(
             joinedload(Ticket.empresa),
             joinedload(Ticket.setor),
         )
-        .order_by(Ticket.updated_at.desc().nulls_last(), Ticket.id.desc())
+        .order_by(last_unread_at.desc(), Ticket.id.desc())
         .limit(limit),
         db,
         atendente,
@@ -296,25 +310,24 @@ def build_notificacao_itens(
     for t in rows:
         uc = _unread_count_for_ticket(db, t, atendente.id)
         if uc <= 0:
-            continue
+            uc = 1
         emp = t.empresa.nome if t.empresa else "—"
         setor = t.setor.nome if t.setor else "—"
         assunto = (t.assunto or "").strip() or "—"
+        preview = _preview_ultima_nao_lida(db, t, atendente.id)
+        descricao = f"Nova resposta do cliente — {preview}" if preview else f"{emp} · {setor}"
         out.append(
             NotificacaoItem(
                 tipo="mensagens_nao_lidas",
                 ticket_id=t.id,
                 titulo=f"{t.protocolo} — {assunto[:80]}{'…' if len(assunto) > 80 else ''}",
-                descricao=f"{emp} · {setor}",
+                descricao=descricao,
                 count=uc,
                 href=f"/tickets/{t.id}",
                 created_at=t.updated_at or t.created_at,
             )
         )
 
-    nao = _count_tickets_com_nao_lidas(db, atendente)
-    wpp_resp = _count_wpp_respostas_pendentes(db, atendente)
-    _append_fallback_itens(out, nao_lidas=nao, wpp_resp=wpp_resp)
     return out
 
 

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session, joinedload
-from sqlalchemy import desc, or_
+from sqlalchemy import desc, func, or_
 
 from app.database import get_db
 from app.models.atendente import Atendente
@@ -531,13 +531,9 @@ def _pode_ver_chat(db: Session, atendente: Atendente, c: WhatsappChat) -> bool:
     if c.atendente_id == atendente.id:
         return True
     vis = ids_setores_visiveis_atendente(db, atendente)
-    # Chats without a setor_id are considered public (the queue). Allow
-    # visibility to attendants for queue items (so they can assume and
-    # view messages while waiting). For other states (e.g. encerrado)
-    # require either being the attendant or having the setor visible.
     if c.setor_id is None:
         return c.estado == "aguardando_atendente"
-    if c.estado in ("aguardando_atendente", "encerrado", "aguardando_avaliacao"):
+    if c.estado in ("aguardando_atendente", "encerrado", "aguardando_avaliacao", "em_atendimento"):
         return c.setor_id in vis
     return False
 
@@ -627,15 +623,20 @@ def listar_encerrados(
         )
     if atendente_id:
         q = q.filter(WhatsappChat.atendente_id == atendente_id)
+    ref_data = func.coalesce(
+        WhatsappChat.encerramento_at,
+        WhatsappChat.atendimento_inicio_at,
+        WhatsappChat.created_at,
+    )
     if encerramento_inicio:
-        q = q.filter(WhatsappChat.encerramento_at >= encerramento_inicio)
+        q = q.filter(ref_data >= encerramento_inicio)
     if encerramento_fim:
-        q = q.filter(WhatsappChat.encerramento_at <= encerramento_fim)
+        q = q.filter(ref_data <= encerramento_fim)
     if atendente.role != "admin":
         vis = ids_setores_visiveis_atendente(db, atendente)
         q = q.filter(or_(WhatsappChat.atendente_id == atendente.id, WhatsappChat.setor_id.in_(vis)))
     total = q.count()
-    rows = q.order_by(desc(WhatsappChat.encerramento_at), desc(WhatsappChat.id)).offset(offset).limit(limit).all()
+    rows = q.order_by(desc(ref_data), desc(WhatsappChat.id)).offset(offset).limit(limit).all()
     return ListaPaginada(items=[_chat_read(db, c, revelar_avaliacao=True) for c in rows], total=total)
 
 
@@ -877,16 +878,29 @@ def registrar_demanda(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    from app.services.whatsapp_chat_demandas import criar_demanda_chat, demanda_para_read
+    from app.services.whatsapp_chat_demandas import (
+        criar_demanda_chat,
+        criar_marco_demanda_mensagem,
+        demanda_para_read,
+        remover_marco_demanda_mensagem,
+    )
 
-    c = db.query(WhatsappChat).filter(WhatsappChat.id == chat_id).first()
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     if not c:
         raise HTTPException(status_code=404, detail="Chat não encontrado")
     if not _pode_registrar_demanda(db, atendente, c):
         raise HTTPException(status_code=403, detail="Sem permissão para registrar demanda neste chat")
     row = criar_demanda_chat(db, c, atendente, data, desfecho="resolvido_sessao")
+    marco = criar_marco_demanda_mensagem(db, chat=c, atendente=atendente, demanda=row)
     db.commit()
-    assert row is not None
+    db.refresh(marco)
+    marco = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == marco.id)
+        .first()
+    )
+    emit_chat_mensagem_from_models(db, c, marco, exclude_atendente_id=atendente.id)
     return demanda_para_read(row)
 
 
@@ -928,6 +942,7 @@ def excluir_demanda(
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
     from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
+    from app.services.whatsapp_chat_demandas import remover_marco_demanda_mensagem
 
     c = db.query(WhatsappChat).filter(WhatsappChat.id == chat_id).first()
     if not c:
@@ -943,6 +958,7 @@ def excluir_demanda(
         raise HTTPException(status_code=404, detail="Demanda não encontrada")
     if atendente.role != "admin" and row.atendente_id != atendente.id:
         raise HTTPException(status_code=403, detail="Somente quem registrou ou admin pode excluir")
+    remover_marco_demanda_mensagem(db, chat_id=chat_id, demanda_id=demanda_id)
     db.delete(row)
     db.commit()
 
@@ -1432,9 +1448,9 @@ def abrir_ticket(
     registrar_primeira_resposta_se_necessario(db, ticket)
     db.add(WhatsappChatTicket(chat_id=chat_id, ticket_id=ticket.id, atendente_id=atendente.id))
     if data.natureza_id is not None:
-        from app.services.whatsapp_chat_demandas import criar_demanda_chat
+        from app.services.whatsapp_chat_demandas import criar_demanda_chat, criar_marco_demanda_mensagem
 
-        criar_demanda_chat(
+        row_dem = criar_demanda_chat(
             db,
             c,
             atendente,
@@ -1446,6 +1462,16 @@ def abrir_ticket(
             desfecho="escalado_ticket",
             ticket_id=ticket.id,
         )
+        marco = criar_marco_demanda_mensagem(db, chat=c, atendente=atendente, demanda=row_dem)
+        db.flush()
+        marco_loaded = (
+            db.query(WhatsappMensagem)
+            .options(joinedload(WhatsappMensagem.atendente))
+            .filter(WhatsappMensagem.id == marco.id)
+            .first()
+        )
+        if marco_loaded:
+            emit_chat_mensagem_from_models(db, c, marco_loaded, exclude_atendente_id=atendente.id)
     db.commit()
     db.refresh(ticket)
     pos_criar_ticket_na_fila(db, ticket)

--- a/backend/app/services/whatsapp_chat_demandas.py
+++ b/backend/app/services/whatsapp_chat_demandas.py
@@ -11,11 +11,67 @@ from sqlalchemy.orm import Session, joinedload
 from app.models.atendente import Atendente
 from app.models.empresa import Empresa
 from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
-from app.models.whatsapp_chat import WhatsappChat
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
 from app.models.whatsapp_chat_demanda import DESFECHOS_DEMANDA, WhatsappChatDemanda
 from app.schemas.dashboard import ContagemIdNome
 from app.schemas.whatsapp_chat import WhatsappChatDemandaCreate, WhatsappChatDemandaRead, WhatsappChatDemandaUpdate
 from app.services.chat_dashboard_filters import apply_chat_dashboard_filters, period_bounds
+
+DESFECHO_MARCO = {
+    "resolvido_sessao": "Resolvido na sessão",
+    "escalado_ticket": "Escalado para ticket",
+}
+
+
+def _rotulo_demanda(row: WhatsappChatDemanda) -> str:
+    nat = row.natureza.nome if row.natureza else "Demanda"
+    if row.motivo and row.motivo.nome:
+        return f"{nat} · {row.motivo.nome}"
+    return nat
+
+
+def corpo_marco_demanda(row: WhatsappChatDemanda) -> str:
+    desfecho = DESFECHO_MARCO.get(row.desfecho, row.desfecho)
+    return f"[demanda_id={row.id}] Demanda registada: {_rotulo_demanda(row)} — {desfecho}"
+
+
+def criar_marco_demanda_mensagem(
+    db: Session,
+    *,
+    chat: WhatsappChat,
+    atendente: Atendente,
+    demanda: WhatsappChatDemanda,
+) -> WhatsappMensagem:
+    evento = "demanda_registrada" if demanda.desfecho == "resolvido_sessao" else "demanda_escalada"
+    m = WhatsappMensagem(
+        chat_id=chat.id,
+        direcao="outbound",
+        corpo=corpo_marco_demanda(demanda),
+        tipo_midia="texto",
+        mimetype=None,
+        midia_nome_arquivo=None,
+        wa_message_id=None,
+        atendente_id=atendente.id,
+        evento_sistema=evento,
+    )
+    db.add(m)
+    db.flush()
+    return m
+
+
+def remover_marco_demanda_mensagem(db: Session, *, chat_id: int, demanda_id: int) -> None:
+    tag = f"[demanda_id={demanda_id}]"
+    rows = (
+        db.query(WhatsappMensagem)
+        .filter(
+            WhatsappMensagem.chat_id == chat_id,
+            WhatsappMensagem.evento_sistema.in_(("demanda_registrada", "demanda_escalada")),
+            WhatsappMensagem.corpo.like(f"{tag}%"),
+        )
+        .all()
+    )
+    for row in rows:
+        db.delete(row)
 
 
 def _validar_natureza_motivo(

--- a/backend/tests/test_notificacoes_itens.py
+++ b/backend/tests/test_notificacoes_itens.py
@@ -64,7 +64,8 @@ def test_admin_nao_conta_nao_lidas_de_outro_responsavel(client, seed_base, auth_
     assert resumo_a1.nao_lidas_count >= 1
 
 
-def test_itens_fallback_quando_contador_positivo(client, seed_base, auth_headers, db_session, monkeypatch):
+def test_itens_link_directo_por_ticket(client, seed_base, auth_headers, db_session, monkeypatch):
+    """Cada pendência de não-lida aponta para /tickets/{id}, nunca listagem genérica (#452)."""
     _criar_ticket_com_mensagem(db_session, seed_base, atendente_id=seed_base["a1"].id)
 
     def fake_unread(db, ticket, atendente_id):
@@ -76,7 +77,23 @@ def test_itens_fallback_quando_contador_positivo(client, seed_base, auth_headers
     itens = build_notificacao_itens(db_session, seed_base["a1"], limit=15)
 
     assert resumo.nao_lidas_count >= 1
-    assert any(i.tipo == "mensagens_nao_lidas" for i in itens)
+    ticket_itens = [i for i in itens if i.tipo == "mensagens_nao_lidas"]
+    assert len(ticket_itens) >= 1
+    for item in ticket_itens:
+        assert item.ticket_id is not None
+        assert item.href == f"/tickets/{item.ticket_id}"
+        assert "situacao=abertos" not in item.href
+
+
+def test_varios_tickets_nao_lidos_links_individuais(client, seed_base, auth_headers, db_session):
+    t1 = _criar_ticket_com_mensagem(db_session, seed_base, atendente_id=seed_base["a1"].id, assunto="Um")
+    t2 = _criar_ticket_com_mensagem(db_session, seed_base, atendente_id=seed_base["a1"].id, assunto="Dois")
+
+    itens = build_notificacao_itens(db_session, seed_base["a1"], limit=15)
+    ticket_itens = [i for i in itens if i.tipo == "mensagens_nao_lidas"]
+    hrefs = {i.href for i in ticket_itens}
+    assert f"/tickets/{t1.id}" in hrefs
+    assert f"/tickets/{t2.id}" in hrefs
 
 
 def test_mensagem_anterior_a_visto_nao_conta(db_session, seed_base):

--- a/backend/tests/test_whatsapp_chat_demandas.py
+++ b/backend/tests/test_whatsapp_chat_demandas.py
@@ -49,6 +49,11 @@ def test_registrar_e_listar_demanda(client, seed_base, auth_headers, db_session)
     assert len(listed) == 1
     assert listed[0]["id"] == body["id"]
 
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    marcos = [m for m in msgs if m.get("evento_sistema") == "demanda_registrada"]
+    assert len(marcos) == 1
+    assert f"[demanda_id={body['id']}]" in marcos[0]["corpo"]
+
 
 def test_abrir_ticket_cria_demanda_escalada(client, seed_base, auth_headers, db_session):
     nat, mot = _seed_natureza_motivo(db_session)
@@ -74,6 +79,26 @@ def test_abrir_ticket_cria_demanda_escalada(client, seed_base, auth_headers, db_
     assert len(demandas) == 1
     assert demandas[0]["desfecho"] == "escalado_ticket"
     assert demandas[0]["ticket_id"] == ticket_ids[-1]
+
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    assert any(m.get("evento_sistema") == "demanda_escalada" for m in msgs)
+
+
+def test_excluir_demanda_remove_marco(client, seed_base, auth_headers, db_session):
+    nat, mot = _seed_natureza_motivo(db_session)
+    cid = _chat_em_atendimento(client, auth_headers, wa_id="5511999007788", msg_id="dm-del")
+    created = client.post(
+        f"/v1/whatsapp/chats/{cid}/demandas",
+        json={"natureza_id": nat.id, "motivo_id": mot.id},
+        headers=auth_headers["a1"],
+    ).json()
+    did = created["id"]
+
+    r = client.delete(f"/v1/whatsapp/chats/{cid}/demandas/{did}", headers=auth_headers["a1"])
+    assert r.status_code == 204
+
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    assert not any(m.get("evento_sistema") == "demanda_registrada" for m in msgs)
 
 
 def test_outro_atendente_nao_registra_demanda(client, seed_base, auth_headers, db_session):

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -142,7 +142,7 @@ def test_colaborador_mesmo_setor_ve_chat_em_atendimento(client, seed_base, auth_
 
     interno = client.post(
         f"/v1/whatsapp/chats/{cid}/comentarios-internos",
-        json={"corpo": "Nota interna de apoio"},
+        json={"texto": "Nota interna de apoio"},
         headers=auth_headers["a2"],
     )
     assert interno.status_code == 201

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -107,7 +107,8 @@ def test_listar_encerrados_filtra_e_respeita_rbac(client, seed_base, auth_header
     assert denied.status_code == 403
 
 
-def test_nao_acessa_chat_em_atendimento_de_outro_atendente_mesmo_setor(client, seed_base, auth_headers):
+def test_colaborador_mesmo_setor_ve_chat_em_atendimento(client, seed_base, auth_headers, db_session):
+    """#455 — colega do setor consulta chat activo; envio ao cliente continua bloqueado (#403)."""
     client.patch(
         "/v1/settings/whatsapp",
         json={"webhook_secret": "rbac-2"},
@@ -126,8 +127,25 @@ def test_nao_acessa_chat_em_atendimento_de_outro_atendente_mesmo_setor(client, s
 
     client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
 
-    denied = client.get(f"/v1/whatsapp/chats/{cid}", headers=auth_headers["a2"])
-    assert denied.status_code == 403
+    seed_base["a2"].setores.append(seed_base["setor1"])
+    db_session.commit()
+
+    ok = client.get(f"/v1/whatsapp/chats/{cid}", headers=auth_headers["a2"])
+    assert ok.status_code == 200
+
+    denied_cliente = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"corpo": "Olá cliente"},
+        headers=auth_headers["a2"],
+    )
+    assert denied_cliente.status_code == 403
+
+    interno = client.post(
+        f"/v1/whatsapp/chats/{cid}/comentarios-internos",
+        json={"corpo": "Nota interna de apoio"},
+        headers=auth_headers["a2"],
+    )
+    assert interno.status_code == 201
 
 
 def test_webhook_guarda_citacao_em_mensagem(client, seed_base, auth_headers):

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -135,7 +135,7 @@ def test_colaborador_mesmo_setor_ve_chat_em_atendimento(client, seed_base, auth_
 
     denied_cliente = client.post(
         f"/v1/whatsapp/chats/{cid}/mensagens",
-        json={"corpo": "Olá cliente"},
+        json={"texto": "Olá cliente"},
         headers=auth_headers["a2"],
     )
     assert denied_cliente.status_code == 403

--- a/frontend/src/components/NavbarNotificacoes.tsx
+++ b/frontend/src/components/NavbarNotificacoes.tsx
@@ -70,7 +70,7 @@ function ListaPendencias({
     return (
       <p className="px-3 py-10 text-center text-sm text-slate-500 dark:text-slate-400 sm:py-6">
         {totalPendencias > 0
-          ? 'Pendências no badge — abra novamente em instantes ou use a listagem de tickets.'
+          ? 'A carregar pendências…'
           : 'Sem pendências'}
       </p>
     )

--- a/frontend/src/constants/contatoClienteLabels.ts
+++ b/frontend/src/constants/contatoClienteLabels.ts
@@ -1,0 +1,23 @@
+/** Copy operacional: contato da empresa cliente vs equipe interna (#447). */
+
+export const CONTATO_CLIENTE = {
+  vincularChat: 'Identificar contato do cliente',
+  vincularCurto: 'Identificar',
+  vincularEmpresa: 'Identificar contato',
+  bannerNaoVinculado:
+    'Contacto não identificado — ainda não está vinculado a nenhuma empresa da rede.',
+  modalTitulo: 'Contato do cliente',
+  modalSubtitulo:
+    'Vincule um cadastro existente ou cadastre este contacto como colaborador da empresa cliente.',
+  buscarPlaceholder: 'Buscar contatos da rede…',
+  selecioneContato: 'Selecione um contato da rede.',
+  selecioneEmpresaContato: 'Selecione a empresa deste contato.',
+  vinculadoSucesso: 'Contato vinculado.',
+  cadastradoSucesso: 'Contato cadastrado e vinculado.',
+  desvinculadoSucesso: 'Vínculo com o contato removido.',
+  informeNome: 'Informe o nome do contato.',
+  nenhumEncontrado: 'Nenhum contato encontrado. Use a aba Cadastrar novo.',
+  digiteParaBuscar: 'Digite um termo para buscar contatos da rede.',
+  cadastrarTicket: 'Cadastrar contato do cliente',
+  remetenteSemCadastro: 'Remetente sem cadastro na rede',
+} as const

--- a/frontend/src/lib/fileTypeIcon.ts
+++ b/frontend/src/lib/fileTypeIcon.ts
@@ -1,0 +1,84 @@
+/** Ícone e rótulo por extensão ou MIME (#453). */
+
+export type FileTypeVisual = {
+  emoji: string
+  label: string
+}
+
+const EXT_MAP: Record<string, FileTypeVisual> = {
+  pdf: { emoji: '📕', label: 'PDF' },
+  doc: { emoji: '📝', label: 'Word' },
+  docx: { emoji: '📝', label: 'Word' },
+  xls: { emoji: '📊', label: 'Excel' },
+  xlsx: { emoji: '📊', label: 'Excel' },
+  ppt: { emoji: '📽️', label: 'PowerPoint' },
+  pptx: { emoji: '📽️', label: 'PowerPoint' },
+  txt: { emoji: '📃', label: 'Texto' },
+  csv: { emoji: '📃', label: 'CSV' },
+  zip: { emoji: '🗜️', label: 'Compactado' },
+  rar: { emoji: '🗜️', label: 'Compactado' },
+  '7z': { emoji: '🗜️', label: 'Compactado' },
+  jpg: { emoji: '🖼️', label: 'Imagem' },
+  jpeg: { emoji: '🖼️', label: 'Imagem' },
+  png: { emoji: '🖼️', label: 'Imagem' },
+  gif: { emoji: '🖼️', label: 'Imagem' },
+  webp: { emoji: '🖼️', label: 'Imagem' },
+  mp3: { emoji: '🎵', label: 'Áudio' },
+  wav: { emoji: '🎵', label: 'Áudio' },
+  ogg: { emoji: '🎵', label: 'Áudio' },
+  mp4: { emoji: '🎬', label: 'Vídeo' },
+  avi: { emoji: '🎬', label: 'Vídeo' },
+  mov: { emoji: '🎬', label: 'Vídeo' },
+  webm: { emoji: '🎬', label: 'Vídeo' },
+}
+
+const MIME_PREFIX: [string, FileTypeVisual][] = [
+  ['application/pdf', EXT_MAP.pdf],
+  ['application/msword', EXT_MAP.doc],
+  ['application/vnd.openxmlformats-officedocument.wordprocessingml', EXT_MAP.docx],
+  ['application/vnd.ms-excel', EXT_MAP.xls],
+  ['application/vnd.openxmlformats-officedocument.spreadsheetml', EXT_MAP.xlsx],
+  ['application/vnd.ms-powerpoint', EXT_MAP.ppt],
+  ['application/vnd.openxmlformats-officedocument.presentationml', EXT_MAP.pptx],
+  ['text/plain', EXT_MAP.txt],
+  ['text/csv', EXT_MAP.csv],
+  ['application/zip', EXT_MAP.zip],
+  ['application/x-rar', EXT_MAP.rar],
+  ['image/', EXT_MAP.jpg],
+  ['audio/', EXT_MAP.mp3],
+  ['video/', EXT_MAP.mp4],
+]
+
+function extensaoDeNome(nome?: string | null): string | null {
+  if (!nome) return null
+  const base = nome.split(/[/\\]/).pop() ?? nome
+  const idx = base.lastIndexOf('.')
+  if (idx <= 0) return null
+  return base.slice(idx + 1).toLowerCase()
+}
+
+export function visualTipoArquivo(
+  nome?: string | null,
+  mime?: string | null,
+): FileTypeVisual {
+  const ext = extensaoDeNome(nome)
+  if (ext && EXT_MAP[ext]) return EXT_MAP[ext]
+  const m = (mime ?? '').toLowerCase()
+  for (const [prefix, visual] of MIME_PREFIX) {
+    if (m.startsWith(prefix)) return visual
+  }
+  return { emoji: '📄', label: 'Ficheiro' }
+}
+
+export function rotuloDownloadArquivo(
+  nome?: string | null,
+  mime?: string | null,
+  tipoMidia?: string | null,
+): string {
+  const tipo = (tipoMidia ?? '').toLowerCase()
+  if (tipo === 'audio') return '🔊 Baixar áudio'
+  if (tipo === 'video') return '🎬 Baixar vídeo'
+  if (tipo === 'imagem' || tipo === 'figurinha') return '📷 Baixar imagem'
+  const v = visualTipoArquivo(nome, mime)
+  return `${v.emoji} Baixar ${v.label}`
+}

--- a/frontend/src/lib/whatsappDemandaUtils.ts
+++ b/frontend/src/lib/whatsappDemandaUtils.ts
@@ -63,11 +63,31 @@ export type TimelineItem =
   | { kind: 'mensagem'; ts: number; mensagem: WhatsappChats.Mensagem }
   | { kind: 'demanda'; ts: number; demanda: WhatsappChats.Demanda }
 
+export function demandasComMarcoMensagem(
+  demandas: WhatsappChats.Demanda[],
+  msgs: WhatsappChats.Mensagem[],
+): WhatsappChats.Demanda[] {
+  const idsComMarco = new Set<number>()
+  for (const m of msgs) {
+    if (m.evento_sistema === 'demanda_registrada' || m.evento_sistema === 'demanda_escalada') {
+      const match = m.corpo?.match(/^\[demanda_id=(\d+)\]/)
+      if (match) idsComMarco.add(Number(match[1]))
+    }
+  }
+  return demandas.filter((d) => !idsComMarco.has(d.id))
+}
+
+export function textoMarcoDemanda(corpo: string | null | undefined): string {
+  if (!corpo) return 'Demanda registada'
+  return corpo.replace(/^\[demanda_id=\d+\]\s*/, '')
+}
+
 export function mergeTimelineChat(
   msgs: WhatsappChats.Mensagem[],
   demandas: WhatsappChats.Demanda[],
 ): TimelineItem[] {
   const items: TimelineItem[] = []
+  const demandasMerge = demandasComMarcoMensagem(demandas, msgs)
   for (const m of mensagensVisiveisConversa(msgs)) {
     items.push({
       kind: 'mensagem',
@@ -75,7 +95,7 @@ export function mergeTimelineChat(
       mensagem: m,
     })
   }
-  for (const d of demandas) {
+  for (const d of demandasMerge) {
     items.push({
       kind: 'demanda',
       ts: d.created_at ? new Date(d.created_at).getTime() : 0,

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -57,6 +57,7 @@ import {
   rotuloPrioridade,
   type PrioridadeTicket,
 } from '../lib/ticketPrioridade'
+import { CONTATO_CLIENTE } from '../constants/contatoClienteLabels'
 
 const ROTULO_CAMPO: Record<string, string> = {
   status_id: 'Status',
@@ -1426,10 +1427,10 @@ export function TicketDetalhe() {
               >
                 {requerCadastroFuncionario ? (
                   <>
-                    <p className="font-medium">Remetente sem cadastro</p>
+                    <p className="font-medium">{CONTATO_CLIENTE.remetenteSemCadastro}</p>
                     {isAdmin && (
                       <Link to={linkCadastroFuncionario} className="mt-1 inline-block font-semibold underline underline-offset-2">
-                        Cadastrar funcionário
+                        {CONTATO_CLIENTE.cadastrarTicket}
                       </Link>
                     )}
                   </>

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState } from 'react'
+import { Button } from '../../components/ui/Button'
+import { KbConsultaButton } from '../../components/KbConsultaModal'
+import type { TipoAnexoPicker } from './WhatsappBarraAnexos'
+import { WhatsappGravadorAudioInline } from './WhatsappGravadorAudioInline'
+
+type Props = {
+  texto: string
+  onTextoChange: (v: string) => void
+  onEnviar: () => void
+  onEnviarInterno?: () => void
+  onEscolherAnexo: (tipo: TipoAnexoPicker) => void
+  onAudioGravado: (file: File) => void
+  enviando: boolean
+  encerrado: boolean
+  podeEnviar: boolean
+  modoInterno: boolean
+  podeDigitar: boolean
+  onInserirReferenciaKb?: (ref: string) => void
+}
+
+type MenuAnexo = { tipo: TipoAnexoPicker; label: string }
+
+const MENU_ANEXOS: MenuAnexo[] = [
+  { tipo: 'documento', label: 'Documento' },
+  { tipo: 'imagem', label: 'Fotos e imagens' },
+  { tipo: 'video', label: 'Vídeo' },
+  { tipo: 'audio', label: 'Áudio (ficheiro)' },
+]
+
+export function WhatsappComposerBar({
+  texto,
+  onTextoChange,
+  onEnviar,
+  onEnviarInterno,
+  onEscolherAnexo,
+  onAudioGravado,
+  enviando,
+  encerrado,
+  podeEnviar,
+  modoInterno,
+  podeDigitar,
+  onInserirReferenciaKb,
+}: Props) {
+  const [menuAberto, setMenuAberto] = useState(false)
+  const [gravando, setGravando] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!menuAberto) return
+    const onDoc = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuAberto(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [menuAberto])
+
+  const temTexto = texto.trim().length > 0
+  const desabilitado = encerrado || !podeDigitar || enviando
+
+  function enviar() {
+    if (modoInterno && onEnviarInterno) onEnviarInterno()
+    else onEnviar()
+  }
+
+  return (
+    <div className="space-y-2">
+      {gravando && podeEnviar && !encerrado && (
+        <WhatsappGravadorAudioInline
+          disabled={enviando}
+          onConcluido={(file) => {
+            setGravando(false)
+            onAudioGravado(file)
+          }}
+          onCancelar={() => setGravando(false)}
+        />
+      )}
+
+      <div className="flex items-end gap-1.5 rounded-2xl bg-slate-100 p-2 shadow-inner dark:bg-slate-900 sm:gap-2">
+        <div className="relative shrink-0" ref={menuRef}>
+          <button
+            type="button"
+            disabled={desabilitado || modoInterno || !podeEnviar}
+            aria-label="Anexos"
+            title={modoInterno ? 'Anexos indisponíveis em modo interno' : 'Anexos'}
+            onClick={() => setMenuAberto((o) => !o)}
+            className="flex h-10 w-10 items-center justify-center rounded-full text-xl text-slate-600 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-40 dark:text-slate-300 dark:hover:bg-slate-800"
+          >
+            +
+          </button>
+          {menuAberto && (
+            <div className="absolute bottom-full left-0 z-20 mb-2 min-w-[11rem] rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900">
+              {MENU_ANEXOS.map((item) => (
+                <button
+                  key={item.tipo}
+                  type="button"
+                  className="block w-full px-4 py-2 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
+                  onClick={() => {
+                    setMenuAberto(false)
+                    onEscolherAnexo(item.tipo)
+                  }}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <button
+          type="button"
+          disabled
+          title="Figurinhas — em breve"
+          aria-label="Figurinhas (em breve)"
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-lg opacity-40"
+        >
+          😊
+        </button>
+
+        {onInserirReferenciaKb && (
+          <KbConsultaButton disabled={encerrado} onInserirReferencia={podeDigitar ? onInserirReferenciaKb : undefined} />
+        )}
+
+        <textarea
+          value={texto}
+          onChange={(e) => onTextoChange(e.target.value)}
+          placeholder={
+            encerrado
+              ? 'Apenas leitura…'
+              : modoInterno
+                ? 'Comentário interno…'
+                : podeEnviar
+                  ? 'Escreva uma mensagem…'
+                  : 'Somente comentários internos…'
+          }
+          rows={1}
+          disabled={desabilitado}
+          className="max-h-32 min-h-[40px] flex-1 resize-none border-none bg-transparent p-2 text-sm focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              if (!desabilitado && temTexto) enviar()
+            }
+          }}
+        />
+
+        {temTexto ? (
+          <Button
+            onClick={enviar}
+            disabled={desabilitado || !temTexto}
+            className="h-10 w-10 shrink-0 rounded-full bg-cyan-600 p-0 text-white shadow-lg shadow-cyan-600/30 hover:bg-cyan-700 disabled:opacity-50"
+            aria-label="Enviar"
+          >
+            {enviando ? '…' : '➤'}
+          </Button>
+        ) : (
+          <button
+            type="button"
+            disabled={desabilitado || modoInterno || !podeEnviar || gravando}
+            aria-label="Gravar áudio"
+            title="Gravar áudio"
+            onClick={() => setGravando(true)}
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-lg text-slate-600 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-40 dark:text-slate-300 dark:hover:bg-slate-800"
+          >
+            🎤
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -22,7 +22,6 @@ import {
 } from '../../api/client'
 
 import { Card } from '../../components/ui/Card'
-import { KbConsultaButton } from '../../components/KbConsultaModal'
 
 import { Button } from '../../components/ui/Button'
 
@@ -48,12 +47,14 @@ import { WhatsappVincFuncionarioModal } from './WhatsappVincFuncionarioModal'
 import { WhatsappDemandasPanel } from './WhatsappDemandasPanel'
 import { WhatsappEncerrarModal } from './WhatsappEncerrarModal'
 import { WhatsappDemandaTimelineMarco } from './WhatsappDemandaTimelineMarco'
-import { WhatsappBarraAnexos, ACCEPT_ANEXO, type TipoAnexoPicker } from './WhatsappBarraAnexos'
-import { WhatsappGravadorAudio } from './WhatsappGravadorAudio'
+import { ACCEPT_ANEXO, type TipoAnexoPicker } from './WhatsappBarraAnexos'
+import { WhatsappComposerBar } from './WhatsappComposerBar'
 import { WhatsappPreviaAnexo } from './WhatsappPreviaAnexo'
 import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
 import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
-import { mergeTimelineChat } from '../../lib/whatsappDemandaUtils'
+import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
+import { rotuloDownloadArquivo, visualTipoArquivo } from '../../lib/fileTypeIcon'
+import { CONTATO_CLIENTE } from '../../constants/contatoClienteLabels'
 
 const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)\]$/
 
@@ -206,18 +207,18 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 
  
 
-  const downloadLabel = {
-    documento: '📄 Baixar Documento',
-    audio: '🔊 Baixar Áudio',
-    video: '🎬 Baixar Vídeo',
-    imagem: '📷 Baixar Imagem',
-    figurinha: '📷 Baixar Imagem',
-  }[tipo] || `📄 Baixar ${tipo || 'Ficheiro'}`
+  const downloadLabel = rotuloDownloadArquivo(
+    tipo === 'documento' ? m.corpo : null,
+    m.mimetype,
+    tipo,
+  )
+  const fileVisual = visualTipoArquivo(tipo === 'documento' ? m.corpo : null, m.mimetype)
 
   return (
 
     <a href={url} download className="flex items-center gap-2 text-xs font-bold underline">
-      <span>{downloadLabel.split(' ')[0]}</span> {downloadLabel.replace(/^\S+\s*/, '')}
+      <span className="text-base" aria-hidden>{fileVisual.emoji}</span>
+      <span>{downloadLabel.replace(/^\S+\s*/, '')}</span>
     </a>
 
   )
@@ -248,7 +249,6 @@ export function WhatsappConversa() {
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const [pickerAnexo, setPickerAnexo] = useState<TipoAnexoPicker>('imagem')
-  const [mostrarGravador, setMostrarGravador] = useState(false)
   const [arquivoPendente, setArquivoPendente] = useState<File | null>(null)
   const [legendaMidia, setLegendaMidia] = useState('')
 
@@ -595,13 +595,11 @@ useEffect(() => {
 }
 
   function abrirPickerAnexo(tipo: TipoAnexoPicker) {
-    setMostrarGravador(false)
     setPickerAnexo(tipo)
     window.setTimeout(() => fileInputRef.current?.click(), 0)
   }
 
   function handleGravacaoConcluida(file: File) {
-    setMostrarGravador(false)
     setArquivoPendente(file)
     setLegendaMidia('')
   }
@@ -896,8 +894,8 @@ useEffect(() => {
                 className="inline-flex text-xs h-8"
                 onClick={() => setModalVincFuncionario(true)}
               >
-                <span className="sm:hidden">Vincular</span>
-                <span className="hidden sm:inline">Vincular funcionário</span>
+                <span className="sm:hidden">{CONTATO_CLIENTE.vincularCurto}</span>
+                <span className="hidden sm:inline">{CONTATO_CLIENTE.vincularChat}</span>
               </Button>
 
                 <Button variant="ghost" className="hidden sm:inline-flex text-xs h-8" onClick={() => setModalTickets(true)}>
@@ -922,11 +920,9 @@ useEffect(() => {
 
         {!encerrado && chat && !chat.funcionario_rede_id && (
           <div className="flex flex-wrap items-center justify-between gap-3 border-b border-violet-200 bg-violet-50 px-4 py-3 text-sm text-violet-950 dark:border-violet-900/40 dark:bg-violet-950/30 dark:text-violet-100">
-            <p>
-              <strong>Contacto não vinculado</strong> a nenhuma empresa ou funcionário cadastrado.
-            </p>
+            <p>{CONTATO_CLIENTE.bannerNaoVinculado}</p>
             <Button variant="primary" className="h-8 shrink-0 text-xs" onClick={() => setModalVincFuncionario(true)}>
-              Vincular a empresa
+              {CONTATO_CLIENTE.vincularEmpresa}
             </Button>
           </div>
         )}
@@ -981,6 +977,29 @@ useEffect(() => {
             }
 
             const m = item.mensagem
+
+            if (m.evento_sistema === 'demanda_registrada' || m.evento_sistema === 'demanda_escalada') {
+              return (
+                <div key={m.id} className="flex w-full justify-center py-2">
+                  <div className="max-w-md rounded-xl border border-violet-200 bg-violet-50/95 px-4 py-2 text-center text-xs shadow-sm dark:border-violet-900/50 dark:bg-violet-950/40">
+                    <p className="font-bold uppercase tracking-wide text-violet-800 dark:text-violet-200">
+                      Demanda registada
+                    </p>
+                    <p className="mt-0.5 font-medium text-violet-950 dark:text-violet-100">
+                      {textoMarcoDemanda(m.corpo)}
+                    </p>
+                    {m.atendente_nome && (
+                      <p className="mt-0.5 text-[10px] text-violet-700/80 dark:text-violet-300/80">
+                        {m.atendente_nome}
+                        {m.created_at
+                          ? ` · ${new Date(m.created_at).toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' })}`
+                          : ''}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )
+            }
 
             const isInbound = m.direcao === 'inbound'
 
@@ -1123,32 +1142,8 @@ useEffect(() => {
             </p>
           )}
 
-          {!encerrado && !modoInterno && podeEnviar && !arquivoPendente && !mostrarGravador && (
-            <WhatsappBarraAnexos
-              disabled={enviando}
-              onEscolher={abrirPickerAnexo}
-              onGravarAudio={() => {
-                setArquivoPendente(null)
-                setMostrarGravador(true)
-              }}
-            />
-          )}
-
           {!encerrado && !modoInterno && !podeEnviar && (
-            <WhatsappBarraAnexos
-              disabled
-              motivoDesabilitado={motivoAnexoDesabilitado}
-              onEscolher={() => {}}
-              onGravarAudio={() => {}}
-            />
-          )}
-
-          {mostrarGravador && podeEnviar && !encerrado && (
-            <WhatsappGravadorAudio
-              disabled={enviando}
-              onConcluido={handleGravacaoConcluida}
-              onCancelar={() => setMostrarGravador(false)}
-            />
+            <p className="mb-2 text-[11px] text-amber-800 dark:text-amber-200">{motivoAnexoDesabilitado}</p>
           )}
 
           {arquivoPendente && (
@@ -1191,79 +1186,27 @@ useEffect(() => {
             </div>
           )}
 
-          <div className="flex items-end gap-2 bg-slate-100 dark:bg-slate-900 p-2 rounded-2xl shadow-inner">
+          <WhatsappComposerBar
+            texto={texto}
+            onTextoChange={setTexto}
+            onEnviar={() => void enviar()}
+            enviando={enviando}
+            encerrado={encerrado}
+            podeEnviar={podeEnviar}
+            modoInterno={modoInterno}
+            podeDigitar={podeDigitarMensagem}
+            onEscolherAnexo={abrirPickerAnexo}
+            onAudioGravado={handleGravacaoConcluida}
+            onInserirReferenciaKb={inserirReferenciaKb}
+          />
 
-            <input
-              type="file"
-              ref={fileInputRef}
-              onChange={handleFileSelecionado}
-              className="hidden"
-              accept={ACCEPT_ANEXO[pickerAnexo]}
-            />
-
-            <KbConsultaButton
-              disabled={encerrado}
-              onInserirReferencia={podeDigitarMensagem ? inserirReferenciaKb : undefined}
-            />
-
-
-
-            <textarea
-
-              value={texto}
-
-              onChange={(e) => setTexto(e.target.value)}
-
-              placeholder={
-                encerrado
-                  ? "Apenas leitura..."
-                  : modoInterno
-                    ? "Escreva um comentário interno..."
-                    : podeEnviar
-                      ? "Escreva uma mensagem..."
-                      : "Somente comentários internos são permitidos."
-              }
-
-              rows={1}
-
-              disabled={encerrado || (!modoInterno && !podeEnviar)}
-
-              className="flex-1 max-h-32 min-h-[40px] resize-none border-none bg-transparent p-2 text-sm focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
-
-              onKeyDown={(e) => {
-
-                if (e.key === 'Enter' && !e.shiftKey) {
-
-                  e.preventDefault()
-
-                  void enviar()
-
-                }
-
-              }}
-
-            />
-
-
-
-            <Button
-
-              onClick={() => void enviar()}
-
-              disabled={
-                enviando || !texto.trim() || encerrado || (!modoInterno && !podeEnviar)
-              }
-
-              className="h-10 w-10 shrink-0 rounded-xl bg-cyan-600 p-0 text-white shadow-lg shadow-cyan-600/30 hover:bg-cyan-700 disabled:opacity-50"
-
-            >
-
-              {enviando ? '...' : modoInterno ? '✎' : '➤'}
-
-            </Button>
-
-          </div>
-
+          <input
+            type="file"
+            ref={fileInputRef}
+            onChange={handleFileSelecionado}
+            className="hidden"
+            accept={ACCEPT_ANEXO[pickerAnexo]}
+          />
         </footer>
 
       </main>

--- a/frontend/src/pages/whatsapp/WhatsappGravadorAudioInline.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappGravadorAudioInline.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Button } from '../../components/ui/Button'
+
+type Props = {
+  disabled?: boolean
+  onConcluido: (file: File) => void
+  onCancelar: () => void
+}
+
+/** Gravação compacta integrada na barra de composição (#443). */
+export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar }: Props) {
+  const [gravando, setGravando] = useState(false)
+  const [segundos, setSegundos] = useState(0)
+  const [erro, setErro] = useState<string | null>(null)
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+  const timerRef = useRef<number | null>(null)
+  const iniciouRef = useRef(false)
+
+  const pararStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach((t) => t.stop())
+    streamRef.current = null
+    if (timerRef.current != null) {
+      window.clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (disabled || iniciouRef.current) return
+    iniciouRef.current = true
+    void (async () => {
+      setErro(null)
+      chunksRef.current = []
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+        streamRef.current = stream
+        const mime = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+          ? 'audio/webm;codecs=opus'
+          : MediaRecorder.isTypeSupported('audio/webm')
+            ? 'audio/webm'
+            : ''
+        const recorder = mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream)
+        recorderRef.current = recorder
+        recorder.ondataavailable = (ev) => {
+          if (ev.data.size > 0) chunksRef.current.push(ev.data)
+        }
+        recorder.onstop = () => {
+          pararStream()
+          const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' })
+          if (blob.size === 0) {
+            setErro('Gravação vazia.')
+            setGravando(false)
+            return
+          }
+          const ext = blob.type.includes('ogg') ? 'ogg' : 'webm'
+          onConcluido(new File([blob], `audio-${Date.now()}.${ext}`, { type: blob.type || 'audio/webm' }))
+        }
+        recorder.start(250)
+        setGravando(true)
+        timerRef.current = window.setInterval(() => setSegundos((s) => s + 1), 1000)
+      } catch {
+        pararStream()
+        setErro('Microfone indisponível.')
+      }
+    })()
+    return () => {
+      pararStream()
+      const rec = recorderRef.current
+      if (rec && rec.state !== 'inactive') rec.stop()
+    }
+  }, [disabled, onConcluido, pararStream])
+
+  const mm = String(Math.floor(segundos / 60)).padStart(2, '0')
+  const ss = String(segundos % 60).padStart(2, '0')
+
+  function parar() {
+    const rec = recorderRef.current
+    if (rec && rec.state !== 'inactive') rec.stop()
+    recorderRef.current = null
+  }
+
+  function cancelar() {
+    chunksRef.current = []
+    pararStream()
+    const rec = recorderRef.current
+    if (rec && rec.state !== 'inactive') rec.stop()
+    recorderRef.current = null
+    onCancelar()
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-rose-200 bg-rose-50/90 px-3 py-2 dark:border-rose-900/40 dark:bg-rose-950/20">
+      <div className="flex items-center gap-2 text-xs">
+        {gravando && <span className="h-2 w-2 animate-pulse rounded-full bg-rose-500" />}
+        <span className="font-medium text-rose-800 dark:text-rose-200">
+          {gravando ? `A gravar ${mm}:${ss}` : 'A preparar microfone…'}
+        </span>
+      </div>
+      <div className="flex gap-2">
+        <Button variant="ghost" className="h-8 text-xs" onClick={cancelar}>
+          Cancelar
+        </Button>
+        <Button variant="danger" className="h-8 text-xs" disabled={!gravando} onClick={parar}>
+          Enviar áudio
+        </Button>
+      </div>
+      {erro && <p className="w-full text-xs text-rose-700 dark:text-rose-300">{erro}</p>}
+    </div>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -107,7 +107,8 @@ export function WhatsappHistorico() {
   }, [])
 
   const formatDuration = (chat: WhatsappChats.Chat) => {
-    if (!chat.atendimento_inicio_at || !chat.encerramento_at) return '—'
+    if (!chat.atendimento_inicio_at) return '—'
+    if (!chat.encerramento_at) return 'Em curso'
     const start = new Date(chat.atendimento_inicio_at)
     const end = new Date(chat.encerramento_at)
     const diff = Math.max(0, Math.round((end.getTime() - start.getTime()) / 1000))

--- a/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
@@ -9,6 +9,7 @@ import { SelectComPesquisa } from '../../components/ui/SelectComPesquisa'
 import { CheckboxField } from '../../components/ui/CheckboxField'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { CONTATO_CLIENTE } from '../../constants/contatoClienteLabels'
 
 type Modo = 'vincular' | 'cadastrar'
 type TipoCadastro = 'colaborador' | 'supervisor'
@@ -118,7 +119,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
       .then(setResultados)
       .catch((err) => {
         setResultados([])
-        setErroBusca(mensagemFalhaParaToast(err, 'Não foi possível buscar funcionários.'))
+        setErroBusca(mensagemFalhaParaToast(err, 'Não foi possível buscar contatos da rede.'))
       })
       .finally(() => setLoadingBusca(false))
   }, [debouncedBusca, modo, open])
@@ -157,11 +158,11 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
 
   async function confirmarVinculo() {
     if (!selecionado) {
-      setErroFormulario('Selecione um funcionário.')
+      setErroFormulario(CONTATO_CLIENTE.selecioneContato)
       return
     }
     if (selecionado.empresas.length > 1 && empresaVinculoId === '') {
-      setErroFormulario('Selecione a empresa do funcionário.')
+      setErroFormulario(CONTATO_CLIENTE.selecioneEmpresaContato)
       return
     }
     setErroFormulario(null)
@@ -171,11 +172,11 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
         funcionario_rede_id: selecionado.id,
         empresa_id: empresaVinculoId === '' ? null : Number(empresaVinculoId),
       })
-      toast.showSuccess('Funcionário vinculado ao contato.')
+      toast.showSuccess(CONTATO_CLIENTE.vinculadoSucesso)
       onSuccess(atualizado)
       onClose()
     } catch (err) {
-      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível vincular o funcionário.'))
+      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível vincular o contato.'))
     } finally {
       setSalvando(false)
     }
@@ -183,7 +184,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
 
   async function confirmarCadastro() {
     if (!nomeCadastro.trim()) {
-      setErroFormulario('Informe o nome do funcionário.')
+      setErroFormulario(CONTATO_CLIENTE.informeNome)
       return
     }
     if (redeIdCadastro === '') {
@@ -222,11 +223,11 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
         empresa_ids: empresaIds,
         empresa_id: empresaContextoId === '' ? null : Number(empresaContextoId),
       })
-      toast.showSuccess('Funcionário cadastrado e vinculado ao contato.')
+      toast.showSuccess(CONTATO_CLIENTE.cadastradoSucesso)
       onSuccess(atualizado)
       onClose()
     } catch (err) {
-      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível cadastrar o funcionário.'))
+      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível cadastrar o contato.'))
     } finally {
       setSalvando(false)
     }
@@ -236,11 +237,11 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
     setSalvando(true)
     try {
       const atualizado = await whatsappChats.desvincularFuncionario(chat.id)
-      toast.showSuccess('Vínculo com funcionário removido.')
+      toast.showSuccess(CONTATO_CLIENTE.desvinculadoSucesso)
       onSuccess(atualizado)
       onClose()
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível desvincular o funcionário.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível desvincular o contato.'))
     } finally {
       setSalvando(false)
     }
@@ -251,10 +252,8 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
       <Card className="w-full max-w-lg max-h-[90vh] overflow-y-auto p-6 animate-in zoom-in-95">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h3 className="text-lg font-bold">Funcionário do contato</h3>
-            <p className="mt-1 text-sm text-slate-500">
-              Vincule um cadastro existente ou cadastre o contato como funcionário da rede.
-            </p>
+            <h3 className="text-lg font-bold">{CONTATO_CLIENTE.modalTitulo}</h3>
+            <p className="mt-1 text-sm text-slate-500">{CONTATO_CLIENTE.modalSubtitulo}</p>
           </div>
           <button
             type="button"
@@ -335,7 +334,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
         {modo === 'vincular' ? (
           <div className="mt-4 space-y-4">
             <Input
-              placeholder="Buscar por nome ou e-mail"
+              placeholder={CONTATO_CLIENTE.buscarPlaceholder}
               value={busca}
               onChange={(e) => setBusca(e.target.value)}
             />
@@ -370,11 +369,13 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                 </div>
               ) : (
                 <p className="text-sm text-slate-500">
-                  Nenhum funcionário encontrado. Use a aba <strong>Cadastrar novo</strong>.
+                <p className="text-sm text-slate-500">
+                  Nenhum contato encontrado. Use a aba <strong>Cadastrar novo</strong>.
+                </p>
                 </p>
               )
             ) : (
-              <p className="text-sm text-slate-500">Digite um termo para buscar funcionários.</p>
+              <p className="text-sm text-slate-500">{CONTATO_CLIENTE.digiteParaBuscar}</p>
             )}
             {selecionado && selecionado.empresas.length > 1 && (
               <SelectComPesquisa


### PR DESCRIPTION
## Summary

- **#447** — Copy «contato do cliente» vs atendente interno (chat + ticket)
- **#453** — Ícones por tipo de ficheiro nas mensagens de documento
- **#446** — Marco «Demanda registada» na timeline (evento_sistema + SSE); removido ao excluir demanda
- **#455** — Histórico inclui chats em atendimento; colegas do setor consultam e comentam internamente
- **#443** — Composer estilo WhatsApp Web (+ anexos, emoji em breve, microfone à direita)
- **#452** — Pendências no sino abrem ticket/chat concreto; removido fallback genérico para listagens

Closes #443
Closes #446
Closes #447
Closes #452
Closes #453
Closes #455

## Test plan

- [ ] docker compose run --rm --no-deps backend pytest tests/test_whatsapp_chat_demandas.py tests/test_whatsapp_chats.py tests/test_notificacoes_itens.py -q
- [ ] 
px tsc -b no frontend
- [ ] Composer: menu +, gravar áudio, enviar texto
- [ ] Registar demanda → marco na timeline em tempo real; excluir demanda remove marco
- [ ] Histórico: chat em atendimento visível para colega do setor; envio ao cliente bloqueado
- [ ] Copy «Identificar contato do cliente» no chat sem vínculo
- [ ] Anexo PDF/Word mostra ícone correcto
- [ ] Sino: 1+ tickets não lidos → cada item abre /tickets/{id}; WhatsApp abre /whatsapp/c/{id}