### PR TITLE
feat(chat): foco após envio, emoji contínuo e responder no interno (#539)

### DIFF
--- a/.github/planning-issue-bodies/issues/chat-composer-ux-lote.md
+++ b/.github/planning-issue-bodies/issues/chat-composer-ux-lote.md
@@ -1,0 +1,13 @@
+﻿## Problema (produção)
+1. Após enviar mensagem no WhatsApp ou chat interno, o cursor sai do campo de texto.
+2. Ao escolher um emoji, o painel fecha — enviar vários exige reabrir.
+3. Chat interno (direta, setor/equipe, grupo) não tem «Responder» mensagem (WhatsApp já tem).
+
+## Critérios de aceite
+- [ ] Após enviar texto (WPP e interno), o foco permanece no textarea
+- [ ] Selecionar emoji insere e mantém o painel aberto (fecha só no clique fora / figurinha / X)
+- [ ] Chat interno: botão Responder, preview no composer, citação na bolha; API + migration `reply_to_message_id`
+- [ ] CHANGELOG atualizado
+
+## Fora de escopo
+- Meta templates / mudanças na Evolution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Chat (#539): após enviar mensagem (WhatsApp e chat interno), o cursor permanece no campo de texto; painel de emoji fica aberto ao escolher vários; **Responder** mensagem no chat interno (direta, equipe e grupo)
 - WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homónimos
 - WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos
 - WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede

--- a/backend/alembic/versions/069_chat_interno_reply.py
+++ b/backend/alembic/versions/069_chat_interno_reply.py
@@ -1,0 +1,70 @@
+"""Chat interno: citação (reply) em mensagens (#539).
+
+Revision ID: 069_chat_interno_reply
+Revises: 068_func_rede_telefone
+Create Date: 2026-07-15
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "069_chat_interno_reply"
+down_revision = "068_func_rede_telefone"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("mensagens_internas"):
+        return
+    cols = [c["name"] for c in insp.get_columns("mensagens_internas")]
+    if "reply_to_message_id" not in cols:
+        op.add_column(
+            "mensagens_internas",
+            sa.Column("reply_to_message_id", sa.Integer(), nullable=True),
+        )
+        op.create_foreign_key(
+            "fk_mensagens_internas_reply_to",
+            "mensagens_internas",
+            "mensagens_internas",
+            ["reply_to_message_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+        op.create_index(
+            "ix_mensagens_internas_reply_to_message_id",
+            "mensagens_internas",
+            ["reply_to_message_id"],
+        )
+    if "reply_preview" not in cols:
+        op.add_column(
+            "mensagens_internas",
+            sa.Column("reply_preview", sa.String(length=500), nullable=True),
+        )
+    if "reply_autor_nome" not in cols:
+        op.add_column(
+            "mensagens_internas",
+            sa.Column("reply_autor_nome", sa.String(length=200), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("mensagens_internas"):
+        return
+    cols = [c["name"] for c in insp.get_columns("mensagens_internas")]
+    fks = {fk["name"] for fk in insp.get_foreign_keys("mensagens_internas")}
+    if "fk_mensagens_internas_reply_to" in fks:
+        op.drop_constraint("fk_mensagens_internas_reply_to", "mensagens_internas", type_="foreignkey")
+    idxs = {ix["name"] for ix in insp.get_indexes("mensagens_internas")}
+    if "ix_mensagens_internas_reply_to_message_id" in idxs:
+        op.drop_index("ix_mensagens_internas_reply_to_message_id", table_name="mensagens_internas")
+    if "reply_autor_nome" in cols:
+        op.drop_column("mensagens_internas", "reply_autor_nome")
+    if "reply_preview" in cols:
+        op.drop_column("mensagens_internas", "reply_preview")
+    if "reply_to_message_id" in cols:
+        op.drop_column("mensagens_internas", "reply_to_message_id")

--- a/backend/app/api/chat_interno.py
+++ b/backend/app/api/chat_interno.py
@@ -87,6 +87,9 @@ def _to_mensagem_read(mensagem, *, conversa: ConversaInterna, atendente: Atenden
         pode_editar=perms.pode_editar,
         pode_apagar_para_todos=perms.pode_apagar_para_todos,
         pode_apagar_para_mim=perms.pode_apagar_para_mim,
+        reply_to_message_id=getattr(mensagem, "reply_to_message_id", None),
+        reply_preview=getattr(mensagem, "reply_preview", None),
+        reply_autor_nome=getattr(mensagem, "reply_autor_nome", None),
         created_at=mensagem.created_at,
         editada_em=mensagem.editada_em,
     )
@@ -279,7 +282,9 @@ def enviar_mensagem(
     if conversa.tenant_id != atendente.tenant_id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversa não encontrada.")
     try:
-        mensagem = chat_svc.enviar_mensagem(db, conversa, atendente, body.corpo)
+        mensagem = chat_svc.enviar_mensagem(
+            db, conversa, atendente, body.corpo, reply_to_message_id=body.reply_to_message_id
+        )
         db.commit()
         db.refresh(mensagem)
         _emit_apos_mensagem(db, conversa, mensagem, atendente.id)
@@ -298,6 +303,7 @@ async def enviar_mensagem_midia(
     file: UploadFile = File(...),
     mediatipo: str = Form(..., description="imagem | video | audio | documento"),
     caption: str = Form(""),
+    reply_to_message_id: int | None = Form(None),
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
@@ -320,6 +326,7 @@ async def enviar_mensagem_midia(
             mimetype=mime,
             nome_original=file.filename,
             caption=caption,
+            reply_to_message_id=reply_to_message_id,
         )
         db.commit()
         db.refresh(mensagem)
@@ -385,7 +392,9 @@ def publicar_no_canal_setor(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este setor.")
     try:
         conversa = chat_svc.obter_ou_criar_canal_setor(db, atendente.tenant_id, setor_id)
-        mensagem = chat_svc.enviar_mensagem(db, conversa, atendente, body.corpo)
+        mensagem = chat_svc.enviar_mensagem(
+            db, conversa, atendente, body.corpo, reply_to_message_id=body.reply_to_message_id
+        )
         db.commit()
         db.refresh(mensagem)
         _emit_apos_mensagem(db, conversa, mensagem, atendente.id)
@@ -404,6 +413,7 @@ async def publicar_midia_no_canal_setor(
     file: UploadFile = File(...),
     mediatipo: str = Form(..., description="imagem | video | audio | documento"),
     caption: str = Form(""),
+    reply_to_message_id: int | None = Form(None),
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
@@ -426,6 +436,7 @@ async def publicar_midia_no_canal_setor(
             mimetype=mime,
             nome_original=file.filename,
             caption=caption,
+            reply_to_message_id=reply_to_message_id,
         )
         db.commit()
         db.refresh(mensagem)

--- a/backend/app/models/chat_interno.py
+++ b/backend/app/models/chat_interno.py
@@ -115,9 +115,18 @@ class MensagemInterna(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)
     editada_em = Column(DateTime(timezone=True), nullable=True)
     apagada_em = Column(DateTime(timezone=True), nullable=True)
+    reply_to_message_id = Column(
+        Integer,
+        ForeignKey("mensagens_internas.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    reply_preview = Column(String(500), nullable=True)
+    reply_autor_nome = Column(String(200), nullable=True)
 
     conversa = relationship("ConversaInterna", back_populates="mensagens")
     atendente = relationship("Atendente", backref="mensagens_internas")
+    reply_to = relationship("MensagemInterna", remote_side=[id], foreign_keys=[reply_to_message_id])
     reacoes = relationship(
         "MensagemInternaReacao",
         back_populates="mensagem",

--- a/backend/app/schemas/chat_interno.py
+++ b/backend/app/schemas/chat_interno.py
@@ -28,6 +28,7 @@ class ParticipanteGrupoRead(BaseModel):
 
 class MensagemInternaCreate(BaseModel):
     corpo: str = Field(..., min_length=1, max_length=8000)
+    reply_to_message_id: int | None = Field(None, gt=0)
 
 
 class MensagemInternaUpdate(BaseModel):
@@ -62,6 +63,9 @@ class MensagemInternaRead(BaseModel):
     pode_editar: bool = False
     pode_apagar_para_todos: bool = False
     pode_apagar_para_mim: bool = False
+    reply_to_message_id: int | None = None
+    reply_preview: str | None = None
+    reply_autor_nome: str | None = None
     created_at: datetime
     editada_em: datetime | None = None
 

--- a/backend/app/services/chat_interno.py
+++ b/backend/app/services/chat_interno.py
@@ -551,6 +551,7 @@ def enviar_mensagem(
     conversa: ConversaInterna,
     atendente: Atendente,
     corpo: str,
+    reply_to_message_id: int | None = None,
 ) -> MensagemInterna:
     if not pode_acessar_conversa(db, atendente, conversa):
         raise ChatInternoErro("Sem permissão para esta conversa.")
@@ -558,11 +559,16 @@ def enviar_mensagem(
     if not texto:
         raise ChatInternoErro("Corpo da mensagem não pode ser vazio.")
 
+    reply_id, reply_preview, reply_autor = _resolver_citacao(db, conversa.id, reply_to_message_id)
+
     mensagem = MensagemInterna(
         conversa_id=conversa.id,
         atendente_id=atendente.id,
         corpo=texto,
         tipo_midia=TIPO_MENSAGEM_TEXTO,
+        reply_to_message_id=reply_id,
+        reply_preview=reply_preview,
+        reply_autor_nome=reply_autor,
     )
     db.add(mensagem)
     db.flush()
@@ -608,6 +614,21 @@ def preview_mensagem(mensagem: MensagemInterna) -> str:
     return preview_corpo(mensagem.corpo or "")
 
 
+def _resolver_citacao(
+    db: Session,
+    conversa_id: int,
+    reply_to_message_id: int | None,
+) -> tuple[int | None, str | None, str | None]:
+    if reply_to_message_id is None:
+        return None, None, None
+    citada = obter_mensagem_por_id(db, conversa_id, int(reply_to_message_id))
+    if not citada:
+        raise ChatInternoErro("Mensagem citada não encontrada nesta conversa.")
+    autor = citada.atendente.nome if citada.atendente else "Atendente"
+    preview = (preview_mensagem(citada) or "")[:500] or None
+    return citada.id, preview, autor
+
+
 def enviar_mensagem_midia(
     db: Session,
     conversa: ConversaInterna,
@@ -618,6 +639,7 @@ def enviar_mensagem_midia(
     mimetype: str | None,
     nome_original: str | None,
     caption: str = "",
+    reply_to_message_id: int | None = None,
 ) -> MensagemInterna:
     if not pode_acessar_conversa(db, atendente, conversa):
         raise ChatInternoErro("Sem permissão para esta conversa.")
@@ -637,6 +659,7 @@ def enviar_mensagem_midia(
 
     cap = (caption or "").strip()
     corpo_eff = cap if cap else rotulo_midia(tipo_db)
+    reply_id, reply_preview, reply_autor = _resolver_citacao(db, conversa.id, reply_to_message_id)
 
     mensagem = MensagemInterna(
         conversa_id=conversa.id,
@@ -647,6 +670,9 @@ def enviar_mensagem_midia(
         nome_arquivo=nome_sanitizado,
         storage_key=storage_key,
         tamanho_bytes=len(data),
+        reply_to_message_id=reply_id,
+        reply_preview=reply_preview,
+        reply_autor_nome=reply_autor,
     )
     db.add(mensagem)
     db.flush()

--- a/backend/tests/test_chat_interno_api.py
+++ b/backend/tests/test_chat_interno_api.py
@@ -146,3 +146,26 @@ def test_admin_publica_no_canal_sem_vinculo(client, seed_base, auth_headers):
         headers=auth_headers["admin"],
     )
     assert r.status_code == 201
+
+
+def test_responder_mensagem_interna(client, seed_base, auth_headers):
+    """#539 — reply_to_message_id + preview na leitura."""
+    conv = _criar_direta(client, auth_headers["a1"], seed_base["a2"].id)
+    original = _enviar_mensagem(client, auth_headers["a1"], conv["id"], "Mensagem original")
+    r = client.post(
+        f"/v1/chat-interno/conversas/{conv['id']}/mensagens",
+        json={"corpo": "Resposta citada", "reply_to_message_id": original["id"]},
+        headers=auth_headers["a2"],
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["reply_to_message_id"] == original["id"]
+    assert body["reply_preview"] == "Mensagem original"
+    assert body["reply_autor_nome"]
+
+    r404 = client.post(
+        f"/v1/chat-interno/conversas/{conv['id']}/mensagens",
+        json={"corpo": "x", "reply_to_message_id": 999999},
+        headers=auth_headers["a1"],
+    )
+    assert r404.status_code == 400

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1529,6 +1529,9 @@ export namespace ChatInterno {
     pode_editar?: boolean;
     pode_apagar_para_todos?: boolean;
     pode_apagar_para_mim?: boolean;
+    reply_to_message_id?: number | null;
+    reply_preview?: string | null;
+    reply_autor_nome?: string | null;
     created_at: string;
   }
 
@@ -1571,12 +1574,15 @@ export const chatInterno = {
         antes_de_id: params?.antesDeId,
       }),
     ),
-  enviar: (conversaId: number, corpo: string) =>
+  enviar: (conversaId: number, corpo: string, replyToMessageId?: number | null) =>
     api<ChatInterno.Mensagem>(`/chat-interno/conversas/${conversaId}/mensagens`, {
       method: 'POST',
-      body: JSON.stringify({ corpo }),
+      body: JSON.stringify({
+        corpo,
+        ...(replyToMessageId != null ? { reply_to_message_id: replyToMessageId } : {}),
+      }),
     }),
-  enviarMidia: (conversaId: number, file: File, caption?: string) => {
+  enviarMidia: (conversaId: number, file: File, caption?: string, replyToMessageId?: number | null) => {
     const formData = new FormData();
     formData.append('file', file);
     let mediatipo: ChatInterno.TipoMidia = 'documento';
@@ -1586,6 +1592,7 @@ export const chatInterno = {
     } else if (file.type.startsWith('video/')) mediatipo = 'video';
     formData.append('mediatipo', mediatipo);
     formData.append('caption', caption || '');
+    if (replyToMessageId != null) formData.append('reply_to_message_id', String(replyToMessageId));
     return api<ChatInterno.Mensagem>(`/chat-interno/conversas/${conversaId}/mensagens/midia`, {
       method: 'POST',
       body: formData,

--- a/frontend/src/components/chat-interno/ChatInternoComposerBar.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoComposerBar.tsx
@@ -99,7 +99,8 @@ export function ChatInternoComposerBar({
 
   const temTexto = texto.trim().length > 0
 
-  const desabilitado = enviando || Boolean(midiaPendente)
+  const campoBloqueado = Boolean(midiaPendente)
+  const acoesBloqueadas = enviando || campoBloqueado
 
 
 
@@ -123,10 +124,9 @@ export function ChatInternoComposerBar({
 
   function enviar() {
 
-    if (desabilitado || !temTexto) return
-
+    if (acoesBloqueadas || !temTexto) return
     onEnviar()
-
+    requestAnimationFrame(() => textareaRef.current?.focus())
   }
 
 
@@ -299,7 +299,7 @@ export function ChatInternoComposerBar({
 
             <WhatsappGravadorAudioInline
 
-              disabled={desabilitado}
+              disabled={acoesBloqueadas}
 
               onConcluido={(file) => {
 
@@ -343,7 +343,7 @@ export function ChatInternoComposerBar({
 
               type="button"
 
-              disabled={desabilitado}
+              disabled={acoesBloqueadas}
 
               aria-label="Anexos"
 
@@ -397,7 +397,7 @@ export function ChatInternoComposerBar({
 
               type="button"
 
-              disabled={desabilitado}
+              disabled={acoesBloqueadas}
 
               title="Emoji"
 
@@ -419,7 +419,7 @@ export function ChatInternoComposerBar({
 
               <ChatInternoEmojiPanel
 
-                disabled={desabilitado}
+                disabled={acoesBloqueadas}
 
                 onInserirEmoji={inserirEmojiNoCursor}
 
@@ -445,7 +445,7 @@ export function ChatInternoComposerBar({
 
             rows={1}
 
-            disabled={desabilitado}
+            disabled={campoBloqueado}
 
             className="max-h-32 min-h-[40px] min-w-0 flex-1 resize-none break-words border-none bg-transparent p-2 text-base focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
 
@@ -473,7 +473,7 @@ export function ChatInternoComposerBar({
 
               onClick={enviar}
 
-              disabled={desabilitado || !temTexto}
+              disabled={acoesBloqueadas || !temTexto}
 
               className="h-10 w-10 shrink-0 rounded-full bg-cyan-600 p-0 text-white shadow-lg shadow-cyan-600/30 hover:bg-cyan-700 disabled:opacity-50"
 
@@ -493,7 +493,7 @@ export function ChatInternoComposerBar({
 
               type="button"
 
-              disabled={desabilitado || gravando}
+              disabled={acoesBloqueadas || gravando}
 
               aria-label="Gravar áudio"
 
@@ -592,11 +592,7 @@ function ChatInternoEmojiPanel({
             className="flex h-9 w-9 items-center justify-center rounded-lg text-xl hover:bg-slate-100 disabled:opacity-40 dark:hover:bg-slate-800"
 
             onClick={() => {
-
               onInserirEmoji(e)
-
-              onFechar()
-
             }}
 
           >

--- a/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
@@ -15,6 +15,7 @@ type Props = {
   mensagem: ChatInterno.Mensagem
   onEditar: (novoCorpo: string) => Promise<void>
   onApagar: (escopo: 'todos' | 'para_mim') => Promise<void>
+  onResponder?: () => void
   alinhamento?: 'start' | 'end'
 }
 
@@ -22,6 +23,7 @@ export function ChatInternoMensagemAcoes({
   mensagem,
   onEditar,
   onApagar,
+  onResponder,
   alinhamento = 'end',
 }: Props) {
   const [editando, setEditando] = useState(false)
@@ -33,7 +35,8 @@ export function ChatInternoMensagemAcoes({
   const podeEditar = Boolean(mensagem.pode_editar)
   const podeApagarTodos = Boolean(mensagem.pode_apagar_para_todos)
   const podeApagarMim = Boolean(mensagem.pode_apagar_para_mim)
-  const temAcoes = podeEditar || podeApagarTodos || podeApagarMim
+  const podeResponder = Boolean(onResponder) && !mensagem.apagada
+  const temAcoes = podeEditar || podeApagarTodos || podeApagarMim || podeResponder
 
   const tipoMidia = mensagem.tipo_midia || 'texto'
   const editandoTexto = tipoMidia === 'texto'
@@ -90,6 +93,15 @@ export function ChatInternoMensagemAcoes({
           alinhamento === 'end' ? 'right-1' : 'left-1'
         }`}
       >
+        {podeResponder && (
+          <button
+            type="button"
+            onClick={() => onResponder?.()}
+            className="pointer-events-auto rounded-full bg-white/95 px-2 py-0.5 text-[10px] font-medium text-slate-600 shadow-sm ring-1 ring-slate-200 hover:bg-white dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-600"
+          >
+            Responder
+          </button>
+        )}
         {podeEditar && (
           <button
             type="button"

--- a/frontend/src/components/chat-interno/ChatInternoMidiaPreviewOverlay.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoMidiaPreviewOverlay.tsx
@@ -63,7 +63,6 @@ export function ChatInternoMidiaPreviewOverlay({ arquivo, legendaInicial = '', o
       const pos = start + emoji.length
       el.setSelectionRange(pos, pos)
     })
-    setEmojiAberto(false)
   }
 
   return (

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -47,6 +47,7 @@ export function ChatInternoThread() {
   const [texto, setTexto] = useState('')
   const [loading, setLoading] = useState(true)
   const [enviando, setEnviando] = useState(false)
+  const [msgRespondida, setMsgRespondida] = useState<ChatInterno.Mensagem | null>(null)
   const [forbidden, setForbidden] = useState(false)
   const [erro, setErro] = useState(false)
   const [temMaisAntigas, setTemMaisAntigas] = useState(false)
@@ -326,8 +327,9 @@ export function ChatInternoThread() {
     if (enviando) return
     setEnviando(true)
     try {
-      const msg = await chatInterno.enviarMidia(conversaId, file, caption)
+      const msg = await chatInterno.enviarMidia(conversaId, file, caption, msgRespondida?.id ?? null)
       setTexto('')
+      setMsgRespondida(null)
       setMensagens((prev) => (prev.some((m) => m.id === msg.id) ? prev : [...prev, msg]))
       stickToBottomRef.current = true
       requestAnimationFrame(() => {
@@ -349,8 +351,9 @@ export function ChatInternoThread() {
     if (!corpo || enviando) return
     setEnviando(true)
     try {
-      const msg = await chatInterno.enviar(conversaId, corpo)
+      const msg = await chatInterno.enviar(conversaId, corpo, msgRespondida?.id ?? null)
       setTexto('')
+      setMsgRespondida(null)
       setMensagens((prev) => (prev.some((m) => m.id === msg.id) ? prev : [...prev, msg]))
       stickToBottomRef.current = true
       requestAnimationFrame(() => {
@@ -500,11 +503,25 @@ export function ChatInternoThread() {
                       <span className="font-normal normal-case text-slate-400">· editada</span>
                     )}
                   </div>
+                  {m.reply_to_message_id && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const el = document.querySelector(`[data-chat-msg-id="${m.reply_to_message_id}"]`)
+                        el?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                      }}
+                      className="mb-2 w-full rounded-md border-l-2 border-amber-500 bg-amber-100/80 px-2 py-1 text-left text-[11px] text-amber-950 dark:bg-amber-950/50 dark:text-amber-100"
+                    >
+                      <p className="font-semibold truncate">{m.reply_autor_nome || 'Mensagem'}</p>
+                      <p className="truncate opacity-90">{m.reply_preview || '…'}</p>
+                    </button>
+                  )}
                   <ChatInternoConteudoMensagem conversaId={conversaId} mensagem={m} />
                   <ChatInternoMensagemAcoes
                     mensagem={m}
                     onEditar={(corpo) => editarMensagem(m.id, corpo)}
                     onApagar={(escopo) => apagarMensagem(m.id, escopo)}
+                    onResponder={() => setMsgRespondida(m)}
                   />
                   {!m.apagada && (
                     <ChatInternoReacoesBar
@@ -546,6 +563,23 @@ export function ChatInternoThread() {
                           {m.atendente_nome ?? 'Atendente'}
                         </p>
                       )}
+                      {m.reply_to_message_id && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            const el = document.querySelector(`[data-chat-msg-id="${m.reply_to_message_id}"]`)
+                            el?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                          }}
+                          className={`mb-1 w-full rounded-md border-l-2 px-2 py-1 text-left text-[11px] ${
+                            propria
+                              ? 'border-white/50 bg-white/15 text-white/90'
+                              : 'border-cyan-500 bg-slate-100 text-slate-600 dark:bg-slate-900/60 dark:text-slate-300'
+                          }`}
+                        >
+                          <p className="font-semibold truncate">{m.reply_autor_nome || 'Mensagem'}</p>
+                          <p className="truncate opacity-90">{m.reply_preview || '…'}</p>
+                        </button>
+                      )}
                       <ChatInternoConteudoMensagem
                         conversaId={conversaId}
                         mensagem={m}
@@ -578,6 +612,7 @@ export function ChatInternoThread() {
                       mensagem={m}
                       onEditar={(corpo) => editarMensagem(m.id, corpo)}
                       onApagar={(escopo) => apagarMensagem(m.id, escopo)}
+                      onResponder={() => setMsgRespondida(m)}
                       alinhamento={propria ? 'end' : 'start'}
                     />
                     {!m.apagada && (
@@ -595,6 +630,29 @@ export function ChatInternoThread() {
         )}
         </div>
       </div>
+
+      {msgRespondida && (
+        <div className="flex items-start justify-between gap-3 border-t border-slate-200 bg-slate-50 px-4 py-2 dark:border-slate-800 dark:bg-slate-900/80">
+          <div className="min-w-0 border-l-2 border-cyan-500 pl-2">
+            <p className="text-xs font-semibold text-cyan-700 dark:text-cyan-300">
+              {msgRespondida.atendente_id === user?.id ? 'Você' : msgRespondida.atendente_nome || 'Atendente'}
+            </p>
+            <p className="truncate text-xs text-slate-600 dark:text-slate-300">
+              {msgRespondida.tipo_midia && msgRespondida.tipo_midia !== 'texto'
+                ? `[${msgRespondida.tipo_midia}] ${msgRespondida.corpo}`
+                : msgRespondida.corpo}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setMsgRespondida(null)}
+            className="shrink-0 text-slate-400 hover:text-slate-700 dark:hover:text-slate-200"
+            aria-label="Cancelar resposta"
+          >
+            ×
+          </button>
+        </div>
+      )}
 
       <ChatInternoComposerBar
         texto={texto}

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -64,11 +64,15 @@ export function WhatsappComposerBar({
   }, [menuAberto])
 
   const temTexto = texto.trim().length > 0
-  const desabilitado = encerrado || !podeDigitar || enviando
+  /** Não incluir `enviando`: disabled no textarea remove o foco (#539). */
+  const campoBloqueado = encerrado || !podeDigitar
+  const acoesBloqueadas = campoBloqueado || enviando
 
   function enviar() {
+    if (acoesBloqueadas || !temTexto) return
     if (modoInterno && onEnviarInterno) onEnviarInterno()
     else onEnviar()
+    requestAnimationFrame(() => textareaRef.current?.focus())
   }
 
   function inserirEmojiNoCursor(emoji: string) {
@@ -105,7 +109,7 @@ export function WhatsappComposerBar({
         <div className="relative shrink-0" ref={menuRef}>
           <button
             type="button"
-            disabled={desabilitado || modoInterno || !podeEnviar}
+            disabled={acoesBloqueadas || modoInterno || !podeEnviar}
             aria-label="Anexos"
             title={modoInterno ? 'Anexos indisponíveis em modo interno' : 'Anexos'}
             onClick={() => setMenuAberto((o) => !o)}
@@ -135,7 +139,7 @@ export function WhatsappComposerBar({
         <div className="relative shrink-0" ref={emojiRef}>
           <button
             type="button"
-            disabled={desabilitado || modoInterno || !podeEnviar}
+            disabled={acoesBloqueadas || modoInterno || !podeEnviar}
             title="Emoji e figurinhas"
             aria-label="Emoji e figurinhas"
             aria-expanded={painelEmojiAberto}
@@ -146,7 +150,7 @@ export function WhatsappComposerBar({
           </button>
           {painelEmojiAberto && (
             <WhatsappEmojiFigurinhaPanel
-              disabled={desabilitado || modoInterno || !podeEnviar}
+              disabled={acoesBloqueadas || modoInterno || !podeEnviar}
               onInserirEmoji={inserirEmojiNoCursor}
               onEnviarFigurinha={onEnviarFigurinha}
               onFechar={() => setPainelEmojiAberto(false)}
@@ -172,12 +176,12 @@ export function WhatsappComposerBar({
                   : 'Somente comentários internos…'
           }
           rows={1}
-          disabled={desabilitado}
+          disabled={campoBloqueado}
           className="max-h-32 min-h-[40px] flex-1 resize-none border-none bg-transparent p-2 text-sm focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.shiftKey) {
               e.preventDefault()
-              if (!desabilitado && temTexto) enviar()
+              if (!acoesBloqueadas && temTexto) enviar()
             }
           }}
         />
@@ -185,7 +189,7 @@ export function WhatsappComposerBar({
         {temTexto ? (
           <Button
             onClick={enviar}
-            disabled={desabilitado || !temTexto}
+            disabled={acoesBloqueadas || !temTexto}
             className="h-10 w-10 shrink-0 rounded-full bg-cyan-600 p-0 text-white shadow-lg shadow-cyan-600/30 hover:bg-cyan-700 disabled:opacity-50"
             aria-label="Enviar"
           >
@@ -194,7 +198,7 @@ export function WhatsappComposerBar({
         ) : (
           <button
             type="button"
-            disabled={desabilitado || modoInterno || !podeEnviar || gravando}
+            disabled={acoesBloqueadas || modoInterno || !podeEnviar || gravando}
             aria-label="Gravar áudio"
             title="Gravar áudio"
             onClick={() => setGravando(true)}

--- a/frontend/src/pages/whatsapp/WhatsappEmojiFigurinhaPanel.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappEmojiFigurinhaPanel.tsx
@@ -57,7 +57,6 @@ export function WhatsappEmojiFigurinhaPanel({ disabled, onInserirEmoji, onEnviar
               className="flex h-9 w-9 items-center justify-center rounded-lg text-xl hover:bg-slate-100 disabled:opacity-40 dark:hover:bg-slate-800"
               onClick={() => {
                 onInserirEmoji(e)
-                onFechar()
               }}
             >
               {e}


### PR DESCRIPTION
## Summary
- Cursor permanece no campo de texto após enviar (WhatsApp e chat interno).
- Painel de emoji permanece aberto ao escolher vários emojis.
- Chat interno (direta / equipe / grupo): **Responder** com citação — migration `069`, API e UI.
- Closes #539

## Test plan
- [ ] WhatsApp: enviar texto e continuar digitando sem clicar de novo
- [ ] WhatsApp: abrir emoji, inserir vários sem reabrir o painel
- [ ] Chat interno: idem foco e emoji
- [ ] Chat interno: Responder → banner no composer → enviar → citação na bolha
- [ ] `alembic upgrade head` aplica `069_chat_interno_reply`