### PR TITLE
fix(whatsapp): identificar único, inatividade e Ctrl+V

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - WhatsApp: removido botão duplicado «Identificar contato» no header — fica só o do banner enquanto o contacto não está vinculado; após vincular o CTA some
 - WhatsApp: encerramento por inatividade só conta a partir da última mensagem do cliente quando o chat já está em atendimento e o atendente já enviou mensagem humana (auto_assumido/BOT não disparam o timer)
 - WhatsApp: Ctrl+V no composer cola imagem/ficheiro do clipboard (pré-visualização antes de enviar), como no chat interno
+- Chat: removida a borda branca de foco no campo de mensagem (WhatsApp e chat interno)
 - WhatsApp / modais: ao digitar na descrição da demanda no **Encerrar atendimento**, o campo perdia o foco a cada atualização da conversa — diálogo já não refoca o painel; formulário não é limpo pelo poll
 - Sons de alerta: toque de **abertura de ticket** e de **novo chat** (fila WhatsApp/Portal) estavam trocados — ticket usa `notification.mp3` e chat na fila usa `alerta.mp3`
 - WhatsApp: conversa em atendimento disparava loop de pedidos a `/demandas` (e esgotava recursos do browser com `ERR_INSUFFICIENT_RESOURCES`) — o painel de demandas já não notifica o pai no carregamento inicial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - WhatsApp: encerramento por inatividade só conta a partir da última mensagem do cliente quando o chat já está em atendimento e o atendente já enviou mensagem humana (auto_assumido/BOT não disparam o timer)
 - WhatsApp: Ctrl+V no composer cola imagem/ficheiro do clipboard (pré-visualização antes de enviar), como no chat interno
 - Chat: removida a borda branca de foco no campo de mensagem e nos demais inputs/textareas (outline nativo + alinhamento ao design system)
+- Chat interno: contraste no hover de Responder/Editar/Apagar; duplo clique na mensagem (ou ao lado do balão) inicia resposta e foca o composer — também no WhatsApp
 - WhatsApp / modais: ao digitar na descrição da demanda no **Encerrar atendimento**, o campo perdia o foco a cada atualização da conversa — diálogo já não refoca o painel; formulário não é limpo pelo poll
 - Sons de alerta: toque de **abertura de ticket** e de **novo chat** (fila WhatsApp/Portal) estavam trocados — ticket usa `notification.mp3` e chat na fila usa `alerta.mp3`
 - WhatsApp: conversa em atendimento disparava loop de pedidos a `/demandas` (e esgotava recursos do browser com `ERR_INSUFFICIENT_RESOURCES`) — o painel de demandas já não notifica o pai no carregamento inicial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp: removido botão duplicado «Identificar contato» no header — fica só o do banner enquanto o contacto não está vinculado; após vincular o CTA some
+- WhatsApp: encerramento por inatividade só conta a partir da última mensagem do cliente quando o chat já está em atendimento e o atendente já enviou mensagem humana (auto_assumido/BOT não disparam o timer)
+- WhatsApp: Ctrl+V no composer cola imagem/ficheiro do clipboard (pré-visualização antes de enviar), como no chat interno
 - WhatsApp / modais: ao digitar na descrição da demanda no **Encerrar atendimento**, o campo perdia o foco a cada atualização da conversa — diálogo já não refoca o painel; formulário não é limpo pelo poll
 - Sons de alerta: toque de **abertura de ticket** e de **novo chat** (fila WhatsApp/Portal) estavam trocados — ticket usa `notification.mp3` e chat na fila usa `alerta.mp3`
 - WhatsApp: conversa em atendimento disparava loop de pedidos a `/demandas` (e esgotava recursos do browser com `ERR_INSUFFICIENT_RESOURCES`) — o painel de demandas já não notifica o pai no carregamento inicial

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - WhatsApp: removido botão duplicado «Identificar contato» no header — fica só o do banner enquanto o contacto não está vinculado; após vincular o CTA some
 - WhatsApp: encerramento por inatividade só conta a partir da última mensagem do cliente quando o chat já está em atendimento e o atendente já enviou mensagem humana (auto_assumido/BOT não disparam o timer)
 - WhatsApp: Ctrl+V no composer cola imagem/ficheiro do clipboard (pré-visualização antes de enviar), como no chat interno
-- Chat: removida a borda branca de foco no campo de mensagem (WhatsApp e chat interno)
+- Chat: removida a borda branca de foco no campo de mensagem e nos demais inputs/textareas (outline nativo + alinhamento ao design system)
 - WhatsApp / modais: ao digitar na descrição da demanda no **Encerrar atendimento**, o campo perdia o foco a cada atualização da conversa — diálogo já não refoca o painel; formulário não é limpo pelo poll
 - Sons de alerta: toque de **abertura de ticket** e de **novo chat** (fila WhatsApp/Portal) estavam trocados — ticket usa `notification.mp3` e chat na fila usa `alerta.mp3`
 - WhatsApp: conversa em atendimento disparava loop de pedidos a `/demandas` (e esgotava recursos do browser com `ERR_INSUFFICIENT_RESOURCES`) — o painel de demandas já não notifica o pai no carregamento inicial

--- a/backend/app/services/whatsapp_inactivity_worker.py
+++ b/backend/app/services/whatsapp_inactivity_worker.py
@@ -50,13 +50,31 @@ def _ultima_mensagem_relevante(db: Session, chat_id: int) -> WhatsappMensagem | 
     )
 
 
+def _ultima_outbound_humana(db: Session, chat_id: int) -> WhatsappMensagem | None:
+    """Mensagem enviada pelo atendente (não BOT / auto_assumido / avisos de sistema)."""
+    return (
+        db.query(WhatsappMensagem)
+        .filter(
+            WhatsappMensagem.chat_id == chat_id,
+            WhatsappMensagem.direcao == "outbound",
+            WhatsappMensagem.evento_sistema.is_(None),
+        )
+        .order_by(desc(WhatsappMensagem.created_at), desc(WhatsappMensagem.id))
+        .first()
+    )
+
+
 def _referencia_inatividade_cliente(db: Session, chat: WhatsappChat) -> datetime | None:
     """
     Momento a partir do qual o cliente está inativo.
 
-    Conta desde a última mensagem **do cliente** quando o atendente já respondeu depois
-    (cliente sumiu). Novas mensagens do atendente não reiniciam o timer — evita que
-    o atendente "fale sozinho" e impeça o encerramento.
+    Conta desde a última mensagem **do cliente** somente quando:
+    - o chat já está em atendimento (garantido pelo caller);
+    - o atendente já enviou pelo menos uma mensagem humana (não auto_assumido/BOT);
+    - essa resposta humana é posterior à última inbound (cliente sumiu).
+
+    Mensagens de sistema (auto_assumido, auto_espera, avisos) não disparam o timer.
+    Novas mensagens do atendente não reiniciam o relógio.
     """
     last_in = (
         _mensagens_relevantes_q(db, chat.id)
@@ -64,16 +82,9 @@ def _referencia_inatividade_cliente(db: Session, chat: WhatsappChat) -> datetime
         .order_by(desc(WhatsappMensagem.created_at), desc(WhatsappMensagem.id))
         .first()
     )
-    last_out = (
-        _mensagens_relevantes_q(db, chat.id)
-        .filter(WhatsappMensagem.direcao == "outbound")
-        .order_by(desc(WhatsappMensagem.created_at), desc(WhatsappMensagem.id))
-        .first()
-    )
-    if not last_out:
+    last_out = _ultima_outbound_humana(db, chat.id)
+    if not last_out or last_in is None:
         return None
-    if last_in is None:
-        return last_out.created_at or chat.atendimento_inicio_at
     out_at = last_out.created_at
     in_at = last_in.created_at
     if out_at is None or in_at is None:

--- a/backend/tests/test_whatsapp_inatividade_encerramento.py
+++ b/backend/tests/test_whatsapp_inatividade_encerramento.py
@@ -160,6 +160,41 @@ def test_worker_nao_age_quando_cliente_respondeu_por_ultimo(client, seed_base, a
     assert n == 0
 
 
+def test_worker_nao_age_so_com_auto_assumido(client, seed_base, auth_headers, db_session, monkeypatch):
+    """Mensagem de sistema ao assumir não conta como resposta do atendente."""
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session, wa_id="5511888776655")
+    antiga = datetime.now(timezone.utc) - timedelta(minutes=30)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="inbound",
+            corpo="Preciso de ajuda",
+            tipo_midia="texto",
+            created_at=antiga,
+        )
+    )
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Atendimento iniciado",
+            tipo_midia="texto",
+            evento_sistema="auto_assumido",
+            created_at=antiga + timedelta(minutes=1),
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-assumido"),
+    )
+
+    n = process_whatsapp_inactivity_closures(db_session)
+    assert n == 0
+
+
 def test_worker_aviso_mesmo_com_atendente_enviando_varias_vezes(
     client, seed_base, auth_headers, db_session, monkeypatch
 ):

--- a/frontend/src/components/TicketMensagemEmailOutbox.tsx
+++ b/frontend/src/components/TicketMensagemEmailOutbox.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { ApiError, tickets, type Tickets } from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { Button } from './ui/Button'
+import { TEXTAREA_FIELD_CLASS } from './ui/Input'
 import { useToast } from './ui/Toast'
 import {
   mensagemEmFilaEmail,
@@ -141,7 +142,7 @@ export function TicketMensagemEmailOutbox({ ticketId, msg, podeGerir, onAtualiza
             value={editCorpo}
             onChange={(e) => setEditCorpo(e.target.value)}
             rows={4}
-            className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+            className={TEXTAREA_FIELD_CLASS}
             disabled={busy}
           />
           <div className="flex flex-wrap gap-2">

--- a/frontend/src/components/chat-interno/ChatInternoComposerBar.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoComposerBar.tsx
@@ -46,6 +46,9 @@ type Props = {
 
   labelEnviar?: string
 
+  /** Incrementar para focar o textarea (ex.: após Responder). */
+  focoPedidoEm?: number
+
 }
 
 
@@ -74,6 +77,8 @@ export function ChatInternoComposerBar({
 
   labelEnviar = 'Enviar',
 
+  focoPedidoEm,
+
 }: Props) {
 
   const [menuAberto, setMenuAberto] = useState(false)
@@ -95,7 +100,10 @@ export function ChatInternoComposerBar({
 
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-
+  useEffect(() => {
+    if (focoPedidoEm == null || focoPedidoEm <= 0) return
+    requestAnimationFrame(() => textareaRef.current?.focus())
+  }, [focoPedidoEm])
 
   const temTexto = texto.trim().length > 0
 

--- a/frontend/src/components/chat-interno/ChatInternoComposerBar.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoComposerBar.tsx
@@ -447,7 +447,7 @@ export function ChatInternoComposerBar({
 
             disabled={campoBloqueado}
 
-            className="max-h-32 min-h-[40px] min-w-0 flex-1 resize-none break-words border-none bg-transparent p-2 text-base focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
+            className="max-h-32 min-h-[40px] min-w-0 flex-1 resize-none break-words border-0 bg-transparent p-2 text-base outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
 
             onKeyDown={(e) => {
 

--- a/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
@@ -87,6 +87,9 @@ export function ChatInternoMensagemAcoes({
     )
   }
 
+  const btnAcaoClass =
+    'pointer-events-auto rounded-full bg-white px-2 py-0.5 text-[10px] font-medium text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-100 dark:ring-slate-600 dark:hover:bg-slate-700'
+
   return (
     <>
       <div
@@ -95,11 +98,7 @@ export function ChatInternoMensagemAcoes({
         }`}
       >
         {podeResponder && (
-          <button
-            type="button"
-            onClick={() => onResponder?.()}
-            className="pointer-events-auto rounded-full bg-white/95 px-2 py-0.5 text-[10px] font-medium text-slate-600 shadow-sm ring-1 ring-slate-200 hover:bg-white dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-600"
-          >
+          <button type="button" onClick={() => onResponder?.()} className={btnAcaoClass}>
             Responder
           </button>
         )}
@@ -110,17 +109,13 @@ export function ChatInternoMensagemAcoes({
               setTexto(legendaEditavel(mensagem))
               setEditando(true)
             }}
-            className="pointer-events-auto rounded-full bg-white/95 px-2 py-0.5 text-[10px] font-medium text-slate-600 shadow-sm ring-1 ring-slate-200 hover:bg-white dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-600"
+            className={btnAcaoClass}
           >
             Editar
           </button>
         )}
         {(podeApagarTodos || podeApagarMim) && (
-          <button
-            type="button"
-            onClick={() => setConfirmarApagar(true)}
-            className="pointer-events-auto rounded-full bg-white/95 px-2 py-0.5 text-[10px] font-medium text-slate-600 shadow-sm ring-1 ring-slate-200 hover:bg-white dark:bg-slate-800 dark:text-slate-200 dark:ring-slate-600"
-          >
+          <button type="button" onClick={() => setConfirmarApagar(true)} className={btnAcaoClass}>
             Apagar
           </button>
         )}

--- a/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import type { ChatInterno } from '../../api/client'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
+import { TEXTAREA_FIELD_CLASS } from '../ui/Input'
 
 const ROTULO_SEM_LEGENDA = /^(📷 Imagem|🎬 Vídeo|🎵 Áudio|📄 Documento)$/
 
@@ -55,7 +56,7 @@ export function ChatInternoMensagemAcoes({
           onChange={(e) => setTexto(e.target.value)}
           rows={editandoTexto ? 3 : 2}
           placeholder={editandoTexto ? undefined : 'Legenda da mídia (opcional)'}
-          className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+          className={TEXTAREA_FIELD_CLASS}
         />
         <div className="flex gap-2">
           <button

--- a/frontend/src/components/chat/ChatIniciarConversaModal.tsx
+++ b/frontend/src/components/chat/ChatIniciarConversaModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { whatsappChats, type WhatsappChats } from '../../api/client'
 import { Button } from '../../components/ui/Button'
-import { Input } from '../../components/ui/Input'
+import { Input, TEXTAREA_FIELD_CLASS } from '../../components/ui/Input'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { chatWhatsappLink } from '../../lib/chatHubPaths'
@@ -99,7 +99,7 @@ export function ChatIniciarConversaModal({
               value={mensagem}
               onChange={(e) => setMensagem(e.target.value)}
               rows={3}
-              className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-950"
+              className={`mt-1 ${TEXTAREA_FIELD_CLASS}`}
               placeholder="Ex.: Olá, retorno sobre a sua demanda…"
             />
           </label>

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -24,6 +24,9 @@ export const INPUT_FIELD_CLASS = `
             dark:disabled:bg-slate-900/30 dark:disabled:text-slate-500
           `
 
+/** Mesmo visual do Input para `<textarea>` soltos. */
+export const TEXTAREA_FIELD_CLASS = INPUT_FIELD_CLASS.trim()
+
 function slugFromLabel(label: string) {
   return (
     label

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -29,6 +29,17 @@
     max-height: 100dvh;
     overflow: hidden;
   }
+
+  /* Remove outline nativo (borda branca no dark); o foco fica nos rings/bordas do design system */
+  input:where(
+    :not([type='checkbox']):not([type='radio']):not([type='range']):not([type='file']):not([type='button']):not(
+        [type='submit']
+      ):not([type='reset']):not([type='image']):not([type='hidden'])
+  ),
+  textarea,
+  select {
+    outline: none;
+  }
 }
 
 /* Recharts: remove faixa clara no hover (incompatível com tema escuro) */

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -6,6 +6,7 @@ import { Card } from '../components/ui/Card'
 import { PageContainer } from '../components/ui/PageContainer'
 import { Button } from '../components/ui/Button'
 import { Switch } from '../components/ui/Switch'
+import { TEXTAREA_FIELD_CLASS } from '../components/ui/Input'
 import { useToast } from '../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import {
@@ -421,7 +422,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               value={msgEsperaTexto}
               onChange={(e) => setMsgEsperaTexto(e.target.value)}
               rows={4}
-              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              className={TEXTAREA_FIELD_CLASS}
             />
 
             <Switch
@@ -437,7 +438,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               value={msgAssumidoTexto}
               onChange={(e) => setMsgAssumidoTexto(e.target.value)}
               rows={4}
-              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              className={TEXTAREA_FIELD_CLASS}
             />
 
             <Switch
@@ -453,7 +454,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               value={msgEncerradoTexto}
               onChange={(e) => setMsgEncerradoTexto(e.target.value)}
               rows={4}
-              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              className={TEXTAREA_FIELD_CLASS}
             />
 
             <Switch
@@ -469,7 +470,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               value={msgForaHorarioTexto}
               onChange={(e) => setMsgForaHorarioTexto(e.target.value)}
               rows={4}
-              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              className={TEXTAREA_FIELD_CLASS}
             />
 
             <div className="flex justify-end pt-2">
@@ -562,7 +563,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               onChange={(e) => setMsgInativAvisoTexto(e.target.value)}
               rows={4}
               disabled={!inativEncerramentoAtiva || !msgInativAvisoAtiva}
-              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-500 focus:outline-none focus:ring-1 focus:ring-sky-500 disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              className={`${TEXTAREA_FIELD_CLASS} disabled:opacity-50`}
             />
 
             <div className="flex justify-end pt-2">
@@ -632,7 +633,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               onChange={(e) => setMsgAvaliacaoTexto(e.target.value)}
               rows={4}
               disabled={!avaliacaoAtiva || !msgAvaliacaoAtiva}
-              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              className={`${TEXTAREA_FIELD_CLASS} disabled:opacity-50`}
             />
             <label className="block text-xs font-medium text-slate-600 dark:text-slate-400">
               Mensagem de agradecimento após a nota
@@ -642,7 +643,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               onChange={(e) => setMsgAvaliacaoObrigadoTexto(e.target.value)}
               rows={2}
               disabled={!avaliacaoAtiva || !msgAvaliacaoAtiva}
-              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              className={`${TEXTAREA_FIELD_CLASS} disabled:opacity-50`}
             />
 
             <div className="flex justify-end pt-2">

--- a/frontend/src/pages/KbPortalSettings.tsx
+++ b/frontend/src/pages/KbPortalSettings.tsx
@@ -5,7 +5,7 @@ import { ApiError } from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
-import { Input } from '../components/ui/Input'
+import { Input, TEXTAREA_FIELD_CLASS } from '../components/ui/Input'
 import { CheckboxField } from '../components/ui/CheckboxField'
 import { useToast } from '../components/ui/Toast'
 import { ConfigListPageShell } from '../components/config/ConfigListPageShell'
@@ -181,8 +181,8 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
                 rows={3}
                 value={form.texto_boas_vindas}
                 onChange={(e) => setForm({ ...form, texto_boas_vindas: e.target.value })}
+                className={TEXTAREA_FIELD_CLASS}
                 placeholder="Consulte passo a passo para tirar dúvidas sobre o sistema."
-                className="w-full rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-sm dark:border-slate-600 dark:bg-slate-900"
               />
             </div>
           </Card>
@@ -238,8 +238,8 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
                 rows={2}
                 value={form.chat_texto_boas_vindas}
                 onChange={(e) => setForm({ ...form, chat_texto_boas_vindas: e.target.value })}
+                className={TEXTAREA_FIELD_CLASS}
                 placeholder="Olá! Como podemos ajudar?"
-                className="w-full rounded-xl border border-slate-300 bg-white px-3.5 py-2.5 text-sm dark:border-slate-600 dark:bg-slate-900"
               />
             </div>
           </Card>

--- a/frontend/src/pages/RespostaProntaForm.tsx
+++ b/frontend/src/pages/RespostaProntaForm.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom'
 import { ApiError, respostasProntas, setores, type Setores } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
-import { Input } from '../components/ui/Input'
+import { Input, TEXTAREA_FIELD_CLASS } from '../components/ui/Input'
 import { Switch } from '../components/ui/Switch'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
@@ -163,7 +163,7 @@ export function RespostaProntaForm() {
                   onChange={(e) => setCorpo(e.target.value)}
                   rows={8}
                   required
-                  className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-900 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100"
+                  className={`mt-1 ${TEXTAREA_FIELD_CLASS}`}
                 />
               </label>
             </FormSection>
@@ -173,7 +173,7 @@ export function RespostaProntaForm() {
                 <select
                   value={setorId}
                   onChange={(e) => setSetorId(e.target.value)}
-                  className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm text-slate-900 dark:border-slate-800 dark:bg-slate-950 dark:text-slate-100"
+                  className={`mt-1 ${TEXTAREA_FIELD_CLASS}`}
                 >
                   <option value="">Global — todos os setores</option>
                   {setoresOpts.map((s) => (

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import { ApiError, chatInterno, type ChatInterno } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
@@ -48,6 +48,7 @@ export function ChatInternoThread() {
   const [loading, setLoading] = useState(true)
   const [enviando, setEnviando] = useState(false)
   const [msgRespondida, setMsgRespondida] = useState<ChatInterno.Mensagem | null>(null)
+  const [focoComposerEm, setFocoComposerEm] = useState(0)
   const [forbidden, setForbidden] = useState(false)
   const [erro, setErro] = useState(false)
   const [temMaisAntigas, setTemMaisAntigas] = useState(false)
@@ -323,6 +324,18 @@ export function ChatInternoThread() {
     }
   }
 
+  function iniciarResposta(m: ChatInterno.Mensagem) {
+    if (m.apagada) return
+    setMsgRespondida(m)
+    setFocoComposerEm((n) => n + 1)
+  }
+
+  function duploCliqueResponder(e: MouseEvent, m: ChatInterno.Mensagem) {
+    const t = e.target as HTMLElement
+    if (t.closest('button, a, input, textarea, [role="dialog"]')) return
+    iniciarResposta(m)
+  }
+
   async function enviarMidia(file: File, caption?: string) {
     if (enviando) return
     setEnviando(true)
@@ -492,6 +505,7 @@ export function ChatInternoThread() {
                 <article
                   key={m.id}
                   data-chat-msg-id={m.id}
+                  onDoubleClick={(e) => duploCliqueResponder(e, m)}
                   className="group w-full min-w-0 overflow-hidden rounded-2xl border border-amber-200/80 bg-amber-50/95 p-5 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40"
                 >
                   <div className="mb-2 flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-200">
@@ -521,7 +535,7 @@ export function ChatInternoThread() {
                     mensagem={m}
                     onEditar={(corpo) => editarMensagem(m.id, corpo)}
                     onApagar={(escopo) => apagarMensagem(m.id, escopo)}
-                    onResponder={() => setMsgRespondida(m)}
+                    onResponder={() => iniciarResposta(m)}
                   />
                   {!m.apagada && (
                     <ChatInternoReacoesBar
@@ -544,7 +558,12 @@ export function ChatInternoThread() {
               )
             }
             return (
-              <div key={m.id} data-chat-msg-id={m.id} className={`group flex w-full ${propria ? 'justify-end' : 'justify-start'}`}>
+              <div
+                key={m.id}
+                data-chat-msg-id={m.id}
+                onDoubleClick={(e) => duploCliqueResponder(e, m)}
+                className={`group flex w-full cursor-default ${propria ? 'justify-end' : 'justify-start'}`}
+              >
                 <div
                   className={`flex max-w-[85%] flex-col sm:max-w-[min(65%,28rem)] ${
                     propria ? 'items-end' : 'items-start'
@@ -612,7 +631,7 @@ export function ChatInternoThread() {
                       mensagem={m}
                       onEditar={(corpo) => editarMensagem(m.id, corpo)}
                       onApagar={(escopo) => apagarMensagem(m.id, escopo)}
-                      onResponder={() => setMsgRespondida(m)}
+                      onResponder={() => iniciarResposta(m)}
                       alinhamento={propria ? 'end' : 'start'}
                     />
                     {!m.apagada && (
@@ -662,6 +681,7 @@ export function ChatInternoThread() {
         enviando={enviando}
         placeholder={isSetor ? 'Novo comunicado para o setor…' : 'Escreva uma mensagem…'}
         labelEnviar={isSetor ? 'Publicar' : 'Enviar'}
+        focoPedidoEm={focoComposerEm}
       />
     </div>
   )

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ClipboardEvent } from 'react'
 import { Button } from '../../components/ui/Button'
 import { KbConsultaButton } from '../../components/KbConsultaModal'
 import type { TipoAnexoPicker } from './WhatsappBarraAnexos'
@@ -14,6 +14,8 @@ type Props = {
   onAudioGravado: (file: File) => void
   onInserirEmoji: (emoji: string) => void
   onEnviarFigurinha: (file: File) => void
+  /** Ctrl+V / colar ficheiro do clipboard (imagem, etc.) */
+  onColarArquivo?: (file: File) => void
   enviando: boolean
   encerrado: boolean
   podeEnviar: boolean
@@ -40,6 +42,7 @@ export function WhatsappComposerBar({
   onAudioGravado,
   onInserirEmoji,
   onEnviarFigurinha,
+  onColarArquivo,
   enviando,
   encerrado,
   podeEnviar,
@@ -90,6 +93,17 @@ export function WhatsappComposerBar({
       const pos = start + emoji.length
       el.setSelectionRange(pos, pos)
     })
+  }
+
+  function handlePaste(e: ClipboardEvent<HTMLTextAreaElement>) {
+    if (acoesBloqueadas || modoInterno || !podeEnviar || !onColarArquivo) return
+    const files = Array.from(e.clipboardData?.items ?? [])
+      .filter((item) => item.kind === 'file')
+      .map((item) => item.getAsFile())
+      .filter((file): file is File => Boolean(file))
+    if (files.length === 0) return
+    e.preventDefault()
+    onColarArquivo(files[0])
   }
 
   return (
@@ -184,6 +198,7 @@ export function WhatsappComposerBar({
               if (!acoesBloqueadas && temTexto) enviar()
             }
           }}
+          onPaste={handlePaste}
         />
 
         {temTexto ? (

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -22,6 +22,8 @@ type Props = {
   modoInterno: boolean
   podeDigitar: boolean
   onInserirReferenciaKb?: (ref: string) => void
+  /** Incrementar para focar o textarea (ex.: após Responder). */
+  focoPedidoEm?: number
 }
 
 type MenuAnexo = { tipo: TipoAnexoPicker; label: string }
@@ -49,6 +51,7 @@ export function WhatsappComposerBar({
   modoInterno,
   podeDigitar,
   onInserirReferenciaKb,
+  focoPedidoEm,
 }: Props) {
   const [menuAberto, setMenuAberto] = useState(false)
   const [painelEmojiAberto, setPainelEmojiAberto] = useState(false)
@@ -65,6 +68,11 @@ export function WhatsappComposerBar({
     document.addEventListener('mousedown', onDoc)
     return () => document.removeEventListener('mousedown', onDoc)
   }, [menuAberto])
+
+  useEffect(() => {
+    if (focoPedidoEm == null || focoPedidoEm <= 0) return
+    requestAnimationFrame(() => textareaRef.current?.focus())
+  }, [focoPedidoEm])
 
   const temTexto = texto.trim().length > 0
   /** Não incluir `enviando`: disabled no textarea remove o foco (#539). */

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -191,7 +191,7 @@ export function WhatsappComposerBar({
           }
           rows={1}
           disabled={campoBloqueado}
-          className="max-h-32 min-h-[40px] flex-1 resize-none border-none bg-transparent p-2 text-sm focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
+          className="max-h-32 min-h-[40px] flex-1 resize-none border-0 bg-transparent p-2 text-sm outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.shiftKey) {
               e.preventDefault()

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -28,6 +28,7 @@ import { whatsappMensagensUnicas } from '../../lib/whatsappMensagens'
 import { MensagemRodapeMeta } from '../../components/chat/MensagemRodapeMeta'
 
 import { Card } from '../../components/ui/Card'
+import { TEXTAREA_FIELD_CLASS } from '../../components/ui/Input'
 
 import { Button } from '../../components/ui/Button'
 
@@ -1271,7 +1272,7 @@ useEffect(() => {
                   value={legendaMidia}
                   onChange={(e) => setLegendaMidia(e.target.value)}
                   placeholder="Legenda opcional (visível no WhatsApp)"
-                  className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900"
+                  className={`mt-2 ${TEXTAREA_FIELD_CLASS}`}
                 />
               )}
               <div className="mt-2 flex justify-end gap-2">

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useRef } from 'react'
+import { useCallback, useEffect, useState, useRef, type MouseEvent } from 'react'
 
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
@@ -273,6 +273,7 @@ export function WhatsappConversa() {
 
   // Estados de WhatsApp Clone (Citação e Zoom)
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
+  const [focoComposerEm, setFocoComposerEm] = useState(0)
   const [activeZoomImage, setActiveZoomImage] = useState<string | null>(null)
   const [activeZoomImageCaption, setActiveZoomImageCaption] = useState<string | null>(null)
   const [modoInterno, setModoInterno] = useState(false)
@@ -572,6 +573,18 @@ useEffect(() => {
   function inserirReferenciaKb(ref: string) {
     const sep = texto && !texto.endsWith('\n') ? '\n\n' : texto ? '' : ''
     setTexto(texto + sep + ref)
+  }
+
+  function iniciarResposta(m: WhatsappChats.Mensagem) {
+    setMsgRespondida(m)
+    setFocoComposerEm((n) => n + 1)
+  }
+
+  function duploCliqueResponder(e: MouseEvent, m: WhatsappChats.Mensagem, isSystem: boolean) {
+    if (isSystem || encerrado || !podeEnviar || modoInterno) return
+    const t = e.target as HTMLElement
+    if (t.closest('button, a, input, textarea, video, audio')) return
+    iniciarResposta(m)
   }
 
   async function enviar() {
@@ -1113,11 +1126,12 @@ useEffect(() => {
               <div 
                 key={m.id} 
                 id={`msg-${m.wa_message_id || m.id}`}
-                className={`flex w-full group items-center gap-2 transition-all ${isInbound ? 'justify-start' : 'justify-end'}`}
+                onDoubleClick={(e) => duploCliqueResponder(e, m, isSystem)}
+                className={`flex w-full group cursor-default items-center gap-2 transition-all ${isInbound ? 'justify-start' : 'justify-end'}`}
               >
                 {!isInbound && !isSystem && (
                   <button
-                    onClick={() => setMsgRespondida(m)}
+                    onClick={() => iniciarResposta(m)}
                     className="opacity-25 group-hover:opacity-100 md:opacity-0 transition-opacity p-1.5 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 cursor-pointer shrink-0"
                     title="Responder"
                   >
@@ -1193,7 +1207,7 @@ useEffect(() => {
 
                 {isInbound && !isSystem && (
                   <button
-                    onClick={() => setMsgRespondida(m)}
+                    onClick={() => iniciarResposta(m)}
                     className="opacity-25 group-hover:opacity-100 md:opacity-0 transition-opacity p-1.5 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 cursor-pointer shrink-0"
                     title="Responder"
                   >
@@ -1304,6 +1318,7 @@ useEffect(() => {
               setLegendaMidia('')
             }}
             onInserirReferenciaKb={inserirReferenciaKb}
+            focoPedidoEm={focoComposerEm}
           />
 
           <input

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -984,15 +984,6 @@ useEffect(() => {
               </Button>
             )}
 
-            <Button
-              variant="ghost"
-              className="inline-flex text-xs h-8"
-              onClick={() => setModalVincFuncionario(true)}
-            >
-              <span className="sm:hidden">{CONTATO_CLIENTE.vincularCurto}</span>
-              <span className="hidden sm:inline">{CONTATO_CLIENTE.vincularChat}</span>
-            </Button>
-
             {!encerrado && (
               <>
                 {podeTransferir && (
@@ -1307,6 +1298,10 @@ useEffect(() => {
             onAudioGravado={handleGravacaoConcluida}
             onInserirEmoji={setTexto}
             onEnviarFigurinha={(file) => void enviarFigurinha(file)}
+            onColarArquivo={(file) => {
+              setArquivoPendente(file)
+              setLegendaMidia('')
+            }}
             onInserirReferenciaKb={inserirReferenciaKb}
           />
 


### PR DESCRIPTION
## Summary

Correções de produção no chat WhatsApp:

- Remove o botão duplicado «Identificar contato» no header — fica só o CTA do banner enquanto não há vínculo; após vincular, o CTA some
- Encerramento por inatividade só conta a partir da última mensagem do cliente quando o chat já está em atendimento e o atendente já enviou mensagem humana (`auto_assumido`/BOT não disparam o timer)
- Ctrl+V no composer cola imagem/ficheiro do clipboard com pré-visualização (como no chat interno)

## Test plan

- [ ] Chat sem vínculo: só 1 botão Identificar (banner); após vincular, some
- [ ] Assumir chat sem responder: inatividade **não** avisa; após mensagem humana do atendente + silêncio do cliente, avisa/encerra
- [ ] Ctrl+V com imagem no composer WhatsApp abre pré-visualização e envia
- [ ] `pytest -q tests/test_whatsapp_inatividade_encerramento.py`
