### PR TITLE
feat(chat-interno): editar, apagar, reações e scroll inteligente (#502, #503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Chat operacional: hub unificado em `/chat` com abas Atendendo, Espera e Interno; Histórico permanece em menu separado
 - Chat interno e WhatsApp: indicadores de envio, entrega e leitura nas mensagens (✓ / ✓✓)
 - Notificações: pendência do chat interno abre direto em `/chat/interno/{id}`
+- Chat interno (#503): editar e apagar mensagens de texto — autor ou admin; exclusão lógica com «Mensagem apagada»
+- Chat interno (#502): reações rápidas (👍 ❤️ 😂 😮 😢 🙏) em conversas diretas e canais de setor
+- Chat interno: editar e apagar para todos só nos primeiros 5 minutos; depois «apagar para mim»; opção de limpar conversa só para você
+- Chat interno: ao ler o histórico o scroll não volta sozinho para o fim; ao reabrir a conversa retoma na última mensagem visualizada
 - WhatsApp (#470): áudio gravado na barra de composição é enviado automaticamente ao terminar a gravação (estilo WhatsApp Web)
 - Identidade visual (#434): painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel
 - Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp

--- a/backend/alembic/versions/061_chat_interno_edicao_reacoes.py
+++ b/backend/alembic/versions/061_chat_interno_edicao_reacoes.py
@@ -1,0 +1,55 @@
+"""Chat interno: edição/apagamento de mensagem e reações.
+
+Revision ID: 061_chat_interno_edicao_reacoes
+Revises: 060_mensagem_status
+Create Date: 2026-07-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "061_chat_interno_edicao_reacoes"
+down_revision = "060_mensagem_status"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "mensagens_internas",
+        sa.Column("editada_em", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "mensagens_internas",
+        sa.Column("apagada_em", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_table(
+        "mensagens_internas_reacoes",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("mensagem_id", sa.Integer(), nullable=False),
+        sa.Column("atendente_id", sa.Integer(), nullable=False),
+        sa.Column("emoji", sa.String(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["atendente_id"], ["atendentes.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["mensagem_id"], ["mensagens_internas.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("mensagem_id", "atendente_id", name="uq_mensagens_internas_reacoes_mensagem_atendente"),
+    )
+    op.create_index(
+        "ix_mensagens_internas_reacoes_mensagem_id",
+        "mensagens_internas_reacoes",
+        ["mensagem_id"],
+    )
+    op.create_index(
+        "ix_mensagens_internas_reacoes_atendente_id",
+        "mensagens_internas_reacoes",
+        ["atendente_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_mensagens_internas_reacoes_atendente_id", table_name="mensagens_internas_reacoes")
+    op.drop_index("ix_mensagens_internas_reacoes_mensagem_id", table_name="mensagens_internas_reacoes")
+    op.drop_table("mensagens_internas_reacoes")
+    op.drop_column("mensagens_internas", "apagada_em")
+    op.drop_column("mensagens_internas", "editada_em")

--- a/backend/alembic/versions/062_chat_interno_ocultacao.py
+++ b/backend/alembic/versions/062_chat_interno_ocultacao.py
@@ -1,0 +1,41 @@
+"""Chat interno: ocultação por atendente e janela de edição.
+
+Revision ID: 062_chat_interno_ocultacao
+Revises: 061_chat_interno_edicao_reacoes
+Create Date: 2026-07-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "062_chat_interno_ocultacao"
+down_revision = "061_chat_interno_edicao_reacoes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversas_internas_leituras",
+        sa.Column("historico_oculto_ate", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_table(
+        "mensagens_internas_ocultas",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("mensagem_id", sa.Integer(), nullable=False),
+        sa.Column("atendente_id", sa.Integer(), nullable=False),
+        sa.Column("ocultada_em", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.ForeignKeyConstraint(["atendente_id"], ["atendentes.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["mensagem_id"], ["mensagens_internas.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("mensagem_id", "atendente_id", name="uq_mensagens_internas_ocultas"),
+    )
+    op.create_index("ix_mensagens_internas_ocultas_mensagem_id", "mensagens_internas_ocultas", ["mensagem_id"])
+    op.create_index("ix_mensagens_internas_ocultas_atendente_id", "mensagens_internas_ocultas", ["atendente_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_mensagens_internas_ocultas_atendente_id", table_name="mensagens_internas_ocultas")
+    op.drop_index("ix_mensagens_internas_ocultas_mensagem_id", table_name="mensagens_internas_ocultas")
+    op.drop_table("mensagens_internas_ocultas")
+    op.drop_column("conversas_internas_leituras", "historico_oculto_ate")

--- a/backend/app/api/chat_interno.py
+++ b/backend/app/api/chat_interno.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
+from typing import Literal
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile, status
 from fastapi.responses import FileResponse
 from sqlalchemy.orm import Session
 
@@ -8,7 +10,7 @@ from app.core.auth import obter_atendente_atual
 from app.core.setor_scope import ids_setores_visiveis_atendente
 from app.database import get_db
 from app.models.atendente import Atendente
-from app.models.chat_interno import TIPO_MENSAGEM_TEXTO, ConversaInterna
+from app.models.chat_interno import TIPO_MENSAGEM_TEXTO, ConversaInterna, MensagemInterna
 from app.services import chat_interno_media_storage as media_storage
 from app.schemas.chat_interno import (
     ConversaDiretaCreate,
@@ -16,6 +18,9 @@ from app.schemas.chat_interno import (
     ConversaRead,
     MensagemInternaCreate,
     MensagemInternaRead,
+    MensagemInternaUpdate,
+    ReacaoMensagemCreate,
+    ReacaoMensagemRead,
 )
 from app.schemas.lista_paginada import ListaPaginada
 from app.services import chat_interno as chat_svc
@@ -49,19 +54,31 @@ def _to_conversa_read(db: Session, conversa: ConversaInterna, atendente: Atenden
 def _to_mensagem_read(mensagem, *, conversa: ConversaInterna, atendente: Atendente, db: Session) -> MensagemInternaRead:
     tipo = mensagem.tipo_midia or TIPO_MENSAGEM_TEXTO
     status = chat_svc.status_entrega_mensagem(db, conversa, mensagem, atendente.id)
+    reacoes = [
+        ReacaoMensagemRead(emoji=r.emoji, count=r.count, reagiu_eu=r.reagiu_eu)
+        for r in chat_svc.agregar_reacoes_mensagem(db, mensagem.id, atendente.id)
+    ]
+    perms = chat_svc.permissoes_mensagem(db, conversa, mensagem, atendente)
     return MensagemInternaRead(
         id=mensagem.id,
         conversa_id=mensagem.conversa_id,
         atendente_id=mensagem.atendente_id,
         atendente_nome=mensagem.atendente.nome if mensagem.atendente else None,
-        corpo=mensagem.corpo,
+        corpo=chat_svc.corpo_mensagem_para_leitura(mensagem),
         tipo_midia=tipo,  # type: ignore[arg-type]
         mimetype=mensagem.mimetype,
         nome_arquivo=mensagem.nome_arquivo,
         tamanho_bytes=mensagem.tamanho_bytes,
-        midia_disponivel=bool(mensagem.storage_key),
+        midia_disponivel=bool(mensagem.storage_key) and not chat_svc.mensagem_esta_apagada(mensagem),
         status_entrega=status,  # type: ignore[arg-type]
+        apagada=chat_svc.mensagem_esta_apagada(mensagem),
+        editada=mensagem.editada_em is not None,
+        reacoes=reacoes,
+        pode_editar=perms.pode_editar,
+        pode_apagar_para_todos=perms.pode_apagar_para_todos,
+        pode_apagar_para_mim=perms.pode_apagar_para_mim,
         created_at=mensagem.created_at,
+        editada_em=mensagem.editada_em,
     )
 
 
@@ -74,6 +91,23 @@ def _emit_apos_mensagem(db: Session, conversa: ConversaInterna, mensagem, atende
         mensagem,
         exclude_atendente_id=atendente_id,
     )
+
+
+def _emit_mensagem_atualizada(db: Session, conversa: ConversaInterna, mensagem, *, acao: str) -> None:
+    from app.services.realtime_emit import emit_chat_interno_mensagem_atualizada
+
+    emit_chat_interno_mensagem_atualizada(db, conversa, mensagem, acao=acao)
+
+
+def _obter_mensagem_na_conversa(
+    db: Session,
+    conversa_id: int,
+    mensagem_id: int,
+) -> MensagemInterna:
+    mensagem = chat_svc.obter_mensagem_por_id(db, conversa_id, mensagem_id)
+    if not mensagem:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mensagem não encontrada.")
+    return mensagem
 
 
 def _obter_conversa_ou_404(db: Session, conversa_id: int) -> ConversaInterna:
@@ -149,7 +183,7 @@ def listar_mensagens(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversa não encontrada.")
     _exigir_acesso_conversa(db, atendente, conversa)
 
-    rows, total = chat_svc.listar_mensagens(db, conversa_id, offset=offset, limit=limit)
+    rows, total = chat_svc.listar_mensagens(db, conversa_id, atendente.id, offset=offset, limit=limit)
     return ListaPaginada(
         items=[_to_mensagem_read(m, conversa=conversa, atendente=atendente, db=db) for m in rows],
         total=total,
@@ -234,7 +268,7 @@ def download_mensagem_midia(
     _exigir_acesso_conversa(db, atendente, conversa)
 
     mensagem = chat_svc.obter_mensagem_por_id(db, conversa_id, mensagem_id)
-    if not mensagem or not mensagem.storage_key:
+    if not mensagem or not mensagem.storage_key or chat_svc.mensagem_esta_apagada(mensagem):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mídia não encontrada.")
 
     path = media_storage.caminho_absoluto_arquivo(mensagem.storage_key)
@@ -322,6 +356,124 @@ async def publicar_midia_no_canal_setor(
         db.commit()
         db.refresh(mensagem)
         _emit_apos_mensagem(db, conversa, mensagem, atendente.id)
+        return _to_mensagem_read(mensagem, conversa=conversa, atendente=atendente, db=db)
+    except chat_svc.ChatInternoErro as exc:
+        raise _map_chat_erro(exc) from exc
+
+
+@router.patch("/conversas/{conversa_id}/mensagens/{mensagem_id}", response_model=MensagemInternaRead)
+def editar_mensagem(
+    conversa_id: int,
+    mensagem_id: int,
+    body: MensagemInternaUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    conversa = _obter_conversa_ou_404(db, conversa_id)
+    if conversa.tenant_id != atendente.tenant_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversa não encontrada.")
+    _exigir_acesso_conversa(db, atendente, conversa)
+    mensagem = _obter_mensagem_na_conversa(db, conversa_id, mensagem_id)
+    try:
+        chat_svc.editar_mensagem(db, conversa, mensagem, atendente, body.corpo)
+        db.commit()
+        db.refresh(mensagem)
+        _emit_mensagem_atualizada(db, conversa, mensagem, acao="editada")
+        return _to_mensagem_read(mensagem, conversa=conversa, atendente=atendente, db=db)
+    except chat_svc.ChatInternoErro as exc:
+        raise _map_chat_erro(exc) from exc
+
+
+@router.delete("/conversas/{conversa_id}/mensagens/{mensagem_id}")
+def apagar_mensagem(
+    conversa_id: int,
+    mensagem_id: int,
+    escopo: Literal["todos", "para_mim"] = Query(
+        "todos",
+        description="todos = apagar para todos (até 5 min); para_mim = ocultar só para você",
+    ),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    conversa = _obter_conversa_ou_404(db, conversa_id)
+    if conversa.tenant_id != atendente.tenant_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversa não encontrada.")
+    _exigir_acesso_conversa(db, atendente, conversa)
+    mensagem = _obter_mensagem_na_conversa(db, conversa_id, mensagem_id)
+    try:
+        resultado = chat_svc.apagar_mensagem(db, conversa, mensagem, atendente, escopo=escopo)
+        db.commit()
+        if escopo == "para_mim":
+            return Response(status_code=status.HTTP_204_NO_CONTENT)
+        db.refresh(mensagem)
+        _emit_mensagem_atualizada(db, conversa, mensagem, acao="apagada")
+        return _to_mensagem_read(mensagem, conversa=conversa, atendente=atendente, db=db)
+    except chat_svc.ChatInternoErro as exc:
+        raise _map_chat_erro(exc) from exc
+
+
+@router.post("/conversas/{conversa_id}/limpar", status_code=status.HTTP_204_NO_CONTENT)
+def limpar_conversa(
+    conversa_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    conversa = _obter_conversa_ou_404(db, conversa_id)
+    if conversa.tenant_id != atendente.tenant_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversa não encontrada.")
+    try:
+        chat_svc.limpar_conversa_para_atendente(db, conversa, atendente)
+        db.commit()
+    except chat_svc.ChatInternoErro as exc:
+        raise _map_chat_erro(exc) from exc
+
+
+@router.put(
+    "/conversas/{conversa_id}/mensagens/{mensagem_id}/reacoes",
+    response_model=MensagemInternaRead,
+)
+def definir_reacao_mensagem(
+    conversa_id: int,
+    mensagem_id: int,
+    body: ReacaoMensagemCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    conversa = _obter_conversa_ou_404(db, conversa_id)
+    if conversa.tenant_id != atendente.tenant_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversa não encontrada.")
+    _exigir_acesso_conversa(db, atendente, conversa)
+    mensagem = _obter_mensagem_na_conversa(db, conversa_id, mensagem_id)
+    try:
+        chat_svc.definir_reacao_mensagem(db, conversa, mensagem, atendente, body.emoji)
+        db.commit()
+        db.refresh(mensagem)
+        _emit_mensagem_atualizada(db, conversa, mensagem, acao="reacao")
+        return _to_mensagem_read(mensagem, conversa=conversa, atendente=atendente, db=db)
+    except chat_svc.ChatInternoErro as exc:
+        raise _map_chat_erro(exc) from exc
+
+
+@router.delete(
+    "/conversas/{conversa_id}/mensagens/{mensagem_id}/reacoes",
+    response_model=MensagemInternaRead,
+)
+def remover_reacao_mensagem(
+    conversa_id: int,
+    mensagem_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    conversa = _obter_conversa_ou_404(db, conversa_id)
+    if conversa.tenant_id != atendente.tenant_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversa não encontrada.")
+    _exigir_acesso_conversa(db, atendente, conversa)
+    mensagem = _obter_mensagem_na_conversa(db, conversa_id, mensagem_id)
+    try:
+        chat_svc.remover_reacao_mensagem(db, conversa, mensagem, atendente)
+        db.commit()
+        db.refresh(mensagem)
+        _emit_mensagem_atualizada(db, conversa, mensagem, acao="reacao")
         return _to_mensagem_read(mensagem, conversa=conversa, atendente=atendente, db=db)
     except chat_svc.ChatInternoErro as exc:
         raise _map_chat_erro(exc) from exc

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -40,6 +40,8 @@ from app.models.chat_interno import (
     ConversaInternaLeitura,
     ConversaInternaParticipante,
     MensagemInterna,
+    MensagemInternaReacao,
+    MensagemInternaOculta,
 )
 
 __all__ = [
@@ -99,5 +101,7 @@ __all__ = [
     "ConversaInterna",
     "ConversaInternaParticipante",
     "MensagemInterna",
+    "MensagemInternaReacao",
+    "MensagemInternaOculta",
     "ConversaInternaLeitura",
 ]

--- a/backend/app/models/chat_interno.py
+++ b/backend/app/models/chat_interno.py
@@ -107,9 +107,42 @@ class MensagemInterna(Base):
     storage_key = Column(String(255), nullable=True)
     tamanho_bytes = Column(Integer, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)
+    editada_em = Column(DateTime(timezone=True), nullable=True)
+    apagada_em = Column(DateTime(timezone=True), nullable=True)
 
     conversa = relationship("ConversaInterna", back_populates="mensagens")
     atendente = relationship("Atendente", backref="mensagens_internas")
+    reacoes = relationship(
+        "MensagemInternaReacao",
+        back_populates="mensagem",
+        cascade="all, delete-orphan",
+    )
+
+
+class MensagemInternaReacao(Base):
+    __tablename__ = "mensagens_internas_reacoes"
+    __table_args__ = (
+        UniqueConstraint("mensagem_id", "atendente_id", name="uq_mensagens_internas_reacoes_mensagem_atendente"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    mensagem_id = Column(
+        Integer,
+        ForeignKey("mensagens_internas.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    atendente_id = Column(
+        Integer,
+        ForeignKey("atendentes.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    emoji = Column(String(16), nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    mensagem = relationship("MensagemInterna", back_populates="reacoes")
+    atendente = relationship("Atendente", backref="mensagens_internas_reacoes")
 
 
 class ConversaInternaLeitura(Base):
@@ -132,6 +165,34 @@ class ConversaInternaLeitura(Base):
         index=True,
     )
     last_seen_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    historico_oculto_ate = Column(DateTime(timezone=True), nullable=True)
 
     conversa = relationship("ConversaInterna", back_populates="leituras")
     atendente = relationship("Atendente", backref="conversas_internas_leituras")
+
+
+class MensagemInternaOculta(Base):
+    """Mensagem oculta apenas para um atendente (apagar para mim)."""
+
+    __tablename__ = "mensagens_internas_ocultas"
+    __table_args__ = (
+        UniqueConstraint("mensagem_id", "atendente_id", name="uq_mensagens_internas_ocultas"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    mensagem_id = Column(
+        Integer,
+        ForeignKey("mensagens_internas.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    atendente_id = Column(
+        Integer,
+        ForeignKey("atendentes.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    ocultada_em = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    mensagem = relationship("MensagemInterna", backref="ocultacoes")
+    atendente = relationship("Atendente", backref="mensagens_internas_ocultas")

--- a/backend/app/schemas/chat_interno.py
+++ b/backend/app/schemas/chat_interno.py
@@ -12,6 +12,20 @@ class MensagemInternaCreate(BaseModel):
     corpo: str = Field(..., min_length=1, max_length=8000)
 
 
+class MensagemInternaUpdate(BaseModel):
+    corpo: str = Field(..., min_length=1, max_length=8000)
+
+
+class ReacaoMensagemCreate(BaseModel):
+    emoji: str = Field(..., min_length=1, max_length=16)
+
+
+class ReacaoMensagemRead(BaseModel):
+    emoji: str
+    count: int
+    reagiu_eu: bool = False
+
+
 class MensagemInternaRead(BaseModel):
     id: int
     conversa_id: int
@@ -24,7 +38,14 @@ class MensagemInternaRead(BaseModel):
     tamanho_bytes: int | None = None
     midia_disponivel: bool = False
     status_entrega: Literal["enviada", "entregue", "lida"] | None = None
+    apagada: bool = False
+    editada: bool = False
+    reacoes: list[ReacaoMensagemRead] = Field(default_factory=list)
+    pode_editar: bool = False
+    pode_apagar_para_todos: bool = False
+    pode_apagar_para_mim: bool = False
     created_at: datetime
+    editada_em: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/chat_interno.py
+++ b/backend/app/services/chat_interno.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
@@ -21,6 +21,8 @@ from app.models.chat_interno import (
     ConversaInternaLeitura,
     ConversaInternaParticipante,
     MensagemInterna,
+    MensagemInternaOculta,
+    MensagemInternaReacao,
 )
 from app.services import chat_interno_media_storage as media_storage
 from app.services.mensagem_status import STATUS_ENVIADA, STATUS_LIDA
@@ -28,6 +30,11 @@ from app.services.mensagem_status import STATUS_ENVIADA, STATUS_LIDA
 
 class ChatInternoErro(ValueError):
     """Erro de validação de domínio do chat interno."""
+
+
+CORPO_MENSAGEM_APAGADA = "Mensagem apagada"
+_EMOJIS_REACAO_PERMITIDOS = frozenset({"👍", "❤️", "😂", "😮", "😢", "🙏"})
+JANELA_EDICAO_MINUTOS = 5
 
 
 @dataclass
@@ -170,12 +177,18 @@ def contar_nao_lidas(
         )
         .scalar()
     )
+    historico = obter_historico_oculto_ate(db, conversa.id, atendente_id)
+    ocultas = ids_mensagens_ocultas_para_atendente(db, conversa.id, atendente_id)
     q = db.query(func.count(MensagemInterna.id)).filter(
         MensagemInterna.conversa_id == conversa.id,
         MensagemInterna.atendente_id != atendente_id,
     )
     if last_seen is not None:
         q = q.filter(MensagemInterna.created_at > last_seen)
+    if historico is not None:
+        q = q.filter(MensagemInterna.created_at > historico)
+    if ocultas:
+        q = q.filter(~MensagemInterna.id.in_(ocultas))
     return int(q.scalar() or 0)
 
 
@@ -186,6 +199,86 @@ def obter_ultima_mensagem(db: Session, conversa_id: int) -> MensagemInterna | No
         .order_by(MensagemInterna.created_at.desc(), MensagemInterna.id.desc())
         .first()
     )
+
+
+def _as_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def dentro_janela_edicao_apagar_todos(mensagem: MensagemInterna, agora: datetime | None = None) -> bool:
+    agora = _as_utc(agora or datetime.now(timezone.utc))
+    created = _as_utc(mensagem.created_at)
+    limite = agora - timedelta(minutes=JANELA_EDICAO_MINUTOS)
+    return created >= limite
+
+
+def obter_historico_oculto_ate(db: Session, conversa_id: int, atendente_id: int) -> datetime | None:
+    return (
+        db.query(ConversaInternaLeitura.historico_oculto_ate)
+        .filter(
+            ConversaInternaLeitura.conversa_id == conversa_id,
+            ConversaInternaLeitura.atendente_id == atendente_id,
+        )
+        .scalar()
+    )
+
+
+def ids_mensagens_ocultas_para_atendente(db: Session, conversa_id: int, atendente_id: int) -> set[int]:
+    rows = (
+        db.query(MensagemInternaOculta.mensagem_id)
+        .join(MensagemInterna, MensagemInterna.id == MensagemInternaOculta.mensagem_id)
+        .filter(
+            MensagemInterna.conversa_id == conversa_id,
+            MensagemInternaOculta.atendente_id == atendente_id,
+        )
+        .all()
+    )
+    return {int(mid) for (mid,) in rows}
+
+
+def mensagem_visivel_para_atendente(
+    db: Session,
+    mensagem: MensagemInterna,
+    atendente_id: int,
+    *,
+    historico_oculto_ate: datetime | None = None,
+    ocultas_ids: set[int] | None = None,
+) -> bool:
+    if historico_oculto_ate is None:
+        historico_oculto_ate = obter_historico_oculto_ate(db, mensagem.conversa_id, atendente_id)
+    if historico_oculto_ate is not None and _as_utc(mensagem.created_at) <= _as_utc(historico_oculto_ate):
+        return False
+    if ocultas_ids is None:
+        ocultas_ids = ids_mensagens_ocultas_para_atendente(db, mensagem.conversa_id, atendente_id)
+    return mensagem.id not in ocultas_ids
+
+
+def obter_ultima_mensagem_visivel(db: Session, conversa_id: int, atendente_id: int) -> MensagemInterna | None:
+    historico = obter_historico_oculto_ate(db, conversa_id, atendente_id)
+    ocultas = ids_mensagens_ocultas_para_atendente(db, conversa_id, atendente_id)
+    candidatas = (
+        db.query(MensagemInterna)
+        .filter(MensagemInterna.conversa_id == conversa_id)
+        .order_by(MensagemInterna.created_at.desc(), MensagemInterna.id.desc())
+        .limit(80)
+        .all()
+    )
+    for mensagem in candidatas:
+        if mensagem_visivel_para_atendente(
+            db,
+            mensagem,
+            atendente_id,
+            historico_oculto_ate=historico,
+            ocultas_ids=ocultas,
+        ):
+            return mensagem
+    return None
+
+
+def conversa_tem_mensagens_visiveis(db: Session, conversa_id: int, atendente_id: int) -> bool:
+    return obter_ultima_mensagem_visivel(db, conversa_id, atendente_id) is not None
 
 
 def titulo_conversa(db: Session, conversa: ConversaInterna, atendente_id: int) -> str:
@@ -250,14 +343,17 @@ def listar_conversas_inbox(db: Session, atendente: Atendente) -> list[ConversaIn
 
     resumos: list[ConversaInboxResumo] = []
     for conversa in conversas:
-        ultima = obter_ultima_mensagem(db, conversa.id)
+        nao_lidas = contar_nao_lidas(db, conversa, atendente.id)
+        ultima = obter_ultima_mensagem_visivel(db, conversa.id, atendente.id)
+        if ultima is None and nao_lidas == 0:
+            continue
         resumos.append(
             ConversaInboxResumo(
                 conversa=conversa,
                 titulo=titulo_conversa(db, conversa, atendente.id),
                 ultima_mensagem_corpo=preview_mensagem(ultima) if ultima else None,
                 ultima_mensagem_em=ultima.created_at if ultima else None,
-                nao_lidas_count=contar_nao_lidas(db, conversa, atendente.id),
+                nao_lidas_count=nao_lidas,
             )
         )
 
@@ -321,6 +417,8 @@ def rotulo_midia(tipo_midia: str) -> str:
 
 
 def preview_mensagem(mensagem: MensagemInterna) -> str:
+    if mensagem.apagada_em is not None:
+        return CORPO_MENSAGEM_APAGADA
     tipo = mensagem.tipo_midia or TIPO_MENSAGEM_TEXTO
     if tipo in TIPOS_MENSAGEM_MIDIA:
         texto = (mensagem.corpo or "").strip()
@@ -510,10 +608,19 @@ def obter_conversa_por_id(db: Session, conversa_id: int) -> ConversaInterna | No
 def listar_mensagens(
     db: Session,
     conversa_id: int,
+    atendente_id: int,
     offset: int = 0,
     limit: int = 50,
 ) -> tuple[list[MensagemInterna], int]:
+    historico = obter_historico_oculto_ate(db, conversa_id, atendente_id)
+    ocultas = ids_mensagens_ocultas_para_atendente(db, conversa_id, atendente_id)
+
     base = db.query(MensagemInterna).filter(MensagemInterna.conversa_id == conversa_id)
+    if historico is not None:
+        base = base.filter(MensagemInterna.created_at > historico)
+    if ocultas:
+        base = base.filter(~MensagemInterna.id.in_(ocultas))
+
     total = int(base.count())
     rows = (
         base.options(joinedload(MensagemInterna.atendente))
@@ -544,3 +651,314 @@ def listar_conversas_com_nao_lidas(
 ) -> list[ConversaInboxResumo]:
     resumos = [r for r in listar_conversas_inbox(db, atendente) if r.nao_lidas_count > 0]
     return resumos[:limit]
+
+
+def mensagem_esta_apagada(mensagem: MensagemInterna) -> bool:
+    return mensagem.apagada_em is not None
+
+
+@dataclass
+class PermissoesMensagem:
+    pode_editar: bool
+    pode_apagar_para_todos: bool
+    pode_apagar_para_mim: bool
+
+
+def _eh_autor_mensagem(mensagem: MensagemInterna, atendente: Atendente) -> bool:
+    return mensagem.atendente_id == atendente.id
+
+
+def _pode_apagar_para_todos(
+    db: Session,
+    conversa: ConversaInterna,
+    mensagem: MensagemInterna,
+    atendente: Atendente,
+) -> bool:
+    if mensagem_esta_apagada(mensagem):
+        return False
+    if not dentro_janela_edicao_apagar_todos(mensagem):
+        return False
+    if _eh_autor_mensagem(mensagem, atendente):
+        return True
+    if atendente.role == "admin" and conversa.tipo == TIPO_CONVERSA_SETOR:
+        return True
+    return False
+
+
+def permissoes_mensagem(
+    db: Session,
+    conversa: ConversaInterna,
+    mensagem: MensagemInterna,
+    atendente: Atendente,
+) -> PermissoesMensagem:
+    if not mensagem_visivel_para_atendente(db, mensagem, atendente.id):
+        return PermissoesMensagem(False, False, False)
+
+    tipo = mensagem.tipo_midia or TIPO_MENSAGEM_TEXTO
+    in_window = dentro_janela_edicao_apagar_todos(mensagem)
+    is_author = _eh_autor_mensagem(mensagem, atendente)
+
+    pode_editar = (
+        is_author
+        and in_window
+        and not mensagem_esta_apagada(mensagem)
+        and tipo == TIPO_MENSAGEM_TEXTO
+    )
+    pode_apagar_para_todos = _pode_apagar_para_todos(db, conversa, mensagem, atendente)
+    pode_apagar_para_mim = True
+
+    return PermissoesMensagem(
+        pode_editar=pode_editar,
+        pode_apagar_para_todos=pode_apagar_para_todos,
+        pode_apagar_para_mim=pode_apagar_para_mim,
+    )
+
+
+def pode_modificar_mensagem(atendente: Atendente, mensagem: MensagemInterna) -> bool:
+    """Legado — preferir permissoes_mensagem."""
+    if mensagem_esta_apagada(mensagem):
+        return False
+    if not dentro_janela_edicao_apagar_todos(mensagem):
+        return False
+    return mensagem.atendente_id == atendente.id
+
+
+def editar_mensagem(
+    db: Session,
+    conversa: ConversaInterna,
+    mensagem: MensagemInterna,
+    atendente: Atendente,
+    novo_corpo: str,
+) -> MensagemInterna:
+    if not pode_acessar_conversa(db, atendente, conversa):
+        raise ChatInternoErro("Sem permissão para esta conversa.")
+    if mensagem.conversa_id != conversa.id:
+        raise ChatInternoErro("Mensagem não pertence a esta conversa.")
+    if mensagem_esta_apagada(mensagem):
+        raise ChatInternoErro("Mensagem apagada não pode ser editada.")
+    if not _eh_autor_mensagem(mensagem, atendente):
+        raise ChatInternoErro("Sem permissão para editar esta mensagem.")
+    if not dentro_janela_edicao_apagar_todos(mensagem):
+        raise ChatInternoErro(
+            f"Só é possível editar mensagens nos primeiros {JANELA_EDICAO_MINUTOS} minutos."
+        )
+    tipo = mensagem.tipo_midia or TIPO_MENSAGEM_TEXTO
+    if tipo != TIPO_MENSAGEM_TEXTO:
+        raise ChatInternoErro("Somente mensagens de texto podem ser editadas.")
+
+    texto = novo_corpo.strip()
+    if not texto:
+        raise ChatInternoErro("Corpo da mensagem não pode ser vazio.")
+
+    mensagem.corpo = texto
+    mensagem.editada_em = datetime.now(timezone.utc)
+    db.flush()
+    return mensagem
+
+
+def apagar_mensagem_para_todos(
+    db: Session,
+    conversa: ConversaInterna,
+    mensagem: MensagemInterna,
+    atendente: Atendente,
+) -> MensagemInterna:
+    if not pode_acessar_conversa(db, atendente, conversa):
+        raise ChatInternoErro("Sem permissão para esta conversa.")
+    if mensagem.conversa_id != conversa.id:
+        raise ChatInternoErro("Mensagem não pertence a esta conversa.")
+    if mensagem_esta_apagada(mensagem):
+        return mensagem
+    if not _pode_apagar_para_todos(db, conversa, mensagem, atendente):
+        raise ChatInternoErro(
+            f"Só é possível apagar para todos nos primeiros {JANELA_EDICAO_MINUTOS} minutos."
+        )
+
+    now = datetime.now(timezone.utc)
+    mensagem.apagada_em = now
+    mensagem.corpo = CORPO_MENSAGEM_APAGADA
+    db.flush()
+    return mensagem
+
+
+def ocultar_mensagem_para_atendente(
+    db: Session,
+    conversa: ConversaInterna,
+    mensagem: MensagemInterna,
+    atendente: Atendente,
+) -> None:
+    if not pode_acessar_conversa(db, atendente, conversa):
+        raise ChatInternoErro("Sem permissão para esta conversa.")
+    if mensagem.conversa_id != conversa.id:
+        raise ChatInternoErro("Mensagem não pertence a esta conversa.")
+    if not mensagem_visivel_para_atendente(db, mensagem, atendente.id):
+        raise ChatInternoErro("Mensagem não encontrada.")
+    if mensagem_esta_apagada(mensagem) and _eh_autor_mensagem(mensagem, atendente):
+        return
+
+    existente = (
+        db.query(MensagemInternaOculta)
+        .filter(
+            MensagemInternaOculta.mensagem_id == mensagem.id,
+            MensagemInternaOculta.atendente_id == atendente.id,
+        )
+        .first()
+    )
+    if not existente:
+        db.add(
+            MensagemInternaOculta(
+                mensagem_id=mensagem.id,
+                atendente_id=atendente.id,
+            )
+        )
+        db.flush()
+
+
+def limpar_conversa_para_atendente(
+    db: Session,
+    conversa: ConversaInterna,
+    atendente: Atendente,
+) -> None:
+    if not pode_acessar_conversa(db, atendente, conversa):
+        raise ChatInternoErro("Sem permissão para esta conversa.")
+
+    now = datetime.now(timezone.utc)
+    row = (
+        db.query(ConversaInternaLeitura)
+        .filter(
+            ConversaInternaLeitura.conversa_id == conversa.id,
+            ConversaInternaLeitura.atendente_id == atendente.id,
+        )
+        .first()
+    )
+    if row:
+        row.historico_oculto_ate = now
+        row.last_seen_at = now
+    else:
+        db.add(
+            ConversaInternaLeitura(
+                conversa_id=conversa.id,
+                atendente_id=atendente.id,
+                last_seen_at=now,
+                historico_oculto_ate=now,
+            )
+        )
+    db.flush()
+
+
+def apagar_mensagem(
+    db: Session,
+    conversa: ConversaInterna,
+    mensagem: MensagemInterna,
+    atendente: Atendente,
+    *,
+    escopo: str,
+) -> MensagemInterna | None:
+    if escopo == "todos":
+        return apagar_mensagem_para_todos(db, conversa, mensagem, atendente)
+    if escopo == "para_mim":
+        ocultar_mensagem_para_atendente(db, conversa, mensagem, atendente)
+        return None
+    raise ChatInternoErro("Escopo de exclusão inválido.")
+
+
+def _validar_emoji_reacao(emoji: str) -> str:
+    valor = (emoji or "").strip()
+    if valor not in _EMOJIS_REACAO_PERMITIDOS:
+        raise ChatInternoErro("Emoji de reação inválido.")
+    return valor
+
+
+def definir_reacao_mensagem(
+    db: Session,
+    conversa: ConversaInterna,
+    mensagem: MensagemInterna,
+    atendente: Atendente,
+    emoji: str,
+) -> MensagemInterna:
+    if not pode_acessar_conversa(db, atendente, conversa):
+        raise ChatInternoErro("Sem permissão para esta conversa.")
+    if mensagem.conversa_id != conversa.id:
+        raise ChatInternoErro("Mensagem não pertence a esta conversa.")
+    if mensagem_esta_apagada(mensagem):
+        raise ChatInternoErro("Não é possível reagir a mensagem apagada.")
+
+    emoji_ok = _validar_emoji_reacao(emoji)
+    row = (
+        db.query(MensagemInternaReacao)
+        .filter(
+            MensagemInternaReacao.mensagem_id == mensagem.id,
+            MensagemInternaReacao.atendente_id == atendente.id,
+        )
+        .first()
+    )
+    if row:
+        if row.emoji == emoji_ok:
+            db.delete(row)
+        else:
+            row.emoji = emoji_ok
+    else:
+        db.add(
+            MensagemInternaReacao(
+                mensagem_id=mensagem.id,
+                atendente_id=atendente.id,
+                emoji=emoji_ok,
+            )
+        )
+    db.flush()
+    db.refresh(mensagem)
+    return mensagem
+
+
+def remover_reacao_mensagem(
+    db: Session,
+    conversa: ConversaInterna,
+    mensagem: MensagemInterna,
+    atendente: Atendente,
+) -> MensagemInterna:
+    if not pode_acessar_conversa(db, atendente, conversa):
+        raise ChatInternoErro("Sem permissão para esta conversa.")
+    if mensagem.conversa_id != conversa.id:
+        raise ChatInternoErro("Mensagem não pertence a esta conversa.")
+
+    db.query(MensagemInternaReacao).filter(
+        MensagemInternaReacao.mensagem_id == mensagem.id,
+        MensagemInternaReacao.atendente_id == atendente.id,
+    ).delete(synchronize_session=False)
+    db.flush()
+    db.refresh(mensagem)
+    return mensagem
+
+
+@dataclass
+class ReacaoAgregada:
+    emoji: str
+    count: int
+    reagiu_eu: bool
+
+
+def agregar_reacoes_mensagem(
+    db: Session,
+    mensagem_id: int,
+    viewer_id: int,
+) -> list[ReacaoAgregada]:
+    rows = (
+        db.query(MensagemInternaReacao.emoji, MensagemInternaReacao.atendente_id)
+        .filter(MensagemInternaReacao.mensagem_id == mensagem_id)
+        .all()
+    )
+    por_emoji: dict[str, dict[str, int | bool]] = {}
+    for emoji, atendente_id in rows:
+        bucket = por_emoji.setdefault(emoji, {"count": 0, "reagiu_eu": False})
+        bucket["count"] = int(bucket["count"]) + 1
+        if atendente_id == viewer_id:
+            bucket["reagiu_eu"] = True
+    return [
+        ReacaoAgregada(emoji=emoji, count=int(data["count"]), reagiu_eu=bool(data["reagiu_eu"]))
+        for emoji, data in sorted(por_emoji.items(), key=lambda item: (-int(item[1]["count"]), item[0]))
+    ]
+
+
+def corpo_mensagem_para_leitura(mensagem: MensagemInterna) -> str:
+    if mensagem_esta_apagada(mensagem):
+        return CORPO_MENSAGEM_APAGADA
+    return mensagem.corpo

--- a/backend/app/services/realtime_emit.py
+++ b/backend/app/services/realtime_emit.py
@@ -392,3 +392,22 @@ def emit_chat_interno_lido(
         "leitor_atendente_id": leitor_atendente_id,
     }
     _publish_to_atendentes(recipients, "chat.interno.lido", payload)
+
+
+def emit_chat_interno_mensagem_atualizada(
+    db: Session,
+    conversa: Any,
+    mensagem: Any,
+    *,
+    acao: str,
+) -> None:
+    """Mensagem editada, apagada ou com reação alterada."""
+    recipients = ids_destinatarios_chat_interno_mensagem(db, conversa)
+    payload = {
+        "conversa_id": conversa.id,
+        "mensagem_id": getattr(mensagem, "id", None),
+        "acao": acao,
+    }
+    _publish_to_atendentes(recipients, "chat.interno.mensagem.atualizada", payload)
+    if acao in {"editada", "apagada"}:
+        _emit_notificacao_after_counter_change(db)

--- a/backend/tests/test_chat_interno_edicao_reacoes.py
+++ b/backend/tests/test_chat_interno_edicao_reacoes.py
@@ -1,0 +1,198 @@
+"""Chat interno — janela de edição, apagar para mim e limpar conversa."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from app.services import chat_interno as chat_svc
+
+
+def _enviar_direta(db_session, seed_base, remetente, destino, corpo: str):
+    conversa = chat_svc.obter_ou_criar_conversa_direta(db_session, 1, remetente.id, destino.id)
+    mensagem = chat_svc.enviar_mensagem(db_session, conversa, remetente, corpo)
+    db_session.commit()
+    return conversa, mensagem
+
+
+def test_editar_mensagem_autor(client, seed_base, auth_headers, db_session):
+    conversa, mensagem = _enviar_direta(db_session, seed_base, seed_base["a1"], seed_base["admin"], "Original")
+
+    r = client.patch(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens/{mensagem.id}",
+        headers=auth_headers["a1"],
+        json={"corpo": "Corrigido"},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["corpo"] == "Corrigido"
+    assert data["editada"] is True
+    assert data["pode_editar"] is True
+
+
+def test_editar_mensagem_403_outro_atendente(client, seed_base, auth_headers, db_session):
+    conversa, mensagem = _enviar_direta(db_session, seed_base, seed_base["a1"], seed_base["admin"], "Original")
+
+    r = client.patch(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens/{mensagem.id}",
+        headers=auth_headers["a2"],
+        json={"corpo": "Tentativa"},
+    )
+    assert r.status_code == 403
+
+
+def test_admin_nao_edita_mensagem_alheia(client, seed_base, auth_headers, db_session):
+    conversa, mensagem = _enviar_direta(db_session, seed_base, seed_base["a1"], seed_base["admin"], "Original")
+
+    r = client.patch(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens/{mensagem.id}",
+        headers=auth_headers["admin"],
+        json={"corpo": "Admin corrigiu"},
+    )
+    assert r.status_code == 403
+
+
+def test_editar_bloqueado_apos_janela(client, seed_base, auth_headers, db_session):
+    conversa, mensagem = _enviar_direta(db_session, seed_base, seed_base["a1"], seed_base["admin"], "Original")
+    mensagem.created_at = datetime.now(timezone.utc) - timedelta(minutes=6)
+    db_session.commit()
+
+    r = client.patch(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens/{mensagem.id}",
+        headers=auth_headers["a1"],
+        json={"corpo": "Tarde"},
+    )
+    assert r.status_code == 400
+
+
+def test_apagar_mensagem_para_todos(client, seed_base, auth_headers, db_session):
+    conversa, mensagem = _enviar_direta(db_session, seed_base, seed_base["a1"], seed_base["admin"], "Apagar isso")
+
+    r = client.delete(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens/{mensagem.id}?escopo=todos",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["apagada"] is True
+    assert data["corpo"] == chat_svc.CORPO_MENSAGEM_APAGADA
+
+    r_admin = client.get(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens",
+        headers=auth_headers["admin"],
+    )
+    assert r_admin.json()["items"][0]["apagada"] is True
+
+
+def test_apagar_para_mim_oculta_somente_autor(client, seed_base, auth_headers, db_session):
+    conversa, mensagem = _enviar_direta(db_session, seed_base, seed_base["a1"], seed_base["admin"], "Só para mim")
+
+    r = client.delete(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens/{mensagem.id}?escopo=para_mim",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 204
+
+    r_a1 = client.get(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens",
+        headers=auth_headers["a1"],
+    )
+    assert r_a1.json()["total"] == 0
+
+    r_admin = client.get(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens",
+        headers=auth_headers["admin"],
+    )
+    assert r_admin.json()["total"] == 1
+    assert r_admin.json()["items"][0]["corpo"] == "Só para mim"
+
+
+def test_apagar_para_todos_bloqueado_apos_janela(client, seed_base, auth_headers, db_session):
+    conversa, mensagem = _enviar_direta(db_session, seed_base, seed_base["a1"], seed_base["admin"], "Velha")
+    mensagem.created_at = datetime.now(timezone.utc) - timedelta(minutes=6)
+    db_session.commit()
+
+    r = client.delete(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens/{mensagem.id}?escopo=todos",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 400
+
+    r_ok = client.delete(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens/{mensagem.id}?escopo=para_mim",
+        headers=auth_headers["a1"],
+    )
+    assert r_ok.status_code == 204
+
+
+def test_limpar_conversa_somente_para_quem_limpou(client, seed_base, auth_headers, db_session):
+    conversa, _ = _enviar_direta(db_session, seed_base, seed_base["a1"], seed_base["admin"], "Msg 1")
+    chat_svc.enviar_mensagem(db_session, conversa, seed_base["admin"], "Msg 2")
+    db_session.commit()
+
+    r = client.post(
+        f"/v1/chat-interno/conversas/{conversa.id}/limpar",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 204
+
+    r_a1 = client.get(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens",
+        headers=auth_headers["a1"],
+    )
+    assert r_a1.json()["total"] == 0
+
+    r_admin = client.get(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens",
+        headers=auth_headers["admin"],
+    )
+    assert r_admin.json()["total"] == 2
+
+    r_inbox_a1 = client.get("/v1/chat-interno/conversas", headers=auth_headers["a1"])
+    assert all(c["id"] != conversa.id for c in r_inbox_a1.json())
+
+    r_inbox_admin = client.get("/v1/chat-interno/conversas", headers=auth_headers["admin"])
+    assert any(c["id"] == conversa.id for c in r_inbox_admin.json())
+
+
+def test_reacao_toggle_e_remover(client, seed_base, auth_headers, db_session):
+    conversa, mensagem = _enviar_direta(db_session, seed_base, seed_base["a1"], seed_base["admin"], "Reagir")
+
+    r1 = client.put(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens/{mensagem.id}/reacoes",
+        headers=auth_headers["admin"],
+        json={"emoji": "👍"},
+    )
+    assert r1.status_code == 200
+
+    r_del = client.delete(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens/{mensagem.id}?escopo=todos",
+        headers=auth_headers["a1"],
+    )
+    assert r_del.status_code == 200
+
+    r = client.put(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens/{mensagem.id}/reacoes",
+        headers=auth_headers["admin"],
+        json={"emoji": "👍"},
+    )
+    assert r.status_code == 400
+
+
+def test_apagar_mensagem_midia_bloqueia_download(client, seed_base, auth_headers, db_session):
+    conversa = chat_svc.obter_ou_criar_conversa_direta(db_session, 1, seed_base["a1"].id, seed_base["admin"].id)
+    mensagem = chat_svc.enviar_mensagem(db_session, conversa, seed_base["a1"], "texto placeholder")
+    mensagem.tipo_midia = chat_svc.TIPO_MENSAGEM_IMAGEM
+    mensagem.storage_key = "fake/key"
+    db_session.commit()
+
+    r_del = client.delete(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens/{mensagem.id}?escopo=todos",
+        headers=auth_headers["a1"],
+    )
+    assert r_del.status_code == 200
+
+    r_dl = client.get(
+        f"/v1/chat-interno/conversas/{conversa.id}/mensagens/{mensagem.id}/download",
+        headers=auth_headers["admin"],
+    )
+    assert r_dl.status_code == 404

--- a/backend/tests/test_realtime_chat_interno.py
+++ b/backend/tests/test_realtime_chat_interno.py
@@ -101,3 +101,31 @@ def test_emit_chat_interno_canal_setor_notifica_todos_membros(client, seed_base,
     assert seed_base["admin"].id in destinatarios
     assert seed_base["a1"].id not in destinatarios
     assert seed_base["a2"].id not in destinatarios
+
+
+def test_emit_chat_interno_mensagem_atualizada(client, seed_base, db_session, monkeypatch):
+    conversa = chat_svc.obter_ou_criar_conversa_direta(db_session, 1, seed_base["a1"].id, seed_base["admin"].id)
+    mensagem = chat_svc.enviar_mensagem(db_session, conversa, seed_base["a1"], "Editar isto")
+    db_session.commit()
+
+    eventos: list[tuple[str, dict]] = []
+
+    def fake_publish(atendente_ids, event_type, payload):
+        for _aid in atendente_ids:
+            eventos.append((event_type, payload))
+
+    monkeypatch.setattr("app.services.realtime_emit._publish_to_atendentes", fake_publish)
+    monkeypatch.setattr("app.services.realtime_emit._emit_notificacao_after_counter_change", lambda db: None)
+
+    from app.services.realtime_emit import emit_chat_interno_mensagem_atualizada
+
+    chat_svc.editar_mensagem(db_session, conversa, mensagem, seed_base["a1"], "Corrigido")
+    db_session.commit()
+    emit_chat_interno_mensagem_atualizada(db_session, conversa, mensagem, acao="editada")
+
+    assert len(eventos) >= 1
+    etype, payload = eventos[0]
+    assert etype == "chat.interno.mensagem.atualizada"
+    assert payload["conversa_id"] == conversa.id
+    assert payload["mensagem_id"] == mensagem.id
+    assert payload["acao"] == "editada"

--- a/docs/REALTIME_SSE.md
+++ b/docs/REALTIME_SSE.md
@@ -26,6 +26,7 @@ Evento inicial ao conectar:
 | `ticket.fila` | Ticket aberto sem responsável | `{ ticket_id, setor_id, protocolo }` |
 | `notificacao.contagem` | RT-F3 — contadores navbar | `NotificacaoResumo` (compatível com `/notificacoes/resumo`) |
 | `chat.interno.mensagem` | Nova mensagem no chat interno | `{ conversa_id, tipo, setor_id?, remetente_id, corpo_preview }` |
+| `chat.interno.mensagem.atualizada` | Mensagem editada, apagada ou reação alterada | `{ conversa_id, mensagem_id, acao }` — `acao`: `editada` \| `apagada` \| `reacao` |
 
 Destinatários filtrados por RBAC (setor homônimo + admin).
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1344,6 +1344,12 @@ export namespace ChatInterno {
 
   export type TipoMidia = 'texto' | 'imagem' | 'video' | 'audio' | 'documento';
 
+  export interface ReacaoMensagem {
+    emoji: string;
+    count: number;
+    reagiu_eu: boolean;
+  }
+
   export interface Mensagem {
     id: number;
     conversa_id: number;
@@ -1356,6 +1362,13 @@ export namespace ChatInterno {
     tamanho_bytes?: number | null;
     midia_disponivel?: boolean;
     status_entrega?: 'enviada' | 'entregue' | 'lida' | null;
+    apagada?: boolean;
+    editada?: boolean;
+    editada_em?: string | null;
+    reacoes?: ReacaoMensagem[];
+    pode_editar?: boolean;
+    pode_apagar_para_todos?: boolean;
+    pode_apagar_para_mim?: boolean;
     created_at: string;
   }
 }
@@ -1391,6 +1404,27 @@ export const chatInterno = {
   },
   marcarVisto: (conversaId: number) =>
     api<void>(`/chat-interno/conversas/${conversaId}/visto`, { method: 'POST' }),
+  editarMensagem: (conversaId: number, mensagemId: number, corpo: string) =>
+    api<ChatInterno.Mensagem>(`/chat-interno/conversas/${conversaId}/mensagens/${mensagemId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ corpo }),
+    }),
+  apagarMensagem: (conversaId: number, mensagemId: number, escopo: 'todos' | 'para_mim') =>
+    api<ChatInterno.Mensagem | void>(
+      `/chat-interno/conversas/${conversaId}/mensagens/${mensagemId}?escopo=${escopo}`,
+      { method: 'DELETE' },
+    ),
+  limparConversa: (conversaId: number) =>
+    api<void>(`/chat-interno/conversas/${conversaId}/limpar`, { method: 'POST' }),
+  definirReacao: (conversaId: number, mensagemId: number, emoji: string) =>
+    api<ChatInterno.Mensagem>(`/chat-interno/conversas/${conversaId}/mensagens/${mensagemId}/reacoes`, {
+      method: 'PUT',
+      body: JSON.stringify({ emoji }),
+    }),
+  removerReacao: (conversaId: number, mensagemId: number) =>
+    api<ChatInterno.Mensagem>(`/chat-interno/conversas/${conversaId}/mensagens/${mensagemId}/reacoes`, {
+      method: 'DELETE',
+    }),
   obterCanalSetor: (setorId: number) =>
     api<ChatInterno.Conversa>(`/chat-interno/setores/${setorId}/canal`),
   publicarCanalSetor: (setorId: number, corpo: string) =>

--- a/frontend/src/components/chat-interno/ChatInternoConteudoMensagem.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoConteudoMensagem.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 import { fetchChatInternoMidiaBlob, type ChatInterno } from '../../api/client'
 
 const ROTULO_SEM_LEGENDA = /^(📷 Imagem|🎬 Vídeo|🎵 Áudio|📄 Documento)$/
@@ -7,9 +7,18 @@ type Props = {
   conversaId: number
   mensagem: ChatInterno.Mensagem
   textoClaro?: boolean
+  /** Rodapé compacto (hora/status) embutido no canto — estilo WhatsApp Web para texto curto */
+  rodape?: ReactNode
+  somenteTextoCompacto?: boolean
 }
 
-export function ChatInternoConteudoMensagem({ conversaId, mensagem, textoClaro }: Props) {
+export function ChatInternoConteudoMensagem({
+  conversaId,
+  mensagem,
+  textoClaro,
+  rodape,
+  somenteTextoCompacto = false,
+}: Props) {
   const tipo = (mensagem.tipo_midia || 'texto').toLowerCase()
   const [url, setUrl] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
@@ -48,10 +57,37 @@ export function ChatInternoConteudoMensagem({ conversaId, mensagem, textoClaro }
   const legenda =
     mensagem.corpo && !ROTULO_SEM_LEGENDA.test(mensagem.corpo.trim()) ? mensagem.corpo : null
 
-  if (tipo === 'texto' || !mensagem.tipo_midia || mensagem.tipo_midia === 'texto') {
+  if (mensagem.apagada) {
     return (
       <p
-        className={`whitespace-pre-wrap break-words [overflow-wrap:anywhere] ${
+        className={`text-sm italic opacity-70 ${
+          textoClaro ? 'text-cyan-100' : 'text-slate-500 dark:text-slate-400'
+        }`}
+      >
+        Mensagem apagada
+      </p>
+    )
+  }
+
+  if (tipo === 'texto' || !mensagem.tipo_midia || mensagem.tipo_midia === 'texto') {
+    if (somenteTextoCompacto && rodape) {
+      return (
+        <div className="relative min-w-[3.5rem]">
+          <p
+            className={`whitespace-pre-wrap break-words text-sm leading-[1.35] [overflow-wrap:anywhere] ${
+              textoClaro ? 'text-white' : 'text-slate-900 dark:text-slate-100'
+            }`}
+          >
+            {mensagem.corpo}
+            <span aria-hidden className="inline-block w-[4.25rem] h-[0.85rem]" />
+          </p>
+          <div className="absolute bottom-0 right-0 flex items-center gap-0.5 pl-1">{rodape}</div>
+        </div>
+      )
+    }
+    return (
+      <p
+        className={`whitespace-pre-wrap break-words text-sm leading-[1.35] [overflow-wrap:anywhere] ${
           textoClaro ? 'text-white' : 'text-slate-900 dark:text-slate-100'
         }`}
       >

--- a/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useState } from 'react'
+import type { ChatInterno } from '../../api/client'
+import { ConfirmDialog } from '../ui/ConfirmDialog'
+
+type Props = {
+  mensagem: ChatInterno.Mensagem
+  onEditar: (novoCorpo: string) => Promise<void>
+  onApagar: (escopo: 'todos' | 'para_mim') => Promise<void>
+  alinhamento?: 'start' | 'end'
+}
+
+export function ChatInternoMensagemAcoes({
+  mensagem,
+  onEditar,
+  onApagar,
+  alinhamento = 'end',
+}: Props) {
+  const [editando, setEditando] = useState(false)
+  const [texto, setTexto] = useState(mensagem.corpo)
+  const [salvando, setSalvando] = useState(false)
+  const [confirmarApagar, setConfirmarApagar] = useState(false)
+  const [apagando, setApagando] = useState(false)
+
+  const podeEditar = Boolean(mensagem.pode_editar)
+  const podeApagarTodos = Boolean(mensagem.pode_apagar_para_todos)
+  const podeApagarMim = Boolean(mensagem.pode_apagar_para_mim)
+  const temAcoes = podeEditar || podeApagarTodos || podeApagarMim
+
+  useEffect(() => {
+    if (!editando) setTexto(mensagem.corpo)
+  }, [mensagem.corpo, editando])
+
+  if (mensagem.apagada || !temAcoes) return null
+
+  if (editando && podeEditar && (mensagem.tipo_midia || 'texto') === 'texto') {
+    return (
+      <div className="mt-1 w-full min-w-[min(100%,18rem)] space-y-2">
+        <textarea
+          value={texto}
+          onChange={(e) => setTexto(e.target.value)}
+          rows={3}
+          className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+        />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            disabled={salvando || !texto.trim()}
+            onClick={() => {
+              setSalvando(true)
+              void onEditar(texto.trim())
+                .then(() => setEditando(false))
+                .finally(() => setSalvando(false))
+            }}
+            className="rounded-lg bg-cyan-600 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+          >
+            Salvar
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setTexto(mensagem.corpo)
+              setEditando(false)
+            }}
+            className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50 dark:border-slate-500 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div
+        className={`pointer-events-none absolute top-1 z-10 flex gap-0.5 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100 ${
+          alinhamento === 'end' ? 'right-1' : 'left-1'
+        }`}
+      >
+        {podeEditar && (mensagem.tipo_midia || 'texto') === 'texto' && (
+          <button
+            type="button"
+            onClick={() => setEditando(true)}
+            className="pointer-events-auto rounded-full bg-white/95 px-2 py-0.5 text-[10px] font-medium text-slate-600 shadow-sm ring-1 ring-slate-200 hover:bg-white dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-600"
+          >
+            Editar
+          </button>
+        )}
+        {(podeApagarTodos || podeApagarMim) && (
+          <button
+            type="button"
+            onClick={() => setConfirmarApagar(true)}
+            className="pointer-events-auto rounded-full bg-white/95 px-2 py-0.5 text-[10px] font-medium text-slate-600 shadow-sm ring-1 ring-slate-200 hover:bg-white dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-600"
+          >
+            Apagar
+          </button>
+        )}
+      </div>
+      <ConfirmDialog
+        open={confirmarApagar}
+        title="Apagar mensagem?"
+        message={
+          podeApagarTodos
+            ? 'Nos primeiros 5 minutos você pode apagar para todos ou só para você.'
+            : 'A mensagem será removida apenas da sua visualização.'
+        }
+        confirmLabel={podeApagarTodos ? 'Apagar para todos' : 'Apagar para mim'}
+        cancelLabel="Cancelar"
+        variant="danger"
+        loading={apagando}
+        hideActions
+        onCancel={() => setConfirmarApagar(false)}
+        onConfirm={() => {}}
+      >
+        <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={() => setConfirmarApagar(false)}
+            className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-500 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+          >
+            Cancelar
+          </button>
+          {podeApagarMim && (
+            <button
+              type="button"
+              disabled={apagando}
+              onClick={() => {
+                setApagando(true)
+                void onApagar('para_mim')
+                  .then(() => setConfirmarApagar(false))
+                  .finally(() => setApagando(false))
+              }}
+              className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50 dark:border-slate-500 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+            >
+              Apagar para mim
+            </button>
+          )}
+          {podeApagarTodos && (
+            <button
+              type="button"
+              disabled={apagando}
+              onClick={() => {
+                setApagando(true)
+                void onApagar('todos')
+                  .then(() => setConfirmarApagar(false))
+                  .finally(() => setApagando(false))
+              }}
+              className="rounded-lg bg-rose-600 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-700 disabled:opacity-50"
+            >
+              Apagar para todos
+            </button>
+          )}
+        </div>
+      </ConfirmDialog>
+    </>
+  )
+}

--- a/frontend/src/components/chat-interno/ChatInternoReacoesBar.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoReacoesBar.tsx
@@ -1,0 +1,61 @@
+import type { ChatInterno } from '../../api/client'
+import { EMOJIS_REACAO_CHAT_INTERNO } from '../../lib/chatInternoReacoes'
+
+type Props = {
+  reacoes: ChatInterno.ReacaoMensagem[]
+  onReagir: (emoji: string) => void
+  alinhamento?: 'start' | 'end'
+}
+
+export function ChatInternoReacoesBar({ reacoes, onReagir, alinhamento = 'end' }: Props) {
+  const temReacoes = reacoes.length > 0
+
+  return (
+    <>
+      <div
+        className={`pointer-events-none absolute bottom-[calc(100%-4px)] z-10 flex opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 md:opacity-0 md:group-hover:opacity-100 ${
+          alinhamento === 'end' ? 'right-0 justify-end' : 'left-0 justify-start'
+        }`}
+      >
+        <div className="pointer-events-auto flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
+          {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
+            <button
+              key={emoji}
+              type="button"
+              onClick={() => onReagir(emoji)}
+              className="rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
+              aria-label={`Reagir com ${emoji}`}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {temReacoes ? (
+        <div
+          className={`relative z-[1] -mt-2.5 flex flex-wrap gap-1 ${
+            alinhamento === 'end' ? 'justify-end' : 'justify-start'
+          }`}
+        >
+          {reacoes.map((r) => (
+            <button
+              key={r.emoji}
+              type="button"
+              onClick={() => onReagir(r.emoji)}
+              className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] shadow-sm transition ${
+                r.reagiu_eu
+                  ? 'border-cyan-400/60 bg-white text-slate-800 dark:bg-slate-800 dark:text-slate-100'
+                  : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200'
+              }`}
+              title={r.reagiu_eu ? 'Remover sua reação' : 'Reagir'}
+            >
+              <span>{r.emoji}</span>
+              <span className="font-medium tabular-nums">{r.count}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/frontend/src/components/chat/MensagemRodapeMeta.tsx
+++ b/frontend/src/components/chat/MensagemRodapeMeta.tsx
@@ -8,6 +8,7 @@ type Props = {
   eventoSistema?: string | null
   variant?: 'claro' | 'escuro'
   prefixo?: string
+  editada?: boolean
   className?: string
 }
 
@@ -18,15 +19,21 @@ export function MensagemRodapeMeta({
   eventoSistema,
   variant = 'escuro',
   prefixo,
+  editada,
   className = '',
 }: Props) {
   const horaFmt = formatarHoraMensagemCurta(hora)
   const exibirStatus = mostrarStatusEntrega(direcao, status, { eventoSistema })
 
-  if (!horaFmt && !exibirStatus && !prefixo) return null
+  if (!horaFmt && !exibirStatus && !prefixo && !editada) return null
 
   return (
     <div className={`mt-1 flex items-center justify-end gap-1 ${className}`}>
+      {editada ? (
+        <span className={`text-[10px] italic ${variant === 'claro' ? 'text-cyan-100/80' : 'text-slate-400'}`}>
+          editada
+        </span>
+      ) : null}
       {prefixo ? <span className="truncate text-[10px] opacity-80">{prefixo}</span> : null}
       {horaFmt ? (
         <span className={`text-[10px] tabular-nums ${variant === 'claro' ? 'text-cyan-100/90' : 'text-slate-400'}`}>

--- a/frontend/src/lib/chatInternoReacoes.ts
+++ b/frontend/src/lib/chatInternoReacoes.ts
@@ -1,0 +1,3 @@
+export const EMOJIS_REACAO_CHAT_INTERNO = ['👍', '❤️', '😂', '😮', '😢', '🙏'] as const
+
+export type EmojiReacaoChatInterno = (typeof EMOJIS_REACAO_CHAT_INTERNO)[number]

--- a/frontend/src/lib/chatInternoScrollMemory.ts
+++ b/frontend/src/lib/chatInternoScrollMemory.ts
@@ -1,0 +1,102 @@
+const STORAGE_PREFIX = 'chat-interno-scroll-v1'
+const NEAR_BOTTOM_PX = 80
+
+export type ChatInternoScrollState = {
+  nearBottom: boolean
+  anchorMessageId: number | null
+  scrollTop: number
+}
+
+function storageKey(conversaId: number): string {
+  return `${STORAGE_PREFIX}:${conversaId}`
+}
+
+export function isNearBottom(el: HTMLElement, threshold = NEAR_BOTTOM_PX): boolean {
+  return el.scrollHeight - el.scrollTop - el.clientHeight <= threshold
+}
+
+export function findAnchorMessageId(container: HTMLElement): number | null {
+  const containerRect = container.getBoundingClientRect()
+  const nodes = container.querySelectorAll<HTMLElement>('[data-chat-msg-id]')
+  for (const node of nodes) {
+    const rect = node.getBoundingClientRect()
+    if (rect.bottom > containerRect.top + 12) {
+      const id = Number(node.dataset.chatMsgId)
+      return Number.isFinite(id) ? id : null
+    }
+  }
+  return null
+}
+
+export function saveChatInternoScroll(conversaId: number, container: HTMLElement): void {
+  try {
+    const state: ChatInternoScrollState = {
+      nearBottom: isNearBottom(container),
+      anchorMessageId: findAnchorMessageId(container),
+      scrollTop: container.scrollTop,
+    }
+    sessionStorage.setItem(storageKey(conversaId), JSON.stringify(state))
+  } catch {
+    // sessionStorage indisponível — ignorar
+  }
+}
+
+export function loadChatInternoScroll(conversaId: number): ChatInternoScrollState | null {
+  try {
+    const raw = sessionStorage.getItem(storageKey(conversaId))
+    if (!raw) return null
+    return JSON.parse(raw) as ChatInternoScrollState
+  } catch {
+    return null
+  }
+}
+
+export function clearChatInternoScroll(conversaId: number): void {
+  try {
+    sessionStorage.removeItem(storageKey(conversaId))
+  } catch {
+    // ignorar
+  }
+}
+
+export function scrollChatToBottom(container: HTMLElement): void {
+  container.scrollTop = container.scrollHeight
+}
+
+export function restoreChatInternoScroll(
+  conversaId: number,
+  container: HTMLElement,
+): boolean {
+  const saved = loadChatInternoScroll(conversaId)
+  if (!saved) {
+    scrollChatToBottom(container)
+    return true
+  }
+
+  if (saved.nearBottom) {
+    scrollChatToBottom(container)
+    return true
+  }
+
+  if (saved.anchorMessageId != null) {
+    const anchor = container.querySelector<HTMLElement>(
+      `[data-chat-msg-id="${saved.anchorMessageId}"]`,
+    )
+    if (anchor) {
+      anchor.scrollIntoView({ block: 'start' })
+      return false
+    }
+  }
+
+  container.scrollTop = saved.scrollTop
+  return false
+}
+
+export function preserveScrollOnContentChange(
+  container: HTMLElement,
+  prevScrollTop: number,
+  prevScrollHeight: number,
+): void {
+  const delta = container.scrollHeight - prevScrollHeight
+  container.scrollTop = prevScrollTop + delta
+}

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -4,12 +4,23 @@ import { ApiError, chatInterno, type ChatInterno } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { ChatInternoComposerBar } from '../../components/chat-interno/ChatInternoComposerBar'
 import { ChatInternoConteudoMensagem } from '../../components/chat-interno/ChatInternoConteudoMensagem'
+import { ChatInternoMensagemAcoes } from '../../components/chat-interno/ChatInternoMensagemAcoes'
+import { ChatInternoReacoesBar } from '../../components/chat-interno/ChatInternoReacoesBar'
 import { MensagemRodapeMeta } from '../../components/chat/MensagemRodapeMeta'
 import { useChatInterno } from '../../contexts/ChatInternoContext'
 import { useToast } from '../../components/ui/Toast'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
 import { useAuth } from '../../contexts/AuthContext'
 import { useEventStream } from '../../contexts/EventStreamContext'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
+import {
+  clearChatInternoScroll,
+  isNearBottom,
+  preserveScrollOnContentChange,
+  restoreChatInternoScroll,
+  saveChatInternoScroll,
+  scrollChatToBottom,
+} from '../../lib/chatInternoScrollMemory'
 import { SemPermissao } from '../SemPermissao'
 
 function formatarHoraMensagem(iso: string): string {
@@ -35,21 +46,50 @@ export function ChatInternoThread() {
   const [forbidden, setForbidden] = useState(false)
   const [erro, setErro] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
+  const stickToBottomRef = useRef(true)
+  const initialScrollRestoredRef = useRef(false)
+  const saveScrollRafRef = useRef<number | null>(null)
 
-  const carregarMensagens = useCallback(async () => {
-    if (!Number.isFinite(conversaId) || conversaId <= 0) return
+  const marcarVistoSeNoFim = useCallback(async () => {
+    const el = scrollRef.current
+    if (!el || !isNearBottom(el)) return
     try {
-      const pagina = await chatInterno.mensagens(conversaId, { offset: 0, limit: 100 })
-      setMensagens(pagina.items)
       await chatInterno.marcarVisto(conversaId)
       void refetchPendenciasResumo()
       void refreshInbox(true)
+    } catch {
+      // silencioso no polling
+    }
+  }, [conversaId, refreshInbox])
+
+  const carregarMensagens = useCallback(async () => {
+    if (!Number.isFinite(conversaId) || conversaId <= 0) return
+    const el = scrollRef.current
+    const stick = stickToBottomRef.current
+    const prevTop = el?.scrollTop ?? 0
+    const prevHeight = el?.scrollHeight ?? 0
+
+    try {
+      const pagina = await chatInterno.mensagens(conversaId, { offset: 0, limit: 100 })
+      setMensagens(pagina.items)
+
+      requestAnimationFrame(() => {
+        const container = scrollRef.current
+        if (!container) return
+        if (stick) {
+          scrollChatToBottom(container)
+        } else if (el) {
+          preserveScrollOnContentChange(container, prevTop, prevHeight)
+        }
+      })
+
+      await marcarVistoSeNoFim()
     } catch (err) {
       if (err instanceof ApiError && err.status === 403) {
         setForbidden(true)
       }
     }
-  }, [conversaId, refreshInbox])
+  }, [conversaId, marcarVistoSeNoFim])
 
   const carregar = useCallback(async () => {
     if (!Number.isFinite(conversaId) || conversaId <= 0) return
@@ -58,9 +98,7 @@ export function ChatInternoThread() {
     try {
       const pagina = await chatInterno.mensagens(conversaId, { offset: 0, limit: 100 })
       setMensagens(pagina.items)
-      await chatInterno.marcarVisto(conversaId)
-      void refetchPendenciasResumo()
-      void refreshInbox(true)
+      await marcarVistoSeNoFim()
     } catch (err) {
       if (err instanceof ApiError && err.status === 403) {
         setForbidden(true)
@@ -71,22 +109,59 @@ export function ChatInternoThread() {
     } finally {
       setLoading(false)
     }
-  }, [conversaId, toast, refreshInbox])
+  }, [conversaId, toast, marcarVistoSeNoFim])
 
   useEffect(() => {
     if (!Number.isFinite(conversaId) || conversaId <= 0) {
       navigate('/chat/interno', { replace: true })
       return
     }
+    initialScrollRestoredRef.current = false
+    stickToBottomRef.current = true
     setLoading(true)
     void carregar()
   }, [conversaId, carregar, navigate])
 
   useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    if (loading || mensagens.length === 0 || initialScrollRestoredRef.current) return
+    initialScrollRestoredRef.current = true
+    requestAnimationFrame(() => {
+      const el = scrollRef.current
+      if (!el) return
+      stickToBottomRef.current = restoreChatInternoScroll(conversaId, el)
+      if (stickToBottomRef.current) {
+        void marcarVistoSeNoFim()
+      }
+    })
+  }, [loading, mensagens.length, conversaId, marcarVistoSeNoFim])
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+
+    const onScroll = () => {
+      stickToBottomRef.current = isNearBottom(el)
+      if (saveScrollRafRef.current != null) cancelAnimationFrame(saveScrollRafRef.current)
+      saveScrollRafRef.current = requestAnimationFrame(() => {
+        saveChatInternoScroll(conversaId, el)
+      })
     }
-  }, [mensagens])
+
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      el.removeEventListener('scroll', onScroll)
+      if (saveScrollRafRef.current != null) cancelAnimationFrame(saveScrollRafRef.current)
+      saveChatInternoScroll(conversaId, el)
+    }
+  }, [conversaId, loading])
+
+  useEffect(() => {
+    if (loading || !initialScrollRestoredRef.current || !stickToBottomRef.current) return
+    requestAnimationFrame(() => {
+      const el = scrollRef.current
+      if (el) scrollChatToBottom(el)
+    })
+  }, [mensagens, loading])
 
   useEffect(() => {
     const unsubMsg = subscribe('chat.interno.mensagem', (payload) => {
@@ -99,9 +174,14 @@ export function ChatInternoThread() {
       if (Number(payload.conversa_id) !== conversaId) return
       void carregarMensagens()
     })
+    const unsubAtualizada = subscribe('chat.interno.mensagem.atualizada', (payload) => {
+      if (Number(payload.conversa_id) !== conversaId) return
+      void carregarMensagens()
+    })
     return () => {
       unsubMsg()
       unsubLido()
+      unsubAtualizada()
     }
   }, [subscribe, conversaId, carregarMensagens, refreshInbox])
 
@@ -111,6 +191,60 @@ export function ChatInternoThread() {
     return () => clearInterval(timer)
   }, [carregarMensagens, useFallback])
 
+  const atualizarMensagemNoEstado = useCallback((msg: ChatInterno.Mensagem) => {
+    setMensagens((prev) => prev.map((m) => (m.id === msg.id ? msg : m)))
+  }, [])
+
+  const [confirmarLimpar, setConfirmarLimpar] = useState(false)
+  const [limpando, setLimpando] = useState(false)
+
+  async function editarMensagem(mensagemId: number, corpo: string) {
+    try {
+      const msg = await chatInterno.editarMensagem(conversaId, mensagemId, corpo)
+      atualizarMensagemNoEstado(msg)
+      void refreshInbox(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível editar a mensagem.'))
+      throw err
+    }
+  }
+
+  async function apagarMensagem(mensagemId: number, escopo: 'todos' | 'para_mim') {
+    try {
+      const msg = await chatInterno.apagarMensagem(conversaId, mensagemId, escopo)
+      if (escopo === 'para_mim' || !msg) {
+        setMensagens((prev) => prev.filter((m) => m.id !== mensagemId))
+      } else {
+        atualizarMensagemNoEstado(msg)
+      }
+      void refreshInbox(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível apagar a mensagem.'))
+      throw err
+    }
+  }
+
+  async function limparConversa() {
+    try {
+      await chatInterno.limparConversa(conversaId)
+      clearChatInternoScroll(conversaId)
+      setMensagens([])
+      void refreshInbox(true)
+      navigate('/chat/interno', { replace: true })
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível limpar a conversa.'))
+    }
+  }
+
+  async function reagirMensagem(mensagemId: number, emoji: string) {
+    try {
+      const msg = await chatInterno.definirReacao(conversaId, mensagemId, emoji)
+      atualizarMensagemNoEstado(msg)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível reagir à mensagem.'))
+    }
+  }
+
   async function enviarMidia(file: File, caption?: string) {
     if (enviando) return
     setEnviando(true)
@@ -118,8 +252,14 @@ export function ChatInternoThread() {
       const msg = await chatInterno.enviarMidia(conversaId, file, caption)
       setTexto('')
       setMensagens((prev) => (prev.some((m) => m.id === msg.id) ? prev : [...prev, msg]))
+      stickToBottomRef.current = true
+      requestAnimationFrame(() => {
+        const el = scrollRef.current
+        if (el) scrollChatToBottom(el)
+      })
       void refreshInbox(true)
       void refetchPendenciasResumo()
+      await chatInterno.marcarVisto(conversaId)
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar o arquivo.'))
     } finally {
@@ -135,8 +275,14 @@ export function ChatInternoThread() {
       const msg = await chatInterno.enviar(conversaId, corpo)
       setTexto('')
       setMensagens((prev) => (prev.some((m) => m.id === msg.id) ? prev : [...prev, msg]))
+      stickToBottomRef.current = true
+      requestAnimationFrame(() => {
+        const el = scrollRef.current
+        if (el) scrollChatToBottom(el)
+      })
       void refreshInbox(true)
       void refetchPendenciasResumo()
+      await chatInterno.marcarVisto(conversaId)
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar a mensagem.'))
     } finally {
@@ -187,13 +333,38 @@ export function ChatInternoThread() {
             {isSetor ? 'Canal do setor — comunicados' : 'Conversa direta'}
           </p>
         </div>
+        <button
+          type="button"
+          onClick={() => setConfirmarLimpar(true)}
+          className="shrink-0 rounded-lg px-3 py-1.5 text-xs font-medium text-slate-600 ring-1 ring-slate-200 hover:bg-slate-100 dark:text-slate-300 dark:ring-slate-600 dark:hover:bg-slate-800"
+          title="Limpar conversa só para você"
+        >
+          Limpar conversa
+        </button>
       </header>
+
+      <ConfirmDialog
+        open={confirmarLimpar}
+        title="Limpar conversa?"
+        message="O histórico será apagado apenas para você. A outra pessoa continua vendo as mensagens."
+        confirmLabel="Limpar para mim"
+        variant="danger"
+        loading={limpando}
+        onCancel={() => setConfirmarLimpar(false)}
+        onConfirm={() => {
+          setLimpando(true)
+          void limparConversa().finally(() => {
+            setLimpando(false)
+            setConfirmarLimpar(false)
+          })
+        }}
+      />
 
       <div
         ref={scrollRef}
         className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto bg-slate-100/90 px-4 py-5 dark:bg-slate-900/60 md:px-6 lg:px-8"
       >
-        <div className="w-full min-w-0 space-y-4">
+        <div className="w-full min-w-0 space-y-1">
         {loading ? (
           <p className="text-center text-base text-slate-400 animate-pulse">Carregando mensagens…</p>
         ) : erro ? (
@@ -205,19 +376,36 @@ export function ChatInternoThread() {
         ) : (
           mensagens.map((m) => {
             const propria = m.atendente_id === user?.id
+            const isTexto = !m.tipo_midia || m.tipo_midia === 'texto'
+            const textoCompacto = isTexto && !m.apagada
             if (isSetor) {
               return (
                 <article
                   key={m.id}
-                  className="w-full min-w-0 overflow-hidden rounded-2xl border border-amber-200/80 bg-amber-50/95 p-5 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40"
+                  data-chat-msg-id={m.id}
+                  className="group w-full min-w-0 overflow-hidden rounded-2xl border border-amber-200/80 bg-amber-50/95 p-5 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40"
                 >
                   <div className="mb-2 flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-200">
                     <span>Comunicado</span>
                     <span className="font-normal normal-case text-slate-500">
                       {m.atendente_nome ?? 'Atendente'}
                     </span>
+                    {m.editada && (
+                      <span className="font-normal normal-case text-slate-400">· editada</span>
+                    )}
                   </div>
                   <ChatInternoConteudoMensagem conversaId={conversaId} mensagem={m} />
+                  <ChatInternoMensagemAcoes
+                    mensagem={m}
+                    onEditar={(corpo) => editarMensagem(m.id, corpo)}
+                    onApagar={(escopo) => apagarMensagem(m.id, escopo)}
+                  />
+                  {!m.apagada && (
+                    <ChatInternoReacoesBar
+                      reacoes={m.reacoes ?? []}
+                      onReagir={(emoji) => void reagirMensagem(m.id, emoji)}
+                    />
+                  )}
                   {m.atendente_id === user?.id ? (
                     <MensagemRodapeMeta
                       hora={m.created_at}
@@ -233,24 +421,67 @@ export function ChatInternoThread() {
               )
             }
             return (
-              <div key={m.id} className={`flex min-w-0 w-full ${propria ? 'justify-end' : 'justify-start'}`}>
+              <div key={m.id} data-chat-msg-id={m.id} className={`group flex w-full ${propria ? 'justify-end' : 'justify-start'}`}>
                 <div
-                  className={`min-w-0 max-w-[min(42rem,78%)] overflow-hidden rounded-2xl px-4 py-3 text-base leading-relaxed shadow-sm ${
-                    propria
-                      ? 'rounded-tr-md bg-cyan-600 text-white'
-                      : 'rounded-tl-md bg-white text-slate-900 dark:bg-slate-800 dark:text-slate-100'
+                  className={`flex max-w-[85%] flex-col sm:max-w-[min(65%,28rem)] ${
+                    propria ? 'items-end' : 'items-start'
                   }`}
                 >
-                  {!propria && (
-                    <p className="mb-1.5 text-xs font-semibold opacity-80">{m.atendente_nome ?? 'Atendente'}</p>
-                  )}
-                  <ChatInternoConteudoMensagem conversaId={conversaId} mensagem={m} textoClaro={propria} />
-                  <MensagemRodapeMeta
-                    hora={m.created_at}
-                    status={propria ? m.status_entrega : null}
-                    direcao={propria ? 'outbound' : 'inbound'}
-                    variant={propria ? 'claro' : 'escuro'}
-                  />
+                  <div className="relative w-fit max-w-full">
+                    <div
+                      className={`relative w-fit max-w-full rounded-lg px-[9px] py-[6px] text-sm shadow-sm ring-1 ring-inset ${
+                        propria
+                          ? 'rounded-tr-none bg-cyan-600 text-white ring-cyan-500/30'
+                          : 'rounded-tl-none bg-white text-slate-900 ring-slate-200/80 dark:bg-slate-800 dark:text-slate-100 dark:ring-slate-700'
+                      }`}
+                    >
+                      {!propria && (
+                        <p className="mb-0.5 text-[11px] font-semibold leading-none text-cyan-700 dark:text-cyan-300">
+                          {m.atendente_nome ?? 'Atendente'}
+                        </p>
+                      )}
+                      <ChatInternoConteudoMensagem
+                        conversaId={conversaId}
+                        mensagem={m}
+                        textoClaro={propria}
+                        somenteTextoCompacto={textoCompacto}
+                        rodape={
+                          textoCompacto ? (
+                            <MensagemRodapeMeta
+                              hora={m.created_at}
+                              status={propria ? m.status_entrega : null}
+                              direcao={propria ? 'outbound' : 'inbound'}
+                              variant={propria ? 'claro' : 'escuro'}
+                              editada={m.editada}
+                              className="!mt-0"
+                            />
+                          ) : undefined
+                        }
+                      />
+                      {!textoCompacto && (
+                        <MensagemRodapeMeta
+                          hora={m.created_at}
+                          status={propria ? m.status_entrega : null}
+                          direcao={propria ? 'outbound' : 'inbound'}
+                          variant={propria ? 'claro' : 'escuro'}
+                          editada={m.editada}
+                        />
+                      )}
+                    </div>
+                    <ChatInternoMensagemAcoes
+                      mensagem={m}
+                      onEditar={(corpo) => editarMensagem(m.id, corpo)}
+                      onApagar={(escopo) => apagarMensagem(m.id, escopo)}
+                      alinhamento={propria ? 'end' : 'start'}
+                    />
+                    {!m.apagada && (
+                      <ChatInternoReacoesBar
+                        reacoes={m.reacoes ?? []}
+                        onReagir={(emoji) => void reagirMensagem(m.id, emoji)}
+                        alinhamento={propria ? 'end' : 'start'}
+                      />
+                    )}
+                  </div>
                 </div>
               </div>
             )


### PR DESCRIPTION
## Summary

- Chat interno v2: editar e apagar mensagens (#503), reações rápidas (#502), regras de janela de 5 minutos e «apagar para mim» / limpar conversa só para o usuário
- Migrations `061` (edição/reações) e `062` (ocultação por participante); SSE `chat.interno.mensagem.atualizada`
- Scroll inteligente na thread: não puxa para o fim ao ler histórico; restaura a última mensagem visualizada ao voltar à conversa

Closes #502
Closes #503

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `docker compose run --rm --no-deps backend pytest -q tests/test_chat_interno_edicao_reacoes.py tests/test_realtime_chat_interno.py` (15 passed)
- [x] `npx tsc -b` no frontend
- [ ] Editar mensagem de texto própria dentro de 5 min; após 5 min só «apagar para mim»
- [ ] Reações em conversa direta e canal setor; toggle ao clicar de novo
- [ ] Limpar conversa oculta histórico só para quem limpou; inbox some até nova mensagem
- [ ] Rolar histórico para cima — polling/SSE não devem puxar para o fim
- [ ] Sair e voltar à conversa — retoma na última mensagem visualizada

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — épico IC chat interno v1+v2 entregue; sem follow-ups obrigatórios pendentes para fechar o lote
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável — N/A
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados — N/A (lote concluído)
