### PR TITLE
fix(whatsapp): correções de produção (#470–#473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#473): modal de encerramento deixava de carregar demandas — polling da conversa refazia o fetch e mantinha «A carregar demandas…» em loop; demanda passa a ser opcional quando o chat encerra por inatividade
+- WhatsApp (#472): banner «contato não identificado» persistia após vincular/cadastrar — polling/SSE com snapshot antigo sobrescrevia o vínculo; sidebar e header atualizam na hora
+- WhatsApp (#471): cache de mídia por mensagem reduz refetch de blobs e mitiga `ERR_INSUFFICIENT_RESOURCES` no carregamento de anexos
+- WhatsApp: aviso de inatividade duplicado quando vários workers processavam o mesmo chat em paralelo (Gunicorn)
 - WhatsApp (#443/#454): painel de emoji e envio de figurinhas no composer; Histórico e Avaliações preservam posição de scroll ao voltar da conversa
 - WhatsApp (#449): corrigido link do Histórico/Avaliações para conversa — query `?from=` separada do `pathname` (React Router v7)
 - Notificações (#452): pendências de mensagem não lida abrem o ticket ou chat concreto (`/tickets/{id}`, `/whatsapp/c/{id}`) — removido fallback genérico para listagens
@@ -29,6 +33,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- WhatsApp (#470): áudio gravado na barra de composição é enviado automaticamente ao terminar a gravação (estilo WhatsApp Web)
 - Identidade visual (#434): painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel
 - Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp
 - Base de conhecimento (#465/#466): portal público `/kb` com logo e nome da empresa (Configurações → Empresa); listagem, busca e leitura de artigos sem login

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -1348,6 +1348,7 @@ def vincular_funcionario(
     db.commit()
     c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     assert c2 is not None
+    emit_chat_fila_from_model(db, c2, estado_anterior=c.estado)
     return _chat_read(db, c2)
 
 
@@ -1367,6 +1368,7 @@ def desvincular_funcionario(
     db.commit()
     c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     assert c2 is not None
+    emit_chat_fila_from_model(db, c2, estado_anterior=c.estado)
     return _chat_read(db, c2)
 
 
@@ -1406,6 +1408,7 @@ def cadastrar_funcionario(
     db.commit()
     c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     assert c2 is not None
+    emit_chat_fila_from_model(db, c2, estado_anterior=c.estado)
     return _chat_read(db, c2)
 
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -258,11 +258,7 @@ async def lifespan(app: FastAPI):
         while True:
             db = SessionLocal()
             try:
-                n = process_whatsapp_inactivity_closures(db, limit=200)
-                if n:
-                    db.commit()
-                else:
-                    db.rollback()
+                process_whatsapp_inactivity_closures(db, limit=200)
             except Exception as e:
                 logger.warning("Worker inatividade WhatsApp: %s", e)
                 db.rollback()

--- a/backend/app/services/whatsapp_inactivity_worker.py
+++ b/backend/app/services/whatsapp_inactivity_worker.py
@@ -92,6 +92,28 @@ def _minutos_desde(ref: datetime | None, now: datetime) -> float:
     return max(0.0, (now - ref).total_seconds() / 60.0)
 
 
+def _normalizar_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _aviso_ja_enviado_no_ciclo(db: Session, chat_id: int, referencia: datetime) -> bool:
+    """Evita reenvio do aviso quando vários workers processam o mesmo chat em paralelo."""
+    ref = _normalizar_utc(referencia)
+    return (
+        db.query(WhatsappMensagem.id)
+        .filter(
+            WhatsappMensagem.chat_id == chat_id,
+            WhatsappMensagem.evento_sistema == "auto_inativ_aviso",
+            WhatsappMensagem.created_at >= ref,
+        )
+        .limit(1)
+        .first()
+        is not None
+    )
+
+
 def _prefixo_bot(texto: str) -> str:
     t = (texto or "").strip()
     if not t:
@@ -135,6 +157,7 @@ def _enviar_texto_sistema(
             evento_sistema=evento_sistema,
         )
     )
+    db.flush()
     return True
 
 
@@ -173,6 +196,9 @@ def _processar_chat_inatividade(
     if _minutos_desde(referencia, now) < aviso_min:
         return False
 
+    if _aviso_ja_enviado_no_ciclo(db, chat.id, referencia):
+        return False
+
     if not bool(getattr(st, "auto_msg_inativ_aviso_ativa", True)):
         _encerrar_por_inatividade(db, chat, st)
         return True
@@ -191,6 +217,9 @@ def process_whatsapp_inactivity_closures(db: Session, *, limit: int = 200) -> in
     """
     Verifica chats em atendimento e envia aviso ou encerra por inatividade do cliente.
     Retorna quantidade de chats alterados.
+
+    Usa lock de linha (FOR UPDATE) e commit por chat para evitar mensagens duplicadas
+    quando Gunicorn roda N workers, cada um com thread de inatividade.
     """
     st = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
     if not st or not bool(getattr(st, "inativ_encerramento_ativa", False)):
@@ -199,18 +228,34 @@ def process_whatsapp_inactivity_closures(db: Session, *, limit: int = 200) -> in
         return 0
 
     now = datetime.now(timezone.utc)
-    chats = (
-        db.query(WhatsappChat)
-        .filter(WhatsappChat.estado == "em_atendimento")
-        .order_by(WhatsappChat.id.asc())
-        .limit(limit)
-        .all()
-    )
+    chat_ids = [
+        row[0]
+        for row in (
+            db.query(WhatsappChat.id)
+            .filter(WhatsappChat.estado == "em_atendimento")
+            .order_by(WhatsappChat.id.asc())
+            .limit(limit)
+            .all()
+        )
+    ]
     alterados = 0
-    for chat in chats:
+    for chat_id in chat_ids:
         try:
+            chat = (
+                db.query(WhatsappChat)
+                .filter(WhatsappChat.id == chat_id, WhatsappChat.estado == "em_atendimento")
+                .with_for_update()
+                .first()
+            )
+            if not chat:
+                db.rollback()
+                continue
             if _processar_chat_inatividade(db, chat, st, now):
+                db.commit()
                 alterados += 1
+            else:
+                db.rollback()
         except Exception as exc:
-            logger.warning("Inatividade WhatsApp (chat=%s): %s", chat.protocolo, exc)
+            db.rollback()
+            logger.warning("Inatividade WhatsApp (chat=%s): %s", chat_id, exc)
     return alterados

--- a/backend/tests/test_whatsapp_inatividade_encerramento.py
+++ b/backend/tests/test_whatsapp_inatividade_encerramento.py
@@ -195,3 +195,59 @@ def test_worker_aviso_mesmo_com_atendente_enviando_varias_vezes(
 
     n = process_whatsapp_inactivity_closures(db_session)
     assert n == 1
+
+
+def test_worker_nao_reenvia_aviso_duplicado_no_mesmo_ciclo(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    """Vários workers Gunicorn não devem reenviar o aviso de inatividade."""
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session, wa_id="5511999443322")
+    antiga_cliente = datetime.now(timezone.utc) - timedelta(minutes=20)
+    antiga_atendente = datetime.now(timezone.utc) - timedelta(minutes=15)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="inbound",
+            corpo="Preciso de ajuda",
+            tipo_midia="texto",
+            created_at=antiga_cliente,
+        )
+    )
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Alguma dúvida?",
+            tipo_midia="texto",
+            atendente_id=1,
+            created_at=antiga_atendente,
+        )
+    )
+    db_session.commit()
+
+    enviados: list[str] = []
+
+    def fake_send(base, inst, key, wa, text):
+        enviados.append(text)
+        return True, None, f"wa-out-dup-{len(enviados)}"
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        fake_send,
+    )
+
+    n1 = process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    n2 = process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+
+    assert n1 == 1
+    assert n2 == 0
+    assert len(enviados) == 1
+    total_avisos = (
+        db_session.query(WhatsappMensagem)
+        .filter(WhatsappMensagem.chat_id == chat.id, WhatsappMensagem.evento_sistema == "auto_inativ_aviso")
+        .count()
+    )
+    assert total_avisos == 1

--- a/frontend/src/lib/whatsappChatMerge.ts
+++ b/frontend/src/lib/whatsappChatMerge.ts
@@ -1,0 +1,58 @@
+import type { WhatsappChats } from '../api/client'
+
+/** Campos de vínculo com contato/empresa — preservados se payload SSE/poll vier desatualizado. */
+const CAMPOS_VINCULO: (keyof WhatsappChats.Chat)[] = [
+  'funcionario_rede_id',
+  'funcionario_nome',
+  'funcionario_email',
+  'funcionario_tipo',
+  'empresa_id',
+  'empresa_nome',
+]
+
+function copiarCamposVinculo(origem: WhatsappChats.Chat, destino: WhatsappChats.Chat): WhatsappChats.Chat {
+  const merged = { ...destino }
+  for (const k of CAMPOS_VINCULO) {
+    ;(merged as Record<string, unknown>)[k] = origem[k]
+  }
+  return merged
+}
+
+/**
+ * Mescla atualizações de chat sem perder vínculo recém-gravado quando SSE/polling
+ * ainda traz snapshot antigo (#472).
+ */
+export function mergeWhatsappChat(
+  prev: WhatsappChats.Chat | null | undefined,
+  next: WhatsappChats.Chat,
+): WhatsappChats.Chat {
+  if (!prev || prev.id !== next.id) return next
+  const merged: WhatsappChats.Chat = { ...prev, ...next }
+  if (prev.funcionario_rede_id && !next.funcionario_rede_id) {
+    return copiarCamposVinculo(prev, merged)
+  }
+  return merged
+}
+
+export function patchWhatsappChatLista(
+  lista: WhatsappChats.Chat[],
+  atualizado: WhatsappChats.Chat,
+): WhatsappChats.Chat[] {
+  const idx = lista.findIndex((c) => c.id === atualizado.id)
+  if (idx < 0) return lista
+  const next = [...lista]
+  next[idx] = mergeWhatsappChat(lista[idx], atualizado)
+  return next
+}
+
+/** Substitui o chat na lista (resposta autoritativa de mutação — vincular/desvincular). */
+export function replaceWhatsappChatLista(
+  lista: WhatsappChats.Chat[],
+  atualizado: WhatsappChats.Chat,
+): WhatsappChats.Chat[] {
+  const idx = lista.findIndex((c) => c.id === atualizado.id)
+  if (idx < 0) return lista
+  const next = [...lista]
+  next[idx] = atualizado
+  return next
+}

--- a/frontend/src/lib/whatsappDemandaUtils.ts
+++ b/frontend/src/lib/whatsappDemandaUtils.ts
@@ -29,6 +29,14 @@ export function mensagensVisiveisConversa(msgs: WhatsappChats.Mensagem[]): Whats
   )
 }
 
+/** Aviso ou encerramento automático por inatividade do cliente — demanda no modal é opcional. */
+export function chatEncerramentoPorInatividade(msgs: WhatsappChats.Mensagem[]): boolean {
+  return msgs.some(
+    (m) =>
+      m.evento_sistema === 'auto_encerrado_inatividade' || m.evento_sistema === 'auto_inativ_aviso',
+  )
+}
+
 export function analisarDemandaPosRegistro(
   demandas: WhatsappChats.Demanda[],
   msgs: WhatsappChats.Mensagem[],

--- a/frontend/src/lib/whatsappMensagens.ts
+++ b/frontend/src/lib/whatsappMensagens.ts
@@ -1,0 +1,18 @@
+import type { WhatsappChats } from '../api/client'
+
+/** Remove duplicatas ao recarregar a conversa (id / wa_message_id). */
+export function whatsappMensagensUnicas(msgs: WhatsappChats.Mensagem[]): WhatsappChats.Mensagem[] {
+  const seenId = new Set<number>()
+  const seenWa = new Set<string>()
+  const out: WhatsappChats.Mensagem[] = []
+  for (const m of msgs) {
+    if (seenId.has(m.id)) continue
+    if (m.wa_message_id) {
+      if (seenWa.has(m.wa_message_id)) continue
+      seenWa.add(m.wa_message_id)
+    }
+    seenId.add(m.id)
+    out.push(m)
+  }
+  return out
+}

--- a/frontend/src/lib/whatsappMidiaCache.ts
+++ b/frontend/src/lib/whatsappMidiaCache.ts
@@ -1,0 +1,48 @@
+/** Cache de blobs/object URLs por mensagem — evita refetch e ERR_INSUFFICIENT_RESOURCES (#471). */
+
+const objectUrls = new Map<string, string>()
+const inflight = new Map<string, Promise<string>>()
+
+function cacheKey(chatId: number, mensagemId: number) {
+  return `${chatId}:${mensagemId}`
+}
+
+export function getWhatsappMidiaObjectUrl(chatId: number, mensagemId: number): string | null {
+  return objectUrls.get(cacheKey(chatId, mensagemId)) ?? null
+}
+
+export async function resolveWhatsappMidiaObjectUrl(
+  chatId: number,
+  mensagemId: number,
+  fetchBlob: () => Promise<Blob>,
+): Promise<string> {
+  const key = cacheKey(chatId, mensagemId)
+  const cached = objectUrls.get(key)
+  if (cached) return cached
+
+  const pending = inflight.get(key)
+  if (pending) return pending
+
+  const promise = fetchBlob().then((blob) => {
+    const existing = objectUrls.get(key)
+    if (existing) return existing
+    const url = URL.createObjectURL(blob)
+    objectUrls.set(key, url)
+    return url
+  }).finally(() => {
+    inflight.delete(key)
+  })
+
+  inflight.set(key, promise)
+  return promise
+}
+
+export function revokeWhatsappMidiaForChat(chatId: number) {
+  const prefix = `${chatId}:`
+  for (const [key, url] of objectUrls.entries()) {
+    if (key.startsWith(prefix)) {
+      URL.revokeObjectURL(url)
+      objectUrls.delete(key)
+    }
+  }
+}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -21,6 +21,11 @@ import {
 
 } from '../../api/client'
 
+import { resolveWhatsappMidiaObjectUrl, revokeWhatsappMidiaForChat } from '../../lib/whatsappMidiaCache'
+import { chatEncerramentoPorInatividade } from '../../lib/whatsappDemandaUtils'
+import { mergeWhatsappChat, patchWhatsappChatLista, replaceWhatsappChatLista } from '../../lib/whatsappChatMerge'
+import { whatsappMensagensUnicas } from '../../lib/whatsappMensagens'
+
 import { Card } from '../../components/ui/Card'
 
 import { Button } from '../../components/ui/Button'
@@ -107,21 +112,17 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 
     }
 
-    let objectUrl: string | null = null
-
     let cancelled = false
 
     setLoading(true)
 
-    fetchWhatsAppMidiaBlob(chatId, m.id)
+    setErr(false)
 
-      .then((blob) => {
+    void resolveWhatsappMidiaObjectUrl(chatId, m.id, () => fetchWhatsAppMidiaBlob(chatId, m.id))
+
+      .then((u) => {
 
         if (cancelled) return
-
-        const u = URL.createObjectURL(blob)
-
-        objectUrl = u
 
         setUrl(u)
 
@@ -135,8 +136,6 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 
       cancelled = true
 
-      if (objectUrl) URL.revokeObjectURL(objectUrl)
-
     }
 
   }, [chatId, m.id, m.midia_disponivel, tipo])
@@ -148,14 +147,6 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 
 
   if (tipo === 'texto' || !m.tipo_midia) return <TextoComLinks texto={m.corpo} />
-
-  if (!m.midia_disponivel) {
-    return (
-      <p className="text-xs italic opacity-70" title="O ficheiro não foi obtido da Evolution API">
-        {m.corpo || 'Mídia não disponível'}
-      </p>
-    )
-  }
 
   if (!m.midia_disponivel) {
     return (
@@ -248,6 +239,8 @@ export function WhatsappConversa() {
 
   const fileInputRef = useRef<HTMLInputElement>(null)
 
+  const carregarGenRef = useRef(0)
+
   const [pickerAnexo, setPickerAnexo] = useState<TipoAnexoPicker>('imagem')
   const [arquivoPendente, setArquivoPendente] = useState<File | null>(null)
   const [legendaMidia, setLegendaMidia] = useState('')
@@ -320,6 +313,15 @@ export function WhatsappConversa() {
   }, [voltarLista, modalEncerrar])
 
   useEffect(() => {
+    if (!modalEncerrar || !chat) return
+    const fechado = chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao'
+    if (fechado && chatEncerramentoPorInatividade(msgs)) {
+      setModalEncerrar(false)
+      toast.showSuccess('Atendimento encerrado automaticamente por inatividade do cliente.')
+    }
+  }, [modalEncerrar, chat, msgs, toast])
+
+  useEffect(() => {
     if (!id) return
     whatsappChats
       .demandas(id)
@@ -351,7 +353,12 @@ export function WhatsappConversa() {
 
       const rows = await whatsappChats.meus()
 
-      setMeusChats(rows)
+      setMeusChats((prev) =>
+        rows.map((row) => {
+          const antigo = prev.find((c) => c.id === row.id)
+          return antigo ? mergeWhatsappChat(antigo, row) : row
+        }),
+      )
 
     } catch { setMeusChats([]) }
 
@@ -365,13 +372,17 @@ export function WhatsappConversa() {
 
     if (!id) return
 
+    const gen = ++carregarGenRef.current
+
     try {
 
       const [c, m] = await Promise.all([whatsappChats.get(id), whatsappChats.mensagens(id)])
 
-      setChat(c)
+      if (gen !== carregarGenRef.current) return
 
-      setMsgs(m)
+      setChat((prev) => mergeWhatsappChat(prev, c))
+
+      setMsgs(whatsappMensagensUnicas(m))
 
     } catch (err) {
 
@@ -380,6 +391,14 @@ export function WhatsappConversa() {
     }
 
   }, [id, toast])
+
+
+
+  const aplicarChatAtualizado = useCallback((atualizado: WhatsappChats.Chat) => {
+    carregarGenRef.current += 1
+    setChat(atualizado)
+    setMeusChats((prev) => replaceWhatsappChatLista(prev, atualizado))
+  }, [])
 
 
 
@@ -398,6 +417,10 @@ export function WhatsappConversa() {
     setLoading(true)
 
     carregar().then(() => whatsappChats.marcarVisto(id)).finally(() => setLoading(false))
+
+    return () => {
+      revokeWhatsappMidiaForChat(Number(id))
+    }
 
   }, [id, carregar])
 
@@ -430,12 +453,17 @@ export function WhatsappConversa() {
       const payloadChatId = Number(payload.chat_id)
       const chatData = payload.chat as WhatsappChats.Chat | undefined
       if (payloadChatId === chatId) {
-        if (chatData) setChat(chatData)
-        else void carregar().catch(() => {})
+        if (chatData) {
+          carregarGenRef.current += 1
+          setChat((prev) => mergeWhatsappChat(prev, chatData))
+          setMeusChats((prev) => patchWhatsappChatLista(prev, chatData))
+        } else {
+          void carregar().catch(() => {})
+        }
       }
       if (chatData && chatData.estado !== 'em_atendimento') {
         setMeusChats((prev) => prev.filter((c) => c.id !== payloadChatId))
-      } else {
+      } else if (!chatData || payloadChatId !== chatId) {
         void carregarSidebar()
       }
     })
@@ -599,9 +627,24 @@ useEffect(() => {
     window.setTimeout(() => fileInputRef.current?.click(), 0)
   }
 
-  function handleGravacaoConcluida(file: File) {
-    setArquivoPendente(file)
-    setLegendaMidia('')
+  async function handleGravacaoConcluida(file: File) {
+    if (!chat || enviando) return
+    setEnviando(true)
+    try {
+      await whatsappChats.enviarMidia(
+        chat.id,
+        file,
+        '',
+        msgRespondida?.wa_message_id || null,
+      )
+      setMsgRespondida(null)
+      toast.showSuccess('Áudio enviado.')
+      await carregar()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao enviar áudio.'))
+    } finally {
+      setEnviando(false)
+    }
   }
 
   function handleFileSelecionado(e: React.ChangeEvent<HTMLInputElement>) {
@@ -1301,7 +1344,7 @@ useEffect(() => {
             chat={chat}
             open={modalVincFuncionario}
             onClose={() => setModalVincFuncionario(false)}
-            onSuccess={(atualizado) => setChat(atualizado)}
+            onSuccess={aplicarChatAtualizado}
           />
         )}
 
@@ -1311,7 +1354,7 @@ useEffect(() => {
           open={modalTickets}
           onClose={() => setModalTickets(false)}
           onSuccess={(atualizado) => {
-            setChat(atualizado)
+            aplicarChatAtualizado(atualizado)
             setDemandasReloadKey((k) => k + 1)
           }}
         />
@@ -1321,6 +1364,7 @@ useEffect(() => {
         <WhatsappEncerrarModal
           open={modalEncerrar}
           chatId={chat.id}
+          chatEstado={chat.estado}
           msgs={msgs}
           onClose={() => setModalEncerrar(false)}
           onEncerrado={(atualizado) => void handleEncerrado(atualizado)}

--- a/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { whatsappChats, type WhatsappChats } from '../../api/client'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
 import { Button } from '../../components/ui/Button'
@@ -7,6 +7,7 @@ import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import {
   analisarDemandaPosRegistro,
+  chatEncerramentoPorInatividade,
   formatarHoraDemanda,
   rotuloDemanda,
 } from '../../lib/whatsappDemandaUtils'
@@ -23,13 +24,35 @@ type AcaoEncerramento = 'manter' | 'editar' | 'nova' | 'registrar' | 'sem_demand
 type Props = {
   open: boolean
   chatId: number
+  chatEstado?: string | null
   msgs: WhatsappChats.Mensagem[]
   onClose: () => void
   onEncerrado: (chat: WhatsappChats.Chat) => void
   onDemandasChange?: () => void
 }
 
-export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado, onDemandasChange }: Props) {
+function definirAcaoInicial(
+  rows: WhatsappChats.Demanda[],
+  msgs: WhatsappChats.Mensagem[],
+  encerramentoPorInatividade: boolean,
+): AcaoEncerramento {
+  const pos = analisarDemandaPosRegistro(rows, msgs)
+  if (rows.length === 0) {
+    return encerramentoPorInatividade ? 'sem_demanda' : 'registrar'
+  }
+  if (pos) return 'nova'
+  return 'manter'
+}
+
+export function WhatsappEncerrarModal({
+  open,
+  chatId,
+  chatEstado,
+  msgs,
+  onClose,
+  onEncerrado,
+  onDemandasChange,
+}: Props) {
   const toast = useToast()
   const [demandas, setDemandas] = useState<WhatsappChats.Demanda[]>([])
   const [loadingDemandas, setLoadingDemandas] = useState(false)
@@ -37,6 +60,11 @@ export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado
   const [acao, setAcao] = useState<AcaoEncerramento>('manter')
   const [form, setForm] = useState<DemandaFormValues>(DEMANDA_FORM_VAZIO)
   const [confirmarSemDemanda, setConfirmarSemDemanda] = useState(false)
+  const acaoEscolhidaRef = useRef(false)
+
+  const encerramentoPorInatividade = useMemo(() => chatEncerramentoPorInatividade(msgs), [msgs])
+  const chatJaEncerrado =
+    chatEstado === 'encerrado' || chatEstado === 'aguardando_avaliacao'
 
   const posRegistro = useMemo(
     () => analisarDemandaPosRegistro(demandas, msgs),
@@ -45,41 +73,50 @@ export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado
 
   const semDemandas = demandas.length === 0
   const demandasResolvidas = demandas.filter((d) => d.desfecho === 'resolvido_sessao')
-
-  const carregarDemandas = useCallback(async () => {
-    setLoadingDemandas(true)
-    try {
-      const rows = await whatsappChats.demandas(chatId)
-      setDemandas(rows)
-      return rows
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar demandas.'))
-      setDemandas([])
-      return []
-    } finally {
-      setLoadingDemandas(false)
-    }
-  }, [chatId, toast])
+  const demandaOpcional = encerramentoPorInatividade && semDemandas
 
   useEffect(() => {
-    if (!open) return
-    void carregarDemandas().then((rows) => {
-      const pos = analisarDemandaPosRegistro(rows, msgs)
-      if (rows.length === 0) {
-        setAcao('registrar')
-        setForm(DEMANDA_FORM_VAZIO)
-        setConfirmarSemDemanda(false)
-      } else if (pos) {
-        setAcao('nova')
-        setForm(DEMANDA_FORM_VAZIO)
-        setConfirmarSemDemanda(false)
-      } else {
-        setAcao('manter')
-        setForm(DEMANDA_FORM_VAZIO)
-        setConfirmarSemDemanda(false)
-      }
-    })
-  }, [open, carregarDemandas, msgs])
+    if (!open) {
+      acaoEscolhidaRef.current = false
+      setDemandas([])
+      setLoadingDemandas(false)
+      setConfirmarSemDemanda(false)
+      return
+    }
+
+    let cancelled = false
+    setLoadingDemandas(true)
+    void whatsappChats
+      .demandas(chatId)
+      .then((rows) => {
+        if (cancelled) return
+        setDemandas(rows)
+        if (!acaoEscolhidaRef.current) {
+          setAcao(definirAcaoInicial(rows, msgs, encerramentoPorInatividade))
+          setForm(DEMANDA_FORM_VAZIO)
+          setConfirmarSemDemanda(false)
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return
+        toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar demandas.'))
+        setDemandas([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingDemandas(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+    // Carrega uma vez ao abrir; msgs em polling não devem refazer fetch (#473).
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- msgs/flags só para acao inicial
+  }, [open, chatId, toast])
+
+  useEffect(() => {
+    if (!open || loadingDemandas || acaoEscolhidaRef.current) return
+    setAcao(definirAcaoInicial(demandas, msgs, encerramentoPorInatividade))
+  }, [open, loadingDemandas, demandas, msgs, encerramentoPorInatividade])
 
   useEffect(() => {
     if (acao === 'editar' && posRegistro) {
@@ -88,6 +125,11 @@ export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado
       setForm(DEMANDA_FORM_VAZIO)
     }
   }, [acao, posRegistro])
+
+  function selecionarAcao(nova: AcaoEncerramento) {
+    acaoEscolhidaRef.current = true
+    setAcao(nova)
+  }
 
   async function executarEncerramento() {
     setSalvando(true)
@@ -99,7 +141,7 @@ export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado
         }
         await whatsappChats.registrarDemanda(chatId, demandaFormPayload(form))
       } else if (acao === 'sem_demanda') {
-        if (!confirmarSemDemanda) {
+        if (!demandaOpcional && !confirmarSemDemanda) {
           toast.showWarning('Confirme que deseja encerrar sem registar demanda.')
           return
         }
@@ -124,12 +166,18 @@ export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado
     }
   }
 
-  const titulo = 'Encerrar atendimento'
+  const titulo = chatJaEncerrado && encerramentoPorInatividade
+    ? 'Atendimento encerrado por inatividade'
+    : 'Encerrar atendimento'
 
   let mensagemIntro =
     'Revise as demandas desta sessão antes de finalizar. O cliente poderá receber pedido de avaliação conforme configuração.'
 
-  if (semDemandas) {
+  if (demandaOpcional) {
+    mensagemIntro = chatJaEncerrado
+      ? 'Este atendimento foi encerrado automaticamente por inatividade do cliente. Registar demanda é opcional.'
+      : 'O cliente está inativo (aviso automático enviado). Pode encerrar sem registar demanda ou classificar opcionalmente.'
+  } else if (semDemandas) {
     mensagemIntro =
       'Registe o motivo do atendimento antes de encerrar, ou confirme explicitamente o encerramento sem demanda.'
   } else if (posRegistro) {
@@ -139,6 +187,9 @@ export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado
 
   const mostrarForm =
     acao === 'registrar' || acao === 'nova' || (acao === 'editar' && posRegistro != null)
+
+  const rotuloBotaoEncerrar =
+    chatJaEncerrado && encerramentoPorInatividade ? 'Concluir' : 'Encerrar atendimento'
 
   return (
     <ConfirmDialog
@@ -192,32 +243,60 @@ export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado
 
           {semDemandas ? (
             <div className="space-y-3">
-              <label className="flex cursor-pointer items-center gap-2 text-sm">
-                <input
-                  type="radio"
-                  name="acao-encerrar"
-                  checked={acao === 'registrar'}
-                  onChange={() => setAcao('registrar')}
-                />
-                Registar demanda e encerrar
-              </label>
-              <label className="flex cursor-pointer items-center gap-2 text-sm">
-                <input
-                  type="radio"
-                  name="acao-encerrar"
-                  checked={acao === 'sem_demanda'}
-                  onChange={() => setAcao('sem_demanda')}
-                />
-                Encerrar sem registar demanda
-              </label>
-              {acao === 'sem_demanda' && (
-                <CheckboxField
-                  checked={confirmarSemDemanda}
-                  onChange={(e) => setConfirmarSemDemanda(e.target.checked)}
-                  variant="inline"
-                >
-                  Confirmo encerrar sem classificar esta sessão
-                </CheckboxField>
+              {demandaOpcional ? (
+                <>
+                  <p className="text-xs text-slate-500">
+                    Registar demanda é opcional neste encerramento por inatividade.
+                  </p>
+                  <label className="flex cursor-pointer items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="acao-encerrar"
+                      checked={acao === 'sem_demanda'}
+                      onChange={() => selecionarAcao('sem_demanda')}
+                    />
+                    {chatJaEncerrado ? 'Concluir sem registar demanda' : 'Encerrar sem registar demanda'}
+                  </label>
+                  <label className="flex cursor-pointer items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="acao-encerrar"
+                      checked={acao === 'registrar'}
+                      onChange={() => selecionarAcao('registrar')}
+                    />
+                    Registar demanda (opcional)
+                  </label>
+                </>
+              ) : (
+                <>
+                  <label className="flex cursor-pointer items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="acao-encerrar"
+                      checked={acao === 'registrar'}
+                      onChange={() => selecionarAcao('registrar')}
+                    />
+                    Registar demanda e encerrar
+                  </label>
+                  <label className="flex cursor-pointer items-center gap-2 text-sm">
+                    <input
+                      type="radio"
+                      name="acao-encerrar"
+                      checked={acao === 'sem_demanda'}
+                      onChange={() => selecionarAcao('sem_demanda')}
+                    />
+                    Encerrar sem registar demanda
+                  </label>
+                  {acao === 'sem_demanda' && (
+                    <CheckboxField
+                      checked={confirmarSemDemanda}
+                      onChange={(e) => setConfirmarSemDemanda(e.target.checked)}
+                      variant="inline"
+                    >
+                      Confirmo encerrar sem classificar esta sessão
+                    </CheckboxField>
+                  )}
+                </>
               )}
             </div>
           ) : posRegistro ? (
@@ -227,7 +306,7 @@ export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado
                   type="radio"
                   name="acao-encerrar"
                   checked={acao === 'manter'}
-                  onChange={() => setAcao('manter')}
+                  onChange={() => selecionarAcao('manter')}
                 />
                 Manter demandas como estão
               </label>
@@ -237,7 +316,7 @@ export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado
                     type="radio"
                     name="acao-encerrar"
                     checked={acao === 'editar'}
-                    onChange={() => setAcao('editar')}
+                    onChange={() => selecionarAcao('editar')}
                   />
                   Editar última demanda «{rotuloDemanda(posRegistro.ultimaDemanda)}»
                 </label>
@@ -247,7 +326,7 @@ export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado
                   type="radio"
                   name="acao-encerrar"
                   checked={acao === 'nova'}
-                  onChange={() => setAcao('nova')}
+                  onChange={() => selecionarAcao('nova')}
                 />
                 Registar nova demanda para o restante da conversa
               </label>
@@ -267,7 +346,7 @@ export function WhatsappEncerrarModal({ open, chatId, msgs, onClose, onEncerrado
               Cancelar
             </Button>
             <Button variant="danger" onClick={() => void executarEncerramento()} loading={salvando}>
-              Encerrar atendimento
+              {rotuloBotaoEncerrar}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- **#470**: áudio gravado é enviado automaticamente ao terminar a gravação (sem ficar pendente na composição)
- **#471**: cache de blob/object URL por mensagem reduz refetch de mídia e mitiga `ERR_INSUFFICIENT_RESOURCES`
- **#472**: sidebar e header atualizam após vincular/cadastrar contato; merge de chat evita que polling/SSE sobrescreva o vínculo; backend emite SSE após vincular/desvincular
- **#473**: modal de encerramento deixa de refazer fetch de demandas a cada poll da conversa (loop «A carregar demandas…»)

Extras no mesmo lote:

- Demanda opcional no encerramento quando o chat fecha por inatividade
- Worker de inatividade: `FOR UPDATE` + deduplicação de avisos BOT em deploy multi-worker
- Mensagens deduplicadas na timeline da conversa

Closes #470
Closes #471
Closes #472
Closes #473

## Test plan

- [ ] Gravar áudio num chat ativo — envia automaticamente sem anexo pendente
- [ ] Abrir conversa com várias mídias — console sem avalanche de `ERR_INSUFFICIENT_RESOURCES`
- [ ] Vincular/cadastrar contato «sem vínculo» — banner some na hora sem F5
- [ ] Encerrar atendimento — modal carrega demandas uma vez, sem loop
- [ ] Encerrar chat por inatividade — demanda opcional no modal
- [ ] `pytest backend/tests/test_whatsapp_inatividade_encerramento.py`
