### PR TITLE
feat(chat-interno): paginação, legenda de mídia e grupos v3 (#505–#507)

### DIFF
--- a/.cursor/commands/subir-local.md
+++ b/.cursor/commands/subir-local.md
@@ -1,0 +1,200 @@
+# Subir local
+
+Suba o DX Connect em **desenvolvimento** (Docker + frontend Vite) e confirme que está acessível.
+
+## Pré-requisitos
+
+- Docker Desktop **rodando**
+- Node.js 18+ e npm (frontend local)
+- Executar na **raiz do repositório**
+
+## Passo 1 — Diagnóstico
+
+```bash
+docker version
+docker compose version
+node --version
+npm --version
+```
+
+Se Docker não responder, **pare** e oriente o usuário a abrir o Docker Desktop.
+
+## Passo 2 — Arquivo `backend/.env`
+
+Se `backend/.env` **não existir**:
+
+```bash
+cp backend/.env.example backend/.env
+```
+
+No Windows (PowerShell):
+
+```powershell
+Copy-Item backend\.env.example backend\.env
+```
+
+Não commitar `.env`.
+
+## Passo 3 — Subir stack Docker
+
+Na raiz:
+
+```bash
+docker compose up -d --build
+```
+
+Use `--build` se `Dockerfile`, `requirements*.txt` ou `docker-compose.yml` mudaram; caso contrário `docker compose up -d` basta.
+
+Serviços esperados:
+
+| Serviço | Porta | Uso |
+|---------|-------|-----|
+| `db` | 5432 | PostgreSQL DX Connect |
+| `backend` | 8000 | API FastAPI |
+| `evolution-api` | 8080 | WhatsApp (dev) |
+| `evolution-db` / `evolution-redis` | interno | Evolution |
+
+Aguarde containers saudáveis:
+
+```bash
+docker compose ps
+```
+
+## Passo 4 — Migrations (recomendado)
+
+Após `git pull` ou ao trabalhar com branch que alterou `backend/alembic/`:
+
+```bash
+docker compose run --rm --no-deps backend alembic heads
+docker compose run --rm --no-deps backend alembic upgrade head
+```
+
+Em dev a API também roda `create_all` no startup, mas **migrations Alembic** mantêm o schema alinhado ao repo (obrigatório após pull com migrations novas).
+
+## Passo 5 — Seed (se banco vazio ou primeiro uso)
+
+O backend tenta seed automático em dev. Se login falhar:
+
+```bash
+docker compose exec backend python -m app.seed
+```
+
+Login dev (só local):
+
+- URL: http://localhost:5173/login
+- E-mail: `admin@email.com`
+- Senha: `admin123`
+
+## Passo 6 — Health check da API
+
+```bash
+curl -s http://localhost:8000/health
+```
+
+Ou abra http://localhost:8000/docs
+
+Se API não subir, inspecione:
+
+```bash
+docker compose logs backend --tail 80
+docker compose logs db --tail 30
+```
+
+## Passo 7 — Frontend (Vite)
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+- App: http://localhost:5173
+- Proxy `/api` → http://localhost:8000 (não precisa `frontend/.env` em dev)
+
+Se `node_modules` já existir e `package.json` não mudou, pule `npm install`.
+
+### Rodar frontend em background (opcional)
+
+Se o agente precisar manter o terminal livre:
+
+**PowerShell:**
+
+```powershell
+cd frontend; Start-Process npm -ArgumentList "run","dev" -NoNewWindow
+```
+
+**bash:**
+
+```bash
+cd frontend && npm run dev
+```
+
+(rodar em terminal em background / segunda aba)
+
+## Passo 8 — Entrega
+
+Reporte:
+
+| Item | Status |
+|------|--------|
+| Docker (`docker compose ps`) | ... |
+| Migrations (`alembic heads`) | ... |
+| API http://localhost:8000/health | ... |
+| Frontend http://localhost:5173 | ... |
+| Login admin | ok / precisa seed |
+
+### URLs úteis
+
+- Painel: http://localhost:5173
+- API docs: http://localhost:8000/docs
+- Evolution (diagnóstico WhatsApp): http://localhost:8080
+
+### Parar ambiente
+
+```bash
+docker compose down
+```
+
+Frontend: `Ctrl+C` no terminal do Vite.
+
+### Rebuild completo (se algo estranho)
+
+```bash
+docker compose down
+docker compose up -d --build
+docker compose run --rm --no-deps backend alembic upgrade head
+```
+
+### Banco dessincronizado (migrations falham / colunas faltando)
+
+Sintomas: `DuplicateTable` no Alembic, `UndefinedColumn` nos logs, `/health` lento ou 500.
+
+Causa comum: volume Postgres antigo + `create_all` em dev sem Alembic alinhado.
+
+**Reset só do Postgres de dev** (apaga dados locais):
+
+```bash
+docker compose stop backend db
+docker volume rm dx-connect_postgres_data
+docker compose up -d
+docker compose run --rm --no-deps backend alembic upgrade head
+docker compose exec backend python -m app.seed
+```
+
+### Frontend: dependências faltando
+
+Se Vite avisar `recharts` / `react-markdown` não resolvidos:
+
+```bash
+cd frontend && npm install
+```
+
+Reinicie `npm run dev` após instalar.
+
+Se o Vite já estava rodando **antes** do `npm install`, pare (`Ctrl+C`) e suba de novo — senão a UI fica preta com erro `Failed to resolve import`.
+
+## Referências
+
+- `README.md` — desenvolvimento
+- `docs/WHATSAPP_EVOLUTION.md` — QR Code WhatsApp em dev
+- `docs/ALEMBIC_MIGRATIONS.md` — troubleshooting migrations

--- a/.cursor/commands/testar-ui.md
+++ b/.cursor/commands/testar-ui.md
@@ -1,0 +1,114 @@
+# Testar UI
+
+Execute **smoke test** da aplicação no navegador integrado do Cursor (MCP `cursor-ide-browser`).
+
+## Quando usar
+
+- Após `/subir-local` ou antes de abrir PR
+- Validar feature implementada (ex.: chat interno IC)
+- Investigar tela branca, erro no console ou 500 no Vite
+
+## Pré-requisitos
+
+1. Ambiente local no ar (`/subir-local` ou equivalente)
+2. API: http://localhost:8000/health → 200
+3. Frontend: http://localhost:5173 → 200
+4. Se Vite foi iniciado **antes** de `npm install`, **reinicie** `npm run dev`
+
+## Escopo do teste
+
+Se o usuário passou rota ou feature, foque nela. Senão, rode o **smoke padrão** abaixo.
+
+## Fluxo (browser MCP)
+
+Use `browser_navigate` → `browser_snapshot` → `browser_console_messages` → `browser_network_requests`.
+
+### 1 — Smoke inicial
+
+```
+GET http://localhost:5173/
+```
+
+Verificar:
+- [ ] Página carrega (não fica preta/vazia)
+- [ ] Console **sem** erros `Failed to resolve import`
+- [ ] Network: scripts principais com status 200 (não 500 em `.tsx`)
+
+Se tela preta: inspecionar network por arquivos com **500** (ex.: `DashboardTickets.tsx` → `recharts` faltando → `cd frontend && npm install` e reiniciar Vite).
+
+### 2 — Login admin
+
+Navegar: http://localhost:5173/login
+
+Credenciais dev:
+- E-mail: `admin@email.com`
+- Senha: `admin123`
+
+- [ ] Formulário visível
+- [ ] Login redireciona para dashboard/home
+- [ ] Sem erro 401/403 inesperado na network (`/api/v1/auth/login`)
+
+Use `browser_fill` + `browser_click` ou interação por refs do snapshot.
+
+### 3 — Navegação mínima pós-login
+
+- [ ] Sidebar/menu carrega
+- [ ] Abrir **Tickets** (ou rota indicada pelo usuário)
+- [ ] Página renderiza sem erro no console
+
+### 4 — Feature sob teste (se informada)
+
+Exemplos:
+
+| Feature | Rota |
+|---------|------|
+| Chat interno IC | `/chat-interno` |
+| Dashboard | `/dashboard` |
+| WhatsApp | `/whatsapp` |
+
+Checklist:
+- [ ] Rota abre sem 404/403 indevido
+- [ ] Elementos principais visíveis no snapshot
+- [ ] Chamadas API relevantes retornam 2xx (network)
+
+### 5 — Screenshot e relatório
+
+Tire `browser_take_screenshot` em caso de falha.
+
+Entregue:
+
+```markdown
+## Resultado UI
+
+| Etapa | Status | Observação |
+|-------|--------|------------|
+| Smoke / | ✅/❌ | ... |
+| Login | ✅/❌ | ... |
+| Navegação | ✅/❌ | ... |
+| Feature X | ✅/❌ | ... |
+
+## Erros de console
+- ...
+
+## Requests com falha
+- ...
+
+## Correção sugerida
+- ...
+```
+
+## Se encontrar bug
+
+1. Corrija **se estiver no escopo** da sessão (ex.: deps faltando, erro óbvio)
+2. Reexecute o teste afetado
+3. Não commitar sem pedido do usuário
+
+## Subagent
+
+Para testes longos em paralelo com implementação, pode delegar exploração de rotas ao subagent `explore` — mas **interação no browser** faça neste agent (MCP browser não é delegável de forma confiável).
+
+## Referências
+
+- `/subir-local` — subir ambiente
+- Login dev: `README.md`
+- Credenciais só local — nunca produção

--- a/.cursor/rules/project-core.mdc
+++ b/.cursor/rules/project-core.mdc
@@ -29,7 +29,7 @@ docker compose run --rm --no-deps backend pytest -q
 docker compose up -d --build   # só se Dockerfile ou requirements mudaram
 ```
 
-Frontend em dev: `npm run dev` na pasta `frontend/` (proxy `/api` → `:8000`).
+Frontend em dev: `npm run dev` na pasta `frontend/` (proxy `/api` → `:8000`). Use `/subir-local` para subir tudo.
 
 ## Arquitetura de deploy
 

--- a/.cursor/skills/browser-qa/SKILL.md
+++ b/.cursor/skills/browser-qa/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: browser-qa
+description: Executa smoke tests e validação visual do DX Connect no navegador integrado do Cursor. Use após subir ambiente local, antes de PR, ou quando o usuário reportar tela branca/erro na UI.
+---
+
+# Browser QA — DX Connect
+
+Playbook para testes manuais assistidos via MCP `cursor-ide-browser`.
+
+## Pré-check (terminal)
+
+```bash
+curl -s http://localhost:8000/health
+curl -s -o NUL -w "%{http_code}" http://localhost:5173/
+```
+
+Se falhar → `/subir-local` primeiro.
+
+## Problemas comuns
+
+| Sintoma | Causa | Correção |
+|---------|-------|----------|
+| Tela preta | Vite 500 em `.tsx` | Ver network; `npm install`; reiniciar `npm run dev` |
+| `Failed to resolve import "recharts"` | deps não instaladas | `cd frontend && npm install` |
+| 401 após login | seed não rodou | `docker compose exec backend python -m app.seed` |
+| API lenta no /health | IBGE sync no startup | Aguardar ~10s e retry |
+
+## Rotas smoke
+
+| Rota | Esperado |
+|------|----------|
+| `/login` | Form login |
+| `/` ou `/dashboard` | Redirect se autenticado |
+| `/tickets` | Lista tickets |
+| `/chat-interno` | Inbox IC (se implementado) |
+
+## Sequência login
+
+1. `browser_navigate` → `/login`
+2. `browser_snapshot` → refs dos campos
+3. `browser_fill` e-mail e senha
+4. `browser_click` botão entrar
+5. `browser_console_messages` + `browser_network_requests`
+
+## Critério de sucesso
+
+- Zero erros críticos no console
+- Nenhum script `.tsx` com status 500
+- Login admin funciona
+- Rota da feature renderiza conteúdo no snapshot
+
+## Ferramentas MCP
+
+- `browser_navigate`, `browser_snapshot`
+- `browser_console_messages`, `browser_network_requests`
+- `browser_take_screenshot` (evidência)
+- `browser_fill`, `browser_click` (fluxos)
+
+Command associado: `/testar-ui`

--- a/.github/planning-issue-bodies/IC-08-chat-interno-paginacao.md
+++ b/.github/planning-issue-bodies/IC-08-chat-interno-paginacao.md
@@ -1,0 +1,48 @@
+# IC-08 — Chat interno: paginação infinita no histórico
+
+## Contexto
+
+Follow-up pós-lote v2 do chat interno (#502, #503). Hoje a thread carrega `offset=0, limit=100` em ordem ASC — em conversas longas o usuário vê as mensagens **mais antigas**, não as recentes.
+
+## Proposta
+
+### Backend
+
+- Constante fixa `MENSAGENS_POR_PAGINA = 50` (não exposta ao usuário)
+- `GET /conversas/{id}/mensagens?antes_de_id=` opcional
+  - Sem cursor: retorna as **50 mais recentes** (ordem cronológica no JSON)
+  - Com `antes_de_id`: retorna até 50 mensagens **anteriores** ao id
+- Resposta: `items`, `total`, `tem_mais_antigas: bool`
+- Remover `offset`/`limit` configuráveis da API pública
+
+### Frontend
+
+- Carga inicial sem cursor
+- Ao rolar perto do topo: `antes_de_id` = id da mensagem mais antiga carregada; **prepend** com preservação de scroll
+- SSE/polling: merge por `id` (não substituir array inteiro)
+
+## Critérios de aceite
+
+- [ ] Conversa com 200+ mensagens abre nas mais recentes
+- [ ] Rolar ao topo carrega bloco anterior sem pular posição
+- [ ] Indicador «Carregando mensagens anteriores…» no topo
+- [ ] SSE adiciona mensagem nova sem perder histórico já carregado
+- [ ] Scroll inteligente (#504) continua funcionando
+- [ ] Testes backend para cursor e `tem_mais_antigas`
+
+## Regras de produto
+
+- 50 mensagens por bloco, fixo no servidor
+
+## Dependências
+
+- Chat interno v1+v2 mergeados (#478, #502, #503)
+
+## Fora de escopo
+
+- Configuração de tamanho de página pelo usuário
+- Paginação na inbox
+
+## Origem
+
+Lacuna identificada ao fechar épico #478 — lote `feat/chat-interno-v3`.

--- a/.github/planning-issue-bodies/IC-09-chat-interno-legenda-midia.md
+++ b/.github/planning-issue-bodies/IC-09-chat-interno-legenda-midia.md
@@ -1,0 +1,40 @@
+# IC-09 — Chat interno: editar legenda de mídia
+
+## Contexto
+
+Follow-up IC-06 (#503). Edição de texto já funciona com janela de 5 minutos; mídia bloqueada em `permissoes_mensagem` e `editar_mensagem`.
+
+## Proposta
+
+### Backend
+
+- Permitir `PATCH` em mensagens com `tipo_midia` em `TIPOS_MENSAGEM_MIDIA`
+- Só altera `corpo` (legenda); arquivo de mídia inalterado
+- Legenda vazia permitida (remove legenda customizada)
+- Mesmas regras: autor, 5 min, não apagada
+- Admin **não** edita legenda alheia (exceto regra existente de canal setor só para texto — mídia segue autor)
+
+### Frontend
+
+- Menu **Editar** em mensagens de mídia quando `pode_editar`
+- Modo edição da legenda (textarea); preview da mídia permanece
+
+## Critérios de aceite
+
+- [ ] Editar legenda de imagem dentro de 5 min
+- [ ] Adicionar legenda a mídia enviada sem legenda (dentro da janela)
+- [ ] Após 5 min API retorna erro e `pode_editar=false`
+- [ ] SSE propaga alteração na thread aberta
+- [ ] Testes backend
+
+## Dependências
+
+- #503 (edição de texto)
+
+## Fora de escopo
+
+- Substituir arquivo de mídia após envio
+
+## Origem
+
+Fora de escopo IC-06 — lote `feat/chat-interno-v3`.

--- a/.github/planning-issue-bodies/IC-10-chat-interno-grupos.md
+++ b/.github/planning-issue-bodies/IC-10-chat-interno-grupos.md
@@ -1,0 +1,60 @@
+# IC-10 — Chat interno: grupos personalizados
+
+## Contexto
+
+Follow-up épico #478. Atendentes precisam de conversas com **N participantes** escolhidos manualmente, além de direta 1:1 e canal de setor.
+
+## Proposta
+
+### Modelo (migration 063)
+
+- `tipo = 'grupo'`
+- `titulo VARCHAR(120) NOT NULL` para grupos
+- `CheckConstraint` atualizado: setor exige `setor_id`; direta/grupo exigem `setor_id IS NULL`
+- `conversas_internas_participantes`: coluna `papel` (`admin` | `membro`); criador entra como `admin`
+
+### Regras de produto
+
+- Máximo **50 atendentes** por grupo (incluindo criador)
+- **Admins** do grupo: criador (automático) + membros promovidos a admin
+- Só **admins** adicionam/removem membros e promovem/rebaixam admins
+- Removido: não vê nem envia mensagens **novas**; histórico no grupo **preservado** para quem permanece
+- Admin global do sistema **não** vê grupos dos quais não participa (privacidade = direta)
+
+### API
+
+- `POST /conversas/grupo` — `{ titulo, atendente_ids[] }`
+- `PATCH /conversas/{id}/participantes` — adicionar/remover/promover (admins)
+- Inbox inclui `tipo=grupo` com título
+
+### Frontend
+
+- Fluxo «Novo grupo» no modal de conversa (nome + multi-select)
+- Filtro inbox «Grupos»; visual distinto na lista e thread
+- Tela/modal gerenciar membros (admins)
+
+### SSE / notificações
+
+- Destinatários = participantes ativos (como direta)
+
+## Critérios de aceite
+
+- [ ] Criar grupo com 3+ atendentes; todos veem na inbox
+- [ ] Não-participante recebe 403
+- [ ] Admin do grupo adiciona/remove membro; membro comum não
+- [ ] Removido some da inbox e não acessa thread; histórico intacto para demais
+- [ ] Mensagens, mídia, reações, edição e paginação funcionam em grupo
+- [ ] Testes backend (RBAC 403, limite 50)
+
+## Dependências
+
+- IC-08, IC-09 recomendados antes ou no mesmo lote
+
+## Fora de escopo
+
+- Grupos com permissões granulares além de admin/membro
+- Chat com funcionários da rede
+
+## Origem
+
+Fora de escopo v1 #478 — lote `feat/chat-interno-v3`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ Config: `.cursor/hooks.json`
 | `/implementar-issue` | Implementar issue/épico com checklist completo |
 | `/nova-migration` | Criar/validar migration Alembic |
 | `/revisar-e-testar` | Revisão pré-merge com testes |
+| `/subir-local` | Subir Docker, migrations, API e frontend em dev |
+| `/testar-ui` | Smoke test no navegador integrado (login, rotas, console) |
 | `/criar-pr` | PR → watch CI → approve → **merge automático em main** |
 
 ## Subagents (Task tool)
@@ -69,12 +71,15 @@ Use subagents para **paralelizar** ou **isolar** trabalho:
 
 O `/criar-pr` monitora Actions, aprova e **mergeia em `main`** quando CI passa (main = branch de testes). Em falha, corrige e re-monitora (skill **babysit**). Opt-out: pedir `/criar-pr sem merge`.
 
+Para desenvolvimento local: `/subir-local` → `/testar-ui` (navegador integrado).
+
 ## Skills
 
 | Skill | Quando |
 |-------|--------|
 | `design-feature` | Planejar épicos/features (usado por `/planejar-feature`) |
 | `deploy-cliente` | Deploy/atualização de instância por cliente |
+| `browser-qa` | Smoke tests no navegador integrado (`/testar-ui`) |
 
 Skills futuras sugeridas:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Chat interno (#502): reações rápidas (👍 ❤️ 😂 😮 😢 🙏) em conversas diretas e canais de setor
 - Chat interno: editar e apagar para todos só nos primeiros 5 minutos; depois «apagar para mim»; opção de limpar conversa só para você
 - Chat interno: ao ler o histórico o scroll não volta sozinho para o fim; ao reabrir a conversa retoma na última mensagem visualizada
+- Chat interno (#505): paginação infinita — carrega mensagens recentes e busca histórico ao rolar para cima (50 por vez)
+- Chat interno (#506): editar legenda de mensagens com mídia (mesma janela de 5 minutos)
+- Chat interno (#507): grupos personalizados com até 50 atendentes; criador e admins promovidos gerenciam membros
 - WhatsApp (#470): áudio gravado na barra de composição é enviado automaticamente ao terminar a gravação (estilo WhatsApp Web)
 - Identidade visual (#434): painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel
 - Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp

--- a/backend/alembic/versions/063_chat_interno_grupos.py
+++ b/backend/alembic/versions/063_chat_interno_grupos.py
@@ -1,0 +1,39 @@
+"""Chat interno: grupos personalizados e papel de participante.
+
+Revision ID: 063_chat_interno_grupos
+Revises: 062_chat_interno_ocultacao
+Create Date: 2026-07-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "063_chat_interno_grupos"
+down_revision = "062_chat_interno_ocultacao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("conversas_internas", sa.Column("titulo", sa.String(length=120), nullable=True))
+    op.add_column(
+        "conversas_internas_participantes",
+        sa.Column("papel", sa.String(length=20), server_default="membro", nullable=False),
+    )
+    op.drop_constraint("ck_conversas_internas_tipo_setor", "conversas_internas", type_="check")
+    op.create_check_constraint(
+        "ck_conversas_internas_tipo_setor",
+        "conversas_internas",
+        "(tipo = 'setor' AND setor_id IS NOT NULL) OR (tipo IN ('direta', 'grupo') AND setor_id IS NULL)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_conversas_internas_tipo_setor", "conversas_internas", type_="check")
+    op.create_check_constraint(
+        "ck_conversas_internas_tipo_setor",
+        "conversas_internas",
+        "(tipo = 'setor' AND setor_id IS NOT NULL) OR (tipo = 'direta' AND setor_id IS NULL)",
+    )
+    op.drop_column("conversas_internas_participantes", "papel")
+    op.drop_column("conversas_internas", "titulo")

--- a/backend/app/api/chat_interno.py
+++ b/backend/app/api/chat_interno.py
@@ -10,25 +10,25 @@ from app.core.auth import obter_atendente_atual
 from app.core.setor_scope import ids_setores_visiveis_atendente
 from app.database import get_db
 from app.models.atendente import Atendente
-from app.models.chat_interno import TIPO_MENSAGEM_TEXTO, ConversaInterna, MensagemInterna
+from app.models.chat_interno import TIPO_CONVERSA_GRUPO, TIPO_MENSAGEM_TEXTO, ConversaInterna, MensagemInterna
 from app.services import chat_interno_media_storage as media_storage
 from app.schemas.chat_interno import (
     ConversaDiretaCreate,
+    ConversaGrupoCreate,
     ConversaInboxRead,
     ConversaRead,
+    GrupoParticipantesUpdate,
     MensagemInternaCreate,
     MensagemInternaRead,
     MensagemInternaUpdate,
+    MensagensInternasPaginaRead,
+    ParticipanteGrupoRead,
     ReacaoMensagemCreate,
     ReacaoMensagemRead,
 )
-from app.schemas.lista_paginada import ListaPaginada
 from app.services import chat_interno as chat_svc
 
 router = APIRouter(prefix="/chat-interno", tags=["chat-interno"])
-
-_MAX_MENSAGENS = 100
-_DEFAULT_MENSAGENS = 50
 
 
 def _assert_acesso_setor(atendente: Atendente, db: Session, setor_id: int) -> None:
@@ -41,12 +41,22 @@ def _assert_acesso_setor(atendente: Atendente, db: Session, setor_id: int) -> No
 
 def _to_conversa_read(db: Session, conversa: ConversaInterna, atendente: Atendente) -> ConversaRead:
     titulo = chat_svc.titulo_conversa(db, conversa, atendente.id)
+    participantes: list[ParticipanteGrupoRead] | None = None
+    sou_admin_grupo = False
+    if conversa.tipo == TIPO_CONVERSA_GRUPO:
+        participantes = [
+            ParticipanteGrupoRead(atendente_id=a.id, nome=a.nome, papel=papel)  # type: ignore[arg-type]
+            for a, papel in chat_svc.listar_participantes_grupo(db, conversa.id)
+        ]
+        sou_admin_grupo = chat_svc.is_admin_grupo(db, conversa.id, atendente.id)
     return ConversaRead(
         id=conversa.id,
         tipo=conversa.tipo,  # type: ignore[arg-type]
         setor_id=conversa.setor_id,
         setor_nome=conversa.setor.nome if conversa.setor else None,
         titulo=titulo,
+        participantes=participantes,
+        sou_admin_grupo=sou_admin_grupo,
         created_at=conversa.created_at,
     )
 
@@ -170,11 +180,72 @@ def criar_ou_obter_conversa_direta(
         raise _map_chat_erro(exc) from exc
 
 
-@router.get("/conversas/{conversa_id}/mensagens", response_model=ListaPaginada[MensagemInternaRead])
+@router.get("/conversas/{conversa_id}", response_model=ConversaRead)
+def obter_conversa(
+    conversa_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    conversa = _obter_conversa_ou_404(db, conversa_id)
+    if conversa.tenant_id != atendente.tenant_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversa não encontrada.")
+    _exigir_acesso_conversa(db, atendente, conversa)
+    return _to_conversa_read(db, conversa, atendente)
+
+
+@router.post("/conversas/grupo", response_model=ConversaRead, status_code=status.HTTP_201_CREATED)
+def criar_conversa_grupo(
+    body: ConversaGrupoCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    try:
+        conversa = chat_svc.criar_conversa_grupo(
+            db,
+            atendente.tenant_id,
+            atendente,
+            body.titulo,
+            body.atendente_ids,
+        )
+        db.commit()
+        db.refresh(conversa)
+        return _to_conversa_read(db, conversa, atendente)
+    except chat_svc.ChatInternoErro as exc:
+        raise _map_chat_erro(exc) from exc
+
+
+@router.patch("/conversas/{conversa_id}/participantes", response_model=ConversaRead)
+def atualizar_participantes_grupo(
+    conversa_id: int,
+    body: GrupoParticipantesUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    conversa = _obter_conversa_ou_404(db, conversa_id)
+    if conversa.tenant_id != atendente.tenant_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversa não encontrada.")
+    _exigir_acesso_conversa(db, atendente, conversa)
+    try:
+        conversa = chat_svc.atualizar_participantes_grupo(
+            db,
+            conversa,
+            atendente,
+            adicionar=body.adicionar,
+            remover=body.remover,
+            promover_admin=body.promover_admin,
+            rebaixar_admin=body.rebaixar_admin,
+        )
+        db.commit()
+        db.refresh(conversa)
+        return _to_conversa_read(db, conversa, atendente)
+    except chat_svc.ChatInternoErro as exc:
+        raise _map_chat_erro(exc) from exc
+
+
+@router.get("/conversas/{conversa_id}/mensagens", response_model=MensagensInternasPaginaRead)
 def listar_mensagens(
     conversa_id: int,
-    offset: int = Query(0, ge=0),
-    limit: int = Query(_DEFAULT_MENSAGENS, ge=1, le=_MAX_MENSAGENS),
+    antes_de_id: int | None = Query(None, gt=0),
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
@@ -183,10 +254,13 @@ def listar_mensagens(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversa não encontrada.")
     _exigir_acesso_conversa(db, atendente, conversa)
 
-    rows, total = chat_svc.listar_mensagens(db, conversa_id, atendente.id, offset=offset, limit=limit)
-    return ListaPaginada(
+    rows, total, tem_mais_antigas = chat_svc.listar_mensagens(
+        db, conversa_id, atendente.id, antes_de_id=antes_de_id
+    )
+    return MensagensInternasPaginaRead(
         items=[_to_mensagem_read(m, conversa=conversa, atendente=atendente, db=db) for m in rows],
         total=total,
+        tem_mais_antigas=tem_mais_antigas,
     )
 
 

--- a/backend/app/models/chat_interno.py
+++ b/backend/app/models/chat_interno.py
@@ -15,6 +15,10 @@ from app.database import Base
 
 TIPO_CONVERSA_DIRETA = "direta"
 TIPO_CONVERSA_SETOR = "setor"
+TIPO_CONVERSA_GRUPO = "grupo"
+
+PAPEL_PARTICIPANTE_MEMBRO = "membro"
+PAPEL_PARTICIPANTE_ADMIN = "admin"
 
 TIPO_MENSAGEM_TEXTO = "texto"
 TIPO_MENSAGEM_IMAGEM = "imagem"
@@ -33,7 +37,7 @@ class ConversaInterna(Base):
     __tablename__ = "conversas_internas"
     __table_args__ = (
         CheckConstraint(
-            "(tipo = 'setor' AND setor_id IS NOT NULL) OR (tipo = 'direta' AND setor_id IS NULL)",
+            "(tipo = 'setor' AND setor_id IS NOT NULL) OR (tipo IN ('direta', 'grupo') AND setor_id IS NULL)",
             name="ck_conversas_internas_tipo_setor",
         ),
         UniqueConstraint("tenant_id", "setor_id", name="uq_conversas_internas_tenant_setor"),
@@ -42,6 +46,7 @@ class ConversaInterna(Base):
     id = Column(Integer, primary_key=True, index=True)
     tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="CASCADE"), nullable=False, index=True)
     tipo = Column(String(20), nullable=False, index=True)
+    titulo = Column(String(120), nullable=True)
     setor_id = Column(Integer, ForeignKey("setores.id", ondelete="CASCADE"), nullable=True, index=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
@@ -66,7 +71,7 @@ class ConversaInterna(Base):
 
 
 class ConversaInternaParticipante(Base):
-    """Participantes de conversas diretas (canal setor usa vínculo lazy em atendente_setor)."""
+    """Participantes de conversas diretas e grupos (canal setor usa vínculo lazy em atendente_setor)."""
 
     __tablename__ = "conversas_internas_participantes"
     __table_args__ = (
@@ -84,6 +89,7 @@ class ConversaInternaParticipante(Base):
         primary_key=True,
         index=True,
     )
+    papel = Column(String(20), nullable=False, server_default=PAPEL_PARTICIPANTE_MEMBRO)
 
     conversa = relationship("ConversaInterna", back_populates="participantes")
     atendente = relationship("Atendente", backref="conversas_internas_participantes")

--- a/backend/app/schemas/chat_interno.py
+++ b/backend/app/schemas/chat_interno.py
@@ -8,12 +8,30 @@ class ConversaDiretaCreate(BaseModel):
     atendente_id: int = Field(..., gt=0)
 
 
+class ConversaGrupoCreate(BaseModel):
+    titulo: str = Field(..., min_length=1, max_length=120)
+    atendente_ids: list[int] = Field(..., min_length=1)
+
+
+class GrupoParticipantesUpdate(BaseModel):
+    adicionar: list[int] = Field(default_factory=list)
+    remover: list[int] = Field(default_factory=list)
+    promover_admin: list[int] = Field(default_factory=list)
+    rebaixar_admin: list[int] = Field(default_factory=list)
+
+
+class ParticipanteGrupoRead(BaseModel):
+    atendente_id: int
+    nome: str
+    papel: Literal["admin", "membro"]
+
+
 class MensagemInternaCreate(BaseModel):
     corpo: str = Field(..., min_length=1, max_length=8000)
 
 
 class MensagemInternaUpdate(BaseModel):
-    corpo: str = Field(..., min_length=1, max_length=8000)
+    corpo: str = Field(..., max_length=8000)
 
 
 class ReacaoMensagemCreate(BaseModel):
@@ -50,12 +68,20 @@ class MensagemInternaRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class MensagensInternasPaginaRead(BaseModel):
+    items: list[MensagemInternaRead]
+    total: int
+    tem_mais_antigas: bool
+
+
 class ConversaRead(BaseModel):
     id: int
-    tipo: Literal["direta", "setor"]
+    tipo: Literal["direta", "setor", "grupo"]
     setor_id: int | None = None
     setor_nome: str | None = None
     titulo: str | None = None
+    participantes: list[ParticipanteGrupoRead] | None = None
+    sou_admin_grupo: bool = False
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
@@ -63,7 +89,7 @@ class ConversaRead(BaseModel):
 
 class ConversaInboxRead(BaseModel):
     id: int
-    tipo: Literal["direta", "setor"]
+    tipo: Literal["direta", "setor", "grupo"]
     titulo: str
     setor_id: int | None = None
     ultima_mensagem_corpo: str | None = None

--- a/backend/app/services/chat_interno.py
+++ b/backend/app/services/chat_interno.py
@@ -10,7 +10,10 @@ from app.core.setor_scope import atendente_atende_algum_id_setor, ids_setores_vi
 from app.models import Atendente, Setor
 from app.models.chat_interno import (
     TIPO_CONVERSA_DIRETA,
+    TIPO_CONVERSA_GRUPO,
     TIPO_CONVERSA_SETOR,
+    PAPEL_PARTICIPANTE_ADMIN,
+    PAPEL_PARTICIPANTE_MEMBRO,
     TIPO_MENSAGEM_AUDIO,
     TIPO_MENSAGEM_DOCUMENTO,
     TIPO_MENSAGEM_IMAGEM,
@@ -35,6 +38,8 @@ class ChatInternoErro(ValueError):
 CORPO_MENSAGEM_APAGADA = "Mensagem apagada"
 _EMOJIS_REACAO_PERMITIDOS = frozenset({"👍", "❤️", "😂", "😮", "😢", "🙏"})
 JANELA_EDICAO_MINUTOS = 5
+MENSAGENS_POR_PAGINA = 50
+MAX_PARTICIPANTES_GRUPO = 50
 
 
 @dataclass
@@ -61,7 +66,7 @@ def is_participante(db: Session, conversa_id: int, atendente_id: int) -> bool:
 def pode_acessar_conversa(db: Session, atendente: Atendente, conversa: ConversaInterna) -> bool:
     if conversa.tenant_id != atendente.tenant_id:
         return False
-    if conversa.tipo == TIPO_CONVERSA_DIRETA:
+    if conversa.tipo in (TIPO_CONVERSA_DIRETA, TIPO_CONVERSA_GRUPO):
         return is_participante(db, conversa.id, atendente.id)
     if conversa.tipo == TIPO_CONVERSA_SETOR:
         if atendente.role == "admin":
@@ -131,6 +136,165 @@ def obter_ou_criar_conversa_direta(
     )
     db.flush()
     return conversa
+
+
+def is_admin_grupo(db: Session, conversa_id: int, atendente_id: int) -> bool:
+    return (
+        db.query(ConversaInternaParticipante)
+        .filter(
+            ConversaInternaParticipante.conversa_id == conversa_id,
+            ConversaInternaParticipante.atendente_id == atendente_id,
+            ConversaInternaParticipante.papel == PAPEL_PARTICIPANTE_ADMIN,
+        )
+        .first()
+        is not None
+    )
+
+
+def _validar_atendentes_grupo(db: Session, tenant_id: int, atendente_ids: set[int]) -> None:
+    if not atendente_ids:
+        raise ChatInternoErro("Informe pelo menos um participante.")
+    count = (
+        db.query(Atendente)
+        .filter(
+            Atendente.id.in_(atendente_ids),
+            Atendente.tenant_id == tenant_id,
+            Atendente.ativo.is_(True),
+        )
+        .count()
+    )
+    if count != len(atendente_ids):
+        raise ChatInternoErro("Um ou mais atendentes são inválidos ou inativos.")
+
+
+def criar_conversa_grupo(
+    db: Session,
+    tenant_id: int,
+    criador: Atendente,
+    titulo: str,
+    atendente_ids: list[int],
+) -> ConversaInterna:
+    nome = titulo.strip()
+    if not nome:
+        raise ChatInternoErro("Informe o nome do grupo.")
+    if len(nome) > 120:
+        raise ChatInternoErro("Nome do grupo muito longo (máx. 120 caracteres).")
+
+    ids = {int(i) for i in atendente_ids}
+    ids.add(criador.id)
+    if len(ids) < 2:
+        raise ChatInternoErro("Grupo precisa de pelo menos 2 participantes.")
+    if len(ids) > MAX_PARTICIPANTES_GRUPO:
+        raise ChatInternoErro(f"Máximo de {MAX_PARTICIPANTES_GRUPO} participantes por grupo.")
+
+    _validar_atendentes_grupo(db, tenant_id, ids)
+
+    conversa = ConversaInterna(
+        tenant_id=tenant_id,
+        tipo=TIPO_CONVERSA_GRUPO,
+        titulo=nome,
+        setor_id=None,
+    )
+    db.add(conversa)
+    db.flush()
+    db.add_all(
+        [
+            ConversaInternaParticipante(
+                conversa_id=conversa.id,
+                atendente_id=aid,
+                papel=PAPEL_PARTICIPANTE_ADMIN if aid == criador.id else PAPEL_PARTICIPANTE_MEMBRO,
+            )
+            for aid in ids
+        ]
+    )
+    db.flush()
+    return conversa
+
+
+def _contar_admins_grupo(participantes: list[ConversaInternaParticipante]) -> int:
+    return sum(1 for p in participantes if p.papel == PAPEL_PARTICIPANTE_ADMIN)
+
+
+def atualizar_participantes_grupo(
+    db: Session,
+    conversa: ConversaInterna,
+    atendente: Atendente,
+    *,
+    adicionar: list[int] | None = None,
+    remover: list[int] | None = None,
+    promover_admin: list[int] | None = None,
+    rebaixar_admin: list[int] | None = None,
+) -> ConversaInterna:
+    if conversa.tipo != TIPO_CONVERSA_GRUPO:
+        raise ChatInternoErro("Operação válida apenas para grupos.")
+    if not is_admin_grupo(db, conversa.id, atendente.id):
+        raise ChatInternoErro("Sem permissão para gerenciar membros deste grupo.")
+
+    add_ids = list({int(x) for x in (adicionar or [])})
+    rem_ids = list({int(x) for x in (remover or [])})
+    promove_ids = list({int(x) for x in (promover_admin or [])})
+    rebaixa_ids = list({int(x) for x in (rebaixar_admin or [])})
+
+    participantes = (
+        db.query(ConversaInternaParticipante)
+        .filter(ConversaInternaParticipante.conversa_id == conversa.id)
+        .all()
+    )
+    por_id = {p.atendente_id: p for p in participantes}
+
+    for rid in rem_ids:
+        participante = por_id.get(rid)
+        if participante is None:
+            continue
+        if participante.papel == PAPEL_PARTICIPANTE_ADMIN and _contar_admins_grupo(list(por_id.values())) <= 1:
+            raise ChatInternoErro("O grupo precisa de pelo menos um administrador.")
+        db.delete(participante)
+        del por_id[rid]
+
+    prospective_add = [aid for aid in add_ids if aid not in por_id]
+    if prospective_add:
+        _validar_atendentes_grupo(db, conversa.tenant_id, set(prospective_add))
+    for aid in prospective_add:
+        por_id[aid] = ConversaInternaParticipante(
+            conversa_id=conversa.id,
+            atendente_id=aid,
+            papel=PAPEL_PARTICIPANTE_MEMBRO,
+        )
+        db.add(por_id[aid])
+
+    if len(por_id) < 2:
+        raise ChatInternoErro("Grupo precisa de pelo menos 2 participantes.")
+    if len(por_id) > MAX_PARTICIPANTES_GRUPO:
+        raise ChatInternoErro(f"Máximo de {MAX_PARTICIPANTES_GRUPO} participantes por grupo.")
+
+    for aid in promove_ids:
+        if aid in por_id:
+            por_id[aid].papel = PAPEL_PARTICIPANTE_ADMIN
+
+    for aid in rebaixa_ids:
+        participante = por_id.get(aid)
+        if participante is None or participante.papel != PAPEL_PARTICIPANTE_ADMIN:
+            continue
+        if _contar_admins_grupo(list(por_id.values())) <= 1:
+            raise ChatInternoErro("O grupo precisa de pelo menos um administrador.")
+        participante.papel = PAPEL_PARTICIPANTE_MEMBRO
+
+    db.flush()
+    return conversa
+
+
+def listar_participantes_grupo(
+    db: Session,
+    conversa_id: int,
+) -> list[tuple[Atendente, str]]:
+    rows = (
+        db.query(ConversaInternaParticipante, Atendente)
+        .join(Atendente, Atendente.id == ConversaInternaParticipante.atendente_id)
+        .filter(ConversaInternaParticipante.conversa_id == conversa_id)
+        .order_by(Atendente.nome.asc())
+        .all()
+    )
+    return [(atendente, participante.papel) for participante, atendente in rows]
 
 
 def obter_ou_criar_canal_setor(db: Session, tenant_id: int, setor_id: int) -> ConversaInterna:
@@ -282,6 +446,8 @@ def conversa_tem_mensagens_visiveis(db: Session, conversa_id: int, atendente_id:
 
 
 def titulo_conversa(db: Session, conversa: ConversaInterna, atendente_id: int) -> str:
+    if conversa.tipo == TIPO_CONVERSA_GRUPO:
+        return conversa.titulo or "Grupo"
     if conversa.tipo == TIPO_CONVERSA_SETOR:
         if conversa.setor_id is None:
             return "Canal do setor"
@@ -325,6 +491,19 @@ def listar_conversas_inbox(db: Session, atendente: Atendente) -> list[ConversaIn
     )
     conversas.extend(diretas)
 
+    grupos = (
+        db.query(ConversaInterna)
+        .join(ConversaInternaParticipante)
+        .options(joinedload(ConversaInterna.participantes), joinedload(ConversaInterna.setor))
+        .filter(
+            ConversaInterna.tenant_id == atendente.tenant_id,
+            ConversaInterna.tipo == TIPO_CONVERSA_GRUPO,
+            ConversaInternaParticipante.atendente_id == atendente.id,
+        )
+        .all()
+    )
+    conversas.extend(grupos)
+
     q_setor = (
         db.query(ConversaInterna)
         .options(joinedload(ConversaInterna.setor))
@@ -345,7 +524,7 @@ def listar_conversas_inbox(db: Session, atendente: Atendente) -> list[ConversaIn
     for conversa in conversas:
         nao_lidas = contar_nao_lidas(db, conversa, atendente.id)
         ultima = obter_ultima_mensagem_visivel(db, conversa.id, atendente.id)
-        if ultima is None and nao_lidas == 0:
+        if ultima is None and nao_lidas == 0 and conversa.tipo != TIPO_CONVERSA_GRUPO:
             continue
         resumos.append(
             ConversaInboxResumo(
@@ -609,9 +788,9 @@ def listar_mensagens(
     db: Session,
     conversa_id: int,
     atendente_id: int,
-    offset: int = 0,
-    limit: int = 50,
-) -> tuple[list[MensagemInterna], int]:
+    *,
+    antes_de_id: int | None = None,
+) -> tuple[list[MensagemInterna], int, bool]:
     historico = obter_historico_oculto_ate(db, conversa_id, atendente_id)
     ocultas = ids_mensagens_ocultas_para_atendente(db, conversa_id, atendente_id)
 
@@ -622,14 +801,30 @@ def listar_mensagens(
         base = base.filter(~MensagemInterna.id.in_(ocultas))
 
     total = int(base.count())
-    rows = (
-        base.options(joinedload(MensagemInterna.atendente))
-        .order_by(MensagemInterna.created_at.asc(), MensagemInterna.id.asc())
-        .offset(offset)
-        .limit(limit)
-        .all()
-    )
-    return rows, total
+    limit = MENSAGENS_POR_PAGINA
+
+    if antes_de_id is not None:
+        older_base = base.filter(MensagemInterna.id < antes_de_id)
+        older_total = int(older_base.count())
+        rows = (
+            older_base.options(joinedload(MensagemInterna.atendente))
+            .order_by(MensagemInterna.created_at.desc(), MensagemInterna.id.desc())
+            .limit(limit)
+            .all()
+        )
+        rows.reverse()
+        tem_mais_antigas = older_total > limit
+    else:
+        rows = (
+            base.options(joinedload(MensagemInterna.atendente))
+            .order_by(MensagemInterna.created_at.desc(), MensagemInterna.id.desc())
+            .limit(limit)
+            .all()
+        )
+        rows.reverse()
+        tem_mais_antigas = total > limit
+
+    return rows, total, tem_mais_antigas
 
 
 def preview_corpo(corpo: str, max_len: int = 60) -> str:
@@ -702,7 +897,7 @@ def permissoes_mensagem(
         is_author
         and in_window
         and not mensagem_esta_apagada(mensagem)
-        and tipo == TIPO_MENSAGEM_TEXTO
+        and (tipo == TIPO_MENSAGEM_TEXTO or tipo in TIPOS_MENSAGEM_MIDIA)
     )
     pode_apagar_para_todos = _pode_apagar_para_todos(db, conversa, mensagem, atendente)
     pode_apagar_para_mim = True
@@ -743,14 +938,15 @@ def editar_mensagem(
             f"Só é possível editar mensagens nos primeiros {JANELA_EDICAO_MINUTOS} minutos."
         )
     tipo = mensagem.tipo_midia or TIPO_MENSAGEM_TEXTO
-    if tipo != TIPO_MENSAGEM_TEXTO:
-        raise ChatInternoErro("Somente mensagens de texto podem ser editadas.")
-
-    texto = novo_corpo.strip()
-    if not texto:
-        raise ChatInternoErro("Corpo da mensagem não pode ser vazio.")
-
-    mensagem.corpo = texto
+    if tipo == TIPO_MENSAGEM_TEXTO:
+        texto = novo_corpo.strip()
+        if not texto:
+            raise ChatInternoErro("Corpo da mensagem não pode ser vazio.")
+        mensagem.corpo = texto
+    elif tipo in TIPOS_MENSAGEM_MIDIA:
+        mensagem.corpo = novo_corpo.strip()
+    else:
+        raise ChatInternoErro("Somente mensagens de texto ou mídia podem ser editadas.")
     mensagem.editada_em = datetime.now(timezone.utc)
     db.flush()
     return mensagem

--- a/backend/app/services/realtime_emit.py
+++ b/backend/app/services/realtime_emit.py
@@ -319,11 +319,12 @@ def ids_destinatarios_chat_interno_mensagem(
 ) -> set[int]:
     from app.models.chat_interno import (
         TIPO_CONVERSA_DIRETA,
+        TIPO_CONVERSA_GRUPO,
         TIPO_CONVERSA_SETOR,
         ConversaInternaParticipante,
     )
 
-    if conversa.tipo == TIPO_CONVERSA_DIRETA:
+    if conversa.tipo in (TIPO_CONVERSA_DIRETA, TIPO_CONVERSA_GRUPO):
         rows = (
             db.query(ConversaInternaParticipante.atendente_id)
             .filter(ConversaInternaParticipante.conversa_id == conversa.id)

--- a/backend/tests/test_chat_interno_grupos.py
+++ b/backend/tests/test_chat_interno_grupos.py
@@ -1,0 +1,89 @@
+"""Chat interno — grupos personalizados (IC-10)."""
+
+
+def _criar_grupo(client, headers, titulo: str, atendente_ids: list[int]) -> dict:
+    r = client.post(
+        "/v1/chat-interno/conversas/grupo",
+        json={"titulo": titulo, "atendente_ids": atendente_ids},
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def test_criar_grupo_e_inbox(client, seed_base, auth_headers):
+    admin_id = seed_base["admin"].id
+    a2_id = seed_base["a2"].id
+    grupo = _criar_grupo(client, auth_headers["a1"], "Equipe Plantão", [admin_id, a2_id])
+    assert grupo["tipo"] == "grupo"
+    assert grupo["titulo"] == "Equipe Plantão"
+    assert grupo["sou_admin_grupo"] is True
+    assert len(grupo["participantes"]) == 3
+
+    r_admin = client.get("/v1/chat-interno/conversas", headers=auth_headers["admin"])
+    assert any(c["id"] == grupo["id"] and c["tipo"] == "grupo" for c in r_admin.json())
+
+    r_out = client.get(f"/v1/chat-interno/conversas/{grupo['id']}", headers=auth_headers["admin"])
+    assert r_out.status_code == 200
+
+
+def test_403_fora_do_grupo(client, seed_base, auth_headers):
+    grupo = _criar_grupo(client, auth_headers["a1"], "Privado", [seed_base["admin"].id])
+    r = client.get(f"/v1/chat-interno/conversas/{grupo['id']}/mensagens", headers=auth_headers["a2"])
+    assert r.status_code == 403
+
+
+def test_admin_adiciona_e_remove_membro(client, seed_base, auth_headers):
+    grupo = _criar_grupo(client, auth_headers["a1"], "Ops", [seed_base["admin"].id])
+    a2_id = seed_base["a2"].id
+
+    r_add = client.patch(
+        f"/v1/chat-interno/conversas/{grupo['id']}/participantes",
+        json={"adicionar": [a2_id]},
+        headers=auth_headers["a1"],
+    )
+    assert r_add.status_code == 200
+    ids = {p["atendente_id"] for p in r_add.json()["participantes"]}
+    assert a2_id in ids
+
+    r_rm = client.patch(
+        f"/v1/chat-interno/conversas/{grupo['id']}/participantes",
+        json={"remover": [a2_id]},
+        headers=auth_headers["a1"],
+    )
+    assert r_rm.status_code == 200
+    ids2 = {p["atendente_id"] for p in r_rm.json()["participantes"]}
+    assert a2_id not in ids2
+
+    r_a2 = client.get(f"/v1/chat-interno/conversas/{grupo['id']}", headers=auth_headers["a2"])
+    assert r_a2.status_code == 403
+
+
+def test_membro_nao_gerencia_participantes(client, seed_base, auth_headers):
+    grupo = _criar_grupo(client, auth_headers["a1"], "Time", [seed_base["admin"].id])
+    r = client.patch(
+        f"/v1/chat-interno/conversas/{grupo['id']}/participantes",
+        json={"adicionar": [seed_base["a2"].id]},
+        headers=auth_headers["admin"],
+    )
+    assert r.status_code == 403
+
+
+def test_promover_admin(client, seed_base, auth_headers):
+    admin_id = seed_base["admin"].id
+    grupo = _criar_grupo(client, auth_headers["a1"], "Liderança", [admin_id])
+    r = client.patch(
+        f"/v1/chat-interno/conversas/{grupo['id']}/participantes",
+        json={"promover_admin": [admin_id]},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    admin_row = next(p for p in r.json()["participantes"] if p["atendente_id"] == admin_id)
+    assert admin_row["papel"] == "admin"
+
+    r2 = client.patch(
+        f"/v1/chat-interno/conversas/{grupo['id']}/participantes",
+        json={"adicionar": [seed_base["a2"].id]},
+        headers=auth_headers["admin"],
+    )
+    assert r2.status_code == 200

--- a/backend/tests/test_chat_interno_paginacao.py
+++ b/backend/tests/test_chat_interno_paginacao.py
@@ -1,0 +1,67 @@
+"""Paginação de mensagens do chat interno (IC-08)."""
+
+
+def _criar_direta(client, headers, atendente_id: int) -> dict:
+    r = client.post(
+        "/v1/chat-interno/conversas/direta",
+        json={"atendente_id": atendente_id},
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _enviar_mensagem(client, headers, conversa_id: int, corpo: str) -> dict:
+    r = client.post(
+        f"/v1/chat-interno/conversas/{conversa_id}/mensagens",
+        json={"corpo": corpo},
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def test_mensagens_pagina_recentes_e_cursor(client, seed_base, auth_headers):
+    conv = _criar_direta(client, auth_headers["a1"], seed_base["admin"].id)
+    for i in range(55):
+        _enviar_mensagem(client, auth_headers["a1"], conv["id"], f"Msg {i + 1}")
+
+    r = client.get(
+        f"/v1/chat-interno/conversas/{conv['id']}/mensagens",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 55
+    assert body["tem_mais_antigas"] is True
+    assert len(body["items"]) == 50
+    assert body["items"][0]["corpo"] == "Msg 6"
+    assert body["items"][-1]["corpo"] == "Msg 55"
+
+    primeiro_id = body["items"][0]["id"]
+    r2 = client.get(
+        f"/v1/chat-interno/conversas/{conv['id']}/mensagens",
+        params={"antes_de_id": primeiro_id},
+        headers=auth_headers["a1"],
+    )
+    assert r2.status_code == 200
+    body2 = r2.json()
+    assert body2["tem_mais_antigas"] is False
+    assert len(body2["items"]) == 5
+    assert body2["items"][0]["corpo"] == "Msg 1"
+    assert body2["items"][-1]["corpo"] == "Msg 5"
+
+
+def test_mensagens_poucas_sem_mais_antigas(client, seed_base, auth_headers):
+    conv = _criar_direta(client, auth_headers["a1"], seed_base["admin"].id)
+    _enviar_mensagem(client, auth_headers["a1"], conv["id"], "Única")
+
+    r = client.get(
+        f"/v1/chat-interno/conversas/{conv['id']}/mensagens",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] == 1
+    assert body["tem_mais_antigas"] is False
+    assert body["items"][0]["corpo"] == "Única"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1320,7 +1320,13 @@ export const notificacoes = {
 };
 
 export namespace ChatInterno {
-  export type ConversaTipo = 'direta' | 'setor';
+  export type ConversaTipo = 'direta' | 'setor' | 'grupo';
+
+  export interface ParticipanteGrupo {
+    atendente_id: number;
+    nome: string;
+    papel: 'admin' | 'membro';
+  }
 
   export interface ConversaInbox {
     id: number;
@@ -1339,6 +1345,8 @@ export namespace ChatInterno {
     setor_id: number | null;
     setor_nome: string | null;
     titulo: string | null;
+    participantes?: ParticipanteGrupo[] | null;
+    sou_admin_grupo?: boolean;
     created_at: string;
   }
 
@@ -1371,17 +1379,46 @@ export namespace ChatInterno {
     pode_apagar_para_mim?: boolean;
     created_at: string;
   }
+
+  export interface MensagensPagina {
+    items: Mensagem[];
+    total: number;
+    tem_mais_antigas: boolean;
+  }
 }
 
 export const chatInterno = {
   listarConversas: () => api<ChatInterno.ConversaInbox[]>('/chat-interno/conversas'),
+  obterConversa: (conversaId: number) => api<ChatInterno.Conversa>(`/chat-interno/conversas/${conversaId}`),
   criarDireta: (atendente_id: number) =>
     api<ChatInterno.Conversa>('/chat-interno/conversas/direta', {
       method: 'POST',
       body: JSON.stringify({ atendente_id }),
     }),
-  mensagens: (conversaId: number, params?: { offset?: number; limit?: number }) =>
-    listPaginated<ChatInterno.Mensagem>(`/chat-interno/conversas/${conversaId}/mensagens`, params),
+  criarGrupo: (titulo: string, atendente_ids: number[]) =>
+    api<ChatInterno.Conversa>('/chat-interno/conversas/grupo', {
+      method: 'POST',
+      body: JSON.stringify({ titulo, atendente_ids }),
+    }),
+  atualizarParticipantesGrupo: (
+    conversaId: number,
+    data: {
+      adicionar?: number[];
+      remover?: number[];
+      promover_admin?: number[];
+      rebaixar_admin?: number[];
+    },
+  ) =>
+    api<ChatInterno.Conversa>(`/chat-interno/conversas/${conversaId}/participantes`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+  mensagens: (conversaId: number, params?: { antesDeId?: number }) =>
+    api<ChatInterno.MensagensPagina>(
+      withParams(`/chat-interno/conversas/${conversaId}/mensagens`, {
+        antes_de_id: params?.antesDeId,
+      }),
+    ),
   enviar: (conversaId: number, corpo: string) =>
     api<ChatInterno.Mensagem>(`/chat-interno/conversas/${conversaId}/mensagens`, {
       method: 'POST',

--- a/frontend/src/components/chat-interno/ChatInternoFiltroTipo.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoFiltroTipo.tsx
@@ -32,6 +32,19 @@ const FILTROS: FiltroDef[] = [
     ),
   },
   {
+    id: 'grupo',
+    label: 'Grupos',
+    titulo: 'Grupos personalizados da equipe',
+    icon: (
+      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+        <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+        <circle cx="9" cy="7" r="4" />
+        <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+        <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+      </svg>
+    ),
+  },
+  {
     id: 'setor',
     label: 'Setores',
     titulo: 'Canais de comunicado por setor',
@@ -46,13 +59,16 @@ const FILTROS: FiltroDef[] = [
 
 function contagemPorTipo(conversas: { tipo: string; nao_lidas_count: number }[]) {
   const diretas = conversas.filter((c) => c.tipo === 'direta')
+  const grupos = conversas.filter((c) => c.tipo === 'grupo')
   const setores = conversas.filter((c) => c.tipo === 'setor')
   return {
     todas: conversas.length,
     direta: diretas.length,
+    grupo: grupos.length,
     setor: setores.length,
     naoLidasTodas: conversas.reduce((acc, c) => acc + c.nao_lidas_count, 0),
     naoLidasDireta: diretas.reduce((acc, c) => acc + c.nao_lidas_count, 0),
+    naoLidasGrupo: grupos.reduce((acc, c) => acc + c.nao_lidas_count, 0),
     naoLidasSetor: setores.reduce((acc, c) => acc + c.nao_lidas_count, 0),
   }
 }
@@ -68,12 +84,14 @@ export function ChatInternoFiltroTipo({ className = '' }: Props) {
 
   const naoLidasDe = (id: FiltroInboxChatInterno) => {
     if (id === 'direta') return stats.naoLidasDireta
+    if (id === 'grupo') return stats.naoLidasGrupo
     if (id === 'setor') return stats.naoLidasSetor
     return stats.naoLidasTodas
   }
 
   const totalDe = (id: FiltroInboxChatInterno) => {
     if (id === 'direta') return stats.direta
+    if (id === 'grupo') return stats.grupo
     if (id === 'setor') return stats.setor
     return stats.todas
   }
@@ -82,7 +100,7 @@ export function ChatInternoFiltroTipo({ className = '' }: Props) {
     <nav
       role="tablist"
       aria-label="Filtrar conversas internas"
-      className={`grid grid-cols-3 gap-1 rounded-xl border border-slate-200/90 bg-slate-100/80 p-1 dark:border-slate-700/80 dark:bg-slate-900/50 ${className}`}
+      className={`grid grid-cols-4 gap-1 rounded-xl border border-slate-200/90 bg-slate-100/80 p-1 dark:border-slate-700/80 dark:bg-slate-900/50 ${className}`}
     >
       {FILTROS.map((f) => {
         const ativo = filtro === f.id
@@ -132,5 +150,6 @@ export function ChatInternoFiltroTipo({ className = '' }: Props) {
 export const CHAT_INTERNO_FILTRO_VAZIO: Record<FiltroInboxChatInterno, string> = {
   todas: 'Nenhuma conversa ainda.',
   direta: 'Nenhuma conversa direta.',
+  grupo: 'Nenhum grupo criado.',
   setor: 'Nenhum canal de setor.',
 }

--- a/frontend/src/components/chat-interno/ChatInternoGrupoMembrosModal.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoGrupoMembrosModal.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react'
+import { atendentes, chatInterno, type ChatInterno } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useAuth } from '../../contexts/AuthContext'
+import { Button } from '../ui/Button'
+import { useToast } from '../ui/Toast'
+import { MODAL_OVERLAY, MODAL_PANEL_COMPACT } from '../../lib/modalPanel'
+
+type Props = {
+  open: boolean
+  conversaId: number
+  participantes: ChatInterno.ParticipanteGrupo[]
+  onClose: () => void
+  onAtualizado: (conversa: ChatInterno.Conversa) => void
+}
+
+export function ChatInternoGrupoMembrosModal({
+  open,
+  conversaId,
+  participantes,
+  onClose,
+  onAtualizado,
+}: Props) {
+  const toast = useToast()
+  const { user } = useAuth()
+  const [lista, setLista] = useState(participantes)
+  const [busca, setBusca] = useState('')
+  const [resultados, setResultados] = useState<Awaited<ReturnType<typeof atendentes.list>>['items']>([])
+  const [salvando, setSalvando] = useState(false)
+
+  useEffect(() => {
+    if (open) setLista(participantes)
+  }, [open, participantes])
+
+  useEffect(() => {
+    if (!open) {
+      setBusca('')
+      setResultados([])
+      return
+    }
+    const q = busca.trim()
+    if (q.length < 2) {
+      setResultados([])
+      return
+    }
+    const timer = setTimeout(async () => {
+      try {
+        const { items } = await atendentes.list({ busca: q, limit: 15, incluir_inativos: false })
+        const ids = new Set(lista.map((p) => p.atendente_id))
+        setResultados(items.filter((a) => a.id !== user?.id && !ids.has(a.id)))
+      } catch {
+        setResultados([])
+      }
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [busca, open, lista, user?.id])
+
+  async function aplicar(patch: Parameters<typeof chatInterno.atualizarParticipantesGrupo>[1]) {
+    setSalvando(true)
+    try {
+      const conv = await chatInterno.atualizarParticipantesGrupo(conversaId, patch)
+      setLista(conv.participantes ?? [])
+      onAtualizado(conv)
+      toast.showSuccess('Membros atualizados.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível atualizar os membros.'))
+    } finally {
+      setSalvando(false)
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <div className={MODAL_OVERLAY} role="dialog" aria-modal="true" onClick={onClose}>
+      <div className={MODAL_PANEL_COMPACT} onClick={(e) => e.stopPropagation()}>
+        <h2 className="text-lg font-bold text-slate-900 dark:text-white">Membros do grupo</h2>
+        <ul className="mt-4 max-h-40 space-y-1 overflow-y-auto">
+          {lista.map((p) => (
+            <li
+              key={p.atendente_id}
+              className="flex items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm dark:border-slate-700"
+            >
+              <div>
+                <span className="font-medium text-slate-900 dark:text-slate-100">{p.nome}</span>
+                <span className="ml-2 text-xs text-slate-500">{p.papel === 'admin' ? 'Admin' : 'Membro'}</span>
+              </div>
+              <div className="flex shrink-0 gap-1">
+                {p.papel === 'membro' && (
+                  <button
+                    type="button"
+                    disabled={salvando}
+                    className="text-xs text-violet-600 hover:underline"
+                    onClick={() => void aplicar({ promover_admin: [p.atendente_id] })}
+                  >
+                    Tornar admin
+                  </button>
+                )}
+                {p.papel === 'admin' && p.atendente_id !== user?.id && (
+                  <button
+                    type="button"
+                    disabled={salvando}
+                    className="text-xs text-slate-500 hover:underline"
+                    onClick={() => void aplicar({ rebaixar_admin: [p.atendente_id] })}
+                  >
+                    Rebaixar
+                  </button>
+                )}
+                {p.atendente_id !== user?.id && (
+                  <button
+                    type="button"
+                    disabled={salvando}
+                    className="text-xs text-rose-600 hover:underline"
+                    onClick={() => void aplicar({ remover: [p.atendente_id] })}
+                  >
+                    Remover
+                  </button>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        <input
+          type="search"
+          value={busca}
+          onChange={(e) => setBusca(e.target.value)}
+          placeholder="Buscar atendente para adicionar…"
+          className="mt-4 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+        />
+        <ul className="mt-2 max-h-32 space-y-1 overflow-y-auto">
+          {resultados.map((a) => (
+            <li key={a.id}>
+              <button
+                type="button"
+                disabled={salvando}
+                className="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
+                onClick={() => void aplicar({ adicionar: [a.id] })}
+              >
+                {a.nome}
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-4 flex justify-end">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            Fechar
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat-interno/ChatInternoLista.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoLista.tsx
@@ -65,10 +65,14 @@ export function ChatInternoLista() {
                   >
                     <div
                       className={`relative flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white ${
-                        c.tipo === 'setor' ? 'bg-amber-500' : 'bg-cyan-600'
+                        c.tipo === 'setor'
+                          ? 'bg-amber-500'
+                          : c.tipo === 'grupo'
+                            ? 'bg-violet-600'
+                            : 'bg-cyan-600'
                       }`}
                     >
-                      {c.tipo === 'setor' ? 'S' : c.titulo.slice(0, 1).toUpperCase()}
+                      {c.tipo === 'setor' ? 'S' : c.tipo === 'grupo' ? 'G' : c.titulo.slice(0, 1).toUpperCase()}
                       {c.nao_lidas_count > 0 && (
                         <span className="absolute -right-0.5 -top-0.5 h-2.5 w-2.5 rounded-full bg-cyan-600 ring-2 ring-white dark:ring-slate-950" />
                       )}

--- a/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
@@ -2,6 +2,15 @@ import { useEffect, useState } from 'react'
 import type { ChatInterno } from '../../api/client'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 
+const ROTULO_SEM_LEGENDA = /^(📷 Imagem|🎬 Vídeo|🎵 Áudio|📄 Documento)$/
+
+function legendaEditavel(mensagem: ChatInterno.Mensagem): string {
+  const tipo = mensagem.tipo_midia || 'texto'
+  const corpo = mensagem.corpo.trim()
+  if (tipo !== 'texto' && ROTULO_SEM_LEGENDA.test(corpo)) return ''
+  return mensagem.corpo
+}
+
 type Props = {
   mensagem: ChatInterno.Mensagem
   onEditar: (novoCorpo: string) => Promise<void>
@@ -16,7 +25,7 @@ export function ChatInternoMensagemAcoes({
   alinhamento = 'end',
 }: Props) {
   const [editando, setEditando] = useState(false)
-  const [texto, setTexto] = useState(mensagem.corpo)
+  const [texto, setTexto] = useState(() => legendaEditavel(mensagem))
   const [salvando, setSalvando] = useState(false)
   const [confirmarApagar, setConfirmarApagar] = useState(false)
   const [apagando, setApagando] = useState(false)
@@ -26,28 +35,32 @@ export function ChatInternoMensagemAcoes({
   const podeApagarMim = Boolean(mensagem.pode_apagar_para_mim)
   const temAcoes = podeEditar || podeApagarTodos || podeApagarMim
 
+  const tipoMidia = mensagem.tipo_midia || 'texto'
+  const editandoTexto = tipoMidia === 'texto'
+
   useEffect(() => {
-    if (!editando) setTexto(mensagem.corpo)
-  }, [mensagem.corpo, editando])
+    if (!editando) setTexto(legendaEditavel(mensagem))
+  }, [mensagem, editando])
 
   if (mensagem.apagada || !temAcoes) return null
 
-  if (editando && podeEditar && (mensagem.tipo_midia || 'texto') === 'texto') {
+  if (editando && podeEditar) {
     return (
       <div className="mt-1 w-full min-w-[min(100%,18rem)] space-y-2">
         <textarea
           value={texto}
           onChange={(e) => setTexto(e.target.value)}
-          rows={3}
+          rows={editandoTexto ? 3 : 2}
+          placeholder={editandoTexto ? undefined : 'Legenda da mídia (opcional)'}
           className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
         />
         <div className="flex gap-2">
           <button
             type="button"
-            disabled={salvando || !texto.trim()}
+            disabled={salvando || (editandoTexto && !texto.trim())}
             onClick={() => {
               setSalvando(true)
-              void onEditar(texto.trim())
+              void onEditar(editandoTexto ? texto.trim() : texto)
                 .then(() => setEditando(false))
                 .finally(() => setSalvando(false))
             }}
@@ -58,7 +71,7 @@ export function ChatInternoMensagemAcoes({
           <button
             type="button"
             onClick={() => {
-              setTexto(mensagem.corpo)
+              setTexto(legendaEditavel(mensagem))
               setEditando(false)
             }}
             className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50 dark:border-slate-500 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
@@ -77,10 +90,13 @@ export function ChatInternoMensagemAcoes({
           alinhamento === 'end' ? 'right-1' : 'left-1'
         }`}
       >
-        {podeEditar && (mensagem.tipo_midia || 'texto') === 'texto' && (
+        {podeEditar && (
           <button
             type="button"
-            onClick={() => setEditando(true)}
+            onClick={() => {
+              setTexto(legendaEditavel(mensagem))
+              setEditando(true)
+            }}
             className="pointer-events-auto rounded-full bg-white/95 px-2 py-0.5 text-[10px] font-medium text-slate-600 shadow-sm ring-1 ring-slate-200 hover:bg-white dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-600"
           >
             Editar

--- a/frontend/src/components/chat-interno/ChatInternoNovaConversaModal.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoNovaConversaModal.tsx
@@ -13,19 +13,27 @@ type Props = {
   onClose: () => void
 }
 
+type Modo = 'direta' | 'grupo'
+
 export function ChatInternoNovaConversaModal({ open, onClose }: Props) {
   const toast = useToast()
   const navigate = useNavigate()
   const { user } = useAuth()
   const { carregar } = useChatInterno()
+  const [modo, setModo] = useState<Modo>('direta')
   const [busca, setBusca] = useState('')
+  const [tituloGrupo, setTituloGrupo] = useState('')
+  const [selecionados, setSelecionados] = useState<number[]>([])
   const [resultados, setResultados] = useState<Awaited<ReturnType<typeof atendentes.list>>['items']>([])
   const [buscando, setBuscando] = useState(false)
   const [criando, setCriando] = useState(false)
 
   useEffect(() => {
     if (!open) {
+      setModo('direta')
       setBusca('')
+      setTituloGrupo('')
+      setSelecionados([])
       setResultados([])
       return
     }
@@ -48,7 +56,11 @@ export function ChatInternoNovaConversaModal({ open, onClose }: Props) {
     return () => clearTimeout(timer)
   }, [busca, open, user?.id])
 
-  async function iniciar(atendenteId: number) {
+  function toggleSelecionado(id: number) {
+    setSelecionados((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+  }
+
+  async function iniciarDireta(atendenteId: number) {
     setCriando(true)
     try {
       const conv = await chatInterno.criarDireta(atendenteId)
@@ -62,45 +74,157 @@ export function ChatInternoNovaConversaModal({ open, onClose }: Props) {
     }
   }
 
+  async function criarGrupo() {
+    const titulo = tituloGrupo.trim()
+    if (!titulo || selecionados.length === 0) return
+    setCriando(true)
+    try {
+      const conv = await chatInterno.criarGrupo(titulo, selecionados)
+      onClose()
+      await carregar(true)
+      navigate(`/chat/interno/${conv.id}`)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível criar o grupo.'))
+    } finally {
+      setCriando(false)
+    }
+  }
+
   if (!open) return null
 
   return (
     <div className={MODAL_OVERLAY} role="dialog" aria-modal="true" onClick={onClose}>
       <div className={MODAL_PANEL_COMPACT} onClick={(e) => e.stopPropagation()}>
-        <h2 className="text-lg font-bold text-slate-900 dark:text-white">Nova conversa direta</h2>
-        <p className="mt-1 text-sm text-slate-500">Busque um atendente por nome ou e-mail.</p>
-        <input
-          type="search"
-          autoFocus
-          value={busca}
-          onChange={(e) => setBusca(e.target.value)}
-          placeholder="Nome ou e-mail…"
-          className="mt-4 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
-        />
-        <ul className="mt-3 max-h-56 space-y-1 overflow-y-auto">
-          {buscando && <li className="px-2 py-3 text-sm text-slate-400">Buscando…</li>}
-          {!buscando && busca.trim().length >= 2 && resultados.length === 0 && (
-            <li className="px-2 py-3 text-sm text-slate-400">Nenhum atendente encontrado.</li>
-          )}
-          {resultados.map((a) => (
-            <li key={a.id}>
-              <button
-                type="button"
-                disabled={criando}
-                className="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
-                onClick={() => void iniciar(a.id)}
-              >
-                <span className="font-medium text-slate-900 dark:text-slate-100">{a.nome}</span>
-                <span className="block text-xs text-slate-500">{a.email}</span>
-              </button>
-            </li>
-          ))}
-        </ul>
-        <div className="mt-4 flex justify-end">
-          <Button type="button" variant="secondary" onClick={onClose}>
-            Cancelar
-          </Button>
+        <h2 className="text-lg font-bold text-slate-900 dark:text-white">Nova conversa</h2>
+        <div className="mt-3 flex gap-1 rounded-lg border border-slate-200 bg-slate-100 p-1 dark:border-slate-700 dark:bg-slate-900">
+          <button
+            type="button"
+            onClick={() => setModo('direta')}
+            className={`flex-1 rounded-md px-2 py-1.5 text-xs font-semibold ${
+              modo === 'direta'
+                ? 'bg-white text-cyan-700 shadow-sm dark:bg-slate-800 dark:text-cyan-300'
+                : 'text-slate-500'
+            }`}
+          >
+            Direta
+          </button>
+          <button
+            type="button"
+            onClick={() => setModo('grupo')}
+            className={`flex-1 rounded-md px-2 py-1.5 text-xs font-semibold ${
+              modo === 'grupo'
+                ? 'bg-white text-violet-700 shadow-sm dark:bg-slate-800 dark:text-violet-300'
+                : 'text-slate-500'
+            }`}
+          >
+            Grupo
+          </button>
         </div>
+
+        {modo === 'direta' ? (
+          <>
+            <p className="mt-2 text-sm text-slate-500">Busque um atendente por nome ou e-mail.</p>
+            <input
+              type="search"
+              autoFocus
+              value={busca}
+              onChange={(e) => setBusca(e.target.value)}
+              placeholder="Nome ou e-mail…"
+              className="mt-4 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+            />
+            <ul className="mt-3 max-h-56 space-y-1 overflow-y-auto">
+              {buscando && <li className="px-2 py-3 text-sm text-slate-400">Buscando…</li>}
+              {!buscando && busca.trim().length >= 2 && resultados.length === 0 && (
+                <li className="px-2 py-3 text-sm text-slate-400">Nenhum atendente encontrado.</li>
+              )}
+              {resultados.map((a) => (
+                <li key={a.id}>
+                  <button
+                    type="button"
+                    disabled={criando}
+                    className="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
+                    onClick={() => void iniciarDireta(a.id)}
+                  >
+                    <span className="font-medium text-slate-900 dark:text-slate-100">{a.nome}</span>
+                    <span className="block text-xs text-slate-500">{a.email}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <>
+            <p className="mt-2 text-sm text-slate-500">Nome do grupo e participantes (máx. 50).</p>
+            <input
+              type="text"
+              autoFocus
+              value={tituloGrupo}
+              onChange={(e) => setTituloGrupo(e.target.value)}
+              placeholder="Nome do grupo"
+              maxLength={120}
+              className="mt-4 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+            />
+            <input
+              type="search"
+              value={busca}
+              onChange={(e) => setBusca(e.target.value)}
+              placeholder="Adicionar atendentes…"
+              className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+            />
+            {selecionados.length > 0 && (
+              <p className="mt-2 text-xs text-slate-500">{selecionados.length} selecionado(s)</p>
+            )}
+            <ul className="mt-2 max-h-48 space-y-1 overflow-y-auto">
+              {buscando && <li className="px-2 py-2 text-sm text-slate-400">Buscando…</li>}
+              {resultados.map((a) => {
+                const marcado = selecionados.includes(a.id)
+                return (
+                  <li key={a.id}>
+                    <button
+                      type="button"
+                      className={`flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm hover:bg-slate-100 dark:hover:bg-slate-800 ${
+                        marcado ? 'ring-1 ring-violet-400' : ''
+                      }`}
+                      onClick={() => toggleSelecionado(a.id)}
+                    >
+                      <span
+                        className={`flex h-4 w-4 shrink-0 items-center justify-center rounded border ${
+                          marcado ? 'border-violet-600 bg-violet-600 text-white' : 'border-slate-300'
+                        }`}
+                      >
+                        {marcado ? '✓' : ''}
+                      </span>
+                      <span>
+                        <span className="font-medium text-slate-900 dark:text-slate-100">{a.nome}</span>
+                        <span className="block text-xs text-slate-500">{a.email}</span>
+                      </span>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+            <div className="mt-4 flex justify-end gap-2">
+              <Button type="button" variant="secondary" onClick={onClose}>
+                Cancelar
+              </Button>
+              <Button
+                type="button"
+                disabled={criando || !tituloGrupo.trim() || selecionados.length === 0}
+                onClick={() => void criarGrupo()}
+              >
+                Criar grupo
+              </Button>
+            </div>
+          </>
+        )}
+
+        {modo === 'direta' && (
+          <div className="mt-4 flex justify-end">
+            <Button type="button" variant="secondary" onClick={onClose}>
+              Cancelar
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/lib/chatInternoMensagensMerge.ts
+++ b/frontend/src/lib/chatInternoMensagensMerge.ts
@@ -1,0 +1,23 @@
+import type { ChatInterno } from '../api/client'
+
+export function ordenarMensagensChatInterno(mensagens: ChatInterno.Mensagem[]): ChatInterno.Mensagem[] {
+  return [...mensagens].sort((a, b) => a.id - b.id)
+}
+
+export function mergeMensagensChatInterno(
+  prev: ChatInterno.Mensagem[],
+  incoming: ChatInterno.Mensagem[],
+): ChatInterno.Mensagem[] {
+  const byId = new Map(prev.map((m) => [m.id, m]))
+  for (const m of incoming) {
+    byId.set(m.id, m)
+  }
+  return ordenarMensagensChatInterno(Array.from(byId.values()))
+}
+
+export function prependMensagensChatInterno(
+  prev: ChatInterno.Mensagem[],
+  older: ChatInterno.Mensagem[],
+): ChatInterno.Mensagem[] {
+  return mergeMensagensChatInterno(older, prev)
+}

--- a/frontend/src/lib/chatInternoUtils.ts
+++ b/frontend/src/lib/chatInternoUtils.ts
@@ -16,4 +16,4 @@ export function previewTexto(texto: string | null | undefined, max = 80): string
   return `${t.slice(0, max)}…`
 }
 
-export type FiltroInboxChatInterno = 'todas' | 'direta' | 'setor'
+export type FiltroInboxChatInterno = 'todas' | 'direta' | 'setor' | 'grupo'

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import { ApiError, chatInterno, type ChatInterno } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { ChatInternoComposerBar } from '../../components/chat-interno/ChatInternoComposerBar'
+import { ChatInternoGrupoMembrosModal } from '../../components/chat-interno/ChatInternoGrupoMembrosModal'
 import { ChatInternoConteudoMensagem } from '../../components/chat-interno/ChatInternoConteudoMensagem'
 import { ChatInternoMensagemAcoes } from '../../components/chat-interno/ChatInternoMensagemAcoes'
 import { ChatInternoReacoesBar } from '../../components/chat-interno/ChatInternoReacoesBar'
@@ -21,7 +22,10 @@ import {
   saveChatInternoScroll,
   scrollChatToBottom,
 } from '../../lib/chatInternoScrollMemory'
+import { mergeMensagensChatInterno, prependMensagensChatInterno } from '../../lib/chatInternoMensagensMerge'
 import { SemPermissao } from '../SemPermissao'
+
+const SCROLL_TOPO_CARREGAR_PX = 80
 
 function formatarHoraMensagem(iso: string): string {
   const d = new Date(iso)
@@ -45,10 +49,23 @@ export function ChatInternoThread() {
   const [enviando, setEnviando] = useState(false)
   const [forbidden, setForbidden] = useState(false)
   const [erro, setErro] = useState(false)
+  const [temMaisAntigas, setTemMaisAntigas] = useState(false)
+  const [carregandoAntigas, setCarregandoAntigas] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
   const stickToBottomRef = useRef(true)
   const initialScrollRestoredRef = useRef(false)
   const saveScrollRafRef = useRef<number | null>(null)
+  const carregandoAntigasRef = useRef(false)
+  const temMaisAntigasRef = useRef(false)
+  const mensagensRef = useRef<ChatInterno.Mensagem[]>([])
+
+  useEffect(() => {
+    temMaisAntigasRef.current = temMaisAntigas
+  }, [temMaisAntigas])
+
+  useEffect(() => {
+    mensagensRef.current = mensagens
+  }, [mensagens])
 
   const marcarVistoSeNoFim = useCallback(async () => {
     const el = scrollRef.current
@@ -62,7 +79,40 @@ export function ChatInternoThread() {
     }
   }, [conversaId, refreshInbox])
 
-  const carregarMensagens = useCallback(async () => {
+  const carregarMaisAntigas = useCallback(async () => {
+    if (!Number.isFinite(conversaId) || conversaId <= 0) return
+    if (!temMaisAntigasRef.current || carregandoAntigasRef.current) return
+
+    const oldestId = mensagensRef.current[0]?.id
+    if (oldestId == null) return
+
+    const el = scrollRef.current
+    const prevTop = el?.scrollTop ?? 0
+    const prevHeight = el?.scrollHeight ?? 0
+
+    carregandoAntigasRef.current = true
+    setCarregandoAntigas(true)
+    try {
+      const pagina = await chatInterno.mensagens(conversaId, { antesDeId: oldestId })
+      setMensagens((prev) => prependMensagensChatInterno(prev, pagina.items))
+      setTemMaisAntigas(pagina.tem_mais_antigas)
+      requestAnimationFrame(() => {
+        const container = scrollRef.current
+        if (container && el) {
+          preserveScrollOnContentChange(container, prevTop, prevHeight)
+        }
+      })
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        setForbidden(true)
+      }
+    } finally {
+      carregandoAntigasRef.current = false
+      setCarregandoAntigas(false)
+    }
+  }, [conversaId])
+
+  const sincronizarRecentes = useCallback(async () => {
     if (!Number.isFinite(conversaId) || conversaId <= 0) return
     const el = scrollRef.current
     const stick = stickToBottomRef.current
@@ -70,8 +120,12 @@ export function ChatInternoThread() {
     const prevHeight = el?.scrollHeight ?? 0
 
     try {
-      const pagina = await chatInterno.mensagens(conversaId, { offset: 0, limit: 100 })
-      setMensagens(pagina.items)
+      const pagina = await chatInterno.mensagens(conversaId)
+      setMensagens((prev) => {
+        const merged = mergeMensagensChatInterno(prev, pagina.items)
+        setTemMaisAntigas(merged.length < pagina.total)
+        return merged
+      })
 
       requestAnimationFrame(() => {
         const container = scrollRef.current
@@ -96,8 +150,9 @@ export function ChatInternoThread() {
     setErro(false)
     setForbidden(false)
     try {
-      const pagina = await chatInterno.mensagens(conversaId, { offset: 0, limit: 100 })
+      const pagina = await chatInterno.mensagens(conversaId)
       setMensagens(pagina.items)
+      setTemMaisAntigas(pagina.tem_mais_antigas)
       await marcarVistoSeNoFim()
     } catch (err) {
       if (err instanceof ApiError && err.status === 403) {
@@ -118,6 +173,7 @@ export function ChatInternoThread() {
     }
     initialScrollRestoredRef.current = false
     stickToBottomRef.current = true
+    setTemMaisAntigas(false)
     setLoading(true)
     void carregar()
   }, [conversaId, carregar, navigate])
@@ -141,6 +197,13 @@ export function ChatInternoThread() {
 
     const onScroll = () => {
       stickToBottomRef.current = isNearBottom(el)
+      if (
+        el.scrollTop < SCROLL_TOPO_CARREGAR_PX &&
+        temMaisAntigasRef.current &&
+        !carregandoAntigasRef.current
+      ) {
+        void carregarMaisAntigas()
+      }
       if (saveScrollRafRef.current != null) cancelAnimationFrame(saveScrollRafRef.current)
       saveScrollRafRef.current = requestAnimationFrame(() => {
         saveChatInternoScroll(conversaId, el)
@@ -153,7 +216,7 @@ export function ChatInternoThread() {
       if (saveScrollRafRef.current != null) cancelAnimationFrame(saveScrollRafRef.current)
       saveChatInternoScroll(conversaId, el)
     }
-  }, [conversaId, loading])
+  }, [conversaId, loading, carregarMaisAntigas])
 
   useEffect(() => {
     if (loading || !initialScrollRestoredRef.current || !stickToBottomRef.current) return
@@ -168,28 +231,28 @@ export function ChatInternoThread() {
       const id = Number(payload.conversa_id)
       void refreshInbox(true)
       if (id !== conversaId) return
-      void carregarMensagens()
+      void sincronizarRecentes()
     })
     const unsubLido = subscribe('chat.interno.lido', (payload) => {
       if (Number(payload.conversa_id) !== conversaId) return
-      void carregarMensagens()
+      void sincronizarRecentes()
     })
     const unsubAtualizada = subscribe('chat.interno.mensagem.atualizada', (payload) => {
       if (Number(payload.conversa_id) !== conversaId) return
-      void carregarMensagens()
+      void sincronizarRecentes()
     })
     return () => {
       unsubMsg()
       unsubLido()
       unsubAtualizada()
     }
-  }, [subscribe, conversaId, carregarMensagens, refreshInbox])
+  }, [subscribe, conversaId, sincronizarRecentes, refreshInbox])
 
   useEffect(() => {
     const intervalMs = useFallback ? 10_000 : 6_000
-    const timer = setInterval(() => void carregarMensagens(), intervalMs)
+    const timer = setInterval(() => void sincronizarRecentes(), intervalMs)
     return () => clearInterval(timer)
-  }, [carregarMensagens, useFallback])
+  }, [sincronizarRecentes, useFallback])
 
   const atualizarMensagemNoEstado = useCallback((msg: ChatInterno.Mensagem) => {
     setMensagens((prev) => prev.map((m) => (m.id === msg.id ? msg : m)))
@@ -197,6 +260,19 @@ export function ChatInternoThread() {
 
   const [confirmarLimpar, setConfirmarLimpar] = useState(false)
   const [limpando, setLimpando] = useState(false)
+  const [grupoDetalhe, setGrupoDetalhe] = useState<ChatInterno.Conversa | null>(null)
+  const [modalMembros, setModalMembros] = useState(false)
+
+  useEffect(() => {
+    if (meta?.tipo !== 'grupo') {
+      setGrupoDetalhe(null)
+      return
+    }
+    void chatInterno
+      .obterConversa(conversaId)
+      .then(setGrupoDetalhe)
+      .catch(() => setGrupoDetalhe(null))
+  }, [conversaId, meta?.tipo])
 
   async function editarMensagem(mensagemId: number, corpo: string) {
     try {
@@ -229,6 +305,7 @@ export function ChatInternoThread() {
       await chatInterno.limparConversa(conversaId)
       clearChatInternoScroll(conversaId)
       setMensagens([])
+      setTemMaisAntigas(false)
       void refreshInbox(true)
       navigate('/chat/interno', { replace: true })
     } catch (err) {
@@ -307,6 +384,12 @@ export function ChatInternoThread() {
 
   const titulo = meta?.titulo ?? 'Conversa'
   const isSetor = meta?.tipo === 'setor'
+  const isGrupo = meta?.tipo === 'grupo'
+  const subtitulo = isSetor
+    ? 'Canal do setor — comunicados'
+    : isGrupo
+      ? 'Grupo da equipe'
+      : 'Conversa direta'
 
   return (
     <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
@@ -322,17 +405,24 @@ export function ChatInternoThread() {
         </Link>
         <div
           className={`hidden h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white md:flex ${
-            isSetor ? 'bg-amber-500' : 'bg-cyan-600'
+            isSetor ? 'bg-amber-500' : isGrupo ? 'bg-violet-600' : 'bg-cyan-600'
           }`}
         >
-          {isSetor ? 'S' : titulo.slice(0, 1).toUpperCase()}
+          {isSetor ? 'S' : isGrupo ? 'G' : titulo.slice(0, 1).toUpperCase()}
         </div>
         <div className="min-w-0 flex-1">
           <h2 className="truncate text-lg font-bold text-slate-900 dark:text-white">{titulo}</h2>
-          <p className="truncate text-sm text-slate-500">
-            {isSetor ? 'Canal do setor — comunicados' : 'Conversa direta'}
-          </p>
+          <p className="truncate text-sm text-slate-500">{subtitulo}</p>
         </div>
+        {isGrupo && grupoDetalhe?.sou_admin_grupo && (
+          <button
+            type="button"
+            onClick={() => setModalMembros(true)}
+            className="shrink-0 rounded-lg px-3 py-1.5 text-xs font-medium text-violet-700 ring-1 ring-violet-200 hover:bg-violet-50 dark:text-violet-300 dark:ring-violet-800 dark:hover:bg-violet-950/40"
+          >
+            Membros
+          </button>
+        )}
         <button
           type="button"
           onClick={() => setConfirmarLimpar(true)}
@@ -360,11 +450,27 @@ export function ChatInternoThread() {
         }}
       />
 
+      {grupoDetalhe && (
+        <ChatInternoGrupoMembrosModal
+          open={modalMembros}
+          conversaId={conversaId}
+          participantes={grupoDetalhe.participantes ?? []}
+          onClose={() => setModalMembros(false)}
+          onAtualizado={(conv: ChatInterno.Conversa) => {
+            setGrupoDetalhe(conv)
+            void refreshInbox(true)
+          }}
+        />
+      )}
+
       <div
         ref={scrollRef}
         className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto bg-slate-100/90 px-4 py-5 dark:bg-slate-900/60 md:px-6 lg:px-8"
       >
         <div className="w-full min-w-0 space-y-1">
+        {carregandoAntigas && (
+          <p className="py-2 text-center text-sm text-slate-400">Carregando mensagens anteriores…</p>
+        )}
         {loading ? (
           <p className="text-center text-base text-slate-400 animate-pulse">Carregando mensagens…</p>
         ) : erro ? (


### PR DESCRIPTION
## Summary

Fecha o **lote v3 do chat interno** (#505–#507):

- **Paginação infinita** — cursor `antes_de_id`, 50 mensagens por bloco; scroll ao topo carrega histórico sem perder posição
- **Editar legenda de mídia** — mesma janela de 5 minutos das mensagens de texto
- **Grupos personalizados** — criação com título e membros (máx. 50), papéis admin/membro, modal de gestão de membros, filtro **Grupos** na inbox

Inclui migration `063`, testes backend (paginação + grupos) e tooling Cursor compartilhado (`/subir-local`, `/testar-ui`, skill `browser-qa`).

Closes #505
Closes #506
Closes #507

## CHANGELOG

- [x] Atualizei `CHANGELOG.md` → `[Unreleased]` com bullets para #505, #506 e #507

## Test plan

- [x] `docker compose run --rm --no-deps backend pytest tests/test_chat_interno_paginacao.py tests/test_chat_interno_grupos.py -q`
- [x] `npx tsc -b` no frontend
- [x] QA manual no navegador integrado:
  - Criar grupo, promover admin, enviar mensagem, filtro Grupos
  - Paginação com 65+ mensagens (`?antes_de_id=` ao rolar ao topo)
  - Editar legenda de imagem com indicador «editada»
  - Regressão: reações, memória de scroll ao trocar conversa

## Follow-ups / backlog

- [x] Sem follow-ups novos — escopo das três issues coberto
- [ ] Remover/rebaixar membro e adicionar membro via busca: coberto na API/UI v1; não testado manualmente remover nesta sessão
