### PR TITLE
feat(whatsapp): emoji, figurinhas e scroll nas listas (#443/#454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,14 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#443/#454): painel de emoji e envio de figurinhas no composer; Histórico e Avaliações preservam posição de scroll ao voltar da conversa
 - WhatsApp (#449): corrigido link do Histórico/Avaliações para conversa — query `?from=` separada do `pathname` (React Router v7)
 - Notificações (#452): pendências de mensagem não lida abrem o ticket ou chat concreto (`/tickets/{id}`, `/whatsapp/c/{id}`) — removido fallback genérico para listagens
 - WhatsApp (#447): terminologia «contato do cliente» no chat e tickets — distingue colaborador da rede de atendente interno
 - WhatsApp (#453): ícones por tipo de ficheiro (PDF, Word, Excel, etc.) nas mensagens de documento
 - WhatsApp (#446): marco «Demanda registada» na timeline via evento interno + SSE em tempo real; removido ao excluir demanda
 - WhatsApp (#455): Histórico lista chats em atendimento — colegas do setor consultam e comentam internamente; ordenação e filtros de data corrigidos
-- WhatsApp (#443): barra de composição estilo WhatsApp Web (+ anexos, figurinhas em breve, microfone à direita)
+- WhatsApp (#443): barra de composição estilo WhatsApp Web (+ anexos, emoji e figurinhas, microfone à direita)
 - WhatsApp (#445): modal de encerramento substitui `confirm()` nativo — registo/edição de demandas, aviso quando houve conversa após última demanda, marco na timeline e `ConfirmDialog` reutilizável
 - WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape
 - WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -194,6 +194,8 @@ def _tipo_midia_db(slug: str) -> str:
         return "video"
     if s == "audio":
         return "audio"
+    if s in ("figurinha", "sticker"):
+        return "figurinha"
     return "documento"
 
 
@@ -203,6 +205,7 @@ def _rotulo_midia_outbound(tipo_db: str) -> str:
         "video": "[Vídeo enviado]",
         "audio": "[Áudio enviado]",
         "documento": "[Documento enviado]",
+        "figurinha": "[Figurinha enviada]",
     }.get(tipo_db, "[Ficheiro enviado]")
 
 
@@ -1099,7 +1102,7 @@ async def enviar_mensagem_midia(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
     file: UploadFile = File(...),
-    mediatipo: str = Form(..., description="imagem | video | audio | documento"),
+    mediatipo: str = Form(..., description="imagem | video | audio | documento | figurinha"),
     caption: str = Form(""),
     quoted_wa_message_id: str | None = Form(None),
 ):
@@ -1128,10 +1131,14 @@ async def enviar_mensagem_midia(
         raise HTTPException(status_code=500, detail="Não foi possível guardar o ficheiro em disco.")
 
     cap = (caption or "").strip()
-    base_legenda = cap if cap else _rotulo_midia_outbound(tipo_db)
-    nome_atend = (atendente.nome or "").strip()
-    legenda_whatsapp = f"[ {nome_atend} ]: {base_legenda}" if nome_atend else base_legenda
-    corpo_eff = legenda_whatsapp
+    if tipo_db == "figurinha":
+        corpo_eff = _rotulo_midia_outbound(tipo_db)
+        legenda_whatsapp = ""
+    else:
+        base_legenda = cap if cap else _rotulo_midia_outbound(tipo_db)
+        nome_atend = (atendente.nome or "").strip()
+        legenda_whatsapp = f"[ {nome_atend} ]: {base_legenda}" if nome_atend else base_legenda
+        corpo_eff = legenda_whatsapp
 
     b64 = base64.b64encode(data).decode("ascii")
     st = _settings_envio(db)
@@ -1158,6 +1165,15 @@ async def enviar_mensagem_midia(
             st.evolution_api_key,
             c.wa_id,
             audio_base64=b64,
+            quoted=quoted_payload,
+        )
+    elif tipo_db == "figurinha":
+        ok, err, sent_wa_id = evolution_api.evolution_send_sticker(
+            st.evolution_base_url,
+            st.evolution_instance_name,
+            st.evolution_api_key,
+            c.wa_id,
+            sticker_base64=b64,
             quoted=quoted_payload,
         )
     else:

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -214,6 +214,33 @@ def evolution_send_whatsapp_audio(
     return False, f"HTTP {code}", None
 
 
+def evolution_send_sticker(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    number_digits: str,
+    *,
+    sticker_base64: str,
+    quoted: dict[str, Any] | None = None,
+) -> tuple[bool, str | None, str | None]:
+    """POST /message/sendSticker/{instance} — figurinha (WebP/PNG em base64)."""
+    base = base_url.rstrip("/")
+    url = f"{base}/message/sendSticker/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body: dict[str, Any] = {
+        "number": number_digits,
+        "sticker": sticker_base64,
+    }
+    if quoted:
+        body["quoted"] = quoted
+    code, data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=120)
+    if code in (200, 201):
+        return True, None, _extract_wa_message_id(data)
+    if err:
+        return False, err[:1200], None
+    return False, f"HTTP {code}", None
+
+
 def evolution_send_media(
     base_url: str,
     instance: str,

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -705,3 +705,42 @@ def test_enviar_audio_falha_sem_wa_message_id(client, seed_base, auth_headers, m
     rows = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
     assert all(m.get("tipo_midia") != "audio" or m.get("direcao") != "outbound" for m in rows)
 
+
+def test_enviar_figurinha_usa_sendSticker(client, seed_base, auth_headers, monkeypatch):
+    calls: list[str] = []
+
+    def fake_sticker(*_a, **_k):
+        calls.append("sticker")
+        return True, None, "wa-sticker-1"
+
+    def fake_media(*_a, **_k):
+        calls.append("media")
+        return True, None, "wa-media-1"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_sticker", fake_sticker)
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_media", fake_media)
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "stk-out",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999667788", msg_id="stk-out-1")
+
+    webp_bytes = b"RIFF" + b"\x00" * 64
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens/midia",
+        data={"mediatipo": "figurinha", "caption": ""},
+        files={"file": ("fig.webp", webp_bytes, "image/webp")},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 201
+    body = r.json()
+    assert body["tipo_midia"] == "figurinha"
+    assert body["wa_message_id"] == "wa-sticker-1"
+    assert calls == ["sticker"]

--- a/docs/WHATSAPP_EVOLUTION.md
+++ b/docs/WHATSAPP_EVOLUTION.md
@@ -61,6 +61,7 @@ Campos persistidos em `whatsapp_settings` (via **Configurações → WhatsApp**,
 
 - Endpoint típico Evolution v2: `POST {base}/message/sendText/{instance}` com JSON `{ "number": "<DDI+DDD+número>", "text": "..." }` e header `apikey`.
 - **Áudio outbound (#441):** notas de voz usam `POST {base}/message/sendWhatsAppAudio/{instance}` com `{ "number", "audio": "<base64>", "encoding": true }` — a Evolution converte para Ogg Opus compatível com WhatsApp (não usar `sendMedia` com `audio/webm` do browser).
+- **Figurinha outbound (#443):** `POST {base}/message/sendSticker/{instance}` com `{ "number", "sticker": "<base64>" }` (WebP/PNG).
 - O número do cliente é normalizado a dígitos (ex.: `5511999999999`).
 
 ## Ciclo de vida do chat

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1022,6 +1022,19 @@ export const whatsappChats = {
     }),
   porTicket: (ticketId: number) => api<WhatsappChats.Chat[]>(`/whatsapp/chats/por-ticket/${ticketId}`),
   setoresParaTransferencia: () => api<Array<{ id: number; nome: string }>>('/whatsapp/chats/transfer/setores'),
+  enviarFigurinha: (id: number, file: File, quotedWaMessageId?: string | null) => {
+    const formData = new FormData()
+    formData.append('file', file)
+    formData.append('mediatipo', 'figurinha')
+    formData.append('caption', '')
+    if (quotedWaMessageId) {
+      formData.append('quoted_wa_message_id', quotedWaMessageId)
+    }
+    return api<WhatsappChats.Mensagem>(`/whatsapp/chats/${id}/mensagens/midia`, {
+      method: 'POST',
+      body: formData,
+    })
+  },
   enviarMidia: (id: number, file: File, caption?: string, quotedWaMessageId?: string | null) => {
     const formData = new FormData()
     formData.append('file', file)

--- a/frontend/src/hooks/useWhatsappListScrollRestore.ts
+++ b/frontend/src/hooks/useWhatsappListScrollRestore.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+
+import { consumeWhatsappListScroll, type WhatsappListOrigin } from '../lib/whatsappListReturn'
+
+/** Restaura scroll da listagem ao voltar da conversa (#454). */
+export function useWhatsappListScrollRestore(
+  origin: WhatsappListOrigin,
+  returnPath: string,
+  ready: boolean,
+) {
+  useEffect(() => {
+    if (!ready) return
+    const y = consumeWhatsappListScroll(origin, returnPath)
+    if (y == null) return
+    requestAnimationFrame(() => window.scrollTo({ top: y, left: 0 }))
+  }, [origin, returnPath, ready])
+}

--- a/frontend/src/lib/whatsappEmojis.ts
+++ b/frontend/src/lib/whatsappEmojis.ts
@@ -1,0 +1,7 @@
+/** Subconjunto frequente para o painel do composer (estilo WhatsApp Web). */
+export const WHATSAPP_EMOJIS = [
+  '😀', '😃', '😄', '😁', '😅', '😂', '🤣', '😊', '🙂', '😉',
+  '😍', '🥰', '😘', '😋', '🤔', '😐', '😴', '😢', '😭', '😡',
+  '👍', '👎', '👏', '🙏', '🤝', '💪', '✅', '❌', '❤️', '🔥',
+  '🎉', '⭐', '💯', '💬', '📎', '📷', '🎵', '📄', '⏰', '✨',
+] as const

--- a/frontend/src/lib/whatsappListReturn.ts
+++ b/frontend/src/lib/whatsappListReturn.ts
@@ -10,6 +10,33 @@ export type WhatsappListReturnState = {
   whatsappListReturn?: string
 }
 
+const SCROLL_KEY_PREFIX = 'wpp-list-scroll:'
+
+export function whatsappListScrollKey(origin: WhatsappListOrigin, returnPath: string): string {
+  return `${SCROLL_KEY_PREFIX}${origin}:${returnPath}`
+}
+
+export function saveWhatsappListScroll(origin: WhatsappListOrigin, returnPath: string): void {
+  try {
+    sessionStorage.setItem(whatsappListScrollKey(origin, returnPath), String(window.scrollY))
+  } catch {
+    /* quota / modo privado */
+  }
+}
+
+export function consumeWhatsappListScroll(origin: WhatsappListOrigin, returnPath: string): number | null {
+  try {
+    const key = whatsappListScrollKey(origin, returnPath)
+    const raw = sessionStorage.getItem(key)
+    sessionStorage.removeItem(key)
+    if (!raw) return null
+    const y = Number(raw)
+    return Number.isFinite(y) && y >= 0 ? y : null
+  } catch {
+    return null
+  }
+}
+
 export function whatsappConversaState(returnPath: string): WhatsappListReturnState {
   return { whatsappListReturn: returnPath }
 }

--- a/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
@@ -9,7 +9,8 @@ import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { rotuloAvaliacaoChat } from '../../lib/whatsappChatMeta'
-import { buildAvaliacoesReturnPath, whatsappConversaLink } from '../../lib/whatsappListReturn'
+import { buildAvaliacoesReturnPath, saveWhatsappListScroll, whatsappConversaLink } from '../../lib/whatsappListReturn'
+import { useWhatsappListScrollRestore } from '../../hooks/useWhatsappListScrollRestore'
 import { CheckboxField } from '../../components/ui/CheckboxField'
 
 const PAGE_SIZE = 15
@@ -98,6 +99,8 @@ export function WhatsappAvaliacoes() {
     },
     [atendenteId, ate, busca, desde, incluirSemResposta, notaMin, syncUrl, toast],
   )
+
+  useWhatsappListScrollRestore('avaliacoes', avaliacoesReturnPath, !loading)
 
   useEffect(() => {
     void load(0)
@@ -195,6 +198,7 @@ export function WhatsappAvaliacoes() {
                   </p>
                   <Link
                     to={whatsappConversaLink(a.chat_id, avaliacoesReturnPath, 'avaliacoes')}
+                    onClick={() => saveWhatsappListScroll('avaliacoes', avaliacoesReturnPath)}
                     className="mt-1 inline-block text-xs font-medium text-cyan-600 hover:underline dark:text-cyan-400"
                   >
                     Ver conversa

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -3,6 +3,7 @@ import { Button } from '../../components/ui/Button'
 import { KbConsultaButton } from '../../components/KbConsultaModal'
 import type { TipoAnexoPicker } from './WhatsappBarraAnexos'
 import { WhatsappGravadorAudioInline } from './WhatsappGravadorAudioInline'
+import { WhatsappEmojiFigurinhaPanel } from './WhatsappEmojiFigurinhaPanel'
 
 type Props = {
   texto: string
@@ -11,6 +12,8 @@ type Props = {
   onEnviarInterno?: () => void
   onEscolherAnexo: (tipo: TipoAnexoPicker) => void
   onAudioGravado: (file: File) => void
+  onInserirEmoji: (emoji: string) => void
+  onEnviarFigurinha: (file: File) => void
   enviando: boolean
   encerrado: boolean
   podeEnviar: boolean
@@ -35,6 +38,8 @@ export function WhatsappComposerBar({
   onEnviarInterno,
   onEscolherAnexo,
   onAudioGravado,
+  onInserirEmoji,
+  onEnviarFigurinha,
   enviando,
   encerrado,
   podeEnviar,
@@ -43,8 +48,11 @@ export function WhatsappComposerBar({
   onInserirReferenciaKb,
 }: Props) {
   const [menuAberto, setMenuAberto] = useState(false)
+  const [painelEmojiAberto, setPainelEmojiAberto] = useState(false)
   const [gravando, setGravando] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
+  const emojiRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
     if (!menuAberto) return
@@ -61,6 +69,23 @@ export function WhatsappComposerBar({
   function enviar() {
     if (modoInterno && onEnviarInterno) onEnviarInterno()
     else onEnviar()
+  }
+
+  function inserirEmojiNoCursor(emoji: string) {
+    const el = textareaRef.current
+    if (!el) {
+      onInserirEmoji(emoji)
+      return
+    }
+    const start = el.selectionStart ?? texto.length
+    const end = el.selectionEnd ?? texto.length
+    const next = `${texto.slice(0, start)}${emoji}${texto.slice(end)}`
+    onTextoChange(next)
+    requestAnimationFrame(() => {
+      el.focus()
+      const pos = start + emoji.length
+      el.setSelectionRange(pos, pos)
+    })
   }
 
   return (
@@ -107,21 +132,34 @@ export function WhatsappComposerBar({
           )}
         </div>
 
-        <button
-          type="button"
-          disabled
-          title="Figurinhas — em breve"
-          aria-label="Figurinhas (em breve)"
-          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-lg opacity-40"
-        >
-          😊
-        </button>
+        <div className="relative shrink-0" ref={emojiRef}>
+          <button
+            type="button"
+            disabled={desabilitado || modoInterno || !podeEnviar}
+            title="Emoji e figurinhas"
+            aria-label="Emoji e figurinhas"
+            aria-expanded={painelEmojiAberto}
+            onClick={() => setPainelEmojiAberto((o) => !o)}
+            className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-lg text-slate-600 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-40 dark:text-slate-300 dark:hover:bg-slate-800"
+          >
+            😊
+          </button>
+          {painelEmojiAberto && (
+            <WhatsappEmojiFigurinhaPanel
+              disabled={desabilitado || modoInterno || !podeEnviar}
+              onInserirEmoji={inserirEmojiNoCursor}
+              onEnviarFigurinha={onEnviarFigurinha}
+              onFechar={() => setPainelEmojiAberto(false)}
+            />
+          )}
+        </div>
 
         {onInserirReferenciaKb && (
           <KbConsultaButton disabled={encerrado} onInserirReferencia={podeDigitar ? onInserirReferenciaKb : undefined} />
         )}
 
         <textarea
+          ref={textareaRef}
           value={texto}
           onChange={(e) => onTextoChange(e.target.value)}
           placeholder={

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -637,6 +637,21 @@ useEffect(() => {
     }
   }
 
+  async function enviarFigurinha(file: File) {
+    if (!chat || !podeEnviar) return
+    setEnviando(true)
+    try {
+      await whatsappChats.enviarFigurinha(chat.id, file, msgRespondida?.wa_message_id || null)
+      setMsgRespondida(null)
+      toast.showSuccess('Figurinha enviada!')
+      await carregar()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao enviar figurinha'))
+    } finally {
+      setEnviando(false)
+    }
+  }
+
 
 
   async function handleEncerrado(atualizado: WhatsappChats.Chat) {
@@ -1197,6 +1212,8 @@ useEffect(() => {
             podeDigitar={podeDigitarMensagem}
             onEscolherAnexo={abrirPickerAnexo}
             onAudioGravado={handleGravacaoConcluida}
+            onInserirEmoji={setTexto}
+            onEnviarFigurinha={(file) => void enviarFigurinha(file)}
             onInserirReferenciaKb={inserirReferenciaKb}
           />
 

--- a/frontend/src/pages/whatsapp/WhatsappEmojiFigurinhaPanel.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappEmojiFigurinhaPanel.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from 'react'
+
+import { WHATSAPP_EMOJIS } from '../../lib/whatsappEmojis'
+
+type Tab = 'emoji' | 'figurinha'
+
+type Props = {
+  disabled: boolean
+  onInserirEmoji: (emoji: string) => void
+  onEnviarFigurinha: (file: File) => void
+  onFechar: () => void
+}
+
+export function WhatsappEmojiFigurinhaPanel({ disabled, onInserirEmoji, onEnviarFigurinha, onFechar }: Props) {
+  const [tab, setTab] = useState<Tab>('emoji')
+  const panelRef = useRef<HTMLDivElement>(null)
+  const fileRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) onFechar()
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [onFechar])
+
+  return (
+    <div
+      ref={panelRef}
+      className="absolute bottom-full left-0 z-30 mb-2 w-[min(20rem,calc(100vw-2rem))] rounded-xl border border-slate-200 bg-white shadow-lg dark:border-slate-700 dark:bg-slate-900"
+    >
+      <div className="flex border-b border-slate-100 dark:border-slate-800">
+        {(['emoji', 'figurinha'] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            disabled={disabled}
+            onClick={() => setTab(t)}
+            className={`flex-1 px-3 py-2 text-xs font-semibold ${
+              tab === t
+                ? 'border-b-2 border-cyan-600 text-cyan-700 dark:text-cyan-400'
+                : 'text-slate-500 hover:text-slate-700 dark:text-slate-400'
+            }`}
+          >
+            {t === 'emoji' ? 'Emoji' : 'Figurinha'}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'emoji' ? (
+        <div className="grid max-h-48 grid-cols-8 gap-0.5 overflow-y-auto p-2">
+          {WHATSAPP_EMOJIS.map((e) => (
+            <button
+              key={e}
+              type="button"
+              disabled={disabled}
+              className="flex h-9 w-9 items-center justify-center rounded-lg text-xl hover:bg-slate-100 disabled:opacity-40 dark:hover:bg-slate-800"
+              onClick={() => {
+                onInserirEmoji(e)
+                onFechar()
+              }}
+            >
+              {e}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="space-y-2 p-3">
+          <p className="text-xs text-slate-500 dark:text-slate-400">
+            Envie um ficheiro WebP ou PNG (tamanho típico de figurinha WhatsApp).
+          </p>
+          <button
+            type="button"
+            disabled={disabled}
+            className="w-full rounded-lg border border-dashed border-slate-300 px-3 py-4 text-sm font-medium text-slate-700 hover:border-cyan-400 hover:bg-cyan-50 disabled:opacity-40 dark:border-slate-600 dark:text-slate-200 dark:hover:bg-cyan-950/30"
+            onClick={() => fileRef.current?.click()}
+          >
+            Escolher figurinha…
+          </button>
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/webp,image/png,.webp,.png"
+            className="hidden"
+            onChange={(ev) => {
+              const file = ev.target.files?.[0]
+              if (file) {
+                onEnviarFigurinha(file)
+                onFechar()
+              }
+              ev.target.value = ''
+            }}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -10,7 +10,8 @@ import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { AvaliacaoEstrelas } from '../../components/ui/AvaliacaoEstrelas'
 import { rotuloEstadoChat } from '../../lib/whatsappChatMeta'
-import { buildHistoricoReturnPath, whatsappConversaLink } from '../../lib/whatsappListReturn'
+import { buildHistoricoReturnPath, saveWhatsappListScroll, whatsappConversaLink } from '../../lib/whatsappListReturn'
+import { useWhatsappListScrollRestore } from '../../hooks/useWhatsappListScrollRestore'
 
 const PAGE_SIZE = 15
 
@@ -94,6 +95,8 @@ export function WhatsappHistorico() {
       setLoading(false)
     }
   }, [atendenteId, ate, busca, desde, estadoFiltro, syncUrl, toast])
+
+  useWhatsappListScrollRestore('historico', historicoReturnPath, !loading)
 
   useEffect(() => {
     void load(0)
@@ -264,6 +267,7 @@ export function WhatsappHistorico() {
 
                     <Link
                       to={whatsappConversaLink(c.id, historicoReturnPath, 'historico')}
+                      onClick={() => saveWhatsappListScroll('historico', historicoReturnPath)}
                       className="rounded-full bg-slate-100 p-2 text-slate-400 transition-all hover:bg-cyan-600 hover:text-white dark:bg-slate-800 dark:hover:bg-cyan-700"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>


### PR DESCRIPTION
## Summary

- Painel de emoji e envio de figurinhas no composer (Evolution sendSticker)
- Historico e Avaliacoes preservam posicao de scroll ao voltar da conversa
- Teste backend para envio de figurinha

## Test plan

- [ ] Abrir conversa, clicar no botao de emoji, inserir emoji no texto e enviar
- [ ] Aba Figurinha: enviar WebP/PNG e confirmar entrega no WhatsApp
- [ ] Em Historico/Avaliacoes, rolar lista, abrir chat, voltar — posicao de scroll restaurada
- [ ] pytest tests/test_whatsapp_chats.py::test_enviar_figurinha_usa_sendSticker
- [ ] npx tsc -b no frontend
