### PR TITLE
feat(whatsapp): inatividade #577 + classificar demanda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
-- WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown no chat
+- WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown (até o aviso e, após o aviso, até encerrar); enviar mensagem sai da pausa automaticamente
 - WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel
 - PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)
 - Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)
@@ -22,7 +22,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
-- WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** na lista do responsável até registar (ou confirmar sem demanda); banner na conversa sem bloquear a leitura
+- WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** (somente leitura) até registar, manter demandas existentes ou confirmar sem demanda; nova mensagem do mesmo cliente abre chat novo na fila
 - WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat
 - WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)
 - WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
-- WhatsApp: após encerramento por inatividade, o painel abre o modal para o responsável registar a demanda (como no Encerrar manual)
+- WhatsApp: após encerramento por inatividade, banner «Registar demanda» (sem bloquear a conversa); o modal abre só ao clicar — permite reler o chat ou mudar de atendimento e voltar
 - WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat
 - WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)
 - WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp: após encerramento por inatividade, o painel abre o modal para o responsável registar a demanda (como no Encerrar manual)
 - WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat
 - WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)
 - WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat
 - WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)
 - WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda
 - WhatsApp (#571): Esc no zoom da imagem fecha só a visualização, sem sair do chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
-- WhatsApp: após encerramento por inatividade, banner «Registar demanda» (sem bloquear a conversa); o modal abre só ao clicar — permite reler o chat ou mudar de atendimento e voltar
+- WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** na lista do responsável até registar (ou confirmar sem demanda); banner na conversa sem bloquear a leitura
 - WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat
 - WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)
 - WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda

--- a/backend/alembic/versions/074_wpp_classificacao_demanda.py
+++ b/backend/alembic/versions/074_wpp_classificacao_demanda.py
@@ -1,0 +1,42 @@
+"""WhatsApp: classificação de demanda pendente após inatividade.
+
+Revision ID: 074_wpp_classificacao_demanda
+Revises: 073_wpp_inatividade_pausa
+Create Date: 2026-07-18
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "074_wpp_classificacao_demanda"
+down_revision = "073_wpp_inatividade_pausa"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "classificacao_demanda_pendente" not in cols:
+        op.add_column(
+            "whatsapp_chats",
+            sa.Column(
+                "classificacao_demanda_pendente",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "classificacao_demanda_pendente" in cols:
+        op.drop_column("whatsapp_chats", "classificacao_demanda_pendente")

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -268,6 +268,13 @@ def _render_template(
     )
 
 
+def _sair_pausa_inatividade_por_atividade(chat: WhatsappChat) -> None:
+    """Mensagem do cliente ou outbound humana reinicia o ciclo — sai da pausa manual."""
+    if getattr(chat, "inatividade_pausada", False):
+        chat.inatividade_pausada = False
+        chat.inatividade_retomada_em = None
+
+
 def _enviar_texto_whatsapp(
     db: Session,
     *,
@@ -321,6 +328,8 @@ def _enviar_texto_whatsapp(
     )
     if not ok:
         raise HTTPException(status_code=502, detail=err or "Falha ao enviar pela Evolution API")
+    if evento_sistema is None:
+        _sair_pausa_inatividade_por_atividade(chat)
     m = WhatsappMensagem(
         chat_id=chat.id,
         direcao="outbound",
@@ -1383,6 +1392,11 @@ def enviar_mensagem(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
     if c.estado != "em_atendimento":
         raise HTTPException(status_code=400, detail="Só é possível enviar mensagens em chats ativos")
+    if getattr(c, "classificacao_demanda_pendente", False):
+        raise HTTPException(
+            status_code=400,
+            detail="Chat aguarda classificação de demanda — não é possível enviar mensagens ao cliente",
+        )
     _exigir_responsavel_envio_cliente(c, atendente)
     texto = data.texto.strip()
     m = _enviar_texto_whatsapp(
@@ -1418,6 +1432,11 @@ async def enviar_mensagem_midia(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
     if c.estado != "em_atendimento":
         raise HTTPException(status_code=400, detail="Só é possível enviar mensagens em chats ativos")
+    if getattr(c, "classificacao_demanda_pendente", False):
+        raise HTTPException(
+            status_code=400,
+            detail="Chat aguarda classificação de demanda — não é possível enviar mensagens ao cliente",
+        )
     _exigir_responsavel_envio_cliente(c, atendente)
 
     data = await file.read()
@@ -1508,6 +1527,7 @@ async def enviar_mensagem_midia(
         status_entrega=status_inicial_outbound_whatsapp(wa_message_id=sent_wa_id),
     )
     db.add(m)
+    _sair_pausa_inatividade_por_atividade(c)
     db.commit()
     m2 = (
         db.query(WhatsappMensagem)

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -515,6 +515,7 @@ def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False)
         empresa_nome=_empresa_nome_exibicao(emp),
         inatividade_pausada=bool(getattr(c, "inatividade_pausada", False)),
         inatividade_retomada_em=getattr(c, "inatividade_retomada_em", None),
+        classificacao_demanda_pendente=bool(getattr(c, "classificacao_demanda_pendente", False)),
     )
 
 
@@ -629,10 +630,18 @@ def listar_meus_ativos(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
+    """Chats em atendimento + encerrados por inatividade ainda sem classificação de demanda."""
+    from sqlalchemy import or_
+
     q = (
         db.query(WhatsappChat)
         .options(*_CHAT_LOAD_OPTIONS)
-        .filter(WhatsappChat.estado == "em_atendimento")
+        .filter(
+            or_(
+                WhatsappChat.estado == "em_atendimento",
+                WhatsappChat.classificacao_demanda_pendente.is_(True),
+            )
+        )
     )
     if atendente.role != "admin":
         q = q.filter(WhatsappChat.atendente_id == atendente.id)
@@ -1184,6 +1193,8 @@ def registrar_demanda(
         raise HTTPException(status_code=403, detail="Sem permissão para registrar demanda neste chat")
     row = criar_demanda_chat(db, c, atendente, data, desfecho="resolvido_sessao")
     marco = criar_marco_demanda_mensagem(db, chat=c, atendente=atendente, demanda=row)
+    if getattr(c, "classificacao_demanda_pendente", False):
+        c.classificacao_demanda_pendente = False
     db.commit()
     db.refresh(marco)
     marco = (
@@ -1193,6 +1204,8 @@ def registrar_demanda(
         .first()
     )
     emit_chat_mensagem_from_models(db, c, marco, exclude_atendente_id=atendente.id)
+    if c.estado != "em_atendimento":
+        emit_chat_fila_from_model(db, c, estado_anterior=c.estado)
     return demanda_para_read(row)
 
 
@@ -1662,6 +1675,30 @@ def retomar_inatividade(
     db.commit()
     c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     assert c2 is not None
+    return _chat_read(db, c2)
+
+
+@router.post("/{chat_id}/classificacao-demanda/concluir", response_model=WhatsappChatRead)
+def concluir_classificacao_demanda(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Marca classificação pós-inatividade como concluída (ex.: confirmar sem registar demanda)."""
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not getattr(c, "classificacao_demanda_pendente", False):
+        return _chat_read(db, c)
+    if atendente.role != "admin" and c.atendente_id != atendente.id:
+        raise HTTPException(status_code=403, detail="Apenas o responsável pode concluir a classificação")
+    if c.estado not in ("encerrado", "aguardando_avaliacao"):
+        raise HTTPException(status_code=400, detail="Classificação só se aplica a chats já encerrados por inatividade")
+    c.classificacao_demanda_pendente = False
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    emit_chat_fila_from_model(db, c2, estado_anterior=c2.estado)
     return _chat_read(db, c2)
 
 

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -547,13 +547,31 @@ def _exigir_responsavel_envio_cliente(c: WhatsappChat, atendente: Atendente) -> 
 
 
 def _pode_registrar_demanda(db: Session, atendente: Atendente, c: WhatsappChat) -> bool:
-    if c.estado != "em_atendimento":
-        return False
+    """Responsável/admin: em atendimento, ou após encerramento automático por inatividade."""
     if not _pode_ver_chat(db, atendente, c):
         return False
-    if atendente.role == "admin":
+    if atendente.role != "admin" and c.atendente_id != atendente.id:
+        return False
+    if c.estado == "em_atendimento":
         return True
-    return c.atendente_id == atendente.id
+    if c.estado in ("aguardando_avaliacao", "encerrado") and _chat_encerrado_por_inatividade(db, c):
+        return True
+    return False
+
+
+def _chat_encerrado_por_inatividade(db: Session, c: WhatsappChat) -> bool:
+    return (
+        db.query(WhatsappMensagem.id)
+        .filter(
+            WhatsappMensagem.chat_id == c.id,
+            WhatsappMensagem.evento_sistema.in_(
+                ("auto_encerrado_inatividade", "auto_inativ_aviso"),
+            ),
+        )
+        .limit(1)
+        .first()
+        is not None
+    )
 
 
 def _pode_ver_chat(db: Session, atendente: Atendente, c: WhatsappChat) -> bool:

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -90,9 +90,26 @@ def _baixar_midia_inbound(
 
 
 def _chat_aberto_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
+    """Chat ativo para conversa (fila ou em atendimento). Não inclui pós-inatividade a classificar."""
     return (
         db.query(WhatsappChat)
-        .filter(WhatsappChat.wa_id == wa_id, WhatsappChat.estado != "encerrado")
+        .filter(
+            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.estado.in_(("aguardando_atendente", "em_atendimento")),
+            WhatsappChat.classificacao_demanda_pendente.is_(False),
+        )
+        .order_by(WhatsappChat.id.desc())
+        .first()
+    )
+
+
+def _chat_aguardando_avaliacao_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
+    return (
+        db.query(WhatsappChat)
+        .filter(
+            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.estado == "aguardando_avaliacao",
+        )
         .order_by(WhatsappChat.id.desc())
         .first()
     )
@@ -193,10 +210,8 @@ def _try_auto_msg_espera(db: Session, st: WhatsappSettings | None, chat: Whatsap
             evento_sistema="auto_espera",
         )
     )
-    try:
-        db.commit()
-    except Exception:
-        db.rollback()
+    # Flush apenas: commit fica no webhook. commit/rollback aqui apagava chat novo se a auto-msg falhasse.
+    db.flush()
 
 
 def _parse_hhmm(v: str | None) -> tuple[int, int] | None:
@@ -326,10 +341,8 @@ def _try_auto_msg_fora_horario(db: Session, st: WhatsappSettings | None, chat: W
             evento_sistema="auto_fora_horario",
         )
     )
-    try:
-        db.commit()
-    except Exception:
-        db.rollback()
+    # Flush apenas: commit fica no webhook (evita rollback apagar chat recém-criado).
+    db.flush()
 
 
 def _processar_atualizacoes_status_mensagem(db: Session, body: dict) -> int:
@@ -399,40 +412,52 @@ def evolution_webhook(
         )
 
         chat = _chat_aberto_por_wa_id(db, wa_id)
-        if chat and chat.estado == "aguardando_avaliacao":
-            q_prev = item.get("quoted_corpo_preview")
-            if q_prev is not None and len(str(q_prev)) > 500:
-                q_prev = str(q_prev)[:500]
-            msg = WhatsappMensagem(
-                chat_id=chat.id,
-                direcao="inbound",
-                corpo=corpo,
-                tipo_midia=tipo_midia,
-                mimetype=mimetype_val,
-                midia_nome_arquivo=midia_nome,
-                wa_message_id=wa_mid,
-                quoted_wa_message_id=item.get("quoted_wa_message_id"),
-                quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
-                atendente_id=None,
-            )
-            db.add(msg)
-            if push and not chat.cliente_nome:
-                chat.cliente_nome = push
-            try:
-                from app.services.whatsapp_avaliacao import processar_resposta_avaliacao
+        if not chat:
+            chat_aval = _chat_aguardando_avaliacao_por_wa_id(db, wa_id)
+            # Chat a classificar demanda: só reutiliza se for resposta de avaliação (nota 1–5).
+            # Qualquer outra mensagem abre atendimento novo; o pendente permanece.
+            if chat_aval is not None:
+                from app.services.whatsapp_avaliacao import parse_nota_avaliacao
 
-                processar_resposta_avaliacao(
-                    db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
+                pendente = bool(getattr(chat_aval, "classificacao_demanda_pendente", False))
+                nota = parse_nota_avaliacao(corpo) if (tipo or "texto") == "texto" else None
+                if pendente and nota is None:
+                    chat_aval = None
+            if chat_aval is not None:
+                chat = chat_aval
+                q_prev = item.get("quoted_corpo_preview")
+                if q_prev is not None and len(str(q_prev)) > 500:
+                    q_prev = str(q_prev)[:500]
+                msg = WhatsappMensagem(
+                    chat_id=chat.id,
+                    direcao="inbound",
+                    corpo=corpo,
+                    tipo_midia=tipo_midia,
+                    mimetype=mimetype_val,
+                    midia_nome_arquivo=midia_nome,
+                    wa_message_id=wa_mid,
+                    quoted_wa_message_id=item.get("quoted_wa_message_id"),
+                    quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
+                    atendente_id=None,
                 )
-                db.commit()
-                processados += 1
-            except IntegrityError:
-                db.rollback()
-                logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
-            except Exception:
-                db.rollback()
-                raise
-            continue
+                db.add(msg)
+                if push and not chat.cliente_nome:
+                    chat.cliente_nome = push
+                try:
+                    from app.services.whatsapp_avaliacao import processar_resposta_avaliacao
+
+                    processar_resposta_avaliacao(
+                        db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
+                    )
+                    db.commit()
+                    processados += 1
+                except IntegrityError:
+                    db.rollback()
+                    logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
+                except Exception:
+                    db.rollback()
+                    raise
+                continue
 
         if tipo == "texto":
             tipo_midia = "texto"

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -70,6 +70,8 @@ class WhatsappChat(Base):
     empresa_id = Column(Integer, ForeignKey("empresas.id", ondelete="SET NULL"), nullable=True, index=True)
     inatividade_pausada = Column(Boolean, nullable=False, default=False, server_default="false")
     inatividade_retomada_em = Column(DateTime(timezone=True), nullable=True)
+    # Após encerramento por inatividade: responsável deve registar (ou confirmar sem) demanda.
+    classificacao_demanda_pendente = Column(Boolean, nullable=False, default=False, server_default="false")
 
     atendente = relationship("Atendente", backref="whatsapp_chats_atendidos")
     setor = relationship("Setor", backref="whatsapp_chats")

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -48,6 +48,7 @@ class WhatsappChatRead(BaseModel):
     empresa_nome: str | None = None
     inatividade_pausada: bool = False
     inatividade_retomada_em: datetime | None = None
+    classificacao_demanda_pendente: bool = False
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -154,7 +154,39 @@ def _extract_wa_message_id(data: Any) -> str | None:
         if mid:
             s = str(mid).strip()
             return s or None
+    for k in ("keyId", "KeyId", "id", "Id"):
+        mid = data.get(k)
+        if mid and not isinstance(mid, dict):
+            s = str(mid).strip()
+            if s:
+                return s
     return None
+
+
+def evolution_set_webhook(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    *,
+    webhook_url: str,
+    secret: str | None = None,
+    events: list[str] | None = None,
+) -> tuple[int, Any | None, str | None]:
+    """POST /webhook/set/{instance} — garante MESSAGES_UPSERT + MESSAGES_UPDATE."""
+    base = base_url.rstrip("/")
+    url = f"{base}/webhook/set/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    ev = events or ["MESSAGES_UPSERT", "MESSAGES_UPDATE"]
+    webhook: dict[str, Any] = {
+        "enabled": True,
+        "url": webhook_url,
+        "byEvents": False,
+        "events": ev,
+    }
+    if secret:
+        webhook["headers"] = {"X-Dx-Webhook-Secret": secret}
+    body = {"webhook": webhook}
+    return _request_json_with_retry("POST", url, headers=headers, body=body)
 
 
 def evolution_mark_messages_as_read(

--- a/backend/app/services/evolution_embedded.py
+++ b/backend/app/services/evolution_embedded.py
@@ -208,6 +208,17 @@ def provisionar_e_ligar_webhook(db: Session, row: WhatsappSettings) -> dict[str,
     db.commit()
     db.refresh(row)
 
+    # Instâncias reutilizadas (409) podem ter webhook sem MESSAGES_UPDATE — ticks ficariam em ✓ único.
+    wh_code, _wh_data, wh_err = evolution_api.evolution_set_webhook(
+        internal,
+        iname,
+        api_inst,
+        webhook_url=webhook_url,
+        secret=secret,
+    )
+    if wh_code not in (200, 201):
+        logger.warning("Evolution setWebhook falhou (HTTP %s): %s", wh_code, wh_err)
+
     cq, qdata, qerr = evolution_api.evolution_connect(internal, api_inst, iname)
     if cq != 200:
         logger.warning("Connect após provisionar: HTTP %s %s", cq, qerr)

--- a/backend/app/services/evolution_inbound.py
+++ b/backend/app/services/evolution_inbound.py
@@ -185,8 +185,33 @@ def _iter_message_dicts(data: Any) -> Iterator[dict[str, Any]]:
             if isinstance(m, dict):
                 yield m
         return
-    if "key" in data or "message" in data or "Message" in data:
+    # Evolution MESSAGES_UPDATE (formato flat): { keyId, fromMe, status, remoteJid }
+    if "keyId" in data or "KeyId" in data:
         yield data
+        return
+    if "key" in data or "Key" in data or "message" in data or "Message" in data:
+        yield data
+
+
+def _wa_id_e_from_me_de_update(m: dict[str, Any]) -> tuple[str | None, bool | None]:
+    """Extrai wa_message_id e fromMe de update aninhado (key.id) ou flat (keyId)."""
+    key = m.get("key") or m.get("Key")
+    if isinstance(key, dict):
+        mid = key.get("id") or key.get("Id")
+        wa_message_id = str(mid).strip() if mid else None
+        from_me_raw = key.get("fromMe") if "fromMe" in key else key.get("FromMe")
+        from_me = bool(from_me_raw) if from_me_raw is not None else None
+        return wa_message_id or None, from_me
+
+    mid = m.get("keyId") or m.get("KeyId") or m.get("id") or m.get("Id")
+    wa_message_id = str(mid).strip() if mid else None
+    if "fromMe" in m:
+        from_me = bool(m.get("fromMe"))
+    elif "FromMe" in m:
+        from_me = bool(m.get("FromMe"))
+    else:
+        from_me = None
+    return (wa_message_id or None), from_me
 
 
 def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any]]:
@@ -299,26 +324,29 @@ def _ack_de_update_dict(update: dict[str, Any]) -> int | str | None:
 
 def iter_message_status_updates(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any]]:
     """
-  Por cada atualização de ACK em mensagem outbound, produz:
-  wa_message_id, status_entrega (pendente|enviada|entregue|lida|erro)
+    Por cada atualização de ACK em mensagem outbound, produz:
+    wa_message_id, status_entrega (pendente|enviada|entregue|lida|erro)
+
+    Aceita:
+    - formato aninhado: data.key.id + data.update.status
+    - formato Evolution flat: data.keyId + data.fromMe + data.status (ex.: DELIVERY_ACK)
+    - data como lista de qualquer um dos formatos
     """
     from app.services.mensagem_status import ack_evolution_para_status
 
     event = webhook_body.get("event") or webhook_body.get("Event") or ""
-    ev = str(event).lower()
+    ev = str(event).lower().replace("_", ".")
     if "update" not in ev or "message" not in ev:
         return
 
     data = webhook_body.get("data") or webhook_body.get("Data")
     for m in _iter_message_dicts(data):
-        key = m.get("key") or m.get("Key") or {}
-        if not isinstance(key, dict):
-            continue
-        if not (key.get("fromMe") or key.get("FromMe")):
-            continue
-        mid = key.get("id") or key.get("Id")
-        wa_message_id = str(mid).strip() if mid else None
+        wa_message_id, from_me = _wa_id_e_from_me_de_update(m)
         if not wa_message_id:
+            continue
+        # Só atualiza ticks de mensagens enviadas por nós. Se fromMe vier omitido
+        # (alguns payloads), ainda tenta — o lookup no DB exige direcao=outbound.
+        if from_me is False:
             continue
 
         ack_raw = _ack_de_update_dict(m.get("update") or m.get("Update") or {})

--- a/backend/app/services/mensagem_status.py
+++ b/backend/app/services/mensagem_status.py
@@ -23,7 +23,12 @@ def status_deve_atualizar(atual: str | None, novo: str) -> bool:
 
 
 def ack_evolution_para_status(ack: int | str | None) -> str | None:
-    """Mapeia ACK Baileys/Evolution para status_entrega."""
+    """Mapeia ACK Baileys/Evolution para status_entrega.
+
+    Numérico (Baileys WAMessageStatus):
+      0=ERROR, 1=PENDING, 2=SERVER_ACK, 3=DELIVERY_ACK, 4=READ, 5=PLAYED
+    Strings Evolution: PENDING, SERVER_ACK, DELIVERY_ACK, READ, …
+    """
     if ack is None:
         return None
     if isinstance(ack, str):
@@ -46,11 +51,11 @@ def ack_evolution_para_status(ack: int | str | None) -> str | None:
         return None
     if n <= 0:
         return STATUS_ERRO
-    if n == 1:
+    if n in (1, 2):
         return STATUS_ENVIADA
-    if n == 2:
+    if n == 3:
         return STATUS_ENTREGUE
-    if n >= 3:
+    if n >= 4:
         return STATUS_LIDA
     return None
 

--- a/backend/app/services/whatsapp_chat_demandas.py
+++ b/backend/app/services/whatsapp_chat_demandas.py
@@ -125,8 +125,8 @@ def criar_demanda_chat(
     desfecho: str = "resolvido_sessao",
     ticket_id: int | None = None,
 ) -> WhatsappChatDemanda:
-    if chat.estado != "em_atendimento":
-        raise HTTPException(status_code=400, detail="Registre demandas apenas em chats em atendimento")
+    if chat.estado not in ("em_atendimento", "aguardando_avaliacao", "encerrado"):
+        raise HTTPException(status_code=400, detail="Registre demandas apenas em chats em atendimento ou pós-inatividade")
     desfecho_eff = (desfecho or "resolvido_sessao").strip()
     if desfecho_eff not in DESFECHOS_DEMANDA:
         raise HTTPException(status_code=400, detail="Desfecho inválido")
@@ -180,8 +180,8 @@ def atualizar_demanda_chat(
     *,
     atendente: Atendente,
 ) -> WhatsappChatDemanda:
-    if chat.estado != "em_atendimento":
-        raise HTTPException(status_code=400, detail="Edite demandas apenas em chats em atendimento")
+    if chat.estado not in ("em_atendimento", "aguardando_avaliacao", "encerrado"):
+        raise HTTPException(status_code=400, detail="Edite demandas apenas em chats em atendimento ou pós-inatividade")
     if row.desfecho != "resolvido_sessao":
         raise HTTPException(status_code=400, detail="Demandas escaladas para ticket não podem ser editadas")
     if atendente.role != "admin" and row.atendente_id != atendente.id:

--- a/backend/app/services/whatsapp_inactivity_worker.py
+++ b/backend/app/services/whatsapp_inactivity_worker.py
@@ -178,6 +178,7 @@ def _encerrar_por_inatividade(db: Session, chat: WhatsappChat, st: WhatsappSetti
     from app.services.whatsapp_avaliacao import finalizar_atendimento_whatsapp
 
     finalizar_atendimento_whatsapp(db, chat, st, evento_encerrado="auto_encerrado_inatividade")
+    chat.classificacao_demanda_pendente = True
     # Com avaliação ativa o evento_encerrado não é gravado — marco interno para o painel pedir demanda.
     ja_tem = (
         db.query(WhatsappMensagem.id)

--- a/backend/app/services/whatsapp_inactivity_worker.py
+++ b/backend/app/services/whatsapp_inactivity_worker.py
@@ -174,9 +174,35 @@ def _enviar_texto_sistema(
 
 
 def _encerrar_por_inatividade(db: Session, chat: WhatsappChat, st: WhatsappSettings) -> None:
+    from app.models.whatsapp_chat import WhatsappMensagem
     from app.services.whatsapp_avaliacao import finalizar_atendimento_whatsapp
 
     finalizar_atendimento_whatsapp(db, chat, st, evento_encerrado="auto_encerrado_inatividade")
+    # Com avaliação ativa o evento_encerrado não é gravado — marco interno para o painel pedir demanda.
+    ja_tem = (
+        db.query(WhatsappMensagem.id)
+        .filter(
+            WhatsappMensagem.chat_id == chat.id,
+            WhatsappMensagem.evento_sistema == "auto_encerrado_inatividade",
+        )
+        .limit(1)
+        .first()
+    )
+    if not ja_tem:
+        db.add(
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="outbound",
+                corpo="Atendimento encerrado automaticamente por inatividade.",
+                tipo_midia="texto",
+                mimetype=None,
+                midia_nome_arquivo=None,
+                wa_message_id=None,
+                atendente_id=None,
+                evento_sistema="auto_encerrado_inatividade",
+            )
+        )
+        db.flush()
 
 
 def _processar_chat_inatividade(
@@ -268,6 +294,25 @@ def process_whatsapp_inactivity_closures(db: Session, *, limit: int = 200) -> in
             if _processar_chat_inatividade(db, chat, st, now):
                 db.commit()
                 alterados += 1
+                try:
+                    from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
+
+                    emit_chat_fila_from_model(db, chat, estado_anterior="em_atendimento")
+                    last_msg = (
+                        db.query(WhatsappMensagem)
+                        .filter(WhatsappMensagem.chat_id == chat.id)
+                        .order_by(WhatsappMensagem.id.desc())
+                        .first()
+                    )
+                    if last_msg and last_msg.evento_sistema in (
+                        "auto_inativ_aviso",
+                        "auto_encerrado_inatividade",
+                        "auto_avaliacao_solicitacao",
+                        "auto_encerrado",
+                    ):
+                        emit_chat_mensagem_from_models(db, chat, last_msg)
+                except Exception as emit_exc:
+                    logger.warning("SSE pós-inatividade (chat=%s): %s", chat_id, emit_exc)
             else:
                 db.rollback()
         except Exception as exc:

--- a/backend/tests/test_mensagem_status.py
+++ b/backend/tests/test_mensagem_status.py
@@ -10,12 +10,15 @@ from app.services.mensagem_status import (
 
 
 def test_ack_evolution_para_status():
+    # Baileys WAMessageStatus: 1 PENDING, 2 SERVER_ACK, 3 DELIVERY_ACK, 4 READ
     assert ack_evolution_para_status(1) == STATUS_ENVIADA
-    assert ack_evolution_para_status(2) == STATUS_ENTREGUE
-    assert ack_evolution_para_status(3) == STATUS_LIDA
+    assert ack_evolution_para_status(2) == STATUS_ENVIADA
+    assert ack_evolution_para_status(3) == STATUS_ENTREGUE
     assert ack_evolution_para_status(4) == STATUS_LIDA
+    assert ack_evolution_para_status(5) == STATUS_LIDA
     assert ack_evolution_para_status("READ") == STATUS_LIDA
     assert ack_evolution_para_status("DELIVERY_ACK") == STATUS_ENTREGUE
+    assert ack_evolution_para_status("SERVER_ACK") == STATUS_ENVIADA
 
 
 def test_status_deve_atualizar_somente_para_frente():
@@ -29,7 +32,7 @@ def test_status_inicial_outbound_whatsapp():
     assert status_inicial_outbound_whatsapp(wa_message_id=None) == "pendente"
 
 
-def test_iter_message_status_updates():
+def test_iter_message_status_updates_nested():
     body = {
         "event": "messages.update",
         "data": {
@@ -40,4 +43,51 @@ def test_iter_message_status_updates():
     rows = list(iter_message_status_updates(body))
     assert len(rows) == 1
     assert rows[0]["wa_message_id"] == "MSG123"
+    assert rows[0]["status_entrega"] == STATUS_ENTREGUE
+
+
+def test_iter_message_status_updates_evolution_flat():
+    """Payload real Evolution MESSAGES_UPDATE (keyId + status string)."""
+    body = {
+        "event": "messages.update",
+        "data": {
+            "keyId": "3EB0C7B4E7A2B8E6D4F1",
+            "remoteJid": "5511999999999@s.whatsapp.net",
+            "fromMe": True,
+            "status": "DELIVERY_ACK",
+        },
+    }
+    rows = list(iter_message_status_updates(body))
+    assert len(rows) == 1
+    assert rows[0]["wa_message_id"] == "3EB0C7B4E7A2B8E6D4F1"
+    assert rows[0]["status_entrega"] == STATUS_ENTREGUE
+
+
+def test_iter_message_status_updates_evolution_flat_read():
+    body = {
+        "event": "MESSAGES_UPDATE",
+        "data": {
+            "keyId": "ABC123",
+            "fromMe": True,
+            "status": "READ",
+        },
+    }
+    rows = list(iter_message_status_updates(body))
+    assert len(rows) == 1
     assert rows[0]["status_entrega"] == STATUS_LIDA
+
+
+def test_iter_message_status_updates_lista_flat():
+    body = {
+        "event": "messages.update",
+        "data": [
+            {"keyId": "A1", "fromMe": True, "status": "SERVER_ACK"},
+            {"keyId": "A2", "fromMe": True, "status": "DELIVERY_ACK"},
+            {"keyId": "B1", "fromMe": False, "status": "READ"},
+        ],
+    }
+    rows = list(iter_message_status_updates(body))
+    assert [(r["wa_message_id"], r["status_entrega"]) for r in rows] == [
+        ("A1", STATUS_ENVIADA),
+        ("A2", STATUS_ENTREGUE),
+    ]

--- a/backend/tests/test_whatsapp_inatividade_encerramento.py
+++ b/backend/tests/test_whatsapp_inatividade_encerramento.py
@@ -124,6 +124,7 @@ def test_worker_encerra_apos_aviso(client, seed_base, auth_headers, db_session, 
     assert n == 1
     assert chat.estado == "encerrado"
     assert chat.encerramento_at is not None
+    assert chat.classificacao_demanda_pendente is True
     marco = (
         db_session.query(WhatsappMensagem)
         .filter(
@@ -177,6 +178,46 @@ def test_pode_registrar_demanda_apos_encerramento_inatividade(
     )
     assert r.status_code == 201, r.text
     assert r.json()["descricao_curta"] == "Pós-inatividade"
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is False
+
+
+def test_concluir_classificacao_sem_demanda(client, seed_base, auth_headers, db_session, monkeypatch):
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    chat = _chat_em_atendimento(db_session, wa_id="5511999223344", atendente_id=a1_id)
+    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=antiga_aviso,
+        )
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-cls"),
+    )
+    process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is True
+
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    assert any(c["id"] == chat.id and c.get("classificacao_demanda_pendente") for c in meus)
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{chat.id}/classificacao-demanda/concluir",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["classificacao_demanda_pendente"] is False
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is False
 
 
 def test_worker_nao_age_quando_ultima_mensagem_recente_do_cliente(

--- a/backend/tests/test_whatsapp_inatividade_encerramento.py
+++ b/backend/tests/test_whatsapp_inatividade_encerramento.py
@@ -22,13 +22,13 @@ def _configurar_evolution(db_session):
     db_session.commit()
 
 
-def _chat_em_atendimento(db_session, *, wa_id: str = "5511999887766") -> WhatsappChat:
+def _chat_em_atendimento(db_session, *, wa_id: str = "5511999887766", atendente_id: int = 1) -> WhatsappChat:
     chat = WhatsappChat(
         protocolo="WPP-TEST-1",
         wa_id=wa_id,
         cliente_nome="Cliente Teste",
         estado="em_atendimento",
-        atendente_id=1,
+        atendente_id=atendente_id,
     )
     db_session.add(chat)
     db_session.flush()
@@ -124,6 +124,59 @@ def test_worker_encerra_apos_aviso(client, seed_base, auth_headers, db_session, 
     assert n == 1
     assert chat.estado == "encerrado"
     assert chat.encerramento_at is not None
+    marco = (
+        db_session.query(WhatsappMensagem)
+        .filter(
+            WhatsappMensagem.chat_id == chat.id,
+            WhatsappMensagem.evento_sistema == "auto_encerrado_inatividade",
+        )
+        .first()
+    )
+    assert marco is not None
+
+
+def test_pode_registrar_demanda_apos_encerramento_inatividade(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    chat = _chat_em_atendimento(db_session, wa_id="5511999112233", atendente_id=a1_id)
+    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=antiga_aviso,
+        )
+    )
+    nat = TicketNatureza(nome="Nat Inativ", slug="nat-inativ-test", ordem=1, ativo=True)
+    db_session.add(nat)
+    db_session.flush()
+    mot = TicketMotivo(natureza_id=nat.id, nome="Mot Inativ", slug="mot-inativ-test", ordem=1, ativo=True)
+    db_session.add(mot)
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-dem"),
+    )
+    process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+    assert chat.estado == "encerrado"
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{chat.id}/demandas",
+        json={"natureza_id": nat.id, "motivo_id": mot.id, "descricao_curta": "Pós-inatividade"},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["descricao_curta"] == "Pós-inatividade"
 
 
 def test_worker_nao_age_quando_ultima_mensagem_recente_do_cliente(

--- a/backend/tests/test_whatsapp_inatividade_encerramento.py
+++ b/backend/tests/test_whatsapp_inatividade_encerramento.py
@@ -220,6 +220,78 @@ def test_concluir_classificacao_sem_demanda(client, seed_base, auth_headers, db_
     assert chat.classificacao_demanda_pendente is False
 
 
+def test_inbound_abre_chat_novo_quando_pendente_classificacao(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    """Cliente manda mensagem nova: chat a classificar permanece; abre atendimento novo."""
+    from tests.test_whatsapp_chats import _webhook_body
+
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    wa = "5511888001122"
+    chat = _chat_em_atendimento(db_session, wa_id=wa, atendente_id=a1_id)
+    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=antiga_aviso,
+        )
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-new"),
+    )
+    # Também mock envio de auto_espera no webhook (ids únicos — uq wa_message_id)
+    _wa_seq = {"n": 0}
+
+    def _fake_send(*_a, **_k):
+        _wa_seq["n"] += 1
+        return True, None, f"wa-espera-{_wa_seq['n']}"
+
+    monkeypatch.setattr(
+        "app.api.whatsapp_webhook.evolution_api.evolution_send_text",
+        _fake_send,
+    )
+    process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is True
+    pendente_id = chat.id
+    # Libera a conexão StaticPool antes do TestClient (outra Session no mesmo SQLite).
+    db_session.close()
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "sec-pendente-novo"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "sec-pendente-novo"}
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id=wa, msg_id="msg-nova-pos-inativ", text="Oi de novo"),
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("processados", 0) >= 1, body
+
+    fila = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()
+    novos = [c for c in fila if c["wa_id"] == wa and c["id"] != pendente_id]
+    assert len(novos) == 1, fila
+    assert novos[0]["estado"] == "aguardando_atendente"
+    assert novos[0].get("classificacao_demanda_pendente") is False
+
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    pendentes = [c for c in meus if c["id"] == pendente_id]
+    assert len(pendentes) == 1, meus
+    assert pendentes[0].get("classificacao_demanda_pendente") is True
+
+
 def test_worker_nao_age_quando_ultima_mensagem_recente_do_cliente(
     client, seed_base, auth_headers, db_session, monkeypatch
 ):
@@ -444,3 +516,98 @@ def test_worker_nao_reenvia_aviso_duplicado_no_mesmo_ciclo(
         .count()
     )
     assert total_avisos == 1
+
+
+def test_envio_mensagem_sai_da_pausa_inatividade(client, seed_base, auth_headers, db_session, monkeypatch):
+    """Outbound humana do atendente limpa a pausa manual (reinicia o ciclo pelo timestamp da msg)."""
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    chat = _chat_em_atendimento(db_session, wa_id="5511999554422", atendente_id=a1_id)
+    chat.inatividade_pausada = True
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Analisando",
+            tipo_midia="texto",
+            atendente_id=a1_id,
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-despausa"),
+    )
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{chat.id}/mensagens",
+        json={"texto": "Já resolvi"},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 201, r.text
+    db_session.refresh(chat)
+    assert chat.inatividade_pausada is False
+    assert chat.inatividade_retomada_em is None
+
+
+def test_concluir_classificacao_com_demandas_existentes(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    """Confirmar «manter demandas» pós-inatividade limpa o pendente (não fica preso na lista)."""
+    from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+    from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
+
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    chat = _chat_em_atendimento(db_session, wa_id="5511999554433", atendente_id=a1_id)
+    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=antiga_aviso,
+        )
+    )
+    nat = TicketNatureza(nome="Nat Manter", slug="nat-manter-inativ", ordem=1, ativo=True)
+    db_session.add(nat)
+    db_session.flush()
+    mot = TicketMotivo(natureza_id=nat.id, nome="Mot Manter", slug="mot-manter-inativ", ordem=1, ativo=True)
+    db_session.add(mot)
+    db_session.flush()
+    db_session.add(
+        WhatsappChatDemanda(
+            chat_id=chat.id,
+            atendente_id=a1_id,
+            natureza_id=nat.id,
+            motivo_id=mot.id,
+            descricao_curta="Já registada na sessão",
+            desfecho="resolvido_sessao",
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-manter"),
+    )
+    process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is True
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{chat.id}/classificacao-demanda/concluir",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["classificacao_demanda_pendente"] is False
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is False
+
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    assert not any(c["id"] == chat.id for c in meus)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -899,8 +899,9 @@ export namespace WhatsappChats {
     funcionario_tipo?: string | null
     empresa_id?: number | null
     empresa_nome?: string | null
-    inatividade_pausada?: boolean
-    inatividade_retomada_em?: string | null
+  inatividade_pausada?: boolean
+  inatividade_retomada_em?: string | null
+  classificacao_demanda_pendente?: boolean
   }
   export interface EmpresaOpcao {
     id: number
@@ -1182,6 +1183,8 @@ export const whatsappChats = {
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/inatividade/pausar`, { method: 'POST' }),
   retomarInatividade: (id: number) =>
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/inatividade/retomar`, { method: 'POST' }),
+  concluirClassificacaoDemanda: (id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/classificacao-demanda/concluir`, { method: 'POST' }),
   vincularTicket: (id: number, ticketId: number) =>
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/vincular-ticket`, {
       method: 'POST',

--- a/frontend/src/lib/whatsappDemandaUtils.ts
+++ b/frontend/src/lib/whatsappDemandaUtils.ts
@@ -29,7 +29,7 @@ export function mensagensVisiveisConversa<TMsg extends ChatMensagemTimeline>(msg
   )
 }
 
-/** Aviso ou encerramento automático por inatividade do cliente — demanda no modal é opcional. */
+/** Aviso ou encerramento automático por inatividade do cliente. */
 export function chatEncerramentoPorInatividade(msgs: ChatMensagemTimeline[]): boolean {
   return msgs.some(
     (m) =>

--- a/frontend/src/lib/whatsappDemandaUtils.ts
+++ b/frontend/src/lib/whatsappDemandaUtils.ts
@@ -37,6 +37,24 @@ export function chatEncerramentoPorInatividade(msgs: ChatMensagemTimeline[]): bo
   )
 }
 
+const INATIV_DEMANDA_OK_PREFIX = 'dx.whatsapp.inativDemandaOk.'
+
+export function inatividadeDemandaJaClassificada(chatId: number): boolean {
+  try {
+    return localStorage.getItem(`${INATIV_DEMANDA_OK_PREFIX}${chatId}`) === '1'
+  } catch {
+    return false
+  }
+}
+
+export function marcarInatividadeDemandaClassificada(chatId: number): void {
+  try {
+    localStorage.setItem(`${INATIV_DEMANDA_OK_PREFIX}${chatId}`, '1')
+  } catch {
+    /* ignore quota / private mode */
+  }
+}
+
 export function analisarDemandaPosRegistro(
   demandas: ChatDemanda[],
   msgs: ChatMensagemTimeline[],

--- a/frontend/src/lib/whatsappDemandaUtils.ts
+++ b/frontend/src/lib/whatsappDemandaUtils.ts
@@ -37,24 +37,6 @@ export function chatEncerramentoPorInatividade(msgs: ChatMensagemTimeline[]): bo
   )
 }
 
-const INATIV_DEMANDA_OK_PREFIX = 'dx.whatsapp.inativDemandaOk.'
-
-export function inatividadeDemandaJaClassificada(chatId: number): boolean {
-  try {
-    return localStorage.getItem(`${INATIV_DEMANDA_OK_PREFIX}${chatId}`) === '1'
-  } catch {
-    return false
-  }
-}
-
-export function marcarInatividadeDemandaClassificada(chatId: number): void {
-  try {
-    localStorage.setItem(`${INATIV_DEMANDA_OK_PREFIX}${chatId}`, '1')
-  } catch {
-    /* ignore quota / private mode */
-  }
-}
-
 export function analisarDemandaPosRegistro(
   demandas: ChatDemanda[],
   msgs: ChatMensagemTimeline[],

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -507,7 +507,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
                 Encerra chats em atendimento após silêncio. O tempo conta desde a última mensagem (cliente ou
                 atendente). No chat, o responsável pode Pausar o timer durante análises longas — ao pausar/retomar o
-                prazo volta ao valor configurado.
+                prazo volta ao valor configurado. Enviar mensagem (ou o cliente falar) sai automaticamente da pausa.
               </p>
             </div>
 
@@ -515,7 +515,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               checked={inativEncerramentoAtiva}
               onCheckedChange={setInativEncerramentoAtiva}
               label="Encerramento automático por inatividade do cliente"
-              description="Qualquer mensagem (cliente ou atendente) reinicia o timer. Use Pausar no chat se precisar de mais tempo."
+              description="Qualquer mensagem (cliente ou atendente) reinicia o timer e sai da pausa. Use Pausar no chat se precisar de mais tempo em silêncio."
               showStatusPill
               statusOnText="Ativo"
               statusOffText="Inativo"

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -11,7 +11,6 @@ import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { rotuloResponsavelChat } from '../../lib/whatsappChatMeta'
 
-// Componente para cálculo de tempo de espera
 function TempoEspera({ data }: { data?: string | null }) {
   const [minutos, setMinutos] = useState(0)
 
@@ -27,9 +26,13 @@ function TempoEspera({ data }: { data?: string | null }) {
   }, [data])
 
   return (
-    <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
-      minutos > 10 ? 'bg-red-100 text-red-600 animate-pulse' : 'bg-slate-100 text-slate-500 dark:bg-slate-800'
-    }`}>
+    <span
+      className={`rounded-full px-2 py-0.5 text-[10px] font-bold ${
+        minutos > 10
+          ? 'animate-pulse bg-red-100 text-red-600'
+          : 'bg-slate-100 text-slate-500 dark:bg-slate-800'
+      }`}
+    >
       {minutos === 0 ? 'Agora' : `${minutos} min`}
     </span>
   )
@@ -44,22 +47,22 @@ export function WhatsappAtendendo() {
   const isFirstLoad = useRef(true)
   const prevFilaCount = useRef(0)
 
-  const load = useCallback(async (silent = false) => {
-    if (!silent) setLoading(true)
-    try {
-      const [rowsFila, rowsMeus] = await Promise.all([
-        whatsappChats.fila(), 
-        whatsappChats.meus()
-      ])
-      setFila(rowsFila)
-      setMeus(rowsMeus)
-    } catch (err) {
-      if (!silent) toast.showError(mensagemFalhaParaToast(err, 'Erro ao sincronizar dados.'))
-    } finally {
-      setLoading(false)
-      isFirstLoad.current = false
-    }
-  }, [toast])
+  const load = useCallback(
+    async (silent = false) => {
+      if (!silent) setLoading(true)
+      try {
+        const [rowsFila, rowsMeus] = await Promise.all([whatsappChats.fila(), whatsappChats.meus()])
+        setFila(rowsFila)
+        setMeus(rowsMeus)
+      } catch (err) {
+        if (!silent) toast.showError(mensagemFalhaParaToast(err, 'Erro ao sincronizar dados.'))
+      } finally {
+        setLoading(false)
+        isFirstLoad.current = false
+      }
+    },
+    [toast],
+  )
 
   useEffect(() => {
     const refresh = () => void load(true)
@@ -71,7 +74,6 @@ export function WhatsappAtendendo() {
     }
   }, [subscribe, load])
 
-  // Refresh inicial + polling de segurança (#442)
   useEffect(() => {
     void load()
     const intervalMs = useFallback ? 10000 : 8000
@@ -95,21 +97,29 @@ export function WhatsappAtendendo() {
       await load(true)
       void refetchPendenciasResumo()
     } catch (err) {
-      const msg = err instanceof ApiError && err.status === 400
+      const msg =
+        err instanceof ApiError && err.status === 400
           ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'
           : mensagemFalhaParaToast(err)
       toast.showWarning(msg)
     }
   }
 
+  const meusAtivos = meus.filter((c) => c.estado === 'em_atendimento')
+  const meusAClassificar = meus.filter(
+    (c) => c.classificacao_demanda_pendente && c.estado !== 'em_atendimento',
+  )
+
   if (loading && isFirstLoad.current) {
-    return <div className="flex h-64 items-center justify-center text-sm font-medium text-slate-400 animate-pulse">Carregando central de atendimento...</div>
+    return (
+      <div className="flex h-64 items-center justify-center text-sm font-medium text-slate-400 animate-pulse">
+        Carregando central de atendimento...
+      </div>
+    )
   }
 
   return (
     <div className="flex flex-col space-y-8 animate-in fade-in duration-500">
-      
-      {/* Header */}
       <header className="flex flex-wrap items-end justify-between gap-4 border-b pb-6 dark:border-slate-800">
         <div>
           <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Fila de Atendimento</h1>
@@ -118,26 +128,34 @@ export function WhatsappAtendendo() {
         <div className="flex gap-6">
           <div className="text-right">
             <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Na Fila</p>
-            <p className={`text-xl font-mono font-bold ${fila.length > 0 ? 'text-amber-500' : 'text-slate-300'}`}>{fila.length}</p>
+            <p
+              className={`text-xl font-mono font-bold ${fila.length > 0 ? 'text-amber-500' : 'text-slate-300'}`}
+            >
+              {fila.length}
+            </p>
           </div>
           <div className="text-right">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Meus Chats</p>
-            <p className="text-xl font-mono font-bold text-cyan-600">{meus.length}</p>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Comigo</p>
+            <p className="text-xl font-mono font-bold text-cyan-600">{meusAtivos.length}</p>
           </div>
+          {meusAClassificar.length > 0 && (
+            <div className="text-right">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">A classificar</p>
+              <p className="text-xl font-mono font-bold text-amber-600">{meusAClassificar.length}</p>
+            </div>
+          )}
         </div>
       </header>
 
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
-        
-        {/* Coluna da Fila */}
-        <section className="lg:col-span-5 space-y-4">
+        <section className="space-y-4 lg:col-span-5">
           <h2 className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-slate-500">
             Aguardando ({fila.length})
           </h2>
 
           <div className="space-y-3">
             {fila.length === 0 ? (
-              <Card className="border-dashed border-2 bg-transparent p-8 text-center">
+              <Card className="border-2 border-dashed bg-transparent p-8 text-center">
                 <p className="text-sm text-slate-400">Fila vazia. Bom trabalho!</p>
               </Card>
             ) : (
@@ -146,7 +164,7 @@ export function WhatsappAtendendo() {
                   <div className="flex flex-col gap-4">
                     <div className="flex items-start justify-between">
                       <div className="min-w-0">
-                        <div className="flex items-center gap-2 mb-1">
+                        <div className="mb-1 flex items-center gap-2">
                           <span
                             className="min-w-0 truncate font-mono text-[10px] font-bold text-cyan-600"
                             title={exibirProtocolo(c.protocolo)}
@@ -160,7 +178,9 @@ export function WhatsappAtendendo() {
                             </span>
                           )}
                         </div>
-                        <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</h3>
+                        <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">
+                          {c.cliente_nome || 'Cliente'}
+                        </h3>
                         <p className="font-mono text-xs text-slate-500">{c.wa_id}</p>
                         {c.setor_nome && (
                           <p className="mt-1 text-[10px] font-medium text-slate-500 dark:text-slate-400">
@@ -171,17 +191,16 @@ export function WhatsappAtendendo() {
                       <div className="h-2 w-2 rounded-full bg-amber-400 shadow-[0_0_8px_rgba(251,191,36,0.5)]" />
                     </div>
 
-                    {/* Grupo de Botões da Fila */}
                     <div className="flex items-center gap-2 border-t pt-3 dark:border-slate-800">
-                      <Link 
+                      <Link
                         to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
-                        className="flex-1 text-center rounded-lg bg-slate-100 py-2 text-xs font-bold text-slate-600 hover:bg-slate-200 transition-colors dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+                        className="flex-1 rounded-lg bg-slate-100 py-2 text-center text-xs font-bold text-slate-600 transition-colors hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
                       >
                         Visualizar
                       </Link>
-                      <Button 
+                      <Button
                         onClick={() => void assumir(c.id)}
-                        className="flex-1 bg-amber-500 hover:bg-amber-600 text-white"
+                        className="flex-1 bg-amber-500 text-white hover:bg-amber-600"
                       >
                         Atender
                       </Button>
@@ -193,60 +212,109 @@ export function WhatsappAtendendo() {
           </div>
         </section>
 
-        {/* Coluna de Ativos */}
-        <section className="lg:col-span-7 space-y-4">
-          <h2 className="text-xs font-bold uppercase tracking-widest text-slate-500">
-            Em atendimento comigo ({meus.length})
-          </h2>
-
-          <div className="grid gap-4 md:grid-cols-2">
-            {meus.length === 0 ? (
-              <div className="md:col-span-2 rounded-xl border-2 border-dashed p-12 text-center">
-                <p className="text-sm text-slate-400 italic">Você não tem atendimentos em curso.</p>
-              </div>
-            ) : (
-              meus.map((c) => (
-                <Link key={c.id} to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')} className="group">
-                  <Card className="h-full border-none p-5 shadow-sm ring-1 ring-slate-200 transition-all group-hover:ring-cyan-500 dark:ring-slate-800">
-                    <div className="flex flex-col h-full justify-between gap-4">
-                      <div>
-                        <div className="flex justify-between items-start mb-2">
-                          <span
-                            className="min-w-0 truncate text-[10px] font-bold text-cyan-600"
-                            title={exibirProtocolo(c.protocolo)}
-                          >
-                            {exibirProtocolo(c.protocolo)}
-                          </span>
-                          <span className="relative flex h-2 w-2">
-                            <span className="absolute h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75"></span>
-                            <span className="relative h-2 w-2 rounded-full bg-emerald-500"></span>
+        <section className="space-y-8 lg:col-span-7">
+          {meusAClassificar.length > 0 && (
+            <div className="space-y-4">
+              <h2 className="text-xs font-bold uppercase tracking-widest text-amber-700 dark:text-amber-400">
+                A classificar demanda ({meusAClassificar.length})
+              </h2>
+              <div className="grid gap-4 md:grid-cols-2">
+                {meusAClassificar.map((c) => (
+                  <Link
+                    key={c.id}
+                    to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
+                    className="group"
+                  >
+                    <Card className="h-full border-none p-5 shadow-sm ring-1 ring-amber-300 transition-all group-hover:ring-amber-500 dark:ring-amber-800">
+                      <div className="flex h-full flex-col justify-between gap-4">
+                        <div>
+                          <div className="mb-2 flex items-start justify-between gap-2">
+                            <span
+                              className="min-w-0 truncate text-[10px] font-bold text-amber-700 dark:text-amber-400"
+                              title={exibirProtocolo(c.protocolo)}
+                            >
+                              {exibirProtocolo(c.protocolo)}
+                            </span>
+                            <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[9px] font-bold uppercase text-amber-800 dark:bg-amber-950/50 dark:text-amber-200">
+                              Pendente
+                            </span>
+                          </div>
+                          <h3 className="font-bold text-slate-900 transition-colors group-hover:text-amber-700 dark:text-slate-100">
+                            {c.cliente_nome || 'Cliente'}
+                          </h3>
+                          <p className="mt-1 font-mono text-xs text-slate-400">{c.wa_id}</p>
+                          <p className="mt-2 text-[10px] font-medium text-amber-800/80 dark:text-amber-200/80">
+                            Encerrado por inatividade — falta registar a demanda
+                          </p>
+                        </div>
+                        <div className="flex items-center justify-end border-t pt-3 dark:border-slate-800">
+                          <span className="text-xs font-bold text-amber-700 dark:text-amber-400">
+                            Classificar →
                           </span>
                         </div>
-                        <h3 className="font-bold text-slate-900 dark:text-slate-100 group-hover:text-cyan-600 transition-colors">
-                          {c.cliente_nome || 'Cliente'}
-                        </h3>
-                        {!c.funcionario_rede_id && (
-                          <span className="mt-1 inline-flex rounded-full bg-violet-100 px-2 py-0.5 text-[9px] font-medium text-violet-700 dark:bg-violet-950/50 dark:text-violet-300">
-                            Sem vínculo
-                          </span>
-                        )}
-                        <p className="text-xs text-slate-400 font-mono mt-1">{c.wa_id}</p>
-                        <p className="mt-2 text-[10px] font-medium text-slate-500 dark:text-slate-400">
-                          {rotuloResponsavelChat(c)}
-                          {c.setor_nome ? ` • ${c.setor_nome}` : ''}
-                        </p>
                       </div>
-                      
-                      <div className="flex items-center justify-end border-t pt-3 dark:border-slate-800">
-                         <span className="text-xs font-bold text-cyan-600">
-                           Continuar →
-                         </span>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-4">
+            <h2 className="text-xs font-bold uppercase tracking-widest text-slate-500">
+              Em atendimento comigo ({meusAtivos.length})
+            </h2>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              {meusAtivos.length === 0 ? (
+                <div className="rounded-xl border-2 border-dashed p-12 text-center md:col-span-2">
+                  <p className="text-sm italic text-slate-400">Você não tem atendimentos em curso.</p>
+                </div>
+              ) : (
+                meusAtivos.map((c) => (
+                  <Link
+                    key={c.id}
+                    to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
+                    className="group"
+                  >
+                    <Card className="h-full border-none p-5 shadow-sm ring-1 ring-slate-200 transition-all group-hover:ring-cyan-500 dark:ring-slate-800">
+                      <div className="flex h-full flex-col justify-between gap-4">
+                        <div>
+                          <div className="mb-2 flex items-start justify-between">
+                            <span
+                              className="min-w-0 truncate text-[10px] font-bold text-cyan-600"
+                              title={exibirProtocolo(c.protocolo)}
+                            >
+                              {exibirProtocolo(c.protocolo)}
+                            </span>
+                            <span className="relative flex h-2 w-2">
+                              <span className="absolute h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+                              <span className="relative h-2 w-2 rounded-full bg-emerald-500" />
+                            </span>
+                          </div>
+                          <h3 className="font-bold text-slate-900 transition-colors group-hover:text-cyan-600 dark:text-slate-100">
+                            {c.cliente_nome || 'Cliente'}
+                          </h3>
+                          {!c.funcionario_rede_id && (
+                            <span className="mt-1 inline-flex rounded-full bg-violet-100 px-2 py-0.5 text-[9px] font-medium text-violet-700 dark:bg-violet-950/50 dark:text-violet-300">
+                              Sem vínculo
+                            </span>
+                          )}
+                          <p className="mt-1 font-mono text-xs text-slate-400">{c.wa_id}</p>
+                          <p className="mt-2 text-[10px] font-medium text-slate-500 dark:text-slate-400">
+                            {rotuloResponsavelChat(c)}
+                            {c.setor_nome ? ` • ${c.setor_nome}` : ''}
+                          </p>
+                        </div>
+                        <div className="flex items-center justify-end border-t pt-3 dark:border-slate-800">
+                          <span className="text-xs font-bold text-cyan-600">Continuar →</span>
+                        </div>
                       </div>
-                    </div>
-                  </Card>
-                </Link>
-              ))
-            )}
+                    </Card>
+                  </Link>
+                ))
+              )}
+            </div>
           </div>
         </section>
       </div>

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -24,6 +24,8 @@ type Props = {
   onInserirReferenciaKb?: (ref: string) => void
   /** Incrementar para focar o textarea (ex.: após Responder). */
   focoPedidoEm?: number
+  /** Placeholder customizado (ex.: pós-inatividade a classificar). */
+  placeholder?: string
 }
 
 type MenuAnexo = { tipo: TipoAnexoPicker; label: string }
@@ -52,6 +54,7 @@ export function WhatsappComposerBar({
   podeDigitar,
   onInserirReferenciaKb,
   focoPedidoEm,
+  placeholder,
 }: Props) {
   const [menuAberto, setMenuAberto] = useState(false)
   const [painelEmojiAberto, setPainelEmojiAberto] = useState(false)
@@ -189,13 +192,14 @@ export function WhatsappComposerBar({
           value={texto}
           onChange={(e) => onTextoChange(e.target.value)}
           placeholder={
-            encerrado
+            placeholder ??
+            (encerrado
               ? 'Apenas leitura…'
               : modoInterno
                 ? 'Comentário interno…'
                 : podeEnviar
                   ? 'Escreva uma mensagem…'
-                  : 'Somente comentários internos…'
+                  : 'Somente comentários internos…')
           }
           rows={1}
           disabled={campoBloqueado}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -247,10 +247,6 @@ export function WhatsappConversa() {
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const carregarGenRef = useRef(0)
-  const chatRef = useRef(chat)
-  const userIdRef = useRef(user?.id)
-  chatRef.current = chat
-  userIdRef.current = user?.id
 
   const [pickerAnexo, setPickerAnexo] = useState<TipoAnexoPicker>('imagem')
   const [arquivoPendente, setArquivoPendente] = useState<File | null>(null)
@@ -265,6 +261,11 @@ export function WhatsappConversa() {
   const [msgs, setMsgs] = useState<WhatsappChats.Mensagem[]>([])
 
   const [meusChats, setMeusChats] = useState<WhatsappChats.Chat[]>([])
+
+  const chatRef = useRef(chat)
+  const userIdRef = useRef(user?.id)
+  chatRef.current = chat
+  userIdRef.current = user?.id
 
  
 

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -24,8 +24,6 @@ import {
 import { resolveWhatsappMidiaObjectUrl, revokeWhatsappMidiaForChat } from '../../lib/whatsappMidiaCache'
 import {
   chatEncerramentoPorInatividade,
-  inatividadeDemandaJaClassificada,
-  marcarInatividadeDemandaClassificada,
 } from '../../lib/whatsappDemandaUtils'
 import { mergeWhatsappChat, patchWhatsappChatLista, replaceWhatsappChatLista } from '../../lib/whatsappChatMerge'
 import { whatsappMensagensUnicas } from '../../lib/whatsappMensagens'
@@ -346,7 +344,6 @@ export function WhatsappConversa() {
 
   const viuEmAtendimentoRef = useRef(false)
   const inatividadeToastFeitoRef = useRef(false)
-  const [inativDemandaOkLocal, setInativDemandaOkLocal] = useState(false)
 
   useEffect(() => {
     if (chat?.estado === 'em_atendimento') {
@@ -355,16 +352,12 @@ export function WhatsappConversa() {
   }, [chat?.estado])
 
   useEffect(() => {
-    if (!id) return
-    setInativDemandaOkLocal(inatividadeDemandaJaClassificada(Number(id)))
-  }, [id])
-
-  useEffect(() => {
     if (!chat || inatividadeToastFeitoRef.current) return
     if (!viuEmAtendimentoRef.current) return
 
     const fechado = chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao'
     if (!fechado || !chatEncerramentoPorInatividade(msgs)) return
+    if (!chat.classificacao_demanda_pendente) return
 
     const podeClassificar =
       chat.atendente_id === user?.id || user?.role === 'admin'
@@ -850,10 +843,6 @@ useEffect(() => {
 
   async function handleEncerrado(atualizado: WhatsappChats.Chat) {
     setChat(atualizado)
-    if (atualizado.classificacao_demanda_pendente === false) {
-      setInativDemandaOkLocal(true)
-      marcarInatividadeDemandaClassificada(atualizado.id)
-    }
     await Promise.all([carregar(), carregarSidebar()])
     refrescarTimelineDemandas()
     toast.showSuccess(
@@ -880,14 +869,29 @@ useEffect(() => {
 
   const podeTransferir = !encerrado && (isResponsavel || isAdmin)
 
-  const podeEnviar = chat?.estado === 'em_atendimento' && isResponsavel && !encerrado
+  const podeEnviar =
+    chat?.estado === 'em_atendimento' &&
+    isResponsavel &&
+    !encerrado &&
+    !chat?.classificacao_demanda_pendente
 
   const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && (isResponsavel || isAdmin)
 
   const mostrarBannerDemandaInatividade =
     Boolean(chat?.classificacao_demanda_pendente) && (isResponsavel || isAdmin)
 
-  const podeDigitarMensagem = !encerrado && (modoInterno || podeEnviar)
+  const podeDigitarMensagem = !encerrado && !chat?.classificacao_demanda_pendente && (modoInterno || podeEnviar)
+
+  const composerPlaceholder =
+    encerrado || chat?.classificacao_demanda_pendente
+      ? chat?.classificacao_demanda_pendente
+        ? 'Chat aguarda classificação de demanda (somente leitura)'
+        : 'Chat encerrado'
+      : !podeEnviar && chat?.estado === 'em_atendimento'
+        ? 'Apenas o responsável pode enviar ao cliente — use comentário interno'
+        : modoInterno
+          ? 'Comentário interno (não enviado ao cliente)…'
+          : 'Digite uma mensagem…'
 
   const motivoAnexoDesabilitado =
     encerrado

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1488,6 +1488,7 @@ useEffect(() => {
               }}
               onInserirReferenciaKb={inserirReferenciaKb}
               focoPedidoEm={focoComposerEm}
+              placeholder={composerPlaceholder}
             />
           ) : null}
           <input

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -22,7 +22,11 @@ import {
 } from '../../api/client'
 
 import { resolveWhatsappMidiaObjectUrl, revokeWhatsappMidiaForChat } from '../../lib/whatsappMidiaCache'
-import { chatEncerramentoPorInatividade } from '../../lib/whatsappDemandaUtils'
+import {
+  chatEncerramentoPorInatividade,
+  inatividadeDemandaJaClassificada,
+  marcarInatividadeDemandaClassificada,
+} from '../../lib/whatsappDemandaUtils'
 import { mergeWhatsappChat, patchWhatsappChatLista, replaceWhatsappChatLista } from '../../lib/whatsappChatMerge'
 import { whatsappMensagensUnicas } from '../../lib/whatsappMensagens'
 import {
@@ -341,7 +345,8 @@ export function WhatsappConversa() {
   }, [voltarLista, modalEncerrar, activeZoomImage, arquivoPendente])
 
   const viuEmAtendimentoRef = useRef(false)
-  const inatividadeDemandaPromptedRef = useRef(false)
+  const inatividadeToastFeitoRef = useRef(false)
+  const [inativDemandaOkLocal, setInativDemandaOkLocal] = useState(false)
 
   useEffect(() => {
     if (chat?.estado === 'em_atendimento') {
@@ -350,7 +355,12 @@ export function WhatsappConversa() {
   }, [chat?.estado])
 
   useEffect(() => {
-    if (!chat || inatividadeDemandaPromptedRef.current) return
+    if (!id) return
+    setInativDemandaOkLocal(inatividadeDemandaJaClassificada(Number(id)))
+  }, [id])
+
+  useEffect(() => {
+    if (!chat || inatividadeToastFeitoRef.current) return
     if (!viuEmAtendimentoRef.current) return
 
     const fechado = chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao'
@@ -360,9 +370,10 @@ export function WhatsappConversa() {
       chat.atendente_id === user?.id || user?.role === 'admin'
     if (!podeClassificar) return
 
-    inatividadeDemandaPromptedRef.current = true
-    setModalEncerrar(true)
-    toast.showSuccess('Atendimento encerrado automaticamente por inatividade. Registe a demanda da sessão.')
+    inatividadeToastFeitoRef.current = true
+    toast.showSuccess(
+      'Atendimento encerrado por inatividade. Pode reler a conversa e registar a demanda no aviso abaixo.',
+    )
   }, [chat, msgs, user?.id, user?.role, toast])
 
   const refrescarTimelineDemandas = useCallback(() => {
@@ -512,7 +523,7 @@ export function WhatsappConversa() {
 
     setLoading(true)
     viuEmAtendimentoRef.current = false
-    inatividadeDemandaPromptedRef.current = false
+    inatividadeToastFeitoRef.current = false
 
     carregar().then(() => whatsappChats.marcarVisto(id)).finally(() => setLoading(false))
 
@@ -835,12 +846,18 @@ useEffect(() => {
 
   async function handleEncerrado(atualizado: WhatsappChats.Chat) {
     setChat(atualizado)
+    if (chatEncerramentoPorInatividade(msgs)) {
+      marcarInatividadeDemandaClassificada(atualizado.id)
+      setInativDemandaOkLocal(true)
+    }
     await Promise.all([carregar(), carregarSidebar()])
     refrescarTimelineDemandas()
     toast.showSuccess(
       atualizado.estado === 'aguardando_avaliacao'
         ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
-        : 'Atendimento encerrado.',
+        : chatEncerramentoPorInatividade(msgs)
+          ? 'Classificação da sessão concluída.'
+          : 'Atendimento encerrado.',
     )
   }
 
@@ -860,6 +877,14 @@ useEffect(() => {
   const podeEnviar = chat?.estado === 'em_atendimento' && isResponsavel && !encerrado
 
   const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && (isResponsavel || isAdmin)
+
+  const mostrarBannerDemandaInatividade =
+    encerrado &&
+    Boolean(chat) &&
+    chatEncerramentoPorInatividade(msgs) &&
+    (isResponsavel || isAdmin) &&
+    !inativDemandaOkLocal &&
+    demandasTimeline.length === 0
 
   const podeDigitarMensagem = !encerrado && (modoInterno || podeEnviar)
 
@@ -1143,6 +1168,22 @@ useEffect(() => {
             <p>{CONTATO_CLIENTE.bannerNaoVinculado}</p>
             <Button variant="primary" className="h-8 shrink-0 text-xs" onClick={() => setModalVincFuncionario(true)}>
               {CONTATO_CLIENTE.vincularEmpresa}
+            </Button>
+          </div>
+        )}
+
+        {mostrarBannerDemandaInatividade && (
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100">
+            <p>
+              Atendimento encerrado por inatividade. Reler a conversa se precisar e{' '}
+              <strong>registar a demanda</strong> desta sessão.
+            </p>
+            <Button
+              variant="primary"
+              className="h-8 shrink-0 text-xs"
+              onClick={() => setModalEncerrar(true)}
+            >
+              Registar demanda
             </Button>
           </div>
         )}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -247,6 +247,10 @@ export function WhatsappConversa() {
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const carregarGenRef = useRef(0)
+  const chatRef = useRef(chat)
+  const userIdRef = useRef(user?.id)
+  chatRef.current = chat
+  userIdRef.current = user?.id
 
   const [pickerAnexo, setPickerAnexo] = useState<TipoAnexoPicker>('imagem')
   const [arquivoPendente, setArquivoPendente] = useState<File | null>(null)
@@ -535,6 +539,16 @@ export function WhatsappConversa() {
         }
         return [...prev, msg]
       })
+      // ✓✓ azul no WhatsApp do cliente: marcar leitura em inbound novo enquanto o responsável está no chat
+      const c = chatRef.current
+      if (
+        msg.direcao === 'inbound' &&
+        c?.estado === 'em_atendimento' &&
+        c.atendente_id != null &&
+        c.atendente_id === userIdRef.current
+      ) {
+        void whatsappChats.marcarVisto(chatId)
+      }
     })
     const unsubFila = subscribe('chat.fila', (payload) => {
       const payloadChatId = Number(payload.chat_id)

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -592,7 +592,11 @@ export function WhatsappConversa() {
           void carregar().catch(() => {})
         }
       }
-      if (chatData && chatData.estado !== 'em_atendimento') {
+      if (
+        chatData &&
+        chatData.estado !== 'em_atendimento' &&
+        !chatData.classificacao_demanda_pendente
+      ) {
         setMeusChats((prev) => prev.filter((c) => c.id !== payloadChatId))
       } else if (!chatData || payloadChatId !== chatId) {
         void carregarSidebar()
@@ -846,18 +850,20 @@ useEffect(() => {
 
   async function handleEncerrado(atualizado: WhatsappChats.Chat) {
     setChat(atualizado)
-    if (chatEncerramentoPorInatividade(msgs)) {
-      marcarInatividadeDemandaClassificada(atualizado.id)
+    if (atualizado.classificacao_demanda_pendente === false) {
       setInativDemandaOkLocal(true)
+      marcarInatividadeDemandaClassificada(atualizado.id)
     }
     await Promise.all([carregar(), carregarSidebar()])
     refrescarTimelineDemandas()
     toast.showSuccess(
-      atualizado.estado === 'aguardando_avaliacao'
+      atualizado.estado === 'aguardando_avaliacao' && atualizado.classificacao_demanda_pendente
         ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
-        : chatEncerramentoPorInatividade(msgs)
+        : atualizado.classificacao_demanda_pendente === false && chatEncerramentoPorInatividade(msgs)
           ? 'Classificação da sessão concluída.'
-          : 'Atendimento encerrado.',
+          : atualizado.estado === 'aguardando_avaliacao'
+            ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
+            : 'Atendimento encerrado.',
     )
   }
 
@@ -879,12 +885,7 @@ useEffect(() => {
   const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && (isResponsavel || isAdmin)
 
   const mostrarBannerDemandaInatividade =
-    encerrado &&
-    Boolean(chat) &&
-    chatEncerramentoPorInatividade(msgs) &&
-    (isResponsavel || isAdmin) &&
-    !inativDemandaOkLocal &&
-    demandasTimeline.length === 0
+    Boolean(chat?.classificacao_demanda_pendente) && (isResponsavel || isAdmin)
 
   const podeDigitarMensagem = !encerrado && (modoInterno || podeEnviar)
 
@@ -976,6 +977,11 @@ useEffect(() => {
                     <p className="truncate text-sm font-bold text-slate-800 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</p>
 
                     {c.estado === 'aguardando_atendente' && <span className="h-2 w-2 rounded-full bg-amber-500 animate-pulse" />}
+                    {c.classificacao_demanda_pendente && (
+                      <span className="shrink-0 rounded-full bg-amber-100 px-1.5 py-0.5 text-[9px] font-medium text-amber-800 dark:bg-amber-950/50 dark:text-amber-200">
+                        Demanda
+                      </span>
+                    )}
                     {!c.funcionario_rede_id && (
                       <span className="shrink-0 rounded-full bg-violet-100 px-1.5 py-0.5 text-[9px] font-medium text-violet-700 dark:bg-violet-950/50 dark:text-violet-300">
                         Sem vínculo

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -340,14 +340,30 @@ export function WhatsappConversa() {
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [voltarLista, modalEncerrar, activeZoomImage, arquivoPendente])
 
+  const viuEmAtendimentoRef = useRef(false)
+  const inatividadeDemandaPromptedRef = useRef(false)
+
   useEffect(() => {
-    if (!modalEncerrar || !chat) return
-    const fechado = chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao'
-    if (fechado && chatEncerramentoPorInatividade(msgs)) {
-      setModalEncerrar(false)
-      toast.showSuccess('Atendimento encerrado automaticamente por inatividade do cliente.')
+    if (chat?.estado === 'em_atendimento') {
+      viuEmAtendimentoRef.current = true
     }
-  }, [modalEncerrar, chat, msgs, toast])
+  }, [chat?.estado])
+
+  useEffect(() => {
+    if (!chat || inatividadeDemandaPromptedRef.current) return
+    if (!viuEmAtendimentoRef.current) return
+
+    const fechado = chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao'
+    if (!fechado || !chatEncerramentoPorInatividade(msgs)) return
+
+    const podeClassificar =
+      chat.atendente_id === user?.id || user?.role === 'admin'
+    if (!podeClassificar) return
+
+    inatividadeDemandaPromptedRef.current = true
+    setModalEncerrar(true)
+    toast.showSuccess('Atendimento encerrado automaticamente por inatividade. Registe a demanda da sessão.')
+  }, [chat, msgs, user?.id, user?.role, toast])
 
   const refrescarTimelineDemandas = useCallback(() => {
     setDemandasReloadKey((k) => k + 1)
@@ -495,6 +511,8 @@ export function WhatsappConversa() {
     if (!id) return
 
     setLoading(true)
+    viuEmAtendimentoRef.current = false
+    inatividadeDemandaPromptedRef.current = false
 
     carregar().then(() => whatsappChats.marcarVisto(id)).finally(() => setLoading(false))
 

--- a/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
@@ -153,9 +153,6 @@ export function WhatsappEncerrarModal({
           toast.showWarning('Confirme que deseja encerrar sem registar demanda.')
           return
         }
-        if (chatJaEncerrado && encerramentoPorInatividade) {
-          await whatsappChats.concluirClassificacaoDemanda(chatId)
-        }
       } else if (acao === 'nova') {
         if (form.naturezaId === '') {
           toast.showWarning('Selecione a natureza da nova demanda.')
@@ -164,6 +161,16 @@ export function WhatsappEncerrarModal({
         await whatsappChats.registrarDemanda(chatId, demandaFormPayload(form))
       } else if (acao === 'editar' && posRegistro) {
         await whatsappChats.atualizarDemanda(chatId, posRegistro.ultimaDemanda.id, demandaFormPayload(form))
+      }
+
+      // Pós-inatividade: qualquer conclusão (manter/editar/sem demanda/registar) limpa o pendente.
+      // Idempotente se registar demanda já tiver limpo a flag.
+      if (chatJaEncerrado && encerramentoPorInatividade) {
+        const atualizado = await whatsappChats.concluirClassificacaoDemanda(chatId)
+        onDemandasChange?.()
+        onEncerrado(atualizado)
+        onClose()
+        return
       }
 
       const atualizado = await whatsappChats.encerrar(chatId)

--- a/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
@@ -34,11 +34,11 @@ type Props = {
 function definirAcaoInicial(
   rows: WhatsappChats.Demanda[],
   msgs: WhatsappChats.Mensagem[],
-  encerramentoPorInatividade: boolean,
+  _encerramentoPorInatividade: boolean,
 ): AcaoEncerramento {
   const pos = analisarDemandaPosRegistro(rows, msgs)
   if (rows.length === 0) {
-    return encerramentoPorInatividade ? 'sem_demanda' : 'registrar'
+    return 'registrar'
   }
   if (pos) return 'nova'
   return 'manter'
@@ -73,7 +73,8 @@ export function WhatsappEncerrarModal({
 
   const semDemandas = demandas.length === 0
   const demandasResolvidas = demandas.filter((d) => d.desfecho === 'resolvido_sessao')
-  const demandaOpcional = encerramentoPorInatividade && semDemandas
+  // Pós-inatividade também pede registo (como Encerrar manual); só permite skip com confirmação.
+  const demandaOpcional = false
 
   useEffect(() => {
     if (!open) {
@@ -180,10 +181,10 @@ export function WhatsappEncerrarModal({
   let mensagemIntro =
     'Revise as demandas desta sessão antes de finalizar. O cliente poderá receber pedido de avaliação conforme configuração.'
 
-  if (demandaOpcional) {
-    mensagemIntro = chatJaEncerrado
-      ? 'Este atendimento foi encerrado automaticamente por inatividade do cliente. Registar demanda é opcional.'
-      : 'O cliente está inativo (aviso automático enviado). Pode encerrar sem registar demanda ou classificar opcionalmente.'
+  if (chatJaEncerrado && encerramentoPorInatividade) {
+    mensagemIntro = semDemandas
+      ? 'Este atendimento foi encerrado automaticamente por inatividade. Registe a demanda da sessão, ou confirme explicitamente concluir sem demanda.'
+      : 'Este atendimento foi encerrado automaticamente por inatividade. Revise as demandas antes de concluir.'
   } else if (semDemandas) {
     mensagemIntro =
       'Registe o motivo do atendimento antes de encerrar, ou confirme explicitamente o encerramento sem demanda.'
@@ -250,60 +251,32 @@ export function WhatsappEncerrarModal({
 
           {semDemandas ? (
             <div className="space-y-3">
-              {demandaOpcional ? (
-                <>
-                  <p className="text-xs text-slate-500">
-                    Registar demanda é opcional neste encerramento por inatividade.
-                  </p>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <input
-                      type="radio"
-                      name="acao-encerrar"
-                      checked={acao === 'sem_demanda'}
-                      onChange={() => selecionarAcao('sem_demanda')}
-                    />
-                    {chatJaEncerrado ? 'Concluir sem registar demanda' : 'Encerrar sem registar demanda'}
-                  </label>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <input
-                      type="radio"
-                      name="acao-encerrar"
-                      checked={acao === 'registrar'}
-                      onChange={() => selecionarAcao('registrar')}
-                    />
-                    Registar demanda (opcional)
-                  </label>
-                </>
-              ) : (
-                <>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <input
-                      type="radio"
-                      name="acao-encerrar"
-                      checked={acao === 'registrar'}
-                      onChange={() => selecionarAcao('registrar')}
-                    />
-                    Registar demanda e encerrar
-                  </label>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <input
-                      type="radio"
-                      name="acao-encerrar"
-                      checked={acao === 'sem_demanda'}
-                      onChange={() => selecionarAcao('sem_demanda')}
-                    />
-                    Encerrar sem registar demanda
-                  </label>
-                  {acao === 'sem_demanda' && (
-                    <CheckboxField
-                      checked={confirmarSemDemanda}
-                      onChange={(e) => setConfirmarSemDemanda(e.target.checked)}
-                      variant="inline"
-                    >
-                      Confirmo encerrar sem classificar esta sessão
-                    </CheckboxField>
-                  )}
-                </>
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'registrar'}
+                  onChange={() => selecionarAcao('registrar')}
+                />
+                {chatJaEncerrado ? 'Registar demanda e concluir' : 'Registar demanda e encerrar'}
+              </label>
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'sem_demanda'}
+                  onChange={() => selecionarAcao('sem_demanda')}
+                />
+                {chatJaEncerrado ? 'Concluir sem registar demanda' : 'Encerrar sem registar demanda'}
+              </label>
+              {acao === 'sem_demanda' && (
+                <CheckboxField
+                  checked={confirmarSemDemanda}
+                  onChange={(e) => setConfirmarSemDemanda(e.target.checked)}
+                  variant="inline"
+                >
+                  Confirmo {chatJaEncerrado ? 'concluir' : 'encerrar'} sem classificar esta sessão
+                </CheckboxField>
               )}
             </div>
           ) : posRegistro ? (

--- a/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
@@ -153,6 +153,9 @@ export function WhatsappEncerrarModal({
           toast.showWarning('Confirme que deseja encerrar sem registar demanda.')
           return
         }
+        if (chatJaEncerrado && encerramentoPorInatividade) {
+          await whatsappChats.concluirClassificacaoDemanda(chatId)
+        }
       } else if (acao === 'nova') {
         if (form.naturezaId === '') {
           toast.showWarning('Selecione a natureza da nova demanda.')

--- a/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
@@ -22,6 +22,7 @@ function formatMmSs(totalSec: number): string {
 export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatUpdate }: Props) {
   const toast = useToast()
   const [avisoMin, setAvisoMin] = useState(15)
+  const [posAvisoMin, setPosAvisoMin] = useState(5)
   const [ativa, setAtiva] = useState(false)
   const [busy, setBusy] = useState(false)
   const [tick, setTick] = useState(0)
@@ -34,6 +35,7 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
         if (cancelled) return
         setAtiva(Boolean(r.inativ_encerramento_ativa))
         setAvisoMin(Math.max(1, Number(r.inativ_aviso_minutos ?? 15)))
+        setPosAvisoMin(Math.max(1, Number(r.inativ_encerramento_apos_aviso_minutos ?? 5)))
       })
       .catch(() => {
         /* settings indisponíveis — esconde controlo */
@@ -49,29 +51,62 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
     return () => window.clearInterval(id)
   }, [ativa, chat.estado])
 
-  const restanteSec = useMemo(() => {
+  const fase = useMemo(() => {
     void tick
     if (!ativa || chat.estado !== 'em_atendimento') return null
-    if (chat.inatividade_pausada) return avisoMin * 60
+
+    const semComentario = msgs.filter((m) => m.evento_sistema !== 'comentario_interno')
+    const lastAny = semComentario[semComentario.length - 1]
+    const posAvisoAtivo = lastAny?.evento_sistema === 'auto_inativ_aviso'
+
+    if (chat.inatividade_pausada) {
+      return {
+        restanteSec: avisoMin * 60,
+        label: 'Inatividade pausada — prazo reiniciado',
+        pausada: true as const,
+        posAviso: false as const,
+      }
+    }
+
+    if (posAvisoAtivo && lastAny?.created_at) {
+      const elapsed = (Date.now() - new Date(lastAny.created_at).getTime()) / 1000
+      return {
+        restanteSec: Math.max(0, posAvisoMin * 60 - elapsed),
+        label: 'Tempo até encerrar por inatividade (após aviso)',
+        pausada: false as const,
+        posAviso: true as const,
+      }
+    }
 
     const relevant = msgs.filter(
       (m) =>
         m.evento_sistema !== 'comentario_interno' &&
-        (m.direcao === 'inbound' ||
-          (m.direcao === 'outbound' && !m.evento_sistema)),
+        (m.direcao === 'inbound' || (m.direcao === 'outbound' && !m.evento_sistema)),
     )
     const last = relevant[relevant.length - 1]
     const candidatos: number[] = []
     if (last?.created_at) candidatos.push(new Date(last.created_at).getTime())
     if (chat.inatividade_retomada_em) candidatos.push(new Date(chat.inatividade_retomada_em).getTime())
-    if (candidatos.length === 0) return avisoMin * 60
+    if (candidatos.length === 0) {
+      return {
+        restanteSec: avisoMin * 60,
+        label: 'Tempo até o aviso de inatividade',
+        pausada: false as const,
+        posAviso: false as const,
+      }
+    }
 
     const refMs = Math.max(...candidatos)
     const elapsed = (Date.now() - refMs) / 1000
-    return Math.max(0, avisoMin * 60 - elapsed)
-  }, [ativa, chat, msgs, avisoMin, tick])
+    return {
+      restanteSec: Math.max(0, avisoMin * 60 - elapsed),
+      label: 'Tempo até o aviso de inatividade',
+      pausada: false as const,
+      posAviso: false as const,
+    }
+  }, [ativa, chat, msgs, avisoMin, posAvisoMin, tick])
 
-  if (!ativa || chat.estado !== 'em_atendimento' || !isResponsavel || restanteSec == null) {
+  if (!ativa || chat.estado !== 'em_atendimento' || !isResponsavel || fase == null) {
     return null
   }
 
@@ -93,29 +128,27 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
     <div className="flex items-center gap-1.5">
       <span
         className={`tabular-nums text-xs font-semibold ${
-          chat.inatividade_pausada
+          fase.pausada
             ? 'text-amber-600 dark:text-amber-300'
-            : restanteSec <= 60
+            : fase.posAviso || fase.restanteSec <= 60
               ? 'text-rose-600 dark:text-rose-300'
               : 'text-slate-500 dark:text-slate-400'
         }`}
-        title={
-          chat.inatividade_pausada
-            ? 'Inatividade pausada — prazo reiniciado'
-            : 'Tempo até o aviso de inatividade'
-        }
+        title={fase.label}
       >
-        {formatMmSs(restanteSec)}
+        {formatMmSs(fase.restanteSec)}
       </span>
-      <Button
-        type="button"
-        variant="ghost"
-        className="h-8 px-2 text-xs"
-        loading={busy}
-        onClick={() => void toggle()}
-      >
-        {chat.inatividade_pausada ? 'Retomar' : 'Pausar'}
-      </Button>
+      {!fase.posAviso && (
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-8 px-2 text-xs"
+          loading={busy}
+          onClick={() => void toggle()}
+        >
+          {chat.inatividade_pausada ? 'Retomar' : 'Pausar'}
+        </Button>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **#577** — Timer de inatividade conta silêncio desde a **última mensagem** (cliente ou atendente), com Pausar/Retomar e countdown.
- Pós-encerramento por inatividade: chat vai para **classificar demanda**; se o cliente voltar, abre conversa nova.
- **#575** — Ticks ✓✓ azuis só para o responsável (ack/parser Evolution).
- Correções: concluir classificação ao manter/editar; auto-unpause ao enviar mensagem; countdown após aviso de inatividade.

## Test plan
- [ ] Configurar tempos de aviso/encerramento em Config WhatsApp e validar countdown a partir da última mensagem (não só do cliente)
- [ ] Pausar inatividade e conferir que o timer congela; Retomar e countdown continua
- [ ] Enviar mensagem com timer pausado e confirmar auto-unpause
- [ ] Deixar encerrar por inatividade → chat em classificar demanda; cliente manda msg → novo chat
- [ ] Classificar demanda (manter/editar) e concluir sem erro
- [ ] Como responsável: ✓✓ azul após leitura; outro usuário não vê azul indevido
- [ ] `docker compose run --rm --no-deps backend pytest -q backend/tests/test_whatsapp_inatividade_encerramento.py`

Closes #577
Related #575