### PR TITLE
chore(cursor): aprovação humana obrigatória em merge para staging

### DIFF
--- a/.cursor/commands/criar-pr.md
+++ b/.cursor/commands/criar-pr.md
@@ -4,11 +4,14 @@ Finalize a feature, abra Pull Request para **`main`**, acompanhe o CI, aprove e 
 
 > **`main` é branch de testes** neste repo — após CI verde, merge automático é o comportamento padrão do `/criar-pr`.
 > Para **só abrir PR sem merge**, o usuário deve pedir explicitamente: `/criar-pr sem merge`.
+>
+> **Este comando NÃO serve para `staging`.** Release para produção = `/release-staging` (abre PR `main → staging` e **para**; o utilizador mergeia no GitHub). **Nunca** `gh pr merge` com base `staging`.
 
 ## Pré-requisitos
 
 - Feature implementada e revisada (`/revisar-e-testar` recomendado)
 - Branch **não** é `main` nem `staging`
+- Base do PR será **`main`** (nunca `staging`)
 - Testes passando localmente
 - `gh` autenticado (`gh auth status`)
 

--- a/.cursor/commands/release-staging.md
+++ b/.cursor/commands/release-staging.md
@@ -1,0 +1,52 @@
+# Release staging
+
+Abre Pull Request **`main` → `staging`** para o utilizador **analisar e aprovar no GitHub**.
+
+> **`staging` = produção.** O agente **NUNCA** faz `gh pr merge` neste fluxo — nem com CI verde, nem “para facilitar”.
+
+## Pré-requisitos
+
+- Lote testado na `main`
+- `CHANGELOG.md` → `[Unreleased]` com o lote a publicar
+- `gh` autenticado
+
+## Passo 1 — Diagnóstico
+
+```bash
+git fetch origin
+git log origin/staging..origin/main --oneline
+gh pr list --base staging --head main --state open
+```
+
+Se já existir PR aberto `main` → `staging`, **reutilize** (não duplique).
+
+## Passo 2 — Conflitos?
+
+Se `gh pr create` / GitHub indicar conflito:
+
+1. Branch a partir de `origin/staging`: `merge/main-into-staging-YYYYMMDD`
+2. `git merge origin/main` e resolver (código da `main`; `[Unreleased]` = só o que ainda não foi publicado na staging)
+3. Push da branch e **um** PR → `staging`
+4. **Pare** — entregue o URL; **não** mergeie
+
+Não manter dois PRs de release abertos sem explicar; preferir **um** PR mergeável.
+
+## Passo 3 — Criar PR (sem merge)
+
+```bash
+gh pr create --base staging --head main --title "release: main → staging" --body-file .cursor/pr-body-temp.md
+```
+
+Corpo: Summary do lote (`[Unreleased]`), test plan, nota **“Merge apenas após aprovação manual (staging = produção)”**.
+
+## Passo 4 — Entrega
+
+Reporte só:
+
+| Item | Valor |
+|------|-------|
+| URL do PR | ... |
+| Base | staging |
+| Merge pelo agente | ❌ proibido — aguarda aprovação no GitHub |
+
+**Não** executar: `gh pr merge`, `gh pr review --approve` seguido de merge, push para `staging`.

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,16 +1,16 @@
-{
-  "version": 1,
-  "hooks": {
-    "beforeShellExecution": [
-      {
-        "command": "python .cursor/hooks/block_main_branch.py",
-        "matcher": "git "
-      }
-    ],
-    "afterFileEdit": [
-      {
-        "command": "python .cursor/hooks/format_frontend.py"
-      }
-    ]
-  }
-}
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": "py -3 .cursor/hooks/block_main_branch.py",
+        "matcher": "git |gh "
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "command": "py -3 .cursor/hooks/format_frontend.py"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/block_main_branch.py
+++ b/.cursor/hooks/block_main_branch.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Bloqueia git commit/push perigosos em main/staging."""
+"""Bloqueia git/gh perigosos em main/staging (staging = produção)."""
 
 import json
 import re
@@ -29,11 +29,45 @@ def deny(msg: str) -> None:
             {
                 "permission": "deny",
                 "user_message": msg,
-                "agent_message": "Hook block_main_branch bloqueou comando git em branch protegida.",
+                "agent_message": "Hook block_main_branch bloqueou comando em branch protegida / staging.",
             }
         )
     )
     sys.exit(0)
+
+
+def _pr_base_ref(pr_selector: str | None) -> str | None:
+    """baseRefName do PR (número ou PR da branch atual)."""
+    args = ["gh", "pr", "view", "--json", "baseRefName"]
+    if pr_selector:
+        args.insert(3, pr_selector)
+    try:
+        r = subprocess.run(args, capture_output=True, text=True, timeout=15)
+        if r.returncode != 0:
+            return None
+        data = json.loads(r.stdout or "{}")
+        return data.get("baseRefName")
+    except (subprocess.SubprocessError, OSError, json.JSONDecodeError):
+        return None
+
+
+def _blocks_staging_merge(command: str) -> bool:
+    """Impede merge de PR cuja base é staging (produção)."""
+    if not re.search(r"\bgh\s+pr\s+merge\b", command):
+        return False
+
+    m = re.search(r"\bgh\s+pr\s+merge\s+(\d+)\b", command)
+    pr_num = m.group(1) if m else None
+    base = _pr_base_ref(pr_num)
+    if base == "staging":
+        return True
+    if base is None and ("staging" in command.lower() or "main-into-staging" in command.lower()):
+        return True
+    # Sem número e sem API: se a branch atual é de merge para staging, bloquear
+    branch = current_branch()
+    if pr_num is None and branch and re.search(r"main-into-staging|merge/.*staging", branch, re.I):
+        return True
+    return False
 
 
 def main() -> None:
@@ -44,6 +78,17 @@ def main() -> None:
         return
 
     command = payload.get("command") or ""
+
+    # --- gh: nunca mergear PR cuja base é staging ---
+    if re.search(r"\bgh\b", command):
+        if _blocks_staging_merge(command):
+            deny(
+                "Merge de PR para staging bloqueado (staging = produção). "
+                "Abra/atualize o PR e peça aprovação/merge manual no GitHub."
+            )
+        print(json.dumps({"permission": "allow"}))
+        return
+
     if not re.search(r"\bgit\b", command):
         print(json.dumps({"permission": "allow"}))
         return
@@ -56,7 +101,9 @@ def main() -> None:
             r"HEAD:(main|staging)", command
         ):
             deny(
-                "Push para main/staging bloqueado. Abra PR com /criar-pr a partir de uma branch de feature."
+                "Push para main/staging bloqueado. "
+                "Feature → PR para main (/criar-pr). "
+                "Release → PR main→staging (/release-staging) sem merge pelo agente."
             )
 
     # Operações destrutivas na branch atual protegida

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -1,5 +1,5 @@
 ---
-description: Fluxo Git — branch por feature, PR para main, convenções do time
+description: Fluxo Git — branch por feature, PR para main, release staging só com aprovação humana
 alwaysApply: true
 ---
 
@@ -11,7 +11,8 @@ alwaysApply: true
 - **Sempre** criar branch nova antes de codar
 - **Uma feature/lote = uma branch = um PR** para `main`
 - `main` é **branch de testes** — `/criar-pr` mergeia automaticamente após CI verde
-- Não push direto em `main` (sempre via PR)
+- **`staging` é produção** — release só via PR `main → staging`; o agente **nunca** faz o merge
+- Não push direto em `main` nem `staging` (sempre via PR)
 
 ## Após merge na `main` (obrigatório)
 
@@ -49,22 +50,39 @@ git checkout -b feat/minha-feature-123
 
 Use `/iniciar-feature` para automatizar este passo.
 
+## Após merge na `main` (obrigatório)
+
+Quando o PR do lote for **mergeado** e o desenvolvimento daquele lote estiver **fechado para testes** na `main`:
+
+1. **Não** continuar a codar na branch já mergeada
+2. **Sempre** abrir **branch nova** a partir de `main` atualizada antes do próximo trabalho
+3. Usar `/iniciar-feature` — mesmo se o próximo lote for polish ou issues pequenas
+
+Exceção: hotfix urgente na mesma linha só se o PR ainda **não** tiver sido mergeado.
+
 ## Commits
 
 - Mensagens claras, foco no **porquê**
 - Estilo do repo: `feat(tickets): ...`, `fix(frontend): ...`, `chore(deps): ...`
 - **Não commitar** sem pedido explícito do usuário
-- **Não** `--no-verify`, `--force`, `push --force` em `main`
+- **Não** `--no-verify`, `--force`, `push --force` em `main`/`staging`
 
-## Finalização
+## Finalização (feature → main)
 
 1. `/revisar-e-testar` — qualidade + testes
 2. `/criar-pr` — commit (se pendente), push, PR, CI, approve e **merge em main**
 
-## PR
+## PR → main
 
 - Base: **`main`**
 - Corpo: resumo, test plan, link da issue
 - Aguardar CI (pytest + build frontend)
 - `/criar-pr` faz merge automático quando CI passa (main = testes)
-- Para staging/produção: fluxo separado (`main → staging`)
+
+## Release → staging (produção)
+
+- Comando: **`/release-staging`**
+- Abre (ou atualiza) PR **`main` → `staging`**
+- **PROIBIDO** ao agente: `gh pr merge`, push para `staging`, “mergear para facilitar”
+- O utilizador **analisa, aprova e mergeia no GitHub**
+- Rule: `.cursor/rules/staging-release-approval.mdc`

--- a/.cursor/rules/main-pr-batch-delivery.mdc
+++ b/.cursor/rules/main-pr-batch-delivery.mdc
@@ -27,6 +27,7 @@ feature/feat/<lote>  →  PR  →  main  →  (acumular)  →  PR main → stagi
 
 - **`main → staging`**: só quando houver **release** para produção (várias melhorias no `[Unreleased]`), não a cada merge na `main`.
 - **Nunca** commit direto na `main`.
+- **`staging` = produção**: o agente só **abre** o PR (`/release-staging`); **nunca** executa `gh pr merge` — aprovação e merge são **só do utilizador no GitHub**.
 
 ## Nomenclatura de branch
 
@@ -51,4 +52,4 @@ feature/feat/<lote>  →  PR  →  main  →  (acumular)  →  PR main → stagi
 ## Referências
 
 - Encerramento de issues: `.cursor/rules/issue-closure-backlog.mdc`, `docs/ISSUE_CLOSURE.md`
-- Deploy: PR `main → staging`; ver `docs/RELEASES.md` se existir
+- Deploy: `/release-staging` (PR sem merge pelo agente); ver `docs/RELEASES.md` e rule `staging-release-approval`

--- a/.cursor/rules/project-core.mdc
+++ b/.cursor/rules/project-core.mdc
@@ -13,6 +13,7 @@ Sistema interno de helpdesk para redes de postos (tickets, WhatsApp, e-mail, SSE
 - Mudanças **mínimas**: só o necessário para a tarefa; não refatorar código adjacente.
 - **Não commitar** nem sugerir commit/push sem pedido explícito do usuário.
 - Git: branch nova por feature, PR para `main` — ver rule `git-workflow`.
+- **`staging` = produção**: só PR `main → staging` (`/release-staging`); agente **nunca** mergeia — ver `staging-release-approval`.
 
 ## Onde está a verdade
 

--- a/.cursor/rules/staging-release-approval.mdc
+++ b/.cursor/rules/staging-release-approval.mdc
@@ -1,0 +1,35 @@
+---
+description: staging = produção — PR obrigatório e merge só com aprovação humana
+alwaysApply: true
+---
+
+# Release para staging (produção)
+
+## Verdade do deploy
+
+- **`staging` = branch em produção** (deploy/CalVer).
+- **`main` = branch de testes** (CI + validação do time).
+
+## Proibido ao agente (sem exceção “para facilitar”)
+
+1. **`gh pr merge`** de qualquer PR com base **`staging`**
+2. **`git push`** para `staging` / `HEAD:staging` / `origin staging`
+3. **`git merge` / `commit` / `reset`** em cima da branch local `staging` para “empurrar” release
+4. Merge automático após abrir PR **`main → staging`** — mesmo se o utilizador pediu “fazer o deploy”, “facilitar” ou “já está verde”
+5. Criar **segundo PR** paralelo e mergeá-lo no lugar do release sem o utilizador ter **aprovado explicitamente no GitHub** (botão Approve / merge por ele)
+
+## Obrigatório
+
+1. Release = **um único PR** `main` → `staging` (abrir com `/release-staging` ou pedido explícito)
+2. Se houver conflito: resolver numa branch `merge/…`, abrir **um** PR para `staging`, **parar** e entregar o URL
+3. O utilizador (Luis) **analisa e aprova/mergeia no GitHub** — o agente **não** corre `gh pr merge` nesse PR
+4. Após merge humano: deploy/CalVer segue o workflow do repo (`docs/RELEASES.md`)
+
+## Se o utilizador pedir merge em staging
+
+Responder: o PR está pronto no URL; **merge só no GitHub por ti** (staging = produção). Não executar `gh pr merge`.
+
+## Relação com `/criar-pr`
+
+- `/criar-pr` → só **`→ main`** (testes); merge automático CI verde **permitido**
+- `/release-staging` → só **abre** PR `main → staging`; **nunca** mergeia

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,13 +21,14 @@ Guia para desenvolvimento assistido por IA no Cursor (time 2–3 devs).
 | `rbac-setor-scope` | `backend/app/api/**`, `backend/app/core/**` |
 | `alembic-migrations` | `backend/alembic/**` |
 | `git-workflow` | Sempre — branch por feature, PR para `main` |
+| `staging-release-approval` | Sempre — staging = produção; merge só humano |
 | `sse-realtime` | Arquivos SSE/realtime (backend + frontend) |
 
 ## Hooks
 
 | Hook | Evento | Função |
 |------|--------|--------|
-| `block_main_branch.py` | `beforeShellExecution` | Bloqueia commit/push em `main`/`staging` |
+| `block_main_branch.py` | `beforeShellExecution` (`git` / `gh`) | Bloqueia commit/push em `main`/`staging` e **`gh pr merge` com base staging** |
 | `format_frontend.py` | `afterFileEdit` | ESLint `--fix` em `.ts/.tsx` do frontend |
 
 Config: `.cursor/hooks.json`
@@ -43,7 +44,8 @@ Config: `.cursor/hooks.json`
 | `/revisar-e-testar` | Revisão pré-merge com testes |
 | `/subir-local` | Subir Docker, migrations, API e frontend em dev |
 | `/testar-ui` | Smoke test no navegador integrado (login, rotas, console) |
-| `/criar-pr` | PR → watch CI → approve → **merge automático em main** |
+| `/criar-pr` | PR → watch CI → approve → **merge automático em main** (nunca staging) |
+| `/release-staging` | Abre PR `main → staging`; **não mergeia** (aprovação humana) |
 
 ## Subagents (Task tool)
 
@@ -70,6 +72,8 @@ Use subagents para **paralelizar** ou **isolar** trabalho:
 ```
 
 O `/criar-pr` monitora Actions, aprova e **mergeia em `main`** quando CI passa (main = branch de testes). Em falha, corrige e re-monitora (skill **babysit**). Opt-out: pedir `/criar-pr sem merge`.
+
+Release para produção: `/release-staging` — **só abre** o PR; merge em `staging` é **sempre** manual no GitHub.
 
 Para desenvolvimento local: `/subir-local` → `/testar-ui` (navegador integrado).
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -14,12 +14,13 @@ Bump automático no **deploy de `staging`** (fuso `America/Sao_Paulo`).
 ## Fluxo do time
 
 ```
-feature → PR main (+ CHANGELOG) → PR main → staging → deploy → /sobre
+feature → PR main (+ CHANGELOG) → PR main → staging (aprovação humana) → deploy → /sobre
 ```
 
 1. **Cada PR para `main`** com mudança de produto: inclua bullet(s) em `CHANGELOG.md` → `## [Unreleased]`
 2. **PR `main → staging`**: o `[Unreleased]` descreve **todo o lote** que será publicado
-3. **Deploy em `staging`**: consome `[Unreleased]`, gera nova CalVer, append em `docs/releases/manifest.json`, zera `[Unreleased]`
+3. **Merge em `staging`**: **só após análise e aprovação humana no GitHub** (`staging` = produção). Agentes/CI **não** mergeiam este PR automaticamente — usar `/release-staging` para abrir o PR e parar.
+4. **Deploy em `staging`**: consome `[Unreleased]`, gera nova CalVer, append em `docs/releases/manifest.json`, zera `[Unreleased]`
 
 ## Requisito de PR (obrigatório)
 
@@ -73,6 +74,7 @@ Após cada deploy, o workflow commita `VERSION`, `CHANGELOG.md`, `manifest.json`
 
 - [ ] `[Unreleased]` lista **todas** as entregas do lote
 - [ ] Revisão de redação (sem «deploy», «branch», «commit»)
+- [ ] **Aprovação e merge manuais** no GitHub (agente não executa `gh pr merge`)
 
 ## Desenvolvimento local
 


### PR DESCRIPTION
## Summary
- Reforça rules/commands: `staging` = produção; agente nunca faz `gh pr merge` nesse PR
- Novo `/release-staging` (só abre o PR) e rule `staging-release-approval`
- Hook bloqueia `gh pr merge` com base `staging`; `hooks.json` usa `py -3`

## Test plan
- [ ] Rules aparecem no Cursor após pull
- [ ] `/release-staging` documentado em AGENTS.md
- [ ] Tentativa de `gh pr merge` com base staging deve ser bloqueada pelo hook (quando Python disponível)

Made with [Cursor](https://cursor.com)