### PR TITLE
fix(release): bloquear Unreleased vazio no prepare_release

### DIFF
--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -194,7 +194,14 @@ def main() -> int:
         version = next_calver(current_raw or None)
         changes = parse_changelog_unreleased(changelog)
         if not changes:
-            changes = [{"category": "interno", "text": "Atualização do sistema"}]
+            print(
+                "::error::CHANGELOG.md ## [Unreleased] está vazio — não é permitido publicar "
+                "só «Atualização do sistema».\n"
+                "Antes do merge main → staging, confirme que os bullets do lote estão em "
+                "[Unreleased] (conflitos de CHANGELOG costumam esvaziar a seção).",
+                file=sys.stderr,
+            )
+            return 1
         entry = {
             "version": version,
             "version_display": version_display(version),


### PR DESCRIPTION
## Summary
- \prepare_release.py --deploy\ deixa de publicar o fallback «Atualização do sistema» quando \## [Unreleased]\ está vazio — falha com erro explícito.
- Evita repetir o que aconteceu na v26.07.010 (merge main→staging esvaziou o CHANGELOG).

Hotfix das notes da v26.07.010: #563 (staging).

## Test plan
- [ ] CI verde
- [ ] Com Unreleased vazio, \python scripts/prepare_release.py --deploy\ retorna exit 1