### PR TITLE
feat(whatsapp): sugerir nomes semelhantes ao cadastrar contacto (#593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Portal (#602): sócio gere a equipa no `/portal` — cadastro e edição de colaboradores e supervisores (empresas, senha do portal); outros sócios listados com edição limitada; colaborador/supervisor recebem 403
 - Portal (#605): branding white-label no `/portal` — logo e cores da instância (mesmas configurações de Configurações → Base de conhecimento); login e shell aplicam a identidade do contratante, não a marca DeskRudder
 - Portal: shell alinhado ao painel DeskRudder (menu lateral com usuário/Sair, navbar com expandir/recolher); cor do menu lateral configurável (padrão = navbar); chat ao vivo no `/portal` (mesmo canal da `/kb`, isolado por instância); login com logo em destaque, ícone de olho na senha e fundo minimalista; título do portal independente da central `/kb`
+- WhatsApp (#593): ao **cadastrar** contacto no chat, o sistema sugere funcionários com nome semelhante para vincular (evita duplicados); o atendente pode ignorar e criar novo
 - WhatsApp (#591): no detalhe da **Empresa**, nova aba **Chats** com atendimentos filtrados por aquela empresa (busca, paginação, abrir conversa / retomar)
 - WhatsApp (#592): com funcionário em **mais de uma empresa**, o atendimento pode começar sem empresa; o atendente pergunta ao cliente e vincula (ou altera) a qualquer momento antes de encerrar — 1 empresa continua automática
 - WhatsApp (#590): na listagem **Atendimentos**, cada card mostra a **empresa** do contacto (ou «Sem empresa» quando não houver vínculo)

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -848,23 +848,7 @@ def buscar_funcionarios(
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
     term = f"%{busca.strip()}%"
-    rede_ids = [int(r[0]) for r in db.query(Rede.id).filter(Rede.tenant_id == atendente.tenant_id).all()]
-    empresa_ids = [int(r[0]) for r in db.query(Empresa.id).filter(Empresa.tenant_id == atendente.tenant_id).all()]
-    func_ids_junction = [
-        int(r[0])
-        for r in db.query(FuncionarioRedeEmpresa.funcionario_id)
-        .join(Empresa, Empresa.id == FuncionarioRedeEmpresa.empresa_id)
-        .filter(Empresa.tenant_id == atendente.tenant_id)
-        .distinct()
-        .all()
-    ]
-    filtros = []
-    if rede_ids:
-        filtros.append(FuncionarioRede.rede_id.in_(rede_ids))
-    if empresa_ids:
-        filtros.append(FuncionarioRede.empresa_id.in_(empresa_ids))
-    if func_ids_junction:
-        filtros.append(FuncionarioRede.id.in_(func_ids_junction))
+    filtros = _filtros_funcionario_tenant(db, atendente)
     if not filtros:
         return []
     q = (
@@ -923,6 +907,98 @@ def catalogo_funcionarios(
         redes=[WhatsappRedeCatalogoRead(id=r.id, nome=r.nome) for r in redes],
         empresas=[WhatsappEmpresaCatalogoRead(id=e.id, nome=_empresa_nome_exibicao(e) or e.nome, rede_id=int(e.rede_id)) for e in empresas],
     )
+
+
+def _filtros_funcionario_tenant(db: Session, atendente: Atendente) -> list:
+    """Filtros OR para funcionários ativos no tenant do atendente."""
+    rede_ids = [int(r[0]) for r in db.query(Rede.id).filter(Rede.tenant_id == atendente.tenant_id).all()]
+    empresa_ids = [int(r[0]) for r in db.query(Empresa.id).filter(Empresa.tenant_id == atendente.tenant_id).all()]
+    func_ids_junction = [
+        int(r[0])
+        for r in db.query(FuncionarioRedeEmpresa.funcionario_id)
+        .join(Empresa, Empresa.id == FuncionarioRedeEmpresa.empresa_id)
+        .filter(Empresa.tenant_id == atendente.tenant_id)
+        .distinct()
+        .all()
+    ]
+    filtros = []
+    if rede_ids:
+        filtros.append(FuncionarioRede.rede_id.in_(rede_ids))
+    if empresa_ids:
+        filtros.append(FuncionarioRede.empresa_id.in_(empresa_ids))
+    if func_ids_junction:
+        filtros.append(FuncionarioRede.id.in_(func_ids_junction))
+    return filtros
+
+
+@router.get("/funcionarios/similares", response_model=list[WhatsappFuncionarioOpcaoRead])
+def buscar_funcionarios_similares(
+    nome: str = Query(..., min_length=3, description="Nome digitado no cadastro"),
+    limit: int = Query(5, ge=1, le=10),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Sugestões por similaridade de nome (#593) — usado na aba Cadastrar do modal."""
+    from app.services.funcionario_nome_similar import (
+        LIMIAR_ALTA,
+        LIMIAR_SIMILARIDADE,
+        normalizar_nome,
+        ranquear_similares,
+        tokens_significativos,
+    )
+
+    nome_q = nome.strip()
+    nome_norm = normalizar_nome(nome_q)
+    if len(nome_norm) < 3:
+        return []
+
+    filtros = _filtros_funcionario_tenant(db, atendente)
+    if not filtros:
+        return []
+
+    tokens = tokens_significativos(nome_norm)[:2]
+    token_filters = [FuncionarioRede.nome.ilike(f"%{t}%") for t in tokens] if tokens else []
+    q = db.query(FuncionarioRede).filter(FuncionarioRede.ativo.is_(True), or_(*filtros))
+    if token_filters:
+        q = q.filter(or_(*token_filters))
+    candidatos_rows = q.order_by(FuncionarioRede.nome.asc(), FuncionarioRede.id.asc()).limit(300).all()
+
+    candidatos: list[tuple[int, str]] = []
+    for func in candidatos_rows:
+        if _funcionario_no_tenant(db, atendente, func.id) is None:
+            continue
+        candidatos.append((int(func.id), func.nome or ""))
+
+    ranked = ranquear_similares(nome_q, candidatos, limiar=LIMIAR_SIMILARIDADE, limit=limit)
+    if not ranked:
+        return []
+
+    by_id = {int(f.id): f for f in candidatos_rows}
+    redes_cache: dict[int, str] = {
+        int(r.id): r.nome
+        for r in db.query(Rede).filter(Rede.tenant_id == atendente.tenant_id).all()
+    }
+    out: list[WhatsappFuncionarioOpcaoRead] = []
+    for fid, _nome, score in ranked:
+        func = by_id.get(fid)
+        if func is None:
+            continue
+        rid = rede_id_efetiva(db, func)
+        out.append(
+            WhatsappFuncionarioOpcaoRead(
+                id=func.id,
+                nome=func.nome,
+                email=func.email,
+                telefone=getattr(func, "telefone", None),
+                tipo=func.tipo,
+                empresas=_empresas_funcionario(db, func),
+                rede_id=rid,
+                rede_nome=redes_cache.get(int(rid)) if rid is not None else None,
+                similaridade=round(float(score), 3),
+                similaridade_alta=float(score) >= LIMIAR_ALTA,
+            )
+        )
+    return out
 
 
 def _normalize_wa_id(raw: str | None) -> str:

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -75,6 +75,11 @@ class WhatsappFuncionarioOpcaoRead(BaseModel):
     empresas: list[WhatsappEmpresaOpcaoRead] = Field(default_factory=list)
     rede_id: int | None = None
     rede_nome: str | None = None
+    similaridade: float | None = Field(
+        None,
+        description="Score 0–1 quando a listagem é por similaridade de nome (#593).",
+    )
+    similaridade_alta: bool = False
 
 
 class WhatsappContatoRead(BaseModel):

--- a/backend/app/services/funcionario_nome_similar.py
+++ b/backend/app/services/funcionario_nome_similar.py
@@ -1,0 +1,70 @@
+"""Similaridade de nomes de funcionários (dedupe no cadastro WhatsApp).
+
+Critério (#593):
+- Normaliza acentos, caixa e espaços.
+- Pontua com o máximo entre: SequenceMatcher (difflib), Jaccard de tokens
+  e bónus se um nome contém o outro.
+- Limiar mínimo ``LIMIAR_SIMILARIDADE`` (0,72); ``LIMIAR_ALTA`` (0,90) para aviso.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from difflib import SequenceMatcher
+
+LIMIAR_SIMILARIDADE = 0.72
+LIMIAR_ALTA = 0.90
+_TOKEN_MIN = 3
+
+
+def normalizar_nome(texto: str) -> str:
+    s = unicodedata.normalize("NFKD", texto or "")
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    s = s.lower().strip()
+    s = re.sub(r"[^a-z0-9\s]", " ", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def tokens_significativos(nome_norm: str) -> list[str]:
+    return [t for t in nome_norm.split() if len(t) >= _TOKEN_MIN]
+
+
+def score_nomes(a: str, b: str) -> float:
+    na = normalizar_nome(a)
+    nb = normalizar_nome(b)
+    if not na or not nb:
+        return 0.0
+    if na == nb:
+        return 1.0
+    seq = SequenceMatcher(None, na, nb).ratio()
+    ta, tb = set(na.split()), set(nb.split())
+    jaccard = (len(ta & tb) / len(ta | tb)) if (ta | tb) else 0.0
+    if na in nb or nb in na:
+        contain = 0.85 + 0.15 * seq
+    else:
+        contain = 0.0
+    return max(seq, jaccard, contain)
+
+
+def ranquear_similares(
+    nome_consulta: str,
+    candidatos: list[tuple[int, str]],
+    *,
+    limiar: float = LIMIAR_SIMILARIDADE,
+    limit: int = 5,
+) -> list[tuple[int, str, float]]:
+    """
+    ``candidatos``: lista de ``(id, nome)``.
+    Retorna top ``limit`` acima do limiar, ordenados por score desc.
+    """
+    q = (nome_consulta or "").strip()
+    if len(normalizar_nome(q)) < _TOKEN_MIN:
+        return []
+    scored: list[tuple[int, str, float]] = []
+    for cid, nome in candidatos:
+        sc = score_nomes(q, nome)
+        if sc >= limiar:
+            scored.append((cid, nome, sc))
+    scored.sort(key=lambda x: (-x[2], x[1].lower(), x[0]))
+    return scored[: max(1, limit)]

--- a/backend/tests/test_funcionario_nome_similar.py
+++ b/backend/tests/test_funcionario_nome_similar.py
@@ -1,0 +1,79 @@
+"""Testes de similaridade de nome (#593)."""
+
+from __future__ import annotations
+
+from app.services.funcionario_nome_similar import (
+    LIMIAR_SIMILARIDADE,
+    normalizar_nome,
+    ranquear_similares,
+    score_nomes,
+)
+
+
+def test_normalizar_remove_acentos():
+    assert normalizar_nome("Luís Gustavo") == "luis gustavo"
+    assert normalizar_nome("  Maria   Silva ") == "maria silva"
+
+
+def test_score_acentos_e_typo_leve():
+    assert score_nomes("Luis Gustavo", "Luís Gustavo") >= LIMIAR_SIMILARIDADE
+    assert score_nomes("Maria Silva", "Maria Silvs") >= LIMIAR_SIMILARIDADE
+    assert score_nomes("João Pedro", "Carlos Alberto") < LIMIAR_SIMILARIDADE
+
+
+def test_ranquear_top_e_limiar():
+    candidatos = [
+        (1, "Luis Gustavo Santos"),
+        (2, "Luís Gustavo"),
+        (3, "Ana Paula"),
+        (4, "Carlos"),
+    ]
+    ranked = ranquear_similares("Luis Gustavo", candidatos, limit=5)
+    ids = [r[0] for r in ranked]
+    assert 2 in ids
+    assert 1 in ids
+    assert 3 not in ids
+    assert ranked[0][2] >= ranked[-1][2]
+
+
+def test_api_similares_whatsapp(client, seed_base, auth_headers, db_session):
+    from app.models.funcionario_rede import FuncionarioRede
+    from tests.test_whatsapp_chats import _criar_funcionario_colaborador
+
+    func = _criar_funcionario_colaborador(
+        db_session,
+        seed_base,
+        nome="Luís Gustavo",
+        email="luis.g@test.local",
+    )
+    inativo = _criar_funcionario_colaborador(
+        db_session,
+        seed_base,
+        nome="Luis Gustavo Inativo",
+        email="luis.inativo@test.local",
+    )
+    row = db_session.query(FuncionarioRede).filter(FuncionarioRede.id == inativo["id"]).first()
+    assert row is not None
+    row.ativo = False
+    db_session.commit()
+
+    r = client.get(
+        "/v1/whatsapp/chats/funcionarios/similares?nome=Luis%20Gustavo",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200, r.text
+    rows = r.json()
+    ids = [x["id"] for x in rows]
+    assert func["id"] in ids
+    assert inativo["id"] not in ids
+    hit = next(x for x in rows if x["id"] == func["id"])
+    assert hit["similaridade"] is not None
+    assert hit["similaridade"] >= LIMIAR_SIMILARIDADE
+    assert hit["rede_nome"] == seed_base["rede"].nome
+
+    distinto = client.get(
+        "/v1/whatsapp/chats/funcionarios/similares?nome=Zzzzz%20Xxxxx",
+        headers=auth_headers["a1"],
+    )
+    assert distinto.status_code == 200
+    assert distinto.json() == []

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -923,6 +923,8 @@ export namespace WhatsappChats {
     empresas: EmpresaOpcao[]
     rede_id?: number | null
     rede_nome?: string | null
+    similaridade?: number | null
+    similaridade_alta?: boolean
   }
   export interface Contato {
     id: number
@@ -1219,6 +1221,13 @@ export const whatsappChats = {
   buscarFuncionarios: (busca: string, limit = 20) =>
     api<WhatsappChats.FuncionarioOpcao[]>(
       `/whatsapp/chats/funcionarios?${new URLSearchParams({ busca, limit: String(limit) }).toString()}`,
+    ),
+  buscarFuncionariosSimilares: (nome: string, limit = 5) =>
+    api<WhatsappChats.FuncionarioOpcao[]>(
+      `/whatsapp/chats/funcionarios/similares?${new URLSearchParams({
+        nome,
+        limit: String(limit),
+      }).toString()}`,
     ),
   catalogoFuncionarios: () => api<WhatsappChats.FuncionarioCatalogo>('/whatsapp/chats/funcionarios/catalogo'),
   cadastrarFuncionario: (

--- a/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
@@ -39,6 +39,9 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
   const [catalogoLoading, setCatalogoLoading] = useState(false)
 
   const [nomeCadastro, setNomeCadastro] = useState('')
+  const [debouncedNomeCadastro, setDebouncedNomeCadastro] = useState('')
+  const [similares, setSimilares] = useState<WhatsappChats.FuncionarioOpcao[]>([])
+  const [loadingSimilares, setLoadingSimilares] = useState(false)
   const [emailCadastro, setEmailCadastro] = useState('')
   const [tipoCadastro, setTipoCadastro] = useState<TipoCadastro>('colaborador')
   const [escopoCadastro, setEscopoCadastro] = useState<EscopoCadastro>('selected')
@@ -76,6 +79,11 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
   }, [busca])
 
   useEffect(() => {
+    const timer = setTimeout(() => setDebouncedNomeCadastro(nomeCadastro.trim()), 450)
+    return () => clearTimeout(timer)
+  }, [nomeCadastro])
+
+  useEffect(() => {
     if (!open) return
     setModo('vincular')
     setBusca('')
@@ -85,6 +93,8 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
     setSelecionado(null)
     setEmpresaVinculoId('')
     setNomeCadastro(chat.cliente_nome?.trim() || '')
+    setDebouncedNomeCadastro('')
+    setSimilares([])
     setEmailCadastro('')
     setTipoCadastro('colaborador')
     setEscopoCadastro('selected')
@@ -125,6 +135,30 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
   }, [debouncedBusca, modo, open])
 
   useEffect(() => {
+    if (!open || modo !== 'cadastrar' || debouncedNomeCadastro.length < 3) {
+      setSimilares([])
+      setLoadingSimilares(false)
+      return
+    }
+    let cancelled = false
+    setLoadingSimilares(true)
+    whatsappChats
+      .buscarFuncionariosSimilares(debouncedNomeCadastro, 5)
+      .then((rows) => {
+        if (!cancelled) setSimilares(rows)
+      })
+      .catch(() => {
+        if (!cancelled) setSimilares([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingSimilares(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [debouncedNomeCadastro, modo, open])
+
+  useEffect(() => {
     if (!selecionado) {
       setEmpresaVinculoId('')
       return
@@ -154,6 +188,15 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
 
   function toggleEmpresaCadastro(id: number) {
     setEmpresaIdsCadastro((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+  }
+
+  function vincularSugestao(funcionario: WhatsappChats.FuncionarioOpcao) {
+    setSelecionado(funcionario)
+    setBusca(funcionario.nome)
+    setDebouncedBusca(funcionario.nome)
+    setResultados([funcionario])
+    setErroFormulario(null)
+    setModo('vincular')
   }
 
   async function confirmarVinculo() {
@@ -424,6 +467,66 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                   onChange={(e) => setNomeCadastro(e.target.value)}
                   required
                 />
+                {loadingSimilares && debouncedNomeCadastro.length >= 3 && (
+                  <p className="text-xs text-slate-500">A procurar nomes semelhantes…</p>
+                )}
+                {!loadingSimilares && similares.length > 0 && (
+                  <div className="rounded-xl border border-amber-200 bg-amber-50/80 px-3 py-3 dark:border-amber-900/50 dark:bg-amber-950/25">
+                    <p className="text-sm font-medium text-amber-950 dark:text-amber-100">
+                      Encontrámos cadastros com nome semelhante
+                    </p>
+                    <p className="mt-0.5 text-xs text-amber-800/90 dark:text-amber-200/80">
+                      Prefira vincular ao existente para evitar duplicados. Pode ignorar e cadastrar um novo.
+                    </p>
+                    {similares.some((s) => s.similaridade_alta) && (
+                      <p className="mt-2 text-xs font-medium text-amber-900 dark:text-amber-100">
+                        Atenção: há correspondência muito próxima (quase o mesmo nome).
+                      </p>
+                    )}
+                    <ul className="mt-3 max-h-40 space-y-2 overflow-y-auto">
+                      {similares.map((funcionario) => (
+                        <li
+                          key={funcionario.id}
+                          className="rounded-lg border border-amber-200/80 bg-white/80 px-3 py-2 dark:border-amber-900/40 dark:bg-slate-900/60"
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="min-w-0 flex-1">
+                              <p className="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
+                                {funcionario.nome}
+                              </p>
+                              <p className="truncate text-xs text-slate-500">
+                                {funcionario.email || funcionario.telefone || 'Sem e-mail/telefone'}
+                              </p>
+                              <div className="mt-1 flex flex-wrap gap-1">
+                                {funcionario.rede_nome && (
+                                  <span className="rounded bg-violet-100 px-1.5 py-0.5 text-[10px] font-medium text-violet-800 dark:bg-violet-950/50 dark:text-violet-200">
+                                    {funcionario.rede_nome}
+                                  </span>
+                                )}
+                                {funcionario.empresas.map((e) => (
+                                  <span
+                                    key={e.id}
+                                    className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+                                  >
+                                    {e.nome}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                            <Button
+                              type="button"
+                              variant="secondary"
+                              className="h-8 shrink-0 px-2 text-xs"
+                              onClick={() => vincularSugestao(funcionario)}
+                            >
+                              Vincular a este cadastro
+                            </Button>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
                 <Input
                   label="E-mail (opcional)"
                   type="email"


### PR DESCRIPTION
## Summary

- WhatsApp (#593): ao cadastrar contacto no chat, sugere funcionários com nome semelhante (acentos/fuzzy) para vincular em vez de duplicar
- Endpoint `GET /whatsapp/chats/funcionarios/similares` — top 5, só ativos do tenant
- Modal **Cadastrar**: debounce no nome + CTA «Vincular a este cadastro»; cadastro novo continua permitido (aviso se similaridade alta)

Closes #593

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → `[Unreleased]` — Melhorias (#593)

## Test plan

- [x] `pytest tests/test_funcionario_nome_similar.py` (5 passed)
- [x] `test_buscar_funcionarios_whatsapp`
- [ ] CI verde (changelog, backend, frontend)

## Follow-ups / backlog

- [x] Sem follow-ups — escopo da issue atendido (merge automático de duplicados existentes fica fora de escopo)
