### PR TITLE
fix(notificacoes): toques de ticket e novo chat trocados

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- Sons de alerta: toque de **abertura de ticket** e de **novo chat** (fila WhatsApp/Portal) estavam trocados — ticket usa `notification.mp3` e chat na fila usa `alerta.mp3`
 - WhatsApp: conversa em atendimento disparava loop de pedidos a `/demandas` (e esgotava recursos do browser com `ERR_INSUFFICIENT_RESOURCES`) — o painel de demandas já não notifica o pai no carregamento inicial
 - WhatsApp (#473): modal de encerramento deixava de carregar demandas — polling da conversa refazia o fetch e mantinha «A carregar demandas…» em loop; demanda passa a ser opcional quando o chat encerra por inatividade
 - WhatsApp (#472): banner «contato não identificado» persistia após vincular/cadastrar — polling/SSE com snapshot antigo sobrescrevia o vínculo; sidebar e header atualizam na hora

--- a/frontend/public/sons/LEIA-ME.txt
+++ b/frontend/public/sons/LEIA-ME.txt
@@ -1,12 +1,14 @@
-Sons de alerta do DX Connect (pasta public/sons).
+Sons de alerta do DeskRudder (pasta public/sons).
 
 Cada evento usa um arquivo distinto para não se misturar na reprodução:
 
-  alerta.mp3           — ticket novo na fila (sem responsável)
-  ticket-mensagem.mp3  — nova mensagem em ticket já atribuído
-                         (fallback: notification.mp3, se existir)
-  wpp-fila.mp3         — cliente aguardando na fila WhatsApp (loop enquanto houver fila)
-  wpp-mensagem.mp3     — nova mensagem do cliente em chat WhatsApp em atendimento
+  notification.mp3   — ticket novo na fila (sem responsável)
+  ticket-mensagem.mp3 — nova mensagem em ticket já atribuído
+                        (fallback: notification.mp3, se faltar o ficheiro)
+  alerta.mp3         — cliente aguardando na fila WhatsApp / Portal
+                        (loop enquanto houver fila — «novo chat»)
+  wpp-mensagem.mp3   — nova mensagem do cliente em chat em atendimento
+                        (fallback: notification.mp3)
 
 Se um arquivo não existir ou o navegador bloquear autoplay, o sistema usa um beep
 sintetizado diferente por tipo de alerta (frequências distintas).

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -18,14 +18,15 @@ const POLL_STALE_GUARD_MS = 3000
 const ALERT_DEDUP_MS = 2000
 
 /** Tickets na fila sem responsável */
-const SOUND_TICKET_FILA = '/sons/alerta.mp3'
+const SOUND_TICKET_FILA = '/sons/notification.mp3'
 /** Nova mensagem em ticket já atribuído */
 const SOUND_TICKET_MENSAGEM = '/sons/ticket-mensagem.mp3'
 const SOUND_TICKET_MENSAGEM_FALLBACK = '/sons/notification.mp3'
-/** Cliente aguardando na fila WhatsApp (alerta contínuo) */
-const SOUND_WPP_FILA = '/sons/wpp-fila.mp3'
-/** Nova mensagem do cliente em chat WhatsApp em atendimento */
+/** Cliente aguardando na fila WhatsApp / Portal (alerta contínuo) */
+const SOUND_WPP_FILA = '/sons/alerta.mp3'
+/** Nova mensagem do cliente em chat WhatsApp / Portal em atendimento */
 const SOUND_WPP_MENSAGEM = '/sons/wpp-mensagem.mp3'
+const SOUND_WPP_MENSAGEM_FALLBACK = '/sons/notification.mp3'
 
 type AlertKind = 'ticket_fila' | 'ticket_mensagem' | 'wpp_fila_pulse' | 'wpp_mensagem'
 
@@ -186,6 +187,10 @@ function playSrcOnce(src: string, key: string, volume: number): Promise<void> {
     const onError = () => {
       if (key.startsWith('ticket_mensagem:') && src === SOUND_TICKET_MENSAGEM) {
         void playSrcOnce(SOUND_TICKET_MENSAGEM_FALLBACK, `${key}:fallback`, volume).then(finish)
+        return
+      }
+      if (key.startsWith('wpp_mensagem:') && src === SOUND_WPP_MENSAGEM) {
+        void playSrcOnce(SOUND_WPP_MENSAGEM_FALLBACK, `${key}:fallback`, volume).then(finish)
         return
       }
       const kind = key.split(':')[0] as AlertKind
@@ -442,6 +447,7 @@ function preloadSounds() {
     SOUND_TICKET_MENSAGEM_FALLBACK,
     SOUND_WPP_FILA,
     SOUND_WPP_MENSAGEM,
+    SOUND_WPP_MENSAGEM_FALLBACK,
   ]
   for (const src of sources) {
     getAudioElement(`preload:${src}`, src)


### PR DESCRIPTION
## Summary

- Corrige toques de alerta trocados: abertura de ticket usa `notification.mp3`; novo chat (fila WhatsApp/Portal) usa `alerta.mp3`
- Atualiza `LEIA-ME.txt` dos sons e CHANGELOG

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**

## Test plan

- [ ] Abrir ticket sem responsável → toque de ticket (`notification.mp3`)
- [ ] Novo chat na fila WhatsApp/Portal → toque de chat (`alerta.mp3`, inclusive loop da fila)
- [ ] CI verde

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] N/A — hotfix pontual de mapeamento de sons
- [ ] Opcional: acrescentar ficheiros dedicados `ticket-mensagem.mp3` / `wpp-mensagem.mp3` quando houver assets finais
