### PR TITLE
feat(whatsapp): contexto de empresa em atendimentos (#590 #591 #592)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- WhatsApp (#591): no detalhe da **Empresa**, nova aba **Chats** com atendimentos filtrados por aquela empresa (busca, paginação, abrir conversa / retomar)
+- WhatsApp (#592): com funcionário em **mais de uma empresa**, o atendimento pode começar sem empresa; o atendente pergunta ao cliente e vincula (ou altera) a qualquer momento antes de encerrar — 1 empresa continua automática
+- WhatsApp (#590): na listagem **Atendimentos**, cada card mostra a **empresa** do contacto (ou «Sem empresa» quando não houver vínculo)
 - WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown (até o aviso e, após o aviso, até encerrar); enviar mensagem sai da pausa automaticamente
 - WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel
 - PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -29,6 +29,7 @@ from app.schemas.whatsapp_chat import (
     WhatsappChatMensagemCreate,
     WhatsappChatRead,
     WhatsappContatoRead,
+    WhatsappEmpresaContextoBody,
     WhatsappIniciarChatBody,
     WhatsappMensagemRead,
     WhatsappTransferirChatBody,
@@ -401,6 +402,33 @@ def _empresas_funcionario(db: Session, func: FuncionarioRede) -> list[WhatsappEm
     return [WhatsappEmpresaOpcaoRead(id=e.id, nome=_empresa_nome_exibicao(e) or e.nome) for e in rows]
 
 
+def _resolver_empresa_contexto_opcional(
+    db: Session,
+    atendente: Atendente,
+    func: FuncionarioRede,
+    empresa_id: int | None,
+) -> int | None:
+    """Resolve empresa de contexto sem bloquear multi-empresa (#592).
+
+    - 1 empresa → usa automaticamente
+    - >1 e sem empresa_id → None (atendente pergunta ao cliente e vincula depois)
+    - empresa_id informado → valida pertencer ao funcionário
+    """
+    emp_ids = empresa_ids_vinculados(db, func, apenas_ativas=True)
+    if not emp_ids:
+        return None
+    if len(emp_ids) == 1:
+        return next(iter(emp_ids))
+    if empresa_id is None:
+        return None
+    if int(empresa_id) not in emp_ids:
+        raise HTTPException(status_code=400, detail="Empresa inválida para este funcionário")
+    emp = db.query(Empresa).filter(Empresa.id == int(empresa_id), Empresa.tenant_id == atendente.tenant_id).first()
+    if not emp:
+        raise HTTPException(status_code=404, detail="Empresa não encontrada")
+    return int(empresa_id)
+
+
 def _resolver_empresa_vinculo(
     db: Session,
     atendente: Atendente,
@@ -423,6 +451,27 @@ def _resolver_empresa_vinculo(
     if not emp:
         raise HTTPException(status_code=404, detail="Empresa não encontrada")
     return emp
+
+
+def _aplicar_empresa_contexto_chat(
+    db: Session,
+    atendente: Atendente,
+    chat: WhatsappChat,
+    empresa_id: int | None,
+    *,
+    apenas_se_vazio: bool = True,
+) -> None:
+    """Define/atualiza chat.empresa_id a partir do funcionário vinculado (#592)."""
+    if apenas_se_vazio and getattr(chat, "empresa_id", None):
+        return
+    func = getattr(chat, "funcionario_rede", None)
+    if func is None and getattr(chat, "funcionario_rede_id", None):
+        func = db.query(FuncionarioRede).filter(FuncionarioRede.id == chat.funcionario_rede_id).first()
+    if not func:
+        return
+    resolvido = _resolver_empresa_contexto_opcional(db, atendente, func, empresa_id)
+    if resolvido is not None:
+        chat.empresa_id = resolvido
 
 
 def _criar_funcionario_rede(
@@ -522,6 +571,7 @@ def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False)
         funcionario_tipo=func.tipo if func else None,
         empresa_id=getattr(c, "empresa_id", None),
         empresa_nome=_empresa_nome_exibicao(emp),
+        empresas_opcoes=_empresas_funcionario(db, func) if func else [],
         inatividade_pausada=bool(getattr(c, "inatividade_pausada", False)),
         inatividade_retomada_em=getattr(c, "inatividade_retomada_em", None),
         classificacao_demanda_pendente=bool(getattr(c, "classificacao_demanda_pendente", False)),
@@ -664,6 +714,7 @@ def listar_encerrados(
     protocolo: str | None = Query(None, description="Filtro por protocolo"),
     wa_id: str | None = Query(None, description="Filtro por número ou WhatsApp ID"),
     atendente_id: int | None = Query(None, ge=1, description="Filtro por atendente que encerrou"),
+    empresa_id: int | None = Query(None, ge=1, description="Filtrar chats desta empresa (#591)"),
     encerramento_inicio: datetime | None = Query(None, description="Filtro por data de encerramento a partir de"),
     encerramento_fim: datetime | None = Query(None, description="Filtro por data de encerramento até"),
     estado: str | None = Query(
@@ -692,6 +743,15 @@ def listar_encerrados(
         )
     if atendente_id:
         q = q.filter(WhatsappChat.atendente_id == atendente_id)
+    if empresa_id is not None:
+        emp = (
+            db.query(Empresa.id)
+            .filter(Empresa.id == empresa_id, Empresa.tenant_id == atendente.tenant_id)
+            .first()
+        )
+        if not emp:
+            return ListaPaginada(items=[], total=0)
+        q = q.filter(WhatsappChat.empresa_id == empresa_id)
     ref_data = func.coalesce(
         WhatsappChat.encerramento_at,
         WhatsappChat.atendimento_inicio_at,
@@ -1019,11 +1079,7 @@ def iniciar_chat_outbound(
 
     empresa_id: int | None = None
     if func is not None:
-        emps = _empresas_funcionario(db, func)
-        if len(emps) == 1:
-            empresa_id = emps[0].id
-        elif getattr(func, "empresa_id", None):
-            empresa_id = int(func.empresa_id)
+        empresa_id = _resolver_empresa_contexto_opcional(db, atendente, func, data.empresa_id)
 
     existente = _chat_aberto_por_wa_id(db, wa_id)
     if existente:
@@ -1039,8 +1095,8 @@ def iniciar_chat_outbound(
             existente.atendimento_inicio_at = datetime.now(timezone.utc)
             if func is not None and not existente.funcionario_rede_id:
                 existente.funcionario_rede_id = func.id
-            if empresa_id is not None and not existente.empresa_id:
-                existente.empresa_id = empresa_id
+            if not existente.empresa_id:
+                _aplicar_empresa_contexto_chat(db, atendente, existente, data.empresa_id)
             audit_whatsapp_chat(
                 db,
                 chat_id=existente.id,
@@ -1051,6 +1107,12 @@ def iniciar_chat_outbound(
             db.commit()
             db.refresh(existente)
             emit_chat_fila_from_model(db, existente, estado_anterior=estado_anterior)
+        elif not existente.empresa_id and (func is not None or existente.funcionario_rede_id):
+            if func is not None and not existente.funcionario_rede_id:
+                existente.funcionario_rede_id = func.id
+            _aplicar_empresa_contexto_chat(db, atendente, existente, data.empresa_id)
+            db.commit()
+            db.refresh(existente)
         msg_init = (data.mensagem_inicial or "").strip()
         if msg_init:
             try:
@@ -1280,6 +1342,11 @@ def excluir_demanda(
 @router.post("/{chat_id}/assumir", response_model=WhatsappChatRead)
 def assumir(
     chat_id: int,
+    empresa_id: int | None = Query(
+        None,
+        ge=1,
+        description="Empresa de contexto opcional (pode ser definida depois na conversa).",
+    ),
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
@@ -1292,6 +1359,7 @@ def assumir(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
     if c.estado != "aguardando_atendente":
         raise HTTPException(status_code=400, detail="Só é possível assumir chats na fila de espera")
+    _aplicar_empresa_contexto_chat(db, atendente, c, empresa_id)
     estado_anterior = c.estado
     c.estado = "em_atendimento"
     c.atendente_id = atendente.id
@@ -1328,6 +1396,32 @@ def assumir(
     c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     assert c is not None
     return _chat_read(db, c)
+
+
+@router.post("/{chat_id}/empresa-contexto", response_model=WhatsappChatRead)
+def definir_empresa_contexto(
+    chat_id: int,
+    data: WhatsappEmpresaContextoBody,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Define ou altera a empresa de contexto a qualquer momento antes do encerramento (#592)."""
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    if c.estado in ("encerrado", "aguardando_avaliacao"):
+        raise HTTPException(status_code=400, detail="Não é possível alterar a empresa após o encerramento")
+    if not c.funcionario_rede_id:
+        raise HTTPException(status_code=400, detail="Chat sem funcionário vinculado")
+    _aplicar_empresa_contexto_chat(db, atendente, c, data.empresa_id, apenas_se_vazio=False)
+    if not c.empresa_id:
+        raise HTTPException(status_code=400, detail="Selecione a empresa do funcionário")
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    return _chat_read(db, c2)
 
 
 @router.post("/{chat_id}/encerrar", response_model=WhatsappChatRead)

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -23,6 +23,11 @@ class WhatsappMensagemRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class WhatsappEmpresaOpcaoRead(BaseModel):
+    id: int
+    nome: str
+
+
 class WhatsappChatRead(BaseModel):
     id: int
     protocolo: str
@@ -46,16 +51,13 @@ class WhatsappChatRead(BaseModel):
     funcionario_tipo: str | None = None
     empresa_id: int | None = None
     empresa_nome: str | None = None
+    # Empresas do funcionário vinculado — útil quando falta empresa_id de contexto (#592).
+    empresas_opcoes: list[WhatsappEmpresaOpcaoRead] = Field(default_factory=list)
     inatividade_pausada: bool = False
     inatividade_retomada_em: datetime | None = None
     classificacao_demanda_pendente: bool = False
 
     model_config = {"from_attributes": True}
-
-
-class WhatsappEmpresaOpcaoRead(BaseModel):
-    id: int
-    nome: str
 
 
 class WhatsappEmpresaCatalogoRead(BaseModel):
@@ -93,6 +95,10 @@ class WhatsappIniciarChatBody(BaseModel):
         description="Número WhatsApp (dígitos). Obrigatório se funcionário sem telefone ou número avulso.",
     )
     mensagem_inicial: str | None = Field(None, max_length=4000)
+    empresa_id: int | None = Field(
+        None,
+        description="Empresa de contexto opcional. Com >1 empresas, pode ficar em branco e ser definida depois na conversa.",
+    )
 
     @field_validator("telefone", mode="before")
     @classmethod
@@ -101,6 +107,10 @@ class WhatsappIniciarChatBody(BaseModel):
             return None
         digits = "".join(ch for ch in str(v) if ch.isdigit())
         return digits or None
+
+
+class WhatsappEmpresaContextoBody(BaseModel):
+    empresa_id: int = Field(..., ge=1, description="Empresa de contexto do atendimento")
 
 
 class WhatsappRedeCatalogoRead(BaseModel):

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -445,6 +445,97 @@ def test_vincular_funcionario_no_chat(client, seed_base, auth_headers, db_sessio
     assert get_r.json()["funcionario_rede_id"] == func["id"]
 
 
+def test_encerrados_inclui_empresa_nome(client, seed_base, auth_headers, db_session):
+    """#590 — listagem Atendimentos deve serializar empresa_nome do chat."""
+    func = _criar_funcionario_colaborador(db_session, seed_base, email="hist-emp@test.local")
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999445566", msg_id="hist-emp-1")
+    client.post(
+        f"/v1/whatsapp/chats/{cid}/vincular-funcionario",
+        json={"funcionario_rede_id": func["id"]},
+        headers=auth_headers["a1"],
+    )
+    client.post(f"/v1/whatsapp/chats/{cid}/encerrar", headers=auth_headers["a1"])
+
+    hist = client.get("/v1/whatsapp/chats/encerrados", headers=auth_headers["admin"]).json()
+    item = next(x for x in hist["items"] if x["id"] == cid)
+    assert item["empresa_id"] == seed_base["empresa"].id
+    assert item["empresa_nome"]
+
+
+def test_encerrados_filtra_por_empresa_id(client, seed_base, auth_headers, db_session):
+    """#591 — filtro empresa_id isola chats de outras empresas."""
+    from app.models.empresa import Empresa
+    from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
+    from app.models.whatsapp_chat import WhatsappChat
+
+    emp_a = seed_base["empresa"]
+    emp_b = Empresa(tenant_id=1, rede_id=emp_a.rede_id, nome="Empresa Isolamento B", ativo=True)
+    db_session.add(emp_b)
+    db_session.flush()
+
+    fa = FuncionarioRede(
+        nome="Func A",
+        email="func.a.iso@test.local",
+        tipo="colaborador",
+        escopo_empresas="selected",
+        ativo=True,
+        rede_id=emp_a.rede_id,
+        empresa_id=emp_a.id,
+    )
+    fb = FuncionarioRede(
+        nome="Func B",
+        email="func.b.iso@test.local",
+        tipo="colaborador",
+        escopo_empresas="selected",
+        ativo=True,
+        rede_id=emp_a.rede_id,
+        empresa_id=emp_b.id,
+    )
+    db_session.add_all([fa, fb])
+    db_session.flush()
+    db_session.add(FuncionarioRedeEmpresa(funcionario_id=fa.id, empresa_id=emp_a.id))
+    db_session.add(FuncionarioRedeEmpresa(funcionario_id=fb.id, empresa_id=emp_b.id))
+    db_session.commit()
+
+    cid_a = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999110001", msg_id="iso-a-1")
+    client.post(
+        f"/v1/whatsapp/chats/{cid_a}/vincular-funcionario",
+        json={"funcionario_rede_id": fa.id, "empresa_id": emp_a.id},
+        headers=auth_headers["a1"],
+    )
+    client.post(f"/v1/whatsapp/chats/{cid_a}/encerrar", headers=auth_headers["a1"])
+
+    cid_b = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999110002", msg_id="iso-b-1")
+    client.post(
+        f"/v1/whatsapp/chats/{cid_b}/vincular-funcionario",
+        json={"funcionario_rede_id": fb.id, "empresa_id": emp_b.id},
+        headers=auth_headers["a1"],
+    )
+    client.post(f"/v1/whatsapp/chats/{cid_b}/encerrar", headers=auth_headers["a1"])
+
+    # Garante empresa_id no banco (fallback se vínculo legado)
+    for cid, eid in ((cid_a, emp_a.id), (cid_b, emp_b.id)):
+        chat = db_session.query(WhatsappChat).filter(WhatsappChat.id == cid).first()
+        chat.empresa_id = eid
+    db_session.commit()
+
+    only_a = client.get(
+        f"/v1/whatsapp/chats/encerrados?empresa_id={emp_a.id}&estado=todos",
+        headers=auth_headers["admin"],
+    ).json()
+    ids_a = {x["id"] for x in only_a["items"]}
+    assert cid_a in ids_a
+    assert cid_b not in ids_a
+
+    only_b = client.get(
+        f"/v1/whatsapp/chats/encerrados?empresa_id={emp_b.id}&estado=todos",
+        headers=auth_headers["admin"],
+    ).json()
+    ids_b = {x["id"] for x in only_b["items"]}
+    assert cid_b in ids_b
+    assert cid_a not in ids_b
+
+
 def test_buscar_funcionarios_whatsapp(client, seed_base, auth_headers, db_session):
     func = _criar_funcionario_colaborador(db_session, seed_base, nome="Maria Silva", email="maria@test.local")
     r = client.get("/v1/whatsapp/chats/funcionarios?busca=Maria", headers=auth_headers["a1"])
@@ -946,3 +1037,137 @@ def test_iniciar_chat_funcionario_sem_telefone_exige_numero(client, seed_base, a
     f = db_session.query(FuncionarioRede).filter(FuncionarioRede.id == func["id"]).first()
     db_session.refresh(f)
     assert f.telefone == "5511999000033"
+
+
+def _criar_funcionario_multi_empresa(db_session, seed_base, *, email="multi.emp@test.local"):
+    from app.models.empresa import Empresa
+    from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
+
+    emp = seed_base["empresa"]
+    e2 = Empresa(tenant_id=1, rede_id=emp.rede_id, nome="Empresa Filial B", ativo=True)
+    db_session.add(e2)
+    db_session.flush()
+    f = FuncionarioRede(
+        nome="Multi Empresa",
+        email=email,
+        tipo="colaborador",
+        escopo_empresas="selected",
+        ativo=True,
+        rede_id=emp.rede_id,
+        empresa_id=emp.id,
+        telefone="5511999000099",
+    )
+    db_session.add(f)
+    db_session.flush()
+    db_session.add(FuncionarioRedeEmpresa(funcionario_id=f.id, empresa_id=emp.id))
+    db_session.add(FuncionarioRedeEmpresa(funcionario_id=f.id, empresa_id=e2.id))
+    db_session.commit()
+    db_session.refresh(f)
+    db_session.refresh(e2)
+    return {"id": f.id, "empresa_a": emp.id, "empresa_b": e2.id, "telefone": f.telefone}
+
+
+def test_iniciar_chat_1_empresa_auto(client, seed_base, auth_headers, db_session, monkeypatch):
+    """#592 — funcionário com 1 empresa: inicia sem empresa_id no body."""
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out"),
+    )
+    _evolution_settings(client, auth_headers, "iniciar-1emp")
+    func = _criar_funcionario_colaborador(db_session, seed_base, email="um.emp@test.local")
+    from app.models.funcionario_rede import FuncionarioRede
+
+    f = db_session.query(FuncionarioRede).filter(FuncionarioRede.id == func["id"]).first()
+    f.telefone = "5511999000044"
+    db_session.commit()
+
+    r = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"funcionario_id": func["id"]},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["empresa_id"] == seed_base["empresa"].id
+    assert body["empresa_nome"]
+
+
+def test_iniciar_chat_multi_empresa_permite_sem_empresa_id(client, seed_base, auth_headers, db_session, monkeypatch):
+    """#592 — >1 empresas: pode iniciar sem empresa_id e definir depois; inválida → 400."""
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out"),
+    )
+    _evolution_settings(client, auth_headers, "iniciar-multi")
+    multi = _criar_funcionario_multi_empresa(db_session, seed_base)
+
+    sem = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"funcionario_id": multi["id"]},
+        headers=auth_headers["a1"],
+    )
+    assert sem.status_code == 200
+    body = sem.json()
+    assert body["empresa_id"] is None
+    assert body["funcionario_rede_id"] == multi["id"]
+    assert len(body.get("empresas_opcoes") or []) >= 2
+
+    invalid = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"funcionario_id": multi["id"], "telefone": "5511999000077", "empresa_id": 999999},
+        headers=auth_headers["a1"],
+    )
+    assert invalid.status_code == 400
+
+    ok = client.post(
+        f"/v1/whatsapp/chats/{body['id']}/empresa-contexto",
+        json={"empresa_id": multi["empresa_b"]},
+        headers=auth_headers["a1"],
+    )
+    assert ok.status_code == 200
+    assert ok.json()["empresa_id"] == multi["empresa_b"]
+
+    # Pode alterar enquanto não encerrado
+    trocou = client.post(
+        f"/v1/whatsapp/chats/{body['id']}/empresa-contexto",
+        json={"empresa_id": multi["empresa_a"]},
+        headers=auth_headers["a1"],
+    )
+    assert trocou.status_code == 200
+    assert trocou.json()["empresa_id"] == multi["empresa_a"]
+
+
+def test_assumir_multi_empresa_sem_bloquear(client, seed_base, auth_headers, db_session):
+    """#592 — assumir multi-empresa sem empresa_id é permitido; contexto fica para depois."""
+    multi = _criar_funcionario_multi_empresa(db_session, seed_base, email="assumir.multi@test.local")
+    from app.models.whatsapp_chat import WhatsappChat
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "assumir-multi"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "assumir-multi"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511999000088", msg_id="assumir-multi-1"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    chat = db_session.query(WhatsappChat).filter(WhatsappChat.id == cid).first()
+    chat.funcionario_rede_id = multi["id"]
+    chat.empresa_id = None
+    db_session.commit()
+
+    ok = client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    assert ok.status_code == 200
+    assert ok.json()["empresa_id"] is None
+    assert ok.json()["estado"] == "em_atendimento"
+
+    ctx = client.post(
+        f"/v1/whatsapp/chats/{cid}/empresa-contexto",
+        json={"empresa_id": multi["empresa_a"]},
+        headers=auth_headers["a1"],
+    )
+    assert ctx.status_code == 200
+    assert ctx.json()["empresa_id"] == multi["empresa_a"]

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -899,6 +899,7 @@ export namespace WhatsappChats {
     funcionario_tipo?: string | null
     empresa_id?: number | null
     empresa_nome?: string | null
+    empresas_opcoes?: EmpresaOpcao[]
   inatividade_pausada?: boolean
   inatividade_retomada_em?: string | null
   classificacao_demanda_pendente?: boolean
@@ -1140,6 +1141,7 @@ export const whatsappChats = {
     funcionario_id?: number | null
     telefone?: string | null
     mensagem_inicial?: string | null
+    empresa_id?: number | null
   }) =>
     api<WhatsappChats.Chat>('/whatsapp/chats/iniciar', {
       method: 'POST',
@@ -1164,7 +1166,18 @@ export const whatsappChats = {
       method: 'PATCH',
       body: JSON.stringify(data),
     }),
-  assumir: (id: number) => api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/assumir`, { method: 'POST' }),
+  assumir: (id: number, data?: { empresa_id?: number | null }) => {
+    const qs =
+      data?.empresa_id != null && data.empresa_id !== undefined
+        ? `?empresa_id=${encodeURIComponent(String(data.empresa_id))}`
+        : ''
+    return api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/assumir${qs}`, { method: 'POST' })
+  },
+  definirEmpresaContexto: (id: number, empresa_id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/empresa-contexto`, {
+      method: 'POST',
+      body: JSON.stringify({ empresa_id }),
+    }),
   encerrar: (id: number) => api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/encerrar`, { method: 'POST' }),
   transferir: (id: number, data: { setor_id: number; atendente_id?: number | null }) =>
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/transferir`, { method: 'POST', body: JSON.stringify(data) }),

--- a/frontend/src/components/EmpresaChatsPanel.tsx
+++ b/frontend/src/components/EmpresaChatsPanel.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { whatsappChats, type WhatsappChats } from '../api/client'
+import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from './ui/BarraBuscaPaginacao'
+import { Card } from './ui/Card'
+import { Button } from './ui/Button'
+import { AvaliacaoEstrelas } from './ui/AvaliacaoEstrelas'
+import { useToast } from './ui/Toast'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { exibirProtocolo } from '../lib/exibirProtocolo'
+import { rotuloEstadoChat } from '../lib/whatsappChatMeta'
+import { whatsappConversaLink } from '../lib/whatsappListReturn'
+import { ChatIniciarConversaModal } from './chat/ChatIniciarConversaModal'
+
+type Props = {
+  empresaId: number
+}
+
+function formatDuration(chat: WhatsappChats.Chat) {
+  if (!chat.atendimento_inicio_at) return '—'
+  if (!chat.encerramento_at) return 'Em curso'
+  const start = new Date(chat.atendimento_inicio_at)
+  const end = new Date(chat.encerramento_at)
+  const diff = Math.max(0, Math.round((end.getTime() - start.getTime()) / 1000))
+  const minutes = Math.floor(diff / 60)
+  if (minutes < 60) return `${minutes} min`
+  const hours = Math.floor(minutes / 60)
+  const remain = minutes % 60
+  return `${hours}h ${remain}m`
+}
+
+function formatDateTime(iso?: string | null) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function EmpresaChatsPanel({ empresaId }: Props) {
+  const toast = useToast()
+  const [page, setPage] = useState(1)
+  const [busca, setBusca] = useState('')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+  const [items, setItems] = useState<WhatsappChats.Chat[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(false)
+  const [retomarChat, setRetomarChat] = useState<WhatsappChats.Chat | null>(null)
+
+  const returnPath = `/empresas/${empresaId}`
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
+    return () => clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    whatsappChats
+      .encerrados({
+        empresa_id: empresaId,
+        estado: 'todos',
+        offset: (page - 1) * PAGE_SIZE_PADRAO,
+        limit: PAGE_SIZE_PADRAO,
+        busca: debouncedBusca || undefined,
+      })
+      .then(({ items: rows, total: t }) => {
+        if (!cancelled) {
+          setItems(rows)
+          setTotal(t)
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          toast.showError(mensagemFalhaParaToast(err, 'Falha ao carregar chats da empresa.'))
+          setItems([])
+          setTotal(0)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [empresaId, page, debouncedBusca, toast])
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-slate-500 dark:text-slate-400">
+        Chats e atendimentos WhatsApp vinculados a esta empresa.
+      </p>
+      <BarraBuscaPaginacao
+        busca={busca}
+        onBuscaChange={(v) => {
+          setBusca(v)
+          setPage(1)
+        }}
+        placeholder="Protocolo, telefone ou nome…"
+        page={page}
+        total={total}
+        onPageChange={setPage}
+        disabled={loading}
+      />
+
+      {loading && items.length === 0 ? (
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-20 w-full animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <Card className="flex flex-col items-center justify-center border-dashed border-2 py-14 text-center">
+          <h3 className="font-semibold text-slate-900 dark:text-slate-100">Nenhum chat nesta empresa</h3>
+          <p className="mt-1 text-sm text-slate-500">
+            Quando houver atendimentos com esta empresa de contexto, eles aparecem aqui.
+          </p>
+        </Card>
+      ) : (
+        <div className="grid gap-3">
+          {items.map((c) => (
+            <Card
+              key={c.id}
+              className="group border-none p-4 shadow-sm ring-1 ring-slate-200 transition-all hover:ring-cyan-500/50 dark:ring-slate-800"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <div className="flex min-w-[220px] flex-1 items-center gap-4">
+                  <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-slate-50 text-slate-400 transition-colors group-hover:bg-cyan-50 group-hover:text-cyan-600 dark:bg-slate-900 dark:group-hover:bg-cyan-900/20">
+                    <span className="text-sm font-bold">{c.cliente_nome?.charAt(0).toUpperCase() || 'C'}</span>
+                  </div>
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">
+                        {c.cliente_nome || 'Cliente'}
+                      </h3>
+                      <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                        {rotuloEstadoChat(c.estado)}
+                      </span>
+                      <span className="font-mono text-[10px] font-bold text-slate-400">{c.wa_id}</span>
+                    </div>
+                    <p
+                      className="truncate font-mono text-xs font-bold text-cyan-600 dark:text-cyan-400"
+                      title={exibirProtocolo(c.protocolo)}
+                    >
+                      {exibirProtocolo(c.protocolo)}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="hidden text-right sm:block">
+                    <p className="text-[10px] font-bold uppercase tracking-tight text-slate-400">Atendido por</p>
+                    <p className="text-xs font-medium text-slate-700 dark:text-slate-300">
+                      {c.atendente_nome || 'Sistema'}
+                    </p>
+                  </div>
+                  <div className="grid gap-1.5 text-right">
+                    <div>
+                      <p className="text-[10px] font-bold uppercase tracking-tight text-slate-400">Início</p>
+                      <p className="text-xs font-medium text-slate-700 dark:text-slate-300">
+                        {formatDateTime(c.atendimento_inicio_at)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-[10px] font-bold uppercase tracking-tight text-slate-400">Finalizado em</p>
+                      <p className="text-xs font-medium text-slate-700 dark:text-slate-300">
+                        {formatDateTime(c.encerramento_at)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-[10px] font-bold uppercase tracking-tight text-slate-400">Duração</p>
+                      <p className="text-xs font-medium text-slate-700 dark:text-slate-300">{formatDuration(c)}</p>
+                    </div>
+                    <div>
+                      <p className="text-[10px] font-bold uppercase tracking-tight text-slate-400">Avaliação</p>
+                      <div className="flex justify-end">
+                        <AvaliacaoEstrelas chat={c} size="sm" />
+                      </div>
+                    </div>
+                  </div>
+                  <Link
+                    to={whatsappConversaLink(c.id, returnPath)}
+                    className="rounded-full bg-slate-100 p-2 text-slate-400 transition-all hover:bg-cyan-600 hover:text-white dark:bg-slate-800 dark:hover:bg-cyan-700"
+                    title="Ver conversa"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M5 12h14" />
+                      <path d="m12 5 7 7-7 7" />
+                    </svg>
+                  </Link>
+                  {(c.estado === 'encerrado' || c.estado === 'aguardando_avaliacao') && (
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="h-9 px-3 text-xs"
+                      onClick={() => setRetomarChat(c)}
+                    >
+                      Retomar contacto
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <ChatIniciarConversaModal
+        open={retomarChat != null}
+        onClose={() => setRetomarChat(null)}
+        telefoneInicial={retomarChat?.wa_id}
+        funcionarioId={retomarChat?.funcionario_rede_id}
+        empresas={retomarChat?.empresas_opcoes}
+        titulo={retomarChat ? `Retomar ${retomarChat.cliente_nome || retomarChat.wa_id}` : undefined}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/chat/ChatIniciarConversaModal.tsx
+++ b/frontend/src/components/chat/ChatIniciarConversaModal.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { whatsappChats, type WhatsappChats } from '../../api/client'
 import { Button } from '../../components/ui/Button'
 import { Input, TEXTAREA_FIELD_CLASS } from '../../components/ui/Input'
+import { Select } from '../../components/ui/Select'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { chatWhatsappLink } from '../../lib/chatHubPaths'
@@ -14,6 +15,8 @@ type Props = {
   /** Número pré-preenchido (retomar / avulso) */
   telefoneInicial?: string | null
   funcionarioId?: number | null
+  /** Empresas do funcionário (retomar histórico / chat com vínculo) */
+  empresas?: WhatsappChats.EmpresaOpcao[] | null
   titulo?: string
 }
 
@@ -23,21 +26,35 @@ export function ChatIniciarConversaModal({
   contato,
   telefoneInicial,
   funcionarioId,
+  empresas,
   titulo,
 }: Props) {
   const toast = useToast()
   const navigate = useNavigate()
   const [telefone, setTelefone] = useState('')
   const [mensagem, setMensagem] = useState('')
+  const [empresaId, setEmpresaId] = useState<number | ''>('')
   const [salvando, setSalvando] = useState(false)
 
+  const empresasLista = useMemo(() => {
+    if (contato?.empresas?.length) return contato.empresas
+    if (empresas?.length) return empresas
+    return []
+  }, [contato, empresas])
+
+  const multiEmpresa = empresasLista.length > 1
   const precisaTelefone = !(contato?.telefone || telefoneInicial)
 
   useEffect(() => {
     if (!open) return
     setTelefone(contato?.telefone || telefoneInicial || '')
     setMensagem('')
-  }, [open, contato, telefoneInicial])
+    if (empresasLista.length === 1) {
+      setEmpresaId(empresasLista[0].id)
+    } else {
+      setEmpresaId('')
+    }
+  }, [open, contato, telefoneInicial, empresasLista])
 
   if (!open) return null
 
@@ -58,6 +75,7 @@ export function ChatIniciarConversaModal({
         funcionario_id: fid ?? undefined,
         telefone: digits || undefined,
         mensagem_inicial: mensagem.trim() || undefined,
+        empresa_id: empresaId === '' ? undefined : Number(empresaId),
       })
       onClose()
       navigate(chatWhatsappLink(chat.id, 'contatos'))
@@ -93,6 +111,23 @@ export function ChatIniciarConversaModal({
             onChange={(e) => setTelefone(e.target.value)}
             placeholder="5511999999999"
           />
+          {multiEmpresa && (
+            <div className="space-y-1">
+              <Select
+                label="Empresa do atendimento (opcional)"
+                value={empresaId}
+                onChange={(value) => setEmpresaId(value === '' ? '' : Number(value))}
+                options={empresasLista.map((e) => ({ value: e.id, label: e.nome }))}
+                placeholder="Definir depois na conversa"
+                includeEmpty
+                emptyLabel="Definir depois na conversa"
+              />
+              <p className="text-[11px] text-slate-500">
+                Se ainda não souber, pergunte ao cliente na conversa e vincule a empresa a qualquer
+                momento antes de encerrar.
+              </p>
+            </div>
+          )}
           <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
             Mensagem inicial (opcional)
             <textarea

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -22,8 +22,9 @@ import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { TicketsTabelaContexto } from '../components/TicketsTabelaContexto'
 import { FuncionariosEmpresaLista } from '../components/FuncionariosEmpresaLista'
 import { EmpresaPdvsPanel } from '../components/EmpresaPdvsPanel'
+import { EmpresaChatsPanel } from '../components/EmpresaChatsPanel'
 import { SemPermissao } from './SemPermissao'
-type Aba = 'geral' | 'tickets' | 'funcionarios' | 'pdvs'
+type Aba = 'geral' | 'tickets' | 'chats' | 'funcionarios' | 'pdvs'
 
 function DetailRow({ label, value }: { label: string; value: string | null | undefined }) {
   const v = value?.trim()
@@ -313,6 +314,7 @@ export function EmpresaDetalhe() {
           <nav className="flex flex-wrap gap-1 sm:gap-2" aria-label="Seções da empresa">
             {tabBtn('geral', 'Geral')}
             {tabBtn('tickets', 'Tickets')}
+            {tabBtn('chats', 'Chats')}
             {tabBtn('funcionarios', 'Funcionários')}
             {tabBtn('pdvs', 'PDVs')}
           </nav>
@@ -434,6 +436,12 @@ export function EmpresaDetalhe() {
             showEmpresaColumn={false}
             emptyMessage="Nenhum ticket para esta empresa."
           />
+        </section>
+      )}
+
+      {aba === 'chats' && (
+        <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-800/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7">
+          <EmpresaChatsPanel empresaId={empresa.id} />
         </section>
       )}
 

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -182,6 +182,11 @@ export function WhatsappAtendendo() {
                           {c.cliente_nome || 'Cliente'}
                         </h3>
                         <p className="font-mono text-xs text-slate-500">{c.wa_id}</p>
+                        {c.empresa_nome && (
+                          <p className="mt-1 truncate text-[10px] font-medium text-slate-500 dark:text-slate-400">
+                            {c.empresa_nome}
+                          </p>
+                        )}
                         {c.setor_nome && (
                           <p className="mt-1 text-[10px] font-medium text-slate-500 dark:text-slate-400">
                             Setor {c.setor_nome}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -294,6 +294,9 @@ export function WhatsappConversa() {
   const [transferAtendenteId, setTransferAtendenteId] = useState<number | ''>('')
   const [transferindo, setTransferindo] = useState(false)
   const [modalVincFuncionario, setModalVincFuncionario] = useState(false)
+  const [modalEmpresaContexto, setModalEmpresaContexto] = useState(false)
+  const [empresaContextoId, setEmpresaContextoId] = useState<number | ''>('')
+  const [salvandoEmpresaContexto, setSalvandoEmpresaContexto] = useState(false)
 
   const [setoresList, setSetoresList] = useState<Setores.Setor[]>([])
   const [atendentesDestino, setAtendentesDestino] = useState<Atendentes.Atendente[]>([])
@@ -535,6 +538,25 @@ export function WhatsappConversa() {
       setModoInterno(true)
     } else {
       setModoInterno(false)
+    }
+  }, [chat, user?.id])
+
+  useEffect(() => {
+    // 1 empresa e ainda sem contexto: preenche automaticamente sem bloquear o atendimento
+    if (!chat || !user?.id) return
+    if (chat.atendente_id !== user.id || chat.estado !== 'em_atendimento') return
+    if (chat.empresa_id) return
+    const opcoes = chat.empresas_opcoes || []
+    if (opcoes.length !== 1) return
+    let cancelled = false
+    void whatsappChats
+      .definirEmpresaContexto(chat.id, opcoes[0].id)
+      .then((atualizado) => {
+        if (!cancelled) setChat((prev) => mergeWhatsappChat(prev, atualizado))
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
     }
   }, [chat, user?.id])
 
@@ -856,6 +878,31 @@ useEffect(() => {
     )
   }
 
+  async function confirmarEmpresaContexto() {
+    if (!chat || empresaContextoId === '') {
+      toast.showWarning('Selecione a empresa do atendimento.')
+      return
+    }
+    setSalvandoEmpresaContexto(true)
+    try {
+      const atualizado = await whatsappChats.definirEmpresaContexto(chat.id, Number(empresaContextoId))
+      setChat((prev) => mergeWhatsappChat(prev, atualizado))
+      setModalEmpresaContexto(false)
+      setEmpresaContextoId('')
+      toast.showSuccess('Empresa do atendimento definida.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível definir a empresa.'))
+    } finally {
+      setSalvandoEmpresaContexto(false)
+    }
+  }
+
+  function abrirModalEmpresaContexto() {
+    if (!chat) return
+    setEmpresaContextoId(chat.empresa_id ?? '')
+    setModalEmpresaContexto(true)
+  }
+
 
 
   if (loading && !chat) return <div className="flex h-full items-center justify-center italic text-slate-400">Carregando workspace...</div>
@@ -876,6 +923,15 @@ useEffect(() => {
     !chat?.classificacao_demanda_pendente
 
   const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && (isResponsavel || isAdmin)
+
+  const podeDefinirEmpresa =
+    !encerrado &&
+    Boolean(chat?.funcionario_rede_id) &&
+    (chat?.empresas_opcoes?.length ?? 0) > 0 &&
+    (isResponsavel || isAdmin)
+
+  const precisaEmpresaContexto =
+    podeDefinirEmpresa && !chat?.empresa_id && (chat?.empresas_opcoes?.length ?? 0) > 1
 
   const mostrarBannerDemandaInatividade =
     Boolean(chat?.classificacao_demanda_pendente) && (isResponsavel || isAdmin)
@@ -1099,9 +1155,32 @@ useEffect(() => {
                     {chat.funcionario_nome}
                     {chat.funcionario_tipo ? ` · ${chat.funcionario_tipo}` : ''}
                   </Link>
-                  {chat.empresa_nome && (
-                    <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
-                      {chat.empresa_nome}
+                  {chat.empresa_nome ? (
+                    podeDefinirEmpresa && (chat.empresas_opcoes?.length ?? 0) > 1 ? (
+                      <button
+                        type="button"
+                        onClick={abrirModalEmpresaContexto}
+                        className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 transition-colors hover:border-cyan-400 hover:text-cyan-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300"
+                        title="Alterar empresa do atendimento"
+                      >
+                        {chat.empresa_nome}
+                      </button>
+                    ) : (
+                      <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+                        {chat.empresa_nome}
+                      </span>
+                    )
+                  ) : podeDefinirEmpresa ? (
+                    <button
+                      type="button"
+                      onClick={abrirModalEmpresaContexto}
+                      className="inline-flex rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-800 transition-colors hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+                    >
+                      Definir empresa
+                    </button>
+                  ) : (
+                    <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+                      Sem empresa
                     </span>
                   )}
                 </div>
@@ -1178,6 +1257,19 @@ useEffect(() => {
             <p>{CONTATO_CLIENTE.bannerNaoVinculado}</p>
             <Button variant="primary" className="h-8 shrink-0 text-xs" onClick={() => setModalVincFuncionario(true)}>
               {CONTATO_CLIENTE.vincularEmpresa}
+            </Button>
+          </div>
+        )}
+
+        {precisaEmpresaContexto && (
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100">
+            <p>
+              Este contacto pertence a mais de uma empresa. Pergunte ao cliente qual empresa deseja
+              atendimento e vincule quando souber — pode fazer isso a qualquer momento antes de
+              encerrar.
+            </p>
+            <Button variant="primary" className="h-8 shrink-0 text-xs" onClick={abrirModalEmpresaContexto}>
+              Definir empresa
             </Button>
           </div>
         )}
@@ -1577,6 +1669,57 @@ useEffect(() => {
             onClose={() => setModalVincFuncionario(false)}
             onSuccess={aplicarChatAtualizado}
           />
+        )}
+
+        {modalEmpresaContexto && chat && (
+          <div className="fixed inset-0 z-[120] flex items-end justify-center bg-black/50 p-4 sm:items-center">
+            <div
+              className="w-full max-w-md rounded-2xl bg-white p-5 shadow-xl dark:bg-slate-900"
+              role="dialog"
+              aria-modal
+              aria-labelledby="empresa-contexto-titulo"
+            >
+              <h2 id="empresa-contexto-titulo" className="text-lg font-bold text-slate-900 dark:text-white">
+                Empresa do atendimento
+              </h2>
+              <p className="mt-1 text-sm text-slate-500">
+                Vincule a empresa que o cliente indicou. Pode alterar enquanto o chat não estiver
+                encerrado.
+              </p>
+              <div className="mt-4">
+                <Select
+                  label="Empresa"
+                  value={empresaContextoId}
+                  onChange={(value) => setEmpresaContextoId(value === '' ? '' : Number(value))}
+                  options={(chat.empresas_opcoes || []).map((e) => ({ value: e.id, label: e.nome }))}
+                  placeholder="Selecione a empresa"
+                  includeEmpty
+                  emptyLabel="Selecione a empresa"
+                />
+              </div>
+              <div className="mt-5 flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  disabled={salvandoEmpresaContexto}
+                  onClick={() => {
+                    setModalEmpresaContexto(false)
+                    setEmpresaContextoId('')
+                  }}
+                >
+                  Cancelar
+                </Button>
+                <Button
+                  type="button"
+                  loading={salvandoEmpresaContexto}
+                  disabled={empresaContextoId === ''}
+                  onClick={() => void confirmarEmpresaContexto()}
+                >
+                  Confirmar
+                </Button>
+              </div>
+            </div>
+          </div>
         )}
 
       {chat && (

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -230,6 +230,12 @@ export function WhatsappHistorico() {
                       >
                         {exibirProtocolo(c.protocolo)}
                       </p>
+                      <p
+                        className="truncate text-xs text-slate-500 dark:text-slate-400"
+                        title={c.empresa_nome || 'Sem empresa'}
+                      >
+                        {c.empresa_nome || 'Sem empresa'}
+                      </p>
                     </div>
                   </div>
 
@@ -296,6 +302,7 @@ export function WhatsappHistorico() {
         onClose={() => setRetomarChat(null)}
         telefoneInicial={retomarChat?.wa_id}
         funcionarioId={retomarChat?.funcionario_rede_id}
+        empresas={retomarChat?.empresas_opcoes}
         titulo={retomarChat ? `Retomar ${retomarChat.cliente_nome || retomarChat.wa_id}` : undefined}
       />
 


### PR DESCRIPTION
﻿## Summary
- WhatsApp (#590): listagem Atendimentos mostra a empresa do contacto
- WhatsApp (#592): multi-empresa — atendimento pode começar sem empresa; vincular/alterar na conversa a qualquer momento antes de encerrar
- WhatsApp (#591): aba Chats no detalhe da Empresa com filtro por empresa_id

## CHANGELOG
- [x] Atualizado em `[Unreleased]` (ou N/A se não aplicável)

## Test plan
- [x] pytest: test_encerrados_inclui_empresa_nome, test_encerrados_filtra_por_empresa_id, test_iniciar_chat_1_empresa_auto, test_iniciar_chat_multi_empresa_permite_sem_empresa_id, test_assumir_multi_empresa_sem_bloquear
- [ ] UI: Atendimentos exibe empresa / Sem empresa
- [ ] UI: chat multi-empresa — assumir sem empresa, banner Definir empresa, vincular após cliente informar, alterar antes de encerrar
- [ ] UI: Empresa → aba Chats lista só daquela empresa; vazio claro; abrir/retomar

## Follow-ups
- #593 sugestão nome similar (fora deste lote)
- #594/#595 análises (dependem / relacionadas)

Closes #590
Closes #591
Closes #592
