### PR TITLE
feat(kb): base de conhecimento — sugestoes, portal publico e personalizacao

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 - Identidade visual (#434): painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel
 - Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp
+- Base de conhecimento (#465/#466): portal público `/kb` com logo e nome da empresa (Configurações → Empresa); listagem, busca e leitura de artigos sem login
+- Base de conhecimento (#467): personalização do portal em Configurações → Sistema → Base de conhecimento (cores da navbar, textos, links); menu lateral de categorias/subcategorias expansível no /kb; navbar com título centralizado, logo sem fundo branco e menu hamburger
 - Base de conhecimento (#293–#299): menu **Ajuda** para consultar manuais durante o atendimento; gestão de categorias e artigos (admin); consulta integrada em tickets e WhatsApp; manuais «só para a equipe»; imagens no texto; histórico de versões; reordenar categorias arrastando; manuais consultados ficam disponíveis offline neste computador
 - Auditoria (#290–#292): trail expandido com payload, IP, request-id e user-agent; registro de atribuição, transferência, fechamento e reabertura de tickets, ações em chats WhatsApp, envio de e-mail ao cliente, visualização de credencial PDV e exportação de relatórios
 - Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 ### Melhorias
 
 - Identidade visual (#434): painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel
+- Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp
 - Base de conhecimento (#293–#299): menu **Ajuda** para consultar manuais durante o atendimento; gestão de categorias e artigos (admin); consulta integrada em tickets e WhatsApp; manuais «só para a equipe»; imagens no texto; histórico de versões; reordenar categorias arrastando; manuais consultados ficam disponíveis offline neste computador
 - Auditoria (#290–#292): trail expandido com payload, IP, request-id e user-agent; registro de atribuição, transferência, fechamento e reabertura de tickets, ações em chats WhatsApp, envio de e-mail ao cliente, visualização de credencial PDV e exportação de relatórios
 - Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id

--- a/backend/alembic/versions/056_kb_article_motivo_links.py
+++ b/backend/alembic/versions/056_kb_article_motivo_links.py
@@ -1,0 +1,50 @@
+"""KB: vínculos artigo ↔ natureza/motivo (#296).
+
+Revision ID: 056_kb_motivo_links
+Revises: 055_func_rede_email_null
+Create Date: 2026-06-29
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "056_kb_motivo_links"
+down_revision = "055_func_rede_email_null"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "kb_article_motivo_links",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sa.Integer(), nullable=False),
+        sa.Column("article_id", sa.Integer(), nullable=False),
+        sa.Column("motivo_id", sa.Integer(), nullable=True),
+        sa.Column("natureza_id", sa.Integer(), nullable=True),
+        sa.Column("ordem", sa.SmallInteger(), server_default=sa.text("0"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.CheckConstraint(
+            "(motivo_id IS NOT NULL) OR (natureza_id IS NOT NULL)",
+            name="ck_kb_article_motivo_links_target",
+        ),
+        sa.ForeignKeyConstraint(["article_id"], ["kb_articles.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["motivo_id"], ["ticket_motivos.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["natureza_id"], ["ticket_naturezas.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("article_id", "motivo_id", name="uq_kb_article_motivo_links_article_motivo"),
+        sa.UniqueConstraint(
+            "article_id",
+            "natureza_id",
+            name="uq_kb_article_motivo_links_article_natureza",
+        ),
+    )
+    op.create_index("ix_kb_article_motivo_links_tenant_id", "kb_article_motivo_links", ["tenant_id"])
+    op.create_index("ix_kb_article_motivo_links_article_id", "kb_article_motivo_links", ["article_id"])
+    op.create_index("ix_kb_article_motivo_links_motivo_id", "kb_article_motivo_links", ["motivo_id"])
+    op.create_index("ix_kb_article_motivo_links_natureza_id", "kb_article_motivo_links", ["natureza_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("kb_article_motivo_links")

--- a/backend/alembic/versions/057_kb_portal_settings.py
+++ b/backend/alembic/versions/057_kb_portal_settings.py
@@ -1,0 +1,41 @@
+"""KB: personalização do portal público (#467).
+
+Revision ID: 057_kb_portal_settings
+Revises: 056_kb_motivo_links
+Create Date: 2026-06-29
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "057_kb_portal_settings"
+down_revision = "056_kb_motivo_links"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "kb_portal_settings",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sa.Integer(), nullable=False),
+        sa.Column("portal_titulo", sa.String(length=120), nullable=True),
+        sa.Column("texto_boas_vindas", sa.String(length=500), nullable=True),
+        sa.Column("cor_header", sa.String(length=7), server_default="#0B2D4A", nullable=False),
+        sa.Column("cor_primaria", sa.String(length=7), server_default="#0D9488", nullable=False),
+        sa.Column("cor_texto_header", sa.String(length=7), server_default="#FFFFFF", nullable=False),
+        sa.Column("cor_texto_corpo", sa.String(length=7), server_default="#0F172A", nullable=False),
+        sa.Column("cor_fundo", sa.String(length=7), server_default="#F8FAFC", nullable=False),
+        sa.Column("cor_link", sa.String(length=7), nullable=True),
+        sa.Column("exibir_marca_deskrudder", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("tenant_id", name="uq_kb_portal_settings_tenant_id"),
+    )
+    op.create_index("ix_kb_portal_settings_tenant_id", "kb_portal_settings", ["tenant_id"])
+
+
+def downgrade() -> None:
+    op.drop_table("kb_portal_settings")

--- a/backend/app/api/kb.py
+++ b/backend/app/api/kb.py
@@ -13,7 +13,8 @@ from app.core.tenant_context import TenantIdDep
 from app.core.ordenacao_lista import OrdemLista, expr_ordem
 from app.database import get_db
 from app.models.atendente import Atendente
-from app.models.kb import KbArticle, KbArticleMotivoLink, KbArticleStatus, KbArticleVersion, KbCategory
+from app.models.empresa_sistema import EmpresaSistema
+from app.models.kb import KbArticle, KbArticleMotivoLink, KbArticleStatus, KbArticleVersion, KbCategory, KbPortalSettings
 from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
 from app.schemas.kb import (
     KbArticleBrief,
@@ -29,9 +30,13 @@ from app.schemas.kb import (
     KbCategoryReorder,
     KbCategoryUpdate,
     KbImageUploadResponse,
+    KbPortalSettingsRead,
+    KbPortalSettingsUpdate,
+    KbPublicBrandingRead,
 )
 from app.schemas.lista_paginada import ListaPaginada
 from app.services.kb import listar_artigos_sugeridos, registrar_versao_artigo, slug_disponivel
+from app.services.system_logo_storage import caminho_absoluto_logo
 from app.services.kb_media_storage import caminho_absoluto_imagem, gravar_imagem_bytes
 
 router = APIRouter(prefix="/kb", tags=["kb"])
@@ -740,6 +745,149 @@ def servir_imagem_kb(
 
 def _public_cache_headers(response: Response) -> None:
     response.headers["Cache-Control"] = "public, max-age=60"
+
+
+def _empresa_sistema_row(db: Session) -> EmpresaSistema | None:
+    return db.query(EmpresaSistema).order_by(EmpresaSistema.id.asc()).first()
+
+
+def _portal_settings_row(db: Session, tenant_id: int) -> KbPortalSettings | None:
+    return db.query(KbPortalSettings).filter(KbPortalSettings.tenant_id == tenant_id).first()
+
+
+def _get_or_create_portal_settings(db: Session, tenant_id: int) -> KbPortalSettings:
+    row = _portal_settings_row(db, tenant_id)
+    if row:
+        return row
+    row = KbPortalSettings(tenant_id=tenant_id)
+    db.add(row)
+    db.flush()
+    return row
+
+
+def _portal_settings_read(row: KbPortalSettings) -> KbPortalSettingsRead:
+    return KbPortalSettingsRead(
+        portal_titulo=row.portal_titulo,
+        texto_boas_vindas=row.texto_boas_vindas,
+        cor_header=row.cor_header or "#0B2D4A",
+        cor_primaria=row.cor_primaria or "#0D9488",
+        cor_texto_header=row.cor_texto_header or "#FFFFFF",
+        cor_texto_corpo=row.cor_texto_corpo or "#0F172A",
+        cor_fundo=row.cor_fundo or "#F8FAFC",
+        cor_link=row.cor_link,
+        exibir_marca_deskrudder=bool(row.exibir_marca_deskrudder),
+        public_url_preview="/kb",
+    )
+
+
+def _nome_exibicao_empresa(row: EmpresaSistema | None) -> str:
+    if not row:
+        return "Central de ajuda"
+    for attr in ("nome_fantasia", "nome", "razao_social"):
+        val = getattr(row, attr, None)
+        if val and str(val).strip():
+            return str(val).strip()
+    return "Central de ajuda"
+
+
+def _kb_public_branding(db: Session, tenant_id: int) -> KbPublicBrandingRead:
+    row = _empresa_sistema_row(db)
+    settings = _portal_settings_row(db, tenant_id)
+    logo_url = None
+    if row and row.logo_filename and str(row.logo_filename).strip():
+        logo_url = "/v1/kb/public/logo"
+    nome = _nome_exibicao_empresa(row)
+    titulo_custom = (settings.portal_titulo or "").strip() if settings else ""
+    if titulo_custom:
+        portal_titulo = titulo_custom
+    elif nome != "Central de ajuda":
+        portal_titulo = f"Central de ajuda — {nome}"
+    else:
+        portal_titulo = "Central de ajuda"
+    cor_primaria = (settings.cor_primaria if settings else None) or "#0D9488"
+    cor_link = (settings.cor_link if settings and settings.cor_link else None) or cor_primaria
+    return KbPublicBrandingRead(
+        nome_exibicao=nome,
+        portal_titulo=portal_titulo,
+        logo_url=logo_url,
+        texto_boas_vindas=settings.texto_boas_vindas if settings else None,
+        cor_primaria=cor_primaria,
+        cor_header=(settings.cor_header if settings else None) or "#0B2D4A",
+        cor_texto_header=(settings.cor_texto_header if settings else None) or "#FFFFFF",
+        cor_texto_corpo=(settings.cor_texto_corpo if settings else None) or "#0F172A",
+        cor_fundo=(settings.cor_fundo if settings else None) or "#F8FAFC",
+        cor_link=cor_link,
+        exibir_marca_deskrudder=bool(settings.exibir_marca_deskrudder) if settings else True,
+    )
+
+
+@router.get("/portal-settings", response_model=KbPortalSettingsRead)
+def obter_portal_settings(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = _get_or_create_portal_settings(db, atendente.tenant_id)
+    db.commit()
+    return _portal_settings_read(row)
+
+
+@router.put("/portal-settings", response_model=KbPortalSettingsRead)
+def atualizar_portal_settings(
+    data: KbPortalSettingsUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = _get_or_create_portal_settings(db, atendente.tenant_id)
+    update = data.model_dump(exclude_unset=True)
+    if "portal_titulo" in update and update["portal_titulo"] is not None:
+        update["portal_titulo"] = update["portal_titulo"].strip() or None
+    if "texto_boas_vindas" in update and update["texto_boas_vindas"] is not None:
+        update["texto_boas_vindas"] = update["texto_boas_vindas"].strip() or None
+    for key, val in update.items():
+        setattr(row, key, val)
+    registrar_audit(db, "kb_portal_settings", row.id, "update", atendente.id, payload=update)
+    db.commit()
+    db.refresh(row)
+    return _portal_settings_read(row)
+
+
+@router.get("/public/branding", response_model=KbPublicBrandingRead)
+def branding_kb_publico(
+    request: Request,
+    response: Response,
+    tenant_id: TenantIdDep,
+    db: Session = Depends(get_db),
+):
+    check_kb_public_rate_limit(request)
+    _ = tenant_id
+    out = _kb_public_branding(db, tenant_id)
+    _public_cache_headers(response)
+    return out
+
+
+@router.get("/public/logo")
+def logo_kb_publico(
+    request: Request,
+    response: Response,
+    tenant_id: TenantIdDep,
+    db: Session = Depends(get_db),
+):
+    check_kb_public_rate_limit(request)
+    _ = tenant_id
+    row = _empresa_sistema_row(db)
+    if not row or not row.logo_filename:
+        raise HTTPException(status_code=404, detail="Logo não definido.")
+    p = caminho_absoluto_logo(row.logo_filename)
+    if not p:
+        raise HTTPException(status_code=404, detail="Logo não encontrado.")
+    mt = (row.logo_mimetype or "").strip() or "application/octet-stream"
+    _public_cache_headers(response)
+    return FileResponse(
+        path=str(p),
+        media_type=mt,
+        filename=p.name,
+        headers={"Cache-Control": "public, max-age=300"},
+    )
 
 
 @router.get("/public/categories", response_model=list[KbCategoryRead])

--- a/backend/app/api/kb.py
+++ b/backend/app/api/kb.py
@@ -13,7 +13,8 @@ from app.core.tenant_context import TenantIdDep
 from app.core.ordenacao_lista import OrdemLista, expr_ordem
 from app.database import get_db
 from app.models.atendente import Atendente
-from app.models.kb import KbArticle, KbArticleStatus, KbArticleVersion, KbCategory
+from app.models.kb import KbArticle, KbArticleMotivoLink, KbArticleStatus, KbArticleVersion, KbCategory
+from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
 from app.schemas.kb import (
     KbArticleBrief,
     KbArticleCreate,
@@ -21,6 +22,8 @@ from app.schemas.kb import (
     KbArticleUpdate,
     KbArticleVersionDetail,
     KbArticleVersionRead,
+    KbArticleMotivoLinkItem,
+    KbArticleMotivoLinksUpdate,
     KbCategoryCreate,
     KbCategoryRead,
     KbCategoryReorder,
@@ -28,7 +31,7 @@ from app.schemas.kb import (
     KbImageUploadResponse,
 )
 from app.schemas.lista_paginada import ListaPaginada
-from app.services.kb import registrar_versao_artigo, slug_disponivel
+from app.services.kb import listar_artigos_sugeridos, registrar_versao_artigo, slug_disponivel
 from app.services.kb_media_storage import caminho_absoluto_imagem, gravar_imagem_bytes
 
 router = APIRouter(prefix="/kb", tags=["kb"])
@@ -192,6 +195,33 @@ def _get_article_or_404(db: Session, tenant_id: int, article_id: int) -> KbArtic
     if not row:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artigo não encontrado")
     return row
+
+
+def _motivo_link_read(link: KbArticleMotivoLink) -> KbArticleMotivoLinkItem:
+    return KbArticleMotivoLinkItem(
+        id=link.id,
+        motivo_id=link.motivo_id,
+        natureza_id=link.natureza_id,
+        ordem=int(link.ordem or 0),
+        motivo_nome=link.motivo.nome if link.motivo else None,
+        natureza_nome=link.natureza.nome if link.natureza else None,
+    )
+
+
+def _assert_motivo_link_item_valido(db: Session, item: KbArticleMotivoLinkItem) -> tuple[int | None, int | None]:
+    if item.motivo_id is not None and item.natureza_id is not None:
+        raise HTTPException(status_code=400, detail="Informe motivo ou natureza, não ambos no mesmo vínculo.")
+    if item.motivo_id is None and item.natureza_id is None:
+        raise HTTPException(status_code=400, detail="Cada vínculo precisa de motivo ou natureza.")
+    if item.motivo_id is not None:
+        mot = db.query(TicketMotivo).filter(TicketMotivo.id == item.motivo_id, TicketMotivo.ativo.is_(True)).first()
+        if not mot:
+            raise HTTPException(status_code=400, detail=f"Motivo {item.motivo_id} não encontrado.")
+        return item.motivo_id, None
+    nat = db.query(TicketNatureza).filter(TicketNatureza.id == item.natureza_id, TicketNatureza.ativo.is_(True)).first()
+    if not nat:
+        raise HTTPException(status_code=400, detail=f"Natureza {item.natureza_id} não encontrada.")
+    return None, item.natureza_id
 
 
 # --- Categorias (admin) ---
@@ -405,6 +435,104 @@ def consultar_artigos_publicados(
         q = q.filter(or_(KbArticle.titulo.ilike(term), KbArticle.conteudo_markdown.ilike(term)))
     rows = q.order_by(KbArticle.titulo.asc(), KbArticle.id.asc()).limit(limit).all()
     return [_article_brief(r) for r in rows]
+
+
+@router.get("/suggestions", response_model=list[KbArticleBrief])
+def sugestoes_artigos(
+    motivo_id: int | None = Query(None, ge=1),
+    natureza_id: int | None = Query(None, ge=1),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    if motivo_id is None and natureza_id is None:
+        raise HTTPException(status_code=400, detail="Informe motivo_id ou natureza_id.")
+    arts = listar_artigos_sugeridos(
+        db,
+        atendente.tenant_id,
+        motivo_id=motivo_id,
+        natureza_id=natureza_id,
+        incluir_interno_only=True,
+    )
+    return [_article_brief(a) for a in arts]
+
+
+@router.get("/articles/{article_id}/motivo-links", response_model=list[KbArticleMotivoLinkItem])
+def listar_vinculos_motivo_artigo(
+    article_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    _get_article_or_404(db, atendente.tenant_id, article_id)
+    rows = (
+        db.query(KbArticleMotivoLink)
+        .options(joinedload(KbArticleMotivoLink.motivo), joinedload(KbArticleMotivoLink.natureza))
+        .filter(
+            KbArticleMotivoLink.tenant_id == atendente.tenant_id,
+            KbArticleMotivoLink.article_id == article_id,
+        )
+        .order_by(KbArticleMotivoLink.ordem.asc(), KbArticleMotivoLink.id.asc())
+        .all()
+    )
+    return [_motivo_link_read(r) for r in rows]
+
+
+@router.put("/articles/{article_id}/motivo-links", response_model=list[KbArticleMotivoLinkItem])
+def atualizar_vinculos_motivo_artigo(
+    article_id: int,
+    data: KbArticleMotivoLinksUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    _get_article_or_404(db, atendente.tenant_id, article_id)
+    vistos_motivo: set[int] = set()
+    vistos_natureza: set[int] = set()
+    novos: list[KbArticleMotivoLink] = []
+    for idx, item in enumerate(data.links):
+        motivo_id, nat_id = _assert_motivo_link_item_valido(db, item)
+        if motivo_id is not None:
+            if motivo_id in vistos_motivo:
+                raise HTTPException(status_code=400, detail="Motivo duplicado na lista de vínculos.")
+            vistos_motivo.add(motivo_id)
+        else:
+            assert nat_id is not None
+            if nat_id in vistos_natureza:
+                raise HTTPException(status_code=400, detail="Natureza duplicada na lista de vínculos.")
+            vistos_natureza.add(nat_id)
+        novos.append(
+            KbArticleMotivoLink(
+                tenant_id=atendente.tenant_id,
+                article_id=article_id,
+                motivo_id=motivo_id,
+                natureza_id=nat_id,
+                ordem=item.ordem if item.ordem is not None else idx,
+            )
+        )
+    db.query(KbArticleMotivoLink).filter(
+        KbArticleMotivoLink.tenant_id == atendente.tenant_id,
+        KbArticleMotivoLink.article_id == article_id,
+    ).delete(synchronize_session=False)
+    for row in novos:
+        db.add(row)
+    registrar_audit(
+        db,
+        "kb_article",
+        article_id,
+        "motivo_links_update",
+        atendente.id,
+        payload={"count": len(novos)},
+    )
+    db.commit()
+    rows = (
+        db.query(KbArticleMotivoLink)
+        .options(joinedload(KbArticleMotivoLink.motivo), joinedload(KbArticleMotivoLink.natureza))
+        .filter(
+            KbArticleMotivoLink.tenant_id == atendente.tenant_id,
+            KbArticleMotivoLink.article_id == article_id,
+        )
+        .order_by(KbArticleMotivoLink.ordem.asc(), KbArticleMotivoLink.id.asc())
+        .all()
+    )
+    return [_motivo_link_read(r) for r in rows]
 
 
 @router.get("/articles/publicados/{article_id}", response_model=KbArticleRead)
@@ -668,6 +796,29 @@ def listar_artigos_publicos(
     rows = q.order_by(KbArticle.titulo.asc(), KbArticle.id.asc()).limit(limit).all()
     _public_cache_headers(response)
     return [_article_brief(r) for r in rows]
+
+
+@router.get("/public/suggestions", response_model=list[KbArticleBrief])
+def sugestoes_artigos_publicas(
+    request: Request,
+    response: Response,
+    tenant_id: TenantIdDep,
+    motivo_id: int | None = Query(None, ge=1),
+    natureza_id: int | None = Query(None, ge=1),
+    db: Session = Depends(get_db),
+):
+    check_kb_public_rate_limit(request)
+    if motivo_id is None and natureza_id is None:
+        raise HTTPException(status_code=400, detail="Informe motivo_id ou natureza_id.")
+    arts = listar_artigos_sugeridos(
+        db,
+        tenant_id,
+        motivo_id=motivo_id,
+        natureza_id=natureza_id,
+        incluir_interno_only=False,
+    )
+    _public_cache_headers(response)
+    return [_article_brief(a) for a in arts]
 
 
 @router.get("/public/articles/{slug}", response_model=KbArticleRead)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -34,7 +34,7 @@ from app.models.business_calendar import BusinessCalendar
 from app.models.sla_policy import SlaPolicy
 from app.models.sla_alerta_emitido import SlaAlertaEmitido
 from app.models.empresa_pdv import EmpresaPdv, PdvRotulo, PdvTipoAcessoRemoto
-from app.models.kb import KbArticle, KbArticleMotivoLink, KbArticleVersion, KbCategory
+from app.models.kb import KbArticle, KbArticleMotivoLink, KbArticleVersion, KbCategory, KbPortalSettings
 
 __all__ = [
     "Rede",
@@ -89,4 +89,5 @@ __all__ = [
     "KbArticle",
     "KbArticleMotivoLink",
     "KbArticleVersion",
+    "KbPortalSettings",
 ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -34,7 +34,7 @@ from app.models.business_calendar import BusinessCalendar
 from app.models.sla_policy import SlaPolicy
 from app.models.sla_alerta_emitido import SlaAlertaEmitido
 from app.models.empresa_pdv import EmpresaPdv, PdvRotulo, PdvTipoAcessoRemoto
-from app.models.kb import KbArticle, KbArticleVersion, KbCategory
+from app.models.kb import KbArticle, KbArticleMotivoLink, KbArticleVersion, KbCategory
 
 __all__ = [
     "Rede",
@@ -87,5 +87,6 @@ __all__ = [
     "EmpresaPdv",
     "KbCategory",
     "KbArticle",
+    "KbArticleMotivoLink",
     "KbArticleVersion",
 ]

--- a/backend/app/models/kb.py
+++ b/backend/app/models/kb.py
@@ -110,3 +110,24 @@ class KbArticleMotivoLink(Base):
     article = relationship("KbArticle", back_populates="motivo_links")
     motivo = relationship("TicketMotivo")
     natureza = relationship("TicketNatureza")
+
+
+class KbPortalSettings(Base):
+    """Personalização visual do portal público /kb (#467)."""
+
+    __tablename__ = "kb_portal_settings"
+    __table_args__ = (UniqueConstraint("tenant_id", name="uq_kb_portal_settings_tenant_id"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    portal_titulo = Column(String(120), nullable=True)
+    texto_boas_vindas = Column(String(500), nullable=True)
+    cor_header = Column(String(7), nullable=False, server_default="#0B2D4A", default="#0B2D4A")
+    cor_primaria = Column(String(7), nullable=False, server_default="#0D9488", default="#0D9488")
+    cor_texto_header = Column(String(7), nullable=False, server_default="#FFFFFF", default="#FFFFFF")
+    cor_texto_corpo = Column(String(7), nullable=False, server_default="#0F172A", default="#0F172A")
+    cor_fundo = Column(String(7), nullable=False, server_default="#F8FAFC", default="#F8FAFC")
+    cor_link = Column(String(7), nullable=True)
+    exibir_marca_deskrudder = Column(Boolean, nullable=False, server_default="true", default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/app/models/kb.py
+++ b/backend/app/models/kb.py
@@ -69,6 +69,12 @@ class KbArticle(Base):
     category = relationship("KbCategory", back_populates="articles")
     autor = relationship("Atendente", foreign_keys=[autor_atendente_id])
     versions = relationship("KbArticleVersion", back_populates="article", order_by="KbArticleVersion.id.desc()")
+    motivo_links = relationship(
+        "KbArticleMotivoLink",
+        back_populates="article",
+        cascade="all, delete-orphan",
+        order_by="KbArticleMotivoLink.ordem",
+    )
 
 
 class KbArticleVersion(Base):
@@ -84,3 +90,23 @@ class KbArticleVersion(Base):
 
     article = relationship("KbArticle", back_populates="versions")
     autor = relationship("Atendente", foreign_keys=[autor_atendente_id])
+
+
+class KbArticleMotivoLink(Base):
+    __tablename__ = "kb_article_motivo_links"
+    __table_args__ = (
+        UniqueConstraint("article_id", "motivo_id", name="uq_kb_article_motivo_links_article_motivo"),
+        UniqueConstraint("article_id", "natureza_id", name="uq_kb_article_motivo_links_article_natureza"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    article_id = Column(Integer, ForeignKey("kb_articles.id", ondelete="CASCADE"), nullable=False, index=True)
+    motivo_id = Column(Integer, ForeignKey("ticket_motivos.id", ondelete="CASCADE"), nullable=True, index=True)
+    natureza_id = Column(Integer, ForeignKey("ticket_naturezas.id", ondelete="CASCADE"), nullable=True, index=True)
+    ordem = Column(SmallInteger, default=0, nullable=False, server_default="0")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    article = relationship("KbArticle", back_populates="motivo_links")
+    motivo = relationship("TicketMotivo")
+    natureza = relationship("TicketNatureza")

--- a/backend/app/schemas/kb.py
+++ b/backend/app/schemas/kb.py
@@ -107,3 +107,21 @@ class KbArticleVersionDetail(KbArticleVersionRead):
 class KbImageUploadResponse(BaseModel):
     url: str
     filename: str
+
+
+class KbArticleMotivoLinkItem(BaseModel):
+    id: int | None = None
+    motivo_id: int | None = Field(None, ge=1)
+    natureza_id: int | None = Field(None, ge=1)
+    ordem: int = Field(0, ge=0, le=32767)
+    motivo_nome: str | None = None
+    natureza_nome: str | None = None
+
+
+class KbArticleMotivoLinksUpdate(BaseModel):
+    links: list[KbArticleMotivoLinkItem] = Field(default_factory=list, max_length=20)
+
+
+class KbSuggestionsQuery(BaseModel):
+    motivo_id: int | None = Field(None, ge=1)
+    natureza_id: int | None = Field(None, ge=1)

--- a/backend/app/schemas/kb.py
+++ b/backend/app/schemas/kb.py
@@ -125,3 +125,45 @@ class KbArticleMotivoLinksUpdate(BaseModel):
 class KbSuggestionsQuery(BaseModel):
     motivo_id: int | None = Field(None, ge=1)
     natureza_id: int | None = Field(None, ge=1)
+
+
+class KbPublicBrandingRead(BaseModel):
+    nome_exibicao: str
+    portal_titulo: str = "Central de ajuda"
+    logo_url: str | None = None
+    texto_boas_vindas: str | None = None
+    cor_primaria: str = "#0D9488"
+    cor_header: str = "#0B2D4A"
+    cor_texto_header: str = "#FFFFFF"
+    cor_texto_corpo: str = "#0F172A"
+    cor_fundo: str = "#F8FAFC"
+    cor_link: str = "#0D9488"
+    exibir_marca_deskrudder: bool = True
+
+
+class KbPortalSettingsRead(BaseModel):
+    portal_titulo: str | None = None
+    texto_boas_vindas: str | None = None
+    cor_header: str = "#0B2D4A"
+    cor_primaria: str = "#0D9488"
+    cor_texto_header: str = "#FFFFFF"
+    cor_texto_corpo: str = "#0F172A"
+    cor_fundo: str = "#F8FAFC"
+    cor_link: str | None = None
+    exibir_marca_deskrudder: bool = True
+    public_url_preview: str | None = None
+
+
+_HEX_COLOR = r"^#[0-9A-Fa-f]{6}$"
+
+
+class KbPortalSettingsUpdate(BaseModel):
+    portal_titulo: str | None = Field(None, max_length=120)
+    texto_boas_vindas: str | None = Field(None, max_length=500)
+    cor_header: str | None = Field(None, pattern=_HEX_COLOR)
+    cor_primaria: str | None = Field(None, pattern=_HEX_COLOR)
+    cor_texto_header: str | None = Field(None, pattern=_HEX_COLOR)
+    cor_texto_corpo: str | None = Field(None, pattern=_HEX_COLOR)
+    cor_fundo: str | None = Field(None, pattern=_HEX_COLOR)
+    cor_link: str | None = Field(None, pattern=_HEX_COLOR)
+    exibir_marca_deskrudder: bool | None = None

--- a/backend/app/services/kb.py
+++ b/backend/app/services/kb.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import re
 import unicodedata
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
-from app.models.kb import KbArticle, KbArticleStatus, KbArticleVersion, KbCategory
+from app.models.kb import KbArticle, KbArticleStatus, KbArticleVersion, KbCategory, KbArticleMotivoLink
 
 
 def slugify(text: str) -> str:
@@ -49,3 +49,70 @@ def registrar_versao_artigo(db: Session, article: KbArticle, atendente_id: int |
             autor_atendente_id=atendente_id,
         )
     )
+
+
+_MAX_SUGESTOES = 5
+
+
+def listar_artigos_sugeridos(
+    db: Session,
+    tenant_id: int,
+    *,
+    motivo_id: int | None = None,
+    natureza_id: int | None = None,
+    incluir_interno_only: bool = True,
+) -> list[KbArticle]:
+    """Artigos publicados vinculados ao motivo e/ou natureza (máx. 5)."""
+    from app.models.ticket_classificacao import TicketMotivo
+
+    if motivo_id is None and natureza_id is None:
+        return []
+
+    natureza_filtro = natureza_id
+    if motivo_id is not None:
+        motivo = (
+            db.query(TicketMotivo)
+            .filter(TicketMotivo.id == motivo_id, TicketMotivo.ativo.is_(True))
+            .first()
+        )
+        if not motivo:
+            return []
+        natureza_filtro = motivo.natureza_id
+
+    link_filters = []
+    if motivo_id is not None:
+        link_filters.append(KbArticleMotivoLink.motivo_id == motivo_id)
+    if natureza_filtro is not None:
+        link_filters.append(
+            (KbArticleMotivoLink.motivo_id.is_(None))
+            & (KbArticleMotivoLink.natureza_id == natureza_filtro)
+        )
+
+    from sqlalchemy import or_
+
+    q = (
+        db.query(KbArticle, KbArticleMotivoLink.ordem)
+        .join(KbArticleMotivoLink, KbArticleMotivoLink.article_id == KbArticle.id)
+        .options(joinedload(KbArticle.category).joinedload(KbCategory.parent))
+        .filter(
+            KbArticle.tenant_id == tenant_id,
+            KbArticleMotivoLink.tenant_id == tenant_id,
+            KbArticle.status == KbArticleStatus.publicado.value,
+            or_(*link_filters),
+        )
+    )
+    if not incluir_interno_only:
+        q = q.filter(KbArticle.interno_only.is_(False))
+
+    rows = q.order_by(KbArticleMotivoLink.ordem.asc(), KbArticle.titulo.asc(), KbArticle.id.asc()).all()
+
+    vistos: set[int] = set()
+    resultado: list[KbArticle] = []
+    for art, _ordem in rows:
+        if art.id in vistos:
+            continue
+        vistos.add(art.id)
+        resultado.append(art)
+        if len(resultado) >= _MAX_SUGESTOES:
+            break
+    return resultado

--- a/backend/tests/test_kb.py
+++ b/backend/tests/test_kb.py
@@ -84,6 +84,62 @@ def test_atendente_403_kb_admin(client, auth_headers):
     assert r.status_code == 403
 
 
+def test_kb_public_branding_com_logo(client, auth_headers, db_session):
+    png = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01"
+        b"\x00\x00\x05\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+    client.post(
+        "/v1/settings/empresa-sistema/logo",
+        headers=auth_headers["admin"],
+        files={"file": ("logo.png", png, "image/png")},
+    )
+    r = client.get("/v1/kb/public/branding")
+    assert r.status_code == 200
+    assert r.json()["logo_url"] == "/v1/kb/public/logo"
+    r2 = client.get("/v1/kb/public/logo")
+    assert r2.status_code == 200
+
+
+def test_kb_portal_settings_admin(client, auth_headers, db_session):
+    r = client.get("/v1/kb/portal-settings", headers=auth_headers["admin"])
+    assert r.status_code == 200, r.text
+    assert r.json()["cor_header"] == "#0B2D4A"
+
+    r = client.put(
+        "/v1/kb/portal-settings",
+        headers=auth_headers["admin"],
+        json={
+            "portal_titulo": "Ajuda ACME",
+            "cor_header": "#112233",
+            "cor_primaria": "#AABBCC",
+            "cor_texto_header": "#FFFFFF",
+            "cor_texto_corpo": "#222222",
+            "cor_fundo": "#EEEEEE",
+            "cor_link": "#0055AA",
+            "texto_boas_vindas": "Bem-vindo à central de ajuda.",
+            "exibir_marca_deskrudder": False,
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["portal_titulo"] == "Ajuda ACME"
+    assert body["cor_header"] == "#112233"
+
+    r = client.get("/v1/kb/public/branding")
+    assert r.status_code == 200
+    pub = r.json()
+    assert pub["portal_titulo"] == "Ajuda ACME"
+    assert pub["cor_header"] == "#112233"
+    assert pub["cor_link"] == "#0055AA"
+    assert pub["texto_boas_vindas"] == "Bem-vindo à central de ajuda."
+    assert pub["exibir_marca_deskrudder"] is False
+
+    r403 = client.get("/v1/kb/portal-settings", headers=auth_headers["a1"])
+    assert r403.status_code == 403
+
+
 def test_kb_api_publica_sem_auth(client, auth_headers, db_session):
     cat = client.post("/v1/kb/categories", headers=auth_headers["admin"], json={"nome": "Público", "ordem": 0}).json()
     art = client.post(
@@ -101,6 +157,12 @@ def test_kb_api_publica_sem_auth(client, auth_headers, db_session):
     assert r.status_code == 200, r.text
     assert r.headers.get("cache-control") == "public, max-age=60"
     assert any(c["nome"] == "Público" for c in r.json())
+
+    r = client.get("/v1/kb/public/branding")
+    assert r.status_code == 200, r.text
+    branding = r.json()
+    assert "nome_exibicao" in branding
+    assert branding.get("logo_url") is None or branding["logo_url"].endswith("/kb/public/logo")
 
     r = client.get("/v1/kb/public/articles", params={"busca": "visível"})
     assert r.status_code == 200

--- a/backend/tests/test_kb.py
+++ b/backend/tests/test_kb.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from app.models import AuditLog, KbArticle, KbArticleVersion, KbCategory
+from app.models import AuditLog, KbArticle, KbArticleMotivoLink, KbArticleVersion, KbCategory
 
 
 def test_kb_categoria_artigo_crud_publish(client, auth_headers, db_session):
@@ -244,3 +244,94 @@ def test_kb_upload_imagem(client, auth_headers):
     filename = r.json()["filename"]
     r2 = client.get(f"/v1/kb/images/{filename}")
     assert r2.status_code == 200
+
+
+def _seed_classificacao_kb(db_session):
+    from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+
+    nat = TicketNatureza(nome="Erro KB", slug="erro-kb-test", ordem=1, ativo=True)
+    db_session.add(nat)
+    db_session.flush()
+    mot = TicketMotivo(natureza_id=nat.id, nome="PDV KB", slug="pdv-kb-test", ordem=1, ativo=True)
+    db_session.add(mot)
+    db_session.commit()
+    return nat, mot
+
+
+def test_kb_sugestoes_por_motivo_e_natureza(client, auth_headers, db_session):
+    nat, mot = _seed_classificacao_kb(db_session)
+
+    art_mot = client.post(
+        "/v1/kb/articles",
+        headers=auth_headers["admin"],
+        json={"titulo": "Guia PDV", "conteudo_markdown": "passos pdv"},
+    ).json()
+    art_nat = client.post(
+        "/v1/kb/articles",
+        headers=auth_headers["admin"],
+        json={"titulo": "Guia Erro geral", "conteudo_markdown": "passos erro"},
+    ).json()
+    art_rascunho = client.post(
+        "/v1/kb/articles",
+        headers=auth_headers["admin"],
+        json={"titulo": "Rascunho PDV", "conteudo_markdown": "não publicado"},
+    ).json()
+
+    for aid in (art_mot["id"], art_nat["id"]):
+        client.post(f"/v1/kb/articles/{aid}/publish", headers=auth_headers["admin"])
+
+    r = client.put(
+        f"/v1/kb/articles/{art_mot['id']}/motivo-links",
+        headers=auth_headers["admin"],
+        json={"links": [{"motivo_id": mot.id, "ordem": 0}]},
+    )
+    assert r.status_code == 200, r.text
+
+    r = client.put(
+        f"/v1/kb/articles/{art_nat['id']}/motivo-links",
+        headers=auth_headers["admin"],
+        json={"links": [{"natureza_id": nat.id, "ordem": 0}]},
+    )
+    assert r.status_code == 200, r.text
+
+    r = client.put(
+        f"/v1/kb/articles/{art_rascunho['id']}/motivo-links",
+        headers=auth_headers["admin"],
+        json={"links": [{"motivo_id": mot.id, "ordem": 0}]},
+    )
+    assert r.status_code == 200
+
+    r = client.get("/v1/kb/suggestions", headers=auth_headers["a1"], params={"motivo_id": mot.id})
+    assert r.status_code == 200, r.text
+    titulos = [x["titulo"] for x in r.json()]
+    assert "Guia PDV" in titulos
+    assert "Guia Erro geral" in titulos
+    assert "Rascunho PDV" not in titulos
+    assert len(titulos) <= 5
+
+    r = client.get("/v1/kb/suggestions", headers=auth_headers["a1"], params={"natureza_id": nat.id})
+    assert r.status_code == 200
+    assert any(x["titulo"] == "Guia Erro geral" for x in r.json())
+
+    interno = client.post(
+        "/v1/kb/articles",
+        headers=auth_headers["admin"],
+        json={"titulo": "Interno PDV", "conteudo_markdown": "x", "interno_only": True},
+    ).json()
+    client.post(f"/v1/kb/articles/{interno['id']}/publish", headers=auth_headers["admin"])
+    client.put(
+        f"/v1/kb/articles/{interno['id']}/motivo-links",
+        headers=auth_headers["admin"],
+        json={"links": [{"motivo_id": mot.id, "ordem": 0}]},
+    )
+
+    r = client.get("/v1/kb/public/suggestions", params={"motivo_id": mot.id})
+    assert r.status_code == 200
+    assert all(x["titulo"] != "Interno PDV" for x in r.json())
+
+    r = client.get("/v1/kb/suggestions", headers=auth_headers["a1"], params={"motivo_id": mot.id})
+    assert any(x["titulo"] == "Interno PDV" for x in r.json())
+
+    links = db_session.query(KbArticleMotivoLink).filter(KbArticleMotivoLink.article_id == art_mot["id"]).all()
+    assert len(links) == 1
+    assert links[0].motivo_id == mot.id

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,11 @@ services:
       - --port
       - "8000"
       - --reload
+      # Evita reload travado em "Waiting for connections to close" (SSE / event stream).
+      - --reload-exclude
+      - alembic/*
+      - --reload-exclude
+      - tests/*
     ports:
       - "8000:8000"
     depends_on:

--- a/frontend/public/deskrudder-login-bg.svg
+++ b/frontend/public/deskrudder-login-bg.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080" fill="none" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="dr-login-bg" x1="0" y1="0" x2="1920" y2="1080" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0B2D4A"/>
+      <stop offset="0.45" stop-color="#134166"/>
+      <stop offset="1" stop-color="#0A4D6E"/>
+    </linearGradient>
+    <linearGradient id="dr-login-wave" x1="0" y1="0" x2="1920" y2="0" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#14B8A6" stop-opacity="0.35"/>
+      <stop offset="1" stop-color="#0284C7" stop-opacity="0.15"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1920" height="1080" fill="url(#dr-login-bg)"/>
+
+  <path d="M-80 740C320 660 520 860 960 740S1240 620 1160 1080H-80Z" fill="url(#dr-login-wave)" opacity="0.9"/>
+  <path d="M-40 840C480 760 720 960 1160 840S1440 720 1280 1080H-40Z" fill="#0D9488" opacity="0.08"/>
+  <path d="M0 220C420 160 780 320 1260 220S1680 120 1920 520H0Z" fill="#14B8A6" opacity="0.06"/>
+
+  <g stroke="#FFFFFF" stroke-opacity="0.06" stroke-width="1">
+    <line x1="80" y1="160" x2="1840" y2="160"/>
+    <line x1="80" y1="280" x2="1840" y2="280"/>
+    <line x1="80" y1="400" x2="1840" y2="400"/>
+    <line x1="80" y1="520" x2="1840" y2="520"/>
+    <line x1="80" y1="640" x2="1840" y2="640"/>
+    <line x1="320" y1="80" x2="320" y2="1000"/>
+    <line x1="640" y1="80" x2="640" y2="1000"/>
+    <line x1="960" y1="80" x2="960" y2="1000"/>
+    <line x1="1280" y1="80" x2="1280" y2="1000"/>
+    <line x1="1600" y1="80" x2="1600" y2="1000"/>
+  </g>
+</svg>

--- a/frontend/public/deskrudder-login-panel.svg
+++ b/frontend/public/deskrudder-login-panel.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 540 900" fill="none" preserveAspectRatio="xMidYMid slice" aria-label="DeskRudder">
+  <defs>
+    <linearGradient id="dr-panel-bg" x1="0" y1="0" x2="540" y2="900" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0B2D4A"/>
+      <stop offset="0.45" stop-color="#134166"/>
+      <stop offset="1" stop-color="#0A4D6E"/>
+    </linearGradient>
+    <linearGradient id="dr-panel-wave" x1="0" y1="0" x2="540" y2="0" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#14B8A6" stop-opacity="0.35"/>
+      <stop offset="1" stop-color="#0284C7" stop-opacity="0.15"/>
+    </linearGradient>
+    <linearGradient id="dr-panel-mark" x1="170" y1="280" x2="370" y2="480" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#14B8A6"/>
+      <stop offset="0.55" stop-color="#0D9488"/>
+      <stop offset="1" stop-color="#0284C7"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="540" height="900" fill="url(#dr-panel-bg)"/>
+
+  <path d="M-40 620C120 560 220 680 400 620S620 540 580 900H-40Z" fill="url(#dr-panel-wave)" opacity="0.9"/>
+  <path d="M-20 700C160 640 280 760 460 700S640 620 560 900H-20Z" fill="#0D9488" opacity="0.08"/>
+  <path d="M0 180C140 120 260 240 420 180S560 100 540 420H0Z" fill="#14B8A6" opacity="0.06"/>
+
+  <g stroke="#FFFFFF" stroke-opacity="0.06" stroke-width="1">
+    <line x1="48" y1="120" x2="492" y2="120"/>
+    <line x1="48" y1="200" x2="492" y2="200"/>
+    <line x1="48" y1="280" x2="492" y2="280"/>
+    <line x1="120" y1="80" x2="120" y2="820"/>
+    <line x1="270" y1="80" x2="270" y2="820"/>
+    <line x1="420" y1="80" x2="420" y2="820"/>
+  </g>
+
+  <circle cx="270" cy="360" r="118" fill="#14B8A6" fill-opacity="0.12"/>
+
+  <g transform="translate(270 360)">
+    <rect x="-100" y="-100" width="200" height="200" rx="44" fill="url(#dr-panel-mark)"/>
+    <g transform="scale(4.8) translate(-20 -20)">
+      <rect x="7" y="9" width="7" height="5.5" rx="2" fill="#fff" fill-opacity="0.9"/>
+      <circle cx="9.5" cy="16" r="1.2" fill="#fff" fill-opacity="0.75"/>
+      <path d="M16.5 10.5h7v5.5h-7z" fill="#fff" fill-opacity="0.85"/>
+      <path d="M16.5 10.5l3.5 3 3.5-3" stroke="#0D9488" stroke-width="0.9" fill="none" stroke-linejoin="round"/>
+      <path d="M27 10.5h5.5v5.5H27v-1.8h-1.2V12.3H27V10.5z" fill="#fff" fill-opacity="0.9"/>
+      <path d="M11 16.5L20 21M29 16.5L20 21M20 21V24.5" stroke="#fff" stroke-width="1.4" stroke-linecap="round" stroke-opacity="0.75"/>
+      <rect x="17" y="24" width="6" height="2" rx="1" fill="#fff" fill-opacity="0.55"/>
+      <rect x="19" y="26.5" width="2" height="5.5" rx="1" fill="#fff"/>
+      <path d="M14.5 30.5L20 28.5L25.5 30.5V33.5c0 .8-.7 1.5-1.5 1.5h-8c-.8 0-1.5-.7-1.5-1.5v-3z" fill="#fff"/>
+      <circle cx="20" cy="30.5" r="1.35" fill="#C9973A"/>
+    </g>
+  </g>
+
+  <text x="270" y="560" text-anchor="middle" fill="#F8FAFC" font-family="system-ui,sans-serif" font-size="42" font-weight="600">
+    Desk<tspan fill="#5EEAD4" font-weight="700">Rudder</tspan>
+  </text>
+  <text x="270" y="610" text-anchor="middle" fill="#94A3B8" font-family="system-ui,sans-serif" font-size="16" font-weight="500">
+    O leme da sua opera&#231;&#227;o de atendimento
+  </text>
+
+  <rect x="185" y="640" width="170" height="3" rx="1.5" fill="url(#dr-panel-wave)"/>
+</svg>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -37,6 +37,7 @@ import { RespostasProntasPage } from './pages/RespostasProntas'
 import { KbArtigosPage } from './pages/KbArtigos'
 import { KbArtigoForm } from './pages/KbArtigoForm'
 import { KbConsultaSection } from './pages/KbConsulta'
+import { KbPortalSettingsPage } from './pages/KbPortalSettings'
 import { AjudaLayout } from './pages/AjudaLayout'
 import { KbCategoriasPage } from './pages/KbCategorias'
 import { RoteamentoRegrasPage } from './pages/RoteamentoRegras'
@@ -64,6 +65,9 @@ import { AlterarSenha } from './pages/AlterarSenha'
 import { NotificacoesPreferencias } from './pages/NotificacoesPreferencias'
 import { Sobre } from './pages/Sobre'
 import { AcessoNegado } from './pages/AcessoNegado'
+import { KbPublicLayout } from './pages/kb-public/KbPublicLayout'
+import { KbPublicHome } from './pages/kb-public/KbPublicHome'
+import { KbPublicArtigo } from './pages/kb-public/KbPublicArtigo'
 import { ToastProvider } from './components/ui/Toast'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { PageLoading } from './components/ui/PageLoading'
@@ -105,6 +109,10 @@ function AppRoutes() {
       <Route path="/esqueci-senha" element={<EsqueciSenha />} />
       <Route path="/redefinir-senha" element={<RedefinirSenha />} />
       <Route path="/avaliar-ticket" element={<AvaliarTicket />} />
+      <Route path="/kb" element={<KbPublicLayout />}>
+        <Route index element={<KbPublicHome />} />
+        <Route path="a/:slug" element={<KbPublicArtigo />} />
+      </Route>
       <Route
         path="/"
         element={
@@ -153,6 +161,7 @@ function AppRoutes() {
             }
           />
         </Route>
+        <Route path="ajuda/portal" element={<Navigate to="/configuracoes/sistema/base-conhecimento" replace />} />
         <Route
           path="ajuda/artigos/novo"
           element={
@@ -468,6 +477,7 @@ function AppRoutes() {
           <Route path="email" element={<ConfigEmpresaEmail embedded section="email" />} />
           <Route path="empresa-email" element={<Navigate to="empresa" replace />} />
           <Route path="whatsapp" element={<ConfigWhatsapp embedded />} />
+          <Route path="base-conhecimento" element={<KbPortalSettingsPage embedded />} />
           <Route path="auditoria" element={<Auditoria embedded />} />
         </Route>
         <Route

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -159,13 +159,29 @@ async function publicApi<T>(path: string, options: RequestInit = {}): Promise<T>
   const headers: HeadersInit = {
     'Content-Type': 'application/json',
     ...(options.headers as object),
-  };
-  const res = await fetch(`${BASE}${API_VERSION_PREFIX}${path}`, { ...options, headers });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({}));
-    throw new ApiError(mensagemErroApi(err, res.status), res.status, err);
   }
-  return res.json();
+  if (isMultiTenantMode()) {
+    ;(headers as Record<string, string>)['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+  }
+  const res = await fetch(`${BASE}${API_VERSION_PREFIX}${path}`, { ...options, headers })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw new ApiError(mensagemErroApi(err, res.status), res.status, err)
+  }
+  if (res.status === 204) return undefined as T
+  return res.json()
+}
+
+export const kbPublic = {
+  branding: () => publicApi<Kb.PublicBranding>('/kb/public/branding'),
+  logoAssetUrl: () => `${BASE}${API_VERSION_PREFIX}/kb/public/logo`,
+  listCategories: () => publicApi<Kb.Category[]>('/kb/public/categories'),
+  listArticles: (params?: { busca?: string; category_id?: number; limit?: number }) =>
+    publicApi<Kb.ArticleBrief[]>(withParams('/kb/public/articles', params)),
+  getArticleBySlug: (slug: string) =>
+    publicApi<Kb.Article>(`/kb/public/articles/${encodeURIComponent(slug)}`),
+  suggestions: (params: { motivo_id?: number; natureza_id?: number }) =>
+    publicApi<Kb.ArticleBrief[]>(withParams('/kb/public/suggestions', params)),
 }
 
 export const publicCsat = {
@@ -479,10 +495,10 @@ export const kb = {
   consulta: (params?: { busca?: string; category_id?: number; limit?: number }) =>
     api<Kb.ArticleBrief[]>(withParams('/kb/articles/consulta', params)),
   getPublicado: (id: number) => api<Kb.Article>(`/kb/articles/publicados/${id}`),
-  listPublicCategories: () => api<Kb.Category[]>('/kb/public/categories'),
+  listPublicCategories: () => kbPublic.listCategories(),
   listPublicArticles: (params?: { busca?: string; category_id?: number; limit?: number }) =>
-    api<Kb.ArticleBrief[]>(withParams('/kb/public/articles', params)),
-  getPublicArticleBySlug: (slug: string) => api<Kb.Article>(`/kb/public/articles/${encodeURIComponent(slug)}`),
+    kbPublic.listArticles(params),
+  getPublicArticleBySlug: (slug: string) => kbPublic.getArticleBySlug(slug),
   listArticleVersions: (articleId: number) => api<Kb.ArticleVersion[]>(`/kb/articles/${articleId}/versions`),
   listArticleMotivoLinks: (articleId: number) => api<Kb.MotivoLinkItem[]>(`/kb/articles/${articleId}/motivo-links`),
   updateArticleMotivoLinks: (articleId: number, links: Kb.MotivoLinkItem[]) =>
@@ -492,8 +508,10 @@ export const kb = {
     }),
   suggestions: (params: { motivo_id?: number; natureza_id?: number }) =>
     api<Kb.ArticleBrief[]>(withParams('/kb/suggestions', params)),
-  publicSuggestions: (params: { motivo_id?: number; natureza_id?: number }) =>
-    api<Kb.ArticleBrief[]>(withParams('/kb/public/suggestions', params)),
+  publicSuggestions: (params: { motivo_id?: number; natureza_id?: number }) => kbPublic.suggestions(params),
+  getPortalSettings: () => api<Kb.PortalSettings>('/kb/portal-settings'),
+  updatePortalSettings: (data: Kb.PortalSettingsUpdate) =>
+    api<Kb.PortalSettings>('/kb/portal-settings', { method: 'PUT', body: JSON.stringify(data) }),
   getArticleVersion: (articleId: number, versionId: number) =>
     api<Kb.ArticleVersionDetail>(`/kb/articles/${articleId}/versions/${versionId}`),
   uploadImage: (file: File) => {
@@ -2412,6 +2430,42 @@ export namespace Kb {
     ordem?: number;
     motivo_nome?: string | null;
     natureza_nome?: string | null;
+  }
+  export interface PublicBranding {
+    nome_exibicao: string;
+    portal_titulo: string;
+    logo_url: string | null;
+    texto_boas_vindas: string | null;
+    cor_primaria: string;
+    cor_header: string;
+    cor_texto_header: string;
+    cor_texto_corpo: string;
+    cor_fundo: string;
+    cor_link: string;
+    exibir_marca_deskrudder: boolean;
+  }
+  export interface PortalSettings {
+    portal_titulo: string | null;
+    texto_boas_vindas: string | null;
+    cor_header: string;
+    cor_primaria: string;
+    cor_texto_header: string;
+    cor_texto_corpo: string;
+    cor_fundo: string;
+    cor_link: string | null;
+    exibir_marca_deskrudder: boolean;
+    public_url_preview: string | null;
+  }
+  export interface PortalSettingsUpdate {
+    portal_titulo?: string | null;
+    texto_boas_vindas?: string | null;
+    cor_header?: string;
+    cor_primaria?: string;
+    cor_texto_header?: string;
+    cor_texto_corpo?: string;
+    cor_fundo?: string;
+    cor_link?: string | null;
+    exibir_marca_deskrudder?: boolean;
   }
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -484,6 +484,16 @@ export const kb = {
     api<Kb.ArticleBrief[]>(withParams('/kb/public/articles', params)),
   getPublicArticleBySlug: (slug: string) => api<Kb.Article>(`/kb/public/articles/${encodeURIComponent(slug)}`),
   listArticleVersions: (articleId: number) => api<Kb.ArticleVersion[]>(`/kb/articles/${articleId}/versions`),
+  listArticleMotivoLinks: (articleId: number) => api<Kb.MotivoLinkItem[]>(`/kb/articles/${articleId}/motivo-links`),
+  updateArticleMotivoLinks: (articleId: number, links: Kb.MotivoLinkItem[]) =>
+    api<Kb.MotivoLinkItem[]>(`/kb/articles/${articleId}/motivo-links`, {
+      method: 'PUT',
+      body: JSON.stringify({ links }),
+    }),
+  suggestions: (params: { motivo_id?: number; natureza_id?: number }) =>
+    api<Kb.ArticleBrief[]>(withParams('/kb/suggestions', params)),
+  publicSuggestions: (params: { motivo_id?: number; natureza_id?: number }) =>
+    api<Kb.ArticleBrief[]>(withParams('/kb/public/suggestions', params)),
   getArticleVersion: (articleId: number, versionId: number) =>
     api<Kb.ArticleVersionDetail>(`/kb/articles/${articleId}/versions/${versionId}`),
   uploadImage: (file: File) => {
@@ -2394,6 +2404,14 @@ export namespace Kb {
   export interface ImageUpload {
     url: string;
     filename: string;
+  }
+  export interface MotivoLinkItem {
+    id?: number | null;
+    motivo_id?: number | null;
+    natureza_id?: number | null;
+    ordem?: number;
+    motivo_nome?: string | null;
+    natureza_nome?: string | null;
   }
 }
 

--- a/frontend/src/brand/tokens.ts
+++ b/frontend/src/brand/tokens.ts
@@ -70,7 +70,8 @@ export const brandAssets = {
   logoRefV2: '/deskrudder-logo-ref-v2-black.png',
   logoName: '/deskrudder-logo-name.png',
   lockup: '/deskrudder-lockup.png',
-  loginPanel: '/deskrudder-login-panel.png',
+  loginPanel: '/deskrudder-login-panel.svg',
+  loginBackground: '/deskrudder-login-bg.svg',
 } as const
 
 /** Chaves de persistência local (com fallback legado DX Connect). */

--- a/frontend/src/components/KbConsultaPanel.tsx
+++ b/frontend/src/components/KbConsultaPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { kb, type Kb } from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
@@ -41,6 +41,8 @@ function cachedToArticle(c: KbCachedArticle): Kb.Article {
 
 export function KbConsultaPanel({ onInserirReferencia, showInserir = false }: Props) {
   const toast = useToast()
+  const toastRef = useRef(toast)
+  toastRef.current = toast
   const [searchParams, setSearchParams] = useSearchParams()
   const [busca, setBusca] = useState('')
   const [debouncedBusca, setDebouncedBusca] = useState('')
@@ -79,8 +81,9 @@ export function KbConsultaPanel({ onInserirReferencia, showInserir = false }: Pr
 
   const carregar = useCallback(() => {
     if (offline) {
+      const cached = listKbOfflineCache()
       setItens(
-        cacheRecentes.map((c) => ({
+        cached.map((c) => ({
           id: c.id,
           titulo: c.titulo,
           slug: c.slug,
@@ -102,11 +105,11 @@ export function KbConsultaPanel({ onInserirReferencia, showInserir = false }: Pr
     })
       .then(setItens)
       .catch((err) => {
-        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível buscar artigos.'))
+        toastRef.current.showWarning(mensagemFalhaParaToast(err, 'Não foi possível buscar artigos.'))
         setItens([])
       })
       .finally(() => setLoading(false))
-  }, [categoryId, debouncedBusca, cacheRecentes, offline, toast])
+  }, [categoryId, debouncedBusca, offline])
 
   useEffect(() => {
     carregar()
@@ -119,7 +122,7 @@ export function KbConsultaPanel({ onInserirReferencia, showInserir = false }: Pr
         if (offline) {
           const cached = getKbOfflineById(id) ?? (slug ? getKbOfflineBySlug(slug) : null)
           if (!cached) {
-            toast.showWarning('Este manual não está salvo neste computador. Abra-o uma vez com internet.')
+            toastRef.current.showWarning('Este manual não está salvo neste computador. Abra-o uma vez com internet.')
             return
           }
           setArtigo(cachedToArticle(cached))
@@ -133,15 +136,15 @@ export function KbConsultaPanel({ onInserirReferencia, showInserir = false }: Pr
         const cached = getKbOfflineById(id) ?? (slug ? getKbOfflineBySlug(slug) : null)
         if (cached) {
           setArtigo(cachedToArticle(cached))
-          toast.showWarning('Exibindo a última versão salva neste computador.')
+          toastRef.current.showWarning('Exibindo a última versão salva neste computador.')
         } else {
-          toast.showError(mensagemFalhaParaToast(err, 'Artigo não encontrado.'))
+          toastRef.current.showError(mensagemFalhaParaToast(err, 'Artigo não encontrado.'))
         }
       } finally {
         setLoadingArtigo(false)
       }
     },
-    [offline, toast],
+    [offline],
   )
 
   useEffect(() => {

--- a/frontend/src/components/kb/KbArtigoMotivoLinksFields.tsx
+++ b/frontend/src/components/kb/KbArtigoMotivoLinksFields.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react'
+import { ticketClassificacao, type Kb, type TicketClassificacao } from '../../api/client'
+import { Button } from '../ui/Button'
+import { Select } from '../ui/Select'
+
+export type MotivoLinkDraft = {
+  key: string
+  tipo: 'motivo' | 'natureza'
+  targetId: number | ''
+  ordem: number
+}
+
+type Props = {
+  links: MotivoLinkDraft[]
+  onChange: (links: MotivoLinkDraft[]) => void
+  disabled?: boolean
+}
+
+function novoKey() {
+  return `link-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+export function draftFromApiLinks(items: Kb.MotivoLinkItem[]): MotivoLinkDraft[] {
+  return items.map((item, idx) => ({
+    key: `link-${item.id ?? idx}`,
+    tipo: item.motivo_id != null ? 'motivo' : 'natureza',
+    targetId: item.motivo_id ?? item.natureza_id ?? '',
+    ordem: item.ordem ?? idx,
+  }))
+}
+
+export function draftToApiLinks(links: MotivoLinkDraft[]): Kb.MotivoLinkItem[] {
+  return links
+    .filter((l) => l.targetId !== '')
+    .map((l, idx) => ({
+      ordem: l.ordem ?? idx,
+      ...(l.tipo === 'motivo'
+        ? { motivo_id: Number(l.targetId), natureza_id: null }
+        : { natureza_id: Number(l.targetId), motivo_id: null }),
+    }))
+}
+
+export function KbArtigoMotivoLinksFields({ links, onChange, disabled }: Props) {
+  const [naturezas, setNaturezas] = useState<TicketClassificacao.Natureza[]>([])
+  const [motivos, setMotivos] = useState<TicketClassificacao.Motivo[]>([])
+
+  useEffect(() => {
+    ticketClassificacao
+      .listNaturezas({ limit: 100 })
+      .then(({ items }) => setNaturezas(items))
+      .catch(() => setNaturezas([]))
+    ticketClassificacao
+      .listMotivos({ limit: 200 })
+      .then(({ items }) => setMotivos(items))
+      .catch(() => setMotivos([]))
+  }, [])
+
+  function adicionar() {
+    onChange([...links, { key: novoKey(), tipo: 'motivo', targetId: '', ordem: links.length }])
+  }
+
+  function atualizar(key: string, patch: Partial<MotivoLinkDraft>) {
+    onChange(
+      links.map((l) => {
+        if (l.key !== key) return l
+        const next = { ...l, ...patch }
+        if (patch.tipo && patch.tipo !== l.tipo) next.targetId = ''
+        return next
+      }),
+    )
+  }
+
+  function remover(key: string) {
+    onChange(links.filter((l) => l.key !== key))
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-slate-600 dark:text-slate-400">
+        Vincule este manual a naturezas ou motivos de ticket. Até 5 sugestões aparecem ao classificar chamados ou
+        registrar demandas.
+      </p>
+      {links.length === 0 ? (
+        <p className="text-sm text-slate-500 dark:text-slate-400">Nenhum vínculo configurado.</p>
+      ) : (
+        <ul className="space-y-2">
+          {links.map((link) => (
+            <li
+              key={link.key}
+              className="flex flex-col gap-2 rounded-xl border border-slate-200 bg-slate-50/80 p-3 dark:border-slate-800 dark:bg-slate-900/40 sm:flex-row sm:items-end"
+            >
+              <Select
+                label="Tipo"
+                value={link.tipo}
+                onChange={(v) => atualizar(link.key, { tipo: v as 'motivo' | 'natureza' })}
+                options={[
+                  { value: 'motivo', label: 'Motivo específico' },
+                  { value: 'natureza', label: 'Toda a natureza' },
+                ]}
+                disabled={disabled}
+              />
+              {link.tipo === 'natureza' ? (
+                <Select
+                  label="Natureza"
+                  value={link.targetId}
+                  onChange={(v) => atualizar(link.key, { targetId: v === '' ? '' : Number(v) })}
+                  options={naturezas.map((n) => ({ value: n.id, label: n.nome }))}
+                  includeEmpty
+                  emptyLabel="Selecione"
+                  disabled={disabled}
+                  className="min-w-0 flex-1"
+                />
+              ) : (
+                <Select
+                  label="Motivo"
+                  value={link.targetId}
+                  onChange={(v) => atualizar(link.key, { targetId: v === '' ? '' : Number(v) })}
+                  options={motivos.map((m) => {
+                    const nat = naturezas.find((n) => n.id === m.natureza_id)
+                    return { value: m.id, label: nat ? `${nat.nome} › ${m.nome}` : m.nome }
+                  })}
+                  includeEmpty
+                  emptyLabel="Selecione"
+                  disabled={disabled}
+                  className="min-w-0 flex-1"
+                />
+              )}
+              <Button type="button" variant="secondary" onClick={() => remover(link.key)} disabled={disabled}>
+                Remover
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+      <Button type="button" variant="secondary" onClick={adicionar} disabled={disabled || links.length >= 20}>
+        Adicionar vínculo
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/components/kb/KbListaFiltros.tsx
+++ b/frontend/src/components/kb/KbListaFiltros.tsx
@@ -43,6 +43,7 @@ type Props = {
   onStatusChange?: (value: string) => void
   statusOptions?: { value: string; label: string }[]
   paginacao?: PaginacaoProps
+  hideCategoryFilter?: boolean
 }
 
 function PaginacaoBarra({
@@ -109,6 +110,7 @@ export function KbListaFiltros({
   onStatusChange,
   statusOptions,
   paginacao,
+  hideCategoryFilter = false,
 }: Props) {
   const comStatus = Boolean(statusOptions?.length && onStatusChange)
 
@@ -116,7 +118,15 @@ export function KbListaFiltros({
     <section className="mb-4 space-y-0">
       <div className="rounded-xl border border-slate-200/90 bg-slate-50/70 p-4 dark:border-slate-800/80 dark:bg-slate-900/40">
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-12">
-          <div className={comStatus ? 'md:col-span-2 xl:col-span-6' : 'md:col-span-2 xl:col-span-8'}>
+          <div
+            className={
+              hideCategoryFilter
+                ? 'md:col-span-2 xl:col-span-12'
+                : comStatus
+                  ? 'md:col-span-2 xl:col-span-6'
+                  : 'md:col-span-2 xl:col-span-8'
+            }
+          >
             <label htmlFor="kb-filtro-busca" className={labelOverline}>
               Busca
             </label>
@@ -136,6 +146,7 @@ export function KbListaFiltros({
             </div>
           </div>
 
+          {!hideCategoryFilter ? (
           <div className={comStatus ? 'xl:col-span-3' : 'xl:col-span-4'}>
             <Select
               label="Categoria"
@@ -149,6 +160,7 @@ export function KbListaFiltros({
               disabled={disabled}
             />
           </div>
+          ) : null}
 
           {comStatus && statusOptions && onStatusChange ? (
             <div className="xl:col-span-3">

--- a/frontend/src/components/kb/KbSugestoesMotivo.tsx
+++ b/frontend/src/components/kb/KbSugestoesMotivo.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react'
+import { kb, type Kb } from '../../api/client'
+import { KbArtigoPreviewModal } from './KbArtigoPreviewModal'
+
+type Props = {
+  motivoId?: number | ''
+  naturezaId?: number | ''
+  className?: string
+}
+
+export function KbSugestoesMotivo({ motivoId, naturezaId, className = '' }: Props) {
+  const [itens, setItens] = useState<Kb.ArticleBrief[]>([])
+  const [loading, setLoading] = useState(false)
+  const [preview, setPreview] = useState<Kb.Article | null>(null)
+  const [loadingPreview, setLoadingPreview] = useState(false)
+
+  useEffect(() => {
+    if (motivoId === '' && naturezaId === '') {
+      setItens([])
+      return
+    }
+    const params: { motivo_id?: number; natureza_id?: number } = {}
+    if (motivoId !== '') params.motivo_id = Number(motivoId)
+    else if (naturezaId !== '') params.natureza_id = Number(naturezaId)
+    else {
+      setItens([])
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    kb.suggestions(params)
+      .then((rows) => {
+        if (!cancelled) setItens(rows)
+      })
+      .catch(() => {
+        if (!cancelled) setItens([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [motivoId, naturezaId])
+
+  async function abrirArtigo(id: number) {
+    setLoadingPreview(true)
+    try {
+      const full = await kb.getPublicado(id)
+      setPreview(full)
+    } catch {
+      setPreview(null)
+    } finally {
+      setLoadingPreview(false)
+    }
+  }
+
+  if (motivoId === '' && naturezaId === '') return null
+  if (!loading && itens.length === 0) return null
+
+  return (
+    <>
+      <div
+        className={`rounded-xl border border-cyan-200/80 bg-cyan-50/60 px-3 py-2.5 dark:border-cyan-900/50 dark:bg-cyan-950/30 ${className}`.trim()}
+      >
+        <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-cyan-800 dark:text-cyan-200">
+          Manuais sugeridos
+        </p>
+        {loading ? (
+          <p className="text-sm text-slate-600 dark:text-slate-400">Carregando sugestões…</p>
+        ) : (
+          <ul className="space-y-1">
+            {itens.map((item) => (
+              <li key={item.id}>
+                <button
+                  type="button"
+                  onClick={() => void abrirArtigo(item.id)}
+                  className="w-full rounded-lg px-2 py-1.5 text-left text-sm font-medium text-cyan-900 hover:bg-cyan-100/80 dark:text-cyan-100 dark:hover:bg-cyan-900/40"
+                >
+                  {item.titulo}
+                  {item.interno_only ? (
+                    <span className="ml-1.5 text-[10px] font-semibold uppercase text-slate-500">equipe</span>
+                  ) : null}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <KbArtigoPreviewModal
+        open={preview != null}
+        onClose={() => setPreview(null)}
+        titulo={preview?.titulo ?? ''}
+        categoryNome={preview?.category_nome}
+        conteudoMarkdown={preview?.conteudo_markdown ?? ''}
+        loading={loadingPreview}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/tickets/TicketClassificacaoFields.tsx
+++ b/frontend/src/components/tickets/TicketClassificacaoFields.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { ApiError, ticketClassificacao, type TicketClassificacao } from '../../api/client'
 import { Select } from '../ui/Select'
 import { Input } from '../ui/Input'
+import { KbSugestoesMotivo } from '../kb/KbSugestoesMotivo'
 
 export type ClassificacaoFormValue = {
   naturezaId: number | ''
@@ -104,6 +105,11 @@ export function TicketClassificacaoFields({
           placeholder="Obrigatório para motivo Outros"
         />
       ) : null}
+      <KbSugestoesMotivo
+        naturezaId={value.naturezaId}
+        motivoId={value.motivoId}
+        className="mt-1"
+      />
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -107,3 +107,45 @@
   @apply font-semibold text-slate-900 dark:text-slate-50;
 }
 
+/* Portal público /kb — usa cores do branding; ignora tema escuro do app (cards brancos) */
+.kb-public-portal .kb-markdown,
+.dark .kb-public-portal .kb-markdown {
+  color: var(--kb-body-text, #0f172a);
+}
+
+.kb-public-portal .kb-markdown h1,
+.kb-public-portal .kb-markdown h2,
+.kb-public-portal .kb-markdown h3,
+.kb-public-portal .kb-markdown strong,
+.dark .kb-public-portal .kb-markdown h1,
+.dark .kb-public-portal .kb-markdown h2,
+.dark .kb-public-portal .kb-markdown h3,
+.dark .kb-public-portal .kb-markdown strong {
+  color: var(--kb-body-text, #0f172a);
+}
+
+.kb-public-portal .kb-markdown a,
+.dark .kb-public-portal .kb-markdown a {
+  color: var(--kb-link, #0d9488);
+}
+
+.kb-public-portal .kb-markdown code,
+.dark .kb-public-portal .kb-markdown code {
+  @apply bg-slate-100 text-slate-800;
+}
+
+.kb-public-portal .kb-markdown pre,
+.dark .kb-public-portal .kb-markdown pre {
+  @apply border-slate-200 bg-slate-50;
+}
+
+.kb-public-portal .kb-markdown blockquote,
+.dark .kb-public-portal .kb-markdown blockquote {
+  @apply border-slate-300 text-slate-600;
+}
+
+.kb-public-portal .kb-markdown hr,
+.dark .kb-public-portal .kb-markdown hr {
+  @apply border-slate-200;
+}
+

--- a/frontend/src/lib/kbPublicCategorias.ts
+++ b/frontend/src/lib/kbPublicCategorias.ts
@@ -1,0 +1,19 @@
+import type { Kb } from '../api/client'
+import { kbCategoriasRaiz, kbSubcategorias } from './kbCategorias'
+
+export function kbCategoriaTemArtigosPublicos(categoria: Kb.Category, todas: Kb.Category[]): boolean {
+  if (categoria.artigos_count > 0) return true
+  return kbSubcategorias(todas, categoria.id).some((sub) => sub.artigos_count > 0)
+}
+
+export function kbCategoriasRaizPublicas(todas: Kb.Category[]): Kb.Category[] {
+  return kbCategoriasRaiz(todas).filter((c) => kbCategoriaTemArtigosPublicos(c, todas))
+}
+
+export function kbSubcategoriasPublicas(todas: Kb.Category[], parentId: number): Kb.Category[] {
+  return kbSubcategorias(todas, parentId).filter((c) => c.artigos_count > 0)
+}
+
+export function kbCategoriaPorId(todas: Kb.Category[], id: number): Kb.Category | undefined {
+  return todas.find((c) => c.id === id)
+}

--- a/frontend/src/pages/AjudaLayout.tsx
+++ b/frontend/src/pages/AjudaLayout.tsx
@@ -1,7 +1,9 @@
+import { useMemo, useState } from 'react'
 import { Outlet, useLocation } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { ConfigSectionTabs } from '../components/config/ConfigSectionTabs'
+import { Button } from '../components/ui/Button'
 
 const TAB_HINTS: Record<string, string> = {
   consultar: 'Busque e leia manuais publicados pela equipe.',
@@ -18,7 +20,22 @@ function abaAtiva(pathname: string): string {
 export function AjudaLayout() {
   const { isAdmin } = useAuth()
   const { pathname } = useLocation()
+  const [copiado, setCopiado] = useState(false)
   const hint = TAB_HINTS[abaAtiva(pathname)] ?? ''
+  const publicKbUrl = useMemo(
+    () => (typeof window !== 'undefined' ? `${window.location.origin}/kb` : '/kb'),
+    [],
+  )
+
+  async function copiarLinkPublico() {
+    try {
+      await navigator.clipboard.writeText(publicKbUrl)
+      setCopiado(true)
+      window.setTimeout(() => setCopiado(false), 2000)
+    } catch {
+      setCopiado(false)
+    }
+  }
 
   const tabs = [
     { to: '/ajuda/consultar', label: 'Consultar', end: true },
@@ -35,6 +52,26 @@ export function AjudaLayout() {
       <PageHeader
         title="Ajuda"
         subtitle="Manuais e procedimentos para consulta da equipe."
+        actions={
+          <div className="w-fit max-w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5 dark:border-slate-700 dark:bg-slate-800/60">
+            <p className="text-xs font-medium text-slate-500 dark:text-slate-400">
+              Consulta pública para clientes
+            </p>
+            <div className="mt-1 flex flex-wrap items-center gap-2">
+              <a
+                href="/kb"
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm font-medium whitespace-nowrap text-teal-700 hover:underline dark:text-teal-400"
+              >
+                {publicKbUrl}
+              </a>
+              <Button type="button" variant="secondary" className="shrink-0 px-2.5 py-1 text-xs" onClick={() => void copiarLinkPublico()}>
+                {copiado ? 'Copiado!' : 'Copiar'}
+              </Button>
+            </div>
+          </div>
+        }
       />
       <ConfigSectionTabs tabs={tabs} ariaLabel="Seções de ajuda" />
       {hint ? <p className="text-sm text-slate-600 dark:text-slate-400">{hint}</p> : null}

--- a/frontend/src/pages/KbArtigoForm.tsx
+++ b/frontend/src/pages/KbArtigoForm.tsx
@@ -17,6 +17,12 @@ import { kbCategoriasOpcoesSelect } from '../lib/kbCategorias'
 import { KbMarkdownPreview } from '../components/kb/KbMarkdownPreview'
 import { KbMarkdownAjudaModal } from '../components/kb/KbMarkdownAjudaModal'
 import { KbArtigoHistoricoModal } from '../components/kb/KbArtigoHistoricoModal'
+import {
+  draftFromApiLinks,
+  draftToApiLinks,
+  KbArtigoMotivoLinksFields,
+  type MotivoLinkDraft,
+} from '../components/kb/KbArtigoMotivoLinksFields'
 
 type ModoConteudo = 'editar' | 'visualizar'
 
@@ -50,6 +56,7 @@ export function KbArtigoForm() {
   const [loadingVersoes, setLoadingVersoes] = useState(false)
   const [versaoSelecionada, setVersaoSelecionada] = useState<Kb.ArticleVersionDetail | null>(null)
   const [loadingVersao, setLoadingVersao] = useState(false)
+  const [motivoLinks, setMotivoLinks] = useState<MotivoLinkDraft[]>([])
 
   useEffect(() => {
     kb.listCategories()
@@ -96,6 +103,25 @@ export function KbArtigoForm() {
     }
   }, [artigoId, id, isEdit, toast])
 
+  useEffect(() => {
+    if (!isEdit || Number.isNaN(artigoId)) return
+    let cancelled = false
+    kb.listArticleMotivoLinks(artigoId)
+      .then((rows) => {
+        if (!cancelled) setMotivoLinks(draftFromApiLinks(rows))
+      })
+      .catch(() => {
+        if (!cancelled) setMotivoLinks([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [artigoId, isEdit])
+
+  async function salvarMotivoLinks(articleId: number) {
+    await kb.updateArticleMotivoLinks(articleId, draftToApiLinks(motivoLinks))
+  }
+
   function artigoPayload() {
     return {
       titulo: titulo.trim(),
@@ -115,6 +141,7 @@ export function KbArtigoForm() {
     try {
       if (isEdit && !Number.isNaN(artigoId)) {
         await kb.updateArticle(artigoId, artigoPayload())
+        await salvarMotivoLinks(artigoId)
         toast.showSuccess('Artigo salvo.')
       } else {
         const created = await kb.createArticle(artigoPayload())
@@ -136,6 +163,7 @@ export function KbArtigoForm() {
     setSaving(true)
     try {
       await kb.updateArticle(artigoId, artigoPayload())
+      await salvarMotivoLinks(artigoId)
       const pub = await kb.publishArticle(artigoId)
       setStatus(pub.status)
       toast.showSuccess('Artigo publicado.')
@@ -300,6 +328,16 @@ export function KbArtigoForm() {
             </p>
           </div>
         </FormSection>
+
+        {isEdit ? (
+          <FormSection title="Sugestões por classificação">
+            <KbArtigoMotivoLinksFields
+              links={motivoLinks}
+              onChange={setMotivoLinks}
+              disabled={status === 'arquivado' || saving}
+            />
+          </FormSection>
+        ) : null}
 
         <FormSection title="Conteúdo do manual">
           <div className="mb-3 flex flex-wrap items-center gap-2">

--- a/frontend/src/pages/KbPortalSettings.tsx
+++ b/frontend/src/pages/KbPortalSettings.tsx
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { kb, type Kb } from '../api/client'
+import { ApiError } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { Input } from '../components/ui/Input'
+import { useToast } from '../components/ui/Toast'
+import { ConfigListPageShell } from '../components/config/ConfigListPageShell'
+import { SemPermissao } from './SemPermissao'
+
+type FormState = {
+  portal_titulo: string
+  texto_boas_vindas: string
+  cor_header: string
+  cor_primaria: string
+  cor_texto_header: string
+  cor_texto_corpo: string
+  cor_fundo: string
+  cor_link: string
+}
+
+function fromApi(data: Kb.PortalSettings): FormState {
+  return {
+    portal_titulo: data.portal_titulo ?? '',
+    texto_boas_vindas: data.texto_boas_vindas ?? '',
+    cor_header: data.cor_header,
+    cor_primaria: data.cor_primaria,
+    cor_texto_header: data.cor_texto_header,
+    cor_texto_corpo: data.cor_texto_corpo,
+    cor_fundo: data.cor_fundo,
+    cor_link: data.cor_link ?? data.cor_primaria,
+  }
+}
+
+function ColorField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string
+  value: string
+  onChange: (v: string) => void
+}) {
+  return (
+    <div>
+      <label className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">{label}</label>
+      <div className="flex items-center gap-3">
+        <input
+          type="color"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="size-10 cursor-pointer rounded-lg border border-slate-300 bg-white p-0.5 dark:border-slate-600"
+        />
+        <Input value={value} onChange={(e) => onChange(e.target.value)} className="font-mono text-sm" />
+      </div>
+    </div>
+  )
+}
+
+export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean }) {
+  const toast = useToast()
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [form, setForm] = useState<FormState | null>(null)
+
+  const publicUrl = useMemo(
+    () => (typeof window !== 'undefined' ? `${window.location.origin}/kb` : '/kb'),
+    [],
+  )
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    kb.getPortalSettings()
+      .then((data) => setForm(fromApi(data)))
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar as configurações.'))
+      })
+      .finally(() => setLoading(false))
+  }, [toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  async function salvar(e: React.FormEvent) {
+    e.preventDefault()
+    if (!form) return
+    setSaving(true)
+    try {
+      const data = await kb.updatePortalSettings({
+        portal_titulo: form.portal_titulo.trim() || null,
+        texto_boas_vindas: form.texto_boas_vindas.trim() || null,
+        cor_header: form.cor_header,
+        cor_primaria: form.cor_primaria,
+        cor_texto_header: form.cor_texto_header,
+        cor_texto_corpo: form.cor_texto_corpo,
+        cor_fundo: form.cor_fundo,
+        cor_link: form.cor_link.trim() || null,
+      })
+      setForm(fromApi(data))
+      toast.showSuccess('Configurações do portal salvas.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <ConfigListPageShell
+      embedded={embedded}
+      forbidden={forbidden}
+      denied={
+        <SemPermissao
+          title="Você não tem permissão para personalizar o portal público."
+          voltarPara="/configuracoes/sistema/empresa"
+          voltarLabel="Voltar para Sistema"
+        />
+      }
+      title="Base de conhecimento"
+      subtitle="Personalize o portal público /kb — cores, textos e aparência (estilo TomTicket)."
+      actions={
+        <a href="/kb" target="_blank" rel="noreferrer">
+          <Button type="button" variant="secondary">
+            Abrir preview
+          </Button>
+        </a>
+      }
+    >
+      {loading || !form ? (
+        <p className="text-slate-500">Carregando…</p>
+      ) : (
+        <form onSubmit={(e) => void salvar(e)} className="space-y-6">
+          <Card className="space-y-4 p-4 sm:p-5">
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              URL pública:{' '}
+              <a href="/kb" target="_blank" rel="noreferrer" className="font-medium text-teal-700 hover:underline dark:text-teal-400">
+                {publicUrl}
+              </a>
+              . A logo vem de Configurações → Sistema → Empresa.
+            </p>
+
+            <Input
+              label="Título do portal"
+              value={form.portal_titulo}
+              onChange={(e) => setForm({ ...form, portal_titulo: e.target.value })}
+              placeholder="Central de ajuda — Minha Empresa"
+            />
+
+            <div>
+              <label htmlFor="kb-portal-boas-vindas" className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">
+                Texto de boas-vindas
+              </label>
+              <textarea
+                id="kb-portal-boas-vindas"
+                rows={3}
+                value={form.texto_boas_vindas}
+                onChange={(e) => setForm({ ...form, texto_boas_vindas: e.target.value })}
+                placeholder="Consulte passo a passo para tirar dúvidas sobre o sistema."
+                className="w-full rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-sm dark:border-slate-600 dark:bg-slate-900"
+              />
+            </div>
+          </Card>
+
+          <Card className="grid gap-4 p-4 sm:grid-cols-2 sm:p-5">
+            <ColorField label="Cor da barra superior (navbar)" value={form.cor_header} onChange={(v) => setForm({ ...form, cor_header: v })} />
+            <ColorField label="Cor do texto da navbar" value={form.cor_texto_header} onChange={(v) => setForm({ ...form, cor_texto_header: v })} />
+            <ColorField label="Cor de destaque (botões / seleção)" value={form.cor_primaria} onChange={(v) => setForm({ ...form, cor_primaria: v })} />
+            <ColorField label="Cor dos links" value={form.cor_link} onChange={(v) => setForm({ ...form, cor_link: v })} />
+            <ColorField label="Cor do texto principal" value={form.cor_texto_corpo} onChange={(v) => setForm({ ...form, cor_texto_corpo: v })} />
+            <ColorField label="Cor de fundo da página" value={form.cor_fundo} onChange={(v) => setForm({ ...form, cor_fundo: v })} />
+          </Card>
+
+          <div className="flex flex-wrap gap-3">
+            <Button type="submit" loading={saving}>
+              Salvar personalização
+            </Button>
+            <a href="/kb" target="_blank" rel="noreferrer">
+              <Button type="button" variant="secondary">
+                Ver portal público
+              </Button>
+            </a>
+          </div>
+        </form>
+      )}
+    </ConfigListPageShell>
+  )
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -17,44 +17,19 @@ function readRememberedEmail(): string {
   }
 }
 
-/** Decoração leve estilo “plexus” para mobile (sem imagem pesada). */
-function LoginMeshBg() {
+/** Painel lateral estendido em tela cheia; escurece à direita para o formulário. */
+function LoginBackground() {
   return (
-    <div
-      aria-hidden
-      className="pointer-events-none fixed inset-0 -z-10 overflow-hidden lg:hidden"
-    >
-      <div className="absolute -left-1/4 top-0 h-[min(70vh,480px)] w-[min(120vw,600px)] rounded-full bg-cyan-500/[0.12] blur-[80px]" />
-      <div className="absolute -right-1/4 bottom-0 h-[min(50vh,360px)] w-[min(100vw,480px)] rounded-full bg-blue-600/[0.10] blur-[72px]" />
-      <svg className="absolute left-0 top-12 h-64 w-full opacity-[0.2]" viewBox="0 0 400 200" fill="none">
-        <path
-          d="M0 120 L80 60 L160 100 L240 40 L320 90 L400 50"
-          stroke="url(#login-line)"
-          strokeWidth="1"
-        />
-        <path
-          d="M40 180 L120 130 L200 160 L280 110 L360 150"
-          stroke="url(#login-line)"
-          strokeWidth="1"
-          opacity="0.6"
-        />
-        {[
-          [80, 60],
-          [160, 100],
-          [240, 40],
-          [320, 90],
-          [120, 130],
-          [200, 160],
-        ].map(([cx, cy], i) => (
-          <circle key={i} cx={cx} cy={cy} r="2.5" fill="#22d3ee" fillOpacity="0.7" />
-        ))}
-        <defs>
-          <linearGradient id="login-line" x1="0" y1="0" x2="400" y2="0">
-            <stop stopColor="#22d3ee" stopOpacity="0.5" />
-            <stop offset="1" stopColor="#3b82f6" stopOpacity="0.3" />
-          </linearGradient>
-        </defs>
-      </svg>
+    <div aria-hidden className="pointer-events-none fixed inset-0 -z-10 overflow-hidden bg-[#050810]">
+      <img
+        src={brandAssets.loginBackground}
+        alt=""
+        className="absolute inset-0 size-full object-cover object-left"
+        decoding="async"
+        fetchPriority="high"
+      />
+      <div className="absolute inset-0 bg-gradient-to-r from-[#050810]/30 via-[#050810]/55 to-[#050810]/90" />
+      <div className="absolute inset-0 bg-gradient-to-b from-[#050810]/25 via-transparent to-[#050810]/35" />
     </div>
   )
 }
@@ -103,33 +78,19 @@ export function Login() {
 
   return (
     <div
-      className="relative flex min-h-dvh flex-col bg-[#050810] font-sans text-slate-100 antialiased lg:flex-row"
+      className="relative min-h-dvh font-sans text-slate-100 antialiased"
       style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
     >
-      <LoginMeshBg />
+      <LoginBackground />
 
-      <aside
-        className="relative hidden min-h-0 shrink-0 overflow-hidden lg:flex lg:w-[min(44vw,540px)] xl:w-[min(38vw,520px)]"
-        aria-hidden
-      >
-        <img
-          src={brandAssets.loginPanel}
-          alt=""
-          className="absolute inset-0 size-full object-cover object-left"
-          decoding="async"
-          fetchPriority="low"
-        />
-        <div className="absolute inset-0 bg-gradient-to-r from-transparent via-[#050810]/20 to-[#050810]" />
-      </aside>
-
-      <main className="relative flex flex-1 flex-col justify-center px-4 py-10 sm:px-8 lg:px-12 xl:px-16">
-        <div className="mx-auto w-full max-w-[400px] space-y-8 sm:space-y-10">
-          <header className="w-full">
+      <main className="relative flex min-h-dvh flex-col items-center justify-center px-4 py-10 sm:px-8">
+        <div className="w-full max-w-[400px] space-y-8 sm:space-y-10">
+          <header className="flex w-full justify-center">
             <BrandLogo
               variant="full"
               size="lg"
               markVariant="onDark"
-              className="w-full flex-col items-center gap-4 sm:flex-row sm:items-center sm:justify-start sm:gap-5 lg:gap-6"
+              className="flex-col items-center gap-4 sm:flex-row sm:items-center sm:justify-center sm:gap-5"
             />
           </header>
 
@@ -214,7 +175,7 @@ export function Login() {
             </form>
           </div>
 
-          <p className="text-center text-xs leading-relaxed text-slate-500 lg:text-left">
+          <p className="text-center text-xs leading-relaxed text-slate-500">
             Use o usuário cadastrado pelo administrador. Problemas para acessar? Contate o suporte interno.
           </p>
         </div>

--- a/frontend/src/pages/config/ConfigSistemaLayout.tsx
+++ b/frontend/src/pages/config/ConfigSistemaLayout.tsx
@@ -6,6 +6,7 @@ const TABS = [
   { to: '/configuracoes/sistema/empresa', label: 'Empresa' },
   { to: '/configuracoes/sistema/email', label: 'E-mail' },
   { to: '/configuracoes/sistema/whatsapp', label: 'WhatsApp' },
+  { to: '/configuracoes/sistema/base-conhecimento', label: 'Base de conhecimento' },
   { to: '/configuracoes/sistema/auditoria', label: 'Auditoria' },
 ] as const
 
@@ -13,6 +14,7 @@ const TAB_HINTS: Record<string, string> = {
   empresa: 'Dados institucionais da instalação — CNPJ, logo e endereço.',
   email: 'Encaminhamento por setor e envio de respostas aos clientes.',
   whatsapp: 'Conexão, mensagens automáticas, inatividade, avaliação e horários de atendimento.',
+  'base-conhecimento': 'Personalização do portal público /kb — cores, textos e aparência.',
   auditoria: 'Histórico de alterações em cadastros e configurações.',
 }
 
@@ -27,7 +29,7 @@ export function ConfigSistemaLayout() {
 
   return (
     <PageContainer>
-      <PageHeader title="Sistema" subtitle="Empresa, integrações e auditoria." />
+      <PageHeader title="Sistema" subtitle="Empresa, integrações, base de conhecimento e auditoria." />
       <ConfigSectionTabs tabs={[...TABS]} ariaLabel="Seções do sistema" />
       {hint ? <p className="text-sm text-slate-600 dark:text-slate-400">{hint}</p> : null}
       <Outlet />

--- a/frontend/src/pages/kb-public/KbPublicArtigo.tsx
+++ b/frontend/src/pages/kb-public/KbPublicArtigo.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { kbPublic, type Kb } from '../../api/client'
+import { KbMarkdownPreview } from '../../components/kb/KbMarkdownPreview'
+import { useKbPublicBranding } from './KbPublicContext'
+
+export function KbPublicArtigo() {
+  const branding = useKbPublicBranding()
+  const { slug } = useParams<{ slug: string }>()
+  const [artigo, setArtigo] = useState<Kb.Article | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [naoEncontrado, setNaoEncontrado] = useState(false)
+
+  useEffect(() => {
+    if (!slug) {
+      setNaoEncontrado(true)
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    kbPublic
+      .getArticleBySlug(slug)
+      .then((a) => {
+        if (!cancelled) {
+          setArtigo(a)
+          setNaoEncontrado(false)
+          document.title = `${a.titulo} — ${branding.portal_titulo}`
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setArtigo(null)
+          setNaoEncontrado(true)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [slug, branding.portal_titulo])
+
+  const linkStyle = { color: branding.cor_link }
+
+  if (loading) {
+    return <p className="text-sm opacity-60">Carregando manual…</p>
+  }
+
+  if (naoEncontrado || !artigo) {
+    return (
+      <div className="space-y-4">
+        <p>Manual não encontrado ou não está mais disponível.</p>
+        <Link to="/kb" className="text-sm font-medium hover:underline" style={linkStyle}>
+          ← Voltar para a central de ajuda
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <article className="space-y-6">
+      <nav className="text-sm opacity-70">
+        <Link to="/kb" className="font-medium hover:underline" style={linkStyle}>
+          Central de ajuda
+        </Link>
+        {artigo.category_nome ? <span> / {artigo.category_nome}</span> : null}
+      </nav>
+
+      <header>
+        <h1 className="text-2xl font-bold sm:text-3xl" style={{ color: branding.cor_texto_corpo }}>
+          {artigo.titulo}
+        </h1>
+        {artigo.updated_at ? (
+          <p className="mt-2 text-xs opacity-60">
+            Atualizado em {new Date(artigo.updated_at).toLocaleDateString('pt-BR')}
+          </p>
+        ) : null}
+      </header>
+
+      <div
+        className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm sm:p-8"
+        style={{ color: branding.cor_texto_corpo }}
+      >
+        <KbMarkdownPreview markdown={artigo.conteudo_markdown} />
+      </div>
+
+      <Link to="/kb" className="inline-block text-sm font-medium hover:underline" style={linkStyle}>
+        ← Voltar para todos os manuais
+      </Link>
+    </article>
+  )
+}

--- a/frontend/src/pages/kb-public/KbPublicContext.tsx
+++ b/frontend/src/pages/kb-public/KbPublicContext.tsx
@@ -1,0 +1,103 @@
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { kbPublic, type Kb } from '../../api/client'
+
+const SIDEBAR_KEY = 'kb-public-sidebar-collapsed'
+
+type KbPublicContextValue = {
+  branding: Kb.PublicBranding | null
+  categorias: Kb.Category[]
+  categoriasLoading: boolean
+  sidebarCollapsed: boolean
+  setSidebarCollapsed: (v: boolean) => void
+  toggleSidebar: () => void
+}
+
+const KbPublicContext = createContext<KbPublicContextValue | null>(null)
+
+const FALLBACK_BRANDING: Kb.PublicBranding = {
+  nome_exibicao: 'Central de ajuda',
+  portal_titulo: 'Central de ajuda',
+  logo_url: null,
+  texto_boas_vindas: null,
+  cor_primaria: '#0D9488',
+  cor_header: '#0B2D4A',
+  cor_texto_header: '#FFFFFF',
+  cor_texto_corpo: '#0F172A',
+  cor_fundo: '#F8FAFC',
+  cor_link: '#0D9488',
+  exibir_marca_deskrudder: true,
+}
+
+export function KbPublicProvider({ children }: { children: ReactNode }) {
+  const [branding, setBranding] = useState<Kb.PublicBranding | null>(null)
+  const [categorias, setCategorias] = useState<Kb.Category[]>([])
+  const [categoriasLoading, setCategoriasLoading] = useState(true)
+  const [sidebarCollapsed, setSidebarCollapsedState] = useState(() => {
+    try {
+      return localStorage.getItem(SIDEBAR_KEY) === '1'
+    } catch {
+      return false
+    }
+  })
+
+  function setSidebarCollapsed(v: boolean) {
+    setSidebarCollapsedState(v)
+    try {
+      localStorage.setItem(SIDEBAR_KEY, v ? '1' : '0')
+    } catch {
+      /* storage indisponível */
+    }
+  }
+
+  function toggleSidebar() {
+    setSidebarCollapsedState((prev) => {
+      const next = !prev
+      try {
+        localStorage.setItem(SIDEBAR_KEY, next ? '1' : '0')
+      } catch {
+        /* storage indisponível */
+      }
+      return next
+    })
+  }
+
+  useEffect(() => {
+    kbPublic
+      .branding()
+      .then(setBranding)
+      .catch(() => setBranding(FALLBACK_BRANDING))
+  }, [])
+
+  useEffect(() => {
+    kbPublic
+      .listCategories()
+      .then(setCategorias)
+      .catch(() => setCategorias([]))
+      .finally(() => setCategoriasLoading(false))
+  }, [])
+
+  const value = useMemo(
+    () => ({
+      branding,
+      categorias,
+      categoriasLoading,
+      sidebarCollapsed,
+      setSidebarCollapsed,
+      toggleSidebar,
+    }),
+    [branding, categorias, categoriasLoading, sidebarCollapsed],
+  )
+
+  return <KbPublicContext.Provider value={value}>{children}</KbPublicContext.Provider>
+}
+
+export function useKbPublic() {
+  const ctx = useContext(KbPublicContext)
+  if (!ctx) throw new Error('useKbPublic deve ser usado dentro de KbPublicProvider')
+  return ctx
+}
+
+export function useKbPublicBranding(): Kb.PublicBranding {
+  const { branding } = useKbPublic()
+  return branding ?? FALLBACK_BRANDING
+}

--- a/frontend/src/pages/kb-public/KbPublicHome.tsx
+++ b/frontend/src/pages/kb-public/KbPublicHome.tsx
@@ -1,0 +1,101 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { kbPublic } from '../../api/client'
+import { KbListaFiltros } from '../../components/kb/KbListaFiltros'
+import { useKbPublic, useKbPublicBranding } from './KbPublicContext'
+import { tituloCategoriaPublica } from './KbPublicSidebar'
+
+export function KbPublicHome() {
+  const branding = useKbPublicBranding()
+  const { categorias } = useKbPublic()
+  const [searchParams] = useSearchParams()
+  const categoryParam = searchParams.get('c')
+  const categoryId = categoryParam ? Number(categoryParam) : ''
+  const [busca, setBusca] = useState(searchParams.get('busca') ?? '')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+  const [itens, setItens] = useState<Awaited<ReturnType<typeof kbPublic.listArticles>>>([])
+  const [loading, setLoading] = useState(true)
+  const [erro, setErro] = useState<string | null>(null)
+
+  const tituloCategoria = tituloCategoriaPublica(categorias, categoryId ? Number(categoryId) : null)
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBusca(busca.trim()), 350)
+    return () => clearTimeout(t)
+  }, [busca])
+
+  const carregar = useCallback(() => {
+    setLoading(true)
+    setErro(null)
+    kbPublic
+      .listArticles({
+        busca: debouncedBusca || undefined,
+        category_id: categoryId ? Number(categoryId) : undefined,
+        limit: 50,
+      })
+      .then(setItens)
+      .catch(() => {
+        setItens([])
+        setErro('Não foi possível carregar os manuais.')
+      })
+      .finally(() => setLoading(false))
+  }, [categoryId, debouncedBusca])
+
+  useEffect(() => {
+    carregar()
+  }, [carregar])
+
+  const subtitulo =
+    branding.texto_boas_vindas?.trim() ||
+    'Consulte passo a passo para tirar dúvidas sobre o sistema.'
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold" style={{ color: branding.cor_texto_corpo }}>
+          {tituloCategoria ? tituloCategoria : 'Manuais e procedimentos'}
+        </h1>
+        <p className="mt-1 text-sm opacity-80">{subtitulo}</p>
+      </div>
+
+      <KbListaFiltros
+        busca={busca}
+        onBuscaChange={setBusca}
+        categoryId={String(categoryId)}
+        onCategoryChange={() => {}}
+        categorias={[]}
+        disabled={loading}
+        hideCategoryFilter
+      />
+
+      {loading ? (
+        <p className="text-sm opacity-60">Carregando…</p>
+      ) : erro ? (
+        <p className="text-sm text-red-600">{erro}</p>
+      ) : itens.length === 0 ? (
+        <p className="rounded-xl border border-dashed border-slate-300 bg-white px-4 py-8 text-center text-sm text-slate-500">
+          {tituloCategoria
+            ? 'Nenhum manual publicado nesta categoria.'
+            : 'Nenhum manual publicado encontrado.'}
+        </p>
+      ) : (
+        <ul className="divide-y divide-slate-200 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          {itens.map((item) => (
+            <li key={item.id}>
+              <Link
+                to={`/kb/a/${encodeURIComponent(item.slug)}`}
+                className="block px-4 py-4 transition-colors hover:bg-slate-50 sm:px-5"
+                style={{ color: branding.cor_texto_corpo }}
+              >
+                <p className="font-medium">{item.titulo}</p>
+                {item.category_nome ? (
+                  <p className="mt-0.5 text-xs text-slate-500">{item.category_nome}</p>
+                ) : null}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/kb-public/KbPublicLayout.tsx
+++ b/frontend/src/pages/kb-public/KbPublicLayout.tsx
@@ -1,0 +1,89 @@
+import { Link, Outlet } from 'react-router-dom'
+import { kbPublic } from '../../api/client'
+import { KbPublicProvider, useKbPublic, useKbPublicBranding } from './KbPublicContext'
+import { KbPublicSidebar } from './KbPublicSidebar'
+
+const menuIcon = (
+  <svg className="size-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+  </svg>
+)
+
+function KbPublicShell() {
+  const branding = useKbPublicBranding()
+  const { sidebarCollapsed, toggleSidebar } = useKbPublic()
+
+  return (
+    <div
+      className="kb-public-portal flex min-h-dvh flex-col"
+      style={{
+        backgroundColor: branding.cor_fundo,
+        color: branding.cor_texto_corpo,
+        ['--kb-accent' as string]: branding.cor_primaria,
+        ['--kb-header' as string]: branding.cor_header,
+        ['--kb-link' as string]: branding.cor_link,
+        ['--kb-body-text' as string]: branding.cor_texto_corpo,
+      }}
+    >
+      <header
+        className="relative shrink-0 border-b border-black/10 shadow-sm"
+        style={{ backgroundColor: branding.cor_header }}
+      >
+        <div className="flex h-14 items-center px-3 sm:px-4">
+          <div className="z-10 flex items-center gap-2 sm:gap-3">
+            <button
+              type="button"
+              onClick={toggleSidebar}
+              className="flex size-10 shrink-0 items-center justify-center rounded-lg transition-colors hover:bg-white/10"
+              style={{ color: branding.cor_texto_header }}
+              aria-label={sidebarCollapsed ? 'Expandir menu de categorias' : 'Recolher menu de categorias'}
+              aria-expanded={!sidebarCollapsed}
+            >
+              {menuIcon}
+            </button>
+            {branding.logo_url ? (
+              <Link to="/kb" className="flex shrink-0 items-center no-underline" title={branding.nome_exibicao}>
+                <img
+                  src={kbPublic.logoAssetUrl()}
+                  alt={branding.nome_exibicao}
+                  className="h-10 max-h-10 w-auto max-w-[200px] object-contain object-left sm:h-11 sm:max-h-11"
+                />
+              </Link>
+            ) : null}
+          </div>
+
+          <h1
+            className="pointer-events-none absolute inset-x-0 truncate px-24 text-center text-base font-semibold tracking-tight sm:text-lg"
+            style={{ color: branding.cor_texto_header }}
+          >
+            {branding.portal_titulo}
+          </h1>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        <KbPublicSidebar />
+        <main className="min-w-0 flex-1 overflow-auto px-4 py-8 sm:px-6 lg:px-8">
+          <div className="mx-auto w-full max-w-4xl">
+            <Outlet />
+          </div>
+        </main>
+      </div>
+
+      <footer className="shrink-0 border-t border-slate-200 bg-white py-4 text-center text-xs text-slate-500">
+        Central de ajuda fornecida por{' '}
+        <span className="font-medium" style={{ color: branding.cor_primaria }}>
+          DeskRudder
+        </span>
+      </footer>
+    </div>
+  )
+}
+
+export function KbPublicLayout() {
+  return (
+    <KbPublicProvider>
+      <KbPublicShell />
+    </KbPublicProvider>
+  )
+}

--- a/frontend/src/pages/kb-public/KbPublicSidebar.tsx
+++ b/frontend/src/pages/kb-public/KbPublicSidebar.tsx
@@ -1,0 +1,152 @@
+import { useMemo, useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import {
+  kbCategoriaPorId,
+  kbCategoriasRaizPublicas,
+  kbSubcategoriasPublicas,
+} from '../../lib/kbPublicCategorias'
+import { useKbPublic, useKbPublicBranding } from './KbPublicContext'
+
+function Chevron({ aberto }: { aberto: boolean }) {
+  return (
+    <svg
+      className={`size-4 shrink-0 transition-transform ${aberto ? 'rotate-90' : ''}`}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden
+    >
+      <path
+        fillRule="evenodd"
+        d="M7.21 14.77a.75.75 0 01.02-1.06L10.17 10 7.23 6.29a.75.75 0 111.04-1.08l3.5 3.25a.75.75 0 010 1.08l-3.5 3.25a.75.75 0 01-1.06-.02z"
+        clipRule="evenodd"
+      />
+    </svg>
+  )
+}
+
+export function KbPublicSidebar() {
+  const branding = useKbPublicBranding()
+  const { categorias, categoriasLoading, sidebarCollapsed } = useKbPublic()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const selectedId = Number(searchParams.get('c') || '') || null
+  const [expanded, setExpanded] = useState<Set<number>>(() => new Set())
+
+  const raizes = useMemo(() => kbCategoriasRaizPublicas(categorias), [categorias])
+
+  function toggleExpanded(id: number) {
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  function selecionarCategoria(id: number) {
+    const next = new URLSearchParams(searchParams)
+    next.set('c', String(id))
+    next.delete('busca')
+    setSearchParams(next, { replace: true })
+  }
+
+  function handleRaizClick(catId: number) {
+    const subs = kbSubcategoriasPublicas(categorias, catId)
+    if (subs.length > 0) {
+      toggleExpanded(catId)
+      return
+    }
+    selecionarCategoria(catId)
+  }
+
+  if (sidebarCollapsed) {
+    return null
+  }
+
+  return (
+    <aside className="flex w-64 shrink-0 flex-col border-r border-slate-200/80 bg-white lg:w-72">
+      <div className="border-b border-slate-200/80 px-3 py-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Categorias</p>
+      </div>
+
+      <nav className="flex-1 overflow-y-auto px-2 py-3" aria-label="Categorias da base de conhecimento">
+        {categoriasLoading ? (
+          <p className="px-2 text-sm text-slate-500">Carregando…</p>
+        ) : raizes.length === 0 ? (
+          <p className="px-2 text-sm text-slate-500">Nenhuma categoria publicada.</p>
+        ) : (
+          <ul className="space-y-0.5">
+            {raizes.map((root) => {
+              const subs = kbSubcategoriasPublicas(categorias, root.id)
+              const aberto = expanded.has(root.id) || subs.some((s) => s.id === selectedId)
+              const rootSelected = selectedId === root.id
+              return (
+                <li key={root.id}>
+                  <div className="flex items-stretch">
+                    {subs.length > 0 ? (
+                      <button
+                        type="button"
+                        onClick={() => toggleExpanded(root.id)}
+                        className="flex w-8 shrink-0 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+                        aria-label={aberto ? 'Recolher subcategorias' : 'Expandir subcategorias'}
+                      >
+                        <Chevron aberto={aberto} />
+                      </button>
+                    ) : (
+                      <span className="w-8 shrink-0" />
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => handleRaizClick(root.id)}
+                      className={`min-w-0 flex-1 rounded-lg px-2 py-2 text-left text-sm font-medium transition-colors ${
+                        rootSelected ? 'text-white' : 'text-slate-700 hover:bg-slate-100'
+                      }`}
+                      style={rootSelected ? { backgroundColor: branding.cor_primaria } : undefined}
+                    >
+                      {root.nome}
+                    </button>
+                  </div>
+                  {subs.length > 0 && aberto ? (
+                    <ul className="ml-8 mt-0.5 space-y-0.5 border-l border-slate-200 pl-2">
+                      {subs.map((sub) => {
+                        const selected = selectedId === sub.id
+                        return (
+                          <li key={sub.id}>
+                            <button
+                              type="button"
+                              onClick={() => selecionarCategoria(sub.id)}
+                              className={`w-full rounded-lg px-2 py-1.5 text-left text-sm transition-colors ${
+                                selected ? 'font-medium text-white' : 'text-slate-600 hover:bg-slate-100'
+                              }`}
+                              style={selected ? { backgroundColor: branding.cor_primaria } : undefined}
+                            >
+                              {sub.nome}
+                            </button>
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  ) : null}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+
+        <div className="mt-4 border-t border-slate-200/80 pt-3">
+          <Link
+            to="/kb"
+            className="block rounded-lg px-2 py-2 text-sm text-slate-600 hover:bg-slate-100"
+            onClick={() => setSearchParams({}, { replace: true })}
+          >
+            Ver todos os manuais
+          </Link>
+        </div>
+      </nav>
+    </aside>
+  )
+}
+
+export function tituloCategoriaPublica(categorias: ReturnType<typeof useKbPublic>['categorias'], id: number | null) {
+  if (!id) return null
+  return kbCategoriaPorId(categorias, id)?.nome ?? null
+}

--- a/frontend/src/pages/whatsapp/WhatsappDemandaFormFields.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappDemandaFormFields.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { ticketClassificacao, type TicketClassificacao } from '../../api/client'
 import { Input } from '../../components/ui/Input'
 import { Select } from '../../components/ui/Select'
+import { KbSugestoesMotivo } from '../../components/kb/KbSugestoesMotivo'
 
 export type DemandaFormValues = {
   naturezaId: number | ''
@@ -72,6 +73,7 @@ export function WhatsappDemandaFormFields({ values, onChange, disabled, idPrefix
         id={`${idPrefix}-desc`}
         placeholder="Resumo do que foi tratado"
       />
+      <KbSugestoesMotivo naturezaId={values.naturezaId} motivoId={values.motivoId} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **#296**: admin vincula manuais a natureza/motivo; ate 5 sugestoes na classificacao de tickets e demandas WhatsApp.
- **#465/#466**: portal publico `/kb` com logo e nome da empresa, listagem, busca e leitura de artigos sem login.
- **#467**: personalizacao do portal em Configuracoes -> Sistema -> Base de conhecimento (cores, textos, links); menu lateral de categorias; navbar com titulo centralizado, logo e menu hamburger; contraste do markdown corrigido no tema escuro.
- Login: fundo full-screen com asset SVG; `docker-compose` exclui `alembic/*` e `tests/*` do reload do uvicorn.

Closes #296
Closes #465
Closes #466
Closes #467

## Test plan
- [x] `npx tsc -b --noEmit` no frontend
- [x] Portal `/kb` — listagem, artigo, sidebar, navbar e rodape DeskRudder
- [x] Configuracoes -> Sistema -> Base de conhecimento — salvar cores e textos
- [x] Ajuda -> Consultar — link publico e copiar URL
- [x] Ticket/WhatsApp — sugestoes de manual por natureza/motivo
- [ ] `pytest tests/test_kb.py` no CI (ambiente local sem pytest no container)
