### PR TITLE
release: main → staging (portal + WhatsApp operacional)

### DIFF
--- a/.cursor/commands/iniciar-feature.md
+++ b/.cursor/commands/iniciar-feature.md
@@ -8,6 +8,10 @@ Peça se não informado:
 - número/link da issue **ou** slug da feature
 - tipo: `feat` (padrão), `fix`, `chore`, `docs`
 
+## Quando usar (obrigatório)
+
+Após um lote ser **mergeado na `main`** para testes, o próximo trabalho **sempre** começa com este comando (branch nova). Não reutilize a branch já mergeada.
+
 ## Passo 1 — Verificar estado
 
 ```bash

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -9,9 +9,19 @@ alwaysApply: true
 
 - **Nunca** implementar direto em `main` ou `staging`
 - **Sempre** criar branch nova antes de codar
-- **Uma feature = uma branch = um PR** para `main`
+- **Uma feature/lote = uma branch = um PR** para `main`
 - `main` é **branch de testes** — `/criar-pr` mergeia automaticamente após CI verde
 - Não push direto em `main` (sempre via PR)
+
+## Após merge na `main` (obrigatório)
+
+Quando o PR do lote for **mergeado** e o desenvolvimento daquele lote estiver **fechado para testes** na `main`:
+
+1. **Não** continuar a codar na branch já mergeada (ex.: `cursor/…`, `feat/portal-…`)
+2. **Sempre** abrir **branch nova** a partir de `main` atualizada antes do próximo trabalho
+3. Usar `/iniciar-feature` (ou o fluxo abaixo) — mesmo se o próximo lote for “só polish” ou issues pequenas
+
+Exceção: hotfix urgente na mesma linha só se o PR ainda **não** tiver sido mergeado.
 
 ## Nomenclatura de branch
 

--- a/.github/planning-issue-bodies/issues/whatsapp-bugs-producao-epic.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-bugs-producao-epic.md
@@ -1,0 +1,17 @@
+﻿## Objetivo
+Corrigir bugs de UX do WhatsApp encontrados em testes em produção (composer, legendas, vínculo de contacto, Esc no lightbox e scroll ao reabrir chat).
+
+## Issues filhas
+- Composer com dois campos ao anexar imagem
+- Fonte da legenda diferente do texto
+- Vínculo de contacto não persiste em chats posteriores
+- Esc no lightbox sai do chat / troca conversa
+- Legenda de PDF/documento não aparece
+- Scroll ao reabrir chat não volta à última mensagem vista
+
+## Fora de escopo
+- Redesign completo do composer
+- Mudanças em chat interno (exceto se compartilharem o mesmo lightbox/scroll helper)
+
+## Origem
+QA produção — feedback do time.

--- a/.github/planning-issue-bodies/issues/whatsapp-cancelar-audio-envia.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-cancelar-audio-envia.md
@@ -1,0 +1,13 @@
+﻿## Problema
+Ao começar a gravar um áudio no composer e **cancelar**, o áudio é enviado mesmo assim (incluindo “no mudo” / clip vazio ou residual). Cancelar deve descartar a gravação sem enviar.
+
+Provável origem: `WhatsappGravadorAudioInline` / `MediaRecorder` — `cancelar` pode ainda disparar `onstop` com blob que o fluxo trata como envio.
+
+## Critérios de aceite
+- [ ] Cancelar gravação não envia mensagem de áudio
+- [ ] Não cria mensagem vazia/muda no chat nem no WhatsApp do cliente
+- [ ] Após cancelar, o composer volta ao estado normal (microfone disponível)
+- [ ] Enviar (parar e confirmar) continua a enviar o áudio normalmente
+
+## Origem
+Testes em produção — lote WhatsApp UX (#567).

--- a/.github/planning-issue-bodies/issues/whatsapp-composer-dois-campos.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-composer-dois-campos.md
@@ -1,0 +1,10 @@
+﻿## Problema
+QA em produção (WhatsApp): composer com anexo de imagem deixa o campo principal «Escreva uma mensagem…» visível junto com «Legenda opcional», gerando dois campos de texto ao mesmo tempo.
+
+## Critérios de aceite
+- [ ] Com pré-visualização de anexo aberta, só o campo de legenda (ou um único composer) fica editável
+- [ ] O composer principal não permanece ativo/visível por baixo do overlay de anexo
+- [ ] Cancelar ou enviar o anexo restaura o composer normal
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-esc-lightbox.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-esc-lightbox.md
@@ -1,0 +1,10 @@
+﻿## Problema
+Ao visualizar imagem/mídia em tela cheia e pressionar Esc, além de fechar o lightbox o atalho também sai do chat (ou muda para o primeiro chat da lista quando há vários abertos).
+
+## Critérios de aceite
+- [ ] Esc no lightbox fecha só a visualização em tela cheia
+- [ ] Não navega para fora do chat nem troca a conversa ativa
+- [ ] Esc sem lightbox mantém o comportamento atual (ex.: voltar à lista, se aplicável)
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-fonte-legenda.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-fonte-legenda.md
@@ -1,0 +1,9 @@
+﻿## Problema
+A legenda exibida sob imagens no balão do atendente usa tipografia diferente (menor/itálico) da fonte das mensagens de texto normais.
+
+## Critérios de aceite
+- [ ] Legenda de imagem/mídia no balão do atendente usa a mesma família, tamanho e peso do corpo das mensagens de texto
+- [ ] Contraste permanece legível no modo claro e escuro
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-inatividade-timer-pausa.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-inatividade-timer-pausa.md
@@ -1,0 +1,37 @@
+﻿## Problema
+O encerramento automático por inatividade conta desde a **última mensagem do cliente** e **não reinicia** quando o atendente fala. Isso causa:
+
+1. Cliente na fila por vários minutos → ao assumir, o aviso/encerramento dispara cedo demais.
+2. Atendente pede «aguarde, estou analisando» → o chat fecha mesmo com o cliente à espera, se a análise passar do prazo.
+
+## Regra de negócio
+
+### Timer
+- Contar desde a **última mensagem relevante** (cliente **ou** atendente humano).
+- Qualquer mensagem nova (cliente ou atendente) **reinicia** a contagem.
+- Só age em chat `em_atendimento` **depois** da 1ª resposta humana (não dispara na fila / só com `auto_assumido`/BOT).
+- Manter settings: `inativ_aviso_minutos` + `inativ_encerramento_apos_aviso_minutos`.
+
+### Pausa no chat
+- Botão **Pausar** / **Retomar** no header, com **countdown** ao lado.
+- **Pausar:** para o worker e **reseta** o prazo para o valor configurado (ex. 10:00) — não congela o restante.
+- **Retomar:** inicia a regressiva **de novo** a partir do prazo cheio.
+- Enquanto pausado: não envia aviso nem encerra.
+- Ao receber mensagem do cliente: sair da pausa automaticamente (além do retomar manual).
+
+## Critérios de aceite
+- [ ] Após fila longa, o prazo completo conta a partir da última mensagem (ex.: resposta do atendente reinicia)
+- [ ] Mensagem do cliente ou do atendente reinicia a contagem
+- [ ] Countdown visível no chat em atendimento (feature ligada)
+- [ ] Pausar: para o worker e mostra prazo resetado; não encerra
+- [ ] Retomar: inicia regressiva do prazo cheio de novo
+- [ ] `auto_assumido` / fila sem resposta humana: não dispara
+- [ ] Ciclo aviso → encerramento após aviso preservado
+- [ ] Testes backend + texto de ajuda na Config WhatsApp + CHANGELOG
+
+## Origem
+QA produção — análise de regra de negócio. Parte do épico #567 (lote WhatsApp).
+
+## Referência técnica
+- `backend/app/services/whatsapp_inactivity_worker.py` (`_referencia_inatividade_cliente`)
+- Plano: regra inatividade WhatsApp (última msg + pausa com countdown)

--- a/.github/planning-issue-bodies/issues/whatsapp-legenda-pdf.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-legenda-pdf.md
@@ -1,0 +1,10 @@
+﻿## Problema
+No WhatsApp é possível enviar PDF (e outros documentos) com legenda. No DeskRudder a legenda não aparece no balão do chat (imagens já mostram legenda).
+
+## Critérios de aceite
+- [ ] Legenda enviada com documento/PDF aparece no balão (inbound e outbound)
+- [ ] Composer de anexo de documento permite legenda opcional, como em imagens
+- [ ] Legenda vazia ou rótulo técnico interno não é exibida como texto falso
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-midia-sem-legenda-placeholder.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-midia-sem-legenda-placeholder.md
@@ -1,0 +1,12 @@
+﻿## Problema
+Quando o atendente envia imagem/mídia **sem** legenda, o balão mostra texto placeholder do tipo `[ Luan ]: [Imagem enviada]` (ou similar). Sem legenda, deve aparecer **só** a mídia — sem rótulo de texto.
+
+Hoje o filtro de rótulos técnicos (`ROTULO_SEM_LEGENDA`) cobre padrões como `[Imagem]`, mas não variantes como `[Imagem enviada]`, e o prefixo `[ Nome ]:` pode estar a ser concatenado no corpo.
+
+## Critérios de aceite
+- [ ] Imagem/vídeo/documento/áudio enviados sem legenda: balão sem texto de placeholder
+- [ ] Com legenda real: legenda continua a aparecer
+- [ ] Não exibir `[Imagem]`, `[Imagem enviada]` nem equivalentes como corpo da mensagem
+
+## Origem
+Testes em produção — lote WhatsApp UX (#567).

--- a/.github/planning-issue-bodies/issues/whatsapp-scroll-ultima-lida.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-scroll-ultima-lida.md
@@ -1,0 +1,11 @@
+﻿## Problema
+Ao reabrir um chat em andamento, o scroll cai em posição aleatória em vez da última mensagem vista pelo atendente. Comportamento desejado (estilo WhatsApp): restaurar a última posição lida; se o atendente já viu tudo, ir para o fim.
+
+## Critérios de aceite
+- [ ] Reabrir o mesmo chat restaura a última posição de scroll vista pelo atendente
+- [ ] Se já estava no fim (todas vistas), reabre no fim da conversa
+- [ ] Polling/SSE de novas mensagens não “pula” a posição enquanto o atendente lê histórico acima
+- [ ] Comportamento alinhado ao já feito no Histórico/chat interno (memória de scroll por conversa)
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.github/planning-issue-bodies/issues/whatsapp-ticks-entrega-leitura.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-ticks-entrega-leitura.md
@@ -1,0 +1,26 @@
+﻿## Problema
+Mensagens do atendente ficam com um único ✓ no DeskRudder, e no WhatsApp do **cliente** a mensagem não passa a «visualizada» (✓✓ azul) mesmo depois de o cliente ter respondido.
+
+Hoje o ✓✓ azul só aparece se alguém abrir a mesma conversa no **WhatsApp do suporte** (número/instância que recebe o inbound). Isso foge do fluxo do painel.
+
+## Regra de negócio (leitura / ✓✓ azul)
+A mensagem do **cliente** só deve ser marcada como visualizada (e o cliente só deve ver ✓✓ azul nas mensagens **dele** / o estado de leitura correspondente) quando for visualizada pelo **atendente responsável** pelo chat.
+
+- [ ] Visualizada pelo **responsável** do chat → pode marcar como lida / refletir ✓✓ azul no WhatsApp do cliente (conforme API Evolution)
+- [ ] Visualizada por **outro atendente** (ex.: consulta no Histórico, colega do setor) → **não** marcar como lida para o cliente
+- [ ] Visualizada **antes** de alguém assumir o atendimento (fila / sem responsável) → **não** marcar como lida para o cliente
+
+## Sintoma adicional (ticks no painel)
+No DeskRudder, mensagens do atendente ficam com um só ✓ mesmo quando no WhatsApp do cliente já estão entregues/lidas — o painel precisa espelhar entrega (✓✓) e leitura (✓✓ azul) com base nos eventos reais da API, sem depender de abrir o app WhatsApp do suporte.
+
+## Critérios de aceite
+- [ ] ✓ = enviada / aceite pela API
+- [ ] ✓✓ cinza = entregue no dispositivo do cliente
+- [ ] ✓✓ azul = lida, **somente** quando a regra de negócio acima for satisfeita (responsável visualizou)
+- [ ] Abrir o chat no painel como não-responsável ou sem responsável **não** dispara read receipt para o cliente
+- [ ] Abrir o chat como responsável dispara (ou confirma) a leitura conforme a Evolution API
+- [ ] Atualização via webhook/SSE/poll no painel sem precisar do WhatsApp mobile do suporte
+- [ ] Testes cobrindo: responsável vs outro atendente vs sem responsável
+
+## Origem
+Testes em produção — lote WhatsApp UX (#567). Clarificação: read receipt só pelo atendente responsável.

--- a/.github/planning-issue-bodies/issues/whatsapp-vinculo-chats-posteriores.md
+++ b/.github/planning-issue-bodies/issues/whatsapp-vinculo-chats-posteriores.md
@@ -1,0 +1,13 @@
+﻿## Problema
+Após identificar/vincular um contacto novo a uma rede e empresa, quando o mesmo número envia outra mensagem (novo chat ou retomada), o banner «Contacto não identificado» / «Identificar contato» volta a aparecer como se o vínculo não tivesse sido gravado.
+
+Relacionado em parte a #472 (banner no mesmo chat), mas aqui o sintoma é em **chats posteriores** do mesmo contacto.
+
+## Critérios de aceite
+- [ ] Após vincular/cadastrar, chats novos do mesmo `wa_id`/telefone já nascem vinculados (sem pedir identificação de novo)
+- [ ] Telefone/`wa_id` no funcionário da rede permite match em inbound futuro
+- [ ] Banner some e não reaparece após poll/SSE com snapshot antigo
+- [ ] Teste de regressão: vincular → simular novo inbound do mesmo número → chat com vínculo
+
+## Origem
+Testes em produção — lote WhatsApp UX.

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ frontend/public/_debug-*.png
 *.swp
 .DS_Store
 Thumbs.db
+
+# Local Python venv (dev)
+backend/.venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#608): duas mensagens inbound seguidas do mesmo contacto deixam de abrir dois chats/protocolos — lock por `wa_id` no webhook e uma única sequência de auto-mensagens por sessão
 - WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** (somente leitura) até registar, manter demandas existentes ou confirmar sem demanda; nova mensagem do mesmo cliente abre chat novo na fila
 - WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat
 - WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
-- WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown no chat
+- WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown (até o aviso e, após o aviso, até encerrar); enviar mensagem sai da pausa automaticamente
 - WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel
 - PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)
 - Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)
@@ -22,6 +22,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** (somente leitura) até registar, manter demandas existentes ou confirmar sem demanda; nova mensagem do mesmo cliente abre chat novo na fila
+- WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat
 - WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)
 - WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda
 - WhatsApp (#571): Esc no zoom da imagem fecha só a visualização, sem sair do chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown no chat
+- WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel
 - PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)
 - Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)
 - Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima
@@ -20,6 +22,12 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)
+- WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda
+- WhatsApp (#571): Esc no zoom da imagem fecha só a visualização, sem sair do chat
+- WhatsApp (#576): cancelar gravação de áudio já não envia o ficheiro
+- WhatsApp (#573): ao reabrir o chat, o scroll volta à última posição vista (não salta para o início)
+- WhatsApp (#570): contacto já vinculado é reconhecido em chats novos do mesmo número
 - Modo escuro: texto digitado nos campos de pesquisa (listagens e chat interno) volta a ficar legível
 - Equipe online: «0 online» mesmo com painel aberto (lista lia só a memória do worker errado)
 - Chat interno: espaço excessivo entre mensagens após colocar ações/reações fora do balão

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- WhatsApp (#591): no detalhe da **Empresa**, nova aba **Chats** com atendimentos filtrados por aquela empresa (busca, paginação, abrir conversa / retomar)
+- WhatsApp (#592): com funcionário em **mais de uma empresa**, o atendimento pode começar sem empresa; o atendente pergunta ao cliente e vincula (ou altera) a qualquer momento antes de encerrar — 1 empresa continua automática
+- WhatsApp (#590): na listagem **Atendimentos**, cada card mostra a **empresa** do contacto (ou «Sem empresa» quando não houver vínculo)
 - WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown (até o aviso e, após o aviso, até encerrar); enviar mensagem sai da pausa automaticamente
 - WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel
 - PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 ### Correções
 
 - WhatsApp (#608): duas mensagens inbound seguidas do mesmo contacto deixam de abrir dois chats/protocolos — lock por `wa_id` no webhook e uma única sequência de auto-mensagens por sessão
+- WhatsApp (#598): após encerrar com avaliação, janela de ~30 min (configurável) para a nota; se o cliente mandar outro texto, abre atendimento novo com essa mensagem; sem resposta, finaliza sozinho
 - WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** (somente leitura) até registar, manter demandas existentes ou confirmar sem demanda; nova mensagem do mesmo cliente abre chat novo na fila
 - WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat
 - WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Portal (#602): sócio gere a equipa no `/portal` — cadastro e edição de colaboradores e supervisores (empresas, senha do portal); outros sócios listados com edição limitada; colaborador/supervisor recebem 403
 - Portal (#605): branding white-label no `/portal` — logo e cores da instância (mesmas configurações de Configurações → Base de conhecimento); login e shell aplicam a identidade do contratante, não a marca DeskRudder
 - Portal: shell alinhado ao painel DeskRudder (menu lateral com usuário/Sair, navbar com expandir/recolher); cor do menu lateral configurável (padrão = navbar); chat ao vivo no `/portal` (mesmo canal da `/kb`, isolado por instância); login com logo em destaque, ícone de olho na senha e fundo minimalista; título do portal independente da central `/kb`
+- WhatsApp (#593): ao **cadastrar** contacto no chat, o sistema sugere funcionários com nome semelhante para vincular (evita duplicados); o atendente pode ignorar e criar novo
 - WhatsApp (#591): no detalhe da **Empresa**, nova aba **Chats** com atendimentos filtrados por aquela empresa (busca, paginação, abrir conversa / retomar)
 - WhatsApp (#592): com funcionário em **mais de uma empresa**, o atendimento pode começar sem empresa; o atendente pergunta ao cliente e vincula (ou altera) a qualquer momento antes de encerrar — 1 empresa continua automática
 - WhatsApp (#590): na listagem **Atendimentos**, cada card mostra a **empresa** do contacto (ou «Sem empresa» quando não houver vínculo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário
 - WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown (até o aviso e, após o aviso, até encerrar); enviar mensagem sai da pausa automaticamente
 - WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel
 - PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 ### Melhorias
 
 - Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário
+- Portal (#600, #601): cadastro de funcionário pelo modal da Rede permite definir senha do portal na criação; sócio cadastra sem escolher empresas (escopo automático em toda a rede)
+- Portal (#604): RBAC por papel — colaborador vê só os próprios chamados; supervisor vê todos das empresas vinculadas; sócio vê toda a rede
+- Portal (#603): listagem e detalhe de atendimentos WhatsApp no `/portal` (somente leitura), com o mesmo escopo por papel e sem comentários internos da equipe
+- Portal (#602): sócio gere a equipa no `/portal` — cadastro e edição de colaboradores e supervisores (empresas, senha do portal); outros sócios listados com edição limitada; colaborador/supervisor recebem 403
+- Portal (#605): branding white-label no `/portal` — logo e cores da instância (mesmas configurações de Configurações → Base de conhecimento); login e shell aplicam a identidade do contratante, não a marca DeskRudder
+- Portal: shell alinhado ao painel DeskRudder (menu lateral com usuário/Sair, navbar com expandir/recolher); cor do menu lateral configurável (padrão = navbar); chat ao vivo no `/portal` (mesmo canal da `/kb`, isolado por instância); login com logo em destaque, ícone de olho na senha e fundo minimalista; título do portal independente da central `/kb`
 - WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown (até o aviso e, após o aviso, até encerrar); enviar mensagem sai da pausa automaticamente
 - WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel
 - PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homónimos
 - WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos
 - WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede
+- Chat (#607): na aba **Atendendo**, secções **Comigo** e **Outros atendentes** quando o admin acompanha colegas; badge «Você» e destaque visual nos seus; nome do responsável legível nos de outros
+- WhatsApp (#606): conversa mais utilizável no **mobile** — composer com campo largo e botão de manuais só ícone; menu **⋮** com Transferir/Tickets; metadados em linha separada; painel de demandas colapsável; `safe-area` no composer
 
 ### Correções
 

--- a/backend/alembic/versions/073_wpp_inatividade_pausa.py
+++ b/backend/alembic/versions/073_wpp_inatividade_pausa.py
@@ -1,0 +1,44 @@
+"""WhatsApp: pausa do timer de inatividade no chat.
+
+Revision ID: 073_wpp_inatividade_pausa
+Revises: 072_chat_interno_silenciar
+Create Date: 2026-07-18
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "073_wpp_inatividade_pausa"
+down_revision = "072_chat_interno_silenciar"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "inatividade_pausada" not in cols:
+        op.add_column(
+            "whatsapp_chats",
+            sa.Column("inatividade_pausada", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+    if "inatividade_retomada_em" not in cols:
+        op.add_column(
+            "whatsapp_chats",
+            sa.Column("inatividade_retomada_em", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "inatividade_retomada_em" in cols:
+        op.drop_column("whatsapp_chats", "inatividade_retomada_em")
+    if "inatividade_pausada" in cols:
+        op.drop_column("whatsapp_chats", "inatividade_pausada")

--- a/backend/alembic/versions/074_wpp_classificacao_demanda.py
+++ b/backend/alembic/versions/074_wpp_classificacao_demanda.py
@@ -1,0 +1,42 @@
+"""WhatsApp: classificação de demanda pendente após inatividade.
+
+Revision ID: 074_wpp_classificacao_demanda
+Revises: 073_wpp_inatividade_pausa
+Create Date: 2026-07-18
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "074_wpp_classificacao_demanda"
+down_revision = "073_wpp_inatividade_pausa"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "classificacao_demanda_pendente" not in cols:
+        op.add_column(
+            "whatsapp_chats",
+            sa.Column(
+                "classificacao_demanda_pendente",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "classificacao_demanda_pendente" in cols:
+        op.drop_column("whatsapp_chats", "classificacao_demanda_pendente")

--- a/backend/alembic/versions/075_portal_funcionario_auth.py
+++ b/backend/alembic/versions/075_portal_funcionario_auth.py
@@ -1,0 +1,50 @@
+"""Portal funcionário: senha e preferências de acesso (#300/#303).
+
+Revision ID: 075_portal_funcionario_auth
+Revises: 074_wpp_classificacao_demanda
+Create Date: 2026-07-19
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "075_portal_funcionario_auth"
+down_revision = "074_wpp_classificacao_demanda"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("funcionarios_rede"):
+        return
+    cols = {c["name"] for c in insp.get_columns("funcionarios_rede")}
+    if "senha_hash" not in cols:
+        op.add_column("funcionarios_rede", sa.Column("senha_hash", sa.String(255), nullable=True))
+    if "must_change_password" not in cols:
+        op.add_column(
+            "funcionarios_rede",
+            sa.Column("must_change_password", sa.Boolean(), nullable=False, server_default=sa.false()),
+        )
+    if "token_version" not in cols:
+        op.add_column(
+            "funcionarios_rede",
+            sa.Column("token_version", sa.Integer(), nullable=False, server_default="0"),
+        )
+    if "notificar_email_portal" not in cols:
+        op.add_column(
+            "funcionarios_rede",
+            sa.Column("notificar_email_portal", sa.Boolean(), nullable=False, server_default=sa.true()),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("funcionarios_rede"):
+        return
+    cols = {c["name"] for c in insp.get_columns("funcionarios_rede")}
+    for col in ("notificar_email_portal", "token_version", "must_change_password", "senha_hash"):
+        if col in cols:
+            op.drop_column("funcionarios_rede", col)

--- a/backend/alembic/versions/076_kb_portal_cor_sidebar.py
+++ b/backend/alembic/versions/076_kb_portal_cor_sidebar.py
@@ -1,0 +1,43 @@
+"""Cor do menu lateral no branding KB/portal.
+
+Revision ID: 076_kb_portal_cor_sidebar
+Revises: 075_portal_funcionario_auth
+Create Date: 2026-07-20
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "076_kb_portal_cor_sidebar"
+down_revision = "075_portal_funcionario_auth"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("kb_portal_settings"):
+        return
+    cols = {c["name"] for c in insp.get_columns("kb_portal_settings")}
+    if "cor_sidebar" not in cols:
+        op.add_column(
+            "kb_portal_settings",
+            sa.Column("cor_sidebar", sa.String(7), nullable=True),
+        )
+        # Por padrão igual à navbar (cor_header) nas linhas existentes
+        op.execute(
+            sa.text(
+                "UPDATE kb_portal_settings SET cor_sidebar = cor_header WHERE cor_sidebar IS NULL"
+            )
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("kb_portal_settings"):
+        return
+    cols = {c["name"] for c in insp.get_columns("kb_portal_settings")}
+    if "cor_sidebar" in cols:
+        op.drop_column("kb_portal_settings", "cor_sidebar")

--- a/backend/alembic/versions/077_wpp_avaliacao_janela.py
+++ b/backend/alembic/versions/077_wpp_avaliacao_janela.py
@@ -1,0 +1,53 @@
+"""Janela de avaliação WhatsApp (~30 min) + templates timeout/pular.
+
+Revision ID: 077_wpp_avaliacao_janela
+Revises: 076_kb_portal_cor_sidebar
+Create Date: 2026-07-21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "077_wpp_avaliacao_janela"
+down_revision = "076_kb_portal_cor_sidebar"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_settings"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_settings")}
+    if "avaliacao_janela_minutos" not in cols:
+        op.add_column(
+            "whatsapp_settings",
+            sa.Column("avaliacao_janela_minutos", sa.Integer(), nullable=False, server_default="30"),
+        )
+        op.alter_column("whatsapp_settings", "avaliacao_janela_minutos", server_default=None)
+    if "auto_msg_avaliacao_timeout_texto" not in cols:
+        op.add_column(
+            "whatsapp_settings",
+            sa.Column("auto_msg_avaliacao_timeout_texto", sa.Text(), nullable=True),
+        )
+    if "auto_msg_avaliacao_pular_texto" not in cols:
+        op.add_column(
+            "whatsapp_settings",
+            sa.Column("auto_msg_avaliacao_pular_texto", sa.Text(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_settings"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_settings")}
+    for col in (
+        "auto_msg_avaliacao_pular_texto",
+        "auto_msg_avaliacao_timeout_texto",
+        "avaliacao_janela_minutos",
+    ):
+        if col in cols:
+            op.drop_column("whatsapp_settings", col)

--- a/backend/app/api/funcionarios_rede.py
+++ b/backend/app/api/funcionarios_rede.py
@@ -70,6 +70,15 @@ def _para_read(f: FuncionarioRede) -> FuncionarioRedeRead:
     )
 
 
+def _escopo_para_tipo(tipo: str, escopo_informado: str | None) -> str:
+    """Sócio sempre enxerga toda a rede (escopo all), mesmo se o cliente omitir o campo."""
+    tipo_eff = (tipo or "colaborador").strip().lower()
+    if tipo_eff == "socio":
+        return "all"
+    escopo = (escopo_informado or "selected").strip().lower()
+    return escopo if escopo in ("all", "selected") else "selected"
+
+
 def _aplicar_senha_portal(f: FuncionarioRede, senha: str | None, *, must_change: bool | None) -> None:
     if senha is None:
         return
@@ -177,7 +186,7 @@ def criar(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(exigir_admin),
 ):
-    escopo = (data.escopo_empresas or "selected").strip().lower()
+    escopo = _escopo_para_tipo(data.tipo, data.escopo_empresas)
     if escopo not in ("all", "selected"):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="escopo_empresas deve ser all ou selected")
     empresa_ids = list(data.empresa_ids or [])
@@ -275,7 +284,7 @@ def atualizar(
         f.must_change_password = bool(must_change)
     if revogar:
         f.token_version = int(getattr(f, "token_version", 0) or 0) + 1
-    escopo = (escopo_upd or escopo_efetivo(f)).strip().lower()
+    escopo = _escopo_para_tipo(f.tipo, escopo_upd or escopo_efetivo(f))
     if escopo not in ("all", "selected"):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="escopo_empresas deve ser all ou selected")
     ids = list(empresa_ids) if empresa_ids is not None else _empresa_ids_leitura(f)

--- a/backend/app/api/funcionarios_rede.py
+++ b/backend/app/api/funcionarios_rede.py
@@ -25,6 +25,7 @@ from app.services.funcionario_rede_resolver import assert_email_unico_por_rede, 
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import exigir_admin
 from app.core.audit import registrar_audit
+from app.core.security import hash_senha
 
 router = APIRouter(prefix="/funcionarios-rede", tags=["funcionarios-rede"])
 
@@ -61,9 +62,33 @@ def _para_read(f: FuncionarioRede) -> FuncionarioRedeRead:
         rede_id=f.rede_id,
         empresa_id=f.empresa_id,
         empresa_ids=_empresa_ids_leitura(f),
+        portal_habilitado=bool((getattr(f, "senha_hash", None) or "").strip()),
+        must_change_password=bool(getattr(f, "must_change_password", False)),
+        notificar_email_portal=bool(getattr(f, "notificar_email_portal", True)),
         created_at=f.created_at,
         updated_at=f.updated_at,
     )
+
+
+def _aplicar_senha_portal(f: FuncionarioRede, senha: str | None, *, must_change: bool | None) -> None:
+    if senha is None:
+        return
+    senha_limpa = senha.strip()
+    if not senha_limpa:
+        return
+    if len(senha_limpa) < 8:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A senha do portal deve ter ao menos 8 caracteres.",
+        )
+    if not (f.email or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Informe o e-mail do funcionário para habilitar o portal.",
+        )
+    f.senha_hash = hash_senha(senha_limpa)
+    f.must_change_password = True if must_change is None else bool(must_change)
+    f.token_version = int(getattr(f, "token_version", 0) or 0) + 1
 
 
 @router.get("", response_model=ListaPaginada[FuncionarioRedeRead])
@@ -196,6 +221,7 @@ def criar(
     )
     db.add(f)
     db.flush()
+    _aplicar_senha_portal(f, data.senha_portal, must_change=data.must_change_password)
     registrar_audit(db, "funcionario_rede", f.id, "create", atendente.id)
     sincronizar_vinculos_empresas(
         db,
@@ -238,8 +264,17 @@ def atualizar(
     empresa_ids = update.pop("empresa_ids", None)
     empresa_id_upd = update.pop("empresa_id", None)
     escopo_upd = update.pop("escopo_empresas", None)
+    senha_portal = update.pop("senha_portal", None)
+    must_change = update.pop("must_change_password", None)
+    revogar = update.pop("revogar_sessoes_portal", None)
     for k, v in update.items():
         setattr(f, k, v)
+    if senha_portal is not None:
+        _aplicar_senha_portal(f, senha_portal, must_change=must_change)
+    elif must_change is not None:
+        f.must_change_password = bool(must_change)
+    if revogar:
+        f.token_version = int(getattr(f, "token_version", 0) or 0) + 1
     escopo = (escopo_upd or escopo_efetivo(f)).strip().lower()
     if escopo not in ("all", "selected"):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="escopo_empresas deve ser all ou selected")

--- a/backend/app/api/kb.py
+++ b/backend/app/api/kb.py
@@ -50,6 +50,7 @@ from app.schemas.portal_chat import (
     PortalChatSessionRead,
 )
 from app.schemas.lista_paginada import ListaPaginada
+from app.services.instancia_branding import branding_kb_publico as montar_branding_kb_publico
 from app.services.kb import listar_artigos_sugeridos, registrar_versao_artigo, slug_disponivel
 from app.services.kb_feedback import registrar_feedback_artigo_publico
 from app.core.login_protection import client_ip
@@ -798,10 +799,12 @@ def _get_or_create_portal_settings(db: Session, tenant_id: int) -> KbPortalSetti
 
 
 def _portal_settings_read(row: KbPortalSettings) -> KbPortalSettingsRead:
+    cor_header = row.cor_header or "#0B2D4A"
     return KbPortalSettingsRead(
         portal_titulo=row.portal_titulo,
         texto_boas_vindas=row.texto_boas_vindas,
-        cor_header=row.cor_header or "#0B2D4A",
+        cor_header=cor_header,
+        cor_sidebar=(row.cor_sidebar or cor_header),
         cor_primaria=row.cor_primaria or "#0D9488",
         cor_texto_header=row.cor_texto_header or "#FFFFFF",
         cor_texto_corpo=row.cor_texto_corpo or "#0F172A",
@@ -813,49 +816,6 @@ def _portal_settings_read(row: KbPortalSettings) -> KbPortalSettingsRead:
         chat_setor_id=row.chat_setor_id,
         chat_texto_boas_vindas=row.chat_texto_boas_vindas,
         public_url_preview="/kb",
-    )
-
-
-def _nome_exibicao_empresa(row: EmpresaSistema | None) -> str:
-    if not row:
-        return "Central de ajuda"
-    for attr in ("nome_fantasia", "nome", "razao_social"):
-        val = getattr(row, attr, None)
-        if val and str(val).strip():
-            return str(val).strip()
-    return "Central de ajuda"
-
-
-def _kb_public_branding(db: Session, tenant_id: int) -> KbPublicBrandingRead:
-    row = _empresa_sistema_row(db)
-    settings = _portal_settings_row(db, tenant_id)
-    logo_url = None
-    if row and row.logo_filename and str(row.logo_filename).strip():
-        logo_url = "/v1/kb/public/logo"
-    nome = _nome_exibicao_empresa(row)
-    titulo_custom = (settings.portal_titulo or "").strip() if settings else ""
-    if titulo_custom:
-        portal_titulo = titulo_custom
-    elif nome != "Central de ajuda":
-        portal_titulo = f"Central de ajuda — {nome}"
-    else:
-        portal_titulo = "Central de ajuda"
-    cor_primaria = (settings.cor_primaria if settings else None) or "#0D9488"
-    cor_link = (settings.cor_link if settings and settings.cor_link else None) or cor_primaria
-    return KbPublicBrandingRead(
-        nome_exibicao=nome,
-        portal_titulo=portal_titulo,
-        logo_url=logo_url,
-        texto_boas_vindas=settings.texto_boas_vindas if settings else None,
-        cor_primaria=cor_primaria,
-        cor_header=(settings.cor_header if settings else None) or "#0B2D4A",
-        cor_texto_header=(settings.cor_texto_header if settings else None) or "#FFFFFF",
-        cor_texto_corpo=(settings.cor_texto_corpo if settings else None) or "#0F172A",
-        cor_fundo=(settings.cor_fundo if settings else None) or "#F8FAFC",
-        cor_link=cor_link,
-        exibir_marca_deskrudder=bool(settings.exibir_marca_deskrudder) if settings else True,
-        feedback_habilitado=bool(settings.feedback_habilitado) if settings else True,
-        chat_habilitado=bool(settings.chat_habilitado) if settings else False,
     )
 
 
@@ -898,7 +858,7 @@ def atualizar_portal_settings(
 
 
 @router.get("/public/branding", response_model=KbPublicBrandingRead)
-def branding_kb_publico(
+def branding_kb_publico_endpoint(
     request: Request,
     response: Response,
     tenant_id: TenantIdDep,
@@ -906,7 +866,7 @@ def branding_kb_publico(
 ):
     check_kb_public_rate_limit(request)
     _ = tenant_id
-    out = _kb_public_branding(db, tenant_id)
+    out = montar_branding_kb_publico(db, tenant_id)
     _public_cache_headers(response)
     return out
 

--- a/backend/app/api/portal.py
+++ b/backend/app/api/portal.py
@@ -1,0 +1,418 @@
+"""API do portal do cliente — funcionários da rede (#263 / #300–#303)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile, status
+from fastapi.responses import FileResponse
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.login_protection import check_login_rate_limit, delay_on_auth_failure
+from app.core.portal_auth import claims_portal, obter_funcionario_portal
+from app.core.portal_scope import assert_empresa_no_escopo, empresa_ids_visiveis, tenant_id_do_funcionario
+from app.core.security import (
+    criar_access_token,
+    criar_refresh_token,
+    decodificar_refresh_token,
+    hash_senha,
+    verificar_senha,
+)
+from app.core.tenant_context import (
+    assert_token_tenant_matches_request,
+    resolve_tenant_id,
+)
+from app.database import get_db
+from app.models.empresa import Empresa
+from app.models.empresa_pdv import EmpresaPdv
+from app.models.funcionario_rede import FuncionarioRede
+from app.models.setor import Setor
+from app.models.ticket_anexo import TicketAnexo
+from app.schemas.lista_paginada import ListaPaginada
+from app.schemas.portal import (
+    PortalAnexoRead,
+    PortalEmpresaRead,
+    PortalLogin,
+    PortalMe,
+    PortalMensagemRead,
+    PortalPdvRead,
+    PortalPreferenciasUpdate,
+    PortalRefreshRequest,
+    PortalSetorRead,
+    PortalTicketCreate,
+    PortalTicketDetail,
+    PortalTicketListItem,
+    PortalTicketMensagemCreate,
+    PortalToken,
+    PortalTrocarSenha,
+)
+from app.services import portal_tickets as portal_svc
+from app.services import ticket_anexo_storage
+from app.services.funcionario_escopo import rede_id_efetiva
+from app.services.ticket_csat import criar_convite_csat
+
+router = APIRouter(prefix="/portal", tags=["portal-cliente"])
+
+_MAX_PAGE = 50
+_DEFAULT_PAGE = 20
+
+
+def _buscar_funcionario_login(db: Session, email: str) -> FuncionarioRede | None:
+    return (
+        db.query(FuncionarioRede)
+        .filter(
+            func.lower(FuncionarioRede.email) == email,
+            FuncionarioRede.ativo.is_(True),
+        )
+        .first()
+    )
+
+
+def _emitir_tokens(db: Session, funcionario: FuncionarioRede) -> PortalToken:
+    tid = tenant_id_do_funcionario(db, funcionario)
+    claims = claims_portal(funcionario, tenant_id=tid)
+    return PortalToken(
+        access_token=criar_access_token(data=claims),
+        refresh_token=criar_refresh_token(data=claims),
+        must_change_password=bool(getattr(funcionario, "must_change_password", False)),
+    )
+
+
+def _me_read(db: Session, funcionario: FuncionarioRede) -> PortalMe:
+    ids = sorted(empresa_ids_visiveis(db, funcionario))
+    empresas: list[PortalEmpresaRead] = []
+    if ids:
+        rows = db.query(Empresa).filter(Empresa.id.in_(ids)).order_by(Empresa.nome.asc()).all()
+        empresas = [
+            PortalEmpresaRead(id=e.id, nome=e.nome, rede_id=int(e.rede_id)) for e in rows
+        ]
+    return PortalMe(
+        id=funcionario.id,
+        nome=funcionario.nome,
+        email=str(funcionario.email or ""),
+        tipo=funcionario.tipo,
+        rede_id=rede_id_efetiva(db, funcionario),
+        empresas=empresas,
+        must_change_password=bool(getattr(funcionario, "must_change_password", False)),
+        notificar_email_portal=bool(getattr(funcionario, "notificar_email_portal", True)),
+    )
+
+
+@router.post("/auth/login", response_model=PortalToken)
+async def portal_login(request: Request, data: PortalLogin, db: Session = Depends(get_db)):
+    check_login_rate_limit(request)
+    email = data.email.strip().lower()
+    resolve_tenant_id(request)  # valida host multi-tenant
+    funcionario = _buscar_funcionario_login(db, email)
+    if not funcionario or not (funcionario.senha_hash or "").strip():
+        await delay_on_auth_failure()
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="E-mail ou senha inválidos")
+    if not verificar_senha(data.senha, funcionario.senha_hash):
+        await delay_on_auth_failure()
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="E-mail ou senha inválidos")
+    if not funcionario.ativo:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Conta inativa")
+    return _emitir_tokens(db, funcionario)
+
+
+@router.post("/auth/refresh", response_model=PortalToken)
+async def portal_refresh(
+    request: Request,
+    data: PortalRefreshRequest,
+    db: Session = Depends(get_db),
+):
+    payload = decodificar_refresh_token(data.refresh_token)
+    if not payload or "sub" not in payload or payload.get("aud") != "portal":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Refresh token inválido ou expirado")
+    email = str(payload["sub"]).strip().lower()
+    token_tid = payload.get("tid")
+    assert_token_tenant_matches_request(request, token_tid)
+    funcionario = _buscar_funcionario_login(db, email)
+    if not funcionario:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuário não encontrado ou inativo")
+    fid = payload.get("fid")
+    if fid is not None and int(fid) != int(funcionario.id):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Usuário não encontrado ou inativo")
+    token_ver = int(payload.get("ver") or 0)
+    atual_ver = int(getattr(funcionario, "token_version", 0) or 0)
+    if token_ver != atual_ver:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Sessão encerrada. Faça login novamente.",
+        )
+    return _emitir_tokens(db, funcionario)
+
+
+@router.get("/me", response_model=PortalMe)
+def portal_me(
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    return _me_read(db, funcionario)
+
+
+@router.post("/me/trocar-senha", response_model=PortalToken)
+def portal_trocar_senha(
+    data: PortalTrocarSenha,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    if not verificar_senha(data.senha_atual, funcionario.senha_hash or ""):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Senha atual incorreta")
+    if len(data.senha_nova.strip()) < 8:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="A nova senha deve ter ao menos 8 caracteres")
+    if verificar_senha(data.senha_nova, funcionario.senha_hash or ""):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="A nova senha deve ser diferente da atual")
+    funcionario.senha_hash = hash_senha(data.senha_nova.strip())
+    funcionario.must_change_password = False
+    funcionario.token_version = int(getattr(funcionario, "token_version", 0) or 0) + 1
+    db.commit()
+    db.refresh(funcionario)
+    return _emitir_tokens(db, funcionario)
+
+
+@router.patch("/me/preferencias", response_model=PortalMe)
+def portal_preferencias(
+    data: PortalPreferenciasUpdate,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    if data.notificar_email_portal is not None:
+        funcionario.notificar_email_portal = bool(data.notificar_email_portal)
+        db.commit()
+        db.refresh(funcionario)
+    return _me_read(db, funcionario)
+
+
+@router.get("/catalogos/setores", response_model=list[PortalSetorRead])
+def portal_setores(
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    tid = tenant_id_do_funcionario(db, funcionario)
+    rows = (
+        db.query(Setor)
+        .filter(Setor.tenant_id == tid, Setor.ativo.is_(True))
+        .order_by(Setor.nome.asc())
+        .all()
+    )
+    return [PortalSetorRead(id=s.id, nome=s.nome, slug=s.slug) for s in rows]
+
+
+@router.get("/empresas/{empresa_id}/pdvs", response_model=list[PortalPdvRead])
+def portal_pdvs_empresa(
+    empresa_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        assert_empresa_no_escopo(db, funcionario, empresa_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    rows = (
+        db.query(EmpresaPdv)
+        .filter(EmpresaPdv.empresa_id == empresa_id, EmpresaPdv.ativo.is_(True))
+        .order_by(EmpresaPdv.codigo.asc())
+        .all()
+    )
+    return [
+        PortalPdvRead(id=p.id, codigo=p.codigo, papel=getattr(p, "papel", None), ativo=bool(p.ativo))
+        for p in rows
+    ]
+
+
+@router.get("/tickets", response_model=ListaPaginada[PortalTicketListItem])
+def portal_listar_tickets(
+    situacao: str = Query("abertos", description="abertos | fechados | todos"),
+    busca: str | None = Query(None),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    rows, total = portal_svc.listar_tickets(
+        db,
+        funcionario,
+        situacao=situacao,
+        busca=busca,
+        offset=offset,
+        limit=limit,
+    )
+    return ListaPaginada(items=[portal_svc.ticket_para_list_item(t) for t in rows], total=total)
+
+
+@router.post("/tickets", response_model=PortalTicketDetail, status_code=201)
+def portal_criar_ticket(
+    data: PortalTicketCreate,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.criar_ticket(db, funcionario, data)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    return portal_svc.ticket_para_detail(db, ticket)
+
+
+@router.get("/tickets/{ticket_id}", response_model=PortalTicketDetail)
+def portal_obter_ticket(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_svc.ticket_para_detail(db, ticket)
+
+
+@router.get("/tickets/{ticket_id}/mensagens", response_model=list[PortalMensagemRead])
+def portal_listar_mensagens(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_svc.listar_mensagens_publicas(db, funcionario, ticket)
+
+
+@router.post("/tickets/{ticket_id}/mensagens", response_model=PortalMensagemRead, status_code=201)
+def portal_criar_mensagem(
+    ticket_id: int,
+    data: PortalTicketMensagemCreate,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+        m = portal_svc.criar_mensagem_portal(db, funcionario, ticket, data.corpo)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    return portal_svc.mensagem_para_read(db, funcionario, m)
+
+
+@router.get("/tickets/{ticket_id}/anexos", response_model=list[PortalAnexoRead])
+def portal_listar_anexos(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_svc.listar_anexos_publicos(db, ticket)
+
+
+@router.post("/tickets/{ticket_id}/anexos", response_model=PortalAnexoRead, status_code=201)
+async def portal_upload_anexo(
+    ticket_id: int,
+    file: UploadFile = File(...),
+    mensagem_id: int | None = Form(None),
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    if ticket.fechado_em is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Chamado encerrado. Abra um novo chamado para enviar anexos.",
+        )
+    raw = await file.read()
+    try:
+        nome_original, mime = ticket_anexo_storage.validar_upload(file.filename, file.content_type, len(raw))
+        storage_key = ticket_anexo_storage.gravar_bytes_em_disco(raw, mimetype=mime, nome_original=nome_original)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    except OSError as e:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Falha ao gravar arquivo") from e
+
+    msg_id = None
+    if mensagem_id is not None:
+        from app.models.ticket import TicketMensagem
+
+        msg = (
+            db.query(TicketMensagem)
+            .filter(
+                TicketMensagem.id == mensagem_id,
+                TicketMensagem.ticket_id == ticket.id,
+                TicketMensagem.tipo.in_(list(portal_svc.TIPOS_PUBLICOS_PORTAL)),
+            )
+            .first()
+        )
+        if not msg:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Mensagem não encontrada")
+        msg_id = msg.id
+
+    a = TicketAnexo(
+        ticket_id=ticket.id,
+        mensagem_id=msg_id,
+        atendente_id=None,
+        visibilidade="publico",
+        nome_original=nome_original,
+        content_type=mime,
+        tamanho_bytes=len(raw),
+        storage_key=storage_key,
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return PortalAnexoRead(
+        id=a.id,
+        nome_original=a.nome_original,
+        content_type=a.content_type,
+        tamanho_bytes=int(a.tamanho_bytes or 0),
+        mensagem_id=a.mensagem_id,
+        created_at=a.created_at,
+        download_url=f"/v1/portal/tickets/{ticket.id}/anexos/{a.id}/download",
+    )
+
+
+@router.get("/tickets/{ticket_id}/anexos/{anexo_id}/download")
+def portal_download_anexo(
+    ticket_id: int,
+    anexo_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+        a = portal_svc.obter_anexo_publico(db, ticket, anexo_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    path = ticket_anexo_storage.caminho_absoluto_arquivo(a.storage_key)
+    if path is None or not path.is_file():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Arquivo não encontrado no armazenamento")
+    return FileResponse(
+        path=str(path),
+        filename=a.nome_original,
+        media_type=a.content_type or "application/octet-stream",
+    )
+
+
+@router.post("/tickets/{ticket_id}/csat-link")
+def portal_csat_link(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        ticket = portal_svc.obter_ticket_escopo(db, funcionario, ticket_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    if ticket.fechado_em is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Avaliação disponível após o encerramento.")
+    result = criar_convite_csat(db, ticket.id, enviar_email=False, exigir_email_cliente=False)
+    if not result:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Avaliação já registrada ou indisponível.")
+    return {"link": result["link"], "expires_at": result["expires_at"]}

--- a/backend/app/api/portal.py
+++ b/backend/app/api/portal.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Request, Response, UploadFile, status
 from fastapi.responses import FileResponse
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from app.core.kb_public_rate_limit import check_kb_public_rate_limit
 from app.core.login_protection import check_login_rate_limit, delay_on_auth_failure
-from app.core.portal_auth import claims_portal, obter_funcionario_portal
+from app.core.portal_auth import claims_portal, exigir_socio_portal, obter_funcionario_portal
 from app.core.portal_scope import assert_empresa_no_escopo, empresa_ids_visiveis, tenant_id_do_funcionario
 from app.core.security import (
     criar_access_token,
@@ -18,6 +19,7 @@ from app.core.security import (
     verificar_senha,
 )
 from app.core.tenant_context import (
+    TenantIdDep,
     assert_token_tenant_matches_request,
     resolve_tenant_id,
 )
@@ -44,11 +46,22 @@ from app.schemas.portal import (
     PortalTicketMensagemCreate,
     PortalToken,
     PortalTrocarSenha,
+    PortalWhatsappChatDetail,
+    PortalWhatsappChatListItem,
+    PortalWhatsappMensagemRead,
+    PortalEquipeFuncionarioCreate,
+    PortalEquipeFuncionarioRead,
+    PortalEquipeFuncionarioUpdate,
+    PortalPublicBrandingRead,
 )
 from app.services import portal_tickets as portal_svc
+from app.services import portal_whatsapp as portal_wpp_svc
+from app.services import portal_equipe as portal_equipe_svc
+from app.services.instancia_branding import branding_portal_cliente
 from app.services import ticket_anexo_storage
 from app.services.funcionario_escopo import rede_id_efetiva
 from app.services.ticket_csat import criar_convite_csat
+from app.services.whatsapp_media_storage import caminho_absoluto_arquivo
 
 router = APIRouter(prefix="/portal", tags=["portal-cliente"])
 
@@ -400,6 +413,143 @@ def portal_download_anexo(
     )
 
 
+@router.get("/chats", response_model=ListaPaginada[PortalWhatsappChatListItem])
+def portal_listar_chats(
+    situacao: str = Query("abertos", description="abertos | encerrados | todos"),
+    busca: str | None = Query(None),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    rows, total = portal_wpp_svc.listar_chats(
+        db,
+        funcionario,
+        situacao=situacao,
+        busca=busca,
+        offset=offset,
+        limit=limit,
+    )
+    return ListaPaginada(
+        items=[portal_wpp_svc.chat_para_list_item(db, c) for c in rows],
+        total=total,
+    )
+
+
+@router.get("/chats/{chat_id}", response_model=PortalWhatsappChatDetail)
+def portal_obter_chat(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        chat = portal_wpp_svc.obter_chat_escopo(db, funcionario, chat_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_wpp_svc.chat_para_detail(db, chat)
+
+
+@router.get("/chats/{chat_id}/mensagens", response_model=list[PortalWhatsappMensagemRead])
+def portal_listar_mensagens_chat(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        chat = portal_wpp_svc.obter_chat_escopo(db, funcionario, chat_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_wpp_svc.listar_mensagens_visiveis(db, chat)
+
+
+@router.get("/chats/{chat_id}/mensagens/{mensagem_id}/midia")
+def portal_download_midia_chat(
+    chat_id: int,
+    mensagem_id: int,
+    db: Session = Depends(get_db),
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+):
+    try:
+        chat = portal_wpp_svc.obter_chat_escopo(db, funcionario, chat_id)
+        m = portal_wpp_svc.obter_mensagem_midia(db, chat, mensagem_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    path = caminho_absoluto_arquivo(m.midia_nome_arquivo)
+    if path is None or not path.is_file():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ficheiro não encontrado")
+    media_type = m.mimetype or "application/octet-stream"
+    return FileResponse(path, media_type=media_type, filename=path.name)
+
+
+@router.get("/equipe/funcionarios", response_model=ListaPaginada[PortalEquipeFuncionarioRead])
+def portal_equipe_listar(
+    incluir_inativos: bool = Query(False),
+    busca: str | None = Query(None),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    db: Session = Depends(get_db),
+    socio: FuncionarioRede = Depends(exigir_socio_portal),
+):
+    rows, total = portal_equipe_svc.listar_funcionarios(
+        db,
+        socio,
+        incluir_inativos=incluir_inativos,
+        busca=busca,
+        offset=offset,
+        limit=limit,
+    )
+    return ListaPaginada(
+        items=[portal_equipe_svc._para_read(f, socio_id=socio.id) for f in rows],
+        total=total,
+    )
+
+
+@router.get("/equipe/empresas", response_model=list[PortalEmpresaRead])
+def portal_equipe_empresas(
+    db: Session = Depends(get_db),
+    socio: FuncionarioRede = Depends(exigir_socio_portal),
+):
+    rows = portal_equipe_svc.empresas_da_rede(db, socio)
+    return [PortalEmpresaRead(id=e.id, nome=e.nome, rede_id=int(e.rede_id)) for e in rows]
+
+
+@router.get("/equipe/funcionarios/{funcionario_id}", response_model=PortalEquipeFuncionarioRead)
+def portal_equipe_obter(
+    funcionario_id: int,
+    db: Session = Depends(get_db),
+    socio: FuncionarioRede = Depends(exigir_socio_portal),
+):
+    try:
+        f = portal_equipe_svc._obter_na_rede(db, socio, funcionario_id)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_equipe_svc._para_read(f, socio_id=socio.id)
+
+
+@router.post("/equipe/funcionarios", response_model=PortalEquipeFuncionarioRead, status_code=201)
+def portal_equipe_criar(
+    data: PortalEquipeFuncionarioCreate,
+    db: Session = Depends(get_db),
+    socio: FuncionarioRede = Depends(exigir_socio_portal),
+):
+    f = portal_equipe_svc.criar_funcionario(db, socio, data)
+    return portal_equipe_svc._para_read(f, socio_id=socio.id)
+
+
+@router.patch("/equipe/funcionarios/{funcionario_id}", response_model=PortalEquipeFuncionarioRead)
+def portal_equipe_atualizar(
+    funcionario_id: int,
+    data: PortalEquipeFuncionarioUpdate,
+    db: Session = Depends(get_db),
+    socio: FuncionarioRede = Depends(exigir_socio_portal),
+):
+    try:
+        f = portal_equipe_svc.atualizar_funcionario(db, socio, funcionario_id, data)
+    except LookupError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    return portal_equipe_svc._para_read(f, socio_id=socio.id)
+
+
 @router.post("/tickets/{ticket_id}/csat-link")
 def portal_csat_link(
     ticket_id: int,
@@ -416,3 +566,21 @@ def portal_csat_link(
     if not result:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Avaliação já registrada ou indisponível.")
     return {"link": result["link"], "expires_at": result["expires_at"]}
+
+
+def _public_cache_headers(response: Response) -> None:
+    response.headers["Cache-Control"] = "public, max-age=60"
+
+
+@router.get("/public/branding", response_model=PortalPublicBrandingRead)
+def portal_public_branding(
+    request: Request,
+    response: Response,
+    tenant_id: TenantIdDep,
+    db: Session = Depends(get_db),
+):
+    check_kb_public_rate_limit(request)
+    _ = tenant_id
+    out = branding_portal_cliente(db, tenant_id)
+    _public_cache_headers(response)
+    return out

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -1365,6 +1365,12 @@ def criar_mensagem(
         .first()
     )
     assert m is not None
+    if m.tipo == "publico":
+        from app.services.portal_notificacoes import notificar_funcionario_mensagem_publica
+
+        ticket_fresh = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+        if ticket_fresh is not None:
+            notificar_funcionario_mensagem_publica(db, ticket=ticket_fresh, mensagem=m)
     emit_ticket_mensagem_from_model(db, ticket, m, exclude_atendente_id=atendente.id)
     return _mensagem_para_read(m)
 
@@ -1939,9 +1945,12 @@ def atualizar(
         setattr(ticket, k, v)
 
     acabou_de_fechar = False
+    status_portal_notify: tuple[str, str] | None = None
     if "status_id" in update:
         st = db.query(StatusTicket).filter(StatusTicket.id == ticket.status_id).first()
         slug = (st.slug or "").lower() if st else ""
+        if st is not None:
+            status_portal_notify = (st.nome or slug, slug)
         if slug == "fechado":
             if ticket.fechado_em is None:
                 acabou_de_fechar = True
@@ -1961,6 +1970,15 @@ def atualizar(
     sincronizar_sla_violado(db, ticket)
 
     db.commit()
+    if status_portal_notify is not None:
+        from app.services.portal_notificacoes import notificar_funcionario_status
+
+        notificar_funcionario_status(
+            db,
+            ticket=ticket,
+            status_nome=status_portal_notify[0],
+            status_slug=status_portal_notify[1],
+        )
     if acabou_de_fechar:
         processar_hooks_ao_fechar_ticket(db, ticket_id)
         db.commit()

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -848,23 +848,7 @@ def buscar_funcionarios(
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
     term = f"%{busca.strip()}%"
-    rede_ids = [int(r[0]) for r in db.query(Rede.id).filter(Rede.tenant_id == atendente.tenant_id).all()]
-    empresa_ids = [int(r[0]) for r in db.query(Empresa.id).filter(Empresa.tenant_id == atendente.tenant_id).all()]
-    func_ids_junction = [
-        int(r[0])
-        for r in db.query(FuncionarioRedeEmpresa.funcionario_id)
-        .join(Empresa, Empresa.id == FuncionarioRedeEmpresa.empresa_id)
-        .filter(Empresa.tenant_id == atendente.tenant_id)
-        .distinct()
-        .all()
-    ]
-    filtros = []
-    if rede_ids:
-        filtros.append(FuncionarioRede.rede_id.in_(rede_ids))
-    if empresa_ids:
-        filtros.append(FuncionarioRede.empresa_id.in_(empresa_ids))
-    if func_ids_junction:
-        filtros.append(FuncionarioRede.id.in_(func_ids_junction))
+    filtros = _filtros_funcionario_tenant(db, atendente)
     if not filtros:
         return []
     q = (
@@ -923,6 +907,98 @@ def catalogo_funcionarios(
         redes=[WhatsappRedeCatalogoRead(id=r.id, nome=r.nome) for r in redes],
         empresas=[WhatsappEmpresaCatalogoRead(id=e.id, nome=_empresa_nome_exibicao(e) or e.nome, rede_id=int(e.rede_id)) for e in empresas],
     )
+
+
+def _filtros_funcionario_tenant(db: Session, atendente: Atendente) -> list:
+    """Filtros OR para funcionários ativos no tenant do atendente."""
+    rede_ids = [int(r[0]) for r in db.query(Rede.id).filter(Rede.tenant_id == atendente.tenant_id).all()]
+    empresa_ids = [int(r[0]) for r in db.query(Empresa.id).filter(Empresa.tenant_id == atendente.tenant_id).all()]
+    func_ids_junction = [
+        int(r[0])
+        for r in db.query(FuncionarioRedeEmpresa.funcionario_id)
+        .join(Empresa, Empresa.id == FuncionarioRedeEmpresa.empresa_id)
+        .filter(Empresa.tenant_id == atendente.tenant_id)
+        .distinct()
+        .all()
+    ]
+    filtros = []
+    if rede_ids:
+        filtros.append(FuncionarioRede.rede_id.in_(rede_ids))
+    if empresa_ids:
+        filtros.append(FuncionarioRede.empresa_id.in_(empresa_ids))
+    if func_ids_junction:
+        filtros.append(FuncionarioRede.id.in_(func_ids_junction))
+    return filtros
+
+
+@router.get("/funcionarios/similares", response_model=list[WhatsappFuncionarioOpcaoRead])
+def buscar_funcionarios_similares(
+    nome: str = Query(..., min_length=3, description="Nome digitado no cadastro"),
+    limit: int = Query(5, ge=1, le=10),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Sugestões por similaridade de nome (#593) — usado na aba Cadastrar do modal."""
+    from app.services.funcionario_nome_similar import (
+        LIMIAR_ALTA,
+        LIMIAR_SIMILARIDADE,
+        normalizar_nome,
+        ranquear_similares,
+        tokens_significativos,
+    )
+
+    nome_q = nome.strip()
+    nome_norm = normalizar_nome(nome_q)
+    if len(nome_norm) < 3:
+        return []
+
+    filtros = _filtros_funcionario_tenant(db, atendente)
+    if not filtros:
+        return []
+
+    tokens = tokens_significativos(nome_norm)[:2]
+    token_filters = [FuncionarioRede.nome.ilike(f"%{t}%") for t in tokens] if tokens else []
+    q = db.query(FuncionarioRede).filter(FuncionarioRede.ativo.is_(True), or_(*filtros))
+    if token_filters:
+        q = q.filter(or_(*token_filters))
+    candidatos_rows = q.order_by(FuncionarioRede.nome.asc(), FuncionarioRede.id.asc()).limit(300).all()
+
+    candidatos: list[tuple[int, str]] = []
+    for func in candidatos_rows:
+        if _funcionario_no_tenant(db, atendente, func.id) is None:
+            continue
+        candidatos.append((int(func.id), func.nome or ""))
+
+    ranked = ranquear_similares(nome_q, candidatos, limiar=LIMIAR_SIMILARIDADE, limit=limit)
+    if not ranked:
+        return []
+
+    by_id = {int(f.id): f for f in candidatos_rows}
+    redes_cache: dict[int, str] = {
+        int(r.id): r.nome
+        for r in db.query(Rede).filter(Rede.tenant_id == atendente.tenant_id).all()
+    }
+    out: list[WhatsappFuncionarioOpcaoRead] = []
+    for fid, _nome, score in ranked:
+        func = by_id.get(fid)
+        if func is None:
+            continue
+        rid = rede_id_efetiva(db, func)
+        out.append(
+            WhatsappFuncionarioOpcaoRead(
+                id=func.id,
+                nome=func.nome,
+                email=func.email,
+                telefone=getattr(func, "telefone", None),
+                tipo=func.tipo,
+                empresas=_empresas_funcionario(db, func),
+                rede_id=rid,
+                rede_nome=redes_cache.get(int(rid)) if rid is not None else None,
+                similaridade=round(float(score), 3),
+                similaridade_alta=float(score) >= LIMIAR_ALTA,
+            )
+        )
+    return out
 
 
 def _normalize_wa_id(raw: str | None) -> str:

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -29,6 +29,7 @@ from app.schemas.whatsapp_chat import (
     WhatsappChatMensagemCreate,
     WhatsappChatRead,
     WhatsappContatoRead,
+    WhatsappEmpresaContextoBody,
     WhatsappIniciarChatBody,
     WhatsappMensagemRead,
     WhatsappTransferirChatBody,
@@ -401,6 +402,33 @@ def _empresas_funcionario(db: Session, func: FuncionarioRede) -> list[WhatsappEm
     return [WhatsappEmpresaOpcaoRead(id=e.id, nome=_empresa_nome_exibicao(e) or e.nome) for e in rows]
 
 
+def _resolver_empresa_contexto_opcional(
+    db: Session,
+    atendente: Atendente,
+    func: FuncionarioRede,
+    empresa_id: int | None,
+) -> int | None:
+    """Resolve empresa de contexto sem bloquear multi-empresa (#592).
+
+    - 1 empresa → usa automaticamente
+    - >1 e sem empresa_id → None (atendente pergunta ao cliente e vincula depois)
+    - empresa_id informado → valida pertencer ao funcionário
+    """
+    emp_ids = empresa_ids_vinculados(db, func, apenas_ativas=True)
+    if not emp_ids:
+        return None
+    if len(emp_ids) == 1:
+        return next(iter(emp_ids))
+    if empresa_id is None:
+        return None
+    if int(empresa_id) not in emp_ids:
+        raise HTTPException(status_code=400, detail="Empresa inválida para este funcionário")
+    emp = db.query(Empresa).filter(Empresa.id == int(empresa_id), Empresa.tenant_id == atendente.tenant_id).first()
+    if not emp:
+        raise HTTPException(status_code=404, detail="Empresa não encontrada")
+    return int(empresa_id)
+
+
 def _resolver_empresa_vinculo(
     db: Session,
     atendente: Atendente,
@@ -423,6 +451,27 @@ def _resolver_empresa_vinculo(
     if not emp:
         raise HTTPException(status_code=404, detail="Empresa não encontrada")
     return emp
+
+
+def _aplicar_empresa_contexto_chat(
+    db: Session,
+    atendente: Atendente,
+    chat: WhatsappChat,
+    empresa_id: int | None,
+    *,
+    apenas_se_vazio: bool = True,
+) -> None:
+    """Define/atualiza chat.empresa_id a partir do funcionário vinculado (#592)."""
+    if apenas_se_vazio and getattr(chat, "empresa_id", None):
+        return
+    func = getattr(chat, "funcionario_rede", None)
+    if func is None and getattr(chat, "funcionario_rede_id", None):
+        func = db.query(FuncionarioRede).filter(FuncionarioRede.id == chat.funcionario_rede_id).first()
+    if not func:
+        return
+    resolvido = _resolver_empresa_contexto_opcional(db, atendente, func, empresa_id)
+    if resolvido is not None:
+        chat.empresa_id = resolvido
 
 
 def _criar_funcionario_rede(
@@ -522,6 +571,7 @@ def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False)
         funcionario_tipo=func.tipo if func else None,
         empresa_id=getattr(c, "empresa_id", None),
         empresa_nome=_empresa_nome_exibicao(emp),
+        empresas_opcoes=_empresas_funcionario(db, func) if func else [],
         inatividade_pausada=bool(getattr(c, "inatividade_pausada", False)),
         inatividade_retomada_em=getattr(c, "inatividade_retomada_em", None),
         classificacao_demanda_pendente=bool(getattr(c, "classificacao_demanda_pendente", False)),
@@ -664,6 +714,7 @@ def listar_encerrados(
     protocolo: str | None = Query(None, description="Filtro por protocolo"),
     wa_id: str | None = Query(None, description="Filtro por número ou WhatsApp ID"),
     atendente_id: int | None = Query(None, ge=1, description="Filtro por atendente que encerrou"),
+    empresa_id: int | None = Query(None, ge=1, description="Filtrar chats desta empresa (#591)"),
     encerramento_inicio: datetime | None = Query(None, description="Filtro por data de encerramento a partir de"),
     encerramento_fim: datetime | None = Query(None, description="Filtro por data de encerramento até"),
     estado: str | None = Query(
@@ -692,6 +743,15 @@ def listar_encerrados(
         )
     if atendente_id:
         q = q.filter(WhatsappChat.atendente_id == atendente_id)
+    if empresa_id is not None:
+        emp = (
+            db.query(Empresa.id)
+            .filter(Empresa.id == empresa_id, Empresa.tenant_id == atendente.tenant_id)
+            .first()
+        )
+        if not emp:
+            return ListaPaginada(items=[], total=0)
+        q = q.filter(WhatsappChat.empresa_id == empresa_id)
     ref_data = func.coalesce(
         WhatsappChat.encerramento_at,
         WhatsappChat.atendimento_inicio_at,
@@ -1019,11 +1079,7 @@ def iniciar_chat_outbound(
 
     empresa_id: int | None = None
     if func is not None:
-        emps = _empresas_funcionario(db, func)
-        if len(emps) == 1:
-            empresa_id = emps[0].id
-        elif getattr(func, "empresa_id", None):
-            empresa_id = int(func.empresa_id)
+        empresa_id = _resolver_empresa_contexto_opcional(db, atendente, func, data.empresa_id)
 
     existente = _chat_aberto_por_wa_id(db, wa_id)
     if existente:
@@ -1039,8 +1095,8 @@ def iniciar_chat_outbound(
             existente.atendimento_inicio_at = datetime.now(timezone.utc)
             if func is not None and not existente.funcionario_rede_id:
                 existente.funcionario_rede_id = func.id
-            if empresa_id is not None and not existente.empresa_id:
-                existente.empresa_id = empresa_id
+            if not existente.empresa_id:
+                _aplicar_empresa_contexto_chat(db, atendente, existente, data.empresa_id)
             audit_whatsapp_chat(
                 db,
                 chat_id=existente.id,
@@ -1051,6 +1107,12 @@ def iniciar_chat_outbound(
             db.commit()
             db.refresh(existente)
             emit_chat_fila_from_model(db, existente, estado_anterior=estado_anterior)
+        elif not existente.empresa_id and (func is not None or existente.funcionario_rede_id):
+            if func is not None and not existente.funcionario_rede_id:
+                existente.funcionario_rede_id = func.id
+            _aplicar_empresa_contexto_chat(db, atendente, existente, data.empresa_id)
+            db.commit()
+            db.refresh(existente)
         msg_init = (data.mensagem_inicial or "").strip()
         if msg_init:
             try:
@@ -1280,6 +1342,11 @@ def excluir_demanda(
 @router.post("/{chat_id}/assumir", response_model=WhatsappChatRead)
 def assumir(
     chat_id: int,
+    empresa_id: int | None = Query(
+        None,
+        ge=1,
+        description="Empresa de contexto opcional (pode ser definida depois na conversa).",
+    ),
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
@@ -1292,6 +1359,7 @@ def assumir(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
     if c.estado != "aguardando_atendente":
         raise HTTPException(status_code=400, detail="Só é possível assumir chats na fila de espera")
+    _aplicar_empresa_contexto_chat(db, atendente, c, empresa_id)
     estado_anterior = c.estado
     c.estado = "em_atendimento"
     c.atendente_id = atendente.id
@@ -1328,6 +1396,32 @@ def assumir(
     c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     assert c is not None
     return _chat_read(db, c)
+
+
+@router.post("/{chat_id}/empresa-contexto", response_model=WhatsappChatRead)
+def definir_empresa_contexto(
+    chat_id: int,
+    data: WhatsappEmpresaContextoBody,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Define ou altera a empresa de contexto a qualquer momento antes do encerramento (#592)."""
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    if c.estado in ("encerrado", "aguardando_avaliacao"):
+        raise HTTPException(status_code=400, detail="Não é possível alterar a empresa após o encerramento")
+    if not c.funcionario_rede_id:
+        raise HTTPException(status_code=400, detail="Chat sem funcionário vinculado")
+    _aplicar_empresa_contexto_chat(db, atendente, c, data.empresa_id, apenas_se_vazio=False)
+    if not c.empresa_id:
+        raise HTTPException(status_code=400, detail="Selecione a empresa do funcionário")
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    return _chat_read(db, c2)
 
 
 @router.post("/{chat_id}/encerrar", response_model=WhatsappChatRead)

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -60,7 +60,7 @@ from app.services.whatsapp_avaliacao import mensagem_oculta_na_conversa
 from app.services.whatsapp_media_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
 from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
 from app.services.ticket_distribuicao import pos_criar_ticket_na_fila
-from app.services.protocolo_mensal import gerar_protocolo_chat
+from app.services.whatsapp_wa_id_lock import lock_wa_id_para_chat, unlock_wa_id_para_chat
 from app.services.audit_operacional import audit_whatsapp_chat
 
 router = APIRouter(prefix="/whatsapp/chats", tags=["whatsapp-chats"])
@@ -1081,82 +1081,86 @@ def iniciar_chat_outbound(
     if func is not None:
         empresa_id = _resolver_empresa_contexto_opcional(db, atendente, func, data.empresa_id)
 
-    existente = _chat_aberto_por_wa_id(db, wa_id)
-    if existente:
-        if existente.estado == "em_atendimento" and existente.atendente_id not in (None, atendente.id):
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="Já existe um atendimento aberto deste contacto com outro responsável.",
-            )
-        estado_anterior = existente.estado
-        if existente.estado == "aguardando_atendente" or existente.atendente_id is None:
-            existente.estado = "em_atendimento"
-            existente.atendente_id = atendente.id
-            existente.atendimento_inicio_at = datetime.now(timezone.utc)
-            if func is not None and not existente.funcionario_rede_id:
-                existente.funcionario_rede_id = func.id
-            if not existente.empresa_id:
+    lock_wa_id_para_chat(db, wa_id)
+    try:
+        existente = _chat_aberto_por_wa_id(db, wa_id)
+        if existente:
+            if existente.estado == "em_atendimento" and existente.atendente_id not in (None, atendente.id):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="Já existe um atendimento aberto deste contacto com outro responsável.",
+                )
+            estado_anterior = existente.estado
+            if existente.estado == "aguardando_atendente" or existente.atendente_id is None:
+                existente.estado = "em_atendimento"
+                existente.atendente_id = atendente.id
+                existente.atendimento_inicio_at = datetime.now(timezone.utc)
+                if func is not None and not existente.funcionario_rede_id:
+                    existente.funcionario_rede_id = func.id
+                if not existente.empresa_id:
+                    _aplicar_empresa_contexto_chat(db, atendente, existente, data.empresa_id)
+                audit_whatsapp_chat(
+                    db,
+                    chat_id=existente.id,
+                    action="assign",
+                    atendente_id=atendente.id,
+                    payload={"de_estado": estado_anterior, "protocolo": existente.protocolo, "origem": "iniciar_outbound"},
+                )
+                db.commit()
+                db.refresh(existente)
+                emit_chat_fila_from_model(db, existente, estado_anterior=estado_anterior)
+            elif not existente.empresa_id and (func is not None or existente.funcionario_rede_id):
+                if func is not None and not existente.funcionario_rede_id:
+                    existente.funcionario_rede_id = func.id
                 _aplicar_empresa_contexto_chat(db, atendente, existente, data.empresa_id)
-            audit_whatsapp_chat(
-                db,
-                chat_id=existente.id,
-                action="assign",
-                atendente_id=atendente.id,
-                payload={"de_estado": estado_anterior, "protocolo": existente.protocolo, "origem": "iniciar_outbound"},
-            )
-            db.commit()
-            db.refresh(existente)
-            emit_chat_fila_from_model(db, existente, estado_anterior=estado_anterior)
-        elif not existente.empresa_id and (func is not None or existente.funcionario_rede_id):
-            if func is not None and not existente.funcionario_rede_id:
-                existente.funcionario_rede_id = func.id
-            _aplicar_empresa_contexto_chat(db, atendente, existente, data.empresa_id)
-            db.commit()
-            db.refresh(existente)
+                db.commit()
+                db.refresh(existente)
+            msg_init = (data.mensagem_inicial or "").strip()
+            if msg_init:
+                try:
+                    _enviar_texto_whatsapp(db, chat=existente, texto=msg_init, atendente=atendente, evento_sistema=None)
+                except HTTPException:
+                    raise
+            c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == existente.id).first()
+            assert c is not None
+            return _chat_read(db, c)
+
+        # Garante Evolution configurada se houver mensagem inicial (criar chat sem msg ainda exige settings para uso posterior)
+        _settings_envio(db)
+
+        chat = WhatsappChat(
+            protocolo=gerar_protocolo_chat(db),
+            wa_id=wa_id,
+            cliente_nome=(func.nome if func else None),
+            estado="em_atendimento",
+            atendente_id=atendente.id,
+            atendimento_inicio_at=datetime.now(timezone.utc),
+            setor_id=None,
+            funcionario_rede_id=func.id if func else None,
+            empresa_id=empresa_id,
+        )
+        db.add(chat)
+        db.flush()
+        audit_whatsapp_chat(
+            db,
+            chat_id=chat.id,
+            action="create",
+            atendente_id=atendente.id,
+            payload={"protocolo": chat.protocolo, "origem": "iniciar_outbound", "wa_id": wa_id},
+        )
+        db.commit()
+        db.refresh(chat)
+        emit_chat_fila_from_model(db, chat, estado_anterior=None)
+
         msg_init = (data.mensagem_inicial or "").strip()
         if msg_init:
-            try:
-                _enviar_texto_whatsapp(db, chat=existente, texto=msg_init, atendente=atendente, evento_sistema=None)
-            except HTTPException:
-                raise
-        c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == existente.id).first()
+            _enviar_texto_whatsapp(db, chat=chat, texto=msg_init, atendente=atendente, evento_sistema=None)
+
+        c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat.id).first()
         assert c is not None
         return _chat_read(db, c)
-
-    # Garante Evolution configurada se houver mensagem inicial (criar chat sem msg ainda exige settings para uso posterior)
-    _settings_envio(db)
-
-    chat = WhatsappChat(
-        protocolo=gerar_protocolo_chat(db),
-        wa_id=wa_id,
-        cliente_nome=(func.nome if func else None),
-        estado="em_atendimento",
-        atendente_id=atendente.id,
-        atendimento_inicio_at=datetime.now(timezone.utc),
-        setor_id=None,
-        funcionario_rede_id=func.id if func else None,
-        empresa_id=empresa_id,
-    )
-    db.add(chat)
-    db.flush()
-    audit_whatsapp_chat(
-        db,
-        chat_id=chat.id,
-        action="create",
-        atendente_id=atendente.id,
-        payload={"protocolo": chat.protocolo, "origem": "iniciar_outbound", "wa_id": wa_id},
-    )
-    db.commit()
-    db.refresh(chat)
-    emit_chat_fila_from_model(db, chat, estado_anterior=None)
-
-    msg_init = (data.mensagem_inicial or "").strip()
-    if msg_init:
-        _enviar_texto_whatsapp(db, chat=chat, texto=msg_init, atendente=atendente, evento_sistema=None)
-
-    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat.id).first()
-    assert c is not None
-    return _chat_read(db, c)
+    finally:
+        unlock_wa_id_para_chat(db, wa_id)
 
 
 @router.get("/{chat_id}", response_model=WhatsappChatRead)

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -268,6 +268,13 @@ def _render_template(
     )
 
 
+def _sair_pausa_inatividade_por_atividade(chat: WhatsappChat) -> None:
+    """Mensagem do cliente ou outbound humana reinicia o ciclo — sai da pausa manual."""
+    if getattr(chat, "inatividade_pausada", False):
+        chat.inatividade_pausada = False
+        chat.inatividade_retomada_em = None
+
+
 def _enviar_texto_whatsapp(
     db: Session,
     *,
@@ -321,6 +328,8 @@ def _enviar_texto_whatsapp(
     )
     if not ok:
         raise HTTPException(status_code=502, detail=err or "Falha ao enviar pela Evolution API")
+    if evento_sistema is None:
+        _sair_pausa_inatividade_por_atividade(chat)
     m = WhatsappMensagem(
         chat_id=chat.id,
         direcao="outbound",
@@ -515,6 +524,7 @@ def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False)
         empresa_nome=_empresa_nome_exibicao(emp),
         inatividade_pausada=bool(getattr(c, "inatividade_pausada", False)),
         inatividade_retomada_em=getattr(c, "inatividade_retomada_em", None),
+        classificacao_demanda_pendente=bool(getattr(c, "classificacao_demanda_pendente", False)),
     )
 
 
@@ -547,13 +557,31 @@ def _exigir_responsavel_envio_cliente(c: WhatsappChat, atendente: Atendente) -> 
 
 
 def _pode_registrar_demanda(db: Session, atendente: Atendente, c: WhatsappChat) -> bool:
-    if c.estado != "em_atendimento":
-        return False
+    """Responsável/admin: em atendimento, ou após encerramento automático por inatividade."""
     if not _pode_ver_chat(db, atendente, c):
         return False
-    if atendente.role == "admin":
+    if atendente.role != "admin" and c.atendente_id != atendente.id:
+        return False
+    if c.estado == "em_atendimento":
         return True
-    return c.atendente_id == atendente.id
+    if c.estado in ("aguardando_avaliacao", "encerrado") and _chat_encerrado_por_inatividade(db, c):
+        return True
+    return False
+
+
+def _chat_encerrado_por_inatividade(db: Session, c: WhatsappChat) -> bool:
+    return (
+        db.query(WhatsappMensagem.id)
+        .filter(
+            WhatsappMensagem.chat_id == c.id,
+            WhatsappMensagem.evento_sistema.in_(
+                ("auto_encerrado_inatividade", "auto_inativ_aviso"),
+            ),
+        )
+        .limit(1)
+        .first()
+        is not None
+    )
 
 
 def _pode_ver_chat(db: Session, atendente: Atendente, c: WhatsappChat) -> bool:
@@ -611,10 +639,18 @@ def listar_meus_ativos(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
+    """Chats em atendimento + encerrados por inatividade ainda sem classificação de demanda."""
+    from sqlalchemy import or_
+
     q = (
         db.query(WhatsappChat)
         .options(*_CHAT_LOAD_OPTIONS)
-        .filter(WhatsappChat.estado == "em_atendimento")
+        .filter(
+            or_(
+                WhatsappChat.estado == "em_atendimento",
+                WhatsappChat.classificacao_demanda_pendente.is_(True),
+            )
+        )
     )
     if atendente.role != "admin":
         q = q.filter(WhatsappChat.atendente_id == atendente.id)
@@ -1166,6 +1202,8 @@ def registrar_demanda(
         raise HTTPException(status_code=403, detail="Sem permissão para registrar demanda neste chat")
     row = criar_demanda_chat(db, c, atendente, data, desfecho="resolvido_sessao")
     marco = criar_marco_demanda_mensagem(db, chat=c, atendente=atendente, demanda=row)
+    if getattr(c, "classificacao_demanda_pendente", False):
+        c.classificacao_demanda_pendente = False
     db.commit()
     db.refresh(marco)
     marco = (
@@ -1175,6 +1213,8 @@ def registrar_demanda(
         .first()
     )
     emit_chat_mensagem_from_models(db, c, marco, exclude_atendente_id=atendente.id)
+    if c.estado != "em_atendimento":
+        emit_chat_fila_from_model(db, c, estado_anterior=c.estado)
     return demanda_para_read(row)
 
 
@@ -1352,6 +1392,11 @@ def enviar_mensagem(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
     if c.estado != "em_atendimento":
         raise HTTPException(status_code=400, detail="Só é possível enviar mensagens em chats ativos")
+    if getattr(c, "classificacao_demanda_pendente", False):
+        raise HTTPException(
+            status_code=400,
+            detail="Chat aguarda classificação de demanda — não é possível enviar mensagens ao cliente",
+        )
     _exigir_responsavel_envio_cliente(c, atendente)
     texto = data.texto.strip()
     m = _enviar_texto_whatsapp(
@@ -1387,6 +1432,11 @@ async def enviar_mensagem_midia(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
     if c.estado != "em_atendimento":
         raise HTTPException(status_code=400, detail="Só é possível enviar mensagens em chats ativos")
+    if getattr(c, "classificacao_demanda_pendente", False):
+        raise HTTPException(
+            status_code=400,
+            detail="Chat aguarda classificação de demanda — não é possível enviar mensagens ao cliente",
+        )
     _exigir_responsavel_envio_cliente(c, atendente)
 
     data = await file.read()
@@ -1477,6 +1527,7 @@ async def enviar_mensagem_midia(
         status_entrega=status_inicial_outbound_whatsapp(wa_message_id=sent_wa_id),
     )
     db.add(m)
+    _sair_pausa_inatividade_por_atividade(c)
     db.commit()
     m2 = (
         db.query(WhatsappMensagem)
@@ -1644,6 +1695,30 @@ def retomar_inatividade(
     db.commit()
     c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
     assert c2 is not None
+    return _chat_read(db, c2)
+
+
+@router.post("/{chat_id}/classificacao-demanda/concluir", response_model=WhatsappChatRead)
+def concluir_classificacao_demanda(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Marca classificação pós-inatividade como concluída (ex.: confirmar sem registar demanda)."""
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not getattr(c, "classificacao_demanda_pendente", False):
+        return _chat_read(db, c)
+    if atendente.role != "admin" and c.atendente_id != atendente.id:
+        raise HTTPException(status_code=403, detail="Apenas o responsável pode concluir a classificação")
+    if c.estado not in ("encerrado", "aguardando_avaliacao"):
+        raise HTTPException(status_code=400, detail="Classificação só se aplica a chats já encerrados por inatividade")
+    c.classificacao_demanda_pendente = False
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    emit_chat_fila_from_model(db, c2, estado_anterior=c2.estado)
     return _chat_read(db, c2)
 
 

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -60,6 +60,7 @@ from app.services.whatsapp_avaliacao import mensagem_oculta_na_conversa
 from app.services.whatsapp_media_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
 from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
 from app.services.ticket_distribuicao import pos_criar_ticket_na_fila
+from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.whatsapp_wa_id_lock import lock_wa_id_para_chat, unlock_wa_id_para_chat
 from app.services.audit_operacional import audit_whatsapp_chat
 

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -205,6 +205,7 @@ def _tipo_midia_db(slug: str) -> str:
 
 
 def _rotulo_midia_outbound(tipo_db: str) -> str:
+    """Rótulo interno legado — não enviar ao WhatsApp nem gravar como corpo sem caption."""
     return {
         "imagem": "[Imagem enviada]",
         "video": "[Vídeo enviado]",
@@ -212,6 +213,25 @@ def _rotulo_midia_outbound(tipo_db: str) -> str:
         "documento": "[Documento enviado]",
         "figurinha": "[Figurinha enviada]",
     }.get(tipo_db, "[Ficheiro enviado]")
+
+
+def _corpo_e_caption_midia_outbound(
+    tipo_db: str,
+    caption: str | None,
+    nome_atendente: str | None,
+) -> tuple[str, str]:
+    """
+    Retorna (corpo_db, caption_evolution).
+    Sem legenda do utilizador: corpo vazio e caption vazia (só a mídia no WhatsApp).
+    """
+    if tipo_db == "figurinha":
+        return "", ""
+    cap = (caption or "").strip()
+    if not cap:
+        return "", ""
+    nome = (nome_atendente or "").strip()
+    texto = f"[ {nome} ]: {cap}" if nome else cap
+    return texto, texto
 
 
 def _sanitizar_nome_ficheiro(name: str | None, fallback: str) -> str:
@@ -493,6 +513,8 @@ def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False)
         funcionario_tipo=func.tipo if func else None,
         empresa_id=getattr(c, "empresa_id", None),
         empresa_nome=_empresa_nome_exibicao(emp),
+        inatividade_pausada=bool(getattr(c, "inatividade_pausada", False)),
+        inatividade_retomada_em=getattr(c, "inatividade_retomada_em", None),
     )
 
 
@@ -1380,15 +1402,9 @@ async def enviar_mensagem_midia(
         raise HTTPException(status_code=500, detail="Não foi possível guardar o ficheiro em disco.")
 
     cap = (caption or "").strip()
-    if tipo_db == "figurinha":
-        corpo_eff = _rotulo_midia_outbound(tipo_db)
-        legenda_whatsapp = ""
-    else:
-        base_legenda = cap if cap else _rotulo_midia_outbound(tipo_db)
-        nome_atend = (atendente.nome or "").strip()
-        legenda_whatsapp = f"[ {nome_atend} ]: {base_legenda}" if nome_atend else base_legenda
-        corpo_eff = legenda_whatsapp
-
+    corpo_eff, legenda_whatsapp = _corpo_e_caption_midia_outbound(
+        tipo_db, cap, atendente.nome
+    )
     b64 = base64.b64encode(data).decode("ascii")
     st = _settings_envio(db)
     ev_mt = _mediatype_evolution(mediatipo)
@@ -1542,11 +1558,93 @@ def marcar_chat_visto(
         row.last_seen_at = now
     else:
         db.add(WhatsappChatReadModel(chat_id=chat_id, atendente_id=atendente.id, last_seen_at=now))
+
+    # ✓✓ azul no WhatsApp do cliente: só o responsável, em atendimento
+    if (
+        c.estado == "em_atendimento"
+        and c.atendente_id is not None
+        and c.atendente_id == atendente.id
+    ):
+        _marcar_inbound_lido_evolution(db, c)
+
     db.commit()
     from app.services.realtime_emit import emit_notificacao_contagem
 
     emit_notificacao_contagem(db, [atendente.id])
     return None
+
+
+def _marcar_inbound_lido_evolution(db: Session, chat: WhatsappChat) -> None:
+    st = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
+    if not st or not st.evolution_base_url or not st.evolution_instance_name or not st.evolution_api_key:
+        return
+    ids = [
+        row[0]
+        for row in (
+            db.query(WhatsappMensagem.wa_message_id)
+            .filter(
+                WhatsappMensagem.chat_id == chat.id,
+                WhatsappMensagem.direcao == "inbound",
+                WhatsappMensagem.wa_message_id.isnot(None),
+                WhatsappMensagem.wa_message_id != "",
+            )
+            .order_by(WhatsappMensagem.id.desc())
+            .limit(40)
+            .all()
+        )
+        if row[0]
+    ]
+    if not ids:
+        return
+    ok, err = evolution_api.evolution_mark_messages_as_read(
+        st.evolution_base_url,
+        st.evolution_instance_name,
+        st.evolution_api_key,
+        remote_jid=chat.wa_id,
+        message_ids=list(reversed(ids)),
+    )
+    if not ok:
+        logger.warning("markMessageAsRead falhou (chat=%s): %s", chat.id, err)
+
+
+@router.post("/{chat_id}/inatividade/pausar", response_model=WhatsappChatRead)
+def pausar_inatividade(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if c.estado != "em_atendimento":
+        raise HTTPException(status_code=400, detail="Só é possível pausar inatividade em chats em atendimento")
+    if c.atendente_id != atendente.id and atendente.role != "admin":
+        raise HTTPException(status_code=403, detail="Apenas o responsável pode pausar a inatividade")
+    c.inatividade_pausada = True
+    c.inatividade_retomada_em = None
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    return _chat_read(db, c2)
+
+
+@router.post("/{chat_id}/inatividade/retomar", response_model=WhatsappChatRead)
+def retomar_inatividade(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if c.atendente_id != atendente.id and atendente.role != "admin":
+        raise HTTPException(status_code=403, detail="Apenas o responsável pode retomar a inatividade")
+    c.inatividade_pausada = False
+    c.inatividade_retomada_em = datetime.now(timezone.utc)
+    db.commit()
+    c2 = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    assert c2 is not None
+    return _chat_read(db, c2)
 
 
 @router.post("/{chat_id}/vincular-ticket", response_model=WhatsappChatRead)

--- a/backend/app/api/whatsapp_settings.py
+++ b/backend/app/api/whatsapp_settings.py
@@ -51,9 +51,12 @@ def _read_out(row: WhatsappSettings | None) -> WhatsappSettingsRead:
             auto_msg_inativ_aviso_ativa=True,
             auto_msg_inativ_aviso_texto=None,
             avaliacao_ativa=False,
+            avaliacao_janela_minutos=30,
             auto_msg_avaliacao_ativa=True,
             auto_msg_avaliacao_texto=None,
             auto_msg_avaliacao_obrigado_texto=None,
+            auto_msg_avaliacao_timeout_texto=None,
+            auto_msg_avaliacao_pular_texto=None,
         )
     horario_semana = None
     raw = getattr(row, "horario_semana_json", None)
@@ -88,9 +91,12 @@ def _read_out(row: WhatsappSettings | None) -> WhatsappSettingsRead:
         auto_msg_inativ_aviso_ativa=bool(getattr(row, "auto_msg_inativ_aviso_ativa", True)),
         auto_msg_inativ_aviso_texto=getattr(row, "auto_msg_inativ_aviso_texto", None),
         avaliacao_ativa=bool(getattr(row, "avaliacao_ativa", False)),
+        avaliacao_janela_minutos=int(getattr(row, "avaliacao_janela_minutos", None) or 30),
         auto_msg_avaliacao_ativa=bool(getattr(row, "auto_msg_avaliacao_ativa", True)),
         auto_msg_avaliacao_texto=getattr(row, "auto_msg_avaliacao_texto", None),
         auto_msg_avaliacao_obrigado_texto=getattr(row, "auto_msg_avaliacao_obrigado_texto", None),
+        auto_msg_avaliacao_timeout_texto=getattr(row, "auto_msg_avaliacao_timeout_texto", None),
+        auto_msg_avaliacao_pular_texto=getattr(row, "auto_msg_avaliacao_pular_texto", None),
     )
 
 
@@ -162,9 +168,12 @@ def atualizar(
         "inativ_aviso_minutos",
         "inativ_encerramento_apos_aviso_minutos",
         "avaliacao_ativa",
+        "avaliacao_janela_minutos",
         "auto_msg_avaliacao_ativa",
         "auto_msg_avaliacao_texto",
         "auto_msg_avaliacao_obrigado_texto",
+        "auto_msg_avaliacao_timeout_texto",
+        "auto_msg_avaliacao_pular_texto",
     ):
         if k in payload:
             setattr(row, k, payload[k])
@@ -176,6 +185,13 @@ def atualizar(
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Informe minutos válidos para aviso e encerramento após o aviso.",
+            )
+    if bool(getattr(row, "avaliacao_ativa", False)):
+        janela = getattr(row, "avaliacao_janela_minutos", None)
+        if not janela or int(janela) < 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Informe a janela de avaliação em minutos (mínimo 1).",
             )
     if "horario_semana" in payload:
         hs = payload["horario_semana"]

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -90,9 +90,26 @@ def _baixar_midia_inbound(
 
 
 def _chat_aberto_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
+    """Chat ativo para conversa (fila ou em atendimento). Não inclui pós-inatividade a classificar."""
     return (
         db.query(WhatsappChat)
-        .filter(WhatsappChat.wa_id == wa_id, WhatsappChat.estado != "encerrado")
+        .filter(
+            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.estado.in_(("aguardando_atendente", "em_atendimento")),
+            WhatsappChat.classificacao_demanda_pendente.is_(False),
+        )
+        .order_by(WhatsappChat.id.desc())
+        .first()
+    )
+
+
+def _chat_aguardando_avaliacao_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
+    return (
+        db.query(WhatsappChat)
+        .filter(
+            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.estado == "aguardando_avaliacao",
+        )
         .order_by(WhatsappChat.id.desc())
         .first()
     )
@@ -193,10 +210,8 @@ def _try_auto_msg_espera(db: Session, st: WhatsappSettings | None, chat: Whatsap
             evento_sistema="auto_espera",
         )
     )
-    try:
-        db.commit()
-    except Exception:
-        db.rollback()
+    # Flush apenas: commit fica no webhook. commit/rollback aqui apagava chat novo se a auto-msg falhasse.
+    db.flush()
 
 
 def _parse_hhmm(v: str | None) -> tuple[int, int] | None:
@@ -326,10 +341,8 @@ def _try_auto_msg_fora_horario(db: Session, st: WhatsappSettings | None, chat: W
             evento_sistema="auto_fora_horario",
         )
     )
-    try:
-        db.commit()
-    except Exception:
-        db.rollback()
+    # Flush apenas: commit fica no webhook (evita rollback apagar chat recém-criado).
+    db.flush()
 
 
 def _processar_atualizacoes_status_mensagem(db: Session, body: dict) -> int:
@@ -399,40 +412,52 @@ def evolution_webhook(
         )
 
         chat = _chat_aberto_por_wa_id(db, wa_id)
-        if chat and chat.estado == "aguardando_avaliacao":
-            q_prev = item.get("quoted_corpo_preview")
-            if q_prev is not None and len(str(q_prev)) > 500:
-                q_prev = str(q_prev)[:500]
-            msg = WhatsappMensagem(
-                chat_id=chat.id,
-                direcao="inbound",
-                corpo=corpo,
-                tipo_midia=tipo_midia,
-                mimetype=mimetype_val,
-                midia_nome_arquivo=midia_nome,
-                wa_message_id=wa_mid,
-                quoted_wa_message_id=item.get("quoted_wa_message_id"),
-                quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
-                atendente_id=None,
-            )
-            db.add(msg)
-            if push and not chat.cliente_nome:
-                chat.cliente_nome = push
-            try:
-                from app.services.whatsapp_avaliacao import processar_resposta_avaliacao
+        if not chat:
+            chat_aval = _chat_aguardando_avaliacao_por_wa_id(db, wa_id)
+            # Chat a classificar demanda: só reutiliza se for resposta de avaliação (nota 1–5).
+            # Qualquer outra mensagem abre atendimento novo; o pendente permanece.
+            if chat_aval is not None:
+                from app.services.whatsapp_avaliacao import parse_nota_avaliacao
 
-                processar_resposta_avaliacao(
-                    db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
+                pendente = bool(getattr(chat_aval, "classificacao_demanda_pendente", False))
+                nota = parse_nota_avaliacao(corpo) if (tipo or "texto") == "texto" else None
+                if pendente and nota is None:
+                    chat_aval = None
+            if chat_aval is not None:
+                chat = chat_aval
+                q_prev = item.get("quoted_corpo_preview")
+                if q_prev is not None and len(str(q_prev)) > 500:
+                    q_prev = str(q_prev)[:500]
+                msg = WhatsappMensagem(
+                    chat_id=chat.id,
+                    direcao="inbound",
+                    corpo=corpo,
+                    tipo_midia=tipo_midia,
+                    mimetype=mimetype_val,
+                    midia_nome_arquivo=midia_nome,
+                    wa_message_id=wa_mid,
+                    quoted_wa_message_id=item.get("quoted_wa_message_id"),
+                    quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
+                    atendente_id=None,
                 )
-                db.commit()
-                processados += 1
-            except IntegrityError:
-                db.rollback()
-                logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
-            except Exception:
-                db.rollback()
-                raise
-            continue
+                db.add(msg)
+                if push and not chat.cliente_nome:
+                    chat.cliente_nome = push
+                try:
+                    from app.services.whatsapp_avaliacao import processar_resposta_avaliacao
+
+                    processar_resposta_avaliacao(
+                        db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
+                    )
+                    db.commit()
+                    processados += 1
+                except IntegrityError:
+                    db.rollback()
+                    logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
+                except Exception:
+                    db.rollback()
+                    raise
+                continue
 
         if tipo == "texto":
             tipo_midia = "texto"

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session, joinedload
 from app.database import get_db
 from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem, WhatsappSettings
 from app.services import evolution_api
+from app.services.whatsapp_contato_match import funcionario_por_wa_id
 from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.evolution_inbound import iter_inbound_whatsapp_messages, iter_message_status_updates
 from app.services.whatsapp_media_storage import gravar_base64_em_disco
@@ -441,12 +442,15 @@ def evolution_webhook(
         chat_novo = False
         if not chat:
             chat_novo = True
+            func = funcionario_por_wa_id(db, wa_id)
             chat = WhatsappChat(
                 protocolo=gerar_protocolo_chat(db),
                 wa_id=wa_id,
-                cliente_nome=push,
+                cliente_nome=push or (func.nome if func else None),
                 estado="aguardando_atendente",
                 setor_id=None,
+                funcionario_rede_id=func.id if func else None,
+                empresa_id=func.empresa_id if func and getattr(func, "empresa_id", None) else None,
             )
             db.add(chat)
             db.flush()
@@ -486,6 +490,9 @@ def evolution_webhook(
         db.add(msg)
         if push and not chat.cliente_nome:
             chat.cliente_nome = push
+        if getattr(chat, "inatividade_pausada", False):
+            chat.inatividade_pausada = False
+            chat.inatividade_retomada_em = None
         try:
             db.commit()
             processados += 1

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -11,6 +11,7 @@ from app.services.whatsapp_contato_match import funcionario_por_wa_id
 from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.evolution_inbound import iter_inbound_whatsapp_messages, iter_message_status_updates
 from app.services.whatsapp_media_storage import gravar_base64_em_disco
+from app.services.whatsapp_wa_id_lock import lock_wa_id_para_chat, unlock_wa_id_para_chat
 from app.services.whatsapp_auto_messages import (
     DEFAULT_AUTO_MSG_ESPERA,
     DEFAULT_AUTO_MSG_FORA_HORARIO,
@@ -396,148 +397,165 @@ def evolution_webhook(
     processados = 0
     for item in iter_inbound_whatsapp_messages(body):
         wa_id = item["wa_id"]
-        corpo = item["corpo"]
-        wa_mid = item.get("wa_message_id")
-        push = item.get("push_name")
-        tipo = item.get("tipo") or "texto"
-
-        tipo_midia = tipo
-        mimetype_val = item.get("mimetype")
-        midia_nome = _baixar_midia_inbound(
-            item=item,
-            st_media=st_media,
-            tipo=tipo,
-            wa_id=wa_id,
-            wa_mid=wa_mid,
-        )
-
-        chat = _chat_aberto_por_wa_id(db, wa_id)
-        if not chat:
-            chat_aval = _chat_aguardando_avaliacao_por_wa_id(db, wa_id)
-            # Chat a classificar demanda: só reutiliza se for resposta de avaliação (nota 1–5).
-            # Qualquer outra mensagem abre atendimento novo; o pendente permanece.
-            if chat_aval is not None:
-                from app.services.whatsapp_avaliacao import parse_nota_avaliacao
-
-                pendente = bool(getattr(chat_aval, "classificacao_demanda_pendente", False))
-                nota = parse_nota_avaliacao(corpo) if (tipo or "texto") == "texto" else None
-                if pendente and nota is None:
-                    chat_aval = None
-            if chat_aval is not None:
-                chat = chat_aval
-                q_prev = item.get("quoted_corpo_preview")
-                if q_prev is not None and len(str(q_prev)) > 500:
-                    q_prev = str(q_prev)[:500]
-                msg = WhatsappMensagem(
-                    chat_id=chat.id,
-                    direcao="inbound",
-                    corpo=corpo,
-                    tipo_midia=tipo_midia,
-                    mimetype=mimetype_val,
-                    midia_nome_arquivo=midia_nome,
-                    wa_message_id=wa_mid,
-                    quoted_wa_message_id=item.get("quoted_wa_message_id"),
-                    quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
-                    atendente_id=None,
-                )
-                db.add(msg)
-                if push and not chat.cliente_nome:
-                    chat.cliente_nome = push
-                try:
-                    from app.services.whatsapp_avaliacao import processar_resposta_avaliacao
-
-                    processar_resposta_avaliacao(
-                        db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
-                    )
-                    db.commit()
-                    processados += 1
-                except IntegrityError:
-                    db.rollback()
-                    logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
-                except Exception:
-                    db.rollback()
-                    raise
-                continue
-
-        if tipo == "texto":
-            tipo_midia = "texto"
-            mimetype_val = None
-            midia_nome = None
-
-        chat_novo = False
-        if not chat:
-            chat_novo = True
-            func = funcionario_por_wa_id(db, wa_id)
-            chat = WhatsappChat(
-                protocolo=gerar_protocolo_chat(db),
-                wa_id=wa_id,
-                cliente_nome=push or (func.nome if func else None),
-                estado="aguardando_atendente",
-                setor_id=None,
-                funcionario_rede_id=func.id if func else None,
-                empresa_id=func.empresa_id if func and getattr(func, "empresa_id", None) else None,
-            )
-            db.add(chat)
-            db.flush()
-            # mensagem automática: cliente em espera (somente na criação do chat)
-            try:
-                _try_auto_msg_espera(db, st, chat)
-            except Exception:
-                logger.exception("Falha ao enviar mensagem automática de espera (chat=%s)", chat.protocolo)
-            # fora do horário também pode aplicar já na primeira mensagem
-            try:
-                _try_auto_msg_fora_horario(db, st, chat)
-            except Exception:
-                logger.exception("Falha ao enviar mensagem automática fora do horário (chat=%s)", chat.protocolo)
-        else:
-            # se continuar a receber mensagens fora do horário e o chat não está em atendimento, avisar uma vez
-            if chat.estado != "em_atendimento":
-                try:
-                    _try_auto_msg_fora_horario(db, st, chat)
-                except Exception:
-                    logger.exception("Falha ao enviar mensagem automática fora do horário (chat=%s)", chat.protocolo)
-
-        q_prev = item.get("quoted_corpo_preview")
-        if q_prev is not None and len(str(q_prev)) > 500:
-            q_prev = str(q_prev)[:500]
-        msg = WhatsappMensagem(
-            chat_id=chat.id,
-            direcao="inbound",
-            corpo=corpo,
-            tipo_midia=tipo_midia,
-            mimetype=mimetype_val,
-            midia_nome_arquivo=midia_nome,
-            wa_message_id=wa_mid,
-            quoted_wa_message_id=item.get("quoted_wa_message_id"),
-            quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
-            atendente_id=None,
-        )
-        db.add(msg)
-        if push and not chat.cliente_nome:
-            chat.cliente_nome = push
-        if getattr(chat, "inatividade_pausada", False):
-            chat.inatividade_pausada = False
-            chat.inatividade_retomada_em = None
+        lock_wa_id_para_chat(db, wa_id)
         try:
-            db.commit()
-            processados += 1
-            chat_emit = db.query(WhatsappChat).filter(WhatsappChat.id == chat.id).first()
-            msg_emit = (
-                db.query(WhatsappMensagem)
-                .filter(WhatsappMensagem.chat_id == chat.id, WhatsappMensagem.wa_message_id == wa_mid)
-                .first()
+            processados += _processar_mensagem_inbound(
+                db,
+                item=item,
+                st=st,
+                st_media=st_media,
             )
-            if chat_emit and msg_emit:
-                from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
-
-                emit_chat_mensagem_from_models(db, chat_emit, msg_emit)
-                if chat_novo:
-                    emit_chat_fila_from_model(db, chat_emit, estado_anterior=None)
-        except IntegrityError:
-            db.rollback()
-            logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
-        except Exception:
-            db.rollback()
-            raise
+        finally:
+            unlock_wa_id_para_chat(db, wa_id)
 
     return {"ok": True, "processados": processados}
+
+
+def _processar_mensagem_inbound(
+    db: Session,
+    *,
+    item: dict,
+    st: WhatsappSettings | None,
+    st_media: WhatsappSettings | None,
+) -> int:
+    wa_id = item["wa_id"]
+    corpo = item["corpo"]
+    wa_mid = item.get("wa_message_id")
+    push = item.get("push_name")
+    tipo = item.get("tipo") or "texto"
+
+    tipo_midia = tipo
+    mimetype_val = item.get("mimetype")
+    midia_nome = _baixar_midia_inbound(
+        item=item,
+        st_media=st_media,
+        tipo=tipo,
+        wa_id=wa_id,
+        wa_mid=wa_mid,
+    )
+
+    chat = _chat_aberto_por_wa_id(db, wa_id)
+    if not chat:
+        chat_aval = _chat_aguardando_avaliacao_por_wa_id(db, wa_id)
+        # Chat a classificar demanda: só reutiliza se for resposta de avaliação (nota 1–5).
+        # Qualquer outra mensagem abre atendimento novo; o pendente permanece.
+        if chat_aval is not None:
+            from app.services.whatsapp_avaliacao import parse_nota_avaliacao
+
+            pendente = bool(getattr(chat_aval, "classificacao_demanda_pendente", False))
+            nota = parse_nota_avaliacao(corpo) if (tipo or "texto") == "texto" else None
+            if pendente and nota is None:
+                chat_aval = None
+        if chat_aval is not None:
+            chat = chat_aval
+            q_prev = item.get("quoted_corpo_preview")
+            if q_prev is not None and len(str(q_prev)) > 500:
+                q_prev = str(q_prev)[:500]
+            msg = WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="inbound",
+                corpo=corpo,
+                tipo_midia=tipo_midia,
+                mimetype=mimetype_val,
+                midia_nome_arquivo=midia_nome,
+                wa_message_id=wa_mid,
+                quoted_wa_message_id=item.get("quoted_wa_message_id"),
+                quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
+                atendente_id=None,
+            )
+            db.add(msg)
+            if push and not chat.cliente_nome:
+                chat.cliente_nome = push
+            try:
+                from app.services.whatsapp_avaliacao import processar_resposta_avaliacao
+
+                processar_resposta_avaliacao(
+                    db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
+                )
+                db.commit()
+                return 1
+            except IntegrityError:
+                db.rollback()
+                logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
+                return 0
+            except Exception:
+                db.rollback()
+                raise
+
+    if tipo == "texto":
+        tipo_midia = "texto"
+        mimetype_val = None
+        midia_nome = None
+
+    chat_novo = False
+    if not chat:
+        chat_novo = True
+        func = funcionario_por_wa_id(db, wa_id)
+        chat = WhatsappChat(
+            protocolo=gerar_protocolo_chat(db),
+            wa_id=wa_id,
+            cliente_nome=push or (func.nome if func else None),
+            estado="aguardando_atendente",
+            setor_id=None,
+            funcionario_rede_id=func.id if func else None,
+            empresa_id=func.empresa_id if func and getattr(func, "empresa_id", None) else None,
+        )
+        db.add(chat)
+        db.flush()
+        try:
+            _try_auto_msg_espera(db, st, chat)
+        except Exception:
+            logger.exception("Falha ao enviar mensagem automática de espera (chat=%s)", chat.protocolo)
+        try:
+            _try_auto_msg_fora_horario(db, st, chat)
+        except Exception:
+            logger.exception("Falha ao enviar mensagem automática fora do horário (chat=%s)", chat.protocolo)
+    elif chat.estado != "em_atendimento":
+        try:
+            _try_auto_msg_fora_horario(db, st, chat)
+        except Exception:
+            logger.exception("Falha ao enviar mensagem automática fora do horário (chat=%s)", chat.protocolo)
+
+    q_prev = item.get("quoted_corpo_preview")
+    if q_prev is not None and len(str(q_prev)) > 500:
+        q_prev = str(q_prev)[:500]
+    msg = WhatsappMensagem(
+        chat_id=chat.id,
+        direcao="inbound",
+        corpo=corpo,
+        tipo_midia=tipo_midia,
+        mimetype=mimetype_val,
+        midia_nome_arquivo=midia_nome,
+        wa_message_id=wa_mid,
+        quoted_wa_message_id=item.get("quoted_wa_message_id"),
+        quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
+        atendente_id=None,
+    )
+    db.add(msg)
+    if push and not chat.cliente_nome:
+        chat.cliente_nome = push
+    if getattr(chat, "inatividade_pausada", False):
+        chat.inatividade_pausada = False
+        chat.inatividade_retomada_em = None
+    try:
+        db.commit()
+        chat_emit = db.query(WhatsappChat).filter(WhatsappChat.id == chat.id).first()
+        msg_emit = (
+            db.query(WhatsappMensagem)
+            .filter(WhatsappMensagem.chat_id == chat.id, WhatsappMensagem.wa_message_id == wa_mid)
+            .first()
+        )
+        if chat_emit and msg_emit:
+            from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
+
+            emit_chat_mensagem_from_models(db, chat_emit, msg_emit)
+            if chat_novo:
+                emit_chat_fila_from_model(db, chat_emit, estado_anterior=None)
+        return 1
+    except IntegrityError:
+        db.rollback()
+        logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
+        return 0
+    except Exception:
+        db.rollback()
+        raise

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -437,50 +437,57 @@ def _processar_mensagem_inbound(
     chat = _chat_aberto_por_wa_id(db, wa_id)
     if not chat:
         chat_aval = _chat_aguardando_avaliacao_por_wa_id(db, wa_id)
-        # Chat a classificar demanda: só reutiliza se for resposta de avaliação (nota 1–5).
-        # Qualquer outra mensagem abre atendimento novo; o pendente permanece.
         if chat_aval is not None:
-            from app.services.whatsapp_avaliacao import parse_nota_avaliacao
-
-            pendente = bool(getattr(chat_aval, "classificacao_demanda_pendente", False))
-            nota = parse_nota_avaliacao(corpo) if (tipo or "texto") == "texto" else None
-            if pendente and nota is None:
-                chat_aval = None
-        if chat_aval is not None:
-            chat = chat_aval
-            q_prev = item.get("quoted_corpo_preview")
-            if q_prev is not None and len(str(q_prev)) > 500:
-                q_prev = str(q_prev)[:500]
-            msg = WhatsappMensagem(
-                chat_id=chat.id,
-                direcao="inbound",
-                corpo=corpo,
-                tipo_midia=tipo_midia,
-                mimetype=mimetype_val,
-                midia_nome_arquivo=midia_nome,
-                wa_message_id=wa_mid,
-                quoted_wa_message_id=item.get("quoted_wa_message_id"),
-                quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
-                atendente_id=None,
+            from app.services.whatsapp_avaliacao import (
+                encerrar_avaliacao_sem_nota,
+                parse_nota_avaliacao,
+                processar_resposta_avaliacao,
             )
-            db.add(msg)
-            if push and not chat.cliente_nome:
-                chat.cliente_nome = push
-            try:
-                from app.services.whatsapp_avaliacao import processar_resposta_avaliacao
 
-                processar_resposta_avaliacao(
-                    db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
+            nota = parse_nota_avaliacao(corpo) if (tipo or "texto") == "texto" else None
+            if nota is not None:
+                chat = chat_aval
+                q_prev = item.get("quoted_corpo_preview")
+                if q_prev is not None and len(str(q_prev)) > 500:
+                    q_prev = str(q_prev)[:500]
+                msg = WhatsappMensagem(
+                    chat_id=chat.id,
+                    direcao="inbound",
+                    corpo=corpo,
+                    tipo_midia=tipo_midia,
+                    mimetype=mimetype_val,
+                    midia_nome_arquivo=midia_nome,
+                    wa_message_id=wa_mid,
+                    quoted_wa_message_id=item.get("quoted_wa_message_id"),
+                    quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
+                    atendente_id=None,
                 )
-                db.commit()
-                return 1
-            except IntegrityError:
-                db.rollback()
-                logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
-                return 0
-            except Exception:
-                db.rollback()
-                raise
+                db.add(msg)
+                if push and not chat.cliente_nome:
+                    chat.cliente_nome = push
+                try:
+                    resultado = processar_resposta_avaliacao(
+                        db, chat, st, corpo, tipo_midia=tipo or "texto", msg_inbound=msg
+                    )
+                    db.commit()
+                    return 1 if resultado == "nota" else 0
+                except IntegrityError:
+                    db.rollback()
+                    logger.info("Webhook Evolution: mensagem duplicada ignorada (wa_message_id=%s)", wa_mid)
+                    return 0
+                except Exception:
+                    db.rollback()
+                    raise
+            # Não é nota: encerra avaliação sem prender o cliente e segue para chat novo
+            # com esta mesma mensagem (classificação de demanda pendente permanece no chat antigo).
+            if st is not None:
+                try:
+                    encerrar_avaliacao_sem_nota(db, chat_aval, st, motivo="pular")
+                    db.flush()
+                except Exception:
+                    logger.exception(
+                        "Falha ao encerrar avaliação sem nota (chat=%s)", chat_aval.protocolo
+                    )
 
     if tipo == "texto":
         tipo_midia = "texto"

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -26,6 +26,12 @@ def _carregar_atendente_por_token(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Token inválido ou expirado",
         )
+    # Token do portal do cliente não acessa rotas internas (#300)
+    if payload.get("aud") == "portal":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token inválido para o painel interno",
+        )
     email = payload["sub"]
     token_tid = payload.get("tid")
     assert_token_tenant_matches_request(request, token_tid)

--- a/backend/app/core/portal_auth.py
+++ b/backend/app/core/portal_auth.py
@@ -1,0 +1,128 @@
+"""Autenticação JWT do portal do cliente (funcionário da rede)."""
+
+from __future__ import annotations
+
+from fastapi import Depends, HTTPException, Request, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.funcionario_rede import FuncionarioRede
+from app.core.security import decodificar_token
+from app.core.tenant_context import (
+    assert_token_tenant_matches_request,
+    effective_tenant_id,
+    get_request_tenant_id,
+    is_multi_tenant_mode,
+)
+
+PORTAL_AUD = "portal"
+
+security = HTTPBearer(auto_error=False)
+
+
+def claims_portal(funcionario: FuncionarioRede, *, tenant_id: int) -> dict:
+    email = (funcionario.email or "").strip().lower()
+    ver = int(getattr(funcionario, "token_version", 0) or 0)
+    return {
+        "sub": email,
+        "aud": PORTAL_AUD,
+        "fid": int(funcionario.id),
+        "tid": int(tenant_id),
+        "ver": ver,
+    }
+
+
+def token_eh_portal(payload: dict | None) -> bool:
+    if not payload:
+        return False
+    return payload.get("aud") == PORTAL_AUD
+
+
+def _carregar_funcionario_por_token(
+    request: Request,
+    token: str,
+    db: Session,
+) -> FuncionarioRede:
+    payload = decodificar_token(token)
+    if not payload or "sub" not in payload or not token_eh_portal(payload):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token inválido ou expirado",
+        )
+    email = str(payload["sub"]).strip().lower()
+    token_tid = payload.get("tid")
+    assert_token_tenant_matches_request(request, token_tid)
+    if is_multi_tenant_mode():
+        host_tid = get_request_tenant_id(request)
+        tenant_id = int(host_tid if host_tid is not None else token_tid or 0)
+    else:
+        tenant_id = effective_tenant_id()
+
+    fid = payload.get("fid")
+    q = db.query(FuncionarioRede).filter(
+        func.lower(FuncionarioRede.email) == email,
+        FuncionarioRede.ativo.is_(True),
+    )
+    if fid is not None:
+        q = q.filter(FuncionarioRede.id == int(fid))
+    funcionario = q.first()
+    if not funcionario:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Usuário não encontrado ou inativo",
+        )
+    if not (funcionario.senha_hash or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Acesso ao portal não habilitado. Solicite a senha ao suporte.",
+        )
+
+    # Valida tenant via rede/empresa do funcionário
+    from app.core.portal_scope import tenant_id_do_funcionario
+
+    try:
+        tid_func = tenant_id_do_funcionario(db, funcionario)
+    except Exception:
+        tid_func = tenant_id
+    if is_multi_tenant_mode() and int(tid_func) != int(tenant_id):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Usuário não encontrado ou inativo",
+        )
+
+    token_ver = int(payload.get("ver") or 0)
+    atual_ver = int(getattr(funcionario, "token_version", 0) or 0)
+    if token_ver != atual_ver:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Sessão encerrada. Faça login novamente.",
+        )
+
+    path = request.url.path.rstrip("/") or "/"
+    method = request.method.upper()
+    if getattr(funcionario, "must_change_password", False):
+        pode = (path.endswith("/portal/me") and method == "GET") or (
+            path.endswith("/portal/me/trocar-senha") and method == "POST"
+        )
+        if not pode:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Altere sua senha antes de usar o portal.",
+            )
+    return funcionario
+
+
+def obter_funcionario_portal(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+    db: Session = Depends(get_db),
+) -> FuncionarioRede:
+    if not credentials:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token não informado",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+    return _carregar_funcionario_por_token(request, credentials.credentials, db)

--- a/backend/app/core/portal_auth.py
+++ b/backend/app/core/portal_auth.py
@@ -126,3 +126,16 @@ def obter_funcionario_portal(
             headers={"WWW-Authenticate": "Bearer"},
         )
     return _carregar_funcionario_por_token(request, credentials.credentials, db)
+
+
+def exigir_socio_portal(
+    funcionario: FuncionarioRede = Depends(obter_funcionario_portal),
+) -> FuncionarioRede:
+    from app.core.portal_scope import tipo_portal
+
+    if tipo_portal(funcionario) != "socio":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="A gestão de equipe está disponível apenas para sócios.",
+        )
+    return funcionario

--- a/backend/app/core/portal_scope.py
+++ b/backend/app/core/portal_scope.py
@@ -1,37 +1,122 @@
-"""Escopo de dados do portal do cliente (funcionário da rede)."""
+"""Escopo de dados do portal do cliente (funcionário da rede).
+
+RBAC por papel (#604):
+- colaborador: tickets/chats **próprios** (aberto_por / contacto vinculado)
+- supervisor: tickets/chats das **empresas vinculadas**
+- sócio: tudo da **rede**
+
+Ver também `docs/PORTAL_CLIENTE.md`.
+"""
 
 from __future__ import annotations
 
-from sqlalchemy.orm import Session
+from sqlalchemy import or_
+from sqlalchemy.orm import Query, Session
 
 from app.models.empresa import Empresa
 from app.models.funcionario_rede import FuncionarioRede
 from app.models.ticket import Ticket
-from app.services.funcionario_escopo import empresa_ids_vinculados, rede_id_efetiva
+from app.services.funcionario_escopo import empresa_ids_vinculados, escopo_efetivo, rede_id_efetiva
+
+TiposPortal = frozenset({"colaborador", "supervisor", "socio"})
+
+
+def tipo_portal(funcionario: FuncionarioRede) -> str:
+    t = (funcionario.tipo or "colaborador").strip().lower()
+    return t if t in TiposPortal else "colaborador"
 
 
 def empresa_ids_visiveis(db: Session, funcionario: FuncionarioRede) -> set[int]:
     return empresa_ids_vinculados(db, funcionario, apenas_ativas=True)
 
 
-def ticket_no_escopo(db: Session, funcionario: FuncionarioRede, ticket: Ticket) -> bool:
-    """Ticket visível se empresa está no escopo, ou (coordenação) rede sem empresa no escopo do sócio."""
+def _ticket_empresa_rede_visivel(db: Session, funcionario: FuncionarioRede, ticket: Ticket) -> bool:
+    """Empresa/rede do ticket dentro do vínculo do funcionário (sem filtro de autor)."""
     rede_id = rede_id_efetiva(db, funcionario)
     if rede_id is None:
         return False
     if ticket.rede_id is not None and int(ticket.rede_id) != int(rede_id):
-        # Fallback: empresa do ticket pode estar na rede
         if ticket.empresa_id is None:
             return False
     ids = empresa_ids_visiveis(db, funcionario)
     if ticket.empresa_id is not None:
         return int(ticket.empresa_id) in ids
-    # Ticket só com rede (coordenação): sócio/supervisor com escopo all da mesma rede
     if ticket.rede_id is not None and int(ticket.rede_id) == int(rede_id):
-        from app.services.funcionario_escopo import escopo_efetivo
-
         return escopo_efetivo(funcionario) == "all"
     return False
+
+
+def ticket_no_escopo(db: Session, funcionario: FuncionarioRede, ticket: Ticket) -> bool:
+    if not _ticket_empresa_rede_visivel(db, funcionario, ticket):
+        return False
+    if tipo_portal(funcionario) == "colaborador":
+        ap = ticket.aberto_por_id
+        return ap is not None and int(ap) == int(funcionario.id)
+    return True
+
+
+def filtro_query_tickets_portal(query: Query, db: Session, funcionario: FuncionarioRede) -> Query | None:
+    """Aplica escopo RBAC à query de tickets. Retorna None se a listagem deve ser vazia."""
+    ids = empresa_ids_visiveis(db, funcionario)
+    rede_id = rede_id_efetiva(db, funcionario)
+    filtros = []
+    if ids:
+        filtros.append(Ticket.empresa_id.in_(ids))
+    if rede_id is not None and escopo_efetivo(funcionario) == "all":
+        filtros.append((Ticket.empresa_id.is_(None)) & (Ticket.rede_id == rede_id))
+    if not filtros:
+        return None
+    query = query.filter(or_(*filtros))
+    if tipo_portal(funcionario) == "colaborador":
+        query = query.filter(Ticket.aberto_por_id == funcionario.id)
+    return query
+
+
+def chat_no_escopo(db: Session, funcionario: FuncionarioRede, chat) -> bool:
+    """Escopo de chats WhatsApp no portal (#604; API em #603)."""
+    from app.models.whatsapp_chat import WhatsappChat
+
+    if not isinstance(chat, WhatsappChat):
+        return False
+    rede_id = rede_id_efetiva(db, funcionario)
+    if rede_id is None:
+        return False
+    if chat.empresa_id is None:
+        return tipo_portal(funcionario) == "socio" and escopo_efetivo(funcionario) == "all"
+    emp = db.query(Empresa).filter(Empresa.id == chat.empresa_id).first()
+    if not emp or int(emp.rede_id) != int(rede_id):
+        return False
+    papel = tipo_portal(funcionario)
+    if papel == "colaborador":
+        fid = chat.funcionario_rede_id
+        return fid is not None and int(fid) == int(funcionario.id)
+    if papel == "supervisor":
+        return int(chat.empresa_id) in empresa_ids_visiveis(db, funcionario)
+    return True
+
+
+def filtro_query_chats_portal(query: Query, db: Session, funcionario: FuncionarioRede) -> Query | None:
+    """Filtro SQLAlchemy para listagem de chats no portal (#603)."""
+    from app.models.whatsapp_chat import WhatsappChat
+
+    ids = empresa_ids_visiveis(db, funcionario)
+    rede_id = rede_id_efetiva(db, funcionario)
+    if rede_id is None:
+        return None
+    papel = tipo_portal(funcionario)
+    if papel == "colaborador":
+        return query.filter(WhatsappChat.funcionario_rede_id == funcionario.id)
+    if papel == "supervisor":
+        if not ids:
+            return None
+        return query.filter(WhatsappChat.empresa_id.in_(ids))
+    rede_empresa_ids = db.query(Empresa.id).filter(Empresa.rede_id == rede_id)
+    return query.filter(
+        or_(
+            WhatsappChat.empresa_id.in_(rede_empresa_ids),
+            WhatsappChat.empresa_id.is_(None),
+        )
+    )
 
 
 def assert_empresa_no_escopo(db: Session, funcionario: FuncionarioRede, empresa_id: int) -> Empresa:

--- a/backend/app/core/portal_scope.py
+++ b/backend/app/core/portal_scope.py
@@ -1,0 +1,60 @@
+"""Escopo de dados do portal do cliente (funcionário da rede)."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.empresa import Empresa
+from app.models.funcionario_rede import FuncionarioRede
+from app.models.ticket import Ticket
+from app.services.funcionario_escopo import empresa_ids_vinculados, rede_id_efetiva
+
+
+def empresa_ids_visiveis(db: Session, funcionario: FuncionarioRede) -> set[int]:
+    return empresa_ids_vinculados(db, funcionario, apenas_ativas=True)
+
+
+def ticket_no_escopo(db: Session, funcionario: FuncionarioRede, ticket: Ticket) -> bool:
+    """Ticket visível se empresa está no escopo, ou (coordenação) rede sem empresa no escopo do sócio."""
+    rede_id = rede_id_efetiva(db, funcionario)
+    if rede_id is None:
+        return False
+    if ticket.rede_id is not None and int(ticket.rede_id) != int(rede_id):
+        # Fallback: empresa do ticket pode estar na rede
+        if ticket.empresa_id is None:
+            return False
+    ids = empresa_ids_visiveis(db, funcionario)
+    if ticket.empresa_id is not None:
+        return int(ticket.empresa_id) in ids
+    # Ticket só com rede (coordenação): sócio/supervisor com escopo all da mesma rede
+    if ticket.rede_id is not None and int(ticket.rede_id) == int(rede_id):
+        from app.services.funcionario_escopo import escopo_efetivo
+
+        return escopo_efetivo(funcionario) == "all"
+    return False
+
+
+def assert_empresa_no_escopo(db: Session, funcionario: FuncionarioRede, empresa_id: int) -> Empresa:
+    emp = db.query(Empresa).filter(Empresa.id == empresa_id, Empresa.ativo.is_(True)).first()
+    if not emp or int(empresa_id) not in empresa_ids_visiveis(db, funcionario):
+        # 404 para não revelar existência fora do escopo
+        raise LookupError("Empresa não encontrada")
+    return emp
+
+
+def tenant_id_do_funcionario(db: Session, funcionario: FuncionarioRede) -> int:
+    rede_id = rede_id_efetiva(db, funcionario)
+    if rede_id is not None:
+        from app.models.rede import Rede
+
+        rede = db.query(Rede).filter(Rede.id == rede_id).first()
+        if rede is not None:
+            return int(rede.tenant_id)
+    ids = empresa_ids_visiveis(db, funcionario)
+    if ids:
+        emp = db.query(Empresa).filter(Empresa.id == next(iter(ids))).first()
+        if emp is not None:
+            return int(emp.tenant_id)
+    from app.core.tenant_context import effective_tenant_id
+
+    return int(effective_tenant_id())

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -40,7 +40,13 @@ def criar_refresh_token(data: dict) -> str:
 
 def decodificar_token(token: str) -> dict | None:
     try:
-        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        # verify_aud=False: claim `aud` (portal) é validada nas dependências de auth (#300)
+        payload = jwt.decode(
+            token,
+            settings.SECRET_KEY,
+            algorithms=[settings.ALGORITHM],
+            options={"verify_aud": False},
+        )
         if payload.get("type") not in (None, "access"):
             return None
         return payload
@@ -50,7 +56,12 @@ def decodificar_token(token: str) -> dict | None:
 
 def decodificar_refresh_token(token: str) -> dict | None:
     try:
-        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        payload = jwt.decode(
+            token,
+            settings.SECRET_KEY,
+            algorithms=[settings.ALGORITHM],
+            options={"verify_aud": False},
+        )
         if payload.get("type") != "refresh":
             return None
         return payload

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -256,6 +256,7 @@ async def lifespan(app: FastAPI):
 
     def whatsapp_inactivity_loop() -> None:
         from app.database import SessionLocal
+        from app.services.whatsapp_avaliacao import process_whatsapp_avaliacao_timeouts
         from app.services.whatsapp_inactivity_worker import process_whatsapp_inactivity_closures
 
         interval = max(15, settings.WHATSAPP_INACTIVITY_WORKER_INTERVAL_SECONDS)
@@ -263,8 +264,9 @@ async def lifespan(app: FastAPI):
             db = SessionLocal()
             try:
                 process_whatsapp_inactivity_closures(db, limit=200)
+                process_whatsapp_avaliacao_timeouts(db, limit=200)
             except Exception as e:
-                logger.warning("Worker inatividade WhatsApp: %s", e)
+                logger.warning("Worker inatividade/avaliação WhatsApp: %s", e)
                 db.rollback()
             finally:
                 db.close()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -48,6 +48,7 @@ from app.api import (
     kb,
     chat_interno,
     portal_chats,
+    portal,
 )
 from app.config import settings
 from app.core.audit import clear_audit_request_context, set_audit_request_context
@@ -460,6 +461,7 @@ app.include_router(sla.router, prefix=API_V1_PREFIX)
 app.include_router(kb.router, prefix=API_V1_PREFIX)
 app.include_router(chat_interno.router, prefix=API_V1_PREFIX)
 app.include_router(portal_chats.router, prefix=API_V1_PREFIX)
+app.include_router(portal.router, prefix=API_V1_PREFIX)
 
 
 def _app_route_paths() -> set[str]:

--- a/backend/app/models/funcionario_rede.py
+++ b/backend/app/models/funcionario_rede.py
@@ -24,6 +24,11 @@ class FuncionarioRede(Base):
     tipo = Column(String(20), nullable=False)  # socio | supervisor | colaborador
     escopo_empresas = Column(String(20), nullable=False, default="selected")  # all | selected
     ativo = Column(Boolean, default=True)
+    # Auth do portal do cliente (#263 / #300)
+    senha_hash = Column(String(255), nullable=True)
+    must_change_password = Column(Boolean, default=False, nullable=False)
+    token_version = Column(Integer, default=0, nullable=False)
+    notificar_email_portal = Column(Boolean, default=True, nullable=False)
     # Sócio: preenchido rede_id
     rede_id = Column(Integer, ForeignKey("redes.id"), nullable=True)
     # Colaborador: preenchido empresa_id

--- a/backend/app/models/kb.py
+++ b/backend/app/models/kb.py
@@ -130,6 +130,7 @@ class KbPortalSettings(Base):
     portal_titulo = Column(String(120), nullable=True)
     texto_boas_vindas = Column(String(500), nullable=True)
     cor_header = Column(String(7), nullable=False, server_default="#0B2D4A", default="#0B2D4A")
+    cor_sidebar = Column(String(7), nullable=True)
     cor_primaria = Column(String(7), nullable=False, server_default="#0D9488", default="#0D9488")
     cor_texto_header = Column(String(7), nullable=False, server_default="#FFFFFF", default="#FFFFFF")
     cor_texto_corpo = Column(String(7), nullable=False, server_default="#0F172A", default="#0F172A")

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -70,6 +70,8 @@ class WhatsappChat(Base):
     empresa_id = Column(Integer, ForeignKey("empresas.id", ondelete="SET NULL"), nullable=True, index=True)
     inatividade_pausada = Column(Boolean, nullable=False, default=False, server_default="false")
     inatividade_retomada_em = Column(DateTime(timezone=True), nullable=True)
+    # Após encerramento por inatividade: responsável deve registar (ou confirmar sem) demanda.
+    classificacao_demanda_pendente = Column(Boolean, nullable=False, default=False, server_default="false")
 
     atendente = relationship("Atendente", backref="whatsapp_chats_atendidos")
     setor = relationship("Setor", backref="whatsapp_chats")

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -42,9 +42,13 @@ class WhatsappSettings(Base):
     auto_msg_inativ_aviso_ativa = Column(Boolean, nullable=False, default=True)
     auto_msg_inativ_aviso_texto = Column(Text, nullable=True)
     avaliacao_ativa = Column(Boolean, nullable=False, default=False)
+    # Janela após encerrar para o cliente enviar nota 1–5 (depois finaliza sozinho).
+    avaliacao_janela_minutos = Column(Integer, nullable=False, default=30)
     auto_msg_avaliacao_ativa = Column(Boolean, nullable=False, default=True)
     auto_msg_avaliacao_texto = Column(Text, nullable=True)
     auto_msg_avaliacao_obrigado_texto = Column(Text, nullable=True)
+    auto_msg_avaliacao_timeout_texto = Column(Text, nullable=True)
+    auto_msg_avaliacao_pular_texto = Column(Text, nullable=True)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), server_default=func.now())
 
 

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -68,6 +68,8 @@ class WhatsappChat(Base):
         Integer, ForeignKey("funcionarios_rede.id", ondelete="SET NULL"), nullable=True, index=True
     )
     empresa_id = Column(Integer, ForeignKey("empresas.id", ondelete="SET NULL"), nullable=True, index=True)
+    inatividade_pausada = Column(Boolean, nullable=False, default=False, server_default="false")
+    inatividade_retomada_em = Column(DateTime(timezone=True), nullable=True)
 
     atendente = relationship("Atendente", backref="whatsapp_chats_atendidos")
     setor = relationship("Setor", backref="whatsapp_chats")

--- a/backend/app/schemas/funcionario_rede.py
+++ b/backend/app/schemas/funcionario_rede.py
@@ -38,6 +38,9 @@ class FuncionarioRedeCreate(FuncionarioRedeBase):
     rede_id: int | None = None
     empresa_id: int | None = None  # legado colaborador (preferir empresa_ids)
     empresa_ids: list[int] = []  # obrigatório se escopo_empresas == selected
+    # Portal do cliente (#300): senha inicial opcional
+    senha_portal: str | None = None
+    must_change_password: bool = True
 
 
 class FuncionarioRedeUpdate(BaseModel):
@@ -50,6 +53,10 @@ class FuncionarioRedeUpdate(BaseModel):
     rede_id: int | None = None
     empresa_id: int | None = None
     empresa_ids: list[int] | None = None
+    senha_portal: str | None = None
+    must_change_password: bool | None = None
+    notificar_email_portal: bool | None = None
+    revogar_sessoes_portal: bool | None = None
 
     @field_validator("email", mode="before")
     @classmethod
@@ -67,6 +74,9 @@ class FuncionarioRedeRead(FuncionarioRedeBase):
     rede_id: int | None = None
     empresa_id: int | None = None
     empresa_ids: list[int] = []  # preenchido quando escopo_empresas == selected
+    portal_habilitado: bool = False
+    must_change_password: bool = False
+    notificar_email_portal: bool = True
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/backend/app/schemas/kb.py
+++ b/backend/app/schemas/kb.py
@@ -147,6 +147,7 @@ class KbPublicBrandingRead(BaseModel):
     texto_boas_vindas: str | None = None
     cor_primaria: str = "#0D9488"
     cor_header: str = "#0B2D4A"
+    cor_sidebar: str = "#0B2D4A"
     cor_texto_header: str = "#FFFFFF"
     cor_texto_corpo: str = "#0F172A"
     cor_fundo: str = "#F8FAFC"
@@ -160,6 +161,7 @@ class KbPortalSettingsRead(BaseModel):
     portal_titulo: str | None = None
     texto_boas_vindas: str | None = None
     cor_header: str = "#0B2D4A"
+    cor_sidebar: str = "#0B2D4A"
     cor_primaria: str = "#0D9488"
     cor_texto_header: str = "#FFFFFF"
     cor_texto_corpo: str = "#0F172A"
@@ -180,6 +182,7 @@ class KbPortalSettingsUpdate(BaseModel):
     portal_titulo: str | None = Field(None, max_length=120)
     texto_boas_vindas: str | None = Field(None, max_length=500)
     cor_header: str | None = Field(None, pattern=_HEX_COLOR)
+    cor_sidebar: str | None = Field(None, pattern=_HEX_COLOR)
     cor_primaria: str | None = Field(None, pattern=_HEX_COLOR)
     cor_texto_header: str | None = Field(None, pattern=_HEX_COLOR)
     cor_texto_corpo: str | None = Field(None, pattern=_HEX_COLOR)

--- a/backend/app/schemas/portal.py
+++ b/backend/app/schemas/portal.py
@@ -126,3 +126,88 @@ class PortalTicketDetail(PortalTicketListItem):
 
 class PortalMensagemOk(BaseModel):
     detail: str = "ok"
+
+
+class PortalWhatsappChatListItem(BaseModel):
+    id: int
+    protocolo: str
+    estado: str
+    empresa_id: int | None = None
+    empresa_nome: str | None = None
+    setor_nome: str | None = None
+    created_at: datetime | None = None
+    encerramento_at: datetime | None = None
+    ultima_mensagem_em: datetime | None = None
+    ultima_mensagem_preview: str | None = None
+
+
+class PortalWhatsappChatDetail(PortalWhatsappChatListItem):
+    encerrado: bool = False
+
+
+class PortalWhatsappMensagemRead(BaseModel):
+    id: int
+    direcao: str
+    corpo: str
+    tipo_midia: str | None = None
+    midia_disponivel: bool = False
+    autor_nome: str | None = None
+    autor_papel: Literal["equipe", "voce", "sistema"] = "sistema"
+    created_at: datetime | None = None
+
+
+class PortalEquipeFuncionarioRead(BaseModel):
+    id: int
+    nome: str
+    email: str | None = None
+    telefone: str | None = None
+    tipo: str
+    ativo: bool
+    empresa_id: int | None = None
+    empresa_ids: list[int] = []
+    portal_habilitado: bool = False
+    must_change_password: bool = False
+    notificar_email_portal: bool = True
+    editavel: bool = True
+
+
+class PortalEquipeFuncionarioCreate(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=255)
+    email: EmailStr
+    telefone: str | None = None
+    tipo: Literal["colaborador", "supervisor"]
+    ativo: bool = True
+    empresa_id: int | None = None
+    empresa_ids: list[int] = []
+    senha_portal: str | None = None
+    must_change_password: bool = True
+
+
+class PortalEquipeFuncionarioUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=255)
+    email: EmailStr | None = None
+    telefone: str | None = None
+    tipo: Literal["colaborador", "supervisor"] | None = None
+    ativo: bool | None = None
+    empresa_id: int | None = None
+    empresa_ids: list[int] | None = None
+    senha_portal: str | None = None
+    must_change_password: bool | None = None
+    notificar_email_portal: bool | None = None
+    revogar_sessoes_portal: bool | None = None
+
+
+class PortalPublicBrandingRead(BaseModel):
+    nome_exibicao: str
+    portal_titulo: str = "Portal do cliente"
+    logo_url: str | None = None
+    texto_boas_vindas: str | None = None
+    cor_primaria: str = "#0D9488"
+    cor_header: str = "#0B2D4A"
+    cor_sidebar: str = "#0B2D4A"
+    cor_texto_header: str = "#FFFFFF"
+    cor_texto_corpo: str = "#0F172A"
+    cor_fundo: str = "#F8FAFC"
+    cor_link: str = "#0D9488"
+    exibir_marca_deskrudder: bool = True
+    chat_habilitado: bool = False

--- a/backend/app/schemas/portal.py
+++ b/backend/app/schemas/portal.py
@@ -1,0 +1,128 @@
+"""Schemas do portal do cliente (funcionário da rede)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+
+class PortalLogin(BaseModel):
+    email: EmailStr
+    senha: str = Field(..., min_length=1, max_length=128)
+
+
+class PortalToken(BaseModel):
+    access_token: str
+    refresh_token: str | None = None
+    token_type: str = "bearer"
+    must_change_password: bool = False
+
+
+class PortalRefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class PortalTrocarSenha(BaseModel):
+    senha_atual: str = Field(..., min_length=1, max_length=128)
+    senha_nova: str = Field(..., min_length=8, max_length=128)
+
+
+class PortalPreferenciasUpdate(BaseModel):
+    notificar_email_portal: bool | None = None
+
+
+class PortalEmpresaRead(BaseModel):
+    id: int
+    nome: str
+    rede_id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PortalSetorRead(BaseModel):
+    id: int
+    nome: str
+    slug: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PortalPdvRead(BaseModel):
+    id: int
+    codigo: str
+    papel: str | None = None
+    ativo: bool = True
+
+
+class PortalMe(BaseModel):
+    id: int
+    nome: str
+    email: str
+    tipo: str
+    rede_id: int | None = None
+    empresas: list[PortalEmpresaRead] = []
+    must_change_password: bool = False
+    notificar_email_portal: bool = True
+
+
+class PortalTicketCreate(BaseModel):
+    empresa_id: int
+    setor_id: int | None = None
+    assunto: str = Field(..., min_length=3, max_length=255)
+    descricao: str | None = Field(None, max_length=20000)
+    pdv_codigo: str | None = Field(None, max_length=64)
+    motivo_id: int | None = None
+    motivo_outro_texto: str | None = Field(None, max_length=500)
+
+
+class PortalTicketMensagemCreate(BaseModel):
+    corpo: str = Field(..., min_length=1, max_length=20000)
+
+
+class PortalAnexoRead(BaseModel):
+    id: int
+    nome_original: str
+    content_type: str | None = None
+    tamanho_bytes: int
+    mensagem_id: int | None = None
+    created_at: datetime | None = None
+    download_url: str
+
+
+class PortalMensagemRead(BaseModel):
+    id: int
+    tipo: str
+    corpo: str
+    autor_nome: str | None = None
+    autor_papel: Literal["equipe", "voce", "sistema"] = "sistema"
+    created_at: datetime | None = None
+    anexos: list[PortalAnexoRead] = []
+
+
+class PortalTicketListItem(BaseModel):
+    id: int
+    protocolo: str
+    assunto: str
+    status_nome: str | None = None
+    status_slug: str | None = None
+    empresa_id: int | None = None
+    empresa_nome: str | None = None
+    setor_nome: str | None = None
+    prioridade: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    fechado_em: datetime | None = None
+    ultima_mensagem_em: datetime | None = None
+
+
+class PortalTicketDetail(PortalTicketListItem):
+    descricao: str | None = None
+    pode_responder: bool = True
+    csat_token: str | None = None
+    csat_pendente: bool = False
+
+
+class PortalMensagemOk(BaseModel):
+    detail: str = "ok"

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -48,6 +48,7 @@ class WhatsappChatRead(BaseModel):
     empresa_nome: str | None = None
     inatividade_pausada: bool = False
     inatividade_retomada_em: datetime | None = None
+    classificacao_demanda_pendente: bool = False
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -75,6 +75,11 @@ class WhatsappFuncionarioOpcaoRead(BaseModel):
     empresas: list[WhatsappEmpresaOpcaoRead] = Field(default_factory=list)
     rede_id: int | None = None
     rede_nome: str | None = None
+    similaridade: float | None = Field(
+        None,
+        description="Score 0–1 quando a listagem é por similaridade de nome (#593).",
+    )
+    similaridade_alta: bool = False
 
 
 class WhatsappContatoRead(BaseModel):

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -46,6 +46,8 @@ class WhatsappChatRead(BaseModel):
     funcionario_tipo: str | None = None
     empresa_id: int | None = None
     empresa_nome: str | None = None
+    inatividade_pausada: bool = False
+    inatividade_retomada_em: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -23,6 +23,11 @@ class WhatsappMensagemRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class WhatsappEmpresaOpcaoRead(BaseModel):
+    id: int
+    nome: str
+
+
 class WhatsappChatRead(BaseModel):
     id: int
     protocolo: str
@@ -46,16 +51,13 @@ class WhatsappChatRead(BaseModel):
     funcionario_tipo: str | None = None
     empresa_id: int | None = None
     empresa_nome: str | None = None
+    # Empresas do funcionário vinculado — útil quando falta empresa_id de contexto (#592).
+    empresas_opcoes: list[WhatsappEmpresaOpcaoRead] = Field(default_factory=list)
     inatividade_pausada: bool = False
     inatividade_retomada_em: datetime | None = None
     classificacao_demanda_pendente: bool = False
 
     model_config = {"from_attributes": True}
-
-
-class WhatsappEmpresaOpcaoRead(BaseModel):
-    id: int
-    nome: str
 
 
 class WhatsappEmpresaCatalogoRead(BaseModel):
@@ -93,6 +95,10 @@ class WhatsappIniciarChatBody(BaseModel):
         description="Número WhatsApp (dígitos). Obrigatório se funcionário sem telefone ou número avulso.",
     )
     mensagem_inicial: str | None = Field(None, max_length=4000)
+    empresa_id: int | None = Field(
+        None,
+        description="Empresa de contexto opcional. Com >1 empresas, pode ficar em branco e ser definida depois na conversa.",
+    )
 
     @field_validator("telefone", mode="before")
     @classmethod
@@ -101,6 +107,10 @@ class WhatsappIniciarChatBody(BaseModel):
             return None
         digits = "".join(ch for ch in str(v) if ch.isdigit())
         return digits or None
+
+
+class WhatsappEmpresaContextoBody(BaseModel):
+    empresa_id: int = Field(..., ge=1, description="Empresa de contexto do atendimento")
 
 
 class WhatsappRedeCatalogoRead(BaseModel):

--- a/backend/app/schemas/whatsapp_settings.py
+++ b/backend/app/schemas/whatsapp_settings.py
@@ -29,9 +29,12 @@ class WhatsappSettingsRead(BaseModel):
     auto_msg_inativ_aviso_ativa: bool = True
     auto_msg_inativ_aviso_texto: str | None = None
     avaliacao_ativa: bool = False
+    avaliacao_janela_minutos: int = 30
     auto_msg_avaliacao_ativa: bool = True
     auto_msg_avaliacao_texto: str | None = None
     auto_msg_avaliacao_obrigado_texto: str | None = None
+    auto_msg_avaliacao_timeout_texto: str | None = None
+    auto_msg_avaliacao_pular_texto: str | None = None
 
     model_config = {"from_attributes": True}
 
@@ -61,9 +64,12 @@ class WhatsappSettingsUpdate(BaseModel):
     auto_msg_inativ_aviso_ativa: bool | None = None
     auto_msg_inativ_aviso_texto: str | None = None
     avaliacao_ativa: bool | None = None
+    avaliacao_janela_minutos: int | None = Field(None, ge=1, le=24 * 60)
     auto_msg_avaliacao_ativa: bool | None = None
     auto_msg_avaliacao_texto: str | None = None
     auto_msg_avaliacao_obrigado_texto: str | None = None
+    auto_msg_avaliacao_timeout_texto: str | None = None
+    auto_msg_avaliacao_pular_texto: str | None = None
 
     @field_validator("evolution_base_url", mode="before")
     @classmethod

--- a/backend/app/seed_portal_demo.py
+++ b/backend/app/seed_portal_demo.py
@@ -1,0 +1,379 @@
+"""Dados fictícios para testar o portal do cliente (RBAC, tickets, chats).
+
+Uso (dev local):
+
+    docker compose exec backend python -m app.seed_portal_demo
+
+Reexecutar é seguro: atualiza cadastros e recria tickets/chats marcados como demo.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import func
+
+from app.core.security import hash_senha
+from app.core.ticket_prioridade import PrioridadeTicket
+from app.database import SessionLocal
+from app.models.atendente import Atendente
+from app.models.empresa import Empresa
+from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
+from app.models.rede import Rede
+from app.models.setor import Setor
+from app.models.status_ticket import StatusTicket
+from app.models.ticket import Ticket, TicketMensagem
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
+from app.services.funcionario_escopo import sincronizar_vinculos_empresas
+from app.services.protocolo_mensal import gerar_protocolo_chat, gerar_protocolo_ticket
+
+DEMO_TAG = "[Demo]"
+DEMO_PASSWORD = "portal123"
+TENANT_ID = 1
+
+DEMO_EMPRESAS = (
+    ("Posto Centro Demo", "centro"),
+    ("Posto Norte Alpha", "norte"),
+    ("Posto Sul Beta", "sul"),
+)
+
+DEMO_FUNCIONARIOS = (
+    # email, nome, tipo, slugs empresas (colaborador=1, supervisor=N)
+    ("ana.socio@example.com", "Ana Duplex (sócia)", "socio", ()),
+    ("carlos.supervisor@example.com", "Carlos Supervisor", "supervisor", ("centro", "norte")),
+    ("maria.colab@example.com", "Maria Colaboradora", "colaborador", ("centro",)),
+    ("joao.colab@example.com", "João Colaborador", "colaborador", ("norte",)),
+    ("pedro.colab@example.com", "Pedro Colaborador", "colaborador", ("sul",)),
+)
+
+DEMO_TICKETS = (
+    # email autor, slug empresa, assunto, descricao
+    ("maria.colab@example.com", "centro", "PDV travou no abastecimento", "O caixa 01 congela ao finalizar venda."),
+    ("maria.colab@example.com", "centro", "Impressora fiscal sem papel", "Troquei o rolo mas continua pedindo papel."),
+    ("joao.colab@example.com", "norte", "Bomba 3 não conecta na retaguarda", "Sincronização de preços falha desde ontem."),
+    ("pedro.colab@example.com", "sul", "Cartão recusando no caixa", "Só débito; crédito retorna erro genérico."),
+)
+
+DEMO_CHATS = (
+    # email funcionário, slug empresa, wa_id, mensagens (direcao, corpo)
+    (
+        "maria.colab@example.com",
+        "centro",
+        "5511999000001",
+        (
+            ("inbound", "Bom dia, o PDV do caixa 1 travou de novo."),
+            ("outbound", "Olá Maria, estamos verificando. Pode reiniciar o terminal?"),
+            ("inbound", "Reiniciei, voltou a funcionar por enquanto."),
+        ),
+    ),
+    (
+        "joao.colab@example.com",
+        "norte",
+        "5511999000002",
+        (
+            ("inbound", "A bomba 3 não atualiza preço."),
+            ("outbound", "João, vamos checar o link com a retaguarda."),
+        ),
+    ),
+    (
+        "pedro.colab@example.com",
+        "sul",
+        "5511999000003",
+        (
+            ("inbound", "Clientes reclamando de cartão recusado."),
+            ("inbound", "Acontece só no caixa 2."),
+        ),
+    ),
+)
+
+
+def _slug_key(slug: str) -> str:
+    return slug.strip().lower()
+
+
+def _ensure_rede(db) -> Rede:
+    rede = db.query(Rede).order_by(Rede.id.asc()).first()
+    if not rede:
+        rede = Rede(tenant_id=TENANT_ID, nome="Rede Duplex Demo", ativo=True)
+        db.add(rede)
+        db.flush()
+    else:
+        rede.nome = "Rede Duplex Demo"
+        rede.ativo = True
+    return rede
+
+
+def _ensure_empresas(db, rede: Rede) -> dict[str, Empresa]:
+    out: dict[str, Empresa] = {}
+    for nome, slug in DEMO_EMPRESAS:
+        emp = (
+            db.query(Empresa)
+            .filter(Empresa.rede_id == rede.id, func.lower(Empresa.nome) == nome.lower())
+            .first()
+        )
+        if not emp:
+            emp = Empresa(tenant_id=TENANT_ID, rede_id=rede.id, nome=nome, ativo=True)
+            db.add(emp)
+            db.flush()
+        else:
+            emp.ativo = True
+        out[_slug_key(slug)] = emp
+    return out
+
+
+def _upsert_funcionario(
+    db,
+    *,
+    rede: Rede,
+    empresas: dict[str, Empresa],
+    email: str,
+    nome: str,
+    tipo: str,
+    empresa_slugs: tuple[str, ...],
+) -> FuncionarioRede:
+    email_norm = email.strip().lower()
+    f = db.query(FuncionarioRede).filter(func.lower(FuncionarioRede.email) == email_norm).first()
+    if not f:
+        f = FuncionarioRede(email=email_norm, rede_id=rede.id)
+        db.add(f)
+    f.nome = nome
+    f.tipo = tipo
+    f.ativo = True
+    f.escopo_empresas = "all" if tipo == "socio" else "selected"
+    f.senha_hash = hash_senha(DEMO_PASSWORD)
+    f.must_change_password = False
+    f.token_version = int(getattr(f, "token_version", 0) or 0)
+    f.notificar_email_portal = True
+
+    empresa_ids: list[int] = []
+    if tipo == "colaborador" and empresa_slugs:
+        empresa_ids = [empresas[_slug_key(empresa_slugs[0])].id]
+        f.empresa_id = empresa_ids[0]
+    elif tipo == "supervisor":
+        empresa_ids = [empresas[_slug_key(s)].id for s in empresa_slugs]
+        f.empresa_id = None
+    else:
+        f.empresa_id = None
+
+    db.flush()
+    if tipo != "socio":
+        sincronizar_vinculos_empresas(
+            db,
+            f,
+            escopo="selected",
+            rede_id=int(rede.id),
+            empresa_ids=empresa_ids,
+        )
+    return f
+
+
+def _clear_demo_tickets_chats(db) -> None:
+    demo_ticket_ids = [
+        t.id
+        for t in db.query(Ticket).filter(Ticket.assunto.like(f"{DEMO_TAG}%")).all()
+    ]
+    if demo_ticket_ids:
+        db.query(TicketMensagem).filter(TicketMensagem.ticket_id.in_(demo_ticket_ids)).delete(
+            synchronize_session=False
+        )
+        db.query(Ticket).filter(Ticket.id.in_(demo_ticket_ids)).delete(synchronize_session=False)
+
+    demo_wa_ids = [f"5511999{_i:06d}" for _i in range(1, 20)]
+    demo_chat_ids = [
+        c.id
+        for c in db.query(WhatsappChat).filter(WhatsappChat.wa_id.in_(demo_wa_ids)).all()
+    ]
+    if demo_chat_ids:
+        db.query(WhatsappMensagem).filter(WhatsappMensagem.chat_id.in_(demo_chat_ids)).delete(
+            synchronize_session=False
+        )
+        db.query(WhatsappChat).filter(WhatsappChat.id.in_(demo_chat_ids)).delete(synchronize_session=False)
+
+
+def _criar_ticket_demo(
+    db,
+    *,
+    rede: Rede,
+    empresa: Empresa,
+    setor_id: int,
+    status_id: int,
+    autor: FuncionarioRede | None,
+    assunto: str,
+    descricao: str,
+) -> Ticket:
+    t = Ticket(
+        tenant_id=TENANT_ID,
+        protocolo=gerar_protocolo_ticket(db),
+        empresa_id=empresa.id,
+        rede_id=rede.id,
+        setor_id=setor_id,
+        status_id=status_id,
+        aberto_por_id=autor.id if autor else None,
+        prioridade=PrioridadeTicket.normal.value,
+        assunto=f"{DEMO_TAG} {assunto}",
+        descricao=descricao,
+    )
+    db.add(t)
+    db.flush()
+    db.add(
+        TicketMensagem(
+            ticket_id=t.id,
+            tipo="abertura",
+            corpo=descricao,
+            atendente_id=None,
+        )
+    )
+    if autor:
+        db.add(
+            TicketMensagem(
+                ticket_id=t.id,
+                tipo="publico",
+                corpo="Recebemos seu chamado. A equipe já está analisando.",
+                atendente_id=None,
+            )
+        )
+    return t
+
+
+def _criar_chat_demo(
+    db,
+    *,
+    empresa: Empresa,
+    funcionario: FuncionarioRede,
+    setor_id: int,
+    atendente_id: int | None,
+    wa_id: str,
+    mensagens: tuple[tuple[str, str], ...],
+) -> WhatsappChat:
+    chat = WhatsappChat(
+        protocolo=gerar_protocolo_chat(db),
+        wa_id=wa_id,
+        cliente_nome=funcionario.nome,
+        estado="em_atendimento",
+        setor_id=setor_id,
+        atendente_id=atendente_id,
+        funcionario_rede_id=funcionario.id,
+        empresa_id=empresa.id,
+    )
+    db.add(chat)
+    db.flush()
+    seq = 0
+    for direcao, corpo in mensagens:
+        seq += 1
+        db.add(
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao=direcao,
+                corpo=corpo,
+                wa_message_id=f"demo-{wa_id}-{seq}",
+                atendente_id=atendente_id if direcao == "outbound" else None,
+                status_entrega="entregue" if direcao == "outbound" else None,
+            )
+        )
+    # Comentário interno (não deve aparecer no portal)
+    db.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="nota interna: cliente já reportou isso na semana passada",
+            evento_sistema="comentario_interno",
+            wa_message_id=f"demo-{wa_id}-interno",
+            atendente_id=atendente_id,
+        )
+    )
+    return chat
+
+
+def run_seed_portal_demo() -> None:
+    db = SessionLocal()
+    try:
+        rede = _ensure_rede(db)
+        empresas = _ensure_empresas(db, rede)
+
+        setor = db.query(Setor).filter(Setor.ativo.is_(True)).order_by(Setor.id.asc()).first()
+        if not setor:
+            raise RuntimeError("Nenhum setor ativo. Rode python -m app.seed antes.")
+        status = (
+            db.query(StatusTicket)
+            .filter(StatusTicket.slug == "aguardando_atendimento", StatusTicket.ativo.is_(True))
+            .first()
+        )
+        if not status:
+            status = db.query(StatusTicket).filter(StatusTicket.ativo.is_(True)).first()
+        if not status:
+            raise RuntimeError("Nenhum status de ticket. Rode python -m app.seed antes.")
+
+        atendente = db.query(Atendente).filter(Atendente.ativo.is_(True)).order_by(Atendente.id.asc()).first()
+
+        funcionarios: dict[str, FuncionarioRede] = {}
+        for email, nome, tipo, slugs in DEMO_FUNCIONARIOS:
+            f = _upsert_funcionario(
+                db,
+                rede=rede,
+                empresas=empresas,
+                email=email,
+                nome=nome,
+                tipo=tipo,
+                empresa_slugs=slugs,
+            )
+            funcionarios[email] = f
+
+        _clear_demo_tickets_chats(db)
+
+        for email, slug, assunto, descricao in DEMO_TICKETS:
+            autor = funcionarios[email]
+            _criar_ticket_demo(
+                db,
+                rede=rede,
+                empresa=empresas[_slug_key(slug)],
+                setor_id=setor.id,
+                status_id=status.id,
+                autor=autor,
+                assunto=assunto,
+                descricao=descricao,
+            )
+
+        # Ticket aberto pela equipe interna (sem autor portal) — só supervisor/sócio veem
+        _criar_ticket_demo(
+            db,
+            rede=rede,
+            empresa=empresas["centro"],
+            setor_id=setor.id,
+            status_id=status.id,
+            autor=None,
+            assunto="Manutenção programada no servidor",
+            descricao="Chamado interno da equipe de suporte (não aparece para colaborador no portal).",
+        )
+
+        for email, slug, wa_id, mensagens in DEMO_CHATS:
+            _criar_chat_demo(
+                db,
+                empresa=empresas[_slug_key(slug)],
+                funcionario=funcionarios[email],
+                setor_id=setor.id,
+                atendente_id=atendente.id if atendente else None,
+                wa_id=wa_id,
+                mensagens=mensagens,
+            )
+
+        db.commit()
+
+        print("\n=== Portal demo — dados fictícios criados ===\n")
+        print(f"Rede: {rede.nome} (id={rede.id})")
+        print("Empresas:")
+        for slug, emp in empresas.items():
+            print(f"  - {emp.nome} ({slug})")
+        print(f"\nSenha de todos os usuários abaixo: {DEMO_PASSWORD}\n")
+        print("| Papel        | E-mail                      | O que deve ver no portal |")
+        print("|--------------|-----------------------------|---------------------------|")
+        print("| Sócio        | ana.socio@example.com       | Toda a rede (tickets/chats) |")
+        print("| Supervisor   | carlos.supervisor@example.com | Centro + Norte          |")
+        print("| Colaborador  | maria.colab@example.com     | Só os próprios (Centro)   |")
+        print("| Colaborador  | joao.colab@example.com      | Só os próprios (Norte)    |")
+        print("| Colaborador  | pedro.colab@example.com     | Só os próprios (Sul)      |")
+        print("\nTickets e chats marcados com prefixo «[Demo]» no assunto / protocolo WhatsApp.")
+        print("Login: http://localhost:5173/portal/login\n")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    run_seed_portal_demo()

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -157,6 +157,36 @@ def _extract_wa_message_id(data: Any) -> str | None:
     return None
 
 
+def evolution_mark_messages_as_read(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    *,
+    remote_jid: str,
+    message_ids: list[str],
+) -> tuple[bool, str | None]:
+    """POST /chat/markMessageAsRead/{instance} — marca inbound como lida no WhatsApp do cliente."""
+    import re
+
+    ids = [str(i).strip() for i in message_ids if str(i).strip()]
+    if not ids:
+        return True, None
+    base = base_url.rstrip("/")
+    url = f"{base}/chat/markMessageAsRead/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    digits = re.sub(r"\D", "", remote_jid)
+    jid = remote_jid if "@" in remote_jid else f"{digits}@s.whatsapp.net"
+    body = {
+        "readMessages": [{"remoteJid": jid, "fromMe": False, "id": mid} for mid in ids]
+    }
+    code, _data, err = _request_json_with_retry("POST", url, headers=headers, body=body)
+    if code in (200, 201):
+        return True, None
+    if err:
+        return False, err[:800]
+    return False, f"HTTP {code}"
+
+
 def evolution_send_text(
     base_url: str,
     instance: str,

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -154,7 +154,39 @@ def _extract_wa_message_id(data: Any) -> str | None:
         if mid:
             s = str(mid).strip()
             return s or None
+    for k in ("keyId", "KeyId", "id", "Id"):
+        mid = data.get(k)
+        if mid and not isinstance(mid, dict):
+            s = str(mid).strip()
+            if s:
+                return s
     return None
+
+
+def evolution_set_webhook(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    *,
+    webhook_url: str,
+    secret: str | None = None,
+    events: list[str] | None = None,
+) -> tuple[int, Any | None, str | None]:
+    """POST /webhook/set/{instance} — garante MESSAGES_UPSERT + MESSAGES_UPDATE."""
+    base = base_url.rstrip("/")
+    url = f"{base}/webhook/set/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    ev = events or ["MESSAGES_UPSERT", "MESSAGES_UPDATE"]
+    webhook: dict[str, Any] = {
+        "enabled": True,
+        "url": webhook_url,
+        "byEvents": False,
+        "events": ev,
+    }
+    if secret:
+        webhook["headers"] = {"X-Dx-Webhook-Secret": secret}
+    body = {"webhook": webhook}
+    return _request_json_with_retry("POST", url, headers=headers, body=body)
 
 
 def evolution_mark_messages_as_read(

--- a/backend/app/services/evolution_embedded.py
+++ b/backend/app/services/evolution_embedded.py
@@ -208,6 +208,17 @@ def provisionar_e_ligar_webhook(db: Session, row: WhatsappSettings) -> dict[str,
     db.commit()
     db.refresh(row)
 
+    # Instâncias reutilizadas (409) podem ter webhook sem MESSAGES_UPDATE — ticks ficariam em ✓ único.
+    wh_code, _wh_data, wh_err = evolution_api.evolution_set_webhook(
+        internal,
+        iname,
+        api_inst,
+        webhook_url=webhook_url,
+        secret=secret,
+    )
+    if wh_code not in (200, 201):
+        logger.warning("Evolution setWebhook falhou (HTTP %s): %s", wh_code, wh_err)
+
     cq, qdata, qerr = evolution_api.evolution_connect(internal, api_inst, iname)
     if cq != 200:
         logger.warning("Connect após provisionar: HTTP %s %s", cq, qerr)

--- a/backend/app/services/evolution_inbound.py
+++ b/backend/app/services/evolution_inbound.py
@@ -185,8 +185,33 @@ def _iter_message_dicts(data: Any) -> Iterator[dict[str, Any]]:
             if isinstance(m, dict):
                 yield m
         return
-    if "key" in data or "message" in data or "Message" in data:
+    # Evolution MESSAGES_UPDATE (formato flat): { keyId, fromMe, status, remoteJid }
+    if "keyId" in data or "KeyId" in data:
         yield data
+        return
+    if "key" in data or "Key" in data or "message" in data or "Message" in data:
+        yield data
+
+
+def _wa_id_e_from_me_de_update(m: dict[str, Any]) -> tuple[str | None, bool | None]:
+    """Extrai wa_message_id e fromMe de update aninhado (key.id) ou flat (keyId)."""
+    key = m.get("key") or m.get("Key")
+    if isinstance(key, dict):
+        mid = key.get("id") or key.get("Id")
+        wa_message_id = str(mid).strip() if mid else None
+        from_me_raw = key.get("fromMe") if "fromMe" in key else key.get("FromMe")
+        from_me = bool(from_me_raw) if from_me_raw is not None else None
+        return wa_message_id or None, from_me
+
+    mid = m.get("keyId") or m.get("KeyId") or m.get("id") or m.get("Id")
+    wa_message_id = str(mid).strip() if mid else None
+    if "fromMe" in m:
+        from_me = bool(m.get("fromMe"))
+    elif "FromMe" in m:
+        from_me = bool(m.get("FromMe"))
+    else:
+        from_me = None
+    return (wa_message_id or None), from_me
 
 
 def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any]]:
@@ -299,26 +324,29 @@ def _ack_de_update_dict(update: dict[str, Any]) -> int | str | None:
 
 def iter_message_status_updates(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any]]:
     """
-  Por cada atualização de ACK em mensagem outbound, produz:
-  wa_message_id, status_entrega (pendente|enviada|entregue|lida|erro)
+    Por cada atualização de ACK em mensagem outbound, produz:
+    wa_message_id, status_entrega (pendente|enviada|entregue|lida|erro)
+
+    Aceita:
+    - formato aninhado: data.key.id + data.update.status
+    - formato Evolution flat: data.keyId + data.fromMe + data.status (ex.: DELIVERY_ACK)
+    - data como lista de qualquer um dos formatos
     """
     from app.services.mensagem_status import ack_evolution_para_status
 
     event = webhook_body.get("event") or webhook_body.get("Event") or ""
-    ev = str(event).lower()
+    ev = str(event).lower().replace("_", ".")
     if "update" not in ev or "message" not in ev:
         return
 
     data = webhook_body.get("data") or webhook_body.get("Data")
     for m in _iter_message_dicts(data):
-        key = m.get("key") or m.get("Key") or {}
-        if not isinstance(key, dict):
-            continue
-        if not (key.get("fromMe") or key.get("FromMe")):
-            continue
-        mid = key.get("id") or key.get("Id")
-        wa_message_id = str(mid).strip() if mid else None
+        wa_message_id, from_me = _wa_id_e_from_me_de_update(m)
         if not wa_message_id:
+            continue
+        # Só atualiza ticks de mensagens enviadas por nós. Se fromMe vier omitido
+        # (alguns payloads), ainda tenta — o lookup no DB exige direcao=outbound.
+        if from_me is False:
             continue
 
         ack_raw = _ack_de_update_dict(m.get("update") or m.get("Update") or {})

--- a/backend/app/services/funcionario_nome_similar.py
+++ b/backend/app/services/funcionario_nome_similar.py
@@ -1,0 +1,70 @@
+"""Similaridade de nomes de funcionários (dedupe no cadastro WhatsApp).
+
+Critério (#593):
+- Normaliza acentos, caixa e espaços.
+- Pontua com o máximo entre: SequenceMatcher (difflib), Jaccard de tokens
+  e bónus se um nome contém o outro.
+- Limiar mínimo ``LIMIAR_SIMILARIDADE`` (0,72); ``LIMIAR_ALTA`` (0,90) para aviso.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from difflib import SequenceMatcher
+
+LIMIAR_SIMILARIDADE = 0.72
+LIMIAR_ALTA = 0.90
+_TOKEN_MIN = 3
+
+
+def normalizar_nome(texto: str) -> str:
+    s = unicodedata.normalize("NFKD", texto or "")
+    s = "".join(c for c in s if not unicodedata.combining(c))
+    s = s.lower().strip()
+    s = re.sub(r"[^a-z0-9\s]", " ", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def tokens_significativos(nome_norm: str) -> list[str]:
+    return [t for t in nome_norm.split() if len(t) >= _TOKEN_MIN]
+
+
+def score_nomes(a: str, b: str) -> float:
+    na = normalizar_nome(a)
+    nb = normalizar_nome(b)
+    if not na or not nb:
+        return 0.0
+    if na == nb:
+        return 1.0
+    seq = SequenceMatcher(None, na, nb).ratio()
+    ta, tb = set(na.split()), set(nb.split())
+    jaccard = (len(ta & tb) / len(ta | tb)) if (ta | tb) else 0.0
+    if na in nb or nb in na:
+        contain = 0.85 + 0.15 * seq
+    else:
+        contain = 0.0
+    return max(seq, jaccard, contain)
+
+
+def ranquear_similares(
+    nome_consulta: str,
+    candidatos: list[tuple[int, str]],
+    *,
+    limiar: float = LIMIAR_SIMILARIDADE,
+    limit: int = 5,
+) -> list[tuple[int, str, float]]:
+    """
+    ``candidatos``: lista de ``(id, nome)``.
+    Retorna top ``limit`` acima do limiar, ordenados por score desc.
+    """
+    q = (nome_consulta or "").strip()
+    if len(normalizar_nome(q)) < _TOKEN_MIN:
+        return []
+    scored: list[tuple[int, str, float]] = []
+    for cid, nome in candidatos:
+        sc = score_nomes(q, nome)
+        if sc >= limiar:
+            scored.append((cid, nome, sc))
+    scored.sort(key=lambda x: (-x[2], x[1].lower(), x[0]))
+    return scored[: max(1, limit)]

--- a/backend/app/services/instancia_branding.py
+++ b/backend/app/services/instancia_branding.py
@@ -1,0 +1,111 @@
+"""Branding white-label da instância — KB pública (/kb) e portal do cliente (/portal)."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.empresa_sistema import EmpresaSistema
+from app.models.kb import KbPortalSettings
+from app.schemas.kb import KbPublicBrandingRead
+from app.schemas.portal import PortalPublicBrandingRead
+
+DEFAULT_COR_PRIMARIA = "#0D9488"
+DEFAULT_COR_HEADER = "#0B2D4A"
+DEFAULT_COR_TEXTO_HEADER = "#FFFFFF"
+DEFAULT_COR_TEXTO_CORPO = "#0F172A"
+DEFAULT_COR_FUNDO = "#F8FAFC"
+TEXTO_BOAS_VINDAS_PORTAL_PADRAO = (
+    "Acompanhe e abra chamados da sua empresa com a equipe de suporte."
+)
+
+
+def empresa_sistema_row(db: Session) -> EmpresaSistema | None:
+    return db.query(EmpresaSistema).order_by(EmpresaSistema.id.asc()).first()
+
+
+def portal_settings_row(db: Session, tenant_id: int) -> KbPortalSettings | None:
+    return db.query(KbPortalSettings).filter(KbPortalSettings.tenant_id == tenant_id).first()
+
+
+def nome_exibicao_empresa(row: EmpresaSistema | None) -> str:
+    if not row:
+        return "Central de ajuda"
+    for attr in ("nome_fantasia", "nome", "razao_social"):
+        val = getattr(row, attr, None)
+        if val and str(val).strip():
+            return str(val).strip()
+    return "Central de ajuda"
+
+
+def logo_url_publica(row: EmpresaSistema | None) -> str | None:
+    if row and row.logo_filename and str(row.logo_filename).strip():
+        return "/v1/kb/public/logo"
+    return None
+
+
+def _cores_branding(settings: KbPortalSettings | None) -> dict[str, str]:
+    cor_primaria = (settings.cor_primaria if settings else None) or DEFAULT_COR_PRIMARIA
+    cor_link = (settings.cor_link if settings and settings.cor_link else None) or cor_primaria
+    cor_header = (settings.cor_header if settings else None) or DEFAULT_COR_HEADER
+    # Menu lateral: cor própria ou mesma da navbar
+    cor_sidebar = None
+    if settings and settings.cor_sidebar and str(settings.cor_sidebar).strip():
+        cor_sidebar = str(settings.cor_sidebar).strip()
+    return {
+        "cor_primaria": cor_primaria,
+        "cor_header": cor_header,
+        "cor_sidebar": cor_sidebar or cor_header,
+        "cor_texto_header": (settings.cor_texto_header if settings else None) or DEFAULT_COR_TEXTO_HEADER,
+        "cor_texto_corpo": (settings.cor_texto_corpo if settings else None) or DEFAULT_COR_TEXTO_CORPO,
+        "cor_fundo": (settings.cor_fundo if settings else None) or DEFAULT_COR_FUNDO,
+        "cor_link": cor_link,
+    }
+
+
+def branding_kb_publico(db: Session, tenant_id: int) -> KbPublicBrandingRead:
+    row = empresa_sistema_row(db)
+    settings = portal_settings_row(db, tenant_id)
+    nome = nome_exibicao_empresa(row)
+    cores = _cores_branding(settings)
+    titulo_custom = (settings.portal_titulo or "").strip() if settings else ""
+    if titulo_custom:
+        portal_titulo = titulo_custom
+    elif nome != "Central de ajuda":
+        portal_titulo = f"Central de ajuda — {nome}"
+    else:
+        portal_titulo = "Central de ajuda"
+    return KbPublicBrandingRead(
+        nome_exibicao=nome,
+        portal_titulo=portal_titulo,
+        logo_url=logo_url_publica(row),
+        texto_boas_vindas=settings.texto_boas_vindas if settings else None,
+        exibir_marca_deskrudder=bool(settings.exibir_marca_deskrudder) if settings else True,
+        feedback_habilitado=bool(settings.feedback_habilitado) if settings else True,
+        chat_habilitado=bool(settings.chat_habilitado) if settings else False,
+        **cores,
+    )
+
+
+def _titulo_portal_cliente(nome: str) -> str:
+    """Título exibido no /portal — independente do `portal_titulo` da central /kb."""
+    if nome != "Central de ajuda":
+        return f"Portal — {nome}"
+    return "Portal do cliente"
+
+
+def branding_portal_cliente(db: Session, tenant_id: int) -> PortalPublicBrandingRead:
+    row = empresa_sistema_row(db)
+    settings = portal_settings_row(db, tenant_id)
+    nome = nome_exibicao_empresa(row)
+    cores = _cores_branding(settings)
+    portal_titulo = _titulo_portal_cliente(nome)
+    texto = (settings.texto_boas_vindas or "").strip() if settings else ""
+    return PortalPublicBrandingRead(
+        nome_exibicao=nome,
+        portal_titulo=portal_titulo,
+        logo_url=logo_url_publica(row),
+        texto_boas_vindas=texto or TEXTO_BOAS_VINDAS_PORTAL_PADRAO,
+        exibir_marca_deskrudder=bool(settings.exibir_marca_deskrudder) if settings else True,
+        chat_habilitado=bool(settings.chat_habilitado) if settings else False,
+        **cores,
+    )

--- a/backend/app/services/mensagem_status.py
+++ b/backend/app/services/mensagem_status.py
@@ -23,7 +23,12 @@ def status_deve_atualizar(atual: str | None, novo: str) -> bool:
 
 
 def ack_evolution_para_status(ack: int | str | None) -> str | None:
-    """Mapeia ACK Baileys/Evolution para status_entrega."""
+    """Mapeia ACK Baileys/Evolution para status_entrega.
+
+    Numérico (Baileys WAMessageStatus):
+      0=ERROR, 1=PENDING, 2=SERVER_ACK, 3=DELIVERY_ACK, 4=READ, 5=PLAYED
+    Strings Evolution: PENDING, SERVER_ACK, DELIVERY_ACK, READ, …
+    """
     if ack is None:
         return None
     if isinstance(ack, str):
@@ -46,11 +51,11 @@ def ack_evolution_para_status(ack: int | str | None) -> str | None:
         return None
     if n <= 0:
         return STATUS_ERRO
-    if n == 1:
+    if n in (1, 2):
         return STATUS_ENVIADA
-    if n == 2:
+    if n == 3:
         return STATUS_ENTREGUE
-    if n >= 3:
+    if n >= 4:
         return STATUS_LIDA
     return None
 

--- a/backend/app/services/portal_equipe.py
+++ b/backend/app/services/portal_equipe.py
@@ -1,0 +1,273 @@
+"""Gestão de equipe pelo sócio no portal (#602).
+
+Regras:
+- Apenas `tipo=socio` acede à API.
+- CRUD limitado à **rede** do sócio autenticado.
+- Não é possível **criar** ou **promover** outro sócio pelo portal (só colaborador ↔ supervisor).
+- Outros sócios aparecem na listagem (editáveis só em ativo/senha/notificações).
+"""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from app.core.security import hash_senha
+from app.models.empresa import Empresa
+from app.models.funcionario_rede import FuncionarioRede
+from app.schemas.portal import (
+    PortalEquipeFuncionarioCreate,
+    PortalEquipeFuncionarioRead,
+    PortalEquipeFuncionarioUpdate,
+)
+from app.services.funcionario_escopo import (
+    escopo_efetivo,
+    rede_id_efetiva,
+    sincronizar_vinculos_empresas,
+    validar_empresa_ids_na_rede,
+)
+from app.services.funcionario_rede_resolver import assert_email_unico_por_rede
+from app.services.inbound_ticket_reconcile import reconciliar_tickets_pendentes_por_email
+
+TIPOS_PORTAL_EQUIPE = frozenset({"colaborador", "supervisor"})
+
+
+def _rede_id_socio(db: Session, socio: FuncionarioRede) -> int:
+    rid = rede_id_efetiva(db, socio)
+    if rid is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Rede não definida para o sócio.")
+    return int(rid)
+
+
+def _empresa_ids_leitura(f: FuncionarioRede) -> list[int]:
+    if escopo_efetivo(f) == "all":
+        return []
+    ids = [e.empresa_id for e in f.empresas_supervisor]
+    if f.empresa_id is not None and int(f.empresa_id) not in ids:
+        ids.insert(0, int(f.empresa_id))
+    return ids
+
+
+def _aplicar_senha_portal(f: FuncionarioRede, senha: str | None, *, must_change: bool | None) -> None:
+    if senha is None:
+        return
+    senha_limpa = senha.strip()
+    if not senha_limpa:
+        return
+    if len(senha_limpa) < 8:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="A senha do portal deve ter ao menos 8 caracteres.",
+        )
+    if not (f.email or "").strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Informe o e-mail do funcionário para habilitar o portal.",
+        )
+    f.senha_hash = hash_senha(senha_limpa)
+    f.must_change_password = True if must_change is None else bool(must_change)
+    f.token_version = int(getattr(f, "token_version", 0) or 0) + 1
+
+
+def _para_read(f: FuncionarioRede, *, socio_id: int) -> PortalEquipeFuncionarioRead:
+    tipo = (f.tipo or "").strip().lower()
+    return PortalEquipeFuncionarioRead(
+        id=f.id,
+        nome=f.nome,
+        email=f.email,
+        telefone=getattr(f, "telefone", None),
+        tipo=f.tipo,
+        ativo=bool(f.ativo),
+        empresa_id=f.empresa_id,
+        empresa_ids=_empresa_ids_leitura(f),
+        portal_habilitado=bool((getattr(f, "senha_hash", None) or "").strip()),
+        must_change_password=bool(getattr(f, "must_change_password", False)),
+        notificar_email_portal=bool(getattr(f, "notificar_email_portal", True)),
+        editavel=tipo != "socio" or int(f.id) == int(socio_id),
+    )
+
+
+def _obter_na_rede(db: Session, socio: FuncionarioRede, funcionario_id: int) -> FuncionarioRede:
+    rede_id = _rede_id_socio(db, socio)
+    f = db.query(FuncionarioRede).filter(FuncionarioRede.id == funcionario_id).first()
+    if not f or f.rede_id is None or int(f.rede_id) != rede_id:
+        raise LookupError("Funcionário não encontrado")
+    return f
+
+
+def listar_funcionarios(
+    db: Session,
+    socio: FuncionarioRede,
+    *,
+    incluir_inativos: bool = False,
+    busca: str | None = None,
+    offset: int = 0,
+    limit: int = 20,
+) -> tuple[list[FuncionarioRede], int]:
+    rede_id = _rede_id_socio(db, socio)
+    q = db.query(FuncionarioRede).filter(FuncionarioRede.rede_id == rede_id)
+    if not incluir_inativos:
+        q = q.filter(FuncionarioRede.ativo.is_(True))
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter(or_(FuncionarioRede.nome.ilike(term), FuncionarioRede.email.ilike(term)))
+    total = q.count()
+    rows = q.order_by(FuncionarioRede.nome.asc(), FuncionarioRede.id.asc()).offset(offset).limit(limit).all()
+    return rows, total
+
+
+def criar_funcionario(db: Session, socio: FuncionarioRede, data: PortalEquipeFuncionarioCreate) -> FuncionarioRede:
+    rede_id = _rede_id_socio(db, socio)
+    tipo = data.tipo.strip().lower()
+    if tipo not in TIPOS_PORTAL_EQUIPE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No portal só é possível cadastrar colaboradores ou supervisores.",
+        )
+    empresa_ids = list(dict.fromkeys(data.empresa_ids or []))
+    if data.empresa_id and int(data.empresa_id) not in empresa_ids:
+        empresa_ids.insert(0, int(data.empresa_id))
+    if tipo == "colaborador":
+        if len(empresa_ids) != 1:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Selecione uma empresa para o colaborador.")
+    elif not empresa_ids:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Marque ao menos uma empresa para o supervisor.")
+    try:
+        validar_empresa_ids_na_rede(db, rede_id, empresa_ids)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+    try:
+        assert_email_unico_por_rede(db, email=str(data.email), rede_id=rede_id)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+    f = FuncionarioRede(
+        nome=data.nome.strip(),
+        email=str(data.email).strip().lower(),
+        telefone=data.telefone,
+        tipo=tipo,
+        escopo_empresas="selected",
+        ativo=data.ativo,
+        rede_id=rede_id,
+        empresa_id=empresa_ids[0] if tipo == "colaborador" else None,
+    )
+    db.add(f)
+    db.flush()
+    _aplicar_senha_portal(f, data.senha_portal, must_change=data.must_change_password)
+    sincronizar_vinculos_empresas(db, f, escopo="selected", rede_id=rede_id, empresa_ids=empresa_ids)
+    db.commit()
+    db.refresh(f)
+    if f.email:
+        reconciliar_tickets_pendentes_por_email(db, f.email)
+        db.commit()
+    return f
+
+
+def atualizar_funcionario(
+    db: Session,
+    socio: FuncionarioRede,
+    funcionario_id: int,
+    data: PortalEquipeFuncionarioUpdate,
+) -> FuncionarioRede:
+    f = _obter_na_rede(db, socio, funcionario_id)
+    rede_id = _rede_id_socio(db, socio)
+    update = data.model_dump(exclude_unset=True)
+    empresa_ids = update.pop("empresa_ids", None)
+    empresa_id_upd = update.pop("empresa_id", None)
+    senha_portal = update.pop("senha_portal", None)
+    must_change = update.pop("must_change_password", None)
+    revogar = update.pop("revogar_sessoes_portal", None)
+    tipo_upd = update.pop("tipo", None)
+
+    alvo_socio = (f.tipo or "").strip().lower() == "socio"
+    if alvo_socio:
+        if tipo_upd is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="A função de sócio não pode ser alterada pelo portal.",
+            )
+        if empresa_ids is not None or empresa_id_upd is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Sócios têm acesso a toda a rede; vínculos por empresa não se aplicam.",
+            )
+        if int(f.id) != int(socio.id):
+            permitidos = {"ativo", "notificar_email_portal"}
+            if any(k not in permitidos for k in update):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Outros sócios só podem ter situação, senha e notificações alteradas pelo portal.",
+                )
+    else:
+        if tipo_upd is not None:
+            t = tipo_upd.strip().lower()
+            if t not in TIPOS_PORTAL_EQUIPE:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="No portal só é possível alternar entre colaborador e supervisor.",
+                )
+            f.tipo = t
+
+    for k, v in update.items():
+        setattr(f, k, v)
+
+    if senha_portal is not None:
+        _aplicar_senha_portal(f, senha_portal, must_change=must_change)
+    elif must_change is not None:
+        f.must_change_password = bool(must_change)
+    if revogar:
+        f.token_version = int(getattr(f, "token_version", 0) or 0) + 1
+
+    if not alvo_socio:
+        tipo_eff = (f.tipo or "colaborador").strip().lower()
+        ids = list(empresa_ids) if empresa_ids is not None else _empresa_ids_leitura(f)
+        if empresa_id_upd is not None and int(empresa_id_upd) not in ids:
+            ids.insert(0, int(empresa_id_upd))
+        if tipo_eff == "colaborador":
+            if empresa_ids is not None or empresa_id_upd is not None:
+                if len(ids) != 1:
+                    raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Colaborador deve ter uma empresa.")
+        elif empresa_ids is not None or empresa_id_upd is not None:
+            if not ids:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Supervisor precisa de ao menos uma empresa.")
+        if ids:
+            try:
+                validar_empresa_ids_na_rede(db, rede_id, ids)
+            except ValueError as e:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+            sincronizar_vinculos_empresas(
+                db,
+                f,
+                escopo="selected",
+                rede_id=rede_id,
+                empresa_ids=ids,
+            )
+
+    if f.email:
+        try:
+            assert_email_unico_por_rede(
+                db,
+                email=str(f.email),
+                rede_id=rede_id,
+                ignorar_funcionario_id=f.id,
+            )
+        except ValueError as e:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)) from e
+
+    db.commit()
+    db.refresh(f)
+    if f.email:
+        reconciliar_tickets_pendentes_por_email(db, f.email)
+        db.commit()
+    return f
+
+
+def empresas_da_rede(db: Session, socio: FuncionarioRede) -> list[Empresa]:
+    rede_id = _rede_id_socio(db, socio)
+    return (
+        db.query(Empresa)
+        .filter(Empresa.rede_id == rede_id, Empresa.ativo.is_(True))
+        .order_by(Empresa.nome.asc())
+        .all()
+    )

--- a/backend/app/services/portal_notificacoes.py
+++ b/backend/app/services/portal_notificacoes.py
@@ -1,0 +1,147 @@
+"""E-mails ao funcionário sobre eventos do ticket no portal (#303)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.funcionario_rede import FuncionarioRede
+from app.models.ticket import Ticket, TicketMensagem
+from app.services.email_send_sistema import enviar_mensagem_texto_sistema
+
+logger = logging.getLogger(__name__)
+
+# Debounce simples em memória por processo (idempotência básica)
+_ultimos_envios: dict[str, datetime] = {}
+_DEBOUNCE = timedelta(minutes=2)
+
+
+def clear_debounce_for_tests() -> None:
+    """Limpa cache de debounce (apenas testes)."""
+    _ultimos_envios.clear()
+
+
+def _public_app_origin() -> str:
+    host = (settings.CLIENT_APP_HOST or "").strip()
+    if host:
+        host = host.removeprefix("https://").removeprefix("http://").split("/")[0]
+        proto = "https" if settings.is_production else "http"
+        return f"{proto}://{host}"
+    if not settings.is_production:
+        return "http://localhost:5173"
+    base = (settings.CONNECT_APP_BASE_DOMAIN or "").strip()
+    if base:
+        return f"https://{base}"
+    return "http://localhost:5173"
+
+
+def _pode_enviar(chave: str) -> bool:
+    agora = datetime.now(timezone.utc)
+    ultimo = _ultimos_envios.get(chave)
+    if ultimo and agora - ultimo < _DEBOUNCE:
+        return False
+    _ultimos_envios[chave] = agora
+    # Limpa chaves antigas
+    if len(_ultimos_envios) > 500:
+        limite = agora - timedelta(hours=1)
+        for k, v in list(_ultimos_envios.items()):
+            if v < limite:
+                _ultimos_envios.pop(k, None)
+    return True
+
+
+def build_portal_ticket_link(ticket_id: int) -> str:
+    origin = _public_app_origin().rstrip("/")
+    return f"{origin}/portal/tickets/{ticket_id}"
+
+
+def _destinatario_portal(db: Session, ticket: Ticket) -> FuncionarioRede | None:
+    if not ticket.aberto_por_id:
+        return None
+    f = db.query(FuncionarioRede).filter(FuncionarioRede.id == ticket.aberto_por_id).first()
+    if not f or not f.ativo:
+        return None
+    if not (f.email or "").strip():
+        return None
+    if not getattr(f, "notificar_email_portal", True):
+        return None
+    if not (f.senha_hash or "").strip():
+        # Sem acesso ao portal: ainda notifica se tiver e-mail (acompanhamento)
+        pass
+    return f
+
+
+def notificar_funcionario_mensagem_publica(
+    db: Session,
+    *,
+    ticket: Ticket,
+    mensagem: TicketMensagem,
+) -> None:
+    """Dispara e-mail quando a equipe envia mensagem pública no ticket aberto pelo portal."""
+    if mensagem.tipo != "publico":
+        return
+    if not mensagem.atendente_id:
+        return
+    dest = _destinatario_portal(db, ticket)
+    if not dest:
+        return
+    chave = f"msg:{ticket.id}:{mensagem.id}"
+    if not _pode_enviar(chave):
+        return
+    link = build_portal_ticket_link(ticket.id)
+    nome = (dest.nome or "").strip() or "olá"
+    subject = f"Nova resposta no chamado {ticket.protocolo}"
+    trecho = (mensagem.corpo or "").strip()
+    if len(trecho) > 280:
+        trecho = trecho[:277] + "…"
+    body = (
+        f"Olá, {nome},\n\n"
+        f"Há uma nova mensagem da equipe no chamado {ticket.protocolo}.\n\n"
+        f"{trecho}\n\n"
+        f"Acompanhe no portal:\n{link}\n\n"
+        "— Equipe de suporte"
+    )
+    try:
+        enviar_mensagem_texto_sistema(db, to_addr=str(dest.email), subject=subject, body=body)
+    except ValueError as e:
+        logger.warning("Portal e-mail: envio indisponível (%s)", e)
+    except Exception:
+        logger.exception("Portal e-mail: falha ticket_id=%s", ticket.id)
+
+
+def notificar_funcionario_status(
+    db: Session,
+    *,
+    ticket: Ticket,
+    status_nome: str,
+    status_slug: str | None = None,
+) -> None:
+    """Avisa mudança de status relevante (encerrado / aguardando cliente)."""
+    slug = (status_slug or "").strip().lower()
+    relevantes = {"fechado", "aguardando_cliente", "resolvido"}
+    if slug and slug not in relevantes:
+        return
+    dest = _destinatario_portal(db, ticket)
+    if not dest:
+        return
+    chave = f"st:{ticket.id}:{slug or status_nome}"
+    if not _pode_enviar(chave):
+        return
+    link = build_portal_ticket_link(ticket.id)
+    nome = (dest.nome or "").strip() or "olá"
+    subject = f"Atualização do chamado {ticket.protocolo}: {status_nome}"
+    body = (
+        f"Olá, {nome},\n\n"
+        f"O status do chamado {ticket.protocolo} foi atualizado para «{status_nome}».\n\n"
+        f"Veja os detalhes:\n{link}\n\n"
+        "— Equipe de suporte"
+    )
+    try:
+        enviar_mensagem_texto_sistema(db, to_addr=str(dest.email), subject=subject, body=body)
+    except ValueError as e:
+        logger.warning("Portal e-mail status: envio indisponível (%s)", e)
+    except Exception:
+        logger.exception("Portal e-mail status: falha ticket_id=%s", ticket.id)

--- a/backend/app/services/portal_tickets.py
+++ b/backend/app/services/portal_tickets.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session, joinedload
 
 from app.core.portal_scope import (
     assert_empresa_no_escopo,
-    empresa_ids_visiveis,
+    filtro_query_tickets_portal,
     tenant_id_do_funcionario,
     ticket_no_escopo,
 )
@@ -128,24 +128,15 @@ def listar_tickets(
     offset: int = 0,
     limit: int = 20,
 ) -> tuple[list[Ticket], int]:
-    ids = empresa_ids_visiveis(db, funcionario)
-    from app.services.funcionario_escopo import escopo_efetivo, rede_id_efetiva
-
-    rede_id = rede_id_efetiva(db, funcionario)
     q = db.query(Ticket).options(
         joinedload(Ticket.status),
         joinedload(Ticket.empresa),
         joinedload(Ticket.setor),
         joinedload(Ticket.mensagens),
     )
-    filtros = []
-    if ids:
-        filtros.append(Ticket.empresa_id.in_(ids))
-    if rede_id is not None and escopo_efetivo(funcionario) == "all":
-        filtros.append((Ticket.empresa_id.is_(None)) & (Ticket.rede_id == rede_id))
-    if not filtros:
+    q = filtro_query_tickets_portal(q, db, funcionario)
+    if q is None:
         return [], 0
-    q = q.filter(or_(*filtros))
     sit = (situacao or "abertos").strip().lower()
     if sit == "abertos":
         q = q.filter(Ticket.fechado_em.is_(None))

--- a/backend/app/services/portal_tickets.py
+++ b/backend/app/services/portal_tickets.py
@@ -1,0 +1,440 @@
+"""Regras de negócio dos tickets no portal do cliente."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.portal_scope import (
+    assert_empresa_no_escopo,
+    empresa_ids_visiveis,
+    tenant_id_do_funcionario,
+    ticket_no_escopo,
+)
+from app.core.routing import RoutingCanal
+from app.models.empresa import Empresa
+from app.models.funcionario_rede import FuncionarioRede
+from app.models.setor import Setor
+from app.models.status_ticket import StatusTicket
+from app.models.ticket import Ticket, TicketMensagem
+from app.models.ticket_anexo import TicketAnexo
+from app.schemas.portal import (
+    PortalAnexoRead,
+    PortalMensagemRead,
+    PortalTicketCreate,
+    PortalTicketDetail,
+    PortalTicketListItem,
+)
+from app.services.protocolo_mensal import gerar_protocolo_ticket
+from app.services.routing_apply import acoes_efetivas_do_resultado, registrar_roteamento_aplicado
+from app.services.routing_evaluate import RoutingContext, aplicar_roteamento_setor, evaluate_routing
+from app.services.ticket_distribuicao import sincronizar_fila_desde_at, tentar_distribuicao_imediata
+from app.services.realtime_emit import (
+    emit_notificacao_after_counter_change,
+    emit_ticket_fila,
+    emit_ticket_mensagem_from_model,
+)
+
+
+TIPOS_PUBLICOS_PORTAL = frozenset({"abertura", "publico", "email_cliente"})
+
+
+def _status_nome(ticket: Ticket) -> tuple[str | None, str | None]:
+    st = getattr(ticket, "status", None)
+    if st is None:
+        return None, None
+    return getattr(st, "nome", None), getattr(st, "slug", None)
+
+
+def _empresa_nome(ticket: Ticket) -> str | None:
+    emp = getattr(ticket, "empresa", None)
+    return getattr(emp, "nome", None) if emp else None
+
+
+def _setor_nome(ticket: Ticket) -> str | None:
+    setor = getattr(ticket, "setor", None)
+    return getattr(setor, "nome", None) if setor else None
+
+
+def ticket_para_list_item(ticket: Ticket) -> PortalTicketListItem:
+    status_nome, status_slug = _status_nome(ticket)
+    ultima = None
+    msgs = getattr(ticket, "mensagens", None)
+    if msgs:
+        publicas = [m for m in msgs if m.tipo in TIPOS_PUBLICOS_PORTAL]
+        if publicas:
+            ultima = max((m.created_at for m in publicas if m.created_at), default=None)
+    return PortalTicketListItem(
+        id=ticket.id,
+        protocolo=ticket.protocolo,
+        assunto=ticket.assunto,
+        status_nome=status_nome,
+        status_slug=status_slug,
+        empresa_id=ticket.empresa_id,
+        empresa_nome=_empresa_nome(ticket),
+        setor_nome=_setor_nome(ticket),
+        prioridade=str(ticket.prioridade) if ticket.prioridade else None,
+        created_at=ticket.created_at,
+        updated_at=ticket.updated_at,
+        fechado_em=ticket.fechado_em,
+        ultima_mensagem_em=ultima,
+    )
+
+
+def ticket_para_detail(db: Session, ticket: Ticket) -> PortalTicketDetail:
+    base = ticket_para_list_item(ticket)
+    csat_pendente = False
+    if ticket.fechado_em is not None:
+        from app.models.ticket_avaliacao import TicketAvaliacao
+
+        ja_avaliou = (
+            db.query(TicketAvaliacao).filter(TicketAvaliacao.ticket_id == ticket.id).first() is not None
+        )
+        csat_pendente = not ja_avaliou
+    return PortalTicketDetail(
+        **base.model_dump(),
+        descricao=ticket.descricao,
+        pode_responder=ticket.fechado_em is None,
+        csat_token=None,
+        csat_pendente=csat_pendente,
+    )
+
+
+def obter_ticket_escopo(db: Session, funcionario: FuncionarioRede, ticket_id: int) -> Ticket:
+    ticket = (
+        db.query(Ticket)
+        .options(
+            joinedload(Ticket.status),
+            joinedload(Ticket.empresa),
+            joinedload(Ticket.setor),
+            joinedload(Ticket.mensagens),
+        )
+        .filter(Ticket.id == ticket_id)
+        .first()
+    )
+    if not ticket or not ticket_no_escopo(db, funcionario, ticket):
+        raise LookupError("Ticket não encontrado")
+    return ticket
+
+
+def listar_tickets(
+    db: Session,
+    funcionario: FuncionarioRede,
+    *,
+    situacao: str = "abertos",
+    busca: str | None = None,
+    offset: int = 0,
+    limit: int = 20,
+) -> tuple[list[Ticket], int]:
+    ids = empresa_ids_visiveis(db, funcionario)
+    from app.services.funcionario_escopo import escopo_efetivo, rede_id_efetiva
+
+    rede_id = rede_id_efetiva(db, funcionario)
+    q = db.query(Ticket).options(
+        joinedload(Ticket.status),
+        joinedload(Ticket.empresa),
+        joinedload(Ticket.setor),
+        joinedload(Ticket.mensagens),
+    )
+    filtros = []
+    if ids:
+        filtros.append(Ticket.empresa_id.in_(ids))
+    if rede_id is not None and escopo_efetivo(funcionario) == "all":
+        filtros.append((Ticket.empresa_id.is_(None)) & (Ticket.rede_id == rede_id))
+    if not filtros:
+        return [], 0
+    q = q.filter(or_(*filtros))
+    sit = (situacao or "abertos").strip().lower()
+    if sit == "abertos":
+        q = q.filter(Ticket.fechado_em.is_(None))
+    elif sit == "fechados":
+        q = q.filter(Ticket.fechado_em.is_not(None))
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter(or_(Ticket.protocolo.ilike(term), Ticket.assunto.ilike(term)))
+    total = q.count()
+    rows = q.order_by(Ticket.id.desc()).offset(offset).limit(limit).all()
+    return rows, total
+
+
+def criar_ticket(
+    db: Session,
+    funcionario: FuncionarioRede,
+    data: PortalTicketCreate,
+) -> Ticket:
+    emp = assert_empresa_no_escopo(db, funcionario, data.empresa_id)
+    tenant_id = tenant_id_do_funcionario(db, funcionario)
+
+    setor_id_efetivo = data.setor_id
+    rota_resultado = evaluate_routing(
+        db,
+        tenant_id=tenant_id,
+        context=RoutingContext(
+            assunto=data.assunto,
+            canal=RoutingCanal.manual,
+            rede_id=emp.rede_id,
+        ),
+    )
+    if rota_resultado.matched:
+        setor_id_efetivo = aplicar_roteamento_setor(
+            setor_atual=data.setor_id,
+            resultado=rota_resultado,
+            aplicar_setor=data.setor_id is None,
+        )
+
+    if setor_id_efetivo is None:
+        raise ValueError("Selecione o setor de atendimento.")
+
+    setor = db.query(Setor).filter(Setor.id == setor_id_efetivo, Setor.tenant_id == tenant_id, Setor.ativo.is_(True)).first()
+    if not setor:
+        raise ValueError("Setor não encontrado.")
+
+    status_inicial = (
+        db.query(StatusTicket).filter(StatusTicket.ativo.is_(True)).order_by(StatusTicket.ordem).first()
+    )
+    if not status_inicial:
+        raise ValueError("Cadastre ao menos um status de ticket.")
+
+    descricao = (data.descricao or "").strip() or None
+    if data.pdv_codigo and data.pdv_codigo.strip():
+        pdv_line = f"PDV: {data.pdv_codigo.strip()}"
+        descricao = f"{pdv_line}\n\n{descricao}" if descricao else pdv_line
+
+    motivo_id_rota = data.motivo_id
+    atendente_id_rota = None
+    if rota_resultado.matched:
+        mid, aid = acoes_efetivas_do_resultado(
+            db,
+            tenant_id=tenant_id,
+            setor_id=setor_id_efetivo,
+            resultado=rota_resultado,
+        )
+        if motivo_id_rota is None:
+            motivo_id_rota = mid
+        atendente_id_rota = aid
+
+    protocolo = gerar_protocolo_ticket(db)
+    ticket = Ticket(
+        tenant_id=tenant_id,
+        protocolo=protocolo,
+        empresa_id=emp.id,
+        rede_id=emp.rede_id,
+        setor_id=setor_id_efetivo,
+        status_id=status_inicial.id,
+        prioridade="normal",
+        assunto=data.assunto.strip(),
+        descricao=descricao,
+        aberto_por_id=funcionario.id,
+        motivo_id=motivo_id_rota,
+        motivo_outro_texto=(data.motivo_outro_texto or None),
+        atendente_id=atendente_id_rota,
+    )
+    db.add(ticket)
+    db.flush()
+    from app.services.sla_policy import aplicar_sla_snapshot_ao_ticket
+
+    aplicar_sla_snapshot_ao_ticket(db, ticket)
+    if rota_resultado.matched:
+        registrar_roteamento_aplicado(
+            db,
+            resultado=rota_resultado,
+            ticket_id=ticket.id,
+            atendente_audit_id=None,
+        )
+
+    corpo_abertura = descricao or "—"
+    autor = (funcionario.nome or "").strip() or (funcionario.email or "Cliente")
+    msg = TicketMensagem(
+        ticket_id=ticket.id,
+        atendente_id=None,
+        tipo="abertura",
+        corpo=corpo_abertura,
+        autor_externo=autor,
+    )
+    db.add(msg)
+    db.commit()
+    db.refresh(ticket)
+
+    contagem_ja_emitida = False
+    if ticket.atendente_id is None:
+        sincronizar_fila_desde_at(ticket)
+        db.commit()
+        if tentar_distribuicao_imediata(db, ticket):
+            db.commit()
+            emit_notificacao_after_counter_change(db)
+            contagem_ja_emitida = True
+        else:
+            emit_ticket_fila(db, ticket)
+            contagem_ja_emitida = True
+
+    msg_abertura = (
+        db.query(TicketMensagem)
+        .filter(TicketMensagem.ticket_id == ticket.id, TicketMensagem.tipo == "abertura")
+        .order_by(TicketMensagem.id.desc())
+        .first()
+    )
+    if msg_abertura:
+        emit_ticket_mensagem_from_model(
+            db,
+            ticket,
+            msg_abertura,
+            exclude_atendente_id=None,
+            emit_notificacao=not contagem_ja_emitida,
+        )
+    return obter_ticket_escopo(db, funcionario, ticket.id)
+
+
+def mensagem_para_read(
+    db: Session,
+    funcionario: FuncionarioRede,
+    m: TicketMensagem,
+) -> PortalMensagemRead:
+    anexos_rows = (
+        db.query(TicketAnexo)
+        .filter(
+            TicketAnexo.mensagem_id == m.id,
+            TicketAnexo.visibilidade == "publico",
+        )
+        .order_by(TicketAnexo.id.asc())
+        .all()
+    )
+    anexos = [
+        PortalAnexoRead(
+            id=a.id,
+            nome_original=a.nome_original,
+            content_type=a.content_type,
+            tamanho_bytes=int(a.tamanho_bytes or 0),
+            mensagem_id=a.mensagem_id,
+            created_at=a.created_at,
+            download_url=f"/v1/portal/tickets/{m.ticket_id}/anexos/{a.id}/download",
+        )
+        for a in anexos_rows
+    ]
+    if m.atendente_id:
+        atendente = getattr(m, "atendente", None)
+        nome = getattr(atendente, "nome", None) or "Equipe de suporte"
+        papel: str = "equipe"
+    elif m.tipo == "abertura" or m.tipo == "email_cliente":
+        nome = (m.autor_externo or funcionario.nome or "Você")
+        # Se o autor externo for o próprio funcionário ou abertura pelo portal
+        papel = "voce"
+    else:
+        nome = m.autor_externo or "Sistema"
+        papel = "sistema"
+    return PortalMensagemRead(
+        id=m.id,
+        tipo=m.tipo,
+        corpo=m.corpo,
+        autor_nome=nome,
+        autor_papel=papel,  # type: ignore[arg-type]
+        created_at=m.created_at,
+        anexos=anexos,
+    )
+
+
+def listar_mensagens_publicas(
+    db: Session,
+    funcionario: FuncionarioRede,
+    ticket: Ticket,
+) -> list[PortalMensagemRead]:
+    rows = (
+        db.query(TicketMensagem)
+        .options(joinedload(TicketMensagem.atendente))
+        .filter(
+            TicketMensagem.ticket_id == ticket.id,
+            TicketMensagem.tipo.in_(list(TIPOS_PUBLICOS_PORTAL)),
+        )
+        .order_by(TicketMensagem.created_at.asc())
+        .all()
+    )
+    return [mensagem_para_read(db, funcionario, m) for m in rows]
+
+
+def criar_mensagem_portal(
+    db: Session,
+    funcionario: FuncionarioRede,
+    ticket: Ticket,
+    corpo: str,
+) -> TicketMensagem:
+    if ticket.fechado_em is not None:
+        raise ValueError(
+            "Este chamado está encerrado. Abra um novo chamado para continuar o atendimento."
+        )
+    texto = corpo.strip()
+    if not texto:
+        raise ValueError("Mensagem vazia")
+    autor = (funcionario.nome or "").strip() or (funcionario.email or "Cliente")
+    m = TicketMensagem(
+        ticket_id=ticket.id,
+        atendente_id=None,
+        tipo="email_cliente",
+        corpo=texto,
+        autor_externo=autor,
+    )
+    db.add(m)
+    db.flush()
+
+    # Se estava aguardando cliente, volta para em atendimento quando houver esse status
+    st = ticket.status
+    if st is not None and (st.slug or "").lower() == "aguardando_cliente":
+        em_atend = (
+            db.query(StatusTicket)
+            .filter(StatusTicket.slug == "em_atendimento", StatusTicket.ativo.is_(True))
+            .first()
+        )
+        if em_atend:
+            ticket.status_id = em_atend.id
+            ticket.updated_at = datetime.now(timezone.utc)
+
+    from app.services.notificacao_atendente_email import notificar_nova_mensagem_ticket
+
+    notificar_nova_mensagem_ticket(db, ticket=ticket, mensagem=m, autor_atendente_id=None)
+    db.commit()
+    db.refresh(m)
+    m = (
+        db.query(TicketMensagem)
+        .options(joinedload(TicketMensagem.atendente))
+        .filter(TicketMensagem.id == m.id)
+        .first()
+    )
+    assert m is not None
+    emit_ticket_mensagem_from_model(db, ticket, m, exclude_atendente_id=None)
+    return m
+
+
+def listar_anexos_publicos(db: Session, ticket: Ticket) -> list[PortalAnexoRead]:
+    rows = (
+        db.query(TicketAnexo)
+        .filter(TicketAnexo.ticket_id == ticket.id, TicketAnexo.visibilidade == "publico")
+        .order_by(TicketAnexo.id.asc())
+        .all()
+    )
+    return [
+        PortalAnexoRead(
+            id=a.id,
+            nome_original=a.nome_original,
+            content_type=a.content_type,
+            tamanho_bytes=int(a.tamanho_bytes or 0),
+            mensagem_id=a.mensagem_id,
+            created_at=a.created_at,
+            download_url=f"/v1/portal/tickets/{ticket.id}/anexos/{a.id}/download",
+        )
+        for a in rows
+    ]
+
+
+def obter_anexo_publico(db: Session, ticket: Ticket, anexo_id: int) -> TicketAnexo:
+    a = (
+        db.query(TicketAnexo)
+        .filter(
+            TicketAnexo.id == anexo_id,
+            TicketAnexo.ticket_id == ticket.id,
+            TicketAnexo.visibilidade == "publico",
+        )
+        .first()
+    )
+    if not a:
+        raise LookupError("Anexo não encontrado")
+    return a

--- a/backend/app/services/portal_whatsapp.py
+++ b/backend/app/services/portal_whatsapp.py
@@ -1,0 +1,176 @@
+"""Chats WhatsApp no portal autenticado do cliente (#603)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.portal_scope import chat_no_escopo, filtro_query_chats_portal
+from app.models.funcionario_rede import FuncionarioRede
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
+from app.schemas.portal import (
+    PortalWhatsappChatDetail,
+    PortalWhatsappChatListItem,
+    PortalWhatsappMensagemRead,
+)
+from app.services.whatsapp_auto_messages import EVENTOS_MENSAGEM_OCULTA_CONVERSA
+from app.services.whatsapp_avaliacao import mensagem_oculta_na_conversa
+
+EVENTOS_OCULTOS_PORTAL = EVENTOS_MENSAGEM_OCULTA_CONVERSA | frozenset(
+    {
+        "comentario_interno",
+        "transferencia",
+        "demanda_registrada",
+        "demanda_escalada",
+    }
+)
+
+
+def mensagem_visivel_no_portal(m: WhatsappMensagem) -> bool:
+    ev = (getattr(m, "evento_sistema", None) or "").strip()
+    if ev in EVENTOS_OCULTOS_PORTAL:
+        return False
+    if mensagem_oculta_na_conversa(ev or None):
+        return False
+    return True
+
+
+def _preview(corpo: str | None) -> str | None:
+    if not corpo:
+        return None
+    texto = corpo.strip()
+    if len(texto) > 100:
+        return texto[:100] + "…"
+    return texto
+
+
+def _ultima_mensagem_visivel(db: Session, chat_id: int) -> tuple[datetime | None, str | None]:
+    rows = (
+        db.query(WhatsappMensagem)
+        .filter(WhatsappMensagem.chat_id == chat_id)
+        .order_by(WhatsappMensagem.id.desc())
+        .limit(30)
+        .all()
+    )
+    for m in rows:
+        if mensagem_visivel_no_portal(m):
+            return m.created_at, _preview(m.corpo)
+    return None, None
+
+
+def chat_para_list_item(db: Session, chat: WhatsappChat) -> PortalWhatsappChatListItem:
+    ultima_em, preview = _ultima_mensagem_visivel(db, chat.id)
+    emp = getattr(chat, "empresa", None)
+    setor = getattr(chat, "setor", None)
+    return PortalWhatsappChatListItem(
+        id=chat.id,
+        protocolo=chat.protocolo,
+        estado=chat.estado,
+        empresa_id=chat.empresa_id,
+        empresa_nome=getattr(emp, "nome", None) if emp else None,
+        setor_nome=getattr(setor, "nome", None) if setor else None,
+        created_at=chat.created_at,
+        encerramento_at=chat.encerramento_at,
+        ultima_mensagem_em=ultima_em,
+        ultima_mensagem_preview=preview,
+    )
+
+
+def chat_para_detail(db: Session, chat: WhatsappChat) -> PortalWhatsappChatDetail:
+    base = chat_para_list_item(db, chat)
+    return PortalWhatsappChatDetail(**base.model_dump(), encerrado=(chat.estado or "") == "encerrado")
+
+
+def obter_chat_escopo(db: Session, funcionario: FuncionarioRede, chat_id: int) -> WhatsappChat:
+    chat = (
+        db.query(WhatsappChat)
+        .options(
+            joinedload(WhatsappChat.empresa),
+            joinedload(WhatsappChat.setor),
+        )
+        .filter(WhatsappChat.id == chat_id)
+        .first()
+    )
+    if not chat or not chat_no_escopo(db, funcionario, chat):
+        raise LookupError("Atendimento não encontrado")
+    return chat
+
+
+def listar_chats(
+    db: Session,
+    funcionario: FuncionarioRede,
+    *,
+    situacao: str = "abertos",
+    busca: str | None = None,
+    offset: int = 0,
+    limit: int = 20,
+) -> tuple[list[WhatsappChat], int]:
+    q = db.query(WhatsappChat).options(
+        joinedload(WhatsappChat.empresa),
+        joinedload(WhatsappChat.setor),
+    )
+    q = filtro_query_chats_portal(q, db, funcionario)
+    if q is None:
+        return [], 0
+
+    sit = (situacao or "abertos").strip().lower()
+    if sit == "abertos":
+        q = q.filter(WhatsappChat.estado != "encerrado")
+    elif sit == "encerrados":
+        q = q.filter(WhatsappChat.estado == "encerrado")
+
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter(or_(WhatsappChat.protocolo.ilike(term), WhatsappChat.cliente_nome.ilike(term)))
+
+    total = q.count()
+    rows = q.order_by(WhatsappChat.id.desc()).offset(offset).limit(limit).all()
+    return rows, total
+
+
+def mensagem_para_read(m: WhatsappMensagem) -> PortalWhatsappMensagemRead:
+    midia_ok = bool(m.midia_nome_arquivo and str(m.midia_nome_arquivo).strip())
+    if (m.direcao or "").strip().lower() == "inbound":
+        papel: str = "voce"
+        nome = "Você"
+    elif m.atendente_id:
+        atendente = getattr(m, "atendente", None)
+        papel = "equipe"
+        nome = getattr(atendente, "nome", None) or "Equipe de suporte"
+    else:
+        papel = "sistema"
+        nome = "Sistema"
+    return PortalWhatsappMensagemRead(
+        id=m.id,
+        direcao=m.direcao,
+        corpo=m.corpo,
+        tipo_midia=m.tipo_midia,
+        midia_disponivel=midia_ok,
+        autor_nome=nome,
+        autor_papel=papel,  # type: ignore[arg-type]
+        created_at=m.created_at,
+    )
+
+
+def listar_mensagens_visiveis(db: Session, chat: WhatsappChat) -> list[PortalWhatsappMensagemRead]:
+    rows = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.chat_id == chat.id)
+        .order_by(WhatsappMensagem.created_at.asc())
+        .all()
+    )
+    return [mensagem_para_read(m) for m in rows if mensagem_visivel_no_portal(m)]
+
+
+def obter_mensagem_midia(db: Session, chat: WhatsappChat, mensagem_id: int) -> WhatsappMensagem:
+    m = (
+        db.query(WhatsappMensagem)
+        .filter(WhatsappMensagem.chat_id == chat.id, WhatsappMensagem.id == mensagem_id)
+        .first()
+    )
+    if not m or not mensagem_visivel_no_portal(m) or not m.midia_nome_arquivo:
+        raise LookupError("Mídia não encontrada")
+    return m

--- a/backend/app/services/whatsapp_auto_messages.py
+++ b/backend/app/services/whatsapp_auto_messages.py
@@ -37,6 +37,13 @@ DEFAULT_AUTO_MSG_AVALIACAO_SEM_NOTA = (
     "Não foi possível registrar sua avaliação. O atendimento foi encerrado. "
     "Se precisar de algo mais, envie uma nova mensagem por aqui."
 )
+DEFAULT_AUTO_MSG_AVALIACAO_PULAR = (
+    "Sem problema! Vamos abrir um novo atendimento com a sua mensagem."
+)
+DEFAULT_AUTO_MSG_AVALIACAO_TIMEOUT = (
+    "O período para avaliar o atendimento encerrou. "
+    "Se precisar de ajuda, envie uma nova mensagem por aqui."
+)
 
 # Mensagens desta fase não aparecem na conversa do atendente (só no WhatsApp do cliente).
 EVENTOS_MENSAGEM_OCULTA_CONVERSA = frozenset(
@@ -44,6 +51,8 @@ EVENTOS_MENSAGEM_OCULTA_CONVERSA = frozenset(
         "auto_avaliacao_solicitacao",
         "auto_avaliacao_obrigado",
         "auto_avaliacao_sem_nota",
+        "auto_avaliacao_pular",
+        "auto_avaliacao_timeout",
         "avaliacao_cliente_nota",
         "avaliacao_cliente_invalida",
     }

--- a/backend/app/services/whatsapp_avaliacao.py
+++ b/backend/app/services/whatsapp_avaliacao.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from typing import Literal
 
 from sqlalchemy.orm import Session
 
@@ -13,7 +14,9 @@ from app.services import evolution_api
 from app.services.whatsapp_auto_messages import (
     DEFAULT_AUTO_MSG_AVALIACAO,
     DEFAULT_AUTO_MSG_AVALIACAO_OBRIGADO,
+    DEFAULT_AUTO_MSG_AVALIACAO_PULAR,
     DEFAULT_AUTO_MSG_AVALIACAO_SEM_NOTA,
+    DEFAULT_AUTO_MSG_AVALIACAO_TIMEOUT,
     DEFAULT_AUTO_MSG_ENCERRADO,
     EVENTOS_MENSAGEM_OCULTA_CONVERSA,
 )
@@ -21,6 +24,8 @@ from app.services.whatsapp_auto_messages import (
 logger = logging.getLogger(__name__)
 
 _NOTA_RE = re.compile(r"^[1-5]$")
+
+MotivoEncerrarAvaliacao = Literal["pular", "timeout", "invalida"]
 
 
 def parse_nota_avaliacao(texto: str) -> int | None:
@@ -36,6 +41,15 @@ def avaliacao_habilitada(st: WhatsappSettings | None) -> bool:
 
 def mensagem_oculta_na_conversa(evento_sistema: str | None) -> bool:
     return (evento_sistema or "") in EVENTOS_MENSAGEM_OCULTA_CONVERSA
+
+
+def janela_avaliacao_minutos(st: WhatsappSettings | None) -> int:
+    raw = getattr(st, "avaliacao_janela_minutos", None) if st else None
+    try:
+        n = int(raw) if raw is not None else 30
+    except (TypeError, ValueError):
+        n = 30
+    return max(1, n)
 
 
 def _evolution_configurada(st: WhatsappSettings | None) -> bool:
@@ -114,6 +128,40 @@ def _enviar_encerrado(
         _enviar_texto_sistema(db, chat=chat, st=st, texto=txt, evento_sistema=evento_sistema)
 
 
+def encerrar_avaliacao_sem_nota(
+    db: Session,
+    chat: WhatsappChat,
+    st: WhatsappSettings,
+    *,
+    motivo: MotivoEncerrarAvaliacao = "pular",
+    msg_inbound: WhatsappMensagem | None = None,
+    enviar_mensagem: bool = True,
+) -> None:
+    """Finaliza `aguardando_avaliacao` sem nota (pular / timeout / resposta inválida legada)."""
+    if msg_inbound is not None:
+        msg_inbound.evento_sistema = "avaliacao_cliente_invalida"
+    chat.estado = "encerrado"
+    chat.avaliacao_nota = None
+    chat.avaliacao_respondida_at = None
+    db.flush()
+    if not enviar_mensagem or not _evolution_configurada(st):
+        return
+    if not bool(getattr(st, "auto_msg_avaliacao_ativa", True)):
+        return
+    if motivo == "timeout":
+        raw = (getattr(st, "auto_msg_avaliacao_timeout_texto", "") or "").strip() or DEFAULT_AUTO_MSG_AVALIACAO_TIMEOUT
+        evento = "auto_avaliacao_timeout"
+    elif motivo == "pular":
+        raw = (getattr(st, "auto_msg_avaliacao_pular_texto", "") or "").strip() or DEFAULT_AUTO_MSG_AVALIACAO_PULAR
+        evento = "auto_avaliacao_pular"
+    else:
+        raw = DEFAULT_AUTO_MSG_AVALIACAO_SEM_NOTA
+        evento = "auto_avaliacao_sem_nota"
+    txt = _render_template(raw, db=db, chat=chat, st=st)
+    if txt:
+        _enviar_texto_sistema(db, chat=chat, st=st, texto=txt, evento_sistema=evento)
+
+
 def _encerrar_sem_avaliacao(
     db: Session,
     chat: WhatsappChat,
@@ -121,22 +169,8 @@ def _encerrar_sem_avaliacao(
     *,
     msg_inbound: WhatsappMensagem | None = None,
 ) -> None:
-    if msg_inbound is not None:
-        msg_inbound.evento_sistema = "avaliacao_cliente_invalida"
-    chat.estado = "encerrado"
-    chat.avaliacao_nota = None
-    chat.avaliacao_respondida_at = None
-    db.flush()
-    raw = DEFAULT_AUTO_MSG_AVALIACAO_SEM_NOTA
-    txt = _render_template(raw, db=db, chat=chat, st=st)
-    if txt:
-        _enviar_texto_sistema(
-            db,
-            chat=chat,
-            st=st,
-            texto=txt,
-            evento_sistema="auto_avaliacao_sem_nota",
-        )
+    """Compat: resposta inválida no mesmo chat (sem abrir atendimento novo)."""
+    encerrar_avaliacao_sem_nota(db, chat, st, motivo="invalida", msg_inbound=msg_inbound)
 
 
 def finalizar_atendimento_whatsapp(
@@ -188,19 +222,22 @@ def processar_resposta_avaliacao(
     *,
     tipo_midia: str = "texto",
     msg_inbound: WhatsappMensagem | None = None,
-) -> None:
-    """Processa mensagem inbound em chat aguardando_avaliacao."""
+) -> Literal["nota", "nao_nota"]:
+    """
+    Processa inbound em `aguardando_avaliacao`.
+
+    Retorna ``nota`` se registrou 1–5 e encerrou; ``nao_nota`` se a mensagem não é nota
+    (o caller deve encerrar a avaliação e abrir atendimento novo com essa mensagem).
+    """
     if chat.estado != "aguardando_avaliacao" or not st or not _evolution_configurada(st):
-        return
+        return "nao_nota"
 
     if (tipo_midia or "texto").strip().lower() != "texto":
-        _encerrar_sem_avaliacao(db, chat, st, msg_inbound=msg_inbound)
-        return
+        return "nao_nota"
 
     nota = parse_nota_avaliacao(texto)
     if nota is None:
-        _encerrar_sem_avaliacao(db, chat, st, msg_inbound=msg_inbound)
-        return
+        return "nao_nota"
 
     if msg_inbound is not None:
         msg_inbound.evento_sistema = "avaliacao_cliente_nota"
@@ -224,3 +261,67 @@ def processar_resposta_avaliacao(
                 texto=txt,
                 evento_sistema="auto_avaliacao_obrigado",
             )
+    return "nota"
+
+
+def process_whatsapp_avaliacao_timeouts(db: Session, *, limit: int = 200) -> int:
+    """
+    Encerra chats ainda em `aguardando_avaliacao` após a janela configurada
+    (a partir de `encerramento_at`). Retorna quantidade alterada.
+    """
+    st = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
+    if not st or not avaliacao_habilitada(st):
+        return 0
+    if not _evolution_configurada(st):
+        return 0
+
+    minutos = janela_avaliacao_minutos(st)
+    limite = datetime.now(timezone.utc) - timedelta(minutes=minutos)
+    chat_ids = [
+        row[0]
+        for row in (
+            db.query(WhatsappChat.id)
+            .filter(
+                WhatsappChat.estado == "aguardando_avaliacao",
+                WhatsappChat.encerramento_at.isnot(None),
+                WhatsappChat.encerramento_at <= limite,
+            )
+            .order_by(WhatsappChat.id.asc())
+            .limit(limit)
+            .all()
+        )
+    ]
+    alterados = 0
+    for chat_id in chat_ids:
+        try:
+            chat = (
+                db.query(WhatsappChat)
+                .filter(WhatsappChat.id == chat_id, WhatsappChat.estado == "aguardando_avaliacao")
+                .with_for_update()
+                .first()
+            )
+            if not chat:
+                db.rollback()
+                continue
+            enc_at = chat.encerramento_at
+            if enc_at is None:
+                db.rollback()
+                continue
+            if enc_at.tzinfo is None:
+                enc_at = enc_at.replace(tzinfo=timezone.utc)
+            if enc_at > limite:
+                db.rollback()
+                continue
+            encerrar_avaliacao_sem_nota(db, chat, st, motivo="timeout")
+            db.commit()
+            alterados += 1
+            try:
+                from app.services.realtime_emit import emit_chat_fila_from_model
+
+                emit_chat_fila_from_model(db, chat, estado_anterior="aguardando_avaliacao")
+            except Exception as emit_exc:
+                logger.warning("SSE pós-timeout avaliação (chat=%s): %s", chat_id, emit_exc)
+        except Exception as exc:
+            db.rollback()
+            logger.warning("Timeout avaliação WhatsApp (chat=%s): %s", chat_id, exc)
+    return alterados

--- a/backend/app/services/whatsapp_chat_demandas.py
+++ b/backend/app/services/whatsapp_chat_demandas.py
@@ -125,8 +125,8 @@ def criar_demanda_chat(
     desfecho: str = "resolvido_sessao",
     ticket_id: int | None = None,
 ) -> WhatsappChatDemanda:
-    if chat.estado != "em_atendimento":
-        raise HTTPException(status_code=400, detail="Registre demandas apenas em chats em atendimento")
+    if chat.estado not in ("em_atendimento", "aguardando_avaliacao", "encerrado"):
+        raise HTTPException(status_code=400, detail="Registre demandas apenas em chats em atendimento ou pós-inatividade")
     desfecho_eff = (desfecho or "resolvido_sessao").strip()
     if desfecho_eff not in DESFECHOS_DEMANDA:
         raise HTTPException(status_code=400, detail="Desfecho inválido")
@@ -180,8 +180,8 @@ def atualizar_demanda_chat(
     *,
     atendente: Atendente,
 ) -> WhatsappChatDemanda:
-    if chat.estado != "em_atendimento":
-        raise HTTPException(status_code=400, detail="Edite demandas apenas em chats em atendimento")
+    if chat.estado not in ("em_atendimento", "aguardando_avaliacao", "encerrado"):
+        raise HTTPException(status_code=400, detail="Edite demandas apenas em chats em atendimento ou pós-inatividade")
     if row.desfecho != "resolvido_sessao":
         raise HTTPException(status_code=400, detail="Demandas escaladas para ticket não podem ser editadas")
     if atendente.role != "admin" and row.atendente_id != atendente.id:

--- a/backend/app/services/whatsapp_contato_match.py
+++ b/backend/app/services/whatsapp_contato_match.py
@@ -1,0 +1,58 @@
+"""Match de contacto WhatsApp ↔ funcionário da rede por telefone/wa_id."""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy.orm import Session
+
+from app.models.funcionario_rede import FuncionarioRede
+
+
+def digits_wa(raw: str | None) -> str:
+    return re.sub(r"\D", "", raw or "")
+
+
+def variantes_wa_id(wa_id: str | None) -> set[str]:
+    digits = digits_wa(wa_id)
+    out: set[str] = set()
+    if not digits:
+        return out
+    out.add(digits)
+    if digits.startswith("55") and len(digits) >= 12:
+        out.add(digits[2:])
+    elif len(digits) in (10, 11):
+        out.add("55" + digits)
+    return out
+
+
+def funcionario_por_wa_id(db: Session, wa_id: str | None) -> FuncionarioRede | None:
+    """Encontra funcionário ativo cujo telefone corresponde ao wa_id (com/sem DDI 55)."""
+    targets = variantes_wa_id(wa_id)
+    if not targets:
+        return None
+    # Sufixo para pré-filtrar no SQL (evita full scan com LIKE amplo)
+    sample = next(iter(targets))
+    suffix = sample[-8:] if len(sample) >= 8 else sample
+    candidatos = (
+        db.query(FuncionarioRede)
+        .filter(
+            FuncionarioRede.ativo.is_(True),
+            FuncionarioRede.telefone.isnot(None),
+            FuncionarioRede.telefone != "",
+            FuncionarioRede.telefone.ilike(f"%{suffix}%"),
+        )
+        .order_by(FuncionarioRede.id.desc())
+        .limit(80)
+        .all()
+    )
+    for func in candidatos:
+        f_digits = digits_wa(getattr(func, "telefone", None))
+        if not f_digits:
+            continue
+        if f_digits in targets or targets & variantes_wa_id(f_digits):
+            return func
+        # Últimos 11 dígitos (BR sem/com 9 extra)
+        if len(f_digits) >= 11 and len(sample) >= 11 and f_digits[-11:] == sample[-11:]:
+            return func
+    return None

--- a/backend/app/services/whatsapp_inactivity_worker.py
+++ b/backend/app/services/whatsapp_inactivity_worker.py
@@ -66,33 +66,34 @@ def _ultima_outbound_humana(db: Session, chat_id: int) -> WhatsappMensagem | Non
 
 def _referencia_inatividade_cliente(db: Session, chat: WhatsappChat) -> datetime | None:
     """
-    Momento a partir do qual o cliente está inativo.
+    Momento a partir do qual o silêncio conta para inatividade.
 
-    Conta desde a última mensagem **do cliente** somente quando:
-    - o chat já está em atendimento (garantido pelo caller);
-    - o atendente já enviou pelo menos uma mensagem humana (não auto_assumido/BOT);
-    - essa resposta humana é posterior à última inbound (cliente sumiu).
+    Conta desde a **última mensagem relevante** (inbound do cliente **ou** outbound
+    humana do atendente), desde que já exista pelo menos uma outbound humana
+    (não dispara na fila / só com auto_assumido/BOT).
 
-    Mensagens de sistema (auto_assumido, auto_espera, avisos) não disparam o timer.
-    Novas mensagens do atendente não reiniciam o relógio.
+    Comentários internos e eventos de sistema não contam como atividade.
     """
+    last_out = _ultima_outbound_humana(db, chat.id)
+    if not last_out or last_out.created_at is None:
+        return None
+
     last_in = (
         _mensagens_relevantes_q(db, chat.id)
         .filter(WhatsappMensagem.direcao == "inbound")
         .order_by(desc(WhatsappMensagem.created_at), desc(WhatsappMensagem.id))
         .first()
     )
-    last_out = _ultima_outbound_humana(db, chat.id)
-    if not last_out or last_in is None:
-        return None
-    out_at = last_out.created_at
-    in_at = last_in.created_at
-    if out_at is None or in_at is None:
-        return None
-    if out_at <= in_at:
-        # Cliente falou por último ou atendente ainda não respondeu — não encerra.
-        return None
-    return in_at
+
+    candidatos: list[datetime] = [last_out.created_at]
+    if last_in is not None and last_in.created_at is not None:
+        candidatos.append(last_in.created_at)
+
+    retomada = getattr(chat, "inatividade_retomada_em", None)
+    if retomada is not None:
+        candidatos.append(retomada)
+
+    return max(candidatos)
 
 
 def _minutos_desde(ref: datetime | None, now: datetime) -> float:
@@ -186,6 +187,9 @@ def _processar_chat_inatividade(
 ) -> bool:
     """Retorna True se alterou algo no chat (mensagem ou encerramento)."""
     if chat.estado != "em_atendimento":
+        return False
+
+    if getattr(chat, "inatividade_pausada", False):
         return False
 
     aviso_min = int(getattr(st, "inativ_aviso_minutos", 0) or 0)

--- a/backend/app/services/whatsapp_inactivity_worker.py
+++ b/backend/app/services/whatsapp_inactivity_worker.py
@@ -174,9 +174,36 @@ def _enviar_texto_sistema(
 
 
 def _encerrar_por_inatividade(db: Session, chat: WhatsappChat, st: WhatsappSettings) -> None:
+    from app.models.whatsapp_chat import WhatsappMensagem
     from app.services.whatsapp_avaliacao import finalizar_atendimento_whatsapp
 
     finalizar_atendimento_whatsapp(db, chat, st, evento_encerrado="auto_encerrado_inatividade")
+    chat.classificacao_demanda_pendente = True
+    # Com avaliação ativa o evento_encerrado não é gravado — marco interno para o painel pedir demanda.
+    ja_tem = (
+        db.query(WhatsappMensagem.id)
+        .filter(
+            WhatsappMensagem.chat_id == chat.id,
+            WhatsappMensagem.evento_sistema == "auto_encerrado_inatividade",
+        )
+        .limit(1)
+        .first()
+    )
+    if not ja_tem:
+        db.add(
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="outbound",
+                corpo="Atendimento encerrado automaticamente por inatividade.",
+                tipo_midia="texto",
+                mimetype=None,
+                midia_nome_arquivo=None,
+                wa_message_id=None,
+                atendente_id=None,
+                evento_sistema="auto_encerrado_inatividade",
+            )
+        )
+        db.flush()
 
 
 def _processar_chat_inatividade(
@@ -268,6 +295,25 @@ def process_whatsapp_inactivity_closures(db: Session, *, limit: int = 200) -> in
             if _processar_chat_inatividade(db, chat, st, now):
                 db.commit()
                 alterados += 1
+                try:
+                    from app.services.realtime_emit import emit_chat_fila_from_model, emit_chat_mensagem_from_models
+
+                    emit_chat_fila_from_model(db, chat, estado_anterior="em_atendimento")
+                    last_msg = (
+                        db.query(WhatsappMensagem)
+                        .filter(WhatsappMensagem.chat_id == chat.id)
+                        .order_by(WhatsappMensagem.id.desc())
+                        .first()
+                    )
+                    if last_msg and last_msg.evento_sistema in (
+                        "auto_inativ_aviso",
+                        "auto_encerrado_inatividade",
+                        "auto_avaliacao_solicitacao",
+                        "auto_encerrado",
+                    ):
+                        emit_chat_mensagem_from_models(db, chat, last_msg)
+                except Exception as emit_exc:
+                    logger.warning("SSE pós-inatividade (chat=%s): %s", chat_id, emit_exc)
             else:
                 db.rollback()
         except Exception as exc:

--- a/backend/app/services/whatsapp_wa_id_lock.py
+++ b/backend/app/services/whatsapp_wa_id_lock.py
@@ -1,0 +1,49 @@
+"""Serialização por wa_id ao abrir/reutilizar chat WhatsApp (#608)."""
+
+from __future__ import annotations
+
+import threading
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+_WA_LOCK_NS = 608608
+_wa_thread_locks: dict[str, threading.Lock] = {}
+_wa_thread_locks_guard = threading.Lock()
+
+
+def _thread_lock(wa_id: str) -> threading.Lock:
+    with _wa_thread_locks_guard:
+        lock = _wa_thread_locks.get(wa_id)
+        if lock is None:
+            lock = threading.Lock()
+            _wa_thread_locks[wa_id] = lock
+        return lock
+
+
+def lock_wa_id_para_chat(db: Session, wa_id: str) -> None:
+    """
+    Garante uma única criação de chat aberto por contacto.
+
+    PostgreSQL: advisory lock transacional (liberta no commit/rollback).
+    SQLite (testes): lock in-process por wa_id.
+    """
+    wa = (wa_id or "").strip()
+    if not wa:
+        return
+    bind = db.get_bind()
+    if bind.dialect.name == "postgresql":
+        db.execute(
+            text("SELECT pg_advisory_xact_lock(:ns, hashtext(:wa_id))"),
+            {"ns": _WA_LOCK_NS, "wa_id": wa},
+        )
+    else:
+        _thread_lock(wa).acquire()
+
+
+def unlock_wa_id_para_chat(db: Session, wa_id: str) -> None:
+    """Liberta lock in-process (SQLite). No-op em PostgreSQL."""
+    wa = (wa_id or "").strip()
+    if not wa:
+        return
+    if db.get_bind().dialect.name != "postgresql":
+        _thread_lock(wa).release()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,4 +12,4 @@ pydantic-settings==2.14.2
 PyJWT[crypto]==2.13.0
 cryptography>=49.0.0
 bcrypt>=5.0.0,<6
-svix>=1.96.1
+svix>=1.98.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 # Necessário para `Form()` / `UploadFile` (envio de mídia WhatsApp, etc.).
 python-multipart==0.0.32
-fastapi==0.139.0
+fastapi==0.139.2
 starlette==1.3.1
 uvicorn[standard]==0.51.0
 gunicorn==26.0.0

--- a/backend/tests/test_funcionario_nome_similar.py
+++ b/backend/tests/test_funcionario_nome_similar.py
@@ -1,0 +1,79 @@
+"""Testes de similaridade de nome (#593)."""
+
+from __future__ import annotations
+
+from app.services.funcionario_nome_similar import (
+    LIMIAR_SIMILARIDADE,
+    normalizar_nome,
+    ranquear_similares,
+    score_nomes,
+)
+
+
+def test_normalizar_remove_acentos():
+    assert normalizar_nome("Luís Gustavo") == "luis gustavo"
+    assert normalizar_nome("  Maria   Silva ") == "maria silva"
+
+
+def test_score_acentos_e_typo_leve():
+    assert score_nomes("Luis Gustavo", "Luís Gustavo") >= LIMIAR_SIMILARIDADE
+    assert score_nomes("Maria Silva", "Maria Silvs") >= LIMIAR_SIMILARIDADE
+    assert score_nomes("João Pedro", "Carlos Alberto") < LIMIAR_SIMILARIDADE
+
+
+def test_ranquear_top_e_limiar():
+    candidatos = [
+        (1, "Luis Gustavo Santos"),
+        (2, "Luís Gustavo"),
+        (3, "Ana Paula"),
+        (4, "Carlos"),
+    ]
+    ranked = ranquear_similares("Luis Gustavo", candidatos, limit=5)
+    ids = [r[0] for r in ranked]
+    assert 2 in ids
+    assert 1 in ids
+    assert 3 not in ids
+    assert ranked[0][2] >= ranked[-1][2]
+
+
+def test_api_similares_whatsapp(client, seed_base, auth_headers, db_session):
+    from app.models.funcionario_rede import FuncionarioRede
+    from tests.test_whatsapp_chats import _criar_funcionario_colaborador
+
+    func = _criar_funcionario_colaborador(
+        db_session,
+        seed_base,
+        nome="Luís Gustavo",
+        email="luis.g@test.local",
+    )
+    inativo = _criar_funcionario_colaborador(
+        db_session,
+        seed_base,
+        nome="Luis Gustavo Inativo",
+        email="luis.inativo@test.local",
+    )
+    row = db_session.query(FuncionarioRede).filter(FuncionarioRede.id == inativo["id"]).first()
+    assert row is not None
+    row.ativo = False
+    db_session.commit()
+
+    r = client.get(
+        "/v1/whatsapp/chats/funcionarios/similares?nome=Luis%20Gustavo",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200, r.text
+    rows = r.json()
+    ids = [x["id"] for x in rows]
+    assert func["id"] in ids
+    assert inativo["id"] not in ids
+    hit = next(x for x in rows if x["id"] == func["id"])
+    assert hit["similaridade"] is not None
+    assert hit["similaridade"] >= LIMIAR_SIMILARIDADE
+    assert hit["rede_nome"] == seed_base["rede"].nome
+
+    distinto = client.get(
+        "/v1/whatsapp/chats/funcionarios/similares?nome=Zzzzz%20Xxxxx",
+        headers=auth_headers["a1"],
+    )
+    assert distinto.status_code == 200
+    assert distinto.json() == []

--- a/backend/tests/test_mensagem_status.py
+++ b/backend/tests/test_mensagem_status.py
@@ -10,12 +10,15 @@ from app.services.mensagem_status import (
 
 
 def test_ack_evolution_para_status():
+    # Baileys WAMessageStatus: 1 PENDING, 2 SERVER_ACK, 3 DELIVERY_ACK, 4 READ
     assert ack_evolution_para_status(1) == STATUS_ENVIADA
-    assert ack_evolution_para_status(2) == STATUS_ENTREGUE
-    assert ack_evolution_para_status(3) == STATUS_LIDA
+    assert ack_evolution_para_status(2) == STATUS_ENVIADA
+    assert ack_evolution_para_status(3) == STATUS_ENTREGUE
     assert ack_evolution_para_status(4) == STATUS_LIDA
+    assert ack_evolution_para_status(5) == STATUS_LIDA
     assert ack_evolution_para_status("READ") == STATUS_LIDA
     assert ack_evolution_para_status("DELIVERY_ACK") == STATUS_ENTREGUE
+    assert ack_evolution_para_status("SERVER_ACK") == STATUS_ENVIADA
 
 
 def test_status_deve_atualizar_somente_para_frente():
@@ -29,7 +32,7 @@ def test_status_inicial_outbound_whatsapp():
     assert status_inicial_outbound_whatsapp(wa_message_id=None) == "pendente"
 
 
-def test_iter_message_status_updates():
+def test_iter_message_status_updates_nested():
     body = {
         "event": "messages.update",
         "data": {
@@ -40,4 +43,51 @@ def test_iter_message_status_updates():
     rows = list(iter_message_status_updates(body))
     assert len(rows) == 1
     assert rows[0]["wa_message_id"] == "MSG123"
+    assert rows[0]["status_entrega"] == STATUS_ENTREGUE
+
+
+def test_iter_message_status_updates_evolution_flat():
+    """Payload real Evolution MESSAGES_UPDATE (keyId + status string)."""
+    body = {
+        "event": "messages.update",
+        "data": {
+            "keyId": "3EB0C7B4E7A2B8E6D4F1",
+            "remoteJid": "5511999999999@s.whatsapp.net",
+            "fromMe": True,
+            "status": "DELIVERY_ACK",
+        },
+    }
+    rows = list(iter_message_status_updates(body))
+    assert len(rows) == 1
+    assert rows[0]["wa_message_id"] == "3EB0C7B4E7A2B8E6D4F1"
+    assert rows[0]["status_entrega"] == STATUS_ENTREGUE
+
+
+def test_iter_message_status_updates_evolution_flat_read():
+    body = {
+        "event": "MESSAGES_UPDATE",
+        "data": {
+            "keyId": "ABC123",
+            "fromMe": True,
+            "status": "READ",
+        },
+    }
+    rows = list(iter_message_status_updates(body))
+    assert len(rows) == 1
     assert rows[0]["status_entrega"] == STATUS_LIDA
+
+
+def test_iter_message_status_updates_lista_flat():
+    body = {
+        "event": "messages.update",
+        "data": [
+            {"keyId": "A1", "fromMe": True, "status": "SERVER_ACK"},
+            {"keyId": "A2", "fromMe": True, "status": "DELIVERY_ACK"},
+            {"keyId": "B1", "fromMe": False, "status": "READ"},
+        ],
+    }
+    rows = list(iter_message_status_updates(body))
+    assert [(r["wa_message_id"], r["status_entrega"]) for r in rows] == [
+        ("A1", STATUS_ENVIADA),
+        ("A2", STATUS_ENTREGUE),
+    ]

--- a/backend/tests/test_portal_cliente.py
+++ b/backend/tests/test_portal_cliente.py
@@ -1,0 +1,357 @@
+"""Portal do cliente — auth, escopo e tickets (#263 / #300–#303)."""
+
+from __future__ import annotations
+
+from app.core.security import criar_access_token, hash_senha
+from app.models.empresa import Empresa
+from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
+from app.models.ticket import Ticket, TicketMensagem
+
+
+def _criar_funcionario(
+    db_session,
+    seed_base,
+    *,
+    tipo: str,
+    email: str,
+    senha: str = "portal123",
+    empresa=None,
+    empresas_extra=None,
+    ativo: bool = True,
+    rede=None,
+):
+    emp = empresa or seed_base["empresa"]
+    rede_obj = rede or seed_base["rede"]
+    f = FuncionarioRede(
+        nome=f"Func {tipo}",
+        email=email,
+        tipo=tipo,
+        escopo_empresas="all" if tipo == "socio" else "selected",
+        ativo=ativo,
+        rede_id=rede_obj.id,
+        empresa_id=emp.id if tipo == "colaborador" else None,
+        senha_hash=hash_senha(senha),
+        must_change_password=False,
+        token_version=0,
+        notificar_email_portal=True,
+    )
+    db_session.add(f)
+    db_session.flush()
+    if tipo != "socio":
+        ids = [emp.id]
+        if empresas_extra:
+            ids.extend(e.id for e in empresas_extra)
+        for eid in dict.fromkeys(ids):
+            db_session.add(FuncionarioRedeEmpresa(funcionario_id=f.id, empresa_id=eid))
+            if tipo == "colaborador":
+                f.empresa_id = eid
+    db_session.commit()
+    db_session.refresh(f)
+    return f
+
+
+def _portal_headers(funcionario: FuncionarioRede) -> dict[str, str]:
+    tok = criar_access_token(
+        {
+            "sub": funcionario.email,
+            "aud": "portal",
+            "fid": funcionario.id,
+            "tid": 1,
+            "ver": int(funcionario.token_version or 0),
+        }
+    )
+    return {"Authorization": f"Bearer {tok}", "X-Dx-Tenant-Id": "1"}
+
+
+def test_portal_login_ok_e_inativo_403(client, db_session, seed_base):
+    f = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="colab@example.com")
+    r = client.post("/v1/portal/auth/login", json={"email": "colab@example.com", "senha": "portal123"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["access_token"]
+    assert body["must_change_password"] is False
+
+    f.ativo = False
+    db_session.commit()
+    r2 = client.post("/v1/portal/auth/login", json={"email": "colab@example.com", "senha": "portal123"})
+    assert r2.status_code == 401
+
+
+def test_portal_token_nao_acessa_painel_interno(client, db_session, seed_base, auth_headers):
+    f = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="colab2@example.com")
+    headers = _portal_headers(f)
+    r = client.get("/v1/atendentes/me", headers=headers)
+    assert r.status_code == 401
+
+    # Token interno também não passa no portal
+    r2 = client.get("/v1/portal/me", headers=auth_headers["admin"])
+    assert r2.status_code == 401
+
+
+def test_portal_me_escopo_tres_perfis(client, db_session, seed_base):
+    emp2 = Empresa(
+        tenant_id=1,
+        rede_id=seed_base["rede"].id,
+        nome="Empresa 2",
+        ativo=True,
+    )
+    db_session.add(emp2)
+    db_session.commit()
+
+    colab = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="c@example.com")
+    super_v = _criar_funcionario(
+        db_session,
+        seed_base,
+        tipo="supervisor",
+        email="s@example.com",
+        empresas_extra=[emp2],
+    )
+    socio = _criar_funcionario(db_session, seed_base, tipo="socio", email="so@example.com")
+
+    me_c = client.get("/v1/portal/me", headers=_portal_headers(colab)).json()
+    assert len(me_c["empresas"]) == 1
+    assert me_c["empresas"][0]["id"] == seed_base["empresa"].id
+
+    me_s = client.get("/v1/portal/me", headers=_portal_headers(super_v)).json()
+    ids_s = {e["id"] for e in me_s["empresas"]}
+    assert seed_base["empresa"].id in ids_s
+    assert emp2.id in ids_s
+
+    me_so = client.get("/v1/portal/me", headers=_portal_headers(socio)).json()
+    ids_so = {e["id"] for e in me_so["empresas"]}
+    assert seed_base["empresa"].id in ids_so
+    assert emp2.id in ids_so
+
+
+def test_portal_tickets_criacao_listagem_e_cross_empresa(client, db_session, seed_base):
+    emp2 = Empresa(tenant_id=1, rede_id=seed_base["rede"].id, nome="Outra Emp", ativo=True)
+    db_session.add(emp2)
+    db_session.commit()
+
+    colab = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="tix@example.com")
+    headers = _portal_headers(colab)
+
+    r = client.post(
+        "/v1/portal/tickets",
+        headers=headers,
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "PDV offline no posto",
+            "descricao": "Não inicia o sistema",
+        },
+    )
+    assert r.status_code == 201, r.text
+    ticket = r.json()
+    assert ticket["protocolo"].startswith("#T")
+    assert ticket["assunto"] == "PDV offline no posto"
+
+    # aberto_por_id gravado no banco (não exposto no schema do portal)
+    t_db = db_session.query(Ticket).filter(Ticket.id == ticket["id"]).first()
+    assert t_db is not None
+    assert t_db.aberto_por_id == colab.id
+
+    lista = client.get("/v1/portal/tickets", headers=headers)
+    assert lista.status_code == 200
+    assert lista.json()["total"] == 1
+
+    # Empresa fora do escopo → 404
+    r404 = client.post(
+        "/v1/portal/tickets",
+        headers=headers,
+        json={
+            "empresa_id": emp2.id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Não deveria",
+            "descricao": "x",
+        },
+    )
+    assert r404.status_code == 404
+
+    # Ticket de outra empresa não aparece / detalhe 404
+    outro = _criar_funcionario(
+        db_session, seed_base, tipo="colaborador", email="outro@example.com", empresa=emp2
+    )
+    r_outro = client.post(
+        "/v1/portal/tickets",
+        headers=_portal_headers(outro),
+        json={
+            "empresa_id": emp2.id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Ticket alheio",
+            "descricao": "segredo",
+        },
+    )
+    assert r_outro.status_code == 201
+    tid_alheio = r_outro.json()["id"]
+    assert client.get(f"/v1/portal/tickets/{tid_alheio}", headers=headers).status_code == 404
+
+
+def test_portal_mensagens_publicas_omit_internas(client, db_session, seed_base, auth_headers):
+    colab = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="msg@example.com")
+    headers = _portal_headers(colab)
+    created = client.post(
+        "/v1/portal/tickets",
+        headers=headers,
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Preciso de ajuda",
+            "descricao": "Descrição inicial",
+        },
+    ).json()
+    tid = created["id"]
+
+    # Atendente assume e manda pública + interna
+    client.patch(
+        f"/v1/tickets/{tid}",
+        headers=auth_headers["a1"],
+        json={"atendente_id": seed_base["a1"].id},
+    )
+    client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["a1"],
+        json={"corpo": "Estamos analisando", "tipo": "publico"},
+    )
+    client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["a1"],
+        json={"corpo": "nota interna secreta", "tipo": "interno"},
+    )
+
+    msgs = client.get(f"/v1/portal/tickets/{tid}/mensagens", headers=headers)
+    assert msgs.status_code == 200
+    corpos = [m["corpo"] for m in msgs.json()]
+    assert "Estamos analisando" in corpos
+    assert "nota interna secreta" not in corpos
+    assert all(m["tipo"] != "interno" for m in msgs.json())
+
+    # Cliente responde
+    r = client.post(
+        f"/v1/portal/tickets/{tid}/mensagens",
+        headers=headers,
+        json={"corpo": "Obrigado, aguardo"},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["autor_papel"] == "voce"
+
+    m_db = (
+        db_session.query(TicketMensagem)
+        .filter(TicketMensagem.ticket_id == tid, TicketMensagem.tipo == "email_cliente")
+        .first()
+    )
+    assert m_db is not None
+
+
+def test_portal_anexo_upload_e_download(client, db_session, seed_base):
+    colab = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="anx@example.com")
+    headers = _portal_headers(colab)
+    tid = client.post(
+        "/v1/portal/tickets",
+        headers=headers,
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Com anexo",
+            "descricao": "veja o ficheiro",
+        },
+    ).json()["id"]
+
+    up = client.post(
+        f"/v1/portal/tickets/{tid}/anexos",
+        headers=headers,
+        files={"file": ("foto.txt", b"conteudo-teste", "text/plain")},
+    )
+    assert up.status_code == 201, up.text
+    anexo_id = up.json()["id"]
+
+    dl = client.get(f"/v1/portal/tickets/{tid}/anexos/{anexo_id}/download", headers=headers)
+    assert dl.status_code == 200
+    assert dl.content == b"conteudo-teste"
+
+
+def test_portal_notificacao_email_mensagem_publica(client, db_session, seed_base, auth_headers, monkeypatch):
+    from app.services.portal_notificacoes import clear_debounce_for_tests
+
+    clear_debounce_for_tests()
+    enviados: list[dict] = []
+
+    def fake_send(db, *, to_addr, subject, body, **kwargs):
+        enviados.append({"to": to_addr, "subject": subject, "body": body})
+        return "msg-id-fake"
+
+    monkeypatch.setattr(
+        "app.services.portal_notificacoes.enviar_mensagem_texto_sistema",
+        fake_send,
+    )
+
+    colab = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="mail@example.com")
+    headers = _portal_headers(colab)
+    tid = client.post(
+        "/v1/portal/tickets",
+        headers=headers,
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Notificar",
+            "descricao": "x",
+        },
+    ).json()["id"]
+
+    client.patch(
+        f"/v1/tickets/{tid}",
+        headers=auth_headers["a1"],
+        json={"atendente_id": seed_base["a1"].id},
+    )
+    client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["a1"],
+        json={"corpo": "Resposta da equipe", "tipo": "publico"},
+    )
+    assert any("Resposta da equipe" in e["body"] for e in enviados)
+    assert any(e["to"] == "mail@example.com" for e in enviados)
+
+    # Interna não notifica
+    n_antes = len(enviados)
+    client.post(
+        f"/v1/tickets/{tid}/mensagens",
+        headers=auth_headers["a1"],
+        json={"corpo": "só interno", "tipo": "interno"},
+    )
+    assert len(enviados) == n_antes
+
+
+def test_admin_define_senha_portal_no_funcionario(client, db_session, seed_base, auth_headers):
+    # Cria sem senha via API admin
+    r = client.post(
+        "/v1/funcionarios-rede",
+        headers=auth_headers["admin"],
+        json={
+            "nome": "Sem senha",
+            "email": "novoportal@example.com",
+            "tipo": "colaborador",
+            "escopo_empresas": "selected",
+            "empresa_ids": [seed_base["empresa"].id],
+            "rede_id": seed_base["rede"].id,
+            "ativo": True,
+        },
+    )
+    assert r.status_code == 201, r.text
+    fid = r.json()["id"]
+    assert r.json()["portal_habilitado"] is False
+
+    r2 = client.patch(
+        f"/v1/funcionarios-rede/{fid}",
+        headers=auth_headers["admin"],
+        json={"senha_portal": "senhaforte1", "must_change_password": True},
+    )
+    assert r2.status_code == 200, r2.text
+    assert r2.json()["portal_habilitado"] is True
+    assert r2.json()["must_change_password"] is True
+
+    login = client.post(
+        "/v1/portal/auth/login",
+        json={"email": "novoportal@example.com", "senha": "senhaforte1"},
+    )
+    assert login.status_code == 200
+    assert login.json()["must_change_password"] is True

--- a/backend/tests/test_portal_cliente.py
+++ b/backend/tests/test_portal_cliente.py
@@ -355,3 +355,374 @@ def test_admin_define_senha_portal_no_funcionario(client, db_session, seed_base,
     )
     assert login.status_code == 200
     assert login.json()["must_change_password"] is True
+
+
+def test_criar_socio_sem_empresa_ids_normaliza_escopo_all(client, db_session, seed_base, auth_headers):
+    from app.models.funcionario_rede import FuncionarioRede
+    from app.services.funcionario_escopo import empresa_ids_vinculados, escopo_efetivo
+
+    r = client.post(
+        "/v1/funcionarios-rede",
+        headers=auth_headers["admin"],
+        json={
+            "nome": "Sócio Rede",
+            "email": "socio.rede@example.com",
+            "tipo": "socio",
+            "rede_id": seed_base["rede"].id,
+            "ativo": True,
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["escopo_empresas"] == "all"
+    assert body["tipo"] == "socio"
+    f = db_session.query(FuncionarioRede).filter(FuncionarioRede.id == body["id"]).first()
+    assert f is not None
+    assert escopo_efetivo(f) == "all"
+    assert seed_base["empresa"].id in empresa_ids_vinculados(db_session, f)
+
+
+def test_criar_funcionario_com_senha_portal_no_create(client, seed_base, auth_headers):
+    r = client.post(
+        "/v1/funcionarios-rede",
+        headers=auth_headers["admin"],
+        json={
+            "nome": "Com portal",
+            "email": "portal.create@example.com",
+            "tipo": "colaborador",
+            "escopo_empresas": "selected",
+            "empresa_ids": [seed_base["empresa"].id],
+            "rede_id": seed_base["rede"].id,
+            "ativo": True,
+            "senha_portal": "senhaforte1",
+            "must_change_password": True,
+        },
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["portal_habilitado"] is True
+
+    login = client.post(
+        "/v1/portal/auth/login",
+        json={"email": "portal.create@example.com", "senha": "senhaforte1"},
+    )
+    assert login.status_code == 200
+    assert login.json()["must_change_password"] is True
+
+
+def _ticket_portal(client, funcionario, seed_base, *, assunto: str):
+    return client.post(
+        "/v1/portal/tickets",
+        headers=_portal_headers(funcionario),
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": assunto,
+            "descricao": "teste rbac",
+        },
+    )
+
+
+def test_portal_rbac_tickets_por_papel(client, db_session, seed_base, auth_headers):
+    emp2 = Empresa(
+        tenant_id=1,
+        rede_id=seed_base["rede"].id,
+        nome="Empresa RBAC 2",
+        ativo=True,
+    )
+    db_session.add(emp2)
+    db_session.commit()
+
+    colab1 = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="rbac.c1@example.com")
+    colab2 = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="rbac.c2@example.com")
+    supervisor = _criar_funcionario(
+        db_session,
+        seed_base,
+        tipo="supervisor",
+        email="rbac.sup@example.com",
+        empresas_extra=[emp2],
+    )
+    socio = _criar_funcionario(db_session, seed_base, tipo="socio", email="rbac.so@example.com")
+
+    t1 = _ticket_portal(client, colab1, seed_base, assunto="Ticket colab 1").json()
+    t2 = _ticket_portal(client, colab2, seed_base, assunto="Ticket colab 2").json()
+    assert t1["id"] != t2["id"]
+
+    ids_c1 = {x["id"] for x in client.get("/v1/portal/tickets", headers=_portal_headers(colab1)).json()["items"]}
+    assert ids_c1 == {t1["id"]}
+    assert client.get(f"/v1/portal/tickets/{t2['id']}", headers=_portal_headers(colab1)).status_code == 404
+
+    ids_c2 = {x["id"] for x in client.get("/v1/portal/tickets", headers=_portal_headers(colab2)).json()["items"]}
+    assert ids_c2 == {t2["id"]}
+
+    ids_sup = {x["id"] for x in client.get("/v1/portal/tickets", headers=_portal_headers(supervisor)).json()["items"]}
+    assert {t1["id"], t2["id"]} <= ids_sup
+
+    ids_so = {x["id"] for x in client.get("/v1/portal/tickets", headers=_portal_headers(socio)).json()["items"]}
+    assert {t1["id"], t2["id"]} <= ids_so
+
+    interno = client.post(
+        "/v1/tickets",
+        headers=auth_headers["admin"],
+        json={
+            "empresa_id": seed_base["empresa"].id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Aberto pela equipe",
+            "descricao": "interno",
+            "prioridade": "normal",
+        },
+    )
+    assert interno.status_code == 201, interno.text
+    tid_interno = interno.json()["id"]
+    assert tid_interno not in ids_c1
+    assert client.get(f"/v1/portal/tickets/{tid_interno}", headers=_portal_headers(colab1)).status_code == 404
+    assert client.get(f"/v1/portal/tickets/{tid_interno}", headers=_portal_headers(supervisor)).status_code == 200
+    assert client.get(f"/v1/portal/tickets/{tid_interno}", headers=_portal_headers(socio)).status_code == 200
+
+    colab_emp2 = _criar_funcionario(
+        db_session,
+        seed_base,
+        tipo="colaborador",
+        email="rbac.emp2@example.com",
+        empresa=emp2,
+    )
+    t_emp2 = client.post(
+        "/v1/portal/tickets",
+        headers=_portal_headers(colab_emp2),
+        json={
+            "empresa_id": emp2.id,
+            "setor_id": seed_base["setor1"].id,
+            "assunto": "Só emp2",
+            "descricao": "x",
+        },
+    )
+    assert t_emp2.status_code == 201
+    tid_emp2 = t_emp2.json()["id"]
+    assert tid_emp2 not in ids_c1
+    assert client.get(f"/v1/portal/tickets/{tid_emp2}", headers=_portal_headers(supervisor)).status_code == 200
+
+
+def _webhook_whatsapp(wa_id: str, msg_id: str, text: str = "Olá"):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": msg_id,
+                    },
+                    "message": {"conversation": text},
+                }
+            ]
+        },
+    }
+
+
+def _chat_wpp_vinculado(client, seed_base, auth_headers, funcionario_id: int, *, wa_id: str, msg_id: str, secret: str):
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": secret},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": secret}
+    client.post("/v1/webhooks/evolution", json=_webhook_whatsapp(wa_id, msg_id), headers=h)
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    client.post(
+        f"/v1/whatsapp/chats/{cid}/vincular-funcionario",
+        json={"funcionario_rede_id": funcionario_id},
+        headers=auth_headers["a1"],
+    )
+    return cid
+
+
+def test_portal_chats_rbac_e_mensagens(client, db_session, seed_base, auth_headers):
+    colab1 = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="wpp.c1@example.com")
+    colab2 = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="wpp.c2@example.com")
+    supervisor = _criar_funcionario(db_session, seed_base, tipo="supervisor", email="wpp.sup@example.com")
+    socio = _criar_funcionario(db_session, seed_base, tipo="socio", email="wpp.so@example.com")
+
+    cid1 = _chat_wpp_vinculado(
+        client, seed_base, auth_headers, colab1.id, wa_id="5511888000001", msg_id="pw-1", secret="portal-wpp-1"
+    )
+    cid2 = _chat_wpp_vinculado(
+        client, seed_base, auth_headers, colab2.id, wa_id="5511888000002", msg_id="pw-2", secret="portal-wpp-2"
+    )
+
+    ids_c1 = {x["id"] for x in client.get("/v1/portal/chats", headers=_portal_headers(colab1)).json()["items"]}
+    assert ids_c1 == {cid1}
+    assert client.get(f"/v1/portal/chats/{cid2}", headers=_portal_headers(colab1)).status_code == 404
+
+    ids_sup = {x["id"] for x in client.get("/v1/portal/chats", headers=_portal_headers(supervisor)).json()["items"]}
+    assert {cid1, cid2} <= ids_sup
+
+    ids_so = {x["id"] for x in client.get("/v1/portal/chats", headers=_portal_headers(socio)).json()["items"]}
+    assert {cid1, cid2} <= ids_so
+
+    client.post(
+        f"/v1/whatsapp/chats/{cid1}/comentarios-internos",
+        headers=auth_headers["a1"],
+        json={"texto": "nota secreta"},
+    )
+
+    msgs = client.get(f"/v1/portal/chats/{cid1}/mensagens", headers=_portal_headers(colab1)).json()
+    corpos = [m["corpo"] for m in msgs]
+    assert any("Olá" in c for c in corpos)
+    assert not any("nota secreta" in c for c in corpos)
+    assert not any("INTERNO" in c for c in corpos)
+
+    det = client.get(f"/v1/portal/chats/{cid1}", headers=_portal_headers(colab1)).json()
+    assert det["protocolo"].startswith("#")
+    assert det["empresa_id"] == seed_base["empresa"].id
+
+
+def test_portal_equipe_403_nao_socio(client, db_session, seed_base):
+    colab = _criar_funcionario(db_session, seed_base, tipo="colaborador", email="eq.c@example.com")
+    supervisor = _criar_funcionario(db_session, seed_base, tipo="supervisor", email="eq.s@example.com")
+    for headers in (_portal_headers(colab), _portal_headers(supervisor)):
+        assert client.get("/v1/portal/equipe/funcionarios", headers=headers).status_code == 403
+        assert client.get("/v1/portal/equipe/empresas", headers=headers).status_code == 403
+        assert (
+            client.post(
+                "/v1/portal/equipe/funcionarios",
+                headers=headers,
+                json={
+                    "nome": "Novo",
+                    "email": "novo@example.com",
+                    "tipo": "colaborador",
+                    "empresa_id": seed_base["empresa"].id,
+                    "ativo": True,
+                },
+            ).status_code
+            == 403
+        )
+
+
+def test_portal_equipe_socio_crud_e_restricoes(client, db_session, seed_base):
+    emp2 = Empresa(
+        tenant_id=1,
+        rede_id=seed_base["rede"].id,
+        nome="Empresa Equipe 2",
+        ativo=True,
+    )
+    db_session.add(emp2)
+    db_session.commit()
+
+    socio = _criar_funcionario(db_session, seed_base, tipo="socio", email="eq.so@example.com")
+    outro_socio = _criar_funcionario(db_session, seed_base, tipo="socio", email="eq.so2@example.com")
+    headers = _portal_headers(socio)
+
+    lista = client.get("/v1/portal/equipe/funcionarios", headers=headers)
+    assert lista.status_code == 200, lista.text
+    emails = {x["email"] for x in lista.json()["items"]}
+    assert "eq.so@example.com" in emails
+    assert "eq.so2@example.com" in emails
+
+    empresas = client.get("/v1/portal/equipe/empresas", headers=headers)
+    assert empresas.status_code == 200
+    ids_emp = {e["id"] for e in empresas.json()}
+    assert seed_base["empresa"].id in ids_emp
+    assert emp2.id in ids_emp
+
+    r_socio = client.post(
+        "/v1/portal/equipe/funcionarios",
+        headers=headers,
+        json={
+            "nome": "Não pode",
+            "email": "nao.socio@example.com",
+            "tipo": "socio",
+            "ativo": True,
+        },
+    )
+    assert r_socio.status_code == 422
+
+    r_colab = client.post(
+        "/v1/portal/equipe/funcionarios",
+        headers=headers,
+        json={
+            "nome": "Colab Portal",
+            "email": "colab.portal@example.com",
+            "tipo": "colaborador",
+            "empresa_id": seed_base["empresa"].id,
+            "senha_portal": "senhaforte1",
+            "must_change_password": True,
+            "ativo": True,
+        },
+    )
+    assert r_colab.status_code == 201, r_colab.text
+    fid = r_colab.json()["id"]
+    assert r_colab.json()["portal_habilitado"] is True
+    assert r_colab.json()["tipo"] == "colaborador"
+
+    login = client.post(
+        "/v1/portal/auth/login",
+        json={"email": "colab.portal@example.com", "senha": "senhaforte1"},
+    )
+    assert login.status_code == 200
+
+    r_sup = client.patch(
+        f"/v1/portal/equipe/funcionarios/{fid}",
+        headers=headers,
+        json={
+            "tipo": "supervisor",
+            "empresa_ids": [seed_base["empresa"].id, emp2.id],
+            "nome": "Super Portal",
+        },
+    )
+    assert r_sup.status_code == 200, r_sup.text
+    assert r_sup.json()["tipo"] == "supervisor"
+    assert set(r_sup.json()["empresa_ids"]) == {seed_base["empresa"].id, emp2.id}
+
+    r_outro = client.patch(
+        f"/v1/portal/equipe/funcionarios/{outro_socio.id}",
+        headers=headers,
+        json={"nome": "Tentativa inválida", "ativo": False},
+    )
+    assert r_outro.status_code == 400, r_outro.text
+
+    r_outro_ok = client.patch(
+        f"/v1/portal/equipe/funcionarios/{outro_socio.id}",
+        headers=headers,
+        json={"ativo": False, "notificar_email_portal": False},
+    )
+    assert r_outro_ok.status_code == 200, r_outro_ok.text
+    assert r_outro_ok.json()["ativo"] is False
+    assert r_outro_ok.json()["notificar_email_portal"] is False
+
+
+def test_portal_public_branding_compartilha_settings(client, auth_headers):
+    client.put(
+        "/v1/kb/portal-settings",
+        headers=auth_headers["admin"],
+        json={
+            "portal_titulo": "Suporte ACME",
+            "cor_header": "#112233",
+            "cor_primaria": "#AABBCC",
+            "cor_texto_header": "#FFFFFF",
+            "cor_texto_corpo": "#222222",
+            "cor_fundo": "#EEEEEE",
+            "cor_link": "#0055AA",
+            "texto_boas_vindas": "Bem-vindo ao suporte ACME.",
+        },
+    )
+    kb = client.get("/v1/kb/public/branding")
+    portal = client.get("/v1/portal/public/branding")
+    assert kb.status_code == 200, kb.text
+    assert portal.status_code == 200, portal.text
+    kb_body = kb.json()
+    portal_body = portal.json()
+    assert kb_body["cor_primaria"] == "#AABBCC"
+    assert portal_body["cor_primaria"] == "#AABBCC"
+    assert kb_body["portal_titulo"] == "Suporte ACME"
+    assert portal_body["portal_titulo"] == "Portal do cliente"
+    assert portal_body["texto_boas_vindas"] == "Bem-vindo ao suporte ACME."
+
+
+def test_portal_public_branding_fallback_sem_settings(client):
+    r = client.get("/v1/portal/public/branding")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["portal_titulo"] == "Portal do cliente"
+    assert body["cor_primaria"] == "#0D9488"
+    assert body["logo_url"] is None

--- a/backend/tests/test_whatsapp_avaliacao.py
+++ b/backend/tests/test_whatsapp_avaliacao.py
@@ -117,6 +117,9 @@ def test_resposta_nota_encerra_chat(client, seed_base, auth_headers, db_session,
 
 
 def test_resposta_invalida_encerra_sem_avaliacao(client, seed_base, auth_headers, db_session, monkeypatch):
+    """API legada: encerrar_avaliacao_sem_nota com motivo invalida."""
+    from app.services.whatsapp_avaliacao import encerrar_avaliacao_sem_nota
+
     st = _configurar(db_session)
     chat = WhatsappChat(
         protocolo="WPP-AV-2",
@@ -139,7 +142,7 @@ def test_resposta_invalida_encerra_sem_avaliacao(client, seed_base, auth_headers
 
     msg = WhatsappMensagem(chat_id=chat.id, direcao="inbound", corpo="ótimo", tipo_midia="texto")
     db_session.add(msg)
-    processar_resposta_avaliacao(db_session, chat, st, "ótimo", msg_inbound=msg)
+    encerrar_avaliacao_sem_nota(db_session, chat, st, motivo="invalida", msg_inbound=msg)
     db_session.commit()
     db_session.refresh(chat)
 
@@ -148,6 +151,174 @@ def test_resposta_invalida_encerra_sem_avaliacao(client, seed_base, auth_headers
     assert msg.evento_sistema == "avaliacao_cliente_invalida"
     assert enviados
     assert "sem avaliação" in enviados[0].lower() or "encerrado" in enviados[0].lower()
+
+
+def test_processar_nao_nota_nao_altera_chat(client, seed_base, auth_headers, db_session, monkeypatch):
+    st = _configurar(db_session)
+    chat = WhatsappChat(
+        protocolo="WPP-AV-2b",
+        wa_id="5511999223355",
+        estado="aguardando_avaliacao",
+        atendente_id=1,
+        avaliacao_solicitada=True,
+    )
+    db_session.add(chat)
+    db_session.commit()
+    monkeypatch.setattr(
+        "app.services.whatsapp_avaliacao.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "x"),
+    )
+    assert processar_resposta_avaliacao(db_session, chat, st, "ótimo") == "nao_nota"
+    db_session.refresh(chat)
+    assert chat.estado == "aguardando_avaliacao"
+
+
+def test_webhook_texto_nao_nota_abre_chat_novo(client, seed_base, auth_headers, db_session, monkeypatch):
+    """#598 — texto que não é nota encerra avaliação e abre atendimento com a mensagem."""
+    from datetime import datetime, timezone
+
+    from tests.test_whatsapp_chats import _webhook_body
+
+    _configurar(db_session)
+    monkeypatch.setattr(
+        "app.services.whatsapp_avaliacao.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-pular"),
+    )
+    monkeypatch.setattr(
+        "app.api.whatsapp_webhook.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-espera"),
+    )
+    wa = "5511999000598"
+    antigo = WhatsappChat(
+        protocolo="WPP-AV-598-A",
+        wa_id=wa,
+        estado="aguardando_avaliacao",
+        atendente_id=seed_base["a1"].id,
+        avaliacao_solicitada=True,
+        encerramento_at=datetime.now(timezone.utc),
+    )
+    db_session.add(antigo)
+    db_session.commit()
+    antigo_id = antigo.id
+    db_session.close()
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "av-598-pular", "auto_msg_espera_ativa": False, "auto_msg_fora_horario_ativa": False},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "av-598-pular"}
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id=wa, msg_id="598-nao-nota", text="Preciso de ajuda de novo"),
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+
+    db_session.expire_all()
+    antigo2 = db_session.query(WhatsappChat).filter(WhatsappChat.id == antigo_id).first()
+    assert antigo2 is not None
+    assert antigo2.estado == "encerrado"
+    assert antigo2.avaliacao_nota is None
+
+    novos = (
+        db_session.query(WhatsappChat)
+        .filter(
+            WhatsappChat.wa_id == wa,
+            WhatsappChat.estado == "aguardando_atendente",
+        )
+        .all()
+    )
+    assert len(novos) == 1
+    msgs = (
+        db_session.query(WhatsappMensagem)
+        .filter(
+            WhatsappMensagem.chat_id == novos[0].id,
+            WhatsappMensagem.direcao == "inbound",
+        )
+        .all()
+    )
+    assert len(msgs) == 1
+    assert msgs[0].corpo == "Preciso de ajuda de novo"
+
+
+def test_timeout_avaliacao_encerra_chat(client, seed_base, auth_headers, db_session, monkeypatch):
+    """#598 — após a janela, job finaliza aguardando_avaliacao."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.services.whatsapp_avaliacao import process_whatsapp_avaliacao_timeouts
+
+    st = _configurar(db_session)
+    st.avaliacao_janela_minutos = 30
+    db_session.commit()
+
+    enviados: list[str] = []
+
+    def fake_send(base, inst, key, wa, text):
+        enviados.append(text)
+        return True, None, "wa-timeout"
+
+    monkeypatch.setattr("app.services.whatsapp_avaliacao.evolution_api.evolution_send_text", fake_send)
+
+    chat = WhatsappChat(
+        protocolo="WPP-AV-TO",
+        wa_id="5511999000599",
+        estado="aguardando_avaliacao",
+        atendente_id=seed_base["a1"].id,
+        avaliacao_solicitada=True,
+        encerramento_at=datetime.now(timezone.utc) - timedelta(minutes=31),
+    )
+    db_session.add(chat)
+    db_session.commit()
+
+    n = process_whatsapp_avaliacao_timeouts(db_session, limit=50)
+    assert n == 1
+    db_session.refresh(chat)
+    assert chat.estado == "encerrado"
+    assert chat.avaliacao_nota is None
+    assert enviados
+    assert "período" in enviados[0].lower() or "encerrou" in enviados[0].lower() or "nova mensagem" in enviados[0].lower()
+
+
+def test_inbound_apos_timeout_abre_chat_novo(client, seed_base, auth_headers, db_session, monkeypatch):
+    """#598 — após timeout, próxima mensagem abre atendimento novo."""
+    from datetime import datetime, timezone
+
+    from tests.test_whatsapp_chats import _webhook_body
+
+    _configurar(db_session)
+    monkeypatch.setattr(
+        "app.api.whatsapp_webhook.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-esp"),
+    )
+    wa = "5511999000600"
+    db_session.add(
+        WhatsappChat(
+            protocolo="WPP-AV-POS-TO",
+            wa_id=wa,
+            estado="encerrado",
+            atendente_id=seed_base["a1"].id,
+            avaliacao_solicitada=True,
+            encerramento_at=datetime.now(timezone.utc),
+        )
+    )
+    db_session.commit()
+    db_session.close()
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "av-598-pos", "auto_msg_espera_ativa": False, "auto_msg_fora_horario_ativa": False},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "av-598-pos"}
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id=wa, msg_id="598-pos-to", text="Oi de novo"),
+        headers=h,
+    )
+    assert r.status_code == 200
+    fila = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()
+    assert any(c.get("wa_id") == wa for c in fila)
 
 
 def test_mensagens_avaliacao_nao_aparecem_na_conversa(client, seed_base, auth_headers, db_session):

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -445,6 +445,97 @@ def test_vincular_funcionario_no_chat(client, seed_base, auth_headers, db_sessio
     assert get_r.json()["funcionario_rede_id"] == func["id"]
 
 
+def test_encerrados_inclui_empresa_nome(client, seed_base, auth_headers, db_session):
+    """#590 — listagem Atendimentos deve serializar empresa_nome do chat."""
+    func = _criar_funcionario_colaborador(db_session, seed_base, email="hist-emp@test.local")
+    cid = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999445566", msg_id="hist-emp-1")
+    client.post(
+        f"/v1/whatsapp/chats/{cid}/vincular-funcionario",
+        json={"funcionario_rede_id": func["id"]},
+        headers=auth_headers["a1"],
+    )
+    client.post(f"/v1/whatsapp/chats/{cid}/encerrar", headers=auth_headers["a1"])
+
+    hist = client.get("/v1/whatsapp/chats/encerrados", headers=auth_headers["admin"]).json()
+    item = next(x for x in hist["items"] if x["id"] == cid)
+    assert item["empresa_id"] == seed_base["empresa"].id
+    assert item["empresa_nome"]
+
+
+def test_encerrados_filtra_por_empresa_id(client, seed_base, auth_headers, db_session):
+    """#591 — filtro empresa_id isola chats de outras empresas."""
+    from app.models.empresa import Empresa
+    from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
+    from app.models.whatsapp_chat import WhatsappChat
+
+    emp_a = seed_base["empresa"]
+    emp_b = Empresa(tenant_id=1, rede_id=emp_a.rede_id, nome="Empresa Isolamento B", ativo=True)
+    db_session.add(emp_b)
+    db_session.flush()
+
+    fa = FuncionarioRede(
+        nome="Func A",
+        email="func.a.iso@test.local",
+        tipo="colaborador",
+        escopo_empresas="selected",
+        ativo=True,
+        rede_id=emp_a.rede_id,
+        empresa_id=emp_a.id,
+    )
+    fb = FuncionarioRede(
+        nome="Func B",
+        email="func.b.iso@test.local",
+        tipo="colaborador",
+        escopo_empresas="selected",
+        ativo=True,
+        rede_id=emp_a.rede_id,
+        empresa_id=emp_b.id,
+    )
+    db_session.add_all([fa, fb])
+    db_session.flush()
+    db_session.add(FuncionarioRedeEmpresa(funcionario_id=fa.id, empresa_id=emp_a.id))
+    db_session.add(FuncionarioRedeEmpresa(funcionario_id=fb.id, empresa_id=emp_b.id))
+    db_session.commit()
+
+    cid_a = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999110001", msg_id="iso-a-1")
+    client.post(
+        f"/v1/whatsapp/chats/{cid_a}/vincular-funcionario",
+        json={"funcionario_rede_id": fa.id, "empresa_id": emp_a.id},
+        headers=auth_headers["a1"],
+    )
+    client.post(f"/v1/whatsapp/chats/{cid_a}/encerrar", headers=auth_headers["a1"])
+
+    cid_b = _chat_ativo(client, seed_base, auth_headers, wa_id="5511999110002", msg_id="iso-b-1")
+    client.post(
+        f"/v1/whatsapp/chats/{cid_b}/vincular-funcionario",
+        json={"funcionario_rede_id": fb.id, "empresa_id": emp_b.id},
+        headers=auth_headers["a1"],
+    )
+    client.post(f"/v1/whatsapp/chats/{cid_b}/encerrar", headers=auth_headers["a1"])
+
+    # Garante empresa_id no banco (fallback se vínculo legado)
+    for cid, eid in ((cid_a, emp_a.id), (cid_b, emp_b.id)):
+        chat = db_session.query(WhatsappChat).filter(WhatsappChat.id == cid).first()
+        chat.empresa_id = eid
+    db_session.commit()
+
+    only_a = client.get(
+        f"/v1/whatsapp/chats/encerrados?empresa_id={emp_a.id}&estado=todos",
+        headers=auth_headers["admin"],
+    ).json()
+    ids_a = {x["id"] for x in only_a["items"]}
+    assert cid_a in ids_a
+    assert cid_b not in ids_a
+
+    only_b = client.get(
+        f"/v1/whatsapp/chats/encerrados?empresa_id={emp_b.id}&estado=todos",
+        headers=auth_headers["admin"],
+    ).json()
+    ids_b = {x["id"] for x in only_b["items"]}
+    assert cid_b in ids_b
+    assert cid_a not in ids_b
+
+
 def test_buscar_funcionarios_whatsapp(client, seed_base, auth_headers, db_session):
     func = _criar_funcionario_colaborador(db_session, seed_base, nome="Maria Silva", email="maria@test.local")
     r = client.get("/v1/whatsapp/chats/funcionarios?busca=Maria", headers=auth_headers["a1"])
@@ -946,3 +1037,137 @@ def test_iniciar_chat_funcionario_sem_telefone_exige_numero(client, seed_base, a
     f = db_session.query(FuncionarioRede).filter(FuncionarioRede.id == func["id"]).first()
     db_session.refresh(f)
     assert f.telefone == "5511999000033"
+
+
+def _criar_funcionario_multi_empresa(db_session, seed_base, *, email="multi.emp@test.local"):
+    from app.models.empresa import Empresa
+    from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
+
+    emp = seed_base["empresa"]
+    e2 = Empresa(tenant_id=1, rede_id=emp.rede_id, nome="Empresa Filial B", ativo=True)
+    db_session.add(e2)
+    db_session.flush()
+    f = FuncionarioRede(
+        nome="Multi Empresa",
+        email=email,
+        tipo="colaborador",
+        escopo_empresas="selected",
+        ativo=True,
+        rede_id=emp.rede_id,
+        empresa_id=emp.id,
+        telefone="5511999000099",
+    )
+    db_session.add(f)
+    db_session.flush()
+    db_session.add(FuncionarioRedeEmpresa(funcionario_id=f.id, empresa_id=emp.id))
+    db_session.add(FuncionarioRedeEmpresa(funcionario_id=f.id, empresa_id=e2.id))
+    db_session.commit()
+    db_session.refresh(f)
+    db_session.refresh(e2)
+    return {"id": f.id, "empresa_a": emp.id, "empresa_b": e2.id, "telefone": f.telefone}
+
+
+def test_iniciar_chat_1_empresa_auto(client, seed_base, auth_headers, db_session, monkeypatch):
+    """#592 — funcionário com 1 empresa: inicia sem empresa_id no body."""
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out"),
+    )
+    _evolution_settings(client, auth_headers, "iniciar-1emp")
+    func = _criar_funcionario_colaborador(db_session, seed_base, email="um.emp@test.local")
+    from app.models.funcionario_rede import FuncionarioRede
+
+    f = db_session.query(FuncionarioRede).filter(FuncionarioRede.id == func["id"]).first()
+    f.telefone = "5511999000044"
+    db_session.commit()
+
+    r = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"funcionario_id": func["id"]},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["empresa_id"] == seed_base["empresa"].id
+    assert body["empresa_nome"]
+
+
+def test_iniciar_chat_multi_empresa_permite_sem_empresa_id(client, seed_base, auth_headers, db_session, monkeypatch):
+    """#592 — >1 empresas: pode iniciar sem empresa_id e definir depois; inválida → 400."""
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out"),
+    )
+    _evolution_settings(client, auth_headers, "iniciar-multi")
+    multi = _criar_funcionario_multi_empresa(db_session, seed_base)
+
+    sem = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"funcionario_id": multi["id"]},
+        headers=auth_headers["a1"],
+    )
+    assert sem.status_code == 200
+    body = sem.json()
+    assert body["empresa_id"] is None
+    assert body["funcionario_rede_id"] == multi["id"]
+    assert len(body.get("empresas_opcoes") or []) >= 2
+
+    invalid = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"funcionario_id": multi["id"], "telefone": "5511999000077", "empresa_id": 999999},
+        headers=auth_headers["a1"],
+    )
+    assert invalid.status_code == 400
+
+    ok = client.post(
+        f"/v1/whatsapp/chats/{body['id']}/empresa-contexto",
+        json={"empresa_id": multi["empresa_b"]},
+        headers=auth_headers["a1"],
+    )
+    assert ok.status_code == 200
+    assert ok.json()["empresa_id"] == multi["empresa_b"]
+
+    # Pode alterar enquanto não encerrado
+    trocou = client.post(
+        f"/v1/whatsapp/chats/{body['id']}/empresa-contexto",
+        json={"empresa_id": multi["empresa_a"]},
+        headers=auth_headers["a1"],
+    )
+    assert trocou.status_code == 200
+    assert trocou.json()["empresa_id"] == multi["empresa_a"]
+
+
+def test_assumir_multi_empresa_sem_bloquear(client, seed_base, auth_headers, db_session):
+    """#592 — assumir multi-empresa sem empresa_id é permitido; contexto fica para depois."""
+    multi = _criar_funcionario_multi_empresa(db_session, seed_base, email="assumir.multi@test.local")
+    from app.models.whatsapp_chat import WhatsappChat
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "assumir-multi"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "assumir-multi"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511999000088", msg_id="assumir-multi-1"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    chat = db_session.query(WhatsappChat).filter(WhatsappChat.id == cid).first()
+    chat.funcionario_rede_id = multi["id"]
+    chat.empresa_id = None
+    db_session.commit()
+
+    ok = client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    assert ok.status_code == 200
+    assert ok.json()["empresa_id"] is None
+    assert ok.json()["estado"] == "em_atendimento"
+
+    ctx = client.post(
+        f"/v1/whatsapp/chats/{cid}/empresa-contexto",
+        json={"empresa_id": multi["empresa_a"]},
+        headers=auth_headers["a1"],
+    )
+    assert ctx.status_code == 200
+    assert ctx.json()["empresa_id"] == multi["empresa_a"]

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -1171,3 +1171,109 @@ def test_assumir_multi_empresa_sem_bloquear(client, seed_base, auth_headers, db_
     )
     assert ctx.status_code == 200
     assert ctx.json()["empresa_id"] == multi["empresa_a"]
+
+
+def _webhook_body_multi(wa_id: str, messages: list[tuple[str, str]]):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": msg_id,
+                    },
+                    "message": {"conversation": text},
+                }
+                for msg_id, text in messages
+            ]
+        },
+    }
+
+
+def test_webhook_duas_mensagens_mesmo_payload_um_chat(client, seed_base, auth_headers, db_session):
+    """#608 — duas mensagens inbound no mesmo payload → um chat, duas mensagens."""
+    from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "dup-payload", "auto_msg_espera_ativa": False, "auto_msg_fora_horario_ativa": False},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "dup-payload"}
+    wa_id = "5511999000608"
+    body = _webhook_body_multi(
+        wa_id,
+        [("608-a", "Bom dia"), ("608-b", "Td bem?")],
+    )
+    r = client.post("/v1/webhooks/evolution", json=body, headers=h)
+    assert r.status_code == 200
+    assert r.json().get("processados") == 2
+
+    abertos = (
+        db_session.query(WhatsappChat)
+        .filter(
+            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.estado.in_(("aguardando_atendente", "em_atendimento")),
+        )
+        .all()
+    )
+    assert len(abertos) == 1
+    msgs = (
+        db_session.query(WhatsappMensagem)
+        .filter(
+            WhatsappMensagem.chat_id == abertos[0].id,
+            WhatsappMensagem.direcao == "inbound",
+        )
+        .all()
+    )
+    assert len(msgs) == 2
+    assert {m.corpo for m in msgs} == {"Bom dia", "Td bem?"}
+
+
+def test_webhook_mensagens_paralelas_mesmo_wa_id_um_chat(client, seed_base, auth_headers, db_session):
+    """#608 — webhooks paralelos do mesmo wa_id → um único chat aberto."""
+    import threading
+
+    from app.models.whatsapp_chat import WhatsappChat
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "dup-race", "auto_msg_espera_ativa": False, "auto_msg_fora_horario_ativa": False},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "dup-race"}
+    wa_id = "5511999000609"
+    barrier = threading.Barrier(2)
+    errors: list[Exception] = []
+
+    def post(msg_id: str, text: str) -> None:
+        try:
+            barrier.wait(timeout=5)
+            r = client.post(
+                "/v1/webhooks/evolution",
+                json=_webhook_body(wa_id=wa_id, msg_id=msg_id, text=text),
+                headers=h,
+            )
+            assert r.status_code == 200
+        except Exception as exc:
+            errors.append(exc)
+
+    t1 = threading.Thread(target=post, args=("608-r1", "Olá"))
+    t2 = threading.Thread(target=post, args=("608-r2", "Tudo bem?"))
+    t1.start()
+    t2.start()
+    t1.join(timeout=30)
+    t2.join(timeout=30)
+    assert not errors, errors
+
+    abertos = (
+        db_session.query(WhatsappChat)
+        .filter(
+            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.estado.in_(("aguardando_atendente", "em_atendimento")),
+        )
+        .all()
+    )
+    assert len(abertos) == 1

--- a/backend/tests/test_whatsapp_inatividade_encerramento.py
+++ b/backend/tests/test_whatsapp_inatividade_encerramento.py
@@ -126,7 +126,10 @@ def test_worker_encerra_apos_aviso(client, seed_base, auth_headers, db_session, 
     assert chat.encerramento_at is not None
 
 
-def test_worker_nao_age_quando_cliente_respondeu_por_ultimo(client, seed_base, auth_headers, db_session, monkeypatch):
+def test_worker_nao_age_quando_ultima_mensagem_recente_do_cliente(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    """Cliente falou há 1 min — silêncio ainda dentro do prazo."""
     _configurar_evolution(db_session)
     chat = _chat_em_atendimento(db_session, wa_id="5511999665544")
     antiga = datetime.now(timezone.utc) - timedelta(minutes=20)
@@ -195,9 +198,10 @@ def test_worker_nao_age_so_com_auto_assumido(client, seed_base, auth_headers, db
     assert n == 0
 
 
-def test_worker_aviso_mesmo_com_atendente_enviando_varias_vezes(
+def test_worker_nao_avisa_se_ultima_mensagem_recente(
     client, seed_base, auth_headers, db_session, monkeypatch
 ):
+    """Última mensagem do atendente há 2 min reinicia o prazo — não avisa ainda."""
     _configurar_evolution(db_session)
     chat = _chat_em_atendimento(db_session, wa_id="5511999554433")
     t_cliente = datetime.now(timezone.utc) - timedelta(minutes=25)
@@ -229,7 +233,67 @@ def test_worker_aviso_mesmo_com_atendente_enviando_varias_vezes(
     )
 
     n = process_whatsapp_inactivity_closures(db_session)
+    assert n == 0
+
+
+def test_worker_avisa_apos_silencio_desde_ultima_msg_atendente(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session, wa_id="5511999554400")
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="inbound",
+            corpo="Oi",
+            tipo_midia="texto",
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=30),
+        )
+    )
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Aguarde",
+            tipo_midia="texto",
+            atendente_id=1,
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=15),
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-silencio"),
+    )
+
+    n = process_whatsapp_inactivity_closures(db_session)
     assert n == 1
+
+
+def test_worker_respeita_pausa_inatividade(client, seed_base, auth_headers, db_session, monkeypatch):
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session, wa_id="5511999554411")
+    chat.inatividade_pausada = True
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Analisando",
+            tipo_midia="texto",
+            atendente_id=1,
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=30),
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-pausa"),
+    )
+
+    n = process_whatsapp_inactivity_closures(db_session)
+    assert n == 0
 
 
 def test_worker_nao_reenvia_aviso_duplicado_no_mesmo_ciclo(

--- a/backend/tests/test_whatsapp_inatividade_encerramento.py
+++ b/backend/tests/test_whatsapp_inatividade_encerramento.py
@@ -22,13 +22,13 @@ def _configurar_evolution(db_session):
     db_session.commit()
 
 
-def _chat_em_atendimento(db_session, *, wa_id: str = "5511999887766") -> WhatsappChat:
+def _chat_em_atendimento(db_session, *, wa_id: str = "5511999887766", atendente_id: int = 1) -> WhatsappChat:
     chat = WhatsappChat(
         protocolo="WPP-TEST-1",
         wa_id=wa_id,
         cliente_nome="Cliente Teste",
         estado="em_atendimento",
-        atendente_id=1,
+        atendente_id=atendente_id,
     )
     db_session.add(chat)
     db_session.flush()
@@ -124,6 +124,172 @@ def test_worker_encerra_apos_aviso(client, seed_base, auth_headers, db_session, 
     assert n == 1
     assert chat.estado == "encerrado"
     assert chat.encerramento_at is not None
+    assert chat.classificacao_demanda_pendente is True
+    marco = (
+        db_session.query(WhatsappMensagem)
+        .filter(
+            WhatsappMensagem.chat_id == chat.id,
+            WhatsappMensagem.evento_sistema == "auto_encerrado_inatividade",
+        )
+        .first()
+    )
+    assert marco is not None
+
+
+def test_pode_registrar_demanda_apos_encerramento_inatividade(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    chat = _chat_em_atendimento(db_session, wa_id="5511999112233", atendente_id=a1_id)
+    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=antiga_aviso,
+        )
+    )
+    nat = TicketNatureza(nome="Nat Inativ", slug="nat-inativ-test", ordem=1, ativo=True)
+    db_session.add(nat)
+    db_session.flush()
+    mot = TicketMotivo(natureza_id=nat.id, nome="Mot Inativ", slug="mot-inativ-test", ordem=1, ativo=True)
+    db_session.add(mot)
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-dem"),
+    )
+    process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+    assert chat.estado == "encerrado"
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{chat.id}/demandas",
+        json={"natureza_id": nat.id, "motivo_id": mot.id, "descricao_curta": "Pós-inatividade"},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["descricao_curta"] == "Pós-inatividade"
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is False
+
+
+def test_concluir_classificacao_sem_demanda(client, seed_base, auth_headers, db_session, monkeypatch):
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    chat = _chat_em_atendimento(db_session, wa_id="5511999223344", atendente_id=a1_id)
+    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=antiga_aviso,
+        )
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-cls"),
+    )
+    process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is True
+
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    assert any(c["id"] == chat.id and c.get("classificacao_demanda_pendente") for c in meus)
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{chat.id}/classificacao-demanda/concluir",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["classificacao_demanda_pendente"] is False
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is False
+
+
+def test_inbound_abre_chat_novo_quando_pendente_classificacao(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    """Cliente manda mensagem nova: chat a classificar permanece; abre atendimento novo."""
+    from tests.test_whatsapp_chats import _webhook_body
+
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    wa = "5511888001122"
+    chat = _chat_em_atendimento(db_session, wa_id=wa, atendente_id=a1_id)
+    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=antiga_aviso,
+        )
+    )
+    db_session.commit()
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-new"),
+    )
+    # Também mock envio de auto_espera no webhook (ids únicos — uq wa_message_id)
+    _wa_seq = {"n": 0}
+
+    def _fake_send(*_a, **_k):
+        _wa_seq["n"] += 1
+        return True, None, f"wa-espera-{_wa_seq['n']}"
+
+    monkeypatch.setattr(
+        "app.api.whatsapp_webhook.evolution_api.evolution_send_text",
+        _fake_send,
+    )
+    process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is True
+    pendente_id = chat.id
+    # Libera a conexão StaticPool antes do TestClient (outra Session no mesmo SQLite).
+    db_session.close()
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "sec-pendente-novo"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "sec-pendente-novo"}
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id=wa, msg_id="msg-nova-pos-inativ", text="Oi de novo"),
+        headers=h,
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("processados", 0) >= 1, body
+
+    fila = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()
+    novos = [c for c in fila if c["wa_id"] == wa and c["id"] != pendente_id]
+    assert len(novos) == 1, fila
+    assert novos[0]["estado"] == "aguardando_atendente"
+    assert novos[0].get("classificacao_demanda_pendente") is False
+
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    pendentes = [c for c in meus if c["id"] == pendente_id]
+    assert len(pendentes) == 1, meus
+    assert pendentes[0].get("classificacao_demanda_pendente") is True
 
 
 def test_worker_nao_age_quando_ultima_mensagem_recente_do_cliente(
@@ -350,3 +516,98 @@ def test_worker_nao_reenvia_aviso_duplicado_no_mesmo_ciclo(
         .count()
     )
     assert total_avisos == 1
+
+
+def test_envio_mensagem_sai_da_pausa_inatividade(client, seed_base, auth_headers, db_session, monkeypatch):
+    """Outbound humana do atendente limpa a pausa manual (reinicia o ciclo pelo timestamp da msg)."""
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    chat = _chat_em_atendimento(db_session, wa_id="5511999554422", atendente_id=a1_id)
+    chat.inatividade_pausada = True
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Analisando",
+            tipo_midia="texto",
+            atendente_id=a1_id,
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-despausa"),
+    )
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{chat.id}/mensagens",
+        json={"texto": "Já resolvi"},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 201, r.text
+    db_session.refresh(chat)
+    assert chat.inatividade_pausada is False
+    assert chat.inatividade_retomada_em is None
+
+
+def test_concluir_classificacao_com_demandas_existentes(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    """Confirmar «manter demandas» pós-inatividade limpa o pendente (não fica preso na lista)."""
+    from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+    from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
+
+    _configurar_evolution(db_session)
+    a1_id = seed_base["a1"].id
+    chat = _chat_em_atendimento(db_session, wa_id="5511999554433", atendente_id=a1_id)
+    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=antiga_aviso,
+        )
+    )
+    nat = TicketNatureza(nome="Nat Manter", slug="nat-manter-inativ", ordem=1, ativo=True)
+    db_session.add(nat)
+    db_session.flush()
+    mot = TicketMotivo(natureza_id=nat.id, nome="Mot Manter", slug="mot-manter-inativ", ordem=1, ativo=True)
+    db_session.add(mot)
+    db_session.flush()
+    db_session.add(
+        WhatsappChatDemanda(
+            chat_id=chat.id,
+            atendente_id=a1_id,
+            natureza_id=nat.id,
+            motivo_id=mot.id,
+            descricao_curta="Já registada na sessão",
+            desfecho="resolvido_sessao",
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-manter"),
+    )
+    process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is True
+
+    r = client.post(
+        f"/v1/whatsapp/chats/{chat.id}/classificacao-demanda/concluir",
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["classificacao_demanda_pendente"] is False
+    db_session.refresh(chat)
+    assert chat.classificacao_demanda_pendente is False
+
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    assert not any(c["id"] == chat.id for c in meus)

--- a/docs/PORTAL_CLIENTE.md
+++ b/docs/PORTAL_CLIENTE.md
@@ -1,0 +1,73 @@
+# Portal do cliente (`/portal`)
+
+Portal autenticado para funcionários da rede (sócio, supervisor, colaborador) abrirem e acompanharem chamados. Distinto do portal KB público (`/kb`) e do chat visitante (`portal_chat`).
+
+Épico: [#263](https://github.com/lgustavoss/dx-connect/issues/263)
+
+## Autenticação
+
+- JWT com claim `aud=portal` (separado do painel interno)
+- Credenciais em `funcionarios_rede.senha_hash` (admin define no cadastro)
+
+## RBAC por papel (#604)
+
+Escopo implementado em `backend/app/core/portal_scope.py`.
+
+| Papel | Tickets | Chats WhatsApp (API #603) |
+|-------|---------|---------------------------|
+| **Colaborador** | Só os **próprios** (`aberto_por_id` = funcionário) | Só contactos **vinculados** a ele (`funcionario_rede_id`) |
+| **Supervisor** | Todos das **empresas vinculadas** | Todos das empresas vinculadas |
+| **Sócio** | Toda a **rede** (incl. tickets só com `rede_id`) | Toda a rede |
+
+Colaborador **não** vê ticket aberto pela equipe interna (sem `aberto_por_id`) nem chamado de colega da mesma empresa.
+
+Supervisor vê tickets de todos os funcionários das empresas em que está vinculado, não apenas os que ele abriu.
+
+## Chats WhatsApp (#603)
+
+- Listagem em `/portal/chats` e detalhe com timeline legível (somente leitura)
+- Mensagens internas da equipe (comentários, transferências, marcos de demanda, fluxo de avaliação) ficam ocultas
+- API: `GET /v1/portal/chats`, `GET /v1/portal/chats/{id}`, `GET /v1/portal/chats/{id}/mensagens`
+
+## Gestão de equipe (#602)
+
+Disponível apenas para **sócio** autenticado no portal.
+
+- Listagem e CRUD de **colaboradores** e **supervisores** da mesma rede
+- Senha do portal, empresas vinculadas e situação (ativo/inativo)
+- **Não** é possível criar ou promover outro **sócio** pelo portal
+- Outros sócios aparecem na listagem; só é permitido alterar situação, senha e notificações
+- Colaborador e supervisor recebem **403** em `/v1/portal/equipe/*`
+- API: `GET/POST/PATCH /v1/portal/equipe/funcionarios`, `GET /v1/portal/equipe/empresas`
+- UI: menu **Equipe** (só sócio) em `/portal/equipe`
+
+## Branding white-label (#605)
+
+Reutiliza `KbPortalSettings` e logo de **Configurações → Sistema → Empresa** (mesma fonte do `/kb`).
+
+- Admin edita cores e textos em **Configurações → Base de conhecimento**
+- **Título do `/portal`:** derivado do nome da empresa (`Portal — {nome}`), independente do título da central `/kb`
+- **Cores:** navbar (`cor_header`) e menu lateral (`cor_sidebar`, padrão = navbar) configuráveis no painel
+- API pública: `GET /v1/portal/public/branding` (sem auth; logo via `/v1/kb/public/logo`)
+- Login e shell `/portal` aplicam CSS variables (`--portal-primary`, etc.)
+- Fallback com cores padrão e título «Portal do cliente» se settings incompletos
+- Código: `backend/app/services/instancia_branding.py`, `frontend/src/contexts/PortalBrandingContext.tsx`
+
+## Chat ao vivo (widget)
+
+Botão flutuante no `/portal` (mesmo padrão da central `/kb`), habilitado quando **Chat ao vivo** está ativo em Configurações → Base de conhecimento.
+
+- Reutiliza a API pública `portal_chat` (`/v1/kb/public/chat`) — o atendimento aparece no hub **Chat** do painel DeskRudder da **mesma instância**
+- Nome e e-mail pré-preenchidos com o usuário autenticado do portal
+- Token de sessão em `localStorage` separado do visitante `/kb` (`dxconnect.portal.cliente.chat_token`)
+
+### Isolamento entre clientes (produção)
+
+Produção = **single-tenant por instância** (subdomínio + Postgres dedicado). O widget do portal da DuplexSoft só fala com a API dessa instância; o SSE/fila de chat só notifica atendentes daquele DeskRudder. Não há compartilhamento de chats entre clientes DeskRudder.
+
+## Referências de código
+
+- API: `backend/app/api/portal.py`
+- Tickets: `backend/app/services/portal_tickets.py`
+- Equipe: `backend/app/services/portal_equipe.py`
+- Testes: `backend/tests/test_portal_cliente.py`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,7 @@
         "@types/node": "^26.1.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.2",
+        "@vitejs/plugin-react": "^6.0.3",
         "eslint": "^10.5.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
@@ -1629,11 +1629,13 @@
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.2",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
+      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "^1.0.0"
+        "@rolldown/pluginutils": "^1.0.1"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,7 @@
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.7.0",
         "playwright": "^1.61.1",
-        "tailwindcss": "^4.3.2",
+        "tailwindcss": "^4.3.3",
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.63.0",
         "vite": "^8.0.16"
@@ -880,6 +880,13 @@
         "tailwindcss": "4.3.2"
       }
     },
+    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
+      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
@@ -1213,6 +1220,13 @@
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
+    },
+    "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
+      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
@@ -4184,9 +4198,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "@emnapi/runtime": "^1.11.1",
         "@eslint/js": "^9.39.1",
         "@tailwindcss/vite": "^4.3.2",
-        "@types/node": "^26.1.0",
+        "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.2",
@@ -1343,9 +1343,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1720,7 +1720,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "@emnapi/core": "^1.11.2",
         "@emnapi/runtime": "^1.11.1",
         "@eslint/js": "^9.39.1",
-        "@tailwindcss/vite": "^4.3.2",
+        "@tailwindcss/vite": "^4.3.3",
         "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -865,56 +865,49 @@
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
-      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "5.21.6",
+        "enhanced-resolve": "^5.24.1",
         "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.2"
+        "tailwindcss": "4.3.3"
       }
     },
-    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
-      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-x64": "4.3.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
-      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -929,9 +922,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
-      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -946,9 +939,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
-      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -963,9 +956,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
-      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -980,9 +973,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
-      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -997,9 +990,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
-      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
@@ -1017,9 +1010,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
-      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
@@ -1037,9 +1030,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
-      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
@@ -1057,9 +1050,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
-      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
@@ -1077,9 +1070,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
-      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -1173,9 +1166,9 @@
       "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
-      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -1190,9 +1183,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
-      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -1207,26 +1200,19 @@
       }
     },
     "node_modules/@tailwindcss/vite": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.2.tgz",
-      "integrity": "sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/node": "4.3.2",
-        "@tailwindcss/oxide": "4.3.2",
-        "tailwindcss": "4.3.2"
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
-    },
-    "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
@@ -2101,9 +2087,9 @@
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.6",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,7 @@
     "@emnapi/core": "^1.11.2",
     "@emnapi/runtime": "^1.11.1",
     "@eslint/js": "^9.39.1",
-    "@tailwindcss/vite": "^4.3.2",
+    "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "@emnapi/runtime": "^1.11.1",
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.3.2",
-    "@types/node": "^26.1.0",
+    "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.7.0",
     "playwright": "^1.61.1",
-    "tailwindcss": "^4.3.2",
+    "tailwindcss": "^4.3.3",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.63.0",
     "vite": "^8.0.16"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^26.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.2",
+    "@vitejs/plugin-react": "^6.0.3",
     "eslint": "^10.5.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,6 +75,7 @@ import { AcessoNegado } from './pages/AcessoNegado'
 import { KbPublicLayout } from './pages/kb-public/KbPublicLayout'
 import { KbPublicHome } from './pages/kb-public/KbPublicHome'
 import { KbPublicArtigo } from './pages/kb-public/KbPublicArtigo'
+import { PortalBrandingRoot } from './pages/portal/PortalBrandingRoot'
 import { PortalLayout } from './pages/portal/PortalLayout'
 import { PortalLogin } from './pages/portal/PortalLogin'
 import { PortalTrocarSenha } from './pages/portal/PortalTrocarSenha'
@@ -82,6 +83,10 @@ import { PortalTickets } from './pages/portal/PortalTickets'
 import { PortalTicketNovo } from './pages/portal/PortalTicketNovo'
 import { PortalTicketDetalhe } from './pages/portal/PortalTicketDetalhe'
 import { PortalAjudaHome, PortalAjudaArtigo } from './pages/portal/PortalAjuda'
+import { PortalChats } from './pages/portal/PortalChats'
+import { PortalChatDetalhe } from './pages/portal/PortalChatDetalhe'
+import { PortalEquipe } from './pages/portal/PortalEquipe'
+import { PortalEquipeForm } from './pages/portal/PortalEquipeForm'
 import { ToastProvider } from './components/ui/Toast'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { PageLoading } from './components/ui/PageLoading'
@@ -146,13 +151,18 @@ function AppRoutes() {
         <Route index element={<KbPublicHome />} />
         <Route path="a/:slug" element={<KbPublicArtigo />} />
       </Route>
-      <Route path="/portal/login" element={<PortalLogin />} />
-      <Route path="/portal" element={<PortalLayout />}>
+      <Route path="/portal/login" element={<PortalBrandingRoot><PortalLogin /></PortalBrandingRoot>} />
+      <Route path="/portal" element={<PortalBrandingRoot><PortalLayout /></PortalBrandingRoot>}>
         <Route index element={<Navigate to="/portal/tickets" replace />} />
         <Route path="trocar-senha" element={<PortalTrocarSenha />} />
         <Route path="tickets" element={<PortalTickets />} />
         <Route path="tickets/novo" element={<PortalTicketNovo />} />
         <Route path="tickets/:id" element={<PortalTicketDetalhe />} />
+        <Route path="chats" element={<PortalChats />} />
+        <Route path="chats/:id" element={<PortalChatDetalhe />} />
+        <Route path="equipe" element={<PortalEquipe />} />
+        <Route path="equipe/novo" element={<PortalEquipeForm />} />
+        <Route path="equipe/:id" element={<PortalEquipeForm />} />
         <Route path="ajuda" element={<PortalAjudaHome />} />
         <Route path="ajuda/:slug" element={<PortalAjudaArtigo />} />
       </Route>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,6 +75,13 @@ import { AcessoNegado } from './pages/AcessoNegado'
 import { KbPublicLayout } from './pages/kb-public/KbPublicLayout'
 import { KbPublicHome } from './pages/kb-public/KbPublicHome'
 import { KbPublicArtigo } from './pages/kb-public/KbPublicArtigo'
+import { PortalLayout } from './pages/portal/PortalLayout'
+import { PortalLogin } from './pages/portal/PortalLogin'
+import { PortalTrocarSenha } from './pages/portal/PortalTrocarSenha'
+import { PortalTickets } from './pages/portal/PortalTickets'
+import { PortalTicketNovo } from './pages/portal/PortalTicketNovo'
+import { PortalTicketDetalhe } from './pages/portal/PortalTicketDetalhe'
+import { PortalAjudaHome, PortalAjudaArtigo } from './pages/portal/PortalAjuda'
 import { ToastProvider } from './components/ui/Toast'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { PageLoading } from './components/ui/PageLoading'
@@ -138,6 +145,16 @@ function AppRoutes() {
       <Route path="/kb" element={<KbPublicLayout />}>
         <Route index element={<KbPublicHome />} />
         <Route path="a/:slug" element={<KbPublicArtigo />} />
+      </Route>
+      <Route path="/portal/login" element={<PortalLogin />} />
+      <Route path="/portal" element={<PortalLayout />}>
+        <Route index element={<Navigate to="/portal/tickets" replace />} />
+        <Route path="trocar-senha" element={<PortalTrocarSenha />} />
+        <Route path="tickets" element={<PortalTickets />} />
+        <Route path="tickets/novo" element={<PortalTicketNovo />} />
+        <Route path="tickets/:id" element={<PortalTicketDetalhe />} />
+        <Route path="ajuda" element={<PortalAjudaHome />} />
+        <Route path="ajuda/:slug" element={<PortalAjudaArtigo />} />
       </Route>
       <Route
         path="/"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -682,9 +682,12 @@ export namespace WhatsappSettings {
     auto_msg_inativ_aviso_ativa?: boolean
     auto_msg_inativ_aviso_texto?: string | null
     avaliacao_ativa?: boolean
+    avaliacao_janela_minutos?: number
     auto_msg_avaliacao_ativa?: boolean
     auto_msg_avaliacao_texto?: string | null
     auto_msg_avaliacao_obrigado_texto?: string | null
+    auto_msg_avaliacao_timeout_texto?: string | null
+    auto_msg_avaliacao_pular_texto?: string | null
   }
   export interface ProvisionEmbutidoResult {
     instance: string
@@ -718,9 +721,12 @@ export namespace WhatsappSettings {
     auto_msg_inativ_aviso_ativa?: boolean | null
     auto_msg_inativ_aviso_texto?: string | null
     avaliacao_ativa?: boolean | null
+    avaliacao_janela_minutos?: number | null
     auto_msg_avaliacao_ativa?: boolean | null
     auto_msg_avaliacao_texto?: string | null
     auto_msg_avaliacao_obrigado_texto?: string | null
+    auto_msg_avaliacao_timeout_texto?: string | null
+    auto_msg_avaliacao_pular_texto?: string | null
   }
   export interface TesteResult {
     ok: boolean

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -899,8 +899,9 @@ export namespace WhatsappChats {
     funcionario_tipo?: string | null
     empresa_id?: number | null
     empresa_nome?: string | null
-    inatividade_pausada?: boolean
-    inatividade_retomada_em?: string | null
+  inatividade_pausada?: boolean
+  inatividade_retomada_em?: string | null
+  classificacao_demanda_pendente?: boolean
   }
   export interface EmpresaOpcao {
     id: number
@@ -1182,6 +1183,8 @@ export const whatsappChats = {
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/inatividade/pausar`, { method: 'POST' }),
   retomarInatividade: (id: number) =>
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/inatividade/retomar`, { method: 'POST' }),
+  concluirClassificacaoDemanda: (id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/classificacao-demanda/concluir`, { method: 'POST' }),
   vincularTicket: (id: number, ticketId: number) =>
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/vincular-ticket`, {
       method: 'POST',

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2270,6 +2270,21 @@ async function portalApi<T>(path: string, options: RequestInit = {}): Promise<T>
 }
 
 export namespace PortalCliente {
+  export interface PublicBranding {
+    nome_exibicao: string
+    portal_titulo: string
+    logo_url: string | null
+    texto_boas_vindas: string | null
+    cor_primaria: string
+    cor_header: string
+    cor_sidebar: string
+    cor_texto_header: string
+    cor_texto_corpo: string
+    cor_fundo: string
+    cor_link: string
+    exibir_marca_deskrudder: boolean
+    chat_habilitado: boolean
+  }
   export interface Token {
     access_token: string
     refresh_token?: string | null
@@ -2349,9 +2364,73 @@ export namespace PortalCliente {
     motivo_id?: number | null
     motivo_outro_texto?: string | null
   }
+  export interface WhatsappChatListItem {
+    id: number
+    protocolo: string
+    estado: string
+    empresa_id?: number | null
+    empresa_nome?: string | null
+    setor_nome?: string | null
+    created_at?: string | null
+    encerramento_at?: string | null
+    ultima_mensagem_em?: string | null
+    ultima_mensagem_preview?: string | null
+  }
+  export interface WhatsappChatDetail extends WhatsappChatListItem {
+    encerrado: boolean
+  }
+  export interface WhatsappMensagem {
+    id: number
+    direcao: string
+    corpo: string
+    tipo_midia?: string | null
+    midia_disponivel: boolean
+    autor_nome?: string | null
+    autor_papel: 'equipe' | 'voce' | 'sistema'
+    created_at?: string | null
+  }
+  export interface EquipeFuncionario {
+    id: number
+    nome: string
+    email?: string | null
+    telefone?: string | null
+    tipo: string
+    ativo: boolean
+    empresa_id?: number | null
+    empresa_ids: number[]
+    portal_habilitado: boolean
+    must_change_password: boolean
+    notificar_email_portal: boolean
+    editavel: boolean
+  }
+  export interface EquipeCreate {
+    nome: string
+    email: string
+    telefone?: string | null
+    tipo: 'colaborador' | 'supervisor'
+    ativo?: boolean
+    empresa_id?: number
+    empresa_ids?: number[]
+    senha_portal?: string
+    must_change_password?: boolean
+  }
+  export interface EquipeUpdate {
+    nome?: string
+    email?: string
+    telefone?: string | null
+    tipo?: 'colaborador' | 'supervisor'
+    ativo?: boolean
+    empresa_id?: number
+    empresa_ids?: number[]
+    senha_portal?: string
+    must_change_password?: boolean
+    notificar_email_portal?: boolean
+  }
 }
 
 export const portalCliente = {
+  branding: () => publicApi<PortalCliente.PublicBranding>('/portal/public/branding'),
+  logoAssetUrl: () => `${BASE}${API_VERSION_PREFIX}/kb/public/logo`,
   login: (email: string, senha: string) =>
     publicApi<PortalCliente.Token>('/portal/auth/login', {
       method: 'POST',
@@ -2426,6 +2505,57 @@ export const portalCliente = {
   csatLink: (ticketId: number) =>
     portalApi<{ link: string; expires_at: string }>(`/portal/tickets/${ticketId}/csat-link`, {
       method: 'POST',
+    }),
+  listChats: (params?: { situacao?: string; busca?: string; offset?: number; limit?: number }) => {
+    const q = new URLSearchParams()
+    if (params?.situacao) q.set('situacao', params.situacao)
+    if (params?.busca) q.set('busca', params.busca)
+    if (params?.offset != null) q.set('offset', String(params.offset))
+    if (params?.limit != null) q.set('limit', String(params.limit))
+    const qs = q.toString()
+    return portalApi<{ items: PortalCliente.WhatsappChatListItem[]; total: number }>(
+      `/portal/chats${qs ? `?${qs}` : ''}`,
+    )
+  },
+  getChat: (id: number) => portalApi<PortalCliente.WhatsappChatDetail>(`/portal/chats/${id}`),
+  listChatMensagens: (chatId: number) =>
+    portalApi<PortalCliente.WhatsappMensagem[]>(`/portal/chats/${chatId}/mensagens`),
+  fetchChatMidiaBlob: async (chatId: number, mensagemId: number) => {
+    const token = getPortalToken()
+    const headers: HeadersInit = {}
+    if (token) headers['Authorization'] = `Bearer ${token}`
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+    }
+    const res = await fetch(
+      `${BASE}${API_VERSION_PREFIX}/portal/chats/${chatId}/mensagens/${mensagemId}/midia`,
+      { headers },
+    )
+    if (!res.ok) throw new ApiError('Falha ao abrir mídia', res.status, null)
+    return res.blob()
+  },
+  listEquipe: (params?: { incluir_inativos?: boolean; busca?: string; offset?: number; limit?: number }) => {
+    const q = new URLSearchParams()
+    if (params?.incluir_inativos) q.set('incluir_inativos', 'true')
+    if (params?.busca) q.set('busca', params.busca)
+    if (params?.offset != null) q.set('offset', String(params.offset))
+    if (params?.limit != null) q.set('limit', String(params.limit))
+    const qs = q.toString()
+    return portalApi<{ items: PortalCliente.EquipeFuncionario[]; total: number }>(
+      `/portal/equipe/funcionarios${qs ? `?${qs}` : ''}`,
+    )
+  },
+  listEquipeEmpresas: () => portalApi<PortalCliente.Empresa[]>('/portal/equipe/empresas'),
+  getEquipeFuncionario: (id: number) => portalApi<PortalCliente.EquipeFuncionario>(`/portal/equipe/funcionarios/${id}`),
+  createEquipeFuncionario: (data: PortalCliente.EquipeCreate) =>
+    portalApi<PortalCliente.EquipeFuncionario>('/portal/equipe/funcionarios', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  updateEquipeFuncionario: (id: number, data: PortalCliente.EquipeUpdate) =>
+    portalApi<PortalCliente.EquipeFuncionario>(`/portal/equipe/funcionarios/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
     }),
 }
 
@@ -3122,6 +3252,7 @@ export namespace Kb {
     texto_boas_vindas: string | null;
     cor_primaria: string;
     cor_header: string;
+    cor_sidebar: string;
     cor_texto_header: string;
     cor_texto_corpo: string;
     cor_fundo: string;
@@ -3201,6 +3332,7 @@ export namespace Kb {
     portal_titulo: string | null;
     texto_boas_vindas: string | null;
     cor_header: string;
+    cor_sidebar: string;
     cor_primaria: string;
     cor_texto_header: string;
     cor_texto_corpo: string;
@@ -3217,6 +3349,7 @@ export namespace Kb {
     portal_titulo?: string | null;
     texto_boas_vindas?: string | null;
     cor_header?: string;
+    cor_sidebar?: string;
     cor_primaria?: string;
     cor_texto_header?: string;
     cor_texto_corpo?: string;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -923,6 +923,8 @@ export namespace WhatsappChats {
     empresas: EmpresaOpcao[]
     rede_id?: number | null
     rede_nome?: string | null
+    similaridade?: number | null
+    similaridade_alta?: boolean
   }
   export interface Contato {
     id: number
@@ -1219,6 +1221,13 @@ export const whatsappChats = {
   buscarFuncionarios: (busca: string, limit = 20) =>
     api<WhatsappChats.FuncionarioOpcao[]>(
       `/whatsapp/chats/funcionarios?${new URLSearchParams({ busca, limit: String(limit) }).toString()}`,
+    ),
+  buscarFuncionariosSimilares: (nome: string, limit = 5) =>
+    api<WhatsappChats.FuncionarioOpcao[]>(
+      `/whatsapp/chats/funcionarios/similares?${new URLSearchParams({
+        nome,
+        limit: String(limit),
+      }).toString()}`,
     ),
   catalogoFuncionarios: () => api<WhatsappChats.FuncionarioCatalogo>('/whatsapp/chats/funcionarios/catalogo'),
   cadastrarFuncionario: (

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -899,6 +899,8 @@ export namespace WhatsappChats {
     funcionario_tipo?: string | null
     empresa_id?: number | null
     empresa_nome?: string | null
+    inatividade_pausada?: boolean
+    inatividade_retomada_em?: string | null
   }
   export interface EmpresaOpcao {
     id: number
@@ -1176,6 +1178,10 @@ export const whatsappChats = {
       body: JSON.stringify({ texto }),
     }),
   marcarVisto: (id: number) => api<void>(`/whatsapp/chats/${id}/visto`, { method: 'POST' }),
+  pausarInatividade: (id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/inatividade/pausar`, { method: 'POST' }),
+  retomarInatividade: (id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/inatividade/retomar`, { method: 'POST' }),
   vincularTicket: (id: number, ticketId: number) =>
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/vincular-ticket`, {
       method: 'POST',

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -899,6 +899,7 @@ export namespace WhatsappChats {
     funcionario_tipo?: string | null
     empresa_id?: number | null
     empresa_nome?: string | null
+    empresas_opcoes?: EmpresaOpcao[]
   inatividade_pausada?: boolean
   inatividade_retomada_em?: string | null
   classificacao_demanda_pendente?: boolean
@@ -1140,6 +1141,7 @@ export const whatsappChats = {
     funcionario_id?: number | null
     telefone?: string | null
     mensagem_inicial?: string | null
+    empresa_id?: number | null
   }) =>
     api<WhatsappChats.Chat>('/whatsapp/chats/iniciar', {
       method: 'POST',
@@ -1164,7 +1166,18 @@ export const whatsappChats = {
       method: 'PATCH',
       body: JSON.stringify(data),
     }),
-  assumir: (id: number) => api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/assumir`, { method: 'POST' }),
+  assumir: (id: number, data?: { empresa_id?: number | null }) => {
+    const qs =
+      data?.empresa_id != null && data.empresa_id !== undefined
+        ? `?empresa_id=${encodeURIComponent(String(data.empresa_id))}`
+        : ''
+    return api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/assumir${qs}`, { method: 'POST' })
+  },
+  definirEmpresaContexto: (id: number, empresa_id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/empresa-contexto`, {
+      method: 'POST',
+      body: JSON.stringify({ empresa_id }),
+    }),
   encerrar: (id: number) => api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/encerrar`, { method: 'POST' }),
   transferir: (id: number, data: { setor_id: number; atendente_id?: number | null }) =>
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/transferir`, { method: 'POST', body: JSON.stringify(data) }),

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2103,6 +2103,9 @@ export namespace FuncionariosRede {
     rede_id?: number;
     empresa_id?: number;
     empresa_ids: number[];
+    portal_habilitado?: boolean;
+    must_change_password?: boolean;
+    notificar_email_portal?: boolean;
     created_at?: string | null;
     updated_at?: string | null;
   }
@@ -2116,6 +2119,8 @@ export namespace FuncionariosRede {
     rede_id?: number;
     empresa_id?: number;
     empresa_ids?: number[];
+    senha_portal?: string | null;
+    must_change_password?: boolean;
   }
   export interface Update {
     nome?: string;
@@ -2127,7 +2132,301 @@ export namespace FuncionariosRede {
     rede_id?: number;
     empresa_id?: number;
     empresa_ids?: number[];
+    senha_portal?: string | null;
+    must_change_password?: boolean;
+    notificar_email_portal?: boolean;
+    revogar_sessoes_portal?: boolean;
   }
+}
+
+/** Portal do cliente — tokens separados do painel interno (#263). */
+const PORTAL_TOKEN_KEY = 'portal_token'
+const PORTAL_REFRESH_TOKEN_KEY = 'portal_refresh_token'
+
+function getPortalToken(): string | null {
+  return sessionStorage.getItem(PORTAL_TOKEN_KEY) || localStorage.getItem(PORTAL_TOKEN_KEY)
+}
+
+function getPortalRefreshToken(): string | null {
+  return sessionStorage.getItem(PORTAL_REFRESH_TOKEN_KEY) || localStorage.getItem(PORTAL_REFRESH_TOKEN_KEY)
+}
+
+export function clearPortalAuthToken(): void {
+  sessionStorage.removeItem(PORTAL_TOKEN_KEY)
+  localStorage.removeItem(PORTAL_TOKEN_KEY)
+  sessionStorage.removeItem(PORTAL_REFRESH_TOKEN_KEY)
+  localStorage.removeItem(PORTAL_REFRESH_TOKEN_KEY)
+}
+
+function setPortalTokens(
+  tokens: { access_token: string; refresh_token?: string | null },
+  lembrarMe = true,
+) {
+  const store = lembrarMe ? localStorage : sessionStorage
+  store.setItem(PORTAL_TOKEN_KEY, tokens.access_token)
+  if (tokens.refresh_token) store.setItem(PORTAL_REFRESH_TOKEN_KEY, tokens.refresh_token)
+}
+
+function invalidatePortalAndRedirectToLogin(): void {
+  clearPortalAuthToken()
+  const returnTo = `${window.location.pathname}${window.location.search}${window.location.hash}`
+  const qs =
+    returnTo && !returnTo.startsWith('/portal/login')
+      ? `?returnTo=${encodeURIComponent(returnTo)}`
+      : ''
+  window.location.replace(`/portal/login${qs}`)
+}
+
+let portalRefreshInFlight: Promise<{
+  access_token: string
+  refresh_token?: string | null
+  must_change_password?: boolean
+} | null> | null = null
+
+async function refreshPortalAccessToken(): Promise<{
+  access_token: string
+  refresh_token?: string | null
+  must_change_password?: boolean
+} | null> {
+  if (portalRefreshInFlight) return portalRefreshInFlight
+  const refresh_token = getPortalRefreshToken()
+  if (!refresh_token) return null
+  portalRefreshInFlight = (async () => {
+    try {
+      const headers: HeadersInit = { 'Content-Type': 'application/json', 'X-DX-Skip-Refresh': '1' }
+      if (isMultiTenantMode()) {
+        ;(headers as Record<string, string>)['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+      }
+      const res = await fetch(`${BASE}${API_VERSION_PREFIX}/portal/auth/refresh`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ refresh_token }),
+      })
+      if (!res.ok) return null
+      const data = (await res.json()) as {
+        access_token: string
+        refresh_token?: string | null
+        must_change_password?: boolean
+      }
+      const lembrarMe = Boolean(localStorage.getItem(PORTAL_REFRESH_TOKEN_KEY))
+      setPortalTokens(data, lembrarMe)
+      return data
+    } catch {
+      return null
+    } finally {
+      portalRefreshInFlight = null
+    }
+  })()
+  return portalRefreshInFlight
+}
+
+async function portalApi<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const token = getPortalToken()
+  const isFormData =
+    typeof FormData !== 'undefined' && options.body != null && options.body instanceof FormData
+  const headers: HeadersInit = {
+    ...(isFormData ? {} : { 'Content-Type': 'application/json' }),
+    ...(options.headers as object),
+  }
+  if (token) {
+    ;(headers as Record<string, string>)['Authorization'] = `Bearer ${token}`
+  }
+  if (isMultiTenantMode()) {
+    ;(headers as Record<string, string>)['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+  }
+  const res = await fetch(`${BASE}${API_VERSION_PREFIX}${path}`, { ...options, headers })
+
+  if (res.status === 401 && path.startsWith('/portal/auth/login')) {
+    const err = await res.json().catch(() => ({}))
+    let msg = mensagemErroApi(err, 401)
+    if (msg.startsWith('Não foi possível concluir')) msg = 'E-mail ou senha inválidos.'
+    throw new ApiError(msg, 401, err)
+  }
+
+  if (res.status === 401) {
+    const err = await res.json().catch(() => ({}))
+    const skipRefresh =
+      headers instanceof Headers
+        ? headers.has('X-DX-Skip-Refresh')
+        : typeof headers === 'object' &&
+          headers != null &&
+          'X-DX-Skip-Refresh' in (headers as Record<string, unknown>)
+    if (!skipRefresh && !path.startsWith('/portal/auth/refresh')) {
+      const refreshed = await refreshPortalAccessToken()
+      if (refreshed?.access_token) {
+        return portalApi<T>(path, options)
+      }
+    }
+    invalidatePortalAndRedirectToLogin()
+    throw new ApiError(mensagemErroApi(err, 401), 401, err)
+  }
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}))
+    throw new ApiError(mensagemErroApi(err, res.status), res.status, err)
+  }
+  if (res.status === 204) return undefined as T
+  return res.json()
+}
+
+export namespace PortalCliente {
+  export interface Token {
+    access_token: string
+    refresh_token?: string | null
+    must_change_password?: boolean
+  }
+  export interface Empresa {
+    id: number
+    nome: string
+    rede_id: number
+  }
+  export interface Me {
+    id: number
+    nome: string
+    email: string
+    tipo: string
+    rede_id: number | null
+    empresas: Empresa[]
+    must_change_password: boolean
+    notificar_email_portal: boolean
+  }
+  export interface Setor {
+    id: number
+    nome: string
+    slug?: string | null
+  }
+  export interface Pdv {
+    id: number
+    codigo: string
+    papel?: string | null
+    ativo: boolean
+  }
+  export interface TicketListItem {
+    id: number
+    protocolo: string
+    assunto: string
+    status_nome?: string | null
+    status_slug?: string | null
+    empresa_id?: number | null
+    empresa_nome?: string | null
+    setor_nome?: string | null
+    prioridade?: string | null
+    created_at?: string | null
+    updated_at?: string | null
+    fechado_em?: string | null
+    ultima_mensagem_em?: string | null
+  }
+  export interface TicketDetail extends TicketListItem {
+    descricao?: string | null
+    pode_responder: boolean
+    csat_token?: string | null
+    csat_pendente: boolean
+  }
+  export interface Anexo {
+    id: number
+    nome_original: string
+    content_type?: string | null
+    tamanho_bytes: number
+    mensagem_id?: number | null
+    created_at?: string | null
+    download_url: string
+  }
+  export interface Mensagem {
+    id: number
+    tipo: string
+    corpo: string
+    autor_nome?: string | null
+    autor_papel: 'equipe' | 'voce' | 'sistema'
+    created_at?: string | null
+    anexos: Anexo[]
+  }
+  export interface CreateTicket {
+    empresa_id: number
+    setor_id?: number | null
+    assunto: string
+    descricao?: string | null
+    pdv_codigo?: string | null
+    motivo_id?: number | null
+    motivo_outro_texto?: string | null
+  }
+}
+
+export const portalCliente = {
+  login: (email: string, senha: string) =>
+    publicApi<PortalCliente.Token>('/portal/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({ email, senha }),
+    }),
+  setSession: (tokens: PortalCliente.Token, lembrarMe = true) => {
+    setPortalTokens(tokens, lembrarMe)
+  },
+  clearSession: () => clearPortalAuthToken(),
+  hasSession: () => Boolean(getPortalToken()),
+  me: () => portalApi<PortalCliente.Me>('/portal/me'),
+  trocarSenha: (senha_atual: string, senha_nova: string) =>
+    portalApi<PortalCliente.Token>('/portal/me/trocar-senha', {
+      method: 'POST',
+      body: JSON.stringify({ senha_atual, senha_nova }),
+    }),
+  atualizarPreferencias: (data: { notificar_email_portal?: boolean }) =>
+    portalApi<PortalCliente.Me>('/portal/me/preferencias', {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+  listSetores: () => portalApi<PortalCliente.Setor[]>('/portal/catalogos/setores'),
+  listPdvs: (empresaId: number) =>
+    portalApi<PortalCliente.Pdv[]>(`/portal/empresas/${empresaId}/pdvs`),
+  listTickets: (params?: {
+    situacao?: string
+    busca?: string
+    offset?: number
+    limit?: number
+  }) =>
+    portalApi<{ items: PortalCliente.TicketListItem[]; total: number }>(
+      withParams('/portal/tickets', params),
+    ),
+  getTicket: (id: number) => portalApi<PortalCliente.TicketDetail>(`/portal/tickets/${id}`),
+  createTicket: (data: PortalCliente.CreateTicket) =>
+    portalApi<PortalCliente.TicketDetail>('/portal/tickets', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  listMensagens: (ticketId: number) =>
+    portalApi<PortalCliente.Mensagem[]>(`/portal/tickets/${ticketId}/mensagens`),
+  sendMensagem: (ticketId: number, corpo: string) =>
+    portalApi<PortalCliente.Mensagem>(`/portal/tickets/${ticketId}/mensagens`, {
+      method: 'POST',
+      body: JSON.stringify({ corpo }),
+    }),
+  uploadAnexo: async (ticketId: number, file: File, mensagemId?: number) => {
+    const fd = new FormData()
+    fd.append('file', file)
+    if (mensagemId != null) fd.append('mensagem_id', String(mensagemId))
+    return portalApi<PortalCliente.Anexo>(`/portal/tickets/${ticketId}/anexos`, {
+      method: 'POST',
+      body: fd,
+    })
+  },
+  anexoDownloadUrl: (ticketId: number, anexoId: number) =>
+    `${BASE}${API_VERSION_PREFIX}/portal/tickets/${ticketId}/anexos/${anexoId}/download`,
+  fetchAnexoBlob: async (ticketId: number, anexoId: number) => {
+    const token = getPortalToken()
+    const headers: HeadersInit = {}
+    if (token) headers['Authorization'] = `Bearer ${token}`
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+    }
+    const res = await fetch(
+      `${BASE}${API_VERSION_PREFIX}/portal/tickets/${ticketId}/anexos/${anexoId}/download`,
+      { headers },
+    )
+    if (!res.ok) throw new ApiError('Falha ao baixar anexo', res.status, null)
+    return res.blob()
+  },
+  csatLink: (ticketId: number) =>
+    portalApi<{ link: string; expires_at: string }>(`/portal/tickets/${ticketId}/csat-link`, {
+      method: 'POST',
+    }),
 }
 
 export const ticketClassificacao = {

--- a/frontend/src/components/EmpresaChatsPanel.tsx
+++ b/frontend/src/components/EmpresaChatsPanel.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { whatsappChats, type WhatsappChats } from '../api/client'
+import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from './ui/BarraBuscaPaginacao'
+import { Card } from './ui/Card'
+import { Button } from './ui/Button'
+import { AvaliacaoEstrelas } from './ui/AvaliacaoEstrelas'
+import { useToast } from './ui/Toast'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { exibirProtocolo } from '../lib/exibirProtocolo'
+import { rotuloEstadoChat } from '../lib/whatsappChatMeta'
+import { whatsappConversaLink } from '../lib/whatsappListReturn'
+import { ChatIniciarConversaModal } from './chat/ChatIniciarConversaModal'
+
+type Props = {
+  empresaId: number
+}
+
+function formatDuration(chat: WhatsappChats.Chat) {
+  if (!chat.atendimento_inicio_at) return '—'
+  if (!chat.encerramento_at) return 'Em curso'
+  const start = new Date(chat.atendimento_inicio_at)
+  const end = new Date(chat.encerramento_at)
+  const diff = Math.max(0, Math.round((end.getTime() - start.getTime()) / 1000))
+  const minutes = Math.floor(diff / 60)
+  if (minutes < 60) return `${minutes} min`
+  const hours = Math.floor(minutes / 60)
+  const remain = minutes % 60
+  return `${hours}h ${remain}m`
+}
+
+function formatDateTime(iso?: string | null) {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleDateString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function EmpresaChatsPanel({ empresaId }: Props) {
+  const toast = useToast()
+  const [page, setPage] = useState(1)
+  const [busca, setBusca] = useState('')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+  const [items, setItems] = useState<WhatsappChats.Chat[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(false)
+  const [retomarChat, setRetomarChat] = useState<WhatsappChats.Chat | null>(null)
+
+  const returnPath = `/empresas/${empresaId}`
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
+    return () => clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    whatsappChats
+      .encerrados({
+        empresa_id: empresaId,
+        estado: 'todos',
+        offset: (page - 1) * PAGE_SIZE_PADRAO,
+        limit: PAGE_SIZE_PADRAO,
+        busca: debouncedBusca || undefined,
+      })
+      .then(({ items: rows, total: t }) => {
+        if (!cancelled) {
+          setItems(rows)
+          setTotal(t)
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          toast.showError(mensagemFalhaParaToast(err, 'Falha ao carregar chats da empresa.'))
+          setItems([])
+          setTotal(0)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [empresaId, page, debouncedBusca, toast])
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-slate-500 dark:text-slate-400">
+        Chats e atendimentos WhatsApp vinculados a esta empresa.
+      </p>
+      <BarraBuscaPaginacao
+        busca={busca}
+        onBuscaChange={(v) => {
+          setBusca(v)
+          setPage(1)
+        }}
+        placeholder="Protocolo, telefone ou nome…"
+        page={page}
+        total={total}
+        onPageChange={setPage}
+        disabled={loading}
+      />
+
+      {loading && items.length === 0 ? (
+        <div className="space-y-3">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-20 w-full animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <Card className="flex flex-col items-center justify-center border-dashed border-2 py-14 text-center">
+          <h3 className="font-semibold text-slate-900 dark:text-slate-100">Nenhum chat nesta empresa</h3>
+          <p className="mt-1 text-sm text-slate-500">
+            Quando houver atendimentos com esta empresa de contexto, eles aparecem aqui.
+          </p>
+        </Card>
+      ) : (
+        <div className="grid gap-3">
+          {items.map((c) => (
+            <Card
+              key={c.id}
+              className="group border-none p-4 shadow-sm ring-1 ring-slate-200 transition-all hover:ring-cyan-500/50 dark:ring-slate-800"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-4">
+                <div className="flex min-w-[220px] flex-1 items-center gap-4">
+                  <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-slate-50 text-slate-400 transition-colors group-hover:bg-cyan-50 group-hover:text-cyan-600 dark:bg-slate-900 dark:group-hover:bg-cyan-900/20">
+                    <span className="text-sm font-bold">{c.cliente_nome?.charAt(0).toUpperCase() || 'C'}</span>
+                  </div>
+                  <div className="min-w-0">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">
+                        {c.cliente_nome || 'Cliente'}
+                      </h3>
+                      <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                        {rotuloEstadoChat(c.estado)}
+                      </span>
+                      <span className="font-mono text-[10px] font-bold text-slate-400">{c.wa_id}</span>
+                    </div>
+                    <p
+                      className="truncate font-mono text-xs font-bold text-cyan-600 dark:text-cyan-400"
+                      title={exibirProtocolo(c.protocolo)}
+                    >
+                      {exibirProtocolo(c.protocolo)}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-6">
+                  <div className="hidden text-right sm:block">
+                    <p className="text-[10px] font-bold uppercase tracking-tight text-slate-400">Atendido por</p>
+                    <p className="text-xs font-medium text-slate-700 dark:text-slate-300">
+                      {c.atendente_nome || 'Sistema'}
+                    </p>
+                  </div>
+                  <div className="grid gap-1.5 text-right">
+                    <div>
+                      <p className="text-[10px] font-bold uppercase tracking-tight text-slate-400">Início</p>
+                      <p className="text-xs font-medium text-slate-700 dark:text-slate-300">
+                        {formatDateTime(c.atendimento_inicio_at)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-[10px] font-bold uppercase tracking-tight text-slate-400">Finalizado em</p>
+                      <p className="text-xs font-medium text-slate-700 dark:text-slate-300">
+                        {formatDateTime(c.encerramento_at)}
+                      </p>
+                    </div>
+                    <div>
+                      <p className="text-[10px] font-bold uppercase tracking-tight text-slate-400">Duração</p>
+                      <p className="text-xs font-medium text-slate-700 dark:text-slate-300">{formatDuration(c)}</p>
+                    </div>
+                    <div>
+                      <p className="text-[10px] font-bold uppercase tracking-tight text-slate-400">Avaliação</p>
+                      <div className="flex justify-end">
+                        <AvaliacaoEstrelas chat={c} size="sm" />
+                      </div>
+                    </div>
+                  </div>
+                  <Link
+                    to={whatsappConversaLink(c.id, returnPath)}
+                    className="rounded-full bg-slate-100 p-2 text-slate-400 transition-all hover:bg-cyan-600 hover:text-white dark:bg-slate-800 dark:hover:bg-cyan-700"
+                    title="Ver conversa"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M5 12h14" />
+                      <path d="m12 5 7 7-7 7" />
+                    </svg>
+                  </Link>
+                  {(c.estado === 'encerrado' || c.estado === 'aguardando_avaliacao') && (
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      className="h-9 px-3 text-xs"
+                      onClick={() => setRetomarChat(c)}
+                    >
+                      Retomar contacto
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      <ChatIniciarConversaModal
+        open={retomarChat != null}
+        onClose={() => setRetomarChat(null)}
+        telefoneInicial={retomarChat?.wa_id}
+        funcionarioId={retomarChat?.funcionario_rede_id}
+        empresas={retomarChat?.empresas_opcoes}
+        titulo={retomarChat ? `Retomar ${retomarChat.cliente_nome || retomarChat.wa_id}` : undefined}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/KbConsultaModal.tsx
+++ b/frontend/src/components/KbConsultaModal.tsx
@@ -56,10 +56,54 @@ export function KbConsultaModal({ open, onClose, onInserirReferencia, disabled }
 type ButtonProps = {
   disabled?: boolean
   onInserirReferencia?: (texto: string) => void
+  /** Barra do composer WhatsApp — botão redondo; só ícone */
+  modoComposer?: boolean
 }
 
-export function KbConsultaButton({ disabled, onInserirReferencia }: ButtonProps) {
+export function KbConsultaButton({ disabled, onInserirReferencia, modoComposer }: ButtonProps) {
   const [open, setOpen] = useState(false)
+
+  const icon = (
+    <svg className="size-5 shrink-0 sm:size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+      />
+    </svg>
+  )
+
+  if (modoComposer) {
+    return (
+      <>
+        <button
+          type="button"
+          disabled={disabled}
+          aria-label="Consultar manuais"
+          title="Consultar manuais"
+          onClick={() => setOpen(true)}
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-slate-600 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-40 dark:text-slate-300 dark:hover:bg-slate-800"
+        >
+          {icon}
+        </button>
+        <KbConsultaModal
+          open={open}
+          onClose={() => setOpen(false)}
+          onInserirReferencia={
+            onInserirReferencia
+              ? (texto) => {
+                  onInserirReferencia(texto)
+                  setOpen(false)
+                }
+              : undefined
+          }
+          disabled={disabled}
+        />
+      </>
+    )
+  }
+
   return (
     <>
       <Button
@@ -69,15 +113,9 @@ export function KbConsultaButton({ disabled, onInserirReferencia }: ButtonProps)
         onClick={() => setOpen(true)}
         className="inline-flex items-center gap-2 text-xs sm:text-sm"
       >
-        <svg className="size-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-          />
-        </svg>
-        Consultar manuais
+        {icon}
+        <span className="hidden sm:inline">Consultar manuais</span>
+        <span className="sr-only sm:hidden">Consultar manuais</span>
       </Button>
       <KbConsultaModal
         open={open}

--- a/frontend/src/components/chat/ChatIniciarConversaModal.tsx
+++ b/frontend/src/components/chat/ChatIniciarConversaModal.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { whatsappChats, type WhatsappChats } from '../../api/client'
 import { Button } from '../../components/ui/Button'
 import { Input, TEXTAREA_FIELD_CLASS } from '../../components/ui/Input'
+import { Select } from '../../components/ui/Select'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { chatWhatsappLink } from '../../lib/chatHubPaths'
@@ -14,6 +15,8 @@ type Props = {
   /** Número pré-preenchido (retomar / avulso) */
   telefoneInicial?: string | null
   funcionarioId?: number | null
+  /** Empresas do funcionário (retomar histórico / chat com vínculo) */
+  empresas?: WhatsappChats.EmpresaOpcao[] | null
   titulo?: string
 }
 
@@ -23,21 +26,35 @@ export function ChatIniciarConversaModal({
   contato,
   telefoneInicial,
   funcionarioId,
+  empresas,
   titulo,
 }: Props) {
   const toast = useToast()
   const navigate = useNavigate()
   const [telefone, setTelefone] = useState('')
   const [mensagem, setMensagem] = useState('')
+  const [empresaId, setEmpresaId] = useState<number | ''>('')
   const [salvando, setSalvando] = useState(false)
 
+  const empresasLista = useMemo(() => {
+    if (contato?.empresas?.length) return contato.empresas
+    if (empresas?.length) return empresas
+    return []
+  }, [contato, empresas])
+
+  const multiEmpresa = empresasLista.length > 1
   const precisaTelefone = !(contato?.telefone || telefoneInicial)
 
   useEffect(() => {
     if (!open) return
     setTelefone(contato?.telefone || telefoneInicial || '')
     setMensagem('')
-  }, [open, contato, telefoneInicial])
+    if (empresasLista.length === 1) {
+      setEmpresaId(empresasLista[0].id)
+    } else {
+      setEmpresaId('')
+    }
+  }, [open, contato, telefoneInicial, empresasLista])
 
   if (!open) return null
 
@@ -58,6 +75,7 @@ export function ChatIniciarConversaModal({
         funcionario_id: fid ?? undefined,
         telefone: digits || undefined,
         mensagem_inicial: mensagem.trim() || undefined,
+        empresa_id: empresaId === '' ? undefined : Number(empresaId),
       })
       onClose()
       navigate(chatWhatsappLink(chat.id, 'contatos'))
@@ -93,6 +111,23 @@ export function ChatIniciarConversaModal({
             onChange={(e) => setTelefone(e.target.value)}
             placeholder="5511999999999"
           />
+          {multiEmpresa && (
+            <div className="space-y-1">
+              <Select
+                label="Empresa do atendimento (opcional)"
+                value={empresaId}
+                onChange={(value) => setEmpresaId(value === '' ? '' : Number(value))}
+                options={empresasLista.map((e) => ({ value: e.id, label: e.nome }))}
+                placeholder="Definir depois na conversa"
+                includeEmpty
+                emptyLabel="Definir depois na conversa"
+              />
+              <p className="text-[11px] text-slate-500">
+                Se ainda não souber, pergunte ao cliente na conversa e vincule a empresa a qualquer
+                momento antes de encerrar.
+              </p>
+            </div>
+          )}
           <label className="block text-sm font-medium text-slate-700 dark:text-slate-200">
             Mensagem inicial (opcional)
             <textarea

--- a/frontend/src/components/chat/MensagemStatusIcon.tsx
+++ b/frontend/src/components/chat/MensagemStatusIcon.tsx
@@ -10,12 +10,15 @@ type Props = {
 
 function corIcone(status: StatusEntregaMensagem, variant: 'claro' | 'escuro'): string {
   if (status === 'lida') {
-    return variant === 'claro' ? 'text-cyan-100' : 'text-cyan-500 dark:text-cyan-400'
+    return variant === 'claro' ? 'text-sky-200' : 'text-sky-500 dark:text-sky-400'
   }
   if (status === 'erro') {
     return variant === 'claro' ? 'text-rose-200' : 'text-rose-500'
   }
-  return variant === 'claro' ? 'text-cyan-100/90' : 'text-slate-400'
+  if (status === 'entregue') {
+    return variant === 'claro' ? 'text-white/90' : 'text-slate-500 dark:text-slate-400'
+  }
+  return variant === 'claro' ? 'text-white/80' : 'text-slate-400'
 }
 
 function IconePendente({ className }: { className: string }) {

--- a/frontend/src/components/marketing/LandingContactSlot.tsx
+++ b/frontend/src/components/marketing/LandingContactSlot.tsx
@@ -15,8 +15,8 @@ type Props = {
 export function LandingContactSlot({ variant = 'hero', label, className = '' }: Props) {
   const base =
     variant === 'hero'
-      ? 'inline-flex items-center justify-center rounded-xl bg-sky-500 px-6 py-3.5 text-sm font-semibold text-white shadow-lg shadow-sky-900/40 transition hover:bg-sky-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#071826]'
-      : 'inline-flex items-center justify-center rounded-xl bg-sky-500 px-6 py-3 text-sm font-semibold text-white transition hover:bg-sky-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300'
+      ? 'group inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-sky-500 via-sky-400 to-cyan-400 px-6 py-3.5 text-sm font-semibold text-white shadow-[0_16px_40px_rgba(14,165,233,0.25)] transition duration-200 hover:-translate-y-0.5 hover:shadow-[0_20px_50px_rgba(14,165,233,0.32)] focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#071826]'
+      : 'group inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-sky-500 via-sky-400 to-cyan-400 px-6 py-3 text-sm font-semibold text-white shadow-[0_10px_30px_rgba(14,165,233,0.2)] transition duration-200 hover:-translate-y-0.5 hover:shadow-[0_14px_35px_rgba(14,165,233,0.28)] focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-300'
 
   return (
     <a
@@ -25,7 +25,10 @@ export function LandingContactSlot({ variant = 'hero', label, className = '' }: 
       className={`${base} ${className}`.trim()}
       data-landing-contact-slot={variant}
     >
-      {label}
+      <span>{label}</span>
+      <svg viewBox="0 0 20 20" fill="none" className="size-4 transition duration-200 group-hover:translate-x-0.5" aria-hidden>
+        <path d="M4 10h12M12 5l5 5-5 5" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
     </a>
   )
 }

--- a/frontend/src/content/landing.ts
+++ b/frontend/src/content/landing.ts
@@ -20,39 +20,39 @@ export const landingSeo = {
 export const landingHero = {
   brand: APP_NAME,
   tagline: APP_TAGLINE,
-  title: 'Suporte centralizado. Fila sob controle. Cliente bem atendido.',
+  title: 'Suporte centralizado. Operação sob controle. Cliente bem atendido.',
   titleLines: [
-    'Suporte centralizado.',
-    'Fila sob controle.',
-    'Cliente bem atendido.',
+    'Centralize o atendimento.',
+    'Organize a fila.',
+    'Eleve a experiência do cliente.',
   ] as const,
   subtitle:
-    'O DeskRudder reúne chamados, WhatsApp e conhecimento num só painel — para sua empresa organizar o atendimento, acompanhar prazos e saber quem está respondendo o quê.',
+    'O DeskRudder reúne chamados, WhatsApp, e-mail e conhecimento num único painel — para sua empresa operar com mais clareza, velocidade e excelência.',
   ctaPrimary: 'Quero ver uma demonstração',
   ctaSecondary: 'Já sou cliente',
   ctaSecondaryTo: '/login',
-  trustLine: 'Um painel para o time · Fila e prazos visíveis · Ambiente exclusivo da sua empresa',
+  trustLine: 'Visibilidade da operação · Priorização simples · Ambiente exclusivo da sua empresa',
 } as const
 
 export const landingPain = {
-  title: 'Se o suporte ainda vive assim, a operação está no limite',
+  title: 'Quando cada canal vira um problema, a operação perde controle',
   items: [
     {
-      title: 'WhatsApp no celular de cada um',
-      body: 'Conversa some, ninguém assume a fila e o cliente manda a mesma dúvida para três números.',
+      title: 'WhatsApp espalhado por celulares',
+      body: 'As conversas se perdem, ninguém assume e a fila vira um caos de mensagens repetidas.',
     },
     {
-      title: 'E-mail e planilha no lugar do sistema',
-      body: 'Prioridade no feeling, prazo no Excel e zero visão de quem está sobrecarregado.',
+      title: 'Planilha e e-mail no lugar de processo',
+      body: 'A prioridade fica no improviso, e a gestão perde a visão do que está em risco.',
     },
     {
-      title: 'Troca de plantão sem histórico',
-      body: 'O próximo atendente recomeça do zero — e o cliente sente que ninguém resolve.',
+      title: 'Troca de plantão sem contexto',
+      body: 'Cada atendente recomeça do zero, e o cliente sente que ninguém está coordenando a resposta.',
     },
   ],
-  pivotTitle: 'Com o DeskRudder, o suporte ganha um centro de comando',
+  pivotTitle: 'Com o DeskRudder, o suporte passa a ter direção e consistência',
   pivotBody:
-    'Uma fila. Um histórico. Setores com responsabilidade clara. A gestão vê o prazo em risco; o time vê o próximo da fila; o cliente recebe resposta organizada.',
+    'Uma fila. Um histórico. Responsabilidades claras. A gestão vê o risco antes de virar reclamação; o time entende o próximo passo; o cliente sente organização desde o primeiro contato.',
 } as const
 
 export type LandingShowcaseId = 'chat' | 'tickets' | 'sla' | 'kb'
@@ -120,23 +120,23 @@ export const landingShowcases: Array<{
 ]
 
 export const landingOutcomes = {
-  title: 'O que sua empresa ganha no dia a dia',
+  title: 'Resultados que aparecem no dia a dia',
   items: [
     {
       label: 'Fila única',
-      body: 'WhatsApp, e-mail e portal entram no mesmo fluxo. Acaba a disputa por «quem pegou a conversa».',
+      body: 'WhatsApp, e-mail e portal passam a seguir o mesmo fluxo, sem disputa por responsabilidade.',
     },
     {
       label: 'Time organizado',
-      body: 'Cada setor vê o que é dele. A gestão enxerga a operação inteira.',
+      body: 'Cada setor enxerga sua demanda com contexto, e a gestão vê a operação inteira.',
     },
     {
       label: 'Prazos sob controle',
-      body: 'Você vê o risco de atraso a tempo — antes do cliente cobrar no grupo da diretoria.',
+      body: 'O risco de atraso fica visível antes de virar reclamação e prejudicar a confiança.',
     },
     {
-      label: 'Dados da sua empresa',
-      body: 'Ambiente exclusivo. Seu painel, suas regras, seus dados.',
+      label: 'Ambiente exclusivo',
+      body: 'Seu painel, suas regras, seus dados e seus processos — tudo em um espaço seguro para a empresa.',
     },
   ],
 } as const

--- a/frontend/src/contexts/PortalAuthContext.tsx
+++ b/frontend/src/contexts/PortalAuthContext.tsx
@@ -1,0 +1,91 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react'
+import { portalCliente, type PortalCliente } from '../api/client'
+
+interface PortalAuthContextValue {
+  user: PortalCliente.Me | null
+  loading: boolean
+  login: (email: string, senha: string, lembrarMe?: boolean) => Promise<void>
+  logout: () => void
+  refreshUser: () => Promise<void>
+  applyTokens: (tokens: PortalCliente.Token, lembrarMe?: boolean) => Promise<void>
+}
+
+const PortalAuthContext = createContext<PortalAuthContextValue | null>(null)
+
+export function PortalAuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<PortalCliente.Me | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const refreshUser = useCallback(async () => {
+    if (!portalCliente.hasSession()) {
+      setUser(null)
+      return
+    }
+    const me = await portalCliente.me()
+    setUser(me)
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        if (portalCliente.hasSession()) {
+          const me = await portalCliente.me()
+          if (!cancelled) setUser(me)
+        }
+      } catch {
+        if (!cancelled) {
+          portalCliente.clearSession()
+          setUser(null)
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const applyTokens = useCallback(
+    async (tokens: PortalCliente.Token, lembrarMe = true) => {
+      portalCliente.setSession(tokens, lembrarMe)
+      await refreshUser()
+    },
+    [refreshUser],
+  )
+
+  const login = useCallback(
+    async (email: string, senha: string, lembrarMe = true) => {
+      const tokens = await portalCliente.login(email.trim().toLowerCase(), senha)
+      await applyTokens(tokens, lembrarMe)
+    },
+    [applyTokens],
+  )
+
+  const logout = useCallback(() => {
+    portalCliente.clearSession()
+    setUser(null)
+  }, [])
+
+  return (
+    <PortalAuthContext.Provider value={{ user, loading, login, logout, refreshUser, applyTokens }}>
+      {children}
+    </PortalAuthContext.Provider>
+  )
+}
+
+export function usePortalAuth(): PortalAuthContextValue {
+  const ctx = useContext(PortalAuthContext)
+  if (!ctx) {
+    throw new Error('usePortalAuth deve ser usado dentro de PortalAuthProvider')
+  }
+  return ctx
+}

--- a/frontend/src/contexts/PortalBrandingContext.tsx
+++ b/frontend/src/contexts/PortalBrandingContext.tsx
@@ -1,0 +1,121 @@
+import { createContext, useContext, useEffect, useMemo, useState, type CSSProperties, type ReactNode } from 'react'
+import { kbPublic, portalCliente, type PortalCliente } from '../api/client'
+
+const FALLBACK: PortalCliente.PublicBranding = {
+  nome_exibicao: 'Portal do cliente',
+  portal_titulo: 'Portal do cliente',
+  logo_url: null,
+  texto_boas_vindas: 'Acompanhe e abra chamados da sua empresa com a equipe de suporte.',
+  cor_primaria: '#0D9488',
+  cor_header: '#0B2D4A',
+  cor_sidebar: '#0B2D4A',
+  cor_texto_header: '#FFFFFF',
+  cor_texto_corpo: '#0F172A',
+  cor_fundo: '#F8FAFC',
+  cor_link: '#0D9488',
+  exibir_marca_deskrudder: true,
+  chat_habilitado: false,
+}
+
+type PortalBrandingContextValue = {
+  branding: PortalCliente.PublicBranding
+  loading: boolean
+}
+
+const PortalBrandingContext = createContext<PortalBrandingContextValue | null>(null)
+
+export function portalBrandingStyleVars(b: PortalCliente.PublicBranding): CSSProperties {
+  const sidebar = b.cor_sidebar || b.cor_header
+  return {
+    backgroundColor: b.cor_fundo,
+    color: b.cor_texto_corpo,
+    ['--portal-primary' as string]: b.cor_primaria,
+    ['--portal-header' as string]: b.cor_header,
+    ['--portal-sidebar' as string]: sidebar,
+    ['--portal-header-text' as string]: b.cor_texto_header,
+    ['--portal-sidebar-text' as string]: b.cor_texto_header,
+    ['--portal-body' as string]: b.cor_texto_corpo,
+    ['--portal-bg' as string]: b.cor_fundo,
+    ['--portal-link' as string]: b.cor_link,
+  }
+}
+
+function mergeBranding(data: Partial<PortalCliente.PublicBranding>): PortalCliente.PublicBranding {
+  const merged = {
+    ...FALLBACK,
+    ...data,
+    chat_habilitado: Boolean(data.chat_habilitado),
+  }
+  merged.cor_sidebar = data.cor_sidebar || data.cor_header || FALLBACK.cor_sidebar
+  return merged
+}
+
+export function PortalBrandingProvider({ children }: { children: ReactNode }) {
+  const [branding, setBranding] = useState<PortalCliente.PublicBranding | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    portalCliente
+      .branding()
+      .then(async (data) => {
+        if (cancelled) return
+        let chat = Boolean((data as { chat_habilitado?: boolean }).chat_habilitado)
+        if (!('chat_habilitado' in data) || (data as { chat_habilitado?: boolean }).chat_habilitado == null) {
+          try {
+            const kb = await kbPublic.branding()
+            chat = Boolean(kb.chat_habilitado)
+          } catch {
+            chat = false
+          }
+        }
+        setBranding(mergeBranding({ ...data, chat_habilitado: chat }))
+      })
+      .catch(() => {
+        if (!cancelled) setBranding(FALLBACK)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const resolved = branding ?? FALLBACK
+
+  useEffect(() => {
+    document.title = resolved.portal_titulo
+  }, [resolved.portal_titulo])
+
+  const value = useMemo(
+    () => ({
+      branding: resolved,
+      loading,
+    }),
+    [resolved, loading],
+  )
+
+  return (
+    <PortalBrandingContext.Provider value={value}>
+      <div
+        className="portal-cliente min-h-dvh"
+        data-theme="light"
+        style={{ ...portalBrandingStyleVars(resolved), colorScheme: 'light' }}
+      >
+        {children}
+      </div>
+    </PortalBrandingContext.Provider>
+  )
+}
+
+export function usePortalBranding(): PortalCliente.PublicBranding {
+  const ctx = useContext(PortalBrandingContext)
+  if (!ctx) throw new Error('usePortalBranding deve ser usado dentro de PortalBrandingProvider')
+  return ctx.branding
+}
+
+export function usePortalBrandingLoading(): boolean {
+  const ctx = useContext(PortalBrandingContext)
+  return ctx?.loading ?? true
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,7 +1,8 @@
 @import "tailwindcss";
 
-/* Tema escuro por classe no <html> (.dark), alinhado ao Tailwind v4 */
-@custom-variant dark (&:where(.dark, .dark *));
+/* Tema escuro por classe no <html> (.dark), alinhado ao Tailwind v4.
+   Exclui árvores com data-theme="light" (ex.: portal do cliente) para não herdar o dark do painel. */
+@custom-variant dark (&:where(.dark, .dark *):not(:where([data-theme='light'], [data-theme='light'] *)));
 
 @layer base {
   html {

--- a/frontend/src/lib/chatHubLista.ts
+++ b/frontend/src/lib/chatHubLista.ts
@@ -89,6 +89,35 @@ export function ordenarAtendendo(items: ChatHubItem[]): ChatHubItem[] {
   })
 }
 
+export type AtendendoSecoes = {
+  comigo: ChatHubItem[]
+  outros: ChatHubItem[]
+  /** Secções com cabeçalho quando há chats de outros atendentes */
+  mostrarSecoes: boolean
+}
+
+export function separarAtendendoPorResponsavel(
+  items: ChatHubItem[],
+  usuarioId?: number | null,
+): AtendendoSecoes {
+  if (usuarioId == null) {
+    return { comigo: ordenarAtendendo(items), outros: [], mostrarSecoes: false }
+  }
+
+  const comigo: ChatHubItem[] = []
+  const outros: ChatHubItem[] = []
+  for (const item of items) {
+    if (item.atendente_id === usuarioId) comigo.push(item)
+    else outros.push(item)
+  }
+
+  return {
+    comigo: ordenarAtendendo(comigo),
+    outros: ordenarAtendendo(outros),
+    mostrarSecoes: outros.length > 0,
+  }
+}
+
 export function rotuloResponsavelItem(item: ChatHubItem, usuarioId?: number | null): string {
   return rotuloResponsavelChat(item, usuarioId)
 }

--- a/frontend/src/lib/whatsappDemandaUtils.ts
+++ b/frontend/src/lib/whatsappDemandaUtils.ts
@@ -29,7 +29,7 @@ export function mensagensVisiveisConversa<TMsg extends ChatMensagemTimeline>(msg
   )
 }
 
-/** Aviso ou encerramento automático por inatividade do cliente — demanda no modal é opcional. */
+/** Aviso ou encerramento automático por inatividade do cliente. */
 export function chatEncerramentoPorInatividade(msgs: ChatMensagemTimeline[]): boolean {
   return msgs.some(
     (m) =>

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -507,7 +507,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
                 Encerra chats em atendimento após silêncio. O tempo conta desde a última mensagem (cliente ou
                 atendente). No chat, o responsável pode Pausar o timer durante análises longas — ao pausar/retomar o
-                prazo volta ao valor configurado.
+                prazo volta ao valor configurado. Enviar mensagem (ou o cliente falar) sai automaticamente da pausa.
               </p>
             </div>
 
@@ -515,7 +515,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               checked={inativEncerramentoAtiva}
               onCheckedChange={setInativEncerramentoAtiva}
               label="Encerramento automático por inatividade do cliente"
-              description="Qualquer mensagem (cliente ou atendente) reinicia o timer. Use Pausar no chat se precisar de mais tempo."
+              description="Qualquer mensagem (cliente ou atendente) reinicia o timer e sai da pausa. Use Pausar no chat se precisar de mais tempo em silêncio."
               showStatusPill
               statusOnText="Ativo"
               statusOffText="Inativo"

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -505,8 +505,9 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
             <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 dark:border-slate-800/80 dark:bg-slate-800/20 dark:text-slate-200">
               <p className="font-medium">Encerramento por inatividade</p>
               <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
-                Encerra chats em atendimento quando o cliente para de responder. O tempo conta desde a última mensagem
-                do cliente, depois que o atendente já respondeu.
+                Encerra chats em atendimento após silêncio. O tempo conta desde a última mensagem (cliente ou
+                atendente). No chat, o responsável pode Pausar o timer durante análises longas — ao pausar/retomar o
+                prazo volta ao valor configurado.
               </p>
             </div>
 
@@ -514,7 +515,7 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               checked={inativEncerramentoAtiva}
               onCheckedChange={setInativEncerramentoAtiva}
               label="Encerramento automático por inatividade do cliente"
-              description="Novas mensagens do atendente não reiniciam o timer."
+              description="Qualquer mensagem (cliente ou atendente) reinicia o timer. Use Pausar no chat se precisar de mais tempo."
               showStatusPill
               statusOnText="Ativo"
               statusOffText="Inativo"

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -81,6 +81,10 @@ const DEFAULT_MSG_INATIV_AVISO =
 const DEFAULT_MSG_AVALIACAO =
   'Como você avalia o atendimento?\n\nResponda com uma nota de *1* a *5*:\n1 — Péssimo\n2 — Ruim\n3 — Regular\n4 — Bom\n5 — Excelente'
 const DEFAULT_MSG_AVALIACAO_OBRIGADO = 'Obrigado pela sua avaliação! Atendimento encerrado.'
+const DEFAULT_MSG_AVALIACAO_PULAR =
+  'Sem problema! Vamos abrir um novo atendimento com a sua mensagem.'
+const DEFAULT_MSG_AVALIACAO_TIMEOUT =
+  'O período para avaliar o atendimento encerrou. Se precisar de ajuda, envie uma nova mensagem por aqui.'
 
 function renderQrPayload(data: Record<string, unknown> | null | undefined) {
   if (!data || typeof data !== 'object') return null
@@ -150,9 +154,12 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
   const [msgInativAvisoAtiva, setMsgInativAvisoAtiva] = useState(true)
   const [msgInativAvisoTexto, setMsgInativAvisoTexto] = useState(DEFAULT_MSG_INATIV_AVISO)
   const [avaliacaoAtiva, setAvaliacaoAtiva] = useState(false)
+  const [avaliacaoJanelaMinutos, setAvaliacaoJanelaMinutos] = useState('30')
   const [msgAvaliacaoAtiva, setMsgAvaliacaoAtiva] = useState(true)
   const [msgAvaliacaoTexto, setMsgAvaliacaoTexto] = useState(DEFAULT_MSG_AVALIACAO)
   const [msgAvaliacaoObrigadoTexto, setMsgAvaliacaoObrigadoTexto] = useState(DEFAULT_MSG_AVALIACAO_OBRIGADO)
+  const [msgAvaliacaoPularTexto, setMsgAvaliacaoPularTexto] = useState(DEFAULT_MSG_AVALIACAO_PULAR)
+  const [msgAvaliacaoTimeoutTexto, setMsgAvaliacaoTimeoutTexto] = useState(DEFAULT_MSG_AVALIACAO_TIMEOUT)
   const [nomeEmpresaExibicao, setNomeEmpresaExibicao] = useState('')
   const [horarioTimezone, setHorarioTimezone] = useState<string>('America/Sao_Paulo')
   const [usarFeriadosNacionais, setUsarFeriadosNacionais] = useState(false)
@@ -184,11 +191,19 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
         (r.auto_msg_inativ_aviso_texto ?? DEFAULT_MSG_INATIV_AVISO).trim() || DEFAULT_MSG_INATIV_AVISO,
       )
       setAvaliacaoAtiva(Boolean(r.avaliacao_ativa))
+      setAvaliacaoJanelaMinutos(String(r.avaliacao_janela_minutos ?? 30))
       setMsgAvaliacaoAtiva(Boolean(r.auto_msg_avaliacao_ativa ?? true))
       setMsgAvaliacaoTexto((r.auto_msg_avaliacao_texto ?? DEFAULT_MSG_AVALIACAO).trim() || DEFAULT_MSG_AVALIACAO)
       setMsgAvaliacaoObrigadoTexto(
         (r.auto_msg_avaliacao_obrigado_texto ?? DEFAULT_MSG_AVALIACAO_OBRIGADO).trim() ||
           DEFAULT_MSG_AVALIACAO_OBRIGADO,
+      )
+      setMsgAvaliacaoPularTexto(
+        (r.auto_msg_avaliacao_pular_texto ?? DEFAULT_MSG_AVALIACAO_PULAR).trim() || DEFAULT_MSG_AVALIACAO_PULAR,
+      )
+      setMsgAvaliacaoTimeoutTexto(
+        (r.auto_msg_avaliacao_timeout_texto ?? DEFAULT_MSG_AVALIACAO_TIMEOUT).trim() ||
+          DEFAULT_MSG_AVALIACAO_TIMEOUT,
       )
       setHorarioTimezone((r.horario_timezone ?? 'America/Sao_Paulo').trim() || 'America/Sao_Paulo')
       const identidadeSalva = (r.nome_empresa_exibicao ?? '').trim()
@@ -604,8 +619,9 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
             <div className="rounded-lg border border-slate-200 bg-slate-50/60 p-4 text-sm text-slate-700 dark:border-slate-800/80 dark:bg-slate-800/20 dark:text-slate-200">
               <p className="font-medium">Avaliação do atendimento</p>
               <p className="mt-1 text-xs leading-relaxed text-slate-600 dark:text-slate-400">
-                Ao encerrar o chat, o cliente recebe uma solicitação de nota de 1 a 5 antes do atendimento ser
-                finalizado. As notas aparecem no histórico de conversas.
+                Ao encerrar o chat, o cliente recebe um pedido de nota (1 a 5) por um tempo limitado. Se responder com
+                outra mensagem, abrimos um atendimento novo com esse texto — sem prender o cliente. Sem resposta, a
+                janela encerra sozinha.
               </p>
             </div>
 
@@ -617,11 +633,28 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               statusOnText="Ativo"
               statusOffText="Inativo"
             />
+            <div>
+              <label className="text-xs font-medium text-slate-600 dark:text-slate-400">
+                Janela para enviar a nota (minutos)
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={1440}
+                disabled={!avaliacaoAtiva}
+                value={avaliacaoJanelaMinutos}
+                onChange={(e) => setAvaliacaoJanelaMinutos(e.target.value)}
+                className="mt-1 w-full max-w-xs rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm disabled:opacity-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100"
+              />
+              <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                Padrão: 30 minutos a partir do encerramento. Depois disso o chat finaliza sem nota.
+              </p>
+            </div>
             <Switch
               checked={msgAvaliacaoAtiva}
               onCheckedChange={setMsgAvaliacaoAtiva}
               label="Enviar mensagens de avaliação"
-              description="Solicitação da nota e agradecimento após a resposta."
+              description="Solicitação da nota, agradecimento, mensagem ao pular e finalização por tempo."
               showStatusPill
               statusOnText="Enviar"
               statusOffText="Encerrar direto"
@@ -646,19 +679,47 @@ export function ConfigWhatsapp({ embedded = false }: { embedded?: boolean }) {
               disabled={!avaliacaoAtiva || !msgAvaliacaoAtiva}
               className={`${TEXTAREA_FIELD_CLASS} disabled:opacity-50`}
             />
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-400">
+              Mensagem ao pular a nota (cliente manda outro texto)
+            </label>
+            <textarea
+              value={msgAvaliacaoPularTexto}
+              onChange={(e) => setMsgAvaliacaoPularTexto(e.target.value)}
+              rows={2}
+              disabled={!avaliacaoAtiva || !msgAvaliacaoAtiva}
+              className={`${TEXTAREA_FIELD_CLASS} disabled:opacity-50`}
+            />
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-400">
+              Mensagem ao expirar a janela (sem nota)
+            </label>
+            <textarea
+              value={msgAvaliacaoTimeoutTexto}
+              onChange={(e) => setMsgAvaliacaoTimeoutTexto(e.target.value)}
+              rows={2}
+              disabled={!avaliacaoAtiva || !msgAvaliacaoAtiva}
+              className={`${TEXTAREA_FIELD_CLASS} disabled:opacity-50`}
+            />
 
             <div className="flex justify-end pt-2">
               <Button
                 type="button"
                 loading={salvandoAvaliacao}
                 onClick={() => {
+                  const janela = Number.parseInt(avaliacaoJanelaMinutos, 10)
+                  if (avaliacaoAtiva && (!Number.isFinite(janela) || janela < 1)) {
+                    toast.showError('Informe a janela de avaliação em minutos (mínimo 1).')
+                    return
+                  }
                   setSalvandoAvaliacao(true)
                   whatsappSettings
                     .patch({
                       avaliacao_ativa: avaliacaoAtiva,
+                      avaliacao_janela_minutos: Number.isFinite(janela) && janela >= 1 ? janela : 30,
                       auto_msg_avaliacao_ativa: msgAvaliacaoAtiva,
                       auto_msg_avaliacao_texto: msgAvaliacaoTexto,
                       auto_msg_avaliacao_obrigado_texto: msgAvaliacaoObrigadoTexto,
+                      auto_msg_avaliacao_pular_texto: msgAvaliacaoPularTexto,
+                      auto_msg_avaliacao_timeout_texto: msgAvaliacaoTimeoutTexto,
                     })
                     .then(() => toast.showSuccess('Configurações de avaliação atualizadas.'))
                     .catch((err) => toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.')))

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -22,8 +22,9 @@ import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { TicketsTabelaContexto } from '../components/TicketsTabelaContexto'
 import { FuncionariosEmpresaLista } from '../components/FuncionariosEmpresaLista'
 import { EmpresaPdvsPanel } from '../components/EmpresaPdvsPanel'
+import { EmpresaChatsPanel } from '../components/EmpresaChatsPanel'
 import { SemPermissao } from './SemPermissao'
-type Aba = 'geral' | 'tickets' | 'funcionarios' | 'pdvs'
+type Aba = 'geral' | 'tickets' | 'chats' | 'funcionarios' | 'pdvs'
 
 function DetailRow({ label, value }: { label: string; value: string | null | undefined }) {
   const v = value?.trim()
@@ -313,6 +314,7 @@ export function EmpresaDetalhe() {
           <nav className="flex flex-wrap gap-1 sm:gap-2" aria-label="Seções da empresa">
             {tabBtn('geral', 'Geral')}
             {tabBtn('tickets', 'Tickets')}
+            {tabBtn('chats', 'Chats')}
             {tabBtn('funcionarios', 'Funcionários')}
             {tabBtn('pdvs', 'PDVs')}
           </nav>
@@ -434,6 +436,12 @@ export function EmpresaDetalhe() {
             showEmpresaColumn={false}
             emptyMessage="Nenhum ticket para esta empresa."
           />
+        </section>
+      )}
+
+      {aba === 'chats' && (
+        <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-800/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7">
+          <EmpresaChatsPanel empresaId={empresa.id} />
         </section>
       )}
 

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -51,6 +51,10 @@ export function FuncionarioRedeForm() {
   const [redeId, setRedeId] = useState<number | ''>('')
   const [empresaId, setEmpresaId] = useState<number | ''>('')
   const [empresaIds, setEmpresaIds] = useState<number[]>([])
+  const [senhaPortal, setSenhaPortal] = useState('')
+  const [mustChangePassword, setMustChangePassword] = useState(true)
+  const [portalHabilitado, setPortalHabilitado] = useState(false)
+  const [notificarEmailPortal, setNotificarEmailPortal] = useState(true)
 
   useEffect(() => {
     coletarTodasPaginas<Redes.Rede>((o, l) => redes.list({ incluir_inativos: true, offset: o, limit: l })).then(
@@ -115,6 +119,10 @@ export function FuncionarioRedeForm() {
         setRedeId(r)
         setEmpresaId(item.empresa_id ?? '')
         setEmpresaIds(item.empresa_ids ?? [])
+        setPortalHabilitado(Boolean(item.portal_habilitado))
+        setMustChangePassword(Boolean(item.must_change_password))
+        setNotificarEmailPortal(item.notificar_email_portal !== false)
+        setSenhaPortal('')
       })
       .catch((err) => {
         if (!cancelled) {
@@ -186,6 +194,9 @@ export function FuncionarioRedeForm() {
           rede_id: rid,
           empresa_id: escopo === 'selected' && tipo === 'colaborador' && ids.length === 1 ? ids[0] : undefined,
           empresa_ids: escopo === 'selected' ? ids : [],
+          notificar_email_portal: notificarEmailPortal,
+          must_change_password: mustChangePassword,
+          ...(senhaPortal.trim() ? { senha_portal: senhaPortal.trim() } : {}),
         }
         saved = await funcionariosRede.update(funcionarioId, payload)
         toast.showSuccess('Funcionário atualizado.')
@@ -200,6 +211,8 @@ export function FuncionarioRedeForm() {
           rede_id: rid,
           empresa_id: escopo === 'selected' && tipo === 'colaborador' && ids.length === 1 ? ids[0] : undefined,
           empresa_ids: escopo === 'selected' ? ids : [],
+          must_change_password: mustChangePassword,
+          ...(senhaPortal.trim() ? { senha_portal: senhaPortal.trim() } : {}),
         }
         saved = await funcionariosRede.create(payload)
         toast.showSuccess('Funcionário cadastrado.')
@@ -375,6 +388,46 @@ export function FuncionarioRedeForm() {
                   )}
                 </div>
               )}
+            </FormSection>
+
+            <FormSection title="Portal do cliente">
+              <p className="text-xs text-slate-500">
+                Com e-mail e senha, o funcionário acessa{' '}
+                <span className="font-medium text-slate-700 dark:text-slate-200">/portal</span> para abrir e
+                acompanhar chamados.
+                {isEdit && portalHabilitado ? (
+                  <span className="ml-1 text-teal-700 dark:text-teal-400">Portal já habilitado.</span>
+                ) : null}
+              </p>
+              <Input
+                label={isEdit ? 'Nova senha do portal (opcional)' : 'Senha do portal (opcional)'}
+                type="password"
+                value={senhaPortal}
+                onChange={(e) => setSenhaPortal(e.target.value)}
+                autoComplete="new-password"
+                placeholder={email.trim() ? 'Mínimo 8 caracteres' : 'Informe o e-mail primeiro'}
+                disabled={!email.trim()}
+              />
+              <Switch
+                bare
+                checked={mustChangePassword}
+                onCheckedChange={setMustChangePassword}
+                label="Exigir troca de senha no primeiro acesso"
+                showStatusPill
+                statusOnText="Sim"
+                statusOffText="Não"
+              />
+              {isEdit ? (
+                <Switch
+                  bare
+                  checked={notificarEmailPortal}
+                  onCheckedChange={setNotificarEmailPortal}
+                  label="Notificar por e-mail sobre respostas nos chamados"
+                  showStatusPill
+                  statusOnText="Sim"
+                  statusOffText="Não"
+                />
+              ) : null}
             </FormSection>
 
             <FormSection title="Situação no sistema">

--- a/frontend/src/pages/KbPortalSettings.tsx
+++ b/frontend/src/pages/KbPortalSettings.tsx
@@ -15,6 +15,7 @@ type FormState = {
   portal_titulo: string
   texto_boas_vindas: string
   cor_header: string
+  cor_sidebar: string
   cor_primaria: string
   cor_texto_header: string
   cor_texto_corpo: string
@@ -31,6 +32,7 @@ function fromApi(data: Kb.PortalSettings): FormState {
     portal_titulo: data.portal_titulo ?? '',
     texto_boas_vindas: data.texto_boas_vindas ?? '',
     cor_header: data.cor_header,
+    cor_sidebar: data.cor_sidebar || data.cor_header,
     cor_primaria: data.cor_primaria,
     cor_texto_header: data.cor_texto_header,
     cor_texto_corpo: data.cor_texto_corpo,
@@ -80,6 +82,10 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
     () => (typeof window !== 'undefined' ? `${window.location.origin}/kb` : '/kb'),
     [],
   )
+  const portalUrl = useMemo(
+    () => (typeof window !== 'undefined' ? `${window.location.origin}/portal/login` : '/portal/login'),
+    [],
+  )
 
   const load = useCallback(() => {
     setLoading(true)
@@ -112,6 +118,7 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
         portal_titulo: form.portal_titulo.trim() || null,
         texto_boas_vindas: form.texto_boas_vindas.trim() || null,
         cor_header: form.cor_header,
+        cor_sidebar: form.cor_sidebar,
         cor_primaria: form.cor_primaria,
         cor_texto_header: form.cor_texto_header,
         cor_texto_corpo: form.cor_texto_corpo,
@@ -143,13 +150,20 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
         />
       }
       title="Base de conhecimento"
-      subtitle="Personalize o portal público /kb — cores, textos e aparência (estilo TomTicket)."
+      subtitle="Personalize a aparência white-label da instância — cores valem para /kb e /portal; o título abaixo é só da central de ajuda (/kb)."
       actions={
-        <a href="/kb" target="_blank" rel="noreferrer">
-          <Button type="button" variant="secondary">
-            Abrir preview
-          </Button>
-        </a>
+        <>
+          <a href="/kb" target="_blank" rel="noreferrer">
+            <Button type="button" variant="secondary">
+              Abrir /kb
+            </Button>
+          </a>
+          <a href="/portal/login" target="_blank" rel="noreferrer" className="ml-2 inline-block">
+            <Button type="button" variant="secondary">
+              Abrir /portal
+            </Button>
+          </a>
+        </>
       }
     >
       {loading || !form ? (
@@ -158,18 +172,22 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
         <form onSubmit={(e) => void salvar(e)} className="space-y-6">
           <Card className="space-y-4 p-4 sm:p-5">
             <p className="text-sm text-slate-600 dark:text-slate-400">
-              URL pública:{' '}
+              Portal público:{' '}
               <a href="/kb" target="_blank" rel="noreferrer" className="font-medium text-teal-700 hover:underline dark:text-teal-400">
                 {publicUrl}
+              </a>
+              . Portal autenticado:{' '}
+              <a href="/portal/login" target="_blank" rel="noreferrer" className="font-medium text-teal-700 hover:underline dark:text-teal-400">
+                {portalUrl}
               </a>
               . A logo vem de Configurações → Sistema → Empresa.
             </p>
 
             <Input
-              label="Título do portal"
+              label="Título da central de ajuda (/kb)"
               value={form.portal_titulo}
               onChange={(e) => setForm({ ...form, portal_titulo: e.target.value })}
-              placeholder="Central de ajuda — Minha Empresa"
+              placeholder="Suporte — Minha Empresa"
             />
 
             <div>
@@ -209,7 +227,7 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
               checked={form.chat_habilitado}
               onChange={(e) => setForm({ ...form, chat_habilitado: e.target.checked })}
             >
-              Habilitar chat ao vivo para visitantes do /kb
+              Habilitar chat ao vivo no /kb e no /portal
             </CheckboxField>
             <div>
               <label htmlFor="kb-chat-setor" className="mb-1.5 block text-sm font-medium text-slate-700 dark:text-slate-300">
@@ -246,11 +264,16 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
 
           <Card className="grid gap-4 p-4 sm:grid-cols-2 sm:p-5">
             <p className="col-span-full text-xs text-slate-500 dark:text-slate-400">
-              Estas cores afetam o portal /kb e o widget de chat ao vivo (barra superior = cor da navbar; destaque =
-              botões e suas mensagens).
+              Estas cores afetam /kb, /portal e o widget de chat. Navbar e menu lateral podem ter cores
+              independentes (por padrão o menu usa a mesma cor da navbar).
             </p>
             <ColorField label="Cor da barra superior (navbar)" value={form.cor_header} onChange={(v) => setForm({ ...form, cor_header: v })} />
-            <ColorField label="Cor do texto da navbar" value={form.cor_texto_header} onChange={(v) => setForm({ ...form, cor_texto_header: v })} />
+            <ColorField
+              label="Cor do menu lateral (/portal)"
+              value={form.cor_sidebar}
+              onChange={(v) => setForm({ ...form, cor_sidebar: v })}
+            />
+            <ColorField label="Cor do texto da navbar / menu" value={form.cor_texto_header} onChange={(v) => setForm({ ...form, cor_texto_header: v })} />
             <ColorField label="Cor de destaque (botões / seleção)" value={form.cor_primaria} onChange={(v) => setForm({ ...form, cor_primaria: v })} />
             <ColorField label="Cor dos links" value={form.cor_link} onChange={(v) => setForm({ ...form, cor_link: v })} />
             <ColorField label="Cor do texto principal" value={form.cor_texto_corpo} onChange={(v) => setForm({ ...form, cor_texto_corpo: v })} />

--- a/frontend/src/pages/RedeDetalhe.tsx
+++ b/frontend/src/pages/RedeDetalhe.tsx
@@ -176,6 +176,10 @@ export function RedeDetalhe() {
   const [ativoFuncionario, setAtivoFuncionario] = useState(true)
   const [empresaIdFuncionario, setEmpresaIdFuncionario] = useState<number | ''>('')
   const [empresaIdsFuncionario, setEmpresaIdsFuncionario] = useState<number[]>([])
+  const [senhaPortalFuncionario, setSenhaPortalFuncionario] = useState('')
+  const [mustChangePasswordFuncionario, setMustChangePasswordFuncionario] = useState(true)
+  const [portalHabilitadoFuncionario, setPortalHabilitadoFuncionario] = useState(false)
+  const [notificarEmailPortalFuncionario, setNotificarEmailPortalFuncionario] = useState(true)
   const [savingFuncionario, setSavingFuncionario] = useState(false)
 
   const empresasFiltradas = useMemo(() => {
@@ -631,6 +635,10 @@ export function RedeDetalhe() {
     setAtivoFuncionario(f.ativo)
     setEmpresaIdFuncionario(f.empresa_id ?? '')
     setEmpresaIdsFuncionario(f.empresa_ids ?? [])
+    setSenhaPortalFuncionario('')
+    setMustChangePasswordFuncionario(f.must_change_password !== false)
+    setPortalHabilitadoFuncionario(Boolean(f.portal_habilitado))
+    setNotificarEmailPortalFuncionario(f.notificar_email_portal !== false)
   }
 
   function verFuncionarioDetalhe(f: FuncionarioListaItem) {
@@ -654,6 +662,10 @@ export function RedeDetalhe() {
     setAtivoFuncionario(true)
     setEmpresaIdFuncionario('')
     setEmpresaIdsFuncionario([])
+    setSenhaPortalFuncionario('')
+    setMustChangePasswordFuncionario(true)
+    setPortalHabilitadoFuncionario(false)
+    setNotificarEmailPortalFuncionario(true)
     setAba('funcionarios')
     setModalFuncionario(true)
   }
@@ -662,6 +674,10 @@ export function RedeDetalhe() {
     setModalFuncionario(false)
     setModoFuncionario('edit')
     setEditingFuncionarioId(null)
+    setSenhaPortalFuncionario('')
+    setMustChangePasswordFuncionario(true)
+    setPortalHabilitadoFuncionario(false)
+    setNotificarEmailPortalFuncionario(true)
   }
 
   function toggleEmpresaFuncionario(id: number) {
@@ -689,16 +705,34 @@ export function RedeDetalhe() {
         return
       }
     }
+    const senhaPortal = senhaPortalFuncionario.trim()
+    if (senhaPortal) {
+      if (!emailFuncionario.trim()) {
+        toast.showWarning('Informe o e-mail do funcionário para habilitar o portal.')
+        return
+      }
+      if (senhaPortal.length < 8) {
+        toast.showWarning('A senha do portal deve ter ao menos 8 caracteres.')
+        return
+      }
+    }
+    const escopoEmpresas = tipoFuncionario === 'socio' ? 'all' : 'selected'
     setSavingFuncionario(true)
     try {
-      const payload = {
+      const payload: FuncionariosRede.Create = {
         nome: nomeFuncionario.trim(),
         email: emailFuncionario.trim(),
         tipo: tipoFuncionario,
         ativo: ativoFuncionario,
-        rede_id: tipoFuncionario === 'socio' ? redeId : undefined,
+        escopo_empresas: escopoEmpresas,
+        rede_id: redeId,
         empresa_id: tipoFuncionario === 'colaborador' ? Number(empresaIdFuncionario) : undefined,
         empresa_ids: tipoFuncionario === 'supervisor' ? empresaIdsFuncionario : undefined,
+        must_change_password: mustChangePasswordFuncionario,
+        ...(senhaPortal ? { senha_portal: senhaPortal } : {}),
+        ...(editingFuncionarioId
+          ? { notificar_email_portal: notificarEmailPortalFuncionario }
+          : {}),
       }
       const eraEdicao = editingFuncionarioId != null
       let idDetalhe: number
@@ -1669,6 +1703,50 @@ export function RedeDetalhe() {
                       )}
                     </FormSection>
                   )}
+
+                  <FormSection title="Portal do cliente">
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      Com e-mail e senha, o funcionário acessa{' '}
+                      <span className="font-medium text-slate-700 dark:text-slate-200">/portal</span> para abrir e
+                      acompanhar chamados.
+                      {modoFuncionario === 'edit' && portalHabilitadoFuncionario ? (
+                        <span className="ml-1 text-teal-700 dark:text-teal-400">Portal já habilitado.</span>
+                      ) : null}
+                    </p>
+                    <Input
+                      label={
+                        modoFuncionario === 'edit'
+                          ? 'Nova senha do portal (opcional)'
+                          : 'Senha do portal (opcional)'
+                      }
+                      type="password"
+                      value={senhaPortalFuncionario}
+                      onChange={(e) => setSenhaPortalFuncionario(e.target.value)}
+                      autoComplete="new-password"
+                      placeholder={emailFuncionario.trim() ? 'Mínimo 8 caracteres' : 'Informe o e-mail primeiro'}
+                      disabled={!emailFuncionario.trim()}
+                    />
+                    <Switch
+                      bare
+                      checked={mustChangePasswordFuncionario}
+                      onCheckedChange={setMustChangePasswordFuncionario}
+                      label="Exigir troca de senha no primeiro acesso"
+                      showStatusPill
+                      statusOnText="Sim"
+                      statusOffText="Não"
+                    />
+                    {modoFuncionario === 'edit' ? (
+                      <Switch
+                        bare
+                        checked={notificarEmailPortalFuncionario}
+                        onCheckedChange={setNotificarEmailPortalFuncionario}
+                        label="Notificar por e-mail sobre respostas nos chamados"
+                        showStatusPill
+                        statusOnText="Sim"
+                        statusOffText="Não"
+                      />
+                    ) : null}
+                  </FormSection>
 
                   <FormSection title="Situação no sistema">
                     <Switch

--- a/frontend/src/pages/chat/ChatListaAtendendo.tsx
+++ b/frontend/src/pages/chat/ChatListaAtendendo.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { Link, useMatch } from 'react-router-dom'
 import { portalChats, whatsappChats } from '../../api/client'
 import { ChatCanalBadge } from '../../components/chat/ChatCanalBadge'
@@ -14,8 +14,103 @@ import {
   mapWhatsappChat,
   ordenarAtendendo,
   rotuloResponsavelItem,
+  separarAtendendoPorResponsavel,
   type ChatHubItem,
 } from '../../lib/chatHubLista'
+
+type ItemVariant = 'proprio' | 'outro' | 'neutro'
+
+function SecaoAtendendo({
+  titulo,
+  contagem,
+  children,
+}: {
+  titulo: string
+  contagem: number
+  children: ReactNode
+}) {
+  return (
+    <section>
+      <h3 className="sticky top-0 z-10 border-b border-slate-100 bg-white/95 px-3 py-2 text-[10px] font-bold uppercase tracking-widest text-slate-500 backdrop-blur-sm dark:border-slate-800 dark:bg-slate-950/95">
+        {titulo} ({contagem})
+      </h3>
+      <ul className="divide-y divide-slate-100 dark:divide-slate-800">{children}</ul>
+    </section>
+  )
+}
+
+function ChatAtendendoItem({
+  item,
+  ativo,
+  variant,
+  usuarioId,
+}: {
+  item: ChatHubItem
+  ativo: boolean
+  variant: ItemVariant
+  usuarioId?: number | null
+}) {
+  const key = chatHubItemKey(item)
+  const responsavel =
+    item.atendente_nome?.trim() || (item.atendente_id != null ? `Atendente #${item.atendente_id}` : 'Sem responsável')
+
+  return (
+    <li key={key}>
+      <Link
+        to={chatHubItemLink(item, 'atendendo')}
+        className={`flex gap-3 px-3 py-3 transition-colors hover:bg-slate-50 dark:hover:bg-slate-900/50 ${
+          ativo ? 'bg-cyan-50/80 dark:bg-cyan-950/30' : ''
+        } ${variant === 'proprio' ? 'border-l-2 border-cyan-500 pl-[10px]' : ''} ${
+          variant === 'outro' ? 'border-l-2 border-slate-300 pl-[10px] dark:border-slate-600' : ''
+        }`}
+      >
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold ${
+            ativo ? 'bg-cyan-600 text-white' : 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-200'
+          }`}
+        >
+          {item.nome.charAt(0)?.toUpperCase() || '?'}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex min-w-0 flex-1 items-center gap-1.5">
+              <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">{item.nome}</p>
+              {variant === 'proprio' && (
+                <span className="shrink-0 rounded-full bg-cyan-100 px-1.5 py-0.5 text-[9px] font-bold uppercase text-cyan-800 dark:bg-cyan-950/60 dark:text-cyan-200">
+                  Você
+                </span>
+              )}
+            </div>
+            {item.estado === 'aguardando_atendente' && (
+              <span className="h-2 w-2 shrink-0 rounded-full bg-amber-500" title="Aguardando" />
+            )}
+          </div>
+          <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
+            <ChatCanalBadge canal={item.canal} />
+            {variant === 'outro' && (
+              <span
+                className="max-w-[9rem] truncate rounded-full bg-slate-100 px-1.5 py-0.5 text-[9px] font-semibold text-slate-700 dark:bg-slate-800 dark:text-slate-200"
+                title={responsavel}
+              >
+                {responsavel}
+              </span>
+            )}
+            <p className="truncate text-xs text-cyan-600 dark:text-cyan-400" title={exibirProtocolo(item.protocolo)}>
+              {exibirProtocolo(item.protocolo)}
+            </p>
+          </div>
+          {item.ultima_mensagem_preview ? (
+            <p className="mt-0.5 line-clamp-1 text-xs text-slate-500">{item.ultima_mensagem_preview}</p>
+          ) : variant === 'neutro' ? (
+            <p className="truncate text-xs text-slate-500">{rotuloResponsavelItem(item, usuarioId)}</p>
+          ) : variant === 'outro' ? (
+            <p className="truncate text-xs text-slate-500">{item.setor_nome ? `Setor • ${item.setor_nome}` : 'Em atendimento'}</p>
+          ) : null}
+        </div>
+      </Link>
+    </li>
+  )
+}
 
 export function ChatListaAtendendo() {
   const { user } = useAuth()
@@ -64,6 +159,17 @@ export function ChatListaAtendendo() {
   }, [subscribe, load])
 
   const lista = filtrarChatHubPorBusca(meus, busca)
+  const { comigo, outros, mostrarSecoes } = separarAtendendoPorResponsavel(lista, user?.id)
+
+  const renderItem = (item: ChatHubItem, variant: ItemVariant) => (
+    <ChatAtendendoItem
+      key={chatHubItemKey(item)}
+      item={item}
+      ativo={chatAtivoKey === chatHubItemKey(item)}
+      variant={variant}
+      usuarioId={user?.id}
+    />
+  )
 
   if (loading) {
     return <p className="p-4 text-center text-sm text-slate-400 animate-pulse">Carregando…</p>
@@ -77,49 +183,26 @@ export function ChatListaAtendendo() {
     )
   }
 
+  if (!mostrarSecoes) {
+    return (
+      <ul className="divide-y divide-slate-100 dark:divide-slate-800">
+        {comigo.map((item) => renderItem(item, 'neutro'))}
+      </ul>
+    )
+  }
+
   return (
-    <ul className="divide-y divide-slate-100 dark:divide-slate-800">
-      {lista.map((c) => {
-        const key = chatHubItemKey(c)
-        const ativo = chatAtivoKey === key
-        return (
-          <li key={key}>
-            <Link
-              to={chatHubItemLink(c, 'atendendo')}
-              className={`flex gap-3 px-3 py-3 transition-colors hover:bg-slate-50 dark:hover:bg-slate-900/50 ${
-                ativo ? 'bg-cyan-50/80 dark:bg-cyan-950/30' : ''
-              }`}
-            >
-              <div
-                className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold ${
-                  ativo ? 'bg-cyan-600 text-white' : 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-200'
-                }`}
-              >
-                {c.nome.charAt(0)?.toUpperCase() || '?'}
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="flex items-start justify-between gap-2">
-                  <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">{c.nome}</p>
-                  {c.estado === 'aguardando_atendente' && (
-                    <span className="h-2 w-2 shrink-0 rounded-full bg-amber-500" title="Aguardando" />
-                  )}
-                </div>
-                <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
-                  <ChatCanalBadge canal={c.canal} />
-                  <p className="truncate text-xs text-cyan-600 dark:text-cyan-400" title={exibirProtocolo(c.protocolo)}>
-                    {exibirProtocolo(c.protocolo)}
-                  </p>
-                </div>
-                {c.ultima_mensagem_preview ? (
-                  <p className="mt-0.5 line-clamp-1 text-xs text-slate-500">{c.ultima_mensagem_preview}</p>
-                ) : (
-                  <p className="truncate text-xs text-slate-500">{rotuloResponsavelItem(c, user?.id)}</p>
-                )}
-              </div>
-            </Link>
-          </li>
-        )
-      })}
-    </ul>
+    <div>
+      {comigo.length > 0 && (
+        <SecaoAtendendo titulo="Comigo" contagem={comigo.length}>
+          {comigo.map((item) => renderItem(item, 'proprio'))}
+        </SecaoAtendendo>
+      )}
+      {outros.length > 0 && (
+        <SecaoAtendendo titulo="Outros atendentes" contagem={outros.length}>
+          {outros.map((item) => renderItem(item, 'outro'))}
+        </SecaoAtendendo>
+      )}
+    </div>
   )
 }

--- a/frontend/src/pages/kb-public/KbPublicContext.tsx
+++ b/frontend/src/pages/kb-public/KbPublicContext.tsx
@@ -21,6 +21,7 @@ const FALLBACK_BRANDING: Kb.PublicBranding = {
   texto_boas_vindas: null,
   cor_primaria: '#0D9488',
   cor_header: '#0B2D4A',
+  cor_sidebar: '#0B2D4A',
   cor_texto_header: '#FFFFFF',
   cor_texto_corpo: '#0F172A',
   cor_fundo: '#F8FAFC',

--- a/frontend/src/pages/kb-public/KbPublicLayout.tsx
+++ b/frontend/src/pages/kb-public/KbPublicLayout.tsx
@@ -17,9 +17,11 @@ function KbPublicShell() {
   return (
     <div
       className="kb-public-portal flex min-h-dvh flex-col"
+      data-theme="light"
       style={{
         backgroundColor: branding.cor_fundo,
         color: branding.cor_texto_corpo,
+        colorScheme: 'light',
         ['--kb-accent' as string]: branding.cor_primaria,
         ['--kb-header' as string]: branding.cor_header,
         ['--kb-link' as string]: branding.cor_link,

--- a/frontend/src/pages/marketing/LandingPage.tsx
+++ b/frontend/src/pages/marketing/LandingPage.tsx
@@ -24,7 +24,7 @@ function SecondaryLink({ to, children }: { to: string; children: ReactNode }) {
   return (
     <Link
       to={to}
-      className="inline-flex items-center justify-center rounded-xl border border-white/20 bg-white/5 px-6 py-3.5 text-sm font-semibold text-slate-100 backdrop-blur-sm transition hover:border-white/35 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60"
+      className="inline-flex items-center justify-center rounded-2xl border border-sky-400/30 bg-white/5 px-5 py-3 text-sm font-semibold text-sky-100 shadow-[0_0_0_1px_rgba(255,255,255,0.03)] backdrop-blur-sm transition duration-200 hover:-translate-y-0.5 hover:border-sky-300/50 hover:bg-sky-400/15 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60"
     >
       {children}
     </Link>
@@ -35,17 +35,20 @@ function SectionHeading({
   eyebrow,
   title,
   body,
+  align = 'left',
 }: {
   eyebrow?: string
   title: string
   body?: string
+  align?: 'left' | 'center'
 }) {
   return (
-    <div className="max-w-3xl">
+    <div className={align === 'center' ? 'mx-auto max-w-3xl text-center' : 'max-w-3xl'}>
       {eyebrow ? (
-        <p className="mb-3 text-xs font-semibold tracking-[0.2em] text-sky-400 uppercase">{eyebrow}</p>
+        <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-sky-400">{eyebrow}</p>
       ) : null}
-      <h2 className="text-3xl font-bold tracking-tight text-white sm:text-4xl">{title}</h2>
+      <div className={align === 'center' ? 'mx-auto h-px w-20 bg-gradient-to-r from-sky-500/0 via-sky-400/80 to-sky-500/0' : 'h-px w-20 bg-gradient-to-r from-sky-500/0 via-sky-400/80 to-sky-500/0'} />
+      <h2 className="mt-5 text-3xl font-bold tracking-tight text-white sm:text-4xl">{title}</h2>
       {body ? <p className="mt-4 text-lg leading-relaxed text-slate-300">{body}</p> : null}
     </div>
   )
@@ -62,7 +65,6 @@ function scrollToSection(e: MouseEvent<HTMLAnchorElement>, id: string) {
   } else {
     el.scrollIntoView({ behavior: 'smooth', block: 'start' })
   }
-  // Evita hash na URL “prender” o foco sem scroll no container do app
   if (window.history.replaceState) {
     window.history.replaceState(null, '', `#${id}`)
   }
@@ -74,10 +76,50 @@ export function LandingPage() {
   const [lightbox, setLightbox] = useState<LightboxState>(null)
   const closeLightbox = useCallback(() => setLightbox(null), [])
 
+  const heroProofPoints = ['Fila única', 'SLA visível', 'Base de conhecimento', 'Painel executivo']
+  const heroStats = [
+    { value: '+40%', label: 'visibilidade da fila em tempo real' },
+    { value: '0', label: 'perda de contexto entre setores' },
+    { value: '24/7', label: 'controle do fluxo sem improviso' },
+  ]
+  const experienceHighlights = [
+    {
+      title: 'Resposta com contexto',
+      body: 'Cada demanda chega completa, com histórico, prioridade e próximos passos já definidos.',
+    },
+    {
+      title: 'Visibilidade executiva',
+      body: 'SLA, fila e risco ocupam um só painel, para a gestão decidir sem ruído.',
+    },
+    {
+      title: 'Fluxo único',
+      body: 'Chamados, WhatsApp e e-mail seguem o mesmo processo, com menos retrabalho e mais consistência.',
+    },
+  ]
+  const credibilityMetrics = [
+    { value: '3x', label: 'mais velocidade na coordenação' },
+    { value: '100%', label: 'visibilidade da operação em um só painel' },
+    { value: '≤ 1 min', label: 'para entender o próximo passo' },
+  ]
+  const valuePillars = [
+    {
+      title: 'Centralize a operação',
+      body: 'Junte tickets, WhatsApp, e-mail e conhecimento num único contexto, sem perder o histórico.',
+    },
+    {
+      title: 'Acelere a resposta',
+      body: 'Defina prioridades, encaminhe rápido e mantenha o time alinhado com visão real do fluxo.',
+    },
+    {
+      title: 'Mostre resultado',
+      body: 'Tenha métricas claras de SLA, produtividade e atendimento para tomar decisão com confiança.',
+    },
+  ]
+
   return (
     <MarketingLayout>
-      <header className="sticky top-0 z-40 border-b border-white/5 bg-[#071826]/80 backdrop-blur-md">
-        <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-5 py-4 sm:px-8">
+      <header className="sticky top-0 z-40 border-b border-white/5 bg-[#071826]/85 backdrop-blur-xl">
+        <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-4 px-5 py-4 sm:px-8">
           <BrandLogo variant="full" size="md" markVariant="onDark" />
           <nav className="flex flex-wrap items-center justify-end gap-2 sm:gap-4">
             <a
@@ -96,7 +138,7 @@ export function LandingPage() {
             </a>
             <Link
               to={landingHero.ctaSecondaryTo}
-              className="rounded-lg px-3 py-2 text-sm font-semibold text-sky-300 transition hover:text-sky-200"
+              className="rounded-full px-3 py-2 text-sm font-semibold text-sky-300 transition hover:bg-white/5 hover:text-sky-200"
             >
               {landingHero.ctaSecondary}
             </Link>
@@ -110,120 +152,219 @@ export function LandingPage() {
       </header>
 
       <main>
-        <section className="relative mx-auto flex min-h-[calc(100dvh-5.5rem)] w-full max-w-6xl flex-col justify-center px-5 pb-14 pt-8 sm:px-8 sm:pb-16">
-          <div className="grid items-center gap-10 lg:grid-cols-[minmax(0,1.05fr)_minmax(0,1fr)] lg:gap-12 xl:gap-16">
-            <div className="landing-fade-up min-w-0">
-              <p className="mb-5 text-sm font-medium tracking-[0.18em] text-sky-300/90 uppercase">
-                {landingHero.brand}
-                <span className="mx-2 text-slate-500">·</span>
-                <span className="normal-case tracking-normal text-slate-400">{landingHero.tagline}</span>
-              </p>
-              <h1 className="text-[2.15rem] font-bold leading-[1.12] tracking-tight text-white sm:text-5xl lg:text-[3.15rem] lg:leading-[1.1]">
-                {landingHero.titleLines.map((line) => (
-                  <span key={line} className="block">
-                    {line}
-                  </span>
-                ))}
-              </h1>
-              <p className="mt-6 max-w-xl text-base leading-relaxed text-slate-300 sm:text-lg">
-                {landingHero.subtitle}
-              </p>
-              <div className="mt-9 flex flex-wrap items-center gap-3">
-                <LandingContactSlot variant="hero" label={landingHero.ctaPrimary} />
-                <SecondaryLink to={landingHero.ctaSecondaryTo}>{landingHero.ctaSecondary}</SecondaryLink>
+        <section className="relative isolate overflow-hidden py-8 sm:py-10 lg:py-12">
+          <div className="absolute inset-x-0 top-0 -z-10 h-[32rem] bg-[radial-gradient(circle_at_top_left,_rgba(56,189,248,0.22),_transparent_46%),radial-gradient(circle_at_85%_12%,_rgba(14,165,233,0.16),_transparent_38%)]" />
+          <div className="pointer-events-none absolute left-8 top-20 hidden h-40 w-40 rounded-full border border-sky-400/20 bg-sky-400/10 blur-3xl lg:block" />
+          <div className="pointer-events-none absolute right-10 top-24 hidden h-56 w-56 rounded-full border border-white/10 bg-white/5 blur-3xl lg:block" />
+          <div className="mx-auto flex min-h-[calc(100dvh-5.5rem)] w-full max-w-7xl flex-col justify-center px-5 pb-16 pt-8 sm:px-8 sm:pb-20 lg:px-10">
+            <div className="grid items-center gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:gap-12 xl:gap-16">
+              <div className="landing-fade-up min-w-0">
+                <div className="inline-flex items-center gap-2 rounded-full border border-sky-400/30 bg-sky-400/10 px-3.5 py-2 text-sm font-medium text-sky-200 shadow-[0_0_0_1px_rgba(255,255,255,0.03)]">
+                  <span className="size-2 rounded-full bg-sky-400" />
+                  {landingHero.brand} · {landingHero.tagline}
+                </div>
+                <h1 className="mt-6 bg-gradient-to-r from-white via-sky-100 to-slate-400 bg-clip-text text-[2.15rem] font-bold leading-[1.08] tracking-tight text-transparent sm:text-5xl lg:text-[3.2rem] lg:leading-[1.05]">
+                  {landingHero.titleLines.map((line) => (
+                    <span key={line} className="block">
+                      {line}
+                    </span>
+                  ))}
+                </h1>
+                <p className="mt-6 max-w-2xl text-base leading-relaxed text-slate-300 sm:text-lg">
+                  {landingHero.subtitle}
+                </p>
+                <div className="mt-6 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-2 text-sm text-slate-300">
+                  <span className="size-2 rounded-full bg-emerald-400" />
+                  Plataforma premium para operações de suporte que querem excelência
+                </div>
+                <div className="mt-8 flex flex-wrap items-center gap-3">
+                  <LandingContactSlot variant="hero" label={landingHero.ctaPrimary} />
+                  <SecondaryLink to={landingHero.ctaSecondaryTo}>{landingHero.ctaSecondary}</SecondaryLink>
+                </div>
+                <div className="mt-7 flex flex-wrap gap-2">
+                  {heroProofPoints.map((item) => (
+                    <span
+                      key={item}
+                      className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-sm text-slate-300"
+                    >
+                      {item}
+                    </span>
+                  ))}
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-3">
+                  {heroStats.map((stat) => (
+                    <div key={stat.label} className="rounded-2xl border border-white/10 bg-white/[0.04] p-4 backdrop-blur-sm">
+                      <p className="text-xl font-semibold text-white">{stat.value}</p>
+                      <p className="mt-1 text-sm text-slate-400">{stat.label}</p>
+                    </div>
+                  ))}
+                </div>
               </div>
-              <p className="mt-6 max-w-lg text-sm leading-relaxed text-slate-500">{landingHero.trustLine}</p>
-            </div>
 
-            <div className="landing-shot min-w-0 lg:justify-self-stretch">
-              <LandingShotButton
-                label="Painel DeskRudder"
-                onOpen={() =>
-                  setLightbox({
-                    src: landingShots.dashboard,
-                    alt: 'Painel DeskRudder com métricas de chamados e WhatsApp',
-                  })
-                }
-              >
-                <figure className="overflow-hidden rounded-2xl border border-white/12 shadow-2xl shadow-black/50 ring-1 ring-sky-400/15">
-                  <img
-                    src={landingShots.dashboard}
-                    alt="Painel DeskRudder com métricas de chamados e WhatsApp"
-                    className="aspect-[16/10] w-full object-cover object-top"
-                    loading="eager"
-                    fetchPriority="high"
-                  />
-                </figure>
-              </LandingShotButton>
-              <p className="mt-3 text-center text-xs text-slate-500 lg:text-left">
-                Clique na imagem para ampliar
-              </p>
+              <div className="landing-shot min-w-0 lg:justify-self-stretch">
+                <div className="relative overflow-hidden rounded-[1.9rem] border border-white/10 bg-gradient-to-br from-white/[0.08] via-slate-950/80 to-slate-900/90 p-3 shadow-[0_30px_80px_rgba(2,8,23,0.45)] backdrop-blur-xl sm:p-4 before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/70 before:to-transparent">
+                  <div className="mb-4 flex items-center justify-between rounded-full border border-white/10 bg-slate-950/50 px-3 py-2 text-sm text-slate-300">
+                    <span className="font-medium text-white">Operação premium</span>
+                    <span className="rounded-full border border-sky-400/25 bg-sky-400/10 px-2.5 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-sky-300">
+                      em tempo real
+                    </span>
+                  </div>
+                  <LandingShotButton
+                    label="Painel DeskRudder"
+                    onOpen={() =>
+                      setLightbox({
+                        src: landingShots.dashboard,
+                        alt: 'Painel DeskRudder com métricas de chamados e WhatsApp',
+                      })
+                    }
+                  >
+                    <figure className="overflow-hidden rounded-[1.2rem] border border-white/10">
+                      <img
+                        src={landingShots.dashboard}
+                        alt="Painel DeskRudder com métricas de chamados e WhatsApp"
+                        className="aspect-[16/10] w-full object-cover object-top"
+                        loading="eager"
+                        fetchPriority="high"
+                      />
+                    </figure>
+                  </LandingShotButton>
+                  <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                    <div className="rounded-2xl border border-sky-400/20 bg-sky-400/10 p-4">
+                      <p className="text-2xl font-semibold text-white">+40%</p>
+                      <p className="mt-1 text-sm text-slate-300">visibilidade da fila em tempo real</p>
+                    </div>
+                    <div className="rounded-2xl border border-white/10 bg-[#0A1628]/70 p-4">
+                      <p className="text-2xl font-semibold text-white">0</p>
+                      <p className="mt-1 text-sm text-slate-300">perda de conversa entre setores</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-7xl px-5 pb-8 sm:px-8 lg:px-10">
+          <div className="rounded-[1.5rem] border border-white/10 bg-gradient-to-r from-white/[0.06] via-white/[0.03] to-white/[0.05] px-6 py-5 shadow-[0_20px_60px_rgba(2,8,23,0.18)] backdrop-blur-sm sm:px-8">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">Por que empresas escolhem o DeskRudder</p>
+              <div className="flex flex-wrap gap-3 text-sm text-slate-300">
+                <span className="rounded-full border border-sky-400/20 bg-sky-400/10 px-3 py-1">Atendimento centralizado</span>
+                <span className="rounded-full border border-white/10 bg-[#0A1628]/70 px-3 py-1">SLA e prioridade em um só painel</span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-7xl px-5 pb-8 sm:px-8 lg:px-10">
+          <div className="rounded-[1.75rem] border border-sky-400/20 bg-gradient-to-br from-sky-500/10 via-white/[0.03] to-slate-950/80 p-6 shadow-[0_25px_70px_rgba(2,8,23,0.22)] backdrop-blur-md sm:p-8">
+            <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
+              <div className="max-w-2xl">
+                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-sky-400">Confiança operacional</p>
+                <h2 className="mt-3 text-2xl font-semibold text-white sm:text-3xl">Mais controle, menos ruído e menos retrabalho para o time.</h2>
+                <p className="mt-3 text-base leading-relaxed text-slate-300">
+                  O DeskRudder transforma a operação em um ambiente previsível, com contexto claro, prioridades visíveis e decisões mais rápidas.
+                </p>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-3 lg:min-w-[32rem]">
+                {credibilityMetrics.map((metric) => (
+                  <div key={metric.label} className="rounded-2xl border border-white/10 bg-slate-950/50 p-4">
+                    <p className="text-xl font-semibold text-white">{metric.value}</p>
+                    <p className="mt-1 text-sm text-slate-400">{metric.label}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="valor" className="py-14 sm:py-16">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+            <SectionHeading
+              eyebrow="O que muda na operação"
+              title="Uma operação mais limpa, mais rápida e mais previsível"
+              body="A solução foi pensada para dar clareza ao time, reduzir ruído e fazer o atendimento parecer um sistema profissional — e não um improviso."
+            />
+            <div className="mt-10 grid gap-6 lg:grid-cols-3">
+              {valuePillars.map((pillar, index) => (
+                <article key={pillar.title} className="relative overflow-hidden rounded-[1.5rem] border border-white/10 bg-white/[0.03] p-6 shadow-lg shadow-black/10 transition duration-300 hover:-translate-y-1 hover:border-sky-400/25 hover:bg-white/[0.05] before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/70 before:to-transparent">
+                  <div className="inline-flex size-11 items-center justify-center rounded-2xl border border-sky-400/20 bg-sky-500/10 text-sm font-semibold text-sky-200">
+                    0{index + 1}
+                  </div>
+                  <h3 className="mt-4 text-xl font-semibold text-white">{pillar.title}</h3>
+                  <p className="mt-3 text-sm leading-relaxed text-slate-400">{pillar.body}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="pb-8 sm:pb-10">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+            <div className="grid gap-6 lg:grid-cols-3">
+              {experienceHighlights.map((item) => (
+                <div key={item.title} className="relative overflow-hidden rounded-[1.5rem] border border-white/10 bg-gradient-to-br from-white/[0.04] to-white/[0.02] p-6 shadow-[0_15px_45px_rgba(2,8,23,0.12)] before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/60 before:to-transparent">
+                  <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+                  <p className="mt-3 text-sm leading-relaxed text-slate-400">{item.body}</p>
+                </div>
+              ))}
             </div>
           </div>
         </section>
 
         <section className="border-t border-white/10 bg-[#071826]/70 py-16 sm:py-20">
-          <div className="mx-auto max-w-6xl px-5 sm:px-8">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingPain.title} />
             <ul className="mt-10 grid gap-6 md:grid-cols-3">
-              {landingPain.items.map((item) => (
-                <li key={item.title} className="border-l-2 border-rose-400/50 pl-4">
-                  <h3 className="text-lg font-semibold text-white">{item.title}</h3>
+              {landingPain.items.map((item, index) => (
+                <li key={item.title} className="relative overflow-hidden rounded-[1.35rem] border border-rose-400/20 bg-rose-400/10 p-6 transition duration-300 hover:-translate-y-1 hover:border-rose-400/35 before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-rose-400/60 before:to-transparent">
+                  <p className="text-sm font-semibold uppercase tracking-[0.2em] text-rose-300">0{index + 1}</p>
+                  <h3 className="mt-3 text-lg font-semibold text-white">{item.title}</h3>
                   <p className="mt-2 text-sm leading-relaxed text-slate-400">{item.body}</p>
                 </li>
               ))}
             </ul>
-            <div className="mt-12 rounded-2xl border border-sky-500/25 bg-sky-500/5 px-6 py-8 sm:px-8">
+            <div className="mt-10 rounded-[1.5rem] border border-sky-500/25 bg-sky-500/10 px-6 py-8 sm:px-8">
               <h3 className="text-2xl font-bold text-sky-300">{landingPain.pivotTitle}</h3>
-              <p className="mt-3 max-w-3xl text-base leading-relaxed text-slate-300">
-                {landingPain.pivotBody}
-              </p>
+              <p className="mt-3 max-w-3xl text-base leading-relaxed text-slate-300">{landingPain.pivotBody}</p>
             </div>
           </div>
         </section>
 
-        <section className="py-14 sm:py-16">
-          <div className="mx-auto grid max-w-6xl items-center gap-10 px-5 sm:px-8 lg:grid-cols-2">
-            <div>
-              <SectionHeading
-                eyebrow="Na prática"
-                title="Veja o painel que sua equipe vai usar"
-                body="Prints reais do sistema (com dados de demonstração): fila, chamados, chat e conhecimento. Clique na imagem para ampliar."
-              />
-              <div className="mt-6">
-                <LandingContactSlot variant="section" label="Quero ver na prática" />
+        <section className="py-16 sm:py-20">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+            <div className="grid gap-6 lg:grid-cols-2">
+              <div className="rounded-[1.75rem] border border-rose-400/20 bg-rose-500/10 p-8 shadow-[0_20px_60px_rgba(2,8,23,0.16)]">
+                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-rose-300">Antes</p>
+                <h3 className="mt-3 text-2xl font-semibold text-white">Operação fragmentada e reativa</h3>
+                <ul className="mt-5 space-y-3 text-sm leading-relaxed text-slate-300">
+                  <li>• Mensagens espalhadas por celulares e e-mails</li>
+                  <li>• Falta de contexto ao transferir entre setores</li>
+                  <li>• SLA e prioridades invisíveis para a gestão</li>
+                </ul>
+              </div>
+              <div className="rounded-[1.75rem] border border-sky-400/20 bg-gradient-to-br from-sky-500/10 via-white/[0.03] to-slate-950/80 p-8 shadow-[0_20px_60px_rgba(2,8,23,0.16)]">
+                <p className="text-sm font-semibold uppercase tracking-[0.2em] text-sky-300">Depois</p>
+                <h3 className="mt-3 text-2xl font-semibold text-white">Fluxo único, visão clara e resposta mais certeira</h3>
+                <ul className="mt-5 space-y-3 text-sm leading-relaxed text-slate-300">
+                  <li>• Um painel para todos os canais e fornecedores de atendimento</li>
+                  <li>• Histórico completo e responsabilidade bem definida</li>
+                  <li>• Alertas e métricas para gerenciar com excelência</li>
+                </ul>
               </div>
             </div>
-            <LandingShotButton
-              label="Dashboard DeskRudder"
-              onOpen={() =>
-                setLightbox({
-                  src: landingShots.dashboard,
-                  alt: 'Painel DeskRudder com métricas de chamados e WhatsApp',
-                })
-              }
-            >
-              <figure className="overflow-hidden rounded-2xl border border-white/12 shadow-2xl shadow-black/40">
-                <img
-                  src={landingShots.dashboard}
-                  alt="Painel DeskRudder com métricas de chamados e WhatsApp"
-                  className="w-full object-cover object-top"
-                  loading="lazy"
-                />
-              </figure>
-            </LandingShotButton>
           </div>
         </section>
 
-        <section id="produto" className="scroll-mt-24 border-t border-white/10 py-6 sm:py-10">
-          <div className="mx-auto max-w-6xl px-5 sm:px-8">
+        <section id="produto" className="scroll-mt-24 py-16 sm:py-20">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading
               eyebrow="O que você encontra"
-              title="Tudo para gerir o suporte num só lugar"
-              body="Sem promessa de roadmap. Abaixo está o que o DeskRudder já entrega hoje para centralizar o atendimento da sua empresa."
+              title="Tudo o que sua equipe precisa para atender melhor"
+              body="Do canal ao prazo, o DeskRudder reúne cada etapa do atendimento para reduzir ruído, dar contexto e manter o fluxo sob controle."
             />
           </div>
-          <div className="mx-auto mt-12 flex max-w-6xl flex-col gap-20 px-5 sm:px-8 sm:gap-28">
+          <div className="mx-auto mt-12 flex max-w-7xl flex-col gap-8 px-5 sm:px-8 lg:px-10">
             {landingShowcases.map((block, i) => {
               const reverse = i % 2 === 1
               const alt = `Painel DeskRudder — ${block.eyebrow}`
@@ -231,23 +372,16 @@ export function LandingPage() {
                 <article
                   key={block.id}
                   id={block.id}
-                  className="grid items-center gap-10 lg:grid-cols-2 lg:gap-14"
+                  className="relative overflow-hidden grid items-center gap-8 rounded-[1.75rem] border border-white/10 bg-white/[0.035] p-6 shadow-xl shadow-black/15 transition duration-300 hover:-translate-y-1 hover:border-sky-400/25 hover:bg-white/[0.045] lg:grid-cols-2 lg:gap-12 lg:p-8 before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/70 before:to-transparent"
                 >
                   <div className={reverse ? 'lg:order-2' : ''}>
-                    <p className="text-xs font-semibold tracking-[0.18em] text-sky-400 uppercase">
-                      {block.eyebrow}
-                    </p>
-                    <h3 className="mt-3 text-2xl font-bold tracking-tight text-white sm:text-3xl">
-                      {block.title}
-                    </h3>
+                    <p className="text-xs font-semibold uppercase tracking-[0.25em] text-sky-400">{block.eyebrow}</p>
+                    <h3 className="mt-3 text-2xl font-bold tracking-tight text-white sm:text-3xl">{block.title}</h3>
                     <p className="mt-4 text-base leading-relaxed text-slate-300">{block.body}</p>
                     <ul className="mt-6 space-y-3">
                       {block.bullets.map((b) => (
                         <li key={b} className="flex gap-3 text-sm text-slate-300">
-                          <span
-                            className="mt-1.5 size-1.5 shrink-0 rounded-full bg-sky-400"
-                            aria-hidden
-                          />
+                          <span className="mt-1.5 size-1.5 shrink-0 rounded-full bg-sky-400" aria-hidden />
                           <span className="leading-relaxed">{b}</span>
                         </li>
                       ))}
@@ -267,7 +401,7 @@ export function LandingPage() {
           </div>
         </section>
 
-        <section className="mt-16 border-y border-sky-500/20 bg-gradient-to-r from-sky-700/25 via-[#0B2D4A]/80 to-sky-500/20 py-14 sm:py-16">
+        <section className="border-y border-sky-500/20 bg-gradient-to-r from-sky-700/20 via-[#0B2D4A]/85 to-sky-500/20 py-14 sm:py-16">
           <div className="mx-auto max-w-3xl px-5 text-center sm:px-8">
             <h2 className="text-2xl font-bold text-white sm:text-3xl">{landingMidCta.title}</h2>
             <p className="mt-3 text-slate-200">{landingMidCta.body}</p>
@@ -278,15 +412,12 @@ export function LandingPage() {
         </section>
 
         <section id="resultados" className="scroll-mt-24 py-16 sm:py-20">
-          <div className="mx-auto max-w-6xl px-5 sm:px-8">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingOutcomes.title} />
-            <ul className="mt-10 grid gap-6 sm:grid-cols-2">
+            <ul className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
               {landingOutcomes.items.map((item) => (
-                <li
-                  key={item.label}
-                  className="rounded-2xl border border-white/10 bg-white/[0.03] p-6 transition hover:border-sky-500/35"
-                >
-                  <h3 className="text-xl font-semibold text-sky-300">{item.label}</h3>
+                <li key={item.label} className="relative overflow-hidden rounded-[1.35rem] border border-white/10 bg-white/[0.03] p-6 transition duration-300 hover:-translate-y-1 hover:border-sky-500/35 hover:bg-white/[0.05] before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/60 before:to-transparent">
+                  <h3 className="text-lg font-semibold text-sky-300">{item.label}</h3>
                   <p className="mt-2 text-sm leading-relaxed text-slate-400">{item.body}</p>
                 </li>
               ))}
@@ -295,11 +426,11 @@ export function LandingPage() {
         </section>
 
         <section className="border-t border-white/10 bg-[#0A1628]/70 py-16 sm:py-20">
-          <div className="mx-auto max-w-6xl px-5 sm:px-8">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingHowItWorks.title} />
             <ol className="mt-12 grid gap-10 md:grid-cols-3">
               {landingHowItWorks.steps.map((s) => (
-                <li key={s.n}>
+                <li key={s.n} className="relative overflow-hidden rounded-[1.35rem] border border-white/10 bg-white/[0.03] p-6 transition duration-300 hover:-translate-y-1 hover:border-sky-400/25 hover:bg-white/[0.05] before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/60 before:to-transparent">
                   <span className="text-3xl font-bold text-sky-500/45">{s.n}</span>
                   <h3 className="mt-3 text-lg font-semibold text-white">{s.title}</h3>
                   <p className="mt-2 text-sm leading-relaxed text-slate-400">{s.body}</p>
@@ -310,11 +441,11 @@ export function LandingPage() {
         </section>
 
         <section className="py-16 sm:py-20">
-          <div className="mx-auto max-w-6xl px-5 sm:px-8">
+          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingAudience.title} body={landingAudience.body} />
             <ul className="mt-10 grid gap-6 md:grid-cols-3">
               {landingAudience.segments.map((seg) => (
-                <li key={seg.title} className="border-t border-sky-500/40 pt-5">
+                <li key={seg.title} className="relative overflow-hidden rounded-[1.35rem] border border-sky-500/20 bg-sky-500/5 p-6 transition duration-300 hover:-translate-y-1 hover:border-sky-400/35 hover:bg-sky-500/10 before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/60 before:to-transparent">
                   <h3 className="text-lg font-semibold text-white">{seg.title}</h3>
                   <p className="mt-2 text-sm leading-relaxed text-slate-400">{seg.body}</p>
                 </li>
@@ -325,10 +456,11 @@ export function LandingPage() {
 
         <section id="contato" className="scroll-mt-24 border-t border-white/10 py-16 sm:py-24">
           <div className="mx-auto max-w-3xl px-5 text-center sm:px-8">
-            <p className="text-sm font-medium tracking-[0.2em] text-sky-400 uppercase">{APP_NAME}</p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-white sm:text-4xl">
-              {landingFinalCta.title}
-            </h2>
+            <div className="mx-auto inline-flex items-center gap-2 rounded-full border border-sky-400/25 bg-sky-400/10 px-3.5 py-2 text-sm text-sky-200">
+              <span className="size-2 rounded-full bg-sky-400" />
+              {APP_NAME}
+            </div>
+            <h2 className="mt-5 text-3xl font-bold tracking-tight text-white sm:text-4xl">{landingFinalCta.title}</h2>
             <p className="mt-4 text-lg text-slate-300">{landingFinalCta.body}</p>
             <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
               <LandingContactSlot variant="section" label={landingFinalCta.ctaPrimary} />
@@ -339,7 +471,7 @@ export function LandingPage() {
       </main>
 
       <footer className="border-t border-white/10 bg-[#050810]/80 py-10">
-        <div className="mx-auto flex max-w-6xl flex-col gap-6 px-5 sm:flex-row sm:items-end sm:justify-between sm:px-8">
+        <div className="mx-auto flex max-w-7xl flex-col gap-6 px-5 sm:flex-row sm:items-end sm:justify-between sm:px-8 lg:px-10">
           <div>
             <BrandLogo variant="wordmark" size="sm" markVariant="onDark" />
             <p className="mt-2 max-w-md text-sm text-slate-500">{landingFooter.productLine}</p>
@@ -351,9 +483,7 @@ export function LandingPage() {
             <a href={`mailto:${landingContactEmail}`} className="text-slate-400 hover:text-slate-200">
               {landingFooter.contactLabel}: {landingContactEmail}
             </a>
-            <p className="text-xs text-slate-600">
-              © {new Date().getFullYear()} {APP_NAME}
-            </p>
+            <p className="text-xs text-slate-600">© {new Date().getFullYear()} {APP_NAME}</p>
           </div>
         </div>
       </footer>
@@ -375,6 +505,9 @@ export function LandingPage() {
         }
         .landing-shot {
           animation: landing-fade-up 0.9s ease-out both;
+        }
+        body {
+          background-color: #071826;
         }
         @media (prefers-reduced-motion: reduce) {
           .landing-fade-up, .landing-shot { animation: none; }

--- a/frontend/src/pages/portal/PortalAjuda.tsx
+++ b/frontend/src/pages/portal/PortalAjuda.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { kbPublic, type Kb } from '../../api/client'
+import { KbMarkdownPreview } from '../../components/kb/KbMarkdownPreview'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useToast } from '../../components/ui/Toast'
+
+export function PortalAjudaHome() {
+  const [busca, setBusca] = useState('')
+  const [buscaDebounced, setBuscaDebounced] = useState('')
+  const [categorias, setCategorias] = useState<Kb.Category[]>([])
+  const [artigos, setArtigos] = useState<Kb.ArticleBrief[]>([])
+  const [loading, setLoading] = useState(true)
+  const toast = useToast()
+
+  useEffect(() => {
+    const t = window.setTimeout(() => setBuscaDebounced(busca.trim()), 300)
+    return () => window.clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    Promise.all([
+      kbPublic.listCategories(),
+      kbPublic.listArticles({ busca: buscaDebounced || undefined, limit: 40 }),
+    ])
+      .then(([cats, arts]) => {
+        if (cancelled) return
+        setCategorias(cats)
+        setArtigos(arts)
+      })
+      .catch((err) => {
+        if (!cancelled) toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar a ajuda.'))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [buscaDebounced, toast])
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h1 className="text-xl font-semibold text-slate-900">Central de ajuda</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Consulte manuais e artigos antes de abrir um chamado.
+        </p>
+      </div>
+
+      <input
+        type="search"
+        value={busca}
+        onChange={(e) => setBusca(e.target.value)}
+        placeholder="Buscar artigos…"
+        className="w-full rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25"
+      />
+
+      {loading ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-14 animate-pulse rounded-xl bg-slate-100" />
+          ))}
+        </div>
+      ) : (
+        <>
+          {categorias.length > 0 && !buscaDebounced ? (
+            <div className="flex flex-wrap gap-2">
+              {categorias.map((c) => (
+                <span
+                  key={c.id}
+                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600"
+                >
+                  {c.nome}
+                </span>
+              ))}
+            </div>
+          ) : null}
+
+          {artigos.length === 0 ? (
+            <p className="rounded-2xl border border-dashed border-slate-300 px-4 py-8 text-center text-sm text-slate-500">
+              Nenhum artigo encontrado.
+            </p>
+          ) : (
+            <ul className="divide-y divide-slate-100 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+              {artigos.map((a) => (
+                <li key={a.id}>
+                  <Link
+                    to={`/portal/ajuda/${a.slug}`}
+                    className="block px-4 py-3.5 transition hover:bg-teal-50/50"
+                  >
+                    <p className="font-medium text-slate-900">{a.titulo}</p>
+                    {a.category_nome ? (
+                      <p className="mt-0.5 text-sm text-slate-500">{a.category_nome}</p>
+                    ) : null}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+
+      <p className="text-center text-sm text-slate-500">
+        Não achou o que precisava?{' '}
+        <Link to="/portal/tickets/novo" className="font-semibold text-teal-700 hover:underline">
+          Abrir chamado
+        </Link>
+      </p>
+    </div>
+  )
+}
+
+export function PortalAjudaArtigo() {
+  const { slug } = useParams<{ slug: string }>()
+  const [artigo, setArtigo] = useState<Kb.Article | null>(null)
+  const [loading, setLoading] = useState(true)
+  const toast = useToast()
+
+  useEffect(() => {
+    if (!slug) return
+    let cancelled = false
+    setLoading(true)
+    kbPublic
+      .getArticleBySlug(slug)
+      .then((a) => {
+        if (!cancelled) setArtigo(a)
+      })
+      .catch((err) => {
+        if (!cancelled) toast.showError(mensagemFalhaParaToast(err, 'Artigo não encontrado.'))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [slug, toast])
+
+  if (loading) {
+    return <div className="h-64 animate-pulse rounded-2xl bg-slate-100" />
+  }
+  if (!artigo) {
+    return (
+      <div className="space-y-3">
+        <Link to="/portal/ajuda" className="text-sm font-medium text-slate-500 hover:text-slate-800">
+          ← Voltar
+        </Link>
+        <p className="text-sm text-slate-600">Artigo não encontrado.</p>
+      </div>
+    )
+  }
+
+  return (
+    <article className="space-y-4">
+      <Link to="/portal/ajuda" className="text-sm font-medium text-slate-500 hover:text-slate-800">
+        ← Voltar à ajuda
+      </Link>
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h1 className="text-xl font-semibold text-slate-900">{artigo.titulo}</h1>
+        {artigo.category_nome ? (
+          <p className="mt-2 text-sm text-slate-600">{artigo.category_nome}</p>
+        ) : null}
+        <div className="prose prose-slate mt-5 max-w-none prose-a:text-teal-700">
+          <KbMarkdownPreview markdown={artigo.conteudo_markdown || ''} />
+        </div>
+      </div>
+      <p className="text-center text-sm text-slate-500">
+        Ainda com dúvida?{' '}
+        <Link to="/portal/tickets/novo" className="font-semibold text-teal-700 hover:underline">
+          Abrir chamado
+        </Link>
+      </p>
+    </article>
+  )
+}

--- a/frontend/src/pages/portal/PortalAjuda.tsx
+++ b/frontend/src/pages/portal/PortalAjuda.tsx
@@ -4,6 +4,7 @@ import { kbPublic, type Kb } from '../../api/client'
 import { KbMarkdownPreview } from '../../components/kb/KbMarkdownPreview'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { useToast } from '../../components/ui/Toast'
+import { PortalPageHeader, portalCardClass, portalInputClass } from './portalUi'
 
 export function PortalAjudaHome() {
   const [busca, setBusca] = useState('')
@@ -42,26 +43,24 @@ export function PortalAjudaHome() {
   }, [buscaDebounced, toast])
 
   return (
-    <div className="space-y-5">
-      <div>
-        <h1 className="text-xl font-semibold text-slate-900">Central de ajuda</h1>
-        <p className="mt-1 text-sm text-slate-600">
-          Consulte manuais e artigos antes de abrir um chamado.
-        </p>
-      </div>
+    <div className="space-y-6">
+      <PortalPageHeader
+        title="Central de ajuda"
+        subtitle="Consulte manuais e artigos antes de abrir um chamado."
+      />
 
       <input
         type="search"
         value={busca}
         onChange={(e) => setBusca(e.target.value)}
         placeholder="Buscar artigos…"
-        className="w-full rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25"
+        className={portalInputClass}
       />
 
       {loading ? (
-        <div className="space-y-2">
+        <div className="space-y-3">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="h-14 animate-pulse rounded-xl bg-slate-100" />
+            <div key={i} className="h-14 animate-pulse rounded-xl bg-slate-200/60" />
           ))}
         </div>
       ) : (
@@ -71,7 +70,7 @@ export function PortalAjudaHome() {
               {categorias.map((c) => (
                 <span
                   key={c.id}
-                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600"
+                  className="rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-medium text-slate-600 ring-1 ring-slate-200/80"
                 >
                   {c.nome}
                 </span>
@@ -80,17 +79,14 @@ export function PortalAjudaHome() {
           ) : null}
 
           {artigos.length === 0 ? (
-            <p className="rounded-2xl border border-dashed border-slate-300 px-4 py-8 text-center text-sm text-slate-500">
+            <div className="rounded-xl border border-dashed border-slate-300 bg-white px-4 py-10 text-center text-sm text-slate-500">
               Nenhum artigo encontrado.
-            </p>
+            </div>
           ) : (
-            <ul className="divide-y divide-slate-100 overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+            <ul className="space-y-2">
               {artigos.map((a) => (
                 <li key={a.id}>
-                  <Link
-                    to={`/portal/ajuda/${a.slug}`}
-                    className="block px-4 py-3.5 transition hover:bg-teal-50/50"
-                  >
+                  <Link to={`/portal/ajuda/${a.slug}`} className={`block ${portalCardClass}`}>
                     <p className="font-medium text-slate-900">{a.titulo}</p>
                     {a.category_nome ? (
                       <p className="mt-0.5 text-sm text-slate-500">{a.category_nome}</p>
@@ -105,7 +101,11 @@ export function PortalAjudaHome() {
 
       <p className="text-center text-sm text-slate-500">
         Não achou o que precisava?{' '}
-        <Link to="/portal/tickets/novo" className="font-semibold text-teal-700 hover:underline">
+        <Link
+          to="/portal/tickets/novo"
+          className="font-semibold hover:underline"
+          style={{ color: 'var(--portal-link)' }}
+        >
           Abrir chamado
         </Link>
       </p>
@@ -158,18 +158,22 @@ export function PortalAjudaArtigo() {
       <Link to="/portal/ajuda" className="text-sm font-medium text-slate-500 hover:text-slate-800">
         ← Voltar à ajuda
       </Link>
-      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-        <h1 className="text-xl font-semibold text-slate-900">{artigo.titulo}</h1>
+      <div className={`${portalCardClass} p-5 sm:p-6`}>
+        <h1 className="text-xl font-semibold tracking-tight text-slate-900 sm:text-2xl">{artigo.titulo}</h1>
         {artigo.category_nome ? (
-          <p className="mt-2 text-sm text-slate-600">{artigo.category_nome}</p>
+          <p className="mt-2 text-sm text-slate-500">{artigo.category_nome}</p>
         ) : null}
-        <div className="prose prose-slate mt-5 max-w-none prose-a:text-teal-700">
+        <div className="prose prose-slate mt-5 max-w-none prose-a:text-[var(--portal-link)]">
           <KbMarkdownPreview markdown={artigo.conteudo_markdown || ''} />
         </div>
       </div>
       <p className="text-center text-sm text-slate-500">
         Ainda com dúvida?{' '}
-        <Link to="/portal/tickets/novo" className="font-semibold text-teal-700 hover:underline">
+        <Link
+          to="/portal/tickets/novo"
+          className="font-semibold hover:underline"
+          style={{ color: 'var(--portal-link)' }}
+        >
           Abrir chamado
         </Link>
       </p>

--- a/frontend/src/pages/portal/PortalBrandLogo.tsx
+++ b/frontend/src/pages/portal/PortalBrandLogo.tsx
@@ -1,0 +1,29 @@
+import { portalCliente } from '../../api/client'
+import { usePortalBranding } from '../../contexts/PortalBrandingContext'
+
+type Props = {
+  className?: string
+}
+
+export function PortalBrandLogo({ className = 'h-10 w-auto max-w-[12rem] object-contain' }: Props) {
+  const branding = usePortalBranding()
+
+  if (branding.logo_url) {
+    return (
+      <img
+        src={portalCliente.logoAssetUrl()}
+        alt={branding.nome_exibicao}
+        className={className}
+      />
+    )
+  }
+
+  return (
+    <span
+      className="block truncate text-lg font-semibold tracking-tight"
+      style={{ color: branding.cor_header }}
+    >
+      {branding.nome_exibicao}
+    </span>
+  )
+}

--- a/frontend/src/pages/portal/PortalBrandingRoot.tsx
+++ b/frontend/src/pages/portal/PortalBrandingRoot.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react'
+import { PortalBrandingProvider } from '../../contexts/PortalBrandingContext'
+
+export function PortalBrandingRoot({ children }: { children: ReactNode }) {
+  return <PortalBrandingProvider>{children}</PortalBrandingProvider>
+}

--- a/frontend/src/pages/portal/PortalChatDetalhe.tsx
+++ b/frontend/src/pages/portal/PortalChatDetalhe.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { portalCliente, type PortalCliente } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useToast } from '../../components/ui/Toast'
+
+function formatData(iso?: string | null) {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleString('pt-BR', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+function estadoLabel(estado: string) {
+  const s = (estado || '').toLowerCase()
+  if (s === 'encerrado') return 'Encerrado'
+  if (s === 'em_atendimento') return 'Em atendimento'
+  if (s === 'aguardando_atendente') return 'Aguardando'
+  return estado || '—'
+}
+
+export function PortalChatDetalhe() {
+  const { id } = useParams<{ id: string }>()
+  const chatId = Number(id)
+  const [chat, setChat] = useState<PortalCliente.WhatsappChatDetail | null>(null)
+  const [mensagens, setMensagens] = useState<PortalCliente.WhatsappMensagem[]>([])
+  const [loading, setLoading] = useState(true)
+  const bottomRef = useRef<HTMLDivElement | null>(null)
+  const toast = useToast()
+  const navigate = useNavigate()
+
+  const carregar = useCallback(async () => {
+    if (!Number.isFinite(chatId)) return
+    const [c, msgs] = await Promise.all([
+      portalCliente.getChat(chatId),
+      portalCliente.listChatMensagens(chatId),
+    ])
+    setChat(c)
+    setMensagens(msgs)
+  }, [chatId])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    carregar()
+      .catch((err) => {
+        if (!cancelled) {
+          toast.showError(mensagemFalhaParaToast(err, 'Atendimento não encontrado.'))
+          navigate('/portal/chats', { replace: true })
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [carregar, navigate, toast])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+  }, [mensagens.length])
+
+  useEffect(() => {
+    if (!chat || chat.encerrado) return
+    const t = window.setInterval(() => {
+      carregar().catch(() => undefined)
+    }, 15000)
+    return () => window.clearInterval(t)
+  }, [carregar, chat])
+
+  async function abrirMidia(msg: PortalCliente.WhatsappMensagem) {
+    if (!chat || !msg.midia_disponivel) return
+    try {
+      const blob = await portalCliente.fetchChatMidiaBlob(chat.id, msg.id)
+      const url = URL.createObjectURL(blob)
+      window.open(url, '_blank', 'noopener,noreferrer')
+      window.setTimeout(() => URL.revokeObjectURL(url), 60000)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível abrir a mídia.'))
+    }
+  }
+
+  if (loading || !chat) {
+    return (
+      <div className="space-y-4">
+        <div className="h-8 w-48 animate-pulse rounded-lg bg-slate-100" />
+        <div className="h-64 animate-pulse rounded-2xl bg-slate-100" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-[70dvh] flex-col gap-4">
+      <div>
+        <button
+          type="button"
+          onClick={() => navigate('/portal/chats')}
+          className="mb-2 text-sm font-medium text-slate-500 hover:text-slate-800"
+        >
+          ← Voltar
+        </button>
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <p className="font-mono text-xs font-semibold text-teal-700">{chat.protocolo}</p>
+          <h1 className="mt-1 text-lg font-semibold text-slate-900">Atendimento WhatsApp</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            {estadoLabel(chat.estado)}
+            {chat.empresa_nome ? ` · ${chat.empresa_nome}` : ''}
+            {chat.setor_nome ? ` · ${chat.setor_nome}` : ''}
+          </p>
+        </div>
+      </div>
+
+      {chat.encerrado ? (
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+          Este atendimento está encerrado. Para nova conversa, envie mensagem pelo WhatsApp ou{' '}
+          <Link to="/portal/tickets/novo" className="font-semibold text-teal-700 underline-offset-2 hover:underline">
+            abra um chamado
+          </Link>
+          .
+        </div>
+      ) : (
+        <p className="text-xs text-slate-500">
+          Visualização somente leitura. Continue a conversa pelo WhatsApp se o atendimento estiver ativo.
+        </p>
+      )}
+
+      <div className="flex-1 space-y-3 rounded-2xl border border-slate-200 bg-white p-3 shadow-sm">
+        {mensagens.length === 0 ? (
+          <p className="py-8 text-center text-sm text-slate-500">Nenhuma mensagem visível.</p>
+        ) : (
+          mensagens.map((m) => {
+            const isVoce = m.autor_papel === 'voce'
+            return (
+              <div key={m.id} className={`flex ${isVoce ? 'justify-end' : 'justify-start'}`}>
+                <div
+                  className={[
+                    'max-w-[85%] rounded-2xl px-3 py-2 text-sm shadow-sm',
+                    isVoce ? 'bg-teal-600 text-white' : 'bg-slate-100 text-slate-900',
+                  ].join(' ')}
+                >
+                  <p className={`text-[10px] font-medium ${isVoce ? 'text-teal-100' : 'text-slate-500'}`}>
+                    {m.autor_nome || (isVoce ? 'Você' : 'Equipe')}
+                  </p>
+                  <p className="mt-0.5 whitespace-pre-wrap break-words">{m.corpo}</p>
+                  {m.midia_disponivel ? (
+                    <button
+                      type="button"
+                      onClick={() => abrirMidia(m)}
+                      className={`mt-1 text-xs font-semibold underline underline-offset-2 ${
+                        isVoce ? 'text-teal-100' : 'text-teal-700'
+                      }`}
+                    >
+                      Ver {m.tipo_midia || 'anexo'}
+                    </button>
+                  ) : null}
+                  <p className={`mt-1 text-[10px] ${isVoce ? 'text-teal-100/80' : 'text-slate-400'}`}>
+                    {formatData(m.created_at)}
+                  </p>
+                </div>
+              </div>
+            )
+          })
+        )}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/PortalChatWidget.tsx
+++ b/frontend/src/pages/portal/PortalChatWidget.tsx
@@ -1,0 +1,404 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
+import { fetchPortalPublicMidiaBlob, kbPublic, type Kb } from '../../api/client'
+import { ChatMensagemMidia } from '../../components/chat/ChatMensagemMidia'
+import { usePortalAuth } from '../../contexts/PortalAuthContext'
+import { usePortalBranding } from '../../contexts/PortalBrandingContext'
+
+/** Token separado do chat visitante em /kb — mesma API, mesma instância (single-tenant). */
+const LS_TOKEN = 'dxconnect.portal.cliente.chat_token'
+
+type Fase = 'fechado' | 'form' | 'chat'
+
+function brandingVars(b: {
+  cor_fundo: string
+  cor_texto_corpo: string
+  cor_header: string
+  cor_texto_header: string
+  cor_primaria: string
+}): CSSProperties {
+  return {
+    backgroundColor: b.cor_fundo,
+    color: b.cor_texto_corpo,
+    ['--portal-chat-header' as string]: b.cor_header,
+    ['--portal-chat-header-text' as string]: b.cor_texto_header,
+    ['--portal-chat-accent' as string]: b.cor_primaria,
+  }
+}
+
+/**
+ * Chat ao vivo no portal autenticado — reutiliza `/kb/public/chat` (portal_chat).
+ * Em produção cada cliente tem instância própria (subdomínio + Postgres); o chat
+ * só chega ao DeskRudder dessa instância.
+ */
+export function PortalChatWidget() {
+  const branding = usePortalBranding()
+  const { user } = usePortalAuth()
+  const vars = useMemo(() => brandingVars(branding), [branding])
+
+  const [fase, setFase] = useState<Fase>('fechado')
+  const [token, setToken] = useState<string | null>(null)
+  const [nome, setNome] = useState('')
+  const [email, setEmail] = useState('')
+  const [sessao, setSessao] = useState<Kb.PortalChatPublicSession | null>(null)
+  const [texto, setTexto] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [enviando, setEnviando] = useState(false)
+  const [erro, setErro] = useState<string | null>(null)
+  const fimRef = useRef<HTMLDivElement>(null)
+  const lastMsgIdRef = useRef(0)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (!user) return
+    setNome((prev) => prev || user.nome || '')
+    setEmail((prev) => prev || user.email || '')
+  }, [user])
+
+  const abrir = useCallback(() => {
+    setFase((f) => (f === 'fechado' ? 'form' : f))
+    setErro(null)
+  }, [])
+
+  const restaurar = useCallback(async (savedToken: string) => {
+    setLoading(true)
+    try {
+      const data = await kbPublic.obterChat(savedToken)
+      if (data.estado === 'encerrado') {
+        localStorage.removeItem(LS_TOKEN)
+        setFase('form')
+        return
+      }
+      setToken(savedToken)
+      setSessao(data)
+      setNome(data.visitante_nome)
+      lastMsgIdRef.current = data.mensagens.at(-1)?.id ?? 0
+      setFase('chat')
+    } catch {
+      localStorage.removeItem(LS_TOKEN)
+      setFase('form')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!branding.chat_habilitado) return
+    const saved = localStorage.getItem(LS_TOKEN)
+    if (saved) void restaurar(saved)
+  }, [branding.chat_habilitado, restaurar])
+
+  useEffect(() => {
+    fimRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [sessao?.mensagens, sessao?.estado])
+
+  useEffect(() => {
+    if (fase !== 'chat' || !token) return
+    const timer = setInterval(() => {
+      void (async () => {
+        try {
+          const [sessaoAtual, novas] = await Promise.all([
+            kbPublic.obterChat(token),
+            kbPublic.listarMensagensChat(token, lastMsgIdRef.current || undefined),
+          ])
+          setSessao((prev) => {
+            const mergedMsgs =
+              novas.length > 0
+                ? [
+                    ...(prev?.mensagens ?? []),
+                    ...novas.filter((n) => !(prev?.mensagens ?? []).some((m) => m.id === n.id)),
+                  ]
+                : (prev?.mensagens ?? sessaoAtual.mensagens)
+            if (novas.length > 0) lastMsgIdRef.current = novas[novas.length - 1].id
+            return {
+              protocolo: sessaoAtual.protocolo,
+              estado: sessaoAtual.estado,
+              visitante_nome: sessaoAtual.visitante_nome,
+              mensagens: mergedMsgs,
+            }
+          })
+        } catch {
+          /* silencioso */
+        }
+      })()
+    }, 4000)
+    return () => clearInterval(timer)
+  }, [fase, token])
+
+  async function iniciar(e: React.FormEvent) {
+    e.preventDefault()
+    const n = nome.trim()
+    if (!n) {
+      setErro('Informe seu nome.')
+      return
+    }
+    setLoading(true)
+    setErro(null)
+    try {
+      const data = await kbPublic.iniciarChat(
+        { visitante_nome: n, visitante_email: email.trim() || null },
+        token,
+      )
+      localStorage.setItem(LS_TOKEN, data.visitor_token)
+      setToken(data.visitor_token)
+      setSessao({
+        protocolo: data.chat.protocolo,
+        estado: data.chat.estado,
+        visitante_nome: data.chat.visitante_nome,
+        mensagens: data.mensagens,
+      })
+      lastMsgIdRef.current = data.mensagens.at(-1)?.id ?? 0
+      setFase('chat')
+    } catch (err) {
+      setErro(err instanceof Error ? err.message : 'Não foi possível iniciar o chat.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function enviar(corpo?: string) {
+    if (!token) return
+    const textoEnvio = (corpo ?? texto).trim()
+    if (!textoEnvio) return
+    setEnviando(true)
+    try {
+      const msg = await kbPublic.enviarMensagemChat(token, textoEnvio)
+      lastMsgIdRef.current = msg.id
+      const refreshed = await kbPublic.obterChat(token)
+      setSessao(refreshed)
+      lastMsgIdRef.current = refreshed.mensagens.at(-1)?.id ?? msg.id
+      setTexto('')
+    } catch (err) {
+      setErro(err instanceof Error ? err.message : 'Não foi possível enviar.')
+    } finally {
+      setEnviando(false)
+    }
+  }
+
+  async function enviarArquivo(file: File) {
+    if (!token) return
+    setEnviando(true)
+    try {
+      const msg = await kbPublic.enviarMidiaChat(token, file)
+      lastMsgIdRef.current = msg.id
+      const refreshed = await kbPublic.obterChat(token)
+      setSessao(refreshed)
+      lastMsgIdRef.current = refreshed.mensagens.at(-1)?.id ?? msg.id
+    } catch (err) {
+      setErro(err instanceof Error ? err.message : 'Não foi possível enviar o anexo.')
+    } finally {
+      setEnviando(false)
+    }
+  }
+
+  if (!branding.chat_habilitado) return null
+
+  const inputClass =
+    'w-full rounded-lg border border-black/15 bg-white px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-[var(--portal-chat-accent)]/40'
+  const aguardandoAtendente = sessao?.estado === 'aguardando_atendente'
+  const aguardandoAvaliacao = sessao?.estado === 'aguardando_avaliacao'
+  const encerrado = sessao?.estado === 'encerrado'
+  const podeEnviar = sessao?.estado === 'em_atendimento' || aguardandoAvaliacao
+
+  return (
+    <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col items-end gap-3">
+      {fase !== 'fechado' ? (
+        <div
+          className="pointer-events-auto flex w-[min(100vw-2rem,22rem)] flex-col overflow-hidden rounded-2xl border border-black/10 shadow-2xl"
+          style={{ ...vars, maxHeight: 'min(70vh, 32rem)' }}
+        >
+          <header
+            className="flex items-center gap-3 border-b border-black/10 px-3 py-2.5"
+            style={{ backgroundColor: branding.cor_header, color: branding.cor_texto_header }}
+          >
+            {branding.logo_url ? (
+              <img
+                src={kbPublic.logoAssetUrl()}
+                alt=""
+                className="h-9 max-h-9 w-auto max-w-[5.5rem] shrink-0 object-contain object-left"
+              />
+            ) : null}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-sm font-semibold leading-tight">{branding.nome_exibicao}</p>
+              <p className="truncate text-[11px] opacity-90">
+                {sessao?.protocolo ? `${sessao.protocolo} · Fale conosco` : 'Fale conosco'}
+              </p>
+            </div>
+            <button
+              type="button"
+              className="shrink-0 rounded p-1.5 transition-colors hover:bg-white/10"
+              style={{ color: branding.cor_texto_header }}
+              onClick={() => setFase('fechado')}
+              aria-label="Fechar chat"
+            >
+              ✕
+            </button>
+          </header>
+
+          {fase === 'form' ? (
+            <form onSubmit={(e) => void iniciar(e)} className="space-y-3 p-4" style={{ color: branding.cor_texto_corpo }}>
+              <p className="text-sm opacity-90">
+                Converse com a equipe de suporte em tempo real.
+              </p>
+              <input
+                value={nome}
+                onChange={(e) => setNome(e.target.value)}
+                placeholder="Seu nome"
+                className={inputClass}
+                style={{ color: branding.cor_texto_corpo }}
+                readOnly={Boolean(user?.nome)}
+              />
+              <input
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                type="email"
+                placeholder="E-mail"
+                className={inputClass}
+                style={{ color: branding.cor_texto_corpo }}
+                readOnly={Boolean(user?.email)}
+              />
+              {erro ? <p className="text-xs text-red-600">{erro}</p> : null}
+              <button
+                type="submit"
+                disabled={loading}
+                className="w-full rounded-lg px-3 py-2 text-sm font-semibold text-white disabled:opacity-60"
+                style={{ backgroundColor: branding.cor_primaria }}
+              >
+                {loading ? 'Conectando…' : 'Iniciar chat'}
+              </button>
+            </form>
+          ) : null}
+
+          {fase === 'chat' && sessao ? (
+            <>
+              <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3" style={{ backgroundColor: branding.cor_fundo }}>
+                {aguardandoAtendente ? (
+                  <p className="mb-2 text-center text-xs text-amber-800">Aguardando um atendente…</p>
+                ) : null}
+                <div className="flex flex-col gap-2">
+                  {sessao.mensagens.map((m) => {
+                    const visitante = m.direcao === 'inbound'
+                    return (
+                      <div key={m.id} className={`flex ${visitante ? 'justify-end' : 'justify-start'}`}>
+                        <div
+                          className={`max-w-[90%] rounded-2xl px-3 py-2 text-sm ${
+                            visitante ? 'text-white' : 'border border-black/10 bg-white shadow-sm'
+                          }`}
+                          style={
+                            visitante
+                              ? { backgroundColor: branding.cor_primaria }
+                              : { color: branding.cor_texto_corpo }
+                          }
+                        >
+                          {!visitante && m.atendente_nome ? (
+                            <p className="mb-0.5 text-[10px] font-semibold opacity-60">{m.atendente_nome}</p>
+                          ) : null}
+                          <ChatMensagemMidia
+                            mensagem={m}
+                            fetchMidia={() => fetchPortalPublicMidiaBlob(token!, m.id)}
+                          />
+                        </div>
+                      </div>
+                    )
+                  })}
+                  <div ref={fimRef} />
+                </div>
+              </div>
+
+              {aguardandoAvaliacao ? (
+                <div className="border-t border-black/10 p-3" style={{ backgroundColor: branding.cor_fundo }}>
+                  <p className="mb-2 text-center text-xs font-medium">Como você avalia o atendimento?</p>
+                  <div className="flex justify-center gap-2">
+                    {[1, 2, 3, 4, 5].map((nota) => (
+                      <button
+                        key={nota}
+                        type="button"
+                        disabled={enviando}
+                        onClick={() => void enviar(String(nota))}
+                        className="flex size-9 items-center justify-center rounded-full border border-black/15 bg-white text-sm font-bold hover:bg-black/5 disabled:opacity-50"
+                        style={{ color: branding.cor_texto_corpo }}
+                      >
+                        {nota}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ) : encerrado ? (
+                <p className="border-t border-black/10 px-3 py-2 text-center text-xs opacity-70">
+                  Atendimento encerrado.
+                </p>
+              ) : (
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault()
+                    void enviar()
+                  }}
+                  className="flex gap-2 border-t border-black/10 p-3"
+                  style={{ backgroundColor: branding.cor_fundo }}
+                >
+                  {podeEnviar && sessao.estado === 'em_atendimento' ? (
+                    <>
+                      <input
+                        ref={fileInputRef}
+                        type="file"
+                        accept="image/*,audio/*,video/*,.pdf,.doc,.docx"
+                        className="hidden"
+                        onChange={(e) => {
+                          const file = e.target.files?.[0]
+                          if (file) void enviarArquivo(file)
+                          e.target.value = ''
+                        }}
+                      />
+                      <button
+                        type="button"
+                        className="shrink-0 rounded-lg border border-black/15 px-2 text-lg"
+                        onClick={() => fileInputRef.current?.click()}
+                        disabled={enviando}
+                        aria-label="Anexar ficheiro"
+                      >
+                        📎
+                      </button>
+                    </>
+                  ) : null}
+                  <input
+                    value={texto}
+                    onChange={(e) => setTexto(e.target.value)}
+                    placeholder={aguardandoAvaliacao ? 'Digite uma nota de 1 a 5…' : 'Digite sua mensagem…'}
+                    disabled={!podeEnviar}
+                    className={`min-w-0 flex-1 ${inputClass}`}
+                    style={{ color: branding.cor_texto_corpo }}
+                  />
+                  <button
+                    type="submit"
+                    disabled={enviando || !podeEnviar || !texto.trim()}
+                    className="shrink-0 rounded-lg px-3 py-2 text-sm font-semibold text-white disabled:opacity-60"
+                    style={{ backgroundColor: branding.cor_primaria }}
+                  >
+                    Enviar
+                  </button>
+                </form>
+              )}
+              {erro ? <p className="px-3 pb-2 text-xs text-red-600">{erro}</p> : null}
+            </>
+          ) : null}
+        </div>
+      ) : null}
+
+      <button
+        type="button"
+        onClick={abrir}
+        className="pointer-events-auto flex size-14 items-center justify-center rounded-full text-white shadow-lg transition-transform hover:scale-105"
+        style={{ backgroundColor: branding.cor_header }}
+        aria-label="Abrir chat ao vivo"
+      >
+        <svg className="size-7" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+          />
+        </svg>
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/PortalChats.tsx
+++ b/frontend/src/pages/portal/PortalChats.tsx
@@ -8,8 +8,6 @@ import {
   PortalSegmentedControl,
   portalCardClass,
   portalInputClass,
-  portalPrimaryBtnClass,
-  portalSecondaryBtnClass,
 } from './portalUi'
 
 function formatData(iso?: string | null) {
@@ -26,19 +24,29 @@ function formatData(iso?: string | null) {
   }
 }
 
-function statusTone(slug?: string | null) {
-  const s = (slug || '').toLowerCase()
-  if (s === 'fechado' || s === 'resolvido') return 'bg-slate-100 text-slate-600'
-  if (s === 'aguardando_cliente') return 'bg-amber-50 text-amber-800 ring-1 ring-amber-200/60'
-  if (s === 'em_atendimento') return 'bg-emerald-50 text-emerald-800 ring-1 ring-emerald-200/60'
-  return 'bg-sky-50 text-sky-800 ring-1 ring-sky-200/50'
+function estadoLabel(estado: string) {
+  const s = (estado || '').toLowerCase()
+  if (s === 'encerrado') return 'Encerrado'
+  if (s === 'em_atendimento') return 'Em atendimento'
+  if (s === 'aguardando_atendente') return 'Aguardando'
+  if (s === 'aguardando_avaliacao') return 'Aguardando avaliação'
+  if (s === 'classificacao_demanda_pendente') return 'Em classificação'
+  return estado || '—'
 }
 
-export function PortalTickets() {
-  const [situacao, setSituacao] = useState<'abertos' | 'fechados' | 'todos'>('abertos')
+function estadoTone(estado: string) {
+  const s = (estado || '').toLowerCase()
+  if (s === 'encerrado') return 'bg-slate-100 text-slate-600 ring-1 ring-slate-200/80'
+  if (s === 'em_atendimento') return 'bg-emerald-50 text-emerald-800 ring-1 ring-emerald-200/60'
+  if (s === 'aguardando_atendente') return 'bg-sky-50 text-sky-800 ring-1 ring-sky-200/50'
+  return 'bg-amber-50 text-amber-800 ring-1 ring-amber-200/60'
+}
+
+export function PortalChats() {
+  const [situacao, setSituacao] = useState<'abertos' | 'encerrados' | 'todos'>('abertos')
   const [busca, setBusca] = useState('')
   const [buscaDebounced, setBuscaDebounced] = useState('')
-  const [items, setItems] = useState<PortalCliente.TicketListItem[]>([])
+  const [items, setItems] = useState<PortalCliente.WhatsappChatListItem[]>([])
   const [total, setTotal] = useState(0)
   const [loading, setLoading] = useState(true)
   const [erro, setErro] = useState<string | null>(null)
@@ -54,7 +62,7 @@ export function PortalTickets() {
     setLoading(true)
     setErro(null)
     portalCliente
-      .listTickets({ situacao, busca: buscaDebounced || undefined, limit: 50 })
+      .listChats({ situacao, busca: buscaDebounced || undefined, limit: 50 })
       .then((res) => {
         if (cancelled) return
         setItems(res.items)
@@ -62,7 +70,7 @@ export function PortalTickets() {
       })
       .catch((err) => {
         if (cancelled) return
-        const msg = mensagemFalhaParaToast(err, 'Não foi possível carregar os chamados.')
+        const msg = mensagemFalhaParaToast(err, 'Não foi possível carregar os atendimentos.')
         setErro(msg)
         toast.showError(msg)
       })
@@ -78,13 +86,8 @@ export function PortalTickets() {
   return (
     <div className="space-y-6">
       <PortalPageHeader
-        title="Meus chamados"
-        subtitle="Acompanhe o andamento das suas solicitações."
-        action={
-          <Link to="/portal/tickets/novo" className={portalPrimaryBtnClass} style={{ backgroundColor: 'var(--portal-primary)' }}>
-            Abrir chamado
-          </Link>
-        }
+        title="Atendimentos WhatsApp"
+        subtitle="Acompanhe as conversas de suporte vinculadas a você."
       />
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -93,7 +96,7 @@ export function PortalTickets() {
           onChange={setSituacao}
           options={[
             { value: 'abertos', label: 'Abertos' },
-            { value: 'fechados', label: 'Encerrados' },
+            { value: 'encerrados', label: 'Encerrados' },
             { value: 'todos', label: 'Todos' },
           ]}
         />
@@ -101,7 +104,7 @@ export function PortalTickets() {
           type="search"
           value={busca}
           onChange={(e) => setBusca(e.target.value)}
-          placeholder="Buscar protocolo ou assunto…"
+          placeholder="Buscar por protocolo…"
           className={`${portalInputClass} flex-1`}
         />
       </div>
@@ -116,39 +119,31 @@ export function PortalTickets() {
         <div className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-5 text-sm text-rose-800">{erro}</div>
       ) : items.length === 0 ? (
         <div className="rounded-xl border border-dashed border-slate-300 bg-white px-5 py-12 text-center">
-          <p className="text-base font-medium text-slate-900">Nenhum chamado por aqui</p>
-          <p className="mt-1 text-sm text-slate-500">Abra o primeiro chamado ou consulte a base de ajuda.</p>
-          <div className="mt-5 flex flex-wrap justify-center gap-2">
-            <Link to="/portal/tickets/novo" className={portalPrimaryBtnClass} style={{ backgroundColor: 'var(--portal-primary)' }}>
-              Abrir chamado
-            </Link>
-            <Link to="/portal/ajuda" className={portalSecondaryBtnClass}>
-              Ver ajuda
-            </Link>
-          </div>
+          <p className="text-base font-medium text-slate-900">Nenhum atendimento</p>
+          <p className="mt-1 text-sm text-slate-500">Não há conversas com os filtros atuais.</p>
         </div>
       ) : (
         <ul className="space-y-3">
-          {items.map((t) => (
-            <li key={t.id}>
-              <Link to={`/portal/tickets/${t.id}`} className={`block ${portalCardClass}`}>
+          {items.map((c) => (
+            <li key={c.id}>
+              <Link to={`/portal/chats/${c.id}`} className={`block ${portalCardClass}`}>
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <p className="font-mono text-xs font-semibold tracking-wide text-[var(--portal-primary)]">
-                      {t.protocolo}
+                      {c.protocolo}
                     </p>
-                    <h2 className="mt-1 truncate text-base font-semibold text-slate-900">{t.assunto}</h2>
+                    <p className="mt-1 truncate text-base font-medium text-slate-900">
+                      {c.ultima_mensagem_preview || 'Sem mensagens'}
+                    </p>
                     <p className="mt-1 truncate text-sm text-slate-500">
-                      {t.empresa_nome || 'Empresa'} · {t.setor_nome || 'Atendimento'}
+                      {[c.empresa_nome, c.setor_nome].filter(Boolean).join(' · ') || '—'}
                     </p>
                   </div>
-                  <span className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ${statusTone(t.status_slug)}`}>
-                    {t.status_nome || '—'}
+                  <span className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ${estadoTone(c.estado)}`}>
+                    {estadoLabel(c.estado)}
                   </span>
                 </div>
-                <p className="mt-3 text-xs text-slate-400">
-                  Atualizado {formatData(t.ultima_mensagem_em || t.updated_at || t.created_at)}
-                </p>
+                <p className="mt-3 text-xs text-slate-400">{formatData(c.ultima_mensagem_em || c.created_at)}</p>
               </Link>
             </li>
           ))}
@@ -157,7 +152,7 @@ export function PortalTickets() {
 
       {!loading && items.length > 0 ? (
         <p className="text-center text-xs text-slate-400">
-          {total} chamado{total === 1 ? '' : 's'}
+          {total > items.length ? `Mostrando ${items.length} de ${total}` : `${total} atendimento${total === 1 ? '' : 's'}`}
         </p>
       ) : null}
     </div>

--- a/frontend/src/pages/portal/PortalEquipe.tsx
+++ b/frontend/src/pages/portal/PortalEquipe.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react'
+import { Link, Navigate } from 'react-router-dom'
+import { portalCliente, type PortalCliente } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { usePortalAuth } from '../../contexts/PortalAuthContext'
+import { useToast } from '../../components/ui/Toast'
+import { Switch } from '../../components/ui/Switch'
+import {
+  PortalPageHeader,
+  portalCardClass,
+  portalInputClass,
+  portalPrimaryBtnClass,
+} from './portalUi'
+
+const tipoLabel: Record<string, string> = {
+  socio: 'Sócio',
+  supervisor: 'Supervisor',
+  colaborador: 'Colaborador',
+}
+
+export function PortalEquipe() {
+  const { user } = usePortalAuth()
+  const [incluirInativos, setIncluirInativos] = useState(false)
+  const [busca, setBusca] = useState('')
+  const [buscaDebounced, setBuscaDebounced] = useState('')
+  const [items, setItems] = useState<PortalCliente.EquipeFuncionario[]>([])
+  const [loading, setLoading] = useState(true)
+  const toast = useToast()
+
+  useEffect(() => {
+    const t = window.setTimeout(() => setBuscaDebounced(busca.trim()), 300)
+    return () => window.clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    if (user?.tipo !== 'socio') return
+    let cancelled = false
+    setLoading(true)
+    portalCliente
+      .listEquipe({ incluir_inativos: incluirInativos, busca: buscaDebounced || undefined, limit: 50 })
+      .then((res) => {
+        if (!cancelled) setItems(res.items)
+      })
+      .catch((err) => {
+        if (!cancelled) toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar os usuários.'))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [user?.tipo, incluirInativos, buscaDebounced])
+
+  if (user && user.tipo !== 'socio') {
+    return <Navigate to="/portal/tickets" replace />
+  }
+
+  return (
+    <div className="space-y-6">
+      <PortalPageHeader
+        title="Usuários"
+        subtitle="Cadastre colaboradores e supervisores, defina empresas e acesso ao portal."
+        action={
+          <Link to="/portal/equipe/novo" className={portalPrimaryBtnClass} style={{ backgroundColor: 'var(--portal-primary)' }}>
+            Novo usuário
+          </Link>
+        }
+      />
+
+      <div className="flex flex-wrap items-center gap-4">
+        <Switch
+          bare
+          checked={incluirInativos}
+          onCheckedChange={setIncluirInativos}
+          label="Mostrar inativos"
+          showStatusPill
+          statusOnText="Sim"
+          statusOffText="Não"
+        />
+      </div>
+
+      <input
+        type="search"
+        value={busca}
+        onChange={(e) => setBusca(e.target.value)}
+        placeholder="Buscar por nome ou e-mail…"
+        className={portalInputClass}
+      />
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-16 animate-pulse rounded-xl bg-slate-200/60" />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-slate-300 bg-white px-4 py-12 text-center text-sm text-slate-500">
+          Nenhum usuário encontrado.
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((f) => (
+            <li key={f.id}>
+              <Link to={`/portal/equipe/${f.id}`} className={`block ${portalCardClass}`}>
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate font-medium text-slate-900">{f.nome}</p>
+                    <p className="truncate text-sm text-slate-500">{f.email || 'Sem e-mail'}</p>
+                    <p className="mt-1 text-xs text-slate-400">
+                      {f.portal_habilitado ? 'Portal habilitado' : 'Sem acesso ao portal'}
+                      {!f.ativo ? ' · Inativo' : ''}
+                    </p>
+                  </div>
+                  <span className="shrink-0 rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-medium text-slate-700 ring-1 ring-slate-200/80">
+                    {tipoLabel[f.tipo] || f.tipo}
+                  </span>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+

--- a/frontend/src/pages/portal/PortalEquipeForm.tsx
+++ b/frontend/src/pages/portal/PortalEquipeForm.tsx
@@ -1,0 +1,406 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { Link, Navigate, useNavigate, useParams } from 'react-router-dom'
+import { portalCliente, type PortalCliente } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { usePortalAuth } from '../../contexts/PortalAuthContext'
+import { useToast } from '../../components/ui/Toast'
+import { Switch } from '../../components/ui/Switch'
+import { CheckboxField } from '../../components/ui/CheckboxField'
+import {
+  PortalPageHeader,
+  portalInputClass,
+  portalPrimaryBtnClass,
+  portalSecondaryBtnClass,
+} from './portalUi'
+
+type TipoEquipe = 'colaborador' | 'supervisor'
+
+function PortalField({
+  label,
+  children,
+}: {
+  label: string
+  children: ReactNode
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1.5 block text-sm font-medium text-slate-700">{label}</span>
+      {children}
+    </label>
+  )
+}
+
+function PortalFormBlock({
+  title,
+  children,
+}: {
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-slate-400">{title}</h2>
+      <div className="space-y-4">{children}</div>
+    </section>
+  )
+}
+
+export function PortalEquipeForm() {
+  const { id } = useParams<{ id?: string }>()
+  const isEdit = Boolean(id)
+  const funcionarioId = id ? Number(id) : NaN
+  const { user } = usePortalAuth()
+  const navigate = useNavigate()
+  const toast = useToast()
+
+  const [loading, setLoading] = useState(isEdit)
+  const [saving, setSaving] = useState(false)
+  const [editavel, setEditavel] = useState(true)
+  const [empresas, setEmpresas] = useState<PortalCliente.Empresa[]>([])
+
+  const [nome, setNome] = useState('')
+  const [email, setEmail] = useState('')
+  const [telefone, setTelefone] = useState('')
+  const [tipo, setTipo] = useState<TipoEquipe>('colaborador')
+  const [ativo, setAtivo] = useState(true)
+  const [empresaId, setEmpresaId] = useState<number | ''>('')
+  const [empresaIds, setEmpresaIds] = useState<number[]>([])
+  const [senhaPortal, setSenhaPortal] = useState('')
+  const [mustChangePassword, setMustChangePassword] = useState(true)
+  const [portalHabilitado, setPortalHabilitado] = useState(false)
+  const [notificarEmailPortal, setNotificarEmailPortal] = useState(true)
+  const [outroSocio, setOutroSocio] = useState(false)
+  const [membroSocio, setMembroSocio] = useState(false)
+
+  useEffect(() => {
+    if (user?.tipo !== 'socio') return
+    portalCliente.listEquipeEmpresas().then(setEmpresas).catch(() => undefined)
+  }, [user?.tipo])
+
+  useEffect(() => {
+    if (!isEdit || !Number.isFinite(funcionarioId) || user?.tipo !== 'socio') return
+    let cancelled = false
+    setLoading(true)
+    portalCliente
+      .getEquipeFuncionario(funcionarioId)
+      .then((item) => {
+        if (cancelled) return
+        setNome(item.nome)
+        setEmail(item.email || '')
+        setTelefone(item.telefone || '')
+        if (item.tipo === 'colaborador' || item.tipo === 'supervisor') {
+          setTipo(item.tipo)
+        }
+        setMembroSocio(item.tipo === 'socio')
+        setAtivo(item.ativo)
+        setEmpresaId(item.empresa_id ?? '')
+        setEmpresaIds(item.empresa_ids ?? [])
+        setPortalHabilitado(item.portal_habilitado)
+        setMustChangePassword(item.must_change_password !== false)
+        setNotificarEmailPortal(item.notificar_email_portal !== false)
+        setEditavel(item.editavel)
+        setOutroSocio(item.tipo === 'socio' && item.id !== user?.id)
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          toast.showError(mensagemFalhaParaToast(err, 'Membro não encontrado.'))
+          navigate('/portal/equipe', { replace: true })
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [funcionarioId, isEdit, navigate, toast, user?.id, user?.tipo])
+
+  if (user && user.tipo !== 'socio') {
+    return <Navigate to="/portal/tickets" replace />
+  }
+
+  if (loading) {
+    return <div className="h-64 animate-pulse rounded-xl bg-slate-200/60" />
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (outroSocio) {
+      try {
+        setSaving(true)
+        await portalCliente.updateEquipeFuncionario(funcionarioId, {
+          ativo,
+          ...(senhaPortal.trim() ? { senha_portal: senhaPortal.trim() } : {}),
+          must_change_password: mustChangePassword,
+          notificar_email_portal: notificarEmailPortal,
+        })
+        toast.showSuccess('Sócio atualizado.')
+        navigate('/portal/equipe')
+      } catch (err) {
+        toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
+      } finally {
+        setSaving(false)
+      }
+      return
+    }
+
+    if (membroSocio) {
+      if (!nome.trim() || !email.trim()) {
+        toast.showWarning('Informe nome e e-mail.')
+        return
+      }
+      if (senhaPortal.trim() && senhaPortal.trim().length < 8) {
+        toast.showWarning('A senha do portal deve ter ao menos 8 caracteres.')
+        return
+      }
+      setSaving(true)
+      try {
+        await portalCliente.updateEquipeFuncionario(funcionarioId, {
+          nome: nome.trim(),
+          email: email.trim(),
+          telefone: telefone.trim() || null,
+          ativo,
+          ...(senhaPortal.trim() ? { senha_portal: senhaPortal.trim() } : {}),
+          must_change_password: mustChangePassword,
+          notificar_email_portal: notificarEmailPortal,
+        })
+        toast.showSuccess('Seus dados foram atualizados.')
+        navigate('/portal/equipe')
+      } catch (err) {
+        toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
+      } finally {
+        setSaving(false)
+      }
+      return
+    }
+
+    if (!nome.trim() || !email.trim()) {
+      toast.showWarning('Informe nome e e-mail.')
+      return
+    }
+    if (tipo === 'colaborador' && !empresaId) {
+      toast.showWarning('Selecione a empresa do colaborador.')
+      return
+    }
+    if (tipo === 'supervisor' && !empresaIds.length) {
+      toast.showWarning('Marque ao menos uma empresa para o supervisor.')
+      return
+    }
+    if (senhaPortal.trim() && senhaPortal.trim().length < 8) {
+      toast.showWarning('A senha do portal deve ter ao menos 8 caracteres.')
+      return
+    }
+
+    setSaving(true)
+    try {
+      const senhaPayload = senhaPortal.trim() ? { senha_portal: senhaPortal.trim() } : {}
+      if (isEdit) {
+        await portalCliente.updateEquipeFuncionario(funcionarioId, {
+          nome: nome.trim(),
+          email: email.trim(),
+          telefone: telefone.trim() || null,
+          tipo,
+          ativo,
+          empresa_id: tipo === 'colaborador' ? Number(empresaId) : undefined,
+          empresa_ids: tipo === 'supervisor' ? empresaIds : undefined,
+          must_change_password: mustChangePassword,
+          notificar_email_portal: notificarEmailPortal,
+          ...senhaPayload,
+        })
+        toast.showSuccess('Membro atualizado.')
+      } else {
+        await portalCliente.createEquipeFuncionario({
+          nome: nome.trim(),
+          email: email.trim(),
+          telefone: telefone.trim() || null,
+          tipo,
+          ativo,
+          empresa_id: tipo === 'colaborador' ? Number(empresaId) : undefined,
+          empresa_ids: tipo === 'supervisor' ? empresaIds : [],
+          must_change_password: mustChangePassword,
+          ...senhaPayload,
+        })
+        toast.showSuccess('Membro cadastrado.')
+      }
+      navigate('/portal/equipe')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function toggleEmpresa(eid: number) {
+    setEmpresaIds((prev) => (prev.includes(eid) ? prev.filter((x) => x !== eid) : [...prev, eid]))
+  }
+
+  const disabledDados = !editavel || outroSocio
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <Link to="/portal/equipe" className="text-sm font-medium text-slate-500 hover:text-slate-800">
+          ← Voltar à equipe
+        </Link>
+        <div className="mt-2">
+          <PortalPageHeader
+            title={isEdit ? 'Editar membro' : 'Novo membro da equipe'}
+            subtitle={
+              outroSocio
+                ? 'Outro sócio: só é possível alterar situação, senha do portal e notificações.'
+                : membroSocio
+                  ? 'Sócio: acesso a toda a rede (sem vínculo por empresa).'
+                  : undefined
+            }
+          />
+        </div>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-8 rounded-xl border border-slate-200/90 bg-white p-5 shadow-sm sm:p-6"
+      >
+        <PortalFormBlock title="Dados">
+          <PortalField label="Nome *">
+            <input
+              className={portalInputClass}
+              value={nome}
+              onChange={(e) => setNome(e.target.value)}
+              required
+              disabled={disabledDados}
+            />
+          </PortalField>
+          <PortalField label="E-mail *">
+            <input
+              type="email"
+              className={portalInputClass}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={disabledDados}
+            />
+          </PortalField>
+          <PortalField label="Telefone">
+            <input
+              className={portalInputClass}
+              value={telefone}
+              onChange={(e) => setTelefone(e.target.value)}
+              disabled={disabledDados}
+            />
+          </PortalField>
+          {!outroSocio && !membroSocio && editavel ? (
+            <PortalField label="Função">
+              <select
+                className={portalInputClass}
+                value={tipo}
+                onChange={(e) => {
+                  setTipo(e.target.value as TipoEquipe)
+                  setEmpresaId('')
+                  setEmpresaIds([])
+                }}
+              >
+                <option value="colaborador">Colaborador</option>
+                <option value="supervisor">Supervisor</option>
+              </select>
+            </PortalField>
+          ) : null}
+        </PortalFormBlock>
+
+        {!outroSocio && !membroSocio && editavel ? (
+          <PortalFormBlock title="Empresas">
+            {tipo === 'colaborador' ? (
+              <PortalField label="Empresa *">
+                <select
+                  className={portalInputClass}
+                  value={empresaId === '' ? '' : String(empresaId)}
+                  onChange={(e) => setEmpresaId(e.target.value ? Number(e.target.value) : '')}
+                  required
+                >
+                  <option value="">Selecione</option>
+                  {empresas.map((e) => (
+                    <option key={e.id} value={e.id}>
+                      {e.nome}
+                    </option>
+                  ))}
+                </select>
+              </PortalField>
+            ) : (
+              <div className="flex max-h-44 flex-wrap gap-2 overflow-auto rounded-lg border border-slate-200 bg-slate-50/50 p-3">
+                {empresas.map((e) => (
+                  <CheckboxField key={e.id} checked={empresaIds.includes(e.id)} onChange={() => toggleEmpresa(e.id)}>
+                    {e.nome}
+                  </CheckboxField>
+                ))}
+              </div>
+            )}
+          </PortalFormBlock>
+        ) : null}
+
+        <PortalFormBlock title="Portal do cliente">
+          <p className="text-sm text-slate-500">
+            Com e-mail e senha, o membro acessa <span className="font-medium text-slate-700">/portal</span>.
+            {portalHabilitado ? (
+              <span className="ml-1 font-medium text-emerald-700">Portal já habilitado.</span>
+            ) : null}
+          </p>
+          <PortalField label={isEdit ? 'Nova senha do portal (opcional)' : 'Senha do portal (opcional)'}>
+            <input
+              type="password"
+              className={portalInputClass}
+              value={senhaPortal}
+              onChange={(e) => setSenhaPortal(e.target.value)}
+              autoComplete="new-password"
+              disabled={!email.trim()}
+            />
+          </PortalField>
+          <Switch
+            bare
+            checked={mustChangePassword}
+            onCheckedChange={setMustChangePassword}
+            label="Exigir troca de senha no primeiro acesso"
+            showStatusPill
+            statusOnText="Sim"
+            statusOffText="Não"
+          />
+          {isEdit ? (
+            <Switch
+              bare
+              checked={notificarEmailPortal}
+              onCheckedChange={setNotificarEmailPortal}
+              label="Notificar por e-mail sobre respostas nos chamados"
+              showStatusPill
+              statusOnText="Sim"
+              statusOffText="Não"
+            />
+          ) : null}
+        </PortalFormBlock>
+
+        <PortalFormBlock title="Situação">
+          <Switch
+            bare
+            checked={ativo}
+            onCheckedChange={setAtivo}
+            label="Membro ativo"
+            showStatusPill
+            statusOnText="Ativo"
+            statusOffText="Inativo"
+          />
+        </PortalFormBlock>
+
+        <div className="flex flex-col-reverse gap-2 border-t border-slate-100 pt-5 sm:flex-row sm:justify-end">
+          <button type="button" className={portalSecondaryBtnClass} onClick={() => navigate('/portal/equipe')}>
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            className={portalPrimaryBtnClass}
+            style={{ backgroundColor: 'var(--portal-primary)' }}
+            disabled={saving}
+          >
+            {saving ? 'Salvando…' : 'Salvar'}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/PortalLayout.tsx
+++ b/frontend/src/pages/portal/PortalLayout.tsx
@@ -1,11 +1,32 @@
-import { NavLink, Navigate, Outlet, useLocation } from 'react-router-dom'
+import { useState } from 'react'
+import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { PortalAuthProvider, usePortalAuth } from '../../contexts/PortalAuthContext'
+import { usePortalBranding } from '../../contexts/PortalBrandingContext'
 import { PageLoading } from '../../components/ui/PageLoading'
-import { BrandLogo } from '../../brand'
+import { PortalBrandLogo } from './PortalBrandLogo'
+import { PortalChatWidget } from './PortalChatWidget'
+import { PortalSidebar, readPortalSidebarExpanded, writePortalSidebarExpanded } from './PortalSidebar'
+
+function perfilExibicao(tipo: string | undefined): string {
+  if (tipo === 'socio') return 'Sócio'
+  if (tipo === 'supervisor') return 'Supervisor'
+  if (tipo === 'colaborador') return 'Colaborador'
+  return tipo?.trim() || '—'
+}
+
+const menuIcon = (
+  <svg className="size-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+  </svg>
+)
 
 function PortalShell() {
   const { user, loading, logout } = usePortalAuth()
+  const branding = usePortalBranding()
   const location = useLocation()
+  const isSocio = user?.tipo === 'socio'
+  const [sidebarExpanded, setSidebarExpanded] = useState(readPortalSidebarExpanded)
+  const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false)
 
   if (loading) {
     return <PageLoading fullscreen label="Carregando portal…" />
@@ -17,59 +38,85 @@ function PortalShell() {
     return <Navigate to="/portal/trocar-senha" replace />
   }
 
-  const navClass = ({ isActive }: { isActive: boolean }) =>
-    [
-      'flex flex-1 flex-col items-center gap-0.5 rounded-xl px-2 py-2 text-[11px] font-medium transition-colors sm:flex-none sm:flex-row sm:gap-2 sm:px-3 sm:py-2 sm:text-sm',
-      isActive
-        ? 'bg-teal-600 text-white shadow-sm'
-        : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900',
-    ].join(' ')
+  function handleLogout() {
+    logout()
+    window.location.replace('/portal/login')
+  }
+
+  function toggleSidebar() {
+    if (typeof window !== 'undefined' && window.innerWidth >= 768) {
+      setSidebarExpanded((prev) => {
+        const next = !prev
+        writePortalSidebarExpanded(next)
+        return next
+      })
+    } else {
+      setSidebarMobileOpen((o) => !o)
+    }
+  }
+
+  const sidebarW = sidebarExpanded ? '280px' : '80px'
+  const roleLabel = perfilExibicao(user.tipo)
 
   return (
-    <div className="portal-cliente flex min-h-dvh flex-col bg-gradient-to-b from-slate-50 via-white to-teal-50/40">
-      <header className="sticky top-0 z-20 border-b border-slate-200/80 bg-white/90 backdrop-blur-md">
-        <div className="mx-auto flex h-14 max-w-3xl items-center justify-between gap-3 px-4">
-          <div className="flex min-w-0 items-center gap-2.5">
-            <BrandLogo className="h-8 w-auto shrink-0" />
-            <div className="min-w-0">
-              <p className="truncate text-sm font-semibold text-slate-900">Portal do cliente</p>
-              <p className="truncate text-xs text-slate-500">{user.nome}</p>
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={() => {
-              logout()
-              window.location.replace('/portal/login')
-            }}
-            className="shrink-0 rounded-lg px-2.5 py-1.5 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900"
-          >
-            Sair
-          </button>
-        </div>
-      </header>
-
-      <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-5 pb-24 sm:pb-8">
-        <Outlet />
-      </main>
-
-      <nav
-        className="fixed inset-x-0 bottom-0 z-20 border-t border-slate-200/80 bg-white/95 px-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] pt-1.5 backdrop-blur-md sm:static sm:mx-auto sm:mb-6 sm:max-w-3xl sm:rounded-2xl sm:border sm:px-3 sm:py-2 sm:shadow-sm"
-        aria-label="Navegação do portal"
+    <>
+      <div
+        className="flex h-dvh max-h-dvh min-h-0 overflow-hidden bg-gradient-to-b from-slate-50 to-slate-100/90 md:grid md:grid-cols-[var(--portal-sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
+        style={{ ['--portal-sidebar-w' as string]: sidebarW }}
       >
-        <div className="mx-auto flex max-w-3xl items-stretch justify-around gap-1 sm:justify-start sm:gap-2">
-          <NavLink to="/portal/tickets" end className={navClass}>
-            Chamados
-          </NavLink>
-          <NavLink to="/portal/tickets/novo" className={navClass}>
-            Novo
-          </NavLink>
-          <NavLink to="/portal/ajuda" className={navClass}>
-            Ajuda
-          </NavLink>
+        <PortalSidebar
+          expanded={sidebarExpanded}
+          mobileOpen={sidebarMobileOpen}
+          isSocio={isSocio}
+          userNome={user.nome}
+          userRole={roleLabel}
+          exibirMarcaDeskrudder={branding.exibir_marca_deskrudder}
+          onLogout={handleLogout}
+          onMobileClose={() => setSidebarMobileOpen(false)}
+        />
+
+        <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden md:col-start-2 md:row-start-1">
+          <header
+            className="z-30 flex h-16 min-h-[64px] shrink-0 items-center gap-2 border-b border-black/10 px-4 shadow-sm md:gap-3 md:px-6"
+            style={{ backgroundColor: branding.cor_header, color: branding.cor_texto_header }}
+          >
+            <button
+              type="button"
+              onClick={toggleSidebar}
+              className="flex size-10 shrink-0 items-center justify-center rounded-lg transition-colors hover:bg-white/10 touch-manipulation md:size-9"
+              style={{ color: branding.cor_texto_header }}
+              aria-label="Abrir ou recolher menu"
+              aria-expanded={sidebarMobileOpen || sidebarExpanded}
+            >
+              {menuIcon}
+            </button>
+
+            <div className="flex min-w-0 items-center overflow-hidden md:hidden">
+              <PortalBrandLogo className="h-7 w-auto max-w-[9rem] object-contain" />
+            </div>
+
+            <div className="min-w-0 flex-1" />
+
+            <div className="hidden min-w-0 text-right sm:block">
+              <p className="truncate text-sm font-medium" style={{ color: branding.cor_texto_header }}>
+                {user.nome}
+              </p>
+              <p className="truncate text-xs opacity-80" style={{ color: branding.cor_texto_header }}>
+                {roleLabel}
+              </p>
+            </div>
+          </header>
+
+          <main className="min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-8 md:py-8">
+            <div className="mx-auto w-full max-w-4xl">
+              <Outlet />
+            </div>
+          </main>
         </div>
-      </nav>
-    </div>
+      </div>
+
+      <PortalChatWidget />
+    </>
   )
 }
 

--- a/frontend/src/pages/portal/PortalLayout.tsx
+++ b/frontend/src/pages/portal/PortalLayout.tsx
@@ -1,0 +1,82 @@
+import { NavLink, Navigate, Outlet, useLocation } from 'react-router-dom'
+import { PortalAuthProvider, usePortalAuth } from '../../contexts/PortalAuthContext'
+import { PageLoading } from '../../components/ui/PageLoading'
+import { BrandLogo } from '../../brand'
+
+function PortalShell() {
+  const { user, loading, logout } = usePortalAuth()
+  const location = useLocation()
+
+  if (loading) {
+    return <PageLoading fullscreen label="Carregando portal…" />
+  }
+  if (!user) {
+    return <Navigate to="/portal/login" replace state={{ from: location }} />
+  }
+  if (user.must_change_password && location.pathname !== '/portal/trocar-senha') {
+    return <Navigate to="/portal/trocar-senha" replace />
+  }
+
+  const navClass = ({ isActive }: { isActive: boolean }) =>
+    [
+      'flex flex-1 flex-col items-center gap-0.5 rounded-xl px-2 py-2 text-[11px] font-medium transition-colors sm:flex-none sm:flex-row sm:gap-2 sm:px-3 sm:py-2 sm:text-sm',
+      isActive
+        ? 'bg-teal-600 text-white shadow-sm'
+        : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900',
+    ].join(' ')
+
+  return (
+    <div className="portal-cliente flex min-h-dvh flex-col bg-gradient-to-b from-slate-50 via-white to-teal-50/40">
+      <header className="sticky top-0 z-20 border-b border-slate-200/80 bg-white/90 backdrop-blur-md">
+        <div className="mx-auto flex h-14 max-w-3xl items-center justify-between gap-3 px-4">
+          <div className="flex min-w-0 items-center gap-2.5">
+            <BrandLogo className="h-8 w-auto shrink-0" />
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-slate-900">Portal do cliente</p>
+              <p className="truncate text-xs text-slate-500">{user.nome}</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              logout()
+              window.location.replace('/portal/login')
+            }}
+            className="shrink-0 rounded-lg px-2.5 py-1.5 text-xs font-medium text-slate-600 transition-colors hover:bg-slate-100 hover:text-slate-900"
+          >
+            Sair
+          </button>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-5 pb-24 sm:pb-8">
+        <Outlet />
+      </main>
+
+      <nav
+        className="fixed inset-x-0 bottom-0 z-20 border-t border-slate-200/80 bg-white/95 px-2 pb-[max(0.5rem,env(safe-area-inset-bottom))] pt-1.5 backdrop-blur-md sm:static sm:mx-auto sm:mb-6 sm:max-w-3xl sm:rounded-2xl sm:border sm:px-3 sm:py-2 sm:shadow-sm"
+        aria-label="Navegação do portal"
+      >
+        <div className="mx-auto flex max-w-3xl items-stretch justify-around gap-1 sm:justify-start sm:gap-2">
+          <NavLink to="/portal/tickets" end className={navClass}>
+            Chamados
+          </NavLink>
+          <NavLink to="/portal/tickets/novo" className={navClass}>
+            Novo
+          </NavLink>
+          <NavLink to="/portal/ajuda" className={navClass}>
+            Ajuda
+          </NavLink>
+        </div>
+      </nav>
+    </div>
+  )
+}
+
+export function PortalLayout() {
+  return (
+    <PortalAuthProvider>
+      <PortalShell />
+    </PortalAuthProvider>
+  )
+}

--- a/frontend/src/pages/portal/PortalLogin.tsx
+++ b/frontend/src/pages/portal/PortalLogin.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+import { Link, Navigate, useNavigate, useSearchParams } from 'react-router-dom'
+import { PortalAuthProvider, usePortalAuth } from '../../contexts/PortalAuthContext'
+import { Button } from '../../components/ui/Button'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { BrandLogo } from '../../brand'
+import { PageLoading } from '../../components/ui/PageLoading'
+
+const fieldClass =
+  'w-full rounded-xl border border-slate-200 bg-white px-3.5 py-3 text-[0.9375rem] text-slate-900 placeholder:text-slate-400 shadow-sm transition-colors focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25'
+
+function PortalLoginForm() {
+  const { user, loading, login } = usePortalAuth()
+  const [email, setEmail] = useState('')
+  const [senha, setSenha] = useState('')
+  const [lembrarMe, setLembrarMe] = useState(true)
+  const [mostrarSenha, setMostrarSenha] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const { showError, showSuccess } = useToast()
+  const navigate = useNavigate()
+  const [params] = useSearchParams()
+
+  if (loading) {
+    return <PageLoading fullscreen label="Carregando…" />
+  }
+  if (user) {
+    const dest = user.must_change_password ? '/portal/trocar-senha' : '/portal/tickets'
+    return <Navigate to={dest} replace />
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!email.trim() || !senha.trim()) {
+      showError('Informe e-mail e senha.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      await login(email.trim(), senha, lembrarMe)
+      showSuccess('Bem-vindo ao portal.')
+      const returnTo = params.get('returnTo')
+      navigate(returnTo && returnTo.startsWith('/portal') ? returnTo : '/portal/tickets', {
+        replace: true,
+      })
+    } catch (err) {
+      showError(mensagemFalhaParaToast(err, 'Falha no login. Verifique suas credenciais.'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="relative flex min-h-dvh flex-col items-center justify-center bg-gradient-to-br from-slate-100 via-white to-teal-50 px-4 py-10">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-40"
+        style={{
+          backgroundImage:
+            'radial-gradient(circle at 20% 20%, rgba(13,148,136,0.12), transparent 40%), radial-gradient(circle at 80% 80%, rgba(15,23,42,0.06), transparent 45%)',
+        }}
+      />
+      <div className="relative w-full max-w-md">
+        <div className="mb-8 text-center">
+          <BrandLogo className="mx-auto h-10 w-auto" />
+          <h1 className="mt-5 text-2xl font-semibold tracking-tight text-slate-900">
+            Portal do cliente
+          </h1>
+          <p className="mt-2 text-sm leading-relaxed text-slate-600">
+            Acompanhe e abra chamados da sua empresa com a equipe de suporte.
+          </p>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="rounded-2xl border border-slate-200/80 bg-white/95 p-6 shadow-lg shadow-slate-200/60 backdrop-blur"
+        >
+          <label className="mb-4 block">
+            <span className="mb-1.5 block text-sm font-medium text-slate-700">E-mail</span>
+            <input
+              type="email"
+              autoComplete="username"
+              className={fieldClass}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="seu@email.com"
+              required
+            />
+          </label>
+          <label className="mb-4 block">
+            <span className="mb-1.5 block text-sm font-medium text-slate-700">Senha</span>
+            <div className="relative">
+              <input
+                type={mostrarSenha ? 'text' : 'password'}
+                autoComplete="current-password"
+                className={`${fieldClass} pr-16`}
+                value={senha}
+                onChange={(e) => setSenha(e.target.value)}
+                required
+              />
+              <button
+                type="button"
+                className="absolute inset-y-0 right-2 my-auto h-8 rounded-md px-2 text-xs font-medium text-teal-700 hover:bg-teal-50"
+                onClick={() => setMostrarSenha((v) => !v)}
+              >
+                {mostrarSenha ? 'Ocultar' : 'Mostrar'}
+              </button>
+            </div>
+          </label>
+          <label className="mb-5 flex items-center gap-2 text-sm text-slate-600">
+            <input
+              type="checkbox"
+              checked={lembrarMe}
+              onChange={(e) => setLembrarMe(e.target.checked)}
+              className="size-4 rounded border-slate-300 text-teal-600 focus:ring-teal-500"
+            />
+            Manter conectado neste aparelho
+          </label>
+          <Button type="submit" className="w-full" disabled={submitting}>
+            {submitting ? 'Entrando…' : 'Entrar'}
+          </Button>
+        </form>
+
+        <p className="mt-6 text-center text-xs text-slate-500">
+          É da equipe de suporte?{' '}
+          <Link to="/login" className="font-medium text-teal-700 underline-offset-2 hover:underline">
+            Acessar painel interno
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export function PortalLogin() {
+  return (
+    <PortalAuthProvider>
+      <PortalLoginForm />
+    </PortalAuthProvider>
+  )
+}

--- a/frontend/src/pages/portal/PortalLogin.tsx
+++ b/frontend/src/pages/portal/PortalLogin.tsx
@@ -1,17 +1,37 @@
 import { useState } from 'react'
 import { Link, Navigate, useNavigate, useSearchParams } from 'react-router-dom'
 import { PortalAuthProvider, usePortalAuth } from '../../contexts/PortalAuthContext'
-import { Button } from '../../components/ui/Button'
-import { useToast } from '../../components/ui/Toast'
+import { usePortalBranding } from '../../contexts/PortalBrandingContext'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
-import { BrandLogo } from '../../brand'
+import { useToast } from '../../components/ui/Toast'
+import { PortalBrandLogo } from './PortalBrandLogo'
+import { portalInputClass, portalPrimaryBtnClass } from './portalUi'
 import { PageLoading } from '../../components/ui/PageLoading'
 
-const fieldClass =
-  'w-full rounded-xl border border-slate-200 bg-white px-3.5 py-3 text-[0.9375rem] text-slate-900 placeholder:text-slate-400 shadow-sm transition-colors focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25'
+const iconEye = (
+  <svg className="size-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"
+    />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+  </svg>
+)
+
+const iconEyeOff = (
+  <svg className="size-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"
+    />
+  </svg>
+)
 
 function PortalLoginForm() {
   const { user, loading, login } = usePortalAuth()
+  const branding = usePortalBranding()
   const [email, setEmail] = useState('')
   const [senha, setSenha] = useState('')
   const [lembrarMe, setLembrarMe] = useState(true)
@@ -51,36 +71,62 @@ function PortalLoginForm() {
   }
 
   return (
-    <div className="relative flex min-h-dvh flex-col items-center justify-center bg-gradient-to-br from-slate-100 via-white to-teal-50 px-4 py-10">
+    <div className="relative flex min-h-dvh flex-col items-center justify-center overflow-hidden px-4 py-12">
+      {/* Fundo minimalista: grade suave + manchas de marca */}
       <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          backgroundColor: branding.cor_fundo || '#F8FAFC',
+          backgroundImage: [
+            `radial-gradient(ellipse 80% 55% at 50% -10%, color-mix(in srgb, ${branding.cor_header} 22%, transparent), transparent 55%)`,
+            `radial-gradient(ellipse 50% 40% at 100% 100%, color-mix(in srgb, ${branding.cor_primaria} 14%, transparent), transparent 50%)`,
+            `radial-gradient(ellipse 40% 35% at 0% 85%, color-mix(in srgb, ${branding.cor_header} 8%, transparent), transparent 45%)`,
+          ].join(', '),
+        }}
         aria-hidden
-        className="pointer-events-none absolute inset-0 opacity-40"
+      />
+      <div
+        className="pointer-events-none absolute inset-0 opacity-[0.35]"
         style={{
           backgroundImage:
-            'radial-gradient(circle at 20% 20%, rgba(13,148,136,0.12), transparent 40%), radial-gradient(circle at 80% 80%, rgba(15,23,42,0.06), transparent 45%)',
+            'linear-gradient(to right, rgb(15 23 42 / 0.04) 1px, transparent 1px), linear-gradient(to bottom, rgb(15 23 42 / 0.04) 1px, transparent 1px)',
+          backgroundSize: '48px 48px',
+          maskImage: 'radial-gradient(ellipse 70% 60% at 50% 40%, black 20%, transparent 75%)',
         }}
+        aria-hidden
       />
-      <div className="relative w-full max-w-md">
-        <div className="mb-8 text-center">
-          <BrandLogo className="mx-auto h-10 w-auto" />
-          <h1 className="mt-5 text-2xl font-semibold tracking-tight text-slate-900">
-            Portal do cliente
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-1"
+        style={{ backgroundColor: branding.cor_header }}
+        aria-hidden
+      />
+
+      <div className="relative w-full max-w-md animate-[fadeIn_0.45s_ease-out]">
+        <div className="mb-9 text-center">
+          <div className="mx-auto mb-6 flex w-full items-center justify-center">
+            <PortalBrandLogo className="mx-auto h-auto w-full max-h-24 object-contain object-center sm:max-h-28" />
+          </div>
+          <h1
+            className="text-2xl font-semibold tracking-tight sm:text-[1.65rem]"
+            style={{ color: branding.cor_texto_corpo }}
+          >
+            {branding.portal_titulo}
           </h1>
-          <p className="mt-2 text-sm leading-relaxed text-slate-600">
-            Acompanhe e abra chamados da sua empresa com a equipe de suporte.
+          <p className="mx-auto mt-2.5 max-w-sm text-sm leading-relaxed text-slate-500">
+            {branding.texto_boas_vindas}
           </p>
         </div>
 
         <form
           onSubmit={handleSubmit}
-          className="rounded-2xl border border-slate-200/80 bg-white/95 p-6 shadow-lg shadow-slate-200/60 backdrop-blur"
+          className="rounded-2xl border border-slate-200/70 bg-white/90 p-6 shadow-[0_20px_50px_-24px_rgb(15_23_42_/0.25)] backdrop-blur-md sm:p-7"
         >
           <label className="mb-4 block">
             <span className="mb-1.5 block text-sm font-medium text-slate-700">E-mail</span>
             <input
               type="email"
               autoComplete="username"
-              className={fieldClass}
+              className={portalInputClass}
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="seu@email.com"
@@ -93,41 +139,61 @@ function PortalLoginForm() {
               <input
                 type={mostrarSenha ? 'text' : 'password'}
                 autoComplete="current-password"
-                className={`${fieldClass} pr-16`}
+                className={`${portalInputClass} pr-12`}
                 value={senha}
                 onChange={(e) => setSenha(e.target.value)}
                 required
               />
               <button
                 type="button"
-                className="absolute inset-y-0 right-2 my-auto h-8 rounded-md px-2 text-xs font-medium text-teal-700 hover:bg-teal-50"
+                className="absolute right-1.5 top-1/2 flex size-9 -translate-y-1/2 items-center justify-center rounded-lg transition-colors hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--portal-primary)]/30"
+                style={{ color: branding.cor_link }}
                 onClick={() => setMostrarSenha((v) => !v)}
+                aria-label={mostrarSenha ? 'Ocultar senha' : 'Mostrar senha'}
+                aria-pressed={mostrarSenha}
               >
-                {mostrarSenha ? 'Ocultar' : 'Mostrar'}
+                {mostrarSenha ? iconEyeOff : iconEye}
               </button>
             </div>
           </label>
-          <label className="mb-5 flex items-center gap-2 text-sm text-slate-600">
+          <label className="mb-6 flex items-center gap-2.5 text-sm text-slate-600">
             <input
               type="checkbox"
               checked={lembrarMe}
               onChange={(e) => setLembrarMe(e.target.checked)}
-              className="size-4 rounded border-slate-300 text-teal-600 focus:ring-teal-500"
+              className="size-4 rounded border-slate-300 focus:ring-[var(--portal-primary)]"
+              style={{ accentColor: branding.cor_primaria }}
             />
             Manter conectado neste aparelho
           </label>
-          <Button type="submit" className="w-full" disabled={submitting}>
+          <button
+            type="submit"
+            className={`${portalPrimaryBtnClass} w-full py-2.5`}
+            style={{ backgroundColor: 'var(--portal-primary)' }}
+            disabled={submitting}
+          >
             {submitting ? 'Entrando…' : 'Entrar'}
-          </Button>
+          </button>
         </form>
 
-        <p className="mt-6 text-center text-xs text-slate-500">
+        <p className="mt-7 text-center text-xs text-slate-500">
           É da equipe de suporte?{' '}
-          <Link to="/login" className="font-medium text-teal-700 underline-offset-2 hover:underline">
+          <Link
+            to="/login"
+            className="font-medium underline-offset-2 hover:underline"
+            style={{ color: branding.cor_link }}
+          >
             Acessar painel interno
           </Link>
         </p>
       </div>
+
+      <style>{`
+        @keyframes fadeIn {
+          from { opacity: 0; transform: translateY(8px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
     </div>
   )
 }

--- a/frontend/src/pages/portal/PortalSidebar.tsx
+++ b/frontend/src/pages/portal/PortalSidebar.tsx
@@ -1,0 +1,277 @@
+import { NavLink } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { APP_NAME } from '../../brand'
+import { PortalBrandLogo } from './PortalBrandLogo'
+
+const STORAGE_KEY = 'portal-sidebar-expanded'
+const COPYRIGHT_YEAR = new Date().getFullYear()
+
+type NavItem = {
+  to: string
+  label: string
+  end?: boolean
+  icon: ReactNode
+  socioOnly?: boolean
+}
+
+const icons = {
+  tickets: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z" />
+    </svg>
+  ),
+  chats: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+    </svg>
+  ),
+  users: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+    </svg>
+  ),
+  help: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+  ),
+  novo: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+    </svg>
+  ),
+  logout: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+    </svg>
+  ),
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { to: '/portal/tickets', label: 'Chamados', end: true, icon: icons.tickets },
+  { to: '/portal/chats', label: 'Atendimentos', icon: icons.chats },
+  { to: '/portal/equipe', label: 'Usuários', icon: icons.users, socioOnly: true },
+  { to: '/portal/ajuda', label: 'Ajuda', icon: icons.help },
+]
+
+export function readPortalSidebarExpanded(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) !== '0'
+  } catch {
+    return true
+  }
+}
+
+export function writePortalSidebarExpanded(expanded: boolean) {
+  try {
+    localStorage.setItem(STORAGE_KEY, expanded ? '1' : '0')
+  } catch {
+    /* storage indisponível */
+  }
+}
+
+type Props = {
+  expanded: boolean
+  mobileOpen: boolean
+  isSocio: boolean
+  userNome: string
+  userRole: string
+  exibirMarcaDeskrudder?: boolean
+  onLogout: () => void
+  onMobileClose: () => void
+}
+
+function NavItemLink({
+  item,
+  expanded,
+  onNavigate,
+}: {
+  item: NavItem
+  expanded: boolean
+  onNavigate?: () => void
+}) {
+  return (
+    <NavLink
+      to={item.to}
+      end={item.end}
+      title={!expanded ? item.label : undefined}
+      onClick={onNavigate}
+      className={({ isActive }) =>
+        [
+          'flex min-h-[44px] w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors touch-manipulation',
+          isActive
+            ? 'bg-white/15 text-[var(--portal-sidebar-text)] ring-1 ring-white/25'
+            : 'text-[var(--portal-sidebar-text)]/80 hover:bg-white/10 hover:text-[var(--portal-sidebar-text)]',
+          !expanded ? 'md:justify-center md:gap-0 md:px-2' : '',
+        ].join(' ')
+      }
+    >
+      {item.icon}
+      <span className={expanded ? 'min-w-0 truncate' : 'min-w-0 truncate md:hidden'}>{item.label}</span>
+    </NavLink>
+  )
+}
+
+export function PortalSidebar({
+  expanded,
+  mobileOpen,
+  isSocio,
+  userNome,
+  userRole,
+  exibirMarcaDeskrudder = true,
+  onLogout,
+  onMobileClose,
+}: Props) {
+  const items = NAV_ITEMS.filter((item) => !item.socioOnly || isSocio)
+  const initial = userNome?.trim()?.charAt(0)?.toUpperCase() || '?'
+
+  const sidebarContent = (
+    <>
+      <div
+        className={`flex h-16 min-h-[64px] shrink-0 items-center border-b border-white/10 ${expanded ? 'px-3' : 'justify-center md:px-2'}`}
+      >
+        {expanded ? (
+          <PortalBrandLogo className="h-8 w-auto max-w-[11rem] object-contain" />
+        ) : (
+          <PortalBrandLogo className="h-8 w-auto max-w-[2.5rem] object-contain md:mx-auto" />
+        )}
+      </div>
+
+      <nav
+        className={`min-w-0 flex-1 overflow-x-hidden overflow-y-auto py-3 px-2 ${!expanded ? 'md:px-2' : ''}`}
+        aria-label="Menu do portal"
+      >
+        <ul className={`min-w-0 space-y-0.5 px-2 ${!expanded ? 'md:px-0' : ''}`}>
+          {items.map((item) => (
+            <li key={item.to} className="w-full min-w-0">
+              <NavItemLink item={item} expanded={expanded} onNavigate={onMobileClose} />
+            </li>
+          ))}
+          <li className="w-full min-w-0 pt-1">
+            <NavLink
+              to="/portal/tickets/novo"
+              title={!expanded ? 'Novo chamado' : undefined}
+              onClick={onMobileClose}
+              className={({ isActive }) =>
+                [
+                  'flex min-h-[44px] w-full items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors touch-manipulation',
+                  isActive
+                    ? 'bg-[var(--portal-primary)] text-white shadow-sm'
+                    : 'border border-white/25 text-[var(--portal-sidebar-text)] hover:bg-white/10',
+                  !expanded ? 'md:justify-center md:gap-0 md:px-2' : '',
+                ].join(' ')
+              }
+            >
+              {icons.novo}
+              <span className={expanded ? 'min-w-0 truncate' : 'min-w-0 truncate md:hidden'}>
+                Novo chamado
+              </span>
+            </NavLink>
+          </li>
+        </ul>
+      </nav>
+
+      <div className={`shrink-0 border-t border-white/10 p-2 ${!expanded ? 'md:px-2' : ''}`}>
+        <div
+          className={`flex items-center gap-3 px-3 py-2 ${expanded ? 'opacity-100' : 'md:hidden'}`}
+          style={{ color: 'var(--portal-sidebar-text)' }}
+        >
+          <span
+            className="flex size-8 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white shadow-sm"
+            style={{ backgroundColor: 'var(--portal-primary)' }}
+            aria-hidden
+          >
+            {initial}
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium">{userNome}</p>
+            <p className="truncate text-xs opacity-75">{userRole}</p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            onMobileClose()
+            onLogout()
+          }}
+          title="Sair"
+          className={[
+            'mt-2 flex min-h-[44px] w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors hover:bg-white/10 active:bg-white/15 touch-manipulation',
+            expanded ? '' : 'md:justify-center md:px-2',
+          ].join(' ')}
+          style={{ color: 'var(--portal-sidebar-text)' }}
+        >
+          {icons.logout}
+          <span className={expanded ? 'min-w-0 truncate' : 'min-w-0 truncate md:hidden'}>Sair</span>
+        </button>
+        {exibirMarcaDeskrudder ? (
+          <p
+            className={[
+              'mt-2 px-3 py-1 text-[11px] leading-snug opacity-60',
+              expanded ? 'text-left' : 'md:px-1 md:text-center md:text-[9px]',
+            ].join(' ')}
+            style={{ color: 'var(--portal-sidebar-text)' }}
+            title={APP_NAME}
+          >
+            {expanded ? (
+              <>
+                © {COPYRIGHT_YEAR} {APP_NAME}
+              </>
+            ) : (
+              <>
+                <span className="hidden md:inline">© {COPYRIGHT_YEAR}</span>
+                <span className="md:hidden">
+                  © {COPYRIGHT_YEAR} {APP_NAME}
+                </span>
+              </>
+            )}
+          </p>
+        ) : null}
+      </div>
+    </>
+  )
+
+  return (
+    <>
+      <div
+        className={`fixed inset-0 z-40 bg-black/50 transition-opacity duration-200 md:hidden ${
+          mobileOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
+        }`}
+        aria-hidden
+        onClick={onMobileClose}
+      />
+
+      <aside
+        className={[
+          'fixed inset-0 z-50 flex h-full min-w-0 max-w-[100vw] flex-col overflow-x-hidden shadow-xl transition-transform duration-200 ease-out',
+          'md:sticky md:top-0 md:col-start-1 md:row-start-1 md:z-40 md:h-dvh md:max-h-dvh md:max-w-none md:w-full md:translate-x-0 md:self-start md:overflow-hidden md:border-r md:border-black/10 md:shadow-none',
+          mobileOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0',
+        ].join(' ')}
+        style={{
+          backgroundColor: 'var(--portal-sidebar)',
+          color: 'var(--portal-sidebar-text)',
+        }}
+        aria-label="Menu lateral"
+      >
+        <div
+          className="flex h-14 shrink-0 items-center justify-between border-b border-white/10 px-4 md:hidden"
+          style={{ backgroundColor: 'var(--portal-sidebar)' }}
+        >
+          <span className="text-sm font-semibold" style={{ color: 'var(--portal-sidebar-text)' }}>
+            Menu
+          </span>
+          <button
+            type="button"
+            onClick={onMobileClose}
+            className="inline-flex size-10 items-center justify-center rounded-lg hover:bg-white/10"
+            style={{ color: 'var(--portal-sidebar-text)' }}
+            aria-label="Fechar menu"
+          >
+            ×
+          </button>
+        </div>
+        {sidebarContent}
+      </aside>
+    </>
+  )
+}

--- a/frontend/src/pages/portal/PortalTicketDetalhe.tsx
+++ b/frontend/src/pages/portal/PortalTicketDetalhe.tsx
@@ -1,0 +1,252 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { portalCliente, type PortalCliente } from '../../api/client'
+import { Button } from '../../components/ui/Button'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+
+function formatData(iso?: string | null) {
+  if (!iso) return ''
+  try {
+    return new Date(iso).toLocaleString('pt-BR', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+export function PortalTicketDetalhe() {
+  const { id } = useParams<{ id: string }>()
+  const ticketId = Number(id)
+  const [ticket, setTicket] = useState<PortalCliente.TicketDetail | null>(null)
+  const [mensagens, setMensagens] = useState<PortalCliente.Mensagem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [corpo, setCorpo] = useState('')
+  const [enviando, setEnviando] = useState(false)
+  const [file, setFile] = useState<File | null>(null)
+  const bottomRef = useRef<HTMLDivElement | null>(null)
+  const toast = useToast()
+  const navigate = useNavigate()
+
+  const carregar = useCallback(async () => {
+    if (!Number.isFinite(ticketId)) return
+    const [t, msgs] = await Promise.all([
+      portalCliente.getTicket(ticketId),
+      portalCliente.listMensagens(ticketId),
+    ])
+    setTicket(t)
+    setMensagens(msgs)
+  }, [ticketId])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    carregar()
+      .catch((err) => {
+        if (!cancelled) {
+          toast.showError(mensagemFalhaParaToast(err, 'Chamado não encontrado.'))
+          navigate('/portal/tickets', { replace: true })
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [carregar, navigate, toast])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
+  }, [mensagens.length])
+
+  // Polling leve para novas respostas da equipe
+  useEffect(() => {
+    if (!ticket?.pode_responder) return
+    const t = window.setInterval(() => {
+      carregar().catch(() => undefined)
+    }, 15000)
+    return () => window.clearInterval(t)
+  }, [carregar, ticket?.pode_responder])
+
+  async function handleEnviar(e: React.FormEvent) {
+    e.preventDefault()
+    if (!ticket || !ticket.pode_responder) return
+    const texto = corpo.trim()
+    if (!texto && !file) {
+      toast.showError('Escreva uma mensagem ou anexe um ficheiro.')
+      return
+    }
+    setEnviando(true)
+    try {
+      let msg: PortalCliente.Mensagem | null = null
+      if (texto) {
+        msg = await portalCliente.sendMensagem(ticket.id, texto)
+      }
+      if (file) {
+        await portalCliente.uploadAnexo(ticket.id, file, msg?.id)
+      }
+      setCorpo('')
+      setFile(null)
+      await carregar()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar.'))
+    } finally {
+      setEnviando(false)
+    }
+  }
+
+  async function baixarAnexo(anexo: PortalCliente.Anexo) {
+    if (!ticket) return
+    try {
+      const blob = await portalCliente.fetchAnexoBlob(ticket.id, anexo.id)
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = anexo.nome_original
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao baixar anexo.'))
+    }
+  }
+
+  async function abrirCsat() {
+    if (!ticket) return
+    try {
+      const { link } = await portalCliente.csatLink(ticket.id)
+      window.location.href = link
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Avaliação indisponível no momento.'))
+    }
+  }
+
+  if (loading || !ticket) {
+    return (
+      <div className="space-y-4">
+        <div className="h-8 w-48 animate-pulse rounded-lg bg-slate-100" />
+        <div className="h-64 animate-pulse rounded-2xl bg-slate-100" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-[70dvh] flex-col gap-4">
+      <div>
+        <button
+          type="button"
+          onClick={() => navigate('/portal/tickets')}
+          className="mb-2 text-sm font-medium text-slate-500 hover:text-slate-800"
+        >
+          ← Voltar
+        </button>
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <p className="font-mono text-xs font-semibold text-teal-700">{ticket.protocolo}</p>
+          <h1 className="mt-1 text-lg font-semibold text-slate-900">{ticket.assunto}</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            {ticket.status_nome} · {ticket.empresa_nome} · {ticket.setor_nome}
+          </p>
+        </div>
+      </div>
+
+      {ticket.csat_pendente ? (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950">
+          <p className="font-medium">Como foi o atendimento?</p>
+          <p className="mt-0.5 text-amber-900/80">Sua avaliação ajuda a melhorar o suporte.</p>
+          <button
+            type="button"
+            onClick={abrirCsat}
+            className="mt-2 text-sm font-semibold text-amber-900 underline underline-offset-2"
+          >
+            Avaliar agora
+          </button>
+        </div>
+      ) : null}
+
+      {!ticket.pode_responder ? (
+        <div className="rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700">
+          Este chamado está encerrado.{' '}
+          <Link to="/portal/tickets/novo" className="font-semibold text-teal-700 underline-offset-2 hover:underline">
+            Abrir um novo chamado
+          </Link>{' '}
+          se ainda precisar de ajuda.
+        </div>
+      ) : null}
+
+      <div className="flex-1 space-y-3 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        {mensagens.length === 0 ? (
+          <p className="py-8 text-center text-sm text-slate-500">Ainda sem mensagens nesta conversa.</p>
+        ) : (
+          mensagens.map((m) => {
+            const mine = m.autor_papel === 'voce'
+            return (
+              <div key={m.id} className={`flex ${mine ? 'justify-end' : 'justify-start'}`}>
+                <div
+                  className={[
+                    'max-w-[92%] rounded-2xl px-3.5 py-2.5 text-sm shadow-sm sm:max-w-[80%]',
+                    mine
+                      ? 'rounded-br-md bg-teal-600 text-white'
+                      : 'rounded-bl-md border border-slate-200 bg-slate-50 text-slate-800',
+                  ].join(' ')}
+                >
+                  <p className={`text-[11px] font-medium ${mine ? 'text-teal-100' : 'text-slate-500'}`}>
+                    {m.autor_nome || (mine ? 'Você' : 'Equipe')} · {formatData(m.created_at)}
+                  </p>
+                  <p className="mt-1 whitespace-pre-wrap break-words">{m.corpo}</p>
+                  {m.anexos?.length ? (
+                    <ul className="mt-2 space-y-1">
+                      {m.anexos.map((a) => (
+                        <li key={a.id}>
+                          <button
+                            type="button"
+                            onClick={() => baixarAnexo(a)}
+                            className={`text-xs underline underline-offset-2 ${mine ? 'text-teal-50' : 'text-teal-700'}`}
+                          >
+                            {a.nome_original}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </div>
+              </div>
+            )
+          })
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      {ticket.pode_responder ? (
+        <form
+          onSubmit={handleEnviar}
+          className="sticky bottom-20 z-10 space-y-2 rounded-2xl border border-slate-200 bg-white/95 p-3 shadow-lg backdrop-blur sm:static sm:bottom-auto"
+        >
+          <textarea
+            value={corpo}
+            onChange={(e) => setCorpo(e.target.value)}
+            rows={3}
+            placeholder="Escreva sua mensagem…"
+            className="w-full resize-none rounded-xl border border-slate-200 px-3 py-2.5 text-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25"
+          />
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <label className="cursor-pointer text-xs font-medium text-teal-700 hover:underline">
+              <input
+                type="file"
+                className="hidden"
+                onChange={(e) => setFile(e.target.files?.[0] || null)}
+              />
+              {file ? `Anexo: ${file.name}` : 'Anexar ficheiro'}
+            </label>
+            <Button type="submit" disabled={enviando}>
+              {enviando ? 'Enviando…' : 'Enviar'}
+            </Button>
+          </div>
+        </form>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/PortalTicketNovo.tsx
+++ b/frontend/src/pages/portal/PortalTicketNovo.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { kbPublic, portalCliente, type PortalCliente, type Kb } from '../../api/client'
+import { usePortalAuth } from '../../contexts/PortalAuthContext'
+import { Button } from '../../components/ui/Button'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+
+const fieldClass =
+  'w-full rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-900 shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25'
+
+export function PortalTicketNovo() {
+  const { user } = usePortalAuth()
+  const empresas = user?.empresas ?? []
+  const unicaEmpresa = empresas.length === 1 ? empresas[0].id : ''
+  const [empresaId, setEmpresaId] = useState<number | ''>(unicaEmpresa)
+  const [setorId, setSetorId] = useState<number | ''>('')
+  const [setores, setSetores] = useState<PortalCliente.Setor[]>([])
+  const [pdvs, setPdvs] = useState<PortalCliente.Pdv[]>([])
+  const [pdvCodigo, setPdvCodigo] = useState('')
+  const [assunto, setAssunto] = useState('')
+  const [descricao, setDescricao] = useState('')
+  const [sugestoes, setSugestoes] = useState<Kb.ArticleBrief[]>([])
+  const [saving, setSaving] = useState(false)
+  const [anexos, setAnexos] = useState<File[]>([])
+  const toast = useToast()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (empresas.length === 1) setEmpresaId(empresas[0].id)
+  }, [empresas])
+
+  useEffect(() => {
+    portalCliente.listSetores().then(setSetores).catch(() => setSetores([]))
+  }, [])
+
+  useEffect(() => {
+    if (empresaId === '') {
+      setPdvs([])
+      setPdvCodigo('')
+      return
+    }
+    portalCliente
+      .listPdvs(empresaId)
+      .then(setPdvs)
+      .catch(() => setPdvs([]))
+  }, [empresaId])
+
+  useEffect(() => {
+    const q = assunto.trim()
+    if (q.length < 4) {
+      setSugestoes([])
+      return
+    }
+    const t = window.setTimeout(() => {
+      kbPublic
+        .listArticles({ busca: q, limit: 4 })
+        .then(setSugestoes)
+        .catch(() => setSugestoes([]))
+    }, 350)
+    return () => window.clearTimeout(t)
+  }, [assunto])
+
+  const empresaOptions = useMemo(
+    () => empresas.map((e) => ({ value: String(e.id), label: e.nome })),
+    [empresas],
+  )
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (empresaId === '') {
+      toast.showError('Selecione a empresa.')
+      return
+    }
+    if (assunto.trim().length < 3) {
+      toast.showError('Informe um assunto com pelo menos 3 caracteres.')
+      return
+    }
+    setSaving(true)
+    try {
+      const ticket = await portalCliente.createTicket({
+        empresa_id: empresaId,
+        setor_id: setorId === '' ? null : setorId,
+        assunto: assunto.trim(),
+        descricao: descricao.trim() || null,
+        pdv_codigo: pdvCodigo.trim() || null,
+      })
+      for (const file of anexos) {
+        try {
+          await portalCliente.uploadAnexo(ticket.id, file)
+        } catch {
+          /* anexo opcional — ticket já criado */
+        }
+      }
+      toast.showSuccess('Chamado aberto com sucesso.')
+      navigate(`/portal/tickets/${ticket.id}`, { replace: true })
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível abrir o chamado.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h1 className="text-xl font-semibold text-slate-900">Novo chamado</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Descreva o problema com clareza — isso acelera o atendimento.
+        </p>
+      </div>
+
+      {sugestoes.length > 0 ? (
+        <div className="rounded-2xl border border-teal-200 bg-teal-50/60 p-4">
+          <p className="text-sm font-semibold text-teal-900">Antes de abrir — isso pode ajudar</p>
+          <ul className="mt-2 space-y-1.5">
+            {sugestoes.map((a) => (
+              <li key={a.id}>
+                <Link
+                  to={`/portal/ajuda/${a.slug}`}
+                  className="text-sm font-medium text-teal-800 underline-offset-2 hover:underline"
+                >
+                  {a.titulo}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <form onSubmit={handleSubmit} className="space-y-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        {empresas.length === 0 ? (
+          <p className="text-sm text-rose-700">
+            Nenhuma empresa vinculada à sua conta. Peça ao suporte para ajustar o cadastro.
+          </p>
+        ) : (
+          <label className="block">
+            <span className="mb-1.5 block text-sm font-medium text-slate-700">Empresa</span>
+            <select
+              className={fieldClass}
+              value={empresaId === '' ? '' : String(empresaId)}
+              onChange={(e) => setEmpresaId(e.target.value ? Number(e.target.value) : '')}
+              required
+              disabled={empresas.length === 1}
+            >
+              {empresas.length > 1 ? <option value="">Selecione…</option> : null}
+              {empresaOptions.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Setor</span>
+          <select
+            className={fieldClass}
+            value={setorId === '' ? '' : String(setorId)}
+            onChange={(e) => setSetorId(e.target.value ? Number(e.target.value) : '')}
+          >
+            <option value="">Automático / padrão</option>
+            {setores.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.nome}
+              </option>
+            ))}
+          </select>
+          <span className="mt-1 block text-xs text-slate-500">
+            Se não souber, deixe em automático — a equipe roteia o chamado.
+          </span>
+        </label>
+
+        {pdvs.length > 0 ? (
+          <label className="block">
+            <span className="mb-1.5 block text-sm font-medium text-slate-700">PDV (opcional)</span>
+            <select
+              className={fieldClass}
+              value={pdvCodigo}
+              onChange={(e) => setPdvCodigo(e.target.value)}
+            >
+              <option value="">Nenhum / não se aplica</option>
+              {pdvs.map((p) => (
+                <option key={p.id} value={p.codigo}>
+                  {p.codigo}
+                  {p.papel ? ` (${p.papel})` : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Assunto</span>
+          <input
+            className={fieldClass}
+            value={assunto}
+            onChange={(e) => setAssunto(e.target.value)}
+            placeholder="Ex.: PDV 003 não imprime cupom"
+            required
+            minLength={3}
+            maxLength={255}
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Descrição</span>
+          <textarea
+            className={`${fieldClass} min-h-32 resize-y`}
+            value={descricao}
+            onChange={(e) => setDescricao(e.target.value)}
+            placeholder="O que aconteceu, desde quando, e o que já tentou fazer…"
+            maxLength={20000}
+          />
+        </label>
+
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Anexos (opcional)</span>
+          <input
+            type="file"
+            multiple
+            className="block w-full text-sm text-slate-600 file:mr-3 file:rounded-lg file:border-0 file:bg-teal-50 file:px-3 file:py-2 file:text-sm file:font-medium file:text-teal-800 hover:file:bg-teal-100"
+            onChange={(e) => setAnexos(Array.from(e.target.files || []))}
+          />
+          {anexos.length > 0 ? (
+            <p className="mt-1 text-xs text-slate-500">{anexos.length} ficheiro(s) selecionado(s)</p>
+          ) : null}
+        </label>
+
+        <div className="flex flex-wrap gap-2 pt-1">
+          <Button type="submit" disabled={saving || empresas.length === 0}>
+            {saving ? 'Abrindo…' : 'Abrir chamado'}
+          </Button>
+          <Link
+            to="/portal/tickets"
+            className="inline-flex items-center rounded-xl border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+          >
+            Cancelar
+          </Link>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/PortalTickets.tsx
+++ b/frontend/src/pages/portal/PortalTickets.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { portalCliente, type PortalCliente } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useToast } from '../../components/ui/Toast'
+import { Button } from '../../components/ui/Button'
+
+function formatData(iso?: string | null) {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleString('pt-BR', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+function statusTone(slug?: string | null) {
+  const s = (slug || '').toLowerCase()
+  if (s === 'fechado' || s === 'resolvido') return 'bg-slate-100 text-slate-700'
+  if (s === 'aguardando_cliente') return 'bg-amber-50 text-amber-800'
+  if (s === 'em_atendimento') return 'bg-teal-50 text-teal-800'
+  return 'bg-sky-50 text-sky-800'
+}
+
+export function PortalTickets() {
+  const [situacao, setSituacao] = useState<'abertos' | 'fechados' | 'todos'>('abertos')
+  const [busca, setBusca] = useState('')
+  const [buscaDebounced, setBuscaDebounced] = useState('')
+  const [items, setItems] = useState<PortalCliente.TicketListItem[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [erro, setErro] = useState<string | null>(null)
+  const toast = useToast()
+
+  useEffect(() => {
+    const t = window.setTimeout(() => setBuscaDebounced(busca.trim()), 300)
+    return () => window.clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setErro(null)
+    portalCliente
+      .listTickets({ situacao, busca: buscaDebounced || undefined, limit: 50 })
+      .then((res) => {
+        if (cancelled) return
+        setItems(res.items)
+        setTotal(res.total)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        const msg = mensagemFalhaParaToast(err, 'Não foi possível carregar os chamados.')
+        setErro(msg)
+        toast.showError(msg)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- toast estável o suficiente; evita loop
+  }, [situacao, buscaDebounced])
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">Meus chamados</h1>
+          <p className="mt-1 text-sm text-slate-600">Acompanhe o andamento das suas solicitações.</p>
+        </div>
+        <Link to="/portal/tickets/novo">
+          <Button type="button">Abrir chamado</Button>
+        </Link>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="flex rounded-xl border border-slate-200 bg-white p-1 shadow-sm">
+          {(
+            [
+              ['abertos', 'Abertos'],
+              ['fechados', 'Encerrados'],
+              ['todos', 'Todos'],
+            ] as const
+          ).map(([key, label]) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setSituacao(key)}
+              className={[
+                'flex-1 rounded-lg px-3 py-2 text-sm font-medium transition-colors sm:flex-none',
+                situacao === key
+                  ? 'bg-slate-900 text-white'
+                  : 'text-slate-600 hover:bg-slate-50',
+              ].join(' ')}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <input
+          type="search"
+          value={busca}
+          onChange={(e) => setBusca(e.target.value)}
+          placeholder="Buscar protocolo ou assunto…"
+          className="w-full flex-1 rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25"
+        />
+      </div>
+
+      {loading ? (
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-24 animate-pulse rounded-2xl bg-slate-100" />
+          ))}
+        </div>
+      ) : erro ? (
+        <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-6 text-sm text-rose-800">
+          {erro}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-white/70 px-5 py-10 text-center">
+          <p className="text-base font-medium text-slate-900">Nenhum chamado por aqui</p>
+          <p className="mt-1 text-sm text-slate-600">
+            Abra o primeiro chamado ou consulte a base de ajuda antes.
+          </p>
+          <div className="mt-5 flex flex-wrap justify-center gap-2">
+            <Link to="/portal/tickets/novo">
+              <Button type="button">Abrir chamado</Button>
+            </Link>
+            <Link
+              to="/portal/ajuda"
+              className="inline-flex items-center rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
+            >
+              Ver ajuda
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {items.map((t) => (
+            <li key={t.id}>
+              <Link
+                to={`/portal/tickets/${t.id}`}
+                className="block rounded-2xl border border-slate-200/90 bg-white p-4 shadow-sm transition hover:border-teal-300 hover:shadow-md"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="font-mono text-xs font-semibold tracking-wide text-teal-700">
+                      {t.protocolo}
+                    </p>
+                    <h2 className="mt-1 truncate text-base font-semibold text-slate-900">{t.assunto}</h2>
+                    <p className="mt-1 truncate text-sm text-slate-500">
+                      {t.empresa_nome || 'Empresa'} · {t.setor_nome || 'Atendimento'}
+                    </p>
+                  </div>
+                  <span
+                    className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-medium ${statusTone(t.status_slug)}`}
+                  >
+                    {t.status_nome || '—'}
+                  </span>
+                </div>
+                <p className="mt-3 text-xs text-slate-400">
+                  Atualizado {formatData(t.ultima_mensagem_em || t.updated_at || t.created_at)}
+                </p>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {!loading && items.length > 0 ? (
+        <p className="text-center text-xs text-slate-400">
+          {total} chamado{total === 1 ? '' : 's'}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/PortalTrocarSenha.tsx
+++ b/frontend/src/pages/portal/PortalTrocarSenha.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+import { Navigate, useNavigate } from 'react-router-dom'
+import { portalCliente } from '../../api/client'
+import { usePortalAuth } from '../../contexts/PortalAuthContext'
+import { Button } from '../../components/ui/Button'
+import { useToast } from '../../components/ui/Toast'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+
+const fieldClass =
+  'w-full rounded-xl border border-slate-200 bg-white px-3.5 py-3 text-[0.9375rem] text-slate-900 shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25'
+
+export function PortalTrocarSenha() {
+  const { user, applyTokens, refreshUser } = usePortalAuth()
+  const [atual, setAtual] = useState('')
+  const [nova, setNova] = useState('')
+  const [confirma, setConfirma] = useState('')
+  const [saving, setSaving] = useState(false)
+  const toast = useToast()
+  const navigate = useNavigate()
+
+  if (!user) {
+    return <Navigate to="/portal/login" replace />
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (nova.length < 8) {
+      toast.showError('A nova senha deve ter ao menos 8 caracteres.')
+      return
+    }
+    if (nova !== confirma) {
+      toast.showError('A confirmação não confere com a nova senha.')
+      return
+    }
+    setSaving(true)
+    try {
+      const tokens = await portalCliente.trocarSenha(atual, nova)
+      await applyTokens(tokens, true)
+      await refreshUser()
+      toast.showSuccess('Senha atualizada.')
+      navigate('/portal/tickets', { replace: true })
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar a senha.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-md space-y-5">
+      <div>
+        <h1 className="text-xl font-semibold text-slate-900">Definir nova senha</h1>
+        <p className="mt-1 text-sm text-slate-600">
+          Por segurança, altere a senha temporária antes de continuar.
+        </p>
+      </div>
+      <form onSubmit={handleSubmit} className="space-y-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Senha atual</span>
+          <input
+            type="password"
+            className={fieldClass}
+            value={atual}
+            onChange={(e) => setAtual(e.target.value)}
+            required
+            autoComplete="current-password"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Nova senha</span>
+          <input
+            type="password"
+            className={fieldClass}
+            value={nova}
+            onChange={(e) => setNova(e.target.value)}
+            required
+            minLength={8}
+            autoComplete="new-password"
+          />
+        </label>
+        <label className="block">
+          <span className="mb-1.5 block text-sm font-medium text-slate-700">Confirmar nova senha</span>
+          <input
+            type="password"
+            className={fieldClass}
+            value={confirma}
+            onChange={(e) => setConfirma(e.target.value)}
+            required
+            minLength={8}
+            autoComplete="new-password"
+          />
+        </label>
+        <Button type="submit" className="w-full" disabled={saving}>
+          {saving ? 'Salvando…' : 'Salvar e continuar'}
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/pages/portal/portalUi.tsx
+++ b/frontend/src/pages/portal/portalUi.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from 'react'
+
+/** Classes reutilizáveis — visual alinhado ao painel interno (minimalista). */
+export const portalInputClass =
+  'w-full rounded-lg border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-900 shadow-sm transition-colors placeholder:text-slate-400 focus:border-[var(--portal-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--portal-primary)]/20 disabled:cursor-not-allowed disabled:bg-slate-50 disabled:text-slate-500'
+
+export const portalPrimaryBtnClass =
+  'inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:opacity-95 focus:outline-none focus:ring-2 focus:ring-[var(--portal-primary)]/30 disabled:opacity-50'
+
+export const portalSecondaryBtnClass =
+  'inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50'
+
+export const portalCardClass =
+  'rounded-xl border border-slate-200/90 bg-white p-4 shadow-sm transition hover:border-slate-300 hover:shadow-md'
+
+export function PortalPageHeader({
+  title,
+  subtitle,
+  action,
+}: {
+  title: string
+  subtitle?: string
+  action?: ReactNode
+}) {
+  return (
+    <div className="flex flex-wrap items-start justify-between gap-4">
+      <div className="min-w-0">
+        <h1 className="text-xl font-semibold tracking-tight text-slate-900 sm:text-2xl">{title}</h1>
+        {subtitle ? <p className="mt-1 text-sm text-slate-500">{subtitle}</p> : null}
+      </div>
+      {action ? <div className="shrink-0">{action}</div> : null}
+    </div>
+  )
+}
+
+export function PortalSegmentedControl<T extends string>({
+  value,
+  onChange,
+  options,
+}: {
+  value: T
+  onChange: (v: T) => void
+  options: readonly { value: T; label: string }[]
+}) {
+  return (
+    <div className="inline-flex rounded-lg border border-slate-200 bg-slate-100/80 p-1">
+      {options.map((opt) => (
+        <button
+          key={opt.value}
+          type="button"
+          onClick={() => onChange(opt.value)}
+          className={[
+            'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+            value === opt.value ? 'bg-white text-slate-900 shadow-sm' : 'text-slate-600 hover:text-slate-900',
+          ].join(' ')}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export function portalUserInitials(nome: string): string {
+  const parts = nome.trim().split(/\s+/).filter(Boolean)
+  if (!parts.length) return '?'
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
+}

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -182,6 +182,11 @@ export function WhatsappAtendendo() {
                           {c.cliente_nome || 'Cliente'}
                         </h3>
                         <p className="font-mono text-xs text-slate-500">{c.wa_id}</p>
+                        {c.empresa_nome && (
+                          <p className="mt-1 truncate text-[10px] font-medium text-slate-500 dark:text-slate-400">
+                            {c.empresa_nome}
+                          </p>
+                        )}
                         {c.setor_nome && (
                           <p className="mt-1 text-[10px] font-medium text-slate-500 dark:text-slate-400">
                             Setor {c.setor_nome}

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -11,7 +11,6 @@ import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { rotuloResponsavelChat } from '../../lib/whatsappChatMeta'
 
-// Componente para cálculo de tempo de espera
 function TempoEspera({ data }: { data?: string | null }) {
   const [minutos, setMinutos] = useState(0)
 
@@ -27,9 +26,13 @@ function TempoEspera({ data }: { data?: string | null }) {
   }, [data])
 
   return (
-    <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full ${
-      minutos > 10 ? 'bg-red-100 text-red-600 animate-pulse' : 'bg-slate-100 text-slate-500 dark:bg-slate-800'
-    }`}>
+    <span
+      className={`rounded-full px-2 py-0.5 text-[10px] font-bold ${
+        minutos > 10
+          ? 'animate-pulse bg-red-100 text-red-600'
+          : 'bg-slate-100 text-slate-500 dark:bg-slate-800'
+      }`}
+    >
       {minutos === 0 ? 'Agora' : `${minutos} min`}
     </span>
   )
@@ -44,22 +47,22 @@ export function WhatsappAtendendo() {
   const isFirstLoad = useRef(true)
   const prevFilaCount = useRef(0)
 
-  const load = useCallback(async (silent = false) => {
-    if (!silent) setLoading(true)
-    try {
-      const [rowsFila, rowsMeus] = await Promise.all([
-        whatsappChats.fila(), 
-        whatsappChats.meus()
-      ])
-      setFila(rowsFila)
-      setMeus(rowsMeus)
-    } catch (err) {
-      if (!silent) toast.showError(mensagemFalhaParaToast(err, 'Erro ao sincronizar dados.'))
-    } finally {
-      setLoading(false)
-      isFirstLoad.current = false
-    }
-  }, [toast])
+  const load = useCallback(
+    async (silent = false) => {
+      if (!silent) setLoading(true)
+      try {
+        const [rowsFila, rowsMeus] = await Promise.all([whatsappChats.fila(), whatsappChats.meus()])
+        setFila(rowsFila)
+        setMeus(rowsMeus)
+      } catch (err) {
+        if (!silent) toast.showError(mensagemFalhaParaToast(err, 'Erro ao sincronizar dados.'))
+      } finally {
+        setLoading(false)
+        isFirstLoad.current = false
+      }
+    },
+    [toast],
+  )
 
   useEffect(() => {
     const refresh = () => void load(true)
@@ -71,7 +74,6 @@ export function WhatsappAtendendo() {
     }
   }, [subscribe, load])
 
-  // Refresh inicial + polling de segurança (#442)
   useEffect(() => {
     void load()
     const intervalMs = useFallback ? 10000 : 8000
@@ -95,21 +97,29 @@ export function WhatsappAtendendo() {
       await load(true)
       void refetchPendenciasResumo()
     } catch (err) {
-      const msg = err instanceof ApiError && err.status === 400
+      const msg =
+        err instanceof ApiError && err.status === 400
           ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'
           : mensagemFalhaParaToast(err)
       toast.showWarning(msg)
     }
   }
 
+  const meusAtivos = meus.filter((c) => c.estado === 'em_atendimento')
+  const meusAClassificar = meus.filter(
+    (c) => c.classificacao_demanda_pendente && c.estado !== 'em_atendimento',
+  )
+
   if (loading && isFirstLoad.current) {
-    return <div className="flex h-64 items-center justify-center text-sm font-medium text-slate-400 animate-pulse">Carregando central de atendimento...</div>
+    return (
+      <div className="flex h-64 items-center justify-center text-sm font-medium text-slate-400 animate-pulse">
+        Carregando central de atendimento...
+      </div>
+    )
   }
 
   return (
     <div className="flex flex-col space-y-8 animate-in fade-in duration-500">
-      
-      {/* Header */}
       <header className="flex flex-wrap items-end justify-between gap-4 border-b pb-6 dark:border-slate-800">
         <div>
           <h1 className="text-2xl font-bold text-slate-900 dark:text-white">Fila de Atendimento</h1>
@@ -118,26 +128,34 @@ export function WhatsappAtendendo() {
         <div className="flex gap-6">
           <div className="text-right">
             <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Na Fila</p>
-            <p className={`text-xl font-mono font-bold ${fila.length > 0 ? 'text-amber-500' : 'text-slate-300'}`}>{fila.length}</p>
+            <p
+              className={`text-xl font-mono font-bold ${fila.length > 0 ? 'text-amber-500' : 'text-slate-300'}`}
+            >
+              {fila.length}
+            </p>
           </div>
           <div className="text-right">
-            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Meus Chats</p>
-            <p className="text-xl font-mono font-bold text-cyan-600">{meus.length}</p>
+            <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Comigo</p>
+            <p className="text-xl font-mono font-bold text-cyan-600">{meusAtivos.length}</p>
           </div>
+          {meusAClassificar.length > 0 && (
+            <div className="text-right">
+              <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">A classificar</p>
+              <p className="text-xl font-mono font-bold text-amber-600">{meusAClassificar.length}</p>
+            </div>
+          )}
         </div>
       </header>
 
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-12">
-        
-        {/* Coluna da Fila */}
-        <section className="lg:col-span-5 space-y-4">
+        <section className="space-y-4 lg:col-span-5">
           <h2 className="flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-slate-500">
             Aguardando ({fila.length})
           </h2>
 
           <div className="space-y-3">
             {fila.length === 0 ? (
-              <Card className="border-dashed border-2 bg-transparent p-8 text-center">
+              <Card className="border-2 border-dashed bg-transparent p-8 text-center">
                 <p className="text-sm text-slate-400">Fila vazia. Bom trabalho!</p>
               </Card>
             ) : (
@@ -146,7 +164,7 @@ export function WhatsappAtendendo() {
                   <div className="flex flex-col gap-4">
                     <div className="flex items-start justify-between">
                       <div className="min-w-0">
-                        <div className="flex items-center gap-2 mb-1">
+                        <div className="mb-1 flex items-center gap-2">
                           <span
                             className="min-w-0 truncate font-mono text-[10px] font-bold text-cyan-600"
                             title={exibirProtocolo(c.protocolo)}
@@ -160,7 +178,9 @@ export function WhatsappAtendendo() {
                             </span>
                           )}
                         </div>
-                        <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</h3>
+                        <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">
+                          {c.cliente_nome || 'Cliente'}
+                        </h3>
                         <p className="font-mono text-xs text-slate-500">{c.wa_id}</p>
                         {c.setor_nome && (
                           <p className="mt-1 text-[10px] font-medium text-slate-500 dark:text-slate-400">
@@ -171,17 +191,16 @@ export function WhatsappAtendendo() {
                       <div className="h-2 w-2 rounded-full bg-amber-400 shadow-[0_0_8px_rgba(251,191,36,0.5)]" />
                     </div>
 
-                    {/* Grupo de Botões da Fila */}
                     <div className="flex items-center gap-2 border-t pt-3 dark:border-slate-800">
-                      <Link 
+                      <Link
                         to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
-                        className="flex-1 text-center rounded-lg bg-slate-100 py-2 text-xs font-bold text-slate-600 hover:bg-slate-200 transition-colors dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
+                        className="flex-1 rounded-lg bg-slate-100 py-2 text-center text-xs font-bold text-slate-600 transition-colors hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
                       >
                         Visualizar
                       </Link>
-                      <Button 
+                      <Button
                         onClick={() => void assumir(c.id)}
-                        className="flex-1 bg-amber-500 hover:bg-amber-600 text-white"
+                        className="flex-1 bg-amber-500 text-white hover:bg-amber-600"
                       >
                         Atender
                       </Button>
@@ -193,60 +212,109 @@ export function WhatsappAtendendo() {
           </div>
         </section>
 
-        {/* Coluna de Ativos */}
-        <section className="lg:col-span-7 space-y-4">
-          <h2 className="text-xs font-bold uppercase tracking-widest text-slate-500">
-            Em atendimento comigo ({meus.length})
-          </h2>
-
-          <div className="grid gap-4 md:grid-cols-2">
-            {meus.length === 0 ? (
-              <div className="md:col-span-2 rounded-xl border-2 border-dashed p-12 text-center">
-                <p className="text-sm text-slate-400 italic">Você não tem atendimentos em curso.</p>
-              </div>
-            ) : (
-              meus.map((c) => (
-                <Link key={c.id} to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')} className="group">
-                  <Card className="h-full border-none p-5 shadow-sm ring-1 ring-slate-200 transition-all group-hover:ring-cyan-500 dark:ring-slate-800">
-                    <div className="flex flex-col h-full justify-between gap-4">
-                      <div>
-                        <div className="flex justify-between items-start mb-2">
-                          <span
-                            className="min-w-0 truncate text-[10px] font-bold text-cyan-600"
-                            title={exibirProtocolo(c.protocolo)}
-                          >
-                            {exibirProtocolo(c.protocolo)}
-                          </span>
-                          <span className="relative flex h-2 w-2">
-                            <span className="absolute h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75"></span>
-                            <span className="relative h-2 w-2 rounded-full bg-emerald-500"></span>
+        <section className="space-y-8 lg:col-span-7">
+          {meusAClassificar.length > 0 && (
+            <div className="space-y-4">
+              <h2 className="text-xs font-bold uppercase tracking-widest text-amber-700 dark:text-amber-400">
+                A classificar demanda ({meusAClassificar.length})
+              </h2>
+              <div className="grid gap-4 md:grid-cols-2">
+                {meusAClassificar.map((c) => (
+                  <Link
+                    key={c.id}
+                    to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
+                    className="group"
+                  >
+                    <Card className="h-full border-none p-5 shadow-sm ring-1 ring-amber-300 transition-all group-hover:ring-amber-500 dark:ring-amber-800">
+                      <div className="flex h-full flex-col justify-between gap-4">
+                        <div>
+                          <div className="mb-2 flex items-start justify-between gap-2">
+                            <span
+                              className="min-w-0 truncate text-[10px] font-bold text-amber-700 dark:text-amber-400"
+                              title={exibirProtocolo(c.protocolo)}
+                            >
+                              {exibirProtocolo(c.protocolo)}
+                            </span>
+                            <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[9px] font-bold uppercase text-amber-800 dark:bg-amber-950/50 dark:text-amber-200">
+                              Pendente
+                            </span>
+                          </div>
+                          <h3 className="font-bold text-slate-900 transition-colors group-hover:text-amber-700 dark:text-slate-100">
+                            {c.cliente_nome || 'Cliente'}
+                          </h3>
+                          <p className="mt-1 font-mono text-xs text-slate-400">{c.wa_id}</p>
+                          <p className="mt-2 text-[10px] font-medium text-amber-800/80 dark:text-amber-200/80">
+                            Encerrado por inatividade — falta registar a demanda
+                          </p>
+                        </div>
+                        <div className="flex items-center justify-end border-t pt-3 dark:border-slate-800">
+                          <span className="text-xs font-bold text-amber-700 dark:text-amber-400">
+                            Classificar →
                           </span>
                         </div>
-                        <h3 className="font-bold text-slate-900 dark:text-slate-100 group-hover:text-cyan-600 transition-colors">
-                          {c.cliente_nome || 'Cliente'}
-                        </h3>
-                        {!c.funcionario_rede_id && (
-                          <span className="mt-1 inline-flex rounded-full bg-violet-100 px-2 py-0.5 text-[9px] font-medium text-violet-700 dark:bg-violet-950/50 dark:text-violet-300">
-                            Sem vínculo
-                          </span>
-                        )}
-                        <p className="text-xs text-slate-400 font-mono mt-1">{c.wa_id}</p>
-                        <p className="mt-2 text-[10px] font-medium text-slate-500 dark:text-slate-400">
-                          {rotuloResponsavelChat(c)}
-                          {c.setor_nome ? ` • ${c.setor_nome}` : ''}
-                        </p>
                       </div>
-                      
-                      <div className="flex items-center justify-end border-t pt-3 dark:border-slate-800">
-                         <span className="text-xs font-bold text-cyan-600">
-                           Continuar →
-                         </span>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="space-y-4">
+            <h2 className="text-xs font-bold uppercase tracking-widest text-slate-500">
+              Em atendimento comigo ({meusAtivos.length})
+            </h2>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              {meusAtivos.length === 0 ? (
+                <div className="rounded-xl border-2 border-dashed p-12 text-center md:col-span-2">
+                  <p className="text-sm italic text-slate-400">Você não tem atendimentos em curso.</p>
+                </div>
+              ) : (
+                meusAtivos.map((c) => (
+                  <Link
+                    key={c.id}
+                    to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
+                    className="group"
+                  >
+                    <Card className="h-full border-none p-5 shadow-sm ring-1 ring-slate-200 transition-all group-hover:ring-cyan-500 dark:ring-slate-800">
+                      <div className="flex h-full flex-col justify-between gap-4">
+                        <div>
+                          <div className="mb-2 flex items-start justify-between">
+                            <span
+                              className="min-w-0 truncate text-[10px] font-bold text-cyan-600"
+                              title={exibirProtocolo(c.protocolo)}
+                            >
+                              {exibirProtocolo(c.protocolo)}
+                            </span>
+                            <span className="relative flex h-2 w-2">
+                              <span className="absolute h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75" />
+                              <span className="relative h-2 w-2 rounded-full bg-emerald-500" />
+                            </span>
+                          </div>
+                          <h3 className="font-bold text-slate-900 transition-colors group-hover:text-cyan-600 dark:text-slate-100">
+                            {c.cliente_nome || 'Cliente'}
+                          </h3>
+                          {!c.funcionario_rede_id && (
+                            <span className="mt-1 inline-flex rounded-full bg-violet-100 px-2 py-0.5 text-[9px] font-medium text-violet-700 dark:bg-violet-950/50 dark:text-violet-300">
+                              Sem vínculo
+                            </span>
+                          )}
+                          <p className="mt-1 font-mono text-xs text-slate-400">{c.wa_id}</p>
+                          <p className="mt-2 text-[10px] font-medium text-slate-500 dark:text-slate-400">
+                            {rotuloResponsavelChat(c)}
+                            {c.setor_nome ? ` • ${c.setor_nome}` : ''}
+                          </p>
+                        </div>
+                        <div className="flex items-center justify-end border-t pt-3 dark:border-slate-800">
+                          <span className="text-xs font-bold text-cyan-600">Continuar →</span>
+                        </div>
                       </div>
-                    </div>
-                  </Card>
-                </Link>
-              ))
-            )}
+                    </Card>
+                  </Link>
+                ))
+              )}
+            </div>
           </div>
         </section>
       </div>

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -24,6 +24,8 @@ type Props = {
   onInserirReferenciaKb?: (ref: string) => void
   /** Incrementar para focar o textarea (ex.: após Responder). */
   focoPedidoEm?: number
+  /** Placeholder customizado (ex.: pós-inatividade a classificar). */
+  placeholder?: string
 }
 
 type MenuAnexo = { tipo: TipoAnexoPicker; label: string }
@@ -52,6 +54,7 @@ export function WhatsappComposerBar({
   podeDigitar,
   onInserirReferenciaKb,
   focoPedidoEm,
+  placeholder,
 }: Props) {
   const [menuAberto, setMenuAberto] = useState(false)
   const [painelEmojiAberto, setPainelEmojiAberto] = useState(false)
@@ -189,13 +192,14 @@ export function WhatsappComposerBar({
           value={texto}
           onChange={(e) => onTextoChange(e.target.value)}
           placeholder={
-            encerrado
+            placeholder ??
+            (encerrado
               ? 'Apenas leitura…'
               : modoInterno
                 ? 'Comentário interno…'
                 : podeEnviar
                   ? 'Escreva uma mensagem…'
-                  : 'Somente comentários internos…'
+                  : 'Somente comentários internos…')
           }
           rows={1}
           disabled={campoBloqueado}

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -130,7 +130,7 @@ export function WhatsappComposerBar({
         />
       )}
 
-      <div className="flex items-end gap-1.5 rounded-2xl bg-slate-100 p-2 shadow-inner dark:bg-slate-900 sm:gap-2">
+      <div className="flex min-w-0 items-end gap-1 rounded-2xl bg-slate-100 p-1.5 shadow-inner dark:bg-slate-900 sm:gap-2 sm:p-2">
         <div className="relative shrink-0" ref={menuRef}>
           <button
             type="button"
@@ -184,7 +184,11 @@ export function WhatsappComposerBar({
         </div>
 
         {onInserirReferenciaKb && (
-          <KbConsultaButton disabled={encerrado} onInserirReferencia={podeDigitar ? onInserirReferenciaKb : undefined} />
+          <KbConsultaButton
+            disabled={encerrado}
+            modoComposer
+            onInserirReferencia={podeDigitar ? onInserirReferenciaKb : undefined}
+          />
         )}
 
         <textarea
@@ -203,7 +207,7 @@ export function WhatsappComposerBar({
           }
           rows={1}
           disabled={campoBloqueado}
-          className="max-h-32 min-h-[40px] flex-1 resize-none border-0 bg-transparent p-2 text-sm outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0 dark:text-slate-100 placeholder:text-slate-400"
+          className="max-h-32 min-h-[44px] min-w-0 flex-1 resize-none border-0 bg-transparent px-2 py-2.5 text-base outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0 sm:text-sm dark:text-slate-100 placeholder:text-slate-400"
           onKeyDown={(e) => {
             if (e.key === 'Enter' && !e.shiftKey) {
               e.preventDefault()

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -294,6 +294,9 @@ export function WhatsappConversa() {
   const [transferAtendenteId, setTransferAtendenteId] = useState<number | ''>('')
   const [transferindo, setTransferindo] = useState(false)
   const [modalVincFuncionario, setModalVincFuncionario] = useState(false)
+  const [modalEmpresaContexto, setModalEmpresaContexto] = useState(false)
+  const [empresaContextoId, setEmpresaContextoId] = useState<number | ''>('')
+  const [salvandoEmpresaContexto, setSalvandoEmpresaContexto] = useState(false)
 
   const [setoresList, setSetoresList] = useState<Setores.Setor[]>([])
   const [atendentesDestino, setAtendentesDestino] = useState<Atendentes.Atendente[]>([])
@@ -535,6 +538,25 @@ export function WhatsappConversa() {
       setModoInterno(true)
     } else {
       setModoInterno(false)
+    }
+  }, [chat, user?.id])
+
+  useEffect(() => {
+    // 1 empresa e ainda sem contexto: preenche automaticamente sem bloquear o atendimento
+    if (!chat || !user?.id) return
+    if (chat.atendente_id !== user.id || chat.estado !== 'em_atendimento') return
+    if (chat.empresa_id) return
+    const opcoes = chat.empresas_opcoes || []
+    if (opcoes.length !== 1) return
+    let cancelled = false
+    void whatsappChats
+      .definirEmpresaContexto(chat.id, opcoes[0].id)
+      .then((atualizado) => {
+        if (!cancelled) setChat((prev) => mergeWhatsappChat(prev, atualizado))
+      })
+      .catch(() => {})
+    return () => {
+      cancelled = true
     }
   }, [chat, user?.id])
 
@@ -856,6 +878,31 @@ useEffect(() => {
     )
   }
 
+  async function confirmarEmpresaContexto() {
+    if (!chat || empresaContextoId === '') {
+      toast.showWarning('Selecione a empresa do atendimento.')
+      return
+    }
+    setSalvandoEmpresaContexto(true)
+    try {
+      const atualizado = await whatsappChats.definirEmpresaContexto(chat.id, Number(empresaContextoId))
+      setChat((prev) => mergeWhatsappChat(prev, atualizado))
+      setModalEmpresaContexto(false)
+      setEmpresaContextoId('')
+      toast.showSuccess('Empresa do atendimento definida.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível definir a empresa.'))
+    } finally {
+      setSalvandoEmpresaContexto(false)
+    }
+  }
+
+  function abrirModalEmpresaContexto() {
+    if (!chat) return
+    setEmpresaContextoId(chat.empresa_id ?? '')
+    setModalEmpresaContexto(true)
+  }
+
 
 
   if (loading && !chat) return <div className="flex h-full items-center justify-center italic text-slate-400">Carregando workspace...</div>
@@ -876,6 +923,15 @@ useEffect(() => {
     !chat?.classificacao_demanda_pendente
 
   const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && (isResponsavel || isAdmin)
+
+  const podeDefinirEmpresa =
+    !encerrado &&
+    Boolean(chat?.funcionario_rede_id) &&
+    (chat?.empresas_opcoes?.length ?? 0) > 0 &&
+    (isResponsavel || isAdmin)
+
+  const precisaEmpresaContexto =
+    podeDefinirEmpresa && !chat?.empresa_id && (chat?.empresas_opcoes?.length ?? 0) > 1
 
   const mostrarBannerDemandaInatividade =
     Boolean(chat?.classificacao_demanda_pendente) && (isResponsavel || isAdmin)
@@ -1099,9 +1155,32 @@ useEffect(() => {
                     {chat.funcionario_nome}
                     {chat.funcionario_tipo ? ` · ${chat.funcionario_tipo}` : ''}
                   </Link>
-                  {chat.empresa_nome && (
-                    <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
-                      {chat.empresa_nome}
+                  {chat.empresa_nome ? (
+                    podeDefinirEmpresa && (chat.empresas_opcoes?.length ?? 0) > 1 ? (
+                      <button
+                        type="button"
+                        onClick={abrirModalEmpresaContexto}
+                        className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 transition-colors hover:border-cyan-400 hover:text-cyan-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300"
+                        title="Alterar empresa do atendimento"
+                      >
+                        {chat.empresa_nome}
+                      </button>
+                    ) : (
+                      <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+                        {chat.empresa_nome}
+                      </span>
+                    )
+                  ) : podeDefinirEmpresa ? (
+                    <button
+                      type="button"
+                      onClick={abrirModalEmpresaContexto}
+                      className="inline-flex rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-800 transition-colors hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+                    >
+                      Definir empresa
+                    </button>
+                  ) : (
+                    <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+                      Sem empresa
                     </span>
                   )}
                 </div>
@@ -1178,6 +1257,19 @@ useEffect(() => {
             <p>{CONTATO_CLIENTE.bannerNaoVinculado}</p>
             <Button variant="primary" className="h-8 shrink-0 text-xs" onClick={() => setModalVincFuncionario(true)}>
               {CONTATO_CLIENTE.vincularEmpresa}
+            </Button>
+          </div>
+        )}
+
+        {precisaEmpresaContexto && (
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100">
+            <p>
+              Este contacto pertence a mais de uma empresa. Pergunte ao cliente qual empresa deseja
+              atendimento e vincule quando souber — pode fazer isso a qualquer momento antes de
+              encerrar.
+            </p>
+            <Button variant="primary" className="h-8 shrink-0 text-xs" onClick={abrirModalEmpresaContexto}>
+              Definir empresa
             </Button>
           </div>
         )}
@@ -1577,6 +1669,57 @@ useEffect(() => {
             onClose={() => setModalVincFuncionario(false)}
             onSuccess={aplicarChatAtualizado}
           />
+        )}
+
+        {modalEmpresaContexto && chat && (
+          <div className="fixed inset-0 z-[120] flex items-end justify-center bg-black/50 p-4 sm:items-center">
+            <div
+              className="w-full max-w-md rounded-2xl bg-white p-5 shadow-xl dark:bg-slate-900"
+              role="dialog"
+              aria-modal
+              aria-labelledby="empresa-contexto-titulo"
+            >
+              <h2 id="empresa-contexto-titulo" className="text-lg font-bold text-slate-900 dark:text-white">
+                Empresa do atendimento
+              </h2>
+              <p className="mt-1 text-sm text-slate-500">
+                Vincule a empresa que o cliente indicou. Pode alterar enquanto o chat não estiver
+                encerrado.
+              </p>
+              <div className="mt-4">
+                <Select
+                  label="Empresa"
+                  value={empresaContextoId}
+                  onChange={(value) => setEmpresaContextoId(value === '' ? '' : Number(value))}
+                  options={(chat.empresas_opcoes || []).map((e) => ({ value: e.id, label: e.nome }))}
+                  placeholder="Selecione a empresa"
+                  includeEmpty
+                  emptyLabel="Selecione a empresa"
+                />
+              </div>
+              <div className="mt-5 flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  disabled={salvandoEmpresaContexto}
+                  onClick={() => {
+                    setModalEmpresaContexto(false)
+                    setEmpresaContextoId('')
+                  }}
+                >
+                  Cancelar
+                </Button>
+                <Button
+                  type="button"
+                  loading={salvandoEmpresaContexto}
+                  disabled={empresaContextoId === ''}
+                  onClick={() => void confirmarEmpresaContexto()}
+                >
+                  Confirmar
+                </Button>
+              </div>
+            </div>
+          </div>
         )}
 
       {chat && (

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -309,6 +309,8 @@ export function WhatsappConversa() {
   const [demandasReloadKey, setDemandasReloadKey] = useState(0)
   const [demandasTimeline, setDemandasTimeline] = useState<WhatsappChats.Demanda[]>([])
   const [modalEncerrar, setModalEncerrar] = useState(false)
+  const [menuMobileAberto, setMenuMobileAberto] = useState(false)
+  const menuMobileRef = useRef<HTMLDivElement>(null)
   const [filaAguardandoAberta, setFilaAguardandoAberta] = useState(false)
   const { filaCount } = useChatHub()
   const navigate = useNavigate()
@@ -344,6 +346,17 @@ export function WhatsappConversa() {
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [voltarLista, modalEncerrar, activeZoomImage, arquivoPendente])
+
+  useEffect(() => {
+    if (!menuMobileAberto) return
+    const onDoc = (e: globalThis.MouseEvent) => {
+      if (menuMobileRef.current && !menuMobileRef.current.contains(e.target as Node)) {
+        setMenuMobileAberto(false)
+      }
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [menuMobileAberto])
 
   const viuEmAtendimentoRef = useRef(false)
   const inatividadeToastFeitoRef = useRef(false)
@@ -1080,9 +1093,9 @@ useEffect(() => {
 
         {/* Header do Chat */}
 
-        <header className="flex h-16 items-center justify-between border-b border-slate-100 px-4 dark:border-slate-800 shadow-sm z-10">
+        <header className="shrink-0 border-b border-slate-100 shadow-sm z-10 dark:border-slate-800">
 
-          <div className="flex items-center gap-2 min-w-0 sm:gap-3">
+          <div className="flex items-center gap-2 px-3 py-2 sm:px-4">
 
             <Button
               type="button"
@@ -1095,157 +1108,214 @@ useEffect(() => {
               <span className="hidden sm:inline"> Voltar</span>
             </Button>
 
-            <div className="min-w-0">
+            <div className="min-w-0 flex-1">
+              <h1 className="truncate font-bold text-slate-900 dark:text-white">
+                {chat?.cliente_nome || 'Atendimento'}
+              </h1>
+            </div>
 
-              <h1 className="truncate font-bold text-slate-900 dark:text-white">{chat?.cliente_nome || 'Atendimento'}</h1>
+            <div className="flex shrink-0 items-center gap-1 sm:gap-2">
 
-              <div className="flex flex-wrap items-center gap-2 text-[10px]">
-
-                <span className="min-w-0 truncate font-mono font-bold text-cyan-600" title={exibirProtocolo(chat?.protocolo)}>
-                  {exibirProtocolo(chat?.protocolo)}
-                </span>
-
-                <span className="text-slate-300">•</span>
-
-                <span className={`capitalize ${encerrado ? 'text-red-500' : 'text-emerald-500'}`}>
-                  {chat ? rotuloEstadoChat(chat.estado) : '—'}
-                </span>
-
-                {chat && (
-                  <>
-                    <span className="text-slate-300">•</span>
-                    <span className="truncate text-slate-600 dark:text-slate-300">
-                      Responsável: {rotuloResponsavelChat(chat, user?.id)}
-                    </span>
-                    {chat.setor_nome && (
-                      <>
-                        <span className="hidden sm:inline text-slate-300">•</span>
-                        <span className="hidden sm:inline truncate text-slate-500 dark:text-slate-400">
-                          {chat.setor_nome}
-                        </span>
-                      </>
-                    )}
-                  </>
-                )}
-
-              </div>
-
-              {ticketsVinculados.length > 0 && (
-                <div className="mt-1.5 flex flex-wrap gap-1.5">
-                  {ticketsVinculados.map((t) => (
-                    <Link
-                      key={t.id}
-                      to={`/tickets/${t.id}`}
-                      className="inline-flex rounded-full border border-cyan-200/80 bg-cyan-50 px-2 py-0.5 text-[10px] font-medium text-cyan-800 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-300"
-                      title={t.assunto}
-                    >
-                      {exibirProtocolo(t.protocolo)}
-                    </Link>
-                  ))}
-                </div>
-              )}
-
-              {chat?.funcionario_rede_id && (
-                <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-                  <Link
-                    to={`/funcionarios-rede/${chat.funcionario_rede_id}`}
-                    className="inline-flex rounded-full border border-violet-200/80 bg-violet-50 px-2 py-0.5 text-[10px] font-medium text-violet-800 dark:border-violet-800 dark:bg-violet-950/40 dark:text-violet-300"
-                    title={chat.funcionario_email ?? undefined}
-                  >
-                    {chat.funcionario_nome}
-                    {chat.funcionario_tipo ? ` · ${chat.funcionario_tipo}` : ''}
-                  </Link>
-                  {chat.empresa_nome ? (
-                    podeDefinirEmpresa && (chat.empresas_opcoes?.length ?? 0) > 1 ? (
-                      <button
-                        type="button"
-                        onClick={abrirModalEmpresaContexto}
-                        className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 transition-colors hover:border-cyan-400 hover:text-cyan-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300"
-                        title="Alterar empresa do atendimento"
-                      >
-                        {chat.empresa_nome}
-                      </button>
-                    ) : (
-                      <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
-                        {chat.empresa_nome}
-                      </span>
-                    )
-                  ) : podeDefinirEmpresa ? (
-                    <button
-                      type="button"
-                      onClick={abrirModalEmpresaContexto}
-                      className="inline-flex rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-800 transition-colors hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
-                    >
-                      Definir empresa
-                    </button>
-                  ) : (
-                    <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
-                      Sem empresa
+              {modoHub && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="relative h-8 shrink-0 px-2.5 text-xs font-semibold md:hidden"
+                  onClick={() => setFilaAguardandoAberta(true)}
+                  aria-label={filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'}
+                >
+                  Aguardando
+                  {filaCount > 0 && (
+                    <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
+                      {filaCount > 99 ? '99+' : filaCount}
                     </span>
                   )}
-                </div>
+                </Button>
+              )}
+
+              {!encerrado && (
+                <>
+                  {isResponsavel && chat && (
+                    <div className="hidden sm:flex">
+                      <WhatsappInatividadeControle
+                        chat={chat}
+                        msgs={msgs}
+                        isResponsavel={isResponsavel}
+                        onChatUpdate={aplicarChatAtualizado}
+                      />
+                    </div>
+                  )}
+                  {podeTransferir && (
+                    <Button
+                      variant="primary"
+                      className="hidden sm:inline-flex text-xs h-8"
+                      onClick={() => setModalTransferir(true)}
+                    >
+                      Transferir
+                    </Button>
+                  )}
+                  <Button
+                    variant="ghost"
+                    className="hidden sm:inline-flex text-xs h-8"
+                    onClick={() => setModalTickets(true)}
+                  >
+                    Tickets{ticketsVinculados.length > 0 ? ` (${ticketsVinculados.length})` : ''}
+                  </Button>
+
+                  {podeEncerrar && (
+                    <Button variant="danger" className="h-8 px-2.5 text-xs sm:px-3" onClick={() => setModalEncerrar(true)}>
+                      Encerrar
+                    </Button>
+                  )}
+
+                  <div className="relative sm:hidden" ref={menuMobileRef}>
+                    <button
+                      type="button"
+                      aria-label="Mais ações"
+                      aria-expanded={menuMobileAberto}
+                      onClick={() => setMenuMobileAberto((o) => !o)}
+                      className="flex h-8 w-8 items-center justify-center rounded-lg text-lg text-slate-600 transition hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+                    >
+                      ⋮
+                    </button>
+                    {menuMobileAberto && (
+                      <div className="absolute right-0 top-full z-30 mt-1 min-w-[12rem] rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900">
+                        {podeTransferir && (
+                          <button
+                            type="button"
+                            className="block w-full px-4 py-2.5 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
+                            onClick={() => {
+                              setMenuMobileAberto(false)
+                              setModalTransferir(true)
+                            }}
+                          >
+                            Transferir
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          className="block w-full px-4 py-2.5 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
+                          onClick={() => {
+                            setMenuMobileAberto(false)
+                            setModalTickets(true)
+                          }}
+                        >
+                          Tickets{ticketsVinculados.length > 0 ? ` (${ticketsVinculados.length})` : ''}
+                        </button>
+                        {podeDefinirEmpresa && (
+                          <button
+                            type="button"
+                            className="block w-full px-4 py-2.5 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
+                            onClick={() => {
+                              setMenuMobileAberto(false)
+                              abrirModalEmpresaContexto()
+                            }}
+                          >
+                            {chat?.empresa_id ? 'Alterar empresa' : 'Definir empresa'}
+                          </button>
+                        )}
+                        {isResponsavel && chat && (
+                          <div className="border-t border-slate-100 px-3 py-2 dark:border-slate-800">
+                            <WhatsappInatividadeControle
+                              chat={chat}
+                              msgs={msgs}
+                              isResponsavel={isResponsavel}
+                              onChatUpdate={aplicarChatAtualizado}
+                            />
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </>
               )}
 
             </div>
 
           </div>
 
+          <div className="space-y-1.5 px-3 pb-2 sm:px-4 sm:pb-3">
 
-
-          <div className="flex items-center gap-2">
-
-            {modoHub && (
-              <Button
-                type="button"
-                variant="secondary"
-                className="relative h-8 shrink-0 px-2.5 text-xs font-semibold md:hidden"
-                onClick={() => setFilaAguardandoAberta(true)}
-                aria-label={
-                  filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'
-                }
-              >
-                Aguardando
-                {filaCount > 0 && (
-                  <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
-                    {filaCount > 99 ? '99+' : filaCount}
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px]">
+              <span className="min-w-0 truncate font-mono font-bold text-cyan-600" title={exibirProtocolo(chat?.protocolo)}>
+                {exibirProtocolo(chat?.protocolo)}
+              </span>
+              <span className="text-slate-300">•</span>
+              <span className={`capitalize ${encerrado ? 'text-red-500' : 'text-emerald-500'}`}>
+                {chat ? rotuloEstadoChat(chat.estado) : '—'}
+              </span>
+              {chat && (
+                <>
+                  <span className="text-slate-300">•</span>
+                  <span className="max-w-[10rem] truncate text-slate-600 sm:max-w-none dark:text-slate-300">
+                    {rotuloResponsavelChat(chat, user?.id)}
                   </span>
-                )}
-              </Button>
+                  {chat.setor_nome && (
+                    <>
+                      <span className="hidden text-slate-300 sm:inline">•</span>
+                      <span className="hidden max-w-[8rem] truncate text-slate-500 sm:inline dark:text-slate-400">
+                        {chat.setor_nome}
+                      </span>
+                    </>
+                  )}
+                </>
+              )}
+            </div>
+
+            {ticketsVinculados.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {ticketsVinculados.map((t) => (
+                  <Link
+                    key={t.id}
+                    to={`/tickets/${t.id}`}
+                    className="inline-flex rounded-full border border-cyan-200/80 bg-cyan-50 px-2 py-0.5 text-[10px] font-medium text-cyan-800 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-300"
+                    title={t.assunto}
+                  >
+                    {exibirProtocolo(t.protocolo)}
+                  </Link>
+                ))}
+              </div>
             )}
 
-            {!encerrado && (
-              <>
-                {isResponsavel && chat && (
-                  <WhatsappInatividadeControle
-                    chat={chat}
-                    msgs={msgs}
-                    isResponsavel={isResponsavel}
-                    onChatUpdate={aplicarChatAtualizado}
-                  />
-                )}
-                {podeTransferir && (
-                  <Button
-                    variant="primary"
-                    className="hidden sm:inline-flex text-xs h-8"
-                    onClick={() => setModalTransferir(true)}
-                  >
-                    Transferir
-                  </Button>
-                )}
-                <Button
-                  variant="ghost"
-                  className="hidden sm:inline-flex text-xs h-8"
-                  onClick={() => setModalTickets(true)}
+            {chat?.funcionario_rede_id && (
+              <div className="flex flex-wrap items-center gap-1.5">
+                <Link
+                  to={`/funcionarios-rede/${chat.funcionario_rede_id}`}
+                  className="inline-flex max-w-full truncate rounded-full border border-violet-200/80 bg-violet-50 px-2 py-0.5 text-[10px] font-medium text-violet-800 dark:border-violet-800 dark:bg-violet-950/40 dark:text-violet-300"
+                  title={chat.funcionario_email ?? undefined}
                 >
-                  Tickets{ticketsVinculados.length > 0 ? ` (${ticketsVinculados.length})` : ''}
-                </Button>
-
-                {podeEncerrar && (
-                  <Button variant="danger" className="h-8 px-3 text-xs" onClick={() => setModalEncerrar(true)}>
-                    Encerrar
-                  </Button>
+                  {chat.funcionario_nome}
+                  {chat.funcionario_tipo ? ` · ${chat.funcionario_tipo}` : ''}
+                </Link>
+                {chat.empresa_nome ? (
+                  podeDefinirEmpresa && (chat.empresas_opcoes?.length ?? 0) > 1 ? (
+                    <button
+                      type="button"
+                      onClick={abrirModalEmpresaContexto}
+                      className="inline-flex max-w-full truncate rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 transition-colors hover:border-cyan-400 hover:text-cyan-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300"
+                      title="Alterar empresa do atendimento"
+                    >
+                      {chat.empresa_nome}
+                    </button>
+                  ) : (
+                    <span className="inline-flex max-w-full truncate rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
+                      {chat.empresa_nome}
+                    </span>
+                  )
+                ) : podeDefinirEmpresa ? (
+                  <button
+                    type="button"
+                    onClick={abrirModalEmpresaContexto}
+                    className="inline-flex rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-800 transition-colors hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300"
+                  >
+                    Definir empresa
+                  </button>
+                ) : (
+                  <span className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-500 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-400">
+                    Sem empresa
+                  </span>
                 )}
-              </>
+              </div>
             )}
 
           </div>
@@ -1479,7 +1549,7 @@ useEffect(() => {
 
         {/* Footer: Input & Mídia */}
 
-        <footer className="p-4 bg-white dark:bg-slate-950 border-t border-slate-100 dark:border-slate-800">
+        <footer className="shrink-0 border-t border-slate-100 bg-white p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] dark:border-slate-800 dark:bg-slate-950 sm:p-4">
 
           {msgRespondida && (
             <div className="flex items-center justify-between bg-slate-100 dark:bg-slate-900 border-l-4 border-cyan-600 px-4 py-2 rounded-t-xl mb-1 text-xs animate-in slide-in-from-bottom-2 duration-150">

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -68,12 +68,20 @@ import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
 import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { ChatFilaAguardandoSheet } from '../../components/chat/ChatFilaAguardandoSheet'
+import { WhatsappInatividadeControle } from './WhatsappInatividadeControle'
 import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
 import { rotuloDownloadArquivo, visualTipoArquivo } from '../../lib/fileTypeIcon'
 import { CONTATO_CLIENTE } from '../../constants/contatoClienteLabels'
 
-const ROTULO_SEM_LEGENDA = /^\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)\]$/
+const ROTULO_SEM_LEGENDA =
+  /^(?:\[\s*[^\]]+\s*\]:\s*)?\[(Imagem|Áudio|Vídeo|Documento|Figurinha|Contacto|Localização)(\s+enviad[oa])?\]$/i
 
+/** Legenda real sob mídia; ignora placeholders tipo «[Imagem enviada]». */
+function legendaMidiaVisivel(corpo: string | null | undefined): string | null {
+  const t = (corpo || '').trim()
+  if (!t || ROTULO_SEM_LEGENDA.test(t)) return null
+  return t
+}
 
 
 // --- Subcomponente de Renderização de Mídia ---
@@ -153,16 +161,14 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 
 
 
-  const legenda = m.corpo && !ROTULO_SEM_LEGENDA.test(m.corpo.trim()) ? m.corpo : null
-
-
+  const legenda = legendaMidiaVisivel(m.corpo)
 
   if (tipo === 'texto' || !m.tipo_midia) return <TextoComLinks texto={m.corpo} />
 
   if (!m.midia_disponivel) {
     return (
       <p className="text-xs italic opacity-70" title="O ficheiro não foi obtido da Evolution API">
-        {m.corpo || 'Mídia não disponível'}
+        {legenda || 'Mídia não disponível'}
       </p>
     )
   }
@@ -171,60 +177,47 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 
   if (err) return <p className="text-[10px] italic opacity-50">Erro ao carregar mídia</p>
 
-
-
-  const mediaClass = "max-h-64 max-w-full rounded-lg border border-black/5 shadow-sm"
-
-
+  const mediaClass = 'max-h-64 max-w-full rounded-lg border border-black/5 shadow-sm'
 
   if (tipo === 'imagem' || tipo === 'figurinha') {
-
     return (
-
       <div className="space-y-1">
-
-        <img 
-
-          src={url} 
-
-          alt="" 
-
-          className={`${mediaClass} cursor-zoom-in transition-transform duration-200 hover:scale-[1.02]`} 
-
+        <img
+          src={url}
+          alt=""
+          className={`${mediaClass} cursor-zoom-in transition-transform duration-200 hover:scale-[1.02]`}
           onClick={() => onImageClick(url, legenda)}
-
         />
-
-        {legenda && <p className="text-xs opacity-80 italic">{legenda}</p>}
-
+        {legenda ? <TextoComLinks texto={legenda} /> : null}
       </div>
-
     )
-
   }
 
   if (tipo === 'audio') return <CustomAudioPlayer src={url} />
 
-  if (tipo === 'video') return <video controls src={url} className={mediaClass} />
+  if (tipo === 'video') {
+    return (
+      <div className="space-y-1">
+        <video controls src={url} className={mediaClass} />
+        {legenda ? <TextoComLinks texto={legenda} /> : null}
+      </div>
+    )
+  }
 
- 
-
-  const downloadLabel = rotuloDownloadArquivo(
-    tipo === 'documento' ? m.corpo : null,
-    m.mimetype,
-    tipo,
-  )
-  const fileVisual = visualTipoArquivo(tipo === 'documento' ? m.corpo : null, m.mimetype)
+  const downloadLabel = rotuloDownloadArquivo(null, m.mimetype, tipo)
+  const fileVisual = visualTipoArquivo(null, m.mimetype)
 
   return (
-
-    <a href={url} download className="flex items-center gap-2 text-xs font-bold underline">
-      <span className="text-base" aria-hidden>{fileVisual.emoji}</span>
-      <span>{downloadLabel.replace(/^\S+\s*/, '')}</span>
-    </a>
-
+    <div className="space-y-1">
+      <a href={url} download className="flex items-center gap-2 text-xs font-bold underline">
+        <span className="text-base" aria-hidden>
+          {fileVisual.emoji}
+        </span>
+        <span>{downloadLabel.replace(/^\S+\s*/, '')}</span>
+      </a>
+      {legenda ? <TextoComLinks texto={legenda} /> : null}
+    </div>
   )
-
 }
 
 
@@ -323,11 +316,24 @@ export function WhatsappConversa() {
       if (e.key !== 'Escape' || e.defaultPrevented || modalEncerrar) return
       const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase()
       if (tag === 'input' || tag === 'textarea' || tag === 'select') return
+      if (activeZoomImage) {
+        e.preventDefault()
+        e.stopPropagation()
+        setActiveZoomImage(null)
+        setActiveZoomImageCaption(null)
+        return
+      }
+      if (arquivoPendente) {
+        e.preventDefault()
+        setArquivoPendente(null)
+        setLegendaMidia('')
+        return
+      }
       voltarLista()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [voltarLista, modalEncerrar])
+  }, [voltarLista, modalEncerrar, activeZoomImage, arquivoPendente])
 
   useEffect(() => {
     if (!modalEncerrar || !chat) return
@@ -352,20 +358,22 @@ export function WhatsappConversa() {
 
 
 
-  // Scroll: só cola no fim se o utilizador já estiver perto do fundo; senão preserva a posição.
+  // Scroll: restaurar última posição vista; só cola no fim se já estava no fundo.
   useEffect(() => {
     if (!id) return
     initialScrollRestoredRef.current = false
-    stickToBottomRef.current = true
+    stickToBottomRef.current = false
   }, [id])
 
   useEffect(() => {
     if (loading || msgs.length === 0 || initialScrollRestoredRef.current || !id) return
     initialScrollRestoredRef.current = true
     requestAnimationFrame(() => {
-      const el = scrollRef.current
-      if (!el) return
-      stickToBottomRef.current = restoreWhatsappScroll(Number(id), el)
+      requestAnimationFrame(() => {
+        const el = scrollRef.current
+        if (!el) return
+        stickToBottomRef.current = restoreWhatsappScroll(Number(id), el)
+      })
     })
   }, [loading, msgs.length, id])
 
@@ -376,7 +384,6 @@ export function WhatsappConversa() {
       if (el) scrollWhatsappToBottom(el)
     })
   }, [msgs, loading])
-
   useEffect(() => {
     const el = scrollRef.current
     if (!el || !id) return
@@ -1061,6 +1068,14 @@ useEffect(() => {
 
             {!encerrado && (
               <>
+                {isResponsavel && chat && (
+                  <WhatsappInatividadeControle
+                    chat={chat}
+                    msgs={msgs}
+                    isResponsavel={isResponsavel}
+                    onChatUpdate={aplicarChatAtualizado}
+                  />
+                )}
                 {podeTransferir && (
                   <Button
                     variant="primary"
@@ -1070,7 +1085,6 @@ useEffect(() => {
                     Transferir
                   </Button>
                 )}
-
                 <Button
                   variant="ghost"
                   className="hidden sm:inline-flex text-xs h-8"
@@ -1349,10 +1363,18 @@ useEffect(() => {
                   onChange={(e) => setLegendaMidia(e.target.value)}
                   placeholder="Legenda opcional (visível no WhatsApp)"
                   className={`mt-2 ${TEXTAREA_FIELD_CLASS}`}
+                  autoFocus
                 />
               )}
               <div className="mt-2 flex justify-end gap-2">
-                <Button variant="ghost" className="h-8 text-xs" onClick={() => setArquivoPendente(null)}>
+                <Button
+                  variant="ghost"
+                  className="h-8 text-xs"
+                  onClick={() => {
+                    setArquivoPendente(null)
+                    setLegendaMidia('')
+                  }}
+                >
                   Cancelar
                 </Button>
                 <Button className="h-8 text-xs" loading={enviando} onClick={() => void confirmarEnvioMidia()}>
@@ -1362,27 +1384,28 @@ useEffect(() => {
             </div>
           )}
 
-          <WhatsappComposerBar
-            texto={texto}
-            onTextoChange={setTexto}
-            onEnviar={() => void enviar()}
-            enviando={enviando}
-            encerrado={encerrado}
-            podeEnviar={podeEnviar}
-            modoInterno={modoInterno}
-            podeDigitar={podeDigitarMensagem}
-            onEscolherAnexo={abrirPickerAnexo}
-            onAudioGravado={handleGravacaoConcluida}
-            onInserirEmoji={setTexto}
-            onEnviarFigurinha={(file) => void enviarFigurinha(file)}
-            onColarArquivo={(file) => {
-              setArquivoPendente(file)
-              setLegendaMidia('')
-            }}
-            onInserirReferenciaKb={inserirReferenciaKb}
-            focoPedidoEm={focoComposerEm}
-          />
-
+          {!arquivoPendente ? (
+            <WhatsappComposerBar
+              texto={texto}
+              onTextoChange={setTexto}
+              onEnviar={() => void enviar()}
+              enviando={enviando}
+              encerrado={encerrado}
+              podeEnviar={podeEnviar}
+              modoInterno={modoInterno}
+              podeDigitar={podeDigitarMensagem}
+              onEscolherAnexo={abrirPickerAnexo}
+              onAudioGravado={handleGravacaoConcluida}
+              onInserirEmoji={setTexto}
+              onEnviarFigurinha={(file) => void enviarFigurinha(file)}
+              onColarArquivo={(file) => {
+                setArquivoPendente(file)
+                setLegendaMidia('')
+              }}
+              onInserirReferenciaKb={inserirReferenciaKb}
+              focoPedidoEm={focoComposerEm}
+            />
+          ) : null}
           <input
             type="file"
             ref={fileInputRef}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -22,7 +22,9 @@ import {
 } from '../../api/client'
 
 import { resolveWhatsappMidiaObjectUrl, revokeWhatsappMidiaForChat } from '../../lib/whatsappMidiaCache'
-import { chatEncerramentoPorInatividade } from '../../lib/whatsappDemandaUtils'
+import {
+  chatEncerramentoPorInatividade,
+} from '../../lib/whatsappDemandaUtils'
 import { mergeWhatsappChat, patchWhatsappChatLista, replaceWhatsappChatLista } from '../../lib/whatsappChatMerge'
 import { whatsappMensagensUnicas } from '../../lib/whatsappMensagens'
 import {
@@ -262,6 +264,11 @@ export function WhatsappConversa() {
 
   const [meusChats, setMeusChats] = useState<WhatsappChats.Chat[]>([])
 
+  const chatRef = useRef(chat)
+  const userIdRef = useRef(user?.id)
+  chatRef.current = chat
+  userIdRef.current = user?.id
+
  
 
   // Estados de UI
@@ -335,14 +342,32 @@ export function WhatsappConversa() {
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [voltarLista, modalEncerrar, activeZoomImage, arquivoPendente])
 
+  const viuEmAtendimentoRef = useRef(false)
+  const inatividadeToastFeitoRef = useRef(false)
+
   useEffect(() => {
-    if (!modalEncerrar || !chat) return
-    const fechado = chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao'
-    if (fechado && chatEncerramentoPorInatividade(msgs)) {
-      setModalEncerrar(false)
-      toast.showSuccess('Atendimento encerrado automaticamente por inatividade do cliente.')
+    if (chat?.estado === 'em_atendimento') {
+      viuEmAtendimentoRef.current = true
     }
-  }, [modalEncerrar, chat, msgs, toast])
+  }, [chat?.estado])
+
+  useEffect(() => {
+    if (!chat || inatividadeToastFeitoRef.current) return
+    if (!viuEmAtendimentoRef.current) return
+
+    const fechado = chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao'
+    if (!fechado || !chatEncerramentoPorInatividade(msgs)) return
+    if (!chat.classificacao_demanda_pendente) return
+
+    const podeClassificar =
+      chat.atendente_id === user?.id || user?.role === 'admin'
+    if (!podeClassificar) return
+
+    inatividadeToastFeitoRef.current = true
+    toast.showSuccess(
+      'Atendimento encerrado por inatividade. Pode reler a conversa e registar a demanda no aviso abaixo.',
+    )
+  }, [chat, msgs, user?.id, user?.role, toast])
 
   const refrescarTimelineDemandas = useCallback(() => {
     setDemandasReloadKey((k) => k + 1)
@@ -490,6 +515,8 @@ export function WhatsappConversa() {
     if (!id) return
 
     setLoading(true)
+    viuEmAtendimentoRef.current = false
+    inatividadeToastFeitoRef.current = false
 
     carregar().then(() => whatsappChats.marcarVisto(id)).finally(() => setLoading(false))
 
@@ -535,6 +562,16 @@ export function WhatsappConversa() {
         }
         return [...prev, msg]
       })
+      // ✓✓ azul no WhatsApp do cliente: marcar leitura em inbound novo enquanto o responsável está no chat
+      const c = chatRef.current
+      if (
+        msg.direcao === 'inbound' &&
+        c?.estado === 'em_atendimento' &&
+        c.atendente_id != null &&
+        c.atendente_id === userIdRef.current
+      ) {
+        void whatsappChats.marcarVisto(chatId)
+      }
     })
     const unsubFila = subscribe('chat.fila', (payload) => {
       const payloadChatId = Number(payload.chat_id)
@@ -548,7 +585,11 @@ export function WhatsappConversa() {
           void carregar().catch(() => {})
         }
       }
-      if (chatData && chatData.estado !== 'em_atendimento') {
+      if (
+        chatData &&
+        chatData.estado !== 'em_atendimento' &&
+        !chatData.classificacao_demanda_pendente
+      ) {
         setMeusChats((prev) => prev.filter((c) => c.id !== payloadChatId))
       } else if (!chatData || payloadChatId !== chatId) {
         void carregarSidebar()
@@ -805,9 +846,13 @@ useEffect(() => {
     await Promise.all([carregar(), carregarSidebar()])
     refrescarTimelineDemandas()
     toast.showSuccess(
-      atualizado.estado === 'aguardando_avaliacao'
+      atualizado.estado === 'aguardando_avaliacao' && atualizado.classificacao_demanda_pendente
         ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
-        : 'Atendimento encerrado.',
+        : atualizado.classificacao_demanda_pendente === false && chatEncerramentoPorInatividade(msgs)
+          ? 'Classificação da sessão concluída.'
+          : atualizado.estado === 'aguardando_avaliacao'
+            ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
+            : 'Atendimento encerrado.',
     )
   }
 
@@ -824,11 +869,29 @@ useEffect(() => {
 
   const podeTransferir = !encerrado && (isResponsavel || isAdmin)
 
-  const podeEnviar = chat?.estado === 'em_atendimento' && isResponsavel && !encerrado
+  const podeEnviar =
+    chat?.estado === 'em_atendimento' &&
+    isResponsavel &&
+    !encerrado &&
+    !chat?.classificacao_demanda_pendente
 
   const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && (isResponsavel || isAdmin)
 
-  const podeDigitarMensagem = !encerrado && (modoInterno || podeEnviar)
+  const mostrarBannerDemandaInatividade =
+    Boolean(chat?.classificacao_demanda_pendente) && (isResponsavel || isAdmin)
+
+  const podeDigitarMensagem = !encerrado && !chat?.classificacao_demanda_pendente && (modoInterno || podeEnviar)
+
+  const composerPlaceholder =
+    encerrado || chat?.classificacao_demanda_pendente
+      ? chat?.classificacao_demanda_pendente
+        ? 'Chat aguarda classificação de demanda (somente leitura)'
+        : 'Chat encerrado'
+      : !podeEnviar && chat?.estado === 'em_atendimento'
+        ? 'Apenas o responsável pode enviar ao cliente — use comentário interno'
+        : modoInterno
+          ? 'Comentário interno (não enviado ao cliente)…'
+          : 'Digite uma mensagem…'
 
   const motivoAnexoDesabilitado =
     encerrado
@@ -918,6 +981,11 @@ useEffect(() => {
                     <p className="truncate text-sm font-bold text-slate-800 dark:text-slate-100">{c.cliente_nome || 'Cliente'}</p>
 
                     {c.estado === 'aguardando_atendente' && <span className="h-2 w-2 rounded-full bg-amber-500 animate-pulse" />}
+                    {c.classificacao_demanda_pendente && (
+                      <span className="shrink-0 rounded-full bg-amber-100 px-1.5 py-0.5 text-[9px] font-medium text-amber-800 dark:bg-amber-950/50 dark:text-amber-200">
+                        Demanda
+                      </span>
+                    )}
                     {!c.funcionario_rede_id && (
                       <span className="shrink-0 rounded-full bg-violet-100 px-1.5 py-0.5 text-[9px] font-medium text-violet-700 dark:bg-violet-950/50 dark:text-violet-300">
                         Sem vínculo
@@ -1110,6 +1178,22 @@ useEffect(() => {
             <p>{CONTATO_CLIENTE.bannerNaoVinculado}</p>
             <Button variant="primary" className="h-8 shrink-0 text-xs" onClick={() => setModalVincFuncionario(true)}>
               {CONTATO_CLIENTE.vincularEmpresa}
+            </Button>
+          </div>
+        )}
+
+        {mostrarBannerDemandaInatividade && (
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100">
+            <p>
+              Atendimento encerrado por inatividade. Reler a conversa se precisar e{' '}
+              <strong>registar a demanda</strong> desta sessão.
+            </p>
+            <Button
+              variant="primary"
+              className="h-8 shrink-0 text-xs"
+              onClick={() => setModalEncerrar(true)}
+            >
+              Registar demanda
             </Button>
           </div>
         )}
@@ -1404,6 +1488,7 @@ useEffect(() => {
               }}
               onInserirReferenciaKb={inserirReferenciaKb}
               focoPedidoEm={focoComposerEm}
+              placeholder={composerPlaceholder}
             />
           ) : null}
           <input

--- a/frontend/src/pages/whatsapp/WhatsappDemandasPanel.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappDemandasPanel.tsx
@@ -33,6 +33,7 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
   const [form, setForm] = useState<DemandaFormValues>(DEMANDA_FORM_VAZIO)
   const [salvando, setSalvando] = useState(false)
   const [expandido, setExpandido] = useState(false)
+  const [listaVisivel, setListaVisivel] = useState(false)
   const [editandoId, setEditandoId] = useState<number | null>(null)
   const [excluirId, setExcluirId] = useState<number | null>(null)
 
@@ -124,7 +125,14 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
     <>
       <div className="border-b border-slate-100 bg-slate-50/80 px-4 py-2 dark:border-slate-800 dark:bg-slate-900/40">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className="flex min-w-0 flex-1 flex-wrap items-center gap-2 text-left sm:pointer-events-none sm:cursor-default"
+            onClick={() => {
+              if (demandas.length > 0) setListaVisivel((v) => !v)
+            }}
+            aria-expanded={listaVisivel || undefined}
+          >
             <span className="text-[10px] font-bold uppercase tracking-wider text-slate-500">
               Demandas ({demandas.length})
             </span>
@@ -141,7 +149,12 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
             {demandas.length > 3 && (
               <span className="text-[10px] text-slate-400">+{demandas.length - 3}</span>
             )}
-          </div>
+            {demandas.length > 0 && (
+              <span className="text-[10px] font-medium text-cyan-600 sm:hidden dark:text-cyan-400">
+                {listaVisivel ? 'Ocultar' : 'Ver lista'}
+              </span>
+            )}
+          </button>
           {podeRegistrar && (
             <Button
               type="button"
@@ -175,7 +188,7 @@ export function WhatsappDemandasPanel({ chatId, podeRegistrar, onDemandasChange 
         )}
 
         {demandas.length > 0 && (
-          <ul className="mt-2 space-y-1">
+          <ul className={`mt-2 space-y-1 ${listaVisivel ? 'block' : 'hidden sm:block'}`}>
             {demandas.map((d) => {
               const podeAlterar =
                 podeRegistrar &&

--- a/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
@@ -34,11 +34,11 @@ type Props = {
 function definirAcaoInicial(
   rows: WhatsappChats.Demanda[],
   msgs: WhatsappChats.Mensagem[],
-  encerramentoPorInatividade: boolean,
+  _encerramentoPorInatividade: boolean,
 ): AcaoEncerramento {
   const pos = analisarDemandaPosRegistro(rows, msgs)
   if (rows.length === 0) {
-    return encerramentoPorInatividade ? 'sem_demanda' : 'registrar'
+    return 'registrar'
   }
   if (pos) return 'nova'
   return 'manter'
@@ -73,7 +73,8 @@ export function WhatsappEncerrarModal({
 
   const semDemandas = demandas.length === 0
   const demandasResolvidas = demandas.filter((d) => d.desfecho === 'resolvido_sessao')
-  const demandaOpcional = encerramentoPorInatividade && semDemandas
+  // Pós-inatividade também pede registo (como Encerrar manual); só permite skip com confirmação.
+  const demandaOpcional = false
 
   useEffect(() => {
     if (!open) {
@@ -162,6 +163,16 @@ export function WhatsappEncerrarModal({
         await whatsappChats.atualizarDemanda(chatId, posRegistro.ultimaDemanda.id, demandaFormPayload(form))
       }
 
+      // Pós-inatividade: qualquer conclusão (manter/editar/sem demanda/registar) limpa o pendente.
+      // Idempotente se registar demanda já tiver limpo a flag.
+      if (chatJaEncerrado && encerramentoPorInatividade) {
+        const atualizado = await whatsappChats.concluirClassificacaoDemanda(chatId)
+        onDemandasChange?.()
+        onEncerrado(atualizado)
+        onClose()
+        return
+      }
+
       const atualizado = await whatsappChats.encerrar(chatId)
       onDemandasChange?.()
       onEncerrado(atualizado)
@@ -180,10 +191,10 @@ export function WhatsappEncerrarModal({
   let mensagemIntro =
     'Revise as demandas desta sessão antes de finalizar. O cliente poderá receber pedido de avaliação conforme configuração.'
 
-  if (demandaOpcional) {
-    mensagemIntro = chatJaEncerrado
-      ? 'Este atendimento foi encerrado automaticamente por inatividade do cliente. Registar demanda é opcional.'
-      : 'O cliente está inativo (aviso automático enviado). Pode encerrar sem registar demanda ou classificar opcionalmente.'
+  if (chatJaEncerrado && encerramentoPorInatividade) {
+    mensagemIntro = semDemandas
+      ? 'Este atendimento foi encerrado automaticamente por inatividade. Registe a demanda da sessão, ou confirme explicitamente concluir sem demanda.'
+      : 'Este atendimento foi encerrado automaticamente por inatividade. Revise as demandas antes de concluir.'
   } else if (semDemandas) {
     mensagemIntro =
       'Registe o motivo do atendimento antes de encerrar, ou confirme explicitamente o encerramento sem demanda.'
@@ -250,60 +261,32 @@ export function WhatsappEncerrarModal({
 
           {semDemandas ? (
             <div className="space-y-3">
-              {demandaOpcional ? (
-                <>
-                  <p className="text-xs text-slate-500">
-                    Registar demanda é opcional neste encerramento por inatividade.
-                  </p>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <input
-                      type="radio"
-                      name="acao-encerrar"
-                      checked={acao === 'sem_demanda'}
-                      onChange={() => selecionarAcao('sem_demanda')}
-                    />
-                    {chatJaEncerrado ? 'Concluir sem registar demanda' : 'Encerrar sem registar demanda'}
-                  </label>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <input
-                      type="radio"
-                      name="acao-encerrar"
-                      checked={acao === 'registrar'}
-                      onChange={() => selecionarAcao('registrar')}
-                    />
-                    Registar demanda (opcional)
-                  </label>
-                </>
-              ) : (
-                <>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <input
-                      type="radio"
-                      name="acao-encerrar"
-                      checked={acao === 'registrar'}
-                      onChange={() => selecionarAcao('registrar')}
-                    />
-                    Registar demanda e encerrar
-                  </label>
-                  <label className="flex cursor-pointer items-center gap-2 text-sm">
-                    <input
-                      type="radio"
-                      name="acao-encerrar"
-                      checked={acao === 'sem_demanda'}
-                      onChange={() => selecionarAcao('sem_demanda')}
-                    />
-                    Encerrar sem registar demanda
-                  </label>
-                  {acao === 'sem_demanda' && (
-                    <CheckboxField
-                      checked={confirmarSemDemanda}
-                      onChange={(e) => setConfirmarSemDemanda(e.target.checked)}
-                      variant="inline"
-                    >
-                      Confirmo encerrar sem classificar esta sessão
-                    </CheckboxField>
-                  )}
-                </>
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'registrar'}
+                  onChange={() => selecionarAcao('registrar')}
+                />
+                {chatJaEncerrado ? 'Registar demanda e concluir' : 'Registar demanda e encerrar'}
+              </label>
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
+                <input
+                  type="radio"
+                  name="acao-encerrar"
+                  checked={acao === 'sem_demanda'}
+                  onChange={() => selecionarAcao('sem_demanda')}
+                />
+                {chatJaEncerrado ? 'Concluir sem registar demanda' : 'Encerrar sem registar demanda'}
+              </label>
+              {acao === 'sem_demanda' && (
+                <CheckboxField
+                  checked={confirmarSemDemanda}
+                  onChange={(e) => setConfirmarSemDemanda(e.target.checked)}
+                  variant="inline"
+                >
+                  Confirmo {chatJaEncerrado ? 'concluir' : 'encerrar'} sem classificar esta sessão
+                </CheckboxField>
               )}
             </div>
           ) : posRegistro ? (

--- a/frontend/src/pages/whatsapp/WhatsappGravadorAudio.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappGravadorAudio.tsx
@@ -17,6 +17,8 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
   const chunksRef = useRef<Blob[]>([])
   const timerRef = useRef<number | null>(null)
 
+  const canceladoRef = useRef(false)
+
   const pararStream = useCallback(() => {
     streamRef.current?.getTracks().forEach((t) => t.stop())
     streamRef.current = null
@@ -31,6 +33,7 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
   async function iniciar() {
     if (disabled || gravando) return
     setErro(null)
+    canceladoRef.current = false
     chunksRef.current = []
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
@@ -44,10 +47,17 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
       const recorder = mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream)
       recorderRef.current = recorder
       recorder.ondataavailable = (ev) => {
+        if (canceladoRef.current) return
         if (ev.data.size > 0) chunksRef.current.push(ev.data)
       }
       recorder.onstop = () => {
         pararStream()
+        if (canceladoRef.current) {
+          chunksRef.current = []
+          setGravando(false)
+          setSegundos(0)
+          return
+        }
         const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' })
         if (blob.size === 0) {
           setErro('Gravação vazia. Tente novamente.')
@@ -72,14 +82,17 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
   }
 
   function parar() {
+    canceladoRef.current = false
     const rec = recorderRef.current
     if (rec && rec.state !== 'inactive') rec.stop()
     recorderRef.current = null
   }
 
   function cancelar() {
+    canceladoRef.current = true
     if (gravando) {
-      recorderRef.current?.stop()
+      const rec = recorderRef.current
+      if (rec && rec.state !== 'inactive') rec.stop()
       recorderRef.current = null
       chunksRef.current = []
       pararStream()

--- a/frontend/src/pages/whatsapp/WhatsappGravadorAudioInline.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappGravadorAudioInline.tsx
@@ -17,6 +17,7 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
   const chunksRef = useRef<Blob[]>([])
   const timerRef = useRef<number | null>(null)
   const iniciouRef = useRef(false)
+  const canceladoRef = useRef(false)
 
   const pararStream = useCallback(() => {
     streamRef.current?.getTracks().forEach((t) => t.stop())
@@ -30,6 +31,7 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
   useEffect(() => {
     if (disabled || iniciouRef.current) return
     iniciouRef.current = true
+    canceladoRef.current = false
     void (async () => {
       setErro(null)
       chunksRef.current = []
@@ -44,10 +46,16 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
         const recorder = mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream)
         recorderRef.current = recorder
         recorder.ondataavailable = (ev) => {
+          if (canceladoRef.current) return
           if (ev.data.size > 0) chunksRef.current.push(ev.data)
         }
         recorder.onstop = () => {
           pararStream()
+          if (canceladoRef.current) {
+            chunksRef.current = []
+            setGravando(false)
+            return
+          }
           const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' })
           if (blob.size === 0) {
             setErro('Gravação vazia.')
@@ -66,6 +74,7 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
       }
     })()
     return () => {
+      canceladoRef.current = true
       pararStream()
       const rec = recorderRef.current
       if (rec && rec.state !== 'inactive') rec.stop()
@@ -76,17 +85,20 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
   const ss = String(segundos % 60).padStart(2, '0')
 
   function parar() {
+    canceladoRef.current = false
     const rec = recorderRef.current
     if (rec && rec.state !== 'inactive') rec.stop()
     recorderRef.current = null
   }
 
   function cancelar() {
+    canceladoRef.current = true
     chunksRef.current = []
     pararStream()
     const rec = recorderRef.current
     if (rec && rec.state !== 'inactive') rec.stop()
     recorderRef.current = null
+    setGravando(false)
     onCancelar()
   }
 

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -230,6 +230,12 @@ export function WhatsappHistorico() {
                       >
                         {exibirProtocolo(c.protocolo)}
                       </p>
+                      <p
+                        className="truncate text-xs text-slate-500 dark:text-slate-400"
+                        title={c.empresa_nome || 'Sem empresa'}
+                      >
+                        {c.empresa_nome || 'Sem empresa'}
+                      </p>
                     </div>
                   </div>
 
@@ -296,6 +302,7 @@ export function WhatsappHistorico() {
         onClose={() => setRetomarChat(null)}
         telefoneInicial={retomarChat?.wa_id}
         funcionarioId={retomarChat?.funcionario_rede_id}
+        empresas={retomarChat?.empresas_opcoes}
         titulo={retomarChat ? `Retomar ${retomarChat.cliente_nome || retomarChat.wa_id}` : undefined}
       />
 

--- a/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useMemo, useState } from 'react'
+import { whatsappChats, whatsappSettings, type WhatsappChats } from '../../api/client'
+import { Button } from '../../components/ui/Button'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useToast } from '../../components/ui/Toast'
+
+type Props = {
+  chat: WhatsappChats.Chat
+  msgs: WhatsappChats.Mensagem[]
+  isResponsavel: boolean
+  onChatUpdate: (c: WhatsappChats.Chat) => void
+}
+
+function formatMmSs(totalSec: number): string {
+  const s = Math.max(0, Math.floor(totalSec))
+  const mm = String(Math.floor(s / 60)).padStart(2, '0')
+  const ss = String(s % 60).padStart(2, '0')
+  return `${mm}:${ss}`
+}
+
+/** Controlo de inatividade: countdown + pausar/retomar (#577). */
+export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatUpdate }: Props) {
+  const toast = useToast()
+  const [avisoMin, setAvisoMin] = useState(15)
+  const [ativa, setAtiva] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [tick, setTick] = useState(0)
+
+  useEffect(() => {
+    let cancelled = false
+    void whatsappSettings
+      .get()
+      .then((r) => {
+        if (cancelled) return
+        setAtiva(Boolean(r.inativ_encerramento_ativa))
+        setAvisoMin(Math.max(1, Number(r.inativ_aviso_minutos ?? 15)))
+      })
+      .catch(() => {
+        /* settings indisponíveis — esconde controlo */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!ativa || chat.estado !== 'em_atendimento') return
+    const id = window.setInterval(() => setTick((t) => t + 1), 1000)
+    return () => window.clearInterval(id)
+  }, [ativa, chat.estado])
+
+  const restanteSec = useMemo(() => {
+    void tick
+    if (!ativa || chat.estado !== 'em_atendimento') return null
+    if (chat.inatividade_pausada) return avisoMin * 60
+
+    const relevant = msgs.filter(
+      (m) =>
+        m.evento_sistema !== 'comentario_interno' &&
+        (m.direcao === 'inbound' ||
+          (m.direcao === 'outbound' && !m.evento_sistema)),
+    )
+    const last = relevant[relevant.length - 1]
+    const candidatos: number[] = []
+    if (last?.created_at) candidatos.push(new Date(last.created_at).getTime())
+    if (chat.inatividade_retomada_em) candidatos.push(new Date(chat.inatividade_retomada_em).getTime())
+    if (candidatos.length === 0) return avisoMin * 60
+
+    const refMs = Math.max(...candidatos)
+    const elapsed = (Date.now() - refMs) / 1000
+    return Math.max(0, avisoMin * 60 - elapsed)
+  }, [ativa, chat, msgs, avisoMin, tick])
+
+  if (!ativa || chat.estado !== 'em_atendimento' || !isResponsavel || restanteSec == null) {
+    return null
+  }
+
+  async function toggle() {
+    setBusy(true)
+    try {
+      const next = chat.inatividade_pausada
+        ? await whatsappChats.retomarInatividade(chat.id)
+        : await whatsappChats.pausarInatividade(chat.id)
+      onChatUpdate(next)
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível alterar a pausa de inatividade.'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <span
+        className={`tabular-nums text-xs font-semibold ${
+          chat.inatividade_pausada
+            ? 'text-amber-600 dark:text-amber-300'
+            : restanteSec <= 60
+              ? 'text-rose-600 dark:text-rose-300'
+              : 'text-slate-500 dark:text-slate-400'
+        }`}
+        title={
+          chat.inatividade_pausada
+            ? 'Inatividade pausada — prazo reiniciado'
+            : 'Tempo até o aviso de inatividade'
+        }
+      >
+        {formatMmSs(restanteSec)}
+      </span>
+      <Button
+        type="button"
+        variant="ghost"
+        className="h-8 px-2 text-xs"
+        loading={busy}
+        onClick={() => void toggle()}
+      >
+        {chat.inatividade_pausada ? 'Retomar' : 'Pausar'}
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
@@ -22,6 +22,7 @@ function formatMmSs(totalSec: number): string {
 export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatUpdate }: Props) {
   const toast = useToast()
   const [avisoMin, setAvisoMin] = useState(15)
+  const [posAvisoMin, setPosAvisoMin] = useState(5)
   const [ativa, setAtiva] = useState(false)
   const [busy, setBusy] = useState(false)
   const [tick, setTick] = useState(0)
@@ -34,6 +35,7 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
         if (cancelled) return
         setAtiva(Boolean(r.inativ_encerramento_ativa))
         setAvisoMin(Math.max(1, Number(r.inativ_aviso_minutos ?? 15)))
+        setPosAvisoMin(Math.max(1, Number(r.inativ_encerramento_apos_aviso_minutos ?? 5)))
       })
       .catch(() => {
         /* settings indisponíveis — esconde controlo */
@@ -49,29 +51,62 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
     return () => window.clearInterval(id)
   }, [ativa, chat.estado])
 
-  const restanteSec = useMemo(() => {
+  const fase = useMemo(() => {
     void tick
     if (!ativa || chat.estado !== 'em_atendimento') return null
-    if (chat.inatividade_pausada) return avisoMin * 60
+
+    const semComentario = msgs.filter((m) => m.evento_sistema !== 'comentario_interno')
+    const lastAny = semComentario[semComentario.length - 1]
+    const posAvisoAtivo = lastAny?.evento_sistema === 'auto_inativ_aviso'
+
+    if (chat.inatividade_pausada) {
+      return {
+        restanteSec: avisoMin * 60,
+        label: 'Inatividade pausada — prazo reiniciado',
+        pausada: true as const,
+        posAviso: false as const,
+      }
+    }
+
+    if (posAvisoAtivo && lastAny?.created_at) {
+      const elapsed = (Date.now() - new Date(lastAny.created_at).getTime()) / 1000
+      return {
+        restanteSec: Math.max(0, posAvisoMin * 60 - elapsed),
+        label: 'Tempo até encerrar por inatividade (após aviso)',
+        pausada: false as const,
+        posAviso: true as const,
+      }
+    }
 
     const relevant = msgs.filter(
       (m) =>
         m.evento_sistema !== 'comentario_interno' &&
-        (m.direcao === 'inbound' ||
-          (m.direcao === 'outbound' && !m.evento_sistema)),
+        (m.direcao === 'inbound' || (m.direcao === 'outbound' && !m.evento_sistema)),
     )
     const last = relevant[relevant.length - 1]
     const candidatos: number[] = []
     if (last?.created_at) candidatos.push(new Date(last.created_at).getTime())
     if (chat.inatividade_retomada_em) candidatos.push(new Date(chat.inatividade_retomada_em).getTime())
-    if (candidatos.length === 0) return avisoMin * 60
+    if (candidatos.length === 0) {
+      return {
+        restanteSec: avisoMin * 60,
+        label: 'Tempo até o aviso de inatividade',
+        pausada: false as const,
+        posAviso: false as const,
+      }
+    }
 
     const refMs = Math.max(...candidatos)
     const elapsed = (Date.now() - refMs) / 1000
-    return Math.max(0, avisoMin * 60 - elapsed)
-  }, [ativa, chat, msgs, avisoMin, tick])
+    return {
+      restanteSec: Math.max(0, avisoMin * 60 - elapsed),
+      label: 'Tempo até o aviso de inatividade',
+      pausada: false as const,
+      posAviso: false as const,
+    }
+  }, [ativa, chat, msgs, avisoMin, posAvisoMin, tick])
 
-  if (!ativa || chat.estado !== 'em_atendimento' || !isResponsavel || restanteSec == null) {
+  if (!ativa || chat.estado !== 'em_atendimento' || !isResponsavel || fase == null) {
     return null
   }
 
@@ -93,29 +128,27 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
     <div className="flex items-center gap-1.5">
       <span
         className={`tabular-nums text-xs font-semibold ${
-          chat.inatividade_pausada
+          fase.pausada
             ? 'text-amber-600 dark:text-amber-300'
-            : restanteSec <= 60
+            : fase.posAviso || fase.restanteSec <= 60
               ? 'text-rose-600 dark:text-rose-300'
               : 'text-slate-500 dark:text-slate-400'
         }`}
-        title={
-          chat.inatividade_pausada
-            ? 'Inatividade pausada — prazo reiniciado'
-            : 'Tempo até o aviso de inatividade'
-        }
+        title={fase.label}
       >
-        {formatMmSs(restanteSec)}
+        {formatMmSs(fase.restanteSec)}
       </span>
-      <Button
-        type="button"
-        variant="ghost"
-        className="h-8 px-2 text-xs"
-        loading={busy}
-        onClick={() => void toggle()}
-      >
-        {chat.inatividade_pausada ? 'Retomar' : 'Pausar'}
-      </Button>
+      {!fase.posAviso && (
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-8 px-2 text-xs"
+          loading={busy}
+          onClick={() => void toggle()}
+        >
+          {chat.inatividade_pausada ? 'Retomar' : 'Pausar'}
+        </Button>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
@@ -39,6 +39,9 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
   const [catalogoLoading, setCatalogoLoading] = useState(false)
 
   const [nomeCadastro, setNomeCadastro] = useState('')
+  const [debouncedNomeCadastro, setDebouncedNomeCadastro] = useState('')
+  const [similares, setSimilares] = useState<WhatsappChats.FuncionarioOpcao[]>([])
+  const [loadingSimilares, setLoadingSimilares] = useState(false)
   const [emailCadastro, setEmailCadastro] = useState('')
   const [tipoCadastro, setTipoCadastro] = useState<TipoCadastro>('colaborador')
   const [escopoCadastro, setEscopoCadastro] = useState<EscopoCadastro>('selected')
@@ -76,6 +79,11 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
   }, [busca])
 
   useEffect(() => {
+    const timer = setTimeout(() => setDebouncedNomeCadastro(nomeCadastro.trim()), 450)
+    return () => clearTimeout(timer)
+  }, [nomeCadastro])
+
+  useEffect(() => {
     if (!open) return
     setModo('vincular')
     setBusca('')
@@ -85,6 +93,8 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
     setSelecionado(null)
     setEmpresaVinculoId('')
     setNomeCadastro(chat.cliente_nome?.trim() || '')
+    setDebouncedNomeCadastro('')
+    setSimilares([])
     setEmailCadastro('')
     setTipoCadastro('colaborador')
     setEscopoCadastro('selected')
@@ -125,6 +135,30 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
   }, [debouncedBusca, modo, open])
 
   useEffect(() => {
+    if (!open || modo !== 'cadastrar' || debouncedNomeCadastro.length < 3) {
+      setSimilares([])
+      setLoadingSimilares(false)
+      return
+    }
+    let cancelled = false
+    setLoadingSimilares(true)
+    whatsappChats
+      .buscarFuncionariosSimilares(debouncedNomeCadastro, 5)
+      .then((rows) => {
+        if (!cancelled) setSimilares(rows)
+      })
+      .catch(() => {
+        if (!cancelled) setSimilares([])
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingSimilares(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [debouncedNomeCadastro, modo, open])
+
+  useEffect(() => {
     if (!selecionado) {
       setEmpresaVinculoId('')
       return
@@ -154,6 +188,15 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
 
   function toggleEmpresaCadastro(id: number) {
     setEmpresaIdsCadastro((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+  }
+
+  function vincularSugestao(funcionario: WhatsappChats.FuncionarioOpcao) {
+    setSelecionado(funcionario)
+    setBusca(funcionario.nome)
+    setDebouncedBusca(funcionario.nome)
+    setResultados([funcionario])
+    setErroFormulario(null)
+    setModo('vincular')
   }
 
   async function confirmarVinculo() {
@@ -424,6 +467,66 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                   onChange={(e) => setNomeCadastro(e.target.value)}
                   required
                 />
+                {loadingSimilares && debouncedNomeCadastro.length >= 3 && (
+                  <p className="text-xs text-slate-500">A procurar nomes semelhantes…</p>
+                )}
+                {!loadingSimilares && similares.length > 0 && (
+                  <div className="rounded-xl border border-amber-200 bg-amber-50/80 px-3 py-3 dark:border-amber-900/50 dark:bg-amber-950/25">
+                    <p className="text-sm font-medium text-amber-950 dark:text-amber-100">
+                      Encontrámos cadastros com nome semelhante
+                    </p>
+                    <p className="mt-0.5 text-xs text-amber-800/90 dark:text-amber-200/80">
+                      Prefira vincular ao existente para evitar duplicados. Pode ignorar e cadastrar um novo.
+                    </p>
+                    {similares.some((s) => s.similaridade_alta) && (
+                      <p className="mt-2 text-xs font-medium text-amber-900 dark:text-amber-100">
+                        Atenção: há correspondência muito próxima (quase o mesmo nome).
+                      </p>
+                    )}
+                    <ul className="mt-3 max-h-40 space-y-2 overflow-y-auto">
+                      {similares.map((funcionario) => (
+                        <li
+                          key={funcionario.id}
+                          className="rounded-lg border border-amber-200/80 bg-white/80 px-3 py-2 dark:border-amber-900/40 dark:bg-slate-900/60"
+                        >
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="min-w-0 flex-1">
+                              <p className="truncate text-sm font-semibold text-slate-900 dark:text-slate-100">
+                                {funcionario.nome}
+                              </p>
+                              <p className="truncate text-xs text-slate-500">
+                                {funcionario.email || funcionario.telefone || 'Sem e-mail/telefone'}
+                              </p>
+                              <div className="mt-1 flex flex-wrap gap-1">
+                                {funcionario.rede_nome && (
+                                  <span className="rounded bg-violet-100 px-1.5 py-0.5 text-[10px] font-medium text-violet-800 dark:bg-violet-950/50 dark:text-violet-200">
+                                    {funcionario.rede_nome}
+                                  </span>
+                                )}
+                                {funcionario.empresas.map((e) => (
+                                  <span
+                                    key={e.id}
+                                    className="rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600 dark:bg-slate-800 dark:text-slate-300"
+                                  >
+                                    {e.nome}
+                                  </span>
+                                ))}
+                              </div>
+                            </div>
+                            <Button
+                              type="button"
+                              variant="secondary"
+                              className="h-8 shrink-0 px-2 text-xs"
+                              onClick={() => vincularSugestao(funcionario)}
+                            >
+                              Vincular a este cadastro
+                            </Button>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
                 <Input
                   label="E-mail (opcional)"
                   type="email"


### PR DESCRIPTION
## Summary

Release **`main` → `staging`**: publica o lote acumulado em `[Unreleased]` (portal do cliente, WhatsApp operacional, chat hub, correções de produção).

Destaques recentes neste ciclo:
- Portal autenticado (#263 / #600–#605) — login, RBAC, chats, branding, gestão de equipe
- WhatsApp: contexto de empresa (#590–#592), inatividade/classificar demanda, hub Atendendo (#607), UX mobile (#606)
- WhatsApp: lock anti chat duplicado (#608), janela de avaliação ~30 min (#598), sugestão de nome similar no cadastro (#593)

> **Não mergear automaticamente** — aguardar revisão e aprovação manual.

## CHANGELOG

- [x] `CHANGELOG.md` → `[Unreleased]` descreve o lote completo (vira a release no deploy de staging)

## Test plan

- [ ] Revisar bullets do `[Unreleased]` (linguagem para usuário final)
- [ ] CI do PR verde
- [ ] Após merge: deploy staging + migration `077_wpp_avaliacao_janela` (janela de avaliação)
- [ ] Smoke: portal `/portal`, WhatsApp fila/atendendo, cadastro com nome similar, avaliação pós-encerrar
- [ ] Confirmar `/sobre` após deploy com CalVer nova

## Follow-ups / backlog

- [ ] Issues ainda abertas fora deste lote: #594/#595 (análises), #599 (filtros dashboard)
