### PR TITLE
Release: WhatsApp produção lote 1+2 (#439, #456, #457)

### DIFF
--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -59,6 +59,26 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | [#418](https://github.com/lgustavoss/dx-connect/issues/418) | Pausa SLA por status do ticket | Fechada · PR [#427](https://github.com/lgustavoss/dx-connect/pull/427) |
 | [#423](https://github.com/lgustavoss/dx-connect/issues/423) | Demandas resolvidas na sessão | Fechada · PR [#427](https://github.com/lgustavoss/dx-connect/pull/427) |
 
+### Feedback produção — WhatsApp, UX, notificações (2026-06)
+
+| Issue | Título | Estado |
+|-------|--------|--------|
+| [#431](https://github.com/lgustavoss/dx-connect/issues/431) | Mídia inbound webhook + UI | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
+| [#432](https://github.com/lgustavoss/dx-connect/issues/432) | Barra de anexos e pré-visualização | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
+| [#433](https://github.com/lgustavoss/dx-connect/issues/433) | Banner «Sem vínculo» | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
+| [#441](https://github.com/lgustavoss/dx-connect/issues/441) | Áudio outbound nota de voz | Fechada · PR `fix/whatsapp-correcoes` |
+| [#442](https://github.com/lgustavoss/dx-connect/issues/442) | Tempo real / polling | Fechada · PR `fix/whatsapp-correcoes` |
+| [#444](https://github.com/lgustavoss/dx-connect/issues/444) | E-mail opcional no cadastro | Fechada · PR `fix/whatsapp-correcoes` |
+| [#445](https://github.com/lgustavoss/dx-connect/issues/445) | Modal encerramento + demandas | Fechada · PR `fix/whatsapp-correcoes` |
+| [#448](https://github.com/lgustavoss/dx-connect/issues/448) | Histórico e Avaliações | Fechada · PR `fix/whatsapp-correcoes` |
+| [#449](https://github.com/lgustavoss/dx-connect/issues/449) | Botão Voltar na conversa | Fechada · PR `fix/whatsapp-correcoes` |
+| [#446](https://github.com/lgustavoss/dx-connect/issues/446) | Marco timeline demanda (SSE/backend) | Aberta · parcial em `fix/whatsapp-correcoes` |
+| [#443](https://github.com/lgustavoss/dx-connect/issues/443) | Composer estilo WhatsApp Web | Aberta |
+| [#447](https://github.com/lgustavoss/dx-connect/issues/447) | Terminologia contato vs atendente | Aberta |
+| [#452](https://github.com/lgustavoss/dx-connect/issues/452) | Notificações: link directo ao ticket | Aberta · #391 |
+| [#453](https://github.com/lgustavoss/dx-connect/issues/453) | Ícones por tipo de ficheiro | Aberta |
+| [#455](https://github.com/lgustavoss/dx-connect/issues/455) | Chats activos no Histórico (colaboração) | Aberta |
+
 ---
 
 ## Base de conhecimento (#262) — v1 interno fechado

--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -72,12 +72,13 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | [#445](https://github.com/lgustavoss/dx-connect/issues/445) | Modal encerramento + demandas | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
 | [#448](https://github.com/lgustavoss/dx-connect/issues/448) | Histórico e Avaliações | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
 | [#449](https://github.com/lgustavoss/dx-connect/issues/449) | Botão Voltar na conversa | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
-| [#452](https://github.com/lgustavoss/dx-connect/issues/452) | Notificações: link directo ao ticket | PR pendente · branch `feat/whatsapp-ux-lote-2` |
-| [#446](https://github.com/lgustavoss/dx-connect/issues/446) | Marco timeline demanda (SSE/backend) | PR pendente · branch `feat/whatsapp-ux-lote-2` |
-| [#443](https://github.com/lgustavoss/dx-connect/issues/443) | Composer estilo WhatsApp Web | PR pendente · branch `feat/whatsapp-ux-lote-2` |
-| [#447](https://github.com/lgustavoss/dx-connect/issues/447) | Terminologia contato vs atendente | PR pendente · branch `feat/whatsapp-ux-lote-2` |
-| [#453](https://github.com/lgustavoss/dx-connect/issues/453) | Ícones por tipo de ficheiro | PR pendente · branch `feat/whatsapp-ux-lote-2` |
-| [#455](https://github.com/lgustavoss/dx-connect/issues/455) | Chats activos no Histórico (colaboração) | PR pendente · branch `feat/whatsapp-ux-lote-2` |
+| [#452](https://github.com/lgustavoss/dx-connect/issues/452) | Notificações: link directo ao ticket | Fechada · PR [#457](https://github.com/lgustavoss/dx-connect/pull/457) |
+| [#446](https://github.com/lgustavoss/dx-connect/issues/446) | Marco timeline demanda (SSE/backend) | Fechada · PR [#457](https://github.com/lgustavoss/dx-connect/pull/457) |
+| [#443](https://github.com/lgustavoss/dx-connect/issues/443) | Composer estilo WhatsApp Web | Fechada · PR [#457](https://github.com/lgustavoss/dx-connect/pull/457) |
+| [#447](https://github.com/lgustavoss/dx-connect/issues/447) | Terminologia contato vs atendente | Fechada · PR [#457](https://github.com/lgustavoss/dx-connect/pull/457) |
+| [#453](https://github.com/lgustavoss/dx-connect/issues/453) | Ícones por tipo de ficheiro | Fechada · PR [#457](https://github.com/lgustavoss/dx-connect/pull/457) |
+| [#455](https://github.com/lgustavoss/dx-connect/issues/455) | Chats activos no Histórico (colaboração) | Fechada · PR [#457](https://github.com/lgustavoss/dx-connect/pull/457) |
+| [#454](https://github.com/lgustavoss/dx-connect/issues/454) | Voltar no histórico preservando pesquisa | Fechada · duplicada de #449 (PR [#456](https://github.com/lgustavoss/dx-connect/pull/456)) |
 
 ---
 

--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -72,12 +72,12 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | [#445](https://github.com/lgustavoss/dx-connect/issues/445) | Modal encerramento + demandas | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
 | [#448](https://github.com/lgustavoss/dx-connect/issues/448) | Histórico e Avaliações | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
 | [#449](https://github.com/lgustavoss/dx-connect/issues/449) | Botão Voltar na conversa | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
-| [#446](https://github.com/lgustavoss/dx-connect/issues/446) | Marco timeline demanda (SSE/backend) | Aberta · parcial em `fix/whatsapp-correcoes` |
-| [#443](https://github.com/lgustavoss/dx-connect/issues/443) | Composer estilo WhatsApp Web | Aberta |
-| [#447](https://github.com/lgustavoss/dx-connect/issues/447) | Terminologia contato vs atendente | Aberta |
-| [#452](https://github.com/lgustavoss/dx-connect/issues/452) | Notificações: link directo ao ticket | Aberta · #391 |
-| [#453](https://github.com/lgustavoss/dx-connect/issues/453) | Ícones por tipo de ficheiro | Aberta |
-| [#455](https://github.com/lgustavoss/dx-connect/issues/455) | Chats activos no Histórico (colaboração) | Aberta |
+| [#452](https://github.com/lgustavoss/dx-connect/issues/452) | Notificações: link directo ao ticket | PR pendente · branch `feat/whatsapp-ux-lote-2` |
+| [#446](https://github.com/lgustavoss/dx-connect/issues/446) | Marco timeline demanda (SSE/backend) | PR pendente · branch `feat/whatsapp-ux-lote-2` |
+| [#443](https://github.com/lgustavoss/dx-connect/issues/443) | Composer estilo WhatsApp Web | PR pendente · branch `feat/whatsapp-ux-lote-2` |
+| [#447](https://github.com/lgustavoss/dx-connect/issues/447) | Terminologia contato vs atendente | PR pendente · branch `feat/whatsapp-ux-lote-2` |
+| [#453](https://github.com/lgustavoss/dx-connect/issues/453) | Ícones por tipo de ficheiro | PR pendente · branch `feat/whatsapp-ux-lote-2` |
+| [#455](https://github.com/lgustavoss/dx-connect/issues/455) | Chats activos no Histórico (colaboração) | PR pendente · branch `feat/whatsapp-ux-lote-2` |
 
 ---
 

--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -66,12 +66,12 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | [#431](https://github.com/lgustavoss/dx-connect/issues/431) | Mídia inbound webhook + UI | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
 | [#432](https://github.com/lgustavoss/dx-connect/issues/432) | Barra de anexos e pré-visualização | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
 | [#433](https://github.com/lgustavoss/dx-connect/issues/433) | Banner «Sem vínculo» | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
-| [#441](https://github.com/lgustavoss/dx-connect/issues/441) | Áudio outbound nota de voz | Fechada · PR `fix/whatsapp-correcoes` |
-| [#442](https://github.com/lgustavoss/dx-connect/issues/442) | Tempo real / polling | Fechada · PR `fix/whatsapp-correcoes` |
-| [#444](https://github.com/lgustavoss/dx-connect/issues/444) | E-mail opcional no cadastro | Fechada · PR `fix/whatsapp-correcoes` |
-| [#445](https://github.com/lgustavoss/dx-connect/issues/445) | Modal encerramento + demandas | Fechada · PR `fix/whatsapp-correcoes` |
-| [#448](https://github.com/lgustavoss/dx-connect/issues/448) | Histórico e Avaliações | Fechada · PR `fix/whatsapp-correcoes` |
-| [#449](https://github.com/lgustavoss/dx-connect/issues/449) | Botão Voltar na conversa | Fechada · PR `fix/whatsapp-correcoes` |
+| [#441](https://github.com/lgustavoss/dx-connect/issues/441) | Áudio outbound nota de voz | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#442](https://github.com/lgustavoss/dx-connect/issues/442) | Tempo real / polling | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#444](https://github.com/lgustavoss/dx-connect/issues/444) | E-mail opcional no cadastro | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#445](https://github.com/lgustavoss/dx-connect/issues/445) | Modal encerramento + demandas | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#448](https://github.com/lgustavoss/dx-connect/issues/448) | Histórico e Avaliações | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#449](https://github.com/lgustavoss/dx-connect/issues/449) | Botão Voltar na conversa | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
 | [#446](https://github.com/lgustavoss/dx-connect/issues/446) | Marco timeline demanda (SSE/backend) | Aberta · parcial em `fix/whatsapp-correcoes` |
 | [#443](https://github.com/lgustavoss/dx-connect/issues/443) | Composer estilo WhatsApp Web | Aberta |
 | [#447](https://github.com/lgustavoss/dx-connect/issues/447) | Terminologia contato vs atendente | Aberta |

--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -59,6 +59,26 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | [#418](https://github.com/lgustavoss/dx-connect/issues/418) | Pausa SLA por status do ticket | Fechada · PR [#427](https://github.com/lgustavoss/dx-connect/pull/427) |
 | [#423](https://github.com/lgustavoss/dx-connect/issues/423) | Demandas resolvidas na sessão | Fechada · PR [#427](https://github.com/lgustavoss/dx-connect/pull/427) |
 
+### Feedback produção — WhatsApp, UX, notificações (2026-06)
+
+| Issue | Título | Estado |
+|-------|--------|--------|
+| [#431](https://github.com/lgustavoss/dx-connect/issues/431) | Mídia inbound webhook + UI | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
+| [#432](https://github.com/lgustavoss/dx-connect/issues/432) | Barra de anexos e pré-visualização | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
+| [#433](https://github.com/lgustavoss/dx-connect/issues/433) | Banner «Sem vínculo» | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
+| [#441](https://github.com/lgustavoss/dx-connect/issues/441) | Áudio outbound nota de voz | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#442](https://github.com/lgustavoss/dx-connect/issues/442) | Tempo real / polling | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#444](https://github.com/lgustavoss/dx-connect/issues/444) | E-mail opcional no cadastro | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#445](https://github.com/lgustavoss/dx-connect/issues/445) | Modal encerramento + demandas | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#448](https://github.com/lgustavoss/dx-connect/issues/448) | Histórico e Avaliações | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#449](https://github.com/lgustavoss/dx-connect/issues/449) | Botão Voltar na conversa | Fechada · PR [#456](https://github.com/lgustavoss/dx-connect/pull/456) |
+| [#446](https://github.com/lgustavoss/dx-connect/issues/446) | Marco timeline demanda (SSE/backend) | Aberta · parcial em `fix/whatsapp-correcoes` |
+| [#443](https://github.com/lgustavoss/dx-connect/issues/443) | Composer estilo WhatsApp Web | Aberta |
+| [#447](https://github.com/lgustavoss/dx-connect/issues/447) | Terminologia contato vs atendente | Aberta |
+| [#452](https://github.com/lgustavoss/dx-connect/issues/452) | Notificações: link directo ao ticket | Aberta · #391 |
+| [#453](https://github.com/lgustavoss/dx-connect/issues/453) | Ícones por tipo de ficheiro | Aberta |
+| [#455](https://github.com/lgustavoss/dx-connect/issues/455) | Chats activos no Histórico (colaboração) | Aberta |
+
 ---
 
 ## Base de conhecimento (#262) — v1 interno fechado

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape
 - WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)
 - WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais
 - WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#445): modal de encerramento substitui `confirm()` nativo — registo/edição de demandas, aviso quando houve conversa após última demanda, marco na timeline e `ConfirmDialog` reutilizável
+- WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape
+- WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)
+- WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais
+- WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker
+- WhatsApp (#441): áudio gravado pelo atendente enviado como nota de voz via `sendWhatsAppAudio` (encoding Evolution); falha explícita se a API não confirmar entrega
 - WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível
 - WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional
 - WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile
@@ -20,7 +26,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id
 - Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)
 - Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável
-- Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats
+- Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats; edição via `PATCH`, marco na timeline e fluxo completo no modal de encerramento (#445)
 - SLA (#418): pausa automática da contagem quando o ticket está em status configurado (flag `pausa_sla`; «Aguardando cliente» ativado por padrão)
 - SLA: políticas opcionais por natureza do ticket; filtro «em risco» e dashboard usam o motor completo (calendário + pausa); prazo efetivo no card SLA
 - SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker
+- WhatsApp (#441): áudio gravado pelo atendente enviado como nota de voz via `sendWhatsAppAudio` (encoding Evolution); falha explícita se a API não confirmar entrega
 - WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível
 - WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional
 - WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#445): modal de encerramento substitui `confirm()` nativo — registo/edição de demandas, aviso quando houve conversa após última demanda, marco na timeline e `ConfirmDialog` reutilizável
 - WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape
 - WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)
 - WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais
@@ -25,7 +26,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id
 - Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)
 - Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável
-- Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats
+- Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats; edição via `PATCH`, marco na timeline e fluxo completo no modal de encerramento (#445)
 - SLA (#418): pausa automática da contagem quando o ticket está em status configurado (flag `pausa_sla`; «Aguardando cliente» ativado por padrão)
 - SLA: políticas opcionais por natureza do ticket; filtro «em risco» e dashboard usam o motor completo (calendário + pausa); prazo efetivo no card SLA
 - SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais
 - WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível
 - WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional
 - WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)
 - WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais
+- WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker
+- WhatsApp (#441): áudio gravado pelo atendente enviado como nota de voz via `sendWhatsAppAudio` (encoding Evolution); falha explícita se a API não confirmar entrega
 - WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível
 - WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional
 - WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- Notificações (#452): pendências de mensagem não lida abrem o ticket ou chat concreto (`/tickets/{id}`, `/whatsapp/c/{id}`) — removido fallback genérico para listagens
+- WhatsApp (#447): terminologia «contato do cliente» no chat e tickets — distingue colaborador da rede de atendente interno
+- WhatsApp (#453): ícones por tipo de ficheiro (PDF, Word, Excel, etc.) nas mensagens de documento
+- WhatsApp (#446): marco «Demanda registada» na timeline via evento interno + SSE em tempo real; removido ao excluir demanda
+- WhatsApp (#455): Histórico lista chats em atendimento — colegas do setor consultam e comentam internamente; ordenação e filtros de data corrigidos
+- WhatsApp (#443): barra de composição estilo WhatsApp Web (+ anexos, figurinhas em breve, microfone à direita)
 - WhatsApp (#445): modal de encerramento substitui `confirm()` nativo — registo/edição de demandas, aviso quando houve conversa após última demanda, marco na timeline e `ConfirmDialog` reutilizável
 - WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape
 - WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)

--- a/backend/alembic/versions/055_funcionario_rede_email_nullable.py
+++ b/backend/alembic/versions/055_funcionario_rede_email_nullable.py
@@ -1,0 +1,32 @@
+"""funcionarios_rede.email opcional (#444).
+
+Revision ID: 055_funcionario_rede_email_nullable
+Revises: 054_kb_interno_only
+Create Date: 2026-06-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "055_funcionario_rede_email_nullable"
+down_revision = "054_kb_interno_only"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "funcionarios_rede",
+        "email",
+        existing_type=sa.String(length=255),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "funcionarios_rede",
+        "email",
+        existing_type=sa.String(length=255),
+        nullable=False,
+    )

--- a/backend/app/api/funcionarios_rede.py
+++ b/backend/app/api/funcionarios_rede.py
@@ -177,13 +177,15 @@ def criar(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe a rede.")
     if rede_id_final is None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="rede_id não definido para o vínculo.")
-    try:
-        assert_email_unico_por_rede(db, email=str(data.email), rede_id=int(rede_id_final))
-    except ValueError as e:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    email_eff = data.email
+    if email_eff:
+        try:
+            assert_email_unico_por_rede(db, email=str(email_eff), rede_id=int(rede_id_final))
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
     f = FuncionarioRede(
         nome=data.nome,
-        email=data.email,
+        email=email_eff,
         tipo=data.tipo,
         escopo_empresas=escopo,
         ativo=data.ativo,
@@ -202,7 +204,8 @@ def criar(
     )
     db.commit()
     db.refresh(f)
-    reconciliar_tickets_pendentes_por_email(db, f.email)
+    if f.email:
+        reconciliar_tickets_pendentes_por_email(db, f.email)
     db.commit()
     return _para_read(f)
 
@@ -267,7 +270,7 @@ def atualizar(
         rede_id=int(rede_id),
         empresa_ids=ids if escopo == "selected" else None,
     )
-    if f.rede_id is not None:
+    if f.rede_id is not None and f.email:
         try:
             assert_email_unico_por_rede(
                 db,
@@ -280,7 +283,8 @@ def atualizar(
     registrar_audit(db, "funcionario_rede", funcionario_id, "update", atendente.id)
     db.commit()
     db.refresh(f)
-    reconciliar_tickets_pendentes_por_email(db, f.email)
+    if f.email:
+        reconciliar_tickets_pendentes_por_email(db, f.email)
     db.commit()
     return _para_read(f)
 

--- a/backend/app/api/notificacoes.py
+++ b/backend/app/api/notificacoes.py
@@ -107,6 +107,68 @@ def _unread_count_for_ticket(db: Session, ticket: Ticket, atendente_id: int) -> 
     return int(n or 0)
 
 
+def _last_unread_message_at_subq(atendente_id: int):
+    eff = _effective_last_seen_expr(atendente_id)
+    return (
+        select(func.max(TicketMensagem.created_at))
+        .where(
+            TicketMensagem.ticket_id == Ticket.id,
+            TicketMensagem.created_at > eff,
+        )
+        .scalar_subquery()
+    )
+
+
+def _wpp_resposta_pendente_exprs(atendente_id: int):
+    seen_at = (
+        select(WhatsappChatRead.last_seen_at)
+        .where(
+            WhatsappChatRead.chat_id == WhatsappChat.id,
+            WhatsappChatRead.atendente_id == atendente_id,
+        )
+        .limit(1)
+        .scalar_subquery()
+    )
+    inbound_last = (
+        select(func.max(WhatsappMensagem.created_at))
+        .where(
+            WhatsappMensagem.chat_id == WhatsappChat.id,
+            WhatsappMensagem.direcao == "inbound",
+        )
+        .scalar_subquery()
+    )
+    eff_seen = func.coalesce(seen_at, WhatsappChat.atendimento_inicio_at, WhatsappChat.created_at)
+    return inbound_last, eff_seen
+
+
+def _preview_ultima_nao_lida(db: Session, ticket: Ticket, atendente_id: int) -> str | None:
+    ls = (
+        db.query(TicketRead.last_seen_at)
+        .filter(
+            TicketRead.ticket_id == ticket.id,
+            TicketRead.atendente_id == atendente_id,
+        )
+        .scalar()
+    )
+    eff = ls if ls is not None else ticket.created_at
+    corpo = (
+        db.query(TicketMensagem.corpo)
+        .filter(
+            TicketMensagem.ticket_id == ticket.id,
+            TicketMensagem.created_at > eff,
+        )
+        .order_by(TicketMensagem.created_at.desc())
+        .limit(1)
+        .scalar()
+    )
+    if not corpo:
+        return None
+    texto = corpo.strip()
+    if len(texto) > 60:
+        return texto[:60] + "…"
+    return texto
+
+
 def _count_wpp_fila(db: Session, atendente: Atendente) -> int:
     stmt = (
         select(func.count())
@@ -122,23 +184,7 @@ def _count_wpp_fila(db: Session, atendente: Atendente) -> int:
 
 
 def _count_wpp_respostas_pendentes(db: Session, atendente: Atendente) -> int:
-    seen_at = (
-        select(WhatsappChatRead.last_seen_at)
-        .where(
-            WhatsappChatRead.chat_id == WhatsappChat.id,
-            WhatsappChatRead.atendente_id == atendente.id,
-        )
-        .limit(1)
-        .scalar_subquery()
-    )
-    inbound_last = (
-        select(func.max(WhatsappMensagem.created_at))
-        .where(
-            WhatsappMensagem.chat_id == WhatsappChat.id,
-            WhatsappMensagem.direcao == "inbound",
-        )
-        .scalar_subquery()
-    )
+    inbound_last, eff_seen = _wpp_resposta_pendente_exprs(atendente.id)
     stmt = (
         select(func.count())
         .select_from(WhatsappChat)
@@ -146,7 +192,7 @@ def _count_wpp_respostas_pendentes(db: Session, atendente: Atendente) -> int:
             WhatsappChat.estado == "em_atendimento",
             WhatsappChat.atendente_id == atendente.id,
             inbound_last.isnot(None),
-            func.coalesce(seen_at, WhatsappChat.atendimento_inicio_at, WhatsappChat.created_at) < inbound_last,
+            eff_seen < inbound_last,
         )
     )
     if atendente.role != "admin":
@@ -175,42 +221,6 @@ def _wpp_unread_count_for_chat(db: Session, chat_id: int, atendente_id: int) -> 
         .scalar()
     )
     return int(n or 0)
-
-
-def _append_fallback_itens(
-    out: list[NotificacaoItem],
-    *,
-    nao_lidas: int,
-    wpp_resp: int,
-) -> None:
-    """Garante item navegável quando o contador do resumo indica pendências mas a listagem ficou vazia."""
-    has_ticket = any(i.tipo == "mensagens_nao_lidas" for i in out)
-    if nao_lidas > 0 and not has_ticket:
-        out.append(
-            NotificacaoItem(
-                tipo="mensagens_nao_lidas",
-                ticket_id=None,
-                titulo=f"{nao_lidas} ticket(s) com mensagens não lidas",
-                descricao="Abrir tickets em aberto",
-                count=nao_lidas,
-                href="/tickets?situacao=abertos",
-                created_at=datetime.now(timezone.utc),
-            )
-        )
-
-    has_wpp_resp = any(i.tipo == "wpp_chats_com_resposta" for i in out)
-    if wpp_resp > 0 and not has_wpp_resp:
-        out.append(
-            NotificacaoItem(
-                tipo="wpp_chats_com_resposta",
-                ticket_id=None,
-                titulo=f"{wpp_resp} chat(s) com resposta pendente",
-                descricao="WhatsApp — ver meus atendimentos",
-                count=wpp_resp,
-                href="/whatsapp/atendendo",
-                created_at=datetime.now(timezone.utc),
-            )
-        )
 
 
 def build_notificacao_itens(
@@ -250,13 +260,16 @@ def build_notificacao_itens(
             )
         )
 
+    inbound_last, eff_seen = _wpp_resposta_pendente_exprs(atendente.id)
     stmt_wpp = (
         select(WhatsappChat)
         .where(
             WhatsappChat.estado == "em_atendimento",
             WhatsappChat.atendente_id == atendente.id,
+            inbound_last.isnot(None),
+            eff_seen < inbound_last,
         )
-        .order_by(WhatsappChat.id.desc())
+        .order_by(inbound_last.desc(), WhatsappChat.id.desc())
         .limit(limit)
     )
     if atendente.role != "admin":
@@ -266,7 +279,7 @@ def build_notificacao_itens(
     for c in chats:
         uc = _wpp_unread_count_for_chat(db, c.id, atendente.id)
         if uc <= 0:
-            continue
+            uc = 1
         nome = (c.cliente_nome or "").strip() or c.wa_id
         out.append(
             NotificacaoItem(
@@ -280,13 +293,14 @@ def build_notificacao_itens(
             )
         )
 
+    last_unread_at = _last_unread_message_at_subq(atendente.id)
     stmt = _apply_escopo_tickets_nao_lidos(
         select(Ticket)
         .options(
             joinedload(Ticket.empresa),
             joinedload(Ticket.setor),
         )
-        .order_by(Ticket.updated_at.desc().nulls_last(), Ticket.id.desc())
+        .order_by(last_unread_at.desc(), Ticket.id.desc())
         .limit(limit),
         db,
         atendente,
@@ -296,25 +310,24 @@ def build_notificacao_itens(
     for t in rows:
         uc = _unread_count_for_ticket(db, t, atendente.id)
         if uc <= 0:
-            continue
+            uc = 1
         emp = t.empresa.nome if t.empresa else "—"
         setor = t.setor.nome if t.setor else "—"
         assunto = (t.assunto or "").strip() or "—"
+        preview = _preview_ultima_nao_lida(db, t, atendente.id)
+        descricao = f"Nova resposta do cliente — {preview}" if preview else f"{emp} · {setor}"
         out.append(
             NotificacaoItem(
                 tipo="mensagens_nao_lidas",
                 ticket_id=t.id,
                 titulo=f"{t.protocolo} — {assunto[:80]}{'…' if len(assunto) > 80 else ''}",
-                descricao=f"{emp} · {setor}",
+                descricao=descricao,
                 count=uc,
                 href=f"/tickets/{t.id}",
                 created_at=t.updated_at or t.created_at,
             )
         )
 
-    nao = _count_tickets_com_nao_lidas(db, atendente)
-    wpp_resp = _count_wpp_respostas_pendentes(db, atendente)
-    _append_fallback_itens(out, nao_lidas=nao, wpp_resp=wpp_resp)
     return out
 
 

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -63,6 +63,26 @@ logger = logging.getLogger(__name__)
 _MAX_PAGE = 100
 _DEFAULT_PAGE = 20
 
+_ESTADOS_HISTORICO_FINALIZADOS = ("encerrado", "aguardando_avaliacao")
+_ESTADOS_HISTORICO_ATIVOS = ("em_atendimento", "aguardando_atendente")
+
+
+def _estados_historico_filtro(estado: str | None) -> list[str]:
+    s = (estado or "finalizados").strip().lower()
+    if s in ("finalizados", "default"):
+        return list(_ESTADOS_HISTORICO_FINALIZADOS)
+    if s == "encerrado":
+        return ["encerrado"]
+    if s == "aguardando_avaliacao":
+        return ["aguardando_avaliacao"]
+    if s == "em_atendimento":
+        return ["em_atendimento"]
+    if s == "aguardando_atendente":
+        return ["aguardando_atendente"]
+    if s == "todos":
+        return list(_ESTADOS_HISTORICO_FINALIZADOS + _ESTADOS_HISTORICO_ATIVOS)
+    raise HTTPException(status_code=400, detail="Parâmetro estado inválido para histórico.")
+
 _CHAT_LOAD_OPTIONS = (
     joinedload(WhatsappChat.atendente),
     joinedload(WhatsappChat.setor),
@@ -580,12 +600,17 @@ def listar_encerrados(
     atendente_id: int | None = Query(None, ge=1, description="Filtro por atendente que encerrou"),
     encerramento_inicio: datetime | None = Query(None, description="Filtro por data de encerramento a partir de"),
     encerramento_fim: datetime | None = Query(None, description="Filtro por data de encerramento até"),
+    estado: str | None = Query(
+        None,
+        description="finalizados (padrão) | encerrado | aguardando_avaliacao | em_atendimento | aguardando_atendente | todos",
+    ),
     offset: int = Query(0, ge=0),
     limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    q = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.estado == "encerrado")
+    estados = _estados_historico_filtro(estado)
+    q = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.estado.in_(estados))
     if protocolo:
         q = q.filter(WhatsappChat.protocolo.ilike(f"%{protocolo}%"))
     if wa_id:
@@ -621,16 +646,20 @@ def listar_avaliacoes(
     nota_max: int | None = Query(None, ge=1, le=5),
     encerramento_inicio: datetime | None = Query(None),
     encerramento_fim: datetime | None = Query(None),
+    incluir_sem_resposta: bool = Query(
+        False,
+        description="Incluir chats com avaliação solicitada mas sem nota (auditoria)",
+    ),
     offset: int = Query(0, ge=0),
     limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
     db: Session = Depends(get_db),
     _: Atendente = Depends(exigir_admin),
 ):
-    q = (
-        db.query(WhatsappChat)
-        .options(*_CHAT_LOAD_OPTIONS)
-        .filter(WhatsappChat.avaliacao_solicitada.is_(True))
-    )
+    q = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS)
+    if incluir_sem_resposta:
+        q = q.filter(WhatsappChat.avaliacao_solicitada.is_(True))
+    else:
+        q = q.filter(WhatsappChat.avaliacao_nota.isnot(None))
     if busca:
         term = f"%{busca.strip()}%"
         q = q.filter(
@@ -1075,20 +1104,35 @@ async def enviar_mensagem_midia(
         )
         q_prev = _preview_citacao(ref) if ref else None
 
-    ok, err, sent_wa_id = evolution_api.evolution_send_media(
-        st.evolution_base_url,
-        st.evolution_instance_name,
-        st.evolution_api_key,
-        c.wa_id,
-        mediatype=ev_mt,
-        mimetype=mime,
-        caption=legenda_whatsapp,
-        media_base64=b64,
-        file_name=fname,
-        quoted=quoted_payload,
-    )
+    if tipo_db == "audio":
+        ok, err, sent_wa_id = evolution_api.evolution_send_whatsapp_audio(
+            st.evolution_base_url,
+            st.evolution_instance_name,
+            st.evolution_api_key,
+            c.wa_id,
+            audio_base64=b64,
+            quoted=quoted_payload,
+        )
+    else:
+        ok, err, sent_wa_id = evolution_api.evolution_send_media(
+            st.evolution_base_url,
+            st.evolution_instance_name,
+            st.evolution_api_key,
+            c.wa_id,
+            mediatype=ev_mt,
+            mimetype=mime,
+            caption=legenda_whatsapp,
+            media_base64=b64,
+            file_name=fname,
+            quoted=quoted_payload,
+        )
     if not ok:
         raise HTTPException(status_code=502, detail=err or "Falha ao enviar mídia pela Evolution API")
+    if tipo_db == "audio" and not sent_wa_id:
+        raise HTTPException(
+            status_code=502,
+            detail="Evolution API não confirmou entrega do áudio (wa_message_id ausente).",
+        )
 
     m = WhatsappMensagem(
         chat_id=c.id,

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session, joinedload
-from sqlalchemy import desc, or_
+from sqlalchemy import desc, func, or_
 
 from app.database import get_db
 from app.models.atendente import Atendente
@@ -531,13 +531,9 @@ def _pode_ver_chat(db: Session, atendente: Atendente, c: WhatsappChat) -> bool:
     if c.atendente_id == atendente.id:
         return True
     vis = ids_setores_visiveis_atendente(db, atendente)
-    # Chats without a setor_id are considered public (the queue). Allow
-    # visibility to attendants for queue items (so they can assume and
-    # view messages while waiting). For other states (e.g. encerrado)
-    # require either being the attendant or having the setor visible.
     if c.setor_id is None:
         return c.estado == "aguardando_atendente"
-    if c.estado in ("aguardando_atendente", "encerrado", "aguardando_avaliacao"):
+    if c.estado in ("aguardando_atendente", "encerrado", "aguardando_avaliacao", "em_atendimento"):
         return c.setor_id in vis
     return False
 
@@ -627,15 +623,20 @@ def listar_encerrados(
         )
     if atendente_id:
         q = q.filter(WhatsappChat.atendente_id == atendente_id)
+    ref_data = func.coalesce(
+        WhatsappChat.encerramento_at,
+        WhatsappChat.atendimento_inicio_at,
+        WhatsappChat.created_at,
+    )
     if encerramento_inicio:
-        q = q.filter(WhatsappChat.encerramento_at >= encerramento_inicio)
+        q = q.filter(ref_data >= encerramento_inicio)
     if encerramento_fim:
-        q = q.filter(WhatsappChat.encerramento_at <= encerramento_fim)
+        q = q.filter(ref_data <= encerramento_fim)
     if atendente.role != "admin":
         vis = ids_setores_visiveis_atendente(db, atendente)
         q = q.filter(or_(WhatsappChat.atendente_id == atendente.id, WhatsappChat.setor_id.in_(vis)))
     total = q.count()
-    rows = q.order_by(desc(WhatsappChat.encerramento_at), desc(WhatsappChat.id)).offset(offset).limit(limit).all()
+    rows = q.order_by(desc(ref_data), desc(WhatsappChat.id)).offset(offset).limit(limit).all()
     return ListaPaginada(items=[_chat_read(db, c, revelar_avaliacao=True) for c in rows], total=total)
 
 
@@ -877,16 +878,29 @@ def registrar_demanda(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    from app.services.whatsapp_chat_demandas import criar_demanda_chat, demanda_para_read
+    from app.services.whatsapp_chat_demandas import (
+        criar_demanda_chat,
+        criar_marco_demanda_mensagem,
+        demanda_para_read,
+        remover_marco_demanda_mensagem,
+    )
 
-    c = db.query(WhatsappChat).filter(WhatsappChat.id == chat_id).first()
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     if not c:
         raise HTTPException(status_code=404, detail="Chat não encontrado")
     if not _pode_registrar_demanda(db, atendente, c):
         raise HTTPException(status_code=403, detail="Sem permissão para registrar demanda neste chat")
     row = criar_demanda_chat(db, c, atendente, data, desfecho="resolvido_sessao")
+    marco = criar_marco_demanda_mensagem(db, chat=c, atendente=atendente, demanda=row)
     db.commit()
-    assert row is not None
+    db.refresh(marco)
+    marco = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == marco.id)
+        .first()
+    )
+    emit_chat_mensagem_from_models(db, c, marco, exclude_atendente_id=atendente.id)
     return demanda_para_read(row)
 
 
@@ -928,6 +942,7 @@ def excluir_demanda(
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
     from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
+    from app.services.whatsapp_chat_demandas import remover_marco_demanda_mensagem
 
     c = db.query(WhatsappChat).filter(WhatsappChat.id == chat_id).first()
     if not c:
@@ -943,6 +958,7 @@ def excluir_demanda(
         raise HTTPException(status_code=404, detail="Demanda não encontrada")
     if atendente.role != "admin" and row.atendente_id != atendente.id:
         raise HTTPException(status_code=403, detail="Somente quem registrou ou admin pode excluir")
+    remover_marco_demanda_mensagem(db, chat_id=chat_id, demanda_id=demanda_id)
     db.delete(row)
     db.commit()
 
@@ -1432,9 +1448,9 @@ def abrir_ticket(
     registrar_primeira_resposta_se_necessario(db, ticket)
     db.add(WhatsappChatTicket(chat_id=chat_id, ticket_id=ticket.id, atendente_id=atendente.id))
     if data.natureza_id is not None:
-        from app.services.whatsapp_chat_demandas import criar_demanda_chat
+        from app.services.whatsapp_chat_demandas import criar_demanda_chat, criar_marco_demanda_mensagem
 
-        criar_demanda_chat(
+        row_dem = criar_demanda_chat(
             db,
             c,
             atendente,
@@ -1446,6 +1462,16 @@ def abrir_ticket(
             desfecho="escalado_ticket",
             ticket_id=ticket.id,
         )
+        marco = criar_marco_demanda_mensagem(db, chat=c, atendente=atendente, demanda=row_dem)
+        db.flush()
+        marco_loaded = (
+            db.query(WhatsappMensagem)
+            .options(joinedload(WhatsappMensagem.atendente))
+            .filter(WhatsappMensagem.id == marco.id)
+            .first()
+        )
+        if marco_loaded:
+            emit_chat_mensagem_from_models(db, c, marco_loaded, exclude_atendente_id=atendente.id)
     db.commit()
     db.refresh(ticket)
     pos_criar_ticket_na_fila(db, ticket)

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -25,6 +25,7 @@ from app.schemas.whatsapp_chat import (
     WhatsappChatComentarioInternoCreate,
     WhatsappChatDemandaCreate,
     WhatsappChatDemandaRead,
+    WhatsappChatDemandaUpdate,
     WhatsappChatMensagemCreate,
     WhatsappChatRead,
     WhatsappMensagemRead,
@@ -62,6 +63,26 @@ logger = logging.getLogger(__name__)
 
 _MAX_PAGE = 100
 _DEFAULT_PAGE = 20
+
+_ESTADOS_HISTORICO_FINALIZADOS = ("encerrado", "aguardando_avaliacao")
+_ESTADOS_HISTORICO_ATIVOS = ("em_atendimento", "aguardando_atendente")
+
+
+def _estados_historico_filtro(estado: str | None) -> list[str]:
+    s = (estado or "finalizados").strip().lower()
+    if s in ("finalizados", "default"):
+        return list(_ESTADOS_HISTORICO_FINALIZADOS)
+    if s == "encerrado":
+        return ["encerrado"]
+    if s == "aguardando_avaliacao":
+        return ["aguardando_avaliacao"]
+    if s == "em_atendimento":
+        return ["em_atendimento"]
+    if s == "aguardando_atendente":
+        return ["aguardando_atendente"]
+    if s == "todos":
+        return list(_ESTADOS_HISTORICO_FINALIZADOS + _ESTADOS_HISTORICO_ATIVOS)
+    raise HTTPException(status_code=400, detail="Parâmetro estado inválido para histórico.")
 
 _CHAT_LOAD_OPTIONS = (
     joinedload(WhatsappChat.atendente),
@@ -371,7 +392,7 @@ def _criar_funcionario_rede(
     atendente: Atendente,
     *,
     nome: str,
-    email: str,
+    email: str | None,
     tipo: str,
     escopo_empresas: str,
     rede_id: int,
@@ -402,16 +423,18 @@ def _criar_funcionario_rede(
         emps = db.query(Empresa).filter(Empresa.id.in_(ids)).all()
         if any(int(e.tenant_id) != int(atendente.tenant_id) for e in emps):
             raise HTTPException(status_code=400, detail="Empresa inválida para este tenant")
-    try:
-        assert_email_unico_por_rede(db, email=email.strip(), rede_id=int(rede_id))
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    email_norm = (email or "").strip() or None
+    if email_norm:
+        try:
+            assert_email_unico_por_rede(db, email=email_norm, rede_id=int(rede_id))
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
     emp_colab_id: int | None = None
     if escopo == "selected" and tipo_eff == "colaborador" and len(ids) == 1:
         emp_colab_id = ids[0]
     f = FuncionarioRede(
         nome=nome.strip(),
-        email=email.strip(),
+        email=email_norm,
         tipo=tipo_eff,
         escopo_empresas=escopo,
         ativo=True,
@@ -578,12 +601,17 @@ def listar_encerrados(
     atendente_id: int | None = Query(None, ge=1, description="Filtro por atendente que encerrou"),
     encerramento_inicio: datetime | None = Query(None, description="Filtro por data de encerramento a partir de"),
     encerramento_fim: datetime | None = Query(None, description="Filtro por data de encerramento até"),
+    estado: str | None = Query(
+        None,
+        description="finalizados (padrão) | encerrado | aguardando_avaliacao | em_atendimento | aguardando_atendente | todos",
+    ),
     offset: int = Query(0, ge=0),
     limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    q = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.estado == "encerrado")
+    estados = _estados_historico_filtro(estado)
+    q = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.estado.in_(estados))
     if protocolo:
         q = q.filter(WhatsappChat.protocolo.ilike(f"%{protocolo}%"))
     if wa_id:
@@ -619,16 +647,20 @@ def listar_avaliacoes(
     nota_max: int | None = Query(None, ge=1, le=5),
     encerramento_inicio: datetime | None = Query(None),
     encerramento_fim: datetime | None = Query(None),
+    incluir_sem_resposta: bool = Query(
+        False,
+        description="Incluir chats com avaliação solicitada mas sem nota (auditoria)",
+    ),
     offset: int = Query(0, ge=0),
     limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
     db: Session = Depends(get_db),
     _: Atendente = Depends(exigir_admin),
 ):
-    q = (
-        db.query(WhatsappChat)
-        .options(*_CHAT_LOAD_OPTIONS)
-        .filter(WhatsappChat.avaliacao_solicitada.is_(True))
-    )
+    q = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS)
+    if incluir_sem_resposta:
+        q = q.filter(WhatsappChat.avaliacao_solicitada.is_(True))
+    else:
+        q = q.filter(WhatsappChat.avaliacao_nota.isnot(None))
     if busca:
         term = f"%{busca.strip()}%"
         q = q.filter(
@@ -858,6 +890,36 @@ def registrar_demanda(
     return demanda_para_read(row)
 
 
+@router.patch("/{chat_id}/demandas/{demanda_id}", response_model=WhatsappChatDemandaRead)
+def atualizar_demanda(
+    chat_id: int,
+    demanda_id: int,
+    data: WhatsappChatDemandaUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
+    from app.services.whatsapp_chat_demandas import atualizar_demanda_chat, demanda_para_read
+
+    c = db.query(WhatsappChat).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_registrar_demanda(db, atendente, c):
+        raise HTTPException(status_code=403, detail="Sem permissão para alterar demandas neste chat")
+    row = (
+        db.query(WhatsappChatDemanda)
+        .filter(WhatsappChatDemanda.id == demanda_id, WhatsappChatDemanda.chat_id == chat_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Demanda não encontrada")
+    if not data.model_dump(exclude_unset=True):
+        raise HTTPException(status_code=400, detail="Nenhum campo para atualizar")
+    updated = atualizar_demanda_chat(db, c, row, data, atendente=atendente)
+    db.commit()
+    return demanda_para_read(updated)
+
+
 @router.delete("/{chat_id}/demandas/{demanda_id}", status_code=204)
 def excluir_demanda(
     chat_id: int,
@@ -1073,20 +1135,35 @@ async def enviar_mensagem_midia(
         )
         q_prev = _preview_citacao(ref) if ref else None
 
-    ok, err, sent_wa_id = evolution_api.evolution_send_media(
-        st.evolution_base_url,
-        st.evolution_instance_name,
-        st.evolution_api_key,
-        c.wa_id,
-        mediatype=ev_mt,
-        mimetype=mime,
-        caption=legenda_whatsapp,
-        media_base64=b64,
-        file_name=fname,
-        quoted=quoted_payload,
-    )
+    if tipo_db == "audio":
+        ok, err, sent_wa_id = evolution_api.evolution_send_whatsapp_audio(
+            st.evolution_base_url,
+            st.evolution_instance_name,
+            st.evolution_api_key,
+            c.wa_id,
+            audio_base64=b64,
+            quoted=quoted_payload,
+        )
+    else:
+        ok, err, sent_wa_id = evolution_api.evolution_send_media(
+            st.evolution_base_url,
+            st.evolution_instance_name,
+            st.evolution_api_key,
+            c.wa_id,
+            mediatype=ev_mt,
+            mimetype=mime,
+            caption=legenda_whatsapp,
+            media_base64=b64,
+            file_name=fname,
+            quoted=quoted_payload,
+        )
     if not ok:
         raise HTTPException(status_code=502, detail=err or "Falha ao enviar mídia pela Evolution API")
+    if tipo_db == "audio" and not sent_wa_id:
+        raise HTTPException(
+            status_code=502,
+            detail="Evolution API não confirmou entrega do áudio (wa_message_id ausente).",
+        )
 
     m = WhatsappMensagem(
         chat_id=c.id,

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -1073,20 +1073,35 @@ async def enviar_mensagem_midia(
         )
         q_prev = _preview_citacao(ref) if ref else None
 
-    ok, err, sent_wa_id = evolution_api.evolution_send_media(
-        st.evolution_base_url,
-        st.evolution_instance_name,
-        st.evolution_api_key,
-        c.wa_id,
-        mediatype=ev_mt,
-        mimetype=mime,
-        caption=legenda_whatsapp,
-        media_base64=b64,
-        file_name=fname,
-        quoted=quoted_payload,
-    )
+    if tipo_db == "audio":
+        ok, err, sent_wa_id = evolution_api.evolution_send_whatsapp_audio(
+            st.evolution_base_url,
+            st.evolution_instance_name,
+            st.evolution_api_key,
+            c.wa_id,
+            audio_base64=b64,
+            quoted=quoted_payload,
+        )
+    else:
+        ok, err, sent_wa_id = evolution_api.evolution_send_media(
+            st.evolution_base_url,
+            st.evolution_instance_name,
+            st.evolution_api_key,
+            c.wa_id,
+            mediatype=ev_mt,
+            mimetype=mime,
+            caption=legenda_whatsapp,
+            media_base64=b64,
+            file_name=fname,
+            quoted=quoted_payload,
+        )
     if not ok:
         raise HTTPException(status_code=502, detail=err or "Falha ao enviar mídia pela Evolution API")
+    if tipo_db == "audio" and not sent_wa_id:
+        raise HTTPException(
+            status_code=502,
+            detail="Evolution API não confirmou entrega do áudio (wa_message_id ausente).",
+        )
 
     m = WhatsappMensagem(
         chat_id=c.id,

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -371,7 +371,7 @@ def _criar_funcionario_rede(
     atendente: Atendente,
     *,
     nome: str,
-    email: str,
+    email: str | None,
     tipo: str,
     escopo_empresas: str,
     rede_id: int,
@@ -402,16 +402,18 @@ def _criar_funcionario_rede(
         emps = db.query(Empresa).filter(Empresa.id.in_(ids)).all()
         if any(int(e.tenant_id) != int(atendente.tenant_id) for e in emps):
             raise HTTPException(status_code=400, detail="Empresa inválida para este tenant")
-    try:
-        assert_email_unico_por_rede(db, email=email.strip(), rede_id=int(rede_id))
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    email_norm = (email or "").strip() or None
+    if email_norm:
+        try:
+            assert_email_unico_por_rede(db, email=email_norm, rede_id=int(rede_id))
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
     emp_colab_id: int | None = None
     if escopo == "selected" and tipo_eff == "colaborador" and len(ids) == 1:
         emp_colab_id = ids[0]
     f = FuncionarioRede(
         nome=nome.strip(),
-        email=email.strip(),
+        email=email_norm,
         tipo=tipo_eff,
         escopo_empresas=escopo,
         ativo=True,

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -25,6 +25,7 @@ from app.schemas.whatsapp_chat import (
     WhatsappChatComentarioInternoCreate,
     WhatsappChatDemandaCreate,
     WhatsappChatDemandaRead,
+    WhatsappChatDemandaUpdate,
     WhatsappChatMensagemCreate,
     WhatsappChatRead,
     WhatsappMensagemRead,
@@ -887,6 +888,36 @@ def registrar_demanda(
     db.commit()
     assert row is not None
     return demanda_para_read(row)
+
+
+@router.patch("/{chat_id}/demandas/{demanda_id}", response_model=WhatsappChatDemandaRead)
+def atualizar_demanda(
+    chat_id: int,
+    demanda_id: int,
+    data: WhatsappChatDemandaUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
+    from app.services.whatsapp_chat_demandas import atualizar_demanda_chat, demanda_para_read
+
+    c = db.query(WhatsappChat).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_registrar_demanda(db, atendente, c):
+        raise HTTPException(status_code=403, detail="Sem permissão para alterar demandas neste chat")
+    row = (
+        db.query(WhatsappChatDemanda)
+        .filter(WhatsappChatDemanda.id == demanda_id, WhatsappChatDemanda.chat_id == chat_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Demanda não encontrada")
+    if not data.model_dump(exclude_unset=True):
+        raise HTTPException(status_code=400, detail="Nenhum campo para atualizar")
+    updated = atualizar_demanda_chat(db, c, row, data, atendente=atendente)
+    db.commit()
+    return demanda_para_read(updated)
 
 
 @router.delete("/{chat_id}/demandas/{demanda_id}", status_code=204)

--- a/backend/app/models/funcionario_rede.py
+++ b/backend/app/models/funcionario_rede.py
@@ -19,7 +19,7 @@ class FuncionarioRede(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     nome = Column(String(255), nullable=False)
-    email = Column(String(255), nullable=False, index=True)  # único por contexto (rede/empresa)
+    email = Column(String(255), nullable=True, index=True)  # opcional (#444); único por rede quando preenchido
     tipo = Column(String(20), nullable=False)  # socio | supervisor | colaborador
     escopo_empresas = Column(String(20), nullable=False, default="selected")  # all | selected
     ativo = Column(Boolean, default=True)

--- a/backend/app/schemas/funcionario_rede.py
+++ b/backend/app/schemas/funcionario_rede.py
@@ -1,13 +1,24 @@
-from pydantic import BaseModel, ConfigDict, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, field_validator
 from datetime import datetime
+
+
+def _email_vazio_para_none(v: object) -> object:
+    if v is None or (isinstance(v, str) and not v.strip()):
+        return None
+    return v
 
 
 class FuncionarioRedeBase(BaseModel):
     nome: str
-    email: EmailStr
+    email: EmailStr | None = None
     tipo: str  # socio | supervisor | colaborador
     escopo_empresas: str = "selected"  # all | selected
     ativo: bool = True
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def email_opcional(cls, v: object) -> object:
+        return _email_vazio_para_none(v)
 
 
 class FuncionarioRedeCreate(FuncionarioRedeBase):
@@ -25,6 +36,11 @@ class FuncionarioRedeUpdate(BaseModel):
     rede_id: int | None = None
     empresa_id: int | None = None
     empresa_ids: list[int] | None = None
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def email_opcional(cls, v: object) -> object:
+        return _email_vazio_para_none(v)
 
 
 class FuncionarioRedeRead(FuncionarioRedeBase):

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -138,6 +138,12 @@ class WhatsappChatDemandaCreate(BaseModel):
     descricao_curta: str | None = Field(None, max_length=500)
 
 
+class WhatsappChatDemandaUpdate(BaseModel):
+    natureza_id: int | None = None
+    motivo_id: int | None = None
+    descricao_curta: str | None = Field(None, max_length=500)
+
+
 class WhatsappChatDemandaRead(BaseModel):
     id: int
     chat_id: int

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class WhatsappMensagemRead(BaseModel):
@@ -105,7 +105,7 @@ class WhatsappVincularFuncionarioBody(BaseModel):
 
 class WhatsappCadastrarFuncionarioBody(BaseModel):
     nome: str = Field(..., min_length=1, max_length=255)
-    email: str = Field(..., min_length=3, max_length=255)
+    email: str | None = Field(default=None, max_length=255)
     rede_id: int
     tipo: str = Field(default="colaborador", description="colaborador | supervisor")
     escopo_empresas: str = Field(default="selected", description="all | selected")
@@ -114,6 +114,13 @@ class WhatsappCadastrarFuncionarioBody(BaseModel):
         None,
         description="Empresa exibida no chat quando o funcionário tem várias empresas.",
     )
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def email_opcional(cls, v: object) -> str | None:
+        if v is None or (isinstance(v, str) and not v.strip()):
+            return None
+        return str(v).strip()
 
 
 class WhatsappAbrirTicketBody(BaseModel):
@@ -127,6 +134,12 @@ class WhatsappAbrirTicketBody(BaseModel):
 
 class WhatsappChatDemandaCreate(BaseModel):
     natureza_id: int
+    motivo_id: int | None = None
+    descricao_curta: str | None = Field(None, max_length=500)
+
+
+class WhatsappChatDemandaUpdate(BaseModel):
+    natureza_id: int | None = None
     motivo_id: int | None = None
     descricao_curta: str | None = Field(None, max_length=500)
 

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class WhatsappMensagemRead(BaseModel):
@@ -105,7 +105,7 @@ class WhatsappVincularFuncionarioBody(BaseModel):
 
 class WhatsappCadastrarFuncionarioBody(BaseModel):
     nome: str = Field(..., min_length=1, max_length=255)
-    email: str = Field(..., min_length=3, max_length=255)
+    email: str | None = Field(default=None, max_length=255)
     rede_id: int
     tipo: str = Field(default="colaborador", description="colaborador | supervisor")
     escopo_empresas: str = Field(default="selected", description="all | selected")
@@ -114,6 +114,13 @@ class WhatsappCadastrarFuncionarioBody(BaseModel):
         None,
         description="Empresa exibida no chat quando o funcionário tem várias empresas.",
     )
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def email_opcional(cls, v: object) -> str | None:
+        if v is None or (isinstance(v, str) and not v.strip()):
+            return None
+        return str(v).strip()
 
 
 class WhatsappAbrirTicketBody(BaseModel):

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -186,6 +186,34 @@ def evolution_send_text(
     return False, f"HTTP {code}", None
 
 
+def evolution_send_whatsapp_audio(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    number_digits: str,
+    *,
+    audio_base64: str,
+    quoted: dict[str, Any] | None = None,
+) -> tuple[bool, str | None, str | None]:
+    """POST /message/sendWhatsAppAudio/{instance} — nota de voz (PTT) com encoding automático."""
+    base = base_url.rstrip("/")
+    url = f"{base}/message/sendWhatsAppAudio/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body: dict[str, Any] = {
+        "number": number_digits,
+        "audio": audio_base64,
+        "encoding": True,
+    }
+    if quoted:
+        body["quoted"] = quoted
+    code, data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=120)
+    if code in (200, 201):
+        return True, None, _extract_wa_message_id(data)
+    if err:
+        return False, err[:1200], None
+    return False, f"HTTP {code}", None
+
+
 def evolution_send_media(
     base_url: str,
     instance: str,

--- a/backend/app/services/whatsapp_chat_demandas.py
+++ b/backend/app/services/whatsapp_chat_demandas.py
@@ -14,7 +14,7 @@ from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
 from app.models.whatsapp_chat import WhatsappChat
 from app.models.whatsapp_chat_demanda import DESFECHOS_DEMANDA, WhatsappChatDemanda
 from app.schemas.dashboard import ContagemIdNome
-from app.schemas.whatsapp_chat import WhatsappChatDemandaCreate, WhatsappChatDemandaRead
+from app.schemas.whatsapp_chat import WhatsappChatDemandaCreate, WhatsappChatDemandaRead, WhatsappChatDemandaUpdate
 from app.services.chat_dashboard_filters import apply_chat_dashboard_filters, period_bounds
 
 
@@ -114,6 +114,50 @@ def listar_demandas_chat(db: Session, chat_id: int) -> list[WhatsappChatDemandaR
         .all()
     )
     return [demanda_para_read(r) for r in rows]
+
+
+def atualizar_demanda_chat(
+    db: Session,
+    chat: WhatsappChat,
+    row: WhatsappChatDemanda,
+    data: WhatsappChatDemandaUpdate,
+    *,
+    atendente: Atendente,
+) -> WhatsappChatDemanda:
+    if chat.estado != "em_atendimento":
+        raise HTTPException(status_code=400, detail="Edite demandas apenas em chats em atendimento")
+    if row.desfecho != "resolvido_sessao":
+        raise HTTPException(status_code=400, detail="Demandas escaladas para ticket não podem ser editadas")
+    if atendente.role != "admin" and row.atendente_id != atendente.id:
+        raise HTTPException(status_code=403, detail="Somente quem registrou ou admin pode editar")
+    update = data.model_dump(exclude_unset=True)
+    natureza_id = update.get("natureza_id", row.natureza_id)
+    motivo_id = update.get("motivo_id", row.motivo_id)
+    if "motivo_id" in update and update["motivo_id"] is None:
+        motivo_id = None
+    _validar_natureza_motivo(db, natureza_id=int(natureza_id), motivo_id=motivo_id)
+    if "natureza_id" in update:
+        row.natureza_id = int(natureza_id)
+    if "motivo_id" in update or "natureza_id" in update:
+        row.motivo_id = motivo_id
+    if "descricao_curta" in update:
+        desc = (update["descricao_curta"] or "").strip() or None
+        if desc and len(desc) > 500:
+            raise HTTPException(status_code=400, detail="Descrição curta excede 500 caracteres")
+        row.descricao_curta = desc
+    db.flush()
+    refreshed = (
+        db.query(WhatsappChatDemanda)
+        .options(
+            joinedload(WhatsappChatDemanda.natureza),
+            joinedload(WhatsappChatDemanda.motivo),
+            joinedload(WhatsappChatDemanda.atendente),
+        )
+        .filter(WhatsappChatDemanda.id == row.id)
+        .first()
+    )
+    assert refreshed is not None
+    return refreshed
 
 
 def agregar_demandas_por_natureza(

--- a/backend/app/services/whatsapp_chat_demandas.py
+++ b/backend/app/services/whatsapp_chat_demandas.py
@@ -11,11 +11,67 @@ from sqlalchemy.orm import Session, joinedload
 from app.models.atendente import Atendente
 from app.models.empresa import Empresa
 from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
-from app.models.whatsapp_chat import WhatsappChat
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
 from app.models.whatsapp_chat_demanda import DESFECHOS_DEMANDA, WhatsappChatDemanda
 from app.schemas.dashboard import ContagemIdNome
 from app.schemas.whatsapp_chat import WhatsappChatDemandaCreate, WhatsappChatDemandaRead, WhatsappChatDemandaUpdate
 from app.services.chat_dashboard_filters import apply_chat_dashboard_filters, period_bounds
+
+DESFECHO_MARCO = {
+    "resolvido_sessao": "Resolvido na sessão",
+    "escalado_ticket": "Escalado para ticket",
+}
+
+
+def _rotulo_demanda(row: WhatsappChatDemanda) -> str:
+    nat = row.natureza.nome if row.natureza else "Demanda"
+    if row.motivo and row.motivo.nome:
+        return f"{nat} · {row.motivo.nome}"
+    return nat
+
+
+def corpo_marco_demanda(row: WhatsappChatDemanda) -> str:
+    desfecho = DESFECHO_MARCO.get(row.desfecho, row.desfecho)
+    return f"[demanda_id={row.id}] Demanda registada: {_rotulo_demanda(row)} — {desfecho}"
+
+
+def criar_marco_demanda_mensagem(
+    db: Session,
+    *,
+    chat: WhatsappChat,
+    atendente: Atendente,
+    demanda: WhatsappChatDemanda,
+) -> WhatsappMensagem:
+    evento = "demanda_registrada" if demanda.desfecho == "resolvido_sessao" else "demanda_escalada"
+    m = WhatsappMensagem(
+        chat_id=chat.id,
+        direcao="outbound",
+        corpo=corpo_marco_demanda(demanda),
+        tipo_midia="texto",
+        mimetype=None,
+        midia_nome_arquivo=None,
+        wa_message_id=None,
+        atendente_id=atendente.id,
+        evento_sistema=evento,
+    )
+    db.add(m)
+    db.flush()
+    return m
+
+
+def remover_marco_demanda_mensagem(db: Session, *, chat_id: int, demanda_id: int) -> None:
+    tag = f"[demanda_id={demanda_id}]"
+    rows = (
+        db.query(WhatsappMensagem)
+        .filter(
+            WhatsappMensagem.chat_id == chat_id,
+            WhatsappMensagem.evento_sistema.in_(("demanda_registrada", "demanda_escalada")),
+            WhatsappMensagem.corpo.like(f"{tag}%"),
+        )
+        .all()
+    )
+    for row in rows:
+        db.delete(row)
 
 
 def _validar_natureza_motivo(

--- a/backend/tests/test_notificacoes_itens.py
+++ b/backend/tests/test_notificacoes_itens.py
@@ -64,7 +64,8 @@ def test_admin_nao_conta_nao_lidas_de_outro_responsavel(client, seed_base, auth_
     assert resumo_a1.nao_lidas_count >= 1
 
 
-def test_itens_fallback_quando_contador_positivo(client, seed_base, auth_headers, db_session, monkeypatch):
+def test_itens_link_directo_por_ticket(client, seed_base, auth_headers, db_session, monkeypatch):
+    """Cada pendência de não-lida aponta para /tickets/{id}, nunca listagem genérica (#452)."""
     _criar_ticket_com_mensagem(db_session, seed_base, atendente_id=seed_base["a1"].id)
 
     def fake_unread(db, ticket, atendente_id):
@@ -76,7 +77,23 @@ def test_itens_fallback_quando_contador_positivo(client, seed_base, auth_headers
     itens = build_notificacao_itens(db_session, seed_base["a1"], limit=15)
 
     assert resumo.nao_lidas_count >= 1
-    assert any(i.tipo == "mensagens_nao_lidas" for i in itens)
+    ticket_itens = [i for i in itens if i.tipo == "mensagens_nao_lidas"]
+    assert len(ticket_itens) >= 1
+    for item in ticket_itens:
+        assert item.ticket_id is not None
+        assert item.href == f"/tickets/{item.ticket_id}"
+        assert "situacao=abertos" not in item.href
+
+
+def test_varios_tickets_nao_lidos_links_individuais(client, seed_base, auth_headers, db_session):
+    t1 = _criar_ticket_com_mensagem(db_session, seed_base, atendente_id=seed_base["a1"].id, assunto="Um")
+    t2 = _criar_ticket_com_mensagem(db_session, seed_base, atendente_id=seed_base["a1"].id, assunto="Dois")
+
+    itens = build_notificacao_itens(db_session, seed_base["a1"], limit=15)
+    ticket_itens = [i for i in itens if i.tipo == "mensagens_nao_lidas"]
+    hrefs = {i.href for i in ticket_itens}
+    assert f"/tickets/{t1.id}" in hrefs
+    assert f"/tickets/{t2.id}" in hrefs
 
 
 def test_mensagem_anterior_a_visto_nao_conta(db_session, seed_base):

--- a/backend/tests/test_whatsapp_avaliacao.py
+++ b/backend/tests/test_whatsapp_avaliacao.py
@@ -220,3 +220,82 @@ def test_listar_avaliacoes_admin(client, seed_base, auth_headers, db_session):
 
     r403 = client.get("/v1/whatsapp/chats/avaliacoes", headers=auth_headers["a1"])
     assert r403.status_code == 403
+
+
+def test_historico_inclui_aguardando_avaliacao(client, seed_base, auth_headers, db_session, monkeypatch):
+    """#448 — sessão aguardando avaliação aparece no histórico (filtro padrão)."""
+    _configurar(db_session)
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "hist-av"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "hist-av"}
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {"remoteJid": "5511777666555@s.whatsapp.net", "fromMe": False, "id": "hist-av-1"},
+                    "message": {"conversation": "Oi"},
+                }
+            ]
+        },
+    }
+    client.post("/v1/webhooks/evolution", json=body, headers=h)
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    monkeypatch.setattr(
+        "app.services.whatsapp_avaliacao.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-hist"),
+    )
+    enc = client.post(f"/v1/whatsapp/chats/{cid}/encerrar", headers=auth_headers["a1"])
+    assert enc.json()["estado"] == "aguardando_avaliacao"
+
+    hist = client.get("/v1/whatsapp/chats/encerrados", headers=auth_headers["admin"]).json()
+    assert any(item["id"] == cid for item in hist["items"])
+    assert any(item["estado"] == "aguardando_avaliacao" for item in hist["items"] if item["id"] == cid)
+
+    so_encerrado = client.get("/v1/whatsapp/chats/encerrados?estado=encerrado", headers=auth_headers["admin"]).json()
+    assert not any(item["id"] == cid for item in so_encerrado["items"])
+
+
+def test_avaliacoes_exclui_sem_nota_por_defeito(client, seed_base, auth_headers, db_session):
+    """#448 — aba Avaliações lista só chats com nota respondida."""
+    _configurar(db_session)
+    db_session.add(
+        WhatsappChat(
+            protocolo="WPP-AV-SEM",
+            wa_id="5511999000011",
+            cliente_nome="Sem nota",
+            estado="aguardando_avaliacao",
+            atendente_id=1,
+            avaliacao_solicitada=True,
+            avaliacao_nota=None,
+        )
+    )
+    db_session.add(
+        WhatsappChat(
+            protocolo="WPP-AV-COM",
+            wa_id="5511999000022",
+            cliente_nome="Com nota",
+            estado="encerrado",
+            atendente_id=1,
+            avaliacao_solicitada=True,
+            avaliacao_nota=5,
+        )
+    )
+    db_session.commit()
+
+    body = client.get("/v1/whatsapp/chats/avaliacoes", headers=auth_headers["admin"]).json()
+    ids = [item["chat_id"] for item in body["items"]]
+    assert any(item["nota"] == 5 for item in body["items"])
+    assert all(item.get("nota") is not None for item in body["items"])
+    assert not any(item.get("sem_avaliacao") for item in body["items"])
+
+    audit = client.get(
+        "/v1/whatsapp/chats/avaliacoes?incluir_sem_resposta=true",
+        headers=auth_headers["admin"],
+    ).json()
+    assert any(item.get("sem_avaliacao") for item in audit["items"])
+

--- a/backend/tests/test_whatsapp_chat_demandas.py
+++ b/backend/tests/test_whatsapp_chat_demandas.py
@@ -102,3 +102,55 @@ def test_dashboard_agrega_demandas_por_natureza(client, seed_base, auth_headers,
     assert row is not None
     assert row["total"] >= 1
     assert row["nome"] == "Dúvida WPP"
+
+
+def test_atualizar_demanda_resolvido_sessao(client, seed_base, auth_headers, db_session):
+    from app.models.ticket_classificacao import TicketNatureza
+
+    nat, mot = _seed_natureza_motivo(db_session)
+    nat2 = TicketNatureza(nome="Outra WPP", slug="outra-wpp-test", ordem=2, ativo=True)
+    db_session.add(nat2)
+    db_session.commit()
+
+    cid = _chat_em_atendimento(client, auth_headers, wa_id="5511999005566", msg_id="dm-5")
+    created = client.post(
+        f"/v1/whatsapp/chats/{cid}/demandas",
+        json={"natureza_id": nat.id, "motivo_id": mot.id, "descricao_curta": "Antes"},
+        headers=auth_headers["a1"],
+    ).json()
+    did = created["id"]
+
+    r = client.patch(
+        f"/v1/whatsapp/chats/{cid}/demandas/{did}",
+        json={"natureza_id": nat2.id, "motivo_id": None, "descricao_curta": "Depois"},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["natureza_nome"] == "Outra WPP"
+    assert body["motivo_id"] is None
+    assert body["descricao_curta"] == "Depois"
+
+
+def test_nao_edita_demanda_escalada(client, seed_base, auth_headers, db_session):
+    nat, mot = _seed_natureza_motivo(db_session)
+    cid = _chat_em_atendimento(client, auth_headers, wa_id="5511999006677", msg_id="dm-6")
+    client.post(
+        f"/v1/whatsapp/chats/{cid}/abrir-ticket",
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Escalado",
+            "natureza_id": nat.id,
+            "motivo_id": mot.id,
+        },
+        headers=auth_headers["a1"],
+    )
+    demandas = client.get(f"/v1/whatsapp/chats/{cid}/demandas", headers=auth_headers["a1"]).json()
+    did = demandas[0]["id"]
+    denied = client.patch(
+        f"/v1/whatsapp/chats/{cid}/demandas/{did}",
+        json={"descricao_curta": "Tentativa"},
+        headers=auth_headers["a1"],
+    )
+    assert denied.status_code == 400

--- a/backend/tests/test_whatsapp_chat_demandas.py
+++ b/backend/tests/test_whatsapp_chat_demandas.py
@@ -49,6 +49,11 @@ def test_registrar_e_listar_demanda(client, seed_base, auth_headers, db_session)
     assert len(listed) == 1
     assert listed[0]["id"] == body["id"]
 
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    marcos = [m for m in msgs if m.get("evento_sistema") == "demanda_registrada"]
+    assert len(marcos) == 1
+    assert f"[demanda_id={body['id']}]" in marcos[0]["corpo"]
+
 
 def test_abrir_ticket_cria_demanda_escalada(client, seed_base, auth_headers, db_session):
     nat, mot = _seed_natureza_motivo(db_session)
@@ -74,6 +79,26 @@ def test_abrir_ticket_cria_demanda_escalada(client, seed_base, auth_headers, db_
     assert len(demandas) == 1
     assert demandas[0]["desfecho"] == "escalado_ticket"
     assert demandas[0]["ticket_id"] == ticket_ids[-1]
+
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    assert any(m.get("evento_sistema") == "demanda_escalada" for m in msgs)
+
+
+def test_excluir_demanda_remove_marco(client, seed_base, auth_headers, db_session):
+    nat, mot = _seed_natureza_motivo(db_session)
+    cid = _chat_em_atendimento(client, auth_headers, wa_id="5511999007788", msg_id="dm-del")
+    created = client.post(
+        f"/v1/whatsapp/chats/{cid}/demandas",
+        json={"natureza_id": nat.id, "motivo_id": mot.id},
+        headers=auth_headers["a1"],
+    ).json()
+    did = created["id"]
+
+    r = client.delete(f"/v1/whatsapp/chats/{cid}/demandas/{did}", headers=auth_headers["a1"])
+    assert r.status_code == 204
+
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    assert not any(m.get("evento_sistema") == "demanda_registrada" for m in msgs)
 
 
 def test_outro_atendente_nao_registra_demanda(client, seed_base, auth_headers, db_session):

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -474,6 +474,28 @@ def test_cadastrar_funcionario_no_chat(client, seed_base, auth_headers, db_sessi
     assert any(re["id"] == seed_base["rede"].id for re in catalogo.json()["redes"])
 
 
+def test_cadastrar_funcionario_no_chat_sem_email(client, seed_base, auth_headers):
+    """#444 — cadastro pelo WhatsApp sem e-mail vincula o contacto."""
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999112244", msg_id="func-sem-email")
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/cadastrar-funcionario",
+        json={
+            "nome": "Contacto Só WhatsApp",
+            "rede_id": seed_base["rede"].id,
+            "tipo": "colaborador",
+            "escopo_empresas": "selected",
+            "empresa_ids": [seed_base["empresa"].id],
+        },
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["funcionario_nome"] == "Contacto Só WhatsApp"
+    assert body["funcionario_email"] is None
+    assert body["funcionario_rede_id"] is not None
+    assert body["empresa_id"] == seed_base["empresa"].id
+
+
 def test_admin_nao_envia_ao_cliente_usa_comentario_interno(client, seed_base, auth_headers, monkeypatch):
     """#403 — admin acompanha chat alheio; mensagem ao cliente bloqueada; comentário interno permitido."""
     sent = {"n": 0, "seq": 0}
@@ -594,4 +616,74 @@ def test_webhook_inbound_midia_grava_ficheiro(client, seed_base, auth_headers, m
     )
     assert r_mid.status_code == 200
     assert r_mid.headers.get("content-type", "").startswith("image/")
+
+
+def test_enviar_audio_usa_sendWhatsAppAudio(client, seed_base, auth_headers, monkeypatch):
+    """#441 — áudio outbound via sendWhatsAppAudio com encoding, não sendMedia."""
+    calls: list[str] = []
+
+    def fake_audio(*_a, **_k):
+        calls.append("audio")
+        return True, None, "wa-audio-1"
+
+    def fake_media(*_a, **_k):
+        calls.append("media")
+        return True, None, "wa-media-1"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_whatsapp_audio", fake_audio)
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_media", fake_media)
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "aud-out",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999445566", msg_id="aud-out-1")
+
+    webm_bytes = b"\x1a\x45\xdf\xa3" + b"\x00" * 64
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens/midia",
+        data={"mediatipo": "audio", "caption": ""},
+        files={"file": ("gravacao.webm", webm_bytes, "audio/webm")},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["tipo_midia"] == "audio"
+    assert body["wa_message_id"] == "wa-audio-1"
+    assert calls == ["audio"]
+
+
+def test_enviar_audio_falha_sem_wa_message_id(client, seed_base, auth_headers, monkeypatch):
+    """#441 — não persiste áudio se Evolution não devolver wa_message_id."""
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_whatsapp_audio",
+        lambda *_a, **_k: (True, None, None),
+    )
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "aud-fail",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999556677", msg_id="aud-fail-1")
+    webm_bytes = b"\x1a\x45\xdf\xa3" + b"\x00" * 64
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens/midia",
+        data={"mediatipo": "audio", "caption": ""},
+        files={"file": ("gravacao.webm", webm_bytes, "audio/webm")},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 502
+    rows = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    assert all(m.get("tipo_midia") != "audio" or m.get("direcao") != "outbound" for m in rows)
 

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -107,7 +107,8 @@ def test_listar_encerrados_filtra_e_respeita_rbac(client, seed_base, auth_header
     assert denied.status_code == 403
 
 
-def test_nao_acessa_chat_em_atendimento_de_outro_atendente_mesmo_setor(client, seed_base, auth_headers):
+def test_colaborador_mesmo_setor_ve_chat_em_atendimento(client, seed_base, auth_headers, db_session):
+    """#455 — colega do setor consulta chat activo; envio ao cliente continua bloqueado (#403)."""
     client.patch(
         "/v1/settings/whatsapp",
         json={"webhook_secret": "rbac-2"},
@@ -126,8 +127,25 @@ def test_nao_acessa_chat_em_atendimento_de_outro_atendente_mesmo_setor(client, s
 
     client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
 
-    denied = client.get(f"/v1/whatsapp/chats/{cid}", headers=auth_headers["a2"])
-    assert denied.status_code == 403
+    seed_base["a2"].setores.append(seed_base["setor1"])
+    db_session.commit()
+
+    ok = client.get(f"/v1/whatsapp/chats/{cid}", headers=auth_headers["a2"])
+    assert ok.status_code == 200
+
+    denied_cliente = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Olá cliente"},
+        headers=auth_headers["a2"],
+    )
+    assert denied_cliente.status_code == 403
+
+    interno = client.post(
+        f"/v1/whatsapp/chats/{cid}/comentarios-internos",
+        json={"texto": "Nota interna de apoio"},
+        headers=auth_headers["a2"],
+    )
+    assert interno.status_code == 201
 
 
 def test_webhook_guarda_citacao_em_mensagem(client, seed_base, auth_headers):

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -617,3 +617,73 @@ def test_webhook_inbound_midia_grava_ficheiro(client, seed_base, auth_headers, m
     assert r_mid.status_code == 200
     assert r_mid.headers.get("content-type", "").startswith("image/")
 
+
+def test_enviar_audio_usa_sendWhatsAppAudio(client, seed_base, auth_headers, monkeypatch):
+    """#441 — áudio outbound via sendWhatsAppAudio com encoding, não sendMedia."""
+    calls: list[str] = []
+
+    def fake_audio(*_a, **_k):
+        calls.append("audio")
+        return True, None, "wa-audio-1"
+
+    def fake_media(*_a, **_k):
+        calls.append("media")
+        return True, None, "wa-media-1"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_whatsapp_audio", fake_audio)
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_media", fake_media)
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "aud-out",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999445566", msg_id="aud-out-1")
+
+    webm_bytes = b"\x1a\x45\xdf\xa3" + b"\x00" * 64
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens/midia",
+        data={"mediatipo": "audio", "caption": ""},
+        files={"file": ("gravacao.webm", webm_bytes, "audio/webm")},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["tipo_midia"] == "audio"
+    assert body["wa_message_id"] == "wa-audio-1"
+    assert calls == ["audio"]
+
+
+def test_enviar_audio_falha_sem_wa_message_id(client, seed_base, auth_headers, monkeypatch):
+    """#441 — não persiste áudio se Evolution não devolver wa_message_id."""
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_whatsapp_audio",
+        lambda *_a, **_k: (True, None, None),
+    )
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "aud-fail",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999556677", msg_id="aud-fail-1")
+    webm_bytes = b"\x1a\x45\xdf\xa3" + b"\x00" * 64
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens/midia",
+        data={"mediatipo": "audio", "caption": ""},
+        files={"file": ("gravacao.webm", webm_bytes, "audio/webm")},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 502
+    rows = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    assert all(m.get("tipo_midia") != "audio" or m.get("direcao") != "outbound" for m in rows)
+

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -142,7 +142,7 @@ def test_colaborador_mesmo_setor_ve_chat_em_atendimento(client, seed_base, auth_
 
     interno = client.post(
         f"/v1/whatsapp/chats/{cid}/comentarios-internos",
-        json={"corpo": "Nota interna de apoio"},
+        json={"texto": "Nota interna de apoio"},
         headers=auth_headers["a2"],
     )
     assert interno.status_code == 201

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -107,7 +107,8 @@ def test_listar_encerrados_filtra_e_respeita_rbac(client, seed_base, auth_header
     assert denied.status_code == 403
 
 
-def test_nao_acessa_chat_em_atendimento_de_outro_atendente_mesmo_setor(client, seed_base, auth_headers):
+def test_colaborador_mesmo_setor_ve_chat_em_atendimento(client, seed_base, auth_headers, db_session):
+    """#455 — colega do setor consulta chat activo; envio ao cliente continua bloqueado (#403)."""
     client.patch(
         "/v1/settings/whatsapp",
         json={"webhook_secret": "rbac-2"},
@@ -126,8 +127,25 @@ def test_nao_acessa_chat_em_atendimento_de_outro_atendente_mesmo_setor(client, s
 
     client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
 
-    denied = client.get(f"/v1/whatsapp/chats/{cid}", headers=auth_headers["a2"])
-    assert denied.status_code == 403
+    seed_base["a2"].setores.append(seed_base["setor1"])
+    db_session.commit()
+
+    ok = client.get(f"/v1/whatsapp/chats/{cid}", headers=auth_headers["a2"])
+    assert ok.status_code == 200
+
+    denied_cliente = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"corpo": "Olá cliente"},
+        headers=auth_headers["a2"],
+    )
+    assert denied_cliente.status_code == 403
+
+    interno = client.post(
+        f"/v1/whatsapp/chats/{cid}/comentarios-internos",
+        json={"corpo": "Nota interna de apoio"},
+        headers=auth_headers["a2"],
+    )
+    assert interno.status_code == 201
 
 
 def test_webhook_guarda_citacao_em_mensagem(client, seed_base, auth_headers):

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -135,7 +135,7 @@ def test_colaborador_mesmo_setor_ve_chat_em_atendimento(client, seed_base, auth_
 
     denied_cliente = client.post(
         f"/v1/whatsapp/chats/{cid}/mensagens",
-        json={"corpo": "Olá cliente"},
+        json={"texto": "Olá cliente"},
         headers=auth_headers["a2"],
     )
     assert denied_cliente.status_code == 403

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -595,3 +595,73 @@ def test_webhook_inbound_midia_grava_ficheiro(client, seed_base, auth_headers, m
     assert r_mid.status_code == 200
     assert r_mid.headers.get("content-type", "").startswith("image/")
 
+
+def test_enviar_audio_usa_sendWhatsAppAudio(client, seed_base, auth_headers, monkeypatch):
+    """#441 — áudio outbound via sendWhatsAppAudio com encoding, não sendMedia."""
+    calls: list[str] = []
+
+    def fake_audio(*_a, **_k):
+        calls.append("audio")
+        return True, None, "wa-audio-1"
+
+    def fake_media(*_a, **_k):
+        calls.append("media")
+        return True, None, "wa-media-1"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_whatsapp_audio", fake_audio)
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_media", fake_media)
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "aud-out",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999445566", msg_id="aud-out-1")
+
+    webm_bytes = b"\x1a\x45\xdf\xa3" + b"\x00" * 64
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens/midia",
+        data={"mediatipo": "audio", "caption": ""},
+        files={"file": ("gravacao.webm", webm_bytes, "audio/webm")},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["tipo_midia"] == "audio"
+    assert body["wa_message_id"] == "wa-audio-1"
+    assert calls == ["audio"]
+
+
+def test_enviar_audio_falha_sem_wa_message_id(client, seed_base, auth_headers, monkeypatch):
+    """#441 — não persiste áudio se Evolution não devolver wa_message_id."""
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_whatsapp_audio",
+        lambda *_a, **_k: (True, None, None),
+    )
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "aud-fail",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999556677", msg_id="aud-fail-1")
+    webm_bytes = b"\x1a\x45\xdf\xa3" + b"\x00" * 64
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens/midia",
+        data={"mediatipo": "audio", "caption": ""},
+        files={"file": ("gravacao.webm", webm_bytes, "audio/webm")},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 502
+    rows = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    assert all(m.get("tipo_midia") != "audio" or m.get("direcao") != "outbound" for m in rows)
+

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -474,6 +474,28 @@ def test_cadastrar_funcionario_no_chat(client, seed_base, auth_headers, db_sessi
     assert any(re["id"] == seed_base["rede"].id for re in catalogo.json()["redes"])
 
 
+def test_cadastrar_funcionario_no_chat_sem_email(client, seed_base, auth_headers):
+    """#444 — cadastro pelo WhatsApp sem e-mail vincula o contacto."""
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999112244", msg_id="func-sem-email")
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/cadastrar-funcionario",
+        json={
+            "nome": "Contacto Só WhatsApp",
+            "rede_id": seed_base["rede"].id,
+            "tipo": "colaborador",
+            "escopo_empresas": "selected",
+            "empresa_ids": [seed_base["empresa"].id],
+        },
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["funcionario_nome"] == "Contacto Só WhatsApp"
+    assert body["funcionario_email"] is None
+    assert body["funcionario_rede_id"] is not None
+    assert body["empresa_id"] == seed_base["empresa"].id
+
+
 def test_admin_nao_envia_ao_cliente_usa_comentario_interno(client, seed_base, auth_headers, monkeypatch):
     """#403 — admin acompanha chat alheio; mensagem ao cliente bloqueada; comentário interno permitido."""
     sent = {"n": 0, "seq": 0}

--- a/docs/REALTIME_SSE.md
+++ b/docs/REALTIME_SSE.md
@@ -32,7 +32,8 @@ Destinatários filtrados por RBAC (setor homônimo + admin).
 
 - Cliente fetch-based (suporta Bearer; `EventSource` nativo não envia header)
 - Hook `useEventStream()` + `EventStreamProvider` no `Layout`
-- Reconexão com backoff exponencial; após **3 falhas** consecutivas, `useFallback === true` (consumidores RT-F2 mantêm polling)
+- Reconexão com backoff exponencial; após **3 falhas** consecutivas, `useFallback === true` (intervalos de polling mais frequentes)
+- **Polling de segurança (#442):** WhatsApp (`WhatsappConversa`, `WhatsappAtendendo`) faz refresh periódico **mesmo com SSE conectado** (4–8 s), porque o hub v1 não propaga eventos entre workers Gunicorn
 
 ## Gunicorn e multi-worker
 

--- a/docs/WHATSAPP_EVOLUTION.md
+++ b/docs/WHATSAPP_EVOLUTION.md
@@ -60,6 +60,7 @@ Campos persistidos em `whatsapp_settings` (via **Configurações → WhatsApp**,
 ## Envio (DX Connect → Evolution)
 
 - Endpoint típico Evolution v2: `POST {base}/message/sendText/{instance}` com JSON `{ "number": "<DDI+DDD+número>", "text": "..." }` e header `apikey`.
+- **Áudio outbound (#441):** notas de voz usam `POST {base}/message/sendWhatsAppAudio/{instance}` com `{ "number", "audio": "<base64>", "encoding": true }` — a Evolution converte para Ogg Opus compatível com WhatsApp (não usar `sendMedia` com `audio/webm` do browser).
 - O número do cliente é normalizado a dígitos (ex.: `5511999999999`).
 
 ## Ciclo de vida do chat

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -889,6 +889,11 @@ export namespace WhatsappChats {
     motivo_id?: number | null
     descricao_curta?: string | null
   }
+  export interface DemandaUpdate {
+    natureza_id?: number
+    motivo_id?: number | null
+    descricao_curta?: string | null
+  }
 }
 
 /** Obtém o binário de uma mensagem com mídia (requer JWT; não usar em `src` de img direto). */
@@ -947,6 +952,11 @@ export const whatsappChats = {
     }),
   excluirDemanda: (id: number, demandaId: number) =>
     api<void>(`/whatsapp/chats/${id}/demandas/${demandaId}`, { method: 'DELETE' }),
+  atualizarDemanda: (id: number, demandaId: number, data: WhatsappChats.DemandaUpdate) =>
+    api<WhatsappChats.Demanda>(`/whatsapp/chats/${id}/demandas/${demandaId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
   assumir: (id: number) => api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/assumir`, { method: 'POST' }),
   encerrar: (id: number) => api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/encerrar`, { method: 'POST' }),
   transferir: (id: number, data: { setor_id: number; atendente_id?: number | null }) =>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -889,6 +889,11 @@ export namespace WhatsappChats {
     motivo_id?: number | null
     descricao_curta?: string | null
   }
+  export interface DemandaUpdate {
+    natureza_id?: number
+    motivo_id?: number | null
+    descricao_curta?: string | null
+  }
 }
 
 /** Obtém o binário de uma mensagem com mídia (requer JWT; não usar em `src` de img direto). */
@@ -947,6 +952,11 @@ export const whatsappChats = {
     }),
   excluirDemanda: (id: number, demandaId: number) =>
     api<void>(`/whatsapp/chats/${id}/demandas/${demandaId}`, { method: 'DELETE' }),
+  atualizarDemanda: (id: number, demandaId: number, data: WhatsappChats.DemandaUpdate) =>
+    api<WhatsappChats.Demanda>(`/whatsapp/chats/${id}/demandas/${demandaId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
   assumir: (id: number) => api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/assumir`, { method: 'POST' }),
   encerrar: (id: number) => api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/encerrar`, { method: 'POST' }),
   transferir: (id: number, data: { setor_id: number; atendente_id?: number | null }) =>
@@ -983,7 +993,7 @@ export const whatsappChats = {
     id: number,
     data: {
       nome: string
-      email: string
+      email?: string | null
       rede_id: number
       tipo?: 'colaborador' | 'supervisor'
       escopo_empresas?: 'all' | 'selected'
@@ -1671,7 +1681,7 @@ export namespace FuncionariosRede {
   export interface Funcionario {
     id: number;
     nome: string;
-    email: string;
+    email: string | null;
     tipo: string;
     escopo_empresas: EscopoEmpresas;
     ativo: boolean;
@@ -1683,7 +1693,7 @@ export namespace FuncionariosRede {
   }
   export interface Create {
     nome: string;
-    email: string;
+    email?: string | null;
     tipo: string;
     escopo_empresas?: EscopoEmpresas;
     ativo?: boolean;
@@ -1693,7 +1703,7 @@ export namespace FuncionariosRede {
   }
   export interface Update {
     nome?: string;
-    email?: string;
+    email?: string | null;
     tipo?: string;
     escopo_empresas?: EscopoEmpresas;
     ativo?: boolean;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -983,7 +983,7 @@ export const whatsappChats = {
     id: number,
     data: {
       nome: string
-      email: string
+      email?: string | null
       rede_id: number
       tipo?: 'colaborador' | 'supervisor'
       escopo_empresas?: 'all' | 'selected'
@@ -1671,7 +1671,7 @@ export namespace FuncionariosRede {
   export interface Funcionario {
     id: number;
     nome: string;
-    email: string;
+    email: string | null;
     tipo: string;
     escopo_empresas: EscopoEmpresas;
     ativo: boolean;
@@ -1683,7 +1683,7 @@ export namespace FuncionariosRede {
   }
   export interface Create {
     nome: string;
-    email: string;
+    email?: string | null;
     tipo: string;
     escopo_empresas?: EscopoEmpresas;
     ativo?: boolean;
@@ -1693,7 +1693,7 @@ export namespace FuncionariosRede {
   }
   export interface Update {
     nome?: string;
-    email?: string;
+    email?: string | null;
     tipo?: string;
     escopo_empresas?: EscopoEmpresas;
     ativo?: boolean;

--- a/frontend/src/components/FuncionariosEmpresaLista.tsx
+++ b/frontend/src/components/FuncionariosEmpresaLista.tsx
@@ -59,7 +59,7 @@ export function FuncionariosEmpresaLista({
               </td>
               <td
                 className="max-w-[14rem] truncate px-4 py-3 text-slate-600 dark:text-slate-300 sm:px-6"
-                title={f.email}
+                title={f.email ?? undefined}
               >
                 {f.email}
               </td>

--- a/frontend/src/components/NavbarNotificacoes.tsx
+++ b/frontend/src/components/NavbarNotificacoes.tsx
@@ -70,7 +70,7 @@ function ListaPendencias({
     return (
       <p className="px-3 py-10 text-center text-sm text-slate-500 dark:text-slate-400 sm:py-6">
         {totalPendencias > 0
-          ? 'Pendências no badge — abra novamente em instantes ou use a listagem de tickets.'
+          ? 'A carregar pendências…'
           : 'Sem pendências'}
       </p>
     )

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useId, useRef, type ReactNode } from 'react'
+import { Card } from './Card'
+import { Button } from './Button'
+
+type Props = {
+  open: boolean
+  title: string
+  message?: string
+  confirmLabel?: string
+  cancelLabel?: string
+  variant?: 'danger' | 'primary'
+  loading?: boolean
+  onConfirm: () => void
+  onCancel: () => void
+  children?: ReactNode
+  /** Oculta botões de acção (modal com acções customizadas no children). */
+  hideActions?: boolean
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = 'Confirmar',
+  cancelLabel = 'Cancelar',
+  variant = 'primary',
+  loading = false,
+  onConfirm,
+  onCancel,
+  children,
+  hideActions = false,
+}: Props) {
+  const titleId = useId()
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    dialogRef.current?.focus()
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onCancel()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onCancel])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-[110] flex items-center justify-center bg-slate-900/50 p-4 backdrop-blur-sm"
+      role="presentation"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onCancel()
+      }}
+    >
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="w-full max-w-lg outline-none"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+      >
+        <Card className="animate-in zoom-in-95 border-none p-0 shadow-xl ring-1 ring-slate-200 dark:ring-slate-800">
+          <div className="p-6">
+            <div className="flex items-start justify-between gap-3">
+              <h3 id={titleId} className="text-lg font-bold text-slate-900 dark:text-white">
+                {title}
+              </h3>
+              <button
+                type="button"
+                className="text-slate-500 hover:text-slate-900 dark:hover:text-slate-100"
+                onClick={onCancel}
+                aria-label="Fechar"
+              >
+                &times;
+              </button>
+            </div>
+            {message && <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">{message}</p>}
+            {children && <div className="mt-4">{children}</div>}
+            {!hideActions && (
+              <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <Button variant="secondary" onClick={onCancel} disabled={loading}>
+                  {cancelLabel}
+                </Button>
+                <Button
+                  variant={variant === 'danger' ? 'danger' : 'primary'}
+                  onClick={onConfirm}
+                  loading={loading}
+                >
+                  {confirmLabel}
+                </Button>
+              </div>
+            )}
+          </div>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/Toast.tsx
+++ b/frontend/src/components/ui/Toast.tsx
@@ -61,7 +61,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={value}>
       {children}
-      <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+      <div className="pointer-events-none fixed bottom-4 right-4 z-[200] flex flex-col gap-2">
         {toasts.map((toast) => {
           let styles =
             'bg-slate-800 text-white dark:bg-slate-800 dark:text-slate-100 dark:ring-1 dark:ring-slate-600/60'

--- a/frontend/src/constants/contatoClienteLabels.ts
+++ b/frontend/src/constants/contatoClienteLabels.ts
@@ -1,0 +1,23 @@
+/** Copy operacional: contato da empresa cliente vs equipe interna (#447). */
+
+export const CONTATO_CLIENTE = {
+  vincularChat: 'Identificar contato do cliente',
+  vincularCurto: 'Identificar',
+  vincularEmpresa: 'Identificar contato',
+  bannerNaoVinculado:
+    'Contacto não identificado — ainda não está vinculado a nenhuma empresa da rede.',
+  modalTitulo: 'Contato do cliente',
+  modalSubtitulo:
+    'Vincule um cadastro existente ou cadastre este contacto como colaborador da empresa cliente.',
+  buscarPlaceholder: 'Buscar contatos da rede…',
+  selecioneContato: 'Selecione um contato da rede.',
+  selecioneEmpresaContato: 'Selecione a empresa deste contato.',
+  vinculadoSucesso: 'Contato vinculado.',
+  cadastradoSucesso: 'Contato cadastrado e vinculado.',
+  desvinculadoSucesso: 'Vínculo com o contato removido.',
+  informeNome: 'Informe o nome do contato.',
+  nenhumEncontrado: 'Nenhum contato encontrado. Use a aba Cadastrar novo.',
+  digiteParaBuscar: 'Digite um termo para buscar contatos da rede.',
+  cadastrarTicket: 'Cadastrar contato do cliente',
+  remetenteSemCadastro: 'Remetente sem cadastro na rede',
+} as const

--- a/frontend/src/hooks/useWhatsappVoltarLista.ts
+++ b/frontend/src/hooks/useWhatsappVoltarLista.ts
@@ -1,0 +1,24 @@
+import { useCallback } from 'react'
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
+
+import { resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../lib/whatsappListReturn'
+
+/**
+ * Volta à lista WhatsApp de origem (#449): history.back() no SPA quando possível;
+ * senão state whatsappListReturn, query ?from= ou atendimento.
+ */
+export function useWhatsappVoltarLista(fallbackPath = WHATSAPP_LIST_PATHS.atendendo) {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const [searchParams] = useSearchParams()
+
+  return useCallback(() => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      navigate(-1)
+      return
+    }
+    navigate(
+      resolveWhatsappListFallback(location.state, searchParams.get('from'), fallbackPath),
+    )
+  }, [navigate, location.state, searchParams, fallbackPath])
+}

--- a/frontend/src/lib/fileTypeIcon.ts
+++ b/frontend/src/lib/fileTypeIcon.ts
@@ -1,0 +1,84 @@
+/** Ícone e rótulo por extensão ou MIME (#453). */
+
+export type FileTypeVisual = {
+  emoji: string
+  label: string
+}
+
+const EXT_MAP: Record<string, FileTypeVisual> = {
+  pdf: { emoji: '📕', label: 'PDF' },
+  doc: { emoji: '📝', label: 'Word' },
+  docx: { emoji: '📝', label: 'Word' },
+  xls: { emoji: '📊', label: 'Excel' },
+  xlsx: { emoji: '📊', label: 'Excel' },
+  ppt: { emoji: '📽️', label: 'PowerPoint' },
+  pptx: { emoji: '📽️', label: 'PowerPoint' },
+  txt: { emoji: '📃', label: 'Texto' },
+  csv: { emoji: '📃', label: 'CSV' },
+  zip: { emoji: '🗜️', label: 'Compactado' },
+  rar: { emoji: '🗜️', label: 'Compactado' },
+  '7z': { emoji: '🗜️', label: 'Compactado' },
+  jpg: { emoji: '🖼️', label: 'Imagem' },
+  jpeg: { emoji: '🖼️', label: 'Imagem' },
+  png: { emoji: '🖼️', label: 'Imagem' },
+  gif: { emoji: '🖼️', label: 'Imagem' },
+  webp: { emoji: '🖼️', label: 'Imagem' },
+  mp3: { emoji: '🎵', label: 'Áudio' },
+  wav: { emoji: '🎵', label: 'Áudio' },
+  ogg: { emoji: '🎵', label: 'Áudio' },
+  mp4: { emoji: '🎬', label: 'Vídeo' },
+  avi: { emoji: '🎬', label: 'Vídeo' },
+  mov: { emoji: '🎬', label: 'Vídeo' },
+  webm: { emoji: '🎬', label: 'Vídeo' },
+}
+
+const MIME_PREFIX: [string, FileTypeVisual][] = [
+  ['application/pdf', EXT_MAP.pdf],
+  ['application/msword', EXT_MAP.doc],
+  ['application/vnd.openxmlformats-officedocument.wordprocessingml', EXT_MAP.docx],
+  ['application/vnd.ms-excel', EXT_MAP.xls],
+  ['application/vnd.openxmlformats-officedocument.spreadsheetml', EXT_MAP.xlsx],
+  ['application/vnd.ms-powerpoint', EXT_MAP.ppt],
+  ['application/vnd.openxmlformats-officedocument.presentationml', EXT_MAP.pptx],
+  ['text/plain', EXT_MAP.txt],
+  ['text/csv', EXT_MAP.csv],
+  ['application/zip', EXT_MAP.zip],
+  ['application/x-rar', EXT_MAP.rar],
+  ['image/', EXT_MAP.jpg],
+  ['audio/', EXT_MAP.mp3],
+  ['video/', EXT_MAP.mp4],
+]
+
+function extensaoDeNome(nome?: string | null): string | null {
+  if (!nome) return null
+  const base = nome.split(/[/\\]/).pop() ?? nome
+  const idx = base.lastIndexOf('.')
+  if (idx <= 0) return null
+  return base.slice(idx + 1).toLowerCase()
+}
+
+export function visualTipoArquivo(
+  nome?: string | null,
+  mime?: string | null,
+): FileTypeVisual {
+  const ext = extensaoDeNome(nome)
+  if (ext && EXT_MAP[ext]) return EXT_MAP[ext]
+  const m = (mime ?? '').toLowerCase()
+  for (const [prefix, visual] of MIME_PREFIX) {
+    if (m.startsWith(prefix)) return visual
+  }
+  return { emoji: '📄', label: 'Ficheiro' }
+}
+
+export function rotuloDownloadArquivo(
+  nome?: string | null,
+  mime?: string | null,
+  tipoMidia?: string | null,
+): string {
+  const tipo = (tipoMidia ?? '').toLowerCase()
+  if (tipo === 'audio') return '🔊 Baixar áudio'
+  if (tipo === 'video') return '🎬 Baixar vídeo'
+  if (tipo === 'imagem' || tipo === 'figurinha') return '📷 Baixar imagem'
+  const v = visualTipoArquivo(nome, mime)
+  return `${v.emoji} Baixar ${v.label}`
+}

--- a/frontend/src/lib/whatsappDemandaUtils.ts
+++ b/frontend/src/lib/whatsappDemandaUtils.ts
@@ -1,0 +1,86 @@
+import type { WhatsappChats } from '../api/client'
+
+export type DemandaPosEncerramento = {
+  ultimaDemanda: WhatsappChats.Demanda
+  mensagensApos: number
+  ultimaMensagemAt: string | null
+}
+
+export function formatarHoraDemanda(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function rotuloDemanda(d: WhatsappChats.Demanda): string {
+  return d.motivo_nome ? `${d.natureza_nome} · ${d.motivo_nome}` : d.natureza_nome ?? 'Demanda'
+}
+
+/** Mensagens visíveis na conversa (exclui eventos ocultos de avaliação). */
+export function mensagensVisiveisConversa(msgs: WhatsappChats.Mensagem[]): WhatsappChats.Mensagem[] {
+  return msgs.filter(
+    (m) =>
+      m.evento_sistema !== 'auto_avaliacao_solicitacao' &&
+      m.evento_sistema !== 'avaliacao_cliente_nota',
+  )
+}
+
+export function analisarDemandaPosRegistro(
+  demandas: WhatsappChats.Demanda[],
+  msgs: WhatsappChats.Mensagem[],
+): DemandaPosEncerramento | null {
+  const editaveis = demandas.filter((d) => d.desfecho === 'resolvido_sessao')
+  if (editaveis.length === 0) return null
+  const ultimaDemanda = editaveis.reduce((a, b) => {
+    const ta = a.created_at ? new Date(a.created_at).getTime() : 0
+    const tb = b.created_at ? new Date(b.created_at).getTime() : 0
+    return tb >= ta ? b : a
+  })
+  const tDemanda = ultimaDemanda.created_at ? new Date(ultimaDemanda.created_at).getTime() : 0
+  const visiveis = mensagensVisiveisConversa(msgs)
+  const apos = visiveis.filter((m) => {
+    const t = m.created_at ? new Date(m.created_at).getTime() : 0
+    return t > tDemanda
+  })
+  if (apos.length === 0) return null
+  const ultima = apos.reduce((a, b) => {
+    const ta = a.created_at ? new Date(a.created_at).getTime() : 0
+    const tb = b.created_at ? new Date(b.created_at).getTime() : 0
+    return tb >= ta ? b : a
+  })
+  return {
+    ultimaDemanda,
+    mensagensApos: apos.length,
+    ultimaMensagemAt: ultima.created_at ?? null,
+  }
+}
+
+export type TimelineItem =
+  | { kind: 'mensagem'; ts: number; mensagem: WhatsappChats.Mensagem }
+  | { kind: 'demanda'; ts: number; demanda: WhatsappChats.Demanda }
+
+export function mergeTimelineChat(
+  msgs: WhatsappChats.Mensagem[],
+  demandas: WhatsappChats.Demanda[],
+): TimelineItem[] {
+  const items: TimelineItem[] = []
+  for (const m of mensagensVisiveisConversa(msgs)) {
+    items.push({
+      kind: 'mensagem',
+      ts: m.created_at ? new Date(m.created_at).getTime() : 0,
+      mensagem: m,
+    })
+  }
+  for (const d of demandas) {
+    items.push({
+      kind: 'demanda',
+      ts: d.created_at ? new Date(d.created_at).getTime() : 0,
+      demanda: d,
+    })
+  }
+  return items.sort((a, b) => a.ts - b.ts || (a.kind === 'demanda' ? 1 : 0) - (b.kind === 'demanda' ? 1 : 0))
+}

--- a/frontend/src/lib/whatsappDemandaUtils.ts
+++ b/frontend/src/lib/whatsappDemandaUtils.ts
@@ -63,11 +63,31 @@ export type TimelineItem =
   | { kind: 'mensagem'; ts: number; mensagem: WhatsappChats.Mensagem }
   | { kind: 'demanda'; ts: number; demanda: WhatsappChats.Demanda }
 
+export function demandasComMarcoMensagem(
+  demandas: WhatsappChats.Demanda[],
+  msgs: WhatsappChats.Mensagem[],
+): WhatsappChats.Demanda[] {
+  const idsComMarco = new Set<number>()
+  for (const m of msgs) {
+    if (m.evento_sistema === 'demanda_registrada' || m.evento_sistema === 'demanda_escalada') {
+      const match = m.corpo?.match(/^\[demanda_id=(\d+)\]/)
+      if (match) idsComMarco.add(Number(match[1]))
+    }
+  }
+  return demandas.filter((d) => !idsComMarco.has(d.id))
+}
+
+export function textoMarcoDemanda(corpo: string | null | undefined): string {
+  if (!corpo) return 'Demanda registada'
+  return corpo.replace(/^\[demanda_id=\d+\]\s*/, '')
+}
+
 export function mergeTimelineChat(
   msgs: WhatsappChats.Mensagem[],
   demandas: WhatsappChats.Demanda[],
 ): TimelineItem[] {
   const items: TimelineItem[] = []
+  const demandasMerge = demandasComMarcoMensagem(demandas, msgs)
   for (const m of mensagensVisiveisConversa(msgs)) {
     items.push({
       kind: 'mensagem',
@@ -75,7 +95,7 @@ export function mergeTimelineChat(
       mensagem: m,
     })
   }
-  for (const d of demandas) {
+  for (const d of demandasMerge) {
     items.push({
       kind: 'demanda',
       ts: d.created_at ? new Date(d.created_at).getTime() : 0,

--- a/frontend/src/lib/whatsappListReturn.ts
+++ b/frontend/src/lib/whatsappListReturn.ts
@@ -1,0 +1,77 @@
+export const WHATSAPP_LIST_PATHS = {
+  atendendo: '/whatsapp/atendendo',
+  historico: '/whatsapp/historico',
+  avaliacoes: '/whatsapp/avaliacoes',
+} as const
+
+export type WhatsappListOrigin = keyof typeof WHATSAPP_LIST_PATHS
+
+export type WhatsappListReturnState = {
+  whatsappListReturn?: string
+}
+
+export function whatsappConversaState(returnPath: string): WhatsappListReturnState {
+  return { whatsappListReturn: returnPath }
+}
+
+export function whatsappConversaLink(chatId: number, returnPath: string, from?: WhatsappListOrigin) {
+  const search = from ? `?from=${from}` : ''
+  return {
+    pathname: `/whatsapp/c/${chatId}${search}`,
+    state: whatsappConversaState(returnPath),
+  }
+}
+
+export function resolveWhatsappListFallback(
+  state: unknown,
+  fromQuery: string | null,
+  fallback = WHATSAPP_LIST_PATHS.atendendo,
+): string {
+  const st = state as WhatsappListReturnState | null
+  if (st?.whatsappListReturn?.trim()) return st.whatsappListReturn.trim()
+  const from = fromQuery?.trim().toLowerCase()
+  if (from && from in WHATSAPP_LIST_PATHS) {
+    return WHATSAPP_LIST_PATHS[from as WhatsappListOrigin]
+  }
+  return fallback
+}
+
+export function buildHistoricoReturnPath(filters: {
+  busca: string
+  atendenteId: number | ''
+  desde: string
+  ate: string
+  estado: string
+  offset: number
+}): string {
+  const p = new URLSearchParams()
+  if (filters.busca.trim()) p.set('busca', filters.busca.trim())
+  if (filters.atendenteId !== '') p.set('atendente_id', String(filters.atendenteId))
+  if (filters.desde) p.set('desde', filters.desde)
+  if (filters.ate) p.set('ate', filters.ate)
+  if (filters.estado && filters.estado !== 'finalizados') p.set('estado', filters.estado)
+  if (filters.offset > 0) p.set('offset', String(filters.offset))
+  const qs = p.toString()
+  return qs ? `${WHATSAPP_LIST_PATHS.historico}?${qs}` : WHATSAPP_LIST_PATHS.historico
+}
+
+export function buildAvaliacoesReturnPath(filters: {
+  busca: string
+  atendenteId: number | ''
+  notaMin: number | ''
+  desde: string
+  ate: string
+  incluirSemResposta: boolean
+  offset: number
+}): string {
+  const p = new URLSearchParams()
+  if (filters.busca.trim()) p.set('busca', filters.busca.trim())
+  if (filters.atendenteId !== '') p.set('atendente_id', String(filters.atendenteId))
+  if (filters.notaMin !== '') p.set('nota', String(filters.notaMin))
+  if (filters.desde) p.set('desde', filters.desde)
+  if (filters.ate) p.set('ate', filters.ate)
+  if (filters.incluirSemResposta) p.set('incluir_sem_resposta', 'true')
+  if (filters.offset > 0) p.set('offset', String(filters.offset))
+  const qs = p.toString()
+  return qs ? `${WHATSAPP_LIST_PATHS.avaliacoes}?${qs}` : WHATSAPP_LIST_PATHS.avaliacoes
+}

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -97,7 +97,7 @@ export function FuncionarioRedeForm() {
       .then((item) => {
         if (cancelled) return
         setNome(item.nome)
-        setEmail(item.email)
+        setEmail(item.email || '')
         setTipo(item.tipo as Tipo)
         setEscopoEmpresas((item.escopo_empresas as Escopo) || (item.tipo === 'socio' ? 'all' : 'selected'))
         setAtivo(item.ativo)
@@ -170,12 +170,13 @@ export function FuncionarioRedeForm() {
       }
     }
     setSaving(true)
+    const emailPayload = email.trim() || null
     try {
       let saved: FuncionariosRede.Funcionario
       if (isEdit && !Number.isNaN(funcionarioId)) {
         const payload: FuncionariosRede.Update = {
           nome: nome.trim(),
-          email,
+          email: emailPayload,
           tipo,
           escopo_empresas: escopo,
           ativo,
@@ -188,7 +189,7 @@ export function FuncionarioRedeForm() {
       } else {
         const payload: FuncionariosRede.Create = {
           nome: nome.trim(),
-          email,
+          email: emailPayload,
           tipo,
           escopo_empresas: escopo,
           ativo,
@@ -257,7 +258,15 @@ export function FuncionarioRedeForm() {
           <div className="space-y-6">
             <FormSection title="Dados do funcionário">
               <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-              <Input label="E-mail" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+              <Input
+                label="E-mail (opcional)"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+              <p className="text-xs text-slate-500">
+                Usado para identificar remetente em tickets por e-mail. Contactos só WhatsApp podem ficar em branco.
+              </p>
               <Select
                 label="Tipo"
                 value={tipo}

--- a/frontend/src/pages/FuncionariosRede.tsx
+++ b/frontend/src/pages/FuncionariosRede.tsx
@@ -196,7 +196,7 @@ export function FuncionariosRede() {
                         )}
                       </div>
                     </td>
-                    <td className="max-w-[14rem] truncate px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400" title={f.email}>
+                    <td className="max-w-[14rem] truncate px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400" title={f.email ?? undefined}>
                       {f.email}
                     </td>
                     <td className="whitespace-nowrap px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400">

--- a/frontend/src/pages/RedeDetalhe.tsx
+++ b/frontend/src/pages/RedeDetalhe.tsx
@@ -626,7 +626,7 @@ export function RedeDetalhe() {
 
   function preencherFormFuncionario(f: FuncionarioListaItem) {
     setNomeFuncionario(f.nome)
-    setEmailFuncionario(f.email)
+    setEmailFuncionario(f.email ?? '')
     setTipoFuncionario((f.tipo as TipoFuncionario) || 'colaborador')
     setAtivoFuncionario(f.ativo)
     setEmpresaIdFuncionario(f.empresa_id ?? '')
@@ -1766,7 +1766,7 @@ export function RedeDetalhe() {
                       className="cursor-pointer transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/50"
                     >
                       <td className="px-4 py-3.5 font-medium text-slate-800 sm:px-6 dark:text-slate-100">{f.nome}</td>
-                      <td className="max-w-[12rem] truncate px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-300" title={f.email}>
+                      <td className="max-w-[12rem] truncate px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-300" title={f.email ?? undefined}>
                         {f.email}
                       </td>
                       <td className="whitespace-nowrap px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-300">

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -57,6 +57,7 @@ import {
   rotuloPrioridade,
   type PrioridadeTicket,
 } from '../lib/ticketPrioridade'
+import { CONTATO_CLIENTE } from '../constants/contatoClienteLabels'
 
 const ROTULO_CAMPO: Record<string, string> = {
   status_id: 'Status',
@@ -1426,10 +1427,10 @@ export function TicketDetalhe() {
               >
                 {requerCadastroFuncionario ? (
                   <>
-                    <p className="font-medium">Remetente sem cadastro</p>
+                    <p className="font-medium">{CONTATO_CLIENTE.remetenteSemCadastro}</p>
                     {isAdmin && (
                       <Link to={linkCadastroFuncionario} className="mt-1 inline-block font-semibold underline underline-offset-2">
-                        Cadastrar funcionário
+                        {CONTATO_CLIENTE.cadastrarTicket}
                       </Link>
                     )}
                   </>

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -70,11 +70,11 @@ export function WhatsappAtendendo() {
     }
   }, [subscribe, load])
 
-  // Refresh inicial + polling legado quando SSE indisponível
+  // Refresh inicial + polling de segurança (#442)
   useEffect(() => {
     void load()
-    if (!useFallback) return
-    const timer = setInterval(() => void load(true), 10000)
+    const intervalMs = useFallback ? 10000 : 8000
+    const timer = setInterval(() => void load(true), intervalMs)
     return () => clearInterval(timer)
   }, [load, useFallback])
 

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { ApiError, whatsappChats, type WhatsappChats } from '../../api/client'
+import { whatsappConversaLink, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
 import { useEventStream } from '../../contexts/EventStreamContext'
 import { Card } from '../../components/ui/Card'
@@ -173,7 +174,7 @@ export function WhatsappAtendendo() {
                     {/* Grupo de Botões da Fila */}
                     <div className="flex items-center gap-2 border-t pt-3 dark:border-slate-800">
                       <Link 
-                        to={`/whatsapp/c/${c.id}`}
+                        to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
                         className="flex-1 text-center rounded-lg bg-slate-100 py-2 text-xs font-bold text-slate-600 hover:bg-slate-200 transition-colors dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
                       >
                         Visualizar
@@ -205,7 +206,7 @@ export function WhatsappAtendendo() {
               </div>
             ) : (
               meus.map((c) => (
-                <Link key={c.id} to={`/whatsapp/c/${c.id}`} className="group">
+                <Link key={c.id} to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')} className="group">
                   <Card className="h-full border-none p-5 shadow-sm ring-1 ring-slate-200 transition-all group-hover:ring-cyan-500 dark:ring-slate-800">
                     <div className="flex flex-col h-full justify-between gap-4">
                       <div>

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { ApiError, whatsappChats, type WhatsappChats } from '../../api/client'
+import { whatsappConversaLink, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
 import { useEventStream } from '../../contexts/EventStreamContext'
 import { Card } from '../../components/ui/Card'
@@ -70,11 +71,11 @@ export function WhatsappAtendendo() {
     }
   }, [subscribe, load])
 
-  // Refresh inicial + polling legado quando SSE indisponível
+  // Refresh inicial + polling de segurança (#442)
   useEffect(() => {
     void load()
-    if (!useFallback) return
-    const timer = setInterval(() => void load(true), 10000)
+    const intervalMs = useFallback ? 10000 : 8000
+    const timer = setInterval(() => void load(true), intervalMs)
     return () => clearInterval(timer)
   }, [load, useFallback])
 
@@ -173,7 +174,7 @@ export function WhatsappAtendendo() {
                     {/* Grupo de Botões da Fila */}
                     <div className="flex items-center gap-2 border-t pt-3 dark:border-slate-800">
                       <Link 
-                        to={`/whatsapp/c/${c.id}`}
+                        to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
                         className="flex-1 text-center rounded-lg bg-slate-100 py-2 text-xs font-bold text-slate-600 hover:bg-slate-200 transition-colors dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
                       >
                         Visualizar
@@ -205,7 +206,7 @@ export function WhatsappAtendendo() {
               </div>
             ) : (
               meus.map((c) => (
-                <Link key={c.id} to={`/whatsapp/c/${c.id}`} className="group">
+                <Link key={c.id} to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')} className="group">
                   <Card className="h-full border-none p-5 shadow-sm ring-1 ring-slate-200 transition-all group-hover:ring-cyan-500 dark:ring-slate-800">
                     <div className="flex flex-col h-full justify-between gap-4">
                       <div>

--- a/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
 import { atendentes, whatsappChats, type WhatsappChats, type Atendentes } from '../../api/client'
 import { Card } from '../../components/ui/Card'
 import { Button } from '../../components/ui/Button'
@@ -9,23 +9,64 @@ import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { rotuloAvaliacaoChat } from '../../lib/whatsappChatMeta'
+import { buildAvaliacoesReturnPath, whatsappConversaLink } from '../../lib/whatsappListReturn'
 import { CheckboxField } from '../../components/ui/CheckboxField'
 
 const PAGE_SIZE = 15
 
 export function WhatsappAvaliacoes() {
   const toast = useToast()
+  const [searchParams, setSearchParams] = useSearchParams()
   const [items, setItems] = useState<WhatsappChats.Avaliacao[]>([])
   const [total, setTotal] = useState(0)
-  const [offset, setOffset] = useState(0)
+  const [offset, setOffset] = useState(() => Number(searchParams.get('offset') || 0))
   const [loading, setLoading] = useState(true)
-  const [busca, setBusca] = useState('')
+  const [busca, setBusca] = useState(() => searchParams.get('busca') ?? '')
   const [atendentesList, setAtendentesList] = useState<Atendentes.Atendente[]>([])
-  const [atendenteId, setAtendenteId] = useState<number | ''>('')
-  const [notaMin, setNotaMin] = useState<number | ''>('')
-  const [desde, setDesde] = useState('')
-  const [ate, setAte] = useState('')
-  const [incluirSemResposta, setIncluirSemResposta] = useState(false)
+  const [atendenteId, setAtendenteId] = useState<number | ''>(() => {
+    const v = searchParams.get('atendente_id')
+    return v ? Number(v) : ''
+  })
+  const [notaMin, setNotaMin] = useState<number | ''>(() => {
+    const v = searchParams.get('nota')
+    return v ? Number(v) : ''
+  })
+  const [desde, setDesde] = useState(() => searchParams.get('desde') ?? '')
+  const [ate, setAte] = useState(() => searchParams.get('ate') ?? '')
+  const [incluirSemResposta, setIncluirSemResposta] = useState(
+    () => searchParams.get('incluir_sem_resposta') === 'true',
+  )
+
+  const avaliacoesReturnPath = useMemo(
+    () =>
+      buildAvaliacoesReturnPath({
+        busca,
+        atendenteId,
+        notaMin,
+        desde,
+        ate,
+        incluirSemResposta,
+        offset,
+      }),
+    [ate, atendenteId, busca, desde, incluirSemResposta, notaMin, offset],
+  )
+
+  const syncUrl = useCallback(
+    (from: number) => {
+      const path = buildAvaliacoesReturnPath({
+        busca,
+        atendenteId,
+        notaMin,
+        desde,
+        ate,
+        incluirSemResposta,
+        offset: from,
+      })
+      const qs = path.includes('?') ? path.split('?')[1] : ''
+      setSearchParams(qs ? new URLSearchParams(qs) : new URLSearchParams(), { replace: true })
+    },
+    [ate, atendenteId, busca, desde, incluirSemResposta, notaMin, setSearchParams],
+  )
 
   const load = useCallback(
     async (from: number) => {
@@ -48,13 +89,14 @@ export function WhatsappAvaliacoes() {
         setItems(rows)
         setTotal(t)
         setOffset(from)
+        syncUrl(from)
       } catch (err) {
         toast.showError(mensagemFalhaParaToast(err, 'Falha ao carregar avaliações.'))
       } finally {
         setLoading(false)
       }
     },
-    [atendenteId, ate, busca, desde, incluirSemResposta, notaMin, toast],
+    [atendenteId, ate, busca, desde, incluirSemResposta, notaMin, syncUrl, toast],
   )
 
   useEffect(() => {
@@ -108,7 +150,10 @@ export function WhatsappAvaliacoes() {
           </div>
         </div>
         <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
-          <CheckboxField checked={incluirSemResposta} onChange={setIncluirSemResposta}>
+          <CheckboxField
+            checked={incluirSemResposta}
+            onChange={(e) => setIncluirSemResposta(e.target.checked)}
+          >
             Incluir solicitações sem resposta (auditoria)
           </CheckboxField>
           <Button type="button" onClick={() => void load(0)}>
@@ -149,7 +194,7 @@ export function WhatsappAvaliacoes() {
                       : '—'}
                   </p>
                   <Link
-                    to={`/whatsapp/c/${a.chat_id}`}
+                    to={whatsappConversaLink(a.chat_id, avaliacoesReturnPath, 'avaliacoes')}
                     className="mt-1 inline-block text-xs font-medium text-cyan-600 hover:underline dark:text-cyan-400"
                   >
                     Ver conversa

--- a/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
@@ -9,6 +9,7 @@ import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { rotuloAvaliacaoChat } from '../../lib/whatsappChatMeta'
+import { CheckboxField } from '../../components/ui/CheckboxField'
 
 const PAGE_SIZE = 15
 
@@ -24,6 +25,7 @@ export function WhatsappAvaliacoes() {
   const [notaMin, setNotaMin] = useState<number | ''>('')
   const [desde, setDesde] = useState('')
   const [ate, setAte] = useState('')
+  const [incluirSemResposta, setIncluirSemResposta] = useState(false)
 
   const load = useCallback(
     async (from: number) => {
@@ -41,6 +43,7 @@ export function WhatsappAvaliacoes() {
         }
         if (desde) params.encerramento_inicio = `${desde}T00:00:00`
         if (ate) params.encerramento_fim = `${ate}T23:59:59`
+        if (incluirSemResposta) params.incluir_sem_resposta = 'true'
         const { items: rows, total: t } = await whatsappChats.avaliacoes(params)
         setItems(rows)
         setTotal(t)
@@ -51,7 +54,7 @@ export function WhatsappAvaliacoes() {
         setLoading(false)
       }
     },
-    [atendenteId, ate, busca, desde, notaMin, toast],
+    [atendenteId, ate, busca, desde, incluirSemResposta, notaMin, toast],
   )
 
   useEffect(() => {
@@ -104,7 +107,10 @@ export function WhatsappAvaliacoes() {
             <Input label="Até" type="date" value={ate} onChange={(e) => setAte(e.target.value)} />
           </div>
         </div>
-        <div className="mt-4 flex justify-end">
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+          <CheckboxField checked={incluirSemResposta} onChange={setIncluirSemResposta}>
+            Incluir solicitações sem resposta (auditoria)
+          </CheckboxField>
           <Button type="button" onClick={() => void load(0)}>
             Filtrar
           </Button>

--- a/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
 import { atendentes, whatsappChats, type WhatsappChats, type Atendentes } from '../../api/client'
 import { Card } from '../../components/ui/Card'
 import { Button } from '../../components/ui/Button'
@@ -9,21 +9,64 @@ import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { rotuloAvaliacaoChat } from '../../lib/whatsappChatMeta'
+import { buildAvaliacoesReturnPath, whatsappConversaLink } from '../../lib/whatsappListReturn'
+import { CheckboxField } from '../../components/ui/CheckboxField'
 
 const PAGE_SIZE = 15
 
 export function WhatsappAvaliacoes() {
   const toast = useToast()
+  const [searchParams, setSearchParams] = useSearchParams()
   const [items, setItems] = useState<WhatsappChats.Avaliacao[]>([])
   const [total, setTotal] = useState(0)
-  const [offset, setOffset] = useState(0)
+  const [offset, setOffset] = useState(() => Number(searchParams.get('offset') || 0))
   const [loading, setLoading] = useState(true)
-  const [busca, setBusca] = useState('')
+  const [busca, setBusca] = useState(() => searchParams.get('busca') ?? '')
   const [atendentesList, setAtendentesList] = useState<Atendentes.Atendente[]>([])
-  const [atendenteId, setAtendenteId] = useState<number | ''>('')
-  const [notaMin, setNotaMin] = useState<number | ''>('')
-  const [desde, setDesde] = useState('')
-  const [ate, setAte] = useState('')
+  const [atendenteId, setAtendenteId] = useState<number | ''>(() => {
+    const v = searchParams.get('atendente_id')
+    return v ? Number(v) : ''
+  })
+  const [notaMin, setNotaMin] = useState<number | ''>(() => {
+    const v = searchParams.get('nota')
+    return v ? Number(v) : ''
+  })
+  const [desde, setDesde] = useState(() => searchParams.get('desde') ?? '')
+  const [ate, setAte] = useState(() => searchParams.get('ate') ?? '')
+  const [incluirSemResposta, setIncluirSemResposta] = useState(
+    () => searchParams.get('incluir_sem_resposta') === 'true',
+  )
+
+  const avaliacoesReturnPath = useMemo(
+    () =>
+      buildAvaliacoesReturnPath({
+        busca,
+        atendenteId,
+        notaMin,
+        desde,
+        ate,
+        incluirSemResposta,
+        offset,
+      }),
+    [ate, atendenteId, busca, desde, incluirSemResposta, notaMin, offset],
+  )
+
+  const syncUrl = useCallback(
+    (from: number) => {
+      const path = buildAvaliacoesReturnPath({
+        busca,
+        atendenteId,
+        notaMin,
+        desde,
+        ate,
+        incluirSemResposta,
+        offset: from,
+      })
+      const qs = path.includes('?') ? path.split('?')[1] : ''
+      setSearchParams(qs ? new URLSearchParams(qs) : new URLSearchParams(), { replace: true })
+    },
+    [ate, atendenteId, busca, desde, incluirSemResposta, notaMin, setSearchParams],
+  )
 
   const load = useCallback(
     async (from: number) => {
@@ -41,17 +84,19 @@ export function WhatsappAvaliacoes() {
         }
         if (desde) params.encerramento_inicio = `${desde}T00:00:00`
         if (ate) params.encerramento_fim = `${ate}T23:59:59`
+        if (incluirSemResposta) params.incluir_sem_resposta = 'true'
         const { items: rows, total: t } = await whatsappChats.avaliacoes(params)
         setItems(rows)
         setTotal(t)
         setOffset(from)
+        syncUrl(from)
       } catch (err) {
         toast.showError(mensagemFalhaParaToast(err, 'Falha ao carregar avaliações.'))
       } finally {
         setLoading(false)
       }
     },
-    [atendenteId, ate, busca, desde, notaMin, toast],
+    [atendenteId, ate, busca, desde, incluirSemResposta, notaMin, syncUrl, toast],
   )
 
   useEffect(() => {
@@ -104,7 +149,13 @@ export function WhatsappAvaliacoes() {
             <Input label="Até" type="date" value={ate} onChange={(e) => setAte(e.target.value)} />
           </div>
         </div>
-        <div className="mt-4 flex justify-end">
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+          <CheckboxField
+            checked={incluirSemResposta}
+            onChange={(e) => setIncluirSemResposta(e.target.checked)}
+          >
+            Incluir solicitações sem resposta (auditoria)
+          </CheckboxField>
           <Button type="button" onClick={() => void load(0)}>
             Filtrar
           </Button>
@@ -143,7 +194,7 @@ export function WhatsappAvaliacoes() {
                       : '—'}
                   </p>
                   <Link
-                    to={`/whatsapp/c/${a.chat_id}`}
+                    to={whatsappConversaLink(a.chat_id, avaliacoesReturnPath, 'avaliacoes')}
                     className="mt-1 inline-block text-xs font-medium text-cyan-600 hover:underline dark:text-cyan-400"
                   >
                     Ver conversa

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useRef, useState } from 'react'
+import { Button } from '../../components/ui/Button'
+import { KbConsultaButton } from '../../components/KbConsultaModal'
+import type { TipoAnexoPicker } from './WhatsappBarraAnexos'
+import { WhatsappGravadorAudioInline } from './WhatsappGravadorAudioInline'
+
+type Props = {
+  texto: string
+  onTextoChange: (v: string) => void
+  onEnviar: () => void
+  onEnviarInterno?: () => void
+  onEscolherAnexo: (tipo: TipoAnexoPicker) => void
+  onAudioGravado: (file: File) => void
+  enviando: boolean
+  encerrado: boolean
+  podeEnviar: boolean
+  modoInterno: boolean
+  podeDigitar: boolean
+  onInserirReferenciaKb?: (ref: string) => void
+}
+
+type MenuAnexo = { tipo: TipoAnexoPicker; label: string }
+
+const MENU_ANEXOS: MenuAnexo[] = [
+  { tipo: 'documento', label: 'Documento' },
+  { tipo: 'imagem', label: 'Fotos e imagens' },
+  { tipo: 'video', label: 'Vídeo' },
+  { tipo: 'audio', label: 'Áudio (ficheiro)' },
+]
+
+export function WhatsappComposerBar({
+  texto,
+  onTextoChange,
+  onEnviar,
+  onEnviarInterno,
+  onEscolherAnexo,
+  onAudioGravado,
+  enviando,
+  encerrado,
+  podeEnviar,
+  modoInterno,
+  podeDigitar,
+  onInserirReferenciaKb,
+}: Props) {
+  const [menuAberto, setMenuAberto] = useState(false)
+  const [gravando, setGravando] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!menuAberto) return
+    const onDoc = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuAberto(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [menuAberto])
+
+  const temTexto = texto.trim().length > 0
+  const desabilitado = encerrado || !podeDigitar || enviando
+
+  function enviar() {
+    if (modoInterno && onEnviarInterno) onEnviarInterno()
+    else onEnviar()
+  }
+
+  return (
+    <div className="space-y-2">
+      {gravando && podeEnviar && !encerrado && (
+        <WhatsappGravadorAudioInline
+          disabled={enviando}
+          onConcluido={(file) => {
+            setGravando(false)
+            onAudioGravado(file)
+          }}
+          onCancelar={() => setGravando(false)}
+        />
+      )}
+
+      <div className="flex items-end gap-1.5 rounded-2xl bg-slate-100 p-2 shadow-inner dark:bg-slate-900 sm:gap-2">
+        <div className="relative shrink-0" ref={menuRef}>
+          <button
+            type="button"
+            disabled={desabilitado || modoInterno || !podeEnviar}
+            aria-label="Anexos"
+            title={modoInterno ? 'Anexos indisponíveis em modo interno' : 'Anexos'}
+            onClick={() => setMenuAberto((o) => !o)}
+            className="flex h-10 w-10 items-center justify-center rounded-full text-xl text-slate-600 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-40 dark:text-slate-300 dark:hover:bg-slate-800"
+          >
+            +
+          </button>
+          {menuAberto && (
+            <div className="absolute bottom-full left-0 z-20 mb-2 min-w-[11rem] rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900">
+              {MENU_ANEXOS.map((item) => (
+                <button
+                  key={item.tipo}
+                  type="button"
+                  className="block w-full px-4 py-2 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
+                  onClick={() => {
+                    setMenuAberto(false)
+                    onEscolherAnexo(item.tipo)
+                  }}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <button
+          type="button"
+          disabled
+          title="Figurinhas — em breve"
+          aria-label="Figurinhas (em breve)"
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-lg opacity-40"
+        >
+          😊
+        </button>
+
+        {onInserirReferenciaKb && (
+          <KbConsultaButton disabled={encerrado} onInserirReferencia={podeDigitar ? onInserirReferenciaKb : undefined} />
+        )}
+
+        <textarea
+          value={texto}
+          onChange={(e) => onTextoChange(e.target.value)}
+          placeholder={
+            encerrado
+              ? 'Apenas leitura…'
+              : modoInterno
+                ? 'Comentário interno…'
+                : podeEnviar
+                  ? 'Escreva uma mensagem…'
+                  : 'Somente comentários internos…'
+          }
+          rows={1}
+          disabled={desabilitado}
+          className="max-h-32 min-h-[40px] flex-1 resize-none border-none bg-transparent p-2 text-sm focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault()
+              if (!desabilitado && temTexto) enviar()
+            }
+          }}
+        />
+
+        {temTexto ? (
+          <Button
+            onClick={enviar}
+            disabled={desabilitado || !temTexto}
+            className="h-10 w-10 shrink-0 rounded-full bg-cyan-600 p-0 text-white shadow-lg shadow-cyan-600/30 hover:bg-cyan-700 disabled:opacity-50"
+            aria-label="Enviar"
+          >
+            {enviando ? '…' : '➤'}
+          </Button>
+        ) : (
+          <button
+            type="button"
+            disabled={desabilitado || modoInterno || !podeEnviar || gravando}
+            aria-label="Gravar áudio"
+            title="Gravar áudio"
+            onClick={() => setGravando(true)}
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-lg text-slate-600 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-40 dark:text-slate-300 dark:hover:bg-slate-800"
+          >
+            🎤
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -22,7 +22,6 @@ import {
 } from '../../api/client'
 
 import { Card } from '../../components/ui/Card'
-import { KbConsultaButton } from '../../components/KbConsultaModal'
 
 import { Button } from '../../components/ui/Button'
 
@@ -48,12 +47,14 @@ import { WhatsappVincFuncionarioModal } from './WhatsappVincFuncionarioModal'
 import { WhatsappDemandasPanel } from './WhatsappDemandasPanel'
 import { WhatsappEncerrarModal } from './WhatsappEncerrarModal'
 import { WhatsappDemandaTimelineMarco } from './WhatsappDemandaTimelineMarco'
-import { WhatsappBarraAnexos, ACCEPT_ANEXO, type TipoAnexoPicker } from './WhatsappBarraAnexos'
-import { WhatsappGravadorAudio } from './WhatsappGravadorAudio'
+import { ACCEPT_ANEXO, type TipoAnexoPicker } from './WhatsappBarraAnexos'
+import { WhatsappComposerBar } from './WhatsappComposerBar'
 import { WhatsappPreviaAnexo } from './WhatsappPreviaAnexo'
 import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
 import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
-import { mergeTimelineChat } from '../../lib/whatsappDemandaUtils'
+import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
+import { rotuloDownloadArquivo, visualTipoArquivo } from '../../lib/fileTypeIcon'
+import { CONTATO_CLIENTE } from '../../constants/contatoClienteLabels'
 
 const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)\]$/
 
@@ -206,18 +207,18 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 
  
 
-  const downloadLabel = {
-    documento: '📄 Baixar Documento',
-    audio: '🔊 Baixar Áudio',
-    video: '🎬 Baixar Vídeo',
-    imagem: '📷 Baixar Imagem',
-    figurinha: '📷 Baixar Imagem',
-  }[tipo] || `📄 Baixar ${tipo || 'Ficheiro'}`
+  const downloadLabel = rotuloDownloadArquivo(
+    tipo === 'documento' ? m.corpo : null,
+    m.mimetype,
+    tipo,
+  )
+  const fileVisual = visualTipoArquivo(tipo === 'documento' ? m.corpo : null, m.mimetype)
 
   return (
 
     <a href={url} download className="flex items-center gap-2 text-xs font-bold underline">
-      <span>{downloadLabel.split(' ')[0]}</span> {downloadLabel.replace(/^\S+\s*/, '')}
+      <span className="text-base" aria-hidden>{fileVisual.emoji}</span>
+      <span>{downloadLabel.replace(/^\S+\s*/, '')}</span>
     </a>
 
   )
@@ -248,7 +249,6 @@ export function WhatsappConversa() {
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const [pickerAnexo, setPickerAnexo] = useState<TipoAnexoPicker>('imagem')
-  const [mostrarGravador, setMostrarGravador] = useState(false)
   const [arquivoPendente, setArquivoPendente] = useState<File | null>(null)
   const [legendaMidia, setLegendaMidia] = useState('')
 
@@ -595,13 +595,11 @@ useEffect(() => {
 }
 
   function abrirPickerAnexo(tipo: TipoAnexoPicker) {
-    setMostrarGravador(false)
     setPickerAnexo(tipo)
     window.setTimeout(() => fileInputRef.current?.click(), 0)
   }
 
   function handleGravacaoConcluida(file: File) {
-    setMostrarGravador(false)
     setArquivoPendente(file)
     setLegendaMidia('')
   }
@@ -896,8 +894,8 @@ useEffect(() => {
                 className="inline-flex text-xs h-8"
                 onClick={() => setModalVincFuncionario(true)}
               >
-                <span className="sm:hidden">Vincular</span>
-                <span className="hidden sm:inline">Vincular funcionário</span>
+                <span className="sm:hidden">{CONTATO_CLIENTE.vincularCurto}</span>
+                <span className="hidden sm:inline">{CONTATO_CLIENTE.vincularChat}</span>
               </Button>
 
                 <Button variant="ghost" className="hidden sm:inline-flex text-xs h-8" onClick={() => setModalTickets(true)}>
@@ -922,11 +920,9 @@ useEffect(() => {
 
         {!encerrado && chat && !chat.funcionario_rede_id && (
           <div className="flex flex-wrap items-center justify-between gap-3 border-b border-violet-200 bg-violet-50 px-4 py-3 text-sm text-violet-950 dark:border-violet-900/40 dark:bg-violet-950/30 dark:text-violet-100">
-            <p>
-              <strong>Contacto não vinculado</strong> a nenhuma empresa ou funcionário cadastrado.
-            </p>
+            <p>{CONTATO_CLIENTE.bannerNaoVinculado}</p>
             <Button variant="primary" className="h-8 shrink-0 text-xs" onClick={() => setModalVincFuncionario(true)}>
-              Vincular a empresa
+              {CONTATO_CLIENTE.vincularEmpresa}
             </Button>
           </div>
         )}
@@ -981,6 +977,29 @@ useEffect(() => {
             }
 
             const m = item.mensagem
+
+            if (m.evento_sistema === 'demanda_registrada' || m.evento_sistema === 'demanda_escalada') {
+              return (
+                <div key={m.id} className="flex w-full justify-center py-2">
+                  <div className="max-w-md rounded-xl border border-violet-200 bg-violet-50/95 px-4 py-2 text-center text-xs shadow-sm dark:border-violet-900/50 dark:bg-violet-950/40">
+                    <p className="font-bold uppercase tracking-wide text-violet-800 dark:text-violet-200">
+                      Demanda registada
+                    </p>
+                    <p className="mt-0.5 font-medium text-violet-950 dark:text-violet-100">
+                      {textoMarcoDemanda(m.corpo)}
+                    </p>
+                    {m.atendente_nome && (
+                      <p className="mt-0.5 text-[10px] text-violet-700/80 dark:text-violet-300/80">
+                        {m.atendente_nome}
+                        {m.created_at
+                          ? ` · ${new Date(m.created_at).toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' })}`
+                          : ''}
+                      </p>
+                    )}
+                  </div>
+                </div>
+              )
+            }
 
             const isInbound = m.direcao === 'inbound'
 
@@ -1123,32 +1142,8 @@ useEffect(() => {
             </p>
           )}
 
-          {!encerrado && !modoInterno && podeEnviar && !arquivoPendente && !mostrarGravador && (
-            <WhatsappBarraAnexos
-              disabled={enviando}
-              onEscolher={abrirPickerAnexo}
-              onGravarAudio={() => {
-                setArquivoPendente(null)
-                setMostrarGravador(true)
-              }}
-            />
-          )}
-
           {!encerrado && !modoInterno && !podeEnviar && (
-            <WhatsappBarraAnexos
-              disabled
-              motivoDesabilitado={motivoAnexoDesabilitado}
-              onEscolher={() => {}}
-              onGravarAudio={() => {}}
-            />
-          )}
-
-          {mostrarGravador && podeEnviar && !encerrado && (
-            <WhatsappGravadorAudio
-              disabled={enviando}
-              onConcluido={handleGravacaoConcluida}
-              onCancelar={() => setMostrarGravador(false)}
-            />
+            <p className="mb-2 text-[11px] text-amber-800 dark:text-amber-200">{motivoAnexoDesabilitado}</p>
           )}
 
           {arquivoPendente && (
@@ -1191,79 +1186,27 @@ useEffect(() => {
             </div>
           )}
 
-          <div className="flex items-end gap-2 bg-slate-100 dark:bg-slate-900 p-2 rounded-2xl shadow-inner">
+          <WhatsappComposerBar
+            texto={texto}
+            onTextoChange={setTexto}
+            onEnviar={() => void enviar()}
+            enviando={enviando}
+            encerrado={encerrado}
+            podeEnviar={podeEnviar}
+            modoInterno={modoInterno}
+            podeDigitar={podeDigitarMensagem}
+            onEscolherAnexo={abrirPickerAnexo}
+            onAudioGravado={handleGravacaoConcluida}
+            onInserirReferenciaKb={inserirReferenciaKb}
+          />
 
-            <input
-              type="file"
-              ref={fileInputRef}
-              onChange={handleFileSelecionado}
-              className="hidden"
-              accept={ACCEPT_ANEXO[pickerAnexo]}
-            />
-
-            <KbConsultaButton
-              disabled={encerrado}
-              onInserirReferencia={podeDigitarMensagem ? inserirReferenciaKb : undefined}
-            />
-
-
-
-            <textarea
-
-              value={texto}
-
-              onChange={(e) => setTexto(e.target.value)}
-
-              placeholder={
-                encerrado
-                  ? "Apenas leitura..."
-                  : modoInterno
-                    ? "Escreva um comentário interno..."
-                    : podeEnviar
-                      ? "Escreva uma mensagem..."
-                      : "Somente comentários internos são permitidos."
-              }
-
-              rows={1}
-
-              disabled={encerrado || (!modoInterno && !podeEnviar)}
-
-              className="flex-1 max-h-32 min-h-[40px] resize-none border-none bg-transparent p-2 text-sm focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
-
-              onKeyDown={(e) => {
-
-                if (e.key === 'Enter' && !e.shiftKey) {
-
-                  e.preventDefault()
-
-                  void enviar()
-
-                }
-
-              }}
-
-            />
-
-
-
-            <Button
-
-              onClick={() => void enviar()}
-
-              disabled={
-                enviando || !texto.trim() || encerrado || (!modoInterno && !podeEnviar)
-              }
-
-              className="h-10 w-10 shrink-0 rounded-xl bg-cyan-600 p-0 text-white shadow-lg shadow-cyan-600/30 hover:bg-cyan-700 disabled:opacity-50"
-
-            >
-
-              {enviando ? '...' : modoInterno ? '✎' : '➤'}
-
-            </Button>
-
-          </div>
-
+          <input
+            type="file"
+            ref={fileInputRef}
+            onChange={handleFileSelecionado}
+            className="hidden"
+            accept={ACCEPT_ANEXO[pickerAnexo]}
+          />
         </footer>
 
       </main>

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -46,11 +46,14 @@ import {
 import { WhatsappTicketsModal } from './WhatsappTicketsModal'
 import { WhatsappVincFuncionarioModal } from './WhatsappVincFuncionarioModal'
 import { WhatsappDemandasPanel } from './WhatsappDemandasPanel'
+import { WhatsappEncerrarModal } from './WhatsappEncerrarModal'
+import { WhatsappDemandaTimelineMarco } from './WhatsappDemandaTimelineMarco'
 import { WhatsappBarraAnexos, ACCEPT_ANEXO, type TipoAnexoPicker } from './WhatsappBarraAnexos'
 import { WhatsappGravadorAudio } from './WhatsappGravadorAudio'
 import { WhatsappPreviaAnexo } from './WhatsappPreviaAnexo'
 import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
 import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
+import { mergeTimelineChat } from '../../lib/whatsappDemandaUtils'
 
 const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)\]$/
 
@@ -270,7 +273,6 @@ export function WhatsappConversa() {
   const [texto, setTexto] = useState('')
 
   const [enviando, setEnviando] = useState(false)
-  const [encerrando, setEncerrando] = useState(false)
 
   // Estados de WhatsApp Clone (Citação e Zoom)
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
@@ -293,8 +295,9 @@ export function WhatsappConversa() {
 
   const [modalTickets, setModalTickets] = useState(false)
   const [ticketsVinculados, setTicketsVinculados] = useState<Tickets.Ticket[]>([])
-  const [demandasCount, setDemandasCount] = useState(0)
   const [demandasReloadKey, setDemandasReloadKey] = useState(0)
+  const [demandasTimeline, setDemandasTimeline] = useState<WhatsappChats.Demanda[]>([])
+  const [modalEncerrar, setModalEncerrar] = useState(false)
   const navigate = useNavigate()
   const location = useLocation()
   const [searchParams] = useSearchParams()
@@ -307,14 +310,22 @@ export function WhatsappConversa() {
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== 'Escape' || e.defaultPrevented) return
+      if (e.key !== 'Escape' || e.defaultPrevented || modalEncerrar) return
       const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase()
       if (tag === 'input' || tag === 'textarea' || tag === 'select') return
       voltarLista()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [voltarLista])
+  }, [voltarLista, modalEncerrar])
+
+  useEffect(() => {
+    if (!id) return
+    whatsappChats
+      .demandas(id)
+      .then(setDemandasTimeline)
+      .catch(() => setDemandasTimeline([]))
+  }, [id, demandasReloadKey])
 
 
 
@@ -630,36 +641,15 @@ useEffect(() => {
 
 
 
-  async function encerrar() {
-
-    if (!chat || !confirm('Encerrar este atendimento?')) return
-
-    const podeRegistrarDemanda =
-      chat.estado === 'em_atendimento' &&
-      (chat.atendente_id === user?.id || user?.role === 'admin')
-    if (podeRegistrarDemanda && demandasCount === 0) {
-      const prosseguir = confirm(
-        'Nenhuma demanda foi registrada nesta sessão. Deseja encerrar mesmo assim?',
-      )
-      if (!prosseguir) return
-    }
-
-    setEncerrando(true)
-
-    try {
-
-      const atualizado = await whatsappChats.encerrar(chat.id)
-
-      await Promise.all([carregar(), carregarSidebar()])
-
-      toast.showSuccess(
-        atualizado.estado === 'aguardando_avaliacao'
-          ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
-          : 'Atendimento encerrado.',
-      )
-
-    } finally { setEncerrando(false) }
-
+  async function handleEncerrado(atualizado: WhatsappChats.Chat) {
+    setChat(atualizado)
+    await Promise.all([carregar(), carregarSidebar()])
+    setDemandasReloadKey((k) => k + 1)
+    toast.showSuccess(
+      atualizado.estado === 'aguardando_avaliacao'
+        ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
+        : 'Atendimento encerrado.',
+    )
   }
 
 
@@ -916,7 +906,9 @@ useEffect(() => {
 
                 {podeEncerrar && (
 
-                  <Button variant="danger" className="h-8 px-3 text-xs" onClick={() => void encerrar()} loading={encerrando}>Encerrar</Button>
+                  <Button variant="danger" className="h-8 px-3 text-xs" onClick={() => setModalEncerrar(true)}>
+                    Encerrar
+                  </Button>
 
                 )}
 
@@ -963,7 +955,7 @@ useEffect(() => {
             key={`${chat.id}-${demandasReloadKey}`}
             chatId={chat.id}
             podeRegistrar={isResponsavel || isAdmin}
-            onDemandasChange={setDemandasCount}
+            onDemandasChange={() => setDemandasReloadKey((k) => k + 1)}
           />
         )}
 
@@ -983,7 +975,12 @@ useEffect(() => {
 
         >
 
-          {msgs.map((m) => {
+          {mergeTimelineChat(msgs, demandasTimeline).map((item) => {
+            if (item.kind === 'demanda') {
+              return <WhatsappDemandaTimelineMarco key={`dem-${item.demanda.id}`} demanda={item.demanda} />
+            }
+
+            const m = item.mensagem
 
             const isInbound = m.direcao === 'inbound'
 
@@ -1357,6 +1354,17 @@ useEffect(() => {
             setChat(atualizado)
             setDemandasReloadKey((k) => k + 1)
           }}
+        />
+      )}
+
+      {chat && (
+        <WhatsappEncerrarModal
+          open={modalEncerrar}
+          chatId={chat.id}
+          msgs={msgs}
+          onClose={() => setModalEncerrar(false)}
+          onEncerrado={(atualizado) => void handleEncerrado(atualizado)}
+          onDemandasChange={() => setDemandasReloadKey((k) => k + 1)}
         />
       )}
 

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -413,11 +413,11 @@ export function WhatsappConversa() {
     }
   }, [id, subscribe, carregar, carregarSidebar])
 
-  // Polling legado quando SSE indisponível
+  // Polling de segurança (#442): complementa SSE quando Gunicorn usa N workers in-process
   useEffect(() => {
-    if (!useFallback) return
     if (!chat || chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao') return
-    const t = setInterval(() => void carregar().catch(() => {}), 5000)
+    const intervalMs = useFallback ? 5000 : 4000
+    const t = setInterval(() => void carregar().catch(() => {}), intervalMs)
     return () => clearInterval(t)
   }, [useFallback, chat, carregar])
 

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
 
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
 import {
 
@@ -49,6 +49,8 @@ import { WhatsappDemandasPanel } from './WhatsappDemandasPanel'
 import { WhatsappBarraAnexos, ACCEPT_ANEXO, type TipoAnexoPicker } from './WhatsappBarraAnexos'
 import { WhatsappGravadorAudio } from './WhatsappGravadorAudio'
 import { WhatsappPreviaAnexo } from './WhatsappPreviaAnexo'
+import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
+import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
 
 const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)\]$/
 
@@ -294,6 +296,25 @@ export function WhatsappConversa() {
   const [demandasCount, setDemandasCount] = useState(0)
   const [demandasReloadKey, setDemandasReloadKey] = useState(0)
   const navigate = useNavigate()
+  const location = useLocation()
+  const [searchParams] = useSearchParams()
+  const voltarLista = useWhatsappVoltarLista()
+  const listaRetorno = resolveWhatsappListFallback(
+    location.state,
+    searchParams.get('from'),
+    WHATSAPP_LIST_PATHS.atendendo,
+  )
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || e.defaultPrevented) return
+      const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase()
+      if (tag === 'input' || tag === 'textarea' || tag === 'select') return
+      voltarLista()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [voltarLista])
 
 
 
@@ -716,7 +737,7 @@ useEffect(() => {
 
               key={c.id}
 
-              to={`/whatsapp/c/${c.id}`}
+              to={whatsappConversaLink(c.id, listaRetorno)}
 
               className={`flex items-center p-4 gap-3 transition-colors ${c.id === id ? 'bg-white shadow-sm dark:bg-slate-800' : 'hover:bg-white/40 dark:hover:bg-slate-900/50'}`}
 
@@ -778,7 +799,18 @@ useEffect(() => {
 
         <header className="flex h-16 items-center justify-between border-b border-slate-100 px-4 dark:border-slate-800 shadow-sm z-10">
 
-          <div className="flex items-center gap-3 min-w-0">
+          <div className="flex items-center gap-2 min-w-0 sm:gap-3">
+
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-9 shrink-0 px-2 text-xs font-medium"
+              onClick={voltarLista}
+              aria-label="Voltar à lista"
+            >
+              <span aria-hidden>←</span>
+              <span className="hidden sm:inline"> Voltar</span>
+            </Button>
 
             <div className="min-w-0">
 

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
 
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
 import {
 
@@ -46,9 +46,14 @@ import {
 import { WhatsappTicketsModal } from './WhatsappTicketsModal'
 import { WhatsappVincFuncionarioModal } from './WhatsappVincFuncionarioModal'
 import { WhatsappDemandasPanel } from './WhatsappDemandasPanel'
+import { WhatsappEncerrarModal } from './WhatsappEncerrarModal'
+import { WhatsappDemandaTimelineMarco } from './WhatsappDemandaTimelineMarco'
 import { WhatsappBarraAnexos, ACCEPT_ANEXO, type TipoAnexoPicker } from './WhatsappBarraAnexos'
 import { WhatsappGravadorAudio } from './WhatsappGravadorAudio'
 import { WhatsappPreviaAnexo } from './WhatsappPreviaAnexo'
+import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
+import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
+import { mergeTimelineChat } from '../../lib/whatsappDemandaUtils'
 
 const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)\]$/
 
@@ -268,7 +273,6 @@ export function WhatsappConversa() {
   const [texto, setTexto] = useState('')
 
   const [enviando, setEnviando] = useState(false)
-  const [encerrando, setEncerrando] = useState(false)
 
   // Estados de WhatsApp Clone (Citação e Zoom)
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
@@ -291,9 +295,37 @@ export function WhatsappConversa() {
 
   const [modalTickets, setModalTickets] = useState(false)
   const [ticketsVinculados, setTicketsVinculados] = useState<Tickets.Ticket[]>([])
-  const [demandasCount, setDemandasCount] = useState(0)
   const [demandasReloadKey, setDemandasReloadKey] = useState(0)
+  const [demandasTimeline, setDemandasTimeline] = useState<WhatsappChats.Demanda[]>([])
+  const [modalEncerrar, setModalEncerrar] = useState(false)
   const navigate = useNavigate()
+  const location = useLocation()
+  const [searchParams] = useSearchParams()
+  const voltarLista = useWhatsappVoltarLista()
+  const listaRetorno = resolveWhatsappListFallback(
+    location.state,
+    searchParams.get('from'),
+    WHATSAPP_LIST_PATHS.atendendo,
+  )
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || e.defaultPrevented || modalEncerrar) return
+      const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase()
+      if (tag === 'input' || tag === 'textarea' || tag === 'select') return
+      voltarLista()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [voltarLista, modalEncerrar])
+
+  useEffect(() => {
+    if (!id) return
+    whatsappChats
+      .demandas(id)
+      .then(setDemandasTimeline)
+      .catch(() => setDemandasTimeline([]))
+  }, [id, demandasReloadKey])
 
 
 
@@ -413,11 +445,11 @@ export function WhatsappConversa() {
     }
   }, [id, subscribe, carregar, carregarSidebar])
 
-  // Polling legado quando SSE indisponível
+  // Polling de segurança (#442): complementa SSE quando Gunicorn usa N workers in-process
   useEffect(() => {
-    if (!useFallback) return
     if (!chat || chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao') return
-    const t = setInterval(() => void carregar().catch(() => {}), 5000)
+    const intervalMs = useFallback ? 5000 : 4000
+    const t = setInterval(() => void carregar().catch(() => {}), intervalMs)
     return () => clearInterval(t)
   }, [useFallback, chat, carregar])
 
@@ -609,36 +641,15 @@ useEffect(() => {
 
 
 
-  async function encerrar() {
-
-    if (!chat || !confirm('Encerrar este atendimento?')) return
-
-    const podeRegistrarDemanda =
-      chat.estado === 'em_atendimento' &&
-      (chat.atendente_id === user?.id || user?.role === 'admin')
-    if (podeRegistrarDemanda && demandasCount === 0) {
-      const prosseguir = confirm(
-        'Nenhuma demanda foi registrada nesta sessão. Deseja encerrar mesmo assim?',
-      )
-      if (!prosseguir) return
-    }
-
-    setEncerrando(true)
-
-    try {
-
-      const atualizado = await whatsappChats.encerrar(chat.id)
-
-      await Promise.all([carregar(), carregarSidebar()])
-
-      toast.showSuccess(
-        atualizado.estado === 'aguardando_avaliacao'
-          ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
-          : 'Atendimento encerrado.',
-      )
-
-    } finally { setEncerrando(false) }
-
+  async function handleEncerrado(atualizado: WhatsappChats.Chat) {
+    setChat(atualizado)
+    await Promise.all([carregar(), carregarSidebar()])
+    setDemandasReloadKey((k) => k + 1)
+    toast.showSuccess(
+      atualizado.estado === 'aguardando_avaliacao'
+        ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
+        : 'Atendimento encerrado.',
+    )
   }
 
 
@@ -716,7 +727,7 @@ useEffect(() => {
 
               key={c.id}
 
-              to={`/whatsapp/c/${c.id}`}
+              to={whatsappConversaLink(c.id, listaRetorno)}
 
               className={`flex items-center p-4 gap-3 transition-colors ${c.id === id ? 'bg-white shadow-sm dark:bg-slate-800' : 'hover:bg-white/40 dark:hover:bg-slate-900/50'}`}
 
@@ -778,7 +789,18 @@ useEffect(() => {
 
         <header className="flex h-16 items-center justify-between border-b border-slate-100 px-4 dark:border-slate-800 shadow-sm z-10">
 
-          <div className="flex items-center gap-3 min-w-0">
+          <div className="flex items-center gap-2 min-w-0 sm:gap-3">
+
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-9 shrink-0 px-2 text-xs font-medium"
+              onClick={voltarLista}
+              aria-label="Voltar à lista"
+            >
+              <span aria-hidden>←</span>
+              <span className="hidden sm:inline"> Voltar</span>
+            </Button>
 
             <div className="min-w-0">
 
@@ -884,7 +906,9 @@ useEffect(() => {
 
                 {podeEncerrar && (
 
-                  <Button variant="danger" className="h-8 px-3 text-xs" onClick={() => void encerrar()} loading={encerrando}>Encerrar</Button>
+                  <Button variant="danger" className="h-8 px-3 text-xs" onClick={() => setModalEncerrar(true)}>
+                    Encerrar
+                  </Button>
 
                 )}
 
@@ -931,7 +955,7 @@ useEffect(() => {
             key={`${chat.id}-${demandasReloadKey}`}
             chatId={chat.id}
             podeRegistrar={isResponsavel || isAdmin}
-            onDemandasChange={setDemandasCount}
+            onDemandasChange={() => setDemandasReloadKey((k) => k + 1)}
           />
         )}
 
@@ -951,7 +975,12 @@ useEffect(() => {
 
         >
 
-          {msgs.map((m) => {
+          {mergeTimelineChat(msgs, demandasTimeline).map((item) => {
+            if (item.kind === 'demanda') {
+              return <WhatsappDemandaTimelineMarco key={`dem-${item.demanda.id}`} demanda={item.demanda} />
+            }
+
+            const m = item.mensagem
 
             const isInbound = m.direcao === 'inbound'
 
@@ -1325,6 +1354,17 @@ useEffect(() => {
             setChat(atualizado)
             setDemandasReloadKey((k) => k + 1)
           }}
+        />
+      )}
+
+      {chat && (
+        <WhatsappEncerrarModal
+          open={modalEncerrar}
+          chatId={chat.id}
+          msgs={msgs}
+          onClose={() => setModalEncerrar(false)}
+          onEncerrado={(atualizado) => void handleEncerrado(atualizado)}
+          onDemandasChange={() => setDemandasReloadKey((k) => k + 1)}
         />
       )}
 

--- a/frontend/src/pages/whatsapp/WhatsappDemandaFormFields.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappDemandaFormFields.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from 'react'
+import { ticketClassificacao, type TicketClassificacao } from '../../api/client'
+import { Input } from '../../components/ui/Input'
+import { Select } from '../../components/ui/Select'
+
+export type DemandaFormValues = {
+  naturezaId: number | ''
+  motivoId: number | ''
+  descricaoCurta: string
+}
+
+type Props = {
+  values: DemandaFormValues
+  onChange: (values: DemandaFormValues) => void
+  disabled?: boolean
+  idPrefix?: string
+}
+
+export function WhatsappDemandaFormFields({ values, onChange, disabled, idPrefix = 'dem' }: Props) {
+  const [naturezas, setNaturezas] = useState<TicketClassificacao.Natureza[]>([])
+  const [motivos, setMotivos] = useState<TicketClassificacao.Motivo[]>([])
+
+  useEffect(() => {
+    ticketClassificacao
+      .listNaturezas({ limit: 100 })
+      .then(({ items }) => setNaturezas(items))
+      .catch(() => setNaturezas([]))
+  }, [])
+
+  useEffect(() => {
+    if (values.naturezaId === '') {
+      setMotivos([])
+      return
+    }
+    ticketClassificacao
+      .listMotivos({ natureza_id: Number(values.naturezaId), limit: 100 })
+      .then(({ items }) => setMotivos(items))
+      .catch(() => setMotivos([]))
+  }, [values.naturezaId])
+
+  return (
+    <div className="space-y-3">
+      <Select
+        label="Natureza"
+        value={values.naturezaId}
+        onChange={(v) =>
+          onChange({
+            ...values,
+            naturezaId: v === '' ? '' : Number(v),
+            motivoId: '',
+          })
+        }
+        options={naturezas.map((n) => ({ value: n.id, label: n.nome }))}
+        includeEmpty
+        emptyLabel="Selecione a natureza"
+        disabled={disabled}
+      />
+      <Select
+        label="Motivo (opcional)"
+        value={values.motivoId}
+        onChange={(v) => onChange({ ...values, motivoId: v === '' ? '' : Number(v) })}
+        options={motivos.map((m) => ({ value: m.id, label: m.nome }))}
+        includeEmpty
+        emptyLabel={values.naturezaId === '' ? '—' : 'Opcional'}
+        disabled={disabled || values.naturezaId === ''}
+      />
+      <Input
+        label="Descrição curta (opcional)"
+        value={values.descricaoCurta}
+        onChange={(e) => onChange({ ...values, descricaoCurta: e.target.value })}
+        disabled={disabled}
+        id={`${idPrefix}-desc`}
+        placeholder="Resumo do que foi tratado"
+      />
+    </div>
+  )
+}
+
+export function demandaFormPayload(values: DemandaFormValues) {
+  return {
+    natureza_id: Number(values.naturezaId),
+    motivo_id: values.motivoId === '' ? null : Number(values.motivoId),
+    descricao_curta: values.descricaoCurta.trim() || null,
+  }
+}
+
+export function demandaFormFromDemanda(d: {
+  natureza_id: number
+  motivo_id?: number | null
+  descricao_curta?: string | null
+}): DemandaFormValues {
+  return {
+    naturezaId: d.natureza_id,
+    motivoId: d.motivo_id ?? '',
+    descricaoCurta: d.descricao_curta ?? '',
+  }
+}
+
+export const DEMANDA_FORM_VAZIO: DemandaFormValues = {
+  naturezaId: '',
+  motivoId: '',
+  descricaoCurta: '',
+}

--- a/frontend/src/pages/whatsapp/WhatsappDemandaTimelineMarco.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappDemandaTimelineMarco.tsx
@@ -1,0 +1,36 @@
+import type { WhatsappChats } from '../../api/client'
+import { rotuloDemanda, formatarHoraDemanda } from '../../lib/whatsappDemandaUtils'
+
+const DESFECHO: Record<string, string> = {
+  resolvido_sessao: 'Resolvido na sessão',
+  escalado_ticket: 'Escalado para ticket',
+}
+
+type Props = {
+  demanda: WhatsappChats.Demanda
+}
+
+export function WhatsappDemandaTimelineMarco({ demanda }: Props) {
+  return (
+    <div className="flex w-full justify-center py-2">
+      <div
+        className="max-w-md rounded-xl border border-violet-200 bg-violet-50/95 px-4 py-2 text-center text-xs shadow-sm dark:border-violet-900/50 dark:bg-violet-950/40"
+        title={demanda.descricao_curta ?? undefined}
+      >
+        <p className="font-bold uppercase tracking-wide text-violet-800 dark:text-violet-200">
+          Demanda registada
+        </p>
+        <p className="mt-0.5 font-medium text-violet-950 dark:text-violet-100">{rotuloDemanda(demanda)}</p>
+        <p className="mt-0.5 text-[10px] text-violet-700/80 dark:text-violet-300/80">
+          {DESFECHO[demanda.desfecho] ?? demanda.desfecho}
+          {demanda.atendente_nome ? ` · ${demanda.atendente_nome}` : ''}
+          {' · '}
+          {formatarHoraDemanda(demanda.created_at)}
+        </p>
+        {demanda.descricao_curta && (
+          <p className="mt-1 text-[11px] text-violet-800/90 dark:text-violet-200/90">{demanda.descricao_curta}</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappDemandasPanel.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappDemandasPanel.tsx
@@ -1,15 +1,18 @@
 import { useCallback, useEffect, useState } from 'react'
-import {
-  ticketClassificacao,
-  whatsappChats,
-  type TicketClassificacao,
-  type WhatsappChats,
-} from '../../api/client'
+import { whatsappChats, type WhatsappChats } from '../../api/client'
 import { Button } from '../../components/ui/Button'
-import { Select } from '../../components/ui/Select'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { useAuth } from '../../contexts/AuthContext'
+import { formatarHoraDemanda, rotuloDemanda } from '../../lib/whatsappDemandaUtils'
+import {
+  DEMANDA_FORM_VAZIO,
+  WhatsappDemandaFormFields,
+  demandaFormFromDemanda,
+  demandaFormPayload,
+  type DemandaFormValues,
+} from './WhatsappDemandaFormFields'
 
 type Props = {
   chatId: number
@@ -27,12 +30,11 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
   const { user } = useAuth()
   const [demandas, setDemandas] = useState<WhatsappChats.Demanda[]>([])
   const [loading, setLoading] = useState(true)
-  const [naturezaId, setNaturezaId] = useState<number | ''>('')
-  const [motivoId, setMotivoId] = useState<number | ''>('')
-  const [naturezas, setNaturezas] = useState<TicketClassificacao.Natureza[]>([])
-  const [motivos, setMotivos] = useState<TicketClassificacao.Motivo[]>([])
+  const [form, setForm] = useState<DemandaFormValues>(DEMANDA_FORM_VAZIO)
   const [salvando, setSalvando] = useState(false)
   const [expandido, setExpandido] = useState(false)
+  const [editandoId, setEditandoId] = useState<number | null>(null)
+  const [excluirId, setExcluirId] = useState<number | null>(null)
 
   const carregar = useCallback(async () => {
     try {
@@ -50,64 +52,62 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
     void carregar().finally(() => setLoading(false))
   }, [carregar])
 
-  useEffect(() => {
-    ticketClassificacao
-      .listNaturezas({ limit: 100 })
-      .then(({ items }) => setNaturezas(items))
-      .catch(() => setNaturezas([]))
-  }, [])
+  function resetFormulario() {
+    setForm(DEMANDA_FORM_VAZIO)
+    setEditandoId(null)
+    setExpandido(false)
+  }
 
-  useEffect(() => {
-    if (naturezaId === '') {
-      setMotivos([])
-      setMotivoId('')
-      return
-    }
-    ticketClassificacao
-      .listMotivos({ natureza_id: Number(naturezaId), limit: 100 })
-      .then(({ items }) => setMotivos(items))
-      .catch(() => setMotivos([]))
-  }, [naturezaId])
-
-  async function registrar() {
-    if (naturezaId === '') {
+  async function salvar() {
+    if (form.naturezaId === '') {
       toast.showWarning('Selecione a natureza da demanda.')
       return
     }
     setSalvando(true)
     try {
-      const row = await whatsappChats.registrarDemanda(chatId, {
-        natureza_id: Number(naturezaId),
-        motivo_id: motivoId === '' ? null : Number(motivoId),
-      })
-      setDemandas((prev) => {
-        const next = [...prev, row]
-        onDemandasChange?.(next.length)
-        return next
-      })
-      setNaturezaId('')
-      setMotivoId('')
-      setExpandido(false)
-      toast.showSuccess('Demanda registrada.')
+      const payload = demandaFormPayload(form)
+      if (editandoId != null) {
+        const row = await whatsappChats.atualizarDemanda(chatId, editandoId, payload)
+        setDemandas((prev) => prev.map((d) => (d.id === editandoId ? row : d)))
+        toast.showSuccess('Demanda atualizada.')
+      } else {
+        const row = await whatsappChats.registrarDemanda(chatId, payload)
+        setDemandas((prev) => {
+          const next = [...prev, row]
+          onDemandasChange?.(next.length)
+          return next
+        })
+        toast.showSuccess('Demanda registrada.')
+      }
+      resetFormulario()
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível registrar a demanda.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a demanda.'))
     } finally {
       setSalvando(false)
     }
   }
 
-  async function excluir(demandaId: number) {
-    if (!confirm('Remover este registro de demanda?')) return
+  async function confirmarExclusao() {
+    if (excluirId == null) return
     try {
-      await whatsappChats.excluirDemanda(chatId, demandaId)
+      await whatsappChats.excluirDemanda(chatId, excluirId)
       setDemandas((prev) => {
-        const next = prev.filter((d) => d.id !== demandaId)
+        const next = prev.filter((d) => d.id !== excluirId)
         onDemandasChange?.(next.length)
         return next
       })
+      if (editandoId === excluirId) resetFormulario()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível excluir a demanda.'))
+    } finally {
+      setExcluirId(null)
     }
+  }
+
+  function iniciarEdicao(d: WhatsappChats.Demanda) {
+    setEditandoId(d.id)
+    setForm(demandaFormFromDemanda(d))
+    setExpandido(true)
   }
 
   if (loading) {
@@ -119,105 +119,117 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
   }
 
   return (
-    <div className="border-b border-slate-100 bg-slate-50/80 px-4 py-2 dark:border-slate-800 dark:bg-slate-900/40">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
-            Demandas ({demandas.length})
-          </span>
-          {demandas.slice(0, 3).map((d) => (
-            <span
-              key={d.id}
-              className="inline-flex max-w-[12rem] truncate rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[10px] text-slate-700 dark:border-slate-800 dark:bg-slate-800 dark:text-slate-200"
-              title={d.motivo_nome ? `${d.natureza_nome} · ${d.motivo_nome}` : d.natureza_nome ?? undefined}
-            >
-              {d.natureza_nome}
-              {d.motivo_nome ? ` · ${d.motivo_nome}` : ''}
+    <>
+      <div className="border-b border-slate-100 bg-slate-50/80 px-4 py-2 dark:border-slate-800 dark:bg-slate-900/40">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
+              Demandas ({demandas.length})
             </span>
-          ))}
-          {demandas.length > 3 && (
-            <span className="text-[10px] text-slate-400">+{demandas.length - 3}</span>
+            {demandas.slice(0, 3).map((d) => (
+              <span
+                key={d.id}
+                className="inline-flex max-w-[12rem] truncate rounded-full border border-slate-200 bg-white px-2 py-0.5 text-[10px] text-slate-700 dark:border-slate-800 dark:bg-slate-800 dark:text-slate-200"
+                title={d.descricao_curta ?? rotuloDemanda(d)}
+              >
+                {d.natureza_nome}
+                {d.motivo_nome ? ` · ${d.motivo_nome}` : ''}
+              </span>
+            ))}
+            {demandas.length > 3 && (
+              <span className="text-[10px] text-slate-400">+{demandas.length - 3}</span>
+            )}
+          </div>
+          {podeRegistrar && (
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-7 px-2 text-[10px]"
+              onClick={() => {
+                if (expandido && editandoId == null) {
+                  resetFormulario()
+                } else {
+                  setEditandoId(null)
+                  setForm(DEMANDA_FORM_VAZIO)
+                  setExpandido(true)
+                }
+              }}
+            >
+              {expandido ? 'Cancelar' : '+ Registrar demanda'}
+            </Button>
           )}
         </div>
-        {podeRegistrar && (
-          <Button
-            type="button"
-            variant="ghost"
-            className="h-7 px-2 text-[10px]"
-            onClick={() => setExpandido((v) => !v)}
-          >
-            {expandido ? 'Cancelar' : '+ Registrar demanda'}
-          </Button>
+
+        {expandido && podeRegistrar && (
+          <div className="mt-2 space-y-3 rounded-xl border border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-900">
+            <p className="text-xs font-medium text-slate-600 dark:text-slate-300">
+              {editandoId != null ? 'Editar demanda' : 'Nova demanda'}
+            </p>
+            <WhatsappDemandaFormFields values={form} onChange={setForm} disabled={salvando} idPrefix="panel" />
+            <Button type="button" className="h-9 shrink-0" onClick={() => void salvar()} loading={salvando}>
+              {editandoId != null ? 'Guardar alterações' : 'Registrar'}
+            </Button>
+          </div>
+        )}
+
+        {demandas.length > 0 && (
+          <ul className="mt-2 space-y-1">
+            {demandas.map((d) => {
+              const podeAlterar =
+                podeRegistrar &&
+                d.desfecho === 'resolvido_sessao' &&
+                (user?.role === 'admin' || (user?.id != null && d.atendente_id === user.id))
+              return (
+                <li
+                  key={d.id}
+                  className="flex items-start justify-between gap-2 rounded-lg border border-slate-100 bg-white px-2 py-1.5 text-xs dark:border-slate-800 dark:bg-slate-950/50"
+                >
+                  <div className="min-w-0">
+                    <p className="font-medium text-slate-800 dark:text-slate-100">{rotuloDemanda(d)}</p>
+                    <p className="text-[10px] text-slate-500">
+                      {DESFECHO_ROTULO[d.desfecho] ?? d.desfecho}
+                      {d.atendente_nome ? ` · ${d.atendente_nome}` : ''}
+                      {' · '}
+                      {formatarHoraDemanda(d.created_at)}
+                    </p>
+                    {d.descricao_curta && (
+                      <p className="mt-0.5 text-[10px] text-slate-500">{d.descricao_curta}</p>
+                    )}
+                  </div>
+                  {podeAlterar && (
+                    <div className="flex shrink-0 gap-2">
+                      <button
+                        type="button"
+                        className="text-[10px] font-medium text-cyan-600 hover:underline dark:text-cyan-400"
+                        onClick={() => iniciarEdicao(d)}
+                      >
+                        Editar
+                      </button>
+                      <button
+                        type="button"
+                        className="text-[10px] font-medium text-red-500 hover:underline"
+                        onClick={() => setExcluirId(d.id)}
+                      >
+                        Remover
+                      </button>
+                    </div>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
         )}
       </div>
 
-      {expandido && podeRegistrar && (
-        <div className="mt-2 flex flex-wrap items-end gap-2 rounded-xl border border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-900">
-          <div className="min-w-[10rem] flex-1">
-            <Select
-              label="Natureza"
-              value={naturezaId}
-              onChange={(v) => {
-                setNaturezaId(v === '' ? '' : Number(v))
-                setMotivoId('')
-              }}
-              options={naturezas.map((n) => ({ value: n.id, label: n.nome }))}
-              includeEmpty
-              emptyLabel="Selecione"
-              disabled={salvando}
-            />
-          </div>
-          <div className="min-w-[10rem] flex-1">
-            <Select
-              label="Motivo (opcional)"
-              value={motivoId}
-              onChange={(v) => setMotivoId(v === '' ? '' : Number(v))}
-              options={motivos.map((m) => ({ value: m.id, label: m.nome }))}
-              includeEmpty
-              emptyLabel={naturezaId === '' ? '—' : 'Opcional'}
-              disabled={salvando || naturezaId === ''}
-            />
-          </div>
-          <Button type="button" className="h-9 shrink-0" onClick={() => void registrar()} loading={salvando}>
-            Registrar
-          </Button>
-        </div>
-      )}
-
-      {demandas.length > 0 && (
-        <ul className="mt-2 space-y-1">
-          {demandas.map((d) => {
-            const podeExcluir =
-              user?.role === 'admin' || (user?.id != null && d.atendente_id === user.id)
-            return (
-              <li
-                key={d.id}
-                className="flex items-start justify-between gap-2 rounded-lg border border-slate-100 bg-white px-2 py-1.5 text-xs dark:border-slate-800 dark:bg-slate-950/50"
-              >
-                <div className="min-w-0">
-                  <p className="font-medium text-slate-800 dark:text-slate-100">
-                    {d.natureza_nome}
-                    {d.motivo_nome ? ` · ${d.motivo_nome}` : ''}
-                  </p>
-                  <p className="text-[10px] text-slate-500">
-                    {DESFECHO_ROTULO[d.desfecho] ?? d.desfecho}
-                    {d.atendente_nome ? ` · ${d.atendente_nome}` : ''}
-                  </p>
-                </div>
-                {podeExcluir && d.desfecho === 'resolvido_sessao' && podeRegistrar && (
-                  <button
-                    type="button"
-                    className="shrink-0 text-[10px] text-red-500 hover:underline"
-                    onClick={() => void excluir(d.id)}
-                  >
-                    Remover
-                  </button>
-                )}
-              </li>
-            )
-          })}
-        </ul>
-      )}
-    </div>
+      <ConfirmDialog
+        open={excluirId != null}
+        title="Remover demanda?"
+        message="Este registro de demanda será eliminado desta sessão."
+        confirmLabel="Remover"
+        variant="danger"
+        onConfirm={() => void confirmarExclusao()}
+        onCancel={() => setExcluirId(null)}
+      />
+    </>
   )
 }

--- a/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { whatsappChats, type WhatsappChats } from '../../api/client'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import { Button } from '../../components/ui/Button'
+import { CheckboxField } from '../../components/ui/CheckboxField'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import {
+  analisarDemandaPosRegistro,
+  formatarHoraDemanda,
+  rotuloDemanda,
+} from '../../lib/whatsappDemandaUtils'
+import {
+  DEMANDA_FORM_VAZIO,
+  WhatsappDemandaFormFields,
+  demandaFormFromDemanda,
+  demandaFormPayload,
+  type DemandaFormValues,
+} from './WhatsappDemandaFormFields'
+
+type AcaoEncerramento = 'manter' | 'editar' | 'nova' | 'registrar' | 'sem_demanda'
+
+type Props = {
+  open: boolean
+  chatId: number
+  msgs: WhatsappChats.Mensagem[]
+  onClose: () => void
+  onEncerrado: (chat: WhatsappChats.Chat) => void
+  onDemandasChange?: () => void
+}
+
+export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado, onDemandasChange }: Props) {
+  const toast = useToast()
+  const [demandas, setDemandas] = useState<WhatsappChats.Demanda[]>([])
+  const [loadingDemandas, setLoadingDemandas] = useState(false)
+  const [salvando, setSalvando] = useState(false)
+  const [acao, setAcao] = useState<AcaoEncerramento>('manter')
+  const [form, setForm] = useState<DemandaFormValues>(DEMANDA_FORM_VAZIO)
+  const [confirmarSemDemanda, setConfirmarSemDemanda] = useState(false)
+
+  const posRegistro = useMemo(
+    () => analisarDemandaPosRegistro(demandas, msgs),
+    [demandas, msgs],
+  )
+
+  const semDemandas = demandas.length === 0
+  const demandasResolvidas = demandas.filter((d) => d.desfecho === 'resolvido_sessao')
+
+  const carregarDemandas = useCallback(async () => {
+    setLoadingDemandas(true)
+    try {
+      const rows = await whatsappChats.demandas(chatId)
+      setDemandas(rows)
+      return rows
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar demandas.'))
+      setDemandas([])
+      return []
+    } finally {
+      setLoadingDemandas(false)
+    }
+  }, [chatId, toast])
+
+  useEffect(() => {
+    if (!open) return
+    void carregarDemandas().then((rows) => {
+      const pos = analisarDemandaPosRegistro(rows, msgs)
+      if (rows.length === 0) {
+        setAcao('registrar')
+        setForm(DEMANDA_FORM_VAZIO)
+        setConfirmarSemDemanda(false)
+      } else if (pos) {
+        setAcao('nova')
+        setForm(DEMANDA_FORM_VAZIO)
+        setConfirmarSemDemanda(false)
+      } else {
+        setAcao('manter')
+        setForm(DEMANDA_FORM_VAZIO)
+        setConfirmarSemDemanda(false)
+      }
+    })
+  }, [open, carregarDemandas, msgs])
+
+  useEffect(() => {
+    if (acao === 'editar' && posRegistro) {
+      setForm(demandaFormFromDemanda(posRegistro.ultimaDemanda))
+    } else if (acao === 'nova' || acao === 'registrar') {
+      setForm(DEMANDA_FORM_VAZIO)
+    }
+  }, [acao, posRegistro])
+
+  async function executarEncerramento() {
+    setSalvando(true)
+    try {
+      if (acao === 'registrar') {
+        if (form.naturezaId === '') {
+          toast.showWarning('Selecione a natureza da demanda ou marque encerrar sem registar.')
+          return
+        }
+        await whatsappChats.registrarDemanda(chatId, demandaFormPayload(form))
+      } else if (acao === 'sem_demanda') {
+        if (!confirmarSemDemanda) {
+          toast.showWarning('Confirme que deseja encerrar sem registar demanda.')
+          return
+        }
+      } else if (acao === 'nova') {
+        if (form.naturezaId === '') {
+          toast.showWarning('Selecione a natureza da nova demanda.')
+          return
+        }
+        await whatsappChats.registrarDemanda(chatId, demandaFormPayload(form))
+      } else if (acao === 'editar' && posRegistro) {
+        await whatsappChats.atualizarDemanda(chatId, posRegistro.ultimaDemanda.id, demandaFormPayload(form))
+      }
+
+      const atualizado = await whatsappChats.encerrar(chatId)
+      onDemandasChange?.()
+      onEncerrado(atualizado)
+      onClose()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível encerrar o atendimento.'))
+    } finally {
+      setSalvando(false)
+    }
+  }
+
+  const titulo = 'Encerrar atendimento'
+
+  let mensagemIntro =
+    'Revise as demandas desta sessão antes de finalizar. O cliente poderá receber pedido de avaliação conforme configuração.'
+
+  if (semDemandas) {
+    mensagemIntro =
+      'Registe o motivo do atendimento antes de encerrar, ou confirme explicitamente o encerramento sem demanda.'
+  } else if (posRegistro) {
+    mensagemIntro =
+      'Houve conversa após o último registo de demanda. Escolha se mantém, corrige ou acrescenta outra demanda.'
+  }
+
+  const mostrarForm =
+    acao === 'registrar' || acao === 'nova' || (acao === 'editar' && posRegistro != null)
+
+  return (
+    <ConfirmDialog
+      open={open}
+      title={titulo}
+      message={loadingDemandas ? 'A carregar demandas…' : mensagemIntro}
+      hideActions
+      onConfirm={() => {}}
+      onCancel={onClose}
+    >
+      {!loadingDemandas && (
+        <div className="space-y-4">
+          {demandas.length > 0 && (
+            <div className="rounded-xl border border-slate-200 bg-slate-50/80 p-3 dark:border-slate-800 dark:bg-slate-900/40">
+              <p className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
+                Demandas desta sessão ({demandas.length})
+              </p>
+              <ul className="mt-2 space-y-2">
+                {demandas.map((d) => (
+                  <li key={d.id} className="text-xs text-slate-700 dark:text-slate-200">
+                    <span className="font-medium">{rotuloDemanda(d)}</span>
+                    <span className="text-slate-500"> · {formatarHoraDemanda(d.created_at)}</span>
+                    {d.desfecho === 'escalado_ticket' && (
+                      <span className="ml-1 text-amber-600 dark:text-amber-400">(ticket)</span>
+                    )}
+                    {d.descricao_curta && (
+                      <p className="mt-0.5 text-[11px] text-slate-500">{d.descricao_curta}</p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {posRegistro && (
+            <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-950 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-100">
+              <p className="font-semibold">Conversa continuou após a última demanda</p>
+              <p className="mt-1">
+                «{rotuloDemanda(posRegistro.ultimaDemanda)}» registada às{' '}
+                {formatarHoraDemanda(posRegistro.ultimaDemanda.created_at)}.
+              </p>
+              <p className="mt-1">
+                {posRegistro.mensagensApos} mensagem(ns) depois
+                {posRegistro.ultimaMensagemAt
+                  ? ` (última às ${formatarHoraDemanda(posRegistro.ultimaMensagemAt)})`
+                  : ''}
+                .
+              </p>
+            </div>
+          )}
+
+          {semDemandas ? (
+            <div className="space-y-3">
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'registrar'}
+                  onChange={() => setAcao('registrar')}
+                />
+                Registar demanda e encerrar
+              </label>
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'sem_demanda'}
+                  onChange={() => setAcao('sem_demanda')}
+                />
+                Encerrar sem registar demanda
+              </label>
+              {acao === 'sem_demanda' && (
+                <CheckboxField
+                  checked={confirmarSemDemanda}
+                  onChange={(e) => setConfirmarSemDemanda(e.target.checked)}
+                  variant="inline"
+                >
+                  Confirmo encerrar sem classificar esta sessão
+                </CheckboxField>
+              )}
+            </div>
+          ) : posRegistro ? (
+            <div className="space-y-2 text-sm">
+              <label className="flex cursor-pointer items-center gap-2">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'manter'}
+                  onChange={() => setAcao('manter')}
+                />
+                Manter demandas como estão
+              </label>
+              {demandasResolvidas.length > 0 && (
+                <label className="flex cursor-pointer items-center gap-2">
+                  <input
+                    type="radio"
+                    name="acao-encerrar"
+                    checked={acao === 'editar'}
+                    onChange={() => setAcao('editar')}
+                  />
+                  Editar última demanda «{rotuloDemanda(posRegistro.ultimaDemanda)}»
+                </label>
+              )}
+              <label className="flex cursor-pointer items-center gap-2">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'nova'}
+                  onChange={() => setAcao('nova')}
+                />
+                Registar nova demanda para o restante da conversa
+              </label>
+            </div>
+          ) : (
+            <p className="text-xs text-slate-500">
+              As demandas registadas cobrem esta sessão. Confirme para encerrar.
+            </p>
+          )}
+
+          {mostrarForm && (
+            <WhatsappDemandaFormFields values={form} onChange={setForm} disabled={salvando} idPrefix="enc" />
+          )}
+
+          <div className="flex flex-col-reverse gap-2 border-t border-slate-100 pt-4 dark:border-slate-800 sm:flex-row sm:justify-end">
+            <Button variant="secondary" onClick={onClose} disabled={salvando}>
+              Cancelar
+            </Button>
+            <Button variant="danger" onClick={() => void executarEncerramento()} loading={salvando}>
+              Encerrar atendimento
+            </Button>
+          </div>
+        </div>
+      )}
+    </ConfirmDialog>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappGravadorAudioInline.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappGravadorAudioInline.tsx
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Button } from '../../components/ui/Button'
+
+type Props = {
+  disabled?: boolean
+  onConcluido: (file: File) => void
+  onCancelar: () => void
+}
+
+/** Gravação compacta integrada na barra de composição (#443). */
+export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar }: Props) {
+  const [gravando, setGravando] = useState(false)
+  const [segundos, setSegundos] = useState(0)
+  const [erro, setErro] = useState<string | null>(null)
+  const recorderRef = useRef<MediaRecorder | null>(null)
+  const streamRef = useRef<MediaStream | null>(null)
+  const chunksRef = useRef<Blob[]>([])
+  const timerRef = useRef<number | null>(null)
+  const iniciouRef = useRef(false)
+
+  const pararStream = useCallback(() => {
+    streamRef.current?.getTracks().forEach((t) => t.stop())
+    streamRef.current = null
+    if (timerRef.current != null) {
+      window.clearInterval(timerRef.current)
+      timerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (disabled || iniciouRef.current) return
+    iniciouRef.current = true
+    void (async () => {
+      setErro(null)
+      chunksRef.current = []
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+        streamRef.current = stream
+        const mime = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+          ? 'audio/webm;codecs=opus'
+          : MediaRecorder.isTypeSupported('audio/webm')
+            ? 'audio/webm'
+            : ''
+        const recorder = mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream)
+        recorderRef.current = recorder
+        recorder.ondataavailable = (ev) => {
+          if (ev.data.size > 0) chunksRef.current.push(ev.data)
+        }
+        recorder.onstop = () => {
+          pararStream()
+          const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' })
+          if (blob.size === 0) {
+            setErro('Gravação vazia.')
+            setGravando(false)
+            return
+          }
+          const ext = blob.type.includes('ogg') ? 'ogg' : 'webm'
+          onConcluido(new File([blob], `audio-${Date.now()}.${ext}`, { type: blob.type || 'audio/webm' }))
+        }
+        recorder.start(250)
+        setGravando(true)
+        timerRef.current = window.setInterval(() => setSegundos((s) => s + 1), 1000)
+      } catch {
+        pararStream()
+        setErro('Microfone indisponível.')
+      }
+    })()
+    return () => {
+      pararStream()
+      const rec = recorderRef.current
+      if (rec && rec.state !== 'inactive') rec.stop()
+    }
+  }, [disabled, onConcluido, pararStream])
+
+  const mm = String(Math.floor(segundos / 60)).padStart(2, '0')
+  const ss = String(segundos % 60).padStart(2, '0')
+
+  function parar() {
+    const rec = recorderRef.current
+    if (rec && rec.state !== 'inactive') rec.stop()
+    recorderRef.current = null
+  }
+
+  function cancelar() {
+    chunksRef.current = []
+    pararStream()
+    const rec = recorderRef.current
+    if (rec && rec.state !== 'inactive') rec.stop()
+    recorderRef.current = null
+    onCancelar()
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-rose-200 bg-rose-50/90 px-3 py-2 dark:border-rose-900/40 dark:bg-rose-950/20">
+      <div className="flex items-center gap-2 text-xs">
+        {gravando && <span className="h-2 w-2 animate-pulse rounded-full bg-rose-500" />}
+        <span className="font-medium text-rose-800 dark:text-rose-200">
+          {gravando ? `A gravar ${mm}:${ss}` : 'A preparar microfone…'}
+        </span>
+      </div>
+      <div className="flex gap-2">
+        <Button variant="ghost" className="h-8 text-xs" onClick={cancelar}>
+          Cancelar
+        </Button>
+        <Button variant="danger" className="h-8 text-xs" disabled={!gravando} onClick={parar}>
+          Enviar áudio
+        </Button>
+      </div>
+      {erro && <p className="w-full text-xs text-rose-700 dark:text-rose-300">{erro}</p>}
+    </div>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, useCallback } from 'react'
-import { Link } from 'react-router-dom'
+import { useEffect, useState, useCallback, useMemo } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
 import { atendentes, whatsappChats, type WhatsappChats, type Atendentes } from '../../api/client'
 import { Card } from '../../components/ui/Card'
 import { Button } from '../../components/ui/Button'
@@ -9,20 +9,67 @@ import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { AvaliacaoEstrelas } from '../../components/ui/AvaliacaoEstrelas'
+import { rotuloEstadoChat } from '../../lib/whatsappChatMeta'
+import { buildHistoricoReturnPath, whatsappConversaLink } from '../../lib/whatsappListReturn'
 
-const PAGE_SIZE = 15 // Reduzi para 15 para melhorar o fôlego da página em listas longas
+const PAGE_SIZE = 15
+
+type FiltroEstadoHistorico =
+  | 'finalizados'
+  | 'encerrado'
+  | 'aguardando_avaliacao'
+  | 'em_atendimento'
+  | 'aguardando_atendente'
+  | 'todos'
 
 export function WhatsappHistorico() {
   const toast = useToast()
+  const [searchParams, setSearchParams] = useSearchParams()
   const [items, setItems] = useState<WhatsappChats.Chat[]>([])
   const [total, setTotal] = useState(0)
-  const [offset, setOffset] = useState(0)
+  const [offset, setOffset] = useState(() => Number(searchParams.get('offset') || 0))
   const [loading, setLoading] = useState(true)
-  const [busca, setBusca] = useState('')
+  const [busca, setBusca] = useState(() => searchParams.get('busca') ?? '')
   const [atendentesList, setAtendentesList] = useState<Atendentes.Atendente[]>([])
-  const [atendenteId, setAtendenteId] = useState<number | ''>('')
-  const [desde, setDesde] = useState('')
-  const [ate, setAte] = useState('')
+  const [atendenteId, setAtendenteId] = useState<number | ''>(() => {
+    const v = searchParams.get('atendente_id')
+    return v ? Number(v) : ''
+  })
+  const [desde, setDesde] = useState(() => searchParams.get('desde') ?? '')
+  const [ate, setAte] = useState(() => searchParams.get('ate') ?? '')
+  const [estadoFiltro, setEstadoFiltro] = useState<FiltroEstadoHistorico>(() => {
+    const v = searchParams.get('estado')
+    return (v as FiltroEstadoHistorico) || 'finalizados'
+  })
+
+  const historicoReturnPath = useMemo(
+    () =>
+      buildHistoricoReturnPath({
+        busca,
+        atendenteId,
+        desde,
+        ate,
+        estado: estadoFiltro,
+        offset,
+      }),
+    [ate, atendenteId, busca, desde, estadoFiltro, offset],
+  )
+
+  const syncUrl = useCallback(
+    (from: number) => {
+      const path = buildHistoricoReturnPath({
+        busca,
+        atendenteId,
+        desde,
+        ate,
+        estado: estadoFiltro,
+        offset: from,
+      })
+      const qs = path.includes('?') ? path.split('?')[1] : ''
+      setSearchParams(qs ? new URLSearchParams(qs) : new URLSearchParams(), { replace: true })
+    },
+    [ate, atendenteId, busca, desde, estadoFiltro, setSearchParams],
+  )
 
   const load = useCallback(async (from: number) => {
     setLoading(true)
@@ -35,16 +82,18 @@ export function WhatsappHistorico() {
       if (atendenteId !== '') params.atendente_id = atendenteId
       if (desde) params.encerramento_inicio = `${desde}T00:00:00`
       if (ate) params.encerramento_fim = `${ate}T23:59:59`
+      params.estado = estadoFiltro
       const { items: rows, total: t } = await whatsappChats.encerrados(params)
       setItems(rows)
       setTotal(t)
       setOffset(from)
+      syncUrl(from)
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha ao carregar histórico.'))
     } finally {
       setLoading(false)
     }
-  }, [atendenteId, ate, busca, desde, toast])
+  }, [atendenteId, ate, busca, desde, estadoFiltro, syncUrl, toast])
 
   useEffect(() => {
     void load(0)
@@ -80,7 +129,7 @@ export function WhatsappHistorico() {
       <header className="flex flex-col gap-6 border-b pb-6 dark:border-slate-800 md:flex-row md:items-end md:justify-between">
         <div className="space-y-1">
           <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Histórico de Mensagens</h1>
-          <p className="text-sm text-slate-500">Consulte atendimentos finalizados e protocolos antigos.</p>
+          <p className="text-sm text-slate-500">Consulte sessões finalizadas, aguardando avaliação e chats em aberto (conforme filtro).</p>
         </div>
 
         <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:justify-between flex-1">
@@ -95,7 +144,20 @@ export function WhatsappHistorico() {
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
             </span>
           </div>
-          <div className="grid w-full max-w-full grid-cols-1 gap-3 sm:max-w-xl sm:grid-cols-3">
+          <div className="grid w-full max-w-full grid-cols-1 gap-3 sm:max-w-2xl sm:grid-cols-2 lg:grid-cols-4">
+            <Select
+              label="Estado"
+              value={estadoFiltro}
+              onChange={(value) => setEstadoFiltro(value as FiltroEstadoHistorico)}
+              options={[
+                { value: 'finalizados', label: 'Finalizados (padrão)' },
+                { value: 'encerrado', label: 'Encerrados' },
+                { value: 'aguardando_avaliacao', label: 'Aguardando avaliação' },
+                { value: 'em_atendimento', label: 'Em atendimento' },
+                { value: 'aguardando_atendente', label: 'Aguardando atendente' },
+                { value: 'todos', label: 'Todos' },
+              ]}
+            />
             <Input
               type="date"
               label="De"
@@ -153,6 +215,9 @@ export function WhatsappHistorico() {
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</h3>
+                        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                          {rotuloEstadoChat(c.estado)}
+                        </span>
                         <span className="font-mono text-[10px] font-bold text-slate-400">{c.wa_id}</span>
                       </div>
                       <p
@@ -197,7 +262,7 @@ export function WhatsappHistorico() {
                     </div>
 
                     <Link
-                      to={`/whatsapp/c/${c.id}`}
+                      to={whatsappConversaLink(c.id, historicoReturnPath, 'historico')}
                       className="rounded-full bg-slate-100 p-2 text-slate-400 transition-all hover:bg-cyan-600 hover:text-white dark:bg-slate-800 dark:hover:bg-cyan-700"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, useCallback } from 'react'
-import { Link } from 'react-router-dom'
+import { useEffect, useState, useCallback, useMemo } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
 import { atendentes, whatsappChats, type WhatsappChats, type Atendentes } from '../../api/client'
 import { Card } from '../../components/ui/Card'
 import { Button } from '../../components/ui/Button'
@@ -10,6 +10,7 @@ import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { AvaliacaoEstrelas } from '../../components/ui/AvaliacaoEstrelas'
 import { rotuloEstadoChat } from '../../lib/whatsappChatMeta'
+import { buildHistoricoReturnPath, whatsappConversaLink } from '../../lib/whatsappListReturn'
 
 const PAGE_SIZE = 15
 
@@ -23,16 +24,52 @@ type FiltroEstadoHistorico =
 
 export function WhatsappHistorico() {
   const toast = useToast()
+  const [searchParams, setSearchParams] = useSearchParams()
   const [items, setItems] = useState<WhatsappChats.Chat[]>([])
   const [total, setTotal] = useState(0)
-  const [offset, setOffset] = useState(0)
+  const [offset, setOffset] = useState(() => Number(searchParams.get('offset') || 0))
   const [loading, setLoading] = useState(true)
-  const [busca, setBusca] = useState('')
+  const [busca, setBusca] = useState(() => searchParams.get('busca') ?? '')
   const [atendentesList, setAtendentesList] = useState<Atendentes.Atendente[]>([])
-  const [atendenteId, setAtendenteId] = useState<number | ''>('')
-  const [desde, setDesde] = useState('')
-  const [ate, setAte] = useState('')
-  const [estadoFiltro, setEstadoFiltro] = useState<FiltroEstadoHistorico>('finalizados')
+  const [atendenteId, setAtendenteId] = useState<number | ''>(() => {
+    const v = searchParams.get('atendente_id')
+    return v ? Number(v) : ''
+  })
+  const [desde, setDesde] = useState(() => searchParams.get('desde') ?? '')
+  const [ate, setAte] = useState(() => searchParams.get('ate') ?? '')
+  const [estadoFiltro, setEstadoFiltro] = useState<FiltroEstadoHistorico>(() => {
+    const v = searchParams.get('estado')
+    return (v as FiltroEstadoHistorico) || 'finalizados'
+  })
+
+  const historicoReturnPath = useMemo(
+    () =>
+      buildHistoricoReturnPath({
+        busca,
+        atendenteId,
+        desde,
+        ate,
+        estado: estadoFiltro,
+        offset,
+      }),
+    [ate, atendenteId, busca, desde, estadoFiltro, offset],
+  )
+
+  const syncUrl = useCallback(
+    (from: number) => {
+      const path = buildHistoricoReturnPath({
+        busca,
+        atendenteId,
+        desde,
+        ate,
+        estado: estadoFiltro,
+        offset: from,
+      })
+      const qs = path.includes('?') ? path.split('?')[1] : ''
+      setSearchParams(qs ? new URLSearchParams(qs) : new URLSearchParams(), { replace: true })
+    },
+    [ate, atendenteId, busca, desde, estadoFiltro, setSearchParams],
+  )
 
   const load = useCallback(async (from: number) => {
     setLoading(true)
@@ -50,12 +87,13 @@ export function WhatsappHistorico() {
       setItems(rows)
       setTotal(t)
       setOffset(from)
+      syncUrl(from)
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha ao carregar histórico.'))
     } finally {
       setLoading(false)
     }
-  }, [atendenteId, ate, busca, desde, estadoFiltro, toast])
+  }, [atendenteId, ate, busca, desde, estadoFiltro, syncUrl, toast])
 
   useEffect(() => {
     void load(0)
@@ -224,7 +262,7 @@ export function WhatsappHistorico() {
                     </div>
 
                     <Link
-                      to={`/whatsapp/c/${c.id}`}
+                      to={whatsappConversaLink(c.id, historicoReturnPath, 'historico')}
                       className="rounded-full bg-slate-100 p-2 text-slate-400 transition-all hover:bg-cyan-600 hover:text-white dark:bg-slate-800 dark:hover:bg-cyan-700"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -9,8 +9,17 @@ import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { AvaliacaoEstrelas } from '../../components/ui/AvaliacaoEstrelas'
+import { rotuloEstadoChat } from '../../lib/whatsappChatMeta'
 
-const PAGE_SIZE = 15 // Reduzi para 15 para melhorar o fôlego da página em listas longas
+const PAGE_SIZE = 15
+
+type FiltroEstadoHistorico =
+  | 'finalizados'
+  | 'encerrado'
+  | 'aguardando_avaliacao'
+  | 'em_atendimento'
+  | 'aguardando_atendente'
+  | 'todos'
 
 export function WhatsappHistorico() {
   const toast = useToast()
@@ -23,6 +32,7 @@ export function WhatsappHistorico() {
   const [atendenteId, setAtendenteId] = useState<number | ''>('')
   const [desde, setDesde] = useState('')
   const [ate, setAte] = useState('')
+  const [estadoFiltro, setEstadoFiltro] = useState<FiltroEstadoHistorico>('finalizados')
 
   const load = useCallback(async (from: number) => {
     setLoading(true)
@@ -35,6 +45,7 @@ export function WhatsappHistorico() {
       if (atendenteId !== '') params.atendente_id = atendenteId
       if (desde) params.encerramento_inicio = `${desde}T00:00:00`
       if (ate) params.encerramento_fim = `${ate}T23:59:59`
+      params.estado = estadoFiltro
       const { items: rows, total: t } = await whatsappChats.encerrados(params)
       setItems(rows)
       setTotal(t)
@@ -44,7 +55,7 @@ export function WhatsappHistorico() {
     } finally {
       setLoading(false)
     }
-  }, [atendenteId, ate, busca, desde, toast])
+  }, [atendenteId, ate, busca, desde, estadoFiltro, toast])
 
   useEffect(() => {
     void load(0)
@@ -80,7 +91,7 @@ export function WhatsappHistorico() {
       <header className="flex flex-col gap-6 border-b pb-6 dark:border-slate-800 md:flex-row md:items-end md:justify-between">
         <div className="space-y-1">
           <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Histórico de Mensagens</h1>
-          <p className="text-sm text-slate-500">Consulte atendimentos finalizados e protocolos antigos.</p>
+          <p className="text-sm text-slate-500">Consulte sessões finalizadas, aguardando avaliação e chats em aberto (conforme filtro).</p>
         </div>
 
         <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:justify-between flex-1">
@@ -95,7 +106,20 @@ export function WhatsappHistorico() {
               <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
             </span>
           </div>
-          <div className="grid w-full max-w-full grid-cols-1 gap-3 sm:max-w-xl sm:grid-cols-3">
+          <div className="grid w-full max-w-full grid-cols-1 gap-3 sm:max-w-2xl sm:grid-cols-2 lg:grid-cols-4">
+            <Select
+              label="Estado"
+              value={estadoFiltro}
+              onChange={(value) => setEstadoFiltro(value as FiltroEstadoHistorico)}
+              options={[
+                { value: 'finalizados', label: 'Finalizados (padrão)' },
+                { value: 'encerrado', label: 'Encerrados' },
+                { value: 'aguardando_avaliacao', label: 'Aguardando avaliação' },
+                { value: 'em_atendimento', label: 'Em atendimento' },
+                { value: 'aguardando_atendente', label: 'Aguardando atendente' },
+                { value: 'todos', label: 'Todos' },
+              ]}
+            />
             <Input
               type="date"
               label="De"
@@ -153,6 +177,9 @@ export function WhatsappHistorico() {
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</h3>
+                        <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                          {rotuloEstadoChat(c.estado)}
+                        </span>
                         <span className="font-mono text-[10px] font-bold text-slate-400">{c.wa_id}</span>
                       </div>
                       <p

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -107,7 +107,8 @@ export function WhatsappHistorico() {
   }, [])
 
   const formatDuration = (chat: WhatsappChats.Chat) => {
-    if (!chat.atendimento_inicio_at || !chat.encerramento_at) return '—'
+    if (!chat.atendimento_inicio_at) return '—'
+    if (!chat.encerramento_at) return 'Em curso'
     const start = new Date(chat.atendimento_inicio_at)
     const end = new Date(chat.encerramento_at)
     const diff = Math.max(0, Math.round((end.getTime() - start.getTime()) / 1000))

--- a/frontend/src/pages/whatsapp/WhatsappLayout.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappLayout.tsx
@@ -36,9 +36,9 @@ export function WhatsappLayout() {
               <h1 className="text-3xl font-extrabold tracking-tight text-slate-900 dark:text-white">WhatsApp</h1>
               <p className="text-sm font-medium text-slate-500">
                 {isAvaliacoes
-                  ? 'Avaliações dos clientes (notas não aparecem na conversa)'
+                  ? 'Chats com avaliação respondida pelos clientes'
                   : isHistorico
-                    ? 'Revisão de atendimentos passados'
+                    ? 'Consulta de sessões finalizadas e chats em aberto'
                     : 'Operação em tempo real'}
               </p>
             </div>

--- a/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
@@ -9,6 +9,7 @@ import { SelectComPesquisa } from '../../components/ui/SelectComPesquisa'
 import { CheckboxField } from '../../components/ui/CheckboxField'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { CONTATO_CLIENTE } from '../../constants/contatoClienteLabels'
 
 type Modo = 'vincular' | 'cadastrar'
 type TipoCadastro = 'colaborador' | 'supervisor'
@@ -118,7 +119,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
       .then(setResultados)
       .catch((err) => {
         setResultados([])
-        setErroBusca(mensagemFalhaParaToast(err, 'Não foi possível buscar funcionários.'))
+        setErroBusca(mensagemFalhaParaToast(err, 'Não foi possível buscar contatos da rede.'))
       })
       .finally(() => setLoadingBusca(false))
   }, [debouncedBusca, modo, open])
@@ -157,11 +158,11 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
 
   async function confirmarVinculo() {
     if (!selecionado) {
-      setErroFormulario('Selecione um funcionário.')
+      setErroFormulario(CONTATO_CLIENTE.selecioneContato)
       return
     }
     if (selecionado.empresas.length > 1 && empresaVinculoId === '') {
-      setErroFormulario('Selecione a empresa do funcionário.')
+      setErroFormulario(CONTATO_CLIENTE.selecioneEmpresaContato)
       return
     }
     setErroFormulario(null)
@@ -171,11 +172,11 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
         funcionario_rede_id: selecionado.id,
         empresa_id: empresaVinculoId === '' ? null : Number(empresaVinculoId),
       })
-      toast.showSuccess('Funcionário vinculado ao contato.')
+      toast.showSuccess(CONTATO_CLIENTE.vinculadoSucesso)
       onSuccess(atualizado)
       onClose()
     } catch (err) {
-      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível vincular o funcionário.'))
+      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível vincular o contato.'))
     } finally {
       setSalvando(false)
     }
@@ -183,7 +184,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
 
   async function confirmarCadastro() {
     if (!nomeCadastro.trim()) {
-      setErroFormulario('Informe o nome do funcionário.')
+      setErroFormulario(CONTATO_CLIENTE.informeNome)
       return
     }
     if (redeIdCadastro === '') {
@@ -222,11 +223,11 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
         empresa_ids: empresaIds,
         empresa_id: empresaContextoId === '' ? null : Number(empresaContextoId),
       })
-      toast.showSuccess('Funcionário cadastrado e vinculado ao contato.')
+      toast.showSuccess(CONTATO_CLIENTE.cadastradoSucesso)
       onSuccess(atualizado)
       onClose()
     } catch (err) {
-      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível cadastrar o funcionário.'))
+      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível cadastrar o contato.'))
     } finally {
       setSalvando(false)
     }
@@ -236,11 +237,11 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
     setSalvando(true)
     try {
       const atualizado = await whatsappChats.desvincularFuncionario(chat.id)
-      toast.showSuccess('Vínculo com funcionário removido.')
+      toast.showSuccess(CONTATO_CLIENTE.desvinculadoSucesso)
       onSuccess(atualizado)
       onClose()
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível desvincular o funcionário.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível desvincular o contato.'))
     } finally {
       setSalvando(false)
     }
@@ -251,10 +252,8 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
       <Card className="w-full max-w-lg max-h-[90vh] overflow-y-auto p-6 animate-in zoom-in-95">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h3 className="text-lg font-bold">Funcionário do contato</h3>
-            <p className="mt-1 text-sm text-slate-500">
-              Vincule um cadastro existente ou cadastre o contato como funcionário da rede.
-            </p>
+            <h3 className="text-lg font-bold">{CONTATO_CLIENTE.modalTitulo}</h3>
+            <p className="mt-1 text-sm text-slate-500">{CONTATO_CLIENTE.modalSubtitulo}</p>
           </div>
           <button
             type="button"
@@ -335,7 +334,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
         {modo === 'vincular' ? (
           <div className="mt-4 space-y-4">
             <Input
-              placeholder="Buscar por nome ou e-mail"
+              placeholder={CONTATO_CLIENTE.buscarPlaceholder}
               value={busca}
               onChange={(e) => setBusca(e.target.value)}
             />
@@ -370,11 +369,13 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                 </div>
               ) : (
                 <p className="text-sm text-slate-500">
-                  Nenhum funcionário encontrado. Use a aba <strong>Cadastrar novo</strong>.
+                <p className="text-sm text-slate-500">
+                  Nenhum contato encontrado. Use a aba <strong>Cadastrar novo</strong>.
+                </p>
                 </p>
               )
             ) : (
-              <p className="text-sm text-slate-500">Digite um termo para buscar funcionários.</p>
+              <p className="text-sm text-slate-500">{CONTATO_CLIENTE.digiteParaBuscar}</p>
             )}
             {selecionado && selecionado.empresas.length > 1 && (
               <SelectComPesquisa

--- a/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
@@ -45,6 +45,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
   const [empresaIdCadastro, setEmpresaIdCadastro] = useState<number | ''>('')
   const [empresaIdsCadastro, setEmpresaIdsCadastro] = useState<number[]>([])
   const [empresaContextoId, setEmpresaContextoId] = useState<number | ''>('')
+  const [erroFormulario, setErroFormulario] = useState<string | null>(null)
 
   const empresaItemsVincular = useMemo(
     () => (selecionado?.empresas ?? []).map((e) => ({ id: e.id, label: e.nome })),
@@ -90,6 +91,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
     setEmpresaIdCadastro('')
     setEmpresaIdsCadastro([])
     setEmpresaContextoId('')
+    setErroFormulario(null)
     setCatalogoLoading(true)
     whatsappChats
       .catalogoFuncionarios()
@@ -155,13 +157,14 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
 
   async function confirmarVinculo() {
     if (!selecionado) {
-      toast.showWarning('Selecione um funcionário.')
+      setErroFormulario('Selecione um funcionário.')
       return
     }
     if (selecionado.empresas.length > 1 && empresaVinculoId === '') {
-      toast.showWarning('Selecione a empresa do funcionário.')
+      setErroFormulario('Selecione a empresa do funcionário.')
       return
     }
+    setErroFormulario(null)
     setSalvando(true)
     try {
       const atualizado = await whatsappChats.vincularFuncionario(chat.id, {
@@ -172,7 +175,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
       onSuccess(atualizado)
       onClose()
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível vincular o funcionário.'))
+      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível vincular o funcionário.'))
     } finally {
       setSalvando(false)
     }
@@ -180,41 +183,39 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
 
   async function confirmarCadastro() {
     if (!nomeCadastro.trim()) {
-      toast.showWarning('Informe o nome do funcionário.')
-      return
-    }
-    if (!emailCadastro.trim()) {
-      toast.showWarning('Informe o e-mail do funcionário.')
+      setErroFormulario('Informe o nome do funcionário.')
       return
     }
     if (redeIdCadastro === '') {
-      toast.showWarning('Selecione a rede.')
+      setErroFormulario('Selecione a rede.')
       return
     }
     let empresaIds: number[] = []
     if (escopoCadastro === 'selected') {
       if (tipoCadastro === 'colaborador') {
         if (empresaIdCadastro === '') {
-          toast.showWarning('Selecione a empresa.')
+          setErroFormulario('Selecione a empresa.')
           return
         }
         empresaIds = [Number(empresaIdCadastro)]
       } else if (empresaIdsCadastro.length === 0) {
-        toast.showWarning('Marque ao menos uma empresa.')
+        setErroFormulario('Marque ao menos uma empresa.')
         return
       } else {
         empresaIds = [...empresaIdsCadastro]
       }
     }
     if (empresasContextoOpcoes.length > 1 && empresaContextoId === '') {
-      toast.showWarning('Selecione a empresa exibida no chat.')
+      setErroFormulario('Selecione a empresa exibida no chat.')
       return
     }
+    setErroFormulario(null)
     setSalvando(true)
     try {
+      const emailTrim = emailCadastro.trim()
       const atualizado = await whatsappChats.cadastrarFuncionario(chat.id, {
         nome: nomeCadastro.trim(),
-        email: emailCadastro.trim(),
+        email: emailTrim || null,
         rede_id: Number(redeIdCadastro),
         tipo: tipoCadastro,
         escopo_empresas: escopoCadastro,
@@ -225,7 +226,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
       onSuccess(atualizado)
       onClose()
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível cadastrar o funcionário.'))
+      setErroFormulario(mensagemFalhaParaToast(err, 'Não foi possível cadastrar o funcionário.'))
     } finally {
       setSalvando(false)
     }
@@ -299,7 +300,10 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                 ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-white'
                 : 'text-slate-500 hover:text-slate-800 dark:hover:text-slate-200'
             }`}
-            onClick={() => setModo('vincular')}
+            onClick={() => {
+              setModo('vincular')
+              setErroFormulario(null)
+            }}
           >
             Vincular existente
           </button>
@@ -310,11 +314,23 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                 ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-900 dark:text-white'
                 : 'text-slate-500 hover:text-slate-800 dark:hover:text-slate-200'
             }`}
-            onClick={() => setModo('cadastrar')}
+            onClick={() => {
+              setModo('cadastrar')
+              setErroFormulario(null)
+            }}
           >
             Cadastrar novo
           </button>
         </div>
+
+        {erroFormulario && (
+          <div
+            role="alert"
+            className="mt-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-100"
+          >
+            {erroFormulario}
+          </div>
+        )}
 
         {modo === 'vincular' ? (
           <div className="mt-4 space-y-4">
@@ -343,7 +359,9 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                       <div className="flex items-center justify-between gap-3">
                         <div>
                           <p className="font-semibold text-slate-900 dark:text-slate-100">{funcionario.nome}</p>
-                          <p className="text-xs text-slate-500 dark:text-slate-400">{funcionario.email}</p>
+                          <p className="text-xs text-slate-500 dark:text-slate-400">
+                            {funcionario.email || 'Sem e-mail'}
+                          </p>
                         </div>
                         <span className="text-xs uppercase tracking-wide text-slate-400">{funcionario.tipo}</span>
                       </div>
@@ -381,12 +399,17 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                   required
                 />
                 <Input
-                  label="E-mail"
+                  label="E-mail (opcional)"
                   type="email"
                   value={emailCadastro}
-                  onChange={(e) => setEmailCadastro(e.target.value)}
-                  required
+                  onChange={(e) => {
+                    setEmailCadastro(e.target.value)
+                    setErroFormulario(null)
+                  }}
                 />
+                <p className="text-xs text-slate-500">
+                  Usado para tickets por e-mail; contactos só WhatsApp podem deixar em branco.
+                </p>
                 <p className="text-xs text-slate-500">
                   WhatsApp do contato: <span className="font-mono">{chat.wa_id}</span>
                 </p>


### PR DESCRIPTION
## Summary

Promove para **staging** o lote completo de melhorias WhatsApp e notificações já mergeado em main:

- **PR #439** — mídia inbound, barra de anexos, banner sem vínculo (#431–#433)
- **PR #456** — áudio outbound, tempo real, e-mail opcional, modal encerramento, histórico/avaliações, botão Voltar (#441, #442, #444–#449)
- **PR #457** — composer WA Web, marco demanda, copy contato, ícones ficheiro, colaboração no histórico, links directos no sino (#443, #446, #447, #452, #453, #455)

O CHANGELOG.md → [Unreleased] descreve **tudo** que será publicado no próximo deploy (inclui entregas anteriores ainda não publicadas em staging).

### Migration

- **055** — uncionario_rede.email nullable (cadastro sem e-mail no chat, #444)

## Test plan

- [ ] Deploy staging + lembic upgrade head (migration 055)
- [ ] WhatsApp: receber mídia, enviar anexo/áudio, composer (+/mic)
- [ ] Registar demanda → marco na timeline; encerrar chat (modal)
- [ ] Histórico: chats em atendimento visíveis para colega do setor
- [ ] Sino: pendência abre ticket/chat directo
- [ ] Cadastro funcionário no chat sem e-mail
- [ ] Página Sobre: após deploy, nova CalVer e release notes geradas automaticamente
