### PR TITLE
feat(portal): portal autenticado do funcionário (#263, #600–#605)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ frontend/public/_debug-*.png
 *.swp
 .DS_Store
 Thumbs.db
+
+# Local Python venv (dev)
+backend/.venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário
 - WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown (até o aviso e, após o aviso, até encerrar); enviar mensagem sai da pausa automaticamente
 - WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel
 - PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 ### Melhorias
 
 - Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário
+- Portal (#600, #601): cadastro de funcionário pelo modal da Rede permite definir senha do portal na criação; sócio cadastra sem escolher empresas (escopo automático em toda a rede)
+- Portal (#604): RBAC por papel — colaborador vê só os próprios chamados; supervisor vê todos das empresas vinculadas; sócio vê toda a rede
+- Portal (#603): listagem e detalhe de atendimentos WhatsApp no `/portal` (somente leitura), com o mesmo escopo por papel e sem comentários internos da equipe
+- Portal (#602): sócio gere a equipa no `/portal` — cadastro e edição de colaboradores e supervisores (empresas, senha do portal); outros sócios listados com edição limitada; colaborador/supervisor recebem 403
+- Portal (#605): branding white-label no `/portal` — logo e cores da instância (mesmas configurações de Configurações → Base de conhecimento); login e shell aplicam a identidade do contratante, não a marca DeskRudder
+- Portal: shell alinhado ao painel DeskRudder (menu lateral com usuário/Sair, navbar com expandir/recolher); cor do menu lateral configurável (padrão = navbar); chat ao vivo no `/portal` (mesmo canal da `/kb`, isolado por instância); login com logo em destaque, ícone de olho na senha e fundo minimalista; título do portal independente da central `/kb`
 - WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown (até o aviso e, após o aviso, até encerrar); enviar mensagem sai da pausa automaticamente
 - WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel
 - PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)

--- a/backend/alembic/versions/075_portal_funcionario_auth.py
+++ b/backend/alembic/versions/075_portal_funcionario_auth.py
@@ -1,0 +1,50 @@
+"""Portal funcionário: senha e preferências de acesso (#300/#303).
+
+Revision ID: 075_portal_funcionario_auth
+Revises: 074_wpp_classificacao_demanda
+Create Date: 2026-07-19
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "075_portal_funcionario_auth"
+down_revision = "074_wpp_classificacao_demanda"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("funcionarios_rede"):
+        return
+    cols = {c["name"] for c in insp.get_columns("funcionarios_rede")}
+    if "senha_hash" not in cols:
+        op.add_column("funcionarios_rede", sa.Column("senha_hash", sa.String(255), nullable=True))
+    if "must_change_password" not in cols:
+        op.add_column(
+            "funcionarios_rede",
+            sa.Column("must_change_password", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+    if "token_version" not in cols:
+        op.add_column(
+            "funcionarios_rede",
+            sa.Column("token_version", sa.Integer(), nullable=False, server_default="0"),
+        )
+    if "notificar_email_portal" not in cols:
+        op.add_column(
+            "funcionarios_rede",
+            sa.Column("notificar_email_portal", sa.Boolean(), nullable=False, server_default=sa.true()),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("funcionarios_rede"):
+        return
+    cols = {c["name"] for c in insp.get_columns("funcionarios_rede")}
+    for col in ("notificar_email_portal", "token_version", "must_change_password", "senha_hash"):
+        if col in cols:
+            op.drop_column("funcionarios_rede", col)

--- a/backend/alembic/versions/076_kb_portal_cor_sidebar.py
+++ b/backend/alembic/versions/076_kb_portal_cor_sidebar.py
@@ -1,0 +1,43 @@
+"""Cor do menu lateral no branding KB/portal.
+
+Revision ID: 076_kb_portal_cor_sidebar
+Revises: 075_portal_funcionario_auth
+Create Date: 2026-07-20
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "076_kb_portal_cor_sidebar"
+down_revision = "075_portal_funcionario_auth"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("kb_portal_settings"):
+        return
+    cols = {c["name"] for c in insp.get_columns("kb_portal_settings")}
+    if "cor_sidebar" not in cols:
+        op.add_column(
+            "kb_portal_settings",
+            sa.Column("cor_sidebar", sa.String(7), nullable=True),
+        )
+        # Por padrão igual à navbar (cor_header) nas linhas existentes
+        op.execute(
+            sa.text(
+                "UPDATE kb_portal_settings SET cor_sidebar = cor_header WHERE cor_sidebar IS NULL"
+            )
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("kb_portal_settings"):
+        return
+    cols = {c["name"] for c in insp.get_columns("kb_portal_settings")}
+    if "cor_sidebar" in cols:
+        op.drop_column("kb_portal_settings", "cor_sidebar")

--- a/backend/app/api/funcionarios_rede.py
+++ b/backend/app/api/funcionarios_rede.py
@@ -70,6 +70,15 @@ def _para_read(f: FuncionarioRede) -> FuncionarioRedeRead:
     )
 
 
+def _escopo_para_tipo(tipo: str, escopo_informado: str | None) -> str:
+    """Sócio sempre enxerga toda a rede (escopo all), mesmo se o cliente omitir o campo."""
+    tipo_eff = (tipo or "colaborador").strip().lower()
+    if tipo_eff == "socio":
+        return "all"
+    escopo = (escopo_informado or "selected").strip().lower()
+    return escopo if escopo in ("all", "selected") else "selected"
+
+
 def _aplicar_senha_portal(f: FuncionarioRede, senha: str | None, *, must_change: bool | None) -> None:
     if senha is None:
         return
@@ -177,7 +186,7 @@ def criar(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(exigir_admin),
 ):
-    escopo = (data.escopo_empresas or "selected").strip().lower()
+    escopo = _escopo_para_tipo(data.tipo, data.escopo_empresas)
     if escopo not in ("all", "selected"):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="escopo_empresas deve ser all ou selected")
     empresa_ids = list(data.empresa_ids or [])
@@ -275,7 +284,7 @@ def atualizar(
         f.must_change_password = bool(must_change)
     if revogar:
         f.token_version = int(getattr(f, "token_version", 0) or 0) + 1
-    escopo = (escopo_upd or escopo_efetivo(f)).strip().lower()
+    escopo = _escopo_para_tipo(f.tipo, escopo_upd or escopo_efetivo(f))
     if escopo not in ("all", "selected"):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="escopo_empresas deve ser all ou selected")
     ids = list(empresa_ids) if empresa_ids is not None else _empresa_ids_leitura(f)

--- a/backend/app/api/funcionarios_rede.py
+++ b/backend/app/api/funcionarios_rede.py
@@ -25,6 +25,7 @@ from app.services.funcionario_rede_resolver import assert_email_unico_por_rede, 
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import exigir_admin
 from app.core.audit import registrar_audit
+from app.core.security import hash_senha
 
 router = APIRouter(prefix="/funcionarios-rede", tags=["funcionarios-rede"])
 
@@ -61,9 +62,33 @@ def _para_read(f: FuncionarioRede) -> FuncionarioRedeRead:
         rede_id=f.rede_id,
         empresa_id=f.empresa_id,
         empresa_ids=_empresa_ids_leitura(f),
+        portal_habilitado=bool((getattr(f, "senha_hash", None) or "").strip()),
+        must_change_password=bool(getattr(f, "must_change_password", False)),
+        notificar_email_portal=bool(getattr(f, "notificar_email_portal", True)),
         created_at=f.created_at,
         updated_at=f.updated_at,
     )
+
+
+def _aplicar_senha_portal(f: FuncionarioRede, senha: str | None, *, must_change: bool | None) -> None:
+    if senha is None:
+        return
+    senha_limpa = senha.strip()
+    if not senha_limpa:
+        return
+    if len(senha_limpa) < 8:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A senha do portal deve ter ao menos 8 caracteres.",
+        )
+    if not (f.email or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Informe o e-mail do funcionário para habilitar o portal.",
+        )
+    f.senha_hash = hash_senha(senha_limpa)
+    f.must_change_password = True if must_change is None else bool(must_change)
+    f.token_version = int(getattr(f, "token_version", 0) or 0) + 1
 
 
 @router.get("", response_model=ListaPaginada[FuncionarioRedeRead])
@@ -196,6 +221,7 @@ def criar(
     )
     db.add(f)
     db.flush()
+    _aplicar_senha_portal(f, data.senha_portal, must_change=data.must_change_password)
     registrar_audit(db, "funcionario_rede", f.id, "create", atendente.id)
     sincronizar_vinculos_empresas(
         db,
@@ -238,8 +264,17 @@ def atualizar(
     empresa_ids = update.pop("empresa_ids", None)
     empresa_id_upd = update.pop("empresa_id", None)
     escopo_upd = update.pop("escopo_empresas", None)
+    senha_portal = update.pop("senha_portal", None)
+    must_change = update.pop("must_change_password", None)
+    revogar = update.pop("revogar_sessoes_portal", None)
     for k, v in update.items():
         setattr(f, k, v)
+    if senha_portal is not None:
+        _aplicar_senha_portal(f, senha_portal, must_change=must_change)
+    elif must_change is not None:
+        f.must_change_password = bool(must_change)
+    if revogar:
+        f.token_version = int(getattr(f, "token_version", 0) or 0) + 1
     escopo = (escopo_upd or escopo_efetivo(f)).strip().lower()
     if escopo not in ("all", "selected"):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="escopo_empresas deve ser all ou selected")

--- a/backend/app/api/kb.py
+++ b/backend/app/api/kb.py
@@ -50,6 +50,7 @@ from app.schemas.portal_chat import (
     PortalChatSessionRead,
 )
 from app.schemas.lista_paginada import ListaPaginada
+from app.services.instancia_branding import branding_kb_publico as montar_branding_kb_publico
 from app.services.kb import listar_artigos_sugeridos, registrar_versao_artigo, slug_disponivel
 from app.services.kb_feedback import registrar_feedback_artigo_publico
 from app.core.login_protection import client_ip
@@ -798,10 +799,12 @@ def _get_or_create_portal_settings(db: Session, tenant_id: int) -> KbPortalSetti
 
 
 def _portal_settings_read(row: KbPortalSettings) -> KbPortalSettingsRead:
+    cor_header = row.cor_header or "#0B2D4A"
     return KbPortalSettingsRead(
         portal_titulo=row.portal_titulo,
         texto_boas_vindas=row.texto_boas_vindas,
-        cor_header=row.cor_header or "#0B2D4A",
+        cor_header=cor_header,
+        cor_sidebar=(row.cor_sidebar or cor_header),
         cor_primaria=row.cor_primaria or "#0D9488",
         cor_texto_header=row.cor_texto_header or "#FFFFFF",
         cor_texto_corpo=row.cor_texto_corpo or "#0F172A",
@@ -813,49 +816,6 @@ def _portal_settings_read(row: KbPortalSettings) -> KbPortalSettingsRead:
         chat_setor_id=row.chat_setor_id,
         chat_texto_boas_vindas=row.chat_texto_boas_vindas,
         public_url_preview="/kb",
-    )
-
-
-def _nome_exibicao_empresa(row: EmpresaSistema | None) -> str:
-    if not row:
-        return "Central de ajuda"
-    for attr in ("nome_fantasia", "nome", "razao_social"):
-        val = getattr(row, attr, None)
-        if val and str(val).strip():
-            return str(val).strip()
-    return "Central de ajuda"
-
-
-def _kb_public_branding(db: Session, tenant_id: int) -> KbPublicBrandingRead:
-    row = _empresa_sistema_row(db)
-    settings = _portal_settings_row(db, tenant_id)
-    logo_url = None
-    if row and row.logo_filename and str(row.logo_filename).strip():
-        logo_url = "/v1/kb/public/logo"
-    nome = _nome_exibicao_empresa(row)
-    titulo_custom = (settings.portal_titulo or "").strip() if settings else ""
-    if titulo_custom:
-        portal_titulo = titulo_custom
-    elif nome != "Central de ajuda":
-        portal_titulo = f"Central de ajuda — {nome}"
-    else:
-        portal_titulo = "Central de ajuda"
-    cor_primaria = (settings.cor_primaria if settings else None) or "#0D9488"
-    cor_link = (settings.cor_link if settings and settings.cor_link else None) or cor_primaria
-    return KbPublicBrandingRead(
-        nome_exibicao=nome,
-        portal_titulo=portal_titulo,
-        logo_url=logo_url,
-        texto_boas_vindas=settings.texto_boas_vindas if settings else None,
-        cor_primaria=cor_primaria,
-        cor_header=(settings.cor_header if settings else None) or "#0B2D4A",
-        cor_texto_header=(settings.cor_texto_header if settings else None) or "#FFFFFF",
-        cor_texto_corpo=(settings.cor_texto_corpo if settings else None) or "#0F172A",
-        cor_fundo=(settings.cor_fundo if settings else None) or "#F8FAFC",
-        cor_link=cor_link,
-        exibir_marca_deskrudder=bool(settings.exibir_marca_deskrudder) if settings else True,
-        feedback_habilitado=bool(settings.feedback_habilitado) if settings else True,
-        chat_habilitado=bool(settings.chat_habilitado) if settings else False,
     )
 
 
@@ -898,7 +858,7 @@ def atualizar_portal_settings(
 
 
 @router.get("/public/branding", response_model=KbPublicBrandingRead)
-def branding_kb_publico(
+def branding_kb_publico_endpoint(
     request: Request,
     response: Response,
     tenant_id: TenantIdDep,
@@ -906,7 +866,7 @@ def branding_kb_publico(
 ):
     check_kb_public_rate_limit(request)
     _ = tenant_id
-    out = _kb_public_branding(db, tenant_id)
+    out = montar_branding_kb_publico(db, tenant_id)
     _public_cache_headers(response)
     return out
 

--- a/backend/app/api/portal.py
+++ b/backend/app/api/portal.py
@@ -1,0 +1,418 @@
+"""API do portal do cliente — funcionários da rede (#263 / #300–#303)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile, status
+from fastapi.responses import FileResponse
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.login_protection import check_login_rate_limit, delay_on_auth_failure
+from app.core.portal_auth import claims_portal, obter_funcionario_portal
+from app.core.portal_scope import assert_empresa_no_escopo, empresa_ids_visiveis, tenant_id_do_funcionario
+from app.core.security import (
+    criar_access_token,
+    criar_refresh_token,
+    decodificar_refresh_token,
+    hash_senha,
+    verificar_senha,
+)
+from app.core.tenant_context import (
+    assert_token_tenant_matches_request,
+    resolve_tenant_id,
+)
+from app.database import get_db
+from app.models.empresa import Empresa
+from app.models.empresa_pdv import EmpresaPdv
+from app.models.funcionario_rede import FuncionarioRede
+from app.models.setor import Setor
+from app.models.ticket_anexo import TicketAnexo
+from app.schemas.lista_paginada import ListaPaginada
+from app.schemas.portal import (
+    PortalAnexoRead,
+    PortalEmpresaRead,
+    PortalLogin,
+    PortalMe,
+    PortalMensagemRead,
+    PortalPdvRead,
+    PortalPreferenciasUpdate,
+    PortalRefreshRequest,
+    PortalSetorRead,
+    PortalTicketCreate,
+    PortalTicketDetail,
+    PortalTicketListItem,
+    PortalTicketMensagemCreate,
+    PortalToken,
+    PortalTrocarSenha,
+)
+from app.services import portal_tickets as portal_svc
+from app.services import ticket_anexo_storage
+from app.services.funcionario_escopo import rede_id_efetiva
+from app.services.ticket_csat import criar_convite_csat
+
+router = APIRouter(prefix="/portal", tags=["portal-cliente"])
+
+_MAX_PAGE = 50
+_DEFAULT_PAGE = 20
+
+
+def _buscar_funcionario_login(db: Session, email: str) -> FuncionarioRede | None:
+    return (
+        db.query(FuncionarioRede)
+        .filter(
+            func.lower(FuncionarioRede.email) == email,
+            FuncionarioRede.ativo.is_(True),
+        )
+        .first()
+    )
+
+
+def _emitir_tokens(db: Session, funcionario: FuncionarioRede) -> PortalToken:
+    tid = tenant_id_do_funcionario(db, funcionario)
+    claims = claims_portal(funcionario, tenant_id=tid)
+    return PortalToken(
+        access_token=criar_access_token(data=claims),
+        refresh_token=criar_refresh_token(data=claims),
+        must_change_password=bool(getattr(funcionario, "must_change_password", False)),
+    )
+
+
+def _me_read(db: Session, funcionario: FuncionarioRede) -> PortalMe:
+    ids = sorted(empresa_ids_visiveis(db, funcionario))
+    empresas: list[PortalEmpresaRead] = []
+    if ids:
+        rows = db.query(Empresa).filter(Empresa.id.in_(ids)).order_by(Empresa.nome.asc()).all()
+        empresas = [
+            PortalEmpresaRead(id=e.id, nome=e.nome, rede_id=int(e.rede_id)) for e in rows
+        ]
+    return PortalMe(
+        id=funcionario.id,
+        nome=funcionario.nome,
+        email=str(funcionario.email or ""),
+        tipo=funcionario.tipo,
+        rede_id=rede_id_efetiva(db, funcionario),
+        empresas=empresas,
+        must_change_password=bool(getattr(funcionario, "must_change_password", False)),
+        notificar_email_portal=bool(getattr(funcionario, "notificar_email_portal", True)),
+    )
+
+
+@router.post("/auth/login", response_model=PortalToken)
+async def portal_login(request: Request, data: PortalLogin, db: Session = Depends(get_db)):
+    check_login_rate_limit(request)
+    email = data.email.strip().lower()
+    resolve_tenant_id(request)  # valida host multi-tenant
+    funcionario = _buscar_funcionario_login(db, email)
+    if not funcionario or not (funcionario.senha_hash or "").strip():
+        await delay_on_auth_failure()
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="E-mail ou senha inválidos")
+    if not verificar_senha(data.senha, funcionario.senha_hash):
+        await delay_on_auth_failure()
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="E-mail ou senha inválidos")
+    if not funcionario.ativo:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Conta inativa")
+    return _emitir_tokens(db, funcionario)
+
+
+@router.post("/auth/refresh", response_model=PortalToken)
+async def portal_refresh(
+    request: Request,
+    data: PortalRefreshRequest,
+    db: Session = Depends(get_db),
+):
+    payload = decodificar_refresh_token(data.refresh_token)
+    if not payload or "sub" not in payload or payload.get("aud") != "portal":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Refresh token inválido ou expirado")
+    email = str(payload["sub"]).strip().lower()
+    token_tid = payload.get("tid")
+    assert_token_tenant_matches_request(request, token_tid)
+    funcionario = _buscar_funcionario_login(db, email)
+    if not funcionario:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuário não encontrado ou inativo")
+    fid = payload.get("fid")
+    if fid is not None and int(fid) != int(funcionario.id):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuário não encontrado ou inativo")
+    token_ver = int(payload.get("ver") or 0)
+    atual_ver = int(getattr(funcionario, "token_version", 0) or 0)
+    if token_ver != atual_ver:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Sessão encerrada. Faça login novamente.",
+        )
+    return _emitir_tokens(db, funcionario)
+
+
+@router.get("/me", response_model=PortalMe)
+def portal_me(
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    return _me_read(db, funcionario)
+
+
+@router.post("/me/trocar-senha", response_model=PortalToken)
+def portal_trocar_senha(
+    data: PortalTrocarSenha,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    if not verificar_senha(data.senha_atual, funcionario.senha_hash or ""):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Senha atual incorreta")
+    if len(data.senha_nova.strip()) < 8:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="A nova senha deve ter ao menos 8 caracteres")
+    if verificar_senha(data.senha_nova, funcionario.senha_hash or ""):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="A nova senha deve ser diferente da atual")
+    funcionario.senha_hash = hash_senha(data.senha_nova.strip())
+    funcionario.must_change_password = False
+    funcionario.token_version = int(getattr(funcionario, "token_version", 0) or 0) + 1
+    db.commit()
+    db.refresh(funcionario)
+    return _emitir_tokens(db, funcionario)
+
+
+@router.patch("/me/preferencias", response_model=PortalMe)
+def portal_preferencias(
+    data: PortalPreferenciasUpdate,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    if data.notificar_email_portal is not None:
+        funcionario.notificar_email_portal = bool(data.notificar_email_portal)
+        db.commit()
+        db.refresh(funcionario)
+    return _me_read(db, funcionario)
+
+
+@router.get("/catalogos/setores", response_model=list[PortalSetorRead])
+def portal_setores(
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    tid = tenant_id_do_funcionario(db, funcionario)
+    rows = (
+        db.query(Setor)
+        .filter(Setor.tenant_id == tid, Setor.ativo.is_(True))
+        .order_by(Setor.nome.asc())
+        .all()
+    )
+    return [PortalSetorRead(id=s.id, nome=s.nome, slug=s.slug) for s in rows]
+
+
+@router.get("/empresas/{empresa_id}/pdvs", response_model=list[PortalPdvRead])
+def portal_pdvs_empresa(
+    empresa_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        assert_empresa_no_escopo(db, funcionario, empresa_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    rows = (
+        db.query(EmpresaPdv)
+        .filter(EmpresaPdv.empresa_id == empresa_id, EmpresaPdv.ativo.is_(True))
+        .order_by(EmpresaPdv.codigo.asc())
+        .all()
+    )
+    return [
+        PortalPdvRead(id=p.id, codigo=p.codigo, papel=getattr(p, "papel", None), ativo=bool(p.ativo))
+        for p in rows
+    ]
+
+
+@router.get("/tickets", response_model=ListaPaginada[PortalTicketListItem])
+def portal_listar_tickets(
+    situacao: str = Query("abertos", description="abertos | fechados | todos"),
+    busca: str | None = Query(None),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    rows, total = portal_svc.listar_tickets(
+        db,
+        funcionario,
+        situacao=situacao,
+        busca=busca,
+        offset=offset,
+        limit=limit,
+    )
+    return ListaPaginada(items=[portal_svc.ticket_para_list_item(t) for t in rows], total=total)
+
+
+@router.post("/tickets", response_model=PortalTicketDetail, status_code=201)
+def portal_criar_ticket(
+    data: PortalTicketCreate,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.criar_ticket(db, funcionario, data)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    return portal_svc.ticket_para_detail(db, ticket)
+
+
+@router.get("/tickets/{ticket_id}", response_model=PortalTicketDetail)
+def portal_obter_ticket(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_svc.ticket_para_detail(db, ticket)
+
+
+@router.get("/tickets/{ticket_id}/mensagens", response_model=list[PortalMensagemRead])
+def portal_listar_mensagens(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_svc.listar_mensagens_publicas(db, funcionario, ticket)
+
+
+@router.post("/tickets/{ticket_id}/mensagens", response_model=PortalMensagemRead, status_code=201)
+def portal_criar_mensagem(
+    ticket_id: int,
+    data: PortalTicketMensagemCreate,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+        m = portal_svc.criar_mensagem_portal(db, funcionario, ticket, data.corpo)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    return portal_svc.mensagem_para_read(db, funcionario, m)
+
+
+@router.get("/tickets/{ticket_id}/anexos", response_model=list[PortalAnexoRead])
+def portal_listar_anexos(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_svc.listar_anexos_publicos(db, ticket)
+
+
+@router.post("/tickets/{ticket_id}/anexos", response_model=PortalAnexoRead, status_code=201)
+async def portal_upload_anexo(
+    ticket_id: int,
+    file: UploadFile = File(...),
+    mensagem_id: int | None = Form(None),
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    if ticket.fechado_em is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Chamado encerrado. Abra um novo chamado para enviar anexos.",
+        )
+    raw = await file.read()
+    try:
+        nome_original, mime = ticket_anexo_storage.validar_upload(file.filename, file.content_type, len(raw))
+        storage_key = ticket_anexo_storage.gravar_bytes_em_disco(raw, mimetype=mime, nome_original=nome_original)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    except OSError as e:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Falha ao gravar arquivo") from e
+
+    msg_id = None
+    if mensagem_id is not None:
+        from app.models.ticket import TicketMensagem
+
+        msg = (
+            db.query(TicketMensagem)
+            .filter(
+                TicketMensagem.id == mensagem_id,
+                TicketMensagem.ticket_id == ticket.id,
+                TicketMensagem.tipo.in_(list(portal_svc.TIPOS_PUBLICOS_PORTAL)),
+            )
+            .first()
+        )
+        if not msg:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mensagem não encontrada")
+        msg_id = msg.id
+
+    a = TicketAnexo(
+        ticket_id=ticket.id,
+        mensagem_id=msg_id,
+        atendente_id=None,
+        visibilidade="publico",
+        nome_original=nome_original,
+        content_type=mime,
+        tamanho_bytes=len(raw),
+        storage_key=storage_key,
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return PortalAnexoRead(
+        id=a.id,
+        nome_original=a.nome_original,
+        content_type=a.content_type,
+        tamanho_bytes=int(a.tamanho_bytes or 0),
+        mensagem_id=a.mensagem_id,
+        created_at=a.created_at,
+        download_url=f"/v1/portal/tickets/{ticket.id}/anexos/{a.id}/download",
+    )
+
+
+@router.get("/tickets/{ticket_id}/anexos/{anexo_id}/download")
+def portal_download_anexo(
+    ticket_id: int,
+    anexo_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+        a = portal_svc.obter_anexo_publico(db, ticket, anexo_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    path = ticket_anexo_storage.caminho_absoluto_arquivo(a.storage_key)
+    if path is None or not path.is_file():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Arquivo não encontrado no armazenamento")
+    return FileResponse(
+        path=str(path),
+        filename=a.nome_original,
+        media_type=a.content_type or "application/octet-stream",
+    )
+
+
+@router.post("/tickets/{ticket_id}/csat-link")
+def portal_csat_link(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    if ticket.fechado_em is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Avaliação disponível após o encerramento.")
+    result = criar_convite_csat(db, ticket.id, enviar_email=False, exigir_email_cliente=False)
+    if not result:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Avaliação já registrada ou indisponível.")
+    return {"link": result["link"], "expires_at": result["expires_at"]}

--- a/backend/app/api/portal.py
+++ b/backend/app/api/portal.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile, status
 from fastapi.responses import FileResponse
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from app.core.kb_public_rate_limit import check_kb_public_rate_limit
 from app.core.login_protection import check_login_rate_limit, delay_on_auth_failure
-from app.core.portal_auth import claims_portal, obter_funcionario_portal
+from app.core.portal_auth import claims_portal, exigir_socio_portal, obter_funcionario_portal
 from app.core.portal_scope import assert_empresa_no_escopo, empresa_ids_visiveis, tenant_id_do_funcionario
 from app.core.security import (
     criar_access_token,
@@ -18,6 +19,7 @@ from app.core.security import (
     verificar_senha,
 )
 from app.core.tenant_context import (
+    TenantIdDep,
     assert_token_tenant_matches_request,
     resolve_tenant_id,
 )
@@ -44,11 +46,22 @@ from app.schemas.portal import (
     PortalTicketMensagemCreate,
     PortalToken,
     PortalTrocarSenha,
+    PortalWhatsappChatDetail,
+    PortalWhatsappChatListItem,
+    PortalWhatsappMensagemRead,
+    PortalEquipeFuncionarioCreate,
+    PortalEquipeFuncionarioRead,
+    PortalEquipeFuncionarioUpdate,
+    PortalPublicBrandingRead,
 )
 from app.services import portal_tickets as portal_svc
+from app.services import portal_whatsapp as portal_wpp_svc
+from app.services import portal_equipe as portal_equipe_svc
+from app.services.instancia_branding import branding_portal_cliente
 from app.services import ticket_anexo_storage
 from app.services.funcionario_escopo import rede_id_efetiva
 from app.services.ticket_csat import criar_convite_csat
+from app.services.whatsapp_media_storage import caminho_absoluto_arquivo
 
 router = APIRouter(prefix="/portal", tags=["portal-cliente"])
 
@@ -400,6 +413,143 @@ def portal_download_anexo(
     )
 
 
+@router.get("/chats", response_model=ListaPaginada[PortalWhatsappChatListItem])
+def portal_listar_chats(
+    situacao: str = Query("abertos", description="abertos | encerrados | todos"),
+    busca: str | None = Query(None),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    rows, total = portal_wpp_svc.listar_chats(
+        db,
+        funcionario,
+        situacao=situacao,
+        busca=busca,
+        offset=offset,
+        limit=limit,
+    )
+    return ListaPaginada(
+        items=[portal_wpp_svc.chat_para_list_item(db, c) for c in rows],
+        total=total,
+    )
+
+
+@router.get("/chats/{chat_id}", response_model=PortalWhatsappChatDetail)
+def portal_obter_chat(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        chat = portal_wpp_svc.obter_chat_escopo(db, funcionario, chat_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_wpp_svc.chat_para_detail(db, chat)
+
+
+@router.get("/chats/{chat_id}/mensagens", response_model=list[PortalWhatsappMensagemRead])
+def portal_listar_mensagens_chat(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        chat = portal_wpp_svc.obter_chat_escopo(db, funcionario, chat_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_wpp_svc.listar_mensagens_visiveis(db, chat)
+
+
+@router.get("/chats/{chat_id}/mensagens/{mensagem_id}/midia")
+def portal_download_midia_chat(
+    chat_id: int,
+    mensagem_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        chat = portal_wpp_svc.obter_chat_escopo(db, funcionario, chat_id)
+        m = portal_wpp_svc.obter_mensagem_midia(db, chat, mensagem_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    path = caminho_absoluto_arquivo(m.midia_nome_arquivo)
+    if path is None or not path.is_file():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ficheiro não encontrado")
+    media_type = m.mimetype or "application/octet-stream"
+    return FileResponse(path, media_type=media_type, filename=path.name)
+
+
+@router.get("/equipe/funcionarios", response_model=ListaPaginada[PortalEquipeFuncionarioRead])
+def portal_equipe_listar(
+    incluir_inativos: bool = Query(False),
+    busca: str | None = Query(None),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    db: Session = Depends(get_db),
+    socio: FuncionarioRede = Depends(exigir_socio_portal),
+):
+    rows, total = portal_equipe_svc.listar_funcionarios(
+        db,
+        socio,
+        incluir_inativos=incluir_inativos,
+        busca=busca,
+        offset=offset,
+        limit=limit,
+    )
+    return ListaPaginada(
+        items=[portal_equipe_svc._para_read(f, socio_id=socio.id) for f in rows],
+        total=total,
+    )
+
+
+@router.get("/equipe/empresas", response_model=list[PortalEmpresaRead])
+def portal_equipe_empresas(
+    db: Session = Depends(get_db),
+    socio: FuncionarioRede = Depends(exigir_socio_portal),
+):
+    rows = portal_equipe_svc.empresas_da_rede(db, socio)
+    return [PortalEmpresaRead(id=e.id, nome=e.nome, rede_id=int(e.rede_id)) for e in rows]
+
+
+@router.get("/equipe/funcionarios/{funcionario_id}", response_model=PortalEquipeFuncionarioRead)
+def portal_equipe_obter(
+    funcionario_id: int,
+    db: Session = Depends(get_db),
+    socio: FuncionarioRede = Depends(exigir_socio_portal),
+):
+    try:
+        f = portal_equipe_svc._obter_na_rede(db, socio, funcionario_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_equipe_svc._para_read(f, socio_id=socio.id)
+
+
+@router.post("/equipe/funcionarios", response_model=PortalEquipeFuncionarioRead, status_code=201)
+def portal_equipe_criar(
+    data: PortalEquipeFuncionarioCreate,
+    db: Session = Depends(get_db),
+    socio: FuncionarioRede = Depends(exigir_socio_portal),
+):
+    f = portal_equipe_svc.criar_funcionario(db, socio, data)
+    return portal_equipe_svc._para_read(f, socio_id=socio.id)
+
+
+@router.patch("/equipe/funcionarios/{funcionario_id}", response_model=PortalEquipeFuncionarioRead)
+def portal_equipe_atualizar(
+    funcionario_id: int,
+    data: PortalEquipeFuncionarioUpdate,
+    db: Session = Depends(get_db),
+    socio: FuncionarioRede = Depends(exigir_socio_portal),
+):
+    try:
+        f = portal_equipe_svc.atualizar_funcionario(db, socio, funcionario_id, data)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_equipe_svc._para_read(f, socio_id=socio.id)
+
+
 @router.post("/tickets/{ticket_id}/csat-link")
 def portal_csat_link(
     ticket_id: int,
@@ -416,3 +566,21 @@ def portal_csat_link(
     if not result:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Avaliação já registrada ou indisponível.")
     return {"link": result["link"], "expires_at": result["expires_at"]}
+
+
+def _public_cache_headers(response: Response) -> None:
+    response.headers["Cache-Control"] = "public, max-age=60"
+
+
+@router.get("/public/branding", response_model=PortalPublicBrandingRead)
+def portal_public_branding(
+    request: Request,
+    response: Response,
+    tenant_id: TenantIdDep,
+    db: Session = Depends(get_db),
+):
+    check_kb_public_rate_limit(request)
+    _ = tenant_id
+    out = branding_portal_cliente(db, tenant_id)
+    _public_cache_headers(response)
+    return out

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -1365,6 +1365,12 @@ def criar_mensagem(
         .first()
     )
     assert m is not None
+    if m.tipo == "publico":
+        from app.services.portal_notificacoes import notificar_funcionario_mensagem_publica
+
+        ticket_fresh = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+        if ticket_fresh is not None:
+            notificar_funcionario_mensagem_publica(db, ticket=ticket_fresh, mensagem=m)
     emit_ticket_mensagem_from_model(db, ticket, m, exclude_atendente_id=atendente.id)
     return _mensagem_para_read(m)
 
@@ -1939,9 +1945,12 @@ def atualizar(
         setattr(ticket, k, v)
 
     acabou_de_fechar = False
+    status_portal_notify: tuple[str, str] | None = None
     if "status_id" in update:
         st = db.query(StatusTicket).filter(StatusTicket.id == ticket.status_id).first()
         slug = (st.slug or "").lower() if st else ""
+        if st is not None:
+            status_portal_notify = (st.nome or slug, slug)
         if slug == "fechado":
             if ticket.fechado_em is None:
                 acabou_de_fechar = True
@@ -1961,6 +1970,15 @@ def atualizar(
     sincronizar_sla_violado(db, ticket)
 
     db.commit()
+    if status_portal_notify is not None:
+        from app.services.portal_notificacoes import notificar_funcionario_status
+
+        notificar_funcionario_status(
+            db,
+            ticket=ticket,
+            status_nome=status_portal_notify[0],
+            status_slug=status_portal_notify[1],
+        )
     if acabou_de_fechar:
         processar_hooks_ao_fechar_ticket(db, ticket_id)
         db.commit()

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -26,6 +26,12 @@ def _carregar_atendente_por_token(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token inválido ou expirado",
         )
+    # Token do portal do cliente não acessa rotas internas (#300)
+    if payload.get("aud") == "portal":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token inválido para o painel interno",
+        )
     email = payload["sub"]
     token_tid = payload.get("tid")
     assert_token_tenant_matches_request(request, token_tid)

--- a/backend/app/core/portal_auth.py
+++ b/backend/app/core/portal_auth.py
@@ -1,0 +1,128 @@
+"""Autenticação JWT do portal do cliente (funcionário da rede)."""
+
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.funcionario_rede import FuncionarioRede
+from app.core.security import decodificar_token
+from app.core.tenant_context import (
+    assert_token_tenant_matches_request,
+    effective_tenant_id,
+    get_request_tenant_id,
+    is_multi_tenant_mode,
+)
+
+PORTAL_AUD = "portal"
+
+security = HTTPBearer(auto_error=False)
+
+
+def claims_portal(funcionario: FuncionarioRede, *, tenant_id: int) -> dict:
+    email = (funcionario.email or "").strip().lower()
+    ver = int(getattr(funcionario, "token_version", 0) or 0)
+    return {
+        "sub": email,
+        "aud": PORTAL_AUD,
+        "fid": int(funcionario.id),
+        "tid": int(tenant_id),
+        "ver": ver,
+    }
+
+
+def token_eh_portal(payload: dict | None) -> bool:
+    if not payload:
+        return False
+    return payload.get("aud") == PORTAL_AUD
+
+
+def _carregar_funcionario_por_token(
+    request: Request,
+    token: str,
+    db: Session,
+) -> FuncionarioRede:
+    payload = decodificar_token(token)
+    if not payload or "sub" not in payload or not token_eh_portal(payload):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token inválido ou expirado",
+        )
+    email = str(payload["sub"]).strip().lower()
+    token_tid = payload.get("tid")
+    assert_token_tenant_matches_request(request, token_tid)
+    if is_multi_tenant_mode():
+        host_tid = get_request_tenant_id(request)
+        tenant_id = int(host_tid if host_tid is not None else token_tid or 0)
+    else:
+        tenant_id = effective_tenant_id()
+
+    fid = payload.get("fid")
+    q = db.query(FuncionarioRede).filter(
+        func.lower(FuncionarioRede.email) == email,
+        FuncionarioRede.ativo.is_(True),
+    )
+    if fid is not None:
+        q = q.filter(FuncionarioRede.id == int(fid))
+    funcionario = q.first()
+    if not funcionario:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Usuário não encontrado ou inativo",
+        )
+    if not (funcionario.senha_hash or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Acesso ao portal não habilitado. Solicite a senha ao suporte.",
+        )
+
+    # Valida tenant via rede/empresa do funcionário
+    from app.core.portal_scope import tenant_id_do_funcionario
+
+    try:
+        tid_func = tenant_id_do_funcionario(db, funcionario)
+    except Exception:
+        tid_func = tenant_id
+    if is_multi_tenant_mode() and int(tid_func) != int(tenant_id):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Usuário não encontrado ou inativo",
+        )
+
+    token_ver = int(payload.get("ver") or 0)
+    atual_ver = int(getattr(funcionario, "token_version", 0) or 0)
+    if token_ver != atual_ver:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Sessão encerrada. Faça login novamente.",
+        )
+
+    path = request.url.path.rstrip("/") or "/"
+    method = request.method.upper()
+    if getattr(funcionario, "must_change_password", False):
+        pode = (path.endswith("/portal/me") and method == "GET") or (
+            path.endswith("/portal/me/trocar-senha") and method == "POST"
+        )
+        if not pode:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Altere sua senha antes de usar o portal.",
+            )
+    return funcionario
+
+
+def obter_funcionario_portal(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+    db: Session = Depends(get_db),
+) -> FuncionarioRede:
+    if not credentials:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token não informado",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return _carregar_funcionario_por_token(request, credentials.credentials, db)

--- a/backend/app/core/portal_auth.py
+++ b/backend/app/core/portal_auth.py
@@ -126,3 +126,16 @@ def obter_funcionario_portal(
             headers={"WWW-Authenticate": "Bearer"},
         )
     return _carregar_funcionario_por_token(request, credentials.credentials, db)
+
+
+def exigir_socio_portal(
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+) -> FuncionarioRede:
+    from app.core.portal_scope import tipo_portal
+
+    if tipo_portal(funcionario) != "socio":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="A gestão de equipe está disponível apenas para sócios.",
+        )
+    return funcionario

--- a/backend/app/core/portal_scope.py
+++ b/backend/app/core/portal_scope.py
@@ -1,37 +1,122 @@
-"""Escopo de dados do portal do cliente (funcionário da rede)."""
+"""Escopo de dados do portal do cliente (funcionário da rede).
+
+RBAC por papel (#604):
+- colaborador: tickets/chats **próprios** (aberto_por / contacto vinculado)
+- supervisor: tickets/chats das **empresas vinculadas**
+- sócio: tudo da **rede**
+
+Ver também `docs/PORTAL_CLIENTE.md`.
+"""
 
 from __future__ import annotations
 
-from sqlalchemy.orm import Session
+from sqlalchemy import or_
+from sqlalchemy.orm import Query, Session
 
 from app.models.empresa import Empresa
 from app.models.funcionario_rede import FuncionarioRede
 from app.models.ticket import Ticket
-from app.services.funcionario_escopo import empresa_ids_vinculados, rede_id_efetiva
+from app.services.funcionario_escopo import empresa_ids_vinculados, escopo_efetivo, rede_id_efetiva
+
+TiposPortal = frozenset({"colaborador", "supervisor", "socio"})
+
+
+def tipo_portal(funcionario: FuncionarioRede) -> str:
+    t = (funcionario.tipo or "colaborador").strip().lower()
+    return t if t in TiposPortal else "colaborador"
 
 
 def empresa_ids_visiveis(db: Session, funcionario: FuncionarioRede) -> set[int]:
     return empresa_ids_vinculados(db, funcionario, apenas_ativas=True)
 
 
-def ticket_no_escopo(db: Session, funcionario: FuncionarioRede, ticket: Ticket) -> bool:
-    """Ticket visível se empresa está no escopo, ou (coordenação) rede sem empresa no escopo do sócio."""
+def _ticket_empresa_rede_visivel(db: Session, funcionario: FuncionarioRede, ticket: Ticket) -> bool:
+    """Empresa/rede do ticket dentro do vínculo do funcionário (sem filtro de autor)."""
     rede_id = rede_id_efetiva(db, funcionario)
     if rede_id is None:
         return False
     if ticket.rede_id is not None and int(ticket.rede_id) != int(rede_id):
-        # Fallback: empresa do ticket pode estar na rede
         if ticket.empresa_id is None:
             return False
     ids = empresa_ids_visiveis(db, funcionario)
     if ticket.empresa_id is not None:
         return int(ticket.empresa_id) in ids
-    # Ticket só com rede (coordenação): sócio/supervisor com escopo all da mesma rede
     if ticket.rede_id is not None and int(ticket.rede_id) == int(rede_id):
-        from app.services.funcionario_escopo import escopo_efetivo
-
         return escopo_efetivo(funcionario) == "all"
     return False
+
+
+def ticket_no_escopo(db: Session, funcionario: FuncionarioRede, ticket: Ticket) -> bool:
+    if not _ticket_empresa_rede_visivel(db, funcionario, ticket):
+        return False
+    if tipo_portal(funcionario) == "colaborador":
+        ap = ticket.aberto_por_id
+        return ap is not None and int(ap) == int(funcionario.id)
+    return True
+
+
+def filtro_query_tickets_portal(query: Query, db: Session, funcionario: FuncionarioRede) -> Query | None:
+    """Aplica escopo RBAC à query de tickets. Retorna None se a listagem deve ser vazia."""
+    ids = empresa_ids_visiveis(db, funcionario)
+    rede_id = rede_id_efetiva(db, funcionario)
+    filtros = []
+    if ids:
+        filtros.append(Ticket.empresa_id.in_(ids))
+    if rede_id is not None and escopo_efetivo(funcionario) == "all":
+        filtros.append((Ticket.empresa_id.is_(None)) & (Ticket.rede_id == rede_id))
+    if not filtros:
+        return None
+    query = query.filter(or_(*filtros))
+    if tipo_portal(funcionario) == "colaborador":
+        query = query.filter(Ticket.aberto_por_id == funcionario.id)
+    return query
+
+
+def chat_no_escopo(db: Session, funcionario: FuncionarioRede, chat) -> bool:
+    """Escopo de chats WhatsApp no portal (#604; API em #603)."""
+    from app.models.whatsapp_chat import WhatsappChat
+
+    if not isinstance(chat, WhatsappChat):
+        return False
+    rede_id = rede_id_efetiva(db, funcionario)
+    if rede_id is None:
+        return False
+    if chat.empresa_id is None:
+        return tipo_portal(funcionario) == "socio" and escopo_efetivo(funcionario) == "all"
+    emp = db.query(Empresa).filter(Empresa.id == chat.empresa_id).first()
+    if not emp or int(emp.rede_id) != int(rede_id):
+        return False
+    papel = tipo_portal(funcionario)
+    if papel == "colaborador":
+        fid = chat.funcionario_rede_id
+        return fid is not None and int(fid) == int(funcionario.id)
+    if papel == "supervisor":
+        return int(chat.empresa_id) in empresa_ids_visiveis(db, funcionario)
+    return True
+
+
+def filtro_query_chats_portal(query: Query, db: Session, funcionario: FuncionarioRede) -> Query | None:
+    """Filtro SQLAlchemy para listagem de chats no portal (#603)."""
+    from app.models.whatsapp_chat import WhatsappChat
+
+    ids = empresa_ids_visiveis(db, funcionario)
+    rede_id = rede_id_efetiva(db, funcionario)
+    if rede_id is None:
+        return None
+    papel = tipo_portal(funcionario)
+    if papel == "colaborador":
+        return query.filter(WhatsappChat.funcionario_rede_id == funcionario.id)
+    if papel == "supervisor":
+        if not ids:
+            return None
+        return query.filter(WhatsappChat.empresa_id.in_(ids))
+    rede_empresa_ids = db.query(Empresa.id).filter(Empresa.rede_id == rede_id)
+    return query.filter(
+        or_(
+            WhatsappChat.empresa_id.in_(rede_empresa_ids),
+            WhatsappChat.empresa_id.is_(None),
+        )
+    )
 
 
 def assert_empresa_no_escopo(db: Session, funcionario: FuncionarioRede, empresa_id: int) -> Empresa:

--- a/backend/app/core/portal_scope.py
+++ b/backend/app/core/portal_scope.py
@@ -1,0 +1,60 @@
+"""Escopo de dados do portal do cliente (funcionário da rede)."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.empresa import Empresa
+from app.models.funcionario_rede import FuncionarioRede
+from app.models.ticket import Ticket
+from app.services.funcionario_escopo import empresa_ids_vinculados, rede_id_efetiva
+
+
+def empresa_ids_visiveis(db: Session, funcionario: FuncionarioRede) -> set[int]:
+    return empresa_ids_vinculados(db, funcionario, apenas_ativas=True)
+
+
+def ticket_no_escopo(db: Session, funcionario: FuncionarioRede, ticket: Ticket) -> bool:
+    """Ticket visível se empresa está no escopo, ou (coordenação) rede sem empresa no escopo do sócio."""
+    rede_id = rede_id_efetiva(db, funcionario)
+    if rede_id is None:
+        return False
+    if ticket.rede_id is not None and int(ticket.rede_id) != int(rede_id):
+        # Fallback: empresa do ticket pode estar na rede
+        if ticket.empresa_id is None:
+            return False
+    ids = empresa_ids_visiveis(db, funcionario)
+    if ticket.empresa_id is not None:
+        return int(ticket.empresa_id) in ids
+    # Ticket só com rede (coordenação): sócio/supervisor com escopo all da mesma rede
+    if ticket.rede_id is not None and int(ticket.rede_id) == int(rede_id):
+        from app.services.funcionario_escopo import escopo_efetivo
+
+        return escopo_efetivo(funcionario) == "all"
+    return False
+
+
+def assert_empresa_no_escopo(db: Session, funcionario: FuncionarioRede, empresa_id: int) -> Empresa:
+    emp = db.query(Empresa).filter(Empresa.id == empresa_id, Empresa.ativo.is_(True)).first()
+    if not emp or int(empresa_id) not in empresa_ids_visiveis(db, funcionario):
+        # 404 para não revelar existência fora do escopo
+        raise LookupError("Empresa não encontrada")
+    return emp
+
+
+def tenant_id_do_funcionario(db: Session, funcionario: FuncionarioRede) -> int:
+    rede_id = rede_id_efetiva(db, funcionario)
+    if rede_id is not None:
+        from app.models.rede import Rede
+
+        rede = db.query(Rede).filter(Rede.id == rede_id).first()
+        if rede is not None:
+            return int(rede.tenant_id)
+    ids = empresa_ids_visiveis(db, funcionario)
+    if ids:
+        emp = db.query(Empresa).filter(Empresa.id == next(iter(ids))).first()
+        if emp is not None:
+            return int(emp.tenant_id)
+    from app.core.tenant_context import effective_tenant_id
+
+    return int(effective_tenant_id())

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -40,7 +40,13 @@ def criar_refresh_token(data: dict) -> str:
 
 def decodificar_token(token: str) -> dict | None:
     try:
-        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        # verify_aud=False: claim `aud` (portal) é validada nas dependências de auth (#300)
+        payload = jwt.decode(
+            token,
+            settings.SECRET_KEY,
+            algorithms=[settings.ALGORITHM],
+            options={"verify_aud": False},
+        )
         if payload.get("type") not in (None, "access"):
             return None
         return payload
@@ -50,7 +56,12 @@ def decodificar_token(token: str) -> dict | None:
 
 def decodificar_refresh_token(token: str) -> dict | None:
     try:
-        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        payload = jwt.decode(
+            token,
+            settings.SECRET_KEY,
+            algorithms=[settings.ALGORITHM],
+            options={"verify_aud": False},
+        )
         if payload.get("type") != "refresh":
             return None
         return payload

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,7 @@ from app.api import (
     kb,
     chat_interno,
     portal_chats,
+    portal,
 )
 from app.config import settings
 from app.core.audit import clear_audit_request_context, set_audit_request_context
@@ -460,6 +461,7 @@ app.include_router(sla.router, prefix=API_V1_PREFIX)
 app.include_router(kb.router, prefix=API_V1_PREFIX)
 app.include_router(chat_interno.router, prefix=API_V1_PREFIX)
 app.include_router(portal_chats.router, prefix=API_V1_PREFIX)
+app.include_router(portal.router, prefix=API_V1_PREFIX)
 
 
 def _app_route_paths() -> set[str]:

--- a/backend/app/models/funcionario_rede.py
+++ b/backend/app/models/funcionario_rede.py
@@ -24,6 +24,11 @@ class FuncionarioRede(Base):
     tipo = Column(String(20), nullable=False)  # socio | supervisor | colaborador
     escopo_empresas = Column(String(20), nullable=False, default="selected")  # all | selected
     ativo = Column(Boolean, default=True)
+    # Auth do portal do cliente (#263 / #300)
+    senha_hash = Column(String(255), nullable=True)
+    must_change_password = Column(Boolean, default=False, nullable=False)
+    token_version = Column(Integer, default=0, nullable=False)
+    notificar_email_portal = Column(Boolean, default=True, nullable=False)
     # Sócio: preenchido rede_id
     rede_id = Column(Integer, ForeignKey("redes.id"), nullable=True)
     # Colaborador: preenchido empresa_id

--- a/backend/app/models/kb.py
+++ b/backend/app/models/kb.py
@@ -130,6 +130,7 @@ class KbPortalSettings(Base):
     portal_titulo = Column(String(120), nullable=True)
     texto_boas_vindas = Column(String(500), nullable=True)
     cor_header = Column(String(7), nullable=False, server_default="#0B2D4A", default="#0B2D4A")
+    cor_sidebar = Column(String(7), nullable=True)
     cor_primaria = Column(String(7), nullable=False, server_default="#0D9488", default="#0D9488")
     cor_texto_header = Column(String(7), nullable=False, server_default="#FFFFFF", default="#FFFFFF")
     cor_texto_corpo = Column(String(7), nullable=False, server_default="#0F172A", default="#0F172A")

--- a/backend/app/schemas/funcionario_rede.py
+++ b/backend/app/schemas/funcionario_rede.py
@@ -38,6 +38,9 @@ class FuncionarioRedeCreate(FuncionarioRedeBase):
     rede_id: int | None = None
     empresa_id: int | None = None  # legado colaborador (preferir empresa_ids)
     empresa_ids: list[int] = []  # obrigatório se escopo_empresas == selected
+    # Portal do cliente (#300): senha inicial opcional
+    senha_portal: str | None = None
+    must_change_password: bool = True
 
 
 class FuncionarioRedeUpdate(BaseModel):
@@ -50,6 +53,10 @@ class FuncionarioRedeUpdate(BaseModel):
     rede_id: int | None = None
     empresa_id: int | None = None
     empresa_ids: list[int] | None = None
+    senha_portal: str | None = None
+    must_change_password: bool | None = None
+    notificar_email_portal: bool | None = None
+    revogar_sessoes_portal: bool | None = None
 
     @field_validator("email", mode="before")
     @classmethod
@@ -67,6 +74,9 @@ class FuncionarioRedeRead(FuncionarioRedeBase):
     rede_id: int | None = None
     empresa_id: int | None = None
     empresa_ids: list[int] = []  # preenchido quando escopo_empresas == selected
+    portal_habilitado: bool = False
+    must_change_password: bool = False
+    notificar_email_portal: bool = True
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/backend/app/schemas/kb.py
+++ b/backend/app/schemas/kb.py
@@ -147,6 +147,7 @@ class KbPublicBrandingRead(BaseModel):
     texto_boas_vindas: str | None = None
     cor_primaria: str = "#0D9488"
     cor_header: str = "#0B2D4A"
+    cor_sidebar: str = "#0B2D4A"
     cor_texto_header: str = "#FFFFFF"
     cor_texto_corpo: str = "#0F172A"
     cor_fundo: str = "#F8FAFC"
@@ -160,6 +161,7 @@ class KbPortalSettingsRead(BaseModel):
     portal_titulo: str | None = None
     texto_boas_vindas: str | None = None
     cor_header: str = "#0B2D4A"
+    cor_sidebar: str = "#0B2D4A"
     cor_primaria: str = "#0D9488"
     cor_texto_header: str = "#FFFFFF"
     cor_texto_corpo: str = "#0F172A"
@@ -180,6 +182,7 @@ class KbPortalSettingsUpdate(BaseModel):
     portal_titulo: str | None = Field(None, max_length=120)
     texto_boas_vindas: str | None = Field(None, max_length=500)
     cor_header: str | None = Field(None, pattern=_HEX_COLOR)
+    cor_sidebar: str | None = Field(None, pattern=_HEX_COLOR)
     cor_primaria: str | None = Field(None, pattern=_HEX_COLOR)
     cor_texto_header: str | None = Field(None, pattern=_HEX_COLOR)
     cor_texto_corpo: str | None = Field(None, pattern=_HEX_COLOR)

--- a/backend/app/schemas/portal.py
+++ b/backend/app/schemas/portal.py
@@ -126,3 +126,88 @@ class PortalTicketDetail(PortalTicketListItem):
 
 class PortalMensagemOk(BaseModel):
     detail: str = "ok"
+
+
+class PortalWhatsappChatListItem(BaseModel):
+    id: int
+    protocolo: str
+    estado: str
+    empresa_id: int | None = None
+    empresa_nome: str | None = None
+    setor_nome: str | None = None
+    created_at: datetime | None = None
+    encerramento_at: datetime | None = None
+    ultima_mensagem_em: datetime | None = None
+    ultima_mensagem_preview: str | None = None
+
+
+class PortalWhatsappChatDetail(PortalWhatsappChatListItem):
+    encerrado: bool = False
+
+
+class PortalWhatsappMensagemRead(BaseModel):
+    id: int
+    direcao: str
+    corpo: str
+    tipo_midia: str | None = None
+    midia_disponivel: bool = False
+    autor_nome: str | None = None
+    autor_papel: Literal["equipe", "voce", "sistema"] = "sistema"
+    created_at: datetime | None = None
+
+
+class PortalEquipeFuncionarioRead(BaseModel):
+    id: int
+    nome: str
+    email: str | None = None
+    telefone: str | None = None
+    tipo: str
+    ativo: bool
+    empresa_id: int | None = None
+    empresa_ids: list[int] = []
+    portal_habilitado: bool = False
+    must_change_password: bool = False
+    notificar_email_portal: bool = True
+    editavel: bool = True
+
+
+class PortalEquipeFuncionarioCreate(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=255)
+    email: EmailStr
+    telefone: str | None = None
+    tipo: Literal["colaborador", "supervisor"]
+    ativo: bool = True
+    empresa_id: int | None = None
+    empresa_ids: list[int] = []
+    senha_portal: str | None = None
+    must_change_password: bool = True
+
+
+class PortalEquipeFuncionarioUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=255)
+    email: EmailStr | None = None
+    telefone: str | None = None
+    tipo: Literal["colaborador", "supervisor"] | None = None
+    ativo: bool | None = None
+    empresa_id: int | None = None
+    empresa_ids: list[int] | None = None
+    senha_portal: str | None = None
+    must_change_password: bool | None = None
+    notificar_email_portal: bool | None = None
+    revogar_sessoes_portal: bool | None = None
+
+
+class PortalPublicBrandingRead(BaseModel):
+    nome_exibicao: str
+    portal_titulo: str = "Portal do cliente"
+    logo_url: str | None = None
+    texto_boas_vindas: str | None = None
+    cor_primaria: str = "#0D9488"
+    cor_header: str = "#0B2D4A"
+    cor_sidebar: str = "#0B2D4A"
+    cor_texto_header: str = "#FFFFFF"
+    cor_texto_corpo: str = "#0F172A"
+    cor_fundo: str = "#F8FAFC"
+    cor_link: str = "#0D9488"
+    exibir_marca_deskrudder: bool = True
+    chat_habilitado: bool = False

--- a/backend/app/schemas/portal.py
+++ b/backend/app/schemas/portal.py
@@ -1,0 +1,128 @@
+"""Schemas do portal do cliente (funcionário da rede)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+
+class PortalLogin(BaseModel):
+    email: EmailStr
+    senha: str = Field(..., min_length=1, max_length=128)
+
+
+class PortalToken(BaseModel):
+    access_token: str
+    refresh_token: str | None = None
+    token_type: str = "bearer"
+    must_change_password: bool = False
+
+
+class PortalRefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class PortalTrocarSenha(BaseModel):
+    senha_atual: str = Field(..., min_length=1, max_length=128)
+    senha_nova: str = Field(..., min_length=8, max_length=128)
+
+
+class PortalPreferenciasUpdate(BaseModel):
+    notificar_email_portal: bool | None = None
+
+
+class PortalEmpresaRead(BaseModel):
+    id: int
+    nome: str
+    rede_id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PortalSetorRead(BaseModel):
+    id: int
+    nome: str
+    slug: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PortalPdvRead(BaseModel):
+    id: int
+    codigo: str
+    papel: str | None = None
+    ativo: bool = True
+
+
+class PortalMe(BaseModel):
+    id: int
+    nome: str
+    email: str
+    tipo: str
+    rede_id: int | None = None
+    empresas: list[PortalEmpresaRead] = []
+    must_change_password: bool = False
+    notificar_email_portal: bool = True
+
+
+class PortalTicketCreate(BaseModel):
+    empresa_id: int
+    setor_id: int | None = None
+    assunto: str = Field(..., min_length=3, max_length=255)
+    descricao: str | None = Field(None, max_length=20000)
+    pdv_codigo: str | None = Field(None, max_length=64)
+    motivo_id: int | None = None
+    motivo_outro_texto: str | None = Field(None, max_length=500)
+
+
+class PortalTicketMensagemCreate(BaseModel):
+    corpo: str = Field(..., min_length=1, max_length=20000)
+
+
+class PortalAnexoRead(BaseModel):
+    id: int
+    nome_original: str
+    content_type: str | None = None
+    tamanho_bytes: int
+    mensagem_id: int | None = None
+    created_at: datetime | None = None
+    download_url: str
+
+
+class PortalMensagemRead(BaseModel):
+    id: int
+    tipo: str
+    corpo: str
+    autor_nome: str | None = None
+    autor_papel: Literal["equipe", "voce", "sistema"] = "sistema"
+    created_at: datetime | None = None
+    anexos: list[PortalAnexoRead] = []
+
+
+class PortalTicketListItem(BaseModel):
+    id: int
+    protocolo: str
+    assunto: str
+    status_nome: str | None = None
+    status_slug: str | None = None
+    empresa_id: int | None = None
+    empresa_nome: str | None = None
+    setor_nome: str | None = None
+    prioridade: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    fechado_em: datetime | None = None
+    ultima_mensagem_em: datetime | None = None
+
+
+class PortalTicketDetail(PortalTicketListItem):
+    descricao: str | None = None
+    pode_responder: bool = True
+    csat_token: str | None = None
+    csat_pendente: bool = False
+
+
+class PortalMensagemOk(BaseModel):
+    detail: str = "ok"

--- a/backend/app/seed_portal_demo.py
+++ b/backend/app/seed_portal_demo.py
@@ -1,0 +1,379 @@
+"""Dados fictícios para testar o portal do cliente (RBAC, tickets, chats).
+
+Uso (dev local):
+
+    docker compose exec backend python -m app.seed_portal_demo
+
+Reexecutar é seguro: atualiza cadastros e recria tickets/chats marcados como demo.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import func
+
+from app.core.security import hash_senha
+from app.core.ticket_prioridade import PrioridadeTicket
+from app.database import SessionLocal
+from app.models.atendente import Atendente
+from app.models.empresa import Empresa
+from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
+from app.models.rede import Rede
+from app.models.setor import Setor
+from app.models.status_ticket import StatusTicket
+from app.models.ticket import Ticket, TicketMensagem
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
+from app.services.funcionario_escopo import sincronizar_vinculos_empresas
+from app.services.protocolo_mensal import gerar_protocolo_chat, gerar_protocolo_ticket
+
+DEMO_TAG = "[Demo]"
+DEMO_PASSWORD = "portal123"
+TENANT_ID = 1
+
+DEMO_EMPRESAS = (
+    ("Posto Centro Demo", "centro"),
+    ("Posto Norte Alpha", "norte"),
+    ("Posto Sul Beta", "sul"),
+)
+
+DEMO_FUNCIONARIOS = (
+    # email, nome, tipo, slugs empresas (colaborador=1, supervisor=N)
+    ("ana.socio@example.com", "Ana Duplex (sócia)", "socio", ()),
+    ("carlos.supervisor@example.com", "Carlos Supervisor", "supervisor", ("centro", "norte")),
+    ("maria.colab@example.com", "Maria Colaboradora", "colaborador", ("centro",)),
+    ("joao.colab@example.com", "João Colaborador", "colaborador", ("norte",)),
+    ("pedro.colab@example.com", "Pedro Colaborador", "colaborador", ("sul",)),
+)
+
+DEMO_TICKETS = (
+    # email autor, slug empresa, assunto, descricao
+    ("maria.colab@example.com", "centro", "PDV travou no abastecimento", "O caixa 01 congela ao finalizar venda."),
+    ("maria.colab@example.com", "centro", "Impressora fiscal sem papel", "Troquei o rolo mas continua pedindo papel."),
+    ("joao.colab@example.com", "norte", "Bomba 3 não conecta na retaguarda", "Sincronização de preços falha desde ontem."),
+    ("pedro.colab@example.com", "sul", "Cartão recusando no caixa", "Só débito; crédito retorna erro genérico."),
+)
+
+DEMO_CHATS = (
+    # email funcionário, slug empresa, wa_id, mensagens (direcao, corpo)
+    (
+        "maria.colab@example.com",
+        "centro",
+        "5511999000001",
+        (
+            ("inbound", "Bom dia, o PDV do caixa 1 travou de novo."),
+            ("outbound", "Olá Maria, estamos verificando. Pode reiniciar o terminal?"),
+            ("inbound", "Reiniciei, voltou a funcionar por enquanto."),
+        ),
+    ),
+    (
+        "joao.colab@example.com",
+        "norte",
+        "5511999000002",
+        (
+            ("inbound", "A bomba 3 não atualiza preço."),
+            ("outbound", "João, vamos checar o link com a retaguarda."),
+        ),
+    ),
+    (
+        "pedro.colab@example.com",
+        "sul",
+        "5511999000003",
+        (
+            ("inbound", "Clientes reclamando de cartão recusado."),
+            ("inbound", "Acontece só no caixa 2."),
+        ),
+    ),
+)
+
+
+def _slug_key(slug: str) -> str:
+    return slug.strip().lower()
+
+
+def _ensure_rede(db) -> Rede:
+    rede = db.query(Rede).order_by(Rede.id.asc()).first()
+    if not rede:
+        rede = Rede(tenant_id=TENANT_ID, nome="Rede Duplex Demo", ativo=True)
+        db.add(rede)
+        db.flush()
+    else:
+        rede.nome = "Rede Duplex Demo"
+        rede.ativo = True
+    return rede
+
+
+def _ensure_empresas(db, rede: Rede) -> dict[str, Empresa]:
+    out: dict[str, Empresa] = {}
+    for nome, slug in DEMO_EMPRESAS:
+        emp = (
+            db.query(Empresa)
+            .filter(Empresa.rede_id == rede.id, func.lower(Empresa.nome) == nome.lower())
+            .first()
+        )
+        if not emp:
+            emp = Empresa(tenant_id=TENANT_ID, rede_id=rede.id, nome=nome, ativo=True)
+            db.add(emp)
+            db.flush()
+        else:
+            emp.ativo = True
+        out[_slug_key(slug)] = emp
+    return out
+
+
+def _upsert_funcionario(
+    db,
+    *,
+    rede: Rede,
+    empresas: dict[str, Empresa],
+    email: str,
+    nome: str,
+    tipo: str,
+    empresa_slugs: tuple[str, ...],
+) -> FuncionarioRede:
+    email_norm = email.strip().lower()
+    f = db.query(FuncionarioRede).filter(func.lower(FuncionarioRede.email) == email_norm).first()
+    if not f:
+        f = FuncionarioRede(email=email_norm, rede_id=rede.id)
+        db.add(f)
+    f.nome = nome
+    f.tipo = tipo
+    f.ativo = True
+    f.escopo_empresas = "all" if tipo == "socio" else "selected"
+    f.senha_hash = hash_senha(DEMO_PASSWORD)
+    f.must_change_password = False
+    f.token_version = int(getattr(f, "token_version", 0) or 0)
+    f.notificar_email_portal = True
+
+    empresa_ids: list[int] = []
+    if tipo == "colaborador" and empresa_slugs:
+        empresa_ids = [empresas[_slug_key(empresa_slugs[0])].id]
+        f.empresa_id = empresa_ids[0]
+    elif tipo == "supervisor":
+        empresa_ids = [empresas[_slug_key(s)].id for s in empresa_slugs]
+        f.empresa_id = None
+    else:
+        f.empresa_id = None
+
+    db.flush()
+    if tipo != "socio":
+        sincronizar_vinculos_empresas(
+            db,
+            f,
+            escopo="selected",
+            rede_id=int(rede.id),
+            empresa_ids=empresa_ids,
+        )
+    return f
+
+
+def _clear_demo_tickets_chats(db) -> None:
+    demo_ticket_ids = [
+        t.id
+        for t in db.query(Ticket).filter(Ticket.assunto.like(f"{DEMO_TAG}%")).all()
+    ]
+    if demo_ticket_ids:
+        db.query(TicketMensagem).filter(TicketMensagem.ticket_id.in_(demo_ticket_ids)).delete(
+            synchronize_session=False
+        )
+        db.query(Ticket).filter(Ticket.id.in_(demo_ticket_ids)).delete(synchronize_session=False)
+
+    demo_wa_ids = [f"5511999{_i:06d}" for _i in range(1, 20)]
+    demo_chat_ids = [
+        c.id
+        for c in db.query(WhatsappChat).filter(WhatsappChat.wa_id.in_(demo_wa_ids)).all()
+    ]
+    if demo_chat_ids:
+        db.query(WhatsappMensagem).filter(WhatsappMensagem.chat_id.in_(demo_chat_ids)).delete(
+            synchronize_session=False
+        )
+        db.query(WhatsappChat).filter(WhatsappChat.id.in_(demo_chat_ids)).delete(synchronize_session=False)
+
+
+def _criar_ticket_demo(
+    db,
+    *,
+    rede: Rede,
+    empresa: Empresa,
+    setor_id: int,
+    status_id: int,
+    autor: FuncionarioRede | None,
+    assunto: str,
+    descricao: str,
+) -> Ticket:
+    t = Ticket(
+        tenant_id=TENANT_ID,
+        protocolo=gerar_protocolo_ticket(db),
+        empresa_id=empresa.id,
+        rede_id=rede.id,
+        setor_id=setor_id,
+        status_id=status_id,
+        aberto_por_id=autor.id if autor else None,
+        prioridade=PrioridadeTicket.normal.value,
+        assunto=f"{DEMO_TAG} {assunto}",
+        descricao=descricao,
+    )
+    db.add(t)
+    db.flush()
+    db.add(
+        TicketMensagem(
+            ticket_id=t.id,
+            tipo="abertura",
+            corpo=descricao,
+            atendente_id=None,
+        )
+    )
+    if autor:
+        db.add(
+            TicketMensagem(
+                ticket_id=t.id,
+                tipo="publico",
+                corpo="Recebemos seu chamado. A equipe já está analisando.",
+                atendente_id=None,
+            )
+        )
+    return t
+
+
+def _criar_chat_demo(
+    db,
+    *,
+    empresa: Empresa,
+    funcionario: FuncionarioRede,
+    setor_id: int,
+    atendente_id: int | None,
+    wa_id: str,
+    mensagens: tuple[tuple[str, str], ...],
+) -> WhatsappChat:
+    chat = WhatsappChat(
+        protocolo=gerar_protocolo_chat(db),
+        wa_id=wa_id,
+        cliente_nome=funcionario.nome,
+        estado="em_atendimento",
+        setor_id=setor_id,
+        atendente_id=atendente_id,
+        funcionario_rede_id=funcionario.id,
+        empresa_id=empresa.id,
+    )
+    db.add(chat)
+    db.flush()
+    seq = 0
+    for direcao, corpo in mensagens:
+        seq += 1
+        db.add(
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao=direcao,
+                corpo=corpo,
+                wa_message_id=f"demo-{wa_id}-{seq}",
+                atendente_id=atendente_id if direcao == "outbound" else None,
+                status_entrega="entregue" if direcao == "outbound" else None,
+            )
+        )
+    # Comentário interno (não deve aparecer no portal)
+    db.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="nota interna: cliente já reportou isso na semana passada",
+            evento_sistema="comentario_interno",
+            wa_message_id=f"demo-{wa_id}-interno",
+            atendente_id=atendente_id,
+        )
+    )
+    return chat
+
+
+def run_seed_portal_demo() -> None:
+    db = SessionLocal()
+    try:
+        rede = _ensure_rede(db)
+        empresas = _ensure_empresas(db, rede)
+
+        setor = db.query(Setor).filter(Setor.ativo.is_(True)).order_by(Setor.id.asc()).first()
+        if not setor:
+            raise RuntimeError("Nenhum setor ativo. Rode python -m app.seed antes.")
+        status = (
+            db.query(StatusTicket)
+            .filter(StatusTicket.slug == "aguardando_atendimento", StatusTicket.ativo.is_(True))
+            .first()
+        )
+        if not status:
+            status = db.query(StatusTicket).filter(StatusTicket.ativo.is_(True)).first()
+        if not status:
+            raise RuntimeError("Nenhum status de ticket. Rode python -m app.seed antes.")
+
+        atendente = db.query(Atendente).filter(Atendente.ativo.is_(True)).order_by(Atendente.id.asc()).first()
+
+        funcionarios: dict[str, FuncionarioRede] = {}
+        for email, nome, tipo, slugs in DEMO_FUNCIONARIOS:
+            f = _upsert_funcionario(
+                db,
+                rede=rede,
+                empresas=empresas,
+                email=email,
+                nome=nome,
+                tipo=tipo,
+                empresa_slugs=slugs,
+            )
+            funcionarios[email] = f
+
+        _clear_demo_tickets_chats(db)
+
+        for email, slug, assunto, descricao in DEMO_TICKETS:
+            autor = funcionarios[email]
+            _criar_ticket_demo(
+                db,
+                rede=rede,
+                empresa=empresas[_slug_key(slug)],
+                setor_id=setor.id,
+                status_id=status.id,
+                autor=autor,
+                assunto=assunto,
+                descricao=descricao,
+            )
+
+        # Ticket aberto pela equipe interna (sem autor portal) — só supervisor/sócio veem
+        _criar_ticket_demo(
+            db,
+            rede=rede,
+            empresa=empresas["centro"],
+            setor_id=setor.id,
+            status_id=status.id,
+            autor=None,
+            assunto="Manutenção programada no servidor",
+            descricao="Chamado interno da equipe de suporte (não aparece para colaborador no portal).",
+        )
+
+        for email, slug, wa_id, mensagens in DEMO_CHATS:
+            _criar_chat_demo(
+                db,
+                empresa=empresas[_slug_key(slug)],
+                funcionario=funcionarios[email],
+                setor_id=setor.id,
+                atendente_id=atendente.id if atendente else None,
+                wa_id=wa_id,
+                mensagens=mensagens,
+            )
+
+        db.commit()
+
+        print("\n=== Portal demo — dados fictícios criados ===\n")
+        print(f"Rede: {rede.nome} (id={rede.id})")
+        print("Empresas:")
+        for slug, emp in empresas.items():
+            print(f"  - {emp.nome} ({slug})")
+        print(f"\nSenha de todos os usuários abaixo: {DEMO_PASSWORD}\n")
+        print("| Papel        | E-mail                      | O que deve ver no portal |")
+        print("|--------------|-----------------------------|---------------------------|")
+        print("| Sócio        | ana.socio@example.com       | Toda a rede (tickets/chats) |")
+        print("| Supervisor   | carlos.supervisor@example.com | Centro + Norte          |")
+        print("| Colaborador  | maria.colab@example.com     | Só os próprios (Centro)   |")
+        print("| Colaborador  | joao.colab@example.com      | Só os próprios (Norte)    |")
+        print("| Colaborador  | pedro.colab@example.com     | Só os próprios (Sul)      |")
+        print("\nTickets e chats marcados com prefixo «[Demo]» no assunto / protocolo WhatsApp.")
+        print("Login: http://localhost:5173/portal/login\n")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    run_seed_portal_demo()

--- a/backend/app/services/instancia_branding.py
+++ b/backend/app/services/instancia_branding.py
@@ -1,0 +1,111 @@
+"""Branding white-label da instância — KB pública (/kb) e portal do cliente (/portal)."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.empresa_sistema import EmpresaSistema
+from app.models.kb import KbPortalSettings
+from app.schemas.kb import KbPublicBrandingRead
+from app.schemas.portal import PortalPublicBrandingRead
+
+DEFAULT_COR_PRIMARIA = "#0D9488"
+DEFAULT_COR_HEADER = "#0B2D4A"
+DEFAULT_COR_TEXTO_HEADER = "#FFFFFF"
+DEFAULT_COR_TEXTO_CORPO = "#0F172A"
+DEFAULT_COR_FUNDO = "#F8FAFC"
+TEXTO_BOAS_VINDAS_PORTAL_PADRAO = (
+    "Acompanhe e abra chamados da sua empresa com a equipe de suporte."
+)
+
+
+def empresa_sistema_row(db: Session) -> EmpresaSistema | None:
+    return db.query(EmpresaSistema).order_by(EmpresaSistema.id.asc()).first()
+
+
+def portal_settings_row(db: Session, tenant_id: int) -> KbPortalSettings | None:
+    return db.query(KbPortalSettings).filter(KbPortalSettings.tenant_id == tenant_id).first()
+
+
+def nome_exibicao_empresa(row: EmpresaSistema | None) -> str:
+    if not row:
+        return "Central de ajuda"
+    for attr in ("nome_fantasia", "nome", "razao_social"):
+        val = getattr(row, attr, None)
+        if val and str(val).strip():
+            return str(val).strip()
+    return "Central de ajuda"
+
+
+def logo_url_publica(row: EmpresaSistema | None) -> str | None:
+    if row and row.logo_filename and str(row.logo_filename).strip():
+        return "/v1/kb/public/logo"
+    return None
+
+
+def _cores_branding(settings: KbPortalSettings | None) -> dict[str, str]:
+    cor_primaria = (settings.cor_primaria if settings else None) or DEFAULT_COR_PRIMARIA
+    cor_link = (settings.cor_link if settings and settings.cor_link else None) or cor_primaria
+    cor_header = (settings.cor_header if settings else None) or DEFAULT_COR_HEADER
+    # Menu lateral: cor própria ou mesma da navbar
+    cor_sidebar = None
+    if settings and settings.cor_sidebar and str(settings.cor_sidebar).strip():
+        cor_sidebar = str(settings.cor_sidebar).strip()
+    return {
+        "cor_primaria": cor_primaria,
+        "cor_header": cor_header,
+        "cor_sidebar": cor_sidebar or cor_header,
+        "cor_texto_header": (settings.cor_texto_header if settings else None) or DEFAULT_COR_TEXTO_HEADER,
+        "cor_texto_corpo": (settings.cor_texto_corpo if settings else None) or DEFAULT_COR_TEXTO_CORPO,
+        "cor_fundo": (settings.cor_fundo if settings else None) or DEFAULT_COR_FUNDO,
+        "cor_link": cor_link,
+    }
+
+
+def branding_kb_publico(db: Session, tenant_id: int) -> KbPublicBrandingRead:
+    row = empresa_sistema_row(db)
+    settings = portal_settings_row(db, tenant_id)
+    nome = nome_exibicao_empresa(row)
+    cores = _cores_branding(settings)
+    titulo_custom = (settings.portal_titulo or "").strip() if settings else ""
+    if titulo_custom:
+        portal_titulo = titulo_custom
+    elif nome != "Central de ajuda":
+        portal_titulo = f"Central de ajuda — {nome}"
+    else:
+        portal_titulo = "Central de ajuda"
+    return KbPublicBrandingRead(
+        nome_exibicao=nome,
+        portal_titulo=portal_titulo,
+        logo_url=logo_url_publica(row),
+        texto_boas_vindas=settings.texto_boas_vindas if settings else None,
+        exibir_marca_deskrudder=bool(settings.exibir_marca_deskrudder) if settings else True,
+        feedback_habilitado=bool(settings.feedback_habilitado) if settings else True,
+        chat_habilitado=bool(settings.chat_habilitado) if settings else False,
+        **cores,
+    )
+
+
+def _titulo_portal_cliente(nome: str) -> str:
+    """Título exibido no /portal — independente do `portal_titulo` da central /kb."""
+    if nome != "Central de ajuda":
+        return f"Portal — {nome}"
+    return "Portal do cliente"
+
+
+def branding_portal_cliente(db: Session, tenant_id: int) -> PortalPublicBrandingRead:
+    row = empresa_sistema_row(db)
+    settings = portal_settings_row(db, tenant_id)
+    nome = nome_exibicao_empresa(row)
+    cores = _cores_branding(settings)
+    portal_titulo = _titulo_portal_cliente(nome)
+    texto = (settings.texto_boas_vindas or "").strip() if settings else ""
+    return PortalPublicBrandingRead(
+        nome_exibicao=nome,
+        portal_titulo=portal_titulo,
+        logo_url=logo_url_publica(row),
+        texto_boas_vindas=texto or TEXTO_BOAS_VINDAS_PORTAL_PADRAO,
+        exibir_marca_deskrudder=bool(settings.exibir_marca_deskrudder) if settings else True,
+        chat_habilitado=bool(settings.chat_habilitado) if settings else False,
+        **cores,
+    )

--- a/backend/app/services/portal_equipe.py
+++ b/backend/app/services/portal_equipe.py
@@ -1,0 +1,273 @@
+"""Gestão de equipe pelo sócio no portal (#602).
+
+Regras:
+- Apenas `tipo=socio` acede à API.
+- CRUD limitado à **rede** do sócio autenticado.
+- Não é possível **criar** ou **promover** outro sócio pelo portal (só colaborador ↔ supervisor).
+- Outros sócios aparecem na listagem (editáveis só em ativo/senha/notificações).
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from app.core.security import hash_senha
+from app.models.empresa import Empresa
+from app.models.funcionario_rede import FuncionarioRede
+from app.schemas.portal import (
+    PortalEquipeFuncionarioCreate,
+    PortalEquipeFuncionarioRead,
+    PortalEquipeFuncionarioUpdate,
+)
+from app.services.funcionario_escopo import (
+    escopo_efetivo,
+    rede_id_efetiva,
+    sincronizar_vinculos_empresas,
+    validar_empresa_ids_na_rede,
+)
+from app.services.funcionario_rede_resolver import assert_email_unico_por_rede
+from app.services.inbound_ticket_reconcile import reconciliar_tickets_pendentes_por_email
+
+TIPOS_PORTAL_EQUIPE = frozenset({"colaborador", "supervisor"})
+
+
+def _rede_id_socio(db: Session, socio: FuncionarioRede) -> int:
+    rid = rede_id_efetiva(db, socio)
+    if rid is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Rede não definida para o sócio.")
+    return int(rid)
+
+
+def _empresa_ids_leitura(f: FuncionarioRede) -> list[int]:
+    if escopo_efetivo(f) == "all":
+        return []
+    ids = [e.empresa_id for e in f.empresas_supervisor]
+    if f.empresa_id is not None and int(f.empresa_id) not in ids:
+        ids.insert(0, int(f.empresa_id))
+    return ids
+
+
+def _aplicar_senha_portal(f: FuncionarioRede, senha: str | None, *, must_change: bool | None) -> None:
+    if senha is None:
+        return
+    senha_limpa = senha.strip()
+    if not senha_limpa:
+        return
+    if len(senha_limpa) < 8:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A senha do portal deve ter ao menos 8 caracteres.",
+        )
+    if not (f.email or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Informe o e-mail do funcionário para habilitar o portal.",
+        )
+    f.senha_hash = hash_senha(senha_limpa)
+    f.must_change_password = True if must_change is None else bool(must_change)
+    f.token_version = int(getattr(f, "token_version", 0) or 0) + 1
+
+
+def _para_read(f: FuncionarioRede, *, socio_id: int) -> PortalEquipeFuncionarioRead:
+    tipo = (f.tipo or "").strip().lower()
+    return PortalEquipeFuncionarioRead(
+        id=f.id,
+        nome=f.nome,
+        email=f.email,
+        telefone=getattr(f, "telefone", None),
+        tipo=f.tipo,
+        ativo=bool(f.ativo),
+        empresa_id=f.empresa_id,
+        empresa_ids=_empresa_ids_leitura(f),
+        portal_habilitado=bool((getattr(f, "senha_hash", None) or "").strip()),
+        must_change_password=bool(getattr(f, "must_change_password", False)),
+        notificar_email_portal=bool(getattr(f, "notificar_email_portal", True)),
+        editavel=tipo != "socio" or int(f.id) == int(socio_id),
+    )
+
+
+def _obter_na_rede(db: Session, socio: FuncionarioRede, funcionario_id: int) -> FuncionarioRede:
+    rede_id = _rede_id_socio(db, socio)
+    f = db.query(FuncionarioRede).filter(FuncionarioRede.id == funcionario_id).first()
+    if not f or f.rede_id is None or int(f.rede_id) != rede_id:
+        raise LookupError("Funcionário não encontrado")
+    return f
+
+
+def listar_funcionarios(
+    db: Session,
+    socio: FuncionarioRede,
+    *,
+    incluir_inativos: bool = False,
+    busca: str | None = None,
+    offset: int = 0,
+    limit: int = 20,
+) -> tuple[list[FuncionarioRede], int]:
+    rede_id = _rede_id_socio(db, socio)
+    q = db.query(FuncionarioRede).filter(FuncionarioRede.rede_id == rede_id)
+    if not incluir_inativos:
+        q = q.filter(FuncionarioRede.ativo.is_(True))
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter(or_(FuncionarioRede.nome.ilike(term), FuncionarioRede.email.ilike(term)))
+    total = q.count()
+    rows = q.order_by(FuncionarioRede.nome.asc(), FuncionarioRede.id.asc()).offset(offset).limit(limit).all()
+    return rows, total
+
+
+def criar_funcionario(db: Session, socio: FuncionarioRede, data: PortalEquipeFuncionarioCreate) -> FuncionarioRede:
+    rede_id = _rede_id_socio(db, socio)
+    tipo = data.tipo.strip().lower()
+    if tipo not in TIPOS_PORTAL_EQUIPE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No portal só é possível cadastrar colaboradores ou supervisores.",
+        )
+    empresa_ids = list(dict.fromkeys(data.empresa_ids or []))
+    if data.empresa_id and int(data.empresa_id) not in empresa_ids:
+        empresa_ids.insert(0, int(data.empresa_id))
+    if tipo == "colaborador":
+        if len(empresa_ids) != 1:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Selecione uma empresa para o colaborador.")
+    elif not empresa_ids:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Marque ao menos uma empresa para o supervisor.")
+    try:
+        validar_empresa_ids_na_rede(db, rede_id, empresa_ids)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    try:
+        assert_email_unico_por_rede(db, email=str(data.email), rede_id=rede_id)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+    f = FuncionarioRede(
+        nome=data.nome.strip(),
+        email=str(data.email).strip().lower(),
+        telefone=data.telefone,
+        tipo=tipo,
+        escopo_empresas="selected",
+        ativo=data.ativo,
+        rede_id=rede_id,
+        empresa_id=empresa_ids[0] if tipo == "colaborador" else None,
+    )
+    db.add(f)
+    db.flush()
+    _aplicar_senha_portal(f, data.senha_portal, must_change=data.must_change_password)
+    sincronizar_vinculos_empresas(db, f, escopo="selected", rede_id=rede_id, empresa_ids=empresa_ids)
+    db.commit()
+    db.refresh(f)
+    if f.email:
+        reconciliar_tickets_pendentes_por_email(db, f.email)
+        db.commit()
+    return f
+
+
+def atualizar_funcionario(
+    db: Session,
+    socio: FuncionarioRede,
+    funcionario_id: int,
+    data: PortalEquipeFuncionarioUpdate,
+) -> FuncionarioRede:
+    f = _obter_na_rede(db, socio, funcionario_id)
+    rede_id = _rede_id_socio(db, socio)
+    update = data.model_dump(exclude_unset=True)
+    empresa_ids = update.pop("empresa_ids", None)
+    empresa_id_upd = update.pop("empresa_id", None)
+    senha_portal = update.pop("senha_portal", None)
+    must_change = update.pop("must_change_password", None)
+    revogar = update.pop("revogar_sessoes_portal", None)
+    tipo_upd = update.pop("tipo", None)
+
+    alvo_socio = (f.tipo or "").strip().lower() == "socio"
+    if alvo_socio:
+        if tipo_upd is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="A função de sócio não pode ser alterada pelo portal.",
+            )
+        if empresa_ids is not None or empresa_id_upd is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Sócios têm acesso a toda a rede; vínculos por empresa não se aplicam.",
+            )
+        if int(f.id) != int(socio.id):
+            permitidos = {"ativo", "notificar_email_portal"}
+            if any(k not in permitidos for k in update):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Outros sócios só podem ter situação, senha e notificações alteradas pelo portal.",
+                )
+    else:
+        if tipo_upd is not None:
+            t = tipo_upd.strip().lower()
+            if t not in TIPOS_PORTAL_EQUIPE:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="No portal só é possível alternar entre colaborador e supervisor.",
+                )
+            f.tipo = t
+
+    for k, v in update.items():
+        setattr(f, k, v)
+
+    if senha_portal is not None:
+        _aplicar_senha_portal(f, senha_portal, must_change=must_change)
+    elif must_change is not None:
+        f.must_change_password = bool(must_change)
+    if revogar:
+        f.token_version = int(getattr(f, "token_version", 0) or 0) + 1
+
+    if not alvo_socio:
+        tipo_eff = (f.tipo or "colaborador").strip().lower()
+        ids = list(empresa_ids) if empresa_ids is not None else _empresa_ids_leitura(f)
+        if empresa_id_upd is not None and int(empresa_id_upd) not in ids:
+            ids.insert(0, int(empresa_id_upd))
+        if tipo_eff == "colaborador":
+            if empresa_ids is not None or empresa_id_upd is not None:
+                if len(ids) != 1:
+                    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Colaborador deve ter uma empresa.")
+        elif empresa_ids is not None or empresa_id_upd is not None:
+            if not ids:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Supervisor precisa de ao menos uma empresa.")
+        if ids:
+            try:
+                validar_empresa_ids_na_rede(db, rede_id, ids)
+            except ValueError as e:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+            sincronizar_vinculos_empresas(
+                db,
+                f,
+                escopo="selected",
+                rede_id=rede_id,
+                empresa_ids=ids,
+            )
+
+    if f.email:
+        try:
+            assert_email_unico_por_rede(
+                db,
+                email=str(f.email),
+                rede_id=rede_id,
+                ignorar_funcionario_id=f.id,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+    db.commit()
+    db.refresh(f)
+    if f.email:
+        reconciliar_tickets_pendentes_por_email(db, f.email)
+        db.commit()
+    return f
+
+
+def empresas_da_rede(db: Session, socio: FuncionarioRede) -> list[Empresa]:
+    rede_id = _rede_id_socio(db, socio)
+    return (
+        db.query(Empresa)
+        .filter(Empresa.rede_id == rede_id, Empresa.ativo.is_(True))
+        .order_by(Empresa.nome.asc())
+        .all()
+    )

--- a/backend/app/services/portal_notificacoes.py
+++ b/backend/app/services/portal_notificacoes.py
@@ -1,0 +1,147 @@
+"""E-mails ao funcionário sobre eventos do ticket no portal (#303)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.funcionario_rede import FuncionarioRede
+from app.models.ticket import Ticket, TicketMensagem
+from app.services.email_send_sistema import enviar_mensagem_texto_sistema
+
+logger = logging.getLogger(__name__)
+
+# Debounce simples em memória por processo (idempotência básica)
+_ultimos_envios: dict[str, datetime] = {}
+_DEBOUNCE = timedelta(minutes=2)
+
+
+def clear_debounce_for_tests() -> None:
+    """Limpa cache de debounce (apenas testes)."""
+    _ultimos_envios.clear()
+
+
+def _public_app_origin() -> str:
+    host = (settings.CLIENT_APP_HOST or "").strip()
+    if host:
+        host = host.removeprefix("https://").removeprefix("http://").split("/")[0]
+        proto = "https" if settings.is_production else "http"
+        return f"{proto}://{host}"
+    if not settings.is_production:
+        return "http://localhost:5173"
+    base = (settings.CONNECT_APP_BASE_DOMAIN or "").strip()
+    if base:
+        return f"https://{base}"
+    return "http://localhost:5173"
+
+
+def _pode_enviar(chave: str) -> bool:
+    agora = datetime.now(timezone.utc)
+    ultimo = _ultimos_envios.get(chave)
+    if ultimo and agora - ultimo < _DEBOUNCE:
+        return False
+    _ultimos_envios[chave] = agora
+    # Limpa chaves antigas
+    if len(_ultimos_envios) > 500:
+        limite = agora - timedelta(hours=1)
+        for k, v in list(_ultimos_envios.items()):
+            if v < limite:
+                _ultimos_envios.pop(k, None)
+    return True
+
+
+def build_portal_ticket_link(ticket_id: int) -> str:
+    origin = _public_app_origin().rstrip("/")
+    return f"{origin}/portal/tickets/{ticket_id}"
+
+
+def _destinatario_portal(db: Session, ticket: Ticket) -> FuncionarioRede | None:
+    if not ticket.aberto_por_id:
+        return None
+    f = db.query(FuncionarioRede).filter(FuncionarioRede.id == ticket.aberto_por_id).first()
+    if not f or not f.ativo:
+        return None
+    if not (f.email or "").strip():
+        return None
+    if not getattr(f, "notificar_email_portal", True):
+        return None
+    if not (f.senha_hash or "").strip():
+        # Sem acesso ao portal: ainda notifica se tiver e-mail (acompanhamento)
+        pass
+    return f
+
+
+def notificar_funcionario_mensagem_publica(
+    db: Session,
+    *,
+    ticket: Ticket,
+    mensagem: TicketMensagem,
+) -> None:
+    """Dispara e-mail quando a equipe envia mensagem pública no ticket aberto pelo portal."""
+    if mensagem.tipo != "publico":
+        return
+    if not mensagem.atendente_id:
+        return
+    dest = _destinatario_portal(db, ticket)
+    if not dest:
+        return
+    chave = f"msg:{ticket.id}:{mensagem.id}"
+    if not _pode_enviar(chave):
+        return
+    link = build_portal_ticket_link(ticket.id)
+    nome = (dest.nome or "").strip() or "olá"
+    subject = f"Nova resposta no chamado {ticket.protocolo}"
+    trecho = (mensagem.corpo or "").strip()
+    if len(trecho) > 280:
+        trecho = trecho[:277] + "…"
+    body = (
+        f"Olá, {nome},\n\n"
+        f"Há uma nova mensagem da equipe no chamado {ticket.protocolo}.\n\n"
+        f"{trecho}\n\n"
+        f"Acompanhe no portal:\n{link}\n\n"
+        "— Equipe de suporte"
+    )
+    try:
+        enviar_mensagem_texto_sistema(db, to_addr=str(dest.email), subject=subject, body=body)
+    except ValueError as e:
+        logger.warning("Portal e-mail: envio indisponível (%s)", e)
+    except Exception:
+        logger.exception("Portal e-mail: falha ticket_id=%s", ticket.id)
+
+
+def notificar_funcionario_status(
+    db: Session,
+    *,
+    ticket: Ticket,
+    status_nome: str,
+    status_slug: str | None = None,
+) -> None:
+    """Avisa mudança de status relevante (encerrado / aguardando cliente)."""
+    slug = (status_slug or "").strip().lower()
+    relevantes = {"fechado", "aguardando_cliente", "resolvido"}
+    if slug and slug not in relevantes:
+        return
+    dest = _destinatario_portal(db, ticket)
+    if not dest:
+        return
+    chave = f"st:{ticket.id}:{slug or status_nome}"
+    if not _pode_enviar(chave):
+        return
+    link = build_portal_ticket_link(ticket.id)
+    nome = (dest.nome or "").strip() or "olá"
+    subject = f"Atualização do chamado {ticket.protocolo}: {status_nome}"
+    body = (
+        f"Olá, {nome},\n\n"
+        f"O status do chamado {ticket.protocolo} foi atualizado para «{status_nome}».\n\n"
+        f"Veja os detalhes:\n{link}\n\n"
+        "— Equipe de suporte"
+    )
+    try:
+        enviar_mensagem_texto_sistema(db, to_addr=str(dest.email), subject=subject, body=body)
+    except ValueError as e:
+        logger.warning("Portal e-mail status: envio indisponível (%s)", e)
+    except Exception:
+        logger.exception("Portal e-mail status: falha ticket_id=%s", ticket.id)

--- a/backend/app/services/portal_tickets.py
+++ b/backend/app/services/portal_tickets.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.core.portal_scope import (
     assert_empresa_no_escopo,
-    empresa_ids_visiveis,
+    filtro_query_tickets_portal,
     tenant_id_do_funcionario,
     ticket_no_escopo,
 )
@@ -128,24 +128,15 @@ def listar_tickets(
     offset: int = 0,
     limit: int = 20,
 ) -> tuple[list[Ticket], int]:
-    ids = empresa_ids_visiveis(db, funcionario)
-    from app.services.funcionario_escopo import escopo_efetivo, rede_id_efetiva
-
-    rede_id = rede_id_efetiva(db, funcionario)
     q = db.query(Ticket).options(
         joinedload(Ticket.status),
         joinedload(Ticket.empresa),
         joinedload(Ticket.setor),
         joinedload(Ticket.mensagens),
     )
-    filtros = []
-    if ids:
-        filtros.append(Ticket.empresa_id.in_(ids))
-    if rede_id is not None and escopo_efetivo(funcionario) == "all":
-        filtros.append((Ticket.empresa_id.is_(None)) & (Ticket.rede_id == rede_id))
-    if not filtros:
+    q = filtro_query_tickets_portal(q, db, funcionario)
+    if q is None:
         return [], 0
-    q = q.filter(or_(*filtros))
     sit = (situacao or "abertos").strip().lower()
     if sit == "abertos":
         q = q.filter(Ticket.fechado_em.is_(None))

--- a/backend/app/services/portal_tickets.py
+++ b/backend/app/services/portal_tickets.py
@@ -1,0 +1,440 @@
+"""Regras de negócio dos tickets no portal do cliente."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.portal_scope import (
+    assert_empresa_no_escopo,
+    empresa_ids_visiveis,
+    tenant_id_do_funcionario,
+    ticket_no_escopo,
+)
+from app.core.routing import RoutingCanal
+from app.models.empresa import Empresa
+from app.models.funcionario_rede import FuncionarioRede
+from app.models.setor import Setor
+from app.models.status_ticket import StatusTicket
+from app.models.ticket import Ticket, TicketMensagem
+from app.models.ticket_anexo import TicketAnexo
+from app.schemas.portal import (
+    PortalAnexoRead,
+    PortalMensagemRead,
+    PortalTicketCreate,
+    PortalTicketDetail,
+    PortalTicketListItem,
+)
+from app.services.protocolo_mensal import gerar_protocolo_ticket
+from app.services.routing_apply import acoes_efetivas_do_resultado, registrar_roteamento_aplicado
+from app.services.routing_evaluate import RoutingContext, aplicar_roteamento_setor, evaluate_routing
+from app.services.ticket_distribuicao import sincronizar_fila_desde_at, tentar_distribuicao_imediata
+from app.services.realtime_emit import (
+    emit_notificacao_after_counter_change,
+    emit_ticket_fila,
+    emit_ticket_mensagem_from_model,
+)
+
+
+TIPOS_PUBLICOS_PORTAL = frozenset({"abertura", "publico", "email_cliente"})
+
+
+def _status_nome(ticket: Ticket) -> tuple[str | None, str | None]:
+    st = getattr(ticket, "status", None)
+    if st is None:
+        return None, None
+    return getattr(st, "nome", None), getattr(st, "slug", None)
+
+
+def _empresa_nome(ticket: Ticket) -> str | None:
+    emp = getattr(ticket, "empresa", None)
+    return getattr(emp, "nome", None) if emp else None
+
+
+def _setor_nome(ticket: Ticket) -> str | None:
+    setor = getattr(ticket, "setor", None)
+    return getattr(setor, "nome", None) if setor else None
+
+
+def ticket_para_list_item(ticket: Ticket) -> PortalTicketListItem:
+    status_nome, status_slug = _status_nome(ticket)
+    ultima = None
+    msgs = getattr(ticket, "mensagens", None)
+    if msgs:
+        publicas = [m for m in msgs if m.tipo in TIPOS_PUBLICOS_PORTAL]
+        if publicas:
+            ultima = max((m.created_at for m in publicas if m.created_at), default=None)
+    return PortalTicketListItem(
+        id=ticket.id,
+        protocolo=ticket.protocolo,
+        assunto=ticket.assunto,
+        status_nome=status_nome,
+        status_slug=status_slug,
+        empresa_id=ticket.empresa_id,
+        empresa_nome=_empresa_nome(ticket),
+        setor_nome=_setor_nome(ticket),
+        prioridade=str(ticket.prioridade) if ticket.prioridade else None,
+        created_at=ticket.created_at,
+        updated_at=ticket.updated_at,
+        fechado_em=ticket.fechado_em,
+        ultima_mensagem_em=ultima,
+    )
+
+
+def ticket_para_detail(db: Session, ticket: Ticket) -> PortalTicketDetail:
+    base = ticket_para_list_item(ticket)
+    csat_pendente = False
+    if ticket.fechado_em is not None:
+        from app.models.ticket_avaliacao import TicketAvaliacao
+
+        ja_avaliou = (
+            db.query(TicketAvaliacao).filter(TicketAvaliacao.ticket_id == ticket.id).first() is not None
+        )
+        csat_pendente = not ja_avaliou
+    return PortalTicketDetail(
+        **base.model_dump(),
+        descricao=ticket.descricao,
+        pode_responder=ticket.fechado_em is None,
+        csat_token=None,
+        csat_pendente=csat_pendente,
+    )
+
+
+def obter_ticket_escopo(db: Session, funcionario: FuncionarioRede, ticket_id: int) -> Ticket:
+    ticket = (
+        db.query(Ticket)
+        .options(
+            joinedload(Ticket.status),
+            joinedload(Ticket.empresa),
+            joinedload(Ticket.setor),
+            joinedload(Ticket.mensagens),
+        )
+        .filter(Ticket.id == ticket_id)
+        .first()
+    )
+    if not ticket or not ticket_no_escopo(db, funcionario, ticket):
+        raise LookupError("Ticket não encontrado")
+    return ticket
+
+
+def listar_tickets(
+    db: Session,
+    funcionario: FuncionarioRede,
+    *,
+    situacao: str = "abertos",
+    busca: str | None = None,
+    offset: int = 0,
+    limit: int = 20,
+) -> tuple[list[Ticket], int]:
+    ids = empresa_ids_visiveis(db, funcionario)
+    from app.services.funcionario_escopo import escopo_efetivo, rede_id_efetiva
+
+    rede_id = rede_id_efetiva(db, funcionario)
+    q = db.query(Ticket).options(
+        joinedload(Ticket.status),
+        joinedload(Ticket.empresa),
+        joinedload(Ticket.setor),
+        joinedload(Ticket.mensagens),
+    )
+    filtros = []
+    if ids:
+        filtros.append(Ticket.empresa_id.in_(ids))
+    if rede_id is not None and escopo_efetivo(funcionario) == "all":
+        filtros.append((Ticket.empresa_id.is_(None)) & (Ticket.rede_id == rede_id))
+    if not filtros:
+        return [], 0
+    q = q.filter(or_(*filtros))
+    sit = (situacao or "abertos").strip().lower()
+    if sit == "abertos":
+        q = q.filter(Ticket.fechado_em.is_(None))
+    elif sit == "fechados":
+        q = q.filter(Ticket.fechado_em.is_not(None))
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter(or_(Ticket.protocolo.ilike(term), Ticket.assunto.ilike(term)))
+    total = q.count()
+    rows = q.order_by(Ticket.id.desc()).offset(offset).limit(limit).all()
+    return rows, total
+
+
+def criar_ticket(
+    db: Session,
+    funcionario: FuncionarioRede,
+    data: PortalTicketCreate,
+) -> Ticket:
+    emp = assert_empresa_no_escopo(db, funcionario, data.empresa_id)
+    tenant_id = tenant_id_do_funcionario(db, funcionario)
+
+    setor_id_efetivo = data.setor_id
+    rota_resultado = evaluate_routing(
+        db,
+        tenant_id=tenant_id,
+        context=RoutingContext(
+            assunto=data.assunto,
+            canal=RoutingCanal.manual,
+            rede_id=emp.rede_id,
+        ),
+    )
+    if rota_resultado.matched:
+        setor_id_efetivo = aplicar_roteamento_setor(
+            setor_atual=data.setor_id,
+            resultado=rota_resultado,
+            aplicar_setor=data.setor_id is None,
+        )
+
+    if setor_id_efetivo is None:
+        raise ValueError("Selecione o setor de atendimento.")
+
+    setor = db.query(Setor).filter(Setor.id == setor_id_efetivo, Setor.tenant_id == tenant_id, Setor.ativo.is_(True)).first()
+    if not setor:
+        raise ValueError("Setor não encontrado.")
+
+    status_inicial = (
+        db.query(StatusTicket).filter(StatusTicket.ativo.is_(True)).order_by(StatusTicket.ordem).first()
+    )
+    if not status_inicial:
+        raise ValueError("Cadastre ao menos um status de ticket.")
+
+    descricao = (data.descricao or "").strip() or None
+    if data.pdv_codigo and data.pdv_codigo.strip():
+        pdv_line = f"PDV: {data.pdv_codigo.strip()}"
+        descricao = f"{pdv_line}\n\n{descricao}" if descricao else pdv_line
+
+    motivo_id_rota = data.motivo_id
+    atendente_id_rota = None
+    if rota_resultado.matched:
+        mid, aid = acoes_efetivas_do_resultado(
+            db,
+            tenant_id=tenant_id,
+            setor_id=setor_id_efetivo,
+            resultado=rota_resultado,
+        )
+        if motivo_id_rota is None:
+            motivo_id_rota = mid
+        atendente_id_rota = aid
+
+    protocolo = gerar_protocolo_ticket(db)
+    ticket = Ticket(
+        tenant_id=tenant_id,
+        protocolo=protocolo,
+        empresa_id=emp.id,
+        rede_id=emp.rede_id,
+        setor_id=setor_id_efetivo,
+        status_id=status_inicial.id,
+        prioridade="normal",
+        assunto=data.assunto.strip(),
+        descricao=descricao,
+        aberto_por_id=funcionario.id,
+        motivo_id=motivo_id_rota,
+        motivo_outro_texto=(data.motivo_outro_texto or None),
+        atendente_id=atendente_id_rota,
+    )
+    db.add(ticket)
+    db.flush()
+    from app.services.sla_policy import aplicar_sla_snapshot_ao_ticket
+
+    aplicar_sla_snapshot_ao_ticket(db, ticket)
+    if rota_resultado.matched:
+        registrar_roteamento_aplicado(
+            db,
+            resultado=rota_resultado,
+            ticket_id=ticket.id,
+            atendente_audit_id=None,
+        )
+
+    corpo_abertura = descricao or "—"
+    autor = (funcionario.nome or "").strip() or (funcionario.email or "Cliente")
+    msg = TicketMensagem(
+        ticket_id=ticket.id,
+        atendente_id=None,
+        tipo="abertura",
+        corpo=corpo_abertura,
+        autor_externo=autor,
+    )
+    db.add(msg)
+    db.commit()
+    db.refresh(ticket)
+
+    contagem_ja_emitida = False
+    if ticket.atendente_id is None:
+        sincronizar_fila_desde_at(ticket)
+        db.commit()
+        if tentar_distribuicao_imediata(db, ticket):
+            db.commit()
+            emit_notificacao_after_counter_change(db)
+            contagem_ja_emitida = True
+        else:
+            emit_ticket_fila(db, ticket)
+            contagem_ja_emitida = True
+
+    msg_abertura = (
+        db.query(TicketMensagem)
+        .filter(TicketMensagem.ticket_id == ticket.id, TicketMensagem.tipo == "abertura")
+        .order_by(TicketMensagem.id.desc())
+        .first()
+    )
+    if msg_abertura:
+        emit_ticket_mensagem_from_model(
+            db,
+            ticket,
+            msg_abertura,
+            exclude_atendente_id=None,
+            emit_notificacao=not contagem_ja_emitida,
+        )
+    return obter_ticket_escopo(db, funcionario, ticket.id)
+
+
+def mensagem_para_read(
+    db: Session,
+    funcionario: FuncionarioRede,
+    m: TicketMensagem,
+) -> PortalMensagemRead:
+    anexos_rows = (
+        db.query(TicketAnexo)
+        .filter(
+            TicketAnexo.mensagem_id == m.id,
+            TicketAnexo.visibilidade == "publico",
+        )
+        .order_by(TicketAnexo.id.asc())
+        .all()
+    )
+    anexos = [
+        PortalAnexoRead(
+            id=a.id,
+            nome_original=a.nome_original,
+            content_type=a.content_type,
+            tamanho_bytes=int(a.tamanho_bytes or 0),
+            mensagem_id=a.mensagem_id,
+            created_at=a.created_at,
+            download_url=f"/v1/portal/tickets/{m.ticket_id}/anexos/{a.id}/download",
+        )
+        for a in anexos_rows
+    ]
+    if m.atendente_id:
+        atendente = getattr(m, "atendente", None)
+        nome = getattr(atendente, "nome", None) or "Equipe de suporte"
+        papel: str = "equipe"
+    elif m.tipo == "abertura" or m.tipo == "email_cliente":
+        nome = (m.autor_externo or funcionario.nome or "Você")
+        # Se o autor externo for o próprio funcionário ou abertura pelo portal
+        papel = "voce"
+    else:
+        nome = m.autor_externo or "Sistema"
+        papel = "sistema"
+    return PortalMensagemRead(
+        id=m.id,
+        tipo=m.tipo,
+        corpo=m.corpo,
+        autor_nome=nome,
+        autor_papel=papel,  # type: ignore[arg-type]
+        created_at=m.created_at,
+        anexos=anexos,
+    )
+
+
+def listar_mensagens_publicas(
+    db: Session,
+    funcionario: FuncionarioRede,
+    ticket: Ticket,
+) -> list[PortalMensagemRead]:
+    rows = (
+        db.query(TicketMensagem)
+        .options(joinedload(TicketMensagem.atendente))
+        .filter(
+            TicketMensagem.ticket_id == ticket.id,
+            TicketMensagem.tipo.in_(list(TIPOS_PUBLICOS_PORTAL)),
+        )
+        .order_by(TicketMensagem.created_at.asc())
+        .all()
+    )
+    return [mensagem_para_read(db, funcionario, m) for m in rows]
+
+
+def criar_mensagem_portal(
+    db: Session,
+    funcionario: FuncionarioRede,
+    ticket: Ticket,
+    corpo: str,
+) -> TicketMensagem:
+    if ticket.fechado_em is not None:
+        raise ValueError(
+            "Este chamado está encerrado. Abra um novo chamado para continuar o atendimento."
+        )
+    texto = corpo.strip()
+    if not texto:
+        raise ValueError("Mensagem vazia")
+    autor = (funcionario.nome or "").strip() or (funcionario.email or "Cliente")
+    m = TicketMensagem(
+        ticket_id=ticket.id,
+        atendente_id=None,
+        tipo="email_cliente",
+        corpo=texto,
+        autor_externo=autor,
+    )
+    db.add(m)
+    db.flush()
+
+    # Se estava aguardando cliente, volta para em atendimento quando houver esse status
+    st = ticket.status
+    if st is not None and (st.slug or "").lower() == "aguardando_cliente":
+        em_atend = (
+            db.query(StatusTicket)
+            .filter(StatusTicket.slug == "em_atendimento", StatusTicket.ativo.is_(True))
+            .first()
+        )
+        if em_atend:
+            ticket.status_id = em_atend.id
+            ticket.updated_at = datetime.now(timezone.utc)
+
+    from app.services.notificacao_atendente_email import notificar_nova_mensagem_ticket
+
+    notificar_nova_mensagem_ticket(db, ticket=ticket, mensagem=m, autor_atendente_id=None)
+    db.commit()
+    db.refresh(m)
+    m = (
+        db.query(TicketMensagem)
+        .options(joinedload(TicketMensagem.atendente))
+        .filter(TicketMensagem.id == m.id)
+        .first()
+    )
+    assert m is not None
+    emit_ticket_mensagem_from_model(db, ticket, m, exclude_atendente_id=None)
+    return m
+
+
+def listar_anexos_publicos(db: Session, ticket: Ticket) -> list[PortalAnexoRead]:
+    rows = (
+        db.query(TicketAnexo)
+        .filter(TicketAnexo.ticket_id == ticket.id, TicketAnexo.visibilidade == "publico")
+        .order_by(TicketAnexo.id.asc())
+        .all()
+    )
+    return [
+        PortalAnexoRead(
+            id=a.id,
+            nome_original=a.nome_original,
+            content_type=a.content_type,
+            tamanho_bytes=int(a.tamanho_bytes or 0),
+            mensagem_id=a.mensagem_id,
+            created_at=a.created_at,
+            download_url=f"/v1/portal/tickets/{ticket.id}/anexos/{a.id}/download",
+        )
+        for a in rows
+    ]
+
+
+def obter_anexo_publico(db: Session, ticket: Ticket, anexo_id: int) -> TicketAnexo:
+    a = (
+        db.query(TicketAnexo)
+        .filter(
+            TicketAnexo.id == anexo_id,
+            TicketAnexo.ticket_id == ticket.id,
+            TicketAnexo.visibilidade == "publico",
+        )
+        .first()
+    )
+    if not a:
+        raise LookupError("Anexo não encontrado")
+    return a

--- a/backend/app/services/portal_whatsapp.py
+++ b/backend/app/services/portal_whatsapp.py
@@ -1,0 +1,176 @@
+"""Chats WhatsApp no portal autenticado do cliente (#603)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.portal_scope import chat_no_escopo, filtro_query_chats_portal
+from app.models.funcionario_rede import FuncionarioRede
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
+from app.schemas.portal import (
+    PortalWhatsappChatDetail,
+    PortalWhatsappChatListItem,
+    PortalWhatsappMensagemRead,
+)
+from app.services.whatsapp_auto_messages import EVENTOS_MENSAGEM_OCULTA_CONVERSA
+from app.services.whatsapp_avaliacao import mensagem_oculta_na_conversa
+
+EVENTOS_OCULTOS_PORTAL = EVENTOS_MENSAGEM_OCULTA_CONVERSA | frozenset(
+    {
+        "comentario_interno",
+        "transferencia",
+        "demanda_registrada",
+        "demanda_escalada",
+    }
+)
+
+
+def mensagem_visivel_no_portal(m: WhatsappMensagem) -> bool:
+    ev = (getattr(m, "evento_sistema", None) or "").strip()
+    if ev in EVENTOS_OCULTOS_PORTAL:
+        return False
+    if mensagem_oculta_na_conversa(ev or None):
+        return False
+    return True
+
+
+def _preview(corpo: str | None) -> str | None:
+    if not corpo:
+        return None
+    texto = corpo.strip()
+    if len(texto) > 100:
+        return texto[:100] + "…"
+    return texto
+
+
+def _ultima_mensagem_visivel(db: Session, chat_id: int) -> tuple[datetime | None, str | None]:
+    rows = (
+        db.query(WhatsappMensagem)
+        .filter(WhatsappMensagem.chat_id == chat_id)
+        .order_by(WhatsappMensagem.id.desc())
+        .limit(30)
+        .all()
+    )
+    for m in rows:
+        if mensagem_visivel_no_portal(m):
+            return m.created_at, _preview(m.corpo)
+    return None, None
+
+
+def chat_para_list_item(db: Session, chat: WhatsappChat) -> PortalWhatsappChatListItem:
+    ultima_em, preview = _ultima_mensagem_visivel(db, chat.id)
+    emp = getattr(chat, "empresa", None)
+    setor = getattr(chat, "setor", None)
+    return PortalWhatsappChatListItem(
+        id=chat.id,
+        protocolo=chat.protocolo,
+        estado=chat.estado,
+        empresa_id=chat.empresa_id,
+        empresa_nome=getattr(emp, "nome", None) if emp else None,
+        setor_nome=getattr(setor, "nome", None) if setor else None,
+        created_at=chat.created_at,
+        encerramento_at=chat.encerramento_at,
+        ultima_mensagem_em=ultima_em,
+        ultima_mensagem_preview=preview,
+    )
+
+
+def chat_para_detail(db: Session, chat: WhatsappChat) -> PortalWhatsappChatDetail:
+    base = chat_para_list_item(db, chat)
+    return PortalWhatsappChatDetail(**base.model_dump(), encerrado=(chat.estado or "") == "encerrado")
+
+
+def obter_chat_escopo(db: Session, funcionario: FuncionarioRede, chat_id: int) -> WhatsappChat:
+    chat = (
+        db.query(WhatsappChat)
+        .options(
+            joinedload(WhatsappChat.empresa),
+            joinedload(WhatsappChat.setor),
+        )
+        .filter(WhatsappChat.id == chat_id)
+        .first()
+    )
+    if not chat or not chat_no_escopo(db, funcionario, chat):
+        raise LookupError("Atendimento não encontrado")
+    return chat
+
+
+def listar_chats(
+    db: Session,
+    funcionario: FuncionarioRede,
+    *,
+    situacao: str = "abertos",
+    busca: str | None = None,
+    offset: int = 0,
+    limit: int = 20,
+) -> tuple[list[WhatsappChat], int]:
+    q = db.query(WhatsappChat).options(
+        joinedload(WhatsappChat.empresa),
+        joinedload(WhatsappChat.setor),
+    )
+    q = filtro_query_chats_portal(q, db, funcionario)
+    if q is None:
+        return [], 0
+
+    sit = (situacao or "abertos").strip().lower()
+    if sit == "abertos":
+        q = q.filter(WhatsappChat.estado != "encerrado")
+    elif sit == "encerrados":
+        q = q.filter(WhatsappChat.estado == "encerrado")
+
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter(or_(WhatsappChat.protocolo.ilike(term), WhatsappChat.cliente_nome.ilike(term)))
+
+    total = q.count()
+    rows = q.order_by(WhatsappChat.id.desc()).offset(offset).limit(limit).all()
+    return rows, total
+
+
+def mensagem_para_read(m: WhatsappMensagem) -> PortalWhatsappMensagemRead:
+    midia_ok = bool(m.midia_nome_arquivo and str(m.midia_nome_arquivo).strip())
+    if (m.direcao or "").strip().lower() == "inbound":
+        papel: str = "voce"
+        nome = "Você"
+    elif m.atendente_id:
+        atendente = getattr(m, "atendente", None)
+        papel = "equipe"
+        nome = getattr(atendente, "nome", None) or "Equipe de suporte"
+    else:
+        papel = "sistema"
+        nome = "Sistema"
+    return PortalWhatsappMensagemRead(
+        id=m.id,
+        direcao=m.direcao,
+        corpo=m.corpo,
+        tipo_midia=m.tipo_midia,
+        midia_disponivel=midia_ok,
+        autor_nome=nome,
+        autor_papel=papel,  # type: ignore[arg-type]
+        created_at=m.created_at,
+    )
+
+
+def listar_mensagens_visiveis(db: Session, chat: WhatsappChat) -> list[PortalWhatsappMensagemRead]:
+    rows = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.chat_id == chat.id)
+        .order_by(WhatsappMensagem.created_at.asc())
+        .all()
+    )
+    return [mensagem_para_read(m) for m in rows if mensagem_visivel_no_portal(m)]
+
+
+def obter_mensagem_midia(db: Session, chat: WhatsappChat, mensagem_id: int) -> WhatsappMensagem:
+    m = (
+        db.query(WhatsappMensagem)
+        .filter(WhatsappMensagem.chat_id == chat.id, WhatsappMensagem.id == mensagem_id)
+        .first()
+    )
+    if not m or not mensagem_visivel_no_portal(m) or not m.midia_nome_arquivo:
+        raise LookupError("Mídia não encontrada")
+    return m

--- a/backend/tests/test_portal_cliente.py
+++ b/backend/tests/test_portal_cliente.py
@@ -1,0 +1,357 @@
+"""Portal do cliente — auth, escopo e tickets (#263 / #300–#303)."""
+
+from __future__ import annotations
+
+from app.core.security import criar_access_token, hash_senha
+from app.models.empresa import Empresa
+from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
+from app.models.ticket import Ticket, TicketMensagem
+
+
+def _criar_funcionario(
+    db_session,
+    seed_base,
+    *,
+    tipo: str,
+    email: str,
+    senha: str = "portal123",
+    empresa=None,
+    empresas_extra=None,
+    ativo: bool = True,
+    rede=None,
+):
+    emp = empresa or seed_base["empresa"]
+    rede_obj = rede or seed_base["rede"]
+    f = FuncionarioRede(
+        nome=f"Func {tipo}",
+        email=email,
+        tipo=tipo,
+        escopo_empresas="all" if tipo == "socio" else "selected",
+        ativo=ativo,
+        rede_id=rede_obj.id,
+        empresa_id=emp.id if tipo == "colaborador" else None,
+        senha_hash=hash_senha(senha),
+        must_change_password=False,
+        token_version=0,
+        notificar_email_portal=True,
+    )
+    db_session.add(f)
+    db_session.flush()
+    if tipo != "socio":
+        ids = [emp.id]
+        if empresas_extra:
+            ids.extend(e.id for e in empresas_extra)
+        for eid in dict.fromkeys(ids):
+            db_session.add(FuncionarioRedeEmpresa(funcionario_id=f.id, empresa_id=eid))
+            if tipo == "colaborador":
+                f.empresa_id = eid
+    db_session.commit()
+    db_session.refresh(f)
+    return f
+
+
+def _portal_headers(funcionario: FuncionarioRede) -> dict[str, str]:
+    tok = criar_access_token(
+        {
+            "sub": funcionario.email,
+            "aud": "portal",
+            "fid": funcionario.id,
+            "tid": 1,
+            "ver": int(funcionario.token_version or 0),
+        }
+    )
+    return {"Authorization": f"Bearer {tok}", "X-Dx-Tenant-Id": "1"}
+
+
+def test_portal_login_ok_e_inativo_403(client, db_session, seed_base):
+    f = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="colab@example.com")
+    r = client.post("/v1/portal/auth/login", json={"email": "colab@example.com", "senha": "portal123"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["access_token"]
+    assert body["must_change_password"] is False
+
+    f.ativo = False
+    db_session.commit()
+    r2 = client.post("/v1/portal/auth/login", json={"email": "colab@example.com", "senha": "portal123"})
+    assert r2.status_code == 401
+
+
+def test_portal_token_nao_acessa_painel_interno(client, db_session, seed_base, auth_headers):
+    f = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="colab2@example.com")
+    headers = _portal_headers(f)
+    r = client.get("/v1/atendentes/me", headers=headers)
+    assert r.status_code == 401
+
+    # Token interno também não passa no portal
+    r2 = client.get("/v1/portal/me", headers=auth_headers["admin"])
+    assert r2.status_code == 401
+
+
+def test_portal_me_escopo_tres_perfis(client, db_session, seed_base):
+    emp2 = Empresa(
+        tenant_id=1,
+        rede_id=seed_base["rede"].id,
+        nome="Empresa 2",
+        ativo=True,
+    )
+    db_session.add(emp2)
+    db_session.commit()
+
+    colab = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="c@example.com")
+    super_v = _criar_funcionario(
+        db_session,
+        seed_base,
+        tipo="supervisor",
+        email="s@example.com",
+        empresas_extra=[emp2],
+    )
+    socio = _criar_funcionario(db_session, seed_base, tipo="socio", email="so@example.com")
+
+    me_c = client.get("/v1/portal/me", headers=_portal_headers(colab)).json()
+    assert len(me_c["empresas"]) == 1
+    assert me_c["empresas"][0]["id"] == seed_base["empresa"].id
+
+    me_s = client.get("/v1/portal/me", headers=_portal_headers(super_v)).json()
+    ids_s = {e["id"] for e in me_s["empresas"]}
+    assert seed_base["empresa"].id in ids_s
+    assert emp2.id in ids_s
+
+    me_so = client.get("/v1/portal/me", headers=_portal_headers(socio)).json()
+    ids_so = {e["id"] for e in me_so["empresas"]}
+    assert seed_base["empresa"].id in ids_so
+    assert emp2.id in ids_so
+
+
+def test_portal_tickets_criacao_listagem_e_cross_empresa(client, db_session, seed_base):
+    emp2 = Empresa(tenant_id=1, rede_id=seed_base["rede"].id, nome="Outra Emp", ativo=True)
+    db_session.add(emp2)
+    db_session.commit()
+
+    colab = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="tix@example.com")
+    headers = _portal_headers(colab)
+
+    r = client.post(
+        "/v1/portal/tickets",
+        headers=headers,
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "PDV offline no posto",
+            "descricao": "Não inicia o sistema",
+        },
+    )
+    assert r.status_code == 201, r.text
+    ticket = r.json()
+    assert ticket["protocolo"].startswith("#T")
+    assert ticket["assunto"] == "PDV offline no posto"
+
+    # aberto_por_id gravado no banco (não exposto no schema do portal)
+    t_db = db_session.query(Ticket).filter(Ticket.id == ticket["id"]).first()
+    assert t_db is not None
+    assert t_db.aberto_por_id == colab.id
+
+    lista = client.get("/v1/portal/tickets", headers=headers)
+    assert lista.status_code == 200
+    assert lista.json()["total"] == 1
+
+    # Empresa fora do escopo → 404
+    r404 = client.post(
+        "/v1/portal/tickets",
+        headers=headers,
+        json={
+            "empresa_id": emp2.id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Não deveria",
+            "descricao": "x",
+        },
+    )
+    assert r404.status_code == 404
+
+    # Ticket de outra empresa não aparece / detalhe 404
+    outro = _criar_funcionario(
+        db_session, seed_base, tipo="colaborador", email="outro@example.com", empresa=emp2
+    )
+    r_outro = client.post(
+        "/v1/portal/tickets",
+        headers=_portal_headers(outro),
+        json={
+            "empresa_id": emp2.id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Ticket alheio",
+            "descricao": "segredo",
+        },
+    )
+    assert r_outro.status_code == 201
+    tid_alheio = r_outro.json()["id"]
+    assert client.get(f"/v1/portal/tickets/{tid_alheio}", headers=headers).status_code == 404
+
+
+def test_portal_mensagens_publicas_omit_internas(client, db_session, seed_base, auth_headers):
+    colab = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="msg@example.com")
+    headers = _portal_headers(colab)
+    created = client.post(
+        "/v1/portal/tickets",
+        headers=headers,
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Preciso de ajuda",
+            "descricao": "Descrição inicial",
+        },
+    ).json()
+    tid = created["id"]
+
+    # Atendente assume e manda pública + interna
+    client.patch(
+        f"/v1/tickets/{tid}",
+        headers=auth_headers["a1"],
+        json={"atendente_id": seed_base["a1"].id},
+    )
+    client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["a1"],
+        json={"corpo": "Estamos analisando", "tipo": "publico"},
+    )
+    client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["a1"],
+        json={"corpo": "nota interna secreta", "tipo": "interno"},
+    )
+
+    msgs = client.get(f"/v1/portal/tickets/{tid}/mensagens", headers=headers)
+    assert msgs.status_code == 200
+    corpos = [m["corpo"] for m in msgs.json()]
+    assert "Estamos analisando" in corpos
+    assert "nota interna secreta" not in corpos
+    assert all(m["tipo"] != "interno" for m in msgs.json())
+
+    # Cliente responde
+    r = client.post(
+        f"/v1/portal/tickets/{tid}/mensagens",
+        headers=headers,
+        json={"corpo": "Obrigado, aguardo"},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["autor_papel"] == "voce"
+
+    m_db = (
+        db_session.query(TicketMensagem)
+        .filter(TicketMensagem.ticket_id == tid, TicketMensagem.tipo == "email_cliente")
+        .first()
+    )
+    assert m_db is not None
+
+
+def test_portal_anexo_upload_e_download(client, db_session, seed_base):
+    colab = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="anx@example.com")
+    headers = _portal_headers(colab)
+    tid = client.post(
+        "/v1/portal/tickets",
+        headers=headers,
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Com anexo",
+            "descricao": "veja o ficheiro",
+        },
+    ).json()["id"]
+
+    up = client.post(
+        f"/v1/portal/tickets/{tid}/anexos",
+        headers=headers,
+        files={"file": ("foto.txt", b"conteudo-teste", "text/plain")},
+    )
+    assert up.status_code == 201, up.text
+    anexo_id = up.json()["id"]
+
+    dl = client.get(f"/v1/portal/tickets/{tid}/anexos/{anexo_id}/download", headers=headers)
+    assert dl.status_code == 200
+    assert dl.content == b"conteudo-teste"
+
+
+def test_portal_notificacao_email_mensagem_publica(client, db_session, seed_base, auth_headers, monkeypatch):
+    from app.services.portal_notificacoes import clear_debounce_for_tests
+
+    clear_debounce_for_tests()
+    enviados: list[dict] = []
+
+    def fake_send(db, *, to_addr, subject, body, **kwargs):
+        enviados.append({"to": to_addr, "subject": subject, "body": body})
+        return "msg-id-fake"
+
+    monkeypatch.setattr(
+        "app.services.portal_notificacoes.enviar_mensagem_texto_sistema",
+        fake_send,
+    )
+
+    colab = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="mail@example.com")
+    headers = _portal_headers(colab)
+    tid = client.post(
+        "/v1/portal/tickets",
+        headers=headers,
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Notificar",
+            "descricao": "x",
+        },
+    ).json()["id"]
+
+    client.patch(
+        f"/v1/tickets/{tid}",
+        headers=auth_headers["a1"],
+        json={"atendente_id": seed_base["a1"].id},
+    )
+    client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["a1"],
+        json={"corpo": "Resposta da equipe", "tipo": "publico"},
+    )
+    assert any("Resposta da equipe" in e["body"] for e in enviados)
+    assert any(e["to"] == "mail@example.com" for e in enviados)
+
+    # Interna não notifica
+    n_antes = len(enviados)
+    client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["a1"],
+        json={"corpo": "só interno", "tipo": "interno"},
+    )
+    assert len(enviados) == n_antes
+
+
+def test_admin_define_senha_portal_no_funcionario(client, db_session, seed_base, auth_headers):
+    # Cria sem senha via API admin
+    r = client.post(
+        "/v1/funcionarios-rede",
+        headers=auth_headers["admin"],
+        json={
+            "nome": "Sem senha",
+            "email": "novoportal@example.com",
+            "tipo": "colaborador",
+            "escopo_empresas": "selected",
+            "empresa_ids": [seed_base["empresa"].id],
+            "rede_id": seed_base["rede"].id,
+            "ativo": True,
+        },
+    )
+    assert r.status_code == 201, r.text
+    fid = r.json()["id"]
+    assert r.json()["portal_habilitado"] is False
+
+    r2 = client.patch(
+        f"/v1/funcionarios-rede/{fid}",
+        headers=auth_headers["admin"],
+        json={"senha_portal": "senhaforte1", "must_change_password": True},
+    )
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["portal_habilitado"] is True
+    assert r2.json()["must_change_password"] is True
+
+    login = client.post(
+        "/v1/portal/auth/login",
+        json={"email": "novoportal@example.com", "senha": "senhaforte1"},
+    )
+    assert login.status_code == 200
+    assert login.json()["must_change_password"] is True

--- a/backend/tests/test_portal_cliente.py
+++ b/backend/tests/test_portal_cliente.py
@@ -355,3 +355,374 @@ def test_admin_define_senha_portal_no_funcionario(client, db_session, seed_base,
     )
     assert login.status_code == 200
     assert login.json()["must_change_password"] is True
+
+
+def test_criar_socio_sem_empresa_ids_normaliza_escopo_all(client, db_session, seed_base, auth_headers):
+    from app.models.funcionario_rede import FuncionarioRede
+    from app.services.funcionario_escopo import empresa_ids_vinculados, escopo_efetivo
+
+    r = client.post(
+        "/v1/funcionarios-rede",
+        headers=auth_headers["admin"],
+        json={
+            "nome": "Sócio Rede",
+            "email": "socio.rede@example.com",
+            "tipo": "socio",
+            "rede_id": seed_base["rede"].id,
+            "ativo": True,
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["escopo_empresas"] == "all"
+    assert body["tipo"] == "socio"
+    f = db_session.query(FuncionarioRede).filter(FuncionarioRede.id == body["id"]).first()
+    assert f is not None
+    assert escopo_efetivo(f) == "all"
+    assert seed_base["empresa"].id in empresa_ids_vinculados(db_session, f)
+
+
+def test_criar_funcionario_com_senha_portal_no_create(client, seed_base, auth_headers):
+    r = client.post(
+        "/v1/funcionarios-rede",
+        headers=auth_headers["admin"],
+        json={
+            "nome": "Com portal",
+            "email": "portal.create@example.com",
+            "tipo": "colaborador",
+            "escopo_empresas": "selected",
+            "empresa_ids": [seed_base["empresa"].id],
+            "rede_id": seed_base["rede"].id,
+            "ativo": True,
+            "senha_portal": "senhaforte1",
+            "must_change_password": True,
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["portal_habilitado"] is True
+
+    login = client.post(
+        "/v1/portal/auth/login",
+        json={"email": "portal.create@example.com", "senha": "senhaforte1"},
+    )
+    assert login.status_code == 200
+    assert login.json()["must_change_password"] is True
+
+
+def _ticket_portal(client, funcionario, seed_base, *, assunto: str):
+    return client.post(
+        "/v1/portal/tickets",
+        headers=_portal_headers(funcionario),
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": assunto,
+            "descricao": "teste rbac",
+        },
+    )
+
+
+def test_portal_rbac_tickets_por_papel(client, db_session, seed_base, auth_headers):
+    emp2 = Empresa(
+        tenant_id=1,
+        rede_id=seed_base["rede"].id,
+        nome="Empresa RBAC 2",
+        ativo=True,
+    )
+    db_session.add(emp2)
+    db_session.commit()
+
+    colab1 = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="rbac.c1@example.com")
+    colab2 = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="rbac.c2@example.com")
+    supervisor = _criar_funcionario(
+        db_session,
+        seed_base,
+        tipo="supervisor",
+        email="rbac.sup@example.com",
+        empresas_extra=[emp2],
+    )
+    socio = _criar_funcionario(db_session, seed_base, tipo="socio", email="rbac.so@example.com")
+
+    t1 = _ticket_portal(client, colab1, seed_base, assunto="Ticket colab 1").json()
+    t2 = _ticket_portal(client, colab2, seed_base, assunto="Ticket colab 2").json()
+    assert t1["id"] != t2["id"]
+
+    ids_c1 = {x["id"] for x in client.get("/v1/portal/tickets", headers=_portal_headers(colab1)).json()["items"]}
+    assert ids_c1 == {t1["id"]}
+    assert client.get(f"/v1/portal/tickets/{t2['id']}", headers=_portal_headers(colab1)).status_code == 404
+
+    ids_c2 = {x["id"] for x in client.get("/v1/portal/tickets", headers=_portal_headers(colab2)).json()["items"]}
+    assert ids_c2 == {t2["id"]}
+
+    ids_sup = {x["id"] for x in client.get("/v1/portal/tickets", headers=_portal_headers(supervisor)).json()["items"]}
+    assert {t1["id"], t2["id"]} <= ids_sup
+
+    ids_so = {x["id"] for x in client.get("/v1/portal/tickets", headers=_portal_headers(socio)).json()["items"]}
+    assert {t1["id"], t2["id"]} <= ids_so
+
+    interno = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Aberto pela equipe",
+            "descricao": "interno",
+            "prioridade": "normal",
+        },
+    )
+    assert interno.status_code == 201, interno.text
+    tid_interno = interno.json()["id"]
+    assert tid_interno not in ids_c1
+    assert client.get(f"/v1/portal/tickets/{tid_interno}", headers=_portal_headers(colab1)).status_code == 404
+    assert client.get(f"/v1/portal/tickets/{tid_interno}", headers=_portal_headers(supervisor)).status_code == 200
+    assert client.get(f"/v1/portal/tickets/{tid_interno}", headers=_portal_headers(socio)).status_code == 200
+
+    colab_emp2 = _criar_funcionario(
+        db_session,
+        seed_base,
+        tipo="colaborador",
+        email="rbac.emp2@example.com",
+        empresa=emp2,
+    )
+    t_emp2 = client.post(
+        "/v1/portal/tickets",
+        headers=_portal_headers(colab_emp2),
+        json={
+            "empresa_id": emp2.id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Só emp2",
+            "descricao": "x",
+        },
+    )
+    assert t_emp2.status_code == 201
+    tid_emp2 = t_emp2.json()["id"]
+    assert tid_emp2 not in ids_c1
+    assert client.get(f"/v1/portal/tickets/{tid_emp2}", headers=_portal_headers(supervisor)).status_code == 200
+
+
+def _webhook_whatsapp(wa_id: str, msg_id: str, text: str = "Olá"):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": msg_id,
+                    },
+                    "message": {"conversation": text},
+                }
+            ]
+        },
+    }
+
+
+def _chat_wpp_vinculado(client, seed_base, auth_headers, funcionario_id: int, *, wa_id: str, msg_id: str, secret: str):
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": secret},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": secret}
+    client.post("/v1/webhooks/evolution", json=_webhook_whatsapp(wa_id, msg_id), headers=h)
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    client.post(
+        f"/v1/whatsapp/chats/{cid}/vincular-funcionario",
+        json={"funcionario_rede_id": funcionario_id},
+        headers=auth_headers["a1"],
+    )
+    return cid
+
+
+def test_portal_chats_rbac_e_mensagens(client, db_session, seed_base, auth_headers):
+    colab1 = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="wpp.c1@example.com")
+    colab2 = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="wpp.c2@example.com")
+    supervisor = _criar_funcionario(db_session, seed_base, tipo="supervisor", email="wpp.sup@example.com")
+    socio = _criar_funcionario(db_session, seed_base, tipo="socio", email="wpp.so@example.com")
+
+    cid1 = _chat_wpp_vinculado(
+        client, seed_base, auth_headers, colab1.id, wa_id="5511888000001", msg_id="pw-1", secret="portal-wpp-1"
+    )
+    cid2 = _chat_wpp_vinculado(
+        client, seed_base, auth_headers, colab2.id, wa_id="5511888000002", msg_id="pw-2", secret="portal-wpp-2"
+    )
+
+    ids_c1 = {x["id"] for x in client.get("/v1/portal/chats", headers=_portal_headers(colab1)).json()["items"]}
+    assert ids_c1 == {cid1}
+    assert client.get(f"/v1/portal/chats/{cid2}", headers=_portal_headers(colab1)).status_code == 404
+
+    ids_sup = {x["id"] for x in client.get("/v1/portal/chats", headers=_portal_headers(supervisor)).json()["items"]}
+    assert {cid1, cid2} <= ids_sup
+
+    ids_so = {x["id"] for x in client.get("/v1/portal/chats", headers=_portal_headers(socio)).json()["items"]}
+    assert {cid1, cid2} <= ids_so
+
+    client.post(
+        f"/v1/whatsapp/chats/{cid1}/comentarios-internos",
+        headers=auth_headers["a1"],
+        json={"texto": "nota secreta"},
+    )
+
+    msgs = client.get(f"/v1/portal/chats/{cid1}/mensagens", headers=_portal_headers(colab1)).json()
+    corpos = [m["corpo"] for m in msgs]
+    assert any("Olá" in c for c in corpos)
+    assert not any("nota secreta" in c for c in corpos)
+    assert not any("INTERNO" in c for c in corpos)
+
+    det = client.get(f"/v1/portal/chats/{cid1}", headers=_portal_headers(colab1)).json()
+    assert det["protocolo"].startswith("#")
+    assert det["empresa_id"] == seed_base["empresa"].id
+
+
+def test_portal_equipe_403_nao_socio(client, db_session, seed_base):
+    colab = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="eq.c@example.com")
+    supervisor = _criar_funcionario(db_session, seed_base, tipo="supervisor", email="eq.s@example.com")
+    for headers in (_portal_headers(colab), _portal_headers(supervisor)):
+        assert client.get("/v1/portal/equipe/funcionarios", headers=headers).status_code == 403
+        assert client.get("/v1/portal/equipe/empresas", headers=headers).status_code == 403
+        assert (
+            client.post(
+                "/v1/portal/equipe/funcionarios",
+                headers=headers,
+                json={
+                    "nome": "Novo",
+                    "email": "novo@example.com",
+                    "tipo": "colaborador",
+                    "empresa_id": seed_base["empresa"].id,
+                    "ativo": True,
+                },
+            ).status_code
+            == 403
+        )
+
+
+def test_portal_equipe_socio_crud_e_restricoes(client, db_session, seed_base):
+    emp2 = Empresa(
+        tenant_id=1,
+        rede_id=seed_base["rede"].id,
+        nome="Empresa Equipe 2",
+        ativo=True,
+    )
+    db_session.add(emp2)
+    db_session.commit()
+
+    socio = _criar_funcionario(db_session, seed_base, tipo="socio", email="eq.so@example.com")
+    outro_socio = _criar_funcionario(db_session, seed_base, tipo="socio", email="eq.so2@example.com")
+    headers = _portal_headers(socio)
+
+    lista = client.get("/v1/portal/equipe/funcionarios", headers=headers)
+    assert lista.status_code == 200, lista.text
+    emails = {x["email"] for x in lista.json()["items"]}
+    assert "eq.so@example.com" in emails
+    assert "eq.so2@example.com" in emails
+
+    empresas = client.get("/v1/portal/equipe/empresas", headers=headers)
+    assert empresas.status_code == 200
+    ids_emp = {e["id"] for e in empresas.json()}
+    assert seed_base["empresa"].id in ids_emp
+    assert emp2.id in ids_emp
+
+    r_socio = client.post(
+        "/v1/portal/equipe/funcionarios",
+        headers=headers,
+        json={
+            "nome": "Não pode",
+            "email": "nao.socio@example.com",
+            "tipo": "socio",
+            "ativo": True,
+        },
+    )
+    assert r_socio.status_code == 422
+
+    r_colab = client.post(
+        "/v1/portal/equipe/funcionarios",
+        headers=headers,
+        json={
+            "nome": "Colab Portal",
+            "email": "colab.portal@example.com",
+            "tipo": "colaborador",
+            "empresa_id": seed_base["empresa"].id,
+            "senha_portal": "senhaforte1",
+            "must_change_password": True,
+            "ativo": True,
+        },
+    )
+    assert r_colab.status_code == 201, r_colab.text
+    fid = r_colab.json()["id"]
+    assert r_colab.json()["portal_habilitado"] is True
+    assert r_colab.json()["tipo"] == "colaborador"
+
+    login = client.post(
+        "/v1/portal/auth/login",
+        json={"email": "colab.portal@example.com", "senha": "senhaforte1"},
+    )
+    assert login.status_code == 200
+
+    r_sup = client.patch(
+        f"/v1/portal/equipe/funcionarios/{fid}",
+        headers=headers,
+        json={
+            "tipo": "supervisor",
+            "empresa_ids": [seed_base["empresa"].id, emp2.id],
+            "nome": "Super Portal",
+        },
+    )
+    assert r_sup.status_code == 200, r_sup.text
+    assert r_sup.json()["tipo"] == "supervisor"
+    assert set(r_sup.json()["empresa_ids"]) == {seed_base["empresa"].id, emp2.id}
+
+    r_outro = client.patch(
+        f"/v1/portal/equipe/funcionarios/{outro_socio.id}",
+        headers=headers,
+        json={"nome": "Tentativa inválida", "ativo": False},
+    )
+    assert r_outro.status_code == 400, r_outro.text
+
+    r_outro_ok = client.patch(
+        f"/v1/portal/equipe/funcionarios/{outro_socio.id}",
+        headers=headers,
+        json={"ativo": False, "notificar_email_portal": False},
+    )
+    assert r_outro_ok.status_code == 200, r_outro_ok.text
+    assert r_outro_ok.json()["ativo"] is False
+    assert r_outro_ok.json()["notificar_email_portal"] is False
+
+
+def test_portal_public_branding_compartilha_settings(client, auth_headers):
+    client.put(
+        "/v1/kb/portal-settings",
+        headers=auth_headers["admin"],
+        json={
+            "portal_titulo": "Suporte ACME",
+            "cor_header": "#112233",
+            "cor_primaria": "#AABBCC",
+            "cor_texto_header": "#FFFFFF",
+            "cor_texto_corpo": "#222222",
+            "cor_fundo": "#EEEEEE",
+            "cor_link": "#0055AA",
+            "texto_boas_vindas": "Bem-vindo ao suporte ACME.",
+        },
+    )
+    kb = client.get("/v1/kb/public/branding")
+    portal = client.get("/v1/portal/public/branding")
+    assert kb.status_code == 200, kb.text
+    assert portal.status_code == 200, portal.text
+    kb_body = kb.json()
+    portal_body = portal.json()
+    assert kb_body["cor_primaria"] == "#AABBCC"
+    assert portal_body["cor_primaria"] == "#AABBCC"
+    assert kb_body["portal_titulo"] == "Suporte ACME"
+    assert portal_body["portal_titulo"] == "Portal do cliente"
+    assert portal_body["texto_boas_vindas"] == "Bem-vindo ao suporte ACME."
+
+
+def test_portal_public_branding_fallback_sem_settings(client):
+    r = client.get("/v1/portal/public/branding")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["portal_titulo"] == "Portal do cliente"
+    assert body["cor_primaria"] == "#0D9488"
+    assert body["logo_url"] is None

--- a/docs/PORTAL_CLIENTE.md
+++ b/docs/PORTAL_CLIENTE.md
@@ -1,0 +1,73 @@
+# Portal do cliente (`/portal`)
+
+Portal autenticado para funcionários da rede (sócio, supervisor, colaborador) abrirem e acompanharem chamados. Distinto do portal KB público (`/kb`) e do chat visitante (`portal_chat`).
+
+Épico: [#263](https://github.com/lgustavoss/dx-connect/issues/263)
+
+## Autenticação
+
+- JWT com claim `aud=portal` (separado do painel interno)
+- Credenciais em `funcionarios_rede.senha_hash` (admin define no cadastro)
+
+## RBAC por papel (#604)
+
+Escopo implementado em `backend/app/core/portal_scope.py`.
+
+| Papel | Tickets | Chats WhatsApp (API #603) |
+|-------|---------|---------------------------|
+| **Colaborador** | Só os **próprios** (`aberto_por_id` = funcionário) | Só contactos **vinculados** a ele (`funcionario_rede_id`) |
+| **Supervisor** | Todos das **empresas vinculadas** | Todos das empresas vinculadas |
+| **Sócio** | Toda a **rede** (incl. tickets só com `rede_id`) | Toda a rede |
+
+Colaborador **não** vê ticket aberto pela equipe interna (sem `aberto_por_id`) nem chamado de colega da mesma empresa.
+
+Supervisor vê tickets de todos os funcionários das empresas em que está vinculado, não apenas os que ele abriu.
+
+## Chats WhatsApp (#603)
+
+- Listagem em `/portal/chats` e detalhe com timeline legível (somente leitura)
+- Mensagens internas da equipe (comentários, transferências, marcos de demanda, fluxo de avaliação) ficam ocultas
+- API: `GET /v1/portal/chats`, `GET /v1/portal/chats/{id}`, `GET /v1/portal/chats/{id}/mensagens`
+
+## Gestão de equipe (#602)
+
+Disponível apenas para **sócio** autenticado no portal.
+
+- Listagem e CRUD de **colaboradores** e **supervisores** da mesma rede
+- Senha do portal, empresas vinculadas e situação (ativo/inativo)
+- **Não** é possível criar ou promover outro **sócio** pelo portal
+- Outros sócios aparecem na listagem; só é permitido alterar situação, senha e notificações
+- Colaborador e supervisor recebem **403** em `/v1/portal/equipe/*`
+- API: `GET/POST/PATCH /v1/portal/equipe/funcionarios`, `GET /v1/portal/equipe/empresas`
+- UI: menu **Equipe** (só sócio) em `/portal/equipe`
+
+## Branding white-label (#605)
+
+Reutiliza `KbPortalSettings` e logo de **Configurações → Sistema → Empresa** (mesma fonte do `/kb`).
+
+- Admin edita cores e textos em **Configurações → Base de conhecimento**
+- **Título do `/portal`:** derivado do nome da empresa (`Portal — {nome}`), independente do título da central `/kb`
+- **Cores:** navbar (`cor_header`) e menu lateral (`cor_sidebar`, padrão = navbar) configuráveis no painel
+- API pública: `GET /v1/portal/public/branding` (sem auth; logo via `/v1/kb/public/logo`)
+- Login e shell `/portal` aplicam CSS variables (`--portal-primary`, etc.)
+- Fallback com cores padrão e título «Portal do cliente» se settings incompletos
+- Código: `backend/app/services/instancia_branding.py`, `frontend/src/contexts/PortalBrandingContext.tsx`
+
+## Chat ao vivo (widget)
+
+Botão flutuante no `/portal` (mesmo padrão da central `/kb`), habilitado quando **Chat ao vivo** está ativo em Configurações → Base de conhecimento.
+
+- Reutiliza a API pública `portal_chat` (`/v1/kb/public/chat`) — o atendimento aparece no hub **Chat** do painel DeskRudder da **mesma instância**
+- Nome e e-mail pré-preenchidos com o usuário autenticado do portal
+- Token de sessão em `localStorage` separado do visitante `/kb` (`dxconnect.portal.cliente.chat_token`)
+
+### Isolamento entre clientes (produção)
+
+Produção = **single-tenant por instância** (subdomínio + Postgres dedicado). O widget do portal da DuplexSoft só fala com a API dessa instância; o SSE/fila de chat só notifica atendentes daquele DeskRudder. Não há compartilhamento de chats entre clientes DeskRudder.
+
+## Referências de código
+
+- API: `backend/app/api/portal.py`
+- Tickets: `backend/app/services/portal_tickets.py`
+- Equipe: `backend/app/services/portal_equipe.py`
+- Testes: `backend/tests/test_portal_cliente.py`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,6 +75,7 @@ import { AcessoNegado } from './pages/AcessoNegado'
 import { KbPublicLayout } from './pages/kb-public/KbPublicLayout'
 import { KbPublicHome } from './pages/kb-public/KbPublicHome'
 import { KbPublicArtigo } from './pages/kb-public/KbPublicArtigo'
+import { PortalBrandingRoot } from './pages/portal/PortalBrandingRoot'
 import { PortalLayout } from './pages/portal/PortalLayout'
 import { PortalLogin } from './pages/portal/PortalLogin'
 import { PortalTrocarSenha } from './pages/portal/PortalTrocarSenha'
@@ -82,6 +83,10 @@ import { PortalTickets } from './pages/portal/PortalTickets'
 import { PortalTicketNovo } from './pages/portal/PortalTicketNovo'
 import { PortalTicketDetalhe } from './pages/portal/PortalTicketDetalhe'
 import { PortalAjudaHome, PortalAjudaArtigo } from './pages/portal/PortalAjuda'
+import { PortalChats } from './pages/portal/PortalChats'
+import { PortalChatDetalhe } from './pages/portal/PortalChatDetalhe'
+import { PortalEquipe } from './pages/portal/PortalEquipe'
+import { PortalEquipeForm } from './pages/portal/PortalEquipeForm'
 import { ToastProvider } from './components/ui/Toast'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { PageLoading } from './components/ui/PageLoading'
@@ -146,13 +151,18 @@ function AppRoutes() {
         <Route index element={<KbPublicHome />} />
         <Route path="a/:slug" element={<KbPublicArtigo />} />
       </Route>
-      <Route path="/portal/login" element={<PortalLogin />} />
-      <Route path="/portal" element={<PortalLayout />}>
+      <Route path="/portal/login" element={<PortalBrandingRoot><PortalLogin /></PortalBrandingRoot>} />
+      <Route path="/portal" element={<PortalBrandingRoot><PortalLayout /></PortalBrandingRoot>}>
         <Route index element={<Navigate to="/portal/tickets" replace />} />
         <Route path="trocar-senha" element={<PortalTrocarSenha />} />
         <Route path="tickets" element={<PortalTickets />} />
         <Route path="tickets/novo" element={<PortalTicketNovo />} />
         <Route path="tickets/:id" element={<PortalTicketDetalhe />} />
+        <Route path="chats" element={<PortalChats />} />
+        <Route path="chats/:id" element={<PortalChatDetalhe />} />
+        <Route path="equipe" element={<PortalEquipe />} />
+        <Route path="equipe/novo" element={<PortalEquipeForm />} />
+        <Route path="equipe/:id" element={<PortalEquipeForm />} />
         <Route path="ajuda" element={<PortalAjudaHome />} />
         <Route path="ajuda/:slug" element={<PortalAjudaArtigo />} />
       </Route>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,6 +75,13 @@ import { AcessoNegado } from './pages/AcessoNegado'
 import { KbPublicLayout } from './pages/kb-public/KbPublicLayout'
 import { KbPublicHome } from './pages/kb-public/KbPublicHome'
 import { KbPublicArtigo } from './pages/kb-public/KbPublicArtigo'
+import { PortalLayout } from './pages/portal/PortalLayout'
+import { PortalLogin } from './pages/portal/PortalLogin'
+import { PortalTrocarSenha } from './pages/portal/PortalTrocarSenha'
+import { PortalTickets } from './pages/portal/PortalTickets'
+import { PortalTicketNovo } from './pages/portal/PortalTicketNovo'
+import { PortalTicketDetalhe } from './pages/portal/PortalTicketDetalhe'
+import { PortalAjudaHome, PortalAjudaArtigo } from './pages/portal/PortalAjuda'
 import { ToastProvider } from './components/ui/Toast'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { PageLoading } from './components/ui/PageLoading'
@@ -138,6 +145,16 @@ function AppRoutes() {
       <Route path="/kb" element={<KbPublicLayout />}>
         <Route index element={<KbPublicHome />} />
         <Route path="a/:slug" element={<KbPublicArtigo />} />
+      </Route>
+      <Route path="/portal/login" element={<PortalLogin />} />
+      <Route path="/portal" element={<PortalLayout />}>
+        <Route index element={<Navigate to="/portal/tickets" replace />} />
+        <Route path="trocar-senha" element={<PortalTrocarSenha />} />
+        <Route path="tickets" element={<PortalTickets />} />
+        <Route path="tickets/novo" element={<PortalTicketNovo />} />
+        <Route path="tickets/:id" element={<PortalTicketDetalhe />} />
+        <Route path="ajuda" element={<PortalAjudaHome />} />
+        <Route path="ajuda/:slug" element={<PortalAjudaArtigo />} />
       </Route>
       <Route
         path="/"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2270,6 +2270,21 @@ async function portalApi<T>(path: string, options: RequestInit = {}): Promise<T>
 }
 
 export namespace PortalCliente {
+  export interface PublicBranding {
+    nome_exibicao: string
+    portal_titulo: string
+    logo_url: string | null
+    texto_boas_vindas: string | null
+    cor_primaria: string
+    cor_header: string
+    cor_sidebar: string
+    cor_texto_header: string
+    cor_texto_corpo: string
+    cor_fundo: string
+    cor_link: string
+    exibir_marca_deskrudder: boolean
+    chat_habilitado: boolean
+  }
   export interface Token {
     access_token: string
     refresh_token?: string | null
@@ -2349,9 +2364,73 @@ export namespace PortalCliente {
     motivo_id?: number | null
     motivo_outro_texto?: string | null
   }
+  export interface WhatsappChatListItem {
+    id: number
+    protocolo: string
+    estado: string
+    empresa_id?: number | null
+    empresa_nome?: string | null
+    setor_nome?: string | null
+    created_at?: string | null
+    encerramento_at?: string | null
+    ultima_mensagem_em?: string | null
+    ultima_mensagem_preview?: string | null
+  }
+  export interface WhatsappChatDetail extends WhatsappChatListItem {
+    encerrado: boolean
+  }
+  export interface WhatsappMensagem {
+    id: number
+    direcao: string
+    corpo: string
+    tipo_midia?: string | null
+    midia_disponivel: boolean
+    autor_nome?: string | null
+    autor_papel: 'equipe' | 'voce' | 'sistema'
+    created_at?: string | null
+  }
+  export interface EquipeFuncionario {
+    id: number
+    nome: string
+    email?: string | null
+    telefone?: string | null
+    tipo: string
+    ativo: boolean
+    empresa_id?: number | null
+    empresa_ids: number[]
+    portal_habilitado: boolean
+    must_change_password: boolean
+    notificar_email_portal: boolean
+    editavel: boolean
+  }
+  export interface EquipeCreate {
+    nome: string
+    email: string
+    telefone?: string | null
+    tipo: 'colaborador' | 'supervisor'
+    ativo?: boolean
+    empresa_id?: number
+    empresa_ids?: number[]
+    senha_portal?: string
+    must_change_password?: boolean
+  }
+  export interface EquipeUpdate {
+    nome?: string
+    email?: string
+    telefone?: string | null
+    tipo?: 'colaborador' | 'supervisor'
+    ativo?: boolean
+    empresa_id?: number
+    empresa_ids?: number[]
+    senha_portal?: string
+    must_change_password?: boolean
+    notificar_email_portal?: boolean
+  }
 }
 
 export const portalCliente = {
+  branding: () => publicApi<PortalCliente.PublicBranding>('/portal/public/branding'),
+  logoAssetUrl: () => `${BASE}${API_VERSION_PREFIX}/kb/public/logo`,
   login: (email: string, senha: string) =>
     publicApi<PortalCliente.Token>('/portal/auth/login', {
       method: 'POST',
@@ -2426,6 +2505,57 @@ export const portalCliente = {
   csatLink: (ticketId: number) =>
     portalApi<{ link: string; expires_at: string }>(`/portal/tickets/${ticketId}/csat-link`, {
       method: 'POST',
+    }),
+  listChats: (params?: { situacao?: string; busca?: string; offset?: number; limit?: number }) => {
+    const q = new URLSearchParams()
+    if (params?.situacao) q.set('situacao', params.situacao)
+    if (params?.busca) q.set('busca', params.busca)
+    if (params?.offset != null) q.set('offset', String(params.offset))
+    if (params?.limit != null) q.set('limit', String(params.limit))
+    const qs = q.toString()
+    return portalApi<{ items: PortalCliente.WhatsappChatListItem[]; total: number }>(
+      `/portal/chats${qs ? `?${qs}` : ''}`,
+    )
+  },
+  getChat: (id: number) => portalApi<PortalCliente.WhatsappChatDetail>(`/portal/chats/${id}`),
+  listChatMensagens: (chatId: number) =>
+    portalApi<PortalCliente.WhatsappMensagem[]>(`/portal/chats/${chatId}/mensagens`),
+  fetchChatMidiaBlob: async (chatId: number, mensagemId: number) => {
+    const token = getPortalToken()
+    const headers: HeadersInit = {}
+    if (token) headers['Authorization'] = `Bearer ${token}`
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+    }
+    const res = await fetch(
+      `${BASE}${API_VERSION_PREFIX}/portal/chats/${chatId}/mensagens/${mensagemId}/midia`,
+      { headers },
+    )
+    if (!res.ok) throw new ApiError('Falha ao abrir mídia', res.status, null)
+    return res.blob()
+  },
+  listEquipe: (params?: { incluir_inativos?: boolean; busca?: string; offset?: number; limit?: number }) => {
+    const q = new URLSearchParams()
+    if (params?.incluir_inativos) q.set('incluir_inativos', 'true')
+    if (params?.busca) q.set('busca', params.busca)
+    if (params?.offset != null) q.set('offset', String(params.offset))
+    if (params?.limit != null) q.set('limit', String(params.limit))
+    const qs = q.toString()
+    return portalApi<{ items: PortalCliente.EquipeFuncionario[]; total: number }>(
+      `/portal/equipe/funcionarios${qs ? `?${qs}` : ''}`,
+    )
+  },
+  listEquipeEmpresas: () => portalApi<PortalCliente.Empresa[]>('/portal/equipe/empresas'),
+  getEquipeFuncionario: (id: number) => portalApi<PortalCliente.EquipeFuncionario>(`/portal/equipe/funcionarios/${id}`),
+  createEquipeFuncionario: (data: PortalCliente.EquipeCreate) =>
+    portalApi<PortalCliente.EquipeFuncionario>('/portal/equipe/funcionarios', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  updateEquipeFuncionario: (id: number, data: PortalCliente.EquipeUpdate) =>
+    portalApi<PortalCliente.EquipeFuncionario>(`/portal/equipe/funcionarios/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
     }),
 }
 
@@ -3122,6 +3252,7 @@ export namespace Kb {
     texto_boas_vindas: string | null;
     cor_primaria: string;
     cor_header: string;
+    cor_sidebar: string;
     cor_texto_header: string;
     cor_texto_corpo: string;
     cor_fundo: string;
@@ -3201,6 +3332,7 @@ export namespace Kb {
     portal_titulo: string | null;
     texto_boas_vindas: string | null;
     cor_header: string;
+    cor_sidebar: string;
     cor_primaria: string;
     cor_texto_header: string;
     cor_texto_corpo: string;
@@ -3217,6 +3349,7 @@ export namespace Kb {
     portal_titulo?: string | null;
     texto_boas_vindas?: string | null;
     cor_header?: string;
+    cor_sidebar?: string;
     cor_primaria?: string;
     cor_texto_header?: string;
     cor_texto_corpo?: string;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2103,6 +2103,9 @@ export namespace FuncionariosRede {
     rede_id?: number;
     empresa_id?: number;
     empresa_ids: number[];
+    portal_habilitado?: boolean;
+    must_change_password?: boolean;
+    notificar_email_portal?: boolean;
     created_at?: string | null;
     updated_at?: string | null;
   }
@@ -2116,6 +2119,8 @@ export namespace FuncionariosRede {
     rede_id?: number;
     empresa_id?: number;
     empresa_ids?: number[];
+    senha_portal?: string | null;
+    must_change_password?: boolean;
   }
   export interface Update {
     nome?: string;
@@ -2127,7 +2132,301 @@ export namespace FuncionariosRede {
     rede_id?: number;
     empresa_id?: number;
     empresa_ids?: number[];
+    senha_portal?: string | null;
+    must_change_password?: boolean;
+    notificar_email_portal?: boolean;
+    revogar_sessoes_portal?: boolean;
   }
+}
+
+/** Portal do cliente — tokens separados do painel interno (#263). */
+const PORTAL_TOKEN_KEY = 'portal_token'
+const PORTAL_REFRESH_TOKEN_KEY = 'portal_refresh_token'
+
+function getPortalToken(): string | null {
+  return sessionStorage.getItem(PORTAL_TOKEN_KEY) || localStorage.getItem(PORTAL_TOKEN_KEY)
+}
+
+function getPortalRefreshToken(): string | null {
+  return sessionStorage.getItem(PORTAL_REFRESH_TOKEN_KEY) || localStorage.getItem(PORTAL_REFRESH_TOKEN_KEY)
+}
+
+export function clearPortalAuthToken(): void {
+  sessionStorage.removeItem(PORTAL_TOKEN_KEY)
+  localStorage.removeItem(PORTAL_TOKEN_KEY)
+  sessionStorage.removeItem(PORTAL_REFRESH_TOKEN_KEY)
+  localStorage.removeItem(PORTAL_REFRESH_TOKEN_KEY)
+}
+
+function setPortalTokens(
+  tokens: { access_token: string; refresh_token?: string | null },
+  lembrarMe = true,
+) {
+  const store = lembrarMe ? localStorage : sessionStorage
+  store.setItem(PORTAL_TOKEN_KEY, tokens.access_token)
+  if (tokens.refresh_token) store.setItem(PORTAL_REFRESH_TOKEN_KEY, tokens.refresh_token)
+}
+
+function invalidatePortalAndRedirectToLogin(): void {
+  clearPortalAuthToken()
+  const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`
+  const qs =
+    returnTo && !returnTo.startsWith('/portal/login')
+      ? `?returnTo=${encodeURIComponent(returnTo)}`
+      : ''
+  window.location.replace(`/portal/login${qs}`)
+}
+
+let portalRefreshInFlight: Promise<{
+  access_token: string
+  refresh_token?: string | null
+  must_change_password?: boolean
+} | null> | null = null
+
+async function refreshPortalAccessToken(): Promise<{
+  access_token: string
+  refresh_token?: string | null
+  must_change_password?: boolean
+} | null> {
+  if (portalRefreshInFlight) return portalRefreshInFlight
+  const refresh_token = getPortalRefreshToken()
+  if (!refresh_token) return null
+  portalRefreshInFlight = (async () => {
+    try {
+      const headers: HeadersInit = { 'Content-Type': 'application/json', 'X-DX-Skip-Refresh': '1' }
+      if (isMultiTenantMode()) {
+        ;(headers as Record<string, string>)['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+      }
+      const res = await fetch(`${BASE}${API_VERSION_PREFIX}/portal/auth/refresh`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ refresh_token }),
+      })
+      if (!res.ok) return null
+      const data = (await res.json()) as {
+        access_token: string
+        refresh_token?: string | null
+        must_change_password?: boolean
+      }
+      const lembrarMe = Boolean(localStorage.getItem(PORTAL_REFRESH_TOKEN_KEY))
+      setPortalTokens(data, lembrarMe)
+      return data
+    } catch {
+      return null
+    } finally {
+      portalRefreshInFlight = null
+    }
+  })()
+  return portalRefreshInFlight
+}
+
+async function portalApi<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const token = getPortalToken()
+  const isFormData =
+    typeof FormData !== 'undefined' && options.body != null && options.body instanceof FormData
+  const headers: HeadersInit = {
+    ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
+    ...(options.headers as object),
+  }
+  if (token) {
+    ;(headers as Record<string, string>)['Authorization'] = `Bearer ${token}`
+  }
+  if (isMultiTenantMode()) {
+    ;(headers as Record<string, string>)['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+  }
+  const res = await fetch(`${BASE}${API_VERSION_PREFIX}${path}`, { ...options, headers })
+
+  if (res.status === 401 && path.startsWith('/portal/auth/login')) {
+    const err = await res.json().catch(() => ({}))
+    let msg = mensagemErroApi(err, 401)
+    if (msg.startsWith('Não foi possível concluir')) msg = 'E-mail ou senha inválidos.'
+    throw new ApiError(msg, 401, err)
+  }
+
+  if (res.status === 401) {
+    const err = await res.json().catch(() => ({}))
+    const skipRefresh =
+      headers instanceof Headers
+        ? headers.has('X-DX-Skip-Refresh')
+        : typeof headers === 'object' &&
+          headers != null &&
+          'X-DX-Skip-Refresh' in (headers as Record<string, unknown>)
+    if (!skipRefresh && !path.startsWith('/portal/auth/refresh')) {
+      const refreshed = await refreshPortalAccessToken()
+      if (refreshed?.access_token) {
+        return portalApi<T>(path, options)
+      }
+    }
+    invalidatePortalAndRedirectToLogin()
+    throw new ApiError(mensagemErroApi(err, 401), 401, err)
+  }
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw new ApiError(mensagemErroApi(err, res.status), res.status, err)
+  }
+  if (res.status === 204) return undefined as T
+  return res.json()
+}
+
+export namespace PortalCliente {
+  export interface Token {
+    access_token: string
+    refresh_token?: string | null
+    must_change_password?: boolean
+  }
+  export interface Empresa {
+    id: number
+    nome: string
+    rede_id: number
+  }
+  export interface Me {
+    id: number
+    nome: string
+    email: string
+    tipo: string
+    rede_id: number | null
+    empresas: Empresa[]
+    must_change_password: boolean
+    notificar_email_portal: boolean
+  }
+  export interface Setor {
+    id: number
+    nome: string
+    slug?: string | null
+  }
+  export interface Pdv {
+    id: number
+    codigo: string
+    papel?: string | null
+    ativo: boolean
+  }
+  export interface TicketListItem {
+    id: number
+    protocolo: string
+    assunto: string
+    status_nome?: string | null
+    status_slug?: string | null
+    empresa_id?: number | null
+    empresa_nome?: string | null
+    setor_nome?: string | null
+    prioridade?: string | null
+    created_at?: string | null
+    updated_at?: string | null
+    fechado_em?: string | null
+    ultima_mensagem_em?: string | null
+  }
+  export interface TicketDetail extends TicketListItem {
+    descricao?: string | null
+    pode_responder: boolean
+    csat_token?: string | null
+    csat_pendente: boolean
+  }
+  export interface Anexo {
+    id: number
+    nome_original: string
+    content_type?: string | null
+    tamanho_bytes: number
+    mensagem_id?: number | null
+    created_at?: string | null
+    download_url: string
+  }
+  export interface Mensagem {
+    id: number
+    tipo: string
+    corpo: string
+    autor_nome?: string | null
+    autor_papel: 'equipe' | 'voce' | 'sistema'
+    created_at?: string | null
+    anexos: Anexo[]
+  }
+  export interface CreateTicket {
+    empresa_id: number
+    setor_id?: number | null
+    assunto: string
+    descricao?: string | null
+    pdv_codigo?: string | null
+    motivo_id?: number | null
+    motivo_outro_texto?: string | null
+  }
+}
+
+export const portalCliente = {
+  login: (email: string, senha: string) =>
+    publicApi<PortalCliente.Token>('/portal/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, senha }),
+    }),
+  setSession: (tokens: PortalCliente.Token, lembrarMe = true) => {
+    setPortalTokens(tokens, lembrarMe)
+  },
+  clearSession: () => clearPortalAuthToken(),
+  hasSession: () => Boolean(getPortalToken()),
+  me: () => portalApi<PortalCliente.Me>('/portal/me'),
+  trocarSenha: (senha_atual: string, senha_nova: string) =>
+    portalApi<PortalCliente.Token>('/portal/me/trocar-senha', {
+      method: 'POST',
+      body: JSON.stringify({ senha_atual, senha_nova }),
+    }),
+  atualizarPreferencias: (data: { notificar_email_portal?: boolean }) =>
+    portalApi<PortalCliente.Me>('/portal/me/preferencias', {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+  listSetores: () => portalApi<PortalCliente.Setor[]>('/portal/catalogos/setores'),
+  listPdvs: (empresaId: number) =>
+    portalApi<PortalCliente.Pdv[]>(`/portal/empresas/${empresaId}/pdvs`),
+  listTickets: (params?: {
+    situacao?: string
+    busca?: string
+    offset?: number
+    limit?: number
+  }) =>
+    portalApi<{ items: PortalCliente.TicketListItem[]; total: number }>(
+      withParams('/portal/tickets', params),
+    ),
+  getTicket: (id: number) => portalApi<PortalCliente.TicketDetail>(`/portal/tickets/${id}`),
+  createTicket: (data: PortalCliente.CreateTicket) =>
+    portalApi<PortalCliente.TicketDetail>('/portal/tickets', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  listMensagens: (ticketId: number) =>
+    portalApi<PortalCliente.Mensagem[]>(`/portal/tickets/${ticketId}/mensagens`),
+  sendMensagem: (ticketId: number, corpo: string) =>
+    portalApi<PortalCliente.Mensagem>(`/portal/tickets/${ticketId}/mensagens`, {
+      method: 'POST',
+      body: JSON.stringify({ corpo }),
+    }),
+  uploadAnexo: async (ticketId: number, file: File, mensagemId?: number) => {
+    const fd = new FormData()
+    fd.append('file', file)
+    if (mensagemId != null) fd.append('mensagem_id', String(mensagemId))
+    return portalApi<PortalCliente.Anexo>(`/portal/tickets/${ticketId}/anexos`, {
+      method: 'POST',
+      body: fd,
+    })
+  },
+  anexoDownloadUrl: (ticketId: number, anexoId: number) =>
+    `${BASE}${API_VERSION_PREFIX}/portal/tickets/${ticketId}/anexos/${anexoId}/download`,
+  fetchAnexoBlob: async (ticketId: number, anexoId: number) => {
+    const token = getPortalToken()
+    const headers: HeadersInit = {}
+    if (token) headers['Authorization'] = `Bearer ${token}`
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+    }
+    const res = await fetch(
+      `${BASE}${API_VERSION_PREFIX}/portal/tickets/${ticketId}/anexos/${anexoId}/download`,
+      { headers },
+    )
+    if (!res.ok) throw new ApiError('Falha ao baixar anexo', res.status, null)
+    return res.blob()
+  },
+  csatLink: (ticketId: number) =>
+    portalApi<{ link: string; expires_at: string }>(`/portal/tickets/${ticketId}/csat-link`, {
+      method: 'POST',
+    }),
 }
 
 export const ticketClassificacao = {

--- a/frontend/src/contexts/PortalAuthContext.tsx
+++ b/frontend/src/contexts/PortalAuthContext.tsx
@@ -1,0 +1,91 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react'
+import { portalCliente, type PortalCliente } from '../api/client'
+
+interface PortalAuthContextValue {
+  user: PortalCliente.Me | null
+  loading: boolean
+  login: (email: string, senha: string, lembrarMe?: boolean) => Promise<void>
+  logout: () => void
+  refreshUser: () => Promise<void>
+  applyTokens: (tokens: PortalCliente.Token, lembrarMe?: boolean) => Promise<void>
+}
+
+const PortalAuthContext = createContext<PortalAuthContextValue | null>(null)
+
+export function PortalAuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<PortalCliente.Me | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const refreshUser = useCallback(async () => {
+    if (!portalCliente.hasSession()) {
+      setUser(null)
+      return
+    }
+    const me = await portalCliente.me()
+    setUser(me)
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        if (portalCliente.hasSession()) {
+          const me = await portalCliente.me()
+          if (!cancelled) setUser(me)
+        }
+      } catch {
+        if (!cancelled) {
+          portalCliente.clearSession()
+          setUser(null)
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const applyTokens = useCallback(
+    async (tokens: PortalCliente.Token, lembrarMe = true) => {
+      portalCliente.setSession(tokens, lembrarMe)
+      await refreshUser()
+    },
+    [refreshUser],
+  )
+
+  const login = useCallback(
+    async (email: string, senha: string, lembrarMe = true) => {
+      const tokens = await portalCliente.login(email.trim().toLowerCase(), senha)
+      await applyTokens(tokens, lembrarMe)
+    },
+    [applyTokens],
+  )
+
+  const logout = useCallback(() => {
+    portalCliente.clearSession()
+    setUser(null)
+  }, [])
+
+  return (
+    <PortalAuthContext.Provider value={{ user, loading, login, logout, refreshUser, applyTokens }}>
+      {children}
+    </PortalAuthContext.Provider>
+  )
+}
+
+export function usePortalAuth(): PortalAuthContextValue {
+  const ctx = useContext(PortalAuthContext)
+  if (!ctx) {
+    throw new Error('usePortalAuth deve ser usado dentro de PortalAuthProvider')
+  }
+  return ctx
+}

--- a/frontend/src/contexts/PortalBrandingContext.tsx
+++ b/frontend/src/contexts/PortalBrandingContext.tsx
@@ -1,0 +1,121 @@
+import { createContext, useContext, useEffect, useMemo, useState, type CSSProperties, type ReactNode } from 'react'
+import { kbPublic, portalCliente, type PortalCliente } from '../api/client'
+
+const FALLBACK: PortalCliente.PublicBranding = {
+  nome_exibicao: 'Portal do cliente',
+  portal_titulo: 'Portal do cliente',
+  logo_url: null,
+  texto_boas_vindas: 'Acompanhe e abra chamados da sua empresa com a equipe de suporte.',
+  cor_primaria: '#0D9488',
+  cor_header: '#0B2D4A',
+  cor_sidebar: '#0B2D4A',
+  cor_texto_header: '#FFFFFF',
+  cor_texto_corpo: '#0F172A',
+  cor_fundo: '#F8FAFC',
+  cor_link: '#0D9488',
+  exibir_marca_deskrudder: true,
+  chat_habilitado: false,
+}
+
+type PortalBrandingContextValue = {
+  branding: PortalCliente.PublicBranding
+  loading: boolean
+}
+
+const PortalBrandingContext = createContext<PortalBrandingContextValue | null>(null)
+
+export function portalBrandingStyleVars(b: PortalCliente.PublicBranding): CSSProperties {
+  const sidebar = b.cor_sidebar || b.cor_header
+  return {
+    backgroundColor: b.cor_fundo,
+    color: b.cor_texto_corpo,
+    ['--portal-primary' as string]: b.cor_primaria,
+    ['--portal-header' as string]: b.cor_header,
+    ['--portal-sidebar' as string]: sidebar,
+    ['--portal-header-text' as string]: b.cor_texto_header,
+    ['--portal-sidebar-text' as string]: b.cor_texto_header,
+    ['--portal-body' as string]: b.cor_texto_corpo,
+    ['--portal-bg' as string]: b.cor_fundo,
+    ['--portal-link' as string]: b.cor_link,
+  }
+}
+
+function mergeBranding(data: Partial<PortalCliente.PublicBranding>): PortalCliente.PublicBranding {
+  const merged = {
+    ...FALLBACK,
+    ...data,
+    chat_habilitado: Boolean(data.chat_habilitado),
+  }
+  merged.cor_sidebar = data.cor_sidebar || data.cor_header || FALLBACK.cor_sidebar
+  return merged
+}
+
+export function PortalBrandingProvider({ children }: { children: ReactNode }) {
+  const [branding, setBranding] = useState<PortalCliente.PublicBranding | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    portalCliente
+      .branding()
+      .then(async (data) => {
+        if (cancelled) return
+        let chat = Boolean((data as { chat_habilitado?: boolean }).chat_habilitado)
+        if (!('chat_habilitado' in data) || (data as { chat_habilitado?: boolean }).chat_habilitado == null) {
+          try {
+            const kb = await kbPublic.branding()
+            chat = Boolean(kb.chat_habilitado)
+          } catch {
+            chat = false
+          }
+        }
+        setBranding(mergeBranding({ ...data, chat_habilitado: chat }))
+      })
+      .catch(() => {
+        if (!cancelled) setBranding(FALLBACK)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const resolved = branding ?? FALLBACK
+
+  useEffect(() => {
+    document.title = resolved.portal_titulo
+  }, [resolved.portal_titulo])
+
+  const value = useMemo(
+    () => ({
+      branding: resolved,
+      loading,
+    }),
+    [resolved, loading],
+  )
+
+  return (
+    <PortalBrandingContext.Provider value={value}>
+      <div
+        className="portal-cliente min-h-dvh"
+        data-theme="light"
+        style={{ ...portalBrandingStyleVars(resolved), colorScheme: 'light' }}
+      >
+        {children}
+      </div>
+    </PortalBrandingContext.Provider>
+  )
+}
+
+export function usePortalBranding(): PortalCliente.PublicBranding {
+  const ctx = useContext(PortalBrandingContext)
+  if (!ctx) throw new Error('usePortalBranding deve ser usado dentro de PortalBrandingProvider')
+  return ctx.branding
+}
+
+export function usePortalBrandingLoading(): boolean {
+  const ctx = useContext(PortalBrandingContext)
+  return ctx?.loading ?? true
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,7 +1,8 @@
 @import "tailwindcss";
 
-/* Tema escuro por classe no <html> (.dark), alinhado ao Tailwind v4 */
-@custom-variant dark (&:where(.dark, .dark *));
+/* Tema escuro por classe no <html> (.dark), alinhado ao Tailwind v4.
+   Exclui árvores com data-theme="light" (ex.: portal do cliente) para não herdar o dark do painel. */
+@custom-variant dark (&:where(.dark, .dark *):not(:where([data-theme='light'], [data-theme='light'] *)));
 
 @layer base {
   html {

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -51,6 +51,10 @@ export function FuncionarioRedeForm() {
   const [redeId, setRedeId] = useState<number | ''>('')
   const [empresaId, setEmpresaId] = useState<number | ''>('')
   const [empresaIds, setEmpresaIds] = useState<number[]>([])
+  const [senhaPortal, setSenhaPortal] = useState('')
+  const [mustChangePassword, setMustChangePassword] = useState(true)
+  const [portalHabilitado, setPortalHabilitado] = useState(false)
+  const [notificarEmailPortal, setNotificarEmailPortal] = useState(true)
 
   useEffect(() => {
     coletarTodasPaginas<Redes.Rede>((o, l) => redes.list({ incluir_inativos: true, offset: o, limit: l })).then(
@@ -115,6 +119,10 @@ export function FuncionarioRedeForm() {
         setRedeId(r)
         setEmpresaId(item.empresa_id ?? '')
         setEmpresaIds(item.empresa_ids ?? [])
+        setPortalHabilitado(Boolean(item.portal_habilitado))
+        setMustChangePassword(Boolean(item.must_change_password))
+        setNotificarEmailPortal(item.notificar_email_portal !== false)
+        setSenhaPortal('')
       })
       .catch((err) => {
         if (!cancelled) {
@@ -186,6 +194,9 @@ export function FuncionarioRedeForm() {
           rede_id: rid,
           empresa_id: escopo === 'selected' && tipo === 'colaborador' && ids.length === 1 ? ids[0] : undefined,
           empresa_ids: escopo === 'selected' ? ids : [],
+          notificar_email_portal: notificarEmailPortal,
+          must_change_password: mustChangePassword,
+          ...(senhaPortal.trim() ? { senha_portal: senhaPortal.trim() } : {}),
         }
         saved = await funcionariosRede.update(funcionarioId, payload)
         toast.showSuccess('Funcionário atualizado.')
@@ -200,6 +211,8 @@ export function FuncionarioRedeForm() {
           rede_id: rid,
           empresa_id: escopo === 'selected' && tipo === 'colaborador' && ids.length === 1 ? ids[0] : undefined,
           empresa_ids: escopo === 'selected' ? ids : [],
+          must_change_password: mustChangePassword,
+          ...(senhaPortal.trim() ? { senha_portal: senhaPortal.trim() } : {}),
         }
         saved = await funcionariosRede.create(payload)
         toast.showSuccess('Funcionário cadastrado.')
@@ -375,6 +388,46 @@ export function FuncionarioRedeForm() {
                   )}
                 </div>
               )}
+            </FormSection>
+
+            <FormSection title="Portal do cliente">
+              <p className="text-xs text-slate-500">
+                Com e-mail e senha, o funcionário acessa{' '}
+                <span className="font-medium text-slate-700 dark:text-slate-200">/portal</span> para abrir e
+                acompanhar chamados.
+                {isEdit && portalHabilitado ? (
+                  <span className="ml-1 text-teal-700 dark:text-teal-400">Portal já habilitado.</span>
+                ) : null}
+              </p>
+              <Input
+                label={isEdit ? 'Nova senha do portal (opcional)' : 'Senha do portal (opcional)'}
+                type="password"
+                value={senhaPortal}
+                onChange={(e) => setSenhaPortal(e.target.value)}
+                autoComplete="new-password"
+                placeholder={email.trim() ? 'Mínimo 8 caracteres' : 'Informe o e-mail primeiro'}
+                disabled={!email.trim()}
+              />
+              <Switch
+                bare
+                checked={mustChangePassword}
+                onCheckedChange={setMustChangePassword}
+                label="Exigir troca de senha no primeiro acesso"
+                showStatusPill
+                statusOnText="Sim"
+                statusOffText="Não"
+              />
+              {isEdit ? (
+                <Switch
+                  bare
+                  checked={notificarEmailPortal}
+                  onCheckedChange={setNotificarEmailPortal}
+                  label="Notificar por e-mail sobre respostas nos chamados"
+                  showStatusPill
+                  statusOnText="Sim"
+                  statusOffText="Não"
+                />
+              ) : null}
             </FormSection>
 
             <FormSection title="Situação no sistema">

--- a/frontend/src/pages/KbPortalSettings.tsx
+++ b/frontend/src/pages/KbPortalSettings.tsx
@@ -15,6 +15,7 @@ type FormState = {
   portal_titulo: string
   texto_boas_vindas: string
   cor_header: string
+  cor_sidebar: string
   cor_primaria: string
   cor_texto_header: string
   cor_texto_corpo: string
@@ -31,6 +32,7 @@ function fromApi(data: Kb.PortalSettings): FormState {
     portal_titulo: data.portal_titulo ?? '',
     texto_boas_vindas: data.texto_boas_vindas ?? '',
     cor_header: data.cor_header,
+    cor_sidebar: data.cor_sidebar || data.cor_header,
     cor_primaria: data.cor_primaria,
     cor_texto_header: data.cor_texto_header,
     cor_texto_corpo: data.cor_texto_corpo,
@@ -80,6 +82,10 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
     () => (typeof window !== 'undefined' ? `${window.location.origin}/kb` : '/kb'),
     [],
   )
+  const portalUrl = useMemo(
+    () => (typeof window !== 'undefined' ? `${window.location.origin}/portal/login` : '/portal/login'),
+    [],
+  )
 
   const load = useCallback(() => {
     setLoading(true)
@@ -112,6 +118,7 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
         portal_titulo: form.portal_titulo.trim() || null,
         texto_boas_vindas: form.texto_boas_vindas.trim() || null,
         cor_header: form.cor_header,
+        cor_sidebar: form.cor_sidebar,
         cor_primaria: form.cor_primaria,
         cor_texto_header: form.cor_texto_header,
         cor_texto_corpo: form.cor_texto_corpo,
@@ -143,13 +150,20 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
         />
       }
       title="Base de conhecimento"
-      subtitle="Personalize o portal público /kb — cores, textos e aparência (estilo TomTicket)."
+      subtitle="Personalize a aparência white-label da instância — cores valem para /kb e /portal; o título abaixo é só da central de ajuda (/kb)."
       actions={
-        <a href="/kb" target="_blank" rel="noreferrer">
-          <Button type="button" variant="secondary">
-            Abrir preview
-          </Button>
-        </a>
+        <>
+          <a href="/kb" target="_blank" rel="noreferrer">
+            <Button type="button" variant="secondary">
+              Abrir /kb
+            </Button>
+          </a>
+          <a href="/portal/login" target="_blank" rel="noreferrer" className="ml-2 inline-block">
+            <Button type="button" variant="secondary">
+              Abrir /portal
+            </Button>
+          </a>
+        </>
       }
     >
       {loading || !form ? (
@@ -158,18 +172,22 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
         <form onSubmit={(e) => void salvar(e)} className="space-y-6">
           <Card className="space-y-4 p-4 sm:p-5">
             <p className="text-sm text-slate-600 dark:text-slate-400">
-              URL pública:{' '}
+              Portal público:{' '}
               <a href="/kb" target="_blank" rel="noreferrer" className="font-medium text-teal-700 hover:underline dark:text-teal-400">
                 {publicUrl}
+              </a>
+              . Portal autenticado:{' '}
+              <a href="/portal/login" target="_blank" rel="noreferrer" className="font-medium text-teal-700 hover:underline dark:text-teal-400">
+                {portalUrl}
               </a>
               . A logo vem de Configurações → Sistema → Empresa.
             </p>
 
             <Input
-              label="Título do portal"
+              label="Título da central de ajuda (/kb)"
               value={form.portal_titulo}
               onChange={(e) => setForm({ ...form, portal_titulo: e.target.value })}
-              placeholder="Central de ajuda — Minha Empresa"
+              placeholder="Suporte — Minha Empresa"
             />
 
             <div>
@@ -209,7 +227,7 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
               checked={form.chat_habilitado}
               onChange={(e) => setForm({ ...form, chat_habilitado: e.target.checked })}
             >
-              Habilitar chat ao vivo para visitantes do /kb
+              Habilitar chat ao vivo no /kb e no /portal
             </CheckboxField>
             <div>
               <label htmlFor="kb-chat-setor" className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -246,11 +264,16 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
 
           <Card className="grid gap-4 p-4 sm:grid-cols-2 sm:p-5">
             <p className="col-span-full text-xs text-slate-500 dark:text-slate-400">
-              Estas cores afetam o portal /kb e o widget de chat ao vivo (barra superior = cor da navbar; destaque =
-              botões e suas mensagens).
+              Estas cores afetam /kb, /portal e o widget de chat. Navbar e menu lateral podem ter cores
+              independentes (por padrão o menu usa a mesma cor da navbar).
             </p>
             <ColorField label="Cor da barra superior (navbar)" value={form.cor_header} onChange={(v) => setForm({ ...form, cor_header: v })} />
-            <ColorField label="Cor do texto da navbar" value={form.cor_texto_header} onChange={(v) => setForm({ ...form, cor_texto_header: v })} />
+            <ColorField
+              label="Cor do menu lateral (/portal)"
+              value={form.cor_sidebar}
+              onChange={(v) => setForm({ ...form, cor_sidebar: v })}
+            />
+            <ColorField label="Cor do texto da navbar / menu" value={form.cor_texto_header} onChange={(v) => setForm({ ...form, cor_texto_header: v })} />
             <ColorField label="Cor de destaque (botões / seleção)" value={form.cor_primaria} onChange={(v) => setForm({ ...form, cor_primaria: v })} />
             <ColorField label="Cor dos links" value={form.cor_link} onChange={(v) => setForm({ ...form, cor_link: v })} />
             <ColorField label="Cor do texto principal" value={form.cor_texto_corpo} onChange={(v) => setForm({ ...form, cor_texto_corpo: v })} />

--- a/frontend/src/pages/RedeDetalhe.tsx
+++ b/frontend/src/pages/RedeDetalhe.tsx
@@ -176,6 +176,10 @@ export function RedeDetalhe() {
   const [ativoFuncionario, setAtivoFuncionario] = useState(true)
   const [empresaIdFuncionario, setEmpresaIdFuncionario] = useState<number | ''>('')
   const [empresaIdsFuncionario, setEmpresaIdsFuncionario] = useState<number[]>([])
+  const [senhaPortalFuncionario, setSenhaPortalFuncionario] = useState('')
+  const [mustChangePasswordFuncionario, setMustChangePasswordFuncionario] = useState(true)
+  const [portalHabilitadoFuncionario, setPortalHabilitadoFuncionario] = useState(false)
+  const [notificarEmailPortalFuncionario, setNotificarEmailPortalFuncionario] = useState(true)
   const [savingFuncionario, setSavingFuncionario] = useState(false)
 
   const empresasFiltradas = useMemo(() => {
@@ -631,6 +635,10 @@ export function RedeDetalhe() {
     setAtivoFuncionario(f.ativo)
     setEmpresaIdFuncionario(f.empresa_id ?? '')
     setEmpresaIdsFuncionario(f.empresa_ids ?? [])
+    setSenhaPortalFuncionario('')
+    setMustChangePasswordFuncionario(f.must_change_password !== false)
+    setPortalHabilitadoFuncionario(Boolean(f.portal_habilitado))
+    setNotificarEmailPortalFuncionario(f.notificar_email_portal !== false)
   }
 
   function verFuncionarioDetalhe(f: FuncionarioListaItem) {
@@ -654,6 +662,10 @@ export function RedeDetalhe() {
     setAtivoFuncionario(true)
     setEmpresaIdFuncionario('')
     setEmpresaIdsFuncionario([])
+    setSenhaPortalFuncionario('')
+    setMustChangePasswordFuncionario(true)
+    setPortalHabilitadoFuncionario(false)
+    setNotificarEmailPortalFuncionario(true)
     setAba('funcionarios')
     setModalFuncionario(true)
   }
@@ -662,6 +674,10 @@ export function RedeDetalhe() {
     setModalFuncionario(false)
     setModoFuncionario('edit')
     setEditingFuncionarioId(null)
+    setSenhaPortalFuncionario('')
+    setMustChangePasswordFuncionario(true)
+    setPortalHabilitadoFuncionario(false)
+    setNotificarEmailPortalFuncionario(true)
   }
 
   function toggleEmpresaFuncionario(id: number) {
@@ -689,16 +705,34 @@ export function RedeDetalhe() {
         return
       }
     }
+    const senhaPortal = senhaPortalFuncionario.trim()
+    if (senhaPortal) {
+      if (!emailFuncionario.trim()) {
+        toast.showWarning('Informe o e-mail do funcionário para habilitar o portal.')
+        return
+      }
+      if (senhaPortal.length < 8) {
+        toast.showWarning('A senha do portal deve ter ao menos 8 caracteres.')
+        return
+      }
+    }
+    const escopoEmpresas = tipoFuncionario === 'socio' ? 'all' : 'selected'
     setSavingFuncionario(true)
     try {
-      const payload = {
+      const payload: FuncionariosRede.Create = {
         nome: nomeFuncionario.trim(),
         email: emailFuncionario.trim(),
         tipo: tipoFuncionario,
         ativo: ativoFuncionario,
-        rede_id: tipoFuncionario === 'socio' ? redeId : undefined,
+        escopo_empresas: escopoEmpresas,
+        rede_id: redeId,
         empresa_id: tipoFuncionario === 'colaborador' ? Number(empresaIdFuncionario) : undefined,
         empresa_ids: tipoFuncionario === 'supervisor' ? empresaIdsFuncionario : undefined,
+        must_change_password: mustChangePasswordFuncionario,
+        ...(senhaPortal ? { senha_portal: senhaPortal } : {}),
+        ...(editingFuncionarioId
+          ? { notificar_email_portal: notificarEmailPortalFuncionario }
+          : {}),
       }
       const eraEdicao = editingFuncionarioId != null
       let idDetalhe: number
@@ -1669,6 +1703,50 @@ export function RedeDetalhe() {
                       )}
                     </FormSection>
                   )}
+
+                  <FormSection title="Portal do cliente">
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      Com e-mail e senha, o funcionário acessa{' '}
+                      <span className="font-medium text-slate-700 dark:text-slate-200">/portal</span> para abrir e
+                      acompanhar chamados.
+                      {modoFuncionario === 'edit' && portalHabilitadoFuncionario ? (
+                        <span className="ml-1 text-teal-700 dark:text-teal-400">Portal já habilitado.</span>
+                      ) : null}
+                    </p>
+                    <Input
+                      label={
+                        modoFuncionario === 'edit'
+                          ? 'Nova senha do portal (opcional)'
+                          : 'Senha do portal (opcional)'
+                      }
+                      type="password"
+                      value={senhaPortalFuncionario}
+                      onChange={(e) => setSenhaPortalFuncionario(e.target.value)}
+                      autoComplete="new-password"
+                      placeholder={emailFuncionario.trim() ? 'Mínimo 8 caracteres' : 'Informe o e-mail primeiro'}
+                      disabled={!emailFuncionario.trim()}
+                    />
+                    <Switch
+                      bare
+                      checked={mustChangePasswordFuncionario}
+                      onCheckedChange={setMustChangePasswordFuncionario}
+                      label="Exigir troca de senha no primeiro acesso"
+                      showStatusPill
+                      statusOnText="Sim"
+                      statusOffText="Não"
+                    />
+                    {modoFuncionario === 'edit' ? (
+                      <Switch
+                        bare
+                        checked={notificarEmailPortalFuncionario}
+                        onCheckedChange={setNotificarEmailPortalFuncionario}
+                        label="Notificar por e-mail sobre respostas nos chamados"
+                        showStatusPill
+                        statusOnText="Sim"
+                        statusOffText="Não"
+                      />
+                    ) : null}
+                  </FormSection>
 
                   <FormSection title="Situação no sistema">
                     <Switch

--- a/frontend/src/pages/kb-public/KbPublicContext.tsx
+++ b/frontend/src/pages/kb-public/KbPublicContext.tsx
@@ -21,6 +21,7 @@ const FALLBACK_BRANDING: Kb.PublicBranding = {
   texto_boas_vindas: null,
   cor_primaria: '#0D9488',
   cor_header: '#0B2D4A',
+  cor_sidebar: '#0B2D4A',
   cor_texto_header: '#FFFFFF',
   cor_texto_corpo: '#0F172A',
   cor_fundo: '#F8FAFC',

--- a/frontend/src/pages/kb-public/KbPublicLayout.tsx
+++ b/frontend/src/pages/kb-public/KbPublicLayout.tsx
@@ -17,9 +17,11 @@ function KbPublicShell() {
   return (
     <div
       className="kb-public-portal flex min-h-dvh flex-col"
+      data-theme="light"
       style={{
         backgroundColor: branding.cor_fundo,
         color: branding.cor_texto_corpo,
+        colorScheme: 'light',
         ['--kb-accent' as string]: branding.cor_primaria,
         ['--kb-header' as string]: branding.cor_header,
         ['--kb-link' as string]: branding.cor_link,

--- a/frontend/src/pages/portal/PortalAjuda.tsx
+++ b/frontend/src/pages/portal/PortalAjuda.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { kbPublic, type Kb } from '../../api/client'
+import { KbMarkdownPreview } from '../../components/kb/KbMarkdownPreview'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useToast } from '../../components/ui/Toast'
+
+export function PortalAjudaHome() {
+  const [busca, setBusca] = useState('')
+  const [buscaDebounced, setBuscaDebounced] = useState('')
+  const [categorias, setCategorias] = useState<Kb.Category[]>([])
+  const [artigos, setArtigos] = useState<Kb.ArticleBrief[]>([])
+  const [loading, setLoading] = useState(true)
+  const toast = useToast()
+
+  useEffect(() => {
+    const t = window.setTimeout(() => setBuscaDebounced(busca.trim()), 300)
+    return () => window.clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    Promise.all([
+      kbPublic.listCategories(),
+      kbPublic.listArticles({ busca: buscaDebounced || undefined, limit: 40 }),
+    ])
+      .then(([cats, arts]) => {
+        if (cancelled) return
+        setCategorias(cats)
+        setArtigos(arts)
+      })
+      .catch((err) => {
+        if (!cancelled) toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar a ajuda.'))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [buscaDebounced, toast])
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h1 className="text-xl font-semibold text-slate-900">Central de ajuda</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Consulte manuais e artigos antes de abrir um chamado.
+        </p>
+      </div>
+
+      <input
+        type="search"
+        value={busca}
+        onChange={(e) => setBusca(e.target.value)}
+        placeholder="Buscar artigos…"
+        className="w-full rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25"
+      />
+
+      {loading ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-14 animate-pulse rounded-xl bg-slate-100" />
+          ))}
+        </div>
+      ) : (
+        <>
+          {categorias.length > 0 && !buscaDebounced ? (
+            <div className="flex flex-wrap gap-2">
+              {categorias.map((c) => (
+                <span
+                  key={c.id}
+                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600"
+                >
+                  {c.nome}
+                </span>
+              ))}
+            </div>
+          ) : null}
+
+          {artigos.length === 0 ? (
+            <p className="rounded-2xl border border-dashed border-slate-300 px-4 py-8 text-center text-sm text-slate-500">
+              Nenhum artigo encontrado.
+            </p>
+          ) : (
+            <ul className="divide-y divide-slate-100 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+              {artigos.map((a) => (
+                <li key={a.id}>
+                  <Link
+                    to={`/portal/ajuda/${a.slug}`}
+                    className="block px-4 py-3.5 transition hover:bg-teal-50/50"
+                  >
+                    <p className="font-medium text-slate-900">{a.titulo}</p>
+                    {a.category_nome ? (
+                      <p className="mt-0.5 text-sm text-slate-500">{a.category_nome}</p>
+                    ) : null}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+
+      <p className="text-center text-sm text-slate-500">
+        Não achou o que precisava?{' '}
+        <Link to="/portal/tickets/novo" className="font-semibold text-teal-700 hover:underline">
+          Abrir chamado
+        </Link>
+      </p>
+    </div>
+  )
+}
+
+export function PortalAjudaArtigo() {
+  const { slug } = useParams<{ slug: string }>()
+  const [artigo, setArtigo] = useState<Kb.Article | null>(null)
+  const [loading, setLoading] = useState(true)
+  const toast = useToast()
+
+  useEffect(() => {
+    if (!slug) return
+    let cancelled = false
+    setLoading(true)
+    kbPublic
+      .getArticleBySlug(slug)
+      .then((a) => {
+        if (!cancelled) setArtigo(a)
+      })
+      .catch((err) => {
+        if (!cancelled) toast.showError(mensagemFalhaParaToast(err, 'Artigo não encontrado.'))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [slug, toast])
+
+  if (loading) {
+    return <div className="h-64 animate-pulse rounded-2xl bg-slate-100" />
+  }
+  if (!artigo) {
+    return (
+      <div className="space-y-3">
+        <Link to="/portal/ajuda" className="text-sm font-medium text-slate-500 hover:text-slate-800">
+          ← Voltar
+        </Link>
+        <p className="text-sm text-slate-600">Artigo não encontrado.</p>
+      </div>
+    )
+  }
+
+  return (
+    <article className="space-y-4">
+      <Link to="/portal/ajuda" className="text-sm font-medium text-slate-500 hover:text-slate-800">
+        ← Voltar à ajuda
+      </Link>
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h1 className="text-xl font-semibold text-slate-900">{artigo.titulo}</h1>
+        {artigo.category_nome ? (
+          <p className="mt-2 text-sm text-slate-600">{artigo.category_nome}</p>
+        ) : null}
+        <div className="prose prose-slate mt-5 max-w-none prose-a:text-teal-700">
+          <KbMarkdownPreview markdown={artigo.conteudo_markdown || ''} />
+        </div>
+      </div>
+      <p className="text-center text-sm text-slate-500">
+        Ainda com dúvida?{' '}
+        <Link to="/portal/tickets/novo" className="font-semibold text-teal-700 hover:underline">
+          Abrir chamado
+        </Link>
+      </p>
+    </article>
+  )
+}

--- a/frontend/src/pages/portal/PortalAjuda.tsx
+++ b/frontend/src/pages/portal/PortalAjuda.tsx
@@ -4,6 +4,7 @@ import { kbPublic, type Kb } from '../../api/client'
 import { KbMarkdownPreview } from '../../components/kb/KbMarkdownPreview'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { useToast } from '../../components/ui/Toast'
+import { PortalPageHeader, portalCardClass, portalInputClass } from './portalUi'
 
 export function PortalAjudaHome() {
   const [busca, setBusca] = useState('')
@@ -42,26 +43,24 @@ export function PortalAjudaHome() {
   }, [buscaDebounced, toast])
 
   return (
-    <div className="space-y-5">
-      <div>
-        <h1 className="text-xl font-semibold text-slate-900">Central de ajuda</h1>
-        <p className="mt-1 text-sm text-slate-600">
-          Consulte manuais e artigos antes de abrir um chamado.
-        </p>
-      </div>
+    <div className="space-y-6">
+      <PortalPageHeader
+        title="Central de ajuda"
+        subtitle="Consulte manuais e artigos antes de abrir um chamado."
+      />
 
       <input
         type="search"
         value={busca}
         onChange={(e) => setBusca(e.target.value)}
         placeholder="Buscar artigos…"
-        className="w-full rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25"
+        className={portalInputClass}
       />
 
       {loading ? (
-        <div className="space-y-2">
+        <div className="space-y-3">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="h-14 animate-pulse rounded-xl bg-slate-100" />
+            <div key={i} className="h-14 animate-pulse rounded-xl bg-slate-200/60" />
           ))}
         </div>
       ) : (
@@ -71,7 +70,7 @@ export function PortalAjudaHome() {
               {categorias.map((c) => (
                 <span
                   key={c.id}
-                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600"
+                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200/80"
                 >
                   {c.nome}
                 </span>
@@ -80,17 +79,14 @@ export function PortalAjudaHome() {
           ) : null}
 
           {artigos.length === 0 ? (
-            <p className="rounded-2xl border border-dashed border-slate-300 px-4 py-8 text-center text-sm text-slate-500">
+            <div className="rounded-xl border border-dashed border-slate-300 bg-white px-4 py-10 text-center text-sm text-slate-500">
               Nenhum artigo encontrado.
-            </p>
+            </div>
           ) : (
-            <ul className="divide-y divide-slate-100 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <ul className="space-y-2">
               {artigos.map((a) => (
                 <li key={a.id}>
-                  <Link
-                    to={`/portal/ajuda/${a.slug}`}
-                    className="block px-4 py-3.5 transition hover:bg-teal-50/50"
-                  >
+                  <Link to={`/portal/ajuda/${a.slug}`} className={`block ${portalCardClass}`}>
                     <p className="font-medium text-slate-900">{a.titulo}</p>
                     {a.category_nome ? (
                       <p className="mt-0.5 text-sm text-slate-500">{a.category_nome}</p>
@@ -105,7 +101,11 @@ export function PortalAjudaHome() {
 
       <p className="text-center text-sm text-slate-500">
         Não achou o que precisava?{' '}
-        <Link to="/portal/tickets/novo" className="font-semibold text-teal-700 hover:underline">
+        <Link
+          to="/portal/tickets/novo"
+          className="font-semibold hover:underline"
+          style={{ color: 'var(--portal-link)' }}
+        >
           Abrir chamado
         </Link>
       </p>
@@ -158,18 +158,22 @@ export function PortalAjudaArtigo() {
       <Link to="/portal/ajuda" className="text-sm font-medium text-slate-500 hover:text-slate-800">
         ← Voltar à ajuda
       </Link>
-      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h1 className="text-xl font-semibold text-slate-900">{artigo.titulo}</h1>
+      <div className={`${portalCardClass} p-5 sm:p-6`}>
+        <h1 className="text-xl font-semibold tracking-tight text-slate-900 sm:text-2xl">{artigo.titulo}</h1>
         {artigo.category_nome ? (
-          <p className="mt-2 text-sm text-slate-600">{artigo.category_nome}</p>
+          <p className="mt-2 text-sm text-slate-500">{artigo.category_nome}</p>
         ) : null}
-        <div className="prose prose-slate mt-5 max-w-none prose-a:text-teal-700">
+        <div className="prose prose-slate mt-5 max-w-none prose-a:text-[var(--portal-link)]">
           <KbMarkdownPreview markdown={artigo.conteudo_markdown || ''} />
         </div>
       </div>
       <p className="text-center text-sm text-slate-500">
         Ainda com dúvida?{' '}
-        <Link to="/portal/tickets/novo" className="font-semibold text-teal-700 hover:underline">
+        <Link
+          to="/portal/tickets/novo"
+          className="font-semibold hover:underline"
+          style={{ color: 'var(--portal-link)' }}
+        >
           Abrir chamado
         </Link>
       </p>

--- a/frontend/src/pages/portal/PortalBrandLogo.tsx
+++ b/frontend/src/pages/portal/PortalBrandLogo.tsx
@@ -1,0 +1,29 @@
+import { portalCliente } from '../../api/client'
+import { usePortalBranding } from '../../contexts/PortalBrandingContext'
+
+type Props = {
+  className?: string
+}
+
+export function PortalBrandLogo({ className = 'h-10 w-auto max-w-[12rem] object-contain' }: Props) {
+  const branding = usePortalBranding()
+
+  if (branding.logo_url) {
+    return (
+      <img
+        src={portalCliente.logoAssetUrl()}
+        alt={branding.nome_exibicao}
+        className={className}
+      />
+    )
+  }
+
+  return (
+    <span
+      className="block truncate text-lg font-semibold tracking-tight"
+      style={{ color: branding.cor_header }}
+    >
+      {branding.nome_exibicao}
+    </span>
+  )
+}

--- a/frontend/src/pages/portal/PortalBrandingRoot.tsx
+++ b/frontend/src/pages/portal/PortalBrandingRoot.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react'
+import { PortalBrandingProvider } from '../../contexts/PortalBrandingContext'
+
+export function PortalBrandingRoot({ children }: { children: ReactNode }) {
+  return <PortalBrandingProvider>{children}</PortalBrandingProvider>
+}

--- a/frontend/src/pages/portal/PortalChatDetalhe.tsx
+++ b/frontend/src/pages/portal/PortalChatDetalhe.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { portalCliente, type PortalCliente } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useToast } from '../../components/ui/Toast'
+
+function formatData(iso?: string | null) {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleString('pt-BR', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+function estadoLabel(estado: string) {
+  const s = (estado || '').toLowerCase()
+  if (s === 'encerrado') return 'Encerrado'
+  if (s === 'em_atendimento') return 'Em atendimento'
+  if (s === 'aguardando_atendente') return 'Aguardando'
+  return estado || '—'
+}
+
+export function PortalChatDetalhe() {
+  const { id } = useParams<{ id: string }>()
+  const chatId = Number(id)
+  const [chat, setChat] = useState<PortalCliente.WhatsappChatDetail | null>(null)
+  const [mensagens, setMensagens] = useState<PortalCliente.WhatsappMensagem[]>([])
+  const [loading, setLoading] = useState(true)
+  const bottomRef = useRef<HTMLDivElement | null>(null)
+  const toast = useToast()
+  const navigate = useNavigate()
+
+  const carregar = useCallback(async () => {
+    if (!Number.isFinite(chatId)) return
+    const [c, msgs] = await Promise.all([
+      portalCliente.getChat(chatId),
+      portalCliente.listChatMensagens(chatId),
+    ])
+    setChat(c)
+    setMensagens(msgs)
+  }, [chatId])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    carregar()
+      .catch((err) => {
+        if (!cancelled) {
+          toast.showError(mensagemFalhaParaToast(err, 'Atendimento não encontrado.'))
+          navigate('/portal/chats', { replace: true })
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [carregar, navigate, toast])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+  }, [mensagens.length])
+
+  useEffect(() => {
+    if (!chat || chat.encerrado) return
+    const t = window.setInterval(() => {
+      carregar().catch(() => undefined)
+    }, 15000)
+    return () => window.clearInterval(t)
+  }, [carregar, chat])
+
+  async function abrirMidia(msg: PortalCliente.WhatsappMensagem) {
+    if (!chat || !msg.midia_disponivel) return
+    try {
+      const blob = await portalCliente.fetchChatMidiaBlob(chat.id, msg.id)
+      const url = URL.createObjectURL(blob)
+      window.open(url, '_blank', 'noopener,noreferrer')
+      window.setTimeout(() => URL.revokeObjectURL(url), 60000)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível abrir a mídia.'))
+    }
+  }
+
+  if (loading || !chat) {
+    return (
+      <div className="space-y-4">
+        <div className="h-8 w-48 animate-pulse rounded-lg bg-slate-100" />
+        <div className="h-64 animate-pulse rounded-2xl bg-slate-100" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-[70dvh] flex-col gap-4">
+      <div>
+        <button
+          type="button"
+          onClick={() => navigate('/portal/chats')}
+          className="mb-2 text-sm font-medium text-slate-500 hover:text-slate-800"
+        >
+          ← Voltar
+        </button>
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <p className="font-mono text-xs font-semibold text-teal-700">{chat.protocolo}</p>
+          <h1 className="mt-1 text-lg font-semibold text-slate-900">Atendimento WhatsApp</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            {estadoLabel(chat.estado)}
+            {chat.empresa_nome ? ` · ${chat.empresa_nome}` : ''}
+            {chat.setor_nome ? ` · ${chat.setor_nome}` : ''}
+          </p>
+        </div>
+      </div>
+
+      {chat.encerrado ? (
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+          Este atendimento está encerrado. Para nova conversa, envie mensagem pelo WhatsApp ou{' '}
+          <Link to="/portal/tickets/novo" className="font-semibold text-teal-700 underline-offset-2 hover:underline">
+            abra um chamado
+          </Link>
+          .
+        </div>
+      ) : (
+        <p className="text-xs text-slate-500">
+          Visualização somente leitura. Continue a conversa pelo WhatsApp se o atendimento estiver ativo.
+        </p>
+      )}
+
+      <div className="flex-1 space-y-3 rounded-2xl border border-slate-200 bg-white p-3 shadow-sm">
+        {mensagens.length === 0 ? (
+          <p className="py-8 text-center text-sm text-slate-500">Nenhuma mensagem visível.</p>
+        ) : (
+          mensagens.map((m) => {
+            const isVoce = m.autor_papel === 'voce'
+            return (
+              <div key={m.id} className={`flex ${isVoce ? 'justify-end' : 'justify-start'}`}>
+                <div
+                  className={[
+                    'max-w-[85%] rounded-2xl px-3 py-2 text-sm shadow-sm',
+                    isVoce ? 'bg-teal-600 text-white' : 'bg-slate-100 text-slate-900',
+                  ].join(' ')}
+                >
+                  <p className={`text-[10px] font-medium ${isVoce ? 'text-teal-100' : 'text-slate-500'}`}>
+                    {m.autor_nome || (isVoce ? 'Você' : 'Equipe')}
+                  </p>
+                  <p className="mt-0.5 whitespace-pre-wrap break-words">{m.corpo}</p>
+                  {m.midia_disponivel ? (
+                    <button
+                      type="button"
+                      onClick={() => abrirMidia(m)}
+                      className={`mt-1 text-xs font-semibold underline underline-offset-2 ${
+                        isVoce ? 'text-teal-100' : 'text-teal-700'
+                      }`}
+                    >
+                      Ver {m.tipo_midia || 'anexo'}
+                    </button>
+                  ) : null}
+                  <p className={`mt-1 text-[10px] ${isVoce ? 'text-teal-100/80' : 'text-slate-400'}`}>
+                    {formatData(m.created_at)}
+                  </p>
+                </div>
+              </div>
+            )
+          })
+        )}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/PortalChatWidget.tsx
+++ b/frontend/src/pages/portal/PortalChatWidget.tsx
@@ -1,0 +1,404 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
+import { fetchPortalPublicMidiaBlob, kbPublic, type Kb } from '../../api/client'
+import { ChatMensagemMidia } from '../../components/chat/ChatMensagemMidia'
+import { usePortalAuth } from '../../contexts/PortalAuthContext'
+import { usePortalBranding } from '../../contexts/PortalBrandingContext'
+
+/** Token separado do chat visitante em /kb — mesma API, mesma instância (single-tenant). */
+const LS_TOKEN = 'dxconnect.portal.cliente.chat_token'
+
+type Fase = 'fechado' | 'form' | 'chat'
+
+function brandingVars(b: {
+  cor_fundo: string
+  cor_texto_corpo: string
+  cor_header: string
+  cor_texto_header: string
+  cor_primaria: string
+}): CSSProperties {
+  return {
+    backgroundColor: b.cor_fundo,
+    color: b.cor_texto_corpo,
+    ['--portal-chat-header' as string]: b.cor_header,
+    ['--portal-chat-header-text' as string]: b.cor_texto_header,
+    ['--portal-chat-accent' as string]: b.cor_primaria,
+  }
+}
+
+/**
+ * Chat ao vivo no portal autenticado — reutiliza `/kb/public/chat` (portal_chat).
+ * Em produção cada cliente tem instância própria (subdomínio + Postgres); o chat
+ * só chega ao DeskRudder dessa instância.
+ */
+export function PortalChatWidget() {
+  const branding = usePortalBranding()
+  const { user } = usePortalAuth()
+  const vars = useMemo(() => brandingVars(branding), [branding])
+
+  const [fase, setFase] = useState<Fase>('fechado')
+  const [token, setToken] = useState<string | null>(null)
+  const [nome, setNome] = useState('')
+  const [email, setEmail] = useState('')
+  const [sessao, setSessao] = useState<Kb.PortalChatPublicSession | null>(null)
+  const [texto, setTexto] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [enviando, setEnviando] = useState(false)
+  const [erro, setErro] = useState<string | null>(null)
+  const fimRef = useRef<HTMLDivElement>(null)
+  const lastMsgIdRef = useRef(0)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!user) return
+    setNome((prev) => prev || user.nome || '')
+    setEmail((prev) => prev || user.email || '')
+  }, [user])
+
+  const abrir = useCallback(() => {
+    setFase((f) => (f === 'fechado' ? 'form' : f))
+    setErro(null)
+  }, [])
+
+  const restaurar = useCallback(async (savedToken: string) => {
+    setLoading(true)
+    try {
+      const data = await kbPublic.obterChat(savedToken)
+      if (data.estado === 'encerrado') {
+        localStorage.removeItem(LS_TOKEN)
+        setFase('form')
+        return
+      }
+      setToken(savedToken)
+      setSessao(data)
+      setNome(data.visitante_nome)
+      lastMsgIdRef.current = data.mensagens.at(-1)?.id ?? 0
+      setFase('chat')
+    } catch {
+      localStorage.removeItem(LS_TOKEN)
+      setFase('form')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!branding.chat_habilitado) return
+    const saved = localStorage.getItem(LS_TOKEN)
+    if (saved) void restaurar(saved)
+  }, [branding.chat_habilitado, restaurar])
+
+  useEffect(() => {
+    fimRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [sessao?.mensagens, sessao?.estado])
+
+  useEffect(() => {
+    if (fase !== 'chat' || !token) return
+    const timer = setInterval(() => {
+      void (async () => {
+        try {
+          const [sessaoAtual, novas] = await Promise.all([
+            kbPublic.obterChat(token),
+            kbPublic.listarMensagensChat(token, lastMsgIdRef.current || undefined),
+          ])
+          setSessao((prev) => {
+            const mergedMsgs =
+              novas.length > 0
+                ? [
+                    ...(prev?.mensagens ?? []),
+                    ...novas.filter((n) => !(prev?.mensagens ?? []).some((m) => m.id === n.id)),
+                  ]
+                : (prev?.mensagens ?? sessaoAtual.mensagens)
+            if (novas.length > 0) lastMsgIdRef.current = novas[novas.length - 1].id
+            return {
+              protocolo: sessaoAtual.protocolo,
+              estado: sessaoAtual.estado,
+              visitante_nome: sessaoAtual.visitante_nome,
+              mensagens: mergedMsgs,
+            }
+          })
+        } catch {
+          /* silencioso */
+        }
+      })()
+    }, 4000)
+    return () => clearInterval(timer)
+  }, [fase, token])
+
+  async function iniciar(e: React.FormEvent) {
+    e.preventDefault()
+    const n = nome.trim()
+    if (!n) {
+      setErro('Informe seu nome.')
+      return
+    }
+    setLoading(true)
+    setErro(null)
+    try {
+      const data = await kbPublic.iniciarChat(
+        { visitante_nome: n, visitante_email: email.trim() || null },
+        token,
+      )
+      localStorage.setItem(LS_TOKEN, data.visitor_token)
+      setToken(data.visitor_token)
+      setSessao({
+        protocolo: data.chat.protocolo,
+        estado: data.chat.estado,
+        visitante_nome: data.chat.visitante_nome,
+        mensagens: data.mensagens,
+      })
+      lastMsgIdRef.current = data.mensagens.at(-1)?.id ?? 0
+      setFase('chat')
+    } catch (err) {
+      setErro(err instanceof Error ? err.message : 'Não foi possível iniciar o chat.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function enviar(corpo?: string) {
+    if (!token) return
+    const textoEnvio = (corpo ?? texto).trim()
+    if (!textoEnvio) return
+    setEnviando(true)
+    try {
+      const msg = await kbPublic.enviarMensagemChat(token, textoEnvio)
+      lastMsgIdRef.current = msg.id
+      const refreshed = await kbPublic.obterChat(token)
+      setSessao(refreshed)
+      lastMsgIdRef.current = refreshed.mensagens.at(-1)?.id ?? msg.id
+      setTexto('')
+    } catch (err) {
+      setErro(err instanceof Error ? err.message : 'Não foi possível enviar.')
+    } finally {
+      setEnviando(false)
+    }
+  }
+
+  async function enviarArquivo(file: File) {
+    if (!token) return
+    setEnviando(true)
+    try {
+      const msg = await kbPublic.enviarMidiaChat(token, file)
+      lastMsgIdRef.current = msg.id
+      const refreshed = await kbPublic.obterChat(token)
+      setSessao(refreshed)
+      lastMsgIdRef.current = refreshed.mensagens.at(-1)?.id ?? msg.id
+    } catch (err) {
+      setErro(err instanceof Error ? err.message : 'Não foi possível enviar o anexo.')
+    } finally {
+      setEnviando(false)
+    }
+  }
+
+  if (!branding.chat_habilitado) return null
+
+  const inputClass =
+    'w-full rounded-lg border border-black/15 bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-[var(--portal-chat-accent)]/40'
+  const aguardandoAtendente = sessao?.estado === 'aguardando_atendente'
+  const aguardandoAvaliacao = sessao?.estado === 'aguardando_avaliacao'
+  const encerrado = sessao?.estado === 'encerrado'
+  const podeEnviar = sessao?.estado === 'em_atendimento' || aguardandoAvaliacao
+
+  return (
+    <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col items-end gap-3">
+      {fase !== 'fechado' ? (
+        <div
+          className="pointer-events-auto flex w-[min(100vw-2rem,22rem)] flex-col overflow-hidden rounded-2xl border border-black/10 shadow-2xl"
+          style={{ ...vars, maxHeight: 'min(70vh, 32rem)' }}
+        >
+          <header
+            className="flex items-center gap-3 border-b border-black/10 px-3 py-2.5"
+            style={{ backgroundColor: branding.cor_header, color: branding.cor_texto_header }}
+          >
+            {branding.logo_url ? (
+              <img
+                src={kbPublic.logoAssetUrl()}
+                alt=""
+                className="h-9 max-h-9 w-auto max-w-[5.5rem] shrink-0 object-contain object-left"
+              />
+            ) : null}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-semibold leading-tight">{branding.nome_exibicao}</p>
+              <p className="truncate text-[11px] opacity-90">
+                {sessao?.protocolo ? `${sessao.protocolo} · Fale conosco` : 'Fale conosco'}
+              </p>
+            </div>
+            <button
+              type="button"
+              className="shrink-0 rounded p-1.5 transition-colors hover:bg-white/10"
+              style={{ color: branding.cor_texto_header }}
+              onClick={() => setFase('fechado')}
+              aria-label="Fechar chat"
+            >
+              ✕
+            </button>
+          </header>
+
+          {fase === 'form' ? (
+            <form onSubmit={(e) => void iniciar(e)} className="space-y-3 p-4" style={{ color: branding.cor_texto_corpo }}>
+              <p className="text-sm opacity-90">
+                Converse com a equipe de suporte em tempo real.
+              </p>
+              <input
+                value={nome}
+                onChange={(e) => setNome(e.target.value)}
+                placeholder="Seu nome"
+                className={inputClass}
+                style={{ color: branding.cor_texto_corpo }}
+                readOnly={Boolean(user?.nome)}
+              />
+              <input
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                type="email"
+                placeholder="E-mail"
+                className={inputClass}
+                style={{ color: branding.cor_texto_corpo }}
+                readOnly={Boolean(user?.email)}
+              />
+              {erro ? <p className="text-xs text-red-600">{erro}</p> : null}
+              <button
+                type="submit"
+                disabled={loading}
+                className="w-full rounded-lg px-3 py-2 text-sm font-semibold text-white disabled:opacity-60"
+                style={{ backgroundColor: branding.cor_primaria }}
+              >
+                {loading ? 'Conectando…' : 'Iniciar chat'}
+              </button>
+            </form>
+          ) : null}
+
+          {fase === 'chat' && sessao ? (
+            <>
+              <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3" style={{ backgroundColor: branding.cor_fundo }}>
+                {aguardandoAtendente ? (
+                  <p className="mb-2 text-center text-xs text-amber-800">Aguardando um atendente…</p>
+                ) : null}
+                <div className="flex flex-col gap-2">
+                  {sessao.mensagens.map((m) => {
+                    const visitante = m.direcao === 'inbound'
+                    return (
+                      <div key={m.id} className={`flex ${visitante ? 'justify-end' : 'justify-start'}`}>
+                        <div
+                          className={`max-w-[90%] rounded-2xl px-3 py-2 text-sm ${
+                            visitante ? 'text-white' : 'border border-black/10 bg-white shadow-sm'
+                          }`}
+                          style={
+                            visitante
+                              ? { backgroundColor: branding.cor_primaria }
+                              : { color: branding.cor_texto_corpo }
+                          }
+                        >
+                          {!visitante && m.atendente_nome ? (
+                            <p className="mb-0.5 text-[10px] font-semibold opacity-60">{m.atendente_nome}</p>
+                          ) : null}
+                          <ChatMensagemMidia
+                            mensagem={m}
+                            fetchMidia={() => fetchPortalPublicMidiaBlob(token!, m.id)}
+                          />
+                        </div>
+                      </div>
+                    )
+                  })}
+                  <div ref={fimRef} />
+                </div>
+              </div>
+
+              {aguardandoAvaliacao ? (
+                <div className="border-t border-black/10 p-3" style={{ backgroundColor: branding.cor_fundo }}>
+                  <p className="mb-2 text-center text-xs font-medium">Como você avalia o atendimento?</p>
+                  <div className="flex justify-center gap-2">
+                    {[1, 2, 3, 4, 5].map((nota) => (
+                      <button
+                        key={nota}
+                        type="button"
+                        disabled={enviando}
+                        onClick={() => void enviar(String(nota))}
+                        className="flex size-9 items-center justify-center rounded-full border border-black/15 bg-white text-sm font-bold hover:bg-black/5 disabled:opacity-50"
+                        style={{ color: branding.cor_texto_corpo }}
+                      >
+                        {nota}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ) : encerrado ? (
+                <p className="border-t border-black/10 px-3 py-2 text-center text-xs opacity-70">
+                  Atendimento encerrado.
+                </p>
+              ) : (
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault()
+                    void enviar()
+                  }}
+                  className="flex gap-2 border-t border-black/10 p-3"
+                  style={{ backgroundColor: branding.cor_fundo }}
+                >
+                  {podeEnviar && sessao.estado === 'em_atendimento' ? (
+                    <>
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept="image/*,audio/*,video/*,.pdf,.doc,.docx"
+                        className="hidden"
+                        onChange={(e) => {
+                          const file = e.target.files?.[0]
+                          if (file) void enviarArquivo(file)
+                          e.target.value = ''
+                        }}
+                      />
+                      <button
+                        type="button"
+                        className="shrink-0 rounded-lg border border-black/15 px-2 text-lg"
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={enviando}
+                        aria-label="Anexar ficheiro"
+                      >
+                        📎
+                      </button>
+                    </>
+                  ) : null}
+                  <input
+                    value={texto}
+                    onChange={(e) => setTexto(e.target.value)}
+                    placeholder={aguardandoAvaliacao ? 'Digite uma nota de 1 a 5…' : 'Digite sua mensagem…'}
+                    disabled={!podeEnviar}
+                    className={`min-w-0 flex-1 ${inputClass}`}
+                    style={{ color: branding.cor_texto_corpo }}
+                  />
+                  <button
+                    type="submit"
+                    disabled={enviando || !podeEnviar || !texto.trim()}
+                    className="shrink-0 rounded-lg px-3 py-2 text-sm font-semibold text-white disabled:opacity-60"
+                    style={{ backgroundColor: branding.cor_primaria }}
+                  >
+                    Enviar
+                  </button>
+                </form>
+              )}
+              {erro ? <p className="px-3 pb-2 text-xs text-red-600">{erro}</p> : null}
+            </>
+          ) : null}
+        </div>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={abrir}
+        className="pointer-events-auto flex size-14 items-center justify-center rounded-full text-white shadow-lg transition-transform hover:scale-105"
+        style={{ backgroundColor: branding.cor_header }}
+        aria-label="Abrir chat ao vivo"
+      >
+        <svg className="size-7" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+          />
+        </svg>
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/PortalChats.tsx
+++ b/frontend/src/pages/portal/PortalChats.tsx
@@ -8,8 +8,6 @@ import {
   PortalSegmentedControl,
   portalCardClass,
   portalInputClass,
-  portalPrimaryBtnClass,
-  portalSecondaryBtnClass,
 } from './portalUi'
 
 function formatData(iso?: string | null) {
@@ -26,19 +24,29 @@ function formatData(iso?: string | null) {
   }
 }
 
-function statusTone(slug?: string | null) {
-  const s = (slug || '').toLowerCase()
-  if (s === 'fechado' || s === 'resolvido') return 'bg-slate-100 text-slate-600'
-  if (s === 'aguardando_cliente') return 'bg-amber-50 text-amber-800 ring-1 ring-amber-200/60'
-  if (s === 'em_atendimento') return 'bg-emerald-50 text-emerald-800 ring-1 ring-emerald-200/60'
-  return 'bg-sky-50 text-sky-800 ring-1 ring-sky-200/50'
+function estadoLabel(estado: string) {
+  const s = (estado || '').toLowerCase()
+  if (s === 'encerrado') return 'Encerrado'
+  if (s === 'em_atendimento') return 'Em atendimento'
+  if (s === 'aguardando_atendente') return 'Aguardando'
+  if (s === 'aguardando_avaliacao') return 'Aguardando avaliação'
+  if (s === 'classificacao_demanda_pendente') return 'Em classificação'
+  return estado || '—'
 }
 
-export function PortalTickets() {
-  const [situacao, setSituacao] = useState<'abertos' | 'fechados' | 'todos'>('abertos')
+function estadoTone(estado: string) {
+  const s = (estado || '').toLowerCase()
+  if (s === 'encerrado') return 'bg-slate-100 text-slate-600 ring-1 ring-slate-200/80'
+  if (s === 'em_atendimento') return 'bg-emerald-50 text-emerald-800 ring-1 ring-emerald-200/60'
+  if (s === 'aguardando_atendente') return 'bg-sky-50 text-sky-800 ring-1 ring-sky-200/50'
+  return 'bg-amber-50 text-amber-800 ring-1 ring-amber-200/60'
+}
+
+export function PortalChats() {
+  const [situacao, setSituacao] = useState<'abertos' | 'encerrados' | 'todos'>('abertos')
   const [busca, setBusca] = useState('')
   const [buscaDebounced, setBuscaDebounced] = useState('')
-  const [items, setItems] = useState<PortalCliente.TicketListItem[]>([])
+  const [items, setItems] = useState<PortalCliente.WhatsappChatListItem[]>([])
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
   const [erro, setErro] = useState<string | null>(null)
@@ -54,7 +62,7 @@ export function PortalTickets() {
     setLoading(true)
     setErro(null)
     portalCliente
-      .listTickets({ situacao, busca: buscaDebounced || undefined, limit: 50 })
+      .listChats({ situacao, busca: buscaDebounced || undefined, limit: 50 })
       .then((res) => {
         if (cancelled) return
         setItems(res.items)
@@ -62,7 +70,7 @@ export function PortalTickets() {
       })
       .catch((err) => {
         if (cancelled) return
-        const msg = mensagemFalhaParaToast(err, 'Não foi possível carregar os chamados.')
+        const msg = mensagemFalhaParaToast(err, 'Não foi possível carregar os atendimentos.')
         setErro(msg)
         toast.showError(msg)
       })
@@ -78,13 +86,8 @@ export function PortalTickets() {
   return (
     <div className="space-y-6">
       <PortalPageHeader
-        title="Meus chamados"
-        subtitle="Acompanhe o andamento das suas solicitações."
-        action={
-          <Link to="/portal/tickets/novo" className={portalPrimaryBtnClass} style={{ backgroundColor: 'var(--portal-primary)' }}>
-            Abrir chamado
-          </Link>
-        }
+        title="Atendimentos WhatsApp"
+        subtitle="Acompanhe as conversas de suporte vinculadas a você."
       />
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -93,7 +96,7 @@ export function PortalTickets() {
           onChange={setSituacao}
           options={[
             { value: 'abertos', label: 'Abertos' },
-            { value: 'fechados', label: 'Encerrados' },
+            { value: 'encerrados', label: 'Encerrados' },
             { value: 'todos', label: 'Todos' },
           ]}
         />
@@ -101,7 +104,7 @@ export function PortalTickets() {
           type="search"
           value={busca}
           onChange={(e) => setBusca(e.target.value)}
-          placeholder="Buscar protocolo ou assunto…"
+          placeholder="Buscar por protocolo…"
           className={`${portalInputClass} flex-1`}
         />
       </div>
@@ -116,39 +119,31 @@ export function PortalTickets() {
         <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-5 text-sm text-rose-800">{erro}</div>
       ) : items.length === 0 ? (
         <div className="rounded-xl border border-dashed border-slate-300 bg-white px-5 py-12 text-center">
-          <p className="text-base font-medium text-slate-900">Nenhum chamado por aqui</p>
-          <p className="mt-1 text-sm text-slate-500">Abra o primeiro chamado ou consulte a base de ajuda.</p>
-          <div className="mt-5 flex flex-wrap justify-center gap-2">
-            <Link to="/portal/tickets/novo" className={portalPrimaryBtnClass} style={{ backgroundColor: 'var(--portal-primary)' }}>
-              Abrir chamado
-            </Link>
-            <Link to="/portal/ajuda" className={portalSecondaryBtnClass}>
-              Ver ajuda
-            </Link>
-          </div>
+          <p className="text-base font-medium text-slate-900">Nenhum atendimento</p>
+          <p className="mt-1 text-sm text-slate-500">Não há conversas com os filtros atuais.</p>
         </div>
       ) : (
         <ul className="space-y-3">
-          {items.map((t) => (
-            <li key={t.id}>
-              <Link to={`/portal/tickets/${t.id}`} className={`block ${portalCardClass}`}>
+          {items.map((c) => (
+            <li key={c.id}>
+              <Link to={`/portal/chats/${c.id}`} className={`block ${portalCardClass}`}>
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <p className="font-mono text-xs font-semibold tracking-wide text-[var(--portal-primary)]">
-                      {t.protocolo}
+                      {c.protocolo}
                     </p>
-                    <h2 className="mt-1 truncate text-base font-semibold text-slate-900">{t.assunto}</h2>
+                    <p className="mt-1 truncate text-base font-medium text-slate-900">
+                      {c.ultima_mensagem_preview || 'Sem mensagens'}
+                    </p>
                     <p className="mt-1 truncate text-sm text-slate-500">
-                      {t.empresa_nome || 'Empresa'} · {t.setor_nome || 'Atendimento'}
+                      {[c.empresa_nome, c.setor_nome].filter(Boolean).join(' · ') || '—'}
                     </p>
                   </div>
-                  <span className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ${statusTone(t.status_slug)}`}>
-                    {t.status_nome || '—'}
+                  <span className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ${estadoTone(c.estado)}`}>
+                    {estadoLabel(c.estado)}
                   </span>
                 </div>
-                <p className="mt-3 text-xs text-slate-400">
-                  Atualizado {formatData(t.ultima_mensagem_em || t.updated_at || t.created_at)}
-                </p>
+                <p className="mt-3 text-xs text-slate-400">{formatData(c.ultima_mensagem_em || c.created_at)}</p>
               </Link>
             </li>
           ))}
@@ -157,7 +152,7 @@ export function PortalTickets() {
 
       {!loading && items.length > 0 ? (
         <p className="text-center text-xs text-slate-400">
-          {total} chamado{total === 1 ? '' : 's'}
+          {total > items.length ? `Mostrando ${items.length} de ${total}` : `${total} atendimento${total === 1 ? '' : 's'}`}
         </p>
       ) : null}
     </div>

--- a/frontend/src/pages/portal/PortalEquipe.tsx
+++ b/frontend/src/pages/portal/PortalEquipe.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react'
+import { Link, Navigate } from 'react-router-dom'
+import { portalCliente, type PortalCliente } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { usePortalAuth } from '../../contexts/PortalAuthContext'
+import { useToast } from '../../components/ui/Toast'
+import { Switch } from '../../components/ui/Switch'
+import {
+  PortalPageHeader,
+  portalCardClass,
+  portalInputClass,
+  portalPrimaryBtnClass,
+} from './portalUi'
+
+const tipoLabel: Record<string, string> = {
+  socio: 'Sócio',
+  supervisor: 'Supervisor',
+  colaborador: 'Colaborador',
+}
+
+export function PortalEquipe() {
+  const { user } = usePortalAuth()
+  const [incluirInativos, setIncluirInativos] = useState(false)
+  const [busca, setBusca] = useState('')
+  const [buscaDebounced, setBuscaDebounced] = useState('')
+  const [items, setItems] = useState<PortalCliente.EquipeFuncionario[]>([])
+  const [loading, setLoading] = useState(true)
+  const toast = useToast()
+
+  useEffect(() => {
+    const t = window.setTimeout(() => setBuscaDebounced(busca.trim()), 300)
+    return () => window.clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    if (user?.tipo !== 'socio') return
+    let cancelled = false
+    setLoading(true)
+    portalCliente
+      .listEquipe({ incluir_inativos: incluirInativos, busca: buscaDebounced || undefined, limit: 50 })
+      .then((res) => {
+        if (!cancelled) setItems(res.items)
+      })
+      .catch((err) => {
+        if (!cancelled) toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar os usuários.'))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.tipo, incluirInativos, buscaDebounced])
+
+  if (user && user.tipo !== 'socio') {
+    return <Navigate to="/portal/tickets" replace />
+  }
+
+  return (
+    <div className="space-y-6">
+      <PortalPageHeader
+        title="Usuários"
+        subtitle="Cadastre colaboradores e supervisores, defina empresas e acesso ao portal."
+        action={
+          <Link to="/portal/equipe/novo" className={portalPrimaryBtnClass} style={{ backgroundColor: 'var(--portal-primary)' }}>
+            Novo usuário
+          </Link>
+        }
+      />
+
+      <div className="flex flex-wrap items-center gap-4">
+        <Switch
+          bare
+          checked={incluirInativos}
+          onCheckedChange={setIncluirInativos}
+          label="Mostrar inativos"
+          showStatusPill
+          statusOnText="Sim"
+          statusOffText="Não"
+        />
+      </div>
+
+      <input
+        type="search"
+        value={busca}
+        onChange={(e) => setBusca(e.target.value)}
+        placeholder="Buscar por nome ou e-mail…"
+        className={portalInputClass}
+      />
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-16 animate-pulse rounded-xl bg-slate-200/60" />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-slate-300 bg-white px-4 py-12 text-center text-sm text-slate-500">
+          Nenhum usuário encontrado.
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((f) => (
+            <li key={f.id}>
+              <Link to={`/portal/equipe/${f.id}`} className={`block ${portalCardClass}`}>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate font-medium text-slate-900">{f.nome}</p>
+                    <p className="truncate text-sm text-slate-500">{f.email || 'Sem e-mail'}</p>
+                    <p className="mt-1 text-xs text-slate-400">
+                      {f.portal_habilitado ? 'Portal habilitado' : 'Sem acesso ao portal'}
+                      {!f.ativo ? ' · Inativo' : ''}
+                    </p>
+                  </div>
+                  <span className="shrink-0 rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-medium text-slate-700 ring-1 ring-slate-200/80">
+                    {tipoLabel[f.tipo] || f.tipo}
+                  </span>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+

--- a/frontend/src/pages/portal/PortalEquipeForm.tsx
+++ b/frontend/src/pages/portal/PortalEquipeForm.tsx
@@ -1,0 +1,406 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { Link, Navigate, useNavigate, useParams } from 'react-router-dom'
+import { portalCliente, type PortalCliente } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { usePortalAuth } from '../../contexts/PortalAuthContext'
+import { useToast } from '../../components/ui/Toast'
+import { Switch } from '../../components/ui/Switch'
+import { CheckboxField } from '../../components/ui/CheckboxField'
+import {
+  PortalPageHeader,
+  portalInputClass,
+  portalPrimaryBtnClass,
+  portalSecondaryBtnClass,
+} from './portalUi'
+
+type TipoEquipe = 'colaborador' | 'supervisor'
+
+function PortalField({
+  label,
+  children,
+}: {
+  label: string
+  children: ReactNode
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1.5 block text-sm font-medium text-slate-700">{label}</span>
+      {children}
+    </label>
+  )
+}
+
+function PortalFormBlock({
+  title,
+  children,
+}: {
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-slate-400">{title}</h2>
+      <div className="space-y-4">{children}</div>
+    </section>
+  )
+}
+
+export function PortalEquipeForm() {
+  const { id } = useParams<{ id?: string }>()
+  const isEdit = Boolean(id)
+  const funcionarioId = id ? Number(id) : NaN
+  const { user } = usePortalAuth()
+  const navigate = useNavigate()
+  const toast = useToast()
+
+  const [loading, setLoading] = useState(isEdit)
+  const [saving, setSaving] = useState(false)
+  const [editavel, setEditavel] = useState(true)
+  const [empresas, setEmpresas] = useState<PortalCliente.Empresa[]>([])
+
+  const [nome, setNome] = useState('')
+  const [email, setEmail] = useState('')
+  const [telefone, setTelefone] = useState('')
+  const [tipo, setTipo] = useState<TipoEquipe>('colaborador')
+  const [ativo, setAtivo] = useState(true)
+  const [empresaId, setEmpresaId] = useState<number | ''>('')
+  const [empresaIds, setEmpresaIds] = useState<number[]>([])
+  const [senhaPortal, setSenhaPortal] = useState('')
+  const [mustChangePassword, setMustChangePassword] = useState(true)
+  const [portalHabilitado, setPortalHabilitado] = useState(false)
+  const [notificarEmailPortal, setNotificarEmailPortal] = useState(true)
+  const [outroSocio, setOutroSocio] = useState(false)
+  const [membroSocio, setMembroSocio] = useState(false)
+
+  useEffect(() => {
+    if (user?.tipo !== 'socio') return
+    portalCliente.listEquipeEmpresas().then(setEmpresas).catch(() => undefined)
+  }, [user?.tipo])
+
+  useEffect(() => {
+    if (!isEdit || !Number.isFinite(funcionarioId) || user?.tipo !== 'socio') return
+    let cancelled = false
+    setLoading(true)
+    portalCliente
+      .getEquipeFuncionario(funcionarioId)
+      .then((item) => {
+        if (cancelled) return
+        setNome(item.nome)
+        setEmail(item.email || '')
+        setTelefone(item.telefone || '')
+        if (item.tipo === 'colaborador' || item.tipo === 'supervisor') {
+          setTipo(item.tipo)
+        }
+        setMembroSocio(item.tipo === 'socio')
+        setAtivo(item.ativo)
+        setEmpresaId(item.empresa_id ?? '')
+        setEmpresaIds(item.empresa_ids ?? [])
+        setPortalHabilitado(item.portal_habilitado)
+        setMustChangePassword(item.must_change_password !== false)
+        setNotificarEmailPortal(item.notificar_email_portal !== false)
+        setEditavel(item.editavel)
+        setOutroSocio(item.tipo === 'socio' && item.id !== user?.id)
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          toast.showError(mensagemFalhaParaToast(err, 'Membro não encontrado.'))
+          navigate('/portal/equipe', { replace: true })
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [funcionarioId, isEdit, navigate, toast, user?.id, user?.tipo])
+
+  if (user && user.tipo !== 'socio') {
+    return <Navigate to="/portal/tickets" replace />
+  }
+
+  if (loading) {
+    return <div className="h-64 animate-pulse rounded-xl bg-slate-200/60" />
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (outroSocio) {
+      try {
+        setSaving(true)
+        await portalCliente.updateEquipeFuncionario(funcionarioId, {
+          ativo,
+          ...(senhaPortal.trim() ? { senha_portal: senhaPortal.trim() } : {}),
+          must_change_password: mustChangePassword,
+          notificar_email_portal: notificarEmailPortal,
+        })
+        toast.showSuccess('Sócio atualizado.')
+        navigate('/portal/equipe')
+      } catch (err) {
+        toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
+      } finally {
+        setSaving(false)
+      }
+      return
+    }
+
+    if (membroSocio) {
+      if (!nome.trim() || !email.trim()) {
+        toast.showWarning('Informe nome e e-mail.')
+        return
+      }
+      if (senhaPortal.trim() && senhaPortal.trim().length < 8) {
+        toast.showWarning('A senha do portal deve ter ao menos 8 caracteres.')
+        return
+      }
+      setSaving(true)
+      try {
+        await portalCliente.updateEquipeFuncionario(funcionarioId, {
+          nome: nome.trim(),
+          email: email.trim(),
+          telefone: telefone.trim() || null,
+          ativo,
+          ...(senhaPortal.trim() ? { senha_portal: senhaPortal.trim() } : {}),
+          must_change_password: mustChangePassword,
+          notificar_email_portal: notificarEmailPortal,
+        })
+        toast.showSuccess('Seus dados foram atualizados.')
+        navigate('/portal/equipe')
+      } catch (err) {
+        toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
+      } finally {
+        setSaving(false)
+      }
+      return
+    }
+
+    if (!nome.trim() || !email.trim()) {
+      toast.showWarning('Informe nome e e-mail.')
+      return
+    }
+    if (tipo === 'colaborador' && !empresaId) {
+      toast.showWarning('Selecione a empresa do colaborador.')
+      return
+    }
+    if (tipo === 'supervisor' && !empresaIds.length) {
+      toast.showWarning('Marque ao menos uma empresa para o supervisor.')
+      return
+    }
+    if (senhaPortal.trim() && senhaPortal.trim().length < 8) {
+      toast.showWarning('A senha do portal deve ter ao menos 8 caracteres.')
+      return
+    }
+
+    setSaving(true)
+    try {
+      const senhaPayload = senhaPortal.trim() ? { senha_portal: senhaPortal.trim() } : {}
+      if (isEdit) {
+        await portalCliente.updateEquipeFuncionario(funcionarioId, {
+          nome: nome.trim(),
+          email: email.trim(),
+          telefone: telefone.trim() || null,
+          tipo,
+          ativo,
+          empresa_id: tipo === 'colaborador' ? Number(empresaId) : undefined,
+          empresa_ids: tipo === 'supervisor' ? empresaIds : undefined,
+          must_change_password: mustChangePassword,
+          notificar_email_portal: notificarEmailPortal,
+          ...senhaPayload,
+        })
+        toast.showSuccess('Membro atualizado.')
+      } else {
+        await portalCliente.createEquipeFuncionario({
+          nome: nome.trim(),
+          email: email.trim(),
+          telefone: telefone.trim() || null,
+          tipo,
+          ativo,
+          empresa_id: tipo === 'colaborador' ? Number(empresaId) : undefined,
+          empresa_ids: tipo === 'supervisor' ? empresaIds : [],
+          must_change_password: mustChangePassword,
+          ...senhaPayload,
+        })
+        toast.showSuccess('Membro cadastrado.')
+      }
+      navigate('/portal/equipe')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function toggleEmpresa(eid: number) {
+    setEmpresaIds((prev) => (prev.includes(eid) ? prev.filter((x) => x !== eid) : [...prev, eid]))
+  }
+
+  const disabledDados = !editavel || outroSocio
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link to="/portal/equipe" className="text-sm font-medium text-slate-500 hover:text-slate-800">
+          ← Voltar à equipe
+        </Link>
+        <div className="mt-2">
+          <PortalPageHeader
+            title={isEdit ? 'Editar membro' : 'Novo membro da equipe'}
+            subtitle={
+              outroSocio
+                ? 'Outro sócio: só é possível alterar situação, senha do portal e notificações.'
+                : membroSocio
+                  ? 'Sócio: acesso a toda a rede (sem vínculo por empresa).'
+                  : undefined
+            }
+          />
+        </div>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-8 rounded-xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-6"
+      >
+        <PortalFormBlock title="Dados">
+          <PortalField label="Nome *">
+            <input
+              className={portalInputClass}
+              value={nome}
+              onChange={(e) => setNome(e.target.value)}
+              required
+              disabled={disabledDados}
+            />
+          </PortalField>
+          <PortalField label="E-mail *">
+            <input
+              type="email"
+              className={portalInputClass}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={disabledDados}
+            />
+          </PortalField>
+          <PortalField label="Telefone">
+            <input
+              className={portalInputClass}
+              value={telefone}
+              onChange={(e) => setTelefone(e.target.value)}
+              disabled={disabledDados}
+            />
+          </PortalField>
+          {!outroSocio && !membroSocio && editavel ? (
+            <PortalField label="Função">
+              <select
+                className={portalInputClass}
+                value={tipo}
+                onChange={(e) => {
+                  setTipo(e.target.value as TipoEquipe)
+                  setEmpresaId('')
+                  setEmpresaIds([])
+                }}
+              >
+                <option value="colaborador">Colaborador</option>
+                <option value="supervisor">Supervisor</option>
+              </select>
+            </PortalField>
+          ) : null}
+        </PortalFormBlock>
+
+        {!outroSocio && !membroSocio && editavel ? (
+          <PortalFormBlock title="Empresas">
+            {tipo === 'colaborador' ? (
+              <PortalField label="Empresa *">
+                <select
+                  className={portalInputClass}
+                  value={empresaId === '' ? '' : String(empresaId)}
+                  onChange={(e) => setEmpresaId(e.target.value ? Number(e.target.value) : '')}
+                  required
+                >
+                  <option value="">Selecione</option>
+                  {empresas.map((e) => (
+                    <option key={e.id} value={e.id}>
+                      {e.nome}
+                    </option>
+                  ))}
+                </select>
+              </PortalField>
+            ) : (
+              <div className="flex max-h-44 flex-wrap gap-2 overflow-auto rounded-lg border border-slate-200 bg-slate-50/50 p-3">
+                {empresas.map((e) => (
+                  <CheckboxField key={e.id} checked={empresaIds.includes(e.id)} onChange={() => toggleEmpresa(e.id)}>
+                    {e.nome}
+                  </CheckboxField>
+                ))}
+              </div>
+            )}
+          </PortalFormBlock>
+        ) : null}
+
+        <PortalFormBlock title="Portal do cliente">
+          <p className="text-sm text-slate-500">
+            Com e-mail e senha, o membro acessa <span className="font-medium text-slate-700">/portal</span>.
+            {portalHabilitado ? (
+              <span className="ml-1 font-medium text-emerald-700">Portal já habilitado.</span>
+            ) : null}
+          </p>
+          <PortalField label={isEdit ? 'Nova senha do portal (opcional)' : 'Senha do portal (opcional)'}>
+            <input
+              type="password"
+              className={portalInputClass}
+              value={senhaPortal}
+              onChange={(e) => setSenhaPortal(e.target.value)}
+              autoComplete="new-password"
+              disabled={!email.trim()}
+            />
+          </PortalField>
+          <Switch
+            bare
+            checked={mustChangePassword}
+            onCheckedChange={setMustChangePassword}
+            label="Exigir troca de senha no primeiro acesso"
+            showStatusPill
+            statusOnText="Sim"
+            statusOffText="Não"
+          />
+          {isEdit ? (
+            <Switch
+              bare
+              checked={notificarEmailPortal}
+              onCheckedChange={setNotificarEmailPortal}
+              label="Notificar por e-mail sobre respostas nos chamados"
+              showStatusPill
+              statusOnText="Sim"
+              statusOffText="Não"
+            />
+          ) : null}
+        </PortalFormBlock>
+
+        <PortalFormBlock title="Situação">
+          <Switch
+            bare
+            checked={ativo}
+            onCheckedChange={setAtivo}
+            label="Membro ativo"
+            showStatusPill
+            statusOnText="Ativo"
+            statusOffText="Inativo"
+          />
+        </PortalFormBlock>
+
+        <div className="flex flex-col-reverse gap-2 border-t border-slate-100 pt-5 sm:flex-row sm:justify-end">
+          <button type="button" className={portalSecondaryBtnClass} onClick={() => navigate('/portal/equipe')}>
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            className={portalPrimaryBtnClass}
+            style={{ backgroundColor: 'var(--portal-primary)' }}
+            disabled={saving}
+          >
+            {saving ? 'Salvando…' : 'Salvar'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/PortalLayout.tsx
+++ b/frontend/src/pages/portal/PortalLayout.tsx
@@ -1,11 +1,32 @@
-import { NavLink, Navigate, Outlet, useLocation } from 'react-router-dom'
+import { useState } from 'react'
+import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { PortalAuthProvider, usePortalAuth } from '../../contexts/PortalAuthContext'
+import { usePortalBranding } from '../../contexts/PortalBrandingContext'
 import { PageLoading } from '../../components/ui/PageLoading'
-import { BrandLogo } from '../../brand'
+import { PortalBrandLogo } from './PortalBrandLogo'
+import { PortalChatWidget } from './PortalChatWidget'
+import { PortalSidebar, readPortalSidebarExpanded, writePortalSidebarExpanded } from './PortalSidebar'
+
+function perfilExibicao(tipo: string | undefined): string {
+  if (tipo === 'socio') return 'Sócio'
+  if (tipo === 'supervisor') return 'Supervisor'
+  if (tipo === 'colaborador') return 'Colaborador'
+  return tipo?.trim() || '—'
+}
+
+const menuIcon = (
+  <svg className="size-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+  </svg>
+)
 
 function PortalShell() {
   const { user, loading, logout } = usePortalAuth()
+  const branding = usePortalBranding()
   const location = useLocation()
+  const isSocio = user?.tipo === 'socio'
+  const [sidebarExpanded, setSidebarExpanded] = useState(readPortalSidebarExpanded)
+  const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false)
 
   if (loading) {
     return <PageLoading fullscreen label="Carregando portal…" />
@@ -17,59 +38,85 @@ function PortalShell() {
     return <Navigate to="/portal/trocar-senha" replace />
   }
 
-  const navClass = ({ isActive }: { isActive: boolean }) =>
-    [
-      'flex flex-1 flex-col items-center gap-0.5 rounded-xl px-2 py-2 text-[11px] font-medium transition-colors sm:flex-none sm:flex-row sm:gap-2 sm:px-3 sm:py-2 sm:text-sm',
-      isActive
-        ? 'bg-teal-600 text-white shadow-sm'
-        : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900',
-    ].join(' ')
+  function handleLogout() {
+    logout()
+    window.location.replace('/portal/login')
+  }
+
+  function toggleSidebar() {
+    if (typeof window !== 'undefined' && window.innerWidth >= 768) {
+      setSidebarExpanded((prev) => {
+        const next = !prev
+        writePortalSidebarExpanded(next)
+        return next
+      })
+    } else {
+      setSidebarMobileOpen((o) => !o)
+    }
+  }
+
+  const sidebarW = sidebarExpanded ? '280px' : '80px'
+  const roleLabel = perfilExibicao(user.tipo)
 
   return (
-    <div className="portal-cliente flex min-h-dvh flex-col bg-gradient-to-b from-slate-50 via-white to-teal-50/40">
-      <header className="sticky top-0 z-20 border-b border-slate-200/80 bg-white/90 backdrop-blur-md">
-        <div className="mx-auto flex h-14 max-w-3xl items-center justify-between gap-3 px-4">
-          <div className="flex min-w-0 items-center gap-2.5">
-            <BrandLogo className="h-8 w-auto shrink-0" />
-            <div className="min-w-0">
-              <p className="truncate text-sm font-semibold text-slate-900">Portal do cliente</p>
-              <p className="truncate text-xs text-slate-500">{user.nome}</p>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={() => {
-              logout()
-              window.location.replace('/portal/login')
-            }}
-            className="shrink-0 rounded-lg px-2.5 py-1.5 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900"
-          >
-            Sair
-          </button>
-        </div>
-      </header>
-
-      <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-5 pb-24 sm:pb-8">
-        <Outlet />
-      </main>
-
-      <nav
-        className="fixed inset-x-0 bottom-0 z-20 border-t border-slate-200/80 bg-white/95 px-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] pt-1.5 backdrop-blur-md sm:static sm:mx-auto sm:mb-6 sm:max-w-3xl sm:rounded-2xl sm:border sm:px-3 sm:py-2 sm:shadow-sm"
-        aria-label="Navegação do portal"
+    <>
+      <div
+        className="flex h-dvh max-h-dvh min-h-0 overflow-hidden bg-gradient-to-b from-slate-50 to-slate-100/90 md:grid md:grid-cols-[var(--portal-sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
+        style={{ ['--portal-sidebar-w' as string]: sidebarW }}
       >
-        <div className="mx-auto flex max-w-3xl items-stretch justify-around gap-1 sm:justify-start sm:gap-2">
-          <NavLink to="/portal/tickets" end className={navClass}>
-            Chamados
-          </NavLink>
-          <NavLink to="/portal/tickets/novo" className={navClass}>
-            Novo
-          </NavLink>
-          <NavLink to="/portal/ajuda" className={navClass}>
-            Ajuda
-          </NavLink>
+        <PortalSidebar
+          expanded={sidebarExpanded}
+          mobileOpen={sidebarMobileOpen}
+          isSocio={isSocio}
+          userNome={user.nome}
+          userRole={roleLabel}
+          exibirMarcaDeskrudder={branding.exibir_marca_deskrudder}
+          onLogout={handleLogout}
+          onMobileClose={() => setSidebarMobileOpen(false)}
+        />
+
+        <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden md:col-start-2 md:row-start-1">
+          <header
+            className="z-30 flex h-16 min-h-[64px] shrink-0 items-center gap-2 border-b border-black/10 px-4 shadow-sm md:gap-3 md:px-6"
+            style={{ backgroundColor: branding.cor_header, color: branding.cor_texto_header }}
+          >
+            <button
+              type="button"
+              onClick={toggleSidebar}
+              className="flex size-10 shrink-0 items-center justify-center rounded-lg transition-colors hover:bg-white/10 touch-manipulation md:size-9"
+              style={{ color: branding.cor_texto_header }}
+              aria-label="Abrir ou recolher menu"
+              aria-expanded={sidebarMobileOpen || sidebarExpanded}
+            >
+              {menuIcon}
+            </button>
+
+            <div className="flex min-w-0 items-center overflow-hidden md:hidden">
+              <PortalBrandLogo className="h-7 w-auto max-w-[9rem] object-contain" />
+            </div>
+
+            <div className="min-w-0 flex-1" />
+
+            <div className="hidden min-w-0 text-right sm:block">
+              <p className="truncate text-sm font-medium" style={{ color: branding.cor_texto_header }}>
+                {user.nome}
+              </p>
+              <p className="truncate text-xs opacity-80" style={{ color: branding.cor_texto_header }}>
+                {roleLabel}
+              </p>
+            </div>
+          </header>
+
+          <main className="min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-8 md:py-8">
+            <div className="mx-auto w-full max-w-4xl">
+              <Outlet />
+            </div>
+          </main>
         </div>
-      </nav>
-    </div>
+      </div>
+
+      <PortalChatWidget />
+    </>
   )
 }
 

--- a/frontend/src/pages/portal/PortalLayout.tsx
+++ b/frontend/src/pages/portal/PortalLayout.tsx
@@ -1,0 +1,82 @@
+import { NavLink, Navigate, Outlet, useLocation } from 'react-router-dom'
+import { PortalAuthProvider, usePortalAuth } from '../../contexts/PortalAuthContext'
+import { PageLoading } from '../../components/ui/PageLoading'
+import { BrandLogo } from '../../brand'
+
+function PortalShell() {
+  const { user, loading, logout } = usePortalAuth()
+  const location = useLocation()
+
+  if (loading) {
+    return <PageLoading fullscreen label="Carregando portal…" />
+  }
+  if (!user) {
+    return <Navigate to="/portal/login" replace state={{ from: location }} />
+  }
+  if (user.must_change_password && location.pathname !== '/portal/trocar-senha') {
+    return <Navigate to="/portal/trocar-senha" replace />
+  }
+
+  const navClass = ({ isActive }: { isActive: boolean }) =>
+    [
+      'flex flex-1 flex-col items-center gap-0.5 rounded-xl px-2 py-2 text-[11px] font-medium transition-colors sm:flex-none sm:flex-row sm:gap-2 sm:px-3 sm:py-2 sm:text-sm',
+      isActive
+        ? 'bg-teal-600 text-white shadow-sm'
+        : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900',
+    ].join(' ')
+
+  return (
+    <div className="portal-cliente flex min-h-dvh flex-col bg-gradient-to-b from-slate-50 via-white to-teal-50/40">
+      <header className="sticky top-0 z-20 border-b border-slate-200/80 bg-white/90 backdrop-blur-md">
+        <div className="mx-auto flex h-14 max-w-3xl items-center justify-between gap-3 px-4">
+          <div className="flex min-w-0 items-center gap-2.5">
+            <BrandLogo className="h-8 w-auto shrink-0" />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-slate-900">Portal do cliente</p>
+              <p className="truncate text-xs text-slate-500">{user.nome}</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              logout()
+              window.location.replace('/portal/login')
+            }}
+            className="shrink-0 rounded-lg px-2.5 py-1.5 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900"
+          >
+            Sair
+          </button>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-5 pb-24 sm:pb-8">
+        <Outlet />
+      </main>
+
+      <nav
+        className="fixed inset-x-0 bottom-0 z-20 border-t border-slate-200/80 bg-white/95 px-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] pt-1.5 backdrop-blur-md sm:static sm:mx-auto sm:mb-6 sm:max-w-3xl sm:rounded-2xl sm:border sm:px-3 sm:py-2 sm:shadow-sm"
+        aria-label="Navegação do portal"
+      >
+        <div className="mx-auto flex max-w-3xl items-stretch justify-around gap-1 sm:justify-start sm:gap-2">
+          <NavLink to="/portal/tickets" end className={navClass}>
+            Chamados
+          </NavLink>
+          <NavLink to="/portal/tickets/novo" className={navClass}>
+            Novo
+          </NavLink>
+          <NavLink to="/portal/ajuda" className={navClass}>
+            Ajuda
+          </NavLink>
+        </div>
+      </nav>
+    </div>
+  )
+}
+
+export function PortalLayout() {
+  return (
+    <PortalAuthProvider>
+      <PortalShell />
+    </PortalAuthProvider>
+  )
+}

--- a/frontend/src/pages/portal/PortalLogin.tsx
+++ b/frontend/src/pages/portal/PortalLogin.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+import { Link, Navigate, useNavigate, useSearchParams } from 'react-router-dom'
+import { PortalAuthProvider, usePortalAuth } from '../../contexts/PortalAuthContext'
+import { Button } from '../../components/ui/Button'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { BrandLogo } from '../../brand'
+import { PageLoading } from '../../components/ui/PageLoading'
+
+const fieldClass =
+  'w-full rounded-xl border border-slate-200 bg-white px-3.5 py-3 text-[0.9375rem] text-slate-900 placeholder:text-slate-400 shadow-sm transition-colors focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25'
+
+function PortalLoginForm() {
+  const { user, loading, login } = usePortalAuth()
+  const [email, setEmail] = useState('')
+  const [senha, setSenha] = useState('')
+  const [lembrarMe, setLembrarMe] = useState(true)
+  const [mostrarSenha, setMostrarSenha] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const { showError, showSuccess } = useToast()
+  const navigate = useNavigate()
+  const [params] = useSearchParams()
+
+  if (loading) {
+    return <PageLoading fullscreen label="Carregando…" />
+  }
+  if (user) {
+    const dest = user.must_change_password ? '/portal/trocar-senha' : '/portal/tickets'
+    return <Navigate to={dest} replace />
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!email.trim() || !senha.trim()) {
+      showError('Informe e-mail e senha.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      await login(email.trim(), senha, lembrarMe)
+      showSuccess('Bem-vindo ao portal.')
+      const returnTo = params.get('returnTo')
+      navigate(returnTo && returnTo.startsWith('/portal') ? returnTo : '/portal/tickets', {
+        replace: true,
+      })
+    } catch (err) {
+      showError(mensagemFalhaParaToast(err, 'Falha no login. Verifique suas credenciais.'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="relative flex min-h-dvh flex-col items-center justify-center bg-gradient-to-br from-slate-100 via-white to-teal-50 px-4 py-10">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-40"
+        style={{
+          backgroundImage:
+            'radial-gradient(circle at 20% 20%, rgba(13,148,136,0.12), transparent 40%), radial-gradient(circle at 80% 80%, rgba(15,23,42,0.06), transparent 45%)',
+        }}
+      />
+      <div className="relative w-full max-w-md">
+        <div className="mb-8 text-center">
+          <BrandLogo className="mx-auto h-10 w-auto" />
+          <h1 className="mt-5 text-2xl font-semibold tracking-tight text-slate-900">
+            Portal do cliente
+          </h1>
+          <p className="mt-2 text-sm leading-relaxed text-slate-600">
+            Acompanhe e abra chamados da sua empresa com a equipe de suporte.
+          </p>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="rounded-2xl border border-slate-200/80 bg-white/95 p-6 shadow-lg shadow-slate-200/60 backdrop-blur"
+        >
+          <label className="mb-4 block">
+            <span className="mb-1.5 block text-sm font-medium text-slate-700">E-mail</span>
+            <input
+              type="email"
+              autoComplete="username"
+              className={fieldClass}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="seu@email.com"
+              required
+            />
+          </label>
+          <label className="mb-4 block">
+            <span className="mb-1.5 block text-sm font-medium text-slate-700">Senha</span>
+            <div className="relative">
+              <input
+                type={mostrarSenha ? 'text' : 'password'}
+                autoComplete="current-password"
+                className={`${fieldClass} pr-16`}
+                value={senha}
+                onChange={(e) => setSenha(e.target.value)}
+                required
+              />
+              <button
+                type="button"
+                className="absolute inset-y-0 right-2 my-auto h-8 rounded-md px-2 text-xs font-medium text-teal-700 hover:bg-teal-50"
+                onClick={() => setMostrarSenha((v) => !v)}
+              >
+                {mostrarSenha ? 'Ocultar' : 'Mostrar'}
+              </button>
+            </div>
+          </label>
+          <label className="mb-5 flex items-center gap-2 text-sm text-slate-600">
+            <input
+              type="checkbox"
+              checked={lembrarMe}
+              onChange={(e) => setLembrarMe(e.target.checked)}
+              className="size-4 rounded border-slate-300 text-teal-600 focus:ring-teal-500"
+            />
+            Manter conectado neste aparelho
+          </label>
+          <Button type="submit" className="w-full" disabled={submitting}>
+            {submitting ? 'Entrando…' : 'Entrar'}
+          </Button>
+        </form>
+
+        <p className="mt-6 text-center text-xs text-slate-500">
+          É da equipe de suporte?{' '}
+          <Link to="/login" className="font-medium text-teal-700 underline-offset-2 hover:underline">
+            Acessar painel interno
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export function PortalLogin() {
+  return (
+    <PortalAuthProvider>
+      <PortalLoginForm />
+    </PortalAuthProvider>
+  )
+}

--- a/frontend/src/pages/portal/PortalLogin.tsx
+++ b/frontend/src/pages/portal/PortalLogin.tsx
@@ -1,17 +1,37 @@
 import { useState } from 'react'
 import { Link, Navigate, useNavigate, useSearchParams } from 'react-router-dom'
 import { PortalAuthProvider, usePortalAuth } from '../../contexts/PortalAuthContext'
-import { Button } from '../../components/ui/Button'
-import { useToast } from '../../components/ui/Toast'
+import { usePortalBranding } from '../../contexts/PortalBrandingContext'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
-import { BrandLogo } from '../../brand'
+import { useToast } from '../../components/ui/Toast'
+import { PortalBrandLogo } from './PortalBrandLogo'
+import { portalInputClass, portalPrimaryBtnClass } from './portalUi'
 import { PageLoading } from '../../components/ui/PageLoading'
 
-const fieldClass =
-  'w-full rounded-xl border border-slate-200 bg-white px-3.5 py-3 text-[0.9375rem] text-slate-900 placeholder:text-slate-400 shadow-sm transition-colors focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25'
+const iconEye = (
+  <svg className="size-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
+    />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+  </svg>
+)
+
+const iconEyeOff = (
+  <svg className="size-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"
+    />
+  </svg>
+)
 
 function PortalLoginForm() {
   const { user, loading, login } = usePortalAuth()
+  const branding = usePortalBranding()
   const [email, setEmail] = useState('')
   const [senha, setSenha] = useState('')
   const [lembrarMe, setLembrarMe] = useState(true)
@@ -51,36 +71,62 @@ function PortalLoginForm() {
   }
 
   return (
-    <div className="relative flex min-h-dvh flex-col items-center justify-center bg-gradient-to-br from-slate-100 via-white to-teal-50 px-4 py-10">
+    <div className="relative flex min-h-dvh flex-col items-center justify-center overflow-hidden px-4 py-12">
+      {/* Fundo minimalista: grade suave + manchas de marca */}
       <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundColor: branding.cor_fundo || '#F8FAFC',
+          backgroundImage: [
+            `radial-gradient(ellipse 80% 55% at 50% -10%, color-mix(in srgb, ${branding.cor_header} 22%, transparent), transparent 55%)`,
+            `radial-gradient(ellipse 50% 40% at 100% 100%, color-mix(in srgb, ${branding.cor_primaria} 14%, transparent), transparent 50%)`,
+            `radial-gradient(ellipse 40% 35% at 0% 85%, color-mix(in srgb, ${branding.cor_header} 8%, transparent), transparent 45%)`,
+          ].join(', '),
+        }}
         aria-hidden
-        className="pointer-events-none absolute inset-0 opacity-40"
+      />
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.35]"
         style={{
           backgroundImage:
-            'radial-gradient(circle at 20% 20%, rgba(13,148,136,0.12), transparent 40%), radial-gradient(circle at 80% 80%, rgba(15,23,42,0.06), transparent 45%)',
+            'linear-gradient(to right, rgb(15 23 42 / 0.04) 1px, transparent 1px), linear-gradient(to bottom, rgb(15 23 42 / 0.04) 1px, transparent 1px)',
+          backgroundSize: '48px 48px',
+          maskImage: 'radial-gradient(ellipse 70% 60% at 50% 40%, black 20%, transparent 75%)',
         }}
+        aria-hidden
       />
-      <div className="relative w-full max-w-md">
-        <div className="mb-8 text-center">
-          <BrandLogo className="mx-auto h-10 w-auto" />
-          <h1 className="mt-5 text-2xl font-semibold tracking-tight text-slate-900">
-            Portal do cliente
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-1"
+        style={{ backgroundColor: branding.cor_header }}
+        aria-hidden
+      />
+
+      <div className="relative w-full max-w-md animate-[fadeIn_0.45s_ease-out]">
+        <div className="mb-9 text-center">
+          <div className="mx-auto mb-6 flex w-full items-center justify-center">
+            <PortalBrandLogo className="mx-auto h-auto w-full max-h-24 object-contain object-center sm:max-h-28" />
+          </div>
+          <h1
+            className="text-2xl font-semibold tracking-tight sm:text-[1.65rem]"
+            style={{ color: branding.cor_texto_corpo }}
+          >
+            {branding.portal_titulo}
           </h1>
-          <p className="mt-2 text-sm leading-relaxed text-slate-600">
-            Acompanhe e abra chamados da sua empresa com a equipe de suporte.
+          <p className="mx-auto mt-2.5 max-w-sm text-sm leading-relaxed text-slate-500">
+            {branding.texto_boas_vindas}
           </p>
         </div>
 
         <form
           onSubmit={handleSubmit}
-          className="rounded-2xl border border-slate-200/80 bg-white/95 p-6 shadow-lg shadow-slate-200/60 backdrop-blur"
+          className="rounded-2xl border border-slate-200/70 bg-white/90 p-6 shadow-[0_20px_50px_-24px_rgb(15_23_42_/0.25)] backdrop-blur-md sm:p-7"
         >
           <label className="mb-4 block">
             <span className="mb-1.5 block text-sm font-medium text-slate-700">E-mail</span>
             <input
               type="email"
               autoComplete="username"
-              className={fieldClass}
+              className={portalInputClass}
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="seu@email.com"
@@ -93,41 +139,61 @@ function PortalLoginForm() {
               <input
                 type={mostrarSenha ? 'text' : 'password'}
                 autoComplete="current-password"
-                className={`${fieldClass} pr-16`}
+                className={`${portalInputClass} pr-12`}
                 value={senha}
                 onChange={(e) => setSenha(e.target.value)}
                 required
               />
               <button
                 type="button"
-                className="absolute inset-y-0 right-2 my-auto h-8 rounded-md px-2 text-xs font-medium text-teal-700 hover:bg-teal-50"
+                className="absolute right-1.5 top-1/2 flex size-9 -translate-y-1/2 items-center justify-center rounded-lg transition-colors hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--portal-primary)]/30"
+                style={{ color: branding.cor_link }}
                 onClick={() => setMostrarSenha((v) => !v)}
+                aria-label={mostrarSenha ? 'Ocultar senha' : 'Mostrar senha'}
+                aria-pressed={mostrarSenha}
               >
-                {mostrarSenha ? 'Ocultar' : 'Mostrar'}
+                {mostrarSenha ? iconEyeOff : iconEye}
               </button>
             </div>
           </label>
-          <label className="mb-5 flex items-center gap-2 text-sm text-slate-600">
+          <label className="mb-6 flex items-center gap-2.5 text-sm text-slate-600">
             <input
               type="checkbox"
               checked={lembrarMe}
               onChange={(e) => setLembrarMe(e.target.checked)}
-              className="size-4 rounded border-slate-300 text-teal-600 focus:ring-teal-500"
+              className="size-4 rounded border-slate-300 focus:ring-[var(--portal-primary)]"
+              style={{ accentColor: branding.cor_primaria }}
             />
             Manter conectado neste aparelho
           </label>
-          <Button type="submit" className="w-full" disabled={submitting}>
+          <button
+            type="submit"
+            className={`${portalPrimaryBtnClass} w-full py-2.5`}
+            style={{ backgroundColor: 'var(--portal-primary)' }}
+            disabled={submitting}
+          >
             {submitting ? 'Entrando…' : 'Entrar'}
-          </Button>
+          </button>
         </form>
 
-        <p className="mt-6 text-center text-xs text-slate-500">
+        <p className="mt-7 text-center text-xs text-slate-500">
           É da equipe de suporte?{' '}
-          <Link to="/login" className="font-medium text-teal-700 underline-offset-2 hover:underline">
+          <Link
+            to="/login"
+            className="font-medium underline-offset-2 hover:underline"
+            style={{ color: branding.cor_link }}
+          >
             Acessar painel interno
           </Link>
         </p>
       </div>
+
+      <style>{`
+        @keyframes fadeIn {
+          from { opacity: 0; transform: translateY(8px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
     </div>
   )
 }

--- a/frontend/src/pages/portal/PortalSidebar.tsx
+++ b/frontend/src/pages/portal/PortalSidebar.tsx
@@ -1,0 +1,277 @@
+import { NavLink } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { APP_NAME } from '../../brand'
+import { PortalBrandLogo } from './PortalBrandLogo'
+
+const STORAGE_KEY = 'portal-sidebar-expanded'
+const COPYRIGHT_YEAR = new Date().getFullYear()
+
+type NavItem = {
+  to: string
+  label: string
+  end?: boolean
+  icon: ReactNode
+  socioOnly?: boolean
+}
+
+const icons = {
+  tickets: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z" />
+    </svg>
+  ),
+  chats: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+    </svg>
+  ),
+  users: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+    </svg>
+  ),
+  help: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+  novo: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+    </svg>
+  ),
+  logout: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+    </svg>
+  ),
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { to: '/portal/tickets', label: 'Chamados', end: true, icon: icons.tickets },
+  { to: '/portal/chats', label: 'Atendimentos', icon: icons.chats },
+  { to: '/portal/equipe', label: 'Usuários', icon: icons.users, socioOnly: true },
+  { to: '/portal/ajuda', label: 'Ajuda', icon: icons.help },
+]
+
+export function readPortalSidebarExpanded(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) !== '0'
+  } catch {
+    return true
+  }
+}
+
+export function writePortalSidebarExpanded(expanded: boolean) {
+  try {
+    localStorage.setItem(STORAGE_KEY, expanded ? '1' : '0')
+  } catch {
+    /* storage indisponível */
+  }
+}
+
+type Props = {
+  expanded: boolean
+  mobileOpen: boolean
+  isSocio: boolean
+  userNome: string
+  userRole: string
+  exibirMarcaDeskrudder?: boolean
+  onLogout: () => void
+  onMobileClose: () => void
+}
+
+function NavItemLink({
+  item,
+  expanded,
+  onNavigate,
+}: {
+  item: NavItem
+  expanded: boolean
+  onNavigate?: () => void
+}) {
+  return (
+    <NavLink
+      to={item.to}
+      end={item.end}
+      title={!expanded ? item.label : undefined}
+      onClick={onNavigate}
+      className={({ isActive }) =>
+        [
+          'flex min-h-[44px] w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors touch-manipulation',
+          isActive
+            ? 'bg-white/15 text-[var(--portal-sidebar-text)] ring-1 ring-white/25'
+            : 'text-[var(--portal-sidebar-text)]/80 hover:bg-white/10 hover:text-[var(--portal-sidebar-text)]',
+          !expanded ? 'md:justify-center md:gap-0 md:px-2' : '',
+        ].join(' ')
+      }
+    >
+      {item.icon}
+      <span className={expanded ? 'min-w-0 truncate' : 'min-w-0 truncate md:hidden'}>{item.label}</span>
+    </NavLink>
+  )
+}
+
+export function PortalSidebar({
+  expanded,
+  mobileOpen,
+  isSocio,
+  userNome,
+  userRole,
+  exibirMarcaDeskrudder = true,
+  onLogout,
+  onMobileClose,
+}: Props) {
+  const items = NAV_ITEMS.filter((item) => !item.socioOnly || isSocio)
+  const initial = userNome?.trim()?.charAt(0)?.toUpperCase() || '?'
+
+  const sidebarContent = (
+    <>
+      <div
+        className={`flex h-16 min-h-[64px] shrink-0 items-center border-b border-white/10 ${expanded ? 'px-3' : 'justify-center md:px-2'}`}
+      >
+        {expanded ? (
+          <PortalBrandLogo className="h-8 w-auto max-w-[11rem] object-contain" />
+        ) : (
+          <PortalBrandLogo className="h-8 w-auto max-w-[2.5rem] object-contain md:mx-auto" />
+        )}
+      </div>
+
+      <nav
+        className={`min-w-0 flex-1 overflow-x-hidden overflow-y-auto py-3 px-2 ${!expanded ? 'md:px-2' : ''}`}
+        aria-label="Menu do portal"
+      >
+        <ul className={`min-w-0 space-y-0.5 px-2 ${!expanded ? 'md:px-0' : ''}`}>
+          {items.map((item) => (
+            <li key={item.to} className="w-full min-w-0">
+              <NavItemLink item={item} expanded={expanded} onNavigate={onMobileClose} />
+            </li>
+          ))}
+          <li className="w-full min-w-0 pt-1">
+            <NavLink
+              to="/portal/tickets/novo"
+              title={!expanded ? 'Novo chamado' : undefined}
+              onClick={onMobileClose}
+              className={({ isActive }) =>
+                [
+                  'flex min-h-[44px] w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors touch-manipulation',
+                  isActive
+                    ? 'bg-[var(--portal-primary)] text-white shadow-sm'
+                    : 'border border-white/25 text-[var(--portal-sidebar-text)] hover:bg-white/10',
+                  !expanded ? 'md:justify-center md:gap-0 md:px-2' : '',
+                ].join(' ')
+              }
+            >
+              {icons.novo}
+              <span className={expanded ? 'min-w-0 truncate' : 'min-w-0 truncate md:hidden'}>
+                Novo chamado
+              </span>
+            </NavLink>
+          </li>
+        </ul>
+      </nav>
+
+      <div className={`shrink-0 border-t border-white/10 p-2 ${!expanded ? 'md:px-2' : ''}`}>
+        <div
+          className={`flex items-center gap-3 px-3 py-2 ${expanded ? 'opacity-100' : 'md:hidden'}`}
+          style={{ color: 'var(--portal-sidebar-text)' }}
+        >
+          <span
+            className="flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white shadow-sm"
+            style={{ backgroundColor: 'var(--portal-primary)' }}
+            aria-hidden
+          >
+            {initial}
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">{userNome}</p>
+            <p className="truncate text-xs opacity-75">{userRole}</p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            onMobileClose()
+            onLogout()
+          }}
+          title="Sair"
+          className={[
+            'mt-2 flex min-h-[44px] w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors hover:bg-white/10 active:bg-white/15 touch-manipulation',
+            expanded ? '' : 'md:justify-center md:px-2',
+          ].join(' ')}
+          style={{ color: 'var(--portal-sidebar-text)' }}
+        >
+          {icons.logout}
+          <span className={expanded ? 'min-w-0 truncate' : 'min-w-0 truncate md:hidden'}>Sair</span>
+        </button>
+        {exibirMarcaDeskrudder ? (
+          <p
+            className={[
+              'mt-2 px-3 py-1 text-[11px] leading-snug opacity-60',
+              expanded ? 'text-left' : 'md:px-1 md:text-center md:text-[9px]',
+            ].join(' ')}
+            style={{ color: 'var(--portal-sidebar-text)' }}
+            title={APP_NAME}
+          >
+            {expanded ? (
+              <>
+                © {COPYRIGHT_YEAR} {APP_NAME}
+              </>
+            ) : (
+              <>
+                <span className="hidden md:inline">© {COPYRIGHT_YEAR}</span>
+                <span className="md:hidden">
+                  © {COPYRIGHT_YEAR} {APP_NAME}
+                </span>
+              </>
+            )}
+          </p>
+        ) : null}
+      </div>
+    </>
+  )
+
+  return (
+    <>
+      <div
+        className={`fixed inset-0 z-40 bg-black/50 transition-opacity duration-200 md:hidden ${
+          mobileOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
+        }`}
+        aria-hidden
+        onClick={onMobileClose}
+      />
+
+      <aside
+        className={[
+          'fixed inset-0 z-50 flex h-full min-w-0 max-w-[100vw] flex-col overflow-x-hidden shadow-xl transition-transform duration-200 ease-out',
+          'md:sticky md:top-0 md:col-start-1 md:row-start-1 md:z-40 md:h-dvh md:max-h-dvh md:max-w-none md:w-full md:translate-x-0 md:self-start md:overflow-hidden md:border-r md:border-black/10 md:shadow-none',
+          mobileOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0',
+        ].join(' ')}
+        style={{
+          backgroundColor: 'var(--portal-sidebar)',
+          color: 'var(--portal-sidebar-text)',
+        }}
+        aria-label="Menu lateral"
+      >
+        <div
+          className="flex h-14 shrink-0 items-center justify-between border-b border-white/10 px-4 md:hidden"
+          style={{ backgroundColor: 'var(--portal-sidebar)' }}
+        >
+          <span className="text-sm font-semibold" style={{ color: 'var(--portal-sidebar-text)' }}>
+            Menu
+          </span>
+          <button
+            type="button"
+            onClick={onMobileClose}
+            className="inline-flex size-10 items-center justify-center rounded-lg hover:bg-white/10"
+            style={{ color: 'var(--portal-sidebar-text)' }}
+            aria-label="Fechar menu"
+          >
+            ×
+          </button>
+        </div>
+        {sidebarContent}
+      </aside>
+    </>
+  )
+}

--- a/frontend/src/pages/portal/PortalTicketDetalhe.tsx
+++ b/frontend/src/pages/portal/PortalTicketDetalhe.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { portalCliente, type PortalCliente } from '../../api/client'
+import { Button } from '../../components/ui/Button'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+
+function formatData(iso?: string | null) {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleString('pt-BR', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+export function PortalTicketDetalhe() {
+  const { id } = useParams<{ id: string }>()
+  const ticketId = Number(id)
+  const [ticket, setTicket] = useState<PortalCliente.TicketDetail | null>(null)
+  const [mensagens, setMensagens] = useState<PortalCliente.Mensagem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [corpo, setCorpo] = useState('')
+  const [enviando, setEnviando] = useState(false)
+  const [file, setFile] = useState<File | null>(null)
+  const bottomRef = useRef<HTMLDivElement | null>(null)
+  const toast = useToast()
+  const navigate = useNavigate()
+
+  const carregar = useCallback(async () => {
+    if (!Number.isFinite(ticketId)) return
+    const [t, msgs] = await Promise.all([
+      portalCliente.getTicket(ticketId),
+      portalCliente.listMensagens(ticketId),
+    ])
+    setTicket(t)
+    setMensagens(msgs)
+  }, [ticketId])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    carregar()
+      .catch((err) => {
+        if (!cancelled) {
+          toast.showError(mensagemFalhaParaToast(err, 'Chamado não encontrado.'))
+          navigate('/portal/tickets', { replace: true })
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [carregar, navigate, toast])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+  }, [mensagens.length])
+
+  // Polling leve para novas respostas da equipe
+  useEffect(() => {
+    if (!ticket?.pode_responder) return
+    const t = window.setInterval(() => {
+      carregar().catch(() => undefined)
+    }, 15000)
+    return () => window.clearInterval(t)
+  }, [carregar, ticket?.pode_responder])
+
+  async function handleEnviar(e: React.FormEvent) {
+    e.preventDefault()
+    if (!ticket || !ticket.pode_responder) return
+    const texto = corpo.trim()
+    if (!texto && !file) {
+      toast.showError('Escreva uma mensagem ou anexe um ficheiro.')
+      return
+    }
+    setEnviando(true)
+    try {
+      let msg: PortalCliente.Mensagem | null = null
+      if (texto) {
+        msg = await portalCliente.sendMensagem(ticket.id, texto)
+      }
+      if (file) {
+        await portalCliente.uploadAnexo(ticket.id, file, msg?.id)
+      }
+      setCorpo('')
+      setFile(null)
+      await carregar()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar.'))
+    } finally {
+      setEnviando(false)
+    }
+  }
+
+  async function baixarAnexo(anexo: PortalCliente.Anexo) {
+    if (!ticket) return
+    try {
+      const blob = await portalCliente.fetchAnexoBlob(ticket.id, anexo.id)
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = anexo.nome_original
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao baixar anexo.'))
+    }
+  }
+
+  async function abrirCsat() {
+    if (!ticket) return
+    try {
+      const { link } = await portalCliente.csatLink(ticket.id)
+      window.location.href = link
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Avaliação indisponível no momento.'))
+    }
+  }
+
+  if (loading || !ticket) {
+    return (
+      <div className="space-y-4">
+        <div className="h-8 w-48 animate-pulse rounded-lg bg-slate-100" />
+        <div className="h-64 animate-pulse rounded-2xl bg-slate-100" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-[70dvh] flex-col gap-4">
+      <div>
+        <button
+          type="button"
+          onClick={() => navigate('/portal/tickets')}
+          className="mb-2 text-sm font-medium text-slate-500 hover:text-slate-800"
+        >
+          ← Voltar
+        </button>
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <p className="font-mono text-xs font-semibold text-teal-700">{ticket.protocolo}</p>
+          <h1 className="mt-1 text-lg font-semibold text-slate-900">{ticket.assunto}</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            {ticket.status_nome} · {ticket.empresa_nome} · {ticket.setor_nome}
+          </p>
+        </div>
+      </div>
+
+      {ticket.csat_pendente ? (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950">
+          <p className="font-medium">Como foi o atendimento?</p>
+          <p className="mt-0.5 text-amber-900/80">Sua avaliação ajuda a melhorar o suporte.</p>
+          <button
+            type="button"
+            onClick={abrirCsat}
+            className="mt-2 text-sm font-semibold text-amber-900 underline underline-offset-2"
+          >
+            Avaliar agora
+          </button>
+        </div>
+      ) : null}
+
+      {!ticket.pode_responder ? (
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+          Este chamado está encerrado.{' '}
+          <Link to="/portal/tickets/novo" className="font-semibold text-teal-700 underline-offset-2 hover:underline">
+            Abrir um novo chamado
+          </Link>{' '}
+          se ainda precisar de ajuda.
+        </div>
+      ) : null}
+
+      <div className="flex-1 space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        {mensagens.length === 0 ? (
+          <p className="py-8 text-center text-sm text-slate-500">Ainda sem mensagens nesta conversa.</p>
+        ) : (
+          mensagens.map((m) => {
+            const mine = m.autor_papel === 'voce'
+            return (
+              <div key={m.id} className={`flex ${mine ? 'justify-end' : 'justify-start'}`}>
+                <div
+                  className={[
+                    'max-w-[92%] rounded-2xl px-3.5 py-2.5 text-sm shadow-sm sm:max-w-[80%]',
+                    mine
+                      ? 'rounded-br-md bg-teal-600 text-white'
+                      : 'rounded-bl-md border border-slate-200 bg-slate-50 text-slate-800',
+                  ].join(' ')}
+                >
+                  <p className={`text-[11px] font-medium ${mine ? 'text-teal-100' : 'text-slate-500'}`}>
+                    {m.autor_nome || (mine ? 'Você' : 'Equipe')} · {formatData(m.created_at)}
+                  </p>
+                  <p className="mt-1 whitespace-pre-wrap break-words">{m.corpo}</p>
+                  {m.anexos?.length ? (
+                    <ul className="mt-2 space-y-1">
+                      {m.anexos.map((a) => (
+                        <li key={a.id}>
+                          <button
+                            type="button"
+                            onClick={() => baixarAnexo(a)}
+                            className={`text-xs underline underline-offset-2 ${mine ? 'text-teal-50' : 'text-teal-700'}`}
+                          >
+                            {a.nome_original}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </div>
+              </div>
+            )
+          })
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      {ticket.pode_responder ? (
+        <form
+          onSubmit={handleEnviar}
+          className="sticky bottom-20 z-10 space-y-2 rounded-2xl border border-slate-200 bg-white/95 p-3 shadow-lg backdrop-blur sm:static sm:bottom-auto"
+        >
+          <textarea
+            value={corpo}
+            onChange={(e) => setCorpo(e.target.value)}
+            rows={3}
+            placeholder="Escreva sua mensagem…"
+            className="w-full resize-none rounded-xl border border-slate-200 px-3 py-2.5 text-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25"
+          />
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <label className="cursor-pointer text-xs font-medium text-teal-700 hover:underline">
+              <input
+                type="file"
+                className="hidden"
+                onChange={(e) => setFile(e.target.files?.[0] || null)}
+              />
+              {file ? `Anexo: ${file.name}` : 'Anexar ficheiro'}
+            </label>
+            <Button type="submit" disabled={enviando}>
+              {enviando ? 'Enviando…' : 'Enviar'}
+            </Button>
+          </div>
+        </form>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/PortalTicketNovo.tsx
+++ b/frontend/src/pages/portal/PortalTicketNovo.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { kbPublic, portalCliente, type PortalCliente, type Kb } from '../../api/client'
+import { usePortalAuth } from '../../contexts/PortalAuthContext'
+import { Button } from '../../components/ui/Button'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+
+const fieldClass =
+  'w-full rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-900 shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25'
+
+export function PortalTicketNovo() {
+  const { user } = usePortalAuth()
+  const empresas = user?.empresas ?? []
+  const unicaEmpresa = empresas.length === 1 ? empresas[0].id : ''
+  const [empresaId, setEmpresaId] = useState<number | ''>(unicaEmpresa)
+  const [setorId, setSetorId] = useState<number | ''>('')
+  const [setores, setSetores] = useState<PortalCliente.Setor[]>([])
+  const [pdvs, setPdvs] = useState<PortalCliente.Pdv[]>([])
+  const [pdvCodigo, setPdvCodigo] = useState('')
+  const [assunto, setAssunto] = useState('')
+  const [descricao, setDescricao] = useState('')
+  const [sugestoes, setSugestoes] = useState<Kb.ArticleBrief[]>([])
+  const [saving, setSaving] = useState(false)
+  const [anexos, setAnexos] = useState<File[]>([])
+  const toast = useToast()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (empresas.length === 1) setEmpresaId(empresas[0].id)
+  }, [empresas])
+
+  useEffect(() => {
+    portalCliente.listSetores().then(setSetores).catch(() => setSetores([]))
+  }, [])
+
+  useEffect(() => {
+    if (empresaId === '') {
+      setPdvs([])
+      setPdvCodigo('')
+      return
+    }
+    portalCliente
+      .listPdvs(empresaId)
+      .then(setPdvs)
+      .catch(() => setPdvs([]))
+  }, [empresaId])
+
+  useEffect(() => {
+    const q = assunto.trim()
+    if (q.length < 4) {
+      setSugestoes([])
+      return
+    }
+    const t = window.setTimeout(() => {
+      kbPublic
+        .listArticles({ busca: q, limit: 4 })
+        .then(setSugestoes)
+        .catch(() => setSugestoes([]))
+    }, 350)
+    return () => window.clearTimeout(t)
+  }, [assunto])
+
+  const empresaOptions = useMemo(
+    () => empresas.map((e) => ({ value: String(e.id), label: e.nome })),
+    [empresas],
+  )
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (empresaId === '') {
+      toast.showError('Selecione a empresa.')
+      return
+    }
+    if (assunto.trim().length < 3) {
+      toast.showError('Informe um assunto com pelo menos 3 caracteres.')
+      return
+    }
+    setSaving(true)
+    try {
+      const ticket = await portalCliente.createTicket({
+        empresa_id: empresaId,
+        setor_id: setorId === '' ? null : setorId,
+        assunto: assunto.trim(),
+        descricao: descricao.trim() || null,
+        pdv_codigo: pdvCodigo.trim() || null,
+      })
+      for (const file of anexos) {
+        try {
+          await portalCliente.uploadAnexo(ticket.id, file)
+        } catch {
+          /* anexo opcional — ticket já criado */
+        }
+      }
+      toast.showSuccess('Chamado aberto com sucesso.')
+      navigate(`/portal/tickets/${ticket.id}`, { replace: true })
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível abrir o chamado.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h1 className="text-xl font-semibold text-slate-900">Novo chamado</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Descreva o problema com clareza — isso acelera o atendimento.
+        </p>
+      </div>
+
+      {sugestoes.length > 0 ? (
+        <div className="rounded-2xl border border-teal-200 bg-teal-50/60 p-4">
+          <p className="text-sm font-semibold text-teal-900">Antes de abrir — isso pode ajudar</p>
+          <ul className="mt-2 space-y-1.5">
+            {sugestoes.map((a) => (
+              <li key={a.id}>
+                <Link
+                  to={`/portal/ajuda/${a.slug}`}
+                  className="text-sm font-medium text-teal-800 underline-offset-2 hover:underline"
+                >
+                  {a.titulo}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <form onSubmit={handleSubmit} className="space-y-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        {empresas.length === 0 ? (
+          <p className="text-sm text-rose-700">
+            Nenhuma empresa vinculada à sua conta. Peça ao suporte para ajustar o cadastro.
+          </p>
+        ) : (
+          <label className="block">
+            <span className="mb-1.5 block text-sm font-medium text-slate-700">Empresa</span>
+            <select
+              className={fieldClass}
+              value={empresaId === '' ? '' : String(empresaId)}
+              onChange={(e) => setEmpresaId(e.target.value ? Number(e.target.value) : '')}
+              required
+              disabled={empresas.length === 1}
+            >
+              {empresas.length > 1 ? <option value="">Selecione…</option> : null}
+              {empresaOptions.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Setor</span>
+          <select
+            className={fieldClass}
+            value={setorId === '' ? '' : String(setorId)}
+            onChange={(e) => setSetorId(e.target.value ? Number(e.target.value) : '')}
+          >
+            <option value="">Automático / padrão</option>
+            {setores.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.nome}
+              </option>
+            ))}
+          </select>
+          <span className="mt-1 block text-xs text-slate-500">
+            Se não souber, deixe em automático — a equipe roteia o chamado.
+          </span>
+        </label>
+
+        {pdvs.length > 0 ? (
+          <label className="block">
+            <span className="mb-1.5 block text-sm font-medium text-slate-700">PDV (opcional)</span>
+            <select
+              className={fieldClass}
+              value={pdvCodigo}
+              onChange={(e) => setPdvCodigo(e.target.value)}
+            >
+              <option value="">Nenhum / não se aplica</option>
+              {pdvs.map((p) => (
+                <option key={p.id} value={p.codigo}>
+                  {p.codigo}
+                  {p.papel ? ` (${p.papel})` : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Assunto</span>
+          <input
+            className={fieldClass}
+            value={assunto}
+            onChange={(e) => setAssunto(e.target.value)}
+            placeholder="Ex.: PDV 003 não imprime cupom"
+            required
+            minLength={3}
+            maxLength={255}
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Descrição</span>
+          <textarea
+            className={`${fieldClass} min-h-32 resize-y`}
+            value={descricao}
+            onChange={(e) => setDescricao(e.target.value)}
+            placeholder="O que aconteceu, desde quando, e o que já tentou fazer…"
+            maxLength={20000}
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Anexos (opcional)</span>
+          <input
+            type="file"
+            multiple
+            className="block w-full text-sm text-slate-600 file:mr-3 file:rounded-lg file:border-0 file:bg-teal-50 file:px-3 file:py-2 file:text-sm file:font-medium file:text-teal-800 hover:file:bg-teal-100"
+            onChange={(e) => setAnexos(Array.from(e.target.files || []))}
+          />
+          {anexos.length > 0 ? (
+            <p className="mt-1 text-xs text-slate-500">{anexos.length} ficheiro(s) selecionado(s)</p>
+          ) : null}
+        </label>
+
+        <div className="flex flex-wrap gap-2 pt-1">
+          <Button type="submit" disabled={saving || empresas.length === 0}>
+            {saving ? 'Abrindo…' : 'Abrir chamado'}
+          </Button>
+          <Link
+            to="/portal/tickets"
+            className="inline-flex items-center rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Cancelar
+          </Link>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/PortalTickets.tsx
+++ b/frontend/src/pages/portal/PortalTickets.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { portalCliente, type PortalCliente } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useToast } from '../../components/ui/Toast'
+import { Button } from '../../components/ui/Button'
+
+function formatData(iso?: string | null) {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleString('pt-BR', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+function statusTone(slug?: string | null) {
+  const s = (slug || '').toLowerCase()
+  if (s === 'fechado' || s === 'resolvido') return 'bg-slate-100 text-slate-700'
+  if (s === 'aguardando_cliente') return 'bg-amber-50 text-amber-800'
+  if (s === 'em_atendimento') return 'bg-teal-50 text-teal-800'
+  return 'bg-sky-50 text-sky-800'
+}
+
+export function PortalTickets() {
+  const [situacao, setSituacao] = useState<'abertos' | 'fechados' | 'todos'>('abertos')
+  const [busca, setBusca] = useState('')
+  const [buscaDebounced, setBuscaDebounced] = useState('')
+  const [items, setItems] = useState<PortalCliente.TicketListItem[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [erro, setErro] = useState<string | null>(null)
+  const toast = useToast()
+
+  useEffect(() => {
+    const t = window.setTimeout(() => setBuscaDebounced(busca.trim()), 300)
+    return () => window.clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setErro(null)
+    portalCliente
+      .listTickets({ situacao, busca: buscaDebounced || undefined, limit: 50 })
+      .then((res) => {
+        if (cancelled) return
+        setItems(res.items)
+        setTotal(res.total)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        const msg = mensagemFalhaParaToast(err, 'Não foi possível carregar os chamados.')
+        setErro(msg)
+        toast.showError(msg)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- toast estável o suficiente; evita loop
+  }, [situacao, buscaDebounced])
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">Meus chamados</h1>
+          <p className="mt-1 text-sm text-slate-600">Acompanhe o andamento das suas solicitações.</p>
+        </div>
+        <Link to="/portal/tickets/novo">
+          <Button type="button">Abrir chamado</Button>
+        </Link>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="flex rounded-xl border border-slate-200 bg-white p-1 shadow-sm">
+          {(
+            [
+              ['abertos', 'Abertos'],
+              ['fechados', 'Encerrados'],
+              ['todos', 'Todos'],
+            ] as const
+          ).map(([key, label]) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setSituacao(key)}
+              className={[
+                'flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors sm:flex-none',
+                situacao === key
+                  ? 'bg-slate-900 text-white'
+                  : 'text-slate-600 hover:bg-slate-50',
+              ].join(' ')}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <input
+          type="search"
+          value={busca}
+          onChange={(e) => setBusca(e.target.value)}
+          placeholder="Buscar protocolo ou assunto…"
+          className="w-full flex-1 rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25"
+        />
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-24 animate-pulse rounded-2xl bg-slate-100" />
+          ))}
+        </div>
+      ) : erro ? (
+        <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-6 text-sm text-rose-800">
+          {erro}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-white/70 px-5 py-10 text-center">
+          <p className="text-base font-medium text-slate-900">Nenhum chamado por aqui</p>
+          <p className="mt-1 text-sm text-slate-600">
+            Abra o primeiro chamado ou consulte a base de ajuda antes.
+          </p>
+          <div className="mt-5 flex flex-wrap justify-center gap-2">
+            <Link to="/portal/tickets/novo">
+              <Button type="button">Abrir chamado</Button>
+            </Link>
+            <Link
+              to="/portal/ajuda"
+              className="inline-flex items-center rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            >
+              Ver ajuda
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {items.map((t) => (
+            <li key={t.id}>
+              <Link
+                to={`/portal/tickets/${t.id}`}
+                className="block rounded-2xl border border-slate-200/90 bg-white p-4 shadow-sm transition hover:border-teal-300 hover:shadow-md"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="font-mono text-xs font-semibold tracking-wide text-teal-700">
+                      {t.protocolo}
+                    </p>
+                    <h2 className="mt-1 truncate text-base font-semibold text-slate-900">{t.assunto}</h2>
+                    <p className="mt-1 truncate text-sm text-slate-500">
+                      {t.empresa_nome || 'Empresa'} · {t.setor_nome || 'Atendimento'}
+                    </p>
+                  </div>
+                  <span
+                    className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ${statusTone(t.status_slug)}`}
+                  >
+                    {t.status_nome || '—'}
+                  </span>
+                </div>
+                <p className="mt-3 text-xs text-slate-400">
+                  Atualizado {formatData(t.ultima_mensagem_em || t.updated_at || t.created_at)}
+                </p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {!loading && items.length > 0 ? (
+        <p className="text-center text-xs text-slate-400">
+          {total} chamado{total === 1 ? '' : 's'}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/PortalTrocarSenha.tsx
+++ b/frontend/src/pages/portal/PortalTrocarSenha.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { Navigate, useNavigate } from 'react-router-dom'
+import { portalCliente } from '../../api/client'
+import { usePortalAuth } from '../../contexts/PortalAuthContext'
+import { Button } from '../../components/ui/Button'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+
+const fieldClass =
+  'w-full rounded-xl border border-slate-200 bg-white px-3.5 py-3 text-[0.9375rem] text-slate-900 shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25'
+
+export function PortalTrocarSenha() {
+  const { user, applyTokens, refreshUser } = usePortalAuth()
+  const [atual, setAtual] = useState('')
+  const [nova, setNova] = useState('')
+  const [confirma, setConfirma] = useState('')
+  const [saving, setSaving] = useState(false)
+  const toast = useToast()
+  const navigate = useNavigate()
+
+  if (!user) {
+    return <Navigate to="/portal/login" replace />
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (nova.length < 8) {
+      toast.showError('A nova senha deve ter ao menos 8 caracteres.')
+      return
+    }
+    if (nova !== confirma) {
+      toast.showError('A confirmação não confere com a nova senha.')
+      return
+    }
+    setSaving(true)
+    try {
+      const tokens = await portalCliente.trocarSenha(atual, nova)
+      await applyTokens(tokens, true)
+      await refreshUser()
+      toast.showSuccess('Senha atualizada.')
+      navigate('/portal/tickets', { replace: true })
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar a senha.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-md space-y-5">
+      <div>
+        <h1 className="text-xl font-semibold text-slate-900">Definir nova senha</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Por segurança, altere a senha temporária antes de continuar.
+        </p>
+      </div>
+      <form onSubmit={handleSubmit} className="space-y-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Senha atual</span>
+          <input
+            type="password"
+            className={fieldClass}
+            value={atual}
+            onChange={(e) => setAtual(e.target.value)}
+            required
+            autoComplete="current-password"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Nova senha</span>
+          <input
+            type="password"
+            className={fieldClass}
+            value={nova}
+            onChange={(e) => setNova(e.target.value)}
+            required
+            minLength={8}
+            autoComplete="new-password"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Confirmar nova senha</span>
+          <input
+            type="password"
+            className={fieldClass}
+            value={confirma}
+            onChange={(e) => setConfirma(e.target.value)}
+            required
+            minLength={8}
+            autoComplete="new-password"
+          />
+        </label>
+        <Button type="submit" className="w-full" disabled={saving}>
+          {saving ? 'Salvando…' : 'Salvar e continuar'}
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/portalUi.tsx
+++ b/frontend/src/pages/portal/portalUi.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from 'react'
+
+/** Classes reutilizáveis — visual alinhado ao painel interno (minimalista). */
+export const portalInputClass =
+  'w-full rounded-lg border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-900 shadow-sm transition-colors placeholder:text-slate-400 focus:border-[var(--portal-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--portal-primary)]/20 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-500'
+
+export const portalPrimaryBtnClass =
+  'inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:opacity-95 focus:outline-none focus:ring-2 focus:ring-[var(--portal-primary)]/30 disabled:opacity-50'
+
+export const portalSecondaryBtnClass =
+  'inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50'
+
+export const portalCardClass =
+  'rounded-xl border border-slate-200/90 bg-white p-4 shadow-sm transition hover:border-slate-300 hover:shadow-md'
+
+export function PortalPageHeader({
+  title,
+  subtitle,
+  action,
+}: {
+  title: string
+  subtitle?: string
+  action?: ReactNode
+}) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-4">
+      <div className="min-w-0">
+        <h1 className="text-xl font-semibold tracking-tight text-slate-900 sm:text-2xl">{title}</h1>
+        {subtitle ? <p className="mt-1 text-sm text-slate-500">{subtitle}</p> : null}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  )
+}
+
+export function PortalSegmentedControl<T extends string>({
+  value,
+  onChange,
+  options,
+}: {
+  value: T
+  onChange: (v: T) => void
+  options: readonly { value: T; label: string }[]
+}) {
+  return (
+    <div className="inline-flex rounded-lg border border-slate-200 bg-slate-100/80 p-1">
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          onClick={() => onChange(opt.value)}
+          className={[
+            'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+            value === opt.value ? 'bg-white text-slate-900 shadow-sm' : 'text-slate-600 hover:text-slate-900',
+          ].join(' ')}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export function portalUserInitials(nome: string): string {
+  const parts = nome.trim().split(/\s+/).filter(Boolean)
+  if (!parts.length) return '?'
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
+}


### PR DESCRIPTION
## Summary

Lote do **Portal do cliente** (`/portal`) — épico #263 e follow-ups #600–#605.

- **Auth + tickets (P-01–P-09 / #300–#308):** login JWT `aud=portal`, escopo por papel, chamados, mensagens públicas, anexos, e-mail e ajuda
- **#600/#601:** senha do portal no cadastro (modal Rede); sócio com escopo automático em toda a rede
- **#604:** RBAC — colaborador (próprios), supervisor (empresas), sócio (rede)
- **#603:** atendimentos WhatsApp no portal (somente leitura)
- **#602:** gestão de equipe pelo sócio
- **#605 + polish:** branding white-label, cor do menu lateral, shell alinhado ao DeskRudder, chat ao vivo no `/portal`, login enriquecido, tema claro isolado do dark do painel

## CHANGELOG

- [x] `CHANGELOG.md` → `[Unreleased]` atualizado

## Test plan

- [x] `pytest tests/test_portal_cliente.py`
- [x] Migration `076_kb_portal_cor_sidebar` (head único após apply)
- [x] Manual: login `ana.socio@example.com` → Usuários, chat flutuante, cores navbar/menu, login com logo/olho
- [x] Manual: colaborador sem menu Equipe; chat da instância só no DeskRudder dessa instância

## Issues

Closes #263
Closes #300
Closes #301
Closes #302
Closes #303
Closes #304
Closes #305
Closes #306
Closes #307
Closes #308
Closes #600
Closes #601
Closes #602
Closes #603
Closes #604
Closes #605