### PR TITLE
feat(whatsapp): aba Contatos e chat iniciado pelo atendente (#531)

### DIFF
--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -65,6 +65,7 @@ Meta-issue geral: [#16](https://github.com/lgustavoss/dx-connect/issues/16)
 
 | Issue | Título | Estado |
 |-------|--------|--------|
+| [#531](https://github.com/lgustavoss/dx-connect/issues/531) | Aba Contatos + chat iniciado pelo atendente | Aberta · `feat/whatsapp-contatos-outbound` |
 | [#431](https://github.com/lgustavoss/dx-connect/issues/431) | Mídia inbound webhook + UI | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
 | [#432](https://github.com/lgustavoss/dx-connect/issues/432) | Barra de anexos e pré-visualização | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |
 | [#433](https://github.com/lgustavoss/dx-connect/issues/433) | Banner «Sem vínculo» | Fechada · PR [#439](https://github.com/lgustavoss/dx-connect/pull/439) |

--- a/.github/planning-issue-bodies/issues/whatsapp-contatos-outbound.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-contatos-outbound.md
@@ -1,0 +1,13 @@
+# WhatsApp: aba Contatos e chat iniciado pelo atendente
+
+Issue: https://github.com/lgustavoss/dx-connect/issues/531
+
+## Contexto
+Hoje o chat WhatsApp só nasce quando o cliente envia a primeira mensagem. O atendente precisa poder retomar contato (ex.: atualizar andamento de uma demanda) pelo WhatsApp do cliente.
+
+## Escopo
+- Nova aba **Contatos** no hub `/chat`
+- Lista de funcionários com badge da empresa e telefone
+- Iniciar a partir de contato, número avulso ou chat encerrado
+- Chat já em `em_atendimento` com o iniciador como responsável
+- Campo `telefone` em `funcionarios_rede`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ## [Unreleased]
 
+### Melhorias
+
+- WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede
+
 ### Correções
 
 - Sons de alerta: toque de **abertura de ticket** e de **novo chat** (fila WhatsApp/Portal) estavam trocados — ticket usa `notification.mp3` e chat na fila usa `alerta.mp3`

--- a/backend/alembic/versions/068_func_rede_telefone.py
+++ b/backend/alembic/versions/068_func_rede_telefone.py
@@ -1,0 +1,24 @@
+"""funcionarios_rede.telefone para contato WhatsApp outbound (#531).
+
+Revision ID: 068_func_rede_telefone
+Revises: 067_portal_chat_avaliacao_midia
+Create Date: 2026-07-15
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "068_func_rede_telefone"
+down_revision = "067_portal_chat_avaliacao_midia"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("funcionarios_rede", sa.Column("telefone", sa.String(length=20), nullable=True))
+    op.create_index("ix_funcionarios_rede_telefone", "funcionarios_rede", ["telefone"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_funcionarios_rede_telefone", table_name="funcionarios_rede")
+    op.drop_column("funcionarios_rede", "telefone")

--- a/backend/app/api/funcionarios_rede.py
+++ b/backend/app/api/funcionarios_rede.py
@@ -54,6 +54,7 @@ def _para_read(f: FuncionarioRede) -> FuncionarioRedeRead:
         id=f.id,
         nome=f.nome,
         email=f.email,
+        telefone=getattr(f, "telefone", None),
         tipo=f.tipo,
         escopo_empresas=escopo_efetivo(f),
         ativo=f.ativo,
@@ -186,6 +187,7 @@ def criar(
     f = FuncionarioRede(
         nome=data.nome,
         email=email_eff,
+        telefone=data.telefone,
         tipo=data.tipo,
         escopo_empresas=escopo,
         ativo=data.ativo,

--- a/backend/app/api/redes.py
+++ b/backend/app/api/redes.py
@@ -147,6 +147,7 @@ def listar_funcionarios_da_rede(
                 id=f.id,
                 nome=f.nome,
                 email=f.email,
+                telefone=getattr(f, "telefone", None),
                 tipo=f.tipo,
                 ativo=f.ativo,
                 rede_id=f.rede_id,

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -28,6 +28,8 @@ from app.schemas.whatsapp_chat import (
     WhatsappChatDemandaUpdate,
     WhatsappChatMensagemCreate,
     WhatsappChatRead,
+    WhatsappContatoRead,
+    WhatsappIniciarChatBody,
     WhatsappMensagemRead,
     WhatsappTransferirChatBody,
     WhatsappVincularFuncionarioBody,
@@ -57,6 +59,8 @@ from app.services.whatsapp_avaliacao import mensagem_oculta_na_conversa
 from app.services.whatsapp_media_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
 from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
 from app.services.ticket_distribuicao import pos_criar_ticket_na_fila
+from app.services.protocolo_mensal import gerar_protocolo_chat
+from app.services.audit_operacional import audit_whatsapp_chat
 
 router = APIRouter(prefix="/whatsapp/chats", tags=["whatsapp-chats"])
 
@@ -764,6 +768,7 @@ def buscar_funcionarios(
                 id=func.id,
                 nome=func.nome,
                 email=func.email,
+                telefone=getattr(func, "telefone", None),
                 tipo=func.tipo,
                 empresas=_empresas_funcionario(db, func),
             )
@@ -792,6 +797,227 @@ def catalogo_funcionarios(
         redes=[WhatsappRedeCatalogoRead(id=r.id, nome=r.nome) for r in redes],
         empresas=[WhatsappEmpresaCatalogoRead(id=e.id, nome=_empresa_nome_exibicao(e) or e.nome, rede_id=int(e.rede_id)) for e in empresas],
     )
+
+
+def _normalize_wa_id(raw: str | None) -> str:
+    digits = re.sub(r"\D", "", raw or "")
+    if not digits:
+        raise HTTPException(status_code=400, detail="Informe um número WhatsApp válido.")
+    # Aceita com ou sem DDI; se 10–11 dígitos BR, prefixa 55
+    if len(digits) in (10, 11) and not digits.startswith("55"):
+        digits = "55" + digits
+    if len(digits) < 12:
+        raise HTTPException(status_code=400, detail="Número WhatsApp incompleto.")
+    return digits
+
+
+def _chat_aberto_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
+    return (
+        db.query(WhatsappChat)
+        .options(*_CHAT_LOAD_OPTIONS)
+        .filter(
+            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.estado.in_(("aguardando_atendente", "em_atendimento")),
+        )
+        .order_by(WhatsappChat.id.desc())
+        .first()
+    )
+
+
+@router.get("/contatos", response_model=ListaPaginada[WhatsappContatoRead])
+def listar_contatos(
+    busca: str | None = Query(None, description="Nome, e-mail, telefone ou empresa"),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    rede_ids = [int(r[0]) for r in db.query(Rede.id).filter(Rede.tenant_id == atendente.tenant_id).all()]
+    empresa_ids = [int(r[0]) for r in db.query(Empresa.id).filter(Empresa.tenant_id == atendente.tenant_id).all()]
+    func_ids_junction = [
+        int(r[0])
+        for r in db.query(FuncionarioRedeEmpresa.funcionario_id)
+        .join(Empresa, Empresa.id == FuncionarioRedeEmpresa.empresa_id)
+        .filter(Empresa.tenant_id == atendente.tenant_id)
+        .distinct()
+        .all()
+    ]
+    filtros = []
+    if rede_ids:
+        filtros.append(FuncionarioRede.rede_id.in_(rede_ids))
+    if empresa_ids:
+        filtros.append(FuncionarioRede.empresa_id.in_(empresa_ids))
+    if func_ids_junction:
+        filtros.append(FuncionarioRede.id.in_(func_ids_junction))
+    if not filtros:
+        return ListaPaginada(items=[], total=0)
+
+    q = db.query(FuncionarioRede).filter(FuncionarioRede.ativo.is_(True), or_(*filtros))
+    term_raw = (busca or "").strip()
+    if term_raw:
+        term = f"%{term_raw}%"
+        digits = re.sub(r"\D", "", term_raw)
+        conds = [
+            FuncionarioRede.nome.ilike(term),
+            FuncionarioRede.email.ilike(term),
+        ]
+        if digits:
+            conds.append(FuncionarioRede.telefone.ilike(f"%{digits}%"))
+        # empresas por nome: filtramos após ou via subquery
+        emp_ids_match = [
+            int(r[0])
+            for r in db.query(Empresa.id)
+            .filter(
+                Empresa.tenant_id == atendente.tenant_id,
+                or_(
+                    Empresa.nome.ilike(term),
+                    Empresa.nome_fantasia.ilike(term),
+                    Empresa.razao_social.ilike(term),
+                ),
+            )
+            .all()
+        ]
+        if emp_ids_match:
+            sub_j = db.query(FuncionarioRedeEmpresa.funcionario_id).filter(
+                FuncionarioRedeEmpresa.empresa_id.in_(emp_ids_match)
+            )
+            conds.append(FuncionarioRede.empresa_id.in_(emp_ids_match))
+            conds.append(FuncionarioRede.id.in_(sub_j))
+        q = q.filter(or_(*conds))
+
+    total = q.count()
+    rows = q.order_by(FuncionarioRede.nome.asc(), FuncionarioRede.id.asc()).offset(offset).limit(limit).all()
+    redes_cache: dict[int, str] = {
+        int(r.id): r.nome
+        for r in db.query(Rede).filter(Rede.tenant_id == atendente.tenant_id).all()
+    }
+    items: list[WhatsappContatoRead] = []
+    for func in rows:
+        if _funcionario_no_tenant(db, atendente, func.id) is None:
+            continue
+        rid = rede_id_efetiva(db, func)
+        items.append(
+            WhatsappContatoRead(
+                id=func.id,
+                nome=func.nome,
+                email=func.email,
+                telefone=getattr(func, "telefone", None),
+                tipo=func.tipo,
+                empresas=_empresas_funcionario(db, func),
+                rede_id=rid,
+                rede_nome=redes_cache.get(int(rid)) if rid is not None else None,
+            )
+        )
+    return ListaPaginada(items=items, total=total)
+
+
+@router.post("/iniciar", response_model=WhatsappChatRead)
+def iniciar_chat_outbound(
+    data: WhatsappIniciarChatBody,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Atendente inicia contacto WhatsApp (contato cadastrado, número avulso ou retoma)."""
+    func: FuncionarioRede | None = None
+    if data.funcionario_id is not None:
+        func = _funcionario_no_tenant(db, atendente, data.funcionario_id)
+        if not func:
+            raise HTTPException(status_code=404, detail="Funcionário não encontrado")
+        if not func.ativo:
+            raise HTTPException(status_code=400, detail="Funcionário inativo")
+
+    telefone_body = data.telefone
+    telefone_cadastro = re.sub(r"\D", "", getattr(func, "telefone", None) or "") if func else ""
+    telefone_raw = telefone_body or telefone_cadastro or None
+    if not telefone_raw:
+        raise HTTPException(
+            status_code=400,
+            detail="Informe o número WhatsApp do contato (cadastro ou neste pedido).",
+        )
+    wa_id = _normalize_wa_id(telefone_raw)
+
+    if func is not None and not telefone_cadastro:
+        func.telefone = wa_id
+        db.flush()
+
+    empresa_id: int | None = None
+    if func is not None:
+        emps = _empresas_funcionario(db, func)
+        if len(emps) == 1:
+            empresa_id = emps[0].id
+        elif getattr(func, "empresa_id", None):
+            empresa_id = int(func.empresa_id)
+
+    existente = _chat_aberto_por_wa_id(db, wa_id)
+    if existente:
+        if existente.estado == "em_atendimento" and existente.atendente_id not in (None, atendente.id):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Já existe um atendimento aberto deste contacto com outro responsável.",
+            )
+        estado_anterior = existente.estado
+        if existente.estado == "aguardando_atendente" or existente.atendente_id is None:
+            existente.estado = "em_atendimento"
+            existente.atendente_id = atendente.id
+            existente.atendimento_inicio_at = datetime.now(timezone.utc)
+            if func is not None and not existente.funcionario_rede_id:
+                existente.funcionario_rede_id = func.id
+            if empresa_id is not None and not existente.empresa_id:
+                existente.empresa_id = empresa_id
+            audit_whatsapp_chat(
+                db,
+                chat_id=existente.id,
+                action="assign",
+                atendente_id=atendente.id,
+                payload={"de_estado": estado_anterior, "protocolo": existente.protocolo, "origem": "iniciar_outbound"},
+            )
+            db.commit()
+            db.refresh(existente)
+            emit_chat_fila_from_model(db, existente, estado_anterior=estado_anterior)
+        msg_init = (data.mensagem_inicial or "").strip()
+        if msg_init:
+            try:
+                _enviar_texto_whatsapp(db, chat=existente, texto=msg_init, atendente=atendente, evento_sistema=None)
+            except HTTPException:
+                raise
+        c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == existente.id).first()
+        assert c is not None
+        return _chat_read(db, c)
+
+    # Garante Evolution configurada se houver mensagem inicial (criar chat sem msg ainda exige settings para uso posterior)
+    _settings_envio(db)
+
+    chat = WhatsappChat(
+        protocolo=gerar_protocolo_chat(db),
+        wa_id=wa_id,
+        cliente_nome=(func.nome if func else None),
+        estado="em_atendimento",
+        atendente_id=atendente.id,
+        atendimento_inicio_at=datetime.now(timezone.utc),
+        setor_id=None,
+        funcionario_rede_id=func.id if func else None,
+        empresa_id=empresa_id,
+    )
+    db.add(chat)
+    db.flush()
+    audit_whatsapp_chat(
+        db,
+        chat_id=chat.id,
+        action="create",
+        atendente_id=atendente.id,
+        payload={"protocolo": chat.protocolo, "origem": "iniciar_outbound", "wa_id": wa_id},
+    )
+    db.commit()
+    db.refresh(chat)
+    emit_chat_fila_from_model(db, chat, estado_anterior=None)
+
+    msg_init = (data.mensagem_inicial or "").strip()
+    if msg_init:
+        _enviar_texto_whatsapp(db, chat=chat, texto=msg_init, atendente=atendente, evento_sistema=None)
+
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat.id).first()
+    assert c is not None
+    return _chat_read(db, c)
 
 
 @router.get("/{chat_id}", response_model=WhatsappChatRead)

--- a/backend/app/models/funcionario_rede.py
+++ b/backend/app/models/funcionario_rede.py
@@ -20,6 +20,7 @@ class FuncionarioRede(Base):
     id = Column(Integer, primary_key=True, index=True)
     nome = Column(String(255), nullable=False)
     email = Column(String(255), nullable=True, index=True)  # opcional (#444); único por rede quando preenchido
+    telefone = Column(String(20), nullable=True, index=True)  # WhatsApp (#531); só dígitos
     tipo = Column(String(20), nullable=False)  # socio | supervisor | colaborador
     escopo_empresas = Column(String(20), nullable=False, default="selected")  # all | selected
     ativo = Column(Boolean, default=True)

--- a/backend/app/schemas/funcionario_rede.py
+++ b/backend/app/schemas/funcionario_rede.py
@@ -8,9 +8,17 @@ def _email_vazio_para_none(v: object) -> object:
     return v
 
 
+def _telefone_normalizado(v: object) -> str | None:
+    if v is None or (isinstance(v, str) and not v.strip()):
+        return None
+    digits = "".join(ch for ch in str(v) if ch.isdigit())
+    return digits or None
+
+
 class FuncionarioRedeBase(BaseModel):
     nome: str
     email: EmailStr | None = None
+    telefone: str | None = None
     tipo: str  # socio | supervisor | colaborador
     escopo_empresas: str = "selected"  # all | selected
     ativo: bool = True
@@ -19,6 +27,11 @@ class FuncionarioRedeBase(BaseModel):
     @classmethod
     def email_opcional(cls, v: object) -> object:
         return _email_vazio_para_none(v)
+
+    @field_validator("telefone", mode="before")
+    @classmethod
+    def telefone_opcional(cls, v: object) -> str | None:
+        return _telefone_normalizado(v)
 
 
 class FuncionarioRedeCreate(FuncionarioRedeBase):
@@ -30,6 +43,7 @@ class FuncionarioRedeCreate(FuncionarioRedeBase):
 class FuncionarioRedeUpdate(BaseModel):
     nome: str | None = None
     email: EmailStr | None = None
+    telefone: str | None = None
     tipo: str | None = None
     escopo_empresas: str | None = None
     ativo: bool | None = None
@@ -41,6 +55,11 @@ class FuncionarioRedeUpdate(BaseModel):
     @classmethod
     def email_opcional(cls, v: object) -> object:
         return _email_vazio_para_none(v)
+
+    @field_validator("telefone", mode="before")
+    @classmethod
+    def telefone_opcional(cls, v: object) -> str | None:
+        return _telefone_normalizado(v)
 
 
 class FuncionarioRedeRead(FuncionarioRedeBase):

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -64,9 +64,38 @@ class WhatsappEmpresaCatalogoRead(BaseModel):
 class WhatsappFuncionarioOpcaoRead(BaseModel):
     id: int
     nome: str
-    email: str
+    email: str | None = None
+    telefone: str | None = None
     tipo: str
     empresas: list[WhatsappEmpresaOpcaoRead] = Field(default_factory=list)
+
+
+class WhatsappContatoRead(BaseModel):
+    id: int
+    nome: str
+    email: str | None = None
+    telefone: str | None = None
+    tipo: str
+    empresas: list[WhatsappEmpresaOpcaoRead] = Field(default_factory=list)
+    rede_id: int | None = None
+    rede_nome: str | None = None
+
+
+class WhatsappIniciarChatBody(BaseModel):
+    funcionario_id: int | None = None
+    telefone: str | None = Field(
+        None,
+        description="Número WhatsApp (dígitos). Obrigatório se funcionário sem telefone ou número avulso.",
+    )
+    mensagem_inicial: str | None = Field(None, max_length=4000)
+
+    @field_validator("telefone", mode="before")
+    @classmethod
+    def telefone_digitos(cls, v: object) -> str | None:
+        if v is None or (isinstance(v, str) and not v.strip()):
+            return None
+        digits = "".join(ch for ch in str(v) if ch.isdigit())
+        return digits or None
 
 
 class WhatsappRedeCatalogoRead(BaseModel):

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -744,3 +744,137 @@ def test_enviar_figurinha_usa_sendSticker(client, seed_base, auth_headers, monke
     assert body["tipo_midia"] == "figurinha"
     assert body["wa_message_id"] == "wa-sticker-1"
     assert calls == ["sticker"]
+
+
+def _evolution_settings(client, auth_headers, secret="outb"):
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": secret,
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+
+
+def test_listar_contatos_whatsapp(client, seed_base, auth_headers, db_session):
+    func = _criar_funcionario_colaborador(db_session, seed_base, nome="Ana Contato", email="ana.contato@test.local")
+    from app.models.funcionario_rede import FuncionarioRede
+
+    f = db_session.query(FuncionarioRede).filter(FuncionarioRede.id == func["id"]).first()
+    f.telefone = "5511988776655"
+    db_session.commit()
+
+    r = client.get("/v1/whatsapp/chats/contatos?busca=Ana", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["total"] >= 1
+    ids = [x["id"] for x in body["items"]]
+    assert func["id"] in ids
+    row = next(x for x in body["items"] if x["id"] == func["id"])
+    assert row["telefone"] == "5511988776655"
+    assert any(e["id"] == seed_base["empresa"].id for e in row["empresas"])
+
+
+def test_iniciar_chat_outbound_por_telefone(client, seed_base, auth_headers, monkeypatch):
+    sent = {"n": 0}
+
+    def fake_send(*_a, **_k):
+        sent["n"] += 1
+        return True, None, "wa-out-1"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+    _evolution_settings(client, auth_headers, "iniciar-1")
+
+    r = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"telefone": "11988776655", "mensagem_inicial": "Olá, retorno da demanda"},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["estado"] == "em_atendimento"
+    assert body["atendente_id"] == seed_base["a1"].id
+    assert body["wa_id"] == "5511988776655"
+    assert sent["n"] == 1
+
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    assert any(c["id"] == body["id"] for c in meus)
+
+
+def test_iniciar_chat_reusa_aberto_mesmo_responsavel(client, seed_base, auth_headers, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out"),
+    )
+    _evolution_settings(client, auth_headers, "iniciar-2")
+
+    r1 = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"telefone": "5511999000011"},
+        headers=auth_headers["a1"],
+    )
+    assert r1.status_code == 200
+    cid = r1.json()["id"]
+
+    r2 = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"telefone": "5511999000011"},
+        headers=auth_headers["a1"],
+    )
+    assert r2.status_code == 200
+    assert r2.json()["id"] == cid
+
+
+def test_iniciar_chat_409_outro_responsavel(client, seed_base, auth_headers, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out"),
+    )
+    _evolution_settings(client, auth_headers, "iniciar-3")
+
+    r1 = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"telefone": "5511999000022"},
+        headers=auth_headers["a1"],
+    )
+    assert r1.status_code == 200
+
+    r2 = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"telefone": "5511999000022"},
+        headers=auth_headers["a2"],
+    )
+    assert r2.status_code == 409
+
+
+def test_iniciar_chat_funcionario_sem_telefone_exige_numero(client, seed_base, auth_headers, db_session, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out"),
+    )
+    _evolution_settings(client, auth_headers, "iniciar-4")
+    func = _criar_funcionario_colaborador(db_session, seed_base, nome="Sem Fone", email="semfone@test.local")
+
+    denied = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"funcionario_id": func["id"]},
+        headers=auth_headers["a1"],
+    )
+    assert denied.status_code == 400
+
+    ok = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"funcionario_id": func["id"], "telefone": "5511999000033"},
+        headers=auth_headers["a1"],
+    )
+    assert ok.status_code == 200
+    assert ok.json()["funcionario_rede_id"] == func["id"]
+
+    from app.models.funcionario_rede import FuncionarioRede
+
+    f = db_session.query(FuncionarioRede).filter(FuncionarioRede.id == func["id"]).first()
+    db_session.refresh(f)
+    assert f.telefone == "5511999000033"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -220,6 +220,15 @@ function AppRoutes() {
                 />
               }
             />
+            <Route
+              path="contatos"
+              element={
+                <ChatHubPlaceholder
+                  titulo="Contatos"
+                  subtitulo="Escolha um contacto ou número avulso para iniciar conversa no WhatsApp."
+                />
+              }
+            />
             <Route path="portal" element={<Navigate to="/chat/espera" replace />} />
             <Route path="portal/:chatId" element={<PortalConversa />} />
             <Route

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -901,9 +901,20 @@ export namespace WhatsappChats {
   export interface FuncionarioOpcao {
     id: number
     nome: string
-    email: string
+    email?: string | null
+    telefone?: string | null
     tipo: string
     empresas: EmpresaOpcao[]
+  }
+  export interface Contato {
+    id: number
+    nome: string
+    email?: string | null
+    telefone?: string | null
+    tipo: string
+    empresas: EmpresaOpcao[]
+    rede_id?: number | null
+    rede_nome?: string | null
   }
   export interface EmpresaCatalogo extends EmpresaOpcao {
     rede_id: number
@@ -1112,6 +1123,17 @@ export const portalChats = {
 export const whatsappChats = {
   fila: () => api<WhatsappChats.Chat[]>('/whatsapp/chats/fila'),
   meus: () => api<WhatsappChats.Chat[]>('/whatsapp/chats/meus'),
+  contatos: (params?: { busca?: string; offset?: number; limit?: number }) =>
+    listPaginated<WhatsappChats.Contato>('/whatsapp/chats/contatos', params),
+  iniciar: (data: {
+    funcionario_id?: number | null
+    telefone?: string | null
+    mensagem_inicial?: string | null
+  }) =>
+    api<WhatsappChats.Chat>('/whatsapp/chats/iniciar', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   encerrados: (params?: Record<string, string | number | undefined>) =>
     listPaginated<WhatsappChats.Chat>('/whatsapp/chats/encerrados', params),
   avaliacoes: (params?: Record<string, string | number | undefined>) =>
@@ -2030,6 +2052,7 @@ export namespace FuncionariosRede {
     id: number;
     nome: string;
     email: string | null;
+    telefone?: string | null;
     tipo: string;
     escopo_empresas: EscopoEmpresas;
     ativo: boolean;
@@ -2042,6 +2065,7 @@ export namespace FuncionariosRede {
   export interface Create {
     nome: string;
     email?: string | null;
+    telefone?: string | null;
     tipo: string;
     escopo_empresas?: EscopoEmpresas;
     ativo?: boolean;
@@ -2052,6 +2076,7 @@ export namespace FuncionariosRede {
   export interface Update {
     nome?: string;
     email?: string | null;
+    telefone?: string | null;
     tipo?: string;
     escopo_empresas?: EscopoEmpresas;
     ativo?: boolean;

--- a/frontend/src/components/chat/ChatHubTabs.tsx
+++ b/frontend/src/components/chat/ChatHubTabs.tsx
@@ -1,86 +1,99 @@
-import { Link, useLocation } from 'react-router-dom'
-import { useChatInterno } from '../../contexts/ChatInternoContext'
-import { useChatHub } from '../../contexts/ChatHubContext'
-import { CHAT_HUB_PATHS, chatHubModoDePath } from '../../lib/chatHubPaths'
-
-type TabDef = {
-  id: keyof typeof CHAT_HUB_PATHS
-  to: string
-  label: string
-  icon: React.ReactNode
-  badge?: number
-}
-
-export function ChatHubTabs() {
-  const { pathname } = useLocation()
-  const modo = chatHubModoDePath(pathname)
-  const { filaCount, atendendoCount } = useChatHub()
-  const { conversas } = useChatInterno()
-  const internoNaoLidas = conversas.reduce((acc, c) => acc + c.nao_lidas_count, 0)
-
-  const tabs: TabDef[] = [
-    {
-      id: 'atendendo',
-      to: CHAT_HUB_PATHS.atendendo,
-      label: 'Atendendo',
-      badge: atendendoCount,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-        </svg>
-      ),
-    },
-    {
-      id: 'espera',
-      to: CHAT_HUB_PATHS.espera,
-      label: 'Aguardando',
-      badge: filaCount,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-          <circle cx="12" cy="12" r="10" />
-          <path d="M12 6v6l4 2" />
-        </svg>
-      ),
-    },
-    {
-      id: 'interno',
-      to: CHAT_HUB_PATHS.interno,
-      label: 'Interno',
-      badge: internoNaoLidas,
-      icon: (
-        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-          <rect width="18" height="11" x="3" y="11" rx="2" />
-          <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-        </svg>
-      ),
-    },
-  ]
-
-  return (
-    <nav className="flex shrink-0 border-b border-slate-200 dark:border-slate-800" aria-label="Modos de chat">
-      {tabs.map((tab) => {
-        const ativo = modo === tab.id
-        return (
-          <Link
-            key={tab.id}
-            to={tab.to}
-            title={tab.label}
-            className={`relative flex flex-1 flex-col items-center gap-1 border-b-2 px-1 py-2.5 text-[10px] font-semibold transition-colors ${
-              ativo
-                ? 'border-cyan-500 text-cyan-600 dark:text-cyan-400'
-                : 'border-transparent text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'
-            }`}
-          >
-            <span className={ativo ? 'text-cyan-600 dark:text-cyan-400' : ''}>{tab.icon}</span>
-            <span className="hidden sm:inline">{tab.label}</span>
-            {tab.badge != null && tab.badge > 0 && (
-              <span className="absolute right-1 top-1 min-w-[1rem] rounded-full bg-cyan-600 px-1 text-center text-[9px] font-bold leading-4 text-white">
-                {tab.badge > 99 ? '99+' : tab.badge}
-              </span>
-            )}
-          </Link>
-        )
-      })}
-    </nav>
-  )
-}
+import { Link, useLocation } from 'react-router-dom'
+import { useChatInterno } from '../../contexts/ChatInternoContext'
+import { useChatHub } from '../../contexts/ChatHubContext'
+import { CHAT_HUB_PATHS, chatHubModoDePath } from '../../lib/chatHubPaths'
+
+type TabDef = {
+  id: keyof typeof CHAT_HUB_PATHS
+  to: string
+  label: string
+  icon: React.ReactNode
+  badge?: number
+}
+
+export function ChatHubTabs() {
+  const { pathname } = useLocation()
+  const modo = chatHubModoDePath(pathname)
+  const { filaCount, atendendoCount } = useChatHub()
+  const { conversas } = useChatInterno()
+  const internoNaoLidas = conversas.reduce((acc, c) => acc + c.nao_lidas_count, 0)
+
+  const tabs: TabDef[] = [
+    {
+      id: 'atendendo',
+      to: CHAT_HUB_PATHS.atendendo,
+      label: 'Atendendo',
+      badge: atendendoCount,
+      icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+      ),
+    },
+    {
+      id: 'espera',
+      to: CHAT_HUB_PATHS.espera,
+      label: 'Aguardando',
+      badge: filaCount,
+      icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <circle cx="12" cy="12" r="10" />
+          <path d="M12 6v6l4 2" />
+        </svg>
+      ),
+    },
+    {
+      id: 'contatos',
+      to: CHAT_HUB_PATHS.contatos,
+      label: 'Contatos',
+      icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+          <circle cx="9" cy="7" r="4" />
+          <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+          <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+        </svg>
+      ),
+    },
+    {
+      id: 'interno',
+      to: CHAT_HUB_PATHS.interno,
+      label: 'Interno',
+      badge: internoNaoLidas,
+      icon: (
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <rect width="18" height="11" x="3" y="11" rx="2" />
+          <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+        </svg>
+      ),
+    },
+  ]
+
+  return (
+    <nav className="flex shrink-0 border-b border-slate-200 dark:border-slate-800" aria-label="Modos de chat">
+      {tabs.map((tab) => {
+        const ativo = modo === tab.id
+        return (
+          <Link
+            key={tab.id}
+            to={tab.to}
+            title={tab.label}
+            className={`relative flex flex-1 flex-col items-center gap-1 border-b-2 px-0.5 py-2.5 text-[10px] font-semibold transition-colors ${
+              ativo
+                ? 'border-cyan-500 text-cyan-600 dark:text-cyan-400'
+                : 'border-transparent text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'
+            }`}
+          >
+            <span className={ativo ? 'text-cyan-600 dark:text-cyan-400' : ''}>{tab.icon}</span>
+            <span className="hidden sm:inline">{tab.label}</span>
+            {tab.badge != null && tab.badge > 0 && (
+              <span className="absolute right-0.5 top-1 min-w-[1rem] rounded-full bg-cyan-600 px-1 text-center text-[9px] font-bold leading-4 text-white">
+                {tab.badge > 99 ? '99+' : tab.badge}
+              </span>
+            )}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/frontend/src/components/chat/ChatIniciarConversaModal.tsx
+++ b/frontend/src/components/chat/ChatIniciarConversaModal.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { whatsappChats, type WhatsappChats } from '../../api/client'
+import { Button } from '../../components/ui/Button'
+import { Input } from '../../components/ui/Input'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { chatWhatsappLink } from '../../lib/chatHubPaths'
+
+type Props = {
+  open: boolean
+  onClose: () => void
+  contato?: WhatsappChats.Contato | null
+  /** Número pré-preenchido (retomar / avulso) */
+  telefoneInicial?: string | null
+  funcionarioId?: number | null
+  titulo?: string
+}
+
+export function ChatIniciarConversaModal({
+  open,
+  onClose,
+  contato,
+  telefoneInicial,
+  funcionarioId,
+  titulo,
+}: Props) {
+  const toast = useToast()
+  const navigate = useNavigate()
+  const [telefone, setTelefone] = useState('')
+  const [mensagem, setMensagem] = useState('')
+  const [salvando, setSalvando] = useState(false)
+
+  const precisaTelefone = !(contato?.telefone || telefoneInicial)
+
+  useEffect(() => {
+    if (!open) return
+    setTelefone(contato?.telefone || telefoneInicial || '')
+    setMensagem('')
+  }, [open, contato, telefoneInicial])
+
+  if (!open) return null
+
+  async function confirmar() {
+    const digits = telefone.replace(/\D/g, '')
+    const fid = funcionarioId ?? contato?.id ?? null
+    if (!fid && !digits) {
+      toast.showWarning('Informe o número WhatsApp.')
+      return
+    }
+    if (precisaTelefone && !digits) {
+      toast.showWarning('Informe o número WhatsApp do contato.')
+      return
+    }
+    setSalvando(true)
+    try {
+      const chat = await whatsappChats.iniciar({
+        funcionario_id: fid ?? undefined,
+        telefone: digits || undefined,
+        mensagem_inicial: mensagem.trim() || undefined,
+      })
+      onClose()
+      navigate(chatWhatsappLink(chat.id, 'contatos'))
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível iniciar a conversa.'))
+    } finally {
+      setSalvando(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[120] flex items-end justify-center bg-black/50 p-4 sm:items-center" onClick={onClose}>
+      <div
+        className="w-full max-w-md rounded-2xl bg-white p-5 shadow-xl dark:bg-slate-900"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal
+        aria-labelledby="iniciar-chat-titulo"
+      >
+        <h2 id="iniciar-chat-titulo" className="text-lg font-bold text-slate-900 dark:text-white">
+          {titulo || (contato ? `Contactar ${contato.nome}` : 'Novo contacto WhatsApp')}
+        </h2>
+        {contato && (
+          <p className="mt-1 text-xs text-slate-500">
+            {contato.empresas.map((e) => e.nome).join(' · ') || contato.rede_nome || 'Sem empresa'}
+          </p>
+        )}
+
+        <div className="mt-4 space-y-3">
+          <Input
+            label="WhatsApp"
+            value={telefone}
+            onChange={(e) => setTelefone(e.target.value)}
+            placeholder="5511999999999"
+          />
+          <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
+            Mensagem inicial (opcional)
+            <textarea
+              value={mensagem}
+              onChange={(e) => setMensagem(e.target.value)}
+              rows={3}
+              className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-950"
+              placeholder="Ex.: Olá, retorno sobre a sua demanda…"
+            />
+          </label>
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={onClose} disabled={salvando}>
+            Cancelar
+          </Button>
+          <Button type="button" onClick={() => void confirmar()} loading={salvando}>
+            Iniciar conversa
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/chatHubPaths.ts
+++ b/frontend/src/lib/chatHubPaths.ts
@@ -1,56 +1,30 @@
 export const CHAT_HUB_PATHS = {
-
   atendendo: '/chat/atendendo',
-
   espera: '/chat/espera',
-
+  contatos: '/chat/contatos',
   interno: '/chat/interno',
-
 } as const
-
-
 
 export type ChatHubModo = keyof typeof CHAT_HUB_PATHS
 
-
-
 export function chatHubModoDePath(pathname: string): ChatHubModo {
-
   if (pathname.startsWith('/chat/interno') || pathname === CHAT_HUB_PATHS.interno) return 'interno'
-
   if (pathname.startsWith('/chat/espera')) return 'espera'
-
+  if (pathname.startsWith('/chat/contatos')) return 'contatos'
   return 'atendendo'
-
 }
-
-
 
 export function chatWhatsappLink(chatId: number, from?: ChatHubModo) {
-
   return {
-
     pathname: `/chat/c/${chatId}`,
-
     search: from ? `?from=${from}` : '',
-
   }
-
 }
-
-
 
 export function chatPortalLink(chatId: number) {
-
   return `/chat/portal/${chatId}`
-
 }
-
-
 
 export function chatInternoLink(conversaId: number) {
-
   return `/chat/interno/${conversaId}`
-
 }
-

--- a/frontend/src/lib/whatsappListReturn.ts
+++ b/frontend/src/lib/whatsappListReturn.ts
@@ -60,6 +60,10 @@ export function resolveWhatsappListFallback(
   if (from && from in WHATSAPP_LIST_PATHS) {
     return WHATSAPP_LIST_PATHS[from as WhatsappListOrigin]
   }
+  if (from === 'contatos') return '/chat/contatos'
+  if (from === 'espera') return '/chat/espera'
+  if (from === 'interno') return '/chat/interno'
+  if (from === 'atendendo') return '/chat/atendendo'
   return fallback
 }
 

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -44,6 +44,7 @@ export function FuncionarioRedeForm() {
 
   const [nome, setNome] = useState('')
   const [email, setEmail] = useState('')
+  const [telefone, setTelefone] = useState('')
   const [tipo, setTipo] = useState<Tipo>('colaborador')
   const [escopoEmpresas, setEscopoEmpresas] = useState<Escopo>('selected')
   const [ativo, setAtivo] = useState(true)
@@ -98,6 +99,7 @@ export function FuncionarioRedeForm() {
         if (cancelled) return
         setNome(item.nome)
         setEmail(item.email || '')
+        setTelefone(item.telefone || '')
         setTipo(item.tipo as Tipo)
         setEscopoEmpresas((item.escopo_empresas as Escopo) || (item.tipo === 'socio' ? 'all' : 'selected'))
         setAtivo(item.ativo)
@@ -177,6 +179,7 @@ export function FuncionarioRedeForm() {
         const payload: FuncionariosRede.Update = {
           nome: nome.trim(),
           email: emailPayload,
+          telefone: telefone.replace(/\D/g, '') || null,
           tipo,
           escopo_empresas: escopo,
           ativo,
@@ -190,6 +193,7 @@ export function FuncionarioRedeForm() {
         const payload: FuncionariosRede.Create = {
           nome: nome.trim(),
           email: emailPayload,
+          telefone: telefone.replace(/\D/g, '') || null,
           tipo,
           escopo_empresas: escopo,
           ativo,
@@ -266,6 +270,15 @@ export function FuncionarioRedeForm() {
               />
               <p className="text-xs text-slate-500">
                 Usado para identificar remetente em tickets por e-mail. Contactos só WhatsApp podem ficar em branco.
+              </p>
+              <Input
+                label="WhatsApp (opcional)"
+                value={telefone}
+                onChange={(e) => setTelefone(e.target.value)}
+                placeholder="5511999999999"
+              />
+              <p className="text-xs text-slate-500">
+                Número para iniciar conversa pelo hub Contatos. Preferencialmente com DDI (55).
               </p>
               <Select
                 label="Tipo"

--- a/frontend/src/pages/chat/ChatHubLayout.tsx
+++ b/frontend/src/pages/chat/ChatHubLayout.tsx
@@ -1,108 +1,64 @@
 import { Outlet, useLocation } from 'react-router-dom'
-
 import { ChatHubTabs } from '../../components/chat/ChatHubTabs'
-
 import { ChatHubSearch } from '../../components/chat/ChatHubSearch'
-
 import { ChatInternoLista } from '../../components/chat-interno/ChatInternoLista'
-
 import { chatHubModoDePath } from '../../lib/chatHubPaths'
-
 import { ChatListaAtendendo } from './ChatListaAtendendo'
-
 import { ChatListaEspera } from './ChatListaEspera'
-
-
+import { ChatListaContatos } from './ChatListaContatos'
 
 function ChatHubLista() {
-
   const { pathname } = useLocation()
-
   const modo = chatHubModoDePath(pathname)
 
-
-
   switch (modo) {
-
     case 'espera':
-
       return <ChatListaEspera />
-
     case 'interno':
-
       return <ChatInternoLista />
-
+    case 'contatos':
+      return <ChatListaContatos />
     default:
-
       return <ChatListaAtendendo />
-
   }
-
 }
-
-
 
 export function ChatHubLayout() {
-
   const { pathname } = useLocation()
-
+  const modo = chatHubModoDePath(pathname)
   const emConversa =
-
     /\/chat\/c\/\d+/.test(pathname) ||
-
     /\/chat\/portal\/\d+/.test(pathname) ||
-
     /\/chat\/interno\/\d+/.test(pathname) ||
-
     /\/chat\/interno\/setor\/\d+/.test(pathname)
 
-
-
   return (
-
     <div className="flex h-full min-h-0 w-full overflow-hidden bg-slate-50 dark:bg-slate-950">
-
       <aside
-
         className={`flex h-full min-h-0 shrink-0 flex-col border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-950 md:w-72 lg:w-80 md:border-r ${
-
           emConversa ? 'hidden w-full md:flex' : 'flex w-full'
-
         }`}
-
       >
-
         <ChatHubTabs />
-
-        <ChatHubSearch />
-
+        <ChatHubSearch
+          placeholder={
+            modo === 'contatos'
+              ? 'Buscar contacto, empresa ou telefone'
+              : 'Pesquise por conversas'
+          }
+        />
         <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
-
           <ChatHubLista />
-
         </div>
-
       </aside>
 
-
-
       <main
-
         className={`flex h-full min-h-0 min-w-0 flex-1 flex-col bg-slate-50 dark:bg-slate-950 ${
-
           emConversa ? '' : 'hidden md:flex'
-
         }`}
-
       >
-
         <Outlet />
-
       </main>
-
     </div>
-
   )
-
 }
-

--- a/frontend/src/pages/chat/ChatListaContatos.tsx
+++ b/frontend/src/pages/chat/ChatListaContatos.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useState } from 'react'
+import { whatsappChats, type WhatsappChats } from '../../api/client'
+import { Button } from '../../components/ui/Button'
+import { useChatHub } from '../../contexts/ChatHubContext'
+import { ChatIniciarConversaModal } from '../../components/chat/ChatIniciarConversaModal'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useToast } from '../../components/ui/Toast'
+
+const PAGE = 40
+
+export function ChatListaContatos() {
+  const { busca } = useChatHub()
+  const toast = useToast()
+  const [items, setItems] = useState<WhatsappChats.Contato[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [offset, setOffset] = useState(0)
+  const [modal, setModal] = useState<{
+    contato?: WhatsappChats.Contato | null
+    telefone?: string | null
+    avulso?: boolean
+  } | null>(null)
+
+  const load = useCallback(
+    async (from: number, append: boolean) => {
+      setLoading(true)
+      try {
+        const res = await whatsappChats.contatos({
+          busca: busca.trim() || undefined,
+          offset: from,
+          limit: PAGE,
+        })
+        setTotal(res.total)
+        setOffset(from)
+        setItems((prev) => (append ? [...prev, ...res.items] : res.items))
+      } catch (err) {
+        toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar contatos.'))
+        if (!append) setItems([])
+      } finally {
+        setLoading(false)
+      }
+    },
+    [busca, toast],
+  )
+
+  useEffect(() => {
+    const t = window.setTimeout(() => void load(0, false), 250)
+    return () => window.clearTimeout(t)
+  }, [load])
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="shrink-0 border-b border-slate-100 px-3 py-2 dark:border-slate-800">
+        <Button type="button" variant="secondary" className="h-8 w-full text-xs" onClick={() => setModal({ avulso: true })}>
+          + Número avulso
+        </Button>
+      </div>
+
+      {loading && items.length === 0 ? (
+        <p className="p-4 text-center text-sm text-slate-400 animate-pulse">Carregando…</p>
+      ) : items.length === 0 ? (
+        <p className="p-6 text-center text-sm text-slate-400">
+          {busca.trim() ? 'Nenhum contacto encontrado.' : 'Nenhum contacto cadastrado.'}
+        </p>
+      ) : (
+        <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+          {items.map((c) => (
+            <li key={c.id} className="px-3 py-3">
+              <div className="flex items-start gap-3">
+                <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-slate-200 text-sm font-bold text-slate-600 dark:bg-slate-700 dark:text-slate-200">
+                  {c.nome.charAt(0)?.toUpperCase() || '?'}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">{c.nome}</p>
+                  <div className="mt-0.5 flex flex-wrap gap-1">
+                    {c.empresas.length > 0 ? (
+                      c.empresas.map((e) => (
+                        <span
+                          key={e.id}
+                          className="inline-flex max-w-[10rem] truncate rounded-md bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+                          title={e.nome}
+                        >
+                          {e.nome}
+                        </span>
+                      ))
+                    ) : (
+                      <span className="text-[10px] text-slate-400">{c.rede_nome || 'Sem empresa'}</span>
+                    )}
+                  </div>
+                  <p className="mt-0.5 truncate font-mono text-[11px] text-slate-500">
+                    {c.telefone || 'Sem WhatsApp'}
+                  </p>
+                  <div className="mt-2">
+                    <Button
+                      type="button"
+                      className="h-7 px-2 text-[10px]"
+                      variant={c.telefone ? 'primary' : 'secondary'}
+                      onClick={() => setModal({ contato: c })}
+                    >
+                      {c.telefone ? 'Iniciar conversa' : 'Informar número'}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {items.length < total && (
+        <div className="p-3">
+          <Button
+            type="button"
+            variant="ghost"
+            className="h-8 w-full text-xs"
+            disabled={loading}
+            onClick={() => void load(offset + PAGE, true)}
+          >
+            Carregar mais
+          </Button>
+        </div>
+      )}
+
+      <ChatIniciarConversaModal
+        open={modal != null}
+        onClose={() => setModal(null)}
+        contato={modal?.contato}
+        telefoneInicial={modal?.avulso ? '' : modal?.contato?.telefone}
+        titulo={modal?.avulso ? 'Número avulso' : undefined}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -12,6 +12,7 @@ import { AvaliacaoEstrelas } from '../../components/ui/AvaliacaoEstrelas'
 import { rotuloEstadoChat } from '../../lib/whatsappChatMeta'
 import { buildHistoricoReturnPath, saveWhatsappListScroll, whatsappConversaLink } from '../../lib/whatsappListReturn'
 import { useWhatsappListScrollRestore } from '../../hooks/useWhatsappListScrollRestore'
+import { ChatIniciarConversaModal } from '../../components/chat/ChatIniciarConversaModal'
 
 const PAGE_SIZE = 15
 
@@ -32,6 +33,7 @@ export function WhatsappHistorico() {
   const [loading, setLoading] = useState(true)
   const [busca, setBusca] = useState(() => searchParams.get('busca') ?? '')
   const [atendentesList, setAtendentesList] = useState<Atendentes.Atendente[]>([])
+  const [retomarChat, setRetomarChat] = useState<WhatsappChats.Chat | null>(null)
   const [atendenteId, setAtendenteId] = useState<number | ''>(() => {
     const v = searchParams.get('atendente_id')
     return v ? Number(v) : ''
@@ -267,9 +269,20 @@ export function WhatsappHistorico() {
                       to={whatsappConversaLink(c.id, historicoReturnPath, 'historico')}
                       onClick={() => saveWhatsappListScroll('historico', historicoReturnPath)}
                       className="rounded-full bg-slate-100 p-2 text-slate-400 transition-all hover:bg-cyan-600 hover:text-white dark:bg-slate-800 dark:hover:bg-cyan-700"
+                      title="Ver conversa"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
                     </Link>
+                    {(c.estado === 'encerrado' || c.estado === 'aguardando_avaliacao') && (
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        className="h-9 px-3 text-xs"
+                        onClick={() => setRetomarChat(c)}
+                      >
+                        Retomar contacto
+                      </Button>
+                    )}
                   </div>
                 </div>
               </Card>
@@ -277,6 +290,14 @@ export function WhatsappHistorico() {
           </div>
         )}
       </div>
+
+      <ChatIniciarConversaModal
+        open={retomarChat != null}
+        onClose={() => setRetomarChat(null)}
+        telefoneInicial={retomarChat?.wa_id}
+        funcionarioId={retomarChat?.funcionario_rede_id}
+        titulo={retomarChat ? `Retomar ${retomarChat.cliente_nome || retomarChat.wa_id}` : undefined}
+      />
 
       {/* Paginação Estilizada */}
       <footer className="flex flex-col items-center justify-between gap-4 border-t pt-6 dark:border-slate-800 sm:flex-row">


### PR DESCRIPTION
## Summary
- Nova aba **Contatos** no hub `/chat` com lista de funcionários, badge de empresa e telefone WhatsApp
- `POST /whatsapp/chats/iniciar` cria (ou reutiliza) chat já em atendimento com o iniciador; número avulso e retomar no Histórico
- Campo `telefone` em `funcionarios_rede` (migration `068`) + CRUD/UI de cadastro
- Closes #531

## Test plan
- [x] `pytest` `contatos` / `iniciar_chat` (5 passed)
- [x] `tsc -b` OK
- [ ] Smoke local: Chat → Contatos → iniciar / número avulso
- [ ] Retomar contacto no Histórico
- [ ] Cadastro de funcionário com telefone WhatsApp

Made with [Cursor](https://cursor.com)