### PR TITLE
fix(whatsapp): lock por wa_id evita chat duplicado (#608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#608): duas mensagens inbound seguidas do mesmo contacto deixam de abrir dois chats/protocolos — lock por `wa_id` no webhook e uma única sequência de auto-mensagens por sessão
 - WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** (somente leitura) até registar, manter demandas existentes ou confirmar sem demanda; nova mensagem do mesmo cliente abre chat novo na fila
 - WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat
 - WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -60,7 +60,7 @@ from app.services.whatsapp_avaliacao import mensagem_oculta_na_conversa
 from app.services.whatsapp_media_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
 from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
 from app.services.ticket_distribuicao import pos_criar_ticket_na_fila
-from app.services.protocolo_mensal import gerar_protocolo_chat
+from app.services.whatsapp_wa_id_lock import lock_wa_id_para_chat, unlock_wa_id_para_chat
 from app.services.audit_operacional import audit_whatsapp_chat
 
 router = APIRouter(prefix="/whatsapp/chats", tags=["whatsapp-chats"])
@@ -1081,82 +1081,86 @@ def iniciar_chat_outbound(
     if func is not None:
         empresa_id = _resolver_empresa_contexto_opcional(db, atendente, func, data.empresa_id)
 
-    existente = _chat_aberto_por_wa_id(db, wa_id)
-    if existente:
-        if existente.estado == "em_atendimento" and existente.atendente_id not in (None, atendente.id):
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="Já existe um atendimento aberto deste contacto com outro responsável.",
-            )
-        estado_anterior = existente.estado
-        if existente.estado == "aguardando_atendente" or existente.atendente_id is None:
-            existente.estado = "em_atendimento"
-            existente.atendente_id = atendente.id
-            existente.atendimento_inicio_at = datetime.now(timezone.utc)
-            if func is not None and not existente.funcionario_rede_id:
-                existente.funcionario_rede_id = func.id
-            if not existente.empresa_id:
+    lock_wa_id_para_chat(db, wa_id)
+    try:
+        existente = _chat_aberto_por_wa_id(db, wa_id)
+        if existente:
+            if existente.estado == "em_atendimento" and existente.atendente_id not in (None, atendente.id):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Já existe um atendimento aberto deste contacto com outro responsável.",
+                )
+            estado_anterior = existente.estado
+            if existente.estado == "aguardando_atendente" or existente.atendente_id is None:
+                existente.estado = "em_atendimento"
+                existente.atendente_id = atendente.id
+                existente.atendimento_inicio_at = datetime.now(timezone.utc)
+                if func is not None and not existente.funcionario_rede_id:
+                    existente.funcionario_rede_id = func.id
+                if not existente.empresa_id:
+                    _aplicar_empresa_contexto_chat(db, atendente, existente, data.empresa_id)
+                audit_whatsapp_chat(
+                    db,
+                    chat_id=existente.id,
+                    action="assign",
+                    atendente_id=atendente.id,
+                    payload={"de_estado": estado_anterior, "protocolo": existente.protocolo, "origem": "iniciar_outbound"},
+                )
+                db.commit()
+                db.refresh(existente)
+                emit_chat_fila_from_model(db, existente, estado_anterior=estado_anterior)
+            elif not existente.empresa_id and (func is not None or existente.funcionario_rede_id):
+                if func is not None and not existente.funcionario_rede_id:
+                    existente.funcionario_rede_id = func.id
                 _aplicar_empresa_contexto_chat(db, atendente, existente, data.empresa_id)
-            audit_whatsapp_chat(
-                db,
-                chat_id=existente.id,
-                action="assign",
-                atendente_id=atendente.id,
-                payload={"de_estado": estado_anterior, "protocolo": existente.protocolo, "origem": "iniciar_outbound"},
-            )
-            db.commit()
-            db.refresh(existente)
-            emit_chat_fila_from_model(db, existente, estado_anterior=estado_anterior)
-        elif not existente.empresa_id and (func is not None or existente.funcionario_rede_id):
-            if func is not None and not existente.funcionario_rede_id:
-                existente.funcionario_rede_id = func.id
-            _aplicar_empresa_contexto_chat(db, atendente, existente, data.empresa_id)
-            db.commit()
-            db.refresh(existente)
+                db.commit()
+                db.refresh(existente)
+            msg_init = (data.mensagem_inicial or "").strip()
+            if msg_init:
+                try:
+                    _enviar_texto_whatsapp(db, chat=existente, texto=msg_init, atendente=atendente, evento_sistema=None)
+                except HTTPException:
+                    raise
+            c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == existente.id).first()
+            assert c is not None
+            return _chat_read(db, c)
+
+        # Garante Evolution configurada se houver mensagem inicial (criar chat sem msg ainda exige settings para uso posterior)
+        _settings_envio(db)
+
+        chat = WhatsappChat(
+            protocolo=gerar_protocolo_chat(db),
+            wa_id=wa_id,
+            cliente_nome=(func.nome if func else None),
+            estado="em_atendimento",
+            atendente_id=atendente.id,
+            atendimento_inicio_at=datetime.now(timezone.utc),
+            setor_id=None,
+            funcionario_rede_id=func.id if func else None,
+            empresa_id=empresa_id,
+        )
+        db.add(chat)
+        db.flush()
+        audit_whatsapp_chat(
+            db,
+            chat_id=chat.id,
+            action="create",
+            atendente_id=atendente.id,
+            payload={"protocolo": chat.protocolo, "origem": "iniciar_outbound", "wa_id": wa_id},
+        )
+        db.commit()
+        db.refresh(chat)
+        emit_chat_fila_from_model(db, chat, estado_anterior=None)
+
         msg_init = (data.mensagem_inicial or "").strip()
         if msg_init:
-            try:
-                _enviar_texto_whatsapp(db, chat=existente, texto=msg_init, atendente=atendente, evento_sistema=None)
-            except HTTPException:
-                raise
-        c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == existente.id).first()
+            _enviar_texto_whatsapp(db, chat=chat, texto=msg_init, atendente=atendente, evento_sistema=None)
+
+        c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat.id).first()
         assert c is not None
         return _chat_read(db, c)
-
-    # Garante Evolution configurada se houver mensagem inicial (criar chat sem msg ainda exige settings para uso posterior)
-    _settings_envio(db)
-
-    chat = WhatsappChat(
-        protocolo=gerar_protocolo_chat(db),
-        wa_id=wa_id,
-        cliente_nome=(func.nome if func else None),
-        estado="em_atendimento",
-        atendente_id=atendente.id,
-        atendimento_inicio_at=datetime.now(timezone.utc),
-        setor_id=None,
-        funcionario_rede_id=func.id if func else None,
-        empresa_id=empresa_id,
-    )
-    db.add(chat)
-    db.flush()
-    audit_whatsapp_chat(
-        db,
-        chat_id=chat.id,
-        action="create",
-        atendente_id=atendente.id,
-        payload={"protocolo": chat.protocolo, "origem": "iniciar_outbound", "wa_id": wa_id},
-    )
-    db.commit()
-    db.refresh(chat)
-    emit_chat_fila_from_model(db, chat, estado_anterior=None)
-
-    msg_init = (data.mensagem_inicial or "").strip()
-    if msg_init:
-        _enviar_texto_whatsapp(db, chat=chat, texto=msg_init, atendente=atendente, evento_sistema=None)
-
-    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat.id).first()
-    assert c is not None
-    return _chat_read(db, c)
+    finally:
+        unlock_wa_id_para_chat(db, wa_id)
 
 
 @router.get("/{chat_id}", response_model=WhatsappChatRead)

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -60,6 +60,7 @@ from app.services.whatsapp_avaliacao import mensagem_oculta_na_conversa
 from app.services.whatsapp_media_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
 from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
 from app.services.ticket_distribuicao import pos_criar_ticket_na_fila
+from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.whatsapp_wa_id_lock import lock_wa_id_para_chat, unlock_wa_id_para_chat
 from app.services.audit_operacional import audit_whatsapp_chat
 

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -11,6 +11,7 @@ from app.services.whatsapp_contato_match import funcionario_por_wa_id
 from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.evolution_inbound import iter_inbound_whatsapp_messages, iter_message_status_updates
 from app.services.whatsapp_media_storage import gravar_base64_em_disco
+from app.services.whatsapp_wa_id_lock import lock_wa_id_para_chat, unlock_wa_id_para_chat
 from app.services.whatsapp_auto_messages import (
     DEFAULT_AUTO_MSG_ESPERA,
     DEFAULT_AUTO_MSG_FORA_HORARIO,
@@ -396,148 +397,165 @@ def evolution_webhook(
     processados = 0
     for item in iter_inbound_whatsapp_messages(body):
         wa_id = item["wa_id"]
-        corpo = item["corpo"]
-        wa_mid = item.get("wa_message_id")
-        push = item.get("push_name")
-        tipo = item.get("tipo") or "texto"
-
-        tipo_midia = tipo
-        mimetype_val = item.get("mimetype")
-        midia_nome = _baixar_midia_inbound(
-            item=item,
-            st_media=st_media,
-            tipo=tipo,
-            wa_id=wa_id,
-            wa_mid=wa_mid,
-        )
-
-        chat = _chat_aberto_por_wa_id(db, wa_id)
-        if not chat:
-            chat_aval = _chat_aguardando_avaliacao_por_wa_id(db, wa_id)
-            # Chat a classificar demanda: só reutiliza se for resposta de avaliação (nota 1–5).
-            # Qualquer outra mensagem abre atendimento novo; o pendente permanece.
-            if chat_aval is not None:
-                from app.services.whatsapp_avaliacao import parse_nota_avaliacao
-
-                pendente = bool(getattr(chat_aval, "classificacao_demanda_pendente", False))
-                nota = parse_nota_avaliacao(corpo) if (tipo or "texto") == "texto" else None
-                if pendente and nota is None:
-                    chat_aval = None
-            if chat_aval is not None:
-                chat = chat_aval
-                q_prev = item.get("quoted_corpo_preview")
-                if q_prev is not None and len(str(q_prev)) > 500:
-                    q_prev = str(q_prev)[:500]
-                msg = WhatsappMensagem(
-                    chat_id=chat.id,
-                    direcao="inbound",
-                    corpo=corpo,
-                    tipo_midia=tipo_midia,
-                    mimetype=mimetype_val,
-                    midia_nome_arquivo=midia_nome,
-                    wa_message_id=wa_mid,
-                    quoted_wa_message_id=item.get("quoted_wa_message_id"),
-                    quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
-                    atendente_id=None,
-                )
-                db.add(msg)
-                if push and not chat.cliente_nome:
-                    chat.cliente_nome = push
-                try:
-                    from app.services.whatsapp_avaliacao import processar_resposta_avaliacao
-
-                    processar_resposta_avaliacao(
-                        db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
-                    )
-                    db.commit()
-                    processados += 1
-                except IntegrityError:
-                    db.rollback()
-                    logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
-                except Exception:
-                    db.rollback()
-                    raise
-                continue
-
-        if tipo == "texto":
-            tipo_midia = "texto"
-            mimetype_val = None
-            midia_nome = None
-
-        chat_novo = False
-        if not chat:
-            chat_novo = True
-            func = funcionario_por_wa_id(db, wa_id)
-            chat = WhatsappChat(
-                protocolo=gerar_protocolo_chat(db),
-                wa_id=wa_id,
-                cliente_nome=push or (func.nome if func else None),
-                estado="aguardando_atendente",
-                setor_id=None,
-                funcionario_rede_id=func.id if func else None,
-                empresa_id=func.empresa_id if func and getattr(func, "empresa_id", None) else None,
-            )
-            db.add(chat)
-            db.flush()
-            # mensagem automática: cliente em espera (somente na criação do chat)
-            try:
-                _try_auto_msg_espera(db, st, chat)
-            except Exception:
-                logger.exception("Falha ao enviar mensagem automática de espera (chat=%s)", chat.protocolo)
-            # fora do horário também pode aplicar já na primeira mensagem
-            try:
-                _try_auto_msg_fora_horario(db, st, chat)
-            except Exception:
-                logger.exception("Falha ao enviar mensagem automática fora do horário (chat=%s)", chat.protocolo)
-        else:
-            # se continuar a receber mensagens fora do horário e o chat não está em atendimento, avisar uma vez
-            if chat.estado != "em_atendimento":
-                try:
-                    _try_auto_msg_fora_horario(db, st, chat)
-                except Exception:
-                    logger.exception("Falha ao enviar mensagem automática fora do horário (chat=%s)", chat.protocolo)
-
-        q_prev = item.get("quoted_corpo_preview")
-        if q_prev is not None and len(str(q_prev)) > 500:
-            q_prev = str(q_prev)[:500]
-        msg = WhatsappMensagem(
-            chat_id=chat.id,
-            direcao="inbound",
-            corpo=corpo,
-            tipo_midia=tipo_midia,
-            mimetype=mimetype_val,
-            midia_nome_arquivo=midia_nome,
-            wa_message_id=wa_mid,
-            quoted_wa_message_id=item.get("quoted_wa_message_id"),
-            quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
-            atendente_id=None,
-        )
-        db.add(msg)
-        if push and not chat.cliente_nome:
-            chat.cliente_nome = push
-        if getattr(chat, "inatividade_pausada", False):
-            chat.inatividade_pausada = False
-            chat.inatividade_retomada_em = None
+        lock_wa_id_para_chat(db, wa_id)
         try:
-            db.commit()
-            processados += 1
-            chat_emit = db.query(WhatsappChat).filter(WhatsappChat.id == chat.id).first()
-            msg_emit = (
-                db.query(WhatsappMensagem)
-                .filter(WhatsappMensagem.chat_id == chat.id, WhatsappMensagem.wa_message_id == wa_mid)
-                .first()
+            processados += _processar_mensagem_inbound(
+                db,
+                item=item,
+                st=st,
+                st_media=st_media,
             )
-            if chat_emit and msg_emit:
-                from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
-
-                emit_chat_mensagem_from_models(db, chat_emit, msg_emit)
-                if chat_novo:
-                    emit_chat_fila_from_model(db, chat_emit, estado_anterior=None)
-        except IntegrityError:
-            db.rollback()
-            logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
-        except Exception:
-            db.rollback()
-            raise
+        finally:
+            unlock_wa_id_para_chat(db, wa_id)
 
     return {"ok": True, "processados": processados}
+
+
+def _processar_mensagem_inbound(
+    db: Session,
+    *,
+    item: dict,
+    st: WhatsappSettings | None,
+    st_media: WhatsappSettings | None,
+) -> int:
+    wa_id = item["wa_id"]
+    corpo = item["corpo"]
+    wa_mid = item.get("wa_message_id")
+    push = item.get("push_name")
+    tipo = item.get("tipo") or "texto"
+
+    tipo_midia = tipo
+    mimetype_val = item.get("mimetype")
+    midia_nome = _baixar_midia_inbound(
+        item=item,
+        st_media=st_media,
+        tipo=tipo,
+        wa_id=wa_id,
+        wa_mid=wa_mid,
+    )
+
+    chat = _chat_aberto_por_wa_id(db, wa_id)
+    if not chat:
+        chat_aval = _chat_aguardando_avaliacao_por_wa_id(db, wa_id)
+        # Chat a classificar demanda: só reutiliza se for resposta de avaliação (nota 1–5).
+        # Qualquer outra mensagem abre atendimento novo; o pendente permanece.
+        if chat_aval is not None:
+            from app.services.whatsapp_avaliacao import parse_nota_avaliacao
+
+            pendente = bool(getattr(chat_aval, "classificacao_demanda_pendente", False))
+            nota = parse_nota_avaliacao(corpo) if (tipo or "texto") == "texto" else None
+            if pendente and nota is None:
+                chat_aval = None
+        if chat_aval is not None:
+            chat = chat_aval
+            q_prev = item.get("quoted_corpo_preview")
+            if q_prev is not None and len(str(q_prev)) > 500:
+                q_prev = str(q_prev)[:500]
+            msg = WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="inbound",
+                corpo=corpo,
+                tipo_midia=tipo_midia,
+                mimetype=mimetype_val,
+                midia_nome_arquivo=midia_nome,
+                wa_message_id=wa_mid,
+                quoted_wa_message_id=item.get("quoted_wa_message_id"),
+                quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
+                atendente_id=None,
+            )
+            db.add(msg)
+            if push and not chat.cliente_nome:
+                chat.cliente_nome = push
+            try:
+                from app.services.whatsapp_avaliacao import processar_resposta_avaliacao
+
+                processar_resposta_avaliacao(
+                    db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
+                )
+                db.commit()
+                return 1
+            except IntegrityError:
+                db.rollback()
+                logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
+                return 0
+            except Exception:
+                db.rollback()
+                raise
+
+    if tipo == "texto":
+        tipo_midia = "texto"
+        mimetype_val = None
+        midia_nome = None
+
+    chat_novo = False
+    if not chat:
+        chat_novo = True
+        func = funcionario_por_wa_id(db, wa_id)
+        chat = WhatsappChat(
+            protocolo=gerar_protocolo_chat(db),
+            wa_id=wa_id,
+            cliente_nome=push or (func.nome if func else None),
+            estado="aguardando_atendente",
+            setor_id=None,
+            funcionario_rede_id=func.id if func else None,
+            empresa_id=func.empresa_id if func and getattr(func, "empresa_id", None) else None,
+        )
+        db.add(chat)
+        db.flush()
+        try:
+            _try_auto_msg_espera(db, st, chat)
+        except Exception:
+            logger.exception("Falha ao enviar mensagem automática de espera (chat=%s)", chat.protocolo)
+        try:
+            _try_auto_msg_fora_horario(db, st, chat)
+        except Exception:
+            logger.exception("Falha ao enviar mensagem automática fora do horário (chat=%s)", chat.protocolo)
+    elif chat.estado != "em_atendimento":
+        try:
+            _try_auto_msg_fora_horario(db, st, chat)
+        except Exception:
+            logger.exception("Falha ao enviar mensagem automática fora do horário (chat=%s)", chat.protocolo)
+
+    q_prev = item.get("quoted_corpo_preview")
+    if q_prev is not None and len(str(q_prev)) > 500:
+        q_prev = str(q_prev)[:500]
+    msg = WhatsappMensagem(
+        chat_id=chat.id,
+        direcao="inbound",
+        corpo=corpo,
+        tipo_midia=tipo_midia,
+        mimetype=mimetype_val,
+        midia_nome_arquivo=midia_nome,
+        wa_message_id=wa_mid,
+        quoted_wa_message_id=item.get("quoted_wa_message_id"),
+        quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
+        atendente_id=None,
+    )
+    db.add(msg)
+    if push and not chat.cliente_nome:
+        chat.cliente_nome = push
+    if getattr(chat, "inatividade_pausada", False):
+        chat.inatividade_pausada = False
+        chat.inatividade_retomada_em = None
+    try:
+        db.commit()
+        chat_emit = db.query(WhatsappChat).filter(WhatsappChat.id == chat.id).first()
+        msg_emit = (
+            db.query(WhatsappMensagem)
+            .filter(WhatsappMensagem.chat_id == chat.id, WhatsappMensagem.wa_message_id == wa_mid)
+            .first()
+        )
+        if chat_emit and msg_emit:
+            from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
+
+            emit_chat_mensagem_from_models(db, chat_emit, msg_emit)
+            if chat_novo:
+                emit_chat_fila_from_model(db, chat_emit, estado_anterior=None)
+        return 1
+    except IntegrityError:
+        db.rollback()
+        logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
+        return 0
+    except Exception:
+        db.rollback()
+        raise

--- a/backend/app/services/whatsapp_wa_id_lock.py
+++ b/backend/app/services/whatsapp_wa_id_lock.py
@@ -1,0 +1,49 @@
+"""Serialização por wa_id ao abrir/reutilizar chat WhatsApp (#608)."""
+
+from __future__ import annotations
+
+import threading
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+_WA_LOCK_NS = 608608
+_wa_thread_locks: dict[str, threading.Lock] = {}
+_wa_thread_locks_guard = threading.Lock()
+
+
+def _thread_lock(wa_id: str) -> threading.Lock:
+    with _wa_thread_locks_guard:
+        lock = _wa_thread_locks.get(wa_id)
+        if lock is None:
+            lock = threading.Lock()
+            _wa_thread_locks[wa_id] = lock
+        return lock
+
+
+def lock_wa_id_para_chat(db: Session, wa_id: str) -> None:
+    """
+    Garante uma única criação de chat aberto por contacto.
+
+    PostgreSQL: advisory lock transacional (liberta no commit/rollback).
+    SQLite (testes): lock in-process por wa_id.
+    """
+    wa = (wa_id or "").strip()
+    if not wa:
+        return
+    bind = db.get_bind()
+    if bind.dialect.name == "postgresql":
+        db.execute(
+            text("SELECT pg_advisory_xact_lock(:ns, hashtext(:wa_id))"),
+            {"ns": _WA_LOCK_NS, "wa_id": wa},
+        )
+    else:
+        _thread_lock(wa).acquire()
+
+
+def unlock_wa_id_para_chat(db: Session, wa_id: str) -> None:
+    """Liberta lock in-process (SQLite). No-op em PostgreSQL."""
+    wa = (wa_id or "").strip()
+    if not wa:
+        return
+    if db.get_bind().dialect.name != "postgresql":
+        _thread_lock(wa).release()

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -1171,3 +1171,109 @@ def test_assumir_multi_empresa_sem_bloquear(client, seed_base, auth_headers, db_
     )
     assert ctx.status_code == 200
     assert ctx.json()["empresa_id"] == multi["empresa_a"]
+
+
+def _webhook_body_multi(wa_id: str, messages: list[tuple[str, str]]):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": msg_id,
+                    },
+                    "message": {"conversation": text},
+                }
+                for msg_id, text in messages
+            ]
+        },
+    }
+
+
+def test_webhook_duas_mensagens_mesmo_payload_um_chat(client, seed_base, auth_headers, db_session):
+    """#608 — duas mensagens inbound no mesmo payload → um chat, duas mensagens."""
+    from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "dup-payload", "auto_msg_espera_ativa": False, "auto_msg_fora_horario_ativa": False},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "dup-payload"}
+    wa_id = "5511999000608"
+    body = _webhook_body_multi(
+        wa_id,
+        [("608-a", "Bom dia"), ("608-b", "Td bem?")],
+    )
+    r = client.post("/v1/webhooks/evolution", json=body, headers=h)
+    assert r.status_code == 200
+    assert r.json().get("processados") == 2
+
+    abertos = (
+        db_session.query(WhatsappChat)
+        .filter(
+            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.estado.in_(("aguardando_atendente", "em_atendimento")),
+        )
+        .all()
+    )
+    assert len(abertos) == 1
+    msgs = (
+        db_session.query(WhatsappMensagem)
+        .filter(
+            WhatsappMensagem.chat_id == abertos[0].id,
+            WhatsappMensagem.direcao == "inbound",
+        )
+        .all()
+    )
+    assert len(msgs) == 2
+    assert {m.corpo for m in msgs} == {"Bom dia", "Td bem?"}
+
+
+def test_webhook_mensagens_paralelas_mesmo_wa_id_um_chat(client, seed_base, auth_headers, db_session):
+    """#608 — webhooks paralelos do mesmo wa_id → um único chat aberto."""
+    import threading
+
+    from app.models.whatsapp_chat import WhatsappChat
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "dup-race", "auto_msg_espera_ativa": False, "auto_msg_fora_horario_ativa": False},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "dup-race"}
+    wa_id = "5511999000609"
+    barrier = threading.Barrier(2)
+    errors: list[Exception] = []
+
+    def post(msg_id: str, text: str) -> None:
+        try:
+            barrier.wait(timeout=5)
+            r = client.post(
+                "/v1/webhooks/evolution",
+                json=_webhook_body(wa_id=wa_id, msg_id=msg_id, text=text),
+                headers=h,
+            )
+            assert r.status_code == 200
+        except Exception as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=post, args=("608-r1", "Olá"))
+    t2 = threading.Thread(target=post, args=("608-r2", "Tudo bem?"))
+    t1.start()
+    t2.start()
+    t1.join(timeout=30)
+    t2.join(timeout=30)
+    assert not errors, errors
+
+    abertos = (
+        db_session.query(WhatsappChat)
+        .filter(
+            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.estado.in_(("aguardando_atendente", "em_atendimento")),
+        )
+        .all()
+    )
+    assert len(abertos) == 1


### PR DESCRIPTION
## Summary

Hotfix **#608**: duas mensagens inbound seguidas do mesmo contacto (ou webhooks paralelos) deixam de abrir dois chats/protocolos.

- Lock transacional por `wa_id` (`pg_advisory_xact_lock` em Postgres; `threading.Lock` nos testes SQLite)
- Webhook inbound refatorado: uma mensagem por vez com lock antes de criar/reutilizar chat
- Outbound `iniciar_chat` também serializado pelo mesmo lock
- Auto-mensagens só na abertura da sessão (não repetem na 2ª mensagem do mesmo payload)

Closes #608

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** — bullet em Correções (#608)

## Test plan

- [x] `pytest tests/test_whatsapp_chats.py::test_webhook_duas_mensagens_mesmo_payload_um_chat`
- [x] `pytest tests/test_whatsapp_chats.py::test_webhook_mensagens_paralelas_mesmo_wa_id_um_chat`
- [ ] CI verde (backend + frontend + changelog)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Sem follow-ups — bug fechado com lock + testes de corrida
