### PR TITLE
release: main → staging — Aguardando, Atendimentos e feedback KB (#484, #485, #469)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 
 Formato baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.0.0/).
 Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging`.
@@ -54,6 +54,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp
 - Base de conhecimento (#465/#466): portal público `/kb` com logo e nome da empresa (Configurações → Empresa); listagem, busca e leitura de artigos sem login
 - Base de conhecimento (#467): personalização do portal em Configurações → Sistema → Base de conhecimento (cores da navbar, textos, links); menu lateral de categorias/subcategorias expansível no /kb; navbar com título centralizado, logo sem fundo branco e menu hamburger
+- Base de conhecimento (#469): visitantes do portal `/kb` avaliam manuais como úteis ou não; admin vê totais no artigo e pode ligar/desligar a avaliação nas configurações do portal
 - Base de conhecimento (#293–#299): menu **Ajuda** para consultar manuais durante o atendimento; gestão de categorias e artigos (admin); consulta integrada em tickets e WhatsApp; manuais «só para a equipe»; imagens no texto; histórico de versões; reordenar categorias arrastando; manuais consultados ficam disponíveis offline neste computador
 - Auditoria (#290–#292): trail expandido com payload, IP, request-id e user-agent; registro de atribuição, transferência, fechamento e reabertura de tickets, ações em chats WhatsApp, envio de e-mail ao cliente, visualização de credencial PDV e exportação de relatórios
 - Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Chat interno (IC-F2): mensagens internas no sino de notificações e evento SSE `chat.interno.mensagem`; contador `chat_interno_nao_lidas_count` no badge do navbar
 - Chat interno (IC-F3): inbox unificada, conversas diretas e canais de setor no menu Chat interno; comunicados com visual distinto; link no detalhe do setor; layout com lista lateral fixa para alternar conversas e ver não lidas
 - Chat interno (#495): anexos e mídia — upload, download, pré-visualização no painel e colar imagem (Ctrl+V) no composer
-- Chat operacional: hub unificado em `/chat` com abas Atendendo, Espera e Interno; Histórico permanece em menu separado
+- Chat operacional: hub unificado em `/chat` com abas Atendendo, Aguardando e Interno; tela **Atendimentos** no menu para consulta de chats abertos e encerrados (#485)
+- WhatsApp (#484): aba **Aguardando** no hub; no mobile, atalho na conversa abre a fila para assumir chats sem voltar à lista
 - Chat interno e WhatsApp: indicadores de envio, entrega e leitura nas mensagens (✓ / ✓✓)
 - Notificações: pendência do chat interno abre direto em `/chat/interno/{id}`
 - Chat interno (#503): editar e apagar mensagens de texto — autor ou admin; exclusão lógica com «Mensagem apagada»

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Chat interno (#506): editar legenda de mensagens com mídia (mesma janela de 5 minutos)
 - Chat interno (#507): grupos personalizados com até 50 atendentes; criador e admins promovidos gerenciam membros
 - WhatsApp (#470): áudio gravado na barra de composição é enviado automaticamente ao terminar a gravação (estilo WhatsApp Web)
-- Identidade visual (#434): painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel
+- Identidade visual (#434): marca DeskRudder no login e em todo o painel
+- WhatsApp (#485): menu «Atendimentos» unifica chats abertos e encerrados com filtro por status
 - Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp
 - Base de conhecimento (#465/#466): portal público `/kb` com logo e nome da empresa (Configurações → Empresa); listagem, busca e leitura de artigos sem login
 - Base de conhecimento (#467): personalização do portal em Configurações → Sistema → Base de conhecimento (cores da navbar, textos, links); menu lateral de categorias/subcategorias expansível no /kb; navbar com título centralizado, logo sem fundo branco e menu hamburger

--- a/backend/alembic/versions/064_kb_article_feedback.py
+++ b/backend/alembic/versions/064_kb_article_feedback.py
@@ -1,0 +1,61 @@
+"""KB portal: avaliação útil/não útil em artigos (#469).
+
+Revision ID: 064_kb_article_feedback
+Revises: 063_chat_interno_grupos
+Create Date: 2026-07-11
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "064_kb_article_feedback"
+down_revision = "063_chat_interno_grupos"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "kb_articles",
+        sa.Column("feedback_util_count", sa.Integer(), server_default="0", nullable=False),
+    )
+    op.add_column(
+        "kb_articles",
+        sa.Column("feedback_nao_util_count", sa.Integer(), server_default="0", nullable=False),
+    )
+    op.add_column(
+        "kb_portal_settings",
+        sa.Column("feedback_habilitado", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+    )
+    op.create_table(
+        "kb_article_feedback_votes",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("tenant_id", sa.Integer(), nullable=False),
+        sa.Column("article_id", sa.Integer(), nullable=False),
+        sa.Column("ip_hash", sa.String(length=64), nullable=False),
+        sa.Column("util", sa.Boolean(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.ForeignKeyConstraint(["article_id"], ["kb_articles.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["tenant_id"], ["tenants.id"], ondelete="RESTRICT"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("article_id", "ip_hash", name="uq_kb_article_feedback_votes_article_ip"),
+    )
+    op.create_index(
+        "ix_kb_article_feedback_votes_article_id",
+        "kb_article_feedback_votes",
+        ["article_id"],
+    )
+    op.create_index(
+        "ix_kb_article_feedback_votes_tenant_id",
+        "kb_article_feedback_votes",
+        ["tenant_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_kb_article_feedback_votes_tenant_id", table_name="kb_article_feedback_votes")
+    op.drop_index("ix_kb_article_feedback_votes_article_id", table_name="kb_article_feedback_votes")
+    op.drop_table("kb_article_feedback_votes")
+    op.drop_column("kb_portal_settings", "feedback_habilitado")
+    op.drop_column("kb_articles", "feedback_nao_util_count")
+    op.drop_column("kb_articles", "feedback_util_count")

--- a/backend/app/api/kb.py
+++ b/backend/app/api/kb.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.core.audit import registrar_audit
 from app.core.auth import exigir_admin, obter_atendente_atual
-from app.core.kb_public_rate_limit import check_kb_public_rate_limit
+from app.core.kb_public_rate_limit import check_kb_public_feedback_rate_limit, check_kb_public_rate_limit
 from app.core.tenant_context import TenantIdDep
 from app.core.ordenacao_lista import OrdemLista, expr_ordem
 from app.database import get_db
@@ -19,6 +19,8 @@ from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
 from app.schemas.kb import (
     KbArticleBrief,
     KbArticleCreate,
+    KbArticleFeedbackBody,
+    KbArticleFeedbackRead,
     KbArticleRead,
     KbArticleUpdate,
     KbArticleVersionDetail,
@@ -36,6 +38,8 @@ from app.schemas.kb import (
 )
 from app.schemas.lista_paginada import ListaPaginada
 from app.services.kb import listar_artigos_sugeridos, registrar_versao_artigo, slug_disponivel
+from app.services.kb_feedback import registrar_feedback_artigo_publico
+from app.core.login_protection import client_ip
 from app.services.system_logo_storage import caminho_absoluto_logo
 from app.services.kb_media_storage import caminho_absoluto_imagem, gravar_imagem_bytes
 
@@ -80,6 +84,8 @@ def _article_read(article: KbArticle) -> KbArticleRead:
         autor_nome=article.autor.nome if article.autor else None,
         published_at=article.published_at,
         archived_at=article.archived_at,
+        feedback_util_count=int(article.feedback_util_count or 0),
+        feedback_nao_util_count=int(article.feedback_nao_util_count or 0),
         created_at=article.created_at,
         updated_at=article.updated_at,
     )
@@ -776,6 +782,7 @@ def _portal_settings_read(row: KbPortalSettings) -> KbPortalSettingsRead:
         cor_fundo=row.cor_fundo or "#F8FAFC",
         cor_link=row.cor_link,
         exibir_marca_deskrudder=bool(row.exibir_marca_deskrudder),
+        feedback_habilitado=bool(row.feedback_habilitado),
         public_url_preview="/kb",
     )
 
@@ -818,6 +825,7 @@ def _kb_public_branding(db: Session, tenant_id: int) -> KbPublicBrandingRead:
         cor_fundo=(settings.cor_fundo if settings else None) or "#F8FAFC",
         cor_link=cor_link,
         exibir_marca_deskrudder=bool(settings.exibir_marca_deskrudder) if settings else True,
+        feedback_habilitado=bool(settings.feedback_habilitado) if settings else True,
     )
 
 
@@ -993,3 +1001,23 @@ def obter_artigo_publico_por_slug(
         raise HTTPException(status_code=404, detail="Artigo não encontrado")
     _public_cache_headers(response)
     return _article_read(row)
+
+
+@router.post("/public/articles/{slug}/feedback", response_model=KbArticleFeedbackRead)
+def enviar_feedback_artigo_publico(
+    slug: str,
+    body: KbArticleFeedbackBody,
+    request: Request,
+    tenant_id: TenantIdDep,
+    db: Session = Depends(get_db),
+):
+    check_kb_public_rate_limit(request)
+    check_kb_public_feedback_rate_limit(request)
+    result = registrar_feedback_artigo_publico(
+        db,
+        tenant_id=tenant_id,
+        slug=slug,
+        util=body.util,
+        ip=client_ip(request),
+    )
+    return KbArticleFeedbackRead(**result)

--- a/backend/app/core/kb_public_rate_limit.py
+++ b/backend/app/core/kb_public_rate_limit.py
@@ -11,9 +11,11 @@ from fastapi import HTTPException, Request, status
 from app.core.login_protection import client_ip
 
 _MAX_REQUESTS_PER_MINUTE_PER_IP = 120
+_MAX_FEEDBACK_PER_MINUTE_PER_IP = 20
 
 _lock = Lock()
 _buckets: dict[str, list[float]] = defaultdict(list)
+_feedback_buckets: dict[str, list[float]] = defaultdict(list)
 
 
 def check_kb_public_rate_limit(request: Request) -> None:
@@ -26,5 +28,19 @@ def check_kb_public_rate_limit(request: Request) -> None:
             raise HTTPException(
                 status_code=status.HTTP_429_TOO_MANY_REQUESTS,
                 detail="Muitas consultas à base de conhecimento. Aguarde um minuto.",
+            )
+        bucket.append(now)
+
+
+def check_kb_public_feedback_rate_limit(request: Request) -> None:
+    ip = client_ip(request)
+    now = time.monotonic()
+    with _lock:
+        bucket = _feedback_buckets[ip]
+        bucket[:] = [t for t in bucket if now - t < 60]
+        if len(bucket) >= _MAX_FEEDBACK_PER_MINUTE_PER_IP:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Muitas avaliações em pouco tempo. Aguarde um minuto.",
             )
         bucket.append(now)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -34,7 +34,7 @@ from app.models.business_calendar import BusinessCalendar
 from app.models.sla_policy import SlaPolicy
 from app.models.sla_alerta_emitido import SlaAlertaEmitido
 from app.models.empresa_pdv import EmpresaPdv, PdvRotulo, PdvTipoAcessoRemoto
-from app.models.kb import KbArticle, KbArticleMotivoLink, KbArticleVersion, KbCategory, KbPortalSettings
+from app.models.kb import KbArticle, KbArticleFeedbackVote, KbArticleMotivoLink, KbArticleVersion, KbCategory, KbPortalSettings
 from app.models.chat_interno import (
     ConversaInterna,
     ConversaInternaLeitura,
@@ -95,6 +95,7 @@ __all__ = [
     "EmpresaPdv",
     "KbCategory",
     "KbArticle",
+    "KbArticleFeedbackVote",
     "KbArticleMotivoLink",
     "KbArticleVersion",
     "KbPortalSettings",

--- a/backend/app/models/kb.py
+++ b/backend/app/models/kb.py
@@ -63,10 +63,17 @@ class KbArticle(Base):
     autor_atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True, index=True)
     published_at = Column(DateTime(timezone=True), nullable=True)
     archived_at = Column(DateTime(timezone=True), nullable=True)
+    feedback_util_count = Column(Integer, nullable=False, server_default="0", default=0)
+    feedback_nao_util_count = Column(Integer, nullable=False, server_default="0", default=0)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
     category = relationship("KbCategory", back_populates="articles")
+    feedback_votes = relationship(
+        "KbArticleFeedbackVote",
+        back_populates="article",
+        cascade="all, delete-orphan",
+    )
     autor = relationship("Atendente", foreign_keys=[autor_atendente_id])
     versions = relationship("KbArticleVersion", back_populates="article", order_by="KbArticleVersion.id.desc()")
     motivo_links = relationship(
@@ -129,5 +136,24 @@ class KbPortalSettings(Base):
     cor_fundo = Column(String(7), nullable=False, server_default="#F8FAFC", default="#F8FAFC")
     cor_link = Column(String(7), nullable=True)
     exibir_marca_deskrudder = Column(Boolean, nullable=False, server_default="true", default=True)
+    feedback_habilitado = Column(Boolean, nullable=False, server_default="true", default=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+
+class KbArticleFeedbackVote(Base):
+    """Voto de utilidade em artigo público — um por IP (hash) por artigo (#469)."""
+
+    __tablename__ = "kb_article_feedback_votes"
+    __table_args__ = (
+        UniqueConstraint("article_id", "ip_hash", name="uq_kb_article_feedback_votes_article_ip"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    article_id = Column(Integer, ForeignKey("kb_articles.id", ondelete="CASCADE"), nullable=False, index=True)
+    ip_hash = Column(String(64), nullable=False)
+    util = Column(Boolean, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    article = relationship("KbArticle", back_populates="feedback_votes")

--- a/backend/app/schemas/kb.py
+++ b/backend/app/schemas/kb.py
@@ -67,6 +67,8 @@ class KbArticleRead(BaseModel):
     autor_nome: str | None = None
     published_at: datetime | None
     archived_at: datetime | None
+    feedback_util_count: int = 0
+    feedback_nao_util_count: int = 0
     created_at: datetime
     updated_at: datetime | None
 
@@ -127,6 +129,17 @@ class KbSuggestionsQuery(BaseModel):
     natureza_id: int | None = Field(None, ge=1)
 
 
+class KbArticleFeedbackBody(BaseModel):
+    util: bool
+
+
+class KbArticleFeedbackRead(BaseModel):
+    util: bool
+    ja_avaliado: bool
+    feedback_util_count: int
+    feedback_nao_util_count: int
+
+
 class KbPublicBrandingRead(BaseModel):
     nome_exibicao: str
     portal_titulo: str = "Central de ajuda"
@@ -139,6 +152,7 @@ class KbPublicBrandingRead(BaseModel):
     cor_fundo: str = "#F8FAFC"
     cor_link: str = "#0D9488"
     exibir_marca_deskrudder: bool = True
+    feedback_habilitado: bool = True
 
 
 class KbPortalSettingsRead(BaseModel):
@@ -151,6 +165,7 @@ class KbPortalSettingsRead(BaseModel):
     cor_fundo: str = "#F8FAFC"
     cor_link: str | None = None
     exibir_marca_deskrudder: bool = True
+    feedback_habilitado: bool = True
     public_url_preview: str | None = None
 
 
@@ -167,3 +182,4 @@ class KbPortalSettingsUpdate(BaseModel):
     cor_fundo: str | None = Field(None, pattern=_HEX_COLOR)
     cor_link: str | None = Field(None, pattern=_HEX_COLOR)
     exibir_marca_deskrudder: bool | None = None
+    feedback_habilitado: bool | None = None

--- a/backend/app/services/kb_feedback.py
+++ b/backend/app/services/kb_feedback.py
@@ -1,0 +1,88 @@
+"""Feedback público de utilidade em artigos KB (#469)."""
+
+from __future__ import annotations
+
+import hashlib
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.models.kb import KbArticle, KbArticleFeedbackVote, KbArticleStatus, KbPortalSettings
+
+
+def hash_ip(ip: str) -> str:
+    return hashlib.sha256(ip.encode("utf-8")).hexdigest()
+
+
+def _portal_feedback_habilitado(db: Session, tenant_id: int) -> bool:
+    row = db.query(KbPortalSettings).filter(KbPortalSettings.tenant_id == tenant_id).first()
+    if not row:
+        return True
+    return bool(row.feedback_habilitado)
+
+
+def _artigo_publico_por_slug(db: Session, tenant_id: int, slug: str) -> KbArticle | None:
+    return (
+        db.query(KbArticle)
+        .filter(
+            KbArticle.tenant_id == tenant_id,
+            KbArticle.slug == slug,
+            KbArticle.status == KbArticleStatus.publicado.value,
+            KbArticle.interno_only.is_(False),
+        )
+        .first()
+    )
+
+
+def registrar_feedback_artigo_publico(
+    db: Session,
+    *,
+    tenant_id: int,
+    slug: str,
+    util: bool,
+    ip: str,
+) -> dict:
+    if not _portal_feedback_habilitado(db, tenant_id):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Avaliação de artigos desabilitada.")
+
+    article = _artigo_publico_por_slug(db, tenant_id, slug)
+    if not article:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artigo não encontrado")
+
+    ip_digest = hash_ip(ip)
+    existente = (
+        db.query(KbArticleFeedbackVote)
+        .filter(
+            KbArticleFeedbackVote.article_id == article.id,
+            KbArticleFeedbackVote.ip_hash == ip_digest,
+        )
+        .first()
+    )
+    if existente:
+        return {
+            "util": bool(existente.util),
+            "ja_avaliado": True,
+            "feedback_util_count": int(article.feedback_util_count or 0),
+            "feedback_nao_util_count": int(article.feedback_nao_util_count or 0),
+        }
+
+    vote = KbArticleFeedbackVote(
+        tenant_id=tenant_id,
+        article_id=article.id,
+        ip_hash=ip_digest,
+        util=util,
+    )
+    db.add(vote)
+    if util:
+        article.feedback_util_count = int(article.feedback_util_count or 0) + 1
+    else:
+        article.feedback_nao_util_count = int(article.feedback_nao_util_count or 0) + 1
+    db.commit()
+    db.refresh(article)
+
+    return {
+        "util": util,
+        "ja_avaliado": False,
+        "feedback_util_count": int(article.feedback_util_count or 0),
+        "feedback_nao_util_count": int(article.feedback_nao_util_count or 0),
+    }

--- a/backend/app/services/system_release.py
+++ b/backend/app/services/system_release.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,44 @@ from app.config import settings
 
 _DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 _REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_LEGACY_BRAND_RE = re.compile(r"DX/Duplexsoft|Duplexsoft|DX Connect|DX-Connect", re.IGNORECASE)
+
+
+def sanitize_release_text(text: str) -> str:
+    """Remove referências à marca legada em textos voltados ao usuário (release notes)."""
+    result = text
+    for old, new in (
+        (
+            "painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel",
+            "marca DeskRudder no login e em todo o painel",
+        ),
+        (
+            "assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel",
+            "marca DeskRudder no login e em todo o painel",
+        ),
+    ):
+        result = result.replace(old, new)
+    if _LEGACY_BRAND_RE.search(result) and "Identidade visual (#434)" in result:
+        return "Identidade visual (#434): marca DeskRudder no login e em todo o painel"
+    return result
+
+
+def _sanitize_release(rel: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not rel:
+        return rel
+    out = dict(rel)
+    changes = []
+    for ch in out.get("changes") or []:
+        if not isinstance(ch, dict):
+            changes.append(ch)
+            continue
+        item = dict(ch)
+        if isinstance(item.get("text"), str):
+            item["text"] = sanitize_release_text(item["text"])
+        changes.append(item)
+    out["changes"] = changes
+    return out
 
 
 def version_display(version: str) -> str:
@@ -50,7 +89,7 @@ def reload_release_notes_cache() -> None:
 def release_notes_payload(*, version_override: str | None = None) -> dict[str, Any]:
     raw = _load_release_notes_raw()
     version = version_override or resolve_app_version()
-    releases: list[dict[str, Any]] = list(raw.get("releases") or [])
+    releases: list[dict[str, Any]] = [_sanitize_release(r) or r for r in (raw.get("releases") or [])]
 
     current = None
     if version:

--- a/backend/tests/test_kb.py
+++ b/backend/tests/test_kb.py
@@ -397,3 +397,54 @@ def test_kb_sugestoes_por_motivo_e_natureza(client, auth_headers, db_session):
     links = db_session.query(KbArticleMotivoLink).filter(KbArticleMotivoLink.article_id == art_mot["id"]).all()
     assert len(links) == 1
     assert links[0].motivo_id == mot.id
+
+
+def test_kb_feedback_artigo_publico(client, auth_headers, db_session):
+    art = client.post(
+        "/v1/kb/articles",
+        headers=auth_headers["admin"],
+        json={"titulo": "Manual com feedback", "conteudo_markdown": "Conteúdo"},
+    ).json()
+    client.post(f"/v1/kb/articles/{art['id']}/publish", headers=auth_headers["admin"])
+    slug = art["slug"]
+
+    r = client.post(f"/v1/kb/public/articles/{slug}/feedback", json={"util": True})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["util"] is True
+    assert body["ja_avaliado"] is False
+    assert body["feedback_util_count"] == 1
+    assert body["feedback_nao_util_count"] == 0
+
+    r_dup = client.post(f"/v1/kb/public/articles/{slug}/feedback", json={"util": False})
+    assert r_dup.status_code == 200, r_dup.text
+    dup = r_dup.json()
+    assert dup["ja_avaliado"] is True
+    assert dup["util"] is True
+    assert dup["feedback_util_count"] == 1
+
+    r_admin = client.get(f"/v1/kb/articles/{art['id']}", headers=auth_headers["admin"])
+    assert r_admin.status_code == 200
+    admin = r_admin.json()
+    assert admin["feedback_util_count"] == 1
+    assert admin["feedback_nao_util_count"] == 0
+
+    client.put(
+        "/v1/kb/portal-settings",
+        headers=auth_headers["admin"],
+        json={"feedback_habilitado": False},
+    )
+    r_off = client.post(f"/v1/kb/public/articles/{slug}/feedback", json={"util": True})
+    assert r_off.status_code == 403
+
+    client.put(
+        "/v1/kb/portal-settings",
+        headers=auth_headers["admin"],
+        json={"feedback_habilitado": True},
+    )
+    r_brand = client.get("/v1/kb/public/branding")
+    assert r_brand.status_code == 200
+    assert r_brand.json()["feedback_habilitado"] is True
+
+    r404 = client.post("/v1/kb/public/articles/slug-inexistente/feedback", json={"util": True})
+    assert r404.status_code == 404

--- a/backend/tests/test_system_release.py
+++ b/backend/tests/test_system_release.py
@@ -10,7 +10,12 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from app.services.system_release import reload_release_notes_cache, resolve_app_version, version_display
+from app.services.system_release import (
+    reload_release_notes_cache,
+    resolve_app_version,
+    sanitize_release_text,
+    version_display,
+)
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = ROOT / "scripts"
@@ -127,6 +132,52 @@ def test_system_release_notes_authenticated(client, auth_headers, monkeypatch, t
     assert body["current_version"] == "26.06.001"
     assert body["current"]["changes"][0]["text"] == "Teste"
     assert body["upcoming"] == []
+
+
+def test_sanitize_release_text_removes_legacy_brand():
+    raw = (
+        "Identidade visual (#434): painel lateral do login e assets legados "
+        "DX/Duplexsoft removidos — marca DeskRudder em todo o painel"
+    )
+    assert sanitize_release_text(raw) == (
+        "Identidade visual (#434): marca DeskRudder no login e em todo o painel"
+    )
+    assert "DX" not in sanitize_release_text(raw)
+    assert "Duplexsoft" not in sanitize_release_text(raw)
+
+
+def test_system_release_notes_sanitize_legacy_brand(client, auth_headers, monkeypatch, tmp_path):
+    data_path = tmp_path / "release_notes.json"
+    legacy = (
+        "Identidade visual (#434): painel lateral do login e assets legados "
+        "DX/Duplexsoft removidos — marca DeskRudder em todo o painel"
+    )
+    payload = {
+        "current_version": "26.07.001",
+        "releases": [
+            {
+                "version": "26.07.001",
+                "version_display": "v26.07.001",
+                "date": "2026-07-11",
+                "status": "published",
+                "changes": [{"category": "melhorias", "text": legacy}],
+            }
+        ],
+        "upcoming": [],
+    }
+    data_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    import app.services.system_release as sr
+
+    monkeypatch.setattr(sr, "_DATA_DIR", tmp_path)
+    reload_release_notes_cache()
+    monkeypatch.setenv("DX_CONNECT_VERSION", "26.07.001")
+
+    body = client.get("/v1/system/release-notes", headers=auth_headers["admin"]).json()
+    text = body["releases"][0]["changes"][0]["text"]
+    assert "DX" not in text
+    assert "Duplexsoft" not in text
+    assert "DeskRudder" in text
 
 
 def test_health_includes_version(client, monkeypatch):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -214,8 +214,8 @@ function AppRoutes() {
               path="espera"
               element={
                 <ChatHubPlaceholder
-                  titulo="Fila de espera"
-                  subtitulo="Assuma um chat da fila ou abra um já em atendimento."
+                  titulo="Aguardando"
+                  subtitulo="Chats na fila — assuma um novo atendimento."
                 />
               }
             />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -180,6 +180,11 @@ export const kbPublic = {
     publicApi<Kb.ArticleBrief[]>(withParams('/kb/public/articles', params)),
   getArticleBySlug: (slug: string) =>
     publicApi<Kb.Article>(`/kb/public/articles/${encodeURIComponent(slug)}`),
+  submitArticleFeedback: (slug: string, data: { util: boolean }) =>
+    publicApi<Kb.ArticleFeedback>(`/kb/public/articles/${encodeURIComponent(slug)}/feedback`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   suggestions: (params: { motivo_id?: number; natureza_id?: number }) =>
     publicApi<Kb.ArticleBrief[]>(withParams('/kb/public/suggestions', params)),
 }
@@ -2571,6 +2576,14 @@ export namespace Kb {
     autor_atendente_id: number | null;
     archived_at: string | null;
     created_at: string;
+    feedback_util_count?: number;
+    feedback_nao_util_count?: number;
+  }
+  export interface ArticleFeedback {
+    util: boolean;
+    ja_avaliado: boolean;
+    feedback_util_count: number;
+    feedback_nao_util_count: number;
   }
   export interface ArticleCreate {
     titulo: string;
@@ -2622,6 +2635,7 @@ export namespace Kb {
     cor_fundo: string;
     cor_link: string;
     exibir_marca_deskrudder: boolean;
+    feedback_habilitado: boolean;
   }
   export interface PortalSettings {
     portal_titulo: string | null;
@@ -2633,6 +2647,7 @@ export namespace Kb {
     cor_fundo: string;
     cor_link: string | null;
     exibir_marca_deskrudder: boolean;
+    feedback_habilitado: boolean;
     public_url_preview: string | null;
   }
   export interface PortalSettingsUpdate {
@@ -2645,6 +2660,7 @@ export namespace Kb {
     cor_fundo?: string;
     cor_link?: string | null;
     exibir_marca_deskrudder?: boolean;
+    feedback_habilitado?: boolean;
   }
 }
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -222,7 +222,7 @@ const navStructure: NavItem[] = [
   { type: 'link', to: '/', label: 'Dashboard', icon: 'dashboard' },
   { type: 'link', to: '/tickets', label: 'Tickets', icon: 'tickets' },
   { type: 'link', to: '/chat/atendendo', label: 'Chat', icon: 'chat', activePrefix: '/chat/' },
-  { type: 'link', to: '/whatsapp/historico', label: 'Histórico', icon: 'chatHistory' },
+  { type: 'link', to: '/whatsapp/historico', label: 'Atendimentos', icon: 'chatHistory' },
   {
     type: 'group',
     id: 'clientes',

--- a/frontend/src/components/chat/ChatFilaAguardandoSheet.tsx
+++ b/frontend/src/components/chat/ChatFilaAguardandoSheet.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useId, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ChatListaEspera } from '../../pages/chat/ChatListaEspera'
+
+type Props = {
+  open: boolean
+  onClose: () => void
+}
+
+export function ChatFilaAguardandoSheet({ open, onClose }: Props) {
+  const navigate = useNavigate()
+  const titleId = useId()
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    panelRef.current?.focus()
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] md:hidden"
+      role="presentation"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="absolute inset-0 bg-slate-900/40 backdrop-blur-[2px]" aria-hidden />
+      <div
+        ref={panelRef}
+        tabIndex={-1}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="absolute inset-x-0 bottom-0 flex max-h-[min(85vh,32rem)] flex-col rounded-t-2xl bg-white shadow-2xl outline-none dark:bg-slate-950"
+      >
+        <div className="flex shrink-0 items-center justify-between border-b border-slate-200 px-4 py-3 dark:border-slate-800">
+          <h2 id={titleId} className="text-base font-bold text-slate-900 dark:text-white">
+            Aguardando
+          </h2>
+          <button
+            type="button"
+            className="rounded-lg px-2 py-1 text-2xl leading-none text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+            onClick={onClose}
+            aria-label="Fechar"
+          >
+            &times;
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <ChatListaEspera
+            ignorarBusca
+            onChatAssumido={(chatId) => {
+              navigate(`/chat/c/${chatId}`)
+              onClose()
+            }}
+            onVerChat={onClose}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/ChatHubTabs.tsx
+++ b/frontend/src/components/chat/ChatHubTabs.tsx
@@ -33,7 +33,7 @@ export function ChatHubTabs() {
     {
       id: 'espera',
       to: CHAT_HUB_PATHS.espera,
-      label: 'Espera',
+      label: 'Aguardando',
       badge: filaCount,
       icon: (
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>

--- a/frontend/src/lib/whatsappListReturn.ts
+++ b/frontend/src/lib/whatsappListReturn.ts
@@ -76,7 +76,7 @@ export function buildHistoricoReturnPath(filters: {
   if (filters.atendenteId !== '') p.set('atendente_id', String(filters.atendenteId))
   if (filters.desde) p.set('desde', filters.desde)
   if (filters.ate) p.set('ate', filters.ate)
-  if (filters.estado && filters.estado !== 'finalizados') p.set('estado', filters.estado)
+  if (filters.estado && filters.estado !== 'todos') p.set('estado', filters.estado)
   if (filters.offset > 0) p.set('offset', String(filters.offset))
   const qs = p.toString()
   return qs ? `${WHATSAPP_LIST_PATHS.historico}?${qs}` : WHATSAPP_LIST_PATHS.historico

--- a/frontend/src/pages/KbArtigoForm.tsx
+++ b/frontend/src/pages/KbArtigoForm.tsx
@@ -57,6 +57,8 @@ export function KbArtigoForm() {
   const [versaoSelecionada, setVersaoSelecionada] = useState<Kb.ArticleVersionDetail | null>(null)
   const [loadingVersao, setLoadingVersao] = useState(false)
   const [motivoLinks, setMotivoLinks] = useState<MotivoLinkDraft[]>([])
+  const [feedbackUtil, setFeedbackUtil] = useState(0)
+  const [feedbackNaoUtil, setFeedbackNaoUtil] = useState(0)
 
   useEffect(() => {
     kb.listCategories()
@@ -82,6 +84,8 @@ export function KbArtigoForm() {
         setConteudo(item.conteudo_markdown)
         setInternoOnly(item.interno_only)
         setStatus(item.status)
+        setFeedbackUtil(item.feedback_util_count ?? 0)
+        setFeedbackNaoUtil(item.feedback_nao_util_count ?? 0)
       })
       .catch((err) => {
         if (cancelled) return
@@ -328,6 +332,24 @@ export function KbArtigoForm() {
             </p>
           </div>
         </FormSection>
+
+        {isEdit && status === 'publicado' && !internoOnly ? (
+          <FormSection title="Avaliações do portal">
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              Visitantes da central de ajuda podem marcar se o manual foi útil.
+            </p>
+            <div className="mt-3 flex flex-wrap gap-6 text-sm">
+              <div>
+                <span className="font-semibold text-teal-700 dark:text-teal-400">{feedbackUtil}</span>
+                <span className="ml-1 text-slate-600 dark:text-slate-400">úteis</span>
+              </div>
+              <div>
+                <span className="font-semibold text-slate-700 dark:text-slate-300">{feedbackNaoUtil}</span>
+                <span className="ml-1 text-slate-600 dark:text-slate-400">não úteis</span>
+              </div>
+            </div>
+          </FormSection>
+        ) : null}
 
         {isEdit ? (
           <FormSection title="Sugestões por classificação">

--- a/frontend/src/pages/KbPortalSettings.tsx
+++ b/frontend/src/pages/KbPortalSettings.tsx
@@ -5,6 +5,7 @@ import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { Input } from '../components/ui/Input'
+import { CheckboxField } from '../components/ui/CheckboxField'
 import { useToast } from '../components/ui/Toast'
 import { ConfigListPageShell } from '../components/config/ConfigListPageShell'
 import { SemPermissao } from './SemPermissao'
@@ -18,6 +19,7 @@ type FormState = {
   cor_texto_corpo: string
   cor_fundo: string
   cor_link: string
+  feedback_habilitado: boolean
 }
 
 function fromApi(data: Kb.PortalSettings): FormState {
@@ -30,6 +32,7 @@ function fromApi(data: Kb.PortalSettings): FormState {
     cor_texto_corpo: data.cor_texto_corpo,
     cor_fundo: data.cor_fundo,
     cor_link: data.cor_link ?? data.cor_primaria,
+    feedback_habilitado: data.feedback_habilitado,
   }
 }
 
@@ -103,6 +106,7 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
         cor_texto_corpo: form.cor_texto_corpo,
         cor_fundo: form.cor_fundo,
         cor_link: form.cor_link.trim() || null,
+        feedback_habilitado: form.feedback_habilitado,
       })
       setForm(fromApi(data))
       toast.showSuccess('Configurações do portal salvas.')
@@ -167,6 +171,18 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
                 className="w-full rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-sm dark:border-slate-600 dark:bg-slate-900"
               />
             </div>
+          </Card>
+
+          <Card className="p-4 sm:p-5">
+            <CheckboxField
+              checked={form.feedback_habilitado}
+              onChange={(e) => setForm({ ...form, feedback_habilitado: e.target.checked })}
+            >
+              Permitir avaliação «útil / não útil» nos manuais do portal
+            </CheckboxField>
+            <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+              Quando desligado, os visitantes não veem os botões de feedback no fim de cada artigo.
+            </p>
           </Card>
 
           <Card className="grid gap-4 p-4 sm:grid-cols-2 sm:p-5">

--- a/frontend/src/pages/chat/ChatListaEspera.tsx
+++ b/frontend/src/pages/chat/ChatListaEspera.tsx
@@ -41,7 +41,16 @@ function TempoEspera({ data }: { data?: string | null }) {
   )
 }
 
-export function ChatListaEspera() {
+type Props = {
+  /** Drawer mobile: não aplica busca global do hub */
+  ignorarBusca?: boolean
+  /** Após assumir com sucesso (ex.: navegar e fechar drawer) */
+  onChatAssumido?: (chatId: number) => void
+  /** Ao abrir um chat da lista (link Ver) */
+  onVerChat?: () => void
+}
+
+export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerChat }: Props = {}) {
   const toast = useToast()
   const { busca, refreshContagens } = useChatHub()
   const { subscribe, useFallback } = useEventStream()
@@ -77,6 +86,7 @@ export function ChatListaEspera() {
       await load()
       void refreshContagens()
       void refetchPendenciasResumo()
+      onChatAssumido?.(id)
     } catch (err) {
       const msg =
         err instanceof ApiError && err.status === 400
@@ -86,7 +96,7 @@ export function ChatListaEspera() {
     }
   }
 
-  const lista = filtrarPorBusca(fila, busca)
+  const lista = ignorarBusca ? fila : filtrarPorBusca(fila, busca)
 
   if (loading) {
     return <p className="p-4 text-center text-sm text-slate-400 animate-pulse">Carregando fila…</p>
@@ -121,6 +131,7 @@ export function ChatListaEspera() {
               <div className="mt-2 flex gap-2">
                 <Link
                   to={chatWhatsappLink(c.id, 'espera')}
+                  onClick={() => onVerChat?.()}
                   className="flex-1 rounded-lg border border-slate-200 py-1.5 text-center text-xs font-semibold text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
                 >
                   Ver

--- a/frontend/src/pages/kb-public/KbPublicArtigo.tsx
+++ b/frontend/src/pages/kb-public/KbPublicArtigo.tsx
@@ -3,6 +3,7 @@ import { Link, useParams } from 'react-router-dom'
 import { kbPublic, type Kb } from '../../api/client'
 import { KbMarkdownPreview } from '../../components/kb/KbMarkdownPreview'
 import { useKbPublicBranding } from './KbPublicContext'
+import { KbPublicArtigoFeedback } from './KbPublicArtigoFeedback'
 
 export function KbPublicArtigo() {
   const branding = useKbPublicBranding()
@@ -85,6 +86,8 @@ export function KbPublicArtigo() {
       >
         <KbMarkdownPreview markdown={artigo.conteudo_markdown} />
       </div>
+
+      <KbPublicArtigoFeedback slug={artigo.slug} />
 
       <Link to="/kb" className="inline-block text-sm font-medium hover:underline" style={linkStyle}>
         ← Voltar para todos os manuais

--- a/frontend/src/pages/kb-public/KbPublicArtigoFeedback.tsx
+++ b/frontend/src/pages/kb-public/KbPublicArtigoFeedback.tsx
@@ -1,0 +1,102 @@
+import { useCallback, useEffect, useState } from 'react'
+import { kbPublic } from '../../api/client'
+import { useKbPublicBranding } from './KbPublicContext'
+
+const STORAGE_PREFIX = 'kb-feedback:'
+
+function feedbackStorageKey(slug: string) {
+  return `${STORAGE_PREFIX}${slug}`
+}
+
+function lerVotoLocal(slug: string): boolean | null {
+  try {
+    const raw = localStorage.getItem(feedbackStorageKey(slug))
+    if (raw === '1') return true
+    if (raw === '0') return false
+  } catch {
+    /* storage indisponível */
+  }
+  return null
+}
+
+function salvarVotoLocal(slug: string, util: boolean) {
+  try {
+    localStorage.setItem(feedbackStorageKey(slug), util ? '1' : '0')
+  } catch {
+    /* storage indisponível */
+  }
+}
+
+type Props = {
+  slug: string
+}
+
+export function KbPublicArtigoFeedback({ slug }: Props) {
+  const branding = useKbPublicBranding()
+  const [voto, setVoto] = useState<boolean | null>(() => lerVotoLocal(slug))
+  const [enviando, setEnviando] = useState(false)
+  const [erro, setErro] = useState<string | null>(null)
+
+  useEffect(() => {
+    setVoto(lerVotoLocal(slug))
+    setErro(null)
+  }, [slug])
+
+  const enviar = useCallback(
+    async (util: boolean) => {
+      if (voto != null || enviando) return
+      setEnviando(true)
+      setErro(null)
+      try {
+        const res = await kbPublic.submitArticleFeedback(slug, { util })
+        setVoto(res.util)
+        salvarVotoLocal(slug, res.util)
+      } catch {
+        setErro('Não foi possível registrar sua avaliação. Tente novamente em instantes.')
+      } finally {
+        setEnviando(false)
+      }
+    },
+    [enviando, slug, voto],
+  )
+
+  if (!branding.feedback_habilitado) {
+    return null
+  }
+
+  if (voto != null) {
+    return (
+      <p className="text-center text-sm opacity-70" role="status">
+        Obrigado pelo feedback{voto ? ' — marcou como útil' : ''}.
+      </p>
+    )
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-5 text-center dark:border-slate-700 dark:bg-slate-900/40">
+      <p className="text-sm font-medium" style={{ color: branding.cor_texto_corpo }}>
+        Este manual foi útil?
+      </p>
+      <div className="mt-3 flex flex-wrap items-center justify-center gap-2">
+        <button
+          type="button"
+          disabled={enviando}
+          onClick={() => void enviar(true)}
+          className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-teal-300 hover:text-teal-800 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-200"
+          style={{ borderColor: enviando ? undefined : branding.cor_primaria + '55' }}
+        >
+          Sim
+        </button>
+        <button
+          type="button"
+          disabled={enviando}
+          onClick={() => void enviar(false)}
+          className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-300 hover:text-slate-800 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-300"
+        >
+          Não
+        </button>
+      </div>
+      {erro ? <p className="mt-2 text-xs text-amber-700 dark:text-amber-400">{erro}</p> : null}
+    </div>
+  )
+}

--- a/frontend/src/pages/kb-public/KbPublicContext.tsx
+++ b/frontend/src/pages/kb-public/KbPublicContext.tsx
@@ -26,6 +26,7 @@ const FALLBACK_BRANDING: Kb.PublicBranding = {
   cor_fundo: '#F8FAFC',
   cor_link: '#0D9488',
   exibir_marca_deskrudder: true,
+  feedback_habilitado: true,
 }
 
 export function KbPublicProvider({ children }: { children: ReactNode }) {

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -58,6 +58,8 @@ import { WhatsappComposerBar } from './WhatsappComposerBar'
 import { WhatsappPreviaAnexo } from './WhatsappPreviaAnexo'
 import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
 import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
+import { useChatHub } from '../../contexts/ChatHubContext'
+import { ChatFilaAguardandoSheet } from '../../components/chat/ChatFilaAguardandoSheet'
 import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
 import { rotuloDownloadArquivo, visualTipoArquivo } from '../../lib/fileTypeIcon'
 import { CONTATO_CLIENTE } from '../../constants/contatoClienteLabels'
@@ -292,6 +294,8 @@ export function WhatsappConversa() {
   const [demandasReloadKey, setDemandasReloadKey] = useState(0)
   const [demandasTimeline, setDemandasTimeline] = useState<WhatsappChats.Demanda[]>([])
   const [modalEncerrar, setModalEncerrar] = useState(false)
+  const [filaAguardandoAberta, setFilaAguardandoAberta] = useState(false)
+  const { filaCount } = useChatHub()
   const navigate = useNavigate()
   const location = useLocation()
   const [searchParams] = useSearchParams()
@@ -957,6 +961,25 @@ useEffect(() => {
 
           <div className="flex items-center gap-2">
 
+            {modoHub && (
+              <Button
+                type="button"
+                variant="secondary"
+                className="relative h-8 shrink-0 px-2.5 text-xs font-semibold md:hidden"
+                onClick={() => setFilaAguardandoAberta(true)}
+                aria-label={
+                  filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'
+                }
+              >
+                Aguardando
+                {filaCount > 0 && (
+                  <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
+                    {filaCount > 99 ? '99+' : filaCount}
+                  </span>
+                )}
+              </Button>
+            )}
+
              {!encerrado && (
 
               <>
@@ -1434,6 +1457,13 @@ useEffect(() => {
             📥 Baixar Imagem
           </a>
         </div>
+      )}
+
+      {modoHub && (
+        <ChatFilaAguardandoSheet
+          open={filaAguardandoAberta}
+          onClose={() => setFilaAguardandoAberta(false)}
+        />
       )}
       
     </div>

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -40,7 +40,7 @@ export function WhatsappHistorico() {
   const [ate, setAte] = useState(() => searchParams.get('ate') ?? '')
   const [estadoFiltro, setEstadoFiltro] = useState<FiltroEstadoHistorico>(() => {
     const v = searchParams.get('estado')
-    return (v as FiltroEstadoHistorico) || 'finalizados'
+    return (v as FiltroEstadoHistorico) || 'todos'
   })
 
   const historicoReturnPath = useMemo(
@@ -90,7 +90,7 @@ export function WhatsappHistorico() {
       setOffset(from)
       syncUrl(from)
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Falha ao carregar histórico.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao carregar atendimentos.'))
     } finally {
       setLoading(false)
     }
@@ -132,8 +132,8 @@ export function WhatsappHistorico() {
       {/* Header com Filtros Rápidos */}
       <header className="flex flex-col gap-6 border-b pb-6 dark:border-slate-800 md:flex-row md:items-end md:justify-between">
         <div className="space-y-1">
-          <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Histórico de Mensagens</h1>
-          <p className="text-sm text-slate-500">Consulte sessões finalizadas, aguardando avaliação e chats em aberto (conforme filtro).</p>
+          <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Atendimentos</h1>
+          <p className="text-sm text-slate-500">Acompanhe todo o ciclo dos chats — em andamento, aguardando e finalizados.</p>
         </div>
 
         <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:justify-between flex-1">
@@ -154,12 +154,10 @@ export function WhatsappHistorico() {
               value={estadoFiltro}
               onChange={(value) => setEstadoFiltro(value as FiltroEstadoHistorico)}
               options={[
-                { value: 'finalizados', label: 'Finalizados (padrão)' },
-                { value: 'encerrado', label: 'Encerrados' },
-                { value: 'aguardando_avaliacao', label: 'Aguardando avaliação' },
-                { value: 'em_atendimento', label: 'Em atendimento' },
-                { value: 'aguardando_atendente', label: 'Aguardando atendente' },
                 { value: 'todos', label: 'Todos' },
+                { value: 'em_atendimento', label: 'Em andamento' },
+                { value: 'aguardando_atendente', label: 'Aguardando' },
+                { value: 'finalizados', label: 'Finalizados' },
               ]}
             />
             <Input

--- a/frontend/src/pages/whatsapp/WhatsappLayout.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappLayout.tsx
@@ -38,7 +38,7 @@ export function WhatsappLayout() {
                 {isAvaliacoes
                   ? 'Chats com avaliação respondida pelos clientes'
                   : isHistorico
-                    ? 'Consulta de sessões finalizadas e chats em aberto'
+                    ? 'Todos os atendimentos — abertos, em espera e finalizados'
                     : 'Operação em tempo real'}
               </p>
             </div>
@@ -56,7 +56,7 @@ export function WhatsappLayout() {
             Atendimento
           </Link>
           <Link to="/whatsapp/historico" className={tabClass(isHistorico)}>
-            Histórico
+            Atendimentos
           </Link>
           {user?.role === 'admin' && (
             <Link to="/whatsapp/avaliacoes" className={tabClass(isAvaliacoes)}>

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -42,6 +42,27 @@ CATEGORY_MAP = {
     "changed": "melhorias",
 }
 
+_LEGACY_BRAND_RE = re.compile(r"DX/Duplexsoft|Duplexsoft|DX Connect|DX-Connect", re.IGNORECASE)
+
+
+def sanitize_release_text(text: str) -> str:
+    """Remove referências à marca legada em textos voltados ao usuário (release notes)."""
+    result = text
+    for old, new in (
+        (
+            "painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel",
+            "marca DeskRudder no login e em todo o painel",
+        ),
+        (
+            "assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel",
+            "marca DeskRudder no login e em todo o painel",
+        ),
+    ):
+        result = result.replace(old, new)
+    if _LEGACY_BRAND_RE.search(result) and "Identidade visual (#434)" in result:
+        return "Identidade visual (#434): marca DeskRudder no login e em todo o painel"
+    return result
+
 
 def _today_sp() -> str:
     return datetime.now(ZoneInfo("America/Sao_Paulo")).strftime("%Y-%m-%d")
@@ -78,7 +99,9 @@ def parse_changelog_unreleased(text: str) -> list[dict[str, str]]:
             continue
         bullet = re.match(r"^-\s+(.+)$", line.strip())
         if bullet:
-            changes.append({"category": current_cat, "text": bullet.group(1).strip()})
+            changes.append(
+                {"category": current_cat, "text": sanitize_release_text(bullet.group(1).strip())}
+            )
     return changes
 
 
@@ -120,7 +143,16 @@ def finalize_changelog_release(text: str, version: str, date: str) -> str:
 
 
 def build_payload(*, current_version: str | None, manifest: dict, upcoming: list[dict]) -> dict:
-    releases = manifest.get("releases") or []
+    releases = []
+    for rel in manifest.get("releases") or []:
+        entry = dict(rel)
+        entry["changes"] = [
+            {**ch, "text": sanitize_release_text(ch["text"])}
+            if isinstance(ch, dict) and isinstance(ch.get("text"), str)
+            else ch
+            for ch in entry.get("changes") or []
+        ]
+        releases.append(entry)
     current = None
     if current_version:
         for rel in releases:


### PR DESCRIPTION
## Summary

Promove para **staging** o lote acumulado em `main` desde o release #510 (`v26.07.001`):

- **#485** — Menu **Atendimentos** (ex-Histórico) com filtros por status
- **#484** — Aba **Aguardando** no hub de chat; atalho mobile na conversa WhatsApp para assumir chats da fila
- **#469** — Avaliação útil/não útil no portal `/kb`; contadores no admin e toggle nas configurações do portal
- **#511** — Sanitização de release notes (sem referências de identidade legada na API)

O `[Unreleased]` do CHANGELOG descreve o lote completo publicado neste deploy.

## Test plan

- [x] CI em `main` verde no merge do #512
- [ ] Após merge: deploy automático em `staging` (workflow Deploy)
- [ ] Smoke: hub `/chat` → aba Aguardando; mobile conversa WhatsApp → drawer fila
- [ ] Smoke: portal `/kb` → votar útil/não útil; admin vê totais
- [ ] Smoke: menu Atendimentos com filtros
- [ ] `/sobre` atualiza com nova CalVer após deploy