### PR TITLE
feat(whatsapp): janela de avaliacao ~30 min apos encerrar (#598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 ### Correções
 
 - WhatsApp (#608): duas mensagens inbound seguidas do mesmo contacto deixam de abrir dois chats/protocolos — lock por `wa_id` no webhook e uma única sequência de auto-mensagens por sessão
+- WhatsApp (#598): após encerrar com avaliação, janela de ~30 min (configurável) para a nota; se o cliente mandar outro texto, abre atendimento novo com essa mensagem; sem resposta, finaliza sozinho
 - WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** (somente leitura) até registar, manter demandas existentes ou confirmar sem demanda; nova mensagem do mesmo cliente abre chat novo na fila
 - WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat
 - WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)

--- a/backend/alembic/versions/077_wpp_avaliacao_janela.py
+++ b/backend/alembic/versions/077_wpp_avaliacao_janela.py
@@ -1,0 +1,53 @@
+"""Janela de avaliação WhatsApp (~30 min) + templates timeout/pular.
+
+Revision ID: 077_wpp_avaliacao_janela
+Revises: 076_kb_portal_cor_sidebar
+Create Date: 2026-07-21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "077_wpp_avaliacao_janela"
+down_revision = "076_kb_portal_cor_sidebar"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_settings"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_settings")}
+    if "avaliacao_janela_minutos" not in cols:
+        op.add_column(
+            "whatsapp_settings",
+            sa.Column("avaliacao_janela_minutos", sa.Integer(), nullable=False, server_default="30"),
+        )
+        op.alter_column("whatsapp_settings", "avaliacao_janela_minutos", server_default=None)
+    if "auto_msg_avaliacao_timeout_texto" not in cols:
+        op.add_column(
+            "whatsapp_settings",
+            sa.Column("auto_msg_avaliacao_timeout_texto", sa.Text(), nullable=True),
+        )
+    if "auto_msg_avaliacao_pular_texto" not in cols:
+        op.add_column(
+            "whatsapp_settings",
+            sa.Column("auto_msg_avaliacao_pular_texto", sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_settings"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_settings")}
+    for col in (
+        "auto_msg_avaliacao_pular_texto",
+        "auto_msg_avaliacao_timeout_texto",
+        "avaliacao_janela_minutos",
+    ):
+        if col in cols:
+            op.drop_column("whatsapp_settings", col)

--- a/backend/app/api/whatsapp_settings.py
+++ b/backend/app/api/whatsapp_settings.py
@@ -51,9 +51,12 @@ def _read_out(row: WhatsappSettings | None) -> WhatsappSettingsRead:
             auto_msg_inativ_aviso_ativa=True,
             auto_msg_inativ_aviso_texto=None,
             avaliacao_ativa=False,
+            avaliacao_janela_minutos=30,
             auto_msg_avaliacao_ativa=True,
             auto_msg_avaliacao_texto=None,
             auto_msg_avaliacao_obrigado_texto=None,
+            auto_msg_avaliacao_timeout_texto=None,
+            auto_msg_avaliacao_pular_texto=None,
         )
     horario_semana = None
     raw = getattr(row, "horario_semana_json", None)
@@ -88,9 +91,12 @@ def _read_out(row: WhatsappSettings | None) -> WhatsappSettingsRead:
         auto_msg_inativ_aviso_ativa=bool(getattr(row, "auto_msg_inativ_aviso_ativa", True)),
         auto_msg_inativ_aviso_texto=getattr(row, "auto_msg_inativ_aviso_texto", None),
         avaliacao_ativa=bool(getattr(row, "avaliacao_ativa", False)),
+        avaliacao_janela_minutos=int(getattr(row, "avaliacao_janela_minutos", None) or 30),
         auto_msg_avaliacao_ativa=bool(getattr(row, "auto_msg_avaliacao_ativa", True)),
         auto_msg_avaliacao_texto=getattr(row, "auto_msg_avaliacao_texto", None),
         auto_msg_avaliacao_obrigado_texto=getattr(row, "auto_msg_avaliacao_obrigado_texto", None),
+        auto_msg_avaliacao_timeout_texto=getattr(row, "auto_msg_avaliacao_timeout_texto", None),
+        auto_msg_avaliacao_pular_texto=getattr(row, "auto_msg_avaliacao_pular_texto", None),
     )
 
 
@@ -162,9 +168,12 @@ def atualizar(
         "inativ_aviso_minutos",
         "inativ_encerramento_apos_aviso_minutos",
         "avaliacao_ativa",
+        "avaliacao_janela_minutos",
         "auto_msg_avaliacao_ativa",
         "auto_msg_avaliacao_texto",
         "auto_msg_avaliacao_obrigado_texto",
+        "auto_msg_avaliacao_timeout_texto",
+        "auto_msg_avaliacao_pular_texto",
     ):
         if k in payload:
             setattr(row, k, payload[k])
@@ -176,6 +185,13 @@ def atualizar(
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Informe minutos válidos para aviso e encerramento após o aviso.",
+            )
+    if bool(getattr(row, "avaliacao_ativa", False)):
+        janela = getattr(row, "avaliacao_janela_minutos", None)
+        if not janela or int(janela) < 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Informe a janela de avaliação em minutos (mínimo 1).",
             )
     if "horario_semana" in payload:
         hs = payload["horario_semana"]

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -437,50 +437,57 @@ def _processar_mensagem_inbound(
     chat = _chat_aberto_por_wa_id(db, wa_id)
     if not chat:
         chat_aval = _chat_aguardando_avaliacao_por_wa_id(db, wa_id)
-        # Chat a classificar demanda: só reutiliza se for resposta de avaliação (nota 1–5).
-        # Qualquer outra mensagem abre atendimento novo; o pendente permanece.
         if chat_aval is not None:
-            from app.services.whatsapp_avaliacao import parse_nota_avaliacao
-
-            pendente = bool(getattr(chat_aval, "classificacao_demanda_pendente", False))
-            nota = parse_nota_avaliacao(corpo) if (tipo or "texto") == "texto" else None
-            if pendente and nota is None:
-                chat_aval = None
-        if chat_aval is not None:
-            chat = chat_aval
-            q_prev = item.get("quoted_corpo_preview")
-            if q_prev is not None and len(str(q_prev)) > 500:
-                q_prev = str(q_prev)[:500]
-            msg = WhatsappMensagem(
-                chat_id=chat.id,
-                direcao="inbound",
-                corpo=corpo,
-                tipo_midia=tipo_midia,
-                mimetype=mimetype_val,
-                midia_nome_arquivo=midia_nome,
-                wa_message_id=wa_mid,
-                quoted_wa_message_id=item.get("quoted_wa_message_id"),
-                quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
-                atendente_id=None,
+            from app.services.whatsapp_avaliacao import (
+                encerrar_avaliacao_sem_nota,
+                parse_nota_avaliacao,
+                processar_resposta_avaliacao,
             )
-            db.add(msg)
-            if push and not chat.cliente_nome:
-                chat.cliente_nome = push
-            try:
-                from app.services.whatsapp_avaliacao import processar_resposta_avaliacao
 
-                processar_resposta_avaliacao(
-                    db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
+            nota = parse_nota_avaliacao(corpo) if (tipo or "texto") == "texto" else None
+            if nota is not None:
+                chat = chat_aval
+                q_prev = item.get("quoted_corpo_preview")
+                if q_prev is not None and len(str(q_prev)) > 500:
+                    q_prev = str(q_prev)[:500]
+                msg = WhatsappMensagem(
+                    chat_id=chat.id,
+                    direcao="inbound",
+                    corpo=corpo,
+                    tipo_midia=tipo_midia,
+                    mimetype=mimetype_val,
+                    midia_nome_arquivo=midia_nome,
+                    wa_message_id=wa_mid,
+                    quoted_wa_message_id=item.get("quoted_wa_message_id"),
+                    quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
+                    atendente_id=None,
                 )
-                db.commit()
-                return 1
-            except IntegrityError:
-                db.rollback()
-                logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
-                return 0
-            except Exception:
-                db.rollback()
-                raise
+                db.add(msg)
+                if push and not chat.cliente_nome:
+                    chat.cliente_nome = push
+                try:
+                    resultado = processar_resposta_avaliacao(
+                        db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
+                    )
+                    db.commit()
+                    return 1 if resultado == "nota" else 0
+                except IntegrityError:
+                    db.rollback()
+                    logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
+                    return 0
+                except Exception:
+                    db.rollback()
+                    raise
+            # Não é nota: encerra avaliação sem prender o cliente e segue para chat novo
+            # com esta mesma mensagem (classificação de demanda pendente permanece no chat antigo).
+            if st is not None:
+                try:
+                    encerrar_avaliacao_sem_nota(db, chat_aval, st, motivo="pular")
+                    db.flush()
+                except Exception:
+                    logger.exception(
+                        "Falha ao encerrar avaliação sem nota (chat=%s)", chat_aval.protocolo
+                    )
 
     if tipo == "texto":
         tipo_midia = "texto"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -256,6 +256,7 @@ async def lifespan(app: FastAPI):
 
     def whatsapp_inactivity_loop() -> None:
         from app.database import SessionLocal
+        from app.services.whatsapp_avaliacao import process_whatsapp_avaliacao_timeouts
         from app.services.whatsapp_inactivity_worker import process_whatsapp_inactivity_closures
 
         interval = max(15, settings.WHATSAPP_INACTIVITY_WORKER_INTERVAL_SECONDS)
@@ -263,8 +264,9 @@ async def lifespan(app: FastAPI):
             db = SessionLocal()
             try:
                 process_whatsapp_inactivity_closures(db, limit=200)
+                process_whatsapp_avaliacao_timeouts(db, limit=200)
             except Exception as e:
-                logger.warning("Worker inatividade WhatsApp: %s", e)
+                logger.warning("Worker inatividade/avaliação WhatsApp: %s", e)
                 db.rollback()
             finally:
                 db.close()

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -42,9 +42,13 @@ class WhatsappSettings(Base):
     auto_msg_inativ_aviso_ativa = Column(Boolean, nullable=False, default=True)
     auto_msg_inativ_aviso_texto = Column(Text, nullable=True)
     avaliacao_ativa = Column(Boolean, nullable=False, default=False)
+    # Janela após encerrar para o cliente enviar nota 1–5 (depois finaliza sozinho).
+    avaliacao_janela_minutos = Column(Integer, nullable=False, default=30)
     auto_msg_avaliacao_ativa = Column(Boolean, nullable=False, default=True)
     auto_msg_avaliacao_texto = Column(Text, nullable=True)
     auto_msg_avaliacao_obrigado_texto = Column(Text, nullable=True)
+    auto_msg_avaliacao_timeout_texto = Column(Text, nullable=True)
+    auto_msg_avaliacao_pular_texto = Column(Text, nullable=True)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
 
 

--- a/backend/app/schemas/whatsapp_settings.py
+++ b/backend/app/schemas/whatsapp_settings.py
@@ -29,9 +29,12 @@ class WhatsappSettingsRead(BaseModel):
     auto_msg_inativ_aviso_ativa: bool = True
     auto_msg_inativ_aviso_texto: str | None = None
     avaliacao_ativa: bool = False
+    avaliacao_janela_minutos: int = 30
     auto_msg_avaliacao_ativa: bool = True
     auto_msg_avaliacao_texto: str | None = None
     auto_msg_avaliacao_obrigado_texto: str | None = None
+    auto_msg_avaliacao_timeout_texto: str | None = None
+    auto_msg_avaliacao_pular_texto: str | None = None
 
     model_config = {"from_attributes": True}
 
@@ -61,9 +64,12 @@ class WhatsappSettingsUpdate(BaseModel):
     auto_msg_inativ_aviso_ativa: bool | None = None
     auto_msg_inativ_aviso_texto: str | None = None
     avaliacao_ativa: bool | None = None
+    avaliacao_janela_minutos: int | None = Field(None, ge=1, le=24 * 60)
     auto_msg_avaliacao_ativa: bool | None = None
     auto_msg_avaliacao_texto: str | None = None
     auto_msg_avaliacao_obrigado_texto: str | None = None
+    auto_msg_avaliacao_timeout_texto: str | None = None
+    auto_msg_avaliacao_pular_texto: str | None = None
 
     @field_validator("evolution_base_url", mode="before")
     @classmethod

--- a/backend/app/services/whatsapp_auto_messages.py
+++ b/backend/app/services/whatsapp_auto_messages.py
@@ -37,6 +37,13 @@ DEFAULT_AUTO_MSG_AVALIACAO_SEM_NOTA = (
     "Não foi possível registrar sua avaliação. O atendimento foi encerrado. "
     "Se precisar de algo mais, envie uma nova mensagem por aqui."
 )
+DEFAULT_AUTO_MSG_AVALIACAO_PULAR = (
+    "Sem problema! Vamos abrir um novo atendimento com a sua mensagem."
+)
+DEFAULT_AUTO_MSG_AVALIACAO_TIMEOUT = (
+    "O período para avaliar o atendimento encerrou. "
+    "Se precisar de ajuda, envie uma nova mensagem por aqui."
+)
 
 # Mensagens desta fase não aparecem na conversa do atendente (só no WhatsApp do cliente).
 EVENTOS_MENSAGEM_OCULTA_CONVERSA = frozenset(
@@ -44,6 +51,8 @@ EVENTOS_MENSAGEM_OCULTA_CONVERSA = frozenset(
         "auto_avaliacao_solicitacao",
         "auto_avaliacao_obrigado",
         "auto_avaliacao_sem_nota",
+        "auto_avaliacao_pular",
+        "auto_avaliacao_timeout",
         "avaliacao_cliente_nota",
         "avaliacao_cliente_invalida",
     }

--- a/backend/app/services/whatsapp_avaliacao.py
+++ b/backend/app/services/whatsapp_avaliacao.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from typing import Literal
 
 from sqlalchemy.orm import Session
 
@@ -13,7 +14,9 @@ from app.services import evolution_api
 from app.services.whatsapp_auto_messages import (
     DEFAULT_AUTO_MSG_AVALIACAO,
     DEFAULT_AUTO_MSG_AVALIACAO_OBRIGADO,
+    DEFAULT_AUTO_MSG_AVALIACAO_PULAR,
     DEFAULT_AUTO_MSG_AVALIACAO_SEM_NOTA,
+    DEFAULT_AUTO_MSG_AVALIACAO_TIMEOUT,
     DEFAULT_AUTO_MSG_ENCERRADO,
     EVENTOS_MENSAGEM_OCULTA_CONVERSA,
 )
@@ -21,6 +24,8 @@ from app.services.whatsapp_auto_messages import (
 logger = logging.getLogger(__name__)
 
 _NOTA_RE = re.compile(r"^[1-5]$")
+
+MotivoEncerrarAvaliacao = Literal["pular", "timeout", "invalida"]
 
 
 def parse_nota_avaliacao(texto: str) -> int | None:
@@ -36,6 +41,15 @@ def avaliacao_habilitada(st: WhatsappSettings | None) -> bool:
 
 def mensagem_oculta_na_conversa(evento_sistema: str | None) -> bool:
     return (evento_sistema or "") in EVENTOS_MENSAGEM_OCULTA_CONVERSA
+
+
+def janela_avaliacao_minutos(st: WhatsappSettings | None) -> int:
+    raw = getattr(st, "avaliacao_janela_minutos", None) if st else None
+    try:
+        n = int(raw) if raw is not None else 30
+    except (TypeError, ValueError):
+        n = 30
+    return max(1, n)
 
 
 def _evolution_configurada(st: WhatsappSettings | None) -> bool:
@@ -114,6 +128,40 @@ def _enviar_encerrado(
         _enviar_texto_sistema(db, chat=chat, st=st, texto=txt, evento_sistema=evento_sistema)
 
 
+def encerrar_avaliacao_sem_nota(
+    db: Session,
+    chat: WhatsappChat,
+    st: WhatsappSettings,
+    *,
+    motivo: MotivoEncerrarAvaliacao = "pular",
+    msg_inbound: WhatsappMensagem | None = None,
+    enviar_mensagem: bool = True,
+) -> None:
+    """Finaliza `aguardando_avaliacao` sem nota (pular / timeout / resposta inválida legada)."""
+    if msg_inbound is not None:
+        msg_inbound.evento_sistema = "avaliacao_cliente_invalida"
+    chat.estado = "encerrado"
+    chat.avaliacao_nota = None
+    chat.avaliacao_respondida_at = None
+    db.flush()
+    if not enviar_mensagem or not _evolution_configurada(st):
+        return
+    if not bool(getattr(st, "auto_msg_avaliacao_ativa", True)):
+        return
+    if motivo == "timeout":
+        raw = (getattr(st, "auto_msg_avaliacao_timeout_texto", "") or "").strip() or DEFAULT_AUTO_MSG_AVALIACAO_TIMEOUT
+        evento = "auto_avaliacao_timeout"
+    elif motivo == "pular":
+        raw = (getattr(st, "auto_msg_avaliacao_pular_texto", "") or "").strip() or DEFAULT_AUTO_MSG_AVALIACAO_PULAR
+        evento = "auto_avaliacao_pular"
+    else:
+        raw = DEFAULT_AUTO_MSG_AVALIACAO_SEM_NOTA
+        evento = "auto_avaliacao_sem_nota"
+    txt = _render_template(raw, db=db, chat=chat, st=st)
+    if txt:
+        _enviar_texto_sistema(db, chat=chat, st=st, texto=txt, evento_sistema=evento)
+
+
 def _encerrar_sem_avaliacao(
     db: Session,
     chat: WhatsappChat,
@@ -121,22 +169,8 @@ def _encerrar_sem_avaliacao(
     *,
     msg_inbound: WhatsappMensagem | None = None,
 ) -> None:
-    if msg_inbound is not None:
-        msg_inbound.evento_sistema = "avaliacao_cliente_invalida"
-    chat.estado = "encerrado"
-    chat.avaliacao_nota = None
-    chat.avaliacao_respondida_at = None
-    db.flush()
-    raw = DEFAULT_AUTO_MSG_AVALIACAO_SEM_NOTA
-    txt = _render_template(raw, db=db, chat=chat, st=st)
-    if txt:
-        _enviar_texto_sistema(
-            db,
-            chat=chat,
-            st=st,
-            texto=txt,
-            evento_sistema="auto_avaliacao_sem_nota",
-        )
+    """Compat: resposta inválida no mesmo chat (sem abrir atendimento novo)."""
+    encerrar_avaliacao_sem_nota(db, chat, st, motivo="invalida", msg_inbound=msg_inbound)
 
 
 def finalizar_atendimento_whatsapp(
@@ -188,19 +222,22 @@ def processar_resposta_avaliacao(
     *,
     tipo_midia: str = "texto",
     msg_inbound: WhatsappMensagem | None = None,
-) -> None:
-    """Processa mensagem inbound em chat aguardando_avaliacao."""
+) -> Literal["nota", "nao_nota"]:
+    """
+    Processa inbound em `aguardando_avaliacao`.
+
+    Retorna ``nota`` se registrou 1–5 e encerrou; ``nao_nota`` se a mensagem não é nota
+    (o caller deve encerrar a avaliação e abrir atendimento novo com essa mensagem).
+    """
     if chat.estado != "aguardando_avaliacao" or not st or not _evolution_configurada(st):
-        return
+        return "nao_nota"
 
     if (tipo_midia or "texto").strip().lower() != "texto":
-        _encerrar_sem_avaliacao(db, chat, st, msg_inbound=msg_inbound)
-        return
+        return "nao_nota"
 
     nota = parse_nota_avaliacao(texto)
     if nota is None:
-        _encerrar_sem_avaliacao(db, chat, st, msg_inbound=msg_inbound)
-        return
+        return "nao_nota"
 
     if msg_inbound is not None:
         msg_inbound.evento_sistema = "avaliacao_cliente_nota"
@@ -224,3 +261,67 @@ def processar_resposta_avaliacao(
                 texto=txt,
                 evento_sistema="auto_avaliacao_obrigado",
             )
+    return "nota"
+
+
+def process_whatsapp_avaliacao_timeouts(db: Session, *, limit: int = 200) -> int:
+    """
+    Encerra chats ainda em `aguardando_avaliacao` após a janela configurada
+    (a partir de `encerramento_at`). Retorna quantidade alterada.
+    """
+    st = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
+    if not st or not avaliacao_habilitada(st):
+        return 0
+    if not _evolution_configurada(st):
+        return 0
+
+    minutos = janela_avaliacao_minutos(st)
+    limite = datetime.now(timezone.utc) - timedelta(minutes=minutos)
+    chat_ids = [
+        row[0]
+        for row in (
+            db.query(WhatsappChat.id)
+            .filter(
+                WhatsappChat.estado == "aguardando_avaliacao",
+                WhatsappChat.encerramento_at.isnot(None),
+                WhatsappChat.encerramento_at <= limite,
+            )
+            .order_by(WhatsappChat.id.asc())
+            .limit(limit)
+            .all()
+        )
+    ]
+    alterados = 0
+    for chat_id in chat_ids:
+        try:
+            chat = (
+                db.query(WhatsappChat)
+                .filter(WhatsappChat.id == chat_id, WhatsappChat.estado == "aguardando_avaliacao")
+                .with_for_update()
+                .first()
+            )
+            if not chat:
+                db.rollback()
+                continue
+            enc_at = chat.encerramento_at
+            if enc_at is None:
+                db.rollback()
+                continue
+            if enc_at.tzinfo is None:
+                enc_at = enc_at.replace(tzinfo=timezone.utc)
+            if enc_at > limite:
+                db.rollback()
+                continue
+            encerrar_avaliacao_sem_nota(db, chat, st, motivo="timeout")
+            db.commit()
+            alterados += 1
+            try:
+                from app.services.realtime_emit import emit_chat_fila_from_model
+
+                emit_chat_fila_from_model(db, chat, estado_anterior="aguardando_avaliacao")
+            except Exception as emit_exc:
+                logger.warning("SSE pós-timeout avaliação (chat=%s): %s", chat_id, emit_exc)
+        except Exception as exc:
+            db.rollback()
+            logger.warning("Timeout avaliação WhatsApp (chat=%s): %s", chat_id, exc)
+    return alterados

--- a/backend/tests/test_whatsapp_avaliacao.py
+++ b/backend/tests/test_whatsapp_avaliacao.py
@@ -117,6 +117,9 @@ def test_resposta_nota_encerra_chat(client, seed_base, auth_headers, db_session,
 
 
 def test_resposta_invalida_encerra_sem_avaliacao(client, seed_base, auth_headers, db_session, monkeypatch):
+    """API legada: encerrar_avaliacao_sem_nota com motivo invalida."""
+    from app.services.whatsapp_avaliacao import encerrar_avaliacao_sem_nota
+
     st = _configurar(db_session)
     chat = WhatsappChat(
         protocolo="WPP-AV-2",
@@ -139,7 +142,7 @@ def test_resposta_invalida_encerra_sem_avaliacao(client, seed_base, auth_headers
 
     msg = WhatsappMensagem(chat_id=chat.id, direcao="inbound", corpo="ótimo", tipo_midia="texto")
     db_session.add(msg)
-    processar_resposta_avaliacao(db_session, chat, st, "ótimo", msg_inbound=msg)
+    encerrar_avaliacao_sem_nota(db_session, chat, st, motivo="invalida", msg_inbound=msg)
     db_session.commit()
     db_session.refresh(chat)
 
@@ -148,6 +151,174 @@ def test_resposta_invalida_encerra_sem_avaliacao(client, seed_base, auth_headers
     assert msg.evento_sistema == "avaliacao_cliente_invalida"
     assert enviados
     assert "sem avaliação" in enviados[0].lower() or "encerrado" in enviados[0].lower()
+
+
+def test_processar_nao_nota_nao_altera_chat(client, seed_base, auth_headers, db_session, monkeypatch):
+    st = _configurar(db_session)
+    chat = WhatsappChat(
+        protocolo="WPP-AV-2b",
+        wa_id="5511999223355",
+        estado="aguardando_avaliacao",
+        atendente_id=1,
+        avaliacao_solicitada=True,
+    )
+    db_session.add(chat)
+    db_session.commit()
+    monkeypatch.setattr(
+        "app.services.whatsapp_avaliacao.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "x"),
+    )
+    assert processar_resposta_avaliacao(db_session, chat, st, "ótimo") == "nao_nota"
+    db_session.refresh(chat)
+    assert chat.estado == "aguardando_avaliacao"
+
+
+def test_webhook_texto_nao_nota_abre_chat_novo(client, seed_base, auth_headers, db_session, monkeypatch):
+    """#598 — texto que não é nota encerra avaliação e abre atendimento com a mensagem."""
+    from datetime import datetime, timezone
+
+    from tests.test_whatsapp_chats import _webhook_body
+
+    _configurar(db_session)
+    monkeypatch.setattr(
+        "app.services.whatsapp_avaliacao.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-pular"),
+    )
+    monkeypatch.setattr(
+        "app.api.whatsapp_webhook.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-espera"),
+    )
+    wa = "5511999000598"
+    antigo = WhatsappChat(
+        protocolo="WPP-AV-598-A",
+        wa_id=wa,
+        estado="aguardando_avaliacao",
+        atendente_id=seed_base["a1"].id,
+        avaliacao_solicitada=True,
+        encerramento_at=datetime.now(timezone.utc),
+    )
+    db_session.add(antigo)
+    db_session.commit()
+    antigo_id = antigo.id
+    db_session.close()
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "av-598-pular", "auto_msg_espera_ativa": False, "auto_msg_fora_horario_ativa": False},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "av-598-pular"}
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id=wa, msg_id="598-nao-nota", text="Preciso de ajuda de novo"),
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+
+    db_session.expire_all()
+    antigo2 = db_session.query(WhatsappChat).filter(WhatsappChat.id == antigo_id).first()
+    assert antigo2 is not None
+    assert antigo2.estado == "encerrado"
+    assert antigo2.avaliacao_nota is None
+
+    novos = (
+        db_session.query(WhatsappChat)
+        .filter(
+            WhatsappChat.wa_id == wa,
+            WhatsappChat.estado == "aguardando_atendente",
+        )
+        .all()
+    )
+    assert len(novos) == 1
+    msgs = (
+        db_session.query(WhatsappMensagem)
+        .filter(
+            WhatsappMensagem.chat_id == novos[0].id,
+            WhatsappMensagem.direcao == "inbound",
+        )
+        .all()
+    )
+    assert len(msgs) == 1
+    assert msgs[0].corpo == "Preciso de ajuda de novo"
+
+
+def test_timeout_avaliacao_encerra_chat(client, seed_base, auth_headers, db_session, monkeypatch):
+    """#598 — após a janela, job finaliza aguardando_avaliacao."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.services.whatsapp_avaliacao import process_whatsapp_avaliacao_timeouts
+
+    st = _configurar(db_session)
+    st.avaliacao_janela_minutos = 30
+    db_session.commit()
+
+    enviados: list[str] = []
+
+    def fake_send(base, inst, key, wa, text):
+        enviados.append(text)
+        return True, None, "wa-timeout"
+
+    monkeypatch.setattr("app.services.whatsapp_avaliacao.evolution_api.evolution_send_text", fake_send)
+
+    chat = WhatsappChat(
+        protocolo="WPP-AV-TO",
+        wa_id="5511999000599",
+        estado="aguardando_avaliacao",
+        atendente_id=seed_base["a1"].id,
+        avaliacao_solicitada=True,
+        encerramento_at=datetime.now(timezone.utc) - timedelta(minutes=31),
+    )
+    db_session.add(chat)
+    db_session.commit()
+
+    n = process_whatsapp_avaliacao_timeouts(db_session, limit=50)
+    assert n == 1
+    db_session.refresh(chat)
+    assert chat.estado == "encerrado"
+    assert chat.avaliacao_nota is None
+    assert enviados
+    assert "período" in enviados[0].lower() or "encerrou" in enviados[0].lower() or "nova mensagem" in enviados[0].lower()
+
+
+def test_inbound_apos_timeout_abre_chat_novo(client, seed_base, auth_headers, db_session, monkeypatch):
+    """#598 — após timeout, próxima mensagem abre atendimento novo."""
+    from datetime import datetime, timezone
+
+    from tests.test_whatsapp_chats import _webhook_body
+
+    _configurar(db_session)
+    monkeypatch.setattr(
+        "app.api.whatsapp_webhook.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-esp"),
+    )
+    wa = "5511999000600"
+    db_session.add(
+        WhatsappChat(
+            protocolo="WPP-AV-POS-TO",
+            wa_id=wa,
+            estado="encerrado",
+            atendente_id=seed_base["a1"].id,
+            avaliacao_solicitada=True,
+            encerramento_at=datetime.now(timezone.utc),
+        )
+    )
+    db_session.commit()
+    db_session.close()
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "av-598-pos", "auto_msg_espera_ativa": False, "auto_msg_fora_horario_ativa": False},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "av-598-pos"}
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id=wa, msg_id="598-pos-to", text="Oi de novo"),
+        headers=h,
+    )
+    assert r.status_code == 200
+    fila = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()
+    assert any(c.get("wa_id") == wa for c in fila)
 
 
 def test_mensagens_avaliacao_nao_aparecem_na_conversa(client, seed_base, auth_headers, db_session):

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -682,9 +682,12 @@ export namespace WhatsappSettings {
     auto_msg_inativ_aviso_ativa?: boolean
     auto_msg_inativ_aviso_texto?: string | null
     avaliacao_ativa?: boolean
+    avaliacao_janela_minutos?: number
     auto_msg_avaliacao_ativa?: boolean
     auto_msg_avaliacao_texto?: string | null
     auto_msg_avaliacao_obrigado_texto?: string | null
+    auto_msg_avaliacao_timeout_texto?: string | null
+    auto_msg_avaliacao_pular_texto?: string | null
   }
   export interface ProvisionEmbutidoResult {
     instance: string
@@ -718,9 +721,12 @@ export namespace WhatsappSettings {
     auto_msg_inativ_aviso_ativa?: boolean | null
     auto_msg_inativ_aviso_texto?: string | null
     avaliacao_ativa?: boolean | null
+    avaliacao_janela_minutos?: number | null
     auto_msg_avaliacao_ativa?: boolean | null
     auto_msg_avaliacao_texto?: string | null
     auto_msg_avaliacao_obrigado_texto?: string | null
+    auto_msg_avaliacao_timeout_texto?: string | null
+    auto_msg_avaliacao_pular_texto?: string | null
   }
   export interface TesteResult {
     ok: boolean

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -81,6 +81,10 @@ const DEFAULT_MSG_INATIV_AVISO =
 const DEFAULT_MSG_AVALIACAO =
   'Como você avalia o atendimento?\n\nResponda com uma nota de *1* a *5*:\n1 — Péssimo\n2 — Ruim\n3 — Regular\n4 — Bom\n5 — Excelente'
 const DEFAULT_MSG_AVALIACAO_OBRIGADO = 'Obrigado pela sua avaliação! Atendimento encerrado.'
+const DEFAULT_MSG_AVALIACAO_PULAR =
+  'Sem problema! Vamos abrir um novo atendimento com a sua mensagem.'
+const DEFAULT_MSG_AVALIACAO_TIMEOUT =
+  'O período para avaliar o atendimento encerrou. Se precisar de ajuda, envie uma nova mensagem por aqui.'
 
 function renderQrPayload(data: Record<string, unknown> | null | undefined) {
   if (!data || typeof data !== 'object') return null
@@ -150,9 +154,12 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
   const [msgInativAvisoAtiva, setMsgInativAvisoAtiva] = useState(true)
   const [msgInativAvisoTexto, setMsgInativAvisoTexto] = useState(DEFAULT_MSG_INATIV_AVISO)
   const [avaliacaoAtiva, setAvaliacaoAtiva] = useState(false)
+  const [avaliacaoJanelaMinutos, setAvaliacaoJanelaMinutos] = useState('30')
   const [msgAvaliacaoAtiva, setMsgAvaliacaoAtiva] = useState(true)
   const [msgAvaliacaoTexto, setMsgAvaliacaoTexto] = useState(DEFAULT_MSG_AVALIACAO)
   const [msgAvaliacaoObrigadoTexto, setMsgAvaliacaoObrigadoTexto] = useState(DEFAULT_MSG_AVALIACAO_OBRIGADO)
+  const [msgAvaliacaoPularTexto, setMsgAvaliacaoPularTexto] = useState(DEFAULT_MSG_AVALIACAO_PULAR)
+  const [msgAvaliacaoTimeoutTexto, setMsgAvaliacaoTimeoutTexto] = useState(DEFAULT_MSG_AVALIACAO_TIMEOUT)
   const [nomeEmpresaExibicao, setNomeEmpresaExibicao] = useState('')
   const [horarioTimezone, setHorarioTimezone] = useState<string>('America/Sao_Paulo')
   const [usarFeriadosNacionais, setUsarFeriadosNacionais] = useState(false)
@@ -184,11 +191,19 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
         (r.auto_msg_inativ_aviso_texto ?? DEFAULT_MSG_INATIV_AVISO).trim() || DEFAULT_MSG_INATIV_AVISO,
       )
       setAvaliacaoAtiva(Boolean(r.avaliacao_ativa))
+      setAvaliacaoJanelaMinutos(String(r.avaliacao_janela_minutos ?? 30))
       setMsgAvaliacaoAtiva(Boolean(r.auto_msg_avaliacao_ativa ?? true))
       setMsgAvaliacaoTexto((r.auto_msg_avaliacao_texto ?? DEFAULT_MSG_AVALIACAO).trim() || DEFAULT_MSG_AVALIACAO)
       setMsgAvaliacaoObrigadoTexto(
         (r.auto_msg_avaliacao_obrigado_texto ?? DEFAULT_MSG_AVALIACAO_OBRIGADO).trim() ||
           DEFAULT_MSG_AVALIACAO_OBRIGADO,
+      )
+      setMsgAvaliacaoPularTexto(
+        (r.auto_msg_avaliacao_pular_texto ?? DEFAULT_MSG_AVALIACAO_PULAR).trim() || DEFAULT_MSG_AVALIACAO_PULAR,
+      )
+      setMsgAvaliacaoTimeoutTexto(
+        (r.auto_msg_avaliacao_timeout_texto ?? DEFAULT_MSG_AVALIACAO_TIMEOUT).trim() ||
+          DEFAULT_MSG_AVALIACAO_TIMEOUT,
       )
       setHorarioTimezone((r.horario_timezone ?? 'America/Sao_Paulo').trim() || 'America/Sao_Paulo')
       const identidadeSalva = (r.nome_empresa_exibicao ?? '').trim()
@@ -604,8 +619,9 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
             <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 dark:border-slate-800/80 dark:bg-slate-800/20 dark:text-slate-200">
               <p className="font-medium">Avaliação do atendimento</p>
               <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
-                Ao encerrar o chat, o cliente recebe uma solicitação de nota de 1 a 5 antes do atendimento ser
-                finalizado. As notas aparecem no histórico de conversas.
+                Ao encerrar o chat, o cliente recebe um pedido de nota (1 a 5) por um tempo limitado. Se responder com
+                outra mensagem, abrimos um atendimento novo com esse texto — sem prender o cliente. Sem resposta, a
+                janela encerra sozinha.
               </p>
             </div>
 
@@ -617,11 +633,28 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               statusOnText="Ativo"
               statusOffText="Inativo"
             />
+            <div>
+              <label className="text-xs font-medium text-slate-600 dark:text-slate-400">
+                Janela para enviar a nota (minutos)
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={1440}
+                disabled={!avaliacaoAtiva}
+                value={avaliacaoJanelaMinutos}
+                onChange={(e) => setAvaliacaoJanelaMinutos(e.target.value)}
+                className="mt-1 w-full max-w-xs rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              />
+              <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                Padrão: 30 minutos a partir do encerramento. Depois disso o chat finaliza sem nota.
+              </p>
+            </div>
             <Switch
               checked={msgAvaliacaoAtiva}
               onCheckedChange={setMsgAvaliacaoAtiva}
               label="Enviar mensagens de avaliação"
-              description="Solicitação da nota e agradecimento após a resposta."
+              description="Solicitação da nota, agradecimento, mensagem ao pular e finalização por tempo."
               showStatusPill
               statusOnText="Enviar"
               statusOffText="Encerrar direto"
@@ -646,19 +679,47 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               disabled={!avaliacaoAtiva || !msgAvaliacaoAtiva}
               className={`${TEXTAREA_FIELD_CLASS} disabled:opacity-50`}
             />
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-400">
+              Mensagem ao pular a nota (cliente manda outro texto)
+            </label>
+            <textarea
+              value={msgAvaliacaoPularTexto}
+              onChange={(e) => setMsgAvaliacaoPularTexto(e.target.value)}
+              rows={2}
+              disabled={!avaliacaoAtiva || !msgAvaliacaoAtiva}
+              className={`${TEXTAREA_FIELD_CLASS} disabled:opacity-50`}
+            />
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-400">
+              Mensagem ao expirar a janela (sem nota)
+            </label>
+            <textarea
+              value={msgAvaliacaoTimeoutTexto}
+              onChange={(e) => setMsgAvaliacaoTimeoutTexto(e.target.value)}
+              rows={2}
+              disabled={!avaliacaoAtiva || !msgAvaliacaoAtiva}
+              className={`${TEXTAREA_FIELD_CLASS} disabled:opacity-50`}
+            />
 
             <div className="flex justify-end pt-2">
               <Button
                 type="button"
                 loading={salvandoAvaliacao}
                 onClick={() => {
+                  const janela = Number.parseInt(avaliacaoJanelaMinutos, 10)
+                  if (avaliacaoAtiva && (!Number.isFinite(janela) || janela < 1)) {
+                    toast.showError('Informe a janela de avaliação em minutos (mínimo 1).')
+                    return
+                  }
                   setSalvandoAvaliacao(true)
                   whatsappSettings
                     .patch({
                       avaliacao_ativa: avaliacaoAtiva,
+                      avaliacao_janela_minutos: Number.isFinite(janela) && janela >= 1 ? janela : 30,
                       auto_msg_avaliacao_ativa: msgAvaliacaoAtiva,
                       auto_msg_avaliacao_texto: msgAvaliacaoTexto,
                       auto_msg_avaliacao_obrigado_texto: msgAvaliacaoObrigadoTexto,
+                      auto_msg_avaliacao_pular_texto: msgAvaliacaoPularTexto,
+                      auto_msg_avaliacao_timeout_texto: msgAvaliacaoTimeoutTexto,
                     })
                     .then(() => toast.showSuccess('Configurações de avaliação atualizadas.'))
                     .catch((err) => toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.')))


### PR DESCRIPTION
## Summary

- WhatsApp (#598): após encerrar com avaliação ativa, janela configurável (~30 min) para nota 1–5
- Texto/mídia que não é nota: encerra avaliação sem nota e **abre atendimento novo** com essa mensagem
- Timeout: worker finaliza `aguardando_avaliacao` e envia mensagem configurável
- Config WhatsApp → Avaliação: minutos + templates (pular / timeout)
- Migration `077_wpp_avaliacao_janela`

Closes #598

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** — Correções (#598)

## Test plan

- [x] `pytest tests/test_whatsapp_avaliacao.py` (nota, pular→novo chat, timeout, inbound pós-timeout)
- [x] `test_inbound_abre_chat_novo_quando_pendente_classificacao` (classificação + novo chat)
- [x] `alembic heads` → único head `077_wpp_avaliacao_janela`
- [ ] CI verde (changelog, backend, frontend)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Sem follow-ups — escopo da issue atendido
