### PR TITLE
fix(whatsapp): contexto rede/empresa ao vincular + foco no Encerrar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homónimos
 - WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos
 - WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede
 
 ### Correções
 
+- WhatsApp / modais: ao digitar na descrição da demanda no **Encerrar atendimento**, o campo perdia o foco a cada atualização da conversa — diálogo já não refoca o painel; formulário não é limpo pelo poll
 - Sons de alerta: toque de **abertura de ticket** e de **novo chat** (fila WhatsApp/Portal) estavam trocados — ticket usa `notification.mp3` e chat na fila usa `alerta.mp3`
 - WhatsApp: conversa em atendimento disparava loop de pedidos a `/demandas` (e esgotava recursos do browser com `ERR_INSUFFICIENT_RESOURCES`) — o painel de demandas já não notifica o pai no carregamento inicial
 - WhatsApp (#473): modal de encerramento deixava de carregar demandas — polling da conversa refazia o fetch e mantinha «A carregar demandas…» em loop; demanda passa a ser opcional quando o chat encerra por inatividade

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -759,10 +759,15 @@ def buscar_funcionarios(
         .limit(limit)
     )
     rows = q.all()
+    redes_cache: dict[int, str] = {
+        int(r.id): r.nome
+        for r in db.query(Rede).filter(Rede.tenant_id == atendente.tenant_id).all()
+    }
     out: list[WhatsappFuncionarioOpcaoRead] = []
     for func in rows:
         if _funcionario_no_tenant(db, atendente, func.id) is None:
             continue
+        rid = rede_id_efetiva(db, func)
         out.append(
             WhatsappFuncionarioOpcaoRead(
                 id=func.id,
@@ -771,6 +776,8 @@ def buscar_funcionarios(
                 telefone=getattr(func, "telefone", None),
                 tipo=func.tipo,
                 empresas=_empresas_funcionario(db, func),
+                rede_id=rid,
+                rede_nome=redes_cache.get(int(rid)) if rid is not None else None,
             )
         )
     return out

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -68,6 +68,8 @@ class WhatsappFuncionarioOpcaoRead(BaseModel):
     telefone: str | None = None
     tipo: str
     empresas: list[WhatsappEmpresaOpcaoRead] = Field(default_factory=list)
+    rede_id: int | None = None
+    rede_nome: str | None = None
 
 
 class WhatsappContatoRead(BaseModel):

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -449,8 +449,12 @@ def test_buscar_funcionarios_whatsapp(client, seed_base, auth_headers, db_sessio
     func = _criar_funcionario_colaborador(db_session, seed_base, nome="Maria Silva", email="maria@test.local")
     r = client.get("/v1/whatsapp/chats/funcionarios?busca=Maria", headers=auth_headers["a1"])
     assert r.status_code == 200
-    ids = [x["id"] for x in r.json()]
+    rows = r.json()
+    ids = [x["id"] for x in rows]
     assert func["id"] in ids
+    hit = next(x for x in rows if x["id"] == func["id"])
+    assert hit["rede_nome"] == seed_base["rede"].nome
+    assert any(e["id"] == seed_base["empresa"].id for e in hit["empresas"])
 
 
 def test_desvincular_funcionario_no_chat(client, seed_base, auth_headers, db_session):

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -905,6 +905,8 @@ export namespace WhatsappChats {
     telefone?: string | null
     tipo: string
     empresas: EmpresaOpcao[]
+    rede_id?: number | null
+    rede_nome?: string | null
   }
   export interface Contato {
     id: number

--- a/frontend/src/components/chat/ChatEncerrarModal.tsx
+++ b/frontend/src/components/chat/ChatEncerrarModal.tsx
@@ -123,11 +123,18 @@ export function ChatEncerrarModal<TChat extends { estado: string }>({
     } else if (acao === 'nova' || acao === 'registrar') {
       setForm(DEMANDA_FORM_VAZIO)
     }
-  }, [acao, posRegistro])
+    // Só ao mudar a ação — posRegistro muda com poll de msgs e não deve limpar o que o usuário digita.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intencional
+  }, [acao])
 
   function selecionarAcao(nova: AcaoEncerramento) {
     acaoEscolhidaRef.current = true
     setAcao(nova)
+  }
+
+  function atualizarForm(next: DemandaFormValues) {
+    acaoEscolhidaRef.current = true
+    setForm(next)
   }
 
   async function executarEncerramento() {
@@ -336,7 +343,7 @@ export function ChatEncerrarModal<TChat extends { estado: string }>({
           )}
 
           {mostrarForm && (
-            <WhatsappDemandaFormFields values={form} onChange={setForm} disabled={salvando} idPrefix="enc" />
+            <WhatsappDemandaFormFields values={form} onChange={atualizarForm} disabled={salvando} idPrefix="enc" />
           )}
 
           <div className="flex flex-col-reverse gap-2 border-t border-slate-100 pt-4 dark:border-slate-800 sm:flex-row sm:justify-end">

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -32,19 +32,22 @@ export function ConfirmDialog({
 }: Props) {
   const titleId = useId()
   const dialogRef = useRef<HTMLDivElement>(null)
+  const onCancelRef = useRef(onCancel)
+  onCancelRef.current = onCancel
 
   useEffect(() => {
     if (!open) return
+    // Só ao abrir — não refocar quando onCancel muda a cada re-render do pai (poll/SSE).
     dialogRef.current?.focus()
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault()
-        onCancel()
+        onCancelRef.current()
       }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [open, onCancel])
+  }, [open])
 
   if (!open) return null
 

--- a/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
@@ -124,11 +124,18 @@ export function WhatsappEncerrarModal({
     } else if (acao === 'nova' || acao === 'registrar') {
       setForm(DEMANDA_FORM_VAZIO)
     }
-  }, [acao, posRegistro])
+    // Só ao mudar a ação — posRegistro muda com poll de msgs e não deve limpar o que o usuário digita.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intencional
+  }, [acao])
 
   function selecionarAcao(nova: AcaoEncerramento) {
     acaoEscolhidaRef.current = true
     setAcao(nova)
+  }
+
+  function atualizarForm(next: DemandaFormValues) {
+    acaoEscolhidaRef.current = true
+    setForm(next)
   }
 
   async function executarEncerramento() {
@@ -338,7 +345,7 @@ export function WhatsappEncerrarModal({
           )}
 
           {mostrarForm && (
-            <WhatsappDemandaFormFields values={form} onChange={setForm} disabled={salvando} idPrefix="enc" />
+            <WhatsappDemandaFormFields values={form} onChange={atualizarForm} disabled={salvando} idPrefix="enc" />
           )}
 
           <div className="flex flex-col-reverse gap-2 border-t border-slate-100 pt-4 dark:border-slate-800 sm:flex-row sm:justify-end">

--- a/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
@@ -355,23 +355,48 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                           : 'hover:bg-white dark:hover:bg-slate-800'
                       }`}
                     >
-                      <div className="flex items-center justify-between gap-3">
-                        <div>
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 flex-1">
                           <p className="font-semibold text-slate-900 dark:text-slate-100">{funcionario.nome}</p>
                           <p className="text-xs text-slate-500 dark:text-slate-400">
                             {funcionario.email || 'Sem e-mail'}
                           </p>
+                          <div className="mt-1 flex flex-wrap items-center gap-1">
+                            {funcionario.rede_nome && (
+                              <span
+                                className="inline-flex max-w-full truncate rounded-md bg-violet-100 px-1.5 py-0.5 text-[10px] font-medium text-violet-800 dark:bg-violet-950/50 dark:text-violet-200"
+                                title={funcionario.rede_nome}
+                              >
+                                {funcionario.rede_nome}
+                              </span>
+                            )}
+                            {funcionario.empresas.length > 0 ? (
+                              funcionario.empresas.map((e) => (
+                                <span
+                                  key={e.id}
+                                  className="inline-flex max-w-[10rem] truncate rounded-md bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+                                  title={e.nome}
+                                >
+                                  {e.nome}
+                                </span>
+                              ))
+                            ) : (
+                              !funcionario.rede_nome && (
+                                <span className="text-[10px] text-slate-400">Sem empresa</span>
+                              )
+                            )}
+                          </div>
                         </div>
-                        <span className="text-xs uppercase tracking-wide text-slate-400">{funcionario.tipo}</span>
+                        <span className="shrink-0 text-xs uppercase tracking-wide text-slate-400">
+                          {funcionario.tipo}
+                        </span>
                       </div>
                     </button>
                   ))}
                 </div>
               ) : (
                 <p className="text-sm text-slate-500">
-                <p className="text-sm text-slate-500">
                   Nenhum contato encontrado. Use a aba <strong>Cadastrar novo</strong>.
-                </p>
                 </p>
               )
             ) : (


### PR DESCRIPTION
## Summary
- Na busca **Vincular existente**, cada resultado mostra rede e empresa(s) para distinguir homónimos.
- **Encerrar atendimento**: o campo de descrição deixa de perder o foco a cada atualização da conversa (`ConfirmDialog` só foca ao abrir; formulário não é limpo pelo poll de mensagens).

## Test plan
- [ ] Identificar contato → buscar nome → ver badges de rede e empresa
- [ ] Encerrar atendimento → registar demanda → digitar na descrição curta sem perder o foco
- [ ] Escape no modal de encerrar continua a fechar

Made with [Cursor](https://cursor.com)