### PR TITLE
fix(alembic): revision 055 cabe em varchar(32)

### DIFF
--- a/backend/alembic/versions/055_func_rede_email_null.py
+++ b/backend/alembic/versions/055_func_rede_email_null.py
@@ -1,6 +1,6 @@
 """funcionarios_rede.email opcional (#444).
 
-Revision ID: 055_funcionario_rede_email_nullable
+Revision ID: 055_func_rede_email_null
 Revises: 054_kb_interno_only
 Create Date: 2026-06-17
 """
@@ -8,7 +8,7 @@ Create Date: 2026-06-17
 import sqlalchemy as sa
 from alembic import op
 
-revision = "055_funcionario_rede_email_nullable"
+revision = "055_func_rede_email_null"
 down_revision = "054_kb_interno_only"
 branch_labels = None
 depends_on = None


### PR DESCRIPTION
## Summary

Alinha `main` com a correcção já aplicada em `staging` (deploy v26.06.006).

O revision `055_funcionario_rede_email_nullable` (35 chars) excedia o limite de `alembic_version.version_num` (`varchar(32)`), quebrando `alembic upgrade head` no deploy.

Renomeado para `055_func_rede_email_null` (22 chars). Sem alteração de DDL.

## Test plan

- [ ] `alembic heads` / `alembic history` sem erro
- [ ] CI backend passa