### PR TITLE
docs(saas): épico DR, roadmap e revisão LP-02 (#519)

### DIFF
--- a/.github/planning-issue-bodies/DR-00-analise-vocabulario.md
+++ b/.github/planning-issue-bodies/DR-00-analise-vocabulario.md
@@ -1,0 +1,27 @@
+# DR-00 — Análise e vocabulário SaaS vs produto
+
+## Origem
+
+Planejamento 2026-07 — separar camada SaaS DeskRudder do produto por instância (incl. papel do KB).
+
+## Objetivo
+
+Documentar e publicar o vocabulário acordado; alinhar issues relacionadas (fechar #464; revisar #516; comentar #263, #170, #16).
+
+## Entrega
+
+- Análise: `.github/planning-issue-bodies/analises/saas-deskrudder-licencas-vs-produto.md`
+- Índice atualizado em `ISSUES_CRIADAS.md`
+- Comentários/hygiene nas issues referenciadas
+
+## Critérios de aceite
+
+- [ ] Análise versionada no repositório
+- [ ] Épico DR e filhas abertos no GitHub
+- [ ] #516 atualizada (sem reuso do chat `/kb`)
+- [ ] #464 fechada ou checklist atualizado (KB white-label entregue)
+- [ ] Comentários de roadmap em #263, #170, #16
+
+## Labels
+
+`documentation`, `epic`

--- a/.github/planning-issue-bodies/DR-01-modelo-licenca-cliente-saas.md
+++ b/.github/planning-issue-bodies/DR-01-modelo-licenca-cliente-saas.md
@@ -1,0 +1,43 @@
+# DR-01 — Modelo Licença / ClienteSaaS (backend)
+
+## Contexto
+
+Épico: DeskRudder SaaS — licenças e instâncias.
+
+A **instância comercial** DeskRudder precisa persistir os clientes pagantes (e trials): slug, status, datas de renovação, plano — ortogonal a `Rede`/`Empresa` do helpdesk na instância do cliente.
+
+## Objetivo
+
+Modelo de dados na BD da instância DeskRudder para registro SaaS.
+
+## Escopo
+
+### Dentro
+
+- Entidade(s) ex.: `ClienteSaaS` / `LicencaDeskRudder` com: nome, slug único, status (`trial` | `ativo` | `suspenso` | `churn`), `data_inicio`, `data_renovacao`, plano (texto/enum inicial), URL/host da instância, notas
+- Migration Alembic (head único)
+- Sem provisionamento automático nesta issue (DR-04)
+
+### Fora
+
+- UI (DR-03), API completa além do necessário para testes de modelo (API em DR-02)
+- Cobrança / gateway
+- Dados nas BD dos clientes provisionados
+
+## RBAC
+
+- Admin (e perfil comercial, se existir) na instância DeskRudder — detalhar em DR-02
+
+## Critérios de aceite
+
+- [ ] Migration aplica em ambiente limpo; `alembic heads` único
+- [ ] Constraints: slug único; status validado
+- [ ] Testes de modelo/repositório básicos
+
+## Dependências
+
+- Nenhuma de produto; #170 para URL/host real da instância
+
+## Labels
+
+`enhancement`, `backend`, `python`

--- a/.github/planning-issue-bodies/DR-02-api-admin-saas.md
+++ b/.github/planning-issue-bodies/DR-02-api-admin-saas.md
@@ -1,0 +1,45 @@
+# DR-02 — API admin SaaS (backend)
+
+## Contexto
+
+Parte de: DR-01 (modelo).
+
+## Objetivo
+
+API REST admin para CRUD de clientes SaaS / licenças e ações stub de provisionar/suspender.
+
+## Escopo
+
+### Dentro
+
+- `GET/POST /v1/saas/clientes` (ou prefixo acordado)
+- `GET/PATCH /v1/saas/clientes/{id}`
+- Ação suspender / reativar
+- Ação «registrar instância provisionada» (URL/host) sem orquestrar Docker ainda
+- Stub ou flag para «solicitar provisionamento» (implementação real em DR-04)
+- OpenAPI + testes (happy path + 403)
+
+### Fora
+
+- Orquestração shell/Docker (DR-04)
+- UI (DR-03)
+- Trial público (DR-07)
+
+## RBAC
+
+- `exigir_admin` (ou papel comercial dedicado na instância DeskRudder)
+- Não expor rotas em instâncias de clientes que não sejam a comercial (feature flag / config `SAAS_CONTROL_PLANE=true` ou similar)
+
+## Critérios de aceite
+
+- [ ] CRUD funciona com testes
+- [ ] 403 para atendente sem permissão
+- [ ] Feature isolada à instância control-plane (não vazar para instâncias de clientes)
+
+## Dependências
+
+- Requer: DR-01
+
+## Labels
+
+`enhancement`, `backend`, `python`

--- a/.github/planning-issue-bodies/DR-03-ui-painel-licencas.md
+++ b/.github/planning-issue-bodies/DR-03-ui-painel-licencas.md
@@ -1,0 +1,44 @@
+# DR-03 — UI painel de licenças (frontend)
+
+## Contexto
+
+Parte de: DR-02.
+
+## Objetivo
+
+Painel interno na instância DeskRudder para listar, criar e editar clientes SaaS / licenças; link para a URL da instância do cliente (onde vive o `/kb` daquele cliente).
+
+## Escopo
+
+### Dentro
+
+- Rota admin (ex. `/saas/licencas` ou sob Configurações)
+- Listagem com status e data de renovação
+- Formulário criar/editar
+- Link externo para host da instância
+- Mensagens de erro em português
+
+### Fora
+
+- Wizard de provisionamento Docker (DR-04)
+- Landing pública (DR-05 / #515)
+- Billing
+
+## RBAC
+
+- Visível só para admin (e comercial, se aplicável); menu oculto se control-plane desligado
+
+## Critérios de aceite
+
+- [ ] Admin vê listagem e detalhe
+- [ ] Atendente comum não acessa (UI + API)
+- [ ] Link da instância abre URL correta
+- [ ] `npm run build` passa
+
+## Dependências
+
+- Requer: DR-02
+
+## Labels
+
+`enhancement`, `frontend`, `ux`

--- a/.github/planning-issue-bodies/DR-04-provisionamento-instancias.md
+++ b/.github/planning-issue-bodies/DR-04-provisionamento-instancias.md
@@ -1,0 +1,44 @@
+# DR-04 — Provisionamento de instâncias a partir do painel
+
+## Contexto
+
+Parte do épico SaaS. Infra manual já existe (#170): `provision-client.sh`, `stack-client.sh`, `deploy/clients/`.
+
+## Objetivo
+
+A partir do painel DR-03, disparar (job/API) o provisionamento de uma nova instância para um `ClienteSaaS` (slug → subdomínio + Postgres + stack), com audit trail.
+
+## Escopo
+
+### Dentro
+
+- Integração com scripts/runbook existentes (ou worker que os invoca com segurança)
+- Status do job: pendente / em progresso / sucesso / falha
+- Atualizar host/URL no registro SaaS ao concluir
+- Documentar pré-requisitos de servidor (SSH, permissões) em `docs/` ou runbook
+
+### Fora
+
+- Redesign completo da infra (#170 continua dono do isolamento)
+- Billing
+- Path-based multi-tenant na mesma BD
+
+## RBAC
+
+- Só admin control-plane; ação auditable
+
+## Critérios de aceite
+
+- [ ] Ação «Provisionar» cria/atualiza stack para o slug
+- [ ] Falhas ficam registradas e visíveis na UI
+- [ ] Instância sobe com health ok (checklist alinhado a #170)
+- [ ] Não altera o modelo single-tenant (1 Postgres por cliente)
+
+## Dependências
+
+- Requer: DR-01, DR-02, DR-03 (mínimo)
+- Relacionado: #170
+
+## Labels
+
+`enhancement`, `backend`, `frontend`

--- a/.github/planning-issue-bodies/DR-05-landing-lp01-vinculo.md
+++ b/.github/planning-issue-bodies/DR-05-landing-lp01-vinculo.md
@@ -1,0 +1,29 @@
+# DR-05 — Landing LP-01 (vínculo ao épico SaaS)
+
+## Contexto
+
+Issue existente: [#515](https://github.com/lgustavoss/dx-connect/issues/515) — Landing page pública `deskrudder.com.br`.
+
+Esta issue **não duplica** #515: registra o vínculo ao épico SaaS e o alinhamento de copy do KB.
+
+## Objetivo
+
+Implementar #515 com copy correta:
+
+- KB como **benefício do produto**: cada cliente DeskRudder publica o próprio portal de manuais para o cliente final
+- Não apresentar `/kb` de `deskrudder.com.br` como o produto principal de marketing misturado com a home comercial
+- Slot para contato comercial (DR-06 / #516)
+
+## Critérios de aceite
+
+- [ ] Critérios de #515 atendidos
+- [ ] Copy do bloco KB alinhada à análise SaaS vs produto
+- [ ] Slot reservado para DR-06
+
+## Dependências
+
+- Implementação rastreada em #515
+
+## Labels
+
+`marketing`, `frontend`, `ux`

--- a/.github/planning-issue-bodies/DR-06-contato-comercial-landing.md
+++ b/.github/planning-issue-bodies/DR-06-contato-comercial-landing.md
@@ -1,0 +1,42 @@
+# DR-06 — Contato comercial na landing (canal B2B)
+
+## Contexto
+
+Issue existente revisada: [#516](https://github.com/lgustavoss/dx-connect/issues/516).
+
+**Decisão de produto (2026-07):** o chat do portal `/kb` serve o **cliente final** do cliente DeskRudder. O contato na landing é **prospect → comercial DeskRudder**. **Não** reutilizar `/kb/public/chat/*` nem `portal_chats` como canal de venda.
+
+## Objetivo
+
+Canal de contato na landing (`/`) da instância `deskrudder.com.br`: widget ou formulário + conversa/ticket no setor Comercial, domínio próprio (leads comerciais ou inbox dedicada).
+
+## Escopo
+
+### Dentro
+
+- UX «Fale conosco» na LP-01
+- Captura nome + e-mail (+ mensagem)
+- Roteamento para equipe comercial na instância DeskRudder
+- Modelo/API **separados** do portal KB do produto (pode inspirar UX, não compartilhar fila `/kb`)
+
+### Fora
+
+- Reuso de `portal_chats` / badge Portal do produto
+- Trial (DR-07)
+- CRM do produto CM02 (#322) — opcional integração futura
+
+## Critérios de aceite
+
+- [ ] Prospect inicia contato na landing; comercial DeskRudder recebe
+- [ ] Fluxo **não** passa por endpoints `/kb/public/chat/*`
+- [ ] `/kb` nas instâncias de clientes inalterado
+- [ ] `npm run build` / testes relevantes passam
+
+## Dependências
+
+- Requer: LP-01 / #515 (slot)
+- Substitui premissa antiga de #516
+
+## Labels
+
+`marketing`, `frontend`, `backend`, `ux`

--- a/.github/planning-issue-bodies/DR-07-trial-pre-cadastro.md
+++ b/.github/planning-issue-bodies/DR-07-trial-pre-cadastro.md
@@ -1,0 +1,38 @@
+# DR-07 — Trial / pré-cadastro
+
+## Contexto
+
+Ex-LP-03. Parte do épico SaaS (Fase 4 do roadmap).
+
+## Objetivo
+
+Formulário público (landing ou rota dedicada) que cria lead + licença em status `trial` e, quando DR-04 existir, dispara ou enfileira provisionamento.
+
+## Escopo
+
+### Dentro
+
+- Formulário: nome, e-mail, empresa, slug desejado
+- Cria registro SaaS `trial` com prazo configurável
+- Notifica equipe DeskRudder
+- Ligação opcional a DR-04
+
+### Fora
+
+- Gateway de pagamento
+- Trial self-service total sem revisão humana (pode ser v1 com aprovação manual)
+
+## Critérios de aceite
+
+- [ ] Submissão cria registro trial visível no painel DR-03
+- [ ] Validação de slug (formato + unicidade)
+- [ ] E-mail/notificação interna à equipe
+
+## Dependências
+
+- Requer: DR-01, DR-02, DR-03
+- Ideal: DR-04 para provision automático
+
+## Labels
+
+`enhancement`, `frontend`, `backend`, `marketing`

--- a/.github/planning-issue-bodies/DR-08-renovacoes-alertas.md
+++ b/.github/planning-issue-bodies/DR-08-renovacoes-alertas.md
@@ -1,0 +1,37 @@
+# DR-08 — Renovações e alertas
+
+## Contexto
+
+Parte do épico SaaS (Fase 4).
+
+## Objetivo
+
+Monitorar `data_renovacao` das licenças; alertar equipe DeskRudder; atualizar status (ex. vencido → suspenso) conforme regras.
+
+## Escopo
+
+### Dentro
+
+- Job periódico (ou check no login admin) para licenças próximas do vencimento
+- Notificação in-app e/ou e-mail interno
+- UI no painel: destaque «vence em X dias» / vencidas
+- Ação manual renovar (estender data) e suspender
+
+### Fora
+
+- Cobrança automática / boleto do *SaaS DeskRudder* (épico futuro de billing control-plane)
+- Suspender automaticamente a stack Docker (pode ser follow-up de DR-04)
+
+## Critérios de aceite
+
+- [ ] Lista mostra renovação e alertas
+- [ ] Equipe recebe aviso antes do vencimento (janela configurável)
+- [ ] Renovação manual atualiza data e status
+
+## Dependências
+
+- Requer: DR-01, DR-02, DR-03
+
+## Labels
+
+`enhancement`, `backend`, `frontend`

--- a/.github/planning-issue-bodies/DR-epic-saas-licencas-instancias.md
+++ b/.github/planning-issue-bodies/DR-epic-saas-licencas-instancias.md
@@ -1,0 +1,73 @@
+# [Épico] DeskRudder SaaS — licenças, instâncias e go-to-market
+
+## Contexto
+
+O DeskRudder é vendido para empresas que dão suporte a outros sistemas. Cada cliente pagante recebe uma **instância isolada** (subdomínio + PostgreSQL — #170) com o produto completo, incluindo o portal `/kb` white-label para o **cliente final dele**.
+
+Falta a **camada SaaS** na instância comercial (`deskrudder.com.br`): landing, contato comercial B2B, registro de licenças/renovações e orquestração de provisionamento.
+
+Análise: `.github/planning-issue-bodies/analises/saas-deskrudder-licencas-vs-produto.md`
+
+## Objetivo
+
+Entregar go-to-market + operação mínima de licenças:
+
+1. Landing pública e canal de contato comercial (prospect → DeskRudder)
+2. Modelo e painel de clientes SaaS / licenças (slug, status, renovação)
+3. Provisionamento de instâncias (manual → automático)
+4. Trial e alertas de renovação
+
+## Não confundir
+
+| Isto | Não é |
+|------|-------|
+| Painel de licenças DeskRudder | CM/FN (#321–#375) — módulos do produto na instância do cliente |
+| Contato comercial na LP | Chat do `/kb` (cliente final ↔ cliente DeskRudder) |
+| Portal #263 | Login do funcionário da rede na instância do cliente |
+
+## Fases
+
+| Fase | Issues | Entrega |
+|------|--------|---------|
+| **DR-F0** | DR-00 | Vocabulário / higiene (#464 fechar) |
+| **DR-F1** | DR-05, DR-06 | Landing + contato comercial |
+| **DR-F2** | DR-01, DR-02, DR-03 | Modelo + API + UI licenças (registro manual de instância já provisionada) |
+| **DR-F3** | DR-04, DR-07, DR-08 | Provision automático, trial, renovações |
+
+## Issues filhas
+
+| ID | Título | GitHub |
+|----|--------|--------|
+| DR-00 | Análise e vocabulário SaaS vs produto | [#520](https://github.com/lgustavoss/dx-connect/issues/520) fechada |
+| DR-01 | Modelo Licença / ClienteSaaS (backend) | [#521](https://github.com/lgustavoss/dx-connect/issues/521) |
+| DR-02 | API admin SaaS (backend) | [#522](https://github.com/lgustavoss/dx-connect/issues/522) |
+| DR-03 | UI painel de licenças (frontend) | [#523](https://github.com/lgustavoss/dx-connect/issues/523) |
+| DR-04 | Provisionamento de instâncias | [#524](https://github.com/lgustavoss/dx-connect/issues/524) |
+| DR-05 | Landing LP-01 — vínculo | [#525](https://github.com/lgustavoss/dx-connect/issues/525) / [#515](https://github.com/lgustavoss/dx-connect/issues/515) |
+| DR-06 | Contato comercial na landing | [#526](https://github.com/lgustavoss/dx-connect/issues/526) / [#516](https://github.com/lgustavoss/dx-connect/issues/516) |
+| DR-07 | Trial / pré-cadastro | [#527](https://github.com/lgustavoss/dx-connect/issues/527) |
+| DR-08 | Renovações e alertas | [#528](https://github.com/lgustavoss/dx-connect/issues/528) |
+
+Épico: [#519](https://github.com/lgustavoss/dx-connect/issues/519)
+
+## Relacionado
+
+- Deploy: #170
+- Portal KB entregue: #464
+- Portal funcionário: #263
+- Produto CM/FN: #321–#328
+- Meta: #16
+
+## Fora do v1
+
+- Billing automático via gateway de pagamento do *produto DeskRudder*
+- Login do cliente final no control-plane SaaS
+- Path `www.deskrudder.com.br/cliente01` como isolamento (usa-se subdomínio)
+
+## Labels
+
+`epic`, `enhancement`, `fase-interna`
+
+## Roadmap
+
+Ver fases 0–4 em `ISSUES_CRIADAS.md` (seção SaaS / roadmap).

--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -13,15 +13,17 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | RT | [#256](https://github.com/lgustavoss/dx-connect/issues/256) | #264–#269 |
 | T | [#257](https://github.com/lgustavoss/dx-connect/issues/257) | #270–#273 |
 | R | [#258](https://github.com/lgustavoss/dx-connect/issues/258) | #274–#276 |
-| S | [#259](https://github.com/lgustavoss/dx-connect/issues/259) | #277–#281 · follow-ups [#416](https://github.com/lgustavoss/dx-connect/issues/416)–[#418](https://github.com/lgustavoss/dx-connect/issues/418) fechados · [#419](https://github.com/lgustavoss/dx-connect/issues/419) backlog |
+| S | [#259](https://github.com/lgustavoss/dx-connect/issues/259) | #277–#281 · follow-ups [#416](https://github.com/lgustavoss/dx-connect/issues/416)–[#418](https://github.com/lgustavoss/dx-connect/issues/418) fechados · [#419](https://github.com/lgustavoss/dx-connect/issues/419) Fase 4 roadmap |
 | D | [#260](https://github.com/lgustavoss/dx-connect/issues/260) | #282–#289 |
 | A | [#261](https://github.com/lgustavoss/dx-connect/issues/261) | #290–#292 fechados · PR [#428](https://github.com/lgustavoss/dx-connect/pull/428) |
-| KB | [#262](https://github.com/lgustavoss/dx-connect/issues/262) | #293–#295, #297–#299 fechados · #296 backlog |
-| P | [#263](https://github.com/lgustavoss/dx-connect/issues/263) | #300–#308 |
+| KB | [#262](https://github.com/lgustavoss/dx-connect/issues/262) | #293–#295, #297–#299 fechados · #296 fechada · portal público [#464](https://github.com/lgustavoss/dx-connect/issues/464) fechado |
+| P | [#263](https://github.com/lgustavoss/dx-connect/issues/263) | #300–#308 · **Fase 3** roadmap |
 
 ---
 
-## Comercial / financeiro (2026-06-18)
+## Comercial / financeiro (2026-06-18) — **módulos do produto** (Fase 2 roadmap)
+
+> Não confundir com o painel de **licenças SaaS** (#519). CM/FN roda **dentro** da instância do cliente DeskRudder.
 
 | Prefixo | Épico | Issues filhas |
 |---------|-------|---------------|
@@ -92,7 +94,7 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 | [#297](https://github.com/lgustavoss/dx-connect/issues/297) | Editor admin (v1 markdown) | Fechada · branch `feat/kb-v1` |
 | [#298](https://github.com/lgustavoss/dx-connect/issues/298) | Gestão categorias + DnD ordem | Fechada · branch `feat/kb-v1` |
 | [#299](https://github.com/lgustavoss/dx-connect/issues/299) | Consulta interna + cache offline | Fechada · branch `feat/kb-v1` |
-| [#296](https://github.com/lgustavoss/dx-connect/issues/296) | Sugestões por natureza/motivo | Backlog |
+| [#296](https://github.com/lgustavoss/dx-connect/issues/296) | Sugestões por natureza/motivo | Fechada |
 
 ---
 
@@ -115,9 +117,57 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 
 ---
 
+## Marketing / landing DeskRudder (2026-07)
+
+| Rascunho | Título | Issue GitHub |
+|----------|--------|--------------|
+| [`LP-01-landing-page-marketing.md`](LP-01-landing-page-marketing.md) | Landing pública — deskrudder.com.br | [#515](https://github.com/lgustavoss/dx-connect/issues/515) |
+| [`LP-02-landing-chat-comercial.md`](LP-02-landing-chat-comercial.md) | Contato comercial B2B (não reusa `/kb`) | [#516](https://github.com/lgustavoss/dx-connect/issues/516) revisada |
+
+---
+
+## SaaS DeskRudder — licenças e instâncias (2026-07)
+
+Análise: [`analises/saas-deskrudder-licencas-vs-produto.md`](analises/saas-deskrudder-licencas-vs-produto.md)
+
+**Duas camadas:** (1) SaaS DeskRudder — LP, licenças, provisionar instâncias; (2) produto por instância — helpdesk, KB white-label do cliente, CM/FN, portal #263.
+
+Épico: [#519](https://github.com/lgustavoss/dx-connect/issues/519)
+
+| Prefixo | Issue | Título | Estado |
+|---------|-------|--------|--------|
+| DR-00 | [#520](https://github.com/lgustavoss/dx-connect/issues/520) | Análise / vocabulário | Fechada |
+| DR-01 | [#521](https://github.com/lgustavoss/dx-connect/issues/521) | Modelo Licença / ClienteSaaS | Aberta |
+| DR-02 | [#522](https://github.com/lgustavoss/dx-connect/issues/522) | API admin SaaS | Aberta |
+| DR-03 | [#523](https://github.com/lgustavoss/dx-connect/issues/523) | UI painel de licenças | Aberta |
+| DR-04 | [#524](https://github.com/lgustavoss/dx-connect/issues/524) | Provisionamento via painel | Aberta |
+| DR-05 | [#525](https://github.com/lgustavoss/dx-connect/issues/525) / [#515](https://github.com/lgustavoss/dx-connect/issues/515) | Landing LP-01 | Aberta |
+| DR-06 | [#526](https://github.com/lgustavoss/dx-connect/issues/526) / [#516](https://github.com/lgustavoss/dx-connect/issues/516) | Contato comercial LP | Aberta |
+| DR-07 | [#527](https://github.com/lgustavoss/dx-connect/issues/527) | Trial / pré-cadastro | Aberta |
+| DR-08 | [#528](https://github.com/lgustavoss/dx-connect/issues/528) | Renovações e alertas | Aberta |
+
+Corpos locais: `DR-epic-saas-licencas-instancias.md`, `DR-00`…`DR-08-*.md`
+
+### Roadmap de desenvolvimento (tudo entra — ordem)
+
+| Fase | Foco | Issues |
+|------|------|--------|
+| **0** | Higiene / vocabulário | #520 (feita); #464 fechado |
+| **1** | Go-to-market SaaS | #515, #516 → #521–#523 |
+| **2** | Produto CM/FN | #321 → #328 |
+| **3** | Portal funcionário | #263 / #300–#308 |
+| **4** | SaaS avançado + polish | #524, #527, #528; #120–#124; #419; fechar #170 |
+
+Hotfixes de produção furam a fila. CM/FN (#321–#375) = módulos **do produto** na instância do cliente, não o painel de licenças.
+
+Portal KB white-label: [#464](https://github.com/lgustavoss/dx-connect/issues/464) **fechado** (entregue) — cada cliente publica `/kb` para o cliente final dele.
+
+---
+
 ## Análises de viabilidade (documentação)
 
 Material de apoio à decisão — **não** substitui issues no GitHub:
 
+- [`analises/saas-deskrudder-licencas-vs-produto.md`](analises/saas-deskrudder-licencas-vs-produto.md)
 - [`analises/integracao-retaguarda.md`](analises/integracao-retaguarda.md)
 - [`analises/filas-tickets-vs-chats.md`](analises/filas-tickets-vs-chats.md)

--- a/.github/planning-issue-bodies/LP-01-landing-page-marketing.md
+++ b/.github/planning-issue-bodies/LP-01-landing-page-marketing.md
@@ -1,0 +1,171 @@
+# [Marketing] Landing page pública — deskrudder.com.br
+
+## Contexto
+
+O **DeskRudder** (DX Connect) já possui rotas públicas (`/login`, `/kb`, `/avaliar-ticket`), mas não há uma **página institucional** na raiz do domínio para divulgação comercial.
+
+Hoje, quem acessa a URL do sistema tende a cair no **login** ou no painel autenticado. Para prospecção (redes de postos, coordenadores de suporte, gestores de TI), precisamos de uma landing em **`deskrudder.com.br/`** que apresente o produto e suas funcionalidades **já em operação**.
+
+**Marca:** DeskRudder — tagline «Organize. Foque. Direcione» (`frontend/src/brand/tokens.ts`).
+
+**Relacionado:** LP-02 / DR-06 (contato comercial B2B na landing — **não** o chat do `/kb` do produto). Esta issue cobre **somente** o conteúdo e layout da página; o canal de contato é entregue em LP-02.
+
+**Épico SaaS:** ver `DR-epic-saas-licencas-instancias.md` e análise `analises/saas-deskrudder-licencas-vs-produto.md`.
+
+## Objetivo
+
+Publicar uma landing page **responsiva**, em português, que:
+
+1. Explique o produto em linguagem de negócio (não técnica).
+2. Destaque módulos **já operacionais** (inventário abaixo).
+3. Direcione interessados para contato (espaço reservado para o widget LP-02) e clientes existentes para `/login`.
+4. Reutilize identidade visual DeskRudder (cores, logo, gradientes).
+5. Seja indexável (SEO básico: title, description, Open Graph).
+
+## Público-alvo
+
+- Gestores de TI / operações de redes de postos
+- Coordenadores de suporte e SAC
+- Donos de software house que revendem suporte
+- Prospects que chegam por indicação, LinkedIn, eventos, etc.
+
+## Inventário de funcionalidades (copy — só o que está em operação)
+
+Agrupar na landing em **blocos de valor** (4–6 cards), não em lista de issues:
+
+### 1. Atendimento multicanal
+- Tickets por e-mail e abertura manual — fila, prioridade, transferência, histórico
+- WhatsApp integrado (Evolution API) — inbox unificada, fila Aguardando/Atendendo, mídia, áudio, demandas por sessão
+- Hub de chat (`/chat`) — WhatsApp + chat interno num só lugar
+- Portal KB com chat ao vivo (#468) — visitante no `/kb` fala com atendente na mesma inbox
+
+### 2. Organização e produtividade da equipe
+- Setores e atendentes com RBAC (admin vs atendente, escopo por setor)
+- Distribuição automática de tickets (round-robin, menor carga)
+- Roteamento automático por regras (setor, prioridade, natureza, motivo)
+- Chat interno — direto 1:1, canais por setor, grupos, anexos, reações
+- Notificações em tempo real (SSE)
+
+### 3. SLA e visibilidade gerencial
+- Políticas de SLA por setor/prioridade/natureza
+- Calendário comercial e pausa automática
+- Alertas em risco/violado (e-mail + SSE)
+- Dashboards e relatórios exportáveis (CSV)
+
+### 4. Base de conhecimento
+- Manuais internos no menu Ajuda
+- Portal público `/kb` **por instância**: cada cliente DeskRudder publica os próprios manuais (marca/logo) para o **cliente final dele** — não misturar com a home comercial `deskrudder.com.br`
+- Chat ao vivo no portal do cliente (visitante ↔ atendentes daquele cliente)
+- Sugestão de manuais na classificação de tickets/demandas
+
+### 5. Cadastro e contexto do cliente
+- Redes, empresas e funcionários (sócio, supervisor, colaborador)
+- Vínculo de contato WhatsApp ao cadastro
+
+### 6. Governança e confiança
+- Auditoria expandida (ações, IP, request-id, exportação CSV)
+- Atendimento humano no WhatsApp (sem chatbot — decisão #122)
+- Deploy single-tenant por cliente (dados isolados por instância)
+
+> **Regra de copy:** não citar «em breve», roadmap ou features parciais.
+
+## Proposta de UX
+
+### Seções (scroll único)
+
+1. **Hero** — logo, tagline, subtítulo, CTA primário (área para LP-02) + secundário «Já sou cliente» → `/login`
+2. **Problema → solução** — caos de WhatsApp + e-mail + planilhas vs centralização
+3. **Funcionalidades** — 4–6 cards com ícone + título + 2 linhas (blocos acima)
+4. **Como funciona** — 3 passos: configure setores → atenda num hub → meça com dashboards
+5. **Diferenciais** — SLA, KB + chat no portal, chat interno, auditoria, atendimento humano
+6. **Público** — redes de postos, suporte B2B, equipes multicanal
+7. **CTA final** — reforço de contato (placeholder para widget LP-02)
+8. **Rodapé** — link login, e-mail institucional (constante/env), versão opcional, privacidade (quando existir)
+
+### Rascunho Hero (revisar na implementação)
+
+- **Título:** «Centralize o atendimento da sua rede em um só lugar»
+- **Subtítulo:** «Tickets, WhatsApp, base de conhecimento e SLA — com equipe organizada por setor e visibilidade em tempo real.»
+- **CTA secundário:** «Já sou cliente» → `/login`
+
+### Comportamento de rotas
+
+| Visitante | URL `/` | Demais rotas |
+|-----------|---------|--------------|
+| Anônimo | Landing pública | `/login`, `/kb`, etc. como hoje |
+| Autenticado | Redirecionar para dashboard (`/` → painel ou `/dashboard`) | Inalterado |
+
+> A landing **não** substitui `/kb` nem `/login`. É a home do domínio `deskrudder.com.br` para quem não está logado.
+
+## Escopo
+
+### Dentro
+
+- Página pública em `/` (visitante anônimo)
+- Copy centralizado em `frontend/src/content/landing.ts` (ou equivalente)
+- Layout marketing sem shell do painel (`MarketingLayout`)
+- Reuso de `brand/tokens.ts`, `BrandLogo`, Tailwind
+- Meta tags + Open Graph (imagem: lockup ou asset em `public/`)
+- Responsivo mobile-first (320px+)
+- `npm run build` sem regressão
+
+### Fora
+
+- Widget de chat (LP-02)
+- Depoimentos e logos de clientes
+- CMS/admin para editar textos
+- Formulário de lead com backend
+- Pré-cadastro e trial gratuito (épico futuro LP-03+)
+- Blog, pricing, comparativo com concorrentes
+- i18n, A/B testing, analytics (follow-ups)
+
+## Mapa técnico
+
+| Ação | Caminho provável |
+|------|------------------|
+| criar | `frontend/src/pages/marketing/LandingPage.tsx` |
+| criar | `frontend/src/pages/marketing/MarketingLayout.tsx` |
+| criar | `frontend/src/content/landing.ts` |
+| criar | `frontend/src/components/marketing/*` (seções Hero, Features, etc.) |
+| alterar | `frontend/src/App.tsx` — rota `/` pública + redirect se autenticado |
+| reutilizar | `frontend/src/brand/tokens.ts` |
+
+**Backend / migration:** não necessário.
+
+## RBAC
+
+- Rota 100% pública — sem auth.
+- Não expor URLs internas de clientes, credenciais ou dados de tenant.
+- Screenshots (se usados): ambiente demo/staging sanitizado.
+
+## Critérios de aceite
+
+- [ ] Visitante anônimo em `deskrudder.com.br/` vê a landing (não o login)
+- [ ] Usuário autenticado em `/` é redirecionado ao painel
+- [ ] Conteúdo cobre os 6 blocos de funcionalidades (sem prometer o que não existe)
+- [ ] Visual alinhado à marca DeskRudder
+- [ ] Layout responsivo — legível em mobile
+- [ ] CTA «Já sou cliente» leva a `/login`
+- [ ] Área reservada no layout para montar o widget de LP-02 (slot ou import futuro)
+- [ ] `<title>` e `meta description` preenchidos; Open Graph com imagem
+- [ ] Sem depoimentos de clientes na v1
+- [ ] `npm run build` passa
+
+## Dependências
+
+- Nenhuma issue bloqueante de backend.
+- **LP-02** depende desta issue (ou pode ser desenvolvida em paralelo se o slot do widget existir).
+
+## Deploy / infra (nota operacional)
+
+- `deskrudder.com.br` deve apontar para a **instância comercial/marketing** do DeskRudder (single-tenant).
+- Não confundir com subdomínios de clientes (`cliente.connect...`).
+
+## Labels
+
+`marketing`, `frontend`, `ux`, `fase-interna`
+
+## Próximo passo
+
+→ `/implementar-issue @LP-01-landing-page-marketing.md`  
+→ Em seguida: LP-02 (chat comercial na landing)

--- a/.github/planning-issue-bodies/LP-02-landing-chat-comercial.md
+++ b/.github/planning-issue-bodies/LP-02-landing-chat-comercial.md
@@ -1,0 +1,124 @@
+# [Marketing] Contato comercial na landing — canal B2B (LP-02)
+
+## Contexto
+
+Épico: **DeskRudder SaaS** (licenças, instâncias e go-to-market) + landing [#515](https://github.com/lgustavoss/dx-connect/issues/515).
+
+Parte de: **LP-01** (landing institucional) e **DR-06**.
+
+### Decisão de produto (2026-07)
+
+O DeskRudder é vendido para empresas de suporte. O portal `/kb` é **módulo do produto por instância**: cada cliente DeskRudder publica manuais (e chat opcional) para o **cliente final dele**.
+
+| Canal | Público | Objetivo |
+|-------|---------|----------|
+| Chat `/kb` na instância do cliente | Cliente final | Suporte / dúvida sobre manuais daquele cliente |
+| Contato na landing `deskrudder.com.br` | Prospect | Comercial DeskRudder (venda / demo) |
+
+**Não** reutilizar `/kb/public/chat/*`, `portal_chats` nem o badge «Portal» do produto como funil de venda.
+
+Análise: `.github/planning-issue-bodies/analises/saas-deskrudder-licencas-vs-produto.md`
+
+## Objetivo
+
+Exibir contato **«Fale conosco»** na landing (`/`) da instância comercial DeskRudder, com captura de lead (nome + e-mail + mensagem) e atendimento pela equipe comercial — domínio de dados **próprio** (não a fila do portal KB).
+
+## Pré-requisitos operacionais (fora do código)
+
+Na instância `deskrudder.com.br`:
+
+- [ ] Setor **Comercial** (ou equivalente)
+- [ ] Atendentes responsáveis por prospects
+- [ ] Processo para monitorar leads/conversas comerciais (inbox ou tickets dedicados)
+
+## Proposta técnica (v1)
+
+### Abordagem
+
+Canal B2B dedicado na superfície SaaS. Pode **inspirar** UX no widget do `/kb`, mas:
+
+- Novos endpoints e/ou modelo (ex. `comercial_leads` / conversas comerciais), **ou** ticket público no setor Comercial
+- **Não** chamar `POST /kb/public/chat/session`
+- **Não** misturar com `portal_chats` das instâncias de clientes
+
+### Arquivos / áreas prováveis
+
+| Ação | Caminho |
+|------|---------|
+| criar | API + modelo lead/conversa comercial (backend) |
+| criar | Widget/formulário na landing (`frontend/src/pages/marketing/` ou `components/marketing/`) |
+| alterar | `LandingPage` / slot CTA (LP-01) |
+| testes | Backend + smoke na instância comercial |
+
+### Textos sugeridos
+
+| Elemento | Copy |
+|----------|------|
+| Botão / CTA | «Fale conosco» |
+| Formulário | Nome + e-mail (+ mensagem) |
+| Título | «Tire dúvidas sobre o DeskRudder» |
+| Placeholder | «Como podemos ajudar?» |
+
+## Escopo
+
+### Dentro
+
+- Contato na landing LP-01
+- Persistência e atendimento na instância DeskRudder (comercial)
+- Graceful se canal desabilitado (landing não quebra)
+- `npm run build` / testes relevantes
+
+### Fora
+
+- Reuso da API/fila `/kb/public/chat/*`
+- Alterar comportamento do `/kb` nas instâncias de clientes
+- Trial / pré-cadastro (DR-07)
+- Painel completo de CRM produto (#322)
+- Provisionamento (DR-04)
+
+## RBAC e privacidade
+
+- Rotas públicas de captura — sem auth do visitante
+- Dados do prospect só na BD da **instância comercial** DeskRudder
+- Atendentes comercial/admin veem leads; não expor a outras instâncias
+
+## Critérios de aceite
+
+- [ ] Prospect inicia contato na landing; equipe comercial recebe
+- [ ] Fluxo **não** usa `/kb/public/chat/*` nem `portal_chats` do produto
+- [ ] `/kb` em instâncias de clientes permanece inalterado
+- [ ] Copy é de contato comercial DeskRudder
+- [ ] Landing não quebra se canal estiver desligado
+- [ ] `npm run build` passa
+
+## Testes
+
+- [ ] Fluxo visitante → comercial → resposta (staging instância comercial)
+- [ ] Regressão: chat `/kb` do produto em instância de cliente
+
+## Dependências
+
+- **Requer:** LP-01 / #515 (slot)
+- **Épico SaaS:** DR-06
+- **Relacionado:** DR-07 (trial), DR-01+ (licenças)
+
+## Ordem sugerida (mesmo lote com LP-01)
+
+1. LP-01 — layout landing + rota `/` (#515)
+2. LP-02 / DR-06 — canal comercial B2B
+3. Smoke ponta a ponta na instância comercial
+
+## Follow-ups
+
+- **DR-07** — trial / pré-cadastro
+- **DR-01…03** — painel de licenças
+- **DR-04** — provisionamento automático
+
+## Labels
+
+`marketing`, `frontend`, `backend`, `ux`, `fase-interna`
+
+## Próximo passo
+
+→ Implementar após ou junto com LP-01 na branch `feat/landing-deskrudder`  
+→ Body canônico também em `DR-06-contato-comercial-landing.md`

--- a/.github/planning-issue-bodies/README.md
+++ b/.github/planning-issue-bodies/README.md
@@ -6,7 +6,9 @@
 |------|------|
 | Issues abertas (texto, aceite, comentários) | **GitHub** — fonte da verdade |
 | Índice de épicos e números | [`ISSUES_CRIADAS.md`](ISSUES_CRIADAS.md) |
-| Análises / spikes de viabilidade | [`analises/`](analises/) |
+| Análises / spikes de viabilidade | [`analises/`](analises/) — inclui SaaS vs produto |
+
+Épico SaaS DeskRudder (licenças/instâncias): [#519](https://github.com/lgustavoss/dx-connect/issues/519).
 
 Não mantemos cópias locais do **corpo** de issues já publicadas no GitHub. Isso evita divergência entre repositório e o que o time revisa na issue.
 

--- a/.github/planning-issue-bodies/analises/saas-deskrudder-licencas-vs-produto.md
+++ b/.github/planning-issue-bodies/analises/saas-deskrudder-licencas-vs-produto.md
@@ -1,0 +1,96 @@
+# Análise — SaaS DeskRudder vs produto por instância
+
+**Data:** 2026-07-14  
+**Status:** decisão de vocabulário e roadmap (documentação)  
+**Não substitui** issues no GitHub — ver épico DR e índice em `ISSUES_CRIADAS.md`.
+
+---
+
+## Contexto
+
+O DeskRudder é um produto SaaS para **empresas que dão suporte a outros sistemas**. Havia confusão entre:
+
+1. Camada para **vender e operar** o DeskRudder (LP, licenças, instâncias)
+2. Módulos **dentro** de cada instância do cliente (helpdesk, KB, CRM, etc.)
+3. O papel do portal `/kb`
+
+Esta análise fixa o vocabulário e a relação com épicos existentes.
+
+---
+
+## Duas camadas
+
+| Camada | Quem usa | O que é |
+|--------|----------|---------|
+| **SaaS DeskRudder** | Equipe DeskRudder + prospects | Landing `deskrudder.com.br`, painel de licenças/instâncias, contato comercial B2B, trial/renovações |
+| **Produto (por instância)** | Atendentes do cliente; funcionários da rede (#263); cliente final no `/kb` | Helpdesk, KB white-label, CM/FN, portal autenticado do funcionário |
+
+**CM/FN (#321–#375)** = módulos do **produto** que o cliente DeskRudder usa no negócio dele (custos, CRM, contratos, NFe, boletos). **Não** é o painel de licenças SaaS.
+
+---
+
+## Personas
+
+| Persona | Onde age | Objetivo |
+|---------|----------|----------|
+| **Prospect** | Landing `deskrudder.com.br` | Conhecer o produto e falar com o comercial DeskRudder |
+| **Operador DeskRudder** | Instância comercial / painel SaaS | Gerir licenças, renovações, provisionar instâncias, atender leads |
+| **Cliente DeskRudder** (empresa de suporte) | Instância dela (`cliente01.deskrudder.com.br`) | Atender as redes/empresas que ela suporte; publicar manuais no `/kb` |
+| **Cliente final** | `/kb` (e futuramente portal #263) da **instância do cliente DeskRudder** | Consultar manuais / abrir ticket com o suporte que o atende |
+
+---
+
+## Papel do KB
+
+O portal `/kb` é **módulo do produto**, não canal SaaS:
+
+- Cada cliente DeskRudder cria **seu próprio** portal de manuais (marca, artigos, chat opcional) para o **cliente final dele**.
+- `cliente01` e `cliente02` têm KBs **diferentes** por isolamento de instância (Postgres + stack dedicados — #170).
+- Chat do `/kb` = cliente final ↔ atendentes **daquele** cliente DeskRudder.
+- **Não** reutilizar esse chat na landing comercial DeskRudder (público e objetivo distintos).
+
+Épico de produto [#464](https://github.com/lgustavoss/dx-connect/issues/464) (portal KB white-label) está **entregue** e deve ser fechado; não é trabalho da camada SaaS.
+
+---
+
+## URL de instância
+
+Decisão vigente (#170, `docs/DEPLOYMENT_ARCHITECTURE.md`):
+
+- **Subdomínio** por cliente: `cliente01.deskrudder.com.br`
+- **PostgreSQL dedicado** por cliente
+- O discurso `www.deskrudder.com.br/cliente01` = **slug** no painel SaaS (redirect/alias possível), **não** path compartilhando a mesma BD
+
+---
+
+## Relação com épicos existentes
+
+| Épico / faixa | Camada | Notas |
+|---------------|--------|-------|
+| #515, #516 | SaaS | LP + contato comercial (LP-02 revisada — sem chat `/kb`) |
+| Épico DR (novo) | SaaS | Licenças, provisionamento, trial, renovações |
+| #170 | Infra SaaS | Scripts/runbook; DR-04 orquestra via produto |
+| #321–#375 (CM/FN) | Produto | Roadmap Fase 2 |
+| #263 / #300–#308 | Produto | Portal funcionário — Fase 3 |
+| #464 / KB | Produto | Entregue — fechar |
+| #419, #120–#124 | Produto | Entram no roadmap (Fases 3–4); não “futuro eterno” |
+
+---
+
+## Roadmap resumido
+
+| Fase | Foco |
+|------|------|
+| 0 | Higiene, vocabulário, abrir issues DR |
+| 1 | Go-to-market SaaS: LP, contato comercial, painel licenças (manual + #170) |
+| 2 | CM/FN (#321 → #328) |
+| 3 | Portal funcionário (#263) |
+| 4 | Provision automático, trial, renovações; RBAC; SLA WhatsApp |
+
+Hotfixes de produção furam a fila.
+
+---
+
+## Conclusão
+
+Documentar e desenvolver a camada SaaS **em paralelo** ao aprofundamento do produto, sem misturar personas nem reutilizar o chat `/kb` para funil comercial. Tudo o que está no backlog aberto permanece no plano de entrega — a ordenação é por fase, não por descarte.


### PR DESCRIPTION
## Summary

- Documenta a camada **SaaS DeskRudder** (licenças, instâncias, go-to-market) vs módulos do **produto por instância**
- Versiona análise, bodies do épico [#519](https://github.com/lgustavoss/dx-connect/issues/519) (DR-00…08), LP-01/LP-02 revisada (contato comercial **sem** reusar chat `/kb`) e índice com roadmap em fases 0–4

## CHANGELOG (obrigatório se há mudança de produto)

- [x] N/A — apenas documentação de planejamento (`.github/planning-issue-bodies/`), sem mudança de produto em runtime

## Test plan

- [x] Revisar links das issues #519–#528 / #515–#516 no índice
- [x] CI (changelog/docs-only deve passar)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Épico SaaS e filhas já abertos no GitHub (#519–#528)
- [x] #464 fechada; higiene em #16, #170, #263
- [x] Próximo código: Fase 1 — #515 + #516 → #521–#523
