### PR TITLE
fix(chat): ações fora do balão e scroll estável no WhatsApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp: o feed deixa de puxar sozinho para o fim enquanto você lê mensagens acima; ao reabrir a conversa, retoma a posição em que parou
 - Chat interno: ações (Responder/Editar/Apagar) e reações ficam fora do balão da mensagem
 - Chat interno: clique na imagem abre visualização em tela cheia (antes só tinha o cursor de zoom, sem ação)
 - Anexos de ticket: ficheiros deixam de desaparecer após atualização do sistema; se o arquivo já tiver sido perdido, o aviso deixa isso claro

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- Chat interno: ações (Responder/Editar/Apagar) e reações ficam fora do balão da mensagem
 - Chat interno: clique na imagem abre visualização em tela cheia (antes só tinha o cursor de zoom, sem ação)
 - Anexos de ticket: ficheiros deixam de desaparecer após atualização do sistema; se o arquivo já tiver sido perdido, o aviso deixa isso claro
 - WhatsApp: removido botão duplicado «Identificar contato» no header — fica só o do banner enquanto o contacto não está vinculado; após vincular o CTA some

--- a/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
@@ -88,13 +88,13 @@ export function ChatInternoMensagemAcoes({
   }
 
   const btnAcaoClass =
-    'pointer-events-auto rounded-full bg-white px-2 py-0.5 text-[10px] font-medium text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-100 dark:ring-slate-600 dark:hover:bg-slate-700'
+    'rounded-full bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-100 dark:ring-slate-600 dark:hover:bg-slate-700'
 
   return (
     <>
       <div
-        className={`pointer-events-none absolute top-1 z-10 flex gap-0.5 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100 ${
-          alinhamento === 'end' ? 'right-1' : 'left-1'
+        className={`pointer-events-none absolute bottom-full z-10 mb-1 flex gap-1 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 ${
+          alinhamento === 'end' ? 'right-0 justify-end' : 'left-0 justify-start'
         }`}
       >
         {podeResponder && (

--- a/frontend/src/components/chat-interno/ChatInternoReacoesBar.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoReacoesBar.tsx
@@ -9,15 +9,14 @@ type Props = {
 
 export function ChatInternoReacoesBar({ reacoes, onReagir, alinhamento = 'end' }: Props) {
   const temReacoes = reacoes.length > 0
+  const align = alinhamento === 'end' ? 'justify-end' : 'justify-start'
 
   return (
-    <>
+    <div className={`mt-1.5 flex flex-col gap-1 ${align}`}>
       <div
-        className={`pointer-events-none absolute bottom-[calc(100%-4px)] z-10 flex opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 md:opacity-0 md:group-hover:opacity-100 ${
-          alinhamento === 'end' ? 'right-0 justify-end' : 'left-0 justify-start'
-        }`}
+        className={`flex opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 ${align}`}
       >
-        <div className="pointer-events-auto flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
+        <div className="flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
           {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
             <button
               key={emoji}
@@ -33,11 +32,7 @@ export function ChatInternoReacoesBar({ reacoes, onReagir, alinhamento = 'end' }
       </div>
 
       {temReacoes ? (
-        <div
-          className={`relative z-[1] -mt-2.5 flex flex-wrap gap-1 ${
-            alinhamento === 'end' ? 'justify-end' : 'justify-start'
-          }`}
-        >
+        <div className={`flex flex-wrap gap-1 ${align}`}>
           {reacoes.map((r) => (
             <button
               key={r.emoji}
@@ -56,6 +51,6 @@ export function ChatInternoReacoesBar({ reacoes, onReagir, alinhamento = 'end' }
           ))}
         </div>
       ) : null}
-    </>
+    </div>
   )
 }

--- a/frontend/src/lib/whatsappScrollMemory.ts
+++ b/frontend/src/lib/whatsappScrollMemory.ts
@@ -1,0 +1,94 @@
+/** Memória de scroll do WhatsApp — espelha o padrão do chat interno. */
+
+const STORAGE_PREFIX = 'whatsapp-scroll-v1'
+const NEAR_BOTTOM_PX = 80
+
+export type WhatsappScrollState = {
+  nearBottom: boolean
+  anchorMessageId: number | null
+  scrollTop: number
+}
+
+function storageKey(chatId: number): string {
+  return `${STORAGE_PREFIX}:${chatId}`
+}
+
+export function isNearBottom(el: HTMLElement, threshold = NEAR_BOTTOM_PX): boolean {
+  return el.scrollHeight - el.scrollTop - el.clientHeight <= threshold
+}
+
+export function findWhatsappAnchorMessageId(container: HTMLElement): number | null {
+  const containerRect = container.getBoundingClientRect()
+  const nodes = container.querySelectorAll<HTMLElement>('[data-wa-msg-id]')
+  for (const node of nodes) {
+    const rect = node.getBoundingClientRect()
+    if (rect.bottom > containerRect.top + 12) {
+      const id = Number(node.dataset.waMsgId)
+      return Number.isFinite(id) ? id : null
+    }
+  }
+  return null
+}
+
+export function saveWhatsappScroll(chatId: number, container: HTMLElement): void {
+  try {
+    const state: WhatsappScrollState = {
+      nearBottom: isNearBottom(container),
+      anchorMessageId: findWhatsappAnchorMessageId(container),
+      scrollTop: container.scrollTop,
+    }
+    sessionStorage.setItem(storageKey(chatId), JSON.stringify(state))
+  } catch {
+    // sessionStorage indisponível
+  }
+}
+
+export function loadWhatsappScroll(chatId: number): WhatsappScrollState | null {
+  try {
+    const raw = sessionStorage.getItem(storageKey(chatId))
+    if (!raw) return null
+    return JSON.parse(raw) as WhatsappScrollState
+  } catch {
+    return null
+  }
+}
+
+export function scrollWhatsappToBottom(container: HTMLElement): void {
+  container.scrollTop = container.scrollHeight
+}
+
+/** Restaura posição; devolve se ficou “colado” no fim. */
+export function restoreWhatsappScroll(chatId: number, container: HTMLElement): boolean {
+  const saved = loadWhatsappScroll(chatId)
+  if (!saved) {
+    scrollWhatsappToBottom(container)
+    return true
+  }
+
+  if (saved.nearBottom) {
+    scrollWhatsappToBottom(container)
+    return true
+  }
+
+  if (saved.anchorMessageId != null) {
+    const anchor = container.querySelector<HTMLElement>(
+      `[data-wa-msg-id="${saved.anchorMessageId}"]`,
+    )
+    if (anchor) {
+      anchor.scrollIntoView({ block: 'start' })
+      return false
+    }
+  }
+
+  container.scrollTop = saved.scrollTop
+  return false
+}
+
+export function preserveScrollOnContentChange(
+  container: HTMLElement,
+  prevScrollTop: number,
+  prevScrollHeight: number,
+): void {
+  const delta = container.scrollHeight - prevScrollHeight
+  container.scrollTop = prevScrollTop + delta
+}

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -483,7 +483,7 @@ export function ChatInternoThread() {
         ref={scrollRef}
         className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto bg-slate-100/90 px-4 py-5 dark:bg-slate-900/60 md:px-6 lg:px-8"
       >
-        <div className="w-full min-w-0 space-y-1">
+        <div className="w-full min-w-0 space-y-3">
         {carregandoAntigas && (
           <p className="py-2 text-center text-sm text-slate-400">Carregando mensagens anteriores…</p>
         )}
@@ -502,11 +502,17 @@ export function ChatInternoThread() {
             const textoCompacto = isTexto && !m.apagada
             if (isSetor) {
               return (
+                <div key={m.id} className="group relative w-full min-w-0" data-chat-msg-id={m.id}>
+                <ChatInternoMensagemAcoes
+                  mensagem={m}
+                  onEditar={(corpo) => editarMensagem(m.id, corpo)}
+                  onApagar={(escopo) => apagarMensagem(m.id, escopo)}
+                  onResponder={() => iniciarResposta(m)}
+                  alinhamento="start"
+                />
                 <article
-                  key={m.id}
-                  data-chat-msg-id={m.id}
                   onDoubleClick={(e) => duploCliqueResponder(e, m)}
-                  className="group w-full min-w-0 overflow-hidden rounded-2xl border border-amber-200/80 bg-amber-50/95 p-5 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40"
+                  className="w-full min-w-0 overflow-hidden rounded-2xl border border-amber-200/80 bg-amber-50/95 p-5 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40"
                 >
                   <div className="mb-2 flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-200">
                     <span>Comunicado</span>
@@ -531,18 +537,6 @@ export function ChatInternoThread() {
                     </button>
                   )}
                   <ChatInternoConteudoMensagem conversaId={conversaId} mensagem={m} />
-                  <ChatInternoMensagemAcoes
-                    mensagem={m}
-                    onEditar={(corpo) => editarMensagem(m.id, corpo)}
-                    onApagar={(escopo) => apagarMensagem(m.id, escopo)}
-                    onResponder={() => iniciarResposta(m)}
-                  />
-                  {!m.apagada && (
-                    <ChatInternoReacoesBar
-                      reacoes={m.reacoes ?? []}
-                      onReagir={(emoji) => void reagirMensagem(m.id, emoji)}
-                    />
-                  )}
                   {m.atendente_id === user?.id ? (
                     <MensagemRodapeMeta
                       hora={m.created_at}
@@ -555,6 +549,14 @@ export function ChatInternoThread() {
                     <p className="mt-2 text-xs text-slate-500">{formatarHoraMensagem(m.created_at)}</p>
                   )}
                 </article>
+                  {!m.apagada && (
+                    <ChatInternoReacoesBar
+                      reacoes={m.reacoes ?? []}
+                      onReagir={(emoji) => void reagirMensagem(m.id, emoji)}
+                      alinhamento="start"
+                    />
+                  )}
+                </div>
               )
             }
             return (
@@ -570,63 +572,6 @@ export function ChatInternoThread() {
                   }`}
                 >
                   <div className="relative w-fit max-w-full">
-                    <div
-                      className={`relative w-fit max-w-full rounded-lg px-[9px] py-[6px] text-sm shadow-sm ring-1 ring-inset ${
-                        propria
-                          ? 'rounded-tr-none bg-cyan-600 text-white ring-cyan-500/30'
-                          : 'rounded-tl-none bg-white text-slate-900 ring-slate-200/80 dark:bg-slate-800 dark:text-slate-100 dark:ring-slate-700'
-                      }`}
-                    >
-                      {!propria && (
-                        <p className="mb-0.5 text-[11px] font-semibold leading-none text-cyan-700 dark:text-cyan-300">
-                          {m.atendente_nome ?? 'Atendente'}
-                        </p>
-                      )}
-                      {m.reply_to_message_id && (
-                        <button
-                          type="button"
-                          onClick={() => {
-                            const el = document.querySelector(`[data-chat-msg-id="${m.reply_to_message_id}"]`)
-                            el?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-                          }}
-                          className={`mb-1 w-full rounded-md border-l-2 px-2 py-1 text-left text-[11px] ${
-                            propria
-                              ? 'border-white/50 bg-white/15 text-white/90'
-                              : 'border-cyan-500 bg-slate-100 text-slate-600 dark:bg-slate-900/60 dark:text-slate-300'
-                          }`}
-                        >
-                          <p className="font-semibold truncate">{m.reply_autor_nome || 'Mensagem'}</p>
-                          <p className="truncate opacity-90">{m.reply_preview || '…'}</p>
-                        </button>
-                      )}
-                      <ChatInternoConteudoMensagem
-                        conversaId={conversaId}
-                        mensagem={m}
-                        textoClaro={propria}
-                        somenteTextoCompacto={textoCompacto}
-                        rodape={
-                          textoCompacto ? (
-                            <MensagemRodapeMeta
-                              hora={m.created_at}
-                              status={propria ? m.status_entrega : null}
-                              direcao={propria ? 'outbound' : 'inbound'}
-                              variant={propria ? 'claro' : 'escuro'}
-                              editada={m.editada}
-                              className="!mt-0"
-                            />
-                          ) : undefined
-                        }
-                      />
-                      {!textoCompacto && (
-                        <MensagemRodapeMeta
-                          hora={m.created_at}
-                          status={propria ? m.status_entrega : null}
-                          direcao={propria ? 'outbound' : 'inbound'}
-                          variant={propria ? 'claro' : 'escuro'}
-                          editada={m.editada}
-                        />
-                      )}
-                    </div>
                     <ChatInternoMensagemAcoes
                       mensagem={m}
                       onEditar={(corpo) => editarMensagem(m.id, corpo)}
@@ -634,13 +579,70 @@ export function ChatInternoThread() {
                       onResponder={() => iniciarResposta(m)}
                       alinhamento={propria ? 'end' : 'start'}
                     />
-                    {!m.apagada && (
-                      <ChatInternoReacoesBar
-                        reacoes={m.reacoes ?? []}
-                        onReagir={(emoji) => void reagirMensagem(m.id, emoji)}
-                        alinhamento={propria ? 'end' : 'start'}
+                    <div
+                      className={`relative w-fit max-w-full rounded-lg px-[9px] py-[6px] text-sm shadow-sm ring-1 ring-inset ${
+                        propria
+                          ? 'rounded-tr-none bg-cyan-600 text-white ring-cyan-500/30'
+                          : 'rounded-tl-none bg-white text-slate-900 ring-slate-200/80 dark:bg-slate-800 dark:text-slate-100 dark:ring-slate-700'
+                      }`}
+                    >
+                    {!propria && (
+                      <p className="mb-0.5 text-[11px] font-semibold leading-none text-cyan-700 dark:text-cyan-300">
+                        {m.atendente_nome ?? 'Atendente'}
+                      </p>
+                    )}
+                    {m.reply_to_message_id && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const el = document.querySelector(`[data-chat-msg-id="${m.reply_to_message_id}"]`)
+                          el?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                        }}
+                        className={`mb-1 w-full rounded-md border-l-2 px-2 py-1 text-left text-[11px] ${
+                          propria
+                            ? 'border-white/50 bg-white/15 text-white/90'
+                            : 'border-cyan-500 bg-slate-100 text-slate-600 dark:bg-slate-900/60 dark:text-slate-300'
+                        }`}
+                      >
+                        <p className="font-semibold truncate">{m.reply_autor_nome || 'Mensagem'}</p>
+                        <p className="truncate opacity-90">{m.reply_preview || '…'}</p>
+                      </button>
+                    )}
+                    <ChatInternoConteudoMensagem
+                      conversaId={conversaId}
+                      mensagem={m}
+                      textoClaro={propria}
+                      somenteTextoCompacto={textoCompacto}
+                      rodape={
+                        textoCompacto ? (
+                          <MensagemRodapeMeta
+                            hora={m.created_at}
+                            status={propria ? m.status_entrega : null}
+                            direcao={propria ? 'outbound' : 'inbound'}
+                            variant={propria ? 'claro' : 'escuro'}
+                            editada={m.editada}
+                            className="!mt-0"
+                          />
+                        ) : undefined
+                      }
+                    />
+                    {!textoCompacto && (
+                      <MensagemRodapeMeta
+                        hora={m.created_at}
+                        status={propria ? m.status_entrega : null}
+                        direcao={propria ? 'outbound' : 'inbound'}
+                        variant={propria ? 'claro' : 'escuro'}
+                        editada={m.editada}
                       />
                     )}
+                  </div>
+                  {!m.apagada && (
+                    <ChatInternoReacoesBar
+                      reacoes={m.reacoes ?? []}
+                      onReagir={(emoji) => void reagirMensagem(m.id, emoji)}
+                      alinhamento={propria ? 'end' : 'start'}
+                    />
+                  )}
                   </div>
                 </div>
               </div>

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -25,6 +25,13 @@ import { resolveWhatsappMidiaObjectUrl, revokeWhatsappMidiaForChat } from '../..
 import { chatEncerramentoPorInatividade } from '../../lib/whatsappDemandaUtils'
 import { mergeWhatsappChat, patchWhatsappChatLista, replaceWhatsappChatLista } from '../../lib/whatsappChatMerge'
 import { whatsappMensagensUnicas } from '../../lib/whatsappMensagens'
+import {
+  isNearBottom,
+  preserveScrollOnContentChange,
+  restoreWhatsappScroll,
+  saveWhatsappScroll,
+  scrollWhatsappToBottom,
+} from '../../lib/whatsappScrollMemory'
 import { MensagemRodapeMeta } from '../../components/chat/MensagemRodapeMeta'
 
 import { Card } from '../../components/ui/Card'
@@ -240,6 +247,9 @@ export function WhatsappConversa() {
   // Refs
 
   const scrollRef = useRef<HTMLDivElement>(null)
+  const stickToBottomRef = useRef(true)
+  const initialScrollRestoredRef = useRef(false)
+  const saveScrollRafRef = useRef<number | null>(null)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -342,19 +352,51 @@ export function WhatsappConversa() {
 
 
 
-  // Auto-scroll para o fim
+  // Scroll: só cola no fim se o utilizador já estiver perto do fundo; senão preserva a posição.
+  useEffect(() => {
+    if (!id) return
+    initialScrollRestoredRef.current = false
+    stickToBottomRef.current = true
+  }, [id])
 
   useEffect(() => {
+    if (loading || msgs.length === 0 || initialScrollRestoredRef.current || !id) return
+    initialScrollRestoredRef.current = true
+    requestAnimationFrame(() => {
+      const el = scrollRef.current
+      if (!el) return
+      stickToBottomRef.current = restoreWhatsappScroll(Number(id), el)
+    })
+  }, [loading, msgs.length, id])
 
-    if (scrollRef.current) {
+  useEffect(() => {
+    if (loading || !initialScrollRestoredRef.current || !stickToBottomRef.current) return
+    requestAnimationFrame(() => {
+      const el = scrollRef.current
+      if (el) scrollWhatsappToBottom(el)
+    })
+  }, [msgs, loading])
 
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el || !id) return
+    const chatId = Number(id)
 
+    const onScroll = () => {
+      stickToBottomRef.current = isNearBottom(el)
+      if (saveScrollRafRef.current != null) cancelAnimationFrame(saveScrollRafRef.current)
+      saveScrollRafRef.current = requestAnimationFrame(() => {
+        saveWhatsappScroll(chatId, el)
+      })
     }
 
-  }, [msgs])
-
-
+    el.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      el.removeEventListener('scroll', onScroll)
+      if (saveScrollRafRef.current != null) cancelAnimationFrame(saveScrollRafRef.current)
+      saveWhatsappScroll(chatId, el)
+    }
+  }, [id, loading])
 
   // Carregar lista de chats lateral
 
@@ -384,6 +426,10 @@ export function WhatsappConversa() {
     if (!id) return
 
     const gen = ++carregarGenRef.current
+    const el = scrollRef.current
+    const stick = stickToBottomRef.current
+    const prevTop = el?.scrollTop ?? 0
+    const prevHeight = el?.scrollHeight ?? 0
 
     try {
 
@@ -394,6 +440,17 @@ export function WhatsappConversa() {
       setChat((prev) => mergeWhatsappChat(prev, c))
 
       setMsgs(whatsappMensagensUnicas(m))
+
+      requestAnimationFrame(() => {
+        if (!initialScrollRestoredRef.current) return
+        const container = scrollRef.current
+        if (!container) return
+        if (stick) {
+          scrollWhatsappToBottom(container)
+        } else if (el) {
+          preserveScrollOnContentChange(container, prevTop, prevHeight)
+        }
+      })
 
     } catch (err) {
 
@@ -605,6 +662,7 @@ useEffect(() => {
       setTexto('')
       setMsgRespondida(null)
 
+      stickToBottomRef.current = true
       await carregar()
 
     } catch (err) {
@@ -674,6 +732,7 @@ useEffect(() => {
       )
       setMsgRespondida(null)
       toast.showSuccess('Áudio enviado.')
+      stickToBottomRef.current = true
       await carregar()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha ao enviar áudio.'))
@@ -707,6 +766,7 @@ useEffect(() => {
       setArquivoPendente(null)
       setLegendaMidia('')
       toast.showSuccess('Anexo enviado!')
+      stickToBottomRef.current = true
       await carregar()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha no envio do anexo'))
@@ -722,6 +782,7 @@ useEffect(() => {
       await whatsappChats.enviarFigurinha(chat.id, file, msgRespondida?.wa_message_id || null)
       setMsgRespondida(null)
       toast.showSuccess('Figurinha enviada!')
+      stickToBottomRef.current = true
       await carregar()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha ao enviar figurinha'))
@@ -1126,6 +1187,7 @@ useEffect(() => {
               <div 
                 key={m.id} 
                 id={`msg-${m.wa_message_id || m.id}`}
+                data-wa-msg-id={m.id}
                 onDoubleClick={(e) => duploCliqueResponder(e, m, isSystem)}
                 className={`flex w-full group cursor-default items-center gap-2 transition-all ${isInbound ? 'justify-start' : 'justify-end'}`}
               >


### PR DESCRIPTION
## Summary
- Chat interno: Responder/Editar/Apagar e reações ficam **fora** do balão da mensagem
- WhatsApp: deixa de puxar o feed para o fim enquanto você lê acima; ao reabrir a conversa, retoma a posição em que parou (nesta sessão)

## CHANGELOG
- [x] Bullets em `[Unreleased]` (Correções)

## Test plan
- [ ] Chat interno: hover — ações acima do balão; reações abaixo, sem sobrepor o texto
- [ ] WhatsApp: subir na conversa e esperar polling/SSE — não deve saltar para o fim
- [ ] WhatsApp: sair e voltar — deve reabrir na mensagem em que parou
- [ ] WhatsApp: enviar mensagem — deve ir para o fim