### PR TITLE
fix(ui): busca no dark mode + PDVs (código editável e colunas de acesso)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)
 - Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)
 - Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima
 - Equipe online: lista funciona com vários workers do servidor (presença gravada no banco); admin pode **Forçar saída** de um atendente conectado
@@ -19,6 +20,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- Modo escuro: texto digitado nos campos de pesquisa (listagens e chat interno) volta a ficar legível
 - Equipe online: «0 online» mesmo com painel aberto (lista lia só a memória do worker errado)
 - Chat interno: espaço excessivo entre mensagens após colocar ações/reações fora do balão
 - WhatsApp: o feed deixa de puxar sozinho para o fim enquanto você lê mensagens acima; ao reabrir a conversa, retoma a posição em que parou

--- a/backend/app/api/empresa_pdvs.py
+++ b/backend/app/api/empresa_pdvs.py
@@ -147,6 +147,26 @@ def atualizar_pdv(
         raise HTTPException(status_code=404, detail="PDV não encontrado")
     payload = data.model_dump(exclude_unset=True)
     senha = payload.pop("acesso_remoto_senha", None)
+    if "codigo" in payload:
+        codigo = (payload["codigo"] or "").strip()
+        if not codigo:
+            raise HTTPException(status_code=400, detail="Informe o código do PDV.")
+        conflito = (
+            db.query(EmpresaPdv)
+            .filter(
+                EmpresaPdv.empresa_id == empresa_id,
+                EmpresaPdv.codigo == codigo,
+                EmpresaPdv.id != pdv_id,
+            )
+            .first()
+        )
+        if conflito:
+            raise HTTPException(status_code=400, detail="Já existe um PDV com este código nesta empresa.")
+        payload["codigo"] = codigo
+    if "acesso_remoto_id" in payload and payload["acesso_remoto_id"] is not None:
+        payload["acesso_remoto_id"] = (payload["acesso_remoto_id"] or "").strip() or None
+    if "observacoes" in payload and payload["observacoes"] is not None:
+        payload["observacoes"] = (payload["observacoes"] or "").strip() or None
     _validar_refs(db, data, empresa_id)
     for k, v in payload.items():
         setattr(row, k, v)

--- a/backend/app/schemas/pdv.py
+++ b/backend/app/schemas/pdv.py
@@ -59,6 +59,7 @@ class EmpresaPdvCreate(EmpresaPdvBase):
 
 
 class EmpresaPdvUpdate(BaseModel):
+    codigo: str | None = Field(default=None, min_length=1, max_length=32)
     rotulo_id: int | None = None
     papel: str | None = Field(default=None, pattern=r"^(principal|auxiliar)$")
     usa_tef: bool | None = None

--- a/backend/tests/test_empresa_pdvs.py
+++ b/backend/tests/test_empresa_pdvs.py
@@ -98,3 +98,43 @@ def test_api_revelar_credencial_admin(client, auth_headers, seed_base, pdv_catal
     r = client.get(f"/v1/empresas/{emp.id}/pdvs/{pdv_id}/credencial", headers=auth_headers["admin"])
     assert r.status_code == 200
     assert r.json()["acesso_remoto_senha"] == "revelar-me"
+
+
+def test_api_atualizar_codigo_pdv(client, auth_headers, seed_base, pdv_catalogo):
+    emp = seed_base["empresa"]
+    criado = client.post(
+        f"/v1/empresas/{emp.id}/pdvs",
+        headers=auth_headers["admin"],
+        json={
+            "codigo": "001",
+            "rotulo_id": pdv_catalogo["rotulo"].id,
+            "papel": "principal",
+        },
+    )
+    assert criado.status_code == 201, criado.text
+    pdv_id = criado.json()["id"]
+
+    r = client.patch(
+        f"/v1/empresas/{emp.id}/pdvs/{pdv_id}",
+        headers=auth_headers["admin"],
+        json={"codigo": "010"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["codigo"] == "010"
+
+    client.post(
+        f"/v1/empresas/{emp.id}/pdvs",
+        headers=auth_headers["admin"],
+        json={
+            "codigo": "002",
+            "rotulo_id": pdv_catalogo["rotulo"].id,
+            "papel": "auxiliar",
+        },
+    )
+    conflito = client.patch(
+        f"/v1/empresas/{emp.id}/pdvs/{pdv_id}",
+        headers=auth_headers["admin"],
+        json={"codigo": "002"},
+    )
+    assert conflito.status_code == 400
+    assert "código" in conflito.json()["detail"].lower()

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2277,6 +2277,7 @@ export namespace EmpresaPdv {
     ativo?: boolean;
   }
   export interface Update {
+    codigo?: string;
     rotulo_id?: number;
     papel?: 'principal' | 'auxiliar';
     usa_tef?: boolean;

--- a/frontend/src/components/EmpresaPdvsPanel.tsx
+++ b/frontend/src/components/EmpresaPdvsPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { empresaPdvs, pdvRotulos, pdvTiposAcessoRemoto, type EmpresaPdv, type PdvCatalogo } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Button } from './ui/Button'
+import { IconCopy } from './ui/IconCopy'
 import { IconEye, IconEyeOff } from './ui/IconEye'
 import { IconPencil } from './ui/IconPencil'
 import { Input } from './ui/Input'
@@ -96,6 +97,15 @@ export function EmpresaPdvsPanel({ empresaId }: Props) {
     }
   }
 
+  async function copiarTexto(texto: string, sucesso: string) {
+    try {
+      await navigator.clipboard.writeText(texto)
+      toast.showSuccess(sucesso)
+    } catch {
+      toast.showError('Não foi possível copiar. Selecione o texto manualmente.')
+    }
+  }
+
   async function salvar() {
     if (!form.codigo.trim() || !form.rotulo_id) {
       toast.showWarning('Informe o código e o rótulo do PDV.')
@@ -105,6 +115,7 @@ export function EmpresaPdvsPanel({ empresaId }: Props) {
     try {
       if (editId) {
         const payload: EmpresaPdv.Update = {
+          codigo: form.codigo.trim(),
           rotulo_id: form.rotulo_id,
           papel: form.papel,
           usa_tef: form.usa_tef,
@@ -139,7 +150,8 @@ export function EmpresaPdvsPanel({ empresaId }: Props) {
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <p className="text-sm text-slate-500 dark:text-slate-400">
-          Terminais/pontos de venda desta empresa. O código (ex.: 001) permanece estável ao trocar hardware.
+          Terminais/pontos de venda desta empresa. O código (ex.: 001) identifica o ponto; pode ser alterado se a
+          numeração mudar (único por empresa).
         </p>
         {isAdmin ? (
           <Button type="button" onClick={abrirNovo}>
@@ -161,7 +173,7 @@ export function EmpresaPdvsPanel({ empresaId }: Props) {
         </div>
       ) : (
         <div className="overflow-x-auto">
-          <table className="w-full min-w-[640px] text-left text-sm">
+          <table className="w-full min-w-[800px] text-left text-sm">
             <thead>
               <tr className="border-b border-slate-200 bg-slate-50/60 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-800 dark:bg-slate-800/40">
                 <th className="px-4 py-3">Código</th>
@@ -169,53 +181,83 @@ export function EmpresaPdvsPanel({ empresaId }: Props) {
                 <th className="px-4 py-3">Papel</th>
                 <th className="px-4 py-3">TEF</th>
                 <th className="px-4 py-3">Acesso remoto</th>
+                <th className="px-4 py-3">ID acesso</th>
+                <th className="px-4 py-3">Senha acesso</th>
                 <th className="px-4 py-3 text-right">Ações</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
               {items.map((row) => (
                 <tr key={row.id} className={!row.ativo ? 'opacity-60' : undefined}>
-                  <td className="px-4 py-3 font-mono font-medium">PDV {row.codigo}</td>
+                  <td className="px-4 py-3 font-mono font-medium">{row.codigo}</td>
                   <td className="px-4 py-3">{row.rotulo_nome ?? '—'}</td>
                   <td className="px-4 py-3 capitalize">{row.papel}</td>
                   <td className="px-4 py-3">{row.usa_tef ? 'Sim' : 'Não'}</td>
+                  <td className="px-4 py-3 text-slate-600 dark:text-slate-300">
+                    {row.tipo_acesso_remoto_nome ?? '—'}
+                  </td>
                   <td className="px-4 py-3">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="text-slate-600 dark:text-slate-300">
-                        {row.tipo_acesso_remoto_nome ?? '—'}
-                        {row.acesso_remoto_id ? ` · ${row.acesso_remoto_id}` : ''}
+                    {row.acesso_remoto_id ? (
+                      <span className="inline-flex items-center gap-1">
+                        <span className="font-mono text-slate-700 dark:text-slate-200">{row.acesso_remoto_id}</span>
+                        <button
+                          type="button"
+                          className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+                          onClick={() => void copiarTexto(row.acesso_remoto_id!, 'ID de acesso copiado.')}
+                          aria-label="Copiar ID de acesso remoto"
+                          title="Copiar ID"
+                        >
+                          <IconCopy className="size-4" ariaHidden={false} />
+                        </button>
                       </span>
-                      {row.tem_senha_remota && isAdmin ? (
-                        senhaRevelada?.pdvId === row.id ? (
-                          <span className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-slate-800 dark:bg-slate-800/80 dark:text-slate-200">
-                            {senhaRevelada.senha}
-                            <button
-                              type="button"
-                              className="rounded p-0.5 text-slate-400 transition hover:text-slate-600 dark:hover:text-slate-200"
-                              onClick={() => setSenhaRevelada(null)}
-                              aria-label="Ocultar senha"
-                            >
-                              <IconEyeOff className="size-3.5" ariaHidden={false} />
-                            </button>
-                          </span>
-                        ) : (
+                    ) : (
+                      <span className="text-slate-400">—</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    {row.tem_senha_remota && isAdmin ? (
+                      senhaRevelada?.pdvId === row.id ? (
+                        <span className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-slate-50 px-2 py-0.5 font-mono text-xs text-slate-700 dark:border-slate-800 dark:bg-slate-800/80 dark:text-slate-200">
+                          {senhaRevelada.senha}
                           <button
                             type="button"
-                            className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 disabled:opacity-50 dark:hover:bg-slate-800 dark:hover:text-slate-200"
-                            onClick={() => void revelarSenha(row.id)}
-                            disabled={revelandoPdvId === row.id}
-                            aria-label="Revelar senha de acesso remoto"
-                            title="Revelar senha"
+                            className="rounded p-0.5 text-slate-400 transition hover:text-slate-600 dark:hover:text-slate-200"
+                            onClick={() => void copiarTexto(senhaRevelada.senha, 'Senha copiada.')}
+                            aria-label="Copiar senha de acesso remoto"
+                            title="Copiar senha"
                           >
-                            {revelandoPdvId === row.id ? (
-                              <span className="size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                            ) : (
-                              <IconEye className="size-4" ariaHidden={false} />
-                            )}
+                            <IconCopy className="size-3.5" ariaHidden={false} />
                           </button>
-                        )
-                      ) : null}
-                    </div>
+                          <button
+                            type="button"
+                            className="rounded p-0.5 text-slate-400 transition hover:text-slate-600 dark:hover:text-slate-200"
+                            onClick={() => setSenhaRevelada(null)}
+                            aria-label="Ocultar senha"
+                          >
+                            <IconEyeOff className="size-3.5" ariaHidden={false} />
+                          </button>
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          className="inline-flex size-7 shrink-0 items-center justify-center rounded-md text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 disabled:opacity-50 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+                          onClick={() => void revelarSenha(row.id)}
+                          disabled={revelandoPdvId === row.id}
+                          aria-label="Revelar senha de acesso remoto"
+                          title="Revelar senha"
+                        >
+                          {revelandoPdvId === row.id ? (
+                            <span className="size-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                          ) : (
+                            <IconEye className="size-4" ariaHidden={false} />
+                          )}
+                        </button>
+                      )
+                    ) : row.tem_senha_remota ? (
+                      <span className="text-slate-400">••••</span>
+                    ) : (
+                      <span className="text-slate-400">—</span>
+                    )}
                   </td>
                   <td className="px-4 py-3 text-right">
                     {isAdmin ? (
@@ -246,17 +288,22 @@ export function EmpresaPdvsPanel({ empresaId }: Props) {
             <div className="mt-4 space-y-4">
               <Input
                 label="Código (ex.: 001)"
+                hint="Número do ponto na empresa. Ao trocar o equipamento principal, altere o código aqui (não use o prefixo «PDV»)."
                 value={form.codigo}
                 onChange={(e) => setForm((f) => ({ ...f, codigo: e.target.value }))}
-                disabled={!!editId}
                 required
               />
-              <Select
-                label="Rótulo do dispositivo"
-                value={form.rotulo_id || ''}
-                onChange={(v) => setForm((f) => ({ ...f, rotulo_id: Number(v) }))}
-                options={rotulos.map((r) => ({ value: r.id, label: r.nome }))}
-              />
+              <div>
+                <Select
+                  label="Rótulo do dispositivo"
+                  value={form.rotulo_id || ''}
+                  onChange={(v) => setForm((f) => ({ ...f, rotulo_id: Number(v) }))}
+                  options={rotulos.map((r) => ({ value: r.id, label: r.nome }))}
+                />
+                <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  Tipo do equipamento (ex.: SRV/PDV), não o número do ponto.
+                </p>
+              </div>
               <Select
                 label="Papel"
                 value={form.papel}

--- a/frontend/src/components/chat-interno/ChatInternoGrupoMembrosModal.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoGrupoMembrosModal.tsx
@@ -3,6 +3,7 @@ import { atendentes, chatInterno, type ChatInterno } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { useAuth } from '../../contexts/AuthContext'
 import { Button } from '../ui/Button'
+import { INPUT_FIELD_CLASS } from '../ui/Input'
 import { useToast } from '../ui/Toast'
 import { MODAL_OVERLAY, MODAL_PANEL_SCROLLABLE } from '../../lib/modalPanel'
 
@@ -239,7 +240,7 @@ export function ChatInternoGrupoMembrosModal({
               value={busca}
               onChange={(e) => setBusca(e.target.value)}
               placeholder="Buscar atendente para adicionar…"
-              className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+              className={`mt-2 ${INPUT_FIELD_CLASS} text-sm`}
             />
             <ul className="mt-2 max-h-32 space-y-1 overflow-y-auto">
               {resultados.map((a) => (

--- a/frontend/src/components/chat-interno/ChatInternoNovaConversaModal.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoNovaConversaModal.tsx
@@ -5,6 +5,7 @@ import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { useAuth } from '../../contexts/AuthContext'
 import { useChatInterno } from '../../contexts/ChatInternoContext'
 import { Button } from '../ui/Button'
+import { INPUT_FIELD_CLASS } from '../ui/Input'
 import { useToast } from '../ui/Toast'
 import { MODAL_OVERLAY, MODAL_PANEL_COMPACT } from '../../lib/modalPanel'
 
@@ -130,7 +131,7 @@ export function ChatInternoNovaConversaModal({ open, onClose }: Props) {
               value={busca}
               onChange={(e) => setBusca(e.target.value)}
               placeholder="Nome ou e-mail…"
-              className="mt-4 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+              className={`mt-4 ${INPUT_FIELD_CLASS} text-sm`}
             />
             <ul className="mt-3 max-h-56 space-y-1 overflow-y-auto">
               {buscando && <li className="px-2 py-3 text-sm text-slate-400">Buscando…</li>}
@@ -162,14 +163,14 @@ export function ChatInternoNovaConversaModal({ open, onClose }: Props) {
               onChange={(e) => setTituloGrupo(e.target.value)}
               placeholder="Nome do grupo"
               maxLength={120}
-              className="mt-4 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+              className={`mt-4 ${INPUT_FIELD_CLASS} text-sm`}
             />
             <input
               type="search"
               value={busca}
               onChange={(e) => setBusca(e.target.value)}
               placeholder="Adicionar atendentes…"
-              className="mt-2 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm dark:border-slate-600 dark:bg-slate-900"
+              className={`mt-2 ${INPUT_FIELD_CLASS} text-sm`}
             />
             {selecionados.length > 0 && (
               <p className="mt-2 text-xs text-slate-500">{selecionados.length} selecionado(s)</p>

--- a/frontend/src/components/ui/BarraBuscaPaginacao.tsx
+++ b/frontend/src/components/ui/BarraBuscaPaginacao.tsx
@@ -1,19 +1,20 @@
-import { Button } from './Button';
+import { Button } from './Button'
+import { INPUT_FIELD_CLASS } from './Input'
 
-export const PAGE_SIZE_PADRAO = 20;
+export const PAGE_SIZE_PADRAO = 20
 
 type Props = {
-  busca: string;
-  onBuscaChange: (value: string) => void;
-  placeholder?: string;
+  busca: string
+  onBuscaChange: (value: string) => void
+  placeholder?: string
   /** Página 1-based */
-  page: number;
-  total: number;
-  pageSize?: number;
-  onPageChange: (page: number) => void;
-  disabled?: boolean;
-  extra?: React.ReactNode;
-};
+  page: number
+  total: number
+  pageSize?: number
+  onPageChange: (page: number) => void
+  disabled?: boolean
+  extra?: React.ReactNode
+}
 
 export function BarraBuscaPaginacao({
   busca,
@@ -26,9 +27,9 @@ export function BarraBuscaPaginacao({
   disabled,
   extra,
 }: Props) {
-  const totalPages = Math.max(1, Math.ceil(total / pageSize));
-  const inicio = total === 0 ? 0 : (page - 1) * pageSize + 1;
-  const fim = Math.min(page * pageSize, total);
+  const totalPages = Math.max(1, Math.ceil(total / pageSize))
+  const inicio = total === 0 ? 0 : (page - 1) * pageSize + 1
+  const fim = Math.min(page * pageSize, total)
 
   return (
     <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
@@ -39,12 +40,12 @@ export function BarraBuscaPaginacao({
           onChange={(e) => onBuscaChange(e.target.value)}
           placeholder={placeholder}
           disabled={disabled}
-          className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400"
+          className={`${INPUT_FIELD_CLASS} text-sm`}
           aria-label="Buscar na listagem"
         />
         {extra}
       </div>
-      <div className="flex flex-wrap items-center justify-end gap-2 text-sm text-slate-600">
+      <div className="flex flex-wrap items-center justify-end gap-2 text-sm text-slate-600 dark:text-slate-300">
         <span className="whitespace-nowrap">
           {total > 0 ? `${inicio}–${fim} de ${total}` : '0 resultados'}
         </span>
@@ -71,5 +72,5 @@ export function BarraBuscaPaginacao({
         </Button>
       </div>
     </div>
-  );
+  )
 }

--- a/frontend/src/components/ui/IconCopy.tsx
+++ b/frontend/src/components/ui/IconCopy.tsx
@@ -1,0 +1,23 @@
+interface IconCopyProps {
+  className?: string
+  ariaHidden?: boolean
+}
+
+export function IconCopy({ className = 'size-5', ariaHidden = true }: IconCopyProps) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden={ariaHidden}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+      />
+    </svg>
+  )
+}

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -194,7 +194,14 @@ def main() -> int:
         version = next_calver(current_raw or None)
         changes = parse_changelog_unreleased(changelog)
         if not changes:
-            changes = [{"category": "interno", "text": "Atualização do sistema"}]
+            print(
+                "::error::CHANGELOG.md ## [Unreleased] está vazio — não é permitido publicar "
+                "só «Atualização do sistema».\n"
+                "Antes do merge main → staging, confirme que os bullets do lote estão em "
+                "[Unreleased] (conflitos de CHANGELOG costumam esvaziar a seção).",
+                file=sys.stderr,
+            )
+            return 1
         entry = {
             "version": version,
             "version_display": version_display(version),


### PR DESCRIPTION
## Summary
- Corrige texto invisível nos campos de pesquisa no modo escuro (`BarraBuscaPaginacao` e buscas do chat interno).
- PDVs: código editável na edição; listagem sem prefixo «PDV»; colunas separadas de acesso remoto, ID (copiar) e senha (olho + copiar).
- Inclui o fix do `prepare_release` (falha se `[Unreleased]` estiver vazio) — supersede #564.

## Test plan
- [ ] Modo escuro: digitar em buscas de listagens e no chat interno (nova conversa / membros) e confirmar texto legível
- [ ] Empresa → PDVs: editar código de um PDV existente; conflito de código duplicado retorna erro
- [ ] Listagem: código sem «PDV»; colunas Acesso remoto / ID acesso / Senha acesso
- [ ] Copiar ID e, após revelar, copiar senha; ocultar senha com o olho
- [ ] CI verde (pytest + build frontend)
