### PR TITLE
feat(whatsapp): identificar contato em atendimento encerrado (#534)

### DIFF
--- a/.github/planning-issue-bodies/issues/whatsapp-cadastro-encerrado.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-cadastro-encerrado.md
@@ -1,0 +1,14 @@
+﻿## Problema
+No chat ativo é possível identificar/cadastrar o contato do cliente (funcionário da rede). No Histórico, ao abrir um atendimento já encerrado, o botão e o banner de identificação somem — só a UI bloqueia; a API já permite.
+
+Além disso, o cadastro/vínculo pelo chat não grava o `wa_id` em `funcionarios_rede.telefone`, então o contato pode não aparecer utilizável na aba Contatos / outbound (#531).
+
+## Critérios de aceite
+- [ ] Em conversa encerrada (ou aguardando avaliação), sem vínculo: banner e ação «Identificar contato» disponíveis
+- [ ] Composer, transferir e encerrar continuam indisponíveis no encerrado
+- [ ] Cadastrar ou vincular pelo chat preenche `telefone` a partir do `wa_id` quando o cadastro ainda não tem telefone
+- [ ] Contato fica acionável na aba Contatos após o vínculo/cadastro
+- [ ] Teste cobrindo vincular/cadastrar em chat encerrado e assert de telefone
+
+## Origem
+Feedback de produção após Contatos (#531).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos
 - WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede
 
 ### Correções

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -811,6 +811,18 @@ def _normalize_wa_id(raw: str | None) -> str:
     return digits
 
 
+def _preencher_telefone_do_chat(func: FuncionarioRede, wa_id: str | None) -> None:
+    """Se o cadastro não tem telefone, copia o WhatsApp do chat (aba Contatos / outbound)."""
+    digits = re.sub(r"\D", "", wa_id or "")
+    if not digits:
+        return
+    if re.sub(r"\D", "", getattr(func, "telefone", None) or ""):
+        return
+    if len(digits) in (10, 11) and not digits.startswith("55"):
+        digits = "55" + digits
+    func.telefone = digits
+
+
 def _chat_aberto_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
     return (
         db.query(WhatsappChat)
@@ -1574,6 +1586,7 @@ def vincular_funcionario(
     if not func:
         raise HTTPException(status_code=404, detail="Funcionário não encontrado")
     emp = _resolver_empresa_vinculo(db, atendente, func, data.empresa_id)
+    _preencher_telefone_do_chat(func, c.wa_id)
     c.funcionario_rede_id = func.id
     c.empresa_id = emp.id
     db.commit()
@@ -1633,6 +1646,7 @@ def cadastrar_funcionario(
         empresa_id=data.empresa_id,
         empresa_ids=empresa_ids,
     )
+    _preencher_telefone_do_chat(func, c.wa_id)
     emp = _resolver_empresa_vinculo(db, atendente, func, data.empresa_id)
     c.funcionario_rede_id = func.id
     c.empresa_id = emp.id

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -487,6 +487,12 @@ def test_cadastrar_funcionario_no_chat(client, seed_base, auth_headers, db_sessi
     assert body["funcionario_email"] == "cliente.novo@test.local"
     assert body["empresa_id"] == seed_base["empresa"].id
 
+    from app.models.funcionario_rede import FuncionarioRede
+
+    f = db_session.query(FuncionarioRede).filter(FuncionarioRede.id == body["funcionario_rede_id"]).first()
+    assert f is not None
+    assert f.telefone == "5511999112233"
+
     catalogo = client.get("/v1/whatsapp/chats/funcionarios/catalogo", headers=auth_headers["a1"])
     assert catalogo.status_code == 200
     assert any(re["id"] == seed_base["rede"].id for re in catalogo.json()["redes"])
@@ -512,6 +518,64 @@ def test_cadastrar_funcionario_no_chat_sem_email(client, seed_base, auth_headers
     assert body["funcionario_email"] is None
     assert body["funcionario_rede_id"] is not None
     assert body["empresa_id"] == seed_base["empresa"].id
+
+
+def test_cadastrar_funcionario_em_chat_encerrado(client, seed_base, auth_headers, db_session):
+    """#534 — identificar contato no Histórico (chat já encerrado) e gravar telefone."""
+    wa_id = "5511999112255"
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id=wa_id, msg_id="func-cad-enc")
+    enc = client.post(f"/v1/whatsapp/chats/{cid}/encerrar", headers=auth_headers["a1"])
+    assert enc.status_code == 200
+    assert enc.json()["estado"] in ("encerrado", "aguardando_avaliacao")
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/cadastrar-funcionario",
+        json={
+            "nome": "Cliente Pós Encerrar",
+            "rede_id": seed_base["rede"].id,
+            "tipo": "colaborador",
+            "escopo_empresas": "selected",
+            "empresa_ids": [seed_base["empresa"].id],
+        },
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["funcionario_rede_id"] is not None
+    assert body["funcionario_nome"] == "Cliente Pós Encerrar"
+
+    from app.models.funcionario_rede import FuncionarioRede
+
+    f = db_session.query(FuncionarioRede).filter(FuncionarioRede.id == body["funcionario_rede_id"]).first()
+    assert f is not None
+    assert f.telefone == wa_id
+
+
+def test_vincular_funcionario_em_chat_encerrado_preenche_telefone(
+    client, seed_base, auth_headers, db_session
+):
+    """#534 — vincular existente em chat encerrado preenche telefone se vazio."""
+    wa_id = "5511999112266"
+    func = _criar_funcionario_colaborador(db_session, seed_base, email="vinc-enc@test.local")
+    from app.models.funcionario_rede import FuncionarioRede
+
+    f0 = db_session.query(FuncionarioRede).filter(FuncionarioRede.id == func["id"]).first()
+    assert f0 is not None
+    assert not (f0.telefone or "").strip()
+
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id=wa_id, msg_id="func-vinc-enc")
+    assert client.post(f"/v1/whatsapp/chats/{cid}/encerrar", headers=auth_headers["a1"]).status_code == 200
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{cid}/vincular-funcionario",
+        json={"funcionario_rede_id": func["id"]},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    assert r.json()["funcionario_rede_id"] == func["id"]
+
+    db_session.refresh(f0)
+    assert f0.telefone == wa_id
 
 
 def test_admin_nao_envia_ao_cliente_usa_comentario_interno(client, seed_base, auth_headers, monkeypatch):

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -984,49 +984,48 @@ useEffect(() => {
               </Button>
             )}
 
-             {!encerrado && (
+            <Button
+              variant="ghost"
+              className="inline-flex text-xs h-8"
+              onClick={() => setModalVincFuncionario(true)}
+            >
+              <span className="sm:hidden">{CONTATO_CLIENTE.vincularCurto}</span>
+              <span className="hidden sm:inline">{CONTATO_CLIENTE.vincularChat}</span>
+            </Button>
 
+            {!encerrado && (
               <>
+                {podeTransferir && (
+                  <Button
+                    variant="primary"
+                    className="hidden sm:inline-flex text-xs h-8"
+                    onClick={() => setModalTransferir(true)}
+                  >
+                    Transferir
+                  </Button>
+                )}
 
-              {podeTransferir && (
-              <Button
-  variant="primary"
-  className="hidden sm:inline-flex text-xs h-8"
-  onClick={() => setModalTransferir(true)}
->
-  Transferir
-</Button>
-              )}
-              <Button
-                variant="ghost"
-                className="inline-flex text-xs h-8"
-                onClick={() => setModalVincFuncionario(true)}
-              >
-                <span className="sm:hidden">{CONTATO_CLIENTE.vincularCurto}</span>
-                <span className="hidden sm:inline">{CONTATO_CLIENTE.vincularChat}</span>
-              </Button>
-
-                <Button variant="ghost" className="hidden sm:inline-flex text-xs h-8" onClick={() => setModalTickets(true)}>
+                <Button
+                  variant="ghost"
+                  className="hidden sm:inline-flex text-xs h-8"
+                  onClick={() => setModalTickets(true)}
+                >
                   Tickets{ticketsVinculados.length > 0 ? ` (${ticketsVinculados.length})` : ''}
                 </Button>
 
                 {podeEncerrar && (
-
                   <Button variant="danger" className="h-8 px-3 text-xs" onClick={() => setModalEncerrar(true)}>
                     Encerrar
                   </Button>
-
                 )}
-
               </>
-
             )}
 
           </div>
 
         </header>
 
-        {!encerrado && chat && !chat.funcionario_rede_id && (
+        {chat && !chat.funcionario_rede_id && (
           <div className="flex flex-wrap items-center justify-between gap-3 border-b border-violet-200 bg-violet-50 px-4 py-3 text-sm text-violet-950 dark:border-violet-900/40 dark:bg-violet-950/30 dark:text-violet-100">
             <p>{CONTATO_CLIENTE.bannerNaoVinculado}</p>
             <Button variant="primary" className="h-8 shrink-0 text-xs" onClick={() => setModalVincFuncionario(true)}>


### PR DESCRIPTION
## Summary
- Permite identificar/cadastrar o contato do cliente também em chat **encerrado** (Histórico); composer/transferir/encerrar seguem bloqueados.
- Ao vincular ou cadastrar pelo chat, grava o `wa_id` em `funcionarios_rede.telefone` se ainda estiver vazio — pronto para Contatos / outbound (#531).
- Closes #534

## Test plan
- [ ] No Histórico, abrir atendimento encerrado sem vínculo → banner e Identificar contato disponíveis
- [ ] Cadastrar novo contato → telefone preenchido com o WhatsApp do chat
- [ ] Vincular existente sem telefone → telefone preenchido
- [ ] Contatos lista o número e permite iniciar conversa
- [ ] Chat ativo: fluxo de identificar continua igual

Made with [Cursor](https://cursor.com)