### PR TITLE
feat(presenca): equipe online para admin (#545–#547)

### DIFF
--- a/.github/planning-issue-bodies/ISSUES_CRIADAS.md
+++ b/.github/planning-issue-bodies/ISSUES_CRIADAS.md
@@ -165,6 +165,18 @@ Portal KB white-label: [#464](https://github.com/lgustavoss/dx-connect/issues/46
 
 ---
 
+## Presença de atendentes online (2026-07-16)
+
+| Prefixo | Issue | Título |
+|---------|-------|--------|
+| PR | [#545](https://github.com/lgustavoss/dx-connect/issues/545) | **[Épico] Presença de atendentes online (admin)** |
+| PR-F1 | [#546](https://github.com/lgustavoss/dx-connect/issues/546) | Tracking SSE + API admin (backend) |
+| PR-F2 | [#547](https://github.com/lgustavoss/dx-connect/issues/547) | Tela admin Equipe online (frontend) |
+
+Online = conexão SSE ativa no painel. Lote sugerido: `feat/presenca-online`.
+
+---
+
 ## Análises de viabilidade (documentação)
 
 Material de apoio à decisão — **não** substitui issues no GitHub:

--- a/.github/planning-issue-bodies/issues/presenca-01-backend.md
+++ b/.github/planning-issue-bodies/issues/presenca-01-backend.md
@@ -1,0 +1,74 @@
+## Contexto
+
+Épico: [#545](https://github.com/lgustavoss/dx-connect/issues/545) Presença de atendentes online (admin).
+
+Parte de: **PR-F1** · Issue: [#546](https://github.com/lgustavoss/dx-connect/issues/546)
+
+O `RealtimeHub` já mantém filas por canal `atendente:{id}` em `subscribe` / `unsubscribe`. Falta registrar **quem** está conectado e **desde quando**, e expor isso numa API só para admin.
+
+## Proposta
+
+### Tracking no hub
+
+- Ao `subscribe` em `atendente:{id}`: se for a 1ª conexão desse canal, gravar `online_desde = now()` (UTC).
+- Ao `unsubscribe`: se o canal ficar sem filas, marcar offline (remover do mapa).
+- Multi-aba: contador de conexões; `online_desde` só muda quando o canal passa de 0 → 1 conexão.
+- Opcional v1: evento SSE `presenca.atualizada` para admins (payload mínimo: `{ atendente_id, online, online_desde? }`) — facilita UI sem polling agressivo. Se não houver canal «broadcast admin», aceitar polling na F2.
+
+### API
+
+`GET /v1/presenca/online` (ou `/v1/atendentes/presenca`) — **somente admin**
+
+Resposta sugerida (lista só online, ou todos com flag — preferir **só online** na v1):
+
+```json
+{
+  "itens": [
+    {
+      "atendente_id": 12,
+      "nome": "Maria",
+      "email": "maria@…",
+      "role": "atendente",
+      "online_desde": "2026-07-16T12:00:00Z",
+      "setores": [{ "id": 1, "nome": "Suporte" }]
+    }
+  ]
+}
+```
+
+- Incluir admins online também (eles também usam o painel).
+- Excluir contas `ativo=false` mesmo que ainda tenham SSE residual.
+- Tenant scope: só atendentes do tenant atual.
+
+### Testes
+
+- Integração: simular subscribe/unsubscribe (ou cliente SSE de teste) e assert da API.
+- RBAC: atendente recebe 403; admin 200.
+- Multi-aba: 2 connects → 1 disconnect → ainda online; 2º disconnect → some da lista.
+
+### Docs
+
+- Nota curta em `docs/REALTIME_SSE.md`: presença deriva do hub; limite multi-worker.
+
+## Critérios de aceite
+
+- [ ] Admin lista atendentes online com `online_desde`
+- [ ] Atendente recebe 403
+- [ ] Abre/fecha SSE reflete na lista (após disconnect limpo)
+- [ ] Multi-aba não zera presença até a última conexão
+- [ ] Testes de integração cobrindo happy path + RBAC
+- [ ] Nota multi-worker em `docs/REALTIME_SSE.md`
+
+## Dependências
+
+- Requer: SSE RT-F1 (#264) — já em produção
+
+## Fora de escopo
+
+- Persistência em banco / histórico
+- Redis para multi-worker
+- Status «ausente» manual
+
+## Labels
+
+`backend`, `enhancement`, `python`

--- a/.github/planning-issue-bodies/issues/presenca-02-frontend.md
+++ b/.github/planning-issue-bodies/issues/presenca-02-frontend.md
@@ -1,0 +1,64 @@
+## Contexto
+
+Épico: [#545](https://github.com/lgustavoss/dx-connect/issues/545) Presença de atendentes online (admin).
+
+Parte de: **PR-F2** · Issue: [#547](https://github.com/lgustavoss/dx-connect/issues/547)
+
+Depende de: [#546](https://github.com/lgustavoss/dx-connect/issues/546) (API presença).
+
+## Objetivo
+
+Tela no painel, **somente admin**, listando quem está online e desde quando — para coordenar atendimento de chats e tickets.
+
+## Proposta de UX
+
+### Navegação
+
+- Item no menu (ex.: **Equipe online** ou sob Relatórios/Dashboard) visível só para `role === admin`.
+- Rota sugerida: `/equipe/online` ou `/presenca`.
+
+### Conteúdo
+
+- Tabela ou lista:
+  - Nome
+  - Setores (chips/texto)
+  - Online desde (relativo «há 12 min» + tooltip com horário absoluto)
+  - Role (admin / atendente) — opcional, discreto
+- Estado vazio: «Nenhum atendente online no momento»
+- Contador no topo: «N online»
+- Refresh: polling leve (ex. 15–30 s) e/ou evento SSE `presenca.atualizada` se a F1 emitir
+- Indicador de última atualização
+
+### Fora desta tela (v1)
+
+- Ações na linha (atribuir ticket, ping)
+- Filtro por setor (nice-to-have se barato)
+- Histórico
+
+## Mapa técnico
+
+| Ação | Caminho provável |
+|------|------------------|
+| API client | `frontend/src/api/client.ts` |
+| Página | `frontend/src/pages/PresencaOnline.tsx` (ou pasta `equipe/`) |
+| Rota | `App.tsx` — guard admin |
+| Menu | `Sidebar.tsx` — só admin |
+
+Reutilizar padrões visuais de listagens admin existentes (Auditoria, dashboards) — sem inventar design system novo.
+
+## Critérios de aceite
+
+- [ ] Admin acessa a tela e vê online + desde quando
+- [ ] Atendente não vê o item no menu nem acessa a rota (redirect/403)
+- [ ] Lista atualiza periodicamente (ou via SSE)
+- [ ] Estado vazio legível
+- [ ] Mobile: lista legível
+- [ ] `npm run build` passa
+
+## Dependências
+
+- Requer: PR-F1 (API presença)
+
+## Labels
+
+`frontend`, `ux`, `enhancement`

--- a/.github/planning-issue-bodies/issues/presenca-epic.md
+++ b/.github/planning-issue-bodies/issues/presenca-epic.md
@@ -1,0 +1,44 @@
+## Contexto
+
+Administradores precisam saber **quem está online no painel** e **desde quando**, para coordenar quem pode atender chats (WhatsApp/portal) e tickets.
+
+Hoje o painel já abre SSE (`GET /v1/events/stream`) por atendente autenticado (`RealtimeHub`), mas **não há** tracking de presença nem tela para o admin consultar.
+
+Meta-issue: #16
+
+## Objetivo
+
+Expor presença em tempo quase real: lista de atendentes **online** (painel aberto com SSE ativo) com horário de início da sessão atual, consultável só por **admin**.
+
+## Definição de «online» (v1)
+
+| Critério | Decisão |
+|----------|---------|
+| Sinal | Conexão SSE ativa no hub (`atendente:{id}`) |
+| Multi-aba | Online enquanto houver ≥1 conexão; «desde» = início da sessão contínua (primeira conexão atual) |
+| Offline | Última conexão SSE fechou (aba fechada, logout, rede) |
+| Reinício do backend | Presença zera (memória do processo) — aceitável na v1 |
+| Multi-worker Gunicorn | Limitação conhecida do hub v1 (`docs/REALTIME_SSE.md`): presença confiável com `--workers 1` ou sticky session; Redis fora de escopo |
+
+**Não** confundir com `ativo` no cadastro (conta habilitada). Online = sessão ao vivo no painel.
+
+## Issues filhas
+
+| Fase | Issue | Entrega |
+|------|-------|---------|
+| **PR-F1** | [#546](https://github.com/lgustavoss/dx-connect/issues/546) | Backend: tracking no hub + API admin |
+| **PR-F2** | [#547](https://github.com/lgustavoss/dx-connect/issues/547) | Frontend: tela admin + refresh |
+
+## Fora de escopo (v1)
+
+- Histórico / relatório de horas online
+- Status manual «ausente» / «em pausa»
+- Indicador de presença no chat interno entre pares
+- Redis Pub/Sub para multi-worker
+- Contagem de carga (qtd. chats/tickets abertos) — follow-up possível
+
+## Critérios do épico
+
+- [ ] Admin vê quem está online e desde quando
+- [ ] Atendente não acessa a API/tela de presença
+- [ ] Documentar limite multi-worker se necessário

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Equipe online (#545–#547): administradores veem quem está com o painel aberto e desde quando (menu **Equipe online**), para coordenar atendimento de chats e tickets
 - Chat (#539): após enviar mensagem (WhatsApp e chat interno), o cursor permanece no campo de texto; painel de emoji fica aberto ao escolher vários; **Responder** mensagem no chat interno (direta, equipe e grupo)
 - WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homónimos
 - WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos

--- a/backend/app/api/presenca.py
+++ b/backend/app/api/presenca.py
@@ -1,0 +1,20 @@
+"""Presença online de atendentes — admin (#546 / #547)."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.core.auth import exigir_admin
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.schemas.presenca import PresencaOnlineLista
+from app.services import presenca as presenca_service
+
+router = APIRouter(prefix="/presenca", tags=["presenca"])
+
+
+@router.get("/online", response_model=PresencaOnlineLista)
+async def listar_online(
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return await presenca_service.listar_online(db, tenant_id=admin.tenant_id)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -29,6 +29,7 @@ from app.api import (
     cadastro_aux,
     notificacoes,
     events,
+    presenca,
     whatsapp_settings,
     whatsapp_chats,
     whatsapp_webhook,
@@ -440,6 +441,7 @@ app.include_router(tipo_negocio.router, prefix=API_V1_PREFIX)
 app.include_router(cadastro_aux.router, prefix=API_V1_PREFIX)
 app.include_router(notificacoes.router, prefix=API_V1_PREFIX)
 app.include_router(events.router, prefix=API_V1_PREFIX)
+app.include_router(presenca.router, prefix=API_V1_PREFIX)
 app.include_router(whatsapp_settings.router, prefix=API_V1_PREFIX)
 app.include_router(whatsapp_chats.router, prefix=API_V1_PREFIX)
 app.include_router(whatsapp_webhook.router, prefix=API_V1_PREFIX)

--- a/backend/app/schemas/presenca.py
+++ b/backend/app/schemas/presenca.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PresencaSetorResumo(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    nome: str
+
+
+class PresencaOnlineItem(BaseModel):
+    atendente_id: int
+    nome: str
+    email: str
+    role: str
+    online_desde: datetime
+    setores: list[PresencaSetorResumo] = []
+
+
+class PresencaOnlineLista(BaseModel):
+    itens: list[PresencaOnlineItem]

--- a/backend/app/services/presenca.py
+++ b/backend/app/services/presenca.py
@@ -1,0 +1,48 @@
+"""Presença de atendentes online — deriva do hub SSE (#546)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.atendente import Atendente
+from app.schemas.presenca import PresencaOnlineItem, PresencaOnlineLista, PresencaSetorResumo
+from app.services.realtime_hub import hub
+
+
+async def listar_online(db: Session, *, tenant_id: int) -> PresencaOnlineLista:
+    """Lista atendentes ativos do tenant com conexão SSE no hub."""
+    online = await hub.list_online()
+    if not online:
+        return PresencaOnlineLista(itens=[])
+
+    por_id = {aid: desde for aid, desde in online}
+    rows = (
+        db.query(Atendente)
+        .options(joinedload(Atendente.setores))
+        .filter(
+            Atendente.tenant_id == tenant_id,
+            Atendente.id.in_(list(por_id.keys())),
+            Atendente.ativo.is_(True),
+        )
+        .order_by(Atendente.nome.asc(), Atendente.id.asc())
+        .all()
+    )
+
+    itens: list[PresencaOnlineItem] = []
+    for a in rows:
+        desde = por_id[a.id]
+        if desde.tzinfo is None:
+            desde = desde.replace(tzinfo=timezone.utc)
+        itens.append(
+            PresencaOnlineItem(
+                atendente_id=a.id,
+                nome=a.nome,
+                email=a.email,
+                role=a.role,
+                online_desde=desde,
+                setores=[PresencaSetorResumo(id=s.id, nome=s.nome) for s in sorted(a.setores, key=lambda x: x.nome)],
+            )
+        )
+    return PresencaOnlineLista(itens=itens)

--- a/backend/app/services/realtime_hub.py
+++ b/backend/app/services/realtime_hub.py
@@ -6,6 +6,8 @@ import asyncio
 import json
 import logging
 from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, AsyncIterator
 
 logger = logging.getLogger(__name__)
@@ -18,17 +20,45 @@ def channel_atendente(atendente_id: int) -> str:
     return f"atendente:{atendente_id}"
 
 
+def parse_atendente_channel(channel: str) -> int | None:
+    """Extrai id do canal `atendente:{id}`; None se o formato não bater."""
+    if not channel.startswith("atendente:"):
+        return None
+    raw = channel.split(":", 1)[1]
+    try:
+        return int(raw)
+    except ValueError:
+        return None
+
+
+@dataclass
+class _PresenceEntry:
+    online_desde: datetime
+    connection_count: int
+
+
 class RealtimeHub:
     """Hub in-memory: um canal por atendente, filas asyncio por conexão SSE."""
 
     def __init__(self) -> None:
         self._queues: dict[str, set[asyncio.Queue]] = defaultdict(set)
+        self._presence: dict[int, _PresenceEntry] = {}
         self._lock = asyncio.Lock()
 
     async def subscribe(self, channel: str) -> asyncio.Queue:
         queue: asyncio.Queue = asyncio.Queue(maxsize=256)
         async with self._lock:
             self._queues[channel].add(queue)
+            aid = parse_atendente_channel(channel)
+            if aid is not None:
+                entry = self._presence.get(aid)
+                if entry is None:
+                    self._presence[aid] = _PresenceEntry(
+                        online_desde=datetime.now(timezone.utc),
+                        connection_count=1,
+                    )
+                else:
+                    entry.connection_count += 1
         return queue
 
     async def unsubscribe(self, channel: str, queue: asyncio.Queue) -> None:
@@ -39,6 +69,19 @@ class RealtimeHub:
             subs.discard(queue)
             if not subs:
                 del self._queues[channel]
+            aid = parse_atendente_channel(channel)
+            if aid is not None:
+                entry = self._presence.get(aid)
+                if entry is None:
+                    return
+                entry.connection_count -= 1
+                if entry.connection_count <= 0:
+                    del self._presence[aid]
+
+    async def list_online(self) -> list[tuple[int, datetime]]:
+        """Atendentes com ≥1 conexão SSE e horário de início da sessão atual."""
+        async with self._lock:
+            return [(aid, entry.online_desde) for aid, entry in self._presence.items()]
 
     async def publish(
         self,

--- a/backend/tests/test_presenca.py
+++ b/backend/tests/test_presenca.py
@@ -1,0 +1,97 @@
+"""Presença online de atendentes (#546)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from app.services.realtime_hub import RealtimeHub, channel_atendente, hub
+
+
+def test_hub_presenca_multi_aba_e_offline():
+    async def _run() -> None:
+        h = RealtimeHub()
+        ch = channel_atendente(42)
+        q1 = await h.subscribe(ch)
+        online = await h.list_online()
+        assert len(online) == 1
+        assert online[0][0] == 42
+        desde = online[0][1]
+
+        q2 = await h.subscribe(ch)
+        online2 = await h.list_online()
+        assert len(online2) == 1
+        assert online2[0][1] == desde
+
+        await h.unsubscribe(ch, q1)
+        assert len(await h.list_online()) == 1
+
+        await h.unsubscribe(ch, q2)
+        assert await h.list_online() == []
+
+    asyncio.run(_run())
+
+
+def test_presenca_online_403_atendente(client, seed_base, auth_headers):
+    r = client.get("/v1/presenca/online", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_presenca_online_admin_lista_vazia(client, seed_base, auth_headers):
+    r = client.get("/v1/presenca/online", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    assert r.json() == {"itens": []}
+
+
+def test_presenca_online_admin_ve_atendente_conectado(client, seed_base, auth_headers):
+    async def _connect() -> None:
+        await hub.subscribe(channel_atendente(seed_base["a1"].id))
+
+    asyncio.run(_connect())
+    try:
+        r = client.get("/v1/presenca/online", headers=auth_headers["admin"])
+        assert r.status_code == 200
+        body = r.json()
+        ids = {item["atendente_id"] for item in body["itens"]}
+        assert seed_base["a1"].id in ids
+        item = next(i for i in body["itens"] if i["atendente_id"] == seed_base["a1"].id)
+        assert item["nome"] == seed_base["a1"].nome
+        assert item["email"] == seed_base["a1"].email
+        assert item["online_desde"]
+        assert isinstance(item["setores"], list)
+    finally:
+        async def _cleanup() -> None:
+            # limpa presença do hub global (todas as filas do canal)
+            ch = channel_atendente(seed_base["a1"].id)
+            async with hub._lock:
+                hub._queues.pop(ch, None)
+                hub._presence.pop(seed_base["a1"].id, None)
+
+        asyncio.run(_cleanup())
+
+
+def test_presenca_ignora_inativo(client, seed_base, auth_headers, db_session):
+    a1 = seed_base["a1"]
+    a1.ativo = False
+    db_session.add(a1)
+    db_session.commit()
+
+    async def _connect() -> None:
+        await hub.subscribe(channel_atendente(a1.id))
+
+    asyncio.run(_connect())
+    try:
+        r = client.get("/v1/presenca/online", headers=auth_headers["admin"])
+        assert r.status_code == 200
+        ids = {item["atendente_id"] for item in r.json()["itens"]}
+        assert a1.id not in ids
+    finally:
+        async def _cleanup() -> None:
+            ch = channel_atendente(a1.id)
+            async with hub._lock:
+                hub._queues.pop(ch, None)
+                hub._presence.pop(a1.id, None)
+
+        asyncio.run(_cleanup())
+        a1.ativo = True
+        db_session.add(a1)
+        db_session.commit()

--- a/docs/REALTIME_SSE.md
+++ b/docs/REALTIME_SSE.md
@@ -50,6 +50,13 @@ O hub v1 é **in-process** (`asyncio.Queue` por conexão). Implicações:
 
 **v2 (futuro):** Redis Pub/Sub ou similar para fan-out entre workers.
 
+## Presença online (#546)
+
+- «Online» = canal `atendente:{id}` com ≥1 conexão SSE no hub do processo
+- `online_desde` = instante da primeira conexão da sessão contínua (multi-aba mantém o mesmo horário)
+- API admin: `GET /v1/presenca/online` — lista só contas `ativo` do tenant atual
+- Com `--workers N>1`, cada worker vê só as conexões SSE locais (mesma limitação do pub/sub v1)
+
 ### Limites práticos
 
 - Cada atendente autenticado = **1 conexão HTTP longa** por aba do painel

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { DashboardTickets } from './pages/DashboardTickets'
 import { DashboardChats } from './pages/DashboardChats'
 import { RelatoriosTickets } from './pages/RelatoriosTickets'
 import { RelatoriosChats } from './pages/RelatoriosChats'
+import { PresencaOnline } from './pages/PresencaOnline'
 import { Tickets } from './pages/Tickets'
 import { TicketNovo } from './pages/TicketNovo'
 import { TicketDetalhe } from './pages/TicketDetalhe'
@@ -140,6 +141,14 @@ function AppRoutes() {
         <Route index element={<Dashboard />} />
         <Route path="dashboard/tickets" element={<DashboardTickets />} />
         <Route path="dashboard/chats" element={<DashboardChats />} />
+        <Route
+          path="equipe/online"
+          element={
+            <AdminRoute>
+              <PresencaOnline />
+            </AdminRoute>
+          }
+        />
         <Route
           path="relatorios/tickets"
           element={

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -649,6 +649,10 @@ export const audit = {
   },
 };
 
+export const presenca = {
+  online: () => api<Presenca.ListaOnline>('/presenca/online'),
+};
+
 export namespace WhatsappSettings {
   export interface Read {
     evolution_base_url: string | null
@@ -2916,6 +2920,24 @@ export namespace Audit {
     user_agent: string | null;
     request_id: string | null;
     created_at: string;
+  }
+}
+
+export namespace Presenca {
+  export interface SetorResumo {
+    id: number;
+    nome: string;
+  }
+  export interface ItemOnline {
+    atendente_id: number;
+    nome: string;
+    email: string;
+    role: string;
+    online_desde: string;
+    setores: SetorResumo[];
+  }
+  export interface ListaOnline {
+    itens: ItemOnline[];
   }
 }
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -41,6 +41,16 @@ const icons: Record<string, React.ReactNode> = {
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
     </svg>
   ),
+  equipeOnline: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+      />
+    </svg>
+  ),
   whatsapp: (
     <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
       <path
@@ -214,12 +224,20 @@ interface NavItemLink {
   icon: string
   /** Mantém o item ativo em rotas filhas (ex.: `/chat/c/:id`) */
   activePrefix?: string
+  adminOnly?: boolean
 }
 
 type NavItem = NavItemLink | NavGroup
 
 const navStructure: NavItem[] = [
   { type: 'link', to: '/', label: 'Dashboard', icon: 'dashboard' },
+  {
+    type: 'link',
+    to: '/equipe/online',
+    label: 'Equipe online',
+    icon: 'equipeOnline',
+    adminOnly: true,
+  },
   { type: 'link', to: '/tickets', label: 'Tickets', icon: 'tickets' },
   { type: 'link', to: '/chat/atendendo', label: 'Chat', icon: 'chat', activePrefix: '/chat/' },
   { type: 'link', to: '/whatsapp/historico', label: 'Atendimentos', icon: 'chatHistory' },
@@ -347,9 +365,10 @@ export function Sidebar({
     [closeFlyout, openFlyout]
   )
 
-  const items = navStructure.filter(
-    (item) => item.type === 'link' || !('adminOnly' in item && item.adminOnly) || isAdmin
-  ) as NavItem[]
+  const items = navStructure.filter((item) => {
+    if ('adminOnly' in item && item.adminOnly && !isAdmin) return false
+    return true
+  }) as NavItem[]
 
   // Abrir grupo automaticamente quando a rota pertence a ele
   useEffect(() => {

--- a/frontend/src/pages/PresencaOnline.tsx
+++ b/frontend/src/pages/PresencaOnline.tsx
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ApiError, presenca, type Presenca } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Button } from '../components/ui/Button'
+import { Card } from '../components/ui/Card'
+import { PageContainer, PageHeader } from '../components/ui/PageContainer'
+import { useToast } from '../components/ui/Toast'
+import { SemPermissao } from './SemPermissao'
+
+const POLL_MS = 20_000
+
+function formatarAbsoluto(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+function formatarRelativo(iso: string, agora: number): string {
+  const ms = agora - new Date(iso).getTime()
+  if (Number.isNaN(ms) || ms < 0) return 'agora'
+  const sec = Math.floor(ms / 1000)
+  if (sec < 60) return 'há poucos segundos'
+  const min = Math.floor(sec / 60)
+  if (min < 60) return min === 1 ? 'há 1 min' : `há ${min} min`
+  const h = Math.floor(min / 60)
+  if (h < 24) return h === 1 ? 'há 1 h' : `há ${h} h`
+  const d = Math.floor(h / 24)
+  return d === 1 ? 'há 1 dia' : `há ${d} dias`
+}
+
+function rotuloRole(role: string): string {
+  if (role === 'admin') return 'Admin'
+  return 'Atendente'
+}
+
+export function PresencaOnline() {
+  const toast = useToast()
+  const [itens, setItens] = useState<Presenca.ItemOnline[]>([])
+  const [loading, setLoading] = useState(true)
+  const [semPermissao, setSemPermissao] = useState(false)
+  const [atualizadoEm, setAtualizadoEm] = useState<Date | null>(null)
+  const [agora, setAgora] = useState(() => Date.now())
+
+  const carregar = useCallback(
+    async (silencioso = false) => {
+      try {
+        const data = await presenca.online()
+        setItens(data.itens)
+        setAtualizadoEm(new Date())
+        setSemPermissao(false)
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 403) {
+          setSemPermissao(true)
+          return
+        }
+        if (!silencioso) {
+          toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar a presença.'))
+        }
+      } finally {
+        setLoading(false)
+      }
+    },
+    [toast],
+  )
+
+  useEffect(() => {
+    void carregar()
+  }, [carregar])
+
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      void carregar(true)
+    }, POLL_MS)
+    return () => window.clearInterval(id)
+  }, [carregar])
+
+  useEffect(() => {
+    const id = window.setInterval(() => setAgora(Date.now()), 30_000)
+    return () => window.clearInterval(id)
+  }, [])
+
+  if (semPermissao) {
+    return (
+      <PageContainer>
+        <SemPermissao
+          title="Somente administradores veem quem está online."
+          detail="Peça a um admin para consultar a equipe conectada ao painel."
+        />
+      </PageContainer>
+    )
+  }
+
+  return (
+    <PageContainer maxWidth="5xl">
+      <PageHeader
+        title="Equipe online"
+        subtitle="Atendentes com o painel aberto agora — útil para saber quem pode atender chats e tickets."
+        actions={
+          <Button type="button" variant="secondary" onClick={() => void carregar()} disabled={loading}>
+            Atualizar
+          </Button>
+        }
+      />
+
+      <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600 dark:text-slate-400">
+        <span className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 font-medium text-emerald-800 dark:bg-emerald-950/50 dark:text-emerald-200">
+          <span className="size-2 rounded-full bg-emerald-500" aria-hidden />
+          {itens.length === 1 ? '1 online' : `${itens.length} online`}
+        </span>
+        {atualizadoEm ? (
+          <span>Atualizado às {atualizadoEm.toLocaleTimeString('pt-BR')}</span>
+        ) : null}
+      </div>
+
+      {loading && itens.length === 0 ? (
+        <Card className="space-y-3 p-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-14 animate-pulse rounded-lg bg-slate-100 dark:bg-slate-800/80" />
+          ))}
+        </Card>
+      ) : itens.length === 0 ? (
+        <Card className="p-8 text-center">
+          <p className="text-base font-medium text-slate-800 dark:text-slate-100">
+            Nenhum atendente online no momento
+          </p>
+          <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
+            Quem abrir o painel aparece aqui automaticamente (conexão em tempo real).
+          </p>
+        </Card>
+      ) : (
+        <Card className="overflow-hidden">
+          <div className="-mx-2 overflow-x-auto sm:-mx-0">
+            <table className="min-w-full text-left text-sm">
+              <thead className="border-b border-slate-200 text-xs uppercase tracking-wide text-slate-500 dark:border-slate-700 dark:text-slate-400">
+                <tr>
+                  <th className="px-2 py-2 font-medium sm:px-3">Atendente</th>
+                  <th className="px-2 py-2 font-medium sm:px-3">Setores</th>
+                  <th className="px-2 py-2 font-medium sm:px-3">Perfil</th>
+                  <th className="px-2 py-2 font-medium sm:px-3">Online desde</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                {itens.map((item) => (
+                  <tr key={item.atendente_id}>
+                    <td className="px-2 py-3 sm:px-3">
+                      <div className="flex items-center gap-3">
+                        <span
+                          className="size-2.5 shrink-0 rounded-full bg-emerald-500"
+                          title="Online"
+                          aria-label="Online"
+                        />
+                        <div className="min-w-0">
+                          <p className="font-medium text-slate-900 dark:text-slate-100">{item.nome}</p>
+                          <p className="truncate text-xs text-slate-500 dark:text-slate-400">{item.email}</p>
+                        </div>
+                      </div>
+                    </td>
+                    <td className="px-2 py-3 text-slate-700 dark:text-slate-300 sm:px-3">
+                      {item.setores.length === 0
+                        ? '—'
+                        : item.setores.map((s) => s.nome).join(', ')}
+                    </td>
+                    <td className="px-2 py-3 text-slate-700 dark:text-slate-300 sm:px-3">
+                      {rotuloRole(item.role)}
+                    </td>
+                    <td className="px-2 py-3 sm:px-3">
+                      <span
+                        className="font-medium text-slate-800 dark:text-slate-100"
+                        title={formatarAbsoluto(item.online_desde)}
+                      >
+                        {formatarRelativo(item.online_desde, agora)}
+                      </span>
+                      <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+                        {formatarAbsoluto(item.online_desde)}
+                      </p>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+    </PageContainer>
+  )
+}


### PR DESCRIPTION
## Summary
- Tracking de presença no hub SSE + API admin `GET /v1/presenca/online` (#546)
- Tela **Equipe online** (`/equipe/online`) só para admin, com «desde quando» e refresh periódico (#547)
- Docs SSE + CHANGELOG `[Unreleased]`; fecha o lote do épico #545

Closes #546
Closes #547

## Test plan
- [ ] Login admin → menu **Equipe online** lista quem tem o painel aberto
- [ ] Abrir painel com outro atendente → aparece na lista com horário relativo/absoluto
- [ ] Fechar todas as abas do atendente → some da lista após refresh
- [ ] Login atendente → item some do menu; `/equipe/online` mostra acesso negado
- [ ] `pytest tests/test_presenca.py` passa