### PR TITLE
fix: persistência de anexos e zoom no chat interno

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- Chat interno: clique na imagem abre visualização em tela cheia (antes só tinha o cursor de zoom, sem ação)
+- Anexos de ticket: compose de produção e template por cliente passam a persistir `/app/data` em volume Docker — evita 404 no download após redeploy; mensagem de erro esclarece quando o ficheiro sumiu do disco
 - WhatsApp: removido botão duplicado «Identificar contato» no header — fica só o do banner enquanto o contacto não está vinculado; após vincular o CTA some
 - WhatsApp: encerramento por inatividade só conta a partir da última mensagem do cliente quando o chat já está em atendimento e o atendente já enviou mensagem humana (auto_assumido/BOT não disparam o timer)
 - WhatsApp: Ctrl+V no composer cola imagem/ficheiro do clipboard (pré-visualização antes de enviar), como no chat interno

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -1569,7 +1569,14 @@ def download_anexo(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Anexo não encontrado")
     p = ticket_anexo_storage.caminho_absoluto_arquivo(a.storage_key)
     if not p:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Arquivo não encontrado no storage")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                "Arquivo não encontrado no storage. "
+                "O registo do anexo existe, mas o ficheiro sumiu do disco "
+                "(comum após redeploy sem volume persistente em /app/data)."
+            ),
+        )
 
     # Força download (evita execução inline de tipos perigosos).
     return FileResponse(

--- a/deploy/clients/README.md
+++ b/deploy/clients/README.md
@@ -103,6 +103,12 @@ bash deploy/scripts/stack-client.sh duplexsoft migrate
 bash deploy/scripts/stack-client.sh duplexsoft up
 ```
 
+### Volume `/app/data` (anexos e mídia)
+
+O template monta `backend_data` → `/app/data`. Sem esse volume, cada rebuild apaga anexos de ticket, mídia WhatsApp/chat interno, KB e logos — o metadado fica na BD e o download devolve **404**.
+
+Clientes já provisionados **antes** deste volume: copie o bloco `volumes` do `_template/docker-compose.stack.yml` para o `docker-compose.yml` do cliente e faça `up` de novo. Ficheiros já perdidos não voltam; é preciso reenviar anexos.
+
 ## Backup da base do cliente
 
 ```bash

--- a/deploy/clients/_template/docker-compose.stack.yml
+++ b/deploy/clients/_template/docker-compose.stack.yml
@@ -43,8 +43,13 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    # Persistência de anexos/mídia (ticket, WhatsApp, chat interno, KB, logos)
+    volumes:
+      - backend_data:/app/data
     restart: unless-stopped
 
 volumes:
   db_data:
     name: dx-connect-pgdata-${CLIENT_SLUG}
+  backend_data:
+    name: dx-connect-data-${CLIENT_SLUG}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -89,6 +89,10 @@ services:
     depends_on:
       evolution-api:
         condition: service_started
+    # Anexos de ticket, mídia WhatsApp/chat interno, KB e logos — sem isto, rebuild apaga ficheiros
+    # e o download devolve 404 («Arquivo não encontrado no storage») com metadados ainda na BD.
+    volumes:
+      - backend_data:/app/data
     restart: unless-stopped
 
 networks:
@@ -98,3 +102,4 @@ networks:
 volumes:
   evolution_postgres_data:
   evolution_instances:
+  backend_data:

--- a/docs/PRE_DEPLOY_CHECKLIST.md
+++ b/docs/PRE_DEPLOY_CHECKLIST.md
@@ -25,6 +25,7 @@ Legenda: **OK** atendido no repositório | **Você** validação manual no servi
 | Cadeia de migrations consistente (`revision`/`down_revision`) | **OK** — ver `docs/ALEMBIC_MIGRATIONS.md` (evita quebra de deploy com `KeyError`/`Revision ... is not present`). |
 | Subir banco do zero e rodar app | **Você** — primeiro deploy: criar DB/usuário no provedor; API cria tabelas no startup. |
 | Persistência após reinício | **Você** — dados ficam no PostgreSQL do provedor; reiniciar só o container não apaga o DB. |
+| Ficheiros de anexos/mídia no disco | **OK** — `docker-compose.prod.yml` e template `deploy/clients` montam volume `backend_data` → `/app/data` (tickets, WhatsApp, chat interno, KB, logos). Sem isto, rebuild apaga ficheiros e o download devolve 404. |
 
 ## Frontend
 

--- a/frontend/src/components/chat-interno/ChatInternoConteudoMensagem.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoConteudoMensagem.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import { fetchChatInternoMidiaBlob, type ChatInterno } from '../../api/client'
 
 const ROTULO_SEM_LEGENDA = /^(📷 Imagem|🎬 Vídeo|🎵 Áudio|📄 Documento)$/
@@ -23,6 +24,7 @@ export function ChatInternoConteudoMensagem({
   const [url, setUrl] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [err, setErr] = useState(false)
+  const [zoomAberto, setZoomAberto] = useState(false)
 
   useEffect(() => {
     if (!mensagem.midia_disponivel || tipo === 'texto') {
@@ -54,6 +56,15 @@ export function ChatInternoConteudoMensagem({
     }
   }, [url])
 
+  useEffect(() => {
+    if (!zoomAberto) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setZoomAberto(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [zoomAberto])
+
   const legenda =
     mensagem.corpo && !ROTULO_SEM_LEGENDA.test(mensagem.corpo.trim()) ? mensagem.corpo : null
 
@@ -79,7 +90,7 @@ export function ChatInternoConteudoMensagem({
             }`}
           >
             {mensagem.corpo}
-            <span aria-hidden className="inline-block w-[4.25rem] h-[0.85rem]" />
+            <span aria-hidden className="inline-block h-[0.85rem] w-[4.25rem]" />
           </p>
           <div className="absolute bottom-0 right-0 flex items-center gap-0.5 pl-1">{rodape}</div>
         </div>
@@ -112,14 +123,72 @@ export function ChatInternoConteudoMensagem({
 
   if (tipo === 'imagem') {
     return (
-      <div className="space-y-1">
-        <img src={url} alt="" className={`${mediaClass} cursor-zoom-in`} />
-        {legenda && (
-          <p className={`whitespace-pre-wrap break-words text-sm [overflow-wrap:anywhere] ${textoClaro ? 'text-cyan-50' : ''}`}>
-            {legenda}
-          </p>
-        )}
-      </div>
+      <>
+        <div className="space-y-1">
+          <button
+            type="button"
+            className="block max-w-full cursor-zoom-in rounded-lg border-0 bg-transparent p-0 text-left"
+            onClick={(e) => {
+              e.stopPropagation()
+              setZoomAberto(true)
+            }}
+            onDoubleClick={(e) => e.stopPropagation()}
+            aria-label="Ampliar imagem"
+          >
+            <img
+              src={url}
+              alt=""
+              className={`${mediaClass} transition-transform duration-200 hover:scale-[1.02]`}
+            />
+          </button>
+          {legenda && (
+            <p
+              className={`whitespace-pre-wrap break-words text-sm [overflow-wrap:anywhere] ${textoClaro ? 'text-cyan-50' : ''}`}
+            >
+              {legenda}
+            </p>
+          )}
+        </div>
+        {zoomAberto &&
+          createPortal(
+            <div
+              className="fixed inset-0 z-[200] flex flex-col items-center justify-center bg-black/90 p-4 backdrop-blur-sm animate-in fade-in duration-200"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Imagem ampliada"
+              onClick={() => setZoomAberto(false)}
+            >
+              <button
+                type="button"
+                className="absolute top-4 right-4 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white/10 text-3xl font-bold text-white transition-colors hover:bg-white/20"
+                onClick={() => setZoomAberto(false)}
+                aria-label="Fechar"
+              >
+                &times;
+              </button>
+              <img
+                src={url}
+                alt=""
+                className="max-h-[85vh] max-w-full rounded-lg object-contain shadow-2xl animate-in zoom-in-95 duration-200"
+                onClick={(e) => e.stopPropagation()}
+              />
+              {legenda ? (
+                <p className="mt-4 max-w-2xl rounded-xl bg-black/40 px-4 py-2 text-center text-sm text-white backdrop-blur-md">
+                  {legenda}
+                </p>
+              ) : null}
+              <a
+                href={url}
+                download={mensagem.nome_arquivo || 'imagem.jpg'}
+                className="absolute bottom-4 right-4 flex items-center gap-2 rounded-xl bg-sky-600 px-4 py-2.5 text-xs font-bold text-white shadow-lg transition-all hover:scale-105 hover:bg-sky-500"
+                onClick={(e) => e.stopPropagation()}
+              >
+                Baixar
+              </a>
+            </div>,
+            document.body,
+          )}
+      </>
     )
   }
 

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -656,7 +656,12 @@ export function TicketDetalhe() {
       link.remove()
       URL.revokeObjectURL(url)
     } catch (err) {
-      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível baixar o anexo.'))
+      const msg =
+        err instanceof ApiError && err.status === 404
+          ? err.message ||
+            'Anexo sem ficheiro no servidor (comum após atualização sem volume persistente). Peça reenvio do arquivo.'
+          : mensagemFalhaParaToast(err, 'Não foi possível baixar o anexo.')
+      toast.showWarning(msg)
     }
   }
 


### PR DESCRIPTION
## Summary
- Monta volume Docker `backend_data` → `/app/data` no compose de produção e no template por cliente (evita 404 no download de anexos após redeploy)
- Mensagem de erro mais clara quando o ficheiro sumiu do disco; toast no detalhe do ticket
- Chat interno: clique na imagem abre visualização em tela cheia (Esc / fundo / baixar)

## CHANGELOG
- [x] Atualizei `CHANGELOG.md` → `[Unreleased]`

## Test plan
- [ ] Compose/template incluem volume `/app/data`
- [ ] Download de anexo inexistente no disco mostra mensagem sobre storage/volume
- [ ] Chat interno: clicar numa imagem abre overlay; Esc/× fecham; Baixar funciona
- [ ] CI verde (changelog, backend, frontend)

## Follow-ups / ops
- Em clientes já deployados, acrescentar o volume ao `docker-compose` e fazer `up`; anexos já perdidos precisam reenvio