### PR TITLE
feat(chat-interno): lista de membros do grupo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Equipe online: lista funciona com vários workers do servidor (presença gravada no banco); admin pode **Forçar saída** de um atendente conectado
 - Chat interno: balões mais próximos — opções/reações só no hover; em grupos, avatar e cor por pessoa para distinguir quem fala
 - Equipe online (#545–#547): administradores veem quem está com o painel aberto e desde quando (menu **Equipe online**), para coordenar atendimento de chats e tickets
-- Chat (#539): após enviar mensagem (WhatsApp e chat interno), o cursor permanece no campo de texto; painel de emoji fica aberto ao escolher vários; **Responder** mensagem no chat interno (direta, equipe e grupo)
+- Chat interno: no grupo, clique no nome na barra superior para ver participantes e administradores; admins promovidos também podem gerenciar membros
 - WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homónimos
 - WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos
 - WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede

--- a/frontend/src/components/chat-interno/ChatInternoGrupoMembrosModal.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoGrupoMembrosModal.tsx
@@ -1,23 +1,146 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { atendentes, chatInterno, type ChatInterno } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { useAuth } from '../../contexts/AuthContext'
 import { Button } from '../ui/Button'
 import { useToast } from '../ui/Toast'
-import { MODAL_OVERLAY, MODAL_PANEL_COMPACT } from '../../lib/modalPanel'
+import { MODAL_OVERLAY, MODAL_PANEL_SCROLLABLE } from '../../lib/modalPanel'
 
 type Props = {
   open: boolean
   conversaId: number
+  tituloGrupo?: string
   participantes: ChatInterno.ParticipanteGrupo[]
+  souAdmin?: boolean
   onClose: () => void
   onAtualizado: (conversa: ChatInterno.Conversa) => void
+}
+
+function MembroItem({
+  participante,
+  souAdmin,
+  salvando,
+  userId,
+  onPromover,
+  onRebaixar,
+  onRemover,
+}: {
+  participante: ChatInterno.ParticipanteGrupo
+  souAdmin: boolean
+  salvando: boolean
+  userId?: number
+  onPromover: (id: number) => void
+  onRebaixar: (id: number) => void
+  onRemover: (id: number) => void
+}) {
+  const isAdmin = participante.papel === 'admin'
+  const isSelf = participante.atendente_id === userId
+
+  return (
+    <li
+      className={`flex items-center justify-between gap-2 rounded-lg border px-3 py-2.5 text-sm ${
+        isAdmin
+          ? 'border-violet-200 bg-violet-50/80 dark:border-violet-800 dark:bg-violet-950/30'
+          : 'border-slate-200 dark:border-slate-700'
+      }`}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="truncate font-medium text-slate-900 dark:text-slate-100">{participante.nome}</span>
+          {isSelf && <span className="text-xs text-slate-500">(você)</span>}
+          {isAdmin && (
+            <span className="shrink-0 rounded-full bg-violet-600 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white">
+              Admin
+            </span>
+          )}
+        </div>
+      </div>
+      {souAdmin && (
+        <div className="flex shrink-0 gap-1">
+          {!isAdmin && (
+            <button
+              type="button"
+              disabled={salvando}
+              className="text-xs text-violet-600 hover:underline dark:text-violet-400"
+              onClick={() => onPromover(participante.atendente_id)}
+            >
+              Tornar admin
+            </button>
+          )}
+          {isAdmin && !isSelf && (
+            <button
+              type="button"
+              disabled={salvando}
+              className="text-xs text-slate-500 hover:underline"
+              onClick={() => onRebaixar(participante.atendente_id)}
+            >
+              Rebaixar
+            </button>
+          )}
+          {!isSelf && (
+            <button
+              type="button"
+              disabled={salvando}
+              className="text-xs text-rose-600 hover:underline"
+              onClick={() => onRemover(participante.atendente_id)}
+            >
+              Remover
+            </button>
+          )}
+        </div>
+      )}
+    </li>
+  )
+}
+
+function SecaoMembros({
+  titulo,
+  membros,
+  souAdmin,
+  salvando,
+  userId,
+  onPromover,
+  onRebaixar,
+  onRemover,
+}: {
+  titulo: string
+  membros: ChatInterno.ParticipanteGrupo[]
+  souAdmin: boolean
+  salvando: boolean
+  userId?: number
+  onPromover: (id: number) => void
+  onRebaixar: (id: number) => void
+  onRemover: (id: number) => void
+}) {
+  if (membros.length === 0) return null
+
+  return (
+    <div className="mt-4">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">{titulo}</h3>
+      <ul className="mt-2 space-y-1.5">
+        {membros.map((p) => (
+          <MembroItem
+            key={p.atendente_id}
+            participante={p}
+            souAdmin={souAdmin}
+            salvando={salvando}
+            userId={userId}
+            onPromover={onPromover}
+            onRebaixar={onRebaixar}
+            onRemover={onRemover}
+          />
+        ))}
+      </ul>
+    </div>
+  )
 }
 
 export function ChatInternoGrupoMembrosModal({
   open,
   conversaId,
+  tituloGrupo,
   participantes,
+  souAdmin = false,
   onClose,
   onAtualizado,
 }: Props) {
@@ -33,7 +156,7 @@ export function ChatInternoGrupoMembrosModal({
   }, [open, participantes])
 
   useEffect(() => {
-    if (!open) {
+    if (!open || !souAdmin) {
       setBusca('')
       setResultados([])
       return
@@ -53,7 +176,13 @@ export function ChatInternoGrupoMembrosModal({
       }
     }, 300)
     return () => clearTimeout(timer)
-  }, [busca, open, lista, user?.id])
+  }, [busca, open, lista, user?.id, souAdmin])
+
+  const { admins, membros } = useMemo(() => {
+    const adminList = lista.filter((p) => p.papel === 'admin')
+    const membroList = lista.filter((p) => p.papel !== 'admin')
+    return { admins: adminList, membros: membroList }
+  }, [lista])
 
   async function aplicar(patch: Parameters<typeof chatInterno.atualizarParticipantesGrupo>[1]) {
     setSalvando(true)
@@ -72,78 +201,64 @@ export function ChatInternoGrupoMembrosModal({
   if (!open) return null
 
   return (
-    <div className={MODAL_OVERLAY} role="dialog" aria-modal="true" onClick={onClose}>
-      <div className={MODAL_PANEL_COMPACT} onClick={(e) => e.stopPropagation()}>
-        <h2 className="text-lg font-bold text-slate-900 dark:text-white">Membros do grupo</h2>
-        <ul className="mt-4 max-h-40 space-y-1 overflow-y-auto">
-          {lista.map((p) => (
-            <li
-              key={p.atendente_id}
-              className="flex items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 text-sm dark:border-slate-700"
-            >
-              <div>
-                <span className="font-medium text-slate-900 dark:text-slate-100">{p.nome}</span>
-                <span className="ml-2 text-xs text-slate-500">{p.papel === 'admin' ? 'Admin' : 'Membro'}</span>
-              </div>
-              <div className="flex shrink-0 gap-1">
-                {p.papel === 'membro' && (
-                  <button
-                    type="button"
-                    disabled={salvando}
-                    className="text-xs text-violet-600 hover:underline"
-                    onClick={() => void aplicar({ promover_admin: [p.atendente_id] })}
-                  >
-                    Tornar admin
-                  </button>
-                )}
-                {p.papel === 'admin' && p.atendente_id !== user?.id && (
-                  <button
-                    type="button"
-                    disabled={salvando}
-                    className="text-xs text-slate-500 hover:underline"
-                    onClick={() => void aplicar({ rebaixar_admin: [p.atendente_id] })}
-                  >
-                    Rebaixar
-                  </button>
-                )}
-                {p.atendente_id !== user?.id && (
-                  <button
-                    type="button"
-                    disabled={salvando}
-                    className="text-xs text-rose-600 hover:underline"
-                    onClick={() => void aplicar({ remover: [p.atendente_id] })}
-                  >
-                    Remover
-                  </button>
-                )}
-              </div>
-            </li>
-          ))}
-        </ul>
+    <div className={MODAL_OVERLAY} role="dialog" aria-modal="true" aria-labelledby="grupo-membros-titulo" onClick={onClose}>
+      <div className={MODAL_PANEL_SCROLLABLE} onClick={(e) => e.stopPropagation()}>
+        <h2 id="grupo-membros-titulo" className="text-lg font-bold text-slate-900 dark:text-white">
+          {tituloGrupo ?? 'Grupo'}
+        </h2>
+        <p className="mt-1 text-sm text-slate-500">
+          {lista.length} {lista.length === 1 ? 'participante' : 'participantes'}
+        </p>
 
-        <input
-          type="search"
-          value={busca}
-          onChange={(e) => setBusca(e.target.value)}
-          placeholder="Buscar atendente para adicionar…"
-          className="mt-4 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+        <SecaoMembros
+          titulo="Administradores do grupo"
+          membros={admins}
+          souAdmin={souAdmin}
+          salvando={salvando}
+          userId={user?.id}
+          onPromover={(id) => void aplicar({ promover_admin: [id] })}
+          onRebaixar={(id) => void aplicar({ rebaixar_admin: [id] })}
+          onRemover={(id) => void aplicar({ remover: [id] })}
         />
-        <ul className="mt-2 max-h-32 space-y-1 overflow-y-auto">
-          {resultados.map((a) => (
-            <li key={a.id}>
-              <button
-                type="button"
-                disabled={salvando}
-                className="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
-                onClick={() => void aplicar({ adicionar: [a.id] })}
-              >
-                {a.nome}
-              </button>
-            </li>
-          ))}
-        </ul>
+        <SecaoMembros
+          titulo="Participantes"
+          membros={membros}
+          souAdmin={souAdmin}
+          salvando={salvando}
+          userId={user?.id}
+          onPromover={(id) => void aplicar({ promover_admin: [id] })}
+          onRebaixar={(id) => void aplicar({ rebaixar_admin: [id] })}
+          onRemover={(id) => void aplicar({ remover: [id] })}
+        />
 
-        <div className="mt-4 flex justify-end">
+        {souAdmin && (
+          <>
+            <h3 className="mt-5 text-xs font-semibold uppercase tracking-wide text-slate-500">Adicionar membro</h3>
+            <input
+              type="search"
+              value={busca}
+              onChange={(e) => setBusca(e.target.value)}
+              placeholder="Buscar atendente para adicionar…"
+              className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+            />
+            <ul className="mt-2 max-h-32 space-y-1 overflow-y-auto">
+              {resultados.map((a) => (
+                <li key={a.id}>
+                  <button
+                    type="button"
+                    disabled={salvando}
+                    className="w-full rounded-lg px-3 py-2 text-left text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
+                    onClick={() => void aplicar({ adicionar: [a.id] })}
+                  >
+                    {a.nome}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+
+        <div className="mt-5 flex justify-end">
           <Button type="button" variant="secondary" onClick={onClose}>
             Fechar
           </Button>

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -447,10 +447,13 @@ export function ChatInternoThread() {
   const titulo = meta?.titulo ?? 'Conversa'
   const isSetor = meta?.tipo === 'setor'
   const isGrupo = meta?.tipo === 'grupo'
+  const qtdMembrosGrupo = grupoDetalhe?.participantes?.length ?? 0
   const subtitulo = isSetor
     ? 'Canal do setor — comunicados'
     : isGrupo
-      ? 'Grupo da equipe'
+      ? qtdMembrosGrupo > 0
+        ? `Grupo · ${qtdMembrosGrupo} ${qtdMembrosGrupo === 1 ? 'participante' : 'participantes'}`
+        : 'Grupo da equipe'
       : 'Conversa direta'
 
   return (
@@ -472,18 +475,21 @@ export function ChatInternoThread() {
         >
           {isSetor ? 'S' : isGrupo ? 'G' : titulo.slice(0, 1).toUpperCase()}
         </div>
-        <div className="min-w-0 flex-1">
-          <h2 className="truncate text-lg font-bold text-slate-900 dark:text-white">{titulo}</h2>
-          <p className="truncate text-sm text-slate-500">{subtitulo}</p>
-        </div>
-        {isGrupo && grupoDetalhe?.sou_admin_grupo && (
+        {isGrupo ? (
           <button
             type="button"
             onClick={() => setModalMembros(true)}
-            className="shrink-0 rounded-lg px-3 py-1.5 text-xs font-medium text-violet-700 ring-1 ring-violet-200 hover:bg-violet-50 dark:text-violet-300 dark:ring-violet-800 dark:hover:bg-violet-950/40"
+            className="min-w-0 flex-1 rounded-lg text-left transition hover:bg-slate-50 dark:hover:bg-slate-800/60"
+            aria-label="Ver membros do grupo"
           >
-            Membros
+            <h2 className="truncate text-lg font-bold text-slate-900 dark:text-white">{titulo}</h2>
+            <p className="truncate text-sm text-slate-500">{subtitulo}</p>
           </button>
+        ) : (
+          <div className="min-w-0 flex-1">
+            <h2 className="truncate text-lg font-bold text-slate-900 dark:text-white">{titulo}</h2>
+            <p className="truncate text-sm text-slate-500">{subtitulo}</p>
+          </div>
         )}
         <button
           type="button"
@@ -516,7 +522,9 @@ export function ChatInternoThread() {
         <ChatInternoGrupoMembrosModal
           open={modalMembros}
           conversaId={conversaId}
+          tituloGrupo={grupoDetalhe.titulo ?? titulo}
           participantes={grupoDetalhe.participantes ?? []}
+          souAdmin={grupoDetalhe.sou_admin_grupo ?? false}
           onClose={() => setModalMembros(false)}
           onAtualizado={(conv: ChatInterno.Conversa) => {
             setGrupoDetalhe(conv)


### PR DESCRIPTION
## Summary
- Clique no nome do grupo na barra superior abre a lista de participantes e administradores (estilo WhatsApp).
- Todos os membros podem visualizar; admins do grupo (incluindo promovidos) podem adicionar, promover, rebaixar e remover.

## Test plan
- [ ] Abrir grupo no chat interno e clicar no nome — modal lista admins e participantes
- [ ] Membro comum vê só a lista (sem ações de gestão)
- [ ] Admin promovido consegue adicionar membro ao grupo
- [ ] CI verde (pytest + frontend build)
