### PR TITLE
fix(presenca): heartbeat multi-worker, forçar saída e UX do chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Equipe online: lista funciona com vários workers do servidor (presença gravada no banco); admin pode **Forçar saída** de um atendente conectado
+- Chat interno: balões mais próximos — opções/reações só no hover; em grupos, avatar e cor por pessoa para distinguir quem fala
 - Equipe online (#545–#547): administradores veem quem está com o painel aberto e desde quando (menu **Equipe online**), para coordenar atendimento de chats e tickets
 - Chat (#539): após enviar mensagem (WhatsApp e chat interno), o cursor permanece no campo de texto; painel de emoji fica aberto ao escolher vários; **Responder** mensagem no chat interno (direta, equipe e grupo)
 - WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homónimos
@@ -15,6 +17,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- Equipe online: «0 online» mesmo com painel aberto (lista lia só a memória do worker errado)
+- Chat interno: espaço excessivo entre mensagens após colocar ações/reações fora do balão
 - WhatsApp: o feed deixa de puxar sozinho para o fim enquanto você lê mensagens acima; ao reabrir a conversa, retoma a posição em que parou
 - Chat interno: ações (Responder/Editar/Apagar) e reações ficam fora do balão da mensagem
 - Chat interno: clique na imagem abre visualização em tela cheia (antes só tinha o cursor de zoom, sem ação)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Chat interno (grupos/canal): menções com `@` — autocomplete de participantes e `@all` (todos); destaque visual na mensagem
 - Equipe online: lista funciona com vários workers do servidor (presença gravada no banco); admin pode **Forçar saída** de um atendente conectado
 - Chat interno: balões mais próximos — opções/reações só no hover; em grupos, avatar e cor por pessoa para distinguir quem fala
 - Equipe online (#545–#547): administradores veem quem está com o painel aberto e desde quando (menu **Equipe online**), para coordenar atendimento de chats e tickets

--- a/backend/alembic/versions/070_presenca_heartbeat_token_version.py
+++ b/backend/alembic/versions/070_presenca_heartbeat_token_version.py
@@ -1,0 +1,60 @@
+"""Presença via heartbeat no DB + token_version para forçar saída.
+
+Revision ID: 070_presenca_token
+Revises: 069_chat_interno_reply
+Create Date: 2026-07-16
+
+Online deixa de depender só do hub in-memory (quebra com Gunicorn N>1).
+token_version invalida JWT ao forçar saída do atendente.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "070_presenca_token"
+down_revision = "069_chat_interno_reply"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("atendentes"):
+        return
+    cols = {c["name"] for c in insp.get_columns("atendentes")}
+    if "presenca_online_desde" not in cols:
+        op.add_column(
+            "atendentes",
+            sa.Column("presenca_online_desde", sa.DateTime(timezone=True), nullable=True),
+        )
+    if "presenca_heartbeat_em" not in cols:
+        op.add_column(
+            "atendentes",
+            sa.Column("presenca_heartbeat_em", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.create_index(
+            "ix_atendentes_presenca_heartbeat_em",
+            "atendentes",
+            ["presenca_heartbeat_em"],
+        )
+    if "token_version" not in cols:
+        op.add_column(
+            "atendentes",
+            sa.Column("token_version", sa.Integer(), nullable=False, server_default="0"),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("atendentes"):
+        return
+    cols = {c["name"] for c in insp.get_columns("atendentes")}
+    if "token_version" in cols:
+        op.drop_column("atendentes", "token_version")
+    if "presenca_heartbeat_em" in cols:
+        op.drop_index("ix_atendentes_presenca_heartbeat_em", table_name="atendentes")
+        op.drop_column("atendentes", "presenca_heartbeat_em")
+    if "presenca_online_desde" in cols:
+        op.drop_column("atendentes", "presenca_online_desde")

--- a/backend/alembic/versions/071_chat_interno_mencoes.py
+++ b/backend/alembic/versions/071_chat_interno_mencoes.py
@@ -1,0 +1,34 @@
+"""Chat interno: menções (@user / @all) em mensagens.
+
+Revision ID: 071_chat_interno_mencoes
+Revises: 070_presenca_token
+Create Date: 2026-07-16
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "071_chat_interno_mencoes"
+down_revision = "070_presenca_token"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("mensagens_internas"):
+        return
+    cols = {c["name"] for c in insp.get_columns("mensagens_internas")}
+    if "mencoes" not in cols:
+        op.add_column("mensagens_internas", sa.Column("mencoes", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("mensagens_internas"):
+        return
+    cols = {c["name"] for c in insp.get_columns("mensagens_internas")}
+    if "mencoes" in cols:
+        op.drop_column("mensagens_internas", "mencoes")

--- a/backend/app/api/auth.py
+++ b/backend/app/api/auth.py
@@ -43,8 +43,10 @@ async def login(request: Request, data: AtendenteLogin, db: Session = Depends(ge
         await delay_on_auth_failure()
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="E-mail ou senha inválidos")
     tid_token = int(atendente.tenant_id)
-    access = criar_access_token(data={"sub": atendente.email, "tid": tid_token})
-    refresh = criar_refresh_token(data={"sub": atendente.email, "tid": tid_token})
+    ver = int(getattr(atendente, "token_version", 0) or 0)
+    claims = {"sub": atendente.email, "tid": tid_token, "ver": ver}
+    access = criar_access_token(data=claims)
+    refresh = criar_refresh_token(data=claims)
     return Token(
         access_token=access,
         refresh_token=refresh,
@@ -72,11 +74,20 @@ async def refresh(
     atendente = _buscar_atendente_por_email(db, email, tenant_id)
     if not atendente:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuário não encontrado ou inativo")
+    token_ver = int(payload.get("ver") or 0)
+    atual_ver = int(getattr(atendente, "token_version", 0) or 0)
+    if token_ver != atual_ver:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Sessão encerrada. Faça login novamente.",
+        )
     tid_token = int(atendente.tenant_id)
-    access = criar_access_token(data={"sub": atendente.email, "tid": tid_token})
+    claims = {"sub": atendente.email, "tid": tid_token, "ver": atual_ver}
+    access = criar_access_token(data=claims)
+    refresh = criar_refresh_token(data=claims)
     return Token(
         access_token=access,
-        refresh_token=data.refresh_token,
+        refresh_token=refresh,
         must_change_password=bool(getattr(atendente, "must_change_password", False)),
     )
 

--- a/backend/app/api/chat_interno.py
+++ b/backend/app/api/chat_interno.py
@@ -18,6 +18,7 @@ from app.schemas.chat_interno import (
     ConversaInboxRead,
     ConversaRead,
     GrupoParticipantesUpdate,
+    MencaoMensagemRead,
     MensagemInternaCreate,
     MensagemInternaRead,
     MensagemInternaUpdate,
@@ -68,6 +69,14 @@ def _to_mensagem_read(mensagem, *, conversa: ConversaInterna, atendente: Atenden
         ReacaoMensagemRead(emoji=r.emoji, count=r.count, reagiu_eu=r.reagiu_eu)
         for r in chat_svc.agregar_reacoes_mensagem(db, mensagem.id, atendente.id)
     ]
+    mencoes = [
+        MencaoMensagemRead(
+            tipo=m["tipo"],  # type: ignore[arg-type]
+            atendente_id=m.get("atendente_id"),
+            rotulo=m.get("rotulo"),
+        )
+        for m in chat_svc.mencoes_para_leitura(getattr(mensagem, "mencoes", None))
+    ]
     perms = chat_svc.permissoes_mensagem(db, conversa, mensagem, atendente)
     return MensagemInternaRead(
         id=mensagem.id,
@@ -84,6 +93,7 @@ def _to_mensagem_read(mensagem, *, conversa: ConversaInterna, atendente: Atenden
         apagada=chat_svc.mensagem_esta_apagada(mensagem),
         editada=mensagem.editada_em is not None,
         reacoes=reacoes,
+        mencoes=mencoes,
         pode_editar=perms.pode_editar,
         pode_apagar_para_todos=perms.pode_apagar_para_todos,
         pode_apagar_para_mim=perms.pode_apagar_para_mim,
@@ -283,7 +293,12 @@ def enviar_mensagem(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversa não encontrada.")
     try:
         mensagem = chat_svc.enviar_mensagem(
-            db, conversa, atendente, body.corpo, reply_to_message_id=body.reply_to_message_id
+            db,
+            conversa,
+            atendente,
+            body.corpo,
+            reply_to_message_id=body.reply_to_message_id,
+            mencoes=[m.model_dump() for m in body.mencoes] if body.mencoes else None,
         )
         db.commit()
         db.refresh(mensagem)
@@ -393,7 +408,12 @@ def publicar_no_canal_setor(
     try:
         conversa = chat_svc.obter_ou_criar_canal_setor(db, atendente.tenant_id, setor_id)
         mensagem = chat_svc.enviar_mensagem(
-            db, conversa, atendente, body.corpo, reply_to_message_id=body.reply_to_message_id
+            db,
+            conversa,
+            atendente,
+            body.corpo,
+            reply_to_message_id=body.reply_to_message_id,
+            mencoes=[m.model_dump() for m in body.mencoes] if body.mencoes else None,
         )
         db.commit()
         db.refresh(mensagem)
@@ -460,7 +480,14 @@ def editar_mensagem(
     _exigir_acesso_conversa(db, atendente, conversa)
     mensagem = _obter_mensagem_na_conversa(db, conversa_id, mensagem_id)
     try:
-        chat_svc.editar_mensagem(db, conversa, mensagem, atendente, body.corpo)
+        chat_svc.editar_mensagem(
+            db,
+            conversa,
+            mensagem,
+            atendente,
+            body.corpo,
+            mencoes=[m.model_dump() for m in body.mencoes] if body.mencoes is not None else None,
+        )
         db.commit()
         db.refresh(mensagem)
         _emit_mensagem_atualizada(db, conversa, mensagem, acao="editada")

--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -5,16 +5,38 @@ GET /v1/events/stream — `text/event-stream`, autenticado por JWT (Bearer ou qu
 
 **Gunicorn / produção:** cada worker mantém filas in-process (v1). Com `--workers N`,
 conexões SSE e pub/sub ficam isoladas por processo — ver `docs/REALTIME_SSE.md`.
+
+Presença online grava heartbeat no Postgres a cada ping (funciona com N workers).
 """
+
+import asyncio
+import logging
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import StreamingResponse
 
 from app.core.auth import obter_atendente_sse
+from app.database import SessionLocal
 from app.models.atendente import Atendente
+from app.services.presenca import tocar_presenca
 from app.services.realtime_hub import channel_atendente, stream_channel_events
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/events", tags=["events"])
+
+
+def _presence_tick_sync(atendente_id: int) -> None:
+    db = SessionLocal()
+    try:
+        tocar_presenca(db, atendente_id)
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception("Falha ao gravar presença do atendente %s", atendente_id)
+        raise
+    finally:
+        db.close()
 
 
 @router.get("/stream")
@@ -23,19 +45,24 @@ async def events_stream(
     atendente: Atendente = Depends(obter_atendente_sse),
 ):
     channel = channel_atendente(atendente.id)
+    atendente_id = atendente.id
     initial = {
         "type": "connected",
         "payload": {
-            "atendente_id": atendente.id,
+            "atendente_id": atendente_id,
             "canal": channel,
         },
     }
+
+    async def on_presence_tick() -> None:
+        await asyncio.to_thread(_presence_tick_sync, atendente_id)
 
     async def generate():
         async for chunk in stream_channel_events(
             channel,
             initial_payload=initial,
             disconnect_check=request.is_disconnected,
+            on_presence_tick=on_presence_tick,
         ):
             yield chunk
 

--- a/backend/app/api/presenca.py
+++ b/backend/app/api/presenca.py
@@ -1,6 +1,6 @@
 """Presença online de atendentes — admin (#546 / #547)."""
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, status
 from sqlalchemy.orm import Session
 
 from app.core.auth import exigir_admin
@@ -18,3 +18,14 @@ async def listar_online(
     admin: Atendente = Depends(exigir_admin),
 ):
     return await presenca_service.listar_online(db, tenant_id=admin.tenant_id)
+
+
+@router.post("/online/{atendente_id}/forcar-saida", status_code=status.HTTP_204_NO_CONTENT)
+async def forcar_saida(
+    atendente_id: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    """Encerra a sessão do atendente (invalida tokens) e remove da lista online."""
+    await presenca_service.forcar_saida(db, admin=admin, alvo_id=atendente_id)
+    return None

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -48,6 +48,13 @@ def _carregar_atendente_por_token(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Usuário não encontrado ou inativo",
         )
+    token_ver = int(payload.get("ver") or 0)
+    atual_ver = int(getattr(atendente, "token_version", 0) or 0)
+    if token_ver != atual_ver:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Sessão encerrada. Faça login novamente.",
+        )
     path = request.url.path.rstrip("/") or "/"
     method = request.method.upper()
     if getattr(atendente, "must_change_password", False):

--- a/backend/app/models/atendente.py
+++ b/backend/app/models/atendente.py
@@ -27,6 +27,11 @@ class Atendente(Base):
     role = Column(String(20), nullable=False, default="atendente")  # admin | atendente
     ativo = Column(Boolean, default=True)
     must_change_password = Column(Boolean, nullable=False, default=False)
+    # Presença online (#546+): heartbeat gravado no DB (funciona com Gunicorn N>1).
+    presenca_online_desde = Column(DateTime(timezone=True), nullable=True)
+    presenca_heartbeat_em = Column(DateTime(timezone=True), nullable=True, index=True)
+    # Incrementado ao forçar saída — invalida access/refresh tokens com claim "ver" antigo.
+    token_version = Column(Integer, nullable=False, default=0, server_default="0")
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/app/models/chat_interno.py
+++ b/backend/app/models/chat_interno.py
@@ -4,6 +4,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Integer,
+    JSON,
     String,
     Text,
     UniqueConstraint,
@@ -123,6 +124,8 @@ class MensagemInterna(Base):
     )
     reply_preview = Column(String(500), nullable=True)
     reply_autor_nome = Column(String(200), nullable=True)
+    # Ex.: [{"tipo":"user","atendente_id":12,"rotulo":"Maria"},{"tipo":"all"}]
+    mencoes = Column(JSON, nullable=True)
 
     conversa = relationship("ConversaInterna", back_populates="mensagens")
     atendente = relationship("Atendente", backref="mensagens_internas")

--- a/backend/app/schemas/chat_interno.py
+++ b/backend/app/schemas/chat_interno.py
@@ -26,13 +26,26 @@ class ParticipanteGrupoRead(BaseModel):
     papel: Literal["admin", "membro"]
 
 
+class MencaoMensagemCreate(BaseModel):
+    tipo: Literal["user", "all"]
+    atendente_id: int | None = Field(None, gt=0)
+
+
+class MencaoMensagemRead(BaseModel):
+    tipo: Literal["user", "all"]
+    atendente_id: int | None = None
+    rotulo: str | None = None
+
+
 class MensagemInternaCreate(BaseModel):
     corpo: str = Field(..., min_length=1, max_length=8000)
     reply_to_message_id: int | None = Field(None, gt=0)
+    mencoes: list[MencaoMensagemCreate] | None = None
 
 
 class MensagemInternaUpdate(BaseModel):
     corpo: str = Field(..., max_length=8000)
+    mencoes: list[MencaoMensagemCreate] | None = None
 
 
 class ReacaoMensagemCreate(BaseModel):
@@ -60,6 +73,7 @@ class MensagemInternaRead(BaseModel):
     apagada: bool = False
     editada: bool = False
     reacoes: list[ReacaoMensagemRead] = Field(default_factory=list)
+    mencoes: list[MencaoMensagemRead] = Field(default_factory=list)
     pode_editar: bool = False
     pode_apagar_para_todos: bool = False
     pode_apagar_para_mim: bool = False

--- a/backend/app/services/chat_interno.py
+++ b/backend/app/services/chat_interno.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
@@ -297,6 +298,123 @@ def listar_participantes_grupo(
     return [(atendente, participante.papel) for participante, atendente in rows]
 
 
+def listar_mencionaveis(
+    db: Session,
+    conversa: ConversaInterna,
+    *,
+    excluir_atendente_id: int | None = None,
+) -> list[Atendente]:
+    """Atendentes que podem ser mencionados na conversa (grupo / setor / direta)."""
+    if conversa.tipo == TIPO_CONVERSA_GRUPO:
+        rows = listar_participantes_grupo(db, conversa.id)
+        atendentes = [a for a, _ in rows if a.ativo]
+    elif conversa.tipo == TIPO_CONVERSA_SETOR and conversa.setor_id is not None:
+        from app.models.atendente import atendente_setor
+
+        atendentes = (
+            db.query(Atendente)
+            .join(atendente_setor, atendente_setor.c.atendente_id == Atendente.id)
+            .filter(
+                atendente_setor.c.setor_id == conversa.setor_id,
+                Atendente.tenant_id == conversa.tenant_id,
+                Atendente.ativo.is_(True),
+            )
+            .order_by(Atendente.nome.asc())
+            .all()
+        )
+    elif conversa.tipo == TIPO_CONVERSA_DIRETA:
+        rows = listar_participantes_grupo(db, conversa.id)
+        atendentes = [a for a, _ in rows if a.ativo]
+    else:
+        atendentes = []
+
+    if excluir_atendente_id is not None:
+        atendentes = [a for a in atendentes if a.id != excluir_atendente_id]
+    return atendentes
+
+
+def _token_mencao_no_corpo(corpo: str, token: str) -> bool:
+    """True se `@token` aparece como menção (não no meio de palavra)."""
+    return re.search(rf"(?<!\w)@{re.escape(token)}(?!\w)", corpo, flags=re.IGNORECASE) is not None
+
+
+def normalizar_mencoes(
+    db: Session,
+    conversa: ConversaInterna,
+    remetente: Atendente,
+    corpo: str,
+    mencoes_in: list[dict] | None,
+) -> list[dict] | None:
+    """Valida menções enviadas pelo cliente (ou deriva do texto) e devolve JSON persistível."""
+    if conversa.tipo == TIPO_CONVERSA_DIRETA:
+        # Menções em DM não fazem sentido operacional — ignora.
+        return None
+
+    candidatos = {a.id: a for a in listar_mencionaveis(db, conversa)}
+    out: list[dict] = []
+    visto_ids: set[int] = set()
+    tem_all = False
+
+    raw = mencoes_in or []
+    if not raw:
+        # Deriva do corpo: @all / @todos e @Nome dos participantes.
+        if _token_mencao_no_corpo(corpo, "all") or _token_mencao_no_corpo(corpo, "todos"):
+            tem_all = True
+        for a in sorted(candidatos.values(), key=lambda x: len(x.nome or ""), reverse=True):
+            if a.id == remetente.id:
+                continue
+            if _token_mencao_no_corpo(corpo, a.nome):
+                visto_ids.add(a.id)
+                out.append({"tipo": "user", "atendente_id": a.id, "rotulo": a.nome})
+    else:
+        for item in raw:
+            tipo = (item.get("tipo") or "").strip().lower()
+            if tipo == "all":
+                tem_all = True
+                continue
+            if tipo != "user":
+                raise ChatInternoErro("Tipo de menção inválido.")
+            aid = item.get("atendente_id")
+            if aid is None:
+                raise ChatInternoErro("Menção de usuário exige atendente_id.")
+            aid = int(aid)
+            if aid == remetente.id:
+                continue
+            alvo = candidatos.get(aid)
+            if alvo is None:
+                raise ChatInternoErro("Só é possível mencionar participantes desta conversa.")
+            if aid in visto_ids:
+                continue
+            visto_ids.add(aid)
+            out.append({"tipo": "user", "atendente_id": aid, "rotulo": alvo.nome})
+
+    if tem_all:
+        out.insert(0, {"tipo": "all"})
+
+    return out or None
+
+
+def mencoes_para_leitura(raw) -> list[dict]:
+    if not raw or not isinstance(raw, list):
+        return []
+    itens: list[dict] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        tipo = item.get("tipo")
+        if tipo == "all":
+            itens.append({"tipo": "all", "atendente_id": None, "rotulo": "all"})
+        elif tipo == "user":
+            itens.append(
+                {
+                    "tipo": "user",
+                    "atendente_id": item.get("atendente_id"),
+                    "rotulo": item.get("rotulo"),
+                }
+            )
+    return itens
+
+
 def obter_ou_criar_canal_setor(db: Session, tenant_id: int, setor_id: int) -> ConversaInterna:
     setor = (
         db.query(Setor)
@@ -552,6 +670,7 @@ def enviar_mensagem(
     atendente: Atendente,
     corpo: str,
     reply_to_message_id: int | None = None,
+    mencoes: list[dict] | None = None,
 ) -> MensagemInterna:
     if not pode_acessar_conversa(db, atendente, conversa):
         raise ChatInternoErro("Sem permissão para esta conversa.")
@@ -560,6 +679,7 @@ def enviar_mensagem(
         raise ChatInternoErro("Corpo da mensagem não pode ser vazio.")
 
     reply_id, reply_preview, reply_autor = _resolver_citacao(db, conversa.id, reply_to_message_id)
+    mencoes_norm = normalizar_mencoes(db, conversa, atendente, texto, mencoes)
 
     mensagem = MensagemInterna(
         conversa_id=conversa.id,
@@ -569,6 +689,7 @@ def enviar_mensagem(
         reply_to_message_id=reply_id,
         reply_preview=reply_preview,
         reply_autor_nome=reply_autor,
+        mencoes=mencoes_norm,
     )
     db.add(mensagem)
     db.flush()
@@ -950,6 +1071,7 @@ def editar_mensagem(
     mensagem: MensagemInterna,
     atendente: Atendente,
     novo_corpo: str,
+    mencoes: list[dict] | None = None,
 ) -> MensagemInterna:
     if not pode_acessar_conversa(db, atendente, conversa):
         raise ChatInternoErro("Sem permissão para esta conversa.")
@@ -969,6 +1091,7 @@ def editar_mensagem(
         if not texto:
             raise ChatInternoErro("Corpo da mensagem não pode ser vazio.")
         mensagem.corpo = texto
+        mensagem.mencoes = normalizar_mencoes(db, conversa, atendente, texto, mencoes)
     elif tipo in TIPOS_MENSAGEM_MIDIA:
         mensagem.corpo = novo_corpo.strip()
     else:

--- a/backend/app/services/presenca.py
+++ b/backend/app/services/presenca.py
@@ -1,30 +1,67 @@
-"""Presença de atendentes online — deriva do hub SSE (#546)."""
+"""Presença de atendentes online — heartbeat no DB (#546+ multi-worker)."""
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import logging
+from datetime import datetime, timedelta, timezone
 
+from fastapi import HTTPException, status
 from sqlalchemy.orm import Session, joinedload
 
 from app.models.atendente import Atendente
 from app.schemas.presenca import PresencaOnlineItem, PresencaOnlineLista, PresencaSetorResumo
-from app.services.realtime_hub import hub
+from app.services.realtime_hub import publish_to_atendente
+
+logger = logging.getLogger(__name__)
+
+# SSE ping a cada 30s — offline após ~3 pings perdidos.
+PRESENCA_TTL_SEC = 90
+
+
+def _agora_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _limite_online(agora: datetime | None = None) -> datetime:
+    return (agora or _agora_utc()) - timedelta(seconds=PRESENCA_TTL_SEC)
+
+
+def tocar_presenca(db: Session, atendente_id: int) -> None:
+    """Atualiza heartbeat; reinicia `online_desde` se a sessão anterior expirou."""
+    a = db.query(Atendente).filter(Atendente.id == atendente_id).first()
+    if a is None:
+        return
+    agora = _agora_utc()
+    limite = _limite_online(agora)
+    hb = a.presenca_heartbeat_em
+    if hb is not None and hb.tzinfo is None:
+        hb = hb.replace(tzinfo=timezone.utc)
+    if a.presenca_online_desde is None or hb is None or hb < limite:
+        a.presenca_online_desde = agora
+    a.presenca_heartbeat_em = agora
+    db.add(a)
+
+
+def limpar_presenca(db: Session, atendente_id: int) -> None:
+    a = db.query(Atendente).filter(Atendente.id == atendente_id).first()
+    if a is None:
+        return
+    a.presenca_online_desde = None
+    a.presenca_heartbeat_em = None
+    db.add(a)
 
 
 async def listar_online(db: Session, *, tenant_id: int) -> PresencaOnlineLista:
-    """Lista atendentes ativos do tenant com conexão SSE no hub."""
-    online = await hub.list_online()
-    if not online:
-        return PresencaOnlineLista(itens=[])
-
-    por_id = {aid: desde for aid, desde in online}
+    """Lista atendentes ativos do tenant com heartbeat recente."""
+    limite = _limite_online()
     rows = (
         db.query(Atendente)
         .options(joinedload(Atendente.setores))
         .filter(
             Atendente.tenant_id == tenant_id,
-            Atendente.id.in_(list(por_id.keys())),
             Atendente.ativo.is_(True),
+            Atendente.presenca_heartbeat_em.isnot(None),
+            Atendente.presenca_heartbeat_em >= limite,
         )
         .order_by(Atendente.nome.asc(), Atendente.id.asc())
         .all()
@@ -32,7 +69,9 @@ async def listar_online(db: Session, *, tenant_id: int) -> PresencaOnlineLista:
 
     itens: list[PresencaOnlineItem] = []
     for a in rows:
-        desde = por_id[a.id]
+        desde = a.presenca_online_desde or a.presenca_heartbeat_em
+        if desde is None:
+            continue
         if desde.tzinfo is None:
             desde = desde.replace(tzinfo=timezone.utc)
         itens.append(
@@ -46,3 +85,31 @@ async def listar_online(db: Session, *, tenant_id: int) -> PresencaOnlineLista:
             )
         )
     return PresencaOnlineLista(itens=itens)
+
+
+async def forcar_saida(db: Session, *, admin: Atendente, alvo_id: int) -> None:
+    """Invalida tokens do alvo e remove presença; notifica via SSE se no mesmo worker."""
+    alvo = (
+        db.query(Atendente)
+        .filter(Atendente.id == alvo_id, Atendente.tenant_id == admin.tenant_id)
+        .first()
+    )
+    if alvo is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Atendente não encontrado")
+    if not alvo.ativo:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Atendente já está inativo")
+
+    alvo.token_version = int(getattr(alvo, "token_version", 0) or 0) + 1
+    alvo.presenca_online_desde = None
+    alvo.presenca_heartbeat_em = None
+    db.add(alvo)
+    db.commit()
+
+    try:
+        await publish_to_atendente(
+            alvo.id,
+            "sessao.encerrada",
+            {"motivo": "forcada_por_admin", "admin_id": admin.id},
+        )
+    except Exception:
+        logger.exception("Falha ao publicar sessao.encerrada para atendente %s", alvo.id)

--- a/backend/app/services/realtime_hub.py
+++ b/backend/app/services/realtime_hub.py
@@ -8,7 +8,7 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, AsyncIterator
+from typing import Any, AsyncIterator, Awaitable, Callable
 
 logger = logging.getLogger(__name__)
 
@@ -116,10 +116,16 @@ async def stream_channel_events(
     *,
     initial_payload: dict[str, Any] | None = None,
     disconnect_check: Any | None = None,
+    on_presence_tick: Callable[[], Awaitable[None]] | None = None,
 ) -> AsyncIterator[str]:
     """Gera linhas SSE para um canal, com heartbeat e desconexão limpa."""
     queue = await hub.subscribe(channel)
     try:
+        if on_presence_tick is not None:
+            try:
+                await on_presence_tick()
+            except Exception:
+                logger.exception("Falha no tick inicial de presença (%s)", channel)
         if initial_payload is not None:
             yield format_sse(initial_payload)
         elapsed = 0.0
@@ -133,6 +139,11 @@ async def stream_channel_events(
             except asyncio.TimeoutError:
                 elapsed += _DISCONNECT_POLL_SEC
                 if elapsed >= HEARTBEAT_INTERVAL_SEC:
+                    if on_presence_tick is not None:
+                        try:
+                            await on_presence_tick()
+                        except Exception:
+                            logger.exception("Falha no tick de presença (%s)", channel)
                     yield format_sse({"type": "ping", "payload": {}})
                     elapsed = 0.0
     finally:

--- a/backend/tests/test_chat_interno_mencoes.py
+++ b/backend/tests/test_chat_interno_mencoes.py
@@ -1,0 +1,99 @@
+"""Menções @user / @all no chat interno (grupos)."""
+
+from __future__ import annotations
+
+
+def test_mencao_all_e_usuario_em_grupo(client, seed_base, auth_headers, db_session):
+    from app.models.chat_interno import TIPO_CONVERSA_GRUPO, ConversaInterna, ConversaInternaParticipante
+    from app.models.chat_interno import PAPEL_PARTICIPANTE_ADMIN, PAPEL_PARTICIPANTE_MEMBRO
+
+    admin = seed_base["admin"]
+    a1 = seed_base["a1"]
+    a2 = seed_base["a2"]
+
+    conv = ConversaInterna(tenant_id=admin.tenant_id, tipo=TIPO_CONVERSA_GRUPO, titulo="Suporte")
+    db_session.add(conv)
+    db_session.flush()
+    for aid, papel in (
+        (admin.id, PAPEL_PARTICIPANTE_ADMIN),
+        (a1.id, PAPEL_PARTICIPANTE_MEMBRO),
+        (a2.id, PAPEL_PARTICIPANTE_MEMBRO),
+    ):
+        db_session.add(
+            ConversaInternaParticipante(conversa_id=conv.id, atendente_id=aid, papel=papel)
+        )
+    db_session.commit()
+
+    r = client.post(
+        f"/v1/chat-interno/conversas/{conv.id}/mensagens",
+        headers=auth_headers["admin"],
+        json={
+            "corpo": f"Oi @{a1.nome}, atenção @all",
+            "mencoes": [
+                {"tipo": "all"},
+                {"tipo": "user", "atendente_id": a1.id},
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    tipos = {m["tipo"] for m in body["mencoes"]}
+    assert "all" in tipos
+    assert "user" in tipos
+    user_m = next(m for m in body["mencoes"] if m["tipo"] == "user")
+    assert user_m["atendente_id"] == a1.id
+    assert user_m["rotulo"] == a1.nome
+
+
+def test_mencao_invalida_fora_do_grupo(client, seed_base, auth_headers, db_session):
+    from app.models.chat_interno import TIPO_CONVERSA_GRUPO, ConversaInterna, ConversaInternaParticipante
+    from app.models.chat_interno import PAPEL_PARTICIPANTE_ADMIN, PAPEL_PARTICIPANTE_MEMBRO
+
+    admin = seed_base["admin"]
+    a1 = seed_base["a1"]
+    a2 = seed_base["a2"]
+
+    conv = ConversaInterna(tenant_id=admin.tenant_id, tipo=TIPO_CONVERSA_GRUPO, titulo="Pequeno")
+    db_session.add(conv)
+    db_session.flush()
+    for aid, papel in ((admin.id, PAPEL_PARTICIPANTE_ADMIN), (a1.id, PAPEL_PARTICIPANTE_MEMBRO)):
+        db_session.add(
+            ConversaInternaParticipante(conversa_id=conv.id, atendente_id=aid, papel=papel)
+        )
+    db_session.commit()
+
+    r = client.post(
+        f"/v1/chat-interno/conversas/{conv.id}/mensagens",
+        headers=auth_headers["admin"],
+        json={
+            "corpo": f"Oi @{a2.nome}",
+            "mencoes": [{"tipo": "user", "atendente_id": a2.id}],
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_mencao_derivada_do_corpo_sem_payload(client, seed_base, auth_headers, db_session):
+    from app.models.chat_interno import TIPO_CONVERSA_GRUPO, ConversaInterna, ConversaInternaParticipante
+    from app.models.chat_interno import PAPEL_PARTICIPANTE_ADMIN, PAPEL_PARTICIPANTE_MEMBRO
+
+    admin = seed_base["admin"]
+    a1 = seed_base["a1"]
+
+    conv = ConversaInterna(tenant_id=admin.tenant_id, tipo=TIPO_CONVERSA_GRUPO, titulo="Auto")
+    db_session.add(conv)
+    db_session.flush()
+    for aid, papel in ((admin.id, PAPEL_PARTICIPANTE_ADMIN), (a1.id, PAPEL_PARTICIPANTE_MEMBRO)):
+        db_session.add(
+            ConversaInternaParticipante(conversa_id=conv.id, atendente_id=aid, papel=papel)
+        )
+    db_session.commit()
+
+    r = client.post(
+        f"/v1/chat-interno/conversas/{conv.id}/mensagens",
+        headers=auth_headers["admin"],
+        json={"corpo": f"@{a1.nome} e @all por favor"},
+    )
+    assert r.status_code == 201, r.text
+    tipos = {m["tipo"] for m in r.json()["mencoes"]}
+    assert tipos == {"all", "user"}

--- a/backend/tests/test_events_stream.py
+++ b/backend/tests/test_events_stream.py
@@ -9,7 +9,7 @@ from app.core.security import criar_access_token
 from app.services.realtime_hub import RealtimeHub, channel_atendente, format_sse
 
 
-async def _short_stream(channel, *, initial_payload=None, disconnect_check=None):
+async def _short_stream(channel, *, initial_payload=None, disconnect_check=None, **_kwargs):
     """Generator finito para TestClient (evita conexão longa em testes)."""
     if initial_payload is not None:
         yield format_sse(initial_payload)

--- a/backend/tests/test_presenca.py
+++ b/backend/tests/test_presenca.py
@@ -1,34 +1,10 @@
-"""Presença online de atendentes (#546)."""
+"""Presença online de atendentes (#546+)."""
 
 from __future__ import annotations
 
-import asyncio
+from datetime import datetime, timedelta, timezone
 
-from app.services.realtime_hub import RealtimeHub, channel_atendente, hub
-
-
-def test_hub_presenca_multi_aba_e_offline():
-    async def _run() -> None:
-        h = RealtimeHub()
-        ch = channel_atendente(42)
-        q1 = await h.subscribe(ch)
-        online = await h.list_online()
-        assert len(online) == 1
-        assert online[0][0] == 42
-        desde = online[0][1]
-
-        q2 = await h.subscribe(ch)
-        online2 = await h.list_online()
-        assert len(online2) == 1
-        assert online2[0][1] == desde
-
-        await h.unsubscribe(ch, q1)
-        assert len(await h.list_online()) == 1
-
-        await h.unsubscribe(ch, q2)
-        assert await h.list_online() == []
-
-    asyncio.run(_run())
+from app.services.presenca import PRESENCA_TTL_SEC, tocar_presenca
 
 
 def test_presenca_online_403_atendente(client, seed_base, auth_headers):
@@ -42,56 +18,88 @@ def test_presenca_online_admin_lista_vazia(client, seed_base, auth_headers):
     assert r.json() == {"itens": []}
 
 
-def test_presenca_online_admin_ve_atendente_conectado(client, seed_base, auth_headers):
-    async def _connect() -> None:
-        await hub.subscribe(channel_atendente(seed_base["a1"].id))
+def test_presenca_online_admin_ve_atendente_com_heartbeat(client, seed_base, auth_headers, db_session):
+    a1 = seed_base["a1"]
+    tocar_presenca(db_session, a1.id)
+    db_session.commit()
 
-    asyncio.run(_connect())
-    try:
-        r = client.get("/v1/presenca/online", headers=auth_headers["admin"])
-        assert r.status_code == 200
-        body = r.json()
-        ids = {item["atendente_id"] for item in body["itens"]}
-        assert seed_base["a1"].id in ids
-        item = next(i for i in body["itens"] if i["atendente_id"] == seed_base["a1"].id)
-        assert item["nome"] == seed_base["a1"].nome
-        assert item["email"] == seed_base["a1"].email
-        assert item["online_desde"]
-        assert isinstance(item["setores"], list)
-    finally:
-        async def _cleanup() -> None:
-            # limpa presença do hub global (todas as filas do canal)
-            ch = channel_atendente(seed_base["a1"].id)
-            async with hub._lock:
-                hub._queues.pop(ch, None)
-                hub._presence.pop(seed_base["a1"].id, None)
+    r = client.get("/v1/presenca/online", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    body = r.json()
+    ids = {item["atendente_id"] for item in body["itens"]}
+    assert a1.id in ids
+    item = next(i for i in body["itens"] if i["atendente_id"] == a1.id)
+    assert item["nome"] == a1.nome
+    assert item["email"] == a1.email
+    assert item["online_desde"]
+    assert isinstance(item["setores"], list)
 
-        asyncio.run(_cleanup())
+
+def test_presenca_ignora_heartbeat_expirado(client, seed_base, auth_headers, db_session):
+    a1 = seed_base["a1"]
+    antigo = datetime.now(timezone.utc) - timedelta(seconds=PRESENCA_TTL_SEC + 30)
+    a1.presenca_online_desde = antigo
+    a1.presenca_heartbeat_em = antigo
+    db_session.add(a1)
+    db_session.commit()
+
+    r = client.get("/v1/presenca/online", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    ids = {item["atendente_id"] for item in r.json()["itens"]}
+    assert a1.id not in ids
 
 
 def test_presenca_ignora_inativo(client, seed_base, auth_headers, db_session):
     a1 = seed_base["a1"]
     a1.ativo = False
+    tocar_presenca(db_session, a1.id)
     db_session.add(a1)
     db_session.commit()
 
-    async def _connect() -> None:
-        await hub.subscribe(channel_atendente(a1.id))
-
-    asyncio.run(_connect())
     try:
         r = client.get("/v1/presenca/online", headers=auth_headers["admin"])
         assert r.status_code == 200
         ids = {item["atendente_id"] for item in r.json()["itens"]}
         assert a1.id not in ids
     finally:
-        async def _cleanup() -> None:
-            ch = channel_atendente(a1.id)
-            async with hub._lock:
-                hub._queues.pop(ch, None)
-                hub._presence.pop(a1.id, None)
-
-        asyncio.run(_cleanup())
         a1.ativo = True
+        a1.presenca_online_desde = None
+        a1.presenca_heartbeat_em = None
         db_session.add(a1)
         db_session.commit()
+
+
+def test_forcar_saida_invalida_token_e_remove_presenca(client, seed_base, auth_headers, db_session):
+    a1 = seed_base["a1"]
+    tocar_presenca(db_session, a1.id)
+    db_session.commit()
+
+    r_ok = client.get("/v1/atendentes/me", headers=auth_headers["a1"])
+    assert r_ok.status_code == 200
+
+    r = client.post(
+        f"/v1/presenca/online/{a1.id}/forcar-saida",
+        headers=auth_headers["admin"],
+    )
+    assert r.status_code == 204
+
+    r_me = client.get("/v1/atendentes/me", headers=auth_headers["a1"])
+    assert r_me.status_code == 401
+
+    r_lista = client.get("/v1/presenca/online", headers=auth_headers["admin"])
+    assert r_lista.status_code == 200
+    ids = {item["atendente_id"] for item in r_lista.json()["itens"]}
+    assert a1.id not in ids
+
+
+def test_forcar_saida_403_atendente(client, seed_base, auth_headers):
+    r = client.post(
+        f"/v1/presenca/online/{seed_base['a1'].id}/forcar-saida",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 403
+
+
+def test_forcar_saida_404(client, seed_base, auth_headers):
+    r = client.post("/v1/presenca/online/999999/forcar-saida", headers=auth_headers["admin"])
+    assert r.status_code == 404

--- a/docs/REALTIME_SSE.md
+++ b/docs/REALTIME_SSE.md
@@ -50,12 +50,13 @@ O hub v1 é **in-process** (`asyncio.Queue` por conexão). Implicações:
 
 **v2 (futuro):** Redis Pub/Sub ou similar para fan-out entre workers.
 
-## Presença online (#546)
+## Presença online (#546+)
 
-- «Online» = canal `atendente:{id}` com ≥1 conexão SSE no hub do processo
-- `online_desde` = instante da primeira conexão da sessão contínua (multi-aba mantém o mesmo horário)
+- «Online» = heartbeat recente no Postgres (`presenca_heartbeat_em`), atualizado na conexão SSE e a cada ping (~30 s)
+- TTL: **90 s** sem heartbeat → some da lista (funciona com Gunicorn `--workers N>1`)
+- `online_desde` = início da sessão contínua (reinicia se o heartbeat tinha expirado)
 - API admin: `GET /v1/presenca/online` — lista só contas `ativo` do tenant atual
-- Com `--workers N>1`, cada worker vê só as conexões SSE locais (mesma limitação do pub/sub v1)
+- Forçar saída: `POST /v1/presenca/online/{id}/forcar-saida` — incrementa `token_version` (invalida JWT) e limpa presença; evento SSE `sessao.encerrada` no mesmo worker
 
 ### Limites práticos
 
@@ -68,3 +69,4 @@ O hub v1 é **in-process** (`asyncio.Queue` por conexão). Implicações:
 - Épico: [#256](https://github.com/lgustavoss/dx-connect/issues/256)
 - RT-F1 backend: [#264](https://github.com/lgustavoss/dx-connect/issues/264)
 - RT-F1 frontend: [#267](https://github.com/lgustavoss/dx-connect/issues/267)
+- Presença: [#545](https://github.com/lgustavoss/dx-connect/issues/545)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -651,6 +651,8 @@ export const audit = {
 
 export const presenca = {
   online: () => api<Presenca.ListaOnline>('/presenca/online'),
+  forcarSaida: (atendenteId: number) =>
+    api<void>(`/presenca/online/${atendenteId}/forcar-saida`, { method: 'POST' }),
 };
 
 export namespace WhatsappSettings {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1516,6 +1516,12 @@ export namespace ChatInterno {
     reagiu_eu: boolean;
   }
 
+  export interface MencaoMensagem {
+    tipo: 'user' | 'all';
+    atendente_id?: number | null;
+    rotulo?: string | null;
+  }
+
   export interface Mensagem {
     id: number;
     conversa_id: number;
@@ -1532,6 +1538,7 @@ export namespace ChatInterno {
     editada?: boolean;
     editada_em?: string | null;
     reacoes?: ReacaoMensagem[];
+    mencoes?: MencaoMensagem[];
     pode_editar?: boolean;
     pode_apagar_para_todos?: boolean;
     pode_apagar_para_mim?: boolean;
@@ -1580,12 +1587,18 @@ export const chatInterno = {
         antes_de_id: params?.antesDeId,
       }),
     ),
-  enviar: (conversaId: number, corpo: string, replyToMessageId?: number | null) =>
+  enviar: (
+    conversaId: number,
+    corpo: string,
+    replyToMessageId?: number | null,
+    mencoes?: ChatInterno.MencaoMensagem[] | null,
+  ) =>
     api<ChatInterno.Mensagem>(`/chat-interno/conversas/${conversaId}/mensagens`, {
       method: 'POST',
       body: JSON.stringify({
         corpo,
         ...(replyToMessageId != null ? { reply_to_message_id: replyToMessageId } : {}),
+        ...(mencoes && mencoes.length > 0 ? { mencoes } : {}),
       }),
     }),
   enviarMidia: (conversaId: number, file: File, caption?: string, replyToMessageId?: number | null) => {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Outlet, Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 import { Sidebar } from './Sidebar'
 import { ThemeToggle } from './ThemeToggle'
 import { NavbarNotificacoes } from './NavbarNotificacoes'
 import { useAlertaFilaSemResponsavel } from '../hooks/useAlertaFilaSemResponsavel'
-import { EventStreamProvider } from '../contexts/EventStreamContext'
+import { EventStreamProvider, useEventStream } from '../contexts/EventStreamContext'
 import { BrandLogo } from '../brand'
 import { useTheme } from '../contexts/ThemeContext'
 
@@ -23,6 +23,7 @@ const menuIcon = (
 
 function LayoutInner() {
   const { user, logout, isAdmin } = useAuth()
+  const { subscribe } = useEventStream()
   const location = useLocation()
   const [sidebarExpanded, setSidebarExpanded] = useState(true)
   const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false)
@@ -31,6 +32,12 @@ function LayoutInner() {
 
   const notificacoesEnabled = Boolean(user && !user.must_change_password)
   useAlertaFilaSemResponsavel(notificacoesEnabled)
+
+  useEffect(() => {
+    return subscribe('sessao.encerrada', () => {
+      logout()
+    })
+  }, [subscribe, logout])
 
   if (user?.must_change_password && location.pathname !== '/alterar-senha') {
     return <Navigate to="/alterar-senha" replace />

--- a/frontend/src/components/chat-interno/ChatInternoComposerBar.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoComposerBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { Button } from '../ui/Button'
 
@@ -7,6 +7,12 @@ import { ACCEPT_ANEXO, type TipoAnexoPicker } from '../../pages/whatsapp/Whatsap
 import { WhatsappGravadorAudioInline } from '../../pages/whatsapp/WhatsappGravadorAudioInline'
 
 import { WHATSAPP_EMOJIS } from '../../lib/whatsappEmojis'
+import {
+  detectarMencaoQuery,
+  filtrarMencionaveis,
+  inserirMencaoNoTexto,
+  type MencaoCandidato,
+} from '../../lib/chatInternoMencoes'
 
 import { ChatInternoMidiaPreviewOverlay } from './ChatInternoMidiaPreviewOverlay'
 
@@ -49,6 +55,11 @@ type Props = {
   /** Incrementar para focar o textarea (ex.: após Responder). */
   focoPedidoEm?: number
 
+  /** Participantes mencionáveis (grupo/setor). Sem lista = menções desligadas. */
+  mencionaveis?: MencaoCandidato[]
+
+  meuAtendenteId?: number | null
+
 }
 
 
@@ -79,6 +90,10 @@ export function ChatInternoComposerBar({
 
   focoPedidoEm,
 
+  mencionaveis = [],
+
+  meuAtendenteId,
+
 }: Props) {
 
   const [menuAberto, setMenuAberto] = useState(false)
@@ -91,6 +106,9 @@ export function ChatInternoComposerBar({
 
   const [midiaPendente, setMidiaPendente] = useState<File | null>(null)
   const [legendaPreview, setLegendaPreview] = useState('')
+  const [mencaoStart, setMencaoStart] = useState<number | null>(null)
+  const [mencaoQuery, setMencaoQuery] = useState('')
+  const [mencaoIdx, setMencaoIdx] = useState(0)
 
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -109,6 +127,51 @@ export function ChatInternoComposerBar({
 
   const campoBloqueado = Boolean(midiaPendente)
   const acoesBloqueadas = enviando || campoBloqueado
+
+  const mencoesAtivas = mencionaveis.length > 0
+  const opcoesMencao = useMemo(() => {
+    if (!mencoesAtivas || mencaoStart == null) return []
+    const users = filtrarMencionaveis(mencionaveis, mencaoQuery, meuAtendenteId)
+    const q = mencaoQuery.trim().toLowerCase()
+    const showAll = !q || 'all'.startsWith(q) || 'todos'.startsWith(q)
+    const items: Array<{ kind: 'all' } | { kind: 'user'; c: MencaoCandidato }> = []
+    if (showAll) items.push({ kind: 'all' })
+    for (const c of users) items.push({ kind: 'user', c })
+    return items
+  }, [mencoesAtivas, mencaoStart, mencionaveis, mencaoQuery, meuAtendenteId])
+
+  useEffect(() => {
+    setMencaoIdx(0)
+  }, [mencaoQuery, mencaoStart])
+
+  function atualizarMencaoFromCursor(value: string, cursor: number) {
+    if (!mencoesAtivas) {
+      setMencaoStart(null)
+      return
+    }
+    const hit = detectarMencaoQuery(value, cursor)
+    if (!hit) {
+      setMencaoStart(null)
+      setMencaoQuery('')
+      return
+    }
+    setMencaoStart(hit.start)
+    setMencaoQuery(hit.query)
+  }
+
+  function aplicarMencao(rotulo: string) {
+    const el = textareaRef.current
+    const cursor = el?.selectionStart ?? texto.length
+    const start = mencaoStart ?? cursor
+    const { texto: next, cursor: pos } = inserirMencaoNoTexto(texto, cursor, start, rotulo)
+    onTextoChange(next)
+    setMencaoStart(null)
+    setMencaoQuery('')
+    requestAnimationFrame(() => {
+      el?.focus()
+      el?.setSelectionRange(pos, pos)
+    })
+  }
 
 
 
@@ -441,13 +504,54 @@ export function ChatInternoComposerBar({
 
 
 
+          <div className="relative min-w-0 flex-1">
+            {opcoesMencao.length > 0 && mencaoStart != null ? (
+              <div
+                className="absolute bottom-full left-0 z-20 mb-1 max-h-48 w-full min-w-[12rem] overflow-y-auto rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-600 dark:bg-slate-800"
+                role="listbox"
+                aria-label="Menções"
+              >
+                {opcoesMencao.map((opt, i) => {
+                  const label = opt.kind === 'all' ? '@all — todos do grupo' : `@${opt.c.nome}`
+                  const ativo = i === mencaoIdx
+                  return (
+                    <button
+                      key={opt.kind === 'all' ? 'all' : opt.c.atendente_id}
+                      type="button"
+                      role="option"
+                      aria-selected={ativo}
+                      className={`flex w-full px-3 py-1.5 text-left text-sm ${
+                        ativo
+                          ? 'bg-cyan-50 text-cyan-900 dark:bg-cyan-950/50 dark:text-cyan-100'
+                          : 'text-slate-800 hover:bg-slate-50 dark:text-slate-100 dark:hover:bg-slate-700'
+                      }`}
+                      onMouseDown={(e) => {
+                        e.preventDefault()
+                        aplicarMencao(opt.kind === 'all' ? 'all' : opt.c.nome)
+                      }}
+                    >
+                      {label}
+                    </button>
+                  )
+                })}
+              </div>
+            ) : null}
           <textarea
 
             ref={textareaRef}
 
             value={texto}
 
-            onChange={(e) => onTextoChange(e.target.value)}
+            onChange={(e) => {
+              const v = e.target.value
+              onTextoChange(v)
+              atualizarMencaoFromCursor(v, e.target.selectionStart ?? v.length)
+            }}
+
+            onSelect={(e) => {
+              const t = e.currentTarget
+              atualizarMencaoFromCursor(t.value, t.selectionStart ?? t.value.length)
+            }}
 
             placeholder={placeholder}
 
@@ -455,9 +559,32 @@ export function ChatInternoComposerBar({
 
             disabled={campoBloqueado}
 
-            className="max-h-32 min-h-[40px] min-w-0 flex-1 resize-none break-words border-0 bg-transparent p-2 text-base outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
+            className="max-h-32 min-h-[40px] min-w-0 w-full flex-1 resize-none break-words border-0 bg-transparent p-2 text-base outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
 
             onKeyDown={(e) => {
+              if (opcoesMencao.length > 0 && mencaoStart != null) {
+                if (e.key === 'ArrowDown') {
+                  e.preventDefault()
+                  setMencaoIdx((i) => (i + 1) % opcoesMencao.length)
+                  return
+                }
+                if (e.key === 'ArrowUp') {
+                  e.preventDefault()
+                  setMencaoIdx((i) => (i - 1 + opcoesMencao.length) % opcoesMencao.length)
+                  return
+                }
+                if (e.key === 'Escape') {
+                  e.preventDefault()
+                  setMencaoStart(null)
+                  return
+                }
+                if ((e.key === 'Enter' || e.key === 'Tab') && !e.shiftKey) {
+                  e.preventDefault()
+                  const opt = opcoesMencao[mencaoIdx]
+                  if (opt) aplicarMencao(opt.kind === 'all' ? 'all' : opt.c.nome)
+                  return
+                }
+              }
 
               if (e.key === 'Enter' && !e.shiftKey) {
 
@@ -472,6 +599,7 @@ export function ChatInternoComposerBar({
             onPaste={handlePaste}
 
           />
+          </div>
 
 
 

--- a/frontend/src/components/chat-interno/ChatInternoConteudoMensagem.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoConteudoMensagem.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { fetchChatInternoMidiaBlob, type ChatInterno } from '../../api/client'
+import { segmentarCorpoComMencoes } from '../../lib/chatInternoMencoes'
+import { useAuth } from '../../contexts/AuthContext'
 
 const ROTULO_SEM_LEGENDA = /^(📷 Imagem|🎬 Vídeo|🎵 Áudio|📄 Documento)$/
 
@@ -11,6 +13,43 @@ type Props = {
   /** Rodapé compacto (hora/status) embutido no canto — estilo WhatsApp Web para texto curto */
   rodape?: ReactNode
   somenteTextoCompacto?: boolean
+}
+
+function CorpoComMencoes({
+  corpo,
+  mencoes,
+  textoClaro,
+}: {
+  corpo: string
+  mencoes?: ChatInterno.MencaoMensagem[]
+  textoClaro?: boolean
+}) {
+  const { user } = useAuth()
+  const segs = segmentarCorpoComMencoes(corpo, mencoes, user?.id)
+  return (
+    <>
+      {segs.map((s, i) =>
+        s.kind === 'mention' ? (
+          <span
+            key={i}
+            className={
+              textoClaro
+                ? s.self
+                  ? 'rounded bg-white/25 px-0.5 font-semibold text-white'
+                  : 'font-semibold text-cyan-100'
+                : s.self
+                  ? 'rounded bg-cyan-100 px-0.5 font-semibold text-cyan-800 dark:bg-cyan-900/60 dark:text-cyan-200'
+                  : 'font-semibold text-cyan-700 dark:text-cyan-300'
+            }
+          >
+            {s.value}
+          </span>
+        ) : (
+          <span key={i}>{s.value}</span>
+        ),
+      )}
+    </>
+  )
 }
 
 export function ChatInternoConteudoMensagem({
@@ -89,7 +128,7 @@ export function ChatInternoConteudoMensagem({
               textoClaro ? 'text-white' : 'text-slate-900 dark:text-slate-100'
             }`}
           >
-            {mensagem.corpo}
+            <CorpoComMencoes corpo={mensagem.corpo} mencoes={mensagem.mencoes} textoClaro={textoClaro} />
             <span aria-hidden className="inline-block h-[0.85rem] w-[4.25rem]" />
           </p>
           <div className="absolute bottom-0 right-0 flex items-center gap-0.5 pl-1">{rodape}</div>
@@ -102,7 +141,7 @@ export function ChatInternoConteudoMensagem({
           textoClaro ? 'text-white' : 'text-slate-900 dark:text-slate-100'
         }`}
       >
-        {mensagem.corpo}
+        <CorpoComMencoes corpo={mensagem.corpo} mencoes={mensagem.mencoes} textoClaro={textoClaro} />
       </p>
     )
   }

--- a/frontend/src/components/chat-interno/ChatInternoReacoesBar.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoReacoesBar.tsx
@@ -7,16 +7,19 @@ type Props = {
   alinhamento?: 'start' | 'end'
 }
 
+/** Picker no hover (overlay, sem ocupar espaço); chips só quando há reações. */
 export function ChatInternoReacoesBar({ reacoes, onReagir, alinhamento = 'end' }: Props) {
   const temReacoes = reacoes.length > 0
-  const align = alinhamento === 'end' ? 'justify-end' : 'justify-start'
+  const alignEnd = alinhamento === 'end'
 
   return (
-    <div className={`mt-1.5 flex flex-col gap-1 ${align}`}>
+    <>
       <div
-        className={`flex opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 ${align}`}
+        className={`pointer-events-none absolute top-full z-10 mt-0.5 flex opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 ${
+          alignEnd ? 'right-0 justify-end' : 'left-0 justify-start'
+        }`}
       >
-        <div className="flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
+        <div className="pointer-events-auto flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
           {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
             <button
               key={emoji}
@@ -32,7 +35,11 @@ export function ChatInternoReacoesBar({ reacoes, onReagir, alinhamento = 'end' }
       </div>
 
       {temReacoes ? (
-        <div className={`flex flex-wrap gap-1 ${align}`}>
+        <div
+          className={`relative z-[1] -mt-1.5 flex flex-wrap gap-1 ${
+            alignEnd ? 'justify-end' : 'justify-start'
+          }`}
+        >
           {reacoes.map((r) => (
             <button
               key={r.emoji}
@@ -51,6 +58,6 @@ export function ChatInternoReacoesBar({ reacoes, onReagir, alinhamento = 'end' }
           ))}
         </div>
       ) : null}
-    </div>
+    </>
   )
 }

--- a/frontend/src/lib/chatInternoMencoes.ts
+++ b/frontend/src/lib/chatInternoMencoes.ts
@@ -1,0 +1,126 @@
+/** Menções (@pessoa / @all) no chat interno. */
+
+export type MencaoCandidato = {
+  atendente_id: number
+  nome: string
+}
+
+export type MencaoMensagem = {
+  tipo: 'user' | 'all'
+  atendente_id?: number | null
+  rotulo?: string | null
+}
+
+export type SegmentoMencao =
+  | { kind: 'text'; value: string }
+  | { kind: 'mention'; value: string; self?: boolean }
+
+/** Detecta query após `@` no cursor (ex.: "@lu" → { start, query }). */
+export function detectarMencaoQuery(
+  texto: string,
+  cursor: number,
+): { start: number; query: string } | null {
+  const before = texto.slice(0, cursor)
+  const m = before.match(/(^|[\s])@([^\s@]*)$/)
+  if (!m) return null
+  const atIndex = before.lastIndexOf('@')
+  if (atIndex < 0) return null
+  return { start: atIndex, query: m[2] ?? '' }
+}
+
+export function filtrarMencionaveis(
+  candidatos: MencaoCandidato[],
+  query: string,
+  excluirId?: number | null,
+): MencaoCandidato[] {
+  const q = query.trim().toLowerCase()
+  return candidatos
+    .filter((c) => c.atendente_id !== excluirId)
+    .filter((c) => !q || c.nome.toLowerCase().includes(q))
+    .slice(0, 8)
+}
+
+export function inserirMencaoNoTexto(
+  texto: string,
+  cursor: number,
+  start: number,
+  rotulo: string,
+): { texto: string; cursor: number } {
+  const before = texto.slice(0, start)
+  const after = texto.slice(cursor)
+  const inserido = `@${rotulo} `
+  const novo = `${before}${inserido}${after}`
+  return { texto: novo, cursor: before.length + inserido.length }
+}
+
+export function montarMencoesDoCorpo(
+  corpo: string,
+  candidatos: MencaoCandidato[],
+): MencaoMensagem[] {
+  const out: MencaoMensagem[] = []
+  if (/(?<!\w)@(all|todos)(?!\w)/i.test(corpo)) {
+    out.push({ tipo: 'all', rotulo: 'all' })
+  }
+  const sorted = [...candidatos].sort((a, b) => b.nome.length - a.nome.length)
+  const seen = new Set<number>()
+  for (const c of sorted) {
+    const re = new RegExp(`(?<!\\w)@${escapeRegExp(c.nome)}(?!\\w)`, 'i')
+    if (re.test(corpo) && !seen.has(c.atendente_id)) {
+      seen.add(c.atendente_id)
+      out.push({ tipo: 'user', atendente_id: c.atendente_id, rotulo: c.nome })
+    }
+  }
+  return out
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/** Quebra o corpo em texto + spans de menção para highlight. */
+export function segmentarCorpoComMencoes(
+  corpo: string,
+  mencoes: MencaoMensagem[] | undefined | null,
+  meuId?: number | null,
+): SegmentoMencao[] {
+  if (!corpo) return [{ kind: 'text', value: '' }]
+  const tokens: { token: string; self: boolean }[] = []
+  const list = mencoes ?? []
+  if (list.some((m) => m.tipo === 'all') || /(?<!\w)@(all|todos)(?!\w)/i.test(corpo)) {
+    tokens.push({ token: 'all', self: true })
+    tokens.push({ token: 'todos', self: true })
+  }
+  for (const m of list) {
+    if (m.tipo === 'user' && m.rotulo) {
+      tokens.push({
+        token: m.rotulo,
+        self: m.atendente_id != null && m.atendente_id === meuId,
+      })
+    }
+  }
+  tokens.sort((a, b) => b.token.length - a.token.length)
+  if (tokens.length === 0) return [{ kind: 'text', value: corpo }]
+
+  const uniqueTokens = [...new Map(tokens.map((t) => [t.token.toLowerCase(), t])).values()]
+  const pattern = new RegExp(
+    `(?<!\\w)@(${uniqueTokens.map((t) => escapeRegExp(t.token)).join('|')})(?!\\w)`,
+    'gi',
+  )
+  const selfByLower = new Map(uniqueTokens.map((t) => [t.token.toLowerCase(), t.self]))
+  const segments: SegmentoMencao[] = []
+  let last = 0
+  for (const match of corpo.matchAll(pattern)) {
+    const idx = match.index ?? 0
+    if (idx > last) segments.push({ kind: 'text', value: corpo.slice(last, idx) })
+    const raw = match[0]
+    const key = (match[1] || '').toLowerCase()
+    segments.push({
+      kind: 'mention',
+      value: raw,
+      self: selfByLower.get(key) ?? (key === 'all' || key === 'todos'),
+    })
+    last = idx + raw.length
+  }
+  if (last < corpo.length) segments.push({ kind: 'text', value: corpo.slice(last) })
+  return segments.length ? segments : [{ kind: 'text', value: corpo }]
+}

--- a/frontend/src/lib/chatInternoRemetenteCor.ts
+++ b/frontend/src/lib/chatInternoRemetenteCor.ts
@@ -1,0 +1,41 @@
+/** Cores estáveis por atendente_id — diferencia remetentes em grupos. */
+
+const NOME_CLASSES = [
+  'text-violet-600 dark:text-violet-300',
+  'text-emerald-600 dark:text-emerald-300',
+  'text-orange-600 dark:text-orange-300',
+  'text-rose-600 dark:text-rose-300',
+  'text-sky-600 dark:text-sky-300',
+  'text-amber-700 dark:text-amber-300',
+  'text-fuchsia-600 dark:text-fuchsia-300',
+  'text-teal-600 dark:text-teal-300',
+] as const
+
+const AVATAR_CLASSES = [
+  'bg-violet-500/90',
+  'bg-emerald-500/90',
+  'bg-orange-500/90',
+  'bg-rose-500/90',
+  'bg-sky-500/90',
+  'bg-amber-500/90',
+  'bg-fuchsia-500/90',
+  'bg-teal-500/90',
+] as const
+
+function indiceCor(atendenteId: number): number {
+  return Math.abs(atendenteId) % NOME_CLASSES.length
+}
+
+export function corNomeRemetenteChat(atendenteId: number): string {
+  return NOME_CLASSES[indiceCor(atendenteId)]
+}
+
+export function corAvatarRemetenteChat(atendenteId: number): string {
+  return AVATAR_CLASSES[indiceCor(atendenteId)]
+}
+
+export function inicialNomeRemetente(nome: string | null | undefined): string {
+  const t = (nome ?? '').trim()
+  if (!t) return '?'
+  return t.charAt(0).toUpperCase()
+}

--- a/frontend/src/pages/PresencaOnline.tsx
+++ b/frontend/src/pages/PresencaOnline.tsx
@@ -3,8 +3,10 @@ import { ApiError, presenca, type Presenca } from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { Button } from '../components/ui/Button'
 import { Card } from '../components/ui/Card'
+import { ConfirmDialog } from '../components/ui/ConfirmDialog'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { useToast } from '../components/ui/Toast'
+import { useAuth } from '../contexts/AuthContext'
 import { SemPermissao } from './SemPermissao'
 
 const POLL_MS = 20_000
@@ -44,11 +46,14 @@ function rotuloRole(role: string): string {
 
 export function PresencaOnline() {
   const toast = useToast()
+  const { user } = useAuth()
   const [itens, setItens] = useState<Presenca.ItemOnline[]>([])
   const [loading, setLoading] = useState(true)
   const [semPermissao, setSemPermissao] = useState(false)
   const [atualizadoEm, setAtualizadoEm] = useState<Date | null>(null)
   const [agora, setAgora] = useState(() => Date.now())
+  const [alvoForcar, setAlvoForcar] = useState<Presenca.ItemOnline | null>(null)
+  const [forcando, setForcando] = useState(false)
 
   const carregar = useCallback(
     async (silencioso = false) => {
@@ -146,50 +151,105 @@ export function PresencaOnline() {
                   <th className="px-2 py-2 font-medium sm:px-3">Setores</th>
                   <th className="px-2 py-2 font-medium sm:px-3">Perfil</th>
                   <th className="px-2 py-2 font-medium sm:px-3">Online desde</th>
+                  <th className="px-2 py-2 font-medium sm:px-3">
+                    <span className="sr-only">Ações</span>
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
-                {itens.map((item) => (
-                  <tr key={item.atendente_id}>
-                    <td className="px-2 py-3 sm:px-3">
-                      <div className="flex items-center gap-3">
-                        <span
-                          className="size-2.5 shrink-0 rounded-full bg-emerald-500"
-                          title="Online"
-                          aria-label="Online"
-                        />
-                        <div className="min-w-0">
-                          <p className="font-medium text-slate-900 dark:text-slate-100">{item.nome}</p>
-                          <p className="truncate text-xs text-slate-500 dark:text-slate-400">{item.email}</p>
+                {itens.map((item) => {
+                  const souEu = item.atendente_id === user?.id
+                  return (
+                    <tr key={item.atendente_id}>
+                      <td className="px-2 py-3 sm:px-3">
+                        <div className="flex items-center gap-3">
+                          <span
+                            className="size-2.5 shrink-0 rounded-full bg-emerald-500"
+                            title="Online"
+                            aria-label="Online"
+                          />
+                          <div className="min-w-0">
+                            <p className="font-medium text-slate-900 dark:text-slate-100">
+                              {item.nome}
+                              {souEu ? (
+                                <span className="ml-1.5 text-xs font-normal text-slate-500">(você)</span>
+                              ) : null}
+                            </p>
+                            <p className="truncate text-xs text-slate-500 dark:text-slate-400">{item.email}</p>
+                          </div>
                         </div>
-                      </div>
-                    </td>
-                    <td className="px-2 py-3 text-slate-700 dark:text-slate-300 sm:px-3">
-                      {item.setores.length === 0
-                        ? '—'
-                        : item.setores.map((s) => s.nome).join(', ')}
-                    </td>
-                    <td className="px-2 py-3 text-slate-700 dark:text-slate-300 sm:px-3">
-                      {rotuloRole(item.role)}
-                    </td>
-                    <td className="px-2 py-3 sm:px-3">
-                      <span
-                        className="font-medium text-slate-800 dark:text-slate-100"
-                        title={formatarAbsoluto(item.online_desde)}
-                      >
-                        {formatarRelativo(item.online_desde, agora)}
-                      </span>
-                      <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
-                        {formatarAbsoluto(item.online_desde)}
-                      </p>
-                    </td>
-                  </tr>
-                ))}
+                      </td>
+                      <td className="px-2 py-3 text-slate-700 dark:text-slate-300 sm:px-3">
+                        {item.setores.length === 0
+                          ? '—'
+                          : item.setores.map((s) => s.nome).join(', ')}
+                      </td>
+                      <td className="px-2 py-3 text-slate-700 dark:text-slate-300 sm:px-3">
+                        {rotuloRole(item.role)}
+                      </td>
+                      <td className="px-2 py-3 sm:px-3">
+                        <span
+                          className="font-medium text-slate-800 dark:text-slate-100"
+                          title={formatarAbsoluto(item.online_desde)}
+                        >
+                          {formatarRelativo(item.online_desde, agora)}
+                        </span>
+                        <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+                          {formatarAbsoluto(item.online_desde)}
+                        </p>
+                      </td>
+                      <td className="px-2 py-3 sm:px-3">
+                        {!souEu ? (
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            className="!px-2.5 !py-1 text-xs text-rose-700 hover:bg-rose-50 dark:text-rose-300 dark:hover:bg-rose-950/40"
+                            onClick={() => setAlvoForcar(item)}
+                          >
+                            Forçar saída
+                          </Button>
+                        ) : null}
+                      </td>
+                    </tr>
+                  )
+                })}
               </tbody>
             </table>
           </div>
         </Card>
       )}
+
+      <ConfirmDialog
+        open={alvoForcar != null}
+        title="Forçar saída?"
+        message={
+          alvoForcar
+            ? `${alvoForcar.nome} será desconectado do painel e precisará fazer login novamente.`
+            : ''
+        }
+        confirmLabel="Forçar saída"
+        cancelLabel="Cancelar"
+        variant="danger"
+        loading={forcando}
+        onCancel={() => {
+          if (!forcando) setAlvoForcar(null)
+        }}
+        onConfirm={() => {
+          if (!alvoForcar) return
+          setForcando(true)
+          void presenca
+            .forcarSaida(alvoForcar.atendente_id)
+            .then(() => {
+              toast.showSuccess(`${alvoForcar.nome} foi desconectado.`)
+              setAlvoForcar(null)
+              void carregar(true)
+            })
+            .catch((err) => {
+              toast.showError(mensagemFalhaParaToast(err, 'Não foi possível forçar a saída.'))
+            })
+            .finally(() => setForcando(false))
+        }}
+      />
     </PageContainer>
   )
 }

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { ApiError, chatInterno, type ChatInterno } from '../../api/client'
+import { ApiError, atendentes, chatInterno, type ChatInterno } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { ChatInternoComposerBar } from '../../components/chat-interno/ChatInternoComposerBar'
 import { ChatInternoGrupoMembrosModal } from '../../components/chat-interno/ChatInternoGrupoMembrosModal'
@@ -28,6 +28,7 @@ import {
   corNomeRemetenteChat,
   inicialNomeRemetente,
 } from '../../lib/chatInternoRemetenteCor'
+import { montarMencoesDoCorpo, type MencaoCandidato } from '../../lib/chatInternoMencoes'
 import { SemPermissao } from '../SemPermissao'
 
 const SCROLL_TOPO_CARREGAR_PX = 80
@@ -269,6 +270,7 @@ export function ChatInternoThread() {
   const [limpando, setLimpando] = useState(false)
   const [grupoDetalhe, setGrupoDetalhe] = useState<ChatInterno.Conversa | null>(null)
   const [modalMembros, setModalMembros] = useState(false)
+  const [mencionaveis, setMencionaveis] = useState<MencaoCandidato[]>([])
 
   useEffect(() => {
     if (meta?.tipo !== 'grupo') {
@@ -280,6 +282,39 @@ export function ChatInternoThread() {
       .then(setGrupoDetalhe)
       .catch(() => setGrupoDetalhe(null))
   }, [conversaId, meta?.tipo])
+
+  useEffect(() => {
+    if (meta?.tipo === 'grupo') {
+      setMencionaveis(
+        (grupoDetalhe?.participantes ?? []).map((p) => ({
+          atendente_id: p.atendente_id,
+          nome: p.nome,
+        })),
+      )
+      return
+    }
+    if (meta?.tipo === 'setor' && meta.setor_id) {
+      let cancelled = false
+      void atendentes
+        .listPorSetor(meta.setor_id)
+        .then((lista) => {
+          if (cancelled) return
+          setMencionaveis(
+            lista.map((a) => ({
+              atendente_id: a.id,
+              nome: a.nome,
+            })),
+          )
+        })
+        .catch(() => {
+          if (!cancelled) setMencionaveis([])
+        })
+      return () => {
+        cancelled = true
+      }
+    }
+    setMencionaveis([])
+  }, [meta?.tipo, meta?.setor_id, grupoDetalhe?.participantes])
 
   async function editarMensagem(mensagemId: number, corpo: string) {
     try {
@@ -369,7 +404,13 @@ export function ChatInternoThread() {
     if (!corpo || enviando) return
     setEnviando(true)
     try {
-      const msg = await chatInterno.enviar(conversaId, corpo, msgRespondida?.id ?? null)
+      const mencoes = montarMencoesDoCorpo(corpo, mencionaveis)
+      const msg = await chatInterno.enviar(
+        conversaId,
+        corpo,
+        msgRespondida?.id ?? null,
+        mencoes.length > 0 ? mencoes : null,
+      )
       setTexto('')
       setMsgRespondida(null)
       setMensagens((prev) => (prev.some((m) => m.id === msg.id) ? prev : [...prev, msg]))
@@ -711,9 +752,17 @@ export function ChatInternoThread() {
         onEnviar={() => void enviar()}
         onEnviarMidia={(file, caption) => void enviarMidia(file, caption)}
         enviando={enviando}
-        placeholder={isSetor ? 'Novo comunicado para o setor…' : 'Escreva uma mensagem…'}
+        placeholder={
+          isSetor
+            ? 'Novo comunicado… Use @ para mencionar'
+            : isGrupo
+              ? 'Escreva uma mensagem… Use @ para mencionar'
+              : 'Escreva uma mensagem…'
+        }
         labelEnviar={isSetor ? 'Publicar' : 'Enviar'}
         focoPedidoEm={focoComposerEm}
+        mencionaveis={mencionaveis}
+        meuAtendenteId={user?.id}
       />
     </div>
   )

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -23,6 +23,11 @@ import {
   scrollChatToBottom,
 } from '../../lib/chatInternoScrollMemory'
 import { mergeMensagensChatInterno, prependMensagensChatInterno } from '../../lib/chatInternoMensagensMerge'
+import {
+  corAvatarRemetenteChat,
+  corNomeRemetenteChat,
+  inicialNomeRemetente,
+} from '../../lib/chatInternoRemetenteCor'
 import { SemPermissao } from '../SemPermissao'
 
 const SCROLL_TOPO_CARREGAR_PX = 80
@@ -483,7 +488,7 @@ export function ChatInternoThread() {
         ref={scrollRef}
         className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto bg-slate-100/90 px-4 py-5 dark:bg-slate-900/60 md:px-6 lg:px-8"
       >
-        <div className="w-full min-w-0 space-y-3">
+        <div className="w-full min-w-0 space-y-1">
         {carregandoAntigas && (
           <p className="py-2 text-center text-sm text-slate-400">Carregando mensagens anteriores…</p>
         )}
@@ -496,10 +501,14 @@ export function ChatInternoThread() {
             {isSetor ? 'Nenhum comunicado ainda. Publique o primeiro aviso.' : 'Nenhuma mensagem. Diga olá!'}
           </p>
         ) : (
-          mensagens.map((m) => {
+          mensagens.map((m, idx) => {
             const propria = m.atendente_id === user?.id
             const isTexto = !m.tipo_midia || m.tipo_midia === 'texto'
             const textoCompacto = isTexto && !m.apagada
+            const prev = idx > 0 ? mensagens[idx - 1] : null
+            const mesmoRemetenteQueAnterior = Boolean(prev && prev.atendente_id === m.atendente_id)
+            const mostrarNomeRemetente = !propria && (isGrupo || isSetor) && !mesmoRemetenteQueAnterior
+            const mostrarAvatarGrupo = isGrupo && !propria
             if (isSetor) {
               return (
                 <div key={m.id} className="group relative w-full min-w-0" data-chat-msg-id={m.id}>
@@ -564,8 +573,23 @@ export function ChatInternoThread() {
                 key={m.id}
                 data-chat-msg-id={m.id}
                 onDoubleClick={(e) => duploCliqueResponder(e, m)}
-                className={`group flex w-full cursor-default ${propria ? 'justify-end' : 'justify-start'}`}
+                className={`group flex w-full cursor-default gap-1.5 ${
+                  propria ? 'justify-end' : 'justify-start'
+                } ${mesmoRemetenteQueAnterior && !propria ? 'mt-0.5' : isGrupo && !propria && !mesmoRemetenteQueAnterior ? 'mt-2' : ''}`}
               >
+                {mostrarAvatarGrupo ? (
+                  mesmoRemetenteQueAnterior ? (
+                    <span className="w-7 shrink-0" aria-hidden />
+                  ) : (
+                    <span
+                      className={`mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full text-[11px] font-bold text-white ${corAvatarRemetenteChat(m.atendente_id ?? 0)}`}
+                      title={m.atendente_nome ?? 'Atendente'}
+                      aria-hidden
+                    >
+                      {inicialNomeRemetente(m.atendente_nome)}
+                    </span>
+                  )
+                ) : null}
                 <div
                   className={`flex max-w-[85%] flex-col sm:max-w-[min(65%,28rem)] ${
                     propria ? 'items-end' : 'items-start'
@@ -586,8 +610,14 @@ export function ChatInternoThread() {
                           : 'rounded-tl-none bg-white text-slate-900 ring-slate-200/80 dark:bg-slate-800 dark:text-slate-100 dark:ring-slate-700'
                       }`}
                     >
-                    {!propria && (
-                      <p className="mb-0.5 text-[11px] font-semibold leading-none text-cyan-700 dark:text-cyan-300">
+                    {mostrarNomeRemetente && (
+                      <p
+                        className={`mb-0.5 text-[11px] font-semibold leading-none ${
+                          isGrupo
+                            ? corNomeRemetenteChat(m.atendente_id ?? 0)
+                            : 'text-cyan-700 dark:text-cyan-300'
+                        }`}
+                      >
                         {m.atendente_nome ?? 'Atendente'}
                       </p>
                     )}


### PR DESCRIPTION
## Summary
- Corrige «Equipe online» vazia com Gunicorn multi-worker: presença via heartbeat no Postgres (migration `070`)
- Admin pode **Forçar saída** de atendente (invalida JWT + remove da lista + SSE `sessao.encerrada`)
- Chat interno: balões mais próximos; ações/reações só no hover; em grupos, avatar e cor por remetente

## Test plan
- [ ] `alembic upgrade head` no ambiente de testes
- [ ] Abrir painel como admin → **Equipe online** lista você (e outros com painel aberto)
- [ ] Confirmar com `WEB_CONCURRENCY` > 1 (ou restart/workers) que a lista não fica vazia
- [ ] **Forçar saída** em outro atendente → ele perde a sessão e some da lista
- [ ] Chat interno em grupo: balões próximos; hover mostra Responder/Editar/Apagar e picker; Filipe/Luan com cores/avatares distintos
- [ ] `pytest -q tests/test_presenca.py`

Made with [Cursor](https://cursor.com)