### PR TITLE
feat(chat): hub Atendendo e UX mobile WhatsApp (#607, #606)

### DIFF
--- a/.cursor/commands/iniciar-feature.md
+++ b/.cursor/commands/iniciar-feature.md
@@ -8,6 +8,10 @@ Peça se não informado:
 - número/link da issue **ou** slug da feature
 - tipo: `feat` (padrão), `fix`, `chore`, `docs`
 
+## Quando usar (obrigatório)
+
+Após um lote ser **mergeado na `main`** para testes, o próximo trabalho **sempre** começa com este comando (branch nova). Não reutilize a branch já mergeada.
+
 ## Passo 1 — Verificar estado
 
 ```bash

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -9,9 +9,19 @@ alwaysApply: true
 
 - **Nunca** implementar direto em `main` ou `staging`
 - **Sempre** criar branch nova antes de codar
-- **Uma feature = uma branch = um PR** para `main`
+- **Uma feature/lote = uma branch = um PR** para `main`
 - `main` é **branch de testes** — `/criar-pr` mergeia automaticamente após CI verde
 - Não push direto em `main` (sempre via PR)
+
+## Após merge na `main` (obrigatório)
+
+Quando o PR do lote for **mergeado** e o desenvolvimento daquele lote estiver **fechado para testes** na `main`:
+
+1. **Não** continuar a codar na branch já mergeada (ex.: `cursor/…`, `feat/portal-…`)
+2. **Sempre** abrir **branch nova** a partir de `main` atualizada antes do próximo trabalho
+3. Usar `/iniciar-feature` (ou o fluxo abaixo) — mesmo se o próximo lote for “só polish” ou issues pequenas
+
+Exceção: hotfix urgente na mesma linha só se o PR ainda **não** tiver sido mergeado.
 
 ## Nomenclatura de branch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homónimos
 - WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos
 - WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede
+- Chat (#607): na aba **Atendendo**, secções **Comigo** e **Outros atendentes** quando o admin acompanha colegas; badge «Você» e destaque visual nos seus; nome do responsável legível nos de outros
+- WhatsApp (#606): conversa mais utilizável no **mobile** — composer com campo largo e botão de manuais só ícone; menu **⋮** com Transferir/Tickets; metadados em linha separada; painel de demandas colapsável; `safe-area` no composer
 
 ### Correções
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1720,7 +1720,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/src/components/KbConsultaModal.tsx
+++ b/frontend/src/components/KbConsultaModal.tsx
@@ -56,10 +56,54 @@ export function KbConsultaModal({ open, onClose, onInserirReferencia, disabled }
 type ButtonProps = {
   disabled?: boolean
   onInserirReferencia?: (texto: string) => void
+  /** Barra do composer WhatsApp — botão redondo; só ícone */
+  modoComposer?: boolean
 }
 
-export function KbConsultaButton({ disabled, onInserirReferencia }: ButtonProps) {
+export function KbConsultaButton({ disabled, onInserirReferencia, modoComposer }: ButtonProps) {
   const [open, setOpen] = useState(false)
+
+  const icon = (
+    <svg className="size-5 shrink-0 sm:size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+      />
+    </svg>
+  )
+
+  if (modoComposer) {
+    return (
+      <>
+        <button
+          type="button"
+          disabled={disabled}
+          aria-label="Consultar manuais"
+          title="Consultar manuais"
+          onClick={() => setOpen(true)}
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-slate-600 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-40 dark:text-slate-300 dark:hover:bg-slate-800"
+        >
+          {icon}
+        </button>
+        <KbConsultaModal
+          open={open}
+          onClose={() => setOpen(false)}
+          onInserirReferencia={
+            onInserirReferencia
+              ? (texto) => {
+                  onInserirReferencia(texto)
+                  setOpen(false)
+                }
+              : undefined
+          }
+          disabled={disabled}
+        />
+      </>
+    )
+  }
+
   return (
     <>
       <Button
@@ -69,15 +113,9 @@ export function KbConsultaButton({ disabled, onInserirReferencia }: ButtonProps)
         onClick={() => setOpen(true)}
         className="inline-flex items-center gap-2 text-xs sm:text-sm"
       >
-        <svg className="size-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-          />
-        </svg>
-        Consultar manuais
+        {icon}
+        <span className="hidden sm:inline">Consultar manuais</span>
+        <span className="sr-only sm:hidden">Consultar manuais</span>
       </Button>
       <KbConsultaModal
         open={open}

--- a/frontend/src/lib/chatHubLista.ts
+++ b/frontend/src/lib/chatHubLista.ts
@@ -89,6 +89,35 @@ export function ordenarAtendendo(items: ChatHubItem[]): ChatHubItem[] {
   })
 }
 
+export type AtendendoSecoes = {
+  comigo: ChatHubItem[]
+  outros: ChatHubItem[]
+  /** Secções com cabeçalho quando há chats de outros atendentes */
+  mostrarSecoes: boolean
+}
+
+export function separarAtendendoPorResponsavel(
+  items: ChatHubItem[],
+  usuarioId?: number | null,
+): AtendendoSecoes {
+  if (usuarioId == null) {
+    return { comigo: ordenarAtendendo(items), outros: [], mostrarSecoes: false }
+  }
+
+  const comigo: ChatHubItem[] = []
+  const outros: ChatHubItem[] = []
+  for (const item of items) {
+    if (item.atendente_id === usuarioId) comigo.push(item)
+    else outros.push(item)
+  }
+
+  return {
+    comigo: ordenarAtendendo(comigo),
+    outros: ordenarAtendendo(outros),
+    mostrarSecoes: outros.length > 0,
+  }
+}
+
 export function rotuloResponsavelItem(item: ChatHubItem, usuarioId?: number | null): string {
   return rotuloResponsavelChat(item, usuarioId)
 }

--- a/frontend/src/pages/chat/ChatListaAtendendo.tsx
+++ b/frontend/src/pages/chat/ChatListaAtendendo.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { Link, useMatch } from 'react-router-dom'
 import { portalChats, whatsappChats } from '../../api/client'
 import { ChatCanalBadge } from '../../components/chat/ChatCanalBadge'
@@ -14,8 +14,103 @@ import {
   mapWhatsappChat,
   ordenarAtendendo,
   rotuloResponsavelItem,
+  separarAtendendoPorResponsavel,
   type ChatHubItem,
 } from '../../lib/chatHubLista'
+
+type ItemVariant = 'proprio' | 'outro' | 'neutro'
+
+function SecaoAtendendo({
+  titulo,
+  contagem,
+  children,
+}: {
+  titulo: string
+  contagem: number
+  children: ReactNode
+}) {
+  return (
+    <section>
+      <h3 className="sticky top-0 z-10 border-b border-slate-100 bg-white/95 px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-slate-500 backdrop-blur-sm dark:border-slate-800 dark:bg-slate-950/95">
+        {titulo} ({contagem})
+      </h3>
+      <ul className="divide-y divide-slate-100 dark:divide-slate-800">{children}</ul>
+    </section>
+  )
+}
+
+function ChatAtendendoItem({
+  item,
+  ativo,
+  variant,
+  usuarioId,
+}: {
+  item: ChatHubItem
+  ativo: boolean
+  variant: ItemVariant
+  usuarioId?: number | null
+}) {
+  const key = chatHubItemKey(item)
+  const responsavel =
+    item.atendente_nome?.trim() || (item.atendente_id != null ? `Atendente #${item.atendente_id}` : 'Sem responsável')
+
+  return (
+    <li key={key}>
+      <Link
+        to={chatHubItemLink(item, 'atendendo')}
+        className={`flex gap-3 px-3 py-3 transition-colors hover:bg-slate-50 dark:hover:bg-slate-900/50 ${
+          ativo ? 'bg-cyan-50/80 dark:bg-cyan-950/30' : ''
+        } ${variant === 'proprio' ? 'border-l-2 border-cyan-500 pl-[10px]' : ''} ${
+          variant === 'outro' ? 'border-l-2 border-slate-300 pl-[10px] dark:border-slate-600' : ''
+        }`}
+      >
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold ${
+            ativo ? 'bg-cyan-600 text-white' : 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-200'
+          }`}
+        >
+          {item.nome.charAt(0)?.toUpperCase() || '?'}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex min-w-0 flex-1 items-center gap-1.5">
+              <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">{item.nome}</p>
+              {variant === 'proprio' && (
+                <span className="shrink-0 rounded-full bg-cyan-100 px-1.5 py-0.5 text-[9px] font-bold uppercase text-cyan-800 dark:bg-cyan-950/60 dark:text-cyan-200">
+                  Você
+                </span>
+              )}
+            </div>
+            {item.estado === 'aguardando_atendente' && (
+              <span className="h-2 w-2 shrink-0 rounded-full bg-amber-500" title="Aguardando" />
+            )}
+          </div>
+          <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
+            <ChatCanalBadge canal={item.canal} />
+            {variant === 'outro' && (
+              <span
+                className="max-w-[9rem] truncate rounded-full bg-slate-100 px-1.5 py-0.5 text-[9px] font-semibold text-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                title={responsavel}
+              >
+                {responsavel}
+              </span>
+            )}
+            <p className="truncate text-xs text-cyan-600 dark:text-cyan-400" title={exibirProtocolo(item.protocolo)}>
+              {exibirProtocolo(item.protocolo)}
+            </p>
+          </div>
+          {item.ultima_mensagem_preview ? (
+            <p className="mt-0.5 line-clamp-1 text-xs text-slate-500">{item.ultima_mensagem_preview}</p>
+          ) : variant === 'neutro' ? (
+            <p className="truncate text-xs text-slate-500">{rotuloResponsavelItem(item, usuarioId)}</p>
+          ) : variant === 'outro' ? (
+            <p className="truncate text-xs text-slate-500">{item.setor_nome ? `Setor • ${item.setor_nome}` : 'Em atendimento'}</p>
+          ) : null}
+        </div>
+      </Link>
+    </li>
+  )
+}
 
 export function ChatListaAtendendo() {
   const { user } = useAuth()
@@ -64,6 +159,17 @@ export function ChatListaAtendendo() {
   }, [subscribe, load])
 
   const lista = filtrarChatHubPorBusca(meus, busca)
+  const { comigo, outros, mostrarSecoes } = separarAtendendoPorResponsavel(lista, user?.id)
+
+  const renderItem = (item: ChatHubItem, variant: ItemVariant) => (
+    <ChatAtendendoItem
+      key={chatHubItemKey(item)}
+      item={item}
+      ativo={chatAtivoKey === chatHubItemKey(item)}
+      variant={variant}
+      usuarioId={user?.id}
+    />
+  )
 
   if (loading) {
     return <p className="p-4 text-center text-sm text-slate-400 animate-pulse">Carregando…</p>
@@ -77,49 +183,26 @@ export function ChatListaAtendendo() {
     )
   }
 
+  if (!mostrarSecoes) {
+    return (
+      <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+        {comigo.map((item) => renderItem(item, 'neutro'))}
+      </ul>
+    )
+  }
+
   return (
-    <ul className="divide-y divide-slate-100 dark:divide-slate-800">
-      {lista.map((c) => {
-        const key = chatHubItemKey(c)
-        const ativo = chatAtivoKey === key
-        return (
-          <li key={key}>
-            <Link
-              to={chatHubItemLink(c, 'atendendo')}
-              className={`flex gap-3 px-3 py-3 transition-colors hover:bg-slate-50 dark:hover:bg-slate-900/50 ${
-                ativo ? 'bg-cyan-50/80 dark:bg-cyan-950/30' : ''
-              }`}
-            >
-              <div
-                className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold ${
-                  ativo ? 'bg-cyan-600 text-white' : 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-200'
-                }`}
-              >
-                {c.nome.charAt(0)?.toUpperCase() || '?'}
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="flex items-start justify-between gap-2">
-                  <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">{c.nome}</p>
-                  {c.estado === 'aguardando_atendente' && (
-                    <span className="h-2 w-2 shrink-0 rounded-full bg-amber-500" title="Aguardando" />
-                  )}
-                </div>
-                <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
-                  <ChatCanalBadge canal={c.canal} />
-                  <p className="truncate text-xs text-cyan-600 dark:text-cyan-400" title={exibirProtocolo(c.protocolo)}>
-                    {exibirProtocolo(c.protocolo)}
-                  </p>
-                </div>
-                {c.ultima_mensagem_preview ? (
-                  <p className="mt-0.5 line-clamp-1 text-xs text-slate-500">{c.ultima_mensagem_preview}</p>
-                ) : (
-                  <p className="truncate text-xs text-slate-500">{rotuloResponsavelItem(c, user?.id)}</p>
-                )}
-              </div>
-            </Link>
-          </li>
-        )
-      })}
-    </ul>
+    <div>
+      {comigo.length > 0 && (
+        <SecaoAtendendo titulo="Comigo" contagem={comigo.length}>
+          {comigo.map((item) => renderItem(item, 'proprio'))}
+        </SecaoAtendendo>
+      )}
+      {outros.length > 0 && (
+        <SecaoAtendendo titulo="Outros atendentes" contagem={outros.length}>
+          {outros.map((item) => renderItem(item, 'outro'))}
+        </SecaoAtendendo>
+      )}
+    </div>
   )
 }

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -130,7 +130,7 @@ export function WhatsappComposerBar({
         />
       )}
 
-      <div className="flex items-end gap-1.5 rounded-2xl bg-slate-100 p-2 shadow-inner dark:bg-slate-900 sm:gap-2">
+      <div className="flex min-w-0 items-end gap-1 rounded-2xl bg-slate-100 p-1.5 shadow-inner dark:bg-slate-900 sm:gap-2 sm:p-2">
         <div className="relative shrink-0" ref={menuRef}>
           <button
             type="button"
@@ -184,7 +184,11 @@ export function WhatsappComposerBar({
         </div>
 
         {onInserirReferenciaKb && (
-          <KbConsultaButton disabled={encerrado} onInserirReferencia={podeDigitar ? onInserirReferenciaKb : undefined} />
+          <KbConsultaButton
+            disabled={encerrado}
+            modoComposer
+            onInserirReferencia={podeDigitar ? onInserirReferenciaKb : undefined}
+          />
         )}
 
         <textarea
@@ -203,7 +207,7 @@ export function WhatsappComposerBar({
           }
           rows={1}
           disabled={campoBloqueado}
-          className="max-h-32 min-h-[40px] flex-1 resize-none border-0 bg-transparent p-2 text-sm outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
+          className="max-h-32 min-h-[44px] min-w-0 flex-1 resize-none border-0 bg-transparent px-2 py-2.5 text-base outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0 sm:text-sm dark:text-slate-100 placeholder:text-slate-400"
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.shiftKey) {
               e.preventDefault()

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -309,6 +309,8 @@ export function WhatsappConversa() {
   const [demandasReloadKey, setDemandasReloadKey] = useState(0)
   const [demandasTimeline, setDemandasTimeline] = useState<WhatsappChats.Demanda[]>([])
   const [modalEncerrar, setModalEncerrar] = useState(false)
+  const [menuMobileAberto, setMenuMobileAberto] = useState(false)
+  const menuMobileRef = useRef<HTMLDivElement>(null)
   const [filaAguardandoAberta, setFilaAguardandoAberta] = useState(false)
   const { filaCount } = useChatHub()
   const navigate = useNavigate()
@@ -344,6 +346,17 @@ export function WhatsappConversa() {
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [voltarLista, modalEncerrar, activeZoomImage, arquivoPendente])
+
+  useEffect(() => {
+    if (!menuMobileAberto) return
+    const onDoc = (e: globalThis.MouseEvent) => {
+      if (menuMobileRef.current && !menuMobileRef.current.contains(e.target as Node)) {
+        setMenuMobileAberto(false)
+      }
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [menuMobileAberto])
 
   const viuEmAtendimentoRef = useRef(false)
   const inatividadeToastFeitoRef = useRef(false)
@@ -1080,9 +1093,9 @@ useEffect(() => {
 
         {/* Header do Chat */}
 
-        <header className="flex h-16 items-center justify-between border-b border-slate-100 px-4 dark:border-slate-800 shadow-sm z-10">
+        <header className="shrink-0 border-b border-slate-100 shadow-sm z-10 dark:border-slate-800">
 
-          <div className="flex items-center gap-2 min-w-0 sm:gap-3">
+          <div className="flex items-center gap-2 px-3 py-2 sm:px-4">
 
             <Button
               type="button"
@@ -1095,157 +1108,214 @@ useEffect(() => {
               <span className="hidden sm:inline"> Voltar</span>
             </Button>
 
-            <div className="min-w-0">
+            <div className="min-w-0 flex-1">
+              <h1 className="truncate font-bold text-slate-900 dark:text-white">
+                {chat?.cliente_nome || 'Atendimento'}
+              </h1>
+            </div>
 
-              <h1 className="truncate font-bold text-slate-900 dark:text-white">{chat?.cliente_nome || 'Atendimento'}</h1>
+            <div className="flex shrink-0 items-center gap-1 sm:gap-2">
 
-              <div className="flex flex-wrap items-center gap-2 text-[10px]">
-
-                <span className="min-w-0 truncate font-mono font-bold text-cyan-600" title={exibirProtocolo(chat?.protocolo)}>
-                  {exibirProtocolo(chat?.protocolo)}
-                </span>
-
-                <span className="text-slate-300">•</span>
-
-                <span className={`capitalize ${encerrado ? 'text-red-500' : 'text-emerald-500'}`}>
-                  {chat ? rotuloEstadoChat(chat.estado) : '—'}
-                </span>
-
-                {chat && (
-                  <>
-                    <span className="text-slate-300">•</span>
-                    <span className="truncate text-slate-600 dark:text-slate-300">
-                      Responsável: {rotuloResponsavelChat(chat, user?.id)}
-                    </span>
-                    {chat.setor_nome && (
-                      <>
-                        <span className="hidden sm:inline text-slate-300">•</span>
-                        <span className="hidden sm:inline truncate text-slate-500 dark:text-slate-400">
-                          {chat.setor_nome}
-                        </span>
-                      </>
-                    )}
-                  </>
-                )}
-
-              </div>
-
-              {ticketsVinculados.length > 0 && (
-                <div className="mt-1.5 flex flex-wrap gap-1.5">
-                  {ticketsVinculados.map((t) => (
-                    <Link
-                      key={t.id}
-                      to={`/tickets/${t.id}`}
-                      className="inline-flex rounded-full border border-cyan-200/80 bg-cyan-50 px-2 py-0.5 text-[10px] font-medium text-cyan-800 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-300"
-                      title={t.assunto}
-                    >
-                      {exibirProtocolo(t.protocolo)}
-                    </Link>
-                  ))}
-                </div>
-              )}
-
-              {chat?.funcionario_rede_id && (
-                <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-                  <Link
-                    to={`/funcionarios-rede/${chat.funcionario_rede_id}`}
-                    className="inline-flex rounded-full border border-violet-200/80 bg-violet-50 px-2 py-0.5 text-[10px] font-medium text-violet-800 dark:border-violet-800 dark:bg-violet-950/40 dark:text-violet-300"
-                    title={chat.funcionario_email ?? undefined}
-                  >
-                    {chat.funcionario_nome}
-                    {chat.funcionario_tipo ? ` · ${chat.funcionario_tipo}` : ''}
-                  </Link>
-                  {chat.empresa_nome ? (
-                    podeDefinirEmpresa && (chat.empresas_opcoes?.length ?? 0) > 1 ? (
-                      <button
-                        type="button"
-                        onClick={abrirModalEmpresaContexto}
-                        className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 transition-colors hover:border-cyan-400 hover:text-cyan-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300"
-                        title="Alterar empresa do atendimento"
-                      >
-                        {chat.empresa_nome}
-                      </button>
-                    ) : (
-                      <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
-                        {chat.empresa_nome}
-                      </span>
-                    )
-                  ) : podeDefinirEmpresa ? (
-                    <button
-                      type="button"
-                      onClick={abrirModalEmpresaContexto}
-                      className="inline-flex rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-800 transition-colors hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
-                    >
-                      Definir empresa
-                    </button>
-                  ) : (
-                    <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
-                      Sem empresa
+              {modoHub && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="relative h-8 shrink-0 px-2.5 text-xs font-semibold md:hidden"
+                  onClick={() => setFilaAguardandoAberta(true)}
+                  aria-label={filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'}
+                >
+                  Aguardando
+                  {filaCount > 0 && (
+                    <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
+                      {filaCount > 99 ? '99+' : filaCount}
                     </span>
                   )}
-                </div>
+                </Button>
+              )}
+
+              {!encerrado && (
+                <>
+                  {isResponsavel && chat && (
+                    <div className="hidden sm:flex">
+                      <WhatsappInatividadeControle
+                        chat={chat}
+                        msgs={msgs}
+                        isResponsavel={isResponsavel}
+                        onChatUpdate={aplicarChatAtualizado}
+                      />
+                    </div>
+                  )}
+                  {podeTransferir && (
+                    <Button
+                      variant="primary"
+                      className="hidden sm:inline-flex text-xs h-8"
+                      onClick={() => setModalTransferir(true)}
+                    >
+                      Transferir
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    className="hidden sm:inline-flex text-xs h-8"
+                    onClick={() => setModalTickets(true)}
+                  >
+                    Tickets{ticketsVinculados.length > 0 ? ` (${ticketsVinculados.length})` : ''}
+                  </Button>
+
+                  {podeEncerrar && (
+                    <Button variant="danger" className="h-8 px-2.5 text-xs sm:px-3" onClick={() => setModalEncerrar(true)}>
+                      Encerrar
+                    </Button>
+                  )}
+
+                  <div className="relative sm:hidden" ref={menuMobileRef}>
+                    <button
+                      type="button"
+                      aria-label="Mais ações"
+                      aria-expanded={menuMobileAberto}
+                      onClick={() => setMenuMobileAberto((o) => !o)}
+                      className="flex h-8 w-8 items-center justify-center rounded-lg text-lg text-slate-600 transition hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+                    >
+                      ⋮
+                    </button>
+                    {menuMobileAberto && (
+                      <div className="absolute right-0 top-full z-30 mt-1 min-w-[12rem] rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900">
+                        {podeTransferir && (
+                          <button
+                            type="button"
+                            className="block w-full px-4 py-2.5 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
+                            onClick={() => {
+                              setMenuMobileAberto(false)
+                              setModalTransferir(true)
+                            }}
+                          >
+                            Transferir
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          className="block w-full px-4 py-2.5 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
+                          onClick={() => {
+                            setMenuMobileAberto(false)
+                            setModalTickets(true)
+                          }}
+                        >
+                          Tickets{ticketsVinculados.length > 0 ? ` (${ticketsVinculados.length})` : ''}
+                        </button>
+                        {podeDefinirEmpresa && (
+                          <button
+                            type="button"
+                            className="block w-full px-4 py-2.5 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
+                            onClick={() => {
+                              setMenuMobileAberto(false)
+                              abrirModalEmpresaContexto()
+                            }}
+                          >
+                            {chat?.empresa_id ? 'Alterar empresa' : 'Definir empresa'}
+                          </button>
+                        )}
+                        {isResponsavel && chat && (
+                          <div className="border-t border-slate-100 px-3 py-2 dark:border-slate-800">
+                            <WhatsappInatividadeControle
+                              chat={chat}
+                              msgs={msgs}
+                              isResponsavel={isResponsavel}
+                              onChatUpdate={aplicarChatAtualizado}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </>
               )}
 
             </div>
 
           </div>
 
+          <div className="space-y-1.5 px-3 pb-2 sm:px-4 sm:pb-3">
 
-
-          <div className="flex items-center gap-2">
-
-            {modoHub && (
-              <Button
-                type="button"
-                variant="secondary"
-                className="relative h-8 shrink-0 px-2.5 text-xs font-semibold md:hidden"
-                onClick={() => setFilaAguardandoAberta(true)}
-                aria-label={
-                  filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'
-                }
-              >
-                Aguardando
-                {filaCount > 0 && (
-                  <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
-                    {filaCount > 99 ? '99+' : filaCount}
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px]">
+              <span className="min-w-0 truncate font-mono font-bold text-cyan-600" title={exibirProtocolo(chat?.protocolo)}>
+                {exibirProtocolo(chat?.protocolo)}
+              </span>
+              <span className="text-slate-300">•</span>
+              <span className={`capitalize ${encerrado ? 'text-red-500' : 'text-emerald-500'}`}>
+                {chat ? rotuloEstadoChat(chat.estado) : '—'}
+              </span>
+              {chat && (
+                <>
+                  <span className="text-slate-300">•</span>
+                  <span className="max-w-[10rem] truncate text-slate-600 sm:max-w-none dark:text-slate-300">
+                    {rotuloResponsavelChat(chat, user?.id)}
                   </span>
-                )}
-              </Button>
+                  {chat.setor_nome && (
+                    <>
+                      <span className="hidden text-slate-300 sm:inline">•</span>
+                      <span className="hidden max-w-[8rem] truncate text-slate-500 sm:inline dark:text-slate-400">
+                        {chat.setor_nome}
+                      </span>
+                    </>
+                  )}
+                </>
+              )}
+            </div>
+
+            {ticketsVinculados.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {ticketsVinculados.map((t) => (
+                  <Link
+                    key={t.id}
+                    to={`/tickets/${t.id}`}
+                    className="inline-flex rounded-full border border-cyan-200/80 bg-cyan-50 px-2 py-0.5 text-[10px] font-medium text-cyan-800 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-300"
+                    title={t.assunto}
+                  >
+                    {exibirProtocolo(t.protocolo)}
+                  </Link>
+                ))}
+              </div>
             )}
 
-            {!encerrado && (
-              <>
-                {isResponsavel && chat && (
-                  <WhatsappInatividadeControle
-                    chat={chat}
-                    msgs={msgs}
-                    isResponsavel={isResponsavel}
-                    onChatUpdate={aplicarChatAtualizado}
-                  />
-                )}
-                {podeTransferir && (
-                  <Button
-                    variant="primary"
-                    className="hidden sm:inline-flex text-xs h-8"
-                    onClick={() => setModalTransferir(true)}
-                  >
-                    Transferir
-                  </Button>
-                )}
-                <Button
-                  variant="ghost"
-                  className="hidden sm:inline-flex text-xs h-8"
-                  onClick={() => setModalTickets(true)}
+            {chat?.funcionario_rede_id && (
+              <div className="flex flex-wrap items-center gap-1.5">
+                <Link
+                  to={`/funcionarios-rede/${chat.funcionario_rede_id}`}
+                  className="inline-flex max-w-full truncate rounded-full border border-violet-200/80 bg-violet-50 px-2 py-0.5 text-[10px] font-medium text-violet-800 dark:border-violet-800 dark:bg-violet-950/40 dark:text-violet-300"
+                  title={chat.funcionario_email ?? undefined}
                 >
-                  Tickets{ticketsVinculados.length > 0 ? ` (${ticketsVinculados.length})` : ''}
-                </Button>
-
-                {podeEncerrar && (
-                  <Button variant="danger" className="h-8 px-3 text-xs" onClick={() => setModalEncerrar(true)}>
-                    Encerrar
-                  </Button>
+                  {chat.funcionario_nome}
+                  {chat.funcionario_tipo ? ` · ${chat.funcionario_tipo}` : ''}
+                </Link>
+                {chat.empresa_nome ? (
+                  podeDefinirEmpresa && (chat.empresas_opcoes?.length ?? 0) > 1 ? (
+                    <button
+                      type="button"
+                      onClick={abrirModalEmpresaContexto}
+                      className="inline-flex max-w-full truncate rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 transition-colors hover:border-cyan-400 hover:text-cyan-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300"
+                      title="Alterar empresa do atendimento"
+                    >
+                      {chat.empresa_nome}
+                    </button>
+                  ) : (
+                    <span className="inline-flex max-w-full truncate rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+                      {chat.empresa_nome}
+                    </span>
+                  )
+                ) : podeDefinirEmpresa ? (
+                  <button
+                    type="button"
+                    onClick={abrirModalEmpresaContexto}
+                    className="inline-flex rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-800 transition-colors hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+                  >
+                    Definir empresa
+                  </button>
+                ) : (
+                  <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+                    Sem empresa
+                  </span>
                 )}
-              </>
+              </div>
             )}
 
           </div>
@@ -1479,7 +1549,7 @@ useEffect(() => {
 
         {/* Footer: Input & Mídia */}
 
-        <footer className="p-4 bg-white dark:bg-slate-950 border-t border-slate-100 dark:border-slate-800">
+        <footer className="shrink-0 border-t border-slate-100 bg-white p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] dark:border-slate-800 dark:bg-slate-950 sm:p-4">
 
           {msgRespondida && (
             <div className="flex items-center justify-between bg-slate-100 dark:bg-slate-900 border-l-4 border-cyan-600 px-4 py-2 rounded-t-xl mb-1 text-xs animate-in slide-in-from-bottom-2 duration-150">

--- a/frontend/src/pages/whatsapp/WhatsappDemandasPanel.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappDemandasPanel.tsx
@@ -33,6 +33,7 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
   const [form, setForm] = useState<DemandaFormValues>(DEMANDA_FORM_VAZIO)
   const [salvando, setSalvando] = useState(false)
   const [expandido, setExpandido] = useState(false)
+  const [listaVisivel, setListaVisivel] = useState(false)
   const [editandoId, setEditandoId] = useState<number | null>(null)
   const [excluirId, setExcluirId] = useState<number | null>(null)
 
@@ -124,7 +125,14 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
     <>
       <div className="border-b border-slate-100 bg-slate-50/80 px-4 py-2 dark:border-slate-800 dark:bg-slate-900/40">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className="flex min-w-0 flex-1 flex-wrap items-center gap-2 text-left sm:pointer-events-none sm:cursor-default"
+            onClick={() => {
+              if (demandas.length > 0) setListaVisivel((v) => !v)
+            }}
+            aria-expanded={listaVisivel || undefined}
+          >
             <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
               Demandas ({demandas.length})
             </span>
@@ -141,7 +149,12 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
             {demandas.length > 3 && (
               <span className="text-[10px] text-slate-400">+{demandas.length - 3}</span>
             )}
-          </div>
+            {demandas.length > 0 && (
+              <span className="text-[10px] font-medium text-cyan-600 sm:hidden dark:text-cyan-400">
+                {listaVisivel ? 'Ocultar' : 'Ver lista'}
+              </span>
+            )}
+          </button>
           {podeRegistrar && (
             <Button
               type="button"
@@ -175,7 +188,7 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
         )}
 
         {demandas.length > 0 && (
-          <ul className="mt-2 space-y-1">
+          <ul className={`mt-2 space-y-1 ${listaVisivel ? 'block' : 'hidden sm:block'}`}>
             {demandas.map((d) => {
               const podeAlterar =
                 podeRegistrar &&


### PR DESCRIPTION
## Summary

Lote de melhorias operacionais no hub de chat e na conversa WhatsApp:

- **#607** — Aba **Atendendo**: secções «Comigo» / «Outros atendentes» quando o admin acompanha colegas; badge «Você» e nome do responsável legível nos de outros; atendente comum mantém lista simples.
- **#606** — **Mobile** na conversa WhatsApp: composer utilizável (campo largo, KB só ícone, safe-area); header com menu ⋮ (Transferir, Tickets, inatividade, empresa); metadados em linha separada; painel de demandas colapsável no mobile.
- **Interno** — Rule/command Cursor: após merge na `main`, próximo trabalho sempre em branch nova (`/iniciar-feature`).

Closes #607
Closes #606

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `tsc -b` (frontend)
- [x] `npm run build` (frontend, com `VITE_API_URL`)
- [x] `pytest -q` — 433 passed (2 módulos de CI/release com erro de import no container local)
- [ ] Smoke desktop: aba Atendendo com admin — secções Comigo/Outros visíveis
- [ ] Smoke desktop: atendente comum — lista plana sem secção «Outros»
- [ ] Smoke mobile (~360px): composer legível; menu ⋮ abre Transferir/Tickets; demandas colapsáveis

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — cada um virou issue `#___` ou está documentado como wontfix
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados

Follow-ups já no backlog (não neste PR): #598 (janela 30 min pós-encerrar), chips filtro Todos/Meus/Outros (#607 v2 se pedido).
