### PR TITLE
fix(release): notes reais na v26.07.010 (não «Atualização do sistema»)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ## [Unreleased]
 
-## [26.07.009] - 2026-07-16
+## [26.07.010] - 2026-07-17
 
 ### Melhorias
 
 - Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)
 - Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima
+
+## [26.07.009] - 2026-07-16
+
+### Melhorias
+
+- Chat interno (grupos/canal): menções com `@` — autocomplete de participantes e `@all` (todos); destaque visual na mensagem
 - Equipe online: lista funciona com vários workers do servidor (presença gravada no banco); admin pode **Forçar saída** de um atendente conectado
 - Chat interno: balões mais próximos — opções/reações só no hover; em grupos, avatar e cor por pessoa para distinguir quem fala
 - Equipe online: «0 online» mesmo com painel aberto (lista lia só a memória do worker errado)

--- a/backend/app/data/release_notes.json
+++ b/backend/app/data/release_notes.json
@@ -8,8 +8,12 @@
     "status": "published",
     "changes": [
       {
-        "category": "interno",
-        "text": "Atualização do sistema"
+        "category": "melhorias",
+        "text": "Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)"
+      },
+      {
+        "category": "melhorias",
+        "text": "Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima"
       }
     ]
   },
@@ -913,8 +917,12 @@
       "status": "published",
       "changes": [
         {
-          "category": "interno",
-          "text": "Atualização do sistema"
+          "category": "melhorias",
+          "text": "Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima"
         }
       ]
     }

--- a/docs/releases/manifest.json
+++ b/docs/releases/manifest.json
@@ -899,8 +899,12 @@
       "status": "published",
       "changes": [
         {
-          "category": "interno",
-          "text": "Atualização do sistema"
+          "category": "melhorias",
+          "text": "Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima"
         }
       ]
     }

--- a/frontend/public/release-notes.json
+++ b/frontend/public/release-notes.json
@@ -8,8 +8,12 @@
     "status": "published",
     "changes": [
       {
-        "category": "interno",
-        "text": "Atualização do sistema"
+        "category": "melhorias",
+        "text": "Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)"
+      },
+      {
+        "category": "melhorias",
+        "text": "Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima"
       }
     ]
   },
@@ -913,8 +917,12 @@
       "status": "published",
       "changes": [
         {
-          "category": "interno",
-          "text": "Atualização do sistema"
+          "category": "melhorias",
+          "text": "Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima"
         }
       ]
     }

--- a/scripts/check_changelog.py
+++ b/scripts/check_changelog.py
@@ -26,7 +26,9 @@ SKIP_PREFIXES = (
     "VERSION",
     "docs/releases/",
     "backend/app/data/release_notes.json",
+    "frontend/public/release-notes.json",
     "frontend/public/release_notes.json",
+    "scripts/prepare_release.py",
 )
 
 

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -194,7 +194,14 @@ def main() -> int:
         version = next_calver(current_raw or None)
         changes = parse_changelog_unreleased(changelog)
         if not changes:
-            changes = [{"category": "interno", "text": "Atualização do sistema"}]
+            print(
+                "::error::CHANGELOG.md ## [Unreleased] está vazio — não é permitido publicar "
+                "só «Atualização do sistema».\n"
+                "Antes do merge main → staging, confirme que os bullets do lote estão em "
+                "[Unreleased] (conflitos de CHANGELOG costumam esvaziar a seção).",
+                file=sys.stderr,
+            )
+            return 1
         entry = {
             "version": version,
             "version_display": version_display(version),


### PR DESCRIPTION
## Summary
- Corrige a v26.07.010 no Sobre: no lugar de «Atualização do sistema», mostra alerta sonoro / silenciar grupo e hover estável das ações.
- Restaura o CHANGELOG da 26.07.009 alinhado ao que foi publicado.
- \prepare_release.py --deploy\ passa a **falhar** se \[Unreleased]\ estiver vazio (em vez do fallback genérico).

## Por que aconteceu
No merge \main → staging\ o \CHANGELOG\ ficou com \[Unreleased]\ vazio. O script usava fallback «Atualização do sistema».

## Test plan
- [ ] Após merge/deploy staging, Sobre mostra as melhorias reais da v26.07.010
- [ ] Deploy futuro com Unreleased vazio deve falhar no prepare_release