### PR TITLE
Release: fix link WhatsApp histórico (#460) + alembic 055 (#459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#449): corrigido link do Histórico/Avaliações para conversa — query `?from=` separada do `pathname` (React Router v7)
 - Notificações (#452): pendências de mensagem não lida abrem o ticket ou chat concreto (`/tickets/{id}`, `/whatsapp/c/{id}`) — removido fallback genérico para listagens
 - WhatsApp (#447): terminologia «contato do cliente» no chat e tickets — distingue colaborador da rede de atendente interno
 - WhatsApp (#453): ícones por tipo de ficheiro (PDF, Word, Excel, etc.) nas mensagens de documento

--- a/backend/alembic/versions/055_func_rede_email_null.py
+++ b/backend/alembic/versions/055_func_rede_email_null.py
@@ -1,6 +1,6 @@
 """funcionarios_rede.email opcional (#444).
 
-Revision ID: 055_funcionario_rede_email_nullable
+Revision ID: 055_func_rede_email_null
 Revises: 054_kb_interno_only
 Create Date: 2026-06-17
 """
@@ -8,7 +8,7 @@ Create Date: 2026-06-17
 import sqlalchemy as sa
 from alembic import op
 
-revision = "055_funcionario_rede_email_nullable"
+revision = "055_func_rede_email_null"
 down_revision = "054_kb_interno_only"
 branch_labels = None
 depends_on = None

--- a/frontend/src/lib/whatsappListReturn.ts
+++ b/frontend/src/lib/whatsappListReturn.ts
@@ -15,9 +15,9 @@ export function whatsappConversaState(returnPath: string): WhatsappListReturnSta
 }
 
 export function whatsappConversaLink(chatId: number, returnPath: string, from?: WhatsappListOrigin) {
-  const search = from ? `?from=${from}` : ''
   return {
-    pathname: `/whatsapp/c/${chatId}${search}`,
+    pathname: `/whatsapp/c/${chatId}`,
+    search: from ? `?from=${from}` : '',
     state: whatsappConversaState(returnPath),
   }
 }


### PR DESCRIPTION
## Summary

- **#460** — corrige erro React Router ao abrir chat pelo Histórico (`?from=` em `search`, não em `pathname`)
- **#459** — alinha revision da migration 055 em `main` (já corrigido em staging no deploy anterior)

## Test plan

- [ ] Histórico → abrir chat → sem erro no console
- [ ] Botão Voltar preserva filtros da lista
- [ ] Composer, marco demanda, notificações directas (regressão rápida)