### PR TITLE
fix(whatsapp): loop de /demandas esgotava recursos do browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp: conversa em atendimento disparava loop de pedidos a `/demandas` (e esgotava recursos do browser com `ERR_INSUFFICIENT_RESOURCES`) — o painel de demandas já não notifica o pai no carregamento inicial
 - WhatsApp (#473): modal de encerramento deixava de carregar demandas — polling da conversa refazia o fetch e mantinha «A carregar demandas…» em loop; demanda passa a ser opcional quando o chat encerra por inatividade
 - WhatsApp (#472): banner «contato não identificado» persistia após vincular/cadastrar — polling/SSE com snapshot antigo sobrescrevia o vínculo; sidebar e header atualizam na hora
 - WhatsApp (#471): cache de mídia por mensagem reduz refetch de blobs e mitiga `ERR_INSUFFICIENT_RESOURCES` no carregamento de anexos

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -326,6 +326,10 @@ export function WhatsappConversa() {
     }
   }, [modalEncerrar, chat, msgs, toast])
 
+  const refrescarTimelineDemandas = useCallback(() => {
+    setDemandasReloadKey((k) => k + 1)
+  }, [])
+
   useEffect(() => {
     if (!id) return
     whatsappChats
@@ -717,7 +721,7 @@ useEffect(() => {
   async function handleEncerrado(atualizado: WhatsappChats.Chat) {
     setChat(atualizado)
     await Promise.all([carregar(), carregarSidebar()])
-    setDemandasReloadKey((k) => k + 1)
+    refrescarTimelineDemandas()
     toast.showSuccess(
       atualizado.estado === 'aguardando_avaliacao'
         ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
@@ -1052,10 +1056,10 @@ useEffect(() => {
 
         {chat && chat.estado === 'em_atendimento' && (
           <WhatsappDemandasPanel
-            key={`${chat.id}-${demandasReloadKey}`}
+            key={chat.id}
             chatId={chat.id}
             podeRegistrar={isResponsavel || isAdmin}
-            onDemandasChange={() => setDemandasReloadKey((k) => k + 1)}
+            onDemandasChange={refrescarTimelineDemandas}
           />
         )}
 
@@ -1402,7 +1406,7 @@ useEffect(() => {
           onClose={() => setModalTickets(false)}
           onSuccess={(atualizado) => {
             aplicarChatAtualizado(atualizado)
-            setDemandasReloadKey((k) => k + 1)
+            refrescarTimelineDemandas()
           }}
         />
       )}
@@ -1415,7 +1419,7 @@ useEffect(() => {
           msgs={msgs}
           onClose={() => setModalEncerrar(false)}
           onEncerrado={(atualizado) => void handleEncerrado(atualizado)}
-          onDemandasChange={() => setDemandasReloadKey((k) => k + 1)}
+          onDemandasChange={refrescarTimelineDemandas}
         />
       )}
 

--- a/frontend/src/pages/whatsapp/WhatsappDemandasPanel.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappDemandasPanel.tsx
@@ -40,12 +40,10 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
     try {
       const rows = await whatsappChats.demandas(chatId)
       setDemandas(rows)
-      onDemandasChange?.(rows.length)
     } catch {
       setDemandas([])
-      onDemandasChange?.(0)
     }
-  }, [chatId, onDemandasChange])
+  }, [chatId])
 
   useEffect(() => {
     setLoading(true)
@@ -68,7 +66,11 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
       const payload = demandaFormPayload(form)
       if (editandoId != null) {
         const row = await whatsappChats.atualizarDemanda(chatId, editandoId, payload)
-        setDemandas((prev) => prev.map((d) => (d.id === editandoId ? row : d)))
+        setDemandas((prev) => {
+          const next = prev.map((d) => (d.id === editandoId ? row : d))
+          onDemandasChange?.(next.length)
+          return next
+        })
         toast.showSuccess('Demanda atualizada.')
       } else {
         const row = await whatsappChats.registrarDemanda(chatId, payload)


### PR DESCRIPTION
## Summary
- Corrige loop infinito: `WhatsappDemandasPanel` já não chama `onDemandasChange` no carregamento inicial (só em criar/editar/excluir).
- `key` estável no painel e callback estável para refrescar a timeline — evita remount em cascata e `ERR_INSUFFICIENT_RESOURCES`.

## Test plan
- [ ] Abrir chat em atendimento e confirmar no Network que `/demandas` não dispara em loop
- [ ] Registrar/editar/excluir demanda e ver marco atualizar na timeline
- [ ] Encerrar atendimento com alteração de demanda no modal


Made with [Cursor](https://cursor.com)