### PR TITLE
Release: main → staging

### DIFF
--- a/.github/planning-issue-bodies/issues/whatsapp-bugs-producao-epic.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-bugs-producao-epic.md
@@ -1,0 +1,17 @@
+﻿## Objetivo
+Corrigir bugs de UX do WhatsApp encontrados em testes em produção (composer, legendas, vínculo de contacto, Esc no lightbox e scroll ao reabrir chat).
+
+## Issues filhas
+- Composer com dois campos ao anexar imagem
+- Fonte da legenda diferente do texto
+- Vínculo de contacto não persiste em chats posteriores
+- Esc no lightbox sai do chat / troca conversa
+- Legenda de PDF/documento não aparece
+- Scroll ao reabrir chat não volta à última mensagem vista
+
+## Fora de escopo
+- Redesign completo do composer
+- Mudanças em chat interno (exceto se compartilharem o mesmo lightbox/scroll helper)
+
+## Origem
+QA produção — feedback do time.

--- a/.github/planning-issue-bodies/issues/whatsapp-cancelar-audio-envia.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-cancelar-audio-envia.md
@@ -1,0 +1,13 @@
+﻿## Problema
+Ao começar a gravar um áudio no composer e **cancelar**, o áudio é enviado mesmo assim (incluindo “no mudo” / clip vazio ou residual). Cancelar deve descartar a gravação sem enviar.
+
+Provável origem: `WhatsappGravadorAudioInline` / `MediaRecorder` — `cancelar` pode ainda disparar `onstop` com blob que o fluxo trata como envio.
+
+## Critérios de aceite
+- [ ] Cancelar gravação não envia mensagem de áudio
+- [ ] Não cria mensagem vazia/muda no chat nem no WhatsApp do cliente
+- [ ] Após cancelar, o composer volta ao estado normal (microfone disponível)
+- [ ] Enviar (parar e confirmar) continua a enviar o áudio normalmente
+
+## Origem
+Testes em produção — lote WhatsApp UX (#567).

--- a/.github/planning-issue-bodies/issues/whatsapp-composer-dois-campos.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-composer-dois-campos.md
@@ -1,0 +1,10 @@
+﻿## Problema
+QA em produção (WhatsApp): composer com anexo de imagem deixa o campo principal «Escreva uma mensagem…» visível junto com «Legenda opcional», gerando dois campos de texto ao mesmo tempo.
+
+## Critérios de aceite
+- [ ] Com pré-visualização de anexo aberta, só o campo de legenda (ou um único composer) fica editável
+- [ ] O composer principal não permanece ativo/visível por baixo do overlay de anexo
+- [ ] Cancelar ou enviar o anexo restaura o composer normal
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-esc-lightbox.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-esc-lightbox.md
@@ -1,0 +1,10 @@
+﻿## Problema
+Ao visualizar imagem/mídia em tela cheia e pressionar Esc, além de fechar o lightbox o atalho também sai do chat (ou muda para o primeiro chat da lista quando há vários abertos).
+
+## Critérios de aceite
+- [ ] Esc no lightbox fecha só a visualização em tela cheia
+- [ ] Não navega para fora do chat nem troca a conversa ativa
+- [ ] Esc sem lightbox mantém o comportamento atual (ex.: voltar à lista, se aplicável)
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-fonte-legenda.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-fonte-legenda.md
@@ -1,0 +1,9 @@
+﻿## Problema
+A legenda exibida sob imagens no balão do atendente usa tipografia diferente (menor/itálico) da fonte das mensagens de texto normais.
+
+## Critérios de aceite
+- [ ] Legenda de imagem/mídia no balão do atendente usa a mesma família, tamanho e peso do corpo das mensagens de texto
+- [ ] Contraste permanece legível no modo claro e escuro
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-inatividade-timer-pausa.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-inatividade-timer-pausa.md
@@ -1,0 +1,37 @@
+﻿## Problema
+O encerramento automático por inatividade conta desde a **última mensagem do cliente** e **não reinicia** quando o atendente fala. Isso causa:
+
+1. Cliente na fila por vários minutos → ao assumir, o aviso/encerramento dispara cedo demais.
+2. Atendente pede «aguarde, estou analisando» → o chat fecha mesmo com o cliente à espera, se a análise passar do prazo.
+
+## Regra de negócio
+
+### Timer
+- Contar desde a **última mensagem relevante** (cliente **ou** atendente humano).
+- Qualquer mensagem nova (cliente ou atendente) **reinicia** a contagem.
+- Só age em chat `em_atendimento` **depois** da 1ª resposta humana (não dispara na fila / só com `auto_assumido`/BOT).
+- Manter settings: `inativ_aviso_minutos` + `inativ_encerramento_apos_aviso_minutos`.
+
+### Pausa no chat
+- Botão **Pausar** / **Retomar** no header, com **countdown** ao lado.
+- **Pausar:** para o worker e **reseta** o prazo para o valor configurado (ex. 10:00) — não congela o restante.
+- **Retomar:** inicia a regressiva **de novo** a partir do prazo cheio.
+- Enquanto pausado: não envia aviso nem encerra.
+- Ao receber mensagem do cliente: sair da pausa automaticamente (além do retomar manual).
+
+## Critérios de aceite
+- [ ] Após fila longa, o prazo completo conta a partir da última mensagem (ex.: resposta do atendente reinicia)
+- [ ] Mensagem do cliente ou do atendente reinicia a contagem
+- [ ] Countdown visível no chat em atendimento (feature ligada)
+- [ ] Pausar: para o worker e mostra prazo resetado; não encerra
+- [ ] Retomar: inicia regressiva do prazo cheio de novo
+- [ ] `auto_assumido` / fila sem resposta humana: não dispara
+- [ ] Ciclo aviso → encerramento após aviso preservado
+- [ ] Testes backend + texto de ajuda na Config WhatsApp + CHANGELOG
+
+## Origem
+QA produção — análise de regra de negócio. Parte do épico #567 (lote WhatsApp).
+
+## Referência técnica
+- `backend/app/services/whatsapp_inactivity_worker.py` (`_referencia_inatividade_cliente`)
+- Plano: regra inatividade WhatsApp (última msg + pausa com countdown)

--- a/.github/planning-issue-bodies/issues/whatsapp-legenda-pdf.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-legenda-pdf.md
@@ -1,0 +1,10 @@
+﻿## Problema
+No WhatsApp é possível enviar PDF (e outros documentos) com legenda. No DeskRudder a legenda não aparece no balão do chat (imagens já mostram legenda).
+
+## Critérios de aceite
+- [ ] Legenda enviada com documento/PDF aparece no balão (inbound e outbound)
+- [ ] Composer de anexo de documento permite legenda opcional, como em imagens
+- [ ] Legenda vazia ou rótulo técnico interno não é exibida como texto falso
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-midia-sem-legenda-placeholder.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-midia-sem-legenda-placeholder.md
@@ -1,0 +1,12 @@
+﻿## Problema
+Quando o atendente envia imagem/mídia **sem** legenda, o balão mostra texto placeholder do tipo `[ Luan ]: [Imagem enviada]` (ou similar). Sem legenda, deve aparecer **só** a mídia — sem rótulo de texto.
+
+Hoje o filtro de rótulos técnicos (`ROTULO_SEM_LEGENDA`) cobre padrões como `[Imagem]`, mas não variantes como `[Imagem enviada]`, e o prefixo `[ Nome ]:` pode estar a ser concatenado no corpo.
+
+## Critérios de aceite
+- [ ] Imagem/vídeo/documento/áudio enviados sem legenda: balão sem texto de placeholder
+- [ ] Com legenda real: legenda continua a aparecer
+- [ ] Não exibir `[Imagem]`, `[Imagem enviada]` nem equivalentes como corpo da mensagem
+
+## Origem
+Testes em produção — lote WhatsApp UX (#567).

--- a/.github/planning-issue-bodies/issues/whatsapp-scroll-ultima-lida.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-scroll-ultima-lida.md
@@ -1,0 +1,11 @@
+﻿## Problema
+Ao reabrir um chat em andamento, o scroll cai em posição aleatória em vez da última mensagem vista pelo atendente. Comportamento desejado (estilo WhatsApp): restaurar a última posição lida; se o atendente já viu tudo, ir para o fim.
+
+## Critérios de aceite
+- [ ] Reabrir o mesmo chat restaura a última posição de scroll vista pelo atendente
+- [ ] Se já estava no fim (todas vistas), reabre no fim da conversa
+- [ ] Polling/SSE de novas mensagens não “pula” a posição enquanto o atendente lê histórico acima
+- [ ] Comportamento alinhado ao já feito no Histórico/chat interno (memória de scroll por conversa)
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-ticks-entrega-leitura.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-ticks-entrega-leitura.md
@@ -1,0 +1,26 @@
+﻿## Problema
+Mensagens do atendente ficam com um único ✓ no DeskRudder, e no WhatsApp do **cliente** a mensagem não passa a «visualizada» (✓✓ azul) mesmo depois de o cliente ter respondido.
+
+Hoje o ✓✓ azul só aparece se alguém abrir a mesma conversa no **WhatsApp do suporte** (número/instância que recebe o inbound). Isso foge do fluxo do painel.
+
+## Regra de negócio (leitura / ✓✓ azul)
+A mensagem do **cliente** só deve ser marcada como visualizada (e o cliente só deve ver ✓✓ azul nas mensagens **dele** / o estado de leitura correspondente) quando for visualizada pelo **atendente responsável** pelo chat.
+
+- [ ] Visualizada pelo **responsável** do chat → pode marcar como lida / refletir ✓✓ azul no WhatsApp do cliente (conforme API Evolution)
+- [ ] Visualizada por **outro atendente** (ex.: consulta no Histórico, colega do setor) → **não** marcar como lida para o cliente
+- [ ] Visualizada **antes** de alguém assumir o atendimento (fila / sem responsável) → **não** marcar como lida para o cliente
+
+## Sintoma adicional (ticks no painel)
+No DeskRudder, mensagens do atendente ficam com um só ✓ mesmo quando no WhatsApp do cliente já estão entregues/lidas — o painel precisa espelhar entrega (✓✓) e leitura (✓✓ azul) com base nos eventos reais da API, sem depender de abrir o app WhatsApp do suporte.
+
+## Critérios de aceite
+- [ ] ✓ = enviada / aceite pela API
+- [ ] ✓✓ cinza = entregue no dispositivo do cliente
+- [ ] ✓✓ azul = lida, **somente** quando a regra de negócio acima for satisfeita (responsável visualizou)
+- [ ] Abrir o chat no painel como não-responsável ou sem responsável **não** dispara read receipt para o cliente
+- [ ] Abrir o chat como responsável dispara (ou confirma) a leitura conforme a Evolution API
+- [ ] Atualização via webhook/SSE/poll no painel sem precisar do WhatsApp mobile do suporte
+- [ ] Testes cobrindo: responsável vs outro atendente vs sem responsável
+
+## Origem
+Testes em produção — lote WhatsApp UX (#567). Clarificação: read receipt só pelo atendente responsável.

--- a/.github/planning-issue-bodies/issues/whatsapp-vinculo-chats-posteriores.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-vinculo-chats-posteriores.md
@@ -1,0 +1,13 @@
+﻿## Problema
+Após identificar/vincular um contacto novo a uma rede e empresa, quando o mesmo número envia outra mensagem (novo chat ou retomada), o banner «Contacto não identificado» / «Identificar contato» volta a aparecer como se o vínculo não tivesse sido gravado.
+
+Relacionado em parte a #472 (banner no mesmo chat), mas aqui o sintoma é em **chats posteriores** do mesmo contacto.
+
+## Critérios de aceite
+- [ ] Após vincular/cadastrar, chats novos do mesmo `wa_id`/telefone já nascem vinculados (sem pedir identificação de novo)
+- [ ] Telefone/`wa_id` no funcionário da rede permite match em inbound futuro
+- [ ] Banner some e não reaparece após poll/SSE com snapshot antigo
+- [ ] Teste de regressão: vincular → simular novo inbound do mesmo número → chat com vínculo
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
-- WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown no chat
+- WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown (até o aviso e, após o aviso, até encerrar); enviar mensagem sai da pausa automaticamente
 - WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel
 - PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)
 - Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)
@@ -22,6 +22,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** (somente leitura) até registar, manter demandas existentes ou confirmar sem demanda; nova mensagem do mesmo cliente abre chat novo na fila
+- WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat
 - WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)
 - WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda
 - WhatsApp (#571): Esc no zoom da imagem fecha só a visualização, sem sair do chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown no chat
+- WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel
 - PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)
 - Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)
 - Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima
@@ -20,6 +22,12 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)
+- WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda
+- WhatsApp (#571): Esc no zoom da imagem fecha só a visualização, sem sair do chat
+- WhatsApp (#576): cancelar gravação de áudio já não envia o ficheiro
+- WhatsApp (#573): ao reabrir o chat, o scroll volta à última posição vista (não salta para o início)
+- WhatsApp (#570): contacto já vinculado é reconhecido em chats novos do mesmo número
 - Modo escuro: texto digitado nos campos de pesquisa (listagens e chat interno) volta a ficar legível
 - Equipe online: «0 online» mesmo com painel aberto (lista lia só a memória do worker errado)
 - Chat interno: espaço excessivo entre mensagens após colocar ações/reações fora do balão

--- a/backend/alembic/versions/073_wpp_inatividade_pausa.py
+++ b/backend/alembic/versions/073_wpp_inatividade_pausa.py
@@ -1,0 +1,44 @@
+"""WhatsApp: pausa do timer de inatividade no chat.
+
+Revision ID: 073_wpp_inatividade_pausa
+Revises: 072_chat_interno_silenciar
+Create Date: 2026-07-18
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "073_wpp_inatividade_pausa"
+down_revision = "072_chat_interno_silenciar"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "inatividade_pausada" not in cols:
+        op.add_column(
+            "whatsapp_chats",
+            sa.Column("inatividade_pausada", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+    if "inatividade_retomada_em" not in cols:
+        op.add_column(
+            "whatsapp_chats",
+            sa.Column("inatividade_retomada_em", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "inatividade_retomada_em" in cols:
+        op.drop_column("whatsapp_chats", "inatividade_retomada_em")
+    if "inatividade_pausada" in cols:
+        op.drop_column("whatsapp_chats", "inatividade_pausada")

--- a/backend/alembic/versions/074_wpp_classificacao_demanda.py
+++ b/backend/alembic/versions/074_wpp_classificacao_demanda.py
@@ -1,0 +1,42 @@
+"""WhatsApp: classificação de demanda pendente após inatividade.
+
+Revision ID: 074_wpp_classificacao_demanda
+Revises: 073_wpp_inatividade_pausa
+Create Date: 2026-07-18
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "074_wpp_classificacao_demanda"
+down_revision = "073_wpp_inatividade_pausa"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "classificacao_demanda_pendente" not in cols:
+        op.add_column(
+            "whatsapp_chats",
+            sa.Column(
+                "classificacao_demanda_pendente",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "classificacao_demanda_pendente" in cols:
+        op.drop_column("whatsapp_chats", "classificacao_demanda_pendente")

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -268,6 +268,13 @@ def _render_template(
     )
 
 
+def _sair_pausa_inatividade_por_atividade(chat: WhatsappChat) -> None:
+    """Mensagem do cliente ou outbound humana reinicia o ciclo — sai da pausa manual."""
+    if getattr(chat, "inatividade_pausada", False):
+        chat.inatividade_pausada = False
+        chat.inatividade_retomada_em = None
+
+
 def _enviar_texto_whatsapp(
     db: Session,
     *,
@@ -321,6 +328,8 @@ def _enviar_texto_whatsapp(
     )
     if not ok:
         raise HTTPException(status_code=502, detail=err or "Falha ao enviar pela Evolution API")
+    if evento_sistema is None:
+        _sair_pausa_inatividade_por_atividade(chat)
     m = WhatsappMensagem(
         chat_id=chat.id,
         direcao="outbound",
@@ -515,6 +524,7 @@ def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False)
         empresa_nome=_empresa_nome_exibicao(emp),
         inatividade_pausada=bool(getattr(c, "inatividade_pausada", False)),
         inatividade_retomada_em=getattr(c, "inatividade_retomada_em", None),
+        classificacao_demanda_pendente=bool(getattr(c, "classificacao_demanda_pendente", False)),
     )
 
 
@@ -547,13 +557,31 @@ def _exigir_responsavel_envio_cliente(c: WhatsappChat, atendente: Atendente) -> 
 
 
 def _pode_registrar_demanda(db: Session, atendente: Atendente, c: WhatsappChat) -> bool:
-    if c.estado != "em_atendimento":
-        return False
+    """Responsável/admin: em atendimento, ou após encerramento automático por inatividade."""
     if not _pode_ver_chat(db, atendente, c):
         return False
-    if atendente.role == "admin":
+    if atendente.role != "admin" and c.atendente_id != atendente.id:
+        return False
+    if c.estado == "em_atendimento":
         return True
-    return c.atendente_id == atendente.id
+    if c.estado in ("aguardando_avaliacao", "encerrado") and _chat_encerrado_por_inatividade(db, c):
+        return True
+    return False
+
+
+def _chat_encerrado_por_inatividade(db: Session, c: WhatsappChat) -> bool:
+    return (
+        db.query(WhatsappMensagem.id)
+        .filter(
+            WhatsappMensagem.chat_id == c.id,
+            WhatsappMensagem.evento_sistema.in_(
+                ("auto_encerrado_inatividade", "auto_inativ_aviso"),
+            ),
+        )
+        .limit(1)
+        .first()
+        is not None
+    )
 
 
 def _pode_ver_chat(db: Session, atendente: Atendente, c: WhatsappChat) -> bool:
@@ -611,10 +639,18 @@ def listar_meus_ativos(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
+    """Chats em atendimento + encerrados por inatividade ainda sem classificação de demanda."""
+    from sqlalchemy import or_
+
     q = (
         db.query(WhatsappChat)
         .options(*_CHAT_LOAD_OPTIONS)
-        .filter(WhatsappChat.estado == "em_atendimento")
+        .filter(
+            or_(
+                WhatsappChat.estado == "em_atendimento",
+                WhatsappChat.classificacao_demanda_pendente.is_(True),
+            )
+        )
     )
     if atendente.role != "admin":
         q = q.filter(WhatsappChat.atendente_id == atendente.id)
@@ -1166,6 +1202,8 @@ def registrar_demanda(
         raise HTTPException(status_code=403, detail="Sem permissão para registrar demanda neste chat")
     row = criar_demanda_chat(db, c, atendente, data, desfecho="resolvido_sessao")
     marco = criar_marco_demanda_mensagem(db, chat=c, atendente=atendente, demanda=row)
+    if getattr(c, "classificacao_demanda_pendente", False):
+        c.classificacao_demanda_pendente = False
     db.commit()
     db.refresh(marco)
     marco = (
@@ -1175,6 +1213,8 @@ def registrar_demanda(
         .first()
     )
     emit_chat_mensagem_from_models(db, c, marco, exclude_atendente_id=atendente.id)
+    if c.estado != "em_atendimento":
+        emit_chat_fila_from_model(db, c, estado_anterior=c.estado)
     return demanda_para_read(row)
 
 
@@ -1352,6 +1392,11 @@ def enviar_mensagem(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
     if c.estado != "em_atendimento":
         raise HTTPException(status_code=400, detail="Só é possível enviar mensagens em chats ativos")
+    if getattr(c, "classificacao_demanda_pendente", False):
+        raise HTTPException(
+            status_code=400,
+            detail="Chat aguarda classificação de demanda — não é possível enviar mensagens ao cliente",
+        )
     _exigir_responsavel_envio_cliente(c, atendente)
     texto = data.texto.strip()
     m = _enviar_texto_whatsapp(
@@ -1387,6 +1432,11 @@ async def enviar_mensagem_midia(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
     if c.estado != "em_atendimento":
         raise HTTPException(status_code=400, detail="Só é possível enviar mensagens em chats ativos")
+    if getattr(c, "classificacao_demanda_pendente", False):
+        raise HTTPException(
+            status_code=400,
+            detail="Chat aguarda classificação de demanda — não é possível enviar mensagens ao cliente",
+        )
     _exigir_responsavel_envio_cliente(c, atendente)
 
     data = await file.read()
@@ -1477,6 +1527,7 @@ async def enviar_mensagem_midia(
         status_entrega=status_inicial_outbound_whatsapp(wa_message_id=sent_wa_id),
     )
     db.add(m)
+    _sair_pausa_inatividade_por_atividade(c)
     db.commit()
     m2 = (
         db.query(WhatsappMensagem)
@@ -1644,6 +1695,30 @@ def retomar_inatividade(
     db.commit()
     c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     assert c2 is not None
+    return _chat_read(db, c2)
+
+
+@router.post("/{chat_id}/classificacao-demanda/concluir", response_model=WhatsappChatRead)
+def concluir_classificacao_demanda(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Marca classificação pós-inatividade como concluída (ex.: confirmar sem registar demanda)."""
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not getattr(c, "classificacao_demanda_pendente", False):
+        return _chat_read(db, c)
+    if atendente.role != "admin" and c.atendente_id != atendente.id:
+        raise HTTPException(status_code=403, detail="Apenas o responsável pode concluir a classificação")
+    if c.estado not in ("encerrado", "aguardando_avaliacao"):
+        raise HTTPException(status_code=400, detail="Classificação só se aplica a chats já encerrados por inatividade")
+    c.classificacao_demanda_pendente = False
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    emit_chat_fila_from_model(db, c2, estado_anterior=c2.estado)
     return _chat_read(db, c2)
 
 

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -205,6 +205,7 @@ def _tipo_midia_db(slug: str) -> str:
 
 
 def _rotulo_midia_outbound(tipo_db: str) -> str:
+    """Rótulo interno legado — não enviar ao WhatsApp nem gravar como corpo sem caption."""
     return {
         "imagem": "[Imagem enviada]",
         "video": "[Vídeo enviado]",
@@ -212,6 +213,25 @@ def _rotulo_midia_outbound(tipo_db: str) -> str:
         "documento": "[Documento enviado]",
         "figurinha": "[Figurinha enviada]",
     }.get(tipo_db, "[Ficheiro enviado]")
+
+
+def _corpo_e_caption_midia_outbound(
+    tipo_db: str,
+    caption: str | None,
+    nome_atendente: str | None,
+) -> tuple[str, str]:
+    """
+    Retorna (corpo_db, caption_evolution).
+    Sem legenda do utilizador: corpo vazio e caption vazia (só a mídia no WhatsApp).
+    """
+    if tipo_db == "figurinha":
+        return "", ""
+    cap = (caption or "").strip()
+    if not cap:
+        return "", ""
+    nome = (nome_atendente or "").strip()
+    texto = f"[ {nome} ]: {cap}" if nome else cap
+    return texto, texto
 
 
 def _sanitizar_nome_ficheiro(name: str | None, fallback: str) -> str:
@@ -493,6 +513,8 @@ def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False)
         funcionario_tipo=func.tipo if func else None,
         empresa_id=getattr(c, "empresa_id", None),
         empresa_nome=_empresa_nome_exibicao(emp),
+        inatividade_pausada=bool(getattr(c, "inatividade_pausada", False)),
+        inatividade_retomada_em=getattr(c, "inatividade_retomada_em", None),
     )
 
 
@@ -1380,15 +1402,9 @@ async def enviar_mensagem_midia(
         raise HTTPException(status_code=500, detail="Não foi possível guardar o ficheiro em disco.")
 
     cap = (caption or "").strip()
-    if tipo_db == "figurinha":
-        corpo_eff = _rotulo_midia_outbound(tipo_db)
-        legenda_whatsapp = ""
-    else:
-        base_legenda = cap if cap else _rotulo_midia_outbound(tipo_db)
-        nome_atend = (atendente.nome or "").strip()
-        legenda_whatsapp = f"[ {nome_atend} ]: {base_legenda}" if nome_atend else base_legenda
-        corpo_eff = legenda_whatsapp
-
+    corpo_eff, legenda_whatsapp = _corpo_e_caption_midia_outbound(
+        tipo_db, cap, atendente.nome
+    )
     b64 = base64.b64encode(data).decode("ascii")
     st = _settings_envio(db)
     ev_mt = _mediatype_evolution(mediatipo)
@@ -1542,11 +1558,93 @@ def marcar_chat_visto(
         row.last_seen_at = now
     else:
         db.add(WhatsappChatReadModel(chat_id=chat_id, atendente_id=atendente.id, last_seen_at=now))
+
+    # ✓✓ azul no WhatsApp do cliente: só o responsável, em atendimento
+    if (
+        c.estado == "em_atendimento"
+        and c.atendente_id is not None
+        and c.atendente_id == atendente.id
+    ):
+        _marcar_inbound_lido_evolution(db, c)
+
     db.commit()
     from app.services.realtime_emit import emit_notificacao_contagem
 
     emit_notificacao_contagem(db, [atendente.id])
     return None
+
+
+def _marcar_inbound_lido_evolution(db: Session, chat: WhatsappChat) -> None:
+    st = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
+    if not st or not st.evolution_base_url or not st.evolution_instance_name or not st.evolution_api_key:
+        return
+    ids = [
+        row[0]
+        for row in (
+            db.query(WhatsappMensagem.wa_message_id)
+            .filter(
+                WhatsappMensagem.chat_id == chat.id,
+                WhatsappMensagem.direcao == "inbound",
+                WhatsappMensagem.wa_message_id.isnot(None),
+                WhatsappMensagem.wa_message_id != "",
+            )
+            .order_by(WhatsappMensagem.id.desc())
+            .limit(40)
+            .all()
+        )
+        if row[0]
+    ]
+    if not ids:
+        return
+    ok, err = evolution_api.evolution_mark_messages_as_read(
+        st.evolution_base_url,
+        st.evolution_instance_name,
+        st.evolution_api_key,
+        remote_jid=chat.wa_id,
+        message_ids=list(reversed(ids)),
+    )
+    if not ok:
+        logger.warning("markMessageAsRead falhou (chat=%s): %s", chat.id, err)
+
+
+@router.post("/{chat_id}/inatividade/pausar", response_model=WhatsappChatRead)
+def pausar_inatividade(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if c.estado != "em_atendimento":
+        raise HTTPException(status_code=400, detail="Só é possível pausar inatividade em chats em atendimento")
+    if c.atendente_id != atendente.id and atendente.role != "admin":
+        raise HTTPException(status_code=403, detail="Apenas o responsável pode pausar a inatividade")
+    c.inatividade_pausada = True
+    c.inatividade_retomada_em = None
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    return _chat_read(db, c2)
+
+
+@router.post("/{chat_id}/inatividade/retomar", response_model=WhatsappChatRead)
+def retomar_inatividade(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if c.atendente_id != atendente.id and atendente.role != "admin":
+        raise HTTPException(status_code=403, detail="Apenas o responsável pode retomar a inatividade")
+    c.inatividade_pausada = False
+    c.inatividade_retomada_em = datetime.now(timezone.utc)
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    return _chat_read(db, c2)
 
 
 @router.post("/{chat_id}/vincular-ticket", response_model=WhatsappChatRead)

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -90,9 +90,26 @@ def _baixar_midia_inbound(
 
 
 def _chat_aberto_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
+    """Chat ativo para conversa (fila ou em atendimento). Não inclui pós-inatividade a classificar."""
     return (
         db.query(WhatsappChat)
-        .filter(WhatsappChat.wa_id == wa_id, WhatsappChat.estado != "encerrado")
+        .filter(
+            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.estado.in_(("aguardando_atendente", "em_atendimento")),
+            WhatsappChat.classificacao_demanda_pendente.is_(False),
+        )
+        .order_by(WhatsappChat.id.desc())
+        .first()
+    )
+
+
+def _chat_aguardando_avaliacao_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
+    return (
+        db.query(WhatsappChat)
+        .filter(
+            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.estado == "aguardando_avaliacao",
+        )
         .order_by(WhatsappChat.id.desc())
         .first()
     )
@@ -193,10 +210,8 @@ def _try_auto_msg_espera(db: Session, st: WhatsappSettings | None, chat: Whatsap
             evento_sistema="auto_espera",
         )
     )
-    try:
-        db.commit()
-    except Exception:
-        db.rollback()
+    # Flush apenas: commit fica no webhook. commit/rollback aqui apagava chat novo se a auto-msg falhasse.
+    db.flush()
 
 
 def _parse_hhmm(v: str | None) -> tuple[int, int] | None:
@@ -326,10 +341,8 @@ def _try_auto_msg_fora_horario(db: Session, st: WhatsappSettings | None, chat: W
             evento_sistema="auto_fora_horario",
         )
     )
-    try:
-        db.commit()
-    except Exception:
-        db.rollback()
+    # Flush apenas: commit fica no webhook (evita rollback apagar chat recém-criado).
+    db.flush()
 
 
 def _processar_atualizacoes_status_mensagem(db: Session, body: dict) -> int:
@@ -399,40 +412,52 @@ def evolution_webhook(
         )
 
         chat = _chat_aberto_por_wa_id(db, wa_id)
-        if chat and chat.estado == "aguardando_avaliacao":
-            q_prev = item.get("quoted_corpo_preview")
-            if q_prev is not None and len(str(q_prev)) > 500:
-                q_prev = str(q_prev)[:500]
-            msg = WhatsappMensagem(
-                chat_id=chat.id,
-                direcao="inbound",
-                corpo=corpo,
-                tipo_midia=tipo_midia,
-                mimetype=mimetype_val,
-                midia_nome_arquivo=midia_nome,
-                wa_message_id=wa_mid,
-                quoted_wa_message_id=item.get("quoted_wa_message_id"),
-                quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
-                atendente_id=None,
-            )
-            db.add(msg)
-            if push and not chat.cliente_nome:
-                chat.cliente_nome = push
-            try:
-                from app.services.whatsapp_avaliacao import processar_resposta_avaliacao
+        if not chat:
+            chat_aval = _chat_aguardando_avaliacao_por_wa_id(db, wa_id)
+            # Chat a classificar demanda: só reutiliza se for resposta de avaliação (nota 1–5).
+            # Qualquer outra mensagem abre atendimento novo; o pendente permanece.
+            if chat_aval is not None:
+                from app.services.whatsapp_avaliacao import parse_nota_avaliacao
 
-                processar_resposta_avaliacao(
-                    db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
+                pendente = bool(getattr(chat_aval, "classificacao_demanda_pendente", False))
+                nota = parse_nota_avaliacao(corpo) if (tipo or "texto") == "texto" else None
+                if pendente and nota is None:
+                    chat_aval = None
+            if chat_aval is not None:
+                chat = chat_aval
+                q_prev = item.get("quoted_corpo_preview")
+                if q_prev is not None and len(str(q_prev)) > 500:
+                    q_prev = str(q_prev)[:500]
+                msg = WhatsappMensagem(
+                    chat_id=chat.id,
+                    direcao="inbound",
+                    corpo=corpo,
+                    tipo_midia=tipo_midia,
+                    mimetype=mimetype_val,
+                    midia_nome_arquivo=midia_nome,
+                    wa_message_id=wa_mid,
+                    quoted_wa_message_id=item.get("quoted_wa_message_id"),
+                    quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
+                    atendente_id=None,
                 )
-                db.commit()
-                processados += 1
-            except IntegrityError:
-                db.rollback()
-                logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
-            except Exception:
-                db.rollback()
-                raise
-            continue
+                db.add(msg)
+                if push and not chat.cliente_nome:
+                    chat.cliente_nome = push
+                try:
+                    from app.services.whatsapp_avaliacao import processar_resposta_avaliacao
+
+                    processar_resposta_avaliacao(
+                        db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
+                    )
+                    db.commit()
+                    processados += 1
+                except IntegrityError:
+                    db.rollback()
+                    logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
+                except Exception:
+                    db.rollback()
+                    raise
+                continue
 
         if tipo == "texto":
             tipo_midia = "texto"

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session, joinedload
 from app.database import get_db
 from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem, WhatsappSettings
 from app.services import evolution_api
+from app.services.whatsapp_contato_match import funcionario_por_wa_id
 from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.evolution_inbound import iter_inbound_whatsapp_messages, iter_message_status_updates
 from app.services.whatsapp_media_storage import gravar_base64_em_disco
@@ -441,12 +442,15 @@ def evolution_webhook(
         chat_novo = False
         if not chat:
             chat_novo = True
+            func = funcionario_por_wa_id(db, wa_id)
             chat = WhatsappChat(
                 protocolo=gerar_protocolo_chat(db),
                 wa_id=wa_id,
-                cliente_nome=push,
+                cliente_nome=push or (func.nome if func else None),
                 estado="aguardando_atendente",
                 setor_id=None,
+                funcionario_rede_id=func.id if func else None,
+                empresa_id=func.empresa_id if func and getattr(func, "empresa_id", None) else None,
             )
             db.add(chat)
             db.flush()
@@ -486,6 +490,9 @@ def evolution_webhook(
         db.add(msg)
         if push and not chat.cliente_nome:
             chat.cliente_nome = push
+        if getattr(chat, "inatividade_pausada", False):
+            chat.inatividade_pausada = False
+            chat.inatividade_retomada_em = None
         try:
             db.commit()
             processados += 1

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -70,6 +70,8 @@ class WhatsappChat(Base):
     empresa_id = Column(Integer, ForeignKey("empresas.id", ondelete="SET NULL"), nullable=True, index=True)
     inatividade_pausada = Column(Boolean, nullable=False, default=False, server_default="false")
     inatividade_retomada_em = Column(DateTime(timezone=True), nullable=True)
+    # Após encerramento por inatividade: responsável deve registar (ou confirmar sem) demanda.
+    classificacao_demanda_pendente = Column(Boolean, nullable=False, default=False, server_default="false")
 
     atendente = relationship("Atendente", backref="whatsapp_chats_atendidos")
     setor = relationship("Setor", backref="whatsapp_chats")

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -68,6 +68,8 @@ class WhatsappChat(Base):
         Integer, ForeignKey("funcionarios_rede.id", ondelete="SET NULL"), nullable=True, index=True
     )
     empresa_id = Column(Integer, ForeignKey("empresas.id", ondelete="SET NULL"), nullable=True, index=True)
+    inatividade_pausada = Column(Boolean, nullable=False, default=False, server_default="false")
+    inatividade_retomada_em = Column(DateTime(timezone=True), nullable=True)
 
     atendente = relationship("Atendente", backref="whatsapp_chats_atendidos")
     setor = relationship("Setor", backref="whatsapp_chats")

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -48,6 +48,7 @@ class WhatsappChatRead(BaseModel):
     empresa_nome: str | None = None
     inatividade_pausada: bool = False
     inatividade_retomada_em: datetime | None = None
+    classificacao_demanda_pendente: bool = False
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -46,6 +46,8 @@ class WhatsappChatRead(BaseModel):
     funcionario_tipo: str | None = None
     empresa_id: int | None = None
     empresa_nome: str | None = None
+    inatividade_pausada: bool = False
+    inatividade_retomada_em: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -157,6 +157,36 @@ def _extract_wa_message_id(data: Any) -> str | None:
     return None
 
 
+def evolution_mark_messages_as_read(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    *,
+    remote_jid: str,
+    message_ids: list[str],
+) -> tuple[bool, str | None]:
+    """POST /chat/markMessageAsRead/{instance} — marca inbound como lida no WhatsApp do cliente."""
+    import re
+
+    ids = [str(i).strip() for i in message_ids if str(i).strip()]
+    if not ids:
+        return True, None
+    base = base_url.rstrip("/")
+    url = f"{base}/chat/markMessageAsRead/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    digits = re.sub(r"\D", "", remote_jid)
+    jid = remote_jid if "@" in remote_jid else f"{digits}@s.whatsapp.net"
+    body = {
+        "readMessages": [{"remoteJid": jid, "fromMe": False, "id": mid} for mid in ids]
+    }
+    code, _data, err = _request_json_with_retry("POST", url, headers=headers, body=body)
+    if code in (200, 201):
+        return True, None
+    if err:
+        return False, err[:800]
+    return False, f"HTTP {code}"
+
+
 def evolution_send_text(
     base_url: str,
     instance: str,

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -154,7 +154,39 @@ def _extract_wa_message_id(data: Any) -> str | None:
         if mid:
             s = str(mid).strip()
             return s or None
+    for k in ("keyId", "KeyId", "id", "Id"):
+        mid = data.get(k)
+        if mid and not isinstance(mid, dict):
+            s = str(mid).strip()
+            if s:
+                return s
     return None
+
+
+def evolution_set_webhook(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    *,
+    webhook_url: str,
+    secret: str | None = None,
+    events: list[str] | None = None,
+) -> tuple[int, Any | None, str | None]:
+    """POST /webhook/set/{instance} — garante MESSAGES_UPSERT + MESSAGES_UPDATE."""
+    base = base_url.rstrip("/")
+    url = f"{base}/webhook/set/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    ev = events or ["MESSAGES_UPSERT", "MESSAGES_UPDATE"]
+    webhook: dict[str, Any] = {
+        "enabled": True,
+        "url": webhook_url,
+        "byEvents": False,
+        "events": ev,
+    }
+    if secret:
+        webhook["headers"] = {"X-Dx-Webhook-Secret": secret}
+    body = {"webhook": webhook}
+    return _request_json_with_retry("POST", url, headers=headers, body=body)
 
 
 def evolution_mark_messages_as_read(

--- a/backend/app/services/evolution_embedded.py
+++ b/backend/app/services/evolution_embedded.py
@@ -208,6 +208,17 @@ def provisionar_e_ligar_webhook(db: Session, row: WhatsappSettings) -> dict[str,
     db.commit()
     db.refresh(row)
 
+    # Instâncias reutilizadas (409) podem ter webhook sem MESSAGES_UPDATE — ticks ficariam em ✓ único.
+    wh_code, _wh_data, wh_err = evolution_api.evolution_set_webhook(
+        internal,
+        iname,
+        api_inst,
+        webhook_url=webhook_url,
+        secret=secret,
+    )
+    if wh_code not in (200, 201):
+        logger.warning("Evolution setWebhook falhou (HTTP %s): %s", wh_code, wh_err)
+
     cq, qdata, qerr = evolution_api.evolution_connect(internal, api_inst, iname)
     if cq != 200:
         logger.warning("Connect após provisionar: HTTP %s %s", cq, qerr)

--- a/backend/app/services/evolution_inbound.py
+++ b/backend/app/services/evolution_inbound.py
@@ -185,8 +185,33 @@ def _iter_message_dicts(data: Any) -> Iterator[dict[str, Any]]:
             if isinstance(m, dict):
                 yield m
         return
-    if "key" in data or "message" in data or "Message" in data:
+    # Evolution MESSAGES_UPDATE (formato flat): { keyId, fromMe, status, remoteJid }
+    if "keyId" in data or "KeyId" in data:
         yield data
+        return
+    if "key" in data or "Key" in data or "message" in data or "Message" in data:
+        yield data
+
+
+def _wa_id_e_from_me_de_update(m: dict[str, Any]) -> tuple[str | None, bool | None]:
+    """Extrai wa_message_id e fromMe de update aninhado (key.id) ou flat (keyId)."""
+    key = m.get("key") or m.get("Key")
+    if isinstance(key, dict):
+        mid = key.get("id") or key.get("Id")
+        wa_message_id = str(mid).strip() if mid else None
+        from_me_raw = key.get("fromMe") if "fromMe" in key else key.get("FromMe")
+        from_me = bool(from_me_raw) if from_me_raw is not None else None
+        return wa_message_id or None, from_me
+
+    mid = m.get("keyId") or m.get("KeyId") or m.get("id") or m.get("Id")
+    wa_message_id = str(mid).strip() if mid else None
+    if "fromMe" in m:
+        from_me = bool(m.get("fromMe"))
+    elif "FromMe" in m:
+        from_me = bool(m.get("FromMe"))
+    else:
+        from_me = None
+    return (wa_message_id or None), from_me
 
 
 def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any]]:
@@ -299,26 +324,29 @@ def _ack_de_update_dict(update: dict[str, Any]) -> int | str | None:
 
 def iter_message_status_updates(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any]]:
     """
-  Por cada atualização de ACK em mensagem outbound, produz:
-  wa_message_id, status_entrega (pendente|enviada|entregue|lida|erro)
+    Por cada atualização de ACK em mensagem outbound, produz:
+    wa_message_id, status_entrega (pendente|enviada|entregue|lida|erro)
+
+    Aceita:
+    - formato aninhado: data.key.id + data.update.status
+    - formato Evolution flat: data.keyId + data.fromMe + data.status (ex.: DELIVERY_ACK)
+    - data como lista de qualquer um dos formatos
     """
     from app.services.mensagem_status import ack_evolution_para_status
 
     event = webhook_body.get("event") or webhook_body.get("Event") or ""
-    ev = str(event).lower()
+    ev = str(event).lower().replace("_", ".")
     if "update" not in ev or "message" not in ev:
         return
 
     data = webhook_body.get("data") or webhook_body.get("Data")
     for m in _iter_message_dicts(data):
-        key = m.get("key") or m.get("Key") or {}
-        if not isinstance(key, dict):
-            continue
-        if not (key.get("fromMe") or key.get("FromMe")):
-            continue
-        mid = key.get("id") or key.get("Id")
-        wa_message_id = str(mid).strip() if mid else None
+        wa_message_id, from_me = _wa_id_e_from_me_de_update(m)
         if not wa_message_id:
+            continue
+        # Só atualiza ticks de mensagens enviadas por nós. Se fromMe vier omitido
+        # (alguns payloads), ainda tenta — o lookup no DB exige direcao=outbound.
+        if from_me is False:
             continue
 
         ack_raw = _ack_de_update_dict(m.get("update") or m.get("Update") or {})

--- a/backend/app/services/mensagem_status.py
+++ b/backend/app/services/mensagem_status.py
@@ -23,7 +23,12 @@ def status_deve_atualizar(atual: str | None, novo: str) -> bool:
 
 
 def ack_evolution_para_status(ack: int | str | None) -> str | None:
-    """Mapeia ACK Baileys/Evolution para status_entrega."""
+    """Mapeia ACK Baileys/Evolution para status_entrega.
+
+    Numérico (Baileys WAMessageStatus):
+      0=ERROR, 1=PENDING, 2=SERVER_ACK, 3=DELIVERY_ACK, 4=READ, 5=PLAYED
+    Strings Evolution: PENDING, SERVER_ACK, DELIVERY_ACK, READ, …
+    """
     if ack is None:
         return None
     if isinstance(ack, str):
@@ -46,11 +51,11 @@ def ack_evolution_para_status(ack: int | str | None) -> str | None:
         return None
     if n <= 0:
         return STATUS_ERRO
-    if n == 1:
+    if n in (1, 2):
         return STATUS_ENVIADA
-    if n == 2:
+    if n == 3:
         return STATUS_ENTREGUE
-    if n >= 3:
+    if n >= 4:
         return STATUS_LIDA
     return None
 

--- a/backend/app/services/whatsapp_chat_demandas.py
+++ b/backend/app/services/whatsapp_chat_demandas.py
@@ -125,8 +125,8 @@ def criar_demanda_chat(
     desfecho: str = "resolvido_sessao",
     ticket_id: int | None = None,
 ) -> WhatsappChatDemanda:
-    if chat.estado != "em_atendimento":
-        raise HTTPException(status_code=400, detail="Registre demandas apenas em chats em atendimento")
+    if chat.estado not in ("em_atendimento", "aguardando_avaliacao", "encerrado"):
+        raise HTTPException(status_code=400, detail="Registre demandas apenas em chats em atendimento ou pós-inatividade")
     desfecho_eff = (desfecho or "resolvido_sessao").strip()
     if desfecho_eff not in DESFECHOS_DEMANDA:
         raise HTTPException(status_code=400, detail="Desfecho inválido")
@@ -180,8 +180,8 @@ def atualizar_demanda_chat(
     *,
     atendente: Atendente,
 ) -> WhatsappChatDemanda:
-    if chat.estado != "em_atendimento":
-        raise HTTPException(status_code=400, detail="Edite demandas apenas em chats em atendimento")
+    if chat.estado not in ("em_atendimento", "aguardando_avaliacao", "encerrado"):
+        raise HTTPException(status_code=400, detail="Edite demandas apenas em chats em atendimento ou pós-inatividade")
     if row.desfecho != "resolvido_sessao":
         raise HTTPException(status_code=400, detail="Demandas escaladas para ticket não podem ser editadas")
     if atendente.role != "admin" and row.atendente_id != atendente.id:

--- a/backend/app/services/whatsapp_contato_match.py
+++ b/backend/app/services/whatsapp_contato_match.py
@@ -1,0 +1,58 @@
+"""Match de contacto WhatsApp ↔ funcionário da rede por telefone/wa_id."""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy.orm import Session
+
+from app.models.funcionario_rede import FuncionarioRede
+
+
+def digits_wa(raw: str | None) -> str:
+    return re.sub(r"\D", "", raw or "")
+
+
+def variantes_wa_id(wa_id: str | None) -> set[str]:
+    digits = digits_wa(wa_id)
+    out: set[str] = set()
+    if not digits:
+        return out
+    out.add(digits)
+    if digits.startswith("55") and len(digits) >= 12:
+        out.add(digits[2:])
+    elif len(digits) in (10, 11):
+        out.add("55" + digits)
+    return out
+
+
+def funcionario_por_wa_id(db: Session, wa_id: str | None) -> FuncionarioRede | None:
+    """Encontra funcionário ativo cujo telefone corresponde ao wa_id (com/sem DDI 55)."""
+    targets = variantes_wa_id(wa_id)
+    if not targets:
+        return None
+    # Sufixo para pré-filtrar no SQL (evita full scan com LIKE amplo)
+    sample = next(iter(targets))
+    suffix = sample[-8:] if len(sample) >= 8 else sample
+    candidatos = (
+        db.query(FuncionarioRede)
+        .filter(
+            FuncionarioRede.ativo.is_(True),
+            FuncionarioRede.telefone.isnot(None),
+            FuncionarioRede.telefone != "",
+            FuncionarioRede.telefone.ilike(f"%{suffix}%"),
+        )
+        .order_by(FuncionarioRede.id.desc())
+        .limit(80)
+        .all()
+    )
+    for func in candidatos:
+        f_digits = digits_wa(getattr(func, "telefone", None))
+        if not f_digits:
+            continue
+        if f_digits in targets or targets & variantes_wa_id(f_digits):
+            return func
+        # Últimos 11 dígitos (BR sem/com 9 extra)
+        if len(f_digits) >= 11 and len(sample) >= 11 and f_digits[-11:] == sample[-11:]:
+            return func
+    return None

--- a/backend/app/services/whatsapp_inactivity_worker.py
+++ b/backend/app/services/whatsapp_inactivity_worker.py
@@ -66,33 +66,34 @@ def _ultima_outbound_humana(db: Session, chat_id: int) -> WhatsappMensagem | Non
 
 def _referencia_inatividade_cliente(db: Session, chat: WhatsappChat) -> datetime | None:
     """
-    Momento a partir do qual o cliente está inativo.
+    Momento a partir do qual o silêncio conta para inatividade.
 
-    Conta desde a última mensagem **do cliente** somente quando:
-    - o chat já está em atendimento (garantido pelo caller);
-    - o atendente já enviou pelo menos uma mensagem humana (não auto_assumido/BOT);
-    - essa resposta humana é posterior à última inbound (cliente sumiu).
+    Conta desde a **última mensagem relevante** (inbound do cliente **ou** outbound
+    humana do atendente), desde que já exista pelo menos uma outbound humana
+    (não dispara na fila / só com auto_assumido/BOT).
 
-    Mensagens de sistema (auto_assumido, auto_espera, avisos) não disparam o timer.
-    Novas mensagens do atendente não reiniciam o relógio.
+    Comentários internos e eventos de sistema não contam como atividade.
     """
+    last_out = _ultima_outbound_humana(db, chat.id)
+    if not last_out or last_out.created_at is None:
+        return None
+
     last_in = (
         _mensagens_relevantes_q(db, chat.id)
         .filter(WhatsappMensagem.direcao == "inbound")
         .order_by(desc(WhatsappMensagem.created_at), desc(WhatsappMensagem.id))
         .first()
     )
-    last_out = _ultima_outbound_humana(db, chat.id)
-    if not last_out or last_in is None:
-        return None
-    out_at = last_out.created_at
-    in_at = last_in.created_at
-    if out_at is None or in_at is None:
-        return None
-    if out_at <= in_at:
-        # Cliente falou por último ou atendente ainda não respondeu — não encerra.
-        return None
-    return in_at
+
+    candidatos: list[datetime] = [last_out.created_at]
+    if last_in is not None and last_in.created_at is not None:
+        candidatos.append(last_in.created_at)
+
+    retomada = getattr(chat, "inatividade_retomada_em", None)
+    if retomada is not None:
+        candidatos.append(retomada)
+
+    return max(candidatos)
 
 
 def _minutos_desde(ref: datetime | None, now: datetime) -> float:
@@ -186,6 +187,9 @@ def _processar_chat_inatividade(
 ) -> bool:
     """Retorna True se alterou algo no chat (mensagem ou encerramento)."""
     if chat.estado != "em_atendimento":
+        return False
+
+    if getattr(chat, "inatividade_pausada", False):
         return False
 
     aviso_min = int(getattr(st, "inativ_aviso_minutos", 0) or 0)

--- a/backend/app/services/whatsapp_inactivity_worker.py
+++ b/backend/app/services/whatsapp_inactivity_worker.py
@@ -174,9 +174,36 @@ def _enviar_texto_sistema(
 
 
 def _encerrar_por_inatividade(db: Session, chat: WhatsappChat, st: WhatsappSettings) -> None:
+    from app.models.whatsapp_chat import WhatsappMensagem
     from app.services.whatsapp_avaliacao import finalizar_atendimento_whatsapp
 
     finalizar_atendimento_whatsapp(db, chat, st, evento_encerrado="auto_encerrado_inatividade")
+    chat.classificacao_demanda_pendente = True
+    # Com avaliação ativa o evento_encerrado não é gravado — marco interno para o painel pedir demanda.
+    ja_tem = (
+        db.query(WhatsappMensagem.id)
+        .filter(
+            WhatsappMensagem.chat_id == chat.id,
+            WhatsappMensagem.evento_sistema == "auto_encerrado_inatividade",
+        )
+        .limit(1)
+        .first()
+    )
+    if not ja_tem:
+        db.add(
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="outbound",
+                corpo="Atendimento encerrado automaticamente por inatividade.",
+                tipo_midia="texto",
+                mimetype=None,
+                midia_nome_arquivo=None,
+                wa_message_id=None,
+                atendente_id=None,
+                evento_sistema="auto_encerrado_inatividade",
+            )
+        )
+        db.flush()
 
 
 def _processar_chat_inatividade(
@@ -268,6 +295,25 @@ def process_whatsapp_inactivity_closures(db: Session, *, limit: int = 200) -> in
             if _processar_chat_inatividade(db, chat, st, now):
                 db.commit()
                 alterados += 1
+                try:
+                    from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
+
+                    emit_chat_fila_from_model(db, chat, estado_anterior="em_atendimento")
+                    last_msg = (
+                        db.query(WhatsappMensagem)
+                        .filter(WhatsappMensagem.chat_id == chat.id)
+                        .order_by(WhatsappMensagem.id.desc())
+                        .first()
+                    )
+                    if last_msg and last_msg.evento_sistema in (
+                        "auto_inativ_aviso",
+                        "auto_encerrado_inatividade",
+                        "auto_avaliacao_solicitacao",
+                        "auto_encerrado",
+                    ):
+                        emit_chat_mensagem_from_models(db, chat, last_msg)
+                except Exception as emit_exc:
+                    logger.warning("SSE pós-inatividade (chat=%s): %s", chat_id, emit_exc)
             else:
                 db.rollback()
         except Exception as exc:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,4 +12,4 @@ pydantic-settings==2.14.2
 PyJWT[crypto]==2.13.0
 cryptography>=49.0.0
 bcrypt>=5.0.0,<6
-svix>=1.96.1
+svix>=1.98.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 # Necessário para `Form()` / `UploadFile` (envio de mídia WhatsApp, etc.).
 python-multipart==0.0.32
-fastapi==0.139.0
+fastapi==0.139.2
 starlette==1.3.1
 uvicorn[standard]==0.51.0
 gunicorn==26.0.0

--- a/backend/tests/test_mensagem_status.py
+++ b/backend/tests/test_mensagem_status.py
@@ -10,12 +10,15 @@ from app.services.mensagem_status import (
 
 
 def test_ack_evolution_para_status():
+    # Baileys WAMessageStatus: 1 PENDING, 2 SERVER_ACK, 3 DELIVERY_ACK, 4 READ
     assert ack_evolution_para_status(1) == STATUS_ENVIADA
-    assert ack_evolution_para_status(2) == STATUS_ENTREGUE
-    assert ack_evolution_para_status(3) == STATUS_LIDA
+    assert ack_evolution_para_status(2) == STATUS_ENVIADA
+    assert ack_evolution_para_status(3) == STATUS_ENTREGUE
     assert ack_evolution_para_status(4) == STATUS_LIDA
+    assert ack_evolution_para_status(5) == STATUS_LIDA
     assert ack_evolution_para_status("READ") == STATUS_LIDA
     assert ack_evolution_para_status("DELIVERY_ACK") == STATUS_ENTREGUE
+    assert ack_evolution_para_status("SERVER_ACK") == STATUS_ENVIADA
 
 
 def test_status_deve_atualizar_somente_para_frente():
@@ -29,7 +32,7 @@ def test_status_inicial_outbound_whatsapp():
     assert status_inicial_outbound_whatsapp(wa_message_id=None) == "pendente"
 
 
-def test_iter_message_status_updates():
+def test_iter_message_status_updates_nested():
     body = {
         "event": "messages.update",
         "data": {
@@ -40,4 +43,51 @@ def test_iter_message_status_updates():
     rows = list(iter_message_status_updates(body))
     assert len(rows) == 1
     assert rows[0]["wa_message_id"] == "MSG123"
+    assert rows[0]["status_entrega"] == STATUS_ENTREGUE
+
+
+def test_iter_message_status_updates_evolution_flat():
+    """Payload real Evolution MESSAGES_UPDATE (keyId + status string)."""
+    body = {
+        "event": "messages.update",
+        "data": {
+            "keyId": "3EB0C7B4E7A2B8E6D4F1",
+            "remoteJid": "5511999999999@s.whatsapp.net",
+            "fromMe": True,
+            "status": "DELIVERY_ACK",
+        },
+    }
+    rows = list(iter_message_status_updates(body))
+    assert len(rows) == 1
+    assert rows[0]["wa_message_id"] == "3EB0C7B4E7A2B8E6D4F1"
+    assert rows[0]["status_entrega"] == STATUS_ENTREGUE
+
+
+def test_iter_message_status_updates_evolution_flat_read():
+    body = {
+        "event": "MESSAGES_UPDATE",
+        "data": {
+            "keyId": "ABC123",
+            "fromMe": True,
+            "status": "READ",
+        },
+    }
+    rows = list(iter_message_status_updates(body))
+    assert len(rows) == 1
     assert rows[0]["status_entrega"] == STATUS_LIDA
+
+
+def test_iter_message_status_updates_lista_flat():
+    body = {
+        "event": "messages.update",
+        "data": [
+            {"keyId": "A1", "fromMe": True, "status": "SERVER_ACK"},
+            {"keyId": "A2", "fromMe": True, "status": "DELIVERY_ACK"},
+            {"keyId": "B1", "fromMe": False, "status": "READ"},
+        ],
+    }
+    rows = list(iter_message_status_updates(body))
+    assert [(r["wa_message_id"], r["status_entrega"]) for r in rows] == [
+        ("A1", STATUS_ENVIADA),
+        ("A2", STATUS_ENTREGUE),
+    ]

--- a/backend/tests/test_whatsapp_inatividade_encerramento.py
+++ b/backend/tests/test_whatsapp_inatividade_encerramento.py
@@ -126,7 +126,10 @@ def test_worker_encerra_apos_aviso(client, seed_base, auth_headers, db_session, 
     assert chat.encerramento_at is not None
 
 
-def test_worker_nao_age_quando_cliente_respondeu_por_ultimo(client, seed_base, auth_headers, db_session, monkeypatch):
+def test_worker_nao_age_quando_ultima_mensagem_recente_do_cliente(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    """Cliente falou há 1 min — silêncio ainda dentro do prazo."""
     _configurar_evolution(db_session)
     chat = _chat_em_atendimento(db_session, wa_id="5511999665544")
     antiga = datetime.now(timezone.utc) - timedelta(minutes=20)
@@ -195,9 +198,10 @@ def test_worker_nao_age_so_com_auto_assumido(client, seed_base, auth_headers, db
     assert n == 0
 
 
-def test_worker_aviso_mesmo_com_atendente_enviando_varias_vezes(
+def test_worker_nao_avisa_se_ultima_mensagem_recente(
     client, seed_base, auth_headers, db_session, monkeypatch
 ):
+    """Última mensagem do atendente há 2 min reinicia o prazo — não avisa ainda."""
     _configurar_evolution(db_session)
     chat = _chat_em_atendimento(db_session, wa_id="5511999554433")
     t_cliente = datetime.now(timezone.utc) - timedelta(minutes=25)
@@ -229,7 +233,67 @@ def test_worker_aviso_mesmo_com_atendente_enviando_varias_vezes(
     )
 
     n = process_whatsapp_inactivity_closures(db_session)
+    assert n == 0
+
+
+def test_worker_avisa_apos_silencio_desde_ultima_msg_atendente(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session, wa_id="5511999554400")
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="inbound",
+            corpo="Oi",
+            tipo_midia="texto",
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=30),
+        )
+    )
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Aguarde",
+            tipo_midia="texto",
+            atendente_id=1,
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=15),
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-silencio"),
+    )
+
+    n = process_whatsapp_inactivity_closures(db_session)
     assert n == 1
+
+
+def test_worker_respeita_pausa_inatividade(client, seed_base, auth_headers, db_session, monkeypatch):
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session, wa_id="5511999554411")
+    chat.inatividade_pausada = True
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Analisando",
+            tipo_midia="texto",
+            atendente_id=1,
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=30),
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-pausa"),
+    )
+
+    n = process_whatsapp_inactivity_closures(db_session)
+    assert n == 0
 
 
 def test_worker_nao_reenvia_aviso_duplicado_no_mesmo_ciclo(

--- a/backend/tests/test_whatsapp_inatividade_encerramento.py
+++ b/backend/tests/test_whatsapp_inatividade_encerramento.py
@@ -22,13 +22,13 @@ def _configurar_evolution(db_session):
     db_session.commit()
 
 
-def _chat_em_atendimento(db_session, *, wa_id: str = "5511999887766") -> WhatsappChat:
+def _chat_em_atendimento(db_session, *, wa_id: str = "5511999887766", atendente_id: int = 1) -> WhatsappChat:
     chat = WhatsappChat(
         protocolo="WPP-TEST-1",
         wa_id=wa_id,
         cliente_nome="Cliente Teste",
         estado="em_atendimento",
-        atendente_id=1,
+        atendente_id=atendente_id,
     )
     db_session.add(chat)
     db_session.flush()
@@ -124,6 +124,172 @@ def test_worker_encerra_apos_aviso(client, seed_base, auth_headers, db_session, 
     assert n == 1
     assert chat.estado == "encerrado"
     assert chat.encerramento_at is not None
+    assert chat.classificacao_demanda_pendente is True
+    marco = (
+        db_session.query(WhatsappMensagem)
+        .filter(
+            WhatsappMensagem.chat_id == chat.id,
+            WhatsappMensagem.evento_sistema == "auto_encerrado_inatividade",
+        )
+        .first()
+    )
+    assert marco is not None
+
+
+def test_pode_registrar_demanda_apos_encerramento_inatividade(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    chat = _chat_em_atendimento(db_session, wa_id="5511999112233", atendente_id=a1_id)
+    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=antiga_aviso,
+        )
+    )
+    nat = TicketNatureza(nome="Nat Inativ", slug="nat-inativ-test", ordem=1, ativo=True)
+    db_session.add(nat)
+    db_session.flush()
+    mot = TicketMotivo(natureza_id=nat.id, nome="Mot Inativ", slug="mot-inativ-test", ordem=1, ativo=True)
+    db_session.add(mot)
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-dem"),
+    )
+    process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+    assert chat.estado == "encerrado"
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{chat.id}/demandas",
+        json={"natureza_id": nat.id, "motivo_id": mot.id, "descricao_curta": "Pós-inatividade"},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["descricao_curta"] == "Pós-inatividade"
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is False
+
+
+def test_concluir_classificacao_sem_demanda(client, seed_base, auth_headers, db_session, monkeypatch):
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    chat = _chat_em_atendimento(db_session, wa_id="5511999223344", atendente_id=a1_id)
+    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=antiga_aviso,
+        )
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-cls"),
+    )
+    process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is True
+
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    assert any(c["id"] == chat.id and c.get("classificacao_demanda_pendente") for c in meus)
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{chat.id}/classificacao-demanda/concluir",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["classificacao_demanda_pendente"] is False
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is False
+
+
+def test_inbound_abre_chat_novo_quando_pendente_classificacao(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    """Cliente manda mensagem nova: chat a classificar permanece; abre atendimento novo."""
+    from tests.test_whatsapp_chats import _webhook_body
+
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    wa = "5511888001122"
+    chat = _chat_em_atendimento(db_session, wa_id=wa, atendente_id=a1_id)
+    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=antiga_aviso,
+        )
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-new"),
+    )
+    # Também mock envio de auto_espera no webhook (ids únicos — uq wa_message_id)
+    _wa_seq = {"n": 0}
+
+    def _fake_send(*_a, **_k):
+        _wa_seq["n"] += 1
+        return True, None, f"wa-espera-{_wa_seq['n']}"
+
+    monkeypatch.setattr(
+        "app.api.whatsapp_webhook.evolution_api.evolution_send_text",
+        _fake_send,
+    )
+    process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is True
+    pendente_id = chat.id
+    # Libera a conexão StaticPool antes do TestClient (outra Session no mesmo SQLite).
+    db_session.close()
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "sec-pendente-novo"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "sec-pendente-novo"}
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id=wa, msg_id="msg-nova-pos-inativ", text="Oi de novo"),
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("processados", 0) >= 1, body
+
+    fila = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()
+    novos = [c for c in fila if c["wa_id"] == wa and c["id"] != pendente_id]
+    assert len(novos) == 1, fila
+    assert novos[0]["estado"] == "aguardando_atendente"
+    assert novos[0].get("classificacao_demanda_pendente") is False
+
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    pendentes = [c for c in meus if c["id"] == pendente_id]
+    assert len(pendentes) == 1, meus
+    assert pendentes[0].get("classificacao_demanda_pendente") is True
 
 
 def test_worker_nao_age_quando_ultima_mensagem_recente_do_cliente(
@@ -350,3 +516,98 @@ def test_worker_nao_reenvia_aviso_duplicado_no_mesmo_ciclo(
         .count()
     )
     assert total_avisos == 1
+
+
+def test_envio_mensagem_sai_da_pausa_inatividade(client, seed_base, auth_headers, db_session, monkeypatch):
+    """Outbound humana do atendente limpa a pausa manual (reinicia o ciclo pelo timestamp da msg)."""
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    chat = _chat_em_atendimento(db_session, wa_id="5511999554422", atendente_id=a1_id)
+    chat.inatividade_pausada = True
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Analisando",
+            tipo_midia="texto",
+            atendente_id=a1_id,
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-despausa"),
+    )
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{chat.id}/mensagens",
+        json={"texto": "Já resolvi"},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 201, r.text
+    db_session.refresh(chat)
+    assert chat.inatividade_pausada is False
+    assert chat.inatividade_retomada_em is None
+
+
+def test_concluir_classificacao_com_demandas_existentes(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    """Confirmar «manter demandas» pós-inatividade limpa o pendente (não fica preso na lista)."""
+    from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+    from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
+
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    chat = _chat_em_atendimento(db_session, wa_id="5511999554433", atendente_id=a1_id)
+    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=antiga_aviso,
+        )
+    )
+    nat = TicketNatureza(nome="Nat Manter", slug="nat-manter-inativ", ordem=1, ativo=True)
+    db_session.add(nat)
+    db_session.flush()
+    mot = TicketMotivo(natureza_id=nat.id, nome="Mot Manter", slug="mot-manter-inativ", ordem=1, ativo=True)
+    db_session.add(mot)
+    db_session.flush()
+    db_session.add(
+        WhatsappChatDemanda(
+            chat_id=chat.id,
+            atendente_id=a1_id,
+            natureza_id=nat.id,
+            motivo_id=mot.id,
+            descricao_curta="Já registada na sessão",
+            desfecho="resolvido_sessao",
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-manter"),
+    )
+    process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is True
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{chat.id}/classificacao-demanda/concluir",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["classificacao_demanda_pendente"] is False
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is False
+
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    assert not any(c["id"] == chat.id for c in meus)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,7 @@
         "@types/node": "^26.1.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.2",
+        "@vitejs/plugin-react": "^6.0.3",
         "eslint": "^10.5.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
@@ -1629,11 +1629,13 @@
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.2",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "^1.0.0"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,7 @@
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.7.0",
         "playwright": "^1.61.1",
-        "tailwindcss": "^4.3.2",
+        "tailwindcss": "^4.3.3",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.63.0",
         "vite": "^8.0.16"
@@ -880,6 +880,13 @@
         "tailwindcss": "4.3.2"
       }
     },
+    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
+      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
@@ -1213,6 +1220,13 @@
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
+      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
@@ -4184,9 +4198,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "@emnapi/runtime": "^1.11.1",
         "@eslint/js": "^9.39.1",
         "@tailwindcss/vite": "^4.3.2",
-        "@types/node": "^26.1.0",
+        "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
@@ -1343,9 +1343,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@emnapi/core": "^1.11.2",
         "@emnapi/runtime": "^1.11.1",
         "@eslint/js": "^9.39.1",
-        "@tailwindcss/vite": "^4.3.2",
+        "@tailwindcss/vite": "^4.3.3",
         "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -865,56 +865,49 @@
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
-      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "5.21.6",
+        "enhanced-resolve": "^5.24.1",
         "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.2"
+        "tailwindcss": "4.3.3"
       }
     },
-    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
-      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-x64": "4.3.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
-      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -929,9 +922,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
-      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -946,9 +939,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
-      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -963,9 +956,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
-      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -980,9 +973,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
-      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -997,9 +990,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
-      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
@@ -1017,9 +1010,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
-      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
@@ -1037,9 +1030,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
-      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
@@ -1057,9 +1050,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
-      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
@@ -1077,9 +1070,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
-      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -1173,9 +1166,9 @@
       "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
-      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -1190,9 +1183,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
-      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -1207,26 +1200,19 @@
       }
     },
     "node_modules/@tailwindcss/vite": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.2.tgz",
-      "integrity": "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/node": "4.3.2",
-        "@tailwindcss/oxide": "4.3.2",
-        "tailwindcss": "4.3.2"
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
-    },
-    "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
@@ -2101,9 +2087,9 @@
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.6",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "@emnapi/core": "^1.11.2",
     "@emnapi/runtime": "^1.11.1",
     "@eslint/js": "^9.39.1",
-    "@tailwindcss/vite": "^4.3.2",
+    "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "@emnapi/runtime": "^1.11.1",
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.3.2",
-    "@types/node": "^26.1.0",
+    "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.7.0",
     "playwright": "^1.61.1",
-    "tailwindcss": "^4.3.2",
+    "tailwindcss": "^4.3.3",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.63.0",
     "vite": "^8.0.16"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^26.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.2",
+    "@vitejs/plugin-react": "^6.0.3",
     "eslint": "^10.5.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -899,8 +899,9 @@ export namespace WhatsappChats {
     funcionario_tipo?: string | null
     empresa_id?: number | null
     empresa_nome?: string | null
-    inatividade_pausada?: boolean
-    inatividade_retomada_em?: string | null
+  inatividade_pausada?: boolean
+  inatividade_retomada_em?: string | null
+  classificacao_demanda_pendente?: boolean
   }
   export interface EmpresaOpcao {
     id: number
@@ -1182,6 +1183,8 @@ export const whatsappChats = {
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/inatividade/pausar`, { method: 'POST' }),
   retomarInatividade: (id: number) =>
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/inatividade/retomar`, { method: 'POST' }),
+  concluirClassificacaoDemanda: (id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/classificacao-demanda/concluir`, { method: 'POST' }),
   vincularTicket: (id: number, ticketId: number) =>
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/vincular-ticket`, {
       method: 'POST',

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -899,6 +899,8 @@ export namespace WhatsappChats {
     funcionario_tipo?: string | null
     empresa_id?: number | null
     empresa_nome?: string | null
+    inatividade_pausada?: boolean
+    inatividade_retomada_em?: string | null
   }
   export interface EmpresaOpcao {
     id: number
@@ -1176,6 +1178,10 @@ export const whatsappChats = {
       body: JSON.stringify({ texto }),
     }),
   marcarVisto: (id: number) => api<void>(`/whatsapp/chats/${id}/visto`, { method: 'POST' }),
+  pausarInatividade: (id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/inatividade/pausar`, { method: 'POST' }),
+  retomarInatividade: (id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/inatividade/retomar`, { method: 'POST' }),
   vincularTicket: (id: number, ticketId: number) =>
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/vincular-ticket`, {
       method: 'POST',

--- a/frontend/src/components/chat/MensagemStatusIcon.tsx
+++ b/frontend/src/components/chat/MensagemStatusIcon.tsx
@@ -10,12 +10,15 @@ type Props = {
 
 function corIcone(status: StatusEntregaMensagem, variant: 'claro' | 'escuro'): string {
   if (status === 'lida') {
-    return variant === 'claro' ? 'text-cyan-100' : 'text-cyan-500 dark:text-cyan-400'
+    return variant === 'claro' ? 'text-sky-200' : 'text-sky-500 dark:text-sky-400'
   }
   if (status === 'erro') {
     return variant === 'claro' ? 'text-rose-200' : 'text-rose-500'
   }
-  return variant === 'claro' ? 'text-cyan-100/90' : 'text-slate-400'
+  if (status === 'entregue') {
+    return variant === 'claro' ? 'text-white/90' : 'text-slate-500 dark:text-slate-400'
+  }
+  return variant === 'claro' ? 'text-white/80' : 'text-slate-400'
 }
 
 function IconePendente({ className }: { className: string }) {

--- a/frontend/src/components/marketing/LandingContactSlot.tsx
+++ b/frontend/src/components/marketing/LandingContactSlot.tsx
@@ -15,8 +15,8 @@ type Props = {
 export function LandingContactSlot({ variant = 'hero', label, className = '' }: Props) {
   const base =
     variant === 'hero'
-      ? 'inline-flex items-center justify-center rounded-xl bg-sky-500 px-6 py-3.5 text-sm font-semibold text-white shadow-lg shadow-sky-900/40 transition hover:bg-sky-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#071826]'
-      : 'inline-flex items-center justify-center rounded-xl bg-sky-500 px-6 py-3 text-sm font-semibold text-white transition hover:bg-sky-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300'
+      ? 'group inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-sky-500 via-sky-400 to-cyan-400 px-6 py-3.5 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(14,165,233,0.25)] transition duration-200 hover:-translate-y-0.5 hover:shadow-[0_20px_50px_rgba(14,165,233,0.32)] focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#071826]'
+      : 'group inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-sky-500 via-sky-400 to-cyan-400 px-6 py-3 text-sm font-semibold text-white shadow-[0_10px_30px_rgba(14,165,233,0.2)] transition duration-200 hover:-translate-y-0.5 hover:shadow-[0_14px_35px_rgba(14,165,233,0.28)] focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300'
 
   return (
     <a
@@ -25,7 +25,10 @@ export function LandingContactSlot({ variant = 'hero', label, className = '' }: 
       className={`${base} ${className}`.trim()}
       data-landing-contact-slot={variant}
     >
-      {label}
+      <span>{label}</span>
+      <svg viewBox="0 0 20 20" fill="none" className="size-4 transition duration-200 group-hover:translate-x-0.5" aria-hidden>
+        <path d="M4 10h12M12 5l5 5-5 5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
     </a>
   )
 }

--- a/frontend/src/content/landing.ts
+++ b/frontend/src/content/landing.ts
@@ -20,39 +20,39 @@ export const landingSeo = {
 export const landingHero = {
   brand: APP_NAME,
   tagline: APP_TAGLINE,
-  title: 'Suporte centralizado. Fila sob controle. Cliente bem atendido.',
+  title: 'Suporte centralizado. Operação sob controle. Cliente bem atendido.',
   titleLines: [
-    'Suporte centralizado.',
-    'Fila sob controle.',
-    'Cliente bem atendido.',
+    'Centralize o atendimento.',
+    'Organize a fila.',
+    'Eleve a experiência do cliente.',
   ] as const,
   subtitle:
-    'O DeskRudder reúne chamados, WhatsApp e conhecimento num só painel — para sua empresa organizar o atendimento, acompanhar prazos e saber quem está respondendo o quê.',
+    'O DeskRudder reúne chamados, WhatsApp, e-mail e conhecimento num único painel — para sua empresa operar com mais clareza, velocidade e excelência.',
   ctaPrimary: 'Quero ver uma demonstração',
   ctaSecondary: 'Já sou cliente',
   ctaSecondaryTo: '/login',
-  trustLine: 'Um painel para o time · Fila e prazos visíveis · Ambiente exclusivo da sua empresa',
+  trustLine: 'Visibilidade da operação · Priorização simples · Ambiente exclusivo da sua empresa',
 } as const
 
 export const landingPain = {
-  title: 'Se o suporte ainda vive assim, a operação está no limite',
+  title: 'Quando cada canal vira um problema, a operação perde controle',
   items: [
     {
-      title: 'WhatsApp no celular de cada um',
-      body: 'Conversa some, ninguém assume a fila e o cliente manda a mesma dúvida para três números.',
+      title: 'WhatsApp espalhado por celulares',
+      body: 'As conversas se perdem, ninguém assume e a fila vira um caos de mensagens repetidas.',
     },
     {
-      title: 'E-mail e planilha no lugar do sistema',
-      body: 'Prioridade no feeling, prazo no Excel e zero visão de quem está sobrecarregado.',
+      title: 'Planilha e e-mail no lugar de processo',
+      body: 'A prioridade fica no improviso, e a gestão perde a visão do que está em risco.',
     },
     {
-      title: 'Troca de plantão sem histórico',
-      body: 'O próximo atendente recomeça do zero — e o cliente sente que ninguém resolve.',
+      title: 'Troca de plantão sem contexto',
+      body: 'Cada atendente recomeça do zero, e o cliente sente que ninguém está coordenando a resposta.',
     },
   ],
-  pivotTitle: 'Com o DeskRudder, o suporte ganha um centro de comando',
+  pivotTitle: 'Com o DeskRudder, o suporte passa a ter direção e consistência',
   pivotBody:
-    'Uma fila. Um histórico. Setores com responsabilidade clara. A gestão vê o prazo em risco; o time vê o próximo da fila; o cliente recebe resposta organizada.',
+    'Uma fila. Um histórico. Responsabilidades claras. A gestão vê o risco antes de virar reclamação; o time entende o próximo passo; o cliente sente organização desde o primeiro contato.',
 } as const
 
 export type LandingShowcaseId = 'chat' | 'tickets' | 'sla' | 'kb'
@@ -120,23 +120,23 @@ export const landingShowcases: Array<{
 ]
 
 export const landingOutcomes = {
-  title: 'O que sua empresa ganha no dia a dia',
+  title: 'Resultados que aparecem no dia a dia',
   items: [
     {
       label: 'Fila única',
-      body: 'WhatsApp, e-mail e portal entram no mesmo fluxo. Acaba a disputa por «quem pegou a conversa».',
+      body: 'WhatsApp, e-mail e portal passam a seguir o mesmo fluxo, sem disputa por responsabilidade.',
     },
     {
       label: 'Time organizado',
-      body: 'Cada setor vê o que é dele. A gestão enxerga a operação inteira.',
+      body: 'Cada setor enxerga sua demanda com contexto, e a gestão vê a operação inteira.',
     },
     {
       label: 'Prazos sob controle',
-      body: 'Você vê o risco de atraso a tempo — antes do cliente cobrar no grupo da diretoria.',
+      body: 'O risco de atraso fica visível antes de virar reclamação e prejudicar a confiança.',
     },
     {
-      label: 'Dados da sua empresa',
-      body: 'Ambiente exclusivo. Seu painel, suas regras, seus dados.',
+      label: 'Ambiente exclusivo',
+      body: 'Seu painel, suas regras, seus dados e seus processos — tudo em um espaço seguro para a empresa.',
     },
   ],
 } as const

--- a/frontend/src/lib/whatsappDemandaUtils.ts
+++ b/frontend/src/lib/whatsappDemandaUtils.ts
@@ -29,7 +29,7 @@ export function mensagensVisiveisConversa<TMsg extends ChatMensagemTimeline>(msg
   )
 }
 
-/** Aviso ou encerramento automático por inatividade do cliente — demanda no modal é opcional. */
+/** Aviso ou encerramento automático por inatividade do cliente. */
 export function chatEncerramentoPorInatividade(msgs: ChatMensagemTimeline[]): boolean {
   return msgs.some(
     (m) =>

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -507,7 +507,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
                 Encerra chats em atendimento após silêncio. O tempo conta desde a última mensagem (cliente ou
                 atendente). No chat, o responsável pode Pausar o timer durante análises longas — ao pausar/retomar o
-                prazo volta ao valor configurado.
+                prazo volta ao valor configurado. Enviar mensagem (ou o cliente falar) sai automaticamente da pausa.
               </p>
             </div>
 
@@ -515,7 +515,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               checked={inativEncerramentoAtiva}
               onCheckedChange={setInativEncerramentoAtiva}
               label="Encerramento automático por inatividade do cliente"
-              description="Qualquer mensagem (cliente ou atendente) reinicia o timer. Use Pausar no chat se precisar de mais tempo."
+              description="Qualquer mensagem (cliente ou atendente) reinicia o timer e sai da pausa. Use Pausar no chat se precisar de mais tempo em silêncio."
               showStatusPill
               statusOnText="Ativo"
               statusOffText="Inativo"

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -505,8 +505,9 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
             <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 dark:border-slate-800/80 dark:bg-slate-800/20 dark:text-slate-200">
               <p className="font-medium">Encerramento por inatividade</p>
               <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
-                Encerra chats em atendimento quando o cliente para de responder. O tempo conta desde a última mensagem
-                do cliente, depois que o atendente já respondeu.
+                Encerra chats em atendimento após silêncio. O tempo conta desde a última mensagem (cliente ou
+                atendente). No chat, o responsável pode Pausar o timer durante análises longas — ao pausar/retomar o
+                prazo volta ao valor configurado.
               </p>
             </div>
 
@@ -514,7 +515,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               checked={inativEncerramentoAtiva}
               onCheckedChange={setInativEncerramentoAtiva}
               label="Encerramento automático por inatividade do cliente"
-              description="Novas mensagens do atendente não reiniciam o timer."
+              description="Qualquer mensagem (cliente ou atendente) reinicia o timer. Use Pausar no chat se precisar de mais tempo."
               showStatusPill
               statusOnText="Ativo"
               statusOffText="Inativo"

--- a/frontend/src/pages/marketing/LandingPage.tsx
+++ b/frontend/src/pages/marketing/LandingPage.tsx
@@ -24,7 +24,7 @@ function SecondaryLink({ to, children }: { to: string; children: ReactNode }) {
   return (
     <Link
       to={to}
-      className="inline-flex items-center justify-center rounded-xl border border-white/20 bg-white/5 px-6 py-3.5 text-sm font-semibold text-slate-100 backdrop-blur-sm transition hover:border-white/35 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60"
+      className="inline-flex items-center justify-center rounded-2xl border border-sky-400/30 bg-white/5 px-5 py-3 text-sm font-semibold text-sky-100 shadow-[0_0_0_1px_rgba(255,255,255,0.03)] backdrop-blur-sm transition duration-200 hover:-translate-y-0.5 hover:border-sky-300/50 hover:bg-sky-400/15 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60"
     >
       {children}
     </Link>
@@ -35,17 +35,20 @@ function SectionHeading({
   eyebrow,
   title,
   body,
+  align = 'left',
 }: {
   eyebrow?: string
   title: string
   body?: string
+  align?: 'left' | 'center'
 }) {
   return (
-    <div className="max-w-3xl">
+    <div className={align === 'center' ? 'mx-auto max-w-3xl text-center' : 'max-w-3xl'}>
       {eyebrow ? (
-        <p className="mb-3 text-xs font-semibold tracking-[0.2em] text-sky-400 uppercase">{eyebrow}</p>
+        <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-sky-400">{eyebrow}</p>
       ) : null}
-      <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">{title}</h2>
+      <div className={align === 'center' ? 'mx-auto h-px w-20 bg-gradient-to-r from-sky-500/0 via-sky-400/80 to-sky-500/0' : 'h-px w-20 bg-gradient-to-r from-sky-500/0 via-sky-400/80 to-sky-500/0'} />
+      <h2 className="mt-5 text-3xl font-bold tracking-tight text-white sm:text-4xl">{title}</h2>
       {body ? <p className="mt-4 text-lg leading-relaxed text-slate-300">{body}</p> : null}
     </div>
   )
@@ -62,7 +65,6 @@ function scrollToSection(e: MouseEvent<HTMLAnchorElement>, id: string) {
   } else {
     el.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }
-  // Evita hash na URL “prender” o foco sem scroll no container do app
   if (window.history.replaceState) {
     window.history.replaceState(null, '', `#${id}`)
   }
@@ -74,10 +76,50 @@ export function LandingPage() {
   const [lightbox, setLightbox] = useState<LightboxState>(null)
   const closeLightbox = useCallback(() => setLightbox(null), [])
 
+  const heroProofPoints = ['Fila única', 'SLA visível', 'Base de conhecimento', 'Painel executivo']
+  const heroStats = [
+    { value: '+40%', label: 'visibilidade da fila em tempo real' },
+    { value: '0', label: 'perda de contexto entre setores' },
+    { value: '24/7', label: 'controle do fluxo sem improviso' },
+  ]
+  const experienceHighlights = [
+    {
+      title: 'Resposta com contexto',
+      body: 'Cada demanda chega completa, com histórico, prioridade e próximos passos já definidos.',
+    },
+    {
+      title: 'Visibilidade executiva',
+      body: 'SLA, fila e risco ocupam um só painel, para a gestão decidir sem ruído.',
+    },
+    {
+      title: 'Fluxo único',
+      body: 'Chamados, WhatsApp e e-mail seguem o mesmo processo, com menos retrabalho e mais consistência.',
+    },
+  ]
+  const credibilityMetrics = [
+    { value: '3x', label: 'mais velocidade na coordenação' },
+    { value: '100%', label: 'visibilidade da operação em um só painel' },
+    { value: '≤ 1 min', label: 'para entender o próximo passo' },
+  ]
+  const valuePillars = [
+    {
+      title: 'Centralize a operação',
+      body: 'Junte tickets, WhatsApp, e-mail e conhecimento num único contexto, sem perder o histórico.',
+    },
+    {
+      title: 'Acelere a resposta',
+      body: 'Defina prioridades, encaminhe rápido e mantenha o time alinhado com visão real do fluxo.',
+    },
+    {
+      title: 'Mostre resultado',
+      body: 'Tenha métricas claras de SLA, produtividade e atendimento para tomar decisão com confiança.',
+    },
+  ]
+
   return (
     <MarketingLayout>
-      <header className="sticky top-0 z-40 border-b border-white/5 bg-[#071826]/80 backdrop-blur-md">
-        <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-5 py-4 sm:px-8">
+      <header className="sticky top-0 z-40 border-b border-white/5 bg-[#071826]/85 backdrop-blur-xl">
+        <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-4 px-5 py-4 sm:px-8">
           <BrandLogo variant="full" size="md" markVariant="onDark" />
           <nav className="flex flex-wrap items-center justify-end gap-2 sm:gap-4">
             <a
@@ -96,7 +138,7 @@ export function LandingPage() {
             </a>
             <Link
               to={landingHero.ctaSecondaryTo}
-              className="rounded-lg px-3 py-2 text-sm font-semibold text-sky-300 transition hover:text-sky-200"
+              className="rounded-full px-3 py-2 text-sm font-semibold text-sky-300 transition hover:bg-white/5 hover:text-sky-200"
             >
               {landingHero.ctaSecondary}
             </Link>
@@ -110,120 +152,219 @@ export function LandingPage() {
       </header>
 
       <main>
-        <section className="relative mx-auto flex min-h-[calc(100dvh-5.5rem)] w-full max-w-6xl flex-col justify-center px-5 pb-14 pt-8 sm:px-8 sm:pb-16">
-          <div className="grid items-center gap-10 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)] lg:gap-12 xl:gap-16">
-            <div className="landing-fade-up min-w-0">
-              <p className="mb-5 text-sm font-medium tracking-[0.18em] text-sky-300/90 uppercase">
-                {landingHero.brand}
-                <span className="mx-2 text-slate-500">·</span>
-                <span className="normal-case tracking-normal text-slate-400">{landingHero.tagline}</span>
-              </p>
-              <h1 className="text-[2.15rem] font-bold leading-[1.12] tracking-tight text-white sm:text-5xl lg:text-[3.15rem] lg:leading-[1.1]">
-                {landingHero.titleLines.map((line) => (
-                  <span key={line} className="block">
-                    {line}
-                  </span>
-                ))}
-              </h1>
-              <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-300 sm:text-lg">
-                {landingHero.subtitle}
-              </p>
-              <div className="mt-9 flex flex-wrap items-center gap-3">
-                <LandingContactSlot variant="hero" label={landingHero.ctaPrimary} />
-                <SecondaryLink to={landingHero.ctaSecondaryTo}>{landingHero.ctaSecondary}</SecondaryLink>
+        <section className="relative isolate overflow-hidden py-8 sm:py-10 lg:py-12">
+          <div className="absolute inset-x-0 top-0 -z-10 h-[32rem] bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.22),_transparent_46%),radial-gradient(circle_at_85%_12%,_rgba(14,165,233,0.16),_transparent_38%)]" />
+          <div className="pointer-events-none absolute left-8 top-20 hidden h-40 w-40 rounded-full border border-sky-400/20 bg-sky-400/10 blur-3xl lg:block" />
+          <div className="pointer-events-none absolute right-10 top-24 hidden h-56 w-56 rounded-full border border-white/10 bg-white/5 blur-3xl lg:block" />
+          <div className="mx-auto flex min-h-[calc(100dvh-5.5rem)] w-full max-w-7xl flex-col justify-center px-5 pb-16 pt-8 sm:px-8 sm:pb-20 lg:px-10">
+            <div className="grid items-center gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:gap-12 xl:gap-16">
+              <div className="landing-fade-up min-w-0">
+                <div className="inline-flex items-center gap-2 rounded-full border border-sky-400/30 bg-sky-400/10 px-3.5 py-2 text-sm font-medium text-sky-200 shadow-[0_0_0_1px_rgba(255,255,255,0.03)]">
+                  <span className="size-2 rounded-full bg-sky-400" />
+                  {landingHero.brand} · {landingHero.tagline}
+                </div>
+                <h1 className="mt-6 bg-gradient-to-r from-white via-sky-100 to-slate-400 bg-clip-text text-[2.15rem] font-bold leading-[1.08] tracking-tight text-transparent sm:text-5xl lg:text-[3.2rem] lg:leading-[1.05]">
+                  {landingHero.titleLines.map((line) => (
+                    <span key={line} className="block">
+                      {line}
+                    </span>
+                  ))}
+                </h1>
+                <p className="mt-6 max-w-2xl text-base leading-relaxed text-slate-300 sm:text-lg">
+                  {landingHero.subtitle}
+                </p>
+                <div className="mt-6 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-300">
+                  <span className="size-2 rounded-full bg-emerald-400" />
+                  Plataforma premium para operações de suporte que querem excelência
+                </div>
+                <div className="mt-8 flex flex-wrap items-center gap-3">
+                  <LandingContactSlot variant="hero" label={landingHero.ctaPrimary} />
+                  <SecondaryLink to={landingHero.ctaSecondaryTo}>{landingHero.ctaSecondary}</SecondaryLink>
+                </div>
+                <div className="mt-7 flex flex-wrap gap-2">
+                  {heroProofPoints.map((item) => (
+                    <span
+                      key={item}
+                      className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-slate-300"
+                    >
+                      {item}
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-3">
+                  {heroStats.map((stat) => (
+                    <div key={stat.label} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 backdrop-blur-sm">
+                      <p className="text-xl font-semibold text-white">{stat.value}</p>
+                      <p className="mt-1 text-sm text-slate-400">{stat.label}</p>
+                    </div>
+                  ))}
+                </div>
               </div>
-              <p className="mt-6 max-w-lg text-sm leading-relaxed text-slate-500">{landingHero.trustLine}</p>
-            </div>
 
-            <div className="landing-shot min-w-0 lg:justify-self-stretch">
-              <LandingShotButton
-                label="Painel DeskRudder"
-                onOpen={() =>
-                  setLightbox({
-                    src: landingShots.dashboard,
-                    alt: 'Painel DeskRudder com métricas de chamados e WhatsApp',
-                  })
-                }
-              >
-                <figure className="overflow-hidden rounded-2xl border border-white/12 shadow-2xl shadow-black/50 ring-1 ring-sky-400/15">
-                  <img
-                    src={landingShots.dashboard}
-                    alt="Painel DeskRudder com métricas de chamados e WhatsApp"
-                    className="aspect-[16/10] w-full object-cover object-top"
-                    loading="eager"
-                    fetchPriority="high"
-                  />
-                </figure>
-              </LandingShotButton>
-              <p className="mt-3 text-center text-xs text-slate-500 lg:text-left">
-                Clique na imagem para ampliar
-              </p>
+              <div className="landing-shot min-w-0 lg:justify-self-stretch">
+                <div className="relative overflow-hidden rounded-[1.9rem] border border-white/10 bg-gradient-to-br from-white/[0.08] via-slate-950/80 to-slate-900/90 p-3 shadow-[0_30px_80px_rgba(2,8,23,0.45)] backdrop-blur-xl sm:p-4 before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/70 before:to-transparent">
+                  <div className="mb-4 flex items-center justify-between rounded-full border border-white/10 bg-slate-950/50 px-3 py-2 text-sm text-slate-300">
+                    <span className="font-medium text-white">Operação premium</span>
+                    <span className="rounded-full border border-sky-400/25 bg-sky-400/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-sky-300">
+                      em tempo real
+                    </span>
+                  </div>
+                  <LandingShotButton
+                    label="Painel DeskRudder"
+                    onOpen={() =>
+                      setLightbox({
+                        src: landingShots.dashboard,
+                        alt: 'Painel DeskRudder com métricas de chamados e WhatsApp',
+                      })
+                    }
+                  >
+                    <figure className="overflow-hidden rounded-[1.2rem] border border-white/10">
+                      <img
+                        src={landingShots.dashboard}
+                        alt="Painel DeskRudder com métricas de chamados e WhatsApp"
+                        className="aspect-[16/10] w-full object-cover object-top"
+                        loading="eager"
+                        fetchPriority="high"
+                      />
+                    </figure>
+                  </LandingShotButton>
+                  <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                    <div className="rounded-2xl border border-sky-400/20 bg-sky-400/10 p-4">
+                      <p className="text-2xl font-semibold text-white">+40%</p>
+                      <p className="mt-1 text-sm text-slate-300">visibilidade da fila em tempo real</p>
+                    </div>
+                    <div className="rounded-2xl border border-white/10 bg-[#0A1628]/70 p-4">
+                      <p className="text-2xl font-semibold text-white">0</p>
+                      <p className="mt-1 text-sm text-slate-300">perda de conversa entre setores</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-7xl px-5 pb-8 sm:px-8 lg:px-10">
+          <div className="rounded-[1.5rem] border border-white/10 bg-gradient-to-r from-white/[0.06] via-white/[0.03] to-white/[0.05] px-6 py-5 shadow-[0_20px_60px_rgba(2,8,23,0.18)] backdrop-blur-sm sm:px-8">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">Por que empresas escolhem o DeskRudder</p>
+              <div className="flex flex-wrap gap-3 text-sm text-slate-300">
+                <span className="rounded-full border border-sky-400/20 bg-sky-400/10 px-3 py-1">Atendimento centralizado</span>
+                <span className="rounded-full border border-white/10 bg-[#0A1628]/70 px-3 py-1">SLA e prioridade em um só painel</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-7xl px-5 pb-8 sm:px-8 lg:px-10">
+          <div className="rounded-[1.75rem] border border-sky-400/20 bg-gradient-to-br from-sky-500/10 via-white/[0.03] to-slate-950/80 p-6 shadow-[0_25px_70px_rgba(2,8,23,0.22)] backdrop-blur-md sm:p-8">
+            <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+              <div className="max-w-2xl">
+                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-sky-400">Confiança operacional</p>
+                <h2 className="mt-3 text-2xl font-semibold text-white sm:text-3xl">Mais controle, menos ruído e menos retrabalho para o time.</h2>
+                <p className="mt-3 text-base leading-relaxed text-slate-300">
+                  O DeskRudder transforma a operação em um ambiente previsível, com contexto claro, prioridades visíveis e decisões mais rápidas.
+                </p>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-3 lg:min-w-[32rem]">
+                {credibilityMetrics.map((metric) => (
+                  <div key={metric.label} className="rounded-2xl border border-white/10 bg-slate-950/50 p-4">
+                    <p className="text-xl font-semibold text-white">{metric.value}</p>
+                    <p className="mt-1 text-sm text-slate-400">{metric.label}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="valor" className="py-14 sm:py-16">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+            <SectionHeading
+              eyebrow="O que muda na operação"
+              title="Uma operação mais limpa, mais rápida e mais previsível"
+              body="A solução foi pensada para dar clareza ao time, reduzir ruído e fazer o atendimento parecer um sistema profissional — e não um improviso."
+            />
+            <div className="mt-10 grid gap-6 lg:grid-cols-3">
+              {valuePillars.map((pillar, index) => (
+                <article key={pillar.title} className="relative overflow-hidden rounded-[1.5rem] border border-white/10 bg-white/[0.03] p-6 shadow-lg shadow-black/10 transition duration-300 hover:-translate-y-1 hover:border-sky-400/25 hover:bg-white/[0.05] before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/70 before:to-transparent">
+                  <div className="inline-flex size-11 items-center justify-center rounded-2xl border border-sky-400/20 bg-sky-500/10 text-sm font-semibold text-sky-200">
+                    0{index + 1}
+                  </div>
+                  <h3 className="mt-4 text-xl font-semibold text-white">{pillar.title}</h3>
+                  <p className="mt-3 text-sm leading-relaxed text-slate-400">{pillar.body}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="pb-8 sm:pb-10">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+            <div className="grid gap-6 lg:grid-cols-3">
+              {experienceHighlights.map((item) => (
+                <div key={item.title} className="relative overflow-hidden rounded-[1.5rem] border border-white/10 bg-gradient-to-br from-white/[0.04] to-white/[0.02] p-6 shadow-[0_15px_45px_rgba(2,8,23,0.12)] before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/60 before:to-transparent">
+                  <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+                  <p className="mt-3 text-sm leading-relaxed text-slate-400">{item.body}</p>
+                </div>
+              ))}
             </div>
           </div>
         </section>
 
         <section className="border-t border-white/10 bg-[#071826]/70 py-16 sm:py-20">
-          <div className="mx-auto max-w-6xl px-5 sm:px-8">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingPain.title} />
             <ul className="mt-10 grid gap-6 md:grid-cols-3">
-              {landingPain.items.map((item) => (
-                <li key={item.title} className="border-l-2 border-rose-400/50 pl-4">
-                  <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+              {landingPain.items.map((item, index) => (
+                <li key={item.title} className="relative overflow-hidden rounded-[1.35rem] border border-rose-400/20 bg-rose-400/10 p-6 transition duration-300 hover:-translate-y-1 hover:border-rose-400/35 before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-rose-400/60 before:to-transparent">
+                  <p className="text-sm font-semibold uppercase tracking-[0.2em] text-rose-300">0{index + 1}</p>
+                  <h3 className="mt-3 text-lg font-semibold text-white">{item.title}</h3>
                   <p className="mt-2 text-sm leading-relaxed text-slate-400">{item.body}</p>
                 </li>
               ))}
             </ul>
-            <div className="mt-12 rounded-2xl border border-sky-500/25 bg-sky-500/5 px-6 py-8 sm:px-8">
+            <div className="mt-10 rounded-[1.5rem] border border-sky-500/25 bg-sky-500/10 px-6 py-8 sm:px-8">
               <h3 className="text-2xl font-bold text-sky-300">{landingPain.pivotTitle}</h3>
-              <p className="mt-3 max-w-3xl text-base leading-relaxed text-slate-300">
-                {landingPain.pivotBody}
-              </p>
+              <p className="mt-3 max-w-3xl text-base leading-relaxed text-slate-300">{landingPain.pivotBody}</p>
             </div>
           </div>
         </section>
 
-        <section className="py-14 sm:py-16">
-          <div className="mx-auto grid max-w-6xl items-center gap-10 px-5 sm:px-8 lg:grid-cols-2">
-            <div>
-              <SectionHeading
-                eyebrow="Na prática"
-                title="Veja o painel que sua equipe vai usar"
-                body="Prints reais do sistema (com dados de demonstração): fila, chamados, chat e conhecimento. Clique na imagem para ampliar."
-              />
-              <div className="mt-6">
-                <LandingContactSlot variant="section" label="Quero ver na prática" />
+        <section className="py-16 sm:py-20">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+            <div className="grid gap-6 lg:grid-cols-2">
+              <div className="rounded-[1.75rem] border border-rose-400/20 bg-rose-500/10 p-8 shadow-[0_20px_60px_rgba(2,8,23,0.16)]">
+                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-rose-300">Antes</p>
+                <h3 className="mt-3 text-2xl font-semibold text-white">Operação fragmentada e reativa</h3>
+                <ul className="mt-5 space-y-3 text-sm leading-relaxed text-slate-300">
+                  <li>• Mensagens espalhadas por celulares e e-mails</li>
+                  <li>• Falta de contexto ao transferir entre setores</li>
+                  <li>• SLA e prioridades invisíveis para a gestão</li>
+                </ul>
+              </div>
+              <div className="rounded-[1.75rem] border border-sky-400/20 bg-gradient-to-br from-sky-500/10 via-white/[0.03] to-slate-950/80 p-8 shadow-[0_20px_60px_rgba(2,8,23,0.16)]">
+                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-sky-300">Depois</p>
+                <h3 className="mt-3 text-2xl font-semibold text-white">Fluxo único, visão clara e resposta mais certeira</h3>
+                <ul className="mt-5 space-y-3 text-sm leading-relaxed text-slate-300">
+                  <li>• Um painel para todos os canais e fornecedores de atendimento</li>
+                  <li>• Histórico completo e responsabilidade bem definida</li>
+                  <li>• Alertas e métricas para gerenciar com excelência</li>
+                </ul>
               </div>
             </div>
-            <LandingShotButton
-              label="Dashboard DeskRudder"
-              onOpen={() =>
-                setLightbox({
-                  src: landingShots.dashboard,
-                  alt: 'Painel DeskRudder com métricas de chamados e WhatsApp',
-                })
-              }
-            >
-              <figure className="overflow-hidden rounded-2xl border border-white/12 shadow-2xl shadow-black/40">
-                <img
-                  src={landingShots.dashboard}
-                  alt="Painel DeskRudder com métricas de chamados e WhatsApp"
-                  className="w-full object-cover object-top"
-                  loading="lazy"
-                />
-              </figure>
-            </LandingShotButton>
           </div>
         </section>
 
-        <section id="produto" className="scroll-mt-24 border-t border-white/10 py-6 sm:py-10">
-          <div className="mx-auto max-w-6xl px-5 sm:px-8">
+        <section id="produto" className="scroll-mt-24 py-16 sm:py-20">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading
               eyebrow="O que você encontra"
-              title="Tudo para gerir o suporte num só lugar"
-              body="Sem promessa de roadmap. Abaixo está o que o DeskRudder já entrega hoje para centralizar o atendimento da sua empresa."
+              title="Tudo o que sua equipe precisa para atender melhor"
+              body="Do canal ao prazo, o DeskRudder reúne cada etapa do atendimento para reduzir ruído, dar contexto e manter o fluxo sob controle."
             />
           </div>
-          <div className="mx-auto mt-12 flex max-w-6xl flex-col gap-20 px-5 sm:px-8 sm:gap-28">
+          <div className="mx-auto mt-12 flex max-w-7xl flex-col gap-8 px-5 sm:px-8 lg:px-10">
             {landingShowcases.map((block, i) => {
               const reverse = i % 2 === 1
               const alt = `Painel DeskRudder — ${block.eyebrow}`
@@ -231,23 +372,16 @@ export function LandingPage() {
                 <article
                   key={block.id}
                   id={block.id}
-                  className="grid items-center gap-10 lg:grid-cols-2 lg:gap-14"
+                  className="relative overflow-hidden grid items-center gap-8 rounded-[1.75rem] border border-white/10 bg-white/[0.035] p-6 shadow-xl shadow-black/15 transition duration-300 hover:-translate-y-1 hover:border-sky-400/25 hover:bg-white/[0.045] lg:grid-cols-2 lg:gap-12 lg:p-8 before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/70 before:to-transparent"
                 >
                   <div className={reverse ? 'lg:order-2' : ''}>
-                    <p className="text-xs font-semibold tracking-[0.18em] text-sky-400 uppercase">
-                      {block.eyebrow}
-                    </p>
-                    <h3 className="mt-3 text-2xl font-bold tracking-tight text-white sm:text-3xl">
-                      {block.title}
-                    </h3>
+                    <p className="text-xs font-semibold uppercase tracking-[0.25em] text-sky-400">{block.eyebrow}</p>
+                    <h3 className="mt-3 text-2xl font-bold tracking-tight text-white sm:text-3xl">{block.title}</h3>
                     <p className="mt-4 text-base leading-relaxed text-slate-300">{block.body}</p>
                     <ul className="mt-6 space-y-3">
                       {block.bullets.map((b) => (
                         <li key={b} className="flex gap-3 text-sm text-slate-300">
-                          <span
-                            className="mt-1.5 size-1.5 shrink-0 rounded-full bg-sky-400"
-                            aria-hidden
-                          />
+                          <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-sky-400" aria-hidden />
                           <span className="leading-relaxed">{b}</span>
                         </li>
                       ))}
@@ -267,7 +401,7 @@ export function LandingPage() {
           </div>
         </section>
 
-        <section className="mt-16 border-y border-sky-500/20 bg-gradient-to-r from-sky-700/25 via-[#0B2D4A]/80 to-sky-500/20 py-14 sm:py-16">
+        <section className="border-y border-sky-500/20 bg-gradient-to-r from-sky-700/20 via-[#0B2D4A]/85 to-sky-500/20 py-14 sm:py-16">
           <div className="mx-auto max-w-3xl px-5 text-center sm:px-8">
             <h2 className="text-2xl font-bold text-white sm:text-3xl">{landingMidCta.title}</h2>
             <p className="mt-3 text-slate-200">{landingMidCta.body}</p>
@@ -278,15 +412,12 @@ export function LandingPage() {
         </section>
 
         <section id="resultados" className="scroll-mt-24 py-16 sm:py-20">
-          <div className="mx-auto max-w-6xl px-5 sm:px-8">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingOutcomes.title} />
-            <ul className="mt-10 grid gap-6 sm:grid-cols-2">
+            <ul className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
               {landingOutcomes.items.map((item) => (
-                <li
-                  key={item.label}
-                  className="rounded-2xl border border-white/10 bg-white/[0.03] p-6 transition hover:border-sky-500/35"
-                >
-                  <h3 className="text-xl font-semibold text-sky-300">{item.label}</h3>
+                <li key={item.label} className="relative overflow-hidden rounded-[1.35rem] border border-white/10 bg-white/[0.03] p-6 transition duration-300 hover:-translate-y-1 hover:border-sky-500/35 hover:bg-white/[0.05] before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/60 before:to-transparent">
+                  <h3 className="text-lg font-semibold text-sky-300">{item.label}</h3>
                   <p className="mt-2 text-sm leading-relaxed text-slate-400">{item.body}</p>
                 </li>
               ))}
@@ -295,11 +426,11 @@ export function LandingPage() {
         </section>
 
         <section className="border-t border-white/10 bg-[#0A1628]/70 py-16 sm:py-20">
-          <div className="mx-auto max-w-6xl px-5 sm:px-8">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingHowItWorks.title} />
             <ol className="mt-12 grid gap-10 md:grid-cols-3">
               {landingHowItWorks.steps.map((s) => (
-                <li key={s.n}>
+                <li key={s.n} className="relative overflow-hidden rounded-[1.35rem] border border-white/10 bg-white/[0.03] p-6 transition duration-300 hover:-translate-y-1 hover:border-sky-400/25 hover:bg-white/[0.05] before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/60 before:to-transparent">
                   <span className="text-3xl font-bold text-sky-500/45">{s.n}</span>
                   <h3 className="mt-3 text-lg font-semibold text-white">{s.title}</h3>
                   <p className="mt-2 text-sm leading-relaxed text-slate-400">{s.body}</p>
@@ -310,11 +441,11 @@ export function LandingPage() {
         </section>
 
         <section className="py-16 sm:py-20">
-          <div className="mx-auto max-w-6xl px-5 sm:px-8">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingAudience.title} body={landingAudience.body} />
             <ul className="mt-10 grid gap-6 md:grid-cols-3">
               {landingAudience.segments.map((seg) => (
-                <li key={seg.title} className="border-t border-sky-500/40 pt-5">
+                <li key={seg.title} className="relative overflow-hidden rounded-[1.35rem] border border-sky-500/20 bg-sky-500/5 p-6 transition duration-300 hover:-translate-y-1 hover:border-sky-400/35 hover:bg-sky-500/10 before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/60 before:to-transparent">
                   <h3 className="text-lg font-semibold text-white">{seg.title}</h3>
                   <p className="mt-2 text-sm leading-relaxed text-slate-400">{seg.body}</p>
                 </li>
@@ -325,10 +456,11 @@ export function LandingPage() {
 
         <section id="contato" className="scroll-mt-24 border-t border-white/10 py-16 sm:py-24">
           <div className="mx-auto max-w-3xl px-5 text-center sm:px-8">
-            <p className="text-sm font-medium tracking-[0.2em] text-sky-400 uppercase">{APP_NAME}</p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-white sm:text-4xl">
-              {landingFinalCta.title}
-            </h2>
+            <div className="mx-auto inline-flex items-center gap-2 rounded-full border border-sky-400/25 bg-sky-400/10 px-3.5 py-2 text-sm text-sky-200">
+              <span className="size-2 rounded-full bg-sky-400" />
+              {APP_NAME}
+            </div>
+            <h2 className="mt-5 text-3xl font-bold tracking-tight text-white sm:text-4xl">{landingFinalCta.title}</h2>
             <p className="mt-4 text-lg text-slate-300">{landingFinalCta.body}</p>
             <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
               <LandingContactSlot variant="section" label={landingFinalCta.ctaPrimary} />
@@ -339,7 +471,7 @@ export function LandingPage() {
       </main>
 
       <footer className="border-t border-white/10 bg-[#050810]/80 py-10">
-        <div className="mx-auto flex max-w-6xl flex-col gap-6 px-5 sm:flex-row sm:items-end sm:justify-between sm:px-8">
+        <div className="mx-auto flex max-w-7xl flex-col gap-6 px-5 sm:flex-row sm:items-end sm:justify-between sm:px-8 lg:px-10">
           <div>
             <BrandLogo variant="wordmark" size="sm" markVariant="onDark" />
             <p className="mt-2 max-w-md text-sm text-slate-500">{landingFooter.productLine}</p>
@@ -351,9 +483,7 @@ export function LandingPage() {
             <a href={`mailto:${landingContactEmail}`} className="text-slate-400 hover:text-slate-200">
               {landingFooter.contactLabel}: {landingContactEmail}
             </a>
-            <p className="text-xs text-slate-600">
-              © {new Date().getFullYear()} {APP_NAME}
-            </p>
+            <p className="text-xs text-slate-600">© {new Date().getFullYear()} {APP_NAME}</p>
           </div>
         </div>
       </footer>
@@ -375,6 +505,9 @@ export function LandingPage() {
         }
         .landing-shot {
           animation: landing-fade-up 0.9s ease-out both;
+        }
+        body {
+          background-color: #071826;
         }
         @media (prefers-reduced-motion: reduce) {
           .landing-fade-up, .landing-shot { animation: none; }

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -11,7 +11,6 @@ import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { rotuloResponsavelChat } from '../../lib/whatsappChatMeta'
 
-// Componente para cálculo de tempo de espera
 function TempoEspera({ data }: { data?: string | null }) {
   const [minutos, setMinutos] = useState(0)
 
@@ -27,9 +26,13 @@ function TempoEspera({ data }: { data?: string | null }) {
   }, [data])
 
   return (
-    <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
-      minutos > 10 ? 'bg-red-100 text-red-600 animate-pulse' : 'bg-slate-100 text-slate-500 dark:bg-slate-800'
-    }`}>
+    <span
+      className={`rounded-full px-2 py-0.5 text-[10px] font-bold ${
+        minutos > 10
+          ? 'animate-pulse bg-red-100 text-red-600'
+          : 'bg-slate-100 text-slate-500 dark:bg-slate-800'
+      }`}
+    >
       {minutos === 0 ? 'Agora' : `${minutos} min`}
     </span>
   )
@@ -44,22 +47,22 @@ export function WhatsappAtendendo() {
   const isFirstLoad = useRef(true)
   const prevFilaCount = useRef(0)
 
-  const load = useCallback(async (silent = false) => {
-    if (!silent) setLoading(true)
-    try {
-      const [rowsFila, rowsMeus] = await Promise.all([
-        whatsappChats.fila(), 
-        whatsappChats.meus()
-      ])
-      setFila(rowsFila)
-      setMeus(rowsMeus)
-    } catch (err) {
-      if (!silent) toast.showError(mensagemFalhaParaToast(err, 'Erro ao sincronizar dados.'))
-    } finally {
-      setLoading(false)
-      isFirstLoad.current = false
-    }
-  }, [toast])
+  const load = useCallback(
+    async (silent = false) => {
+      if (!silent) setLoading(true)
+      try {
+        const [rowsFila, rowsMeus] = await Promise.all([whatsappChats.fila(), whatsappChats.meus()])
+        setFila(rowsFila)
+        setMeus(rowsMeus)
+      } catch (err) {
+        if (!silent) toast.showError(mensagemFalhaParaToast(err, 'Erro ao sincronizar dados.'))
+      } finally {
+        setLoading(false)
+        isFirstLoad.current = false
+      }
+    },
+    [toast],
+  )
 
   useEffect(() => {
     const refresh = () => void load(true)
@@ -71,7 +74,6 @@ export function WhatsappAtendendo() {
     }
   }, [subscribe, load])
 
-  // Refresh inicial + polling de segurança (#442)
   useEffect(() => {
     void load()
     const intervalMs = useFallback ? 10000 : 8000
@@ -95,21 +97,29 @@ export function WhatsappAtendendo() {
       await load(true)
       void refetchPendenciasResumo()
     } catch (err) {
-      const msg = err instanceof ApiError && err.status === 400
+      const msg =
+        err instanceof ApiError && err.status === 400
           ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'
           : mensagemFalhaParaToast(err)
       toast.showWarning(msg)
     }
   }
 
+  const meusAtivos = meus.filter((c) => c.estado === 'em_atendimento')
+  const meusAClassificar = meus.filter(
+    (c) => c.classificacao_demanda_pendente && c.estado !== 'em_atendimento',
+  )
+
   if (loading && isFirstLoad.current) {
-    return <div className="flex h-64 items-center justify-center text-sm font-medium text-slate-400 animate-pulse">Carregando central de atendimento...</div>
+    return (
+      <div className="flex h-64 items-center justify-center text-sm font-medium text-slate-400 animate-pulse">
+        Carregando central de atendimento...
+      </div>
+    )
   }
 
   return (
     <div className="flex flex-col space-y-8 animate-in fade-in duration-500">
-      
-      {/* Header */}
       <header className="flex flex-wrap items-end justify-between gap-4 border-b pb-6 dark:border-slate-800">
         <div>
           <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Fila de Atendimento</h1>
@@ -118,26 +128,34 @@ export function WhatsappAtendendo() {
         <div className="flex gap-6">
           <div className="text-right">
             <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Na Fila</p>
-            <p className={`text-xl font-mono font-bold ${fila.length > 0 ? 'text-amber-500' : 'text-slate-300'}`}>{fila.length}</p>
+            <p
+              className={`text-xl font-mono font-bold ${fila.length > 0 ? 'text-amber-500' : 'text-slate-300'}`}
+            >
+              {fila.length}
+            </p>
           </div>
           <div className="text-right">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Meus Chats</p>
-            <p className="text-xl font-mono font-bold text-cyan-600">{meus.length}</p>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Comigo</p>
+            <p className="text-xl font-mono font-bold text-cyan-600">{meusAtivos.length}</p>
           </div>
+          {meusAClassificar.length > 0 && (
+            <div className="text-right">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">A classificar</p>
+              <p className="text-xl font-mono font-bold text-amber-600">{meusAClassificar.length}</p>
+            </div>
+          )}
         </div>
       </header>
 
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
-        
-        {/* Coluna da Fila */}
-        <section className="lg:col-span-5 space-y-4">
+        <section className="space-y-4 lg:col-span-5">
           <h2 className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-slate-500">
             Aguardando ({fila.length})
           </h2>
 
           <div className="space-y-3">
             {fila.length === 0 ? (
-              <Card className="border-dashed border-2 bg-transparent p-8 text-center">
+              <Card className="border-2 border-dashed bg-transparent p-8 text-center">
                 <p className="text-sm text-slate-400">Fila vazia. Bom trabalho!</p>
               </Card>
             ) : (
@@ -146,7 +164,7 @@ export function WhatsappAtendendo() {
                   <div className="flex flex-col gap-4">
                     <div className="flex items-start justify-between">
                       <div className="min-w-0">
-                        <div className="flex items-center gap-2 mb-1">
+                        <div className="mb-1 flex items-center gap-2">
                           <span
                             className="min-w-0 truncate font-mono text-[10px] font-bold text-cyan-600"
                             title={exibirProtocolo(c.protocolo)}
@@ -160,7 +178,9 @@ export function WhatsappAtendendo() {
                             </span>
                           )}
                         </div>
-                        <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</h3>
+                        <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">
+                          {c.cliente_nome || 'Cliente'}
+                        </h3>
                         <p className="font-mono text-xs text-slate-500">{c.wa_id}</p>
                         {c.setor_nome && (
                           <p className="mt-1 text-[10px] font-medium text-slate-500 dark:text-slate-400">
@@ -171,17 +191,16 @@ export function WhatsappAtendendo() {
                       <div className="h-2 w-2 rounded-full bg-amber-400 shadow-[0_0_8px_rgba(251,191,36,0.5)]" />
                     </div>
 
-                    {/* Grupo de Botões da Fila */}
                     <div className="flex items-center gap-2 border-t pt-3 dark:border-slate-800">
-                      <Link 
+                      <Link
                         to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
-                        className="flex-1 text-center rounded-lg bg-slate-100 py-2 text-xs font-bold text-slate-600 hover:bg-slate-200 transition-colors dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+                        className="flex-1 rounded-lg bg-slate-100 py-2 text-center text-xs font-bold text-slate-600 transition-colors hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
                       >
                         Visualizar
                       </Link>
-                      <Button 
+                      <Button
                         onClick={() => void assumir(c.id)}
-                        className="flex-1 bg-amber-500 hover:bg-amber-600 text-white"
+                        className="flex-1 bg-amber-500 text-white hover:bg-amber-600"
                       >
                         Atender
                       </Button>
@@ -193,60 +212,109 @@ export function WhatsappAtendendo() {
           </div>
         </section>
 
-        {/* Coluna de Ativos */}
-        <section className="lg:col-span-7 space-y-4">
-          <h2 className="text-xs font-bold uppercase tracking-widest text-slate-500">
-            Em atendimento comigo ({meus.length})
-          </h2>
-
-          <div className="grid gap-4 md:grid-cols-2">
-            {meus.length === 0 ? (
-              <div className="md:col-span-2 rounded-xl border-2 border-dashed p-12 text-center">
-                <p className="text-sm text-slate-400 italic">Você não tem atendimentos em curso.</p>
-              </div>
-            ) : (
-              meus.map((c) => (
-                <Link key={c.id} to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')} className="group">
-                  <Card className="h-full border-none p-5 shadow-sm ring-1 ring-slate-200 transition-all group-hover:ring-cyan-500 dark:ring-slate-800">
-                    <div className="flex flex-col h-full justify-between gap-4">
-                      <div>
-                        <div className="flex justify-between items-start mb-2">
-                          <span
-                            className="min-w-0 truncate text-[10px] font-bold text-cyan-600"
-                            title={exibirProtocolo(c.protocolo)}
-                          >
-                            {exibirProtocolo(c.protocolo)}
-                          </span>
-                          <span className="relative flex h-2 w-2">
-                            <span className="absolute h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75"></span>
-                            <span className="relative h-2 w-2 rounded-full bg-emerald-500"></span>
+        <section className="space-y-8 lg:col-span-7">
+          {meusAClassificar.length > 0 && (
+            <div className="space-y-4">
+              <h2 className="text-xs font-bold uppercase tracking-widest text-amber-700 dark:text-amber-400">
+                A classificar demanda ({meusAClassificar.length})
+              </h2>
+              <div className="grid gap-4 md:grid-cols-2">
+                {meusAClassificar.map((c) => (
+                  <Link
+                    key={c.id}
+                    to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
+                    className="group"
+                  >
+                    <Card className="h-full border-none p-5 shadow-sm ring-1 ring-amber-300 transition-all group-hover:ring-amber-500 dark:ring-amber-800">
+                      <div className="flex h-full flex-col justify-between gap-4">
+                        <div>
+                          <div className="mb-2 flex items-start justify-between gap-2">
+                            <span
+                              className="min-w-0 truncate text-[10px] font-bold text-amber-700 dark:text-amber-400"
+                              title={exibirProtocolo(c.protocolo)}
+                            >
+                              {exibirProtocolo(c.protocolo)}
+                            </span>
+                            <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[9px] font-bold uppercase text-amber-800 dark:bg-amber-950/50 dark:text-amber-200">
+                              Pendente
+                            </span>
+                          </div>
+                          <h3 className="font-bold text-slate-900 transition-colors group-hover:text-amber-700 dark:text-slate-100">
+                            {c.cliente_nome || 'Cliente'}
+                          </h3>
+                          <p className="mt-1 font-mono text-xs text-slate-400">{c.wa_id}</p>
+                          <p className="mt-2 text-[10px] font-medium text-amber-800/80 dark:text-amber-200/80">
+                            Encerrado por inatividade — falta registar a demanda
+                          </p>
+                        </div>
+                        <div className="flex items-center justify-end border-t pt-3 dark:border-slate-800">
+                          <span className="text-xs font-bold text-amber-700 dark:text-amber-400">
+                            Classificar →
                           </span>
                         </div>
-                        <h3 className="font-bold text-slate-900 dark:text-slate-100 group-hover:text-cyan-600 transition-colors">
-                          {c.cliente_nome || 'Cliente'}
-                        </h3>
-                        {!c.funcionario_rede_id && (
-                          <span className="mt-1 inline-flex rounded-full bg-violet-100 px-2 py-0.5 text-[9px] font-medium text-violet-700 dark:bg-violet-950/50 dark:text-violet-300">
-                            Sem vínculo
-                          </span>
-                        )}
-                        <p className="text-xs text-slate-400 font-mono mt-1">{c.wa_id}</p>
-                        <p className="mt-2 text-[10px] font-medium text-slate-500 dark:text-slate-400">
-                          {rotuloResponsavelChat(c)}
-                          {c.setor_nome ? ` • ${c.setor_nome}` : ''}
-                        </p>
                       </div>
-                      
-                      <div className="flex items-center justify-end border-t pt-3 dark:border-slate-800">
-                         <span className="text-xs font-bold text-cyan-600">
-                           Continuar →
-                         </span>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-4">
+            <h2 className="text-xs font-bold uppercase tracking-widest text-slate-500">
+              Em atendimento comigo ({meusAtivos.length})
+            </h2>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              {meusAtivos.length === 0 ? (
+                <div className="rounded-xl border-2 border-dashed p-12 text-center md:col-span-2">
+                  <p className="text-sm italic text-slate-400">Você não tem atendimentos em curso.</p>
+                </div>
+              ) : (
+                meusAtivos.map((c) => (
+                  <Link
+                    key={c.id}
+                    to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
+                    className="group"
+                  >
+                    <Card className="h-full border-none p-5 shadow-sm ring-1 ring-slate-200 transition-all group-hover:ring-cyan-500 dark:ring-slate-800">
+                      <div className="flex h-full flex-col justify-between gap-4">
+                        <div>
+                          <div className="mb-2 flex items-start justify-between">
+                            <span
+                              className="min-w-0 truncate text-[10px] font-bold text-cyan-600"
+                              title={exibirProtocolo(c.protocolo)}
+                            >
+                              {exibirProtocolo(c.protocolo)}
+                            </span>
+                            <span className="relative flex h-2 w-2">
+                              <span className="absolute h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+                              <span className="relative h-2 w-2 rounded-full bg-emerald-500" />
+                            </span>
+                          </div>
+                          <h3 className="font-bold text-slate-900 transition-colors group-hover:text-cyan-600 dark:text-slate-100">
+                            {c.cliente_nome || 'Cliente'}
+                          </h3>
+                          {!c.funcionario_rede_id && (
+                            <span className="mt-1 inline-flex rounded-full bg-violet-100 px-2 py-0.5 text-[9px] font-medium text-violet-700 dark:bg-violet-950/50 dark:text-violet-300">
+                              Sem vínculo
+                            </span>
+                          )}
+                          <p className="mt-1 font-mono text-xs text-slate-400">{c.wa_id}</p>
+                          <p className="mt-2 text-[10px] font-medium text-slate-500 dark:text-slate-400">
+                            {rotuloResponsavelChat(c)}
+                            {c.setor_nome ? ` • ${c.setor_nome}` : ''}
+                          </p>
+                        </div>
+                        <div className="flex items-center justify-end border-t pt-3 dark:border-slate-800">
+                          <span className="text-xs font-bold text-cyan-600">Continuar →</span>
+                        </div>
                       </div>
-                    </div>
-                  </Card>
-                </Link>
-              ))
-            )}
+                    </Card>
+                  </Link>
+                ))
+              )}
+            </div>
           </div>
         </section>
       </div>

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -24,6 +24,8 @@ type Props = {
   onInserirReferenciaKb?: (ref: string) => void
   /** Incrementar para focar o textarea (ex.: após Responder). */
   focoPedidoEm?: number
+  /** Placeholder customizado (ex.: pós-inatividade a classificar). */
+  placeholder?: string
 }
 
 type MenuAnexo = { tipo: TipoAnexoPicker; label: string }
@@ -52,6 +54,7 @@ export function WhatsappComposerBar({
   podeDigitar,
   onInserirReferenciaKb,
   focoPedidoEm,
+  placeholder,
 }: Props) {
   const [menuAberto, setMenuAberto] = useState(false)
   const [painelEmojiAberto, setPainelEmojiAberto] = useState(false)
@@ -189,13 +192,14 @@ export function WhatsappComposerBar({
           value={texto}
           onChange={(e) => onTextoChange(e.target.value)}
           placeholder={
-            encerrado
+            placeholder ??
+            (encerrado
               ? 'Apenas leitura…'
               : modoInterno
                 ? 'Comentário interno…'
                 : podeEnviar
                   ? 'Escreva uma mensagem…'
-                  : 'Somente comentários internos…'
+                  : 'Somente comentários internos…')
           }
           rows={1}
           disabled={campoBloqueado}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -68,12 +68,20 @@ import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
 import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { ChatFilaAguardandoSheet } from '../../components/chat/ChatFilaAguardandoSheet'
+import { WhatsappInatividadeControle } from './WhatsappInatividadeControle'
 import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
 import { rotuloDownloadArquivo, visualTipoArquivo } from '../../lib/fileTypeIcon'
 import { CONTATO_CLIENTE } from '../../constants/contatoClienteLabels'
 
-const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)\]$/
+const ROTULO_SEM_LEGENDA =
+  /^(?:\[\s*[^\]]+\s*\]:\s*)?\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)(\s+enviad[oa])?\]$/i
 
+/** Legenda real sob mídia; ignora placeholders tipo «[Imagem enviada]». */
+function legendaMidiaVisivel(corpo: string | null | undefined): string | null {
+  const t = (corpo || '').trim()
+  if (!t || ROTULO_SEM_LEGENDA.test(t)) return null
+  return t
+}
 
 
 // --- Subcomponente de Renderização de Mídia ---
@@ -153,16 +161,14 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 
 
 
-  const legenda = m.corpo && !ROTULO_SEM_LEGENDA.test(m.corpo.trim()) ? m.corpo : null
-
-
+  const legenda = legendaMidiaVisivel(m.corpo)
 
   if (tipo === 'texto' || !m.tipo_midia) return <TextoComLinks texto={m.corpo} />
 
   if (!m.midia_disponivel) {
     return (
       <p className="text-xs italic opacity-70" title="O ficheiro não foi obtido da Evolution API">
-        {m.corpo || 'Mídia não disponível'}
+        {legenda || 'Mídia não disponível'}
       </p>
     )
   }
@@ -171,60 +177,47 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 
   if (err) return <p className="text-[10px] italic opacity-50">Erro ao carregar mídia</p>
 
-
-
-  const mediaClass = "max-h-64 max-w-full rounded-lg border border-black/5 shadow-sm"
-
-
+  const mediaClass = 'max-h-64 max-w-full rounded-lg border border-black/5 shadow-sm'
 
   if (tipo === 'imagem' || tipo === 'figurinha') {
-
     return (
-
       <div className="space-y-1">
-
-        <img 
-
-          src={url} 
-
-          alt="" 
-
-          className={`${mediaClass} cursor-zoom-in transition-transform duration-200 hover:scale-[1.02]`} 
-
+        <img
+          src={url}
+          alt=""
+          className={`${mediaClass} cursor-zoom-in transition-transform duration-200 hover:scale-[1.02]`}
           onClick={() => onImageClick(url, legenda)}
-
         />
-
-        {legenda && <p className="text-xs opacity-80 italic">{legenda}</p>}
-
+        {legenda ? <TextoComLinks texto={legenda} /> : null}
       </div>
-
     )
-
   }
 
   if (tipo === 'audio') return <CustomAudioPlayer src={url} />
 
-  if (tipo === 'video') return <video controls src={url} className={mediaClass} />
+  if (tipo === 'video') {
+    return (
+      <div className="space-y-1">
+        <video controls src={url} className={mediaClass} />
+        {legenda ? <TextoComLinks texto={legenda} /> : null}
+      </div>
+    )
+  }
 
- 
-
-  const downloadLabel = rotuloDownloadArquivo(
-    tipo === 'documento' ? m.corpo : null,
-    m.mimetype,
-    tipo,
-  )
-  const fileVisual = visualTipoArquivo(tipo === 'documento' ? m.corpo : null, m.mimetype)
+  const downloadLabel = rotuloDownloadArquivo(null, m.mimetype, tipo)
+  const fileVisual = visualTipoArquivo(null, m.mimetype)
 
   return (
-
-    <a href={url} download className="flex items-center gap-2 text-xs font-bold underline">
-      <span className="text-base" aria-hidden>{fileVisual.emoji}</span>
-      <span>{downloadLabel.replace(/^\S+\s*/, '')}</span>
-    </a>
-
+    <div className="space-y-1">
+      <a href={url} download className="flex items-center gap-2 text-xs font-bold underline">
+        <span className="text-base" aria-hidden>
+          {fileVisual.emoji}
+        </span>
+        <span>{downloadLabel.replace(/^\S+\s*/, '')}</span>
+      </a>
+      {legenda ? <TextoComLinks texto={legenda} /> : null}
+    </div>
   )
-
 }
 
 
@@ -323,11 +316,24 @@ export function WhatsappConversa() {
       if (e.key !== 'Escape' || e.defaultPrevented || modalEncerrar) return
       const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase()
       if (tag === 'input' || tag === 'textarea' || tag === 'select') return
+      if (activeZoomImage) {
+        e.preventDefault()
+        e.stopPropagation()
+        setActiveZoomImage(null)
+        setActiveZoomImageCaption(null)
+        return
+      }
+      if (arquivoPendente) {
+        e.preventDefault()
+        setArquivoPendente(null)
+        setLegendaMidia('')
+        return
+      }
       voltarLista()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [voltarLista, modalEncerrar])
+  }, [voltarLista, modalEncerrar, activeZoomImage, arquivoPendente])
 
   useEffect(() => {
     if (!modalEncerrar || !chat) return
@@ -352,20 +358,22 @@ export function WhatsappConversa() {
 
 
 
-  // Scroll: só cola no fim se o utilizador já estiver perto do fundo; senão preserva a posição.
+  // Scroll: restaurar última posição vista; só cola no fim se já estava no fundo.
   useEffect(() => {
     if (!id) return
     initialScrollRestoredRef.current = false
-    stickToBottomRef.current = true
+    stickToBottomRef.current = false
   }, [id])
 
   useEffect(() => {
     if (loading || msgs.length === 0 || initialScrollRestoredRef.current || !id) return
     initialScrollRestoredRef.current = true
     requestAnimationFrame(() => {
-      const el = scrollRef.current
-      if (!el) return
-      stickToBottomRef.current = restoreWhatsappScroll(Number(id), el)
+      requestAnimationFrame(() => {
+        const el = scrollRef.current
+        if (!el) return
+        stickToBottomRef.current = restoreWhatsappScroll(Number(id), el)
+      })
     })
   }, [loading, msgs.length, id])
 
@@ -376,7 +384,6 @@ export function WhatsappConversa() {
       if (el) scrollWhatsappToBottom(el)
     })
   }, [msgs, loading])
-
   useEffect(() => {
     const el = scrollRef.current
     if (!el || !id) return
@@ -1061,6 +1068,14 @@ useEffect(() => {
 
             {!encerrado && (
               <>
+                {isResponsavel && chat && (
+                  <WhatsappInatividadeControle
+                    chat={chat}
+                    msgs={msgs}
+                    isResponsavel={isResponsavel}
+                    onChatUpdate={aplicarChatAtualizado}
+                  />
+                )}
                 {podeTransferir && (
                   <Button
                     variant="primary"
@@ -1070,7 +1085,6 @@ useEffect(() => {
                     Transferir
                   </Button>
                 )}
-
                 <Button
                   variant="ghost"
                   className="hidden sm:inline-flex text-xs h-8"
@@ -1349,10 +1363,18 @@ useEffect(() => {
                   onChange={(e) => setLegendaMidia(e.target.value)}
                   placeholder="Legenda opcional (visível no WhatsApp)"
                   className={`mt-2 ${TEXTAREA_FIELD_CLASS}`}
+                  autoFocus
                 />
               )}
               <div className="mt-2 flex justify-end gap-2">
-                <Button variant="ghost" className="h-8 text-xs" onClick={() => setArquivoPendente(null)}>
+                <Button
+                  variant="ghost"
+                  className="h-8 text-xs"
+                  onClick={() => {
+                    setArquivoPendente(null)
+                    setLegendaMidia('')
+                  }}
+                >
                   Cancelar
                 </Button>
                 <Button className="h-8 text-xs" loading={enviando} onClick={() => void confirmarEnvioMidia()}>
@@ -1362,27 +1384,28 @@ useEffect(() => {
             </div>
           )}
 
-          <WhatsappComposerBar
-            texto={texto}
-            onTextoChange={setTexto}
-            onEnviar={() => void enviar()}
-            enviando={enviando}
-            encerrado={encerrado}
-            podeEnviar={podeEnviar}
-            modoInterno={modoInterno}
-            podeDigitar={podeDigitarMensagem}
-            onEscolherAnexo={abrirPickerAnexo}
-            onAudioGravado={handleGravacaoConcluida}
-            onInserirEmoji={setTexto}
-            onEnviarFigurinha={(file) => void enviarFigurinha(file)}
-            onColarArquivo={(file) => {
-              setArquivoPendente(file)
-              setLegendaMidia('')
-            }}
-            onInserirReferenciaKb={inserirReferenciaKb}
-            focoPedidoEm={focoComposerEm}
-          />
-
+          {!arquivoPendente ? (
+            <WhatsappComposerBar
+              texto={texto}
+              onTextoChange={setTexto}
+              onEnviar={() => void enviar()}
+              enviando={enviando}
+              encerrado={encerrado}
+              podeEnviar={podeEnviar}
+              modoInterno={modoInterno}
+              podeDigitar={podeDigitarMensagem}
+              onEscolherAnexo={abrirPickerAnexo}
+              onAudioGravado={handleGravacaoConcluida}
+              onInserirEmoji={setTexto}
+              onEnviarFigurinha={(file) => void enviarFigurinha(file)}
+              onColarArquivo={(file) => {
+                setArquivoPendente(file)
+                setLegendaMidia('')
+              }}
+              onInserirReferenciaKb={inserirReferenciaKb}
+              focoPedidoEm={focoComposerEm}
+            />
+          ) : null}
           <input
             type="file"
             ref={fileInputRef}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -22,7 +22,9 @@ import {
 } from '../../api/client'
 
 import { resolveWhatsappMidiaObjectUrl, revokeWhatsappMidiaForChat } from '../../lib/whatsappMidiaCache'
-import { chatEncerramentoPorInatividade } from '../../lib/whatsappDemandaUtils'
+import {
+  chatEncerramentoPorInatividade,
+} from '../../lib/whatsappDemandaUtils'
 import { mergeWhatsappChat, patchWhatsappChatLista, replaceWhatsappChatLista } from '../../lib/whatsappChatMerge'
 import { whatsappMensagensUnicas } from '../../lib/whatsappMensagens'
 import {
@@ -262,6 +264,11 @@ export function WhatsappConversa() {
 
   const [meusChats, setMeusChats] = useState<WhatsappChats.Chat[]>([])
 
+  const chatRef = useRef(chat)
+  const userIdRef = useRef(user?.id)
+  chatRef.current = chat
+  userIdRef.current = user?.id
+
  
 
   // Estados de UI
@@ -335,14 +342,32 @@ export function WhatsappConversa() {
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [voltarLista, modalEncerrar, activeZoomImage, arquivoPendente])
 
+  const viuEmAtendimentoRef = useRef(false)
+  const inatividadeToastFeitoRef = useRef(false)
+
   useEffect(() => {
-    if (!modalEncerrar || !chat) return
-    const fechado = chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao'
-    if (fechado && chatEncerramentoPorInatividade(msgs)) {
-      setModalEncerrar(false)
-      toast.showSuccess('Atendimento encerrado automaticamente por inatividade do cliente.')
+    if (chat?.estado === 'em_atendimento') {
+      viuEmAtendimentoRef.current = true
     }
-  }, [modalEncerrar, chat, msgs, toast])
+  }, [chat?.estado])
+
+  useEffect(() => {
+    if (!chat || inatividadeToastFeitoRef.current) return
+    if (!viuEmAtendimentoRef.current) return
+
+    const fechado = chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao'
+    if (!fechado || !chatEncerramentoPorInatividade(msgs)) return
+    if (!chat.classificacao_demanda_pendente) return
+
+    const podeClassificar =
+      chat.atendente_id === user?.id || user?.role === 'admin'
+    if (!podeClassificar) return
+
+    inatividadeToastFeitoRef.current = true
+    toast.showSuccess(
+      'Atendimento encerrado por inatividade. Pode reler a conversa e registar a demanda no aviso abaixo.',
+    )
+  }, [chat, msgs, user?.id, user?.role, toast])
 
   const refrescarTimelineDemandas = useCallback(() => {
     setDemandasReloadKey((k) => k + 1)
@@ -490,6 +515,8 @@ export function WhatsappConversa() {
     if (!id) return
 
     setLoading(true)
+    viuEmAtendimentoRef.current = false
+    inatividadeToastFeitoRef.current = false
 
     carregar().then(() => whatsappChats.marcarVisto(id)).finally(() => setLoading(false))
 
@@ -535,6 +562,16 @@ export function WhatsappConversa() {
         }
         return [...prev, msg]
       })
+      // ✓✓ azul no WhatsApp do cliente: marcar leitura em inbound novo enquanto o responsável está no chat
+      const c = chatRef.current
+      if (
+        msg.direcao === 'inbound' &&
+        c?.estado === 'em_atendimento' &&
+        c.atendente_id != null &&
+        c.atendente_id === userIdRef.current
+      ) {
+        void whatsappChats.marcarVisto(chatId)
+      }
     })
     const unsubFila = subscribe('chat.fila', (payload) => {
       const payloadChatId = Number(payload.chat_id)
@@ -548,7 +585,11 @@ export function WhatsappConversa() {
           void carregar().catch(() => {})
         }
       }
-      if (chatData && chatData.estado !== 'em_atendimento') {
+      if (
+        chatData &&
+        chatData.estado !== 'em_atendimento' &&
+        !chatData.classificacao_demanda_pendente
+      ) {
         setMeusChats((prev) => prev.filter((c) => c.id !== payloadChatId))
       } else if (!chatData || payloadChatId !== chatId) {
         void carregarSidebar()
@@ -805,9 +846,13 @@ useEffect(() => {
     await Promise.all([carregar(), carregarSidebar()])
     refrescarTimelineDemandas()
     toast.showSuccess(
-      atualizado.estado === 'aguardando_avaliacao'
+      atualizado.estado === 'aguardando_avaliacao' && atualizado.classificacao_demanda_pendente
         ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
-        : 'Atendimento encerrado.',
+        : atualizado.classificacao_demanda_pendente === false && chatEncerramentoPorInatividade(msgs)
+          ? 'Classificação da sessão concluída.'
+          : atualizado.estado === 'aguardando_avaliacao'
+            ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
+            : 'Atendimento encerrado.',
     )
   }
 
@@ -824,11 +869,29 @@ useEffect(() => {
 
   const podeTransferir = !encerrado && (isResponsavel || isAdmin)
 
-  const podeEnviar = chat?.estado === 'em_atendimento' && isResponsavel && !encerrado
+  const podeEnviar =
+    chat?.estado === 'em_atendimento' &&
+    isResponsavel &&
+    !encerrado &&
+    !chat?.classificacao_demanda_pendente
 
   const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && (isResponsavel || isAdmin)
 
-  const podeDigitarMensagem = !encerrado && (modoInterno || podeEnviar)
+  const mostrarBannerDemandaInatividade =
+    Boolean(chat?.classificacao_demanda_pendente) && (isResponsavel || isAdmin)
+
+  const podeDigitarMensagem = !encerrado && !chat?.classificacao_demanda_pendente && (modoInterno || podeEnviar)
+
+  const composerPlaceholder =
+    encerrado || chat?.classificacao_demanda_pendente
+      ? chat?.classificacao_demanda_pendente
+        ? 'Chat aguarda classificação de demanda (somente leitura)'
+        : 'Chat encerrado'
+      : !podeEnviar && chat?.estado === 'em_atendimento'
+        ? 'Apenas o responsável pode enviar ao cliente — use comentário interno'
+        : modoInterno
+          ? 'Comentário interno (não enviado ao cliente)…'
+          : 'Digite uma mensagem…'
 
   const motivoAnexoDesabilitado =
     encerrado
@@ -918,6 +981,11 @@ useEffect(() => {
                     <p className="truncate text-sm font-bold text-slate-800 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</p>
 
                     {c.estado === 'aguardando_atendente' && <span className="h-2 w-2 rounded-full bg-amber-500 animate-pulse" />}
+                    {c.classificacao_demanda_pendente && (
+                      <span className="shrink-0 rounded-full bg-amber-100 px-1.5 py-0.5 text-[9px] font-medium text-amber-800 dark:bg-amber-950/50 dark:text-amber-200">
+                        Demanda
+                      </span>
+                    )}
                     {!c.funcionario_rede_id && (
                       <span className="shrink-0 rounded-full bg-violet-100 px-1.5 py-0.5 text-[9px] font-medium text-violet-700 dark:bg-violet-950/50 dark:text-violet-300">
                         Sem vínculo
@@ -1110,6 +1178,22 @@ useEffect(() => {
             <p>{CONTATO_CLIENTE.bannerNaoVinculado}</p>
             <Button variant="primary" className="h-8 shrink-0 text-xs" onClick={() => setModalVincFuncionario(true)}>
               {CONTATO_CLIENTE.vincularEmpresa}
+            </Button>
+          </div>
+        )}
+
+        {mostrarBannerDemandaInatividade && (
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100">
+            <p>
+              Atendimento encerrado por inatividade. Reler a conversa se precisar e{' '}
+              <strong>registar a demanda</strong> desta sessão.
+            </p>
+            <Button
+              variant="primary"
+              className="h-8 shrink-0 text-xs"
+              onClick={() => setModalEncerrar(true)}
+            >
+              Registar demanda
             </Button>
           </div>
         )}
@@ -1404,6 +1488,7 @@ useEffect(() => {
               }}
               onInserirReferenciaKb={inserirReferenciaKb}
               focoPedidoEm={focoComposerEm}
+              placeholder={composerPlaceholder}
             />
           ) : null}
           <input

--- a/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
@@ -34,11 +34,11 @@ type Props = {
 function definirAcaoInicial(
   rows: WhatsappChats.Demanda[],
   msgs: WhatsappChats.Mensagem[],
-  encerramentoPorInatividade: boolean,
+  _encerramentoPorInatividade: boolean,
 ): AcaoEncerramento {
   const pos = analisarDemandaPosRegistro(rows, msgs)
   if (rows.length === 0) {
-    return encerramentoPorInatividade ? 'sem_demanda' : 'registrar'
+    return 'registrar'
   }
   if (pos) return 'nova'
   return 'manter'
@@ -73,7 +73,8 @@ export function WhatsappEncerrarModal({
 
   const semDemandas = demandas.length === 0
   const demandasResolvidas = demandas.filter((d) => d.desfecho === 'resolvido_sessao')
-  const demandaOpcional = encerramentoPorInatividade && semDemandas
+  // Pós-inatividade também pede registo (como Encerrar manual); só permite skip com confirmação.
+  const demandaOpcional = false
 
   useEffect(() => {
     if (!open) {
@@ -162,6 +163,16 @@ export function WhatsappEncerrarModal({
         await whatsappChats.atualizarDemanda(chatId, posRegistro.ultimaDemanda.id, demandaFormPayload(form))
       }
 
+      // Pós-inatividade: qualquer conclusão (manter/editar/sem demanda/registar) limpa o pendente.
+      // Idempotente se registar demanda já tiver limpo a flag.
+      if (chatJaEncerrado && encerramentoPorInatividade) {
+        const atualizado = await whatsappChats.concluirClassificacaoDemanda(chatId)
+        onDemandasChange?.()
+        onEncerrado(atualizado)
+        onClose()
+        return
+      }
+
       const atualizado = await whatsappChats.encerrar(chatId)
       onDemandasChange?.()
       onEncerrado(atualizado)
@@ -180,10 +191,10 @@ export function WhatsappEncerrarModal({
   let mensagemIntro =
     'Revise as demandas desta sessão antes de finalizar. O cliente poderá receber pedido de avaliação conforme configuração.'
 
-  if (demandaOpcional) {
-    mensagemIntro = chatJaEncerrado
-      ? 'Este atendimento foi encerrado automaticamente por inatividade do cliente. Registar demanda é opcional.'
-      : 'O cliente está inativo (aviso automático enviado). Pode encerrar sem registar demanda ou classificar opcionalmente.'
+  if (chatJaEncerrado && encerramentoPorInatividade) {
+    mensagemIntro = semDemandas
+      ? 'Este atendimento foi encerrado automaticamente por inatividade. Registe a demanda da sessão, ou confirme explicitamente concluir sem demanda.'
+      : 'Este atendimento foi encerrado automaticamente por inatividade. Revise as demandas antes de concluir.'
   } else if (semDemandas) {
     mensagemIntro =
       'Registe o motivo do atendimento antes de encerrar, ou confirme explicitamente o encerramento sem demanda.'
@@ -250,60 +261,32 @@ export function WhatsappEncerrarModal({
 
           {semDemandas ? (
             <div className="space-y-3">
-              {demandaOpcional ? (
-                <>
-                  <p className="text-xs text-slate-500">
-                    Registar demanda é opcional neste encerramento por inatividade.
-                  </p>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <input
-                      type="radio"
-                      name="acao-encerrar"
-                      checked={acao === 'sem_demanda'}
-                      onChange={() => selecionarAcao('sem_demanda')}
-                    />
-                    {chatJaEncerrado ? 'Concluir sem registar demanda' : 'Encerrar sem registar demanda'}
-                  </label>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <input
-                      type="radio"
-                      name="acao-encerrar"
-                      checked={acao === 'registrar'}
-                      onChange={() => selecionarAcao('registrar')}
-                    />
-                    Registar demanda (opcional)
-                  </label>
-                </>
-              ) : (
-                <>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <input
-                      type="radio"
-                      name="acao-encerrar"
-                      checked={acao === 'registrar'}
-                      onChange={() => selecionarAcao('registrar')}
-                    />
-                    Registar demanda e encerrar
-                  </label>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <input
-                      type="radio"
-                      name="acao-encerrar"
-                      checked={acao === 'sem_demanda'}
-                      onChange={() => selecionarAcao('sem_demanda')}
-                    />
-                    Encerrar sem registar demanda
-                  </label>
-                  {acao === 'sem_demanda' && (
-                    <CheckboxField
-                      checked={confirmarSemDemanda}
-                      onChange={(e) => setConfirmarSemDemanda(e.target.checked)}
-                      variant="inline"
-                    >
-                      Confirmo encerrar sem classificar esta sessão
-                    </CheckboxField>
-                  )}
-                </>
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'registrar'}
+                  onChange={() => selecionarAcao('registrar')}
+                />
+                {chatJaEncerrado ? 'Registar demanda e concluir' : 'Registar demanda e encerrar'}
+              </label>
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'sem_demanda'}
+                  onChange={() => selecionarAcao('sem_demanda')}
+                />
+                {chatJaEncerrado ? 'Concluir sem registar demanda' : 'Encerrar sem registar demanda'}
+              </label>
+              {acao === 'sem_demanda' && (
+                <CheckboxField
+                  checked={confirmarSemDemanda}
+                  onChange={(e) => setConfirmarSemDemanda(e.target.checked)}
+                  variant="inline"
+                >
+                  Confirmo {chatJaEncerrado ? 'concluir' : 'encerrar'} sem classificar esta sessão
+                </CheckboxField>
               )}
             </div>
           ) : posRegistro ? (

--- a/frontend/src/pages/whatsapp/WhatsappGravadorAudio.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappGravadorAudio.tsx
@@ -17,6 +17,8 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
   const chunksRef = useRef<Blob[]>([])
   const timerRef = useRef<number | null>(null)
 
+  const canceladoRef = useRef(false)
+
   const pararStream = useCallback(() => {
     streamRef.current?.getTracks().forEach((t) => t.stop())
     streamRef.current = null
@@ -31,6 +33,7 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
   async function iniciar() {
     if (disabled || gravando) return
     setErro(null)
+    canceladoRef.current = false
     chunksRef.current = []
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
@@ -44,10 +47,17 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
       const recorder = mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream)
       recorderRef.current = recorder
       recorder.ondataavailable = (ev) => {
+        if (canceladoRef.current) return
         if (ev.data.size > 0) chunksRef.current.push(ev.data)
       }
       recorder.onstop = () => {
         pararStream()
+        if (canceladoRef.current) {
+          chunksRef.current = []
+          setGravando(false)
+          setSegundos(0)
+          return
+        }
         const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' })
         if (blob.size === 0) {
           setErro('Gravação vazia. Tente novamente.')
@@ -72,14 +82,17 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
   }
 
   function parar() {
+    canceladoRef.current = false
     const rec = recorderRef.current
     if (rec && rec.state !== 'inactive') rec.stop()
     recorderRef.current = null
   }
 
   function cancelar() {
+    canceladoRef.current = true
     if (gravando) {
-      recorderRef.current?.stop()
+      const rec = recorderRef.current
+      if (rec && rec.state !== 'inactive') rec.stop()
       recorderRef.current = null
       chunksRef.current = []
       pararStream()

--- a/frontend/src/pages/whatsapp/WhatsappGravadorAudioInline.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappGravadorAudioInline.tsx
@@ -17,6 +17,7 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
   const chunksRef = useRef<Blob[]>([])
   const timerRef = useRef<number | null>(null)
   const iniciouRef = useRef(false)
+  const canceladoRef = useRef(false)
 
   const pararStream = useCallback(() => {
     streamRef.current?.getTracks().forEach((t) => t.stop())
@@ -30,6 +31,7 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
   useEffect(() => {
     if (disabled || iniciouRef.current) return
     iniciouRef.current = true
+    canceladoRef.current = false
     void (async () => {
       setErro(null)
       chunksRef.current = []
@@ -44,10 +46,16 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
         const recorder = mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream)
         recorderRef.current = recorder
         recorder.ondataavailable = (ev) => {
+          if (canceladoRef.current) return
           if (ev.data.size > 0) chunksRef.current.push(ev.data)
         }
         recorder.onstop = () => {
           pararStream()
+          if (canceladoRef.current) {
+            chunksRef.current = []
+            setGravando(false)
+            return
+          }
           const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' })
           if (blob.size === 0) {
             setErro('Gravação vazia.')
@@ -66,6 +74,7 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
       }
     })()
     return () => {
+      canceladoRef.current = true
       pararStream()
       const rec = recorderRef.current
       if (rec && rec.state !== 'inactive') rec.stop()
@@ -76,17 +85,20 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
   const ss = String(segundos % 60).padStart(2, '0')
 
   function parar() {
+    canceladoRef.current = false
     const rec = recorderRef.current
     if (rec && rec.state !== 'inactive') rec.stop()
     recorderRef.current = null
   }
 
   function cancelar() {
+    canceladoRef.current = true
     chunksRef.current = []
     pararStream()
     const rec = recorderRef.current
     if (rec && rec.state !== 'inactive') rec.stop()
     recorderRef.current = null
+    setGravando(false)
     onCancelar()
   }
 

--- a/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useState } from 'react'
+import { whatsappChats, whatsappSettings, type WhatsappChats } from '../../api/client'
+import { Button } from '../../components/ui/Button'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useToast } from '../../components/ui/Toast'
+
+type Props = {
+  chat: WhatsappChats.Chat
+  msgs: WhatsappChats.Mensagem[]
+  isResponsavel: boolean
+  onChatUpdate: (c: WhatsappChats.Chat) => void
+}
+
+function formatMmSs(totalSec: number): string {
+  const s = Math.max(0, Math.floor(totalSec))
+  const mm = String(Math.floor(s / 60)).padStart(2, '0')
+  const ss = String(s % 60).padStart(2, '0')
+  return `${mm}:${ss}`
+}
+
+/** Controlo de inatividade: countdown + pausar/retomar (#577). */
+export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatUpdate }: Props) {
+  const toast = useToast()
+  const [avisoMin, setAvisoMin] = useState(15)
+  const [ativa, setAtiva] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    void whatsappSettings
+      .get()
+      .then((r) => {
+        if (cancelled) return
+        setAtiva(Boolean(r.inativ_encerramento_ativa))
+        setAvisoMin(Math.max(1, Number(r.inativ_aviso_minutos ?? 15)))
+      })
+      .catch(() => {
+        /* settings indisponíveis — esconde controlo */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!ativa || chat.estado !== 'em_atendimento') return
+    const id = window.setInterval(() => setTick((t) => t + 1), 1000)
+    return () => window.clearInterval(id)
+  }, [ativa, chat.estado])
+
+  const restanteSec = useMemo(() => {
+    void tick
+    if (!ativa || chat.estado !== 'em_atendimento') return null
+    if (chat.inatividade_pausada) return avisoMin * 60
+
+    const relevant = msgs.filter(
+      (m) =>
+        m.evento_sistema !== 'comentario_interno' &&
+        (m.direcao === 'inbound' ||
+          (m.direcao === 'outbound' && !m.evento_sistema)),
+    )
+    const last = relevant[relevant.length - 1]
+    const candidatos: number[] = []
+    if (last?.created_at) candidatos.push(new Date(last.created_at).getTime())
+    if (chat.inatividade_retomada_em) candidatos.push(new Date(chat.inatividade_retomada_em).getTime())
+    if (candidatos.length === 0) return avisoMin * 60
+
+    const refMs = Math.max(...candidatos)
+    const elapsed = (Date.now() - refMs) / 1000
+    return Math.max(0, avisoMin * 60 - elapsed)
+  }, [ativa, chat, msgs, avisoMin, tick])
+
+  if (!ativa || chat.estado !== 'em_atendimento' || !isResponsavel || restanteSec == null) {
+    return null
+  }
+
+  async function toggle() {
+    setBusy(true)
+    try {
+      const next = chat.inatividade_pausada
+        ? await whatsappChats.retomarInatividade(chat.id)
+        : await whatsappChats.pausarInatividade(chat.id)
+      onChatUpdate(next)
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível alterar a pausa de inatividade.'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <span
+        className={`tabular-nums text-xs font-semibold ${
+          chat.inatividade_pausada
+            ? 'text-amber-600 dark:text-amber-300'
+            : restanteSec <= 60
+              ? 'text-rose-600 dark:text-rose-300'
+              : 'text-slate-500 dark:text-slate-400'
+        }`}
+        title={
+          chat.inatividade_pausada
+            ? 'Inatividade pausada — prazo reiniciado'
+            : 'Tempo até o aviso de inatividade'
+        }
+      >
+        {formatMmSs(restanteSec)}
+      </span>
+      <Button
+        type="button"
+        variant="ghost"
+        className="h-8 px-2 text-xs"
+        loading={busy}
+        onClick={() => void toggle()}
+      >
+        {chat.inatividade_pausada ? 'Retomar' : 'Pausar'}
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
@@ -22,6 +22,7 @@ function formatMmSs(totalSec: number): string {
 export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatUpdate }: Props) {
   const toast = useToast()
   const [avisoMin, setAvisoMin] = useState(15)
+  const [posAvisoMin, setPosAvisoMin] = useState(5)
   const [ativa, setAtiva] = useState(false)
   const [busy, setBusy] = useState(false)
   const [tick, setTick] = useState(0)
@@ -34,6 +35,7 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
         if (cancelled) return
         setAtiva(Boolean(r.inativ_encerramento_ativa))
         setAvisoMin(Math.max(1, Number(r.inativ_aviso_minutos ?? 15)))
+        setPosAvisoMin(Math.max(1, Number(r.inativ_encerramento_apos_aviso_minutos ?? 5)))
       })
       .catch(() => {
         /* settings indisponíveis — esconde controlo */
@@ -49,29 +51,62 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
     return () => window.clearInterval(id)
   }, [ativa, chat.estado])
 
-  const restanteSec = useMemo(() => {
+  const fase = useMemo(() => {
     void tick
     if (!ativa || chat.estado !== 'em_atendimento') return null
-    if (chat.inatividade_pausada) return avisoMin * 60
+
+    const semComentario = msgs.filter((m) => m.evento_sistema !== 'comentario_interno')
+    const lastAny = semComentario[semComentario.length - 1]
+    const posAvisoAtivo = lastAny?.evento_sistema === 'auto_inativ_aviso'
+
+    if (chat.inatividade_pausada) {
+      return {
+        restanteSec: avisoMin * 60,
+        label: 'Inatividade pausada — prazo reiniciado',
+        pausada: true as const,
+        posAviso: false as const,
+      }
+    }
+
+    if (posAvisoAtivo && lastAny?.created_at) {
+      const elapsed = (Date.now() - new Date(lastAny.created_at).getTime()) / 1000
+      return {
+        restanteSec: Math.max(0, posAvisoMin * 60 - elapsed),
+        label: 'Tempo até encerrar por inatividade (após aviso)',
+        pausada: false as const,
+        posAviso: true as const,
+      }
+    }
 
     const relevant = msgs.filter(
       (m) =>
         m.evento_sistema !== 'comentario_interno' &&
-        (m.direcao === 'inbound' ||
-          (m.direcao === 'outbound' && !m.evento_sistema)),
+        (m.direcao === 'inbound' || (m.direcao === 'outbound' && !m.evento_sistema)),
     )
     const last = relevant[relevant.length - 1]
     const candidatos: number[] = []
     if (last?.created_at) candidatos.push(new Date(last.created_at).getTime())
     if (chat.inatividade_retomada_em) candidatos.push(new Date(chat.inatividade_retomada_em).getTime())
-    if (candidatos.length === 0) return avisoMin * 60
+    if (candidatos.length === 0) {
+      return {
+        restanteSec: avisoMin * 60,
+        label: 'Tempo até o aviso de inatividade',
+        pausada: false as const,
+        posAviso: false as const,
+      }
+    }
 
     const refMs = Math.max(...candidatos)
     const elapsed = (Date.now() - refMs) / 1000
-    return Math.max(0, avisoMin * 60 - elapsed)
-  }, [ativa, chat, msgs, avisoMin, tick])
+    return {
+      restanteSec: Math.max(0, avisoMin * 60 - elapsed),
+      label: 'Tempo até o aviso de inatividade',
+      pausada: false as const,
+      posAviso: false as const,
+    }
+  }, [ativa, chat, msgs, avisoMin, posAvisoMin, tick])
 
-  if (!ativa || chat.estado !== 'em_atendimento' || !isResponsavel || restanteSec == null) {
+  if (!ativa || chat.estado !== 'em_atendimento' || !isResponsavel || fase == null) {
     return null
   }
 
@@ -93,29 +128,27 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
     <div className="flex items-center gap-1.5">
       <span
         className={`tabular-nums text-xs font-semibold ${
-          chat.inatividade_pausada
+          fase.pausada
             ? 'text-amber-600 dark:text-amber-300'
-            : restanteSec <= 60
+            : fase.posAviso || fase.restanteSec <= 60
               ? 'text-rose-600 dark:text-rose-300'
               : 'text-slate-500 dark:text-slate-400'
         }`}
-        title={
-          chat.inatividade_pausada
-            ? 'Inatividade pausada — prazo reiniciado'
-            : 'Tempo até o aviso de inatividade'
-        }
+        title={fase.label}
       >
-        {formatMmSs(restanteSec)}
+        {formatMmSs(fase.restanteSec)}
       </span>
-      <Button
-        type="button"
-        variant="ghost"
-        className="h-8 px-2 text-xs"
-        loading={busy}
-        onClick={() => void toggle()}
-      >
-        {chat.inatividade_pausada ? 'Retomar' : 'Pausar'}
-      </Button>
+      {!fase.posAviso && (
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-8 px-2 text-xs"
+          loading={busy}
+          onClick={() => void toggle()}
+        >
+          {chat.inatividade_pausada ? 'Retomar' : 'Pausar'}
+        </Button>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Lote de produto em `[Unreleased]` (main → staging):

- WhatsApp (#577): encerramento por inatividade desde a última mensagem; Pausar/Retomar com countdown; enviar mensagem sai da pausa
- WhatsApp (#575): VV azul no WhatsApp do cliente só quando o atendente responsável abre o chat; ticks de entrega/leitura atualizam no painel
- WhatsApp: após inatividade, chat em **A classificar demanda** até registrar/confirmar; correções de mídia, Esc, áudio, scroll, vínculo e legenda (#568–#576)
- PDVs: código editável; listagem só com código; colunas de acesso remoto/ID/senha
- Chat interno: alerta sonoro; silenciar em grupos; balões/hover; participantes no grupo
- Equipe online (#545–#547): quem está com o painel aberto; presença multi-worker; admin pode forçar saída
- WhatsApp Contatos (#531/#534): aba Contatos, vincular em histórico, rede/empresa na busca
- Dependências: FastAPI, svix, Tailwind, Vite plugin-react, @types/node

## Test plan

Checklist smoke em staging (após merge/deploy):

- [ ] Login e navegação básica (tickets, chat hub, configurações)
- [ ] WhatsApp: abrir chat em atendimento; ticks VV; inatividade / Pausar-Retomar (se aplicável)
- [ ] WhatsApp: encerrar por inatividade → classificar demanda; Contatos / vincular
- [ ] Chat interno: mensagem nova com som; silenciar grupo; hover ações
- [ ] Equipe online (admin): lista e forçar saída (se testável)
- [ ] PDVs: editar código e copiar ID/senha
- [ ] Modo escuro: campos de pesquisa legíveis
- [ ] `/sobre` e release notes após deploy (CalVer)

Ref: `docs/RELEASES.md` — checklist PR main → staging.