### PR TITLE
feat(chat-interno): alerta sonoro, silenciar grupo e hover das ações

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
-- Chat interno (grupos/canal): menções com `@` — autocomplete de participantes e `@all` (todos); destaque visual na mensagem
+- Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)
+- Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima
 - Equipe online: lista funciona com vários workers do servidor (presença gravada no banco); admin pode **Forçar saída** de um atendente conectado
 - Chat interno: balões mais próximos — opções/reações só no hover; em grupos, avatar e cor por pessoa para distinguir quem fala
 - Equipe online (#545–#547): administradores veem quem está com o painel aberto e desde quando (menu **Equipe online**), para coordenar atendimento de chats e tickets

--- a/backend/alembic/versions/072_chat_interno_silenciar.py
+++ b/backend/alembic/versions/072_chat_interno_silenciar.py
@@ -1,0 +1,37 @@
+"""Chat interno: silenciar conversa por participante (grupos).
+
+Revision ID: 072_chat_interno_silenciar
+Revises: 071_chat_interno_mencoes
+Create Date: 2026-07-17
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "072_chat_interno_silenciar"
+down_revision = "071_chat_interno_mencoes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("conversas_internas_participantes"):
+        return
+    cols = {c["name"] for c in insp.get_columns("conversas_internas_participantes")}
+    if "silenciado_em" not in cols:
+        op.add_column(
+            "conversas_internas_participantes",
+            sa.Column("silenciado_em", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("conversas_internas_participantes"):
+        return
+    cols = {c["name"] for c in insp.get_columns("conversas_internas_participantes")}
+    if "silenciado_em" in cols:
+        op.drop_column("conversas_internas_participantes", "silenciado_em")

--- a/backend/app/api/chat_interno.py
+++ b/backend/app/api/chat_interno.py
@@ -17,6 +17,7 @@ from app.schemas.chat_interno import (
     ConversaGrupoCreate,
     ConversaInboxRead,
     ConversaRead,
+    ConversaSilenciarUpdate,
     GrupoParticipantesUpdate,
     MencaoMensagemRead,
     MensagemInternaCreate,
@@ -58,6 +59,7 @@ def _to_conversa_read(db: Session, conversa: ConversaInterna, atendente: Atenden
         titulo=titulo,
         participantes=participantes,
         sou_admin_grupo=sou_admin_grupo,
+        silenciado=chat_svc.conversa_esta_silenciada(db, conversa.id, atendente.id),
         created_at=conversa.created_at,
     )
 
@@ -166,6 +168,7 @@ def listar_conversas(
             ultima_mensagem_corpo=r.ultima_mensagem_corpo,
             ultima_mensagem_em=r.ultima_mensagem_em,
             nao_lidas_count=r.nao_lidas_count,
+            silenciado=r.silenciado,
             created_at=r.conversa.created_at,
         )
         for r in resumos
@@ -247,6 +250,31 @@ def atualizar_participantes_grupo(
             remover=body.remover,
             promover_admin=body.promover_admin,
             rebaixar_admin=body.rebaixar_admin,
+        )
+        db.commit()
+        db.refresh(conversa)
+        return _to_conversa_read(db, conversa, atendente)
+    except chat_svc.ChatInternoErro as exc:
+        raise _map_chat_erro(exc) from exc
+
+
+@router.patch("/conversas/{conversa_id}/silenciar", response_model=ConversaRead)
+def silenciar_conversa(
+    conversa_id: int,
+    body: ConversaSilenciarUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    conversa = _obter_conversa_ou_404(db, conversa_id)
+    if conversa.tenant_id != atendente.tenant_id:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Conversa não encontrada.")
+    _exigir_acesso_conversa(db, atendente, conversa)
+    try:
+        conversa = chat_svc.definir_silenciado_conversa(
+            db,
+            conversa,
+            atendente,
+            silenciado=body.silenciado,
         )
         db.commit()
         db.refresh(conversa)

--- a/backend/app/models/chat_interno.py
+++ b/backend/app/models/chat_interno.py
@@ -91,6 +91,7 @@ class ConversaInternaParticipante(Base):
         index=True,
     )
     papel = Column(String(20), nullable=False, server_default=PAPEL_PARTICIPANTE_MEMBRO)
+    silenciado_em = Column(DateTime(timezone=True), nullable=True)
 
     conversa = relationship("ConversaInterna", back_populates="participantes")
     atendente = relationship("Atendente", backref="conversas_internas_participantes")

--- a/backend/app/schemas/chat_interno.py
+++ b/backend/app/schemas/chat_interno.py
@@ -20,6 +20,10 @@ class GrupoParticipantesUpdate(BaseModel):
     rebaixar_admin: list[int] = Field(default_factory=list)
 
 
+class ConversaSilenciarUpdate(BaseModel):
+    silenciado: bool
+
+
 class ParticipanteGrupoRead(BaseModel):
     atendente_id: int
     nome: str
@@ -100,6 +104,7 @@ class ConversaRead(BaseModel):
     titulo: str | None = None
     participantes: list[ParticipanteGrupoRead] | None = None
     sou_admin_grupo: bool = False
+    silenciado: bool = False
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
@@ -113,6 +118,7 @@ class ConversaInboxRead(BaseModel):
     ultima_mensagem_corpo: str | None = None
     ultima_mensagem_em: datetime | None = None
     nao_lidas_count: int = 0
+    silenciado: bool = False
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/chat_interno.py
+++ b/backend/app/services/chat_interno.py
@@ -50,6 +50,7 @@ class ConversaInboxResumo:
     ultima_mensagem_corpo: str | None
     ultima_mensagem_em: datetime | None
     nao_lidas_count: int
+    silenciado: bool = False
 
 
 def is_participante(db: Session, conversa_id: int, atendente_id: int) -> bool:
@@ -150,6 +151,47 @@ def is_admin_grupo(db: Session, conversa_id: int, atendente_id: int) -> bool:
         .first()
         is not None
     )
+
+
+def conversa_esta_silenciada(db: Session, conversa_id: int, atendente_id: int) -> bool:
+    row = (
+        db.query(ConversaInternaParticipante.silenciado_em)
+        .filter(
+            ConversaInternaParticipante.conversa_id == conversa_id,
+            ConversaInternaParticipante.atendente_id == atendente_id,
+        )
+        .first()
+    )
+    return row is not None and row[0] is not None
+
+
+def definir_silenciado_conversa(
+    db: Session,
+    conversa: ConversaInterna,
+    atendente: Atendente,
+    *,
+    silenciado: bool,
+) -> ConversaInterna:
+    """Silencia/dessilencia notificações sonoras para o participante atual (grupos e diretas)."""
+    if conversa.tipo == TIPO_CONVERSA_SETOR:
+        raise ChatInternoErro("Silenciar não está disponível para canais de setor.")
+    if not is_participante(db, conversa.id, atendente.id):
+        raise ChatInternoErro("Sem permissão para esta conversa.")
+
+    participante = (
+        db.query(ConversaInternaParticipante)
+        .filter(
+            ConversaInternaParticipante.conversa_id == conversa.id,
+            ConversaInternaParticipante.atendente_id == atendente.id,
+        )
+        .first()
+    )
+    if participante is None:
+        raise ChatInternoErro("Sem permissão para esta conversa.")
+
+    participante.silenciado_em = datetime.now(timezone.utc) if silenciado else None
+    db.flush()
+    return conversa
 
 
 def _validar_atendentes_grupo(db: Session, tenant_id: int, atendente_ids: set[int]) -> None:
@@ -651,6 +693,7 @@ def listar_conversas_inbox(db: Session, atendente: Atendente) -> list[ConversaIn
                 ultima_mensagem_corpo=preview_mensagem(ultima) if ultima else None,
                 ultima_mensagem_em=ultima.created_at if ultima else None,
                 nao_lidas_count=nao_lidas,
+                silenciado=conversa_esta_silenciada(db, conversa.id, atendente.id),
             )
         )
 

--- a/backend/tests/test_chat_interno_silenciar.py
+++ b/backend/tests/test_chat_interno_silenciar.py
@@ -1,0 +1,56 @@
+"""Chat interno — silenciar grupo (notificações sonoras)."""
+
+
+def _criar_grupo(client, headers, titulo: str, atendente_ids: list[int]) -> dict:
+    r = client.post(
+        "/v1/chat-interno/conversas/grupo",
+        json={"titulo": titulo, "atendente_ids": atendente_ids},
+        headers=headers,
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def test_silenciar_e_dessilenciar_grupo(client, seed_base, auth_headers):
+    grupo = _criar_grupo(client, auth_headers["a1"], "Plantão", [seed_base["admin"].id])
+    assert grupo["silenciado"] is False
+
+    r_mute = client.patch(
+        f"/v1/chat-interno/conversas/{grupo['id']}/silenciar",
+        json={"silenciado": True},
+        headers=auth_headers["a1"],
+    )
+    assert r_mute.status_code == 200, r_mute.text
+    assert r_mute.json()["silenciado"] is True
+
+    r_get = client.get(f"/v1/chat-interno/conversas/{grupo['id']}", headers=auth_headers["a1"])
+    assert r_get.status_code == 200
+    assert r_get.json()["silenciado"] is True
+
+    r_inbox = client.get("/v1/chat-interno/conversas", headers=auth_headers["a1"])
+    assert r_inbox.status_code == 200
+    item = next(c for c in r_inbox.json() if c["id"] == grupo["id"])
+    assert item["silenciado"] is True
+
+    # Preferência é por participante: outro membro não fica silenciado
+    r_other = client.get(f"/v1/chat-interno/conversas/{grupo['id']}", headers=auth_headers["admin"])
+    assert r_other.status_code == 200
+    assert r_other.json()["silenciado"] is False
+
+    r_unmute = client.patch(
+        f"/v1/chat-interno/conversas/{grupo['id']}/silenciar",
+        json={"silenciado": False},
+        headers=auth_headers["a1"],
+    )
+    assert r_unmute.status_code == 200
+    assert r_unmute.json()["silenciado"] is False
+
+
+def test_silenciar_grupo_exige_participante(client, seed_base, auth_headers):
+    grupo = _criar_grupo(client, auth_headers["a1"], "Privado", [seed_base["admin"].id])
+    r = client.patch(
+        f"/v1/chat-interno/conversas/{grupo['id']}/silenciar",
+        json={"silenciado": True},
+        headers=auth_headers["a2"],
+    )
+    assert r.status_code == 403

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1494,6 +1494,7 @@ export namespace ChatInterno {
     ultima_mensagem_corpo: string | null;
     ultima_mensagem_em: string | null;
     nao_lidas_count: number;
+    silenciado?: boolean;
     created_at: string;
   }
 
@@ -1505,6 +1506,7 @@ export namespace ChatInterno {
     titulo: string | null;
     participantes?: ParticipanteGrupo[] | null;
     sou_admin_grupo?: boolean;
+    silenciado?: boolean;
     created_at: string;
   }
 
@@ -1580,6 +1582,11 @@ export const chatInterno = {
     api<ChatInterno.Conversa>(`/chat-interno/conversas/${conversaId}/participantes`, {
       method: 'PATCH',
       body: JSON.stringify(data),
+    }),
+  silenciarConversa: (conversaId: number, silenciado: boolean) =>
+    api<ChatInterno.Conversa>(`/chat-interno/conversas/${conversaId}/silenciar`, {
+      method: 'PATCH',
+      body: JSON.stringify({ silenciado }),
     }),
   mensagens: (conversaId: number, params?: { antesDeId?: number }) =>
     api<ChatInterno.MensagensPagina>(

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../contexts/AuthContext'
 import { Sidebar } from './Sidebar'
 import { ThemeToggle } from './ThemeToggle'
 import { NavbarNotificacoes } from './NavbarNotificacoes'
-import { useAlertaFilaSemResponsavel } from '../hooks/useAlertaFilaSemResponsavel'
+import { useAlertaFilaSemResponsavel, setChatInternoAlertUserId } from '../hooks/useAlertaFilaSemResponsavel'
 import { EventStreamProvider, useEventStream } from '../contexts/EventStreamContext'
 import { BrandLogo } from '../brand'
 import { useTheme } from '../contexts/ThemeContext'
@@ -32,6 +32,11 @@ function LayoutInner() {
 
   const notificacoesEnabled = Boolean(user && !user.must_change_password)
   useAlertaFilaSemResponsavel(notificacoesEnabled)
+
+  useEffect(() => {
+    setChatInternoAlertUserId(user?.id ?? null)
+    return () => setChatInternoAlertUserId(null)
+  }, [user?.id])
 
   useEffect(() => {
     return subscribe('sessao.encerrada', () => {

--- a/frontend/src/components/chat-interno/ChatInternoLista.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoLista.tsx
@@ -85,6 +85,11 @@ export function ChatInternoLista() {
                           }`}
                         >
                           {c.titulo}
+                          {c.silenciado ? (
+                            <span className="ml-1.5 text-[10px] font-medium uppercase tracking-wide text-slate-400">
+                              silenciado
+                            </span>
+                          ) : null}
                         </p>
                         <span className="shrink-0 text-[10px] text-slate-400">
                           {formatarHoraRelativa(c.ultima_mensagem_em)}

--- a/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoMensagemAcoes.tsx
@@ -92,33 +92,47 @@ export function ChatInternoMensagemAcoes({
 
   return (
     <>
+      {/*
+        Ações acima do balão + ponte invisível (h-2) colada no topo do balão.
+        Sem a ponte, o gap faz o hover cair na mensagem de cima e as opções “saltam”.
+      */}
       <div
-        className={`pointer-events-none absolute bottom-full z-10 mb-1 flex gap-1 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 ${
-          alinhamento === 'end' ? 'right-0 justify-end' : 'left-0 justify-start'
+        className={`pointer-events-none absolute bottom-full z-20 flex flex-col ${
+          alinhamento === 'end' ? 'right-0 items-end' : 'left-0 items-start'
         }`}
       >
-        {podeResponder && (
-          <button type="button" onClick={() => onResponder?.()} className={btnAcaoClass}>
-            Responder
-          </button>
-        )}
-        {podeEditar && (
-          <button
-            type="button"
-            onClick={() => {
-              setTexto(legendaEditavel(mensagem))
-              setEditando(true)
-            }}
-            className={btnAcaoClass}
-          >
-            Editar
-          </button>
-        )}
-        {(podeApagarTodos || podeApagarMim) && (
-          <button type="button" onClick={() => setConfirmarApagar(true)} className={btnAcaoClass}>
-            Apagar
-          </button>
-        )}
+        <div
+          className={`flex gap-1 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-[.is-msg-hover]:pointer-events-auto group-[.is-msg-hover]:opacity-100 ${
+            alinhamento === 'end' ? 'justify-end' : 'justify-start'
+          }`}
+        >
+          {podeResponder && (
+            <button type="button" onClick={() => onResponder?.()} className={btnAcaoClass}>
+              Responder
+            </button>
+          )}
+          {podeEditar && (
+            <button
+              type="button"
+              onClick={() => {
+                setTexto(legendaEditavel(mensagem))
+                setEditando(true)
+              }}
+              className={btnAcaoClass}
+            >
+              Editar
+            </button>
+          )}
+          {(podeApagarTodos || podeApagarMim) && (
+            <button type="button" onClick={() => setConfirmarApagar(true)} className={btnAcaoClass}>
+              Apagar
+            </button>
+          )}
+        </div>
+        <div
+          className="h-2 w-full min-w-[8rem] group-hover:pointer-events-auto group-focus-within:pointer-events-auto group-[.is-msg-hover]:pointer-events-auto"
+          aria-hidden
+        />
       </div>
       <ConfirmDialog
         open={confirmarApagar}

--- a/frontend/src/components/chat-interno/ChatInternoReacoesBar.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoReacoesBar.tsx
@@ -14,29 +14,38 @@ export function ChatInternoReacoesBar({ reacoes, onReagir, alinhamento = 'end' }
 
   return (
     <>
+      {/*
+        Picker abaixo do balão + ponte no topo para o mouse não “cair” na mensagem seguinte.
+      */}
       <div
-        className={`pointer-events-none absolute top-full z-10 mt-0.5 flex opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 ${
-          alignEnd ? 'right-0 justify-end' : 'left-0 justify-start'
+        className={`pointer-events-none absolute top-full z-20 flex flex-col ${
+          alignEnd ? 'right-0 items-end' : 'left-0 items-start'
         }`}
       >
-        <div className="pointer-events-auto flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
-          {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
-            <button
-              key={emoji}
-              type="button"
-              onClick={() => onReagir(emoji)}
-              className="rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
-              aria-label={`Reagir com ${emoji}`}
-            >
-              {emoji}
-            </button>
-          ))}
+        <div
+          className="h-2 w-full min-w-[10rem] group-hover:pointer-events-auto group-focus-within:pointer-events-auto group-[.is-msg-hover]:pointer-events-auto"
+          aria-hidden
+        />
+        <div className="opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-[.is-msg-hover]:pointer-events-auto group-[.is-msg-hover]:opacity-100">
+          <div className="flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
+            {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
+              <button
+                key={emoji}
+                type="button"
+                onClick={() => onReagir(emoji)}
+                className="rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
+                aria-label={`Reagir com ${emoji}`}
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
 
       {temReacoes ? (
         <div
-          className={`relative z-[1] -mt-1.5 flex flex-wrap gap-1 ${
+          className={`relative z-[1] mt-1 flex flex-wrap gap-1 ${
             alignEnd ? 'justify-end' : 'justify-start'
           }`}
         >

--- a/frontend/src/contexts/ChatInternoContext.tsx
+++ b/frontend/src/contexts/ChatInternoContext.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react'
 import { chatInterno, type ChatInterno } from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { syncChatInternoMutedIds } from '../hooks/useAlertaFilaSemResponsavel'
 import { useEventStream } from './EventStreamContext'
 import { useToast } from '../components/ui/Toast'
 import type { FiltroInboxChatInterno } from '../lib/chatInternoUtils'
@@ -41,6 +42,7 @@ export function ChatInternoProvider({ children }: { children: ReactNode }) {
       try {
         const rows = await chatInterno.listarConversas()
         setConversas(rows)
+        syncChatInternoMutedIds(rows.filter((c) => c.silenciado).map((c) => c.id))
       } catch (err) {
         setErro(true)
         if (!silent) toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar as conversas.'))

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -9,6 +9,7 @@ const LS_KEY_LAST_WPP_FILA = 'dxconnect.notificacoes.last_wpp_fila'
 const LS_KEY_LAST_WPP_RESP = 'dxconnect.notificacoes.last_wpp_resp'
 const LS_KEY_LAST_PORTAL_FILA = 'dxconnect.notificacoes.last_portal_fila'
 const LS_KEY_LAST_PORTAL_RESP = 'dxconnect.notificacoes.last_portal_resp'
+const LS_KEY_LAST_CHAT_INTERNO = 'dxconnect.notificacoes.last_chat_interno'
 const POLL_MS = 10_000
 /** Fallback de segurança quando SSE está ativo (#266). */
 const POLL_SSE_SAFETY_MS = 60_000
@@ -27,8 +28,11 @@ const SOUND_WPP_FILA = '/sons/alerta.mp3'
 /** Nova mensagem do cliente em chat WhatsApp / Portal em atendimento */
 const SOUND_WPP_MENSAGEM = '/sons/wpp-mensagem.mp3'
 const SOUND_WPP_MENSAGEM_FALLBACK = '/sons/notification.mp3'
+/** Nova mensagem no chat interno (direta, grupo ou canal) */
+const SOUND_CHAT_INTERNO = '/sons/wpp-mensagem.mp3'
+const SOUND_CHAT_INTERNO_FALLBACK = '/sons/notification.mp3'
 
-type AlertKind = 'ticket_fila' | 'ticket_mensagem' | 'wpp_fila_pulse' | 'wpp_mensagem'
+type AlertKind = 'ticket_fila' | 'ticket_mensagem' | 'wpp_fila_pulse' | 'wpp_mensagem' | 'chat_interno_mensagem'
 
 type ListenerFila = (state: { count: number }) => void
 type ListenerResumo = (state: Notificacoes.Resumo) => void
@@ -52,8 +56,14 @@ let prevWppResp: number | null = null
 let prevWppFila: number | null = null
 let prevPortalFila: number | null = null
 let prevPortalResp: number | null = null
+let prevChatInterno: number | null = null
 const listenersFila = new Set<ListenerFila>()
 const listenersResumo = new Set<ListenerResumo>()
+
+/** Preferências de som do chat interno (mute por conversa + conversa aberta). */
+const mutedChatInternoIds = new Set<number>()
+let chatInternoUserId: number | null = null
+let activeChatInternoConversaId: number | null = null
 
 let wppFilaLoopInterval: number | null = null
 let wppFilaLoopAudio: HTMLAudioElement | null = null
@@ -61,8 +71,47 @@ let pollTimerId: number | null = null
 let sseSlowPollMode = false
 let sseListenerCount = 0
 let sseUnsubscribe: (() => void) | null = null
+let chatInternoSseUnsubscribe: (() => void) | null = null
 let lastSemIncreaseAt = 0
 const recentAlertKeys = new Map<string, number>()
+
+export function setChatInternoAlertUserId(userId: number | null) {
+  chatInternoUserId = userId
+}
+
+export function setActiveChatInternoConversaId(conversaId: number | null) {
+  activeChatInternoConversaId = conversaId
+}
+
+export function syncChatInternoMutedIds(ids: Iterable<number>) {
+  mutedChatInternoIds.clear()
+  for (const id of ids) mutedChatInternoIds.add(id)
+}
+
+export function setChatInternoMuted(conversaId: number, muted: boolean) {
+  if (muted) mutedChatInternoIds.add(conversaId)
+  else mutedChatInternoIds.delete(conversaId)
+}
+
+function shouldPlayChatInternoSound(payload: Record<string, unknown>): boolean {
+  const conversaId = typeof payload.conversa_id === 'number' ? payload.conversa_id : null
+  const remetenteId = typeof payload.remetente_id === 'number' ? payload.remetente_id : null
+  if (remetenteId != null && chatInternoUserId != null && remetenteId === chatInternoUserId) {
+    return false
+  }
+  if (conversaId != null && mutedChatInternoIds.has(conversaId)) {
+    return false
+  }
+  if (
+    conversaId != null &&
+    activeChatInternoConversaId === conversaId &&
+    typeof document !== 'undefined' &&
+    document.visibilityState === 'visible'
+  ) {
+    return false
+  }
+  return true
+}
 
 const audioByKey = new Map<string, HTMLAudioElement>()
 const alertQueue: AlertKind[] = []
@@ -112,6 +161,8 @@ function srcForKind(kind: AlertKind): string {
       return SOUND_WPP_FILA
     case 'wpp_mensagem':
       return SOUND_WPP_MENSAGEM
+    case 'chat_interno_mensagem':
+      return SOUND_CHAT_INTERNO
   }
 }
 
@@ -169,6 +220,12 @@ function synthForKind(kind: AlertKind) {
         { freq: 780, ms: 200 },
       ])
       break
+    case 'chat_interno_mensagem':
+      playSynthPattern([
+        { freq: 540, ms: 140 },
+        { freq: 720, ms: 180 },
+      ])
+      break
   }
 }
 
@@ -191,6 +248,10 @@ function playSrcOnce(src: string, key: string, volume: number): Promise<void> {
       }
       if (key.startsWith('wpp_mensagem:') && src === SOUND_WPP_MENSAGEM) {
         void playSrcOnce(SOUND_WPP_MENSAGEM_FALLBACK, `${key}:fallback`, volume).then(finish)
+        return
+      }
+      if (key.startsWith('chat_interno_mensagem:') && src === SOUND_CHAT_INTERNO) {
+        void playSrcOnce(SOUND_CHAT_INTERNO_FALLBACK, `${key}:fallback`, volume).then(finish)
         return
       }
       const kind = key.split(':')[0] as AlertKind
@@ -316,12 +377,14 @@ function persistPrevCounters(r: Notificacoes.Resumo) {
   prevWppFila = r.wpp_fila_count
   prevPortalFila = r.portal_fila_count
   prevPortalResp = r.portal_respostas_count
+  prevChatInterno = r.chat_interno_nao_lidas_count
   setStoredNumber(LS_KEY_LAST_SEM_RESP, r.sem_responsavel_count)
   setStoredNumber(LS_KEY_LAST_NAO_LIDAS, r.nao_lidas_count)
   setStoredNumber(LS_KEY_LAST_WPP_FILA, r.wpp_fila_count)
   setStoredNumber(LS_KEY_LAST_WPP_RESP, r.wpp_respostas_count)
   setStoredNumber(LS_KEY_LAST_PORTAL_FILA, r.portal_fila_count)
   setStoredNumber(LS_KEY_LAST_PORTAL_RESP, r.portal_respostas_count)
+  setStoredNumber(LS_KEY_LAST_CHAT_INTERNO, r.chat_interno_nao_lidas_count)
 }
 
 function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean, source: 'sse' | 'poll' | 'refetch' = 'poll') {
@@ -342,6 +405,7 @@ function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean, source: 'sse
     const prevWppFilaValue = prevWppFila
     const prevPortalFilaValue = prevPortalFila
     const prevPortalRespValue = prevPortalResp
+    const prevChatInternoValue = prevChatInterno
 
     if (shouldEnqueueCounterAlert('ticket_fila', prevSem, r.sem_responsavel_count)) {
       lastSemIncreaseAt = Date.now()
@@ -367,6 +431,14 @@ function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean, source: 'sse
 
     if (shouldEnqueueCounterAlert('wpp_mensagem', prevPortalRespValue, r.portal_respostas_count)) {
       enqueueAlert('wpp_mensagem')
+    }
+
+    // Fallback quando SSE está off: contador sobe sem evento chat.interno.mensagem
+    if (
+      source !== 'sse' &&
+      shouldEnqueueCounterAlert('chat_interno_mensagem', prevChatInternoValue, r.chat_interno_nao_lidas_count)
+    ) {
+      enqueueAlert('chat_interno_mensagem')
     }
   }
 
@@ -448,6 +520,8 @@ function preloadSounds() {
     SOUND_WPP_FILA,
     SOUND_WPP_MENSAGEM,
     SOUND_WPP_MENSAGEM_FALLBACK,
+    SOUND_CHAT_INTERNO,
+    SOUND_CHAT_INTERNO_FALLBACK,
   ]
   for (const src of sources) {
     getAudioElement(`preload:${src}`, src)
@@ -461,6 +535,9 @@ function ensureStarted() {
   prevNaoLidas = getStoredNumber(LS_KEY_LAST_NAO_LIDAS)
   prevWppFila = getStoredNumber(LS_KEY_LAST_WPP_FILA)
   prevWppResp = getStoredNumber(LS_KEY_LAST_WPP_RESP)
+  prevPortalFila = getStoredNumber(LS_KEY_LAST_PORTAL_FILA)
+  prevPortalResp = getStoredNumber(LS_KEY_LAST_PORTAL_RESP)
+  prevChatInterno = getStoredNumber(LS_KEY_LAST_CHAT_INTERNO)
 
   preloadSounds()
 
@@ -509,12 +586,25 @@ export function useAlertaFilaSemResponsavel(enabled: boolean) {
       sseUnsubscribe = subscribe('notificacao.contagem', (payload) => {
         applyNotificacaoResumoSse(payload)
       })
+      chatInternoSseUnsubscribe = subscribe('chat.interno.mensagem', (payload) => {
+        if (!shouldPlayChatInternoSound(payload)) return
+        const conversaId = typeof payload.conversa_id === 'number' ? payload.conversa_id : 'x'
+        const mensagemId = typeof payload.mensagem_id === 'number' ? payload.mensagem_id : Date.now()
+        const key = `chat_interno_mensagem:${conversaId}:${mensagemId}`
+        const now = Date.now()
+        const last = recentAlertKeys.get(key)
+        if (last != null && now - last < ALERT_DEDUP_MS) return
+        recentAlertKeys.set(key, now)
+        enqueueAlert('chat_interno_mensagem')
+      })
     }
     return () => {
       sseListenerCount = Math.max(0, sseListenerCount - 1)
       if (sseListenerCount === 0) {
         sseUnsubscribe?.()
         sseUnsubscribe = null
+        chatInternoSseUnsubscribe?.()
+        chatInternoSseUnsubscribe = null
       }
     }
   }, [enabled, subscribe])

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -13,7 +13,7 @@ import { useToast } from '../../components/ui/Toast'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
 import { useAuth } from '../../contexts/AuthContext'
 import { useEventStream } from '../../contexts/EventStreamContext'
-import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
+import { refetchPendenciasResumo, setActiveChatInternoConversaId, setChatInternoMuted } from '../../hooks/useAlertaFilaSemResponsavel'
 import {
   clearChatInternoScroll,
   isNearBottom,
@@ -271,6 +271,36 @@ export function ChatInternoThread() {
   const [grupoDetalhe, setGrupoDetalhe] = useState<ChatInterno.Conversa | null>(null)
   const [modalMembros, setModalMembros] = useState(false)
   const [mencionaveis, setMencionaveis] = useState<MencaoCandidato[]>([])
+  const [silenciando, setSilenciando] = useState(false)
+  const [hoverMsgId, setHoverMsgId] = useState<number | null>(null)
+  const hoverLeaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  function trancarHoverMensagem(id: number) {
+    if (hoverLeaveTimerRef.current != null) {
+      clearTimeout(hoverLeaveTimerRef.current)
+      hoverLeaveTimerRef.current = null
+    }
+    setHoverMsgId(id)
+  }
+
+  function liberarHoverMensagem(id: number) {
+    if (hoverLeaveTimerRef.current != null) clearTimeout(hoverLeaveTimerRef.current)
+    hoverLeaveTimerRef.current = setTimeout(() => {
+      setHoverMsgId((atual) => (atual === id ? null : atual))
+      hoverLeaveTimerRef.current = null
+    }, 200)
+  }
+
+  useEffect(() => {
+    return () => {
+      if (hoverLeaveTimerRef.current != null) clearTimeout(hoverLeaveTimerRef.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    setActiveChatInternoConversaId(conversaId)
+    return () => setActiveChatInternoConversaId(null)
+  }, [conversaId])
 
   useEffect(() => {
     if (meta?.tipo !== 'grupo') {
@@ -282,6 +312,23 @@ export function ChatInternoThread() {
       .then(setGrupoDetalhe)
       .catch(() => setGrupoDetalhe(null))
   }, [conversaId, meta?.tipo])
+
+  async function alternarSilenciarGrupo() {
+    if (meta?.tipo !== 'grupo' || silenciando) return
+    const proximo = !(grupoDetalhe?.silenciado ?? false)
+    setSilenciando(true)
+    try {
+      const conv = await chatInterno.silenciarConversa(conversaId, proximo)
+      setGrupoDetalhe(conv)
+      setChatInternoMuted(conversaId, conv.silenciado ?? proximo)
+      void refreshInbox(true)
+      toast.showSuccess(proximo ? 'Grupo silenciado.' : 'Som do grupo reativado.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar o silenciar do grupo.'))
+    } finally {
+      setSilenciando(false)
+    }
+  }
 
   useEffect(() => {
     if (meta?.tipo === 'grupo') {
@@ -451,9 +498,14 @@ export function ChatInternoThread() {
   const subtitulo = isSetor
     ? 'Canal do setor — comunicados'
     : isGrupo
-      ? qtdMembrosGrupo > 0
-        ? `Grupo · ${qtdMembrosGrupo} ${qtdMembrosGrupo === 1 ? 'participante' : 'participantes'}`
-        : 'Grupo da equipe'
+      ? [
+          qtdMembrosGrupo > 0
+            ? `Grupo · ${qtdMembrosGrupo} ${qtdMembrosGrupo === 1 ? 'participante' : 'participantes'}`
+            : 'Grupo da equipe',
+          grupoDetalhe?.silenciado ? 'silenciado' : null,
+        ]
+          .filter(Boolean)
+          .join(' · ')
       : 'Conversa direta'
 
   return (
@@ -490,6 +542,21 @@ export function ChatInternoThread() {
             <h2 className="truncate text-lg font-bold text-slate-900 dark:text-white">{titulo}</h2>
             <p className="truncate text-sm text-slate-500">{subtitulo}</p>
           </div>
+        )}
+        {isGrupo && (
+          <button
+            type="button"
+            disabled={silenciando}
+            onClick={() => void alternarSilenciarGrupo()}
+            className={`shrink-0 rounded-lg px-3 py-1.5 text-xs font-medium ring-1 ${
+              grupoDetalhe?.silenciado
+                ? 'text-amber-700 ring-amber-200 hover:bg-amber-50 dark:text-amber-300 dark:ring-amber-800 dark:hover:bg-amber-950/40'
+                : 'text-slate-600 ring-slate-200 hover:bg-slate-100 dark:text-slate-300 dark:ring-slate-600 dark:hover:bg-slate-800'
+            }`}
+            title={grupoDetalhe?.silenciado ? 'Reativar som deste grupo' : 'Silenciar som deste grupo'}
+          >
+            {grupoDetalhe?.silenciado ? 'Ativar som' : 'Silenciar'}
+          </button>
         )}
         <button
           type="button"
@@ -537,7 +604,7 @@ export function ChatInternoThread() {
         ref={scrollRef}
         className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto bg-slate-100/90 px-4 py-5 dark:bg-slate-900/60 md:px-6 lg:px-8"
       >
-        <div className="w-full min-w-0 space-y-1">
+        <div className="w-full min-w-0 space-y-2.5">
         {carregandoAntigas && (
           <p className="py-2 text-center text-sm text-slate-400">Carregando mensagens anteriores…</p>
         )}
@@ -560,7 +627,13 @@ export function ChatInternoThread() {
             const mostrarAvatarGrupo = isGrupo && !propria
             if (isSetor) {
               return (
-                <div key={m.id} className="group relative w-full min-w-0" data-chat-msg-id={m.id}>
+                <div
+                  key={m.id}
+                  className={`group relative z-0 w-full min-w-0 hover:z-20 focus-within:z-20 ${hoverMsgId === m.id ? 'is-msg-hover z-20' : ''}`}
+                  data-chat-msg-id={m.id}
+                  onMouseEnter={() => trancarHoverMensagem(m.id)}
+                  onMouseLeave={() => liberarHoverMensagem(m.id)}
+                >
                 <ChatInternoMensagemAcoes
                   mensagem={m}
                   onEditar={(corpo) => editarMensagem(m.id, corpo)}
@@ -622,9 +695,13 @@ export function ChatInternoThread() {
                 key={m.id}
                 data-chat-msg-id={m.id}
                 onDoubleClick={(e) => duploCliqueResponder(e, m)}
-                className={`group flex w-full cursor-default gap-1.5 ${
+                className={`group relative z-0 flex w-full cursor-default gap-1.5 hover:z-20 focus-within:z-20 ${
+                  hoverMsgId === m.id ? 'is-msg-hover z-20' : ''
+                } ${
                   propria ? 'justify-end' : 'justify-start'
                 } ${mesmoRemetenteQueAnterior && !propria ? 'mt-0.5' : isGrupo && !propria && !mesmoRemetenteQueAnterior ? 'mt-2' : ''}`}
+                onMouseEnter={() => trancarHoverMensagem(m.id)}
+                onMouseLeave={() => liberarHoverMensagem(m.id)}
               >
                 {mostrarAvatarGrupo ? (
                   mesmoRemetenteQueAnterior ? (
@@ -644,7 +721,7 @@ export function ChatInternoThread() {
                     propria ? 'items-end' : 'items-start'
                   }`}
                 >
-                  <div className="relative w-fit max-w-full">
+                  <div className="relative z-0 w-fit max-w-full group-hover:z-20 group-focus-within:z-20">
                     <ChatInternoMensagemAcoes
                       mensagem={m}
                       onEditar={(corpo) => editarMensagem(m.id, corpo)}


### PR DESCRIPTION
## Summary
- Alerta sonoro ao receber nova mensagem no chat interno (respeita conversa aberta e grupos silenciados).
- Em grupos: botão **Silenciar** / **Ativar som** (preferência por pessoa, migration 072).
- Hover estável nas opções Responder/Editar/Apagar e reações — não saltam mais para a mensagem de cima.

## Test plan
- [ ] Receber mensagem em grupo/direta com o painel em outra tela → ouve o som
- [ ] Com a conversa aberta e visível → não toca som
- [ ] Silenciar grupo → novas mensagens sem som; Ativar som → volta a tocar
- [ ] Mensagens coladas: passar o mouse e clicar Editar/Apagar sem o menu saltar
- [ ] CI verde (pytest + frontend + changelog)
