### PR TITLE
fix(whatsapp): bugs de produção (mídia, Esc, áudio, vínculo, ticks, inatividade)

### DIFF
--- a/.github/planning-issue-bodies/issues/whatsapp-bugs-producao-epic.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-bugs-producao-epic.md
@@ -1,0 +1,17 @@
+﻿## Objetivo
+Corrigir bugs de UX do WhatsApp encontrados em testes em produção (composer, legendas, vínculo de contacto, Esc no lightbox e scroll ao reabrir chat).
+
+## Issues filhas
+- Composer com dois campos ao anexar imagem
+- Fonte da legenda diferente do texto
+- Vínculo de contacto não persiste em chats posteriores
+- Esc no lightbox sai do chat / troca conversa
+- Legenda de PDF/documento não aparece
+- Scroll ao reabrir chat não volta à última mensagem vista
+
+## Fora de escopo
+- Redesign completo do composer
+- Mudanças em chat interno (exceto se compartilharem o mesmo lightbox/scroll helper)
+
+## Origem
+QA produção — feedback do time.

--- a/.github/planning-issue-bodies/issues/whatsapp-cancelar-audio-envia.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-cancelar-audio-envia.md
@@ -1,0 +1,13 @@
+﻿## Problema
+Ao começar a gravar um áudio no composer e **cancelar**, o áudio é enviado mesmo assim (incluindo “no mudo” / clip vazio ou residual). Cancelar deve descartar a gravação sem enviar.
+
+Provável origem: `WhatsappGravadorAudioInline` / `MediaRecorder` — `cancelar` pode ainda disparar `onstop` com blob que o fluxo trata como envio.
+
+## Critérios de aceite
+- [ ] Cancelar gravação não envia mensagem de áudio
+- [ ] Não cria mensagem vazia/muda no chat nem no WhatsApp do cliente
+- [ ] Após cancelar, o composer volta ao estado normal (microfone disponível)
+- [ ] Enviar (parar e confirmar) continua a enviar o áudio normalmente
+
+## Origem
+Testes em produção — lote WhatsApp UX (#567).

--- a/.github/planning-issue-bodies/issues/whatsapp-composer-dois-campos.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-composer-dois-campos.md
@@ -1,0 +1,10 @@
+﻿## Problema
+QA em produção (WhatsApp): composer com anexo de imagem deixa o campo principal «Escreva uma mensagem…» visível junto com «Legenda opcional», gerando dois campos de texto ao mesmo tempo.
+
+## Critérios de aceite
+- [ ] Com pré-visualização de anexo aberta, só o campo de legenda (ou um único composer) fica editável
+- [ ] O composer principal não permanece ativo/visível por baixo do overlay de anexo
+- [ ] Cancelar ou enviar o anexo restaura o composer normal
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-esc-lightbox.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-esc-lightbox.md
@@ -1,0 +1,10 @@
+﻿## Problema
+Ao visualizar imagem/mídia em tela cheia e pressionar Esc, além de fechar o lightbox o atalho também sai do chat (ou muda para o primeiro chat da lista quando há vários abertos).
+
+## Critérios de aceite
+- [ ] Esc no lightbox fecha só a visualização em tela cheia
+- [ ] Não navega para fora do chat nem troca a conversa ativa
+- [ ] Esc sem lightbox mantém o comportamento atual (ex.: voltar à lista, se aplicável)
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-fonte-legenda.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-fonte-legenda.md
@@ -1,0 +1,9 @@
+﻿## Problema
+A legenda exibida sob imagens no balão do atendente usa tipografia diferente (menor/itálico) da fonte das mensagens de texto normais.
+
+## Critérios de aceite
+- [ ] Legenda de imagem/mídia no balão do atendente usa a mesma família, tamanho e peso do corpo das mensagens de texto
+- [ ] Contraste permanece legível no modo claro e escuro
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-inatividade-timer-pausa.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-inatividade-timer-pausa.md
@@ -1,0 +1,37 @@
+﻿## Problema
+O encerramento automático por inatividade conta desde a **última mensagem do cliente** e **não reinicia** quando o atendente fala. Isso causa:
+
+1. Cliente na fila por vários minutos → ao assumir, o aviso/encerramento dispara cedo demais.
+2. Atendente pede «aguarde, estou analisando» → o chat fecha mesmo com o cliente à espera, se a análise passar do prazo.
+
+## Regra de negócio
+
+### Timer
+- Contar desde a **última mensagem relevante** (cliente **ou** atendente humano).
+- Qualquer mensagem nova (cliente ou atendente) **reinicia** a contagem.
+- Só age em chat `em_atendimento` **depois** da 1ª resposta humana (não dispara na fila / só com `auto_assumido`/BOT).
+- Manter settings: `inativ_aviso_minutos` + `inativ_encerramento_apos_aviso_minutos`.
+
+### Pausa no chat
+- Botão **Pausar** / **Retomar** no header, com **countdown** ao lado.
+- **Pausar:** para o worker e **reseta** o prazo para o valor configurado (ex. 10:00) — não congela o restante.
+- **Retomar:** inicia a regressiva **de novo** a partir do prazo cheio.
+- Enquanto pausado: não envia aviso nem encerra.
+- Ao receber mensagem do cliente: sair da pausa automaticamente (além do retomar manual).
+
+## Critérios de aceite
+- [ ] Após fila longa, o prazo completo conta a partir da última mensagem (ex.: resposta do atendente reinicia)
+- [ ] Mensagem do cliente ou do atendente reinicia a contagem
+- [ ] Countdown visível no chat em atendimento (feature ligada)
+- [ ] Pausar: para o worker e mostra prazo resetado; não encerra
+- [ ] Retomar: inicia regressiva do prazo cheio de novo
+- [ ] `auto_assumido` / fila sem resposta humana: não dispara
+- [ ] Ciclo aviso → encerramento após aviso preservado
+- [ ] Testes backend + texto de ajuda na Config WhatsApp + CHANGELOG
+
+## Origem
+QA produção — análise de regra de negócio. Parte do épico #567 (lote WhatsApp).
+
+## Referência técnica
+- `backend/app/services/whatsapp_inactivity_worker.py` (`_referencia_inatividade_cliente`)
+- Plano: regra inatividade WhatsApp (última msg + pausa com countdown)

--- a/.github/planning-issue-bodies/issues/whatsapp-legenda-pdf.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-legenda-pdf.md
@@ -1,0 +1,10 @@
+﻿## Problema
+No WhatsApp é possível enviar PDF (e outros documentos) com legenda. No DeskRudder a legenda não aparece no balão do chat (imagens já mostram legenda).
+
+## Critérios de aceite
+- [ ] Legenda enviada com documento/PDF aparece no balão (inbound e outbound)
+- [ ] Composer de anexo de documento permite legenda opcional, como em imagens
+- [ ] Legenda vazia ou rótulo técnico interno não é exibida como texto falso
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-midia-sem-legenda-placeholder.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-midia-sem-legenda-placeholder.md
@@ -1,0 +1,12 @@
+﻿## Problema
+Quando o atendente envia imagem/mídia **sem** legenda, o balão mostra texto placeholder do tipo `[ Luan ]: [Imagem enviada]` (ou similar). Sem legenda, deve aparecer **só** a mídia — sem rótulo de texto.
+
+Hoje o filtro de rótulos técnicos (`ROTULO_SEM_LEGENDA`) cobre padrões como `[Imagem]`, mas não variantes como `[Imagem enviada]`, e o prefixo `[ Nome ]:` pode estar a ser concatenado no corpo.
+
+## Critérios de aceite
+- [ ] Imagem/vídeo/documento/áudio enviados sem legenda: balão sem texto de placeholder
+- [ ] Com legenda real: legenda continua a aparecer
+- [ ] Não exibir `[Imagem]`, `[Imagem enviada]` nem equivalentes como corpo da mensagem
+
+## Origem
+Testes em produção — lote WhatsApp UX (#567).

--- a/.github/planning-issue-bodies/issues/whatsapp-scroll-ultima-lida.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-scroll-ultima-lida.md
@@ -1,0 +1,11 @@
+﻿## Problema
+Ao reabrir um chat em andamento, o scroll cai em posição aleatória em vez da última mensagem vista pelo atendente. Comportamento desejado (estilo WhatsApp): restaurar a última posição lida; se o atendente já viu tudo, ir para o fim.
+
+## Critérios de aceite
+- [ ] Reabrir o mesmo chat restaura a última posição de scroll vista pelo atendente
+- [ ] Se já estava no fim (todas vistas), reabre no fim da conversa
+- [ ] Polling/SSE de novas mensagens não “pula” a posição enquanto o atendente lê histórico acima
+- [ ] Comportamento alinhado ao já feito no Histórico/chat interno (memória de scroll por conversa)
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-ticks-entrega-leitura.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-ticks-entrega-leitura.md
@@ -1,0 +1,26 @@
+﻿## Problema
+Mensagens do atendente ficam com um único ✓ no DeskRudder, e no WhatsApp do **cliente** a mensagem não passa a «visualizada» (✓✓ azul) mesmo depois de o cliente ter respondido.
+
+Hoje o ✓✓ azul só aparece se alguém abrir a mesma conversa no **WhatsApp do suporte** (número/instância que recebe o inbound). Isso foge do fluxo do painel.
+
+## Regra de negócio (leitura / ✓✓ azul)
+A mensagem do **cliente** só deve ser marcada como visualizada (e o cliente só deve ver ✓✓ azul nas mensagens **dele** / o estado de leitura correspondente) quando for visualizada pelo **atendente responsável** pelo chat.
+
+- [ ] Visualizada pelo **responsável** do chat → pode marcar como lida / refletir ✓✓ azul no WhatsApp do cliente (conforme API Evolution)
+- [ ] Visualizada por **outro atendente** (ex.: consulta no Histórico, colega do setor) → **não** marcar como lida para o cliente
+- [ ] Visualizada **antes** de alguém assumir o atendimento (fila / sem responsável) → **não** marcar como lida para o cliente
+
+## Sintoma adicional (ticks no painel)
+No DeskRudder, mensagens do atendente ficam com um só ✓ mesmo quando no WhatsApp do cliente já estão entregues/lidas — o painel precisa espelhar entrega (✓✓) e leitura (✓✓ azul) com base nos eventos reais da API, sem depender de abrir o app WhatsApp do suporte.
+
+## Critérios de aceite
+- [ ] ✓ = enviada / aceite pela API
+- [ ] ✓✓ cinza = entregue no dispositivo do cliente
+- [ ] ✓✓ azul = lida, **somente** quando a regra de negócio acima for satisfeita (responsável visualizou)
+- [ ] Abrir o chat no painel como não-responsável ou sem responsável **não** dispara read receipt para o cliente
+- [ ] Abrir o chat como responsável dispara (ou confirma) a leitura conforme a Evolution API
+- [ ] Atualização via webhook/SSE/poll no painel sem precisar do WhatsApp mobile do suporte
+- [ ] Testes cobrindo: responsável vs outro atendente vs sem responsável
+
+## Origem
+Testes em produção — lote WhatsApp UX (#567). Clarificação: read receipt só pelo atendente responsável.

--- a/.github/planning-issue-bodies/issues/whatsapp-vinculo-chats-posteriores.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-vinculo-chats-posteriores.md
@@ -1,0 +1,13 @@
+﻿## Problema
+Após identificar/vincular um contacto novo a uma rede e empresa, quando o mesmo número envia outra mensagem (novo chat ou retomada), o banner «Contacto não identificado» / «Identificar contato» volta a aparecer como se o vínculo não tivesse sido gravado.
+
+Relacionado em parte a #472 (banner no mesmo chat), mas aqui o sintoma é em **chats posteriores** do mesmo contacto.
+
+## Critérios de aceite
+- [ ] Após vincular/cadastrar, chats novos do mesmo `wa_id`/telefone já nascem vinculados (sem pedir identificação de novo)
+- [ ] Telefone/`wa_id` no funcionário da rede permite match em inbound futuro
+- [ ] Banner some e não reaparece após poll/SSE com snapshot antigo
+- [ ] Teste de regressão: vincular → simular novo inbound do mesmo número → chat com vínculo
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown no chat
+- WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel
 - PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)
 - Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)
 - Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima
@@ -20,6 +22,12 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)
+- WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda
+- WhatsApp (#571): Esc no zoom da imagem fecha só a visualização, sem sair do chat
+- WhatsApp (#576): cancelar gravação de áudio já não envia o ficheiro
+- WhatsApp (#573): ao reabrir o chat, o scroll volta à última posição vista (não salta para o início)
+- WhatsApp (#570): contacto já vinculado é reconhecido em chats novos do mesmo número
 - Modo escuro: texto digitado nos campos de pesquisa (listagens e chat interno) volta a ficar legível
 - Equipe online: «0 online» mesmo com painel aberto (lista lia só a memória do worker errado)
 - Chat interno: espaço excessivo entre mensagens após colocar ações/reações fora do balão

--- a/backend/alembic/versions/073_wpp_inatividade_pausa.py
+++ b/backend/alembic/versions/073_wpp_inatividade_pausa.py
@@ -1,0 +1,44 @@
+"""WhatsApp: pausa do timer de inatividade no chat.
+
+Revision ID: 073_wpp_inatividade_pausa
+Revises: 072_chat_interno_silenciar
+Create Date: 2026-07-18
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "073_wpp_inatividade_pausa"
+down_revision = "072_chat_interno_silenciar"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "inatividade_pausada" not in cols:
+        op.add_column(
+            "whatsapp_chats",
+            sa.Column("inatividade_pausada", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+    if "inatividade_retomada_em" not in cols:
+        op.add_column(
+            "whatsapp_chats",
+            sa.Column("inatividade_retomada_em", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "inatividade_retomada_em" in cols:
+        op.drop_column("whatsapp_chats", "inatividade_retomada_em")
+    if "inatividade_pausada" in cols:
+        op.drop_column("whatsapp_chats", "inatividade_pausada")

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -205,6 +205,7 @@ def _tipo_midia_db(slug: str) -> str:
 
 
 def _rotulo_midia_outbound(tipo_db: str) -> str:
+    """Rótulo interno legado — não enviar ao WhatsApp nem gravar como corpo sem caption."""
     return {
         "imagem": "[Imagem enviada]",
         "video": "[Vídeo enviado]",
@@ -212,6 +213,25 @@ def _rotulo_midia_outbound(tipo_db: str) -> str:
         "documento": "[Documento enviado]",
         "figurinha": "[Figurinha enviada]",
     }.get(tipo_db, "[Ficheiro enviado]")
+
+
+def _corpo_e_caption_midia_outbound(
+    tipo_db: str,
+    caption: str | None,
+    nome_atendente: str | None,
+) -> tuple[str, str]:
+    """
+    Retorna (corpo_db, caption_evolution).
+    Sem legenda do utilizador: corpo vazio e caption vazia (só a mídia no WhatsApp).
+    """
+    if tipo_db == "figurinha":
+        return "", ""
+    cap = (caption or "").strip()
+    if not cap:
+        return "", ""
+    nome = (nome_atendente or "").strip()
+    texto = f"[ {nome} ]: {cap}" if nome else cap
+    return texto, texto
 
 
 def _sanitizar_nome_ficheiro(name: str | None, fallback: str) -> str:
@@ -493,6 +513,8 @@ def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False)
         funcionario_tipo=func.tipo if func else None,
         empresa_id=getattr(c, "empresa_id", None),
         empresa_nome=_empresa_nome_exibicao(emp),
+        inatividade_pausada=bool(getattr(c, "inatividade_pausada", False)),
+        inatividade_retomada_em=getattr(c, "inatividade_retomada_em", None),
     )
 
 
@@ -1380,15 +1402,9 @@ async def enviar_mensagem_midia(
         raise HTTPException(status_code=500, detail="Não foi possível guardar o ficheiro em disco.")
 
     cap = (caption or "").strip()
-    if tipo_db == "figurinha":
-        corpo_eff = _rotulo_midia_outbound(tipo_db)
-        legenda_whatsapp = ""
-    else:
-        base_legenda = cap if cap else _rotulo_midia_outbound(tipo_db)
-        nome_atend = (atendente.nome or "").strip()
-        legenda_whatsapp = f"[ {nome_atend} ]: {base_legenda}" if nome_atend else base_legenda
-        corpo_eff = legenda_whatsapp
-
+    corpo_eff, legenda_whatsapp = _corpo_e_caption_midia_outbound(
+        tipo_db, cap, atendente.nome
+    )
     b64 = base64.b64encode(data).decode("ascii")
     st = _settings_envio(db)
     ev_mt = _mediatype_evolution(mediatipo)
@@ -1542,11 +1558,93 @@ def marcar_chat_visto(
         row.last_seen_at = now
     else:
         db.add(WhatsappChatReadModel(chat_id=chat_id, atendente_id=atendente.id, last_seen_at=now))
+
+    # ✓✓ azul no WhatsApp do cliente: só o responsável, em atendimento
+    if (
+        c.estado == "em_atendimento"
+        and c.atendente_id is not None
+        and c.atendente_id == atendente.id
+    ):
+        _marcar_inbound_lido_evolution(db, c)
+
     db.commit()
     from app.services.realtime_emit import emit_notificacao_contagem
 
     emit_notificacao_contagem(db, [atendente.id])
     return None
+
+
+def _marcar_inbound_lido_evolution(db: Session, chat: WhatsappChat) -> None:
+    st = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
+    if not st or not st.evolution_base_url or not st.evolution_instance_name or not st.evolution_api_key:
+        return
+    ids = [
+        row[0]
+        for row in (
+            db.query(WhatsappMensagem.wa_message_id)
+            .filter(
+                WhatsappMensagem.chat_id == chat.id,
+                WhatsappMensagem.direcao == "inbound",
+                WhatsappMensagem.wa_message_id.isnot(None),
+                WhatsappMensagem.wa_message_id != "",
+            )
+            .order_by(WhatsappMensagem.id.desc())
+            .limit(40)
+            .all()
+        )
+        if row[0]
+    ]
+    if not ids:
+        return
+    ok, err = evolution_api.evolution_mark_messages_as_read(
+        st.evolution_base_url,
+        st.evolution_instance_name,
+        st.evolution_api_key,
+        remote_jid=chat.wa_id,
+        message_ids=list(reversed(ids)),
+    )
+    if not ok:
+        logger.warning("markMessageAsRead falhou (chat=%s): %s", chat.id, err)
+
+
+@router.post("/{chat_id}/inatividade/pausar", response_model=WhatsappChatRead)
+def pausar_inatividade(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if c.estado != "em_atendimento":
+        raise HTTPException(status_code=400, detail="Só é possível pausar inatividade em chats em atendimento")
+    if c.atendente_id != atendente.id and atendente.role != "admin":
+        raise HTTPException(status_code=403, detail="Apenas o responsável pode pausar a inatividade")
+    c.inatividade_pausada = True
+    c.inatividade_retomada_em = None
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    return _chat_read(db, c2)
+
+
+@router.post("/{chat_id}/inatividade/retomar", response_model=WhatsappChatRead)
+def retomar_inatividade(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if c.atendente_id != atendente.id and atendente.role != "admin":
+        raise HTTPException(status_code=403, detail="Apenas o responsável pode retomar a inatividade")
+    c.inatividade_pausada = False
+    c.inatividade_retomada_em = datetime.now(timezone.utc)
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    return _chat_read(db, c2)
 
 
 @router.post("/{chat_id}/vincular-ticket", response_model=WhatsappChatRead)

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session, joinedload
 from app.database import get_db
 from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem, WhatsappSettings
 from app.services import evolution_api
+from app.services.whatsapp_contato_match import funcionario_por_wa_id
 from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.evolution_inbound import iter_inbound_whatsapp_messages, iter_message_status_updates
 from app.services.whatsapp_media_storage import gravar_base64_em_disco
@@ -441,12 +442,15 @@ def evolution_webhook(
         chat_novo = False
         if not chat:
             chat_novo = True
+            func = funcionario_por_wa_id(db, wa_id)
             chat = WhatsappChat(
                 protocolo=gerar_protocolo_chat(db),
                 wa_id=wa_id,
-                cliente_nome=push,
+                cliente_nome=push or (func.nome if func else None),
                 estado="aguardando_atendente",
                 setor_id=None,
+                funcionario_rede_id=func.id if func else None,
+                empresa_id=func.empresa_id if func and getattr(func, "empresa_id", None) else None,
             )
             db.add(chat)
             db.flush()
@@ -486,6 +490,9 @@ def evolution_webhook(
         db.add(msg)
         if push and not chat.cliente_nome:
             chat.cliente_nome = push
+        if getattr(chat, "inatividade_pausada", False):
+            chat.inatividade_pausada = False
+            chat.inatividade_retomada_em = None
         try:
             db.commit()
             processados += 1

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -68,6 +68,8 @@ class WhatsappChat(Base):
         Integer, ForeignKey("funcionarios_rede.id", ondelete="SET NULL"), nullable=True, index=True
     )
     empresa_id = Column(Integer, ForeignKey("empresas.id", ondelete="SET NULL"), nullable=True, index=True)
+    inatividade_pausada = Column(Boolean, nullable=False, default=False, server_default="false")
+    inatividade_retomada_em = Column(DateTime(timezone=True), nullable=True)
 
     atendente = relationship("Atendente", backref="whatsapp_chats_atendidos")
     setor = relationship("Setor", backref="whatsapp_chats")

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -46,6 +46,8 @@ class WhatsappChatRead(BaseModel):
     funcionario_tipo: str | None = None
     empresa_id: int | None = None
     empresa_nome: str | None = None
+    inatividade_pausada: bool = False
+    inatividade_retomada_em: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -157,6 +157,36 @@ def _extract_wa_message_id(data: Any) -> str | None:
     return None
 
 
+def evolution_mark_messages_as_read(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    *,
+    remote_jid: str,
+    message_ids: list[str],
+) -> tuple[bool, str | None]:
+    """POST /chat/markMessageAsRead/{instance} — marca inbound como lida no WhatsApp do cliente."""
+    import re
+
+    ids = [str(i).strip() for i in message_ids if str(i).strip()]
+    if not ids:
+        return True, None
+    base = base_url.rstrip("/")
+    url = f"{base}/chat/markMessageAsRead/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    digits = re.sub(r"\D", "", remote_jid)
+    jid = remote_jid if "@" in remote_jid else f"{digits}@s.whatsapp.net"
+    body = {
+        "readMessages": [{"remoteJid": jid, "fromMe": False, "id": mid} for mid in ids]
+    }
+    code, _data, err = _request_json_with_retry("POST", url, headers=headers, body=body)
+    if code in (200, 201):
+        return True, None
+    if err:
+        return False, err[:800]
+    return False, f"HTTP {code}"
+
+
 def evolution_send_text(
     base_url: str,
     instance: str,

--- a/backend/app/services/whatsapp_contato_match.py
+++ b/backend/app/services/whatsapp_contato_match.py
@@ -1,0 +1,58 @@
+"""Match de contacto WhatsApp ↔ funcionário da rede por telefone/wa_id."""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy.orm import Session
+
+from app.models.funcionario_rede import FuncionarioRede
+
+
+def digits_wa(raw: str | None) -> str:
+    return re.sub(r"\D", "", raw or "")
+
+
+def variantes_wa_id(wa_id: str | None) -> set[str]:
+    digits = digits_wa(wa_id)
+    out: set[str] = set()
+    if not digits:
+        return out
+    out.add(digits)
+    if digits.startswith("55") and len(digits) >= 12:
+        out.add(digits[2:])
+    elif len(digits) in (10, 11):
+        out.add("55" + digits)
+    return out
+
+
+def funcionario_por_wa_id(db: Session, wa_id: str | None) -> FuncionarioRede | None:
+    """Encontra funcionário ativo cujo telefone corresponde ao wa_id (com/sem DDI 55)."""
+    targets = variantes_wa_id(wa_id)
+    if not targets:
+        return None
+    # Sufixo para pré-filtrar no SQL (evita full scan com LIKE amplo)
+    sample = next(iter(targets))
+    suffix = sample[-8:] if len(sample) >= 8 else sample
+    candidatos = (
+        db.query(FuncionarioRede)
+        .filter(
+            FuncionarioRede.ativo.is_(True),
+            FuncionarioRede.telefone.isnot(None),
+            FuncionarioRede.telefone != "",
+            FuncionarioRede.telefone.ilike(f"%{suffix}%"),
+        )
+        .order_by(FuncionarioRede.id.desc())
+        .limit(80)
+        .all()
+    )
+    for func in candidatos:
+        f_digits = digits_wa(getattr(func, "telefone", None))
+        if not f_digits:
+            continue
+        if f_digits in targets or targets & variantes_wa_id(f_digits):
+            return func
+        # Últimos 11 dígitos (BR sem/com 9 extra)
+        if len(f_digits) >= 11 and len(sample) >= 11 and f_digits[-11:] == sample[-11:]:
+            return func
+    return None

--- a/backend/app/services/whatsapp_inactivity_worker.py
+++ b/backend/app/services/whatsapp_inactivity_worker.py
@@ -66,33 +66,34 @@ def _ultima_outbound_humana(db: Session, chat_id: int) -> WhatsappMensagem | Non
 
 def _referencia_inatividade_cliente(db: Session, chat: WhatsappChat) -> datetime | None:
     """
-    Momento a partir do qual o cliente está inativo.
+    Momento a partir do qual o silêncio conta para inatividade.
 
-    Conta desde a última mensagem **do cliente** somente quando:
-    - o chat já está em atendimento (garantido pelo caller);
-    - o atendente já enviou pelo menos uma mensagem humana (não auto_assumido/BOT);
-    - essa resposta humana é posterior à última inbound (cliente sumiu).
+    Conta desde a **última mensagem relevante** (inbound do cliente **ou** outbound
+    humana do atendente), desde que já exista pelo menos uma outbound humana
+    (não dispara na fila / só com auto_assumido/BOT).
 
-    Mensagens de sistema (auto_assumido, auto_espera, avisos) não disparam o timer.
-    Novas mensagens do atendente não reiniciam o relógio.
+    Comentários internos e eventos de sistema não contam como atividade.
     """
+    last_out = _ultima_outbound_humana(db, chat.id)
+    if not last_out or last_out.created_at is None:
+        return None
+
     last_in = (
         _mensagens_relevantes_q(db, chat.id)
         .filter(WhatsappMensagem.direcao == "inbound")
         .order_by(desc(WhatsappMensagem.created_at), desc(WhatsappMensagem.id))
         .first()
     )
-    last_out = _ultima_outbound_humana(db, chat.id)
-    if not last_out or last_in is None:
-        return None
-    out_at = last_out.created_at
-    in_at = last_in.created_at
-    if out_at is None or in_at is None:
-        return None
-    if out_at <= in_at:
-        # Cliente falou por último ou atendente ainda não respondeu — não encerra.
-        return None
-    return in_at
+
+    candidatos: list[datetime] = [last_out.created_at]
+    if last_in is not None and last_in.created_at is not None:
+        candidatos.append(last_in.created_at)
+
+    retomada = getattr(chat, "inatividade_retomada_em", None)
+    if retomada is not None:
+        candidatos.append(retomada)
+
+    return max(candidatos)
 
 
 def _minutos_desde(ref: datetime | None, now: datetime) -> float:
@@ -186,6 +187,9 @@ def _processar_chat_inatividade(
 ) -> bool:
     """Retorna True se alterou algo no chat (mensagem ou encerramento)."""
     if chat.estado != "em_atendimento":
+        return False
+
+    if getattr(chat, "inatividade_pausada", False):
         return False
 
     aviso_min = int(getattr(st, "inativ_aviso_minutos", 0) or 0)

--- a/backend/tests/test_whatsapp_inatividade_encerramento.py
+++ b/backend/tests/test_whatsapp_inatividade_encerramento.py
@@ -126,7 +126,10 @@ def test_worker_encerra_apos_aviso(client, seed_base, auth_headers, db_session, 
     assert chat.encerramento_at is not None
 
 
-def test_worker_nao_age_quando_cliente_respondeu_por_ultimo(client, seed_base, auth_headers, db_session, monkeypatch):
+def test_worker_nao_age_quando_ultima_mensagem_recente_do_cliente(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    """Cliente falou há 1 min — silêncio ainda dentro do prazo."""
     _configurar_evolution(db_session)
     chat = _chat_em_atendimento(db_session, wa_id="5511999665544")
     antiga = datetime.now(timezone.utc) - timedelta(minutes=20)
@@ -195,9 +198,10 @@ def test_worker_nao_age_so_com_auto_assumido(client, seed_base, auth_headers, db
     assert n == 0
 
 
-def test_worker_aviso_mesmo_com_atendente_enviando_varias_vezes(
+def test_worker_nao_avisa_se_ultima_mensagem_recente(
     client, seed_base, auth_headers, db_session, monkeypatch
 ):
+    """Última mensagem do atendente há 2 min reinicia o prazo — não avisa ainda."""
     _configurar_evolution(db_session)
     chat = _chat_em_atendimento(db_session, wa_id="5511999554433")
     t_cliente = datetime.now(timezone.utc) - timedelta(minutes=25)
@@ -229,7 +233,67 @@ def test_worker_aviso_mesmo_com_atendente_enviando_varias_vezes(
     )
 
     n = process_whatsapp_inactivity_closures(db_session)
+    assert n == 0
+
+
+def test_worker_avisa_apos_silencio_desde_ultima_msg_atendente(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session, wa_id="5511999554400")
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="inbound",
+            corpo="Oi",
+            tipo_midia="texto",
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=30),
+        )
+    )
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Aguarde",
+            tipo_midia="texto",
+            atendente_id=1,
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=15),
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-silencio"),
+    )
+
+    n = process_whatsapp_inactivity_closures(db_session)
     assert n == 1
+
+
+def test_worker_respeita_pausa_inatividade(client, seed_base, auth_headers, db_session, monkeypatch):
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session, wa_id="5511999554411")
+    chat.inatividade_pausada = True
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Analisando",
+            tipo_midia="texto",
+            atendente_id=1,
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=30),
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-pausa"),
+    )
+
+    n = process_whatsapp_inactivity_closures(db_session)
+    assert n == 0
 
 
 def test_worker_nao_reenvia_aviso_duplicado_no_mesmo_ciclo(

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -899,6 +899,8 @@ export namespace WhatsappChats {
     funcionario_tipo?: string | null
     empresa_id?: number | null
     empresa_nome?: string | null
+    inatividade_pausada?: boolean
+    inatividade_retomada_em?: string | null
   }
   export interface EmpresaOpcao {
     id: number
@@ -1176,6 +1178,10 @@ export const whatsappChats = {
       body: JSON.stringify({ texto }),
     }),
   marcarVisto: (id: number) => api<void>(`/whatsapp/chats/${id}/visto`, { method: 'POST' }),
+  pausarInatividade: (id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/inatividade/pausar`, { method: 'POST' }),
+  retomarInatividade: (id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/inatividade/retomar`, { method: 'POST' }),
   vincularTicket: (id: number, ticketId: number) =>
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/vincular-ticket`, {
       method: 'POST',

--- a/frontend/src/components/chat/MensagemStatusIcon.tsx
+++ b/frontend/src/components/chat/MensagemStatusIcon.tsx
@@ -10,12 +10,15 @@ type Props = {
 
 function corIcone(status: StatusEntregaMensagem, variant: 'claro' | 'escuro'): string {
   if (status === 'lida') {
-    return variant === 'claro' ? 'text-cyan-100' : 'text-cyan-500 dark:text-cyan-400'
+    return variant === 'claro' ? 'text-sky-200' : 'text-sky-500 dark:text-sky-400'
   }
   if (status === 'erro') {
     return variant === 'claro' ? 'text-rose-200' : 'text-rose-500'
   }
-  return variant === 'claro' ? 'text-cyan-100/90' : 'text-slate-400'
+  if (status === 'entregue') {
+    return variant === 'claro' ? 'text-white/90' : 'text-slate-500 dark:text-slate-400'
+  }
+  return variant === 'claro' ? 'text-white/80' : 'text-slate-400'
 }
 
 function IconePendente({ className }: { className: string }) {

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -505,8 +505,9 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
             <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 dark:border-slate-800/80 dark:bg-slate-800/20 dark:text-slate-200">
               <p className="font-medium">Encerramento por inatividade</p>
               <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
-                Encerra chats em atendimento quando o cliente para de responder. O tempo conta desde a última mensagem
-                do cliente, depois que o atendente já respondeu.
+                Encerra chats em atendimento após silêncio. O tempo conta desde a última mensagem (cliente ou
+                atendente). No chat, o responsável pode Pausar o timer durante análises longas — ao pausar/retomar o
+                prazo volta ao valor configurado.
               </p>
             </div>
 
@@ -514,7 +515,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               checked={inativEncerramentoAtiva}
               onCheckedChange={setInativEncerramentoAtiva}
               label="Encerramento automático por inatividade do cliente"
-              description="Novas mensagens do atendente não reiniciam o timer."
+              description="Qualquer mensagem (cliente ou atendente) reinicia o timer. Use Pausar no chat se precisar de mais tempo."
               showStatusPill
               statusOnText="Ativo"
               statusOffText="Inativo"

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -68,12 +68,20 @@ import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
 import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { ChatFilaAguardandoSheet } from '../../components/chat/ChatFilaAguardandoSheet'
+import { WhatsappInatividadeControle } from './WhatsappInatividadeControle'
 import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
 import { rotuloDownloadArquivo, visualTipoArquivo } from '../../lib/fileTypeIcon'
 import { CONTATO_CLIENTE } from '../../constants/contatoClienteLabels'
 
-const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)\]$/
+const ROTULO_SEM_LEGENDA =
+  /^(?:\[\s*[^\]]+\s*\]:\s*)?\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)(\s+enviad[oa])?\]$/i
 
+/** Legenda real sob mídia; ignora placeholders tipo «[Imagem enviada]». */
+function legendaMidiaVisivel(corpo: string | null | undefined): string | null {
+  const t = (corpo || '').trim()
+  if (!t || ROTULO_SEM_LEGENDA.test(t)) return null
+  return t
+}
 
 
 // --- Subcomponente de Renderização de Mídia ---
@@ -153,16 +161,14 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 
 
 
-  const legenda = m.corpo && !ROTULO_SEM_LEGENDA.test(m.corpo.trim()) ? m.corpo : null
-
-
+  const legenda = legendaMidiaVisivel(m.corpo)
 
   if (tipo === 'texto' || !m.tipo_midia) return <TextoComLinks texto={m.corpo} />
 
   if (!m.midia_disponivel) {
     return (
       <p className="text-xs italic opacity-70" title="O ficheiro não foi obtido da Evolution API">
-        {m.corpo || 'Mídia não disponível'}
+        {legenda || 'Mídia não disponível'}
       </p>
     )
   }
@@ -171,60 +177,47 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 
   if (err) return <p className="text-[10px] italic opacity-50">Erro ao carregar mídia</p>
 
-
-
-  const mediaClass = "max-h-64 max-w-full rounded-lg border border-black/5 shadow-sm"
-
-
+  const mediaClass = 'max-h-64 max-w-full rounded-lg border border-black/5 shadow-sm'
 
   if (tipo === 'imagem' || tipo === 'figurinha') {
-
     return (
-
       <div className="space-y-1">
-
-        <img 
-
-          src={url} 
-
-          alt="" 
-
-          className={`${mediaClass} cursor-zoom-in transition-transform duration-200 hover:scale-[1.02]`} 
-
+        <img
+          src={url}
+          alt=""
+          className={`${mediaClass} cursor-zoom-in transition-transform duration-200 hover:scale-[1.02]`}
           onClick={() => onImageClick(url, legenda)}
-
         />
-
-        {legenda && <p className="text-xs opacity-80 italic">{legenda}</p>}
-
+        {legenda ? <TextoComLinks texto={legenda} /> : null}
       </div>
-
     )
-
   }
 
   if (tipo === 'audio') return <CustomAudioPlayer src={url} />
 
-  if (tipo === 'video') return <video controls src={url} className={mediaClass} />
+  if (tipo === 'video') {
+    return (
+      <div className="space-y-1">
+        <video controls src={url} className={mediaClass} />
+        {legenda ? <TextoComLinks texto={legenda} /> : null}
+      </div>
+    )
+  }
 
- 
-
-  const downloadLabel = rotuloDownloadArquivo(
-    tipo === 'documento' ? m.corpo : null,
-    m.mimetype,
-    tipo,
-  )
-  const fileVisual = visualTipoArquivo(tipo === 'documento' ? m.corpo : null, m.mimetype)
+  const downloadLabel = rotuloDownloadArquivo(null, m.mimetype, tipo)
+  const fileVisual = visualTipoArquivo(null, m.mimetype)
 
   return (
-
-    <a href={url} download className="flex items-center gap-2 text-xs font-bold underline">
-      <span className="text-base" aria-hidden>{fileVisual.emoji}</span>
-      <span>{downloadLabel.replace(/^\S+\s*/, '')}</span>
-    </a>
-
+    <div className="space-y-1">
+      <a href={url} download className="flex items-center gap-2 text-xs font-bold underline">
+        <span className="text-base" aria-hidden>
+          {fileVisual.emoji}
+        </span>
+        <span>{downloadLabel.replace(/^\S+\s*/, '')}</span>
+      </a>
+      {legenda ? <TextoComLinks texto={legenda} /> : null}
+    </div>
   )
-
 }
 
 
@@ -323,11 +316,24 @@ export function WhatsappConversa() {
       if (e.key !== 'Escape' || e.defaultPrevented || modalEncerrar) return
       const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase()
       if (tag === 'input' || tag === 'textarea' || tag === 'select') return
+      if (activeZoomImage) {
+        e.preventDefault()
+        e.stopPropagation()
+        setActiveZoomImage(null)
+        setActiveZoomImageCaption(null)
+        return
+      }
+      if (arquivoPendente) {
+        e.preventDefault()
+        setArquivoPendente(null)
+        setLegendaMidia('')
+        return
+      }
       voltarLista()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [voltarLista, modalEncerrar])
+  }, [voltarLista, modalEncerrar, activeZoomImage, arquivoPendente])
 
   useEffect(() => {
     if (!modalEncerrar || !chat) return
@@ -352,20 +358,22 @@ export function WhatsappConversa() {
 
 
 
-  // Scroll: só cola no fim se o utilizador já estiver perto do fundo; senão preserva a posição.
+  // Scroll: restaurar última posição vista; só cola no fim se já estava no fundo.
   useEffect(() => {
     if (!id) return
     initialScrollRestoredRef.current = false
-    stickToBottomRef.current = true
+    stickToBottomRef.current = false
   }, [id])
 
   useEffect(() => {
     if (loading || msgs.length === 0 || initialScrollRestoredRef.current || !id) return
     initialScrollRestoredRef.current = true
     requestAnimationFrame(() => {
-      const el = scrollRef.current
-      if (!el) return
-      stickToBottomRef.current = restoreWhatsappScroll(Number(id), el)
+      requestAnimationFrame(() => {
+        const el = scrollRef.current
+        if (!el) return
+        stickToBottomRef.current = restoreWhatsappScroll(Number(id), el)
+      })
     })
   }, [loading, msgs.length, id])
 
@@ -376,7 +384,6 @@ export function WhatsappConversa() {
       if (el) scrollWhatsappToBottom(el)
     })
   }, [msgs, loading])
-
   useEffect(() => {
     const el = scrollRef.current
     if (!el || !id) return
@@ -1061,6 +1068,14 @@ useEffect(() => {
 
             {!encerrado && (
               <>
+                {isResponsavel && chat && (
+                  <WhatsappInatividadeControle
+                    chat={chat}
+                    msgs={msgs}
+                    isResponsavel={isResponsavel}
+                    onChatUpdate={aplicarChatAtualizado}
+                  />
+                )}
                 {podeTransferir && (
                   <Button
                     variant="primary"
@@ -1070,7 +1085,6 @@ useEffect(() => {
                     Transferir
                   </Button>
                 )}
-
                 <Button
                   variant="ghost"
                   className="hidden sm:inline-flex text-xs h-8"
@@ -1349,10 +1363,18 @@ useEffect(() => {
                   onChange={(e) => setLegendaMidia(e.target.value)}
                   placeholder="Legenda opcional (visível no WhatsApp)"
                   className={`mt-2 ${TEXTAREA_FIELD_CLASS}`}
+                  autoFocus
                 />
               )}
               <div className="mt-2 flex justify-end gap-2">
-                <Button variant="ghost" className="h-8 text-xs" onClick={() => setArquivoPendente(null)}>
+                <Button
+                  variant="ghost"
+                  className="h-8 text-xs"
+                  onClick={() => {
+                    setArquivoPendente(null)
+                    setLegendaMidia('')
+                  }}
+                >
                   Cancelar
                 </Button>
                 <Button className="h-8 text-xs" loading={enviando} onClick={() => void confirmarEnvioMidia()}>
@@ -1362,27 +1384,28 @@ useEffect(() => {
             </div>
           )}
 
-          <WhatsappComposerBar
-            texto={texto}
-            onTextoChange={setTexto}
-            onEnviar={() => void enviar()}
-            enviando={enviando}
-            encerrado={encerrado}
-            podeEnviar={podeEnviar}
-            modoInterno={modoInterno}
-            podeDigitar={podeDigitarMensagem}
-            onEscolherAnexo={abrirPickerAnexo}
-            onAudioGravado={handleGravacaoConcluida}
-            onInserirEmoji={setTexto}
-            onEnviarFigurinha={(file) => void enviarFigurinha(file)}
-            onColarArquivo={(file) => {
-              setArquivoPendente(file)
-              setLegendaMidia('')
-            }}
-            onInserirReferenciaKb={inserirReferenciaKb}
-            focoPedidoEm={focoComposerEm}
-          />
-
+          {!arquivoPendente ? (
+            <WhatsappComposerBar
+              texto={texto}
+              onTextoChange={setTexto}
+              onEnviar={() => void enviar()}
+              enviando={enviando}
+              encerrado={encerrado}
+              podeEnviar={podeEnviar}
+              modoInterno={modoInterno}
+              podeDigitar={podeDigitarMensagem}
+              onEscolherAnexo={abrirPickerAnexo}
+              onAudioGravado={handleGravacaoConcluida}
+              onInserirEmoji={setTexto}
+              onEnviarFigurinha={(file) => void enviarFigurinha(file)}
+              onColarArquivo={(file) => {
+                setArquivoPendente(file)
+                setLegendaMidia('')
+              }}
+              onInserirReferenciaKb={inserirReferenciaKb}
+              focoPedidoEm={focoComposerEm}
+            />
+          ) : null}
           <input
             type="file"
             ref={fileInputRef}

--- a/frontend/src/pages/whatsapp/WhatsappGravadorAudio.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappGravadorAudio.tsx
@@ -17,6 +17,8 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
   const chunksRef = useRef<Blob[]>([])
   const timerRef = useRef<number | null>(null)
 
+  const canceladoRef = useRef(false)
+
   const pararStream = useCallback(() => {
     streamRef.current?.getTracks().forEach((t) => t.stop())
     streamRef.current = null
@@ -31,6 +33,7 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
   async function iniciar() {
     if (disabled || gravando) return
     setErro(null)
+    canceladoRef.current = false
     chunksRef.current = []
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
@@ -44,10 +47,17 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
       const recorder = mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream)
       recorderRef.current = recorder
       recorder.ondataavailable = (ev) => {
+        if (canceladoRef.current) return
         if (ev.data.size > 0) chunksRef.current.push(ev.data)
       }
       recorder.onstop = () => {
         pararStream()
+        if (canceladoRef.current) {
+          chunksRef.current = []
+          setGravando(false)
+          setSegundos(0)
+          return
+        }
         const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' })
         if (blob.size === 0) {
           setErro('Gravação vazia. Tente novamente.')
@@ -72,14 +82,17 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
   }
 
   function parar() {
+    canceladoRef.current = false
     const rec = recorderRef.current
     if (rec && rec.state !== 'inactive') rec.stop()
     recorderRef.current = null
   }
 
   function cancelar() {
+    canceladoRef.current = true
     if (gravando) {
-      recorderRef.current?.stop()
+      const rec = recorderRef.current
+      if (rec && rec.state !== 'inactive') rec.stop()
       recorderRef.current = null
       chunksRef.current = []
       pararStream()

--- a/frontend/src/pages/whatsapp/WhatsappGravadorAudioInline.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappGravadorAudioInline.tsx
@@ -17,6 +17,7 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
   const chunksRef = useRef<Blob[]>([])
   const timerRef = useRef<number | null>(null)
   const iniciouRef = useRef(false)
+  const canceladoRef = useRef(false)
 
   const pararStream = useCallback(() => {
     streamRef.current?.getTracks().forEach((t) => t.stop())
@@ -30,6 +31,7 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
   useEffect(() => {
     if (disabled || iniciouRef.current) return
     iniciouRef.current = true
+    canceladoRef.current = false
     void (async () => {
       setErro(null)
       chunksRef.current = []
@@ -44,10 +46,16 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
         const recorder = mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream)
         recorderRef.current = recorder
         recorder.ondataavailable = (ev) => {
+          if (canceladoRef.current) return
           if (ev.data.size > 0) chunksRef.current.push(ev.data)
         }
         recorder.onstop = () => {
           pararStream()
+          if (canceladoRef.current) {
+            chunksRef.current = []
+            setGravando(false)
+            return
+          }
           const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' })
           if (blob.size === 0) {
             setErro('Gravação vazia.')
@@ -66,6 +74,7 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
       }
     })()
     return () => {
+      canceladoRef.current = true
       pararStream()
       const rec = recorderRef.current
       if (rec && rec.state !== 'inactive') rec.stop()
@@ -76,17 +85,20 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
   const ss = String(segundos % 60).padStart(2, '0')
 
   function parar() {
+    canceladoRef.current = false
     const rec = recorderRef.current
     if (rec && rec.state !== 'inactive') rec.stop()
     recorderRef.current = null
   }
 
   function cancelar() {
+    canceladoRef.current = true
     chunksRef.current = []
     pararStream()
     const rec = recorderRef.current
     if (rec && rec.state !== 'inactive') rec.stop()
     recorderRef.current = null
+    setGravando(false)
     onCancelar()
   }
 

--- a/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useState } from 'react'
+import { whatsappChats, whatsappSettings, type WhatsappChats } from '../../api/client'
+import { Button } from '../../components/ui/Button'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useToast } from '../../components/ui/Toast'
+
+type Props = {
+  chat: WhatsappChats.Chat
+  msgs: WhatsappChats.Mensagem[]
+  isResponsavel: boolean
+  onChatUpdate: (c: WhatsappChats.Chat) => void
+}
+
+function formatMmSs(totalSec: number): string {
+  const s = Math.max(0, Math.floor(totalSec))
+  const mm = String(Math.floor(s / 60)).padStart(2, '0')
+  const ss = String(s % 60).padStart(2, '0')
+  return `${mm}:${ss}`
+}
+
+/** Controlo de inatividade: countdown + pausar/retomar (#577). */
+export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatUpdate }: Props) {
+  const toast = useToast()
+  const [avisoMin, setAvisoMin] = useState(15)
+  const [ativa, setAtiva] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    void whatsappSettings
+      .get()
+      .then((r) => {
+        if (cancelled) return
+        setAtiva(Boolean(r.inativ_encerramento_ativa))
+        setAvisoMin(Math.max(1, Number(r.inativ_aviso_minutos ?? 15)))
+      })
+      .catch(() => {
+        /* settings indisponíveis — esconde controlo */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!ativa || chat.estado !== 'em_atendimento') return
+    const id = window.setInterval(() => setTick((t) => t + 1), 1000)
+    return () => window.clearInterval(id)
+  }, [ativa, chat.estado])
+
+  const restanteSec = useMemo(() => {
+    void tick
+    if (!ativa || chat.estado !== 'em_atendimento') return null
+    if (chat.inatividade_pausada) return avisoMin * 60
+
+    const relevant = msgs.filter(
+      (m) =>
+        m.evento_sistema !== 'comentario_interno' &&
+        (m.direcao === 'inbound' ||
+          (m.direcao === 'outbound' && !m.evento_sistema)),
+    )
+    const last = relevant[relevant.length - 1]
+    const candidatos: number[] = []
+    if (last?.created_at) candidatos.push(new Date(last.created_at).getTime())
+    if (chat.inatividade_retomada_em) candidatos.push(new Date(chat.inatividade_retomada_em).getTime())
+    if (candidatos.length === 0) return avisoMin * 60
+
+    const refMs = Math.max(...candidatos)
+    const elapsed = (Date.now() - refMs) / 1000
+    return Math.max(0, avisoMin * 60 - elapsed)
+  }, [ativa, chat, msgs, avisoMin, tick])
+
+  if (!ativa || chat.estado !== 'em_atendimento' || !isResponsavel || restanteSec == null) {
+    return null
+  }
+
+  async function toggle() {
+    setBusy(true)
+    try {
+      const next = chat.inatividade_pausada
+        ? await whatsappChats.retomarInatividade(chat.id)
+        : await whatsappChats.pausarInatividade(chat.id)
+      onChatUpdate(next)
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível alterar a pausa de inatividade.'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <span
+        className={`tabular-nums text-xs font-semibold ${
+          chat.inatividade_pausada
+            ? 'text-amber-600 dark:text-amber-300'
+            : restanteSec <= 60
+              ? 'text-rose-600 dark:text-rose-300'
+              : 'text-slate-500 dark:text-slate-400'
+        }`}
+        title={
+          chat.inatividade_pausada
+            ? 'Inatividade pausada — prazo reiniciado'
+            : 'Tempo até o aviso de inatividade'
+        }
+      >
+        {formatMmSs(restanteSec)}
+      </span>
+      <Button
+        type="button"
+        variant="ghost"
+        className="h-8 px-2 text-xs"
+        loading={busy}
+        onClick={() => void toggle()}
+      >
+        {chat.inatividade_pausada ? 'Retomar' : 'Pausar'}
+      </Button>
+    </div>
+  )
+}


### PR DESCRIPTION
﻿## Summary
- Corrige bugs de produção do WhatsApp (#568–#577): composer/legendas/mídia, Esc no lightbox, cancelar áudio, scroll ao reabrir, vínculo em chats novos, ticks de leitura só pelo responsável, inatividade desde a última mensagem com Pausar/Retomar e countdown.
- Migration `073_wpp_inatividade_pausa` + match de contacto por telefone no webhook.
- Closes #568 #569 #570 #571 #572 #573 #574 #575 #576 #577

## Test plan
- [ ] Anexar imagem: só campo de legenda (sem composer duplicado); sem legenda não aparece «[Imagem enviada]»
- [ ] PDF/vídeo com legenda visível no balão; tipografia alinhada ao texto
- [ ] Esc no zoom fecha só o lightbox
- [ ] Cancelar gravação de áudio não envia
- [ ] Reabrir chat restaura última posição de scroll
- [ ] Contacto vinculado → novo inbound do mesmo número já vem identificado
- [ ] Só o responsável ao abrir o chat dispara mark-as-read (✓✓ azul no WhatsApp do cliente)
- [ ] Inatividade: timer reinicia com qualquer mensagem; Pausar/Retomar com countdown; `alembic upgrade head`
- [ ] CI verde

