### PR TITLE
fix(whatsapp): Link do histórico quebra com React Router (#449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#449): corrigido link do Histórico/Avaliações para conversa — query `?from=` separada do `pathname` (React Router v7)
 - Notificações (#452): pendências de mensagem não lida abrem o ticket ou chat concreto (`/tickets/{id}`, `/whatsapp/c/{id}`) — removido fallback genérico para listagens
 - WhatsApp (#447): terminologia «contato do cliente» no chat e tickets — distingue colaborador da rede de atendente interno
 - WhatsApp (#453): ícones por tipo de ficheiro (PDF, Word, Excel, etc.) nas mensagens de documento

--- a/frontend/src/lib/whatsappListReturn.ts
+++ b/frontend/src/lib/whatsappListReturn.ts
@@ -15,9 +15,9 @@ export function whatsappConversaState(returnPath: string): WhatsappListReturnSta
 }
 
 export function whatsappConversaLink(chatId: number, returnPath: string, from?: WhatsappListOrigin) {
-  const search = from ? `?from=${from}` : ''
   return {
-    pathname: `/whatsapp/c/${chatId}${search}`,
+    pathname: `/whatsapp/c/${chatId}`,
+    search: from ? `?from=${from}` : '',
     state: whatsappConversaState(returnPath),
   }
 }


### PR DESCRIPTION
## Summary

Corrige erro ao abrir chat a partir do **Histórico** (ou Avaliações/Atendendo):

```
Cannot include a '?' character in a manually specified `to.pathname` field
```

O React Router exige `?from=historico` em `search`, não em `pathname`.

## Test plan

- [ ] Histórico → abrir chat → sem erro no console
- [ ] Botão Voltar regressa à lista com filtros
- [ ] Avaliações e Atendendo: links para conversa OK