### PR TITLE
feat(saas): painel admin de licenças DeskRudder (#521–#523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
-- SaaS DeskRudder (#519 / #521–#523): painel admin de **licenças** na instância comercial — cadastro de clientes (slug, status, plano, renovação, URL da instância), menu **SaaS DeskRudder → Licenças** e atalho «Painel de licenças» na landing (quando o control-plane está ligado)
+- SaaS DeskRudder (#519 / #521–#523 / #524 / #527 / #528): painel de **licenças** (CRUD, status, URL da instância); **provisionamento** em fila (scripts opcionais no host); formulário público de **trial** em `/trial`; **renovações** com alerta à equipa, destaque na UI e suspensão automática ao vencer; atalho na landing quando o control-plane está ligado
 - Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário
 - Portal (#600, #601): cadastro de funcionário pelo modal da Rede permite definir senha do portal na criação; sócio cadastra sem escolher empresas (escopo automático em toda a rede)
 - Portal (#604): RBAC por papel — colaborador vê só os próprios chamados; supervisor vê todos das empresas vinculadas; sócio vê toda a rede

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- SaaS DeskRudder (#519 / #521–#523): painel admin de **licenças** na instância comercial — cadastro de clientes (slug, status, plano, renovação, URL da instância), menu **SaaS DeskRudder → Licenças** e atalho «Painel de licenças» na landing (quando o control-plane está ligado)
 - Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário
 - Portal (#600, #601): cadastro de funcionário pelo modal da Rede permite definir senha do portal na criação; sócio cadastra sem escolher empresas (escopo automático em toda a rede)
 - Portal (#604): RBAC por papel — colaborador vê só os próprios chamados; supervisor vê todos das empresas vinculadas; sócio vê toda a rede

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,6 +20,9 @@ LOG_LEVEL=INFO
 # CLIENT_APP_HOST=duplexsoft.connect.duplexsoft.com.br   # URL pública do painel (GET /tenant/atual)
 # PASSWORD_RESET_TOKEN_EXPIRE_HOURS=1   # validade do link «esqueci minha senha»
 #
+# --- Control-plane SaaS (só na instância comercial deskrudder.com.br) ---
+# SAAS_CONTROL_PLANE=true   # habilita API /v1/saas/clientes (painel de licenças)
+#
 # --- Multi-tenant legado (só se DX_CONNECT_MULTI_TENANT=true) ---
 # CONNECT_APP_BASE_DOMAIN=connect.duplexsoft.com.br
 # INBOUND_EMAIL_DOMAIN=notify.duplexsoft.com.br

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,7 +21,14 @@ LOG_LEVEL=INFO
 # PASSWORD_RESET_TOKEN_EXPIRE_HOURS=1   # validade do link «esqueci minha senha»
 #
 # --- Control-plane SaaS (só na instância comercial deskrudder.com.br) ---
-# SAAS_CONTROL_PLANE=true   # habilita API /v1/saas/clientes (painel de licenças)
+# SAAS_CONTROL_PLANE=true   # habilita API /v1/saas/*
+# SAAS_NOTIFY_EMAIL=comercial@deskrudder.com.br
+# SAAS_TRIAL_DAYS=14
+# SAAS_RENEWAL_ALERT_DAYS_BEFORE=14
+# SAAS_PROVISION_BASE_DOMAIN=deskrudder.com.br
+# SAAS_PROVISION_API_PORT_START=8001
+# SAAS_PROVISION_EXEC_ENABLED=false   # true só no host com Docker/scripts
+# SAAS_REPO_ROOT=/opt/dx-connect
 #
 # --- Multi-tenant legado (só se DX_CONNECT_MULTI_TENANT=true) ---
 # CONNECT_APP_BASE_DOMAIN=connect.duplexsoft.com.br

--- a/backend/alembic/versions/078_cliente_saas.py
+++ b/backend/alembic/versions/078_cliente_saas.py
@@ -1,0 +1,56 @@
+"""Tabela clientes_saas (licenças DeskRudder / control-plane).
+
+Revision ID: 078_cliente_saas
+Revises: 077_wpp_avaliacao_janela
+Create Date: 2026-07-23
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "078_cliente_saas"
+down_revision = "077_wpp_avaliacao_janela"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("clientes_saas"):
+        return
+    op.create_table(
+        "clientes_saas",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("nome", sa.String(length=200), nullable=False),
+        sa.Column("slug", sa.String(length=80), nullable=False),
+        sa.Column("status", sa.String(length=20), nullable=False, server_default="trial"),
+        sa.Column("plano", sa.String(length=80), nullable=True),
+        sa.Column("data_inicio", sa.Date(), nullable=False),
+        sa.Column("data_renovacao", sa.Date(), nullable=True),
+        sa.Column("instancia_url", sa.String(length=500), nullable=True),
+        sa.Column(
+            "provisionamento_solicitado",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("notas", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("slug", name="uq_clientes_saas_slug"),
+    )
+    op.create_index("ix_clientes_saas_id", "clientes_saas", ["id"])
+    op.create_index("ix_clientes_saas_slug", "clientes_saas", ["slug"])
+    op.alter_column("clientes_saas", "status", server_default=None)
+    op.alter_column("clientes_saas", "provisionamento_solicitado", server_default=None)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("clientes_saas"):
+        return
+    op.drop_index("ix_clientes_saas_slug", table_name="clientes_saas")
+    op.drop_index("ix_clientes_saas_id", table_name="clientes_saas")
+    op.drop_table("clientes_saas")

--- a/backend/alembic/versions/079_saas_provision_trial_renovacao.py
+++ b/backend/alembic/versions/079_saas_provision_trial_renovacao.py
@@ -1,0 +1,76 @@
+"""Provisionamento, trial e renovações SaaS (#524 / #527 / #528).
+
+Revision ID: 079_saas_provision_trial_renovacao
+Revises: 078_cliente_saas
+Create Date: 2026-07-23
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "079_saas_provision_trial_renovacao"
+down_revision = "078_cliente_saas"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("clientes_saas"):
+        cols = {c["name"] for c in insp.get_columns("clientes_saas")}
+        if "contato_email" not in cols:
+            op.add_column("clientes_saas", sa.Column("contato_email", sa.String(length=255), nullable=True))
+        if "contato_nome" not in cols:
+            op.add_column("clientes_saas", sa.Column("contato_nome", sa.String(length=200), nullable=True))
+        if "api_port" not in cols:
+            op.add_column("clientes_saas", sa.Column("api_port", sa.Integer(), nullable=True))
+        if "provisionamento_status" not in cols:
+            op.add_column("clientes_saas", sa.Column("provisionamento_status", sa.String(length=32), nullable=True))
+        if "provisionamento_mensagem" not in cols:
+            op.add_column("clientes_saas", sa.Column("provisionamento_mensagem", sa.Text(), nullable=True))
+        if "provisionamento_atualizado_em" not in cols:
+            op.add_column(
+                "clientes_saas",
+                sa.Column("provisionamento_atualizado_em", sa.DateTime(timezone=True), nullable=True),
+            )
+
+    if not insp.has_table("saas_alerta_emitidos"):
+        op.create_table(
+            "saas_alerta_emitidos",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("cliente_saas_id", sa.Integer(), sa.ForeignKey("clientes_saas.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("evento", sa.String(length=40), nullable=False),
+            sa.Column("referencia_data", sa.Date(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.UniqueConstraint(
+                "cliente_saas_id",
+                "evento",
+                "referencia_data",
+                name="uq_saas_alerta_emitidos_cliente_evento_ref",
+            ),
+        )
+        op.create_index("ix_saas_alerta_emitidos_id", "saas_alerta_emitidos", ["id"])
+        op.create_index("ix_saas_alerta_emitidos_cliente_saas_id", "saas_alerta_emitidos", ["cliente_saas_id"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("saas_alerta_emitidos"):
+        op.drop_index("ix_saas_alerta_emitidos_cliente_saas_id", table_name="saas_alerta_emitidos")
+        op.drop_index("ix_saas_alerta_emitidos_id", table_name="saas_alerta_emitidos")
+        op.drop_table("saas_alerta_emitidos")
+    if insp.has_table("clientes_saas"):
+        cols = {c["name"] for c in insp.get_columns("clientes_saas")}
+        for col in (
+            "provisionamento_atualizado_em",
+            "provisionamento_mensagem",
+            "provisionamento_status",
+            "api_port",
+            "contato_nome",
+            "contato_email",
+        ):
+            if col in cols:
+                op.drop_column("clientes_saas", col)

--- a/backend/app/api/saas.py
+++ b/backend/app/api/saas.py
@@ -1,0 +1,201 @@
+"""API admin SaaS — clientes / licenças DeskRudder (#522).
+
+Só disponível quando `SAAS_CONTROL_PLANE=true` (instância comercial).
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.core.audit import registrar_audit
+from app.core.auth import exigir_admin
+from app.core.ordenacao_lista import OrdemLista, expr_ordem
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.models.cliente_saas import ClienteSaaS
+from app.schemas.lista_paginada import ListaPaginada
+from app.schemas.saas import (
+    ClienteSaaSCreate,
+    ClienteSaaSRead,
+    ClienteSaaSRegistrarInstancia,
+    ClienteSaaSUpdate,
+)
+from app.services import saas_clientes as svc
+
+router = APIRouter(prefix="/saas/clientes", tags=["saas"])
+
+_MAX_PAGE = 100
+_DEFAULT_PAGE = 20
+
+
+class OrdenarClientesSaaSPor(str, Enum):
+    nome = "nome"
+    slug = "slug"
+    status = "status"
+    data_renovacao = "data_renovacao"
+
+
+def exigir_saas_control_plane() -> None:
+    if not settings.SAAS_CONTROL_PLANE:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Painel SaaS não disponível nesta instância",
+        )
+
+
+def _http_from_saas(exc: svc.SaasErro) -> HTTPException:
+    return HTTPException(status_code=exc.status_code, detail=exc.detail)
+
+
+@router.get("", response_model=ListaPaginada[ClienteSaaSRead])
+def listar(
+    busca: str | None = Query(None, description="Filtra por nome ou slug"),
+    status_filtro: str | None = Query(None, alias="status", description="Filtra por status"),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    ordenar_por: OrdenarClientesSaaSPor | None = Query(None),
+    ordem: OrdemLista = Query(OrdemLista.asc),
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    __: Atendente = Depends(exigir_admin),
+):
+    q = db.query(ClienteSaaS)
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter((ClienteSaaS.nome.ilike(term)) | (ClienteSaaS.slug.ilike(term)))
+    if status_filtro and status_filtro.strip():
+        q = q.filter(ClienteSaaS.status == status_filtro.strip().lower())
+    total = q.count()
+    if ordenar_por is None:
+        order_cols = [ClienteSaaS.nome.asc(), ClienteSaaS.id.asc()]
+    elif ordenar_por == OrdenarClientesSaaSPor.nome:
+        order_cols = [expr_ordem(ClienteSaaS.nome, ordem), expr_ordem(ClienteSaaS.id, ordem)]
+    elif ordenar_por == OrdenarClientesSaaSPor.slug:
+        order_cols = [expr_ordem(ClienteSaaS.slug, ordem), expr_ordem(ClienteSaaS.id, ordem)]
+    elif ordenar_por == OrdenarClientesSaaSPor.status:
+        order_cols = [expr_ordem(ClienteSaaS.status, ordem), expr_ordem(ClienteSaaS.id, ordem)]
+    else:
+        order_cols = [expr_ordem(ClienteSaaS.data_renovacao, ordem), expr_ordem(ClienteSaaS.id, ordem)]
+    items = q.order_by(*order_cols).offset(offset).limit(limit).all()
+    return ListaPaginada(items=items, total=total)
+
+
+@router.post("", response_model=ClienteSaaSRead, status_code=201)
+def criar(
+    data: ClienteSaaSCreate,
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    try:
+        row = svc.criar(db, data)
+    except svc.SaasErro as e:
+        raise _http_from_saas(e) from e
+    registrar_audit(db, "cliente_saas", row.id, "create", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.get("/{cliente_id}", response_model=ClienteSaaSRead)
+def obter(
+    cliente_id: int,
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    __: Atendente = Depends(exigir_admin),
+):
+    try:
+        return svc.obter(db, cliente_id)
+    except svc.SaasErro as e:
+        raise _http_from_saas(e) from e
+
+
+@router.patch("/{cliente_id}", response_model=ClienteSaaSRead)
+def atualizar(
+    cliente_id: int,
+    data: ClienteSaaSUpdate,
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    try:
+        row = svc.atualizar(db, cliente_id, data)
+    except svc.SaasErro as e:
+        raise _http_from_saas(e) from e
+    registrar_audit(db, "cliente_saas", cliente_id, "update", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.post("/{cliente_id}/suspender", response_model=ClienteSaaSRead)
+def suspender(
+    cliente_id: int,
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    try:
+        row = svc.suspender(db, cliente_id)
+    except svc.SaasErro as e:
+        raise _http_from_saas(e) from e
+    registrar_audit(db, "cliente_saas", cliente_id, "suspender", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.post("/{cliente_id}/reativar", response_model=ClienteSaaSRead)
+def reativar(
+    cliente_id: int,
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    try:
+        row = svc.reativar(db, cliente_id)
+    except svc.SaasErro as e:
+        raise _http_from_saas(e) from e
+    registrar_audit(db, "cliente_saas", cliente_id, "reativar", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.post("/{cliente_id}/registrar-instancia", response_model=ClienteSaaSRead)
+def registrar_instancia(
+    cliente_id: int,
+    data: ClienteSaaSRegistrarInstancia,
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    try:
+        row = svc.registrar_instancia(db, cliente_id, data)
+    except svc.SaasErro as e:
+        raise _http_from_saas(e) from e
+    registrar_audit(db, "cliente_saas", cliente_id, "registrar_instancia", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.post("/{cliente_id}/solicitar-provisionamento", response_model=ClienteSaaSRead)
+def solicitar_provisionamento(
+    cliente_id: int,
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    try:
+        row = svc.solicitar_provisionamento(db, cliente_id)
+    except svc.SaasErro as e:
+        raise _http_from_saas(e) from e
+    registrar_audit(db, "cliente_saas", cliente_id, "solicitar_provisionamento", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row

--- a/backend/app/api/saas.py
+++ b/backend/app/api/saas.py
@@ -1,4 +1,4 @@
-"""API admin SaaS — clientes / licenças DeskRudder (#522).
+"""API admin SaaS — clientes / licenças DeskRudder (#522 / #524 / #528).
 
 Só disponível quando `SAAS_CONTROL_PLANE=true` (instância comercial).
 """
@@ -22,9 +22,11 @@ from app.schemas.saas import (
     ClienteSaaSCreate,
     ClienteSaaSRead,
     ClienteSaaSRegistrarInstancia,
+    ClienteSaaSRenovar,
     ClienteSaaSUpdate,
 )
 from app.services import saas_clientes as svc
+from app.services import saas_renovacoes
 
 router = APIRouter(prefix="/saas/clientes", tags=["saas"])
 
@@ -49,6 +51,10 @@ def exigir_saas_control_plane() -> None:
 
 def _http_from_saas(exc: svc.SaasErro) -> HTTPException:
     return HTTPException(status_code=exc.status_code, detail=exc.detail)
+
+
+def _read(row: ClienteSaaS) -> ClienteSaaSRead:
+    return ClienteSaaSRead.model_validate(svc.serializar_cliente(row))
 
 
 @router.get("", response_model=ListaPaginada[ClienteSaaSRead])
@@ -81,7 +87,7 @@ def listar(
     else:
         order_cols = [expr_ordem(ClienteSaaS.data_renovacao, ordem), expr_ordem(ClienteSaaS.id, ordem)]
     items = q.order_by(*order_cols).offset(offset).limit(limit).all()
-    return ListaPaginada(items=items, total=total)
+    return ListaPaginada(items=[_read(i) for i in items], total=total)
 
 
 @router.post("", response_model=ClienteSaaSRead, status_code=201)
@@ -98,7 +104,7 @@ def criar(
     registrar_audit(db, "cliente_saas", row.id, "create", atendente.id)
     db.commit()
     db.refresh(row)
-    return row
+    return _read(row)
 
 
 @router.get("/{cliente_id}", response_model=ClienteSaaSRead)
@@ -109,7 +115,7 @@ def obter(
     __: Atendente = Depends(exigir_admin),
 ):
     try:
-        return svc.obter(db, cliente_id)
+        return _read(svc.obter(db, cliente_id))
     except svc.SaasErro as e:
         raise _http_from_saas(e) from e
 
@@ -129,7 +135,7 @@ def atualizar(
     registrar_audit(db, "cliente_saas", cliente_id, "update", atendente.id)
     db.commit()
     db.refresh(row)
-    return row
+    return _read(row)
 
 
 @router.post("/{cliente_id}/suspender", response_model=ClienteSaaSRead)
@@ -146,7 +152,7 @@ def suspender(
     registrar_audit(db, "cliente_saas", cliente_id, "suspender", atendente.id)
     db.commit()
     db.refresh(row)
-    return row
+    return _read(row)
 
 
 @router.post("/{cliente_id}/reativar", response_model=ClienteSaaSRead)
@@ -163,7 +169,30 @@ def reativar(
     registrar_audit(db, "cliente_saas", cliente_id, "reativar", atendente.id)
     db.commit()
     db.refresh(row)
-    return row
+    return _read(row)
+
+
+@router.post("/{cliente_id}/renovar", response_model=ClienteSaaSRead)
+def renovar(
+    cliente_id: int,
+    data: ClienteSaaSRenovar,
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    try:
+        row = saas_renovacoes.renovar(
+            db,
+            cliente_id,
+            dias=data.dias,
+            nova_data=data.nova_data,
+        )
+    except svc.SaasErro as e:
+        raise _http_from_saas(e) from e
+    registrar_audit(db, "cliente_saas", cliente_id, "renovar", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return _read(row)
 
 
 @router.post("/{cliente_id}/registrar-instancia", response_model=ClienteSaaSRead)
@@ -181,7 +210,7 @@ def registrar_instancia(
     registrar_audit(db, "cliente_saas", cliente_id, "registrar_instancia", atendente.id)
     db.commit()
     db.refresh(row)
-    return row
+    return _read(row)
 
 
 @router.post("/{cliente_id}/solicitar-provisionamento", response_model=ClienteSaaSRead)
@@ -198,4 +227,4 @@ def solicitar_provisionamento(
     registrar_audit(db, "cliente_saas", cliente_id, "solicitar_provisionamento", atendente.id)
     db.commit()
     db.refresh(row)
-    return row
+    return _read(row)

--- a/backend/app/api/saas_public.py
+++ b/backend/app/api/saas_public.py
@@ -1,0 +1,49 @@
+"""Endpoints públicos do control-plane SaaS (trial) — #527."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.core.kb_public_rate_limit import check_saas_trial_rate_limit
+from app.database import get_db
+from app.services import saas_clientes as svc
+from app.services.saas_trial import TrialSolicitacaoCreate, TrialSolicitacaoRead, criar_trial_publico
+
+router = APIRouter(prefix="/saas/public", tags=["saas-public"])
+
+
+def exigir_saas_control_plane() -> None:
+    if not settings.SAAS_CONTROL_PLANE:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Painel SaaS não disponível nesta instância",
+        )
+
+
+@router.post("/trial", response_model=TrialSolicitacaoRead, status_code=201)
+def solicitar_trial(
+    data: TrialSolicitacaoCreate,
+    request: Request,
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+):
+    check_saas_trial_rate_limit(request)
+    try:
+        row = criar_trial_publico(db, data)
+    except svc.SaasErro as e:
+        raise HTTPException(status_code=e.status_code, detail=e.detail) from e
+    db.commit()
+    db.refresh(row)
+    return TrialSolicitacaoRead(
+        id=row.id,
+        nome=row.nome,
+        slug=row.slug,
+        status=row.status,
+        data_renovacao=row.data_renovacao,
+        mensagem=(
+            "Pedido de trial recebido. A equipa DeskRudder vai analisar e contactá-lo "
+            f"em {row.contato_email}."
+        ),
+    )

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -76,6 +76,21 @@ class Settings(BaseSettings):
     # Control-plane comercial DeskRudder (painel de licenças / SaaS).
     # True só na instância deskrudder.com.br — False nas instâncias dos clientes.
     SAAS_CONTROL_PLANE: bool = False
+    # Trial público (DR-07): dias até data_renovacao ao criar trial.
+    SAAS_TRIAL_DAYS: int = 14
+    # Renovações (DR-08): janela de alerta antes do vencimento.
+    SAAS_RENEWAL_ALERT_DAYS_BEFORE: int = 14
+    SAAS_RENEWAL_WORKER_INTERVAL_SECONDS: int = 3600
+    # Provisionamento (DR-04): worker + execução opcional dos scripts do host.
+    SAAS_PROVISION_WORKER_INTERVAL_SECONDS: int = 30
+    SAAS_PROVISION_EXEC_ENABLED: bool = False
+    # Domínio base dos clientes (ex.: deskrudder.com.br → slug.deskrudder.com.br).
+    SAAS_PROVISION_BASE_DOMAIN: str | None = None
+    SAAS_PROVISION_API_PORT_START: int = 8001
+    # Caixa da equipe comercial DeskRudder (trial, provisionamento, renovação).
+    SAAS_NOTIFY_EMAIL: str | None = None
+    # Raiz do repositório no host (para provision-client.sh). Vazio = parents do pacote app.
+    SAAS_REPO_ROOT: str | None = None
     # Modo legado: vários clientes no mesmo Postgres (subdomínio numérico + coluna tenant_id).
     # Produção comercial: manter False (um Postgres por cliente / deploy).
     DX_CONNECT_MULTI_TENANT: bool = False

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -73,6 +73,9 @@ class Settings(BaseSettings):
     TICKET_DISTRIBUICAO_WORKER_INTERVAL_SECONDS: int = 45
     SLA_WORKER_INTERVAL_SECONDS: int = 60
 
+    # Control-plane comercial DeskRudder (painel de licenças / SaaS).
+    # True só na instância deskrudder.com.br — False nas instâncias dos clientes.
+    SAAS_CONTROL_PLANE: bool = False
     # Modo legado: vários clientes no mesmo Postgres (subdomínio numérico + coluna tenant_id).
     # Produção comercial: manter False (um Postgres por cliente / deploy).
     DX_CONNECT_MULTI_TENANT: bool = False

--- a/backend/app/core/kb_public_rate_limit.py
+++ b/backend/app/core/kb_public_rate_limit.py
@@ -60,3 +60,21 @@ def check_kb_public_chat_rate_limit(request: Request) -> None:
                 detail="Muitas mensagens no chat. Aguarde um minuto.",
             )
         bucket.append(now)
+
+
+_MAX_TRIAL_PER_HOUR_PER_IP = 5
+_trial_buckets: dict[str, list[float]] = defaultdict(list)
+
+
+def check_saas_trial_rate_limit(request: Request) -> None:
+    ip = client_ip(request)
+    now = time.monotonic()
+    with _lock:
+        bucket = _trial_buckets[ip]
+        bucket[:] = [t for t in bucket if now - t < 3600]
+        if len(bucket) >= _MAX_TRIAL_PER_HOUR_PER_IP:
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail="Muitos pedidos de trial. Aguarde e tente novamente.",
+            )
+        bucket.append(now)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -50,6 +50,7 @@ from app.api import (
     portal_chats,
     portal,
     saas,
+    saas_public,
 )
 from app.config import settings
 from app.core.audit import clear_audit_request_context, set_audit_request_context
@@ -331,6 +332,60 @@ async def lifespan(app: FastAPI):
         name="sla-violacao",
     ).start()
 
+    if settings.SAAS_CONTROL_PLANE:
+
+        def saas_provision_loop() -> None:
+            from app.database import SessionLocal
+            from app.services.saas_provisionamento import processar_provisionamentos_pendentes
+
+            interval = max(10, settings.SAAS_PROVISION_WORKER_INTERVAL_SECONDS)
+            while True:
+                db = SessionLocal()
+                try:
+                    n = processar_provisionamentos_pendentes(db, limit=5)
+                    if n:
+                        db.commit()
+                    else:
+                        db.rollback()
+                except Exception as e:
+                    logger.warning("Worker SaaS provisionamento: %s", e)
+                    db.rollback()
+                finally:
+                    db.close()
+                time.sleep(interval)
+
+        threading.Thread(
+            target=saas_provision_loop,
+            daemon=True,
+            name="saas-provisionamento",
+        ).start()
+
+        def saas_renovacao_loop() -> None:
+            from app.database import SessionLocal
+            from app.services.saas_renovacoes import processar_renovacoes
+
+            interval = max(60, settings.SAAS_RENEWAL_WORKER_INTERVAL_SECONDS)
+            while True:
+                db = SessionLocal()
+                try:
+                    n = processar_renovacoes(db, limit=200)
+                    if n:
+                        db.commit()
+                    else:
+                        db.rollback()
+                except Exception as e:
+                    logger.warning("Worker SaaS renovações: %s", e)
+                    db.rollback()
+                finally:
+                    db.close()
+                time.sleep(interval)
+
+        threading.Thread(
+            target=saas_renovacao_loop,
+            daemon=True,
+            name="saas-renovacoes",
+        ).start()
+
     yield
 
 
@@ -466,6 +521,7 @@ app.include_router(chat_interno.router, prefix=API_V1_PREFIX)
 app.include_router(portal_chats.router, prefix=API_V1_PREFIX)
 app.include_router(portal.router, prefix=API_V1_PREFIX)
 app.include_router(saas.router, prefix=API_V1_PREFIX)
+app.include_router(saas_public.router, prefix=API_V1_PREFIX)
 
 
 def _app_route_paths() -> set[str]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -49,6 +49,7 @@ from app.api import (
     chat_interno,
     portal_chats,
     portal,
+    saas,
 )
 from app.config import settings
 from app.core.audit import clear_audit_request_context, set_audit_request_context
@@ -464,6 +465,7 @@ app.include_router(kb.router, prefix=API_V1_PREFIX)
 app.include_router(chat_interno.router, prefix=API_V1_PREFIX)
 app.include_router(portal_chats.router, prefix=API_V1_PREFIX)
 app.include_router(portal.router, prefix=API_V1_PREFIX)
+app.include_router(saas.router, prefix=API_V1_PREFIX)
 
 
 def _app_route_paths() -> set[str]:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -46,6 +46,7 @@ from app.models.chat_interno import (
     MensagemInternaOculta,
 )
 from app.models.cliente_saas import ClienteSaaS
+from app.models.saas_alerta_emitido import SaasAlertaEmitido
 
 __all__ = [
     "Rede",
@@ -112,4 +113,5 @@ __all__ = [
     "MensagemInternaOculta",
     "ConversaInternaLeitura",
     "ClienteSaaS",
+    "SaasAlertaEmitido",
 ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -45,6 +45,7 @@ from app.models.chat_interno import (
     MensagemInternaReacao,
     MensagemInternaOculta,
 )
+from app.models.cliente_saas import ClienteSaaS
 
 __all__ = [
     "Rede",
@@ -110,4 +111,5 @@ __all__ = [
     "MensagemInternaReacao",
     "MensagemInternaOculta",
     "ConversaInternaLeitura",
+    "ClienteSaaS",
 ]

--- a/backend/app/models/cliente_saas.py
+++ b/backend/app/models/cliente_saas.py
@@ -6,6 +6,7 @@ from sqlalchemy.sql import func
 from app.database import Base
 
 STATUS_CLIENTE_SAAS = ("trial", "ativo", "suspenso", "churn")
+PROVISIONAMENTO_STATUS = ("pendente", "em_progresso", "aguardando_ops", "sucesso", "falha")
 
 
 class ClienteSaaS(Base):
@@ -20,7 +21,13 @@ class ClienteSaaS(Base):
     data_inicio = Column(Date, nullable=False)
     data_renovacao = Column(Date, nullable=True)
     instancia_url = Column(String(500), nullable=True)
+    contato_email = Column(String(255), nullable=True)
+    contato_nome = Column(String(200), nullable=True)
+    api_port = Column(Integer, nullable=True)
     provisionamento_solicitado = Column(Boolean, nullable=False, default=False)
+    provisionamento_status = Column(String(32), nullable=True)
+    provisionamento_mensagem = Column(Text, nullable=True)
+    provisionamento_atualizado_em = Column(DateTime(timezone=True), nullable=True)
     notas = Column(Text, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/app/models/cliente_saas.py
+++ b/backend/app/models/cliente_saas.py
@@ -1,0 +1,26 @@
+"""Cliente SaaS / licença DeskRudder (control-plane comercial) — #521."""
+
+from sqlalchemy import Boolean, Column, Date, DateTime, Integer, String, Text, UniqueConstraint
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+STATUS_CLIENTE_SAAS = ("trial", "ativo", "suspenso", "churn")
+
+
+class ClienteSaaS(Base):
+    __tablename__ = "clientes_saas"
+    __table_args__ = (UniqueConstraint("slug", name="uq_clientes_saas_slug"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    nome = Column(String(200), nullable=False)
+    slug = Column(String(80), nullable=False, index=True)
+    status = Column(String(20), nullable=False, default="trial")
+    plano = Column(String(80), nullable=True)
+    data_inicio = Column(Date, nullable=False)
+    data_renovacao = Column(Date, nullable=True)
+    instancia_url = Column(String(500), nullable=True)
+    provisionamento_solicitado = Column(Boolean, nullable=False, default=False)
+    notas = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/app/models/saas_alerta_emitido.py
+++ b/backend/app/models/saas_alerta_emitido.py
@@ -1,0 +1,32 @@
+"""Dedup de alertas de renovação SaaS (#528)."""
+
+from sqlalchemy import Column, Date, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class SaasAlertaEmitido(Base):
+    __tablename__ = "saas_alerta_emitidos"
+    __table_args__ = (
+        UniqueConstraint(
+            "cliente_saas_id",
+            "evento",
+            "referencia_data",
+            name="uq_saas_alerta_emitidos_cliente_evento_ref",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    cliente_saas_id = Column(
+        Integer,
+        ForeignKey("clientes_saas.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    evento = Column(String(40), nullable=False)
+    referencia_data = Column(Date, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    cliente = relationship("ClienteSaaS", backref="alertas_emitidos")

--- a/backend/app/schemas/saas.py
+++ b/backend/app/schemas/saas.py
@@ -1,0 +1,158 @@
+"""Schemas do painel SaaS / licenças DeskRudder — #521–#522."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, HttpUrl
+
+StatusClienteSaaS = Literal["trial", "ativo", "suspenso", "churn"]
+
+_SLUG_RE = __import__("re").compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+def _validar_slug(v: str) -> str:
+    slug = (v or "").strip().lower()
+    if not slug or len(slug) > 80:
+        raise ValueError("Slug deve ter entre 1 e 80 caracteres")
+    if not _SLUG_RE.match(slug):
+        raise ValueError("Slug deve conter apenas letras minúsculas, números e hífens")
+    return slug
+
+
+class ClienteSaaSBase(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=200)
+    slug: str = Field(..., min_length=1, max_length=80)
+    status: StatusClienteSaaS = "trial"
+    plano: str | None = Field(None, max_length=80)
+    data_inicio: date
+    data_renovacao: date | None = None
+    instancia_url: str | None = Field(None, max_length=500)
+    notas: str | None = None
+
+    @field_validator("nome")
+    @classmethod
+    def strip_nome(cls, v: str) -> str:
+        nome = (v or "").strip()
+        if not nome:
+            raise ValueError("Nome é obrigatório")
+        return nome
+
+    @field_validator("slug")
+    @classmethod
+    def normalize_slug(cls, v: str) -> str:
+        return _validar_slug(v)
+
+    @field_validator("plano")
+    @classmethod
+    def strip_plano(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        plano = v.strip()
+        return plano or None
+
+    @field_validator("instancia_url")
+    @classmethod
+    def normalize_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        url = v.strip()
+        if not url:
+            return None
+        # Aceita host sem esquema; normaliza para https://
+        if "://" not in url:
+            url = f"https://{url}"
+        # Valida via HttpUrl
+        return str(HttpUrl(url))
+
+    @field_validator("notas")
+    @classmethod
+    def strip_notas(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        notas = v.strip()
+        return notas or None
+
+
+class ClienteSaaSCreate(ClienteSaaSBase):
+    pass
+
+
+class ClienteSaaSUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=200)
+    slug: str | None = Field(None, min_length=1, max_length=80)
+    status: StatusClienteSaaS | None = None
+    plano: str | None = Field(None, max_length=80)
+    data_inicio: date | None = None
+    data_renovacao: date | None = None
+    instancia_url: str | None = Field(None, max_length=500)
+    notas: str | None = None
+
+    @field_validator("nome")
+    @classmethod
+    def strip_nome(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        nome = v.strip()
+        if not nome:
+            raise ValueError("Nome é obrigatório")
+        return nome
+
+    @field_validator("slug")
+    @classmethod
+    def normalize_slug(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return _validar_slug(v)
+
+    @field_validator("plano")
+    @classmethod
+    def strip_plano(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        plano = v.strip()
+        return plano or None
+
+    @field_validator("instancia_url")
+    @classmethod
+    def normalize_url(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        url = v.strip()
+        if not url:
+            return None
+        if "://" not in url:
+            url = f"https://{url}"
+        return str(HttpUrl(url))
+
+    @field_validator("notas")
+    @classmethod
+    def strip_notas(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        notas = v.strip()
+        return notas or None
+
+
+class ClienteSaaSRegistrarInstancia(BaseModel):
+    instancia_url: str = Field(..., min_length=1, max_length=500)
+
+    @field_validator("instancia_url")
+    @classmethod
+    def normalize_url(cls, v: str) -> str:
+        url = (v or "").strip()
+        if not url:
+            raise ValueError("URL da instância é obrigatória")
+        if "://" not in url:
+            url = f"https://{url}"
+        return str(HttpUrl(url))
+
+
+class ClienteSaaSRead(ClienteSaaSBase):
+    id: int
+    provisionamento_solicitado: bool = False
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/saas.py
+++ b/backend/app/schemas/saas.py
@@ -29,6 +29,8 @@ class ClienteSaaSBase(BaseModel):
     data_inicio: date
     data_renovacao: date | None = None
     instancia_url: str | None = Field(None, max_length=500)
+    contato_email: str | None = Field(None, max_length=255)
+    contato_nome: str | None = Field(None, max_length=200)
     notas: str | None = None
 
     @field_validator("nome")
@@ -51,6 +53,14 @@ class ClienteSaaSBase(BaseModel):
             return None
         plano = v.strip()
         return plano or None
+
+    @field_validator("contato_email", "contato_nome")
+    @classmethod
+    def strip_contato(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        s = v.strip()
+        return s or None
 
     @field_validator("instancia_url")
     @classmethod
@@ -87,6 +97,8 @@ class ClienteSaaSUpdate(BaseModel):
     data_inicio: date | None = None
     data_renovacao: date | None = None
     instancia_url: str | None = Field(None, max_length=500)
+    contato_email: str | None = Field(None, max_length=255)
+    contato_nome: str | None = Field(None, max_length=200)
     notas: str | None = None
 
     @field_validator("nome")
@@ -113,6 +125,14 @@ class ClienteSaaSUpdate(BaseModel):
             return None
         plano = v.strip()
         return plano or None
+
+    @field_validator("contato_email", "contato_nome")
+    @classmethod
+    def strip_contato(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        s = v.strip()
+        return s or None
 
     @field_validator("instancia_url")
     @classmethod
@@ -149,9 +169,19 @@ class ClienteSaaSRegistrarInstancia(BaseModel):
         return str(HttpUrl(url))
 
 
+class ClienteSaaSRenovar(BaseModel):
+    dias: int | None = Field(None, ge=1, le=3650)
+    nova_data: date | None = None
+
+
 class ClienteSaaSRead(ClienteSaaSBase):
     id: int
+    api_port: int | None = None
     provisionamento_solicitado: bool = False
+    provisionamento_status: str | None = None
+    provisionamento_mensagem: str | None = None
+    provisionamento_atualizado_em: datetime | None = None
+    dias_para_renovacao: int | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None
 

--- a/backend/app/schemas/system.py
+++ b/backend/app/schemas/system.py
@@ -23,6 +23,7 @@ class SystemInfoRead(BaseModel):
     version_display: str | None = None
     git_sha: str | None = None
     environment: str
+    saas_control_plane: bool = False
 
 
 class ReleaseNotesRead(BaseModel):

--- a/backend/app/services/saas_clientes.py
+++ b/backend/app/services/saas_clientes.py
@@ -1,0 +1,84 @@
+"""Regras de negócio do painel SaaS / licenças — #521–#522."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from app.models.cliente_saas import STATUS_CLIENTE_SAAS, ClienteSaaS
+from app.schemas.saas import ClienteSaaSCreate, ClienteSaaSRegistrarInstancia, ClienteSaaSUpdate
+
+
+class SaasErro(Exception):
+    def __init__(self, detail: str, status_code: int = 400):
+        self.detail = detail
+        self.status_code = status_code
+        super().__init__(detail)
+
+
+def obter(db: Session, cliente_id: int) -> ClienteSaaS:
+    row = db.query(ClienteSaaS).filter(ClienteSaaS.id == cliente_id).first()
+    if not row:
+        raise SaasErro("Cliente SaaS não encontrado", 404)
+    return row
+
+
+def _garantir_slug_unico(db: Session, slug: str, excluir_id: int | None = None) -> None:
+    q = db.query(ClienteSaaS).filter(ClienteSaaS.slug == slug)
+    if excluir_id is not None:
+        q = q.filter(ClienteSaaS.id != excluir_id)
+    if q.first():
+        raise SaasErro("Já existe um cliente com este slug", 409)
+
+
+def criar(db: Session, data: ClienteSaaSCreate) -> ClienteSaaS:
+    if data.status not in STATUS_CLIENTE_SAAS:
+        raise SaasErro("Status inválido")
+    _garantir_slug_unico(db, data.slug)
+    row = ClienteSaaS(**data.model_dump())
+    db.add(row)
+    db.flush()
+    return row
+
+
+def atualizar(db: Session, cliente_id: int, data: ClienteSaaSUpdate) -> ClienteSaaS:
+    row = obter(db, cliente_id)
+    payload = data.model_dump(exclude_unset=True)
+    if "status" in payload and payload["status"] not in STATUS_CLIENTE_SAAS:
+        raise SaasErro("Status inválido")
+    if "slug" in payload:
+        _garantir_slug_unico(db, payload["slug"], excluir_id=cliente_id)
+    for k, v in payload.items():
+        setattr(row, k, v)
+    db.flush()
+    return row
+
+
+def suspender(db: Session, cliente_id: int) -> ClienteSaaS:
+    row = obter(db, cliente_id)
+    row.status = "suspenso"
+    db.flush()
+    return row
+
+
+def reativar(db: Session, cliente_id: int) -> ClienteSaaS:
+    row = obter(db, cliente_id)
+    if row.status == "churn":
+        raise SaasErro("Cliente em churn não pode ser reativado por este atalho; edite o status")
+    row.status = "ativo"
+    db.flush()
+    return row
+
+
+def registrar_instancia(db: Session, cliente_id: int, data: ClienteSaaSRegistrarInstancia) -> ClienteSaaS:
+    row = obter(db, cliente_id)
+    row.instancia_url = data.instancia_url
+    db.flush()
+    return row
+
+
+def solicitar_provisionamento(db: Session, cliente_id: int) -> ClienteSaaS:
+    """Stub DR-04: marca pedido sem orquestrar Docker."""
+    row = obter(db, cliente_id)
+    row.provisionamento_solicitado = True
+    db.flush()
+    return row

--- a/backend/app/services/saas_clientes.py
+++ b/backend/app/services/saas_clientes.py
@@ -77,8 +77,33 @@ def registrar_instancia(db: Session, cliente_id: int, data: ClienteSaaSRegistrar
 
 
 def solicitar_provisionamento(db: Session, cliente_id: int) -> ClienteSaaS:
-    """Stub DR-04: marca pedido sem orquestrar Docker."""
-    row = obter(db, cliente_id)
-    row.provisionamento_solicitado = True
-    db.flush()
-    return row
+    """Enfileira provisionamento (DR-04)."""
+    from app.services.saas_provisionamento import enfileirar_provisionamento
+
+    return enfileirar_provisionamento(db, cliente_id)
+
+
+def serializar_cliente(row: ClienteSaaS) -> dict:
+    from app.services.saas_renovacoes import dias_para_renovacao
+
+    return {
+        "id": row.id,
+        "nome": row.nome,
+        "slug": row.slug,
+        "status": row.status,
+        "plano": row.plano,
+        "data_inicio": row.data_inicio,
+        "data_renovacao": row.data_renovacao,
+        "instancia_url": row.instancia_url,
+        "contato_email": row.contato_email,
+        "contato_nome": row.contato_nome,
+        "api_port": row.api_port,
+        "notas": row.notas,
+        "provisionamento_solicitado": bool(row.provisionamento_solicitado),
+        "provisionamento_status": row.provisionamento_status,
+        "provisionamento_mensagem": row.provisionamento_mensagem,
+        "provisionamento_atualizado_em": row.provisionamento_atualizado_em,
+        "dias_para_renovacao": dias_para_renovacao(row.data_renovacao),
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+    }

--- a/backend/app/services/saas_notify.py
+++ b/backend/app/services/saas_notify.py
@@ -1,0 +1,26 @@
+"""Notificações internas da equipe DeskRudder (control-plane SaaS)."""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.services.email_send_sistema import enviar_mensagem_texto_sistema
+
+logger = logging.getLogger(__name__)
+
+
+def notificar_equipe_saas(db: Session, *, subject: str, body: str) -> bool:
+    """Envia e-mail à caixa SAAS_NOTIFY_EMAIL. Retorna False se não configurado / falhou."""
+    to_addr = (settings.SAAS_NOTIFY_EMAIL or "").strip()
+    if not to_addr:
+        logger.info("SAAS_NOTIFY_EMAIL não definido — notificação ignorada: %s", subject)
+        return False
+    try:
+        enviar_mensagem_texto_sistema(db, to_addr=to_addr, subject=subject, body=body)
+        return True
+    except Exception as e:
+        logger.warning("Falha ao notificar equipe SaaS (%s): %s", subject, e)
+        return False

--- a/backend/app/services/saas_provisionamento.py
+++ b/backend/app/services/saas_provisionamento.py
@@ -1,0 +1,199 @@
+"""Provisionamento de instâncias a partir do painel SaaS (#524 / DR-04)."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.cliente_saas import ClienteSaaS
+from app.services.saas_clientes import SaasErro, obter
+from app.services.saas_notify import notificar_equipe_saas
+
+logger = logging.getLogger(__name__)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _repo_root() -> Path:
+    if settings.SAAS_REPO_ROOT and settings.SAAS_REPO_ROOT.strip():
+        return Path(settings.SAAS_REPO_ROOT.strip())
+    # backend/app/services → parents[3] = repo root
+    return Path(__file__).resolve().parents[3]
+
+
+def _alocar_api_port(db: Session) -> int:
+    start = max(1024, int(settings.SAAS_PROVISION_API_PORT_START or 8001))
+    usados = {
+        p
+        for (p,) in db.query(ClienteSaaS.api_port).filter(ClienteSaaS.api_port.isnot(None)).all()
+    }
+    port = start
+    while port in usados and port < 65535:
+        port += 1
+    if port > 65535:
+        raise SaasErro("Não há portas API disponíveis para provisionamento")
+    return port
+
+
+def _montar_instancia_url(slug: str) -> str | None:
+    base = (settings.SAAS_PROVISION_BASE_DOMAIN or "").strip().lstrip(".")
+    if not base:
+        return None
+    return f"https://{slug}.{base}"
+
+
+def enfileirar_provisionamento(db: Session, cliente_id: int) -> ClienteSaaS:
+    row = obter(db, cliente_id)
+    if row.provisionamento_status == "em_progresso":
+        raise SaasErro("Provisionamento já em andamento para este cliente")
+    if row.provisionamento_status == "sucesso" and row.instancia_url:
+        raise SaasErro("Instância já provisionada; use registrar-instância para corrigir a URL")
+
+    if row.api_port is None:
+        row.api_port = _alocar_api_port(db)
+
+    row.provisionamento_solicitado = True
+    row.provisionamento_status = "pendente"
+    row.provisionamento_mensagem = "Aguardando worker de provisionamento"
+    row.provisionamento_atualizado_em = _utcnow()
+    db.flush()
+
+    notificar_equipe_saas(
+        db,
+        subject=f"[DeskRudder] Provisionamento solicitado — {row.nome} ({row.slug})",
+        body=(
+            f"Cliente: {row.nome}\n"
+            f"Slug: {row.slug}\n"
+            f"Porta API: {row.api_port}\n"
+            f"Status: pendente\n"
+            f"Execução automática: {'sim' if settings.SAAS_PROVISION_EXEC_ENABLED else 'não (fila manual)'}\n"
+        ),
+    )
+    return row
+
+
+def _executar_scripts(row: ClienteSaaS) -> str:
+    root = _repo_root()
+    provision = root / "deploy" / "scripts" / "provision-client.sh"
+    stack = root / "deploy" / "scripts" / "stack-client.sh"
+    if not provision.is_file() or not stack.is_file():
+        raise RuntimeError(f"Scripts de deploy não encontrados em {root}/deploy/scripts")
+
+    base = (settings.SAAS_PROVISION_BASE_DOMAIN or "").strip()
+    if not base:
+        raise RuntimeError("SAAS_PROVISION_BASE_DOMAIN não configurado")
+    if row.api_port is None:
+        raise RuntimeError("api_port não definido no cliente")
+
+    dest = root / "deploy" / "clients" / row.slug
+    if not dest.exists():
+        cmd = [
+            "bash",
+            str(provision),
+            "--slug",
+            row.slug,
+            "--base-domain",
+            base,
+            "--api-port",
+            str(row.api_port),
+        ]
+        logger.info("SaaS provision: %s", " ".join(cmd))
+        r = subprocess.run(cmd, cwd=str(root), capture_output=True, text=True, timeout=600)
+        if r.returncode != 0:
+            raise RuntimeError((r.stderr or r.stdout or "falha no provision-client.sh")[:2000])
+
+    for step in ("migrate", "up", "health"):
+        cmd = ["bash", str(stack), row.slug, step]
+        logger.info("SaaS stack: %s", " ".join(cmd))
+        r = subprocess.run(cmd, cwd=str(root), capture_output=True, text=True, timeout=1800)
+        if r.returncode != 0:
+            raise RuntimeError(
+                f"Falha em stack-client.sh {step}: {(r.stderr or r.stdout or '')[:2000]}"
+            )
+
+    url = _montar_instancia_url(row.slug) or f"https://{row.slug}.{base}"
+    return url
+
+
+def processar_provisionamentos_pendentes(db: Session, *, limit: int = 5) -> int:
+    """Worker: processa fila de provisionamento. Retorna quantos jobs tentou."""
+    if not settings.SAAS_CONTROL_PLANE:
+        return 0
+
+    rows = (
+        db.query(ClienteSaaS)
+        .filter(ClienteSaaS.provisionamento_status == "pendente")
+        .order_by(ClienteSaaS.id.asc())
+        .limit(limit)
+        .all()
+    )
+    if not rows:
+        return 0
+
+    processados = 0
+    for row in rows:
+        processados += 1
+        row.provisionamento_status = "em_progresso"
+        row.provisionamento_mensagem = "Provisionamento em andamento"
+        row.provisionamento_atualizado_em = _utcnow()
+        db.flush()
+
+        if not settings.SAAS_PROVISION_EXEC_ENABLED:
+            row.provisionamento_status = "aguardando_ops"
+            row.provisionamento_mensagem = (
+                "Fila registada. Execução automática desligada "
+                "(SAAS_PROVISION_EXEC_ENABLED=false) — ops deve correr provision-client.sh / stack-client.sh."
+            )
+            row.provisionamento_atualizado_em = _utcnow()
+            url = _montar_instancia_url(row.slug)
+            if url and not row.instancia_url:
+                row.instancia_url = url
+            db.flush()
+            continue
+
+        try:
+            url = _executar_scripts(row)
+            row.instancia_url = url
+            row.provisionamento_status = "sucesso"
+            row.provisionamento_mensagem = "Instância provisionada com sucesso"
+            row.provisionamento_atualizado_em = _utcnow()
+            if row.status == "trial":
+                # Mantém trial; ops ativa depois
+                pass
+            db.flush()
+            notificar_equipe_saas(
+                db,
+                subject=f"[DeskRudder] Provisionamento OK — {row.slug}",
+                body=f"URL: {url}\nSlug: {row.slug}\nPorta: {row.api_port}\n",
+            )
+        except Exception as e:
+            logger.exception("Falha no provisionamento SaaS id=%s", row.id)
+            row.provisionamento_status = "falha"
+            row.provisionamento_mensagem = str(e)[:2000]
+            row.provisionamento_atualizado_em = _utcnow()
+            db.flush()
+            notificar_equipe_saas(
+                db,
+                subject=f"[DeskRudder] Provisionamento FALHOU — {row.slug}",
+                body=f"Erro: {row.provisionamento_mensagem}\n",
+            )
+
+    return processados
+
+
+def contagem_fila(db: Session) -> dict[str, int]:
+    q = (
+        db.query(ClienteSaaS.provisionamento_status, func.count())
+        .filter(ClienteSaaS.provisionamento_status.isnot(None))
+        .group_by(ClienteSaaS.provisionamento_status)
+        .all()
+    )
+    return {status: int(n) for status, n in q if status}

--- a/backend/app/services/saas_renovacoes.py
+++ b/backend/app/services/saas_renovacoes.py
@@ -1,0 +1,129 @@
+"""Renovações e alertas de licenças SaaS (#528 / DR-08)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.cliente_saas import ClienteSaaS
+from app.models.saas_alerta_emitido import SaasAlertaEmitido
+from app.services.saas_clientes import SaasErro, obter
+from app.services.saas_notify import notificar_equipe_saas
+
+logger = logging.getLogger(__name__)
+
+EVENTO_EM_RISCO = "renovacao_em_risco"
+EVENTO_VENCIDO = "vencido_suspenso"
+
+
+def renovar(db: Session, cliente_id: int, *, dias: int | None = None, nova_data: date | None = None) -> ClienteSaaS:
+    row = obter(db, cliente_id)
+    if nova_data is not None:
+        row.data_renovacao = nova_data
+    else:
+        base = row.data_renovacao or date.today()
+        if base < date.today():
+            base = date.today()
+        add = dias if dias is not None else max(1, int(settings.SAAS_TRIAL_DAYS or 30))
+        if add < 1:
+            raise SaasErro("Dias de renovação deve ser >= 1")
+        row.data_renovacao = base + timedelta(days=add)
+
+    if row.status in ("suspenso", "trial"):
+        row.status = "ativo"
+    db.flush()
+    return row
+
+
+def _ja_emitido(db: Session, cliente_id: int, evento: str, ref: date) -> bool:
+    return (
+        db.query(SaasAlertaEmitido.id)
+        .filter(
+            SaasAlertaEmitido.cliente_saas_id == cliente_id,
+            SaasAlertaEmitido.evento == evento,
+            SaasAlertaEmitido.referencia_data == ref,
+        )
+        .first()
+        is not None
+    )
+
+
+def _registrar_alerta(db: Session, cliente_id: int, evento: str, ref: date) -> None:
+    db.add(
+        SaasAlertaEmitido(
+            cliente_saas_id=cliente_id,
+            evento=evento,
+            referencia_data=ref,
+        )
+    )
+    db.flush()
+
+
+def processar_renovacoes(db: Session, *, limit: int = 200) -> int:
+    """Worker: alerta próximos vencimentos e suspende vencidos (trial/ativo)."""
+    if not settings.SAAS_CONTROL_PLANE:
+        return 0
+
+    hoje = date.today()
+    janela = max(1, int(settings.SAAS_RENEWAL_ALERT_DAYS_BEFORE or 14))
+    limite_alerta = hoje + timedelta(days=janela)
+
+    acoes = 0
+    rows = (
+        db.query(ClienteSaaS)
+        .filter(
+            ClienteSaaS.data_renovacao.isnot(None),
+            ClienteSaaS.status.in_(("trial", "ativo")),
+        )
+        .order_by(ClienteSaaS.data_renovacao.asc())
+        .limit(limit)
+        .all()
+    )
+
+    for row in rows:
+        ref = row.data_renovacao
+        if ref is None:
+            continue
+
+        if ref < hoje:
+            if not _ja_emitido(db, row.id, EVENTO_VENCIDO, ref):
+                row.status = "suspenso"
+                _registrar_alerta(db, row.id, EVENTO_VENCIDO, ref)
+                notificar_equipe_saas(
+                    db,
+                    subject=f"[DeskRudder] Licença vencida — {row.nome} ({row.slug})",
+                    body=(
+                        f"A licença venceu em {ref.isoformat()} e foi marcada como suspensa.\n"
+                        f"Renove no painel /saas/licencas/{row.id}.\n"
+                    ),
+                )
+                acoes += 1
+            continue
+
+        if hoje <= ref <= limite_alerta:
+            if not _ja_emitido(db, row.id, EVENTO_EM_RISCO, ref):
+                dias = (ref - hoje).days
+                _registrar_alerta(db, row.id, EVENTO_EM_RISCO, ref)
+                notificar_equipe_saas(
+                    db,
+                    subject=f"[DeskRudder] Renovação em {dias} dia(s) — {row.slug}",
+                    body=(
+                        f"Cliente: {row.nome}\n"
+                        f"Slug: {row.slug}\n"
+                        f"Vence em: {ref.isoformat()} ({dias} dia(s))\n"
+                        f"Painel: /saas/licencas/{row.id}\n"
+                    ),
+                )
+                acoes += 1
+
+    return acoes
+
+
+def dias_para_renovacao(data_renovacao: date | None, *, hoje: date | None = None) -> int | None:
+    if data_renovacao is None:
+        return None
+    base = hoje or date.today()
+    return (data_renovacao - base).days

--- a/backend/app/services/saas_trial.py
+++ b/backend/app/services/saas_trial.py
@@ -1,0 +1,88 @@
+"""Trial / pré-cadastro público (#527 / DR-07)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, field_validator
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.cliente_saas import ClienteSaaS
+from app.schemas.saas import ClienteSaaSCreate, _validar_slug
+from app.services import saas_clientes as svc
+from app.services.saas_notify import notificar_equipe_saas
+from app.services.saas_provisionamento import enfileirar_provisionamento
+
+
+class TrialSolicitacaoCreate(BaseModel):
+    empresa: str = Field(..., min_length=1, max_length=200)
+    slug: str = Field(..., min_length=1, max_length=80)
+    contato_nome: str = Field(..., min_length=1, max_length=200)
+    contato_email: EmailStr
+    notas: str | None = None
+    solicitar_provisionamento: bool = False
+
+    model_config = ConfigDict(str_strip_whitespace=True)
+
+    @field_validator("empresa", "contato_nome")
+    @classmethod
+    def non_empty(cls, v: str) -> str:
+        s = (v or "").strip()
+        if not s:
+            raise ValueError("Campo obrigatório")
+        return s
+
+    @field_validator("slug")
+    @classmethod
+    def slug_ok(cls, v: str) -> str:
+        return _validar_slug(v)
+
+
+class TrialSolicitacaoRead(BaseModel):
+    id: int
+    nome: str
+    slug: str
+    status: str
+    data_renovacao: date | None = None
+    mensagem: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+def criar_trial_publico(db: Session, data: TrialSolicitacaoCreate) -> ClienteSaaS:
+    hoje = date.today()
+    dias = max(1, int(settings.SAAS_TRIAL_DAYS or 14))
+    create = ClienteSaaSCreate(
+        nome=data.empresa,
+        slug=data.slug,
+        status="trial",
+        plano="trial",
+        data_inicio=hoje,
+        data_renovacao=hoje + timedelta(days=dias),
+        notas=data.notas,
+    )
+    row = svc.criar(db, create)
+    row.contato_email = str(data.contato_email).strip().lower()
+    row.contato_nome = data.contato_nome.strip()
+    db.flush()
+
+    notificar_equipe_saas(
+        db,
+        subject=f"[DeskRudder] Novo trial — {row.nome} ({row.slug})",
+        body=(
+            f"Empresa: {row.nome}\n"
+            f"Slug: {row.slug}\n"
+            f"Contacto: {row.contato_nome} <{row.contato_email}>\n"
+            f"Trial até: {row.data_renovacao}\n"
+            f"Notas: {row.notas or '—'}\n"
+        ),
+    )
+
+    if data.solicitar_provisionamento:
+        try:
+            enfileirar_provisionamento(db, row.id)
+        except svc.SaasErro:
+            pass
+
+    return row

--- a/backend/app/services/system_release.py
+++ b/backend/app/services/system_release.py
@@ -116,4 +116,5 @@ def system_info_payload() -> dict[str, Any]:
         "version_display": version_display(version) if version else None,
         "git_sha": (os.environ.get("DX_CONNECT_GIT_SHA") or "").strip() or None,
         "environment": settings.ENVIRONMENT,
+        "saas_control_plane": bool(settings.SAAS_CONTROL_PLANE),
     }

--- a/backend/tests/test_saas_clientes.py
+++ b/backend/tests/test_saas_clientes.py
@@ -1,0 +1,132 @@
+"""API e modelo do painel SaaS / licenças (#521–#522)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+
+def test_saas_desligado_404(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", False)
+    r = client.get("/v1/saas/clientes", headers=auth_headers["admin"])
+    assert r.status_code == 404
+
+
+def test_saas_atendente_403(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    r = client.get("/v1/saas/clientes", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_saas_crud_admin(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    h = auth_headers["admin"]
+
+    criar = client.post(
+        "/v1/saas/clientes",
+        headers=h,
+        json={
+            "nome": "Duplex Soft",
+            "slug": "duplex-soft",
+            "status": "trial",
+            "plano": "profissional",
+            "data_inicio": str(date.today()),
+            "data_renovacao": str(date.today()),
+            "instancia_url": "duplexsoft.deskrudder.com.br",
+            "notas": "Cliente piloto",
+        },
+    )
+    assert criar.status_code == 201, criar.text
+    body = criar.json()
+    assert body["slug"] == "duplex-soft"
+    assert body["status"] == "trial"
+    assert body["instancia_url"].startswith("https://")
+    cid = body["id"]
+
+    lista = client.get("/v1/saas/clientes", headers=h)
+    assert lista.status_code == 200
+    assert lista.json()["total"] >= 1
+
+    detalhe = client.get(f"/v1/saas/clientes/{cid}", headers=h)
+    assert detalhe.status_code == 200
+    assert detalhe.json()["nome"] == "Duplex Soft"
+
+    patch = client.patch(
+        f"/v1/saas/clientes/{cid}",
+        headers=h,
+        json={"status": "ativo", "plano": "enterprise"},
+    )
+    assert patch.status_code == 200
+    assert patch.json()["status"] == "ativo"
+    assert patch.json()["plano"] == "enterprise"
+
+    susp = client.post(f"/v1/saas/clientes/{cid}/suspender", headers=h)
+    assert susp.status_code == 200
+    assert susp.json()["status"] == "suspenso"
+
+    reat = client.post(f"/v1/saas/clientes/{cid}/reativar", headers=h)
+    assert reat.status_code == 200
+    assert reat.json()["status"] == "ativo"
+
+    reg = client.post(
+        f"/v1/saas/clientes/{cid}/registrar-instancia",
+        headers=h,
+        json={"instancia_url": "https://cliente01.deskrudder.com.br"},
+    )
+    assert reg.status_code == 200
+    assert "cliente01.deskrudder.com.br" in reg.json()["instancia_url"]
+
+    prov = client.post(f"/v1/saas/clientes/{cid}/solicitar-provisionamento", headers=h)
+    assert prov.status_code == 200
+    assert prov.json()["provisionamento_solicitado"] is True
+
+
+def test_saas_slug_duplicado_409(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    h = auth_headers["admin"]
+    payload = {
+        "nome": "A",
+        "slug": "mesmo-slug",
+        "status": "ativo",
+        "data_inicio": str(date.today()),
+    }
+    assert client.post("/v1/saas/clientes", headers=h, json=payload).status_code == 201
+    r = client.post(
+        "/v1/saas/clientes",
+        headers=h,
+        json={**payload, "nome": "B"},
+    )
+    assert r.status_code == 409
+
+
+def test_saas_slug_invalido_422(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    r = client.post(
+        "/v1/saas/clientes",
+        headers=auth_headers["admin"],
+        json={
+            "nome": "X",
+            "slug": "Invalid_Slug!",
+            "status": "trial",
+            "data_inicio": str(date.today()),
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_system_info_expõe_saas_flag(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    r = client.get("/v1/system/info", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    assert r.json()["saas_control_plane"] is True

--- a/backend/tests/test_saas_fase3.py
+++ b/backend/tests/test_saas_fase3.py
@@ -1,0 +1,192 @@
+"""Provisionamento, trial e renovações SaaS (#524 / #527 / #528)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+
+def test_provisionar_enfileira_sem_exec(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_PROVISION_EXEC_ENABLED", False)
+    monkeypatch.setattr(settings, "SAAS_PROVISION_BASE_DOMAIN", "deskrudder.com.br")
+    h = auth_headers["admin"]
+
+    criar = client.post(
+        "/v1/saas/clientes",
+        headers=h,
+        json={
+            "nome": "Acme",
+            "slug": "acme-suporte",
+            "status": "trial",
+            "data_inicio": str(date.today()),
+        },
+    )
+    assert criar.status_code == 201, criar.text
+    cid = criar.json()["id"]
+
+    r = client.post(f"/v1/saas/clientes/{cid}/solicitar-provisionamento", headers=h)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["provisionamento_solicitado"] is True
+    assert body["provisionamento_status"] == "pendente"
+    assert body["api_port"] is not None
+
+    from app.database import SessionLocal
+    from app.services.saas_provisionamento import processar_provisionamentos_pendentes
+
+    db = SessionLocal()
+    try:
+        n = processar_provisionamentos_pendentes(db, limit=5)
+        db.commit()
+    finally:
+        db.close()
+    assert n >= 1
+
+    detalhe = client.get(f"/v1/saas/clientes/{cid}", headers=h)
+    assert detalhe.status_code == 200
+    d = detalhe.json()
+    assert d["provisionamento_status"] == "aguardando_ops"
+    assert "Execução automática desligada" in (d["provisionamento_mensagem"] or "")
+    assert d["instancia_url"] and "acme-suporte.deskrudder.com.br" in d["instancia_url"]
+
+
+def test_trial_publico_cria_licenca(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_TRIAL_DAYS", 10)
+    monkeypatch.setattr(settings, "SAAS_NOTIFY_EMAIL", None)
+
+    r = client.post(
+        "/v1/saas/public/trial",
+        json={
+            "empresa": "Beta Soft",
+            "slug": "beta-soft",
+            "contato_nome": "Ana",
+            "contato_email": "ana@beta.example",
+            "notas": "Quero testar 2 semanas",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["slug"] == "beta-soft"
+    assert body["status"] == "trial"
+    assert body["data_renovacao"] == str(date.today() + timedelta(days=10))
+
+    lista = client.get("/v1/saas/clientes?busca=beta", headers=auth_headers["admin"])
+    assert lista.status_code == 200
+    assert lista.json()["total"] >= 1
+    item = next(i for i in lista.json()["items"] if i["slug"] == "beta-soft")
+    assert item["contato_email"] == "ana@beta.example"
+
+
+def test_trial_publico_slug_duplicado(client, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    payload = {
+        "empresa": "A",
+        "slug": "dup-trial",
+        "contato_nome": "X",
+        "contato_email": "x@ex.com",
+    }
+    assert client.post("/v1/saas/public/trial", json=payload).status_code == 201
+    r = client.post("/v1/saas/public/trial", json={**payload, "empresa": "B"})
+    assert r.status_code == 409
+
+
+def test_trial_desligado_404(client, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", False)
+    r = client.post(
+        "/v1/saas/public/trial",
+        json={
+            "empresa": "Z",
+            "slug": "z-trial",
+            "contato_nome": "Z",
+            "contato_email": "z@ex.com",
+        },
+    )
+    assert r.status_code == 404
+
+
+def test_renovar_estende_data_e_reativa(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    h = auth_headers["admin"]
+    criar = client.post(
+        "/v1/saas/clientes",
+        headers=h,
+        json={
+            "nome": "Gama",
+            "slug": "gama",
+            "status": "suspenso",
+            "data_inicio": str(date.today() - timedelta(days=40)),
+            "data_renovacao": str(date.today() - timedelta(days=5)),
+        },
+    )
+    cid = criar.json()["id"]
+    r = client.post(f"/v1/saas/clientes/{cid}/renovar", headers=h, json={"dias": 30})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "ativo"
+    assert body["data_renovacao"] == str(date.today() + timedelta(days=30))
+    assert body["dias_para_renovacao"] == 30
+
+
+def test_worker_renovacao_suspende_vencido(client, auth_headers, monkeypatch):
+    from app.config import settings
+    from app.database import SessionLocal
+    from app.services.saas_renovacoes import processar_renovacoes
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_RENEWAL_ALERT_DAYS_BEFORE", 7)
+    h = auth_headers["admin"]
+
+    vencido = client.post(
+        "/v1/saas/clientes",
+        headers=h,
+        json={
+            "nome": "Vencido",
+            "slug": "vencido-co",
+            "status": "ativo",
+            "data_inicio": str(date.today() - timedelta(days=60)),
+            "data_renovacao": str(date.today() - timedelta(days=1)),
+        },
+    ).json()["id"]
+
+    risco = client.post(
+        "/v1/saas/clientes",
+        headers=h,
+        json={
+            "nome": "Risco",
+            "slug": "risco-co",
+            "status": "ativo",
+            "data_inicio": str(date.today()),
+            "data_renovacao": str(date.today() + timedelta(days=3)),
+        },
+    ).json()["id"]
+
+    db = SessionLocal()
+    try:
+        n = processar_renovacoes(db, limit=50)
+        db.commit()
+    finally:
+        db.close()
+    assert n >= 2
+
+    assert client.get(f"/v1/saas/clientes/{vencido}", headers=h).json()["status"] == "suspenso"
+    assert client.get(f"/v1/saas/clientes/{risco}", headers=h).json()["status"] == "ativo"
+
+    # Segunda passagem não reemite (dedup)
+    db = SessionLocal()
+    try:
+        n2 = processar_renovacoes(db, limit=50)
+        db.commit()
+    finally:
+        db.close()
+    assert n2 == 0

--- a/docs/SAAS_CONTROL_PLANE.md
+++ b/docs/SAAS_CONTROL_PLANE.md
@@ -1,0 +1,70 @@
+# Control-plane SaaS DeskRudder
+
+Instância comercial (`deskrudder.com.br`): registo de licenças, trial, provisionamento e alertas de renovação.
+
+**Não** confundir com módulos do produto na instância do cliente (CM/FN, `/kb`, portal).
+
+## Ativar
+
+```bash
+# backend/.env (instância comercial)
+SAAS_CONTROL_PLANE=true
+SAAS_NOTIFY_EMAIL=comercial@deskrudder.com.br
+SAAS_TRIAL_DAYS=14
+SAAS_RENEWAL_ALERT_DAYS_BEFORE=14
+SAAS_PROVISION_BASE_DOMAIN=deskrudder.com.br
+SAAS_PROVISION_API_PORT_START=8001
+# Só no host de deploy com Docker/scripts:
+# SAAS_PROVISION_EXEC_ENABLED=true
+# SAAS_REPO_ROOT=/caminho/do/repo
+
+# frontend
+VITE_SAAS_CONTROL_PLANE=true
+```
+
+Em instâncias de clientes: deixar `SAAS_CONTROL_PLANE=false` (padrão).
+
+## Painel
+
+- UI: `/saas/licencas` (admin)
+- Menu: **SaaS DeskRudder → Licenças**
+- Landing: atalho «Painel de licenças» e formulário de trial em `/trial`
+
+## API
+
+| Método | Rota | Quem |
+|--------|------|------|
+| CRUD + ações | `/v1/saas/clientes` | admin + control-plane |
+| Trial | `POST /v1/saas/public/trial` | público (rate limit) |
+
+Ações: `suspender`, `reativar`, `renovar`, `registrar-instancia`, `solicitar-provisionamento`.
+
+## Provisionamento (DR-04)
+
+1. Admin clica **Solicitar provisionamento** (ou trial com a opção ligada).
+2. Cliente fica com `provisionamento_status=pendente` e `api_port` alocada.
+3. Worker `saas-provisionamento`:
+   - Se `SAAS_PROVISION_EXEC_ENABLED=false` (padrão): mantém na fila, grava URL esperada `https://{slug}.{SAAS_PROVISION_BASE_DOMAIN}` e notifica a equipa — ops corre os scripts manualmente.
+   - Se `true`: executa `deploy/scripts/provision-client.sh` + `stack-client.sh migrate|up|health` no host (`SAAS_REPO_ROOT`).
+
+Pré-requisitos do host: Docker, scripts em `deploy/scripts/`, permissões, DNS/Nginx conforme `deploy/clients/README.md` e skill `deploy-cliente`.
+
+**Não** altera o modelo single-tenant (1 Postgres por cliente).
+
+## Trial (DR-07)
+
+Formulário público cria `ClienteSaaS` com `status=trial`, `data_renovacao = hoje + SAAS_TRIAL_DAYS`, e notifica `SAAS_NOTIFY_EMAIL` (se Resend estiver configurado).
+
+## Renovações (DR-08)
+
+Worker `saas-renovacoes` (intervalo `SAAS_RENEWAL_WORKER_INTERVAL_SECONDS`):
+
+- Dentro da janela `SAAS_RENEWAL_ALERT_DAYS_BEFORE`: e-mail à equipa (dedup por data de renovação).
+- Vencido (`data_renovacao < hoje`) em `trial`/`ativo`: passa a `suspenso` + e-mail.
+- UI: destaque «vence em X dias» / vencidas; ação **Renovar** no detalhe.
+
+## Referências
+
+- Épico: `#519`
+- Issues: DR-01…DR-08 em `.github/planning-issue-bodies/`
+- Deploy por cliente: `docs/DEPLOYMENT_ARCHITECTURE.md`, `deploy/clients/README.md`

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -9,6 +9,10 @@
 # Landing comercial (mailto do CTA «Fale conosco» — #515 / #516)
 # VITE_LANDING_CONTACT_EMAIL=contato@deskrudder.com.br
 
+# Control-plane SaaS (só na instância comercial deskrudder.com.br):
+# mostra atalho «Painel de licenças» na landing. Combinar com SAAS_CONTROL_PLANE=true no backend.
+# VITE_SAAS_CONTROL_PLANE=true
+
 # Single-tenant (produção por cliente): padrão — não envia X-Dx-Tenant-Id
 # VITE_DEFAULT_TENANT_ID=1
 # VITE_CLIENT_APP_HOST=duplexsoft.connect.duplexsoft.com.br

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { EsqueciSenha } from './pages/EsqueciSenha'
 import { RedefinirSenha } from './pages/RedefinirSenha'
 import { AvaliarTicket } from './pages/AvaliarTicket'
 import { LandingPage } from './pages/marketing/LandingPage'
+import { TrialPage } from './pages/marketing/TrialPage'
 import { Dashboard } from './pages/Dashboard'
 import { DashboardTickets } from './pages/DashboardTickets'
 import { DashboardChats } from './pages/DashboardChats'
@@ -147,6 +148,7 @@ function AppRoutes() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
+      <Route path="/trial" element={<TrialPage />} />
       <Route path="/esqueci-senha" element={<EsqueciSenha />} />
       <Route path="/redefinir-senha" element={<RedefinirSenha />} />
       <Route path="/avaliar-ticket" element={<AvaliarTicket />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,6 +72,9 @@ import { AlterarSenha } from './pages/AlterarSenha'
 import { NotificacoesPreferencias } from './pages/NotificacoesPreferencias'
 import { Sobre } from './pages/Sobre'
 import { AcessoNegado } from './pages/AcessoNegado'
+import { SaasLicencas } from './pages/saas/SaasLicencas'
+import { SaasLicencaForm } from './pages/saas/SaasLicencaForm'
+import { SaasLicencaDetalhe } from './pages/saas/SaasLicencaDetalhe'
 import { KbPublicLayout } from './pages/kb-public/KbPublicLayout'
 import { KbPublicHome } from './pages/kb-public/KbPublicHome'
 import { KbPublicArtigo } from './pages/kb-public/KbPublicArtigo'
@@ -237,6 +240,38 @@ function AppRoutes() {
         />
         <Route path="notificacoes/preferencias" element={<NotificacoesPreferencias />} />
         <Route path="sobre" element={<Sobre />} />
+        <Route
+          path="saas/licencas/novo"
+          element={
+            <AdminRoute>
+              <SaasLicencaForm />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="saas/licencas/:id/editar"
+          element={
+            <AdminRoute>
+              <SaasLicencaForm />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="saas/licencas/:id"
+          element={
+            <AdminRoute>
+              <SaasLicencaDetalhe />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="saas/licencas"
+          element={
+            <AdminRoute>
+              <SaasLicencas />
+            </AdminRoute>
+          }
+        />
         <Route path="tickets" element={<Tickets />} />
         <Route path="tickets/novo" element={<TicketNovo />} />
         <Route path="tickets/:id" element={<TicketDetalhe />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3439,6 +3439,7 @@ export namespace System {
     version_display: string | null;
     git_sha: string | null;
     environment: string;
+    saas_control_plane?: boolean;
   }
   export interface ReleaseChange {
     category: string;
@@ -3464,3 +3465,59 @@ export const system = {
   info: () => api<System.Info>('/system/info'),
   releaseNotes: () => api<System.ReleaseNotes>('/system/release-notes'),
 };
+
+export const saasClientes = {
+  list: (params?: {
+    busca?: string;
+    status?: string;
+    ordenar_por?: 'nome' | 'slug' | 'status' | 'data_renovacao';
+    ordem?: 'asc' | 'desc';
+    offset?: number;
+    limit?: number;
+  }) => listPaginated<SaasClientes.Cliente>('/saas/clientes', params),
+  get: (id: number) => api<SaasClientes.Cliente>(`/saas/clientes/${id}`),
+  create: (data: SaasClientes.Create) =>
+    api<SaasClientes.Cliente>('/saas/clientes', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id: number, data: SaasClientes.Update) =>
+    api<SaasClientes.Cliente>(`/saas/clientes/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  suspender: (id: number) =>
+    api<SaasClientes.Cliente>(`/saas/clientes/${id}/suspender`, { method: 'POST' }),
+  reativar: (id: number) =>
+    api<SaasClientes.Cliente>(`/saas/clientes/${id}/reativar`, { method: 'POST' }),
+  registrarInstancia: (id: number, data: { instancia_url: string }) =>
+    api<SaasClientes.Cliente>(`/saas/clientes/${id}/registrar-instancia`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  solicitarProvisionamento: (id: number) =>
+    api<SaasClientes.Cliente>(`/saas/clientes/${id}/solicitar-provisionamento`, { method: 'POST' }),
+};
+
+export namespace SaasClientes {
+  export type Status = 'trial' | 'ativo' | 'suspenso' | 'churn';
+  export interface Cliente {
+    id: number;
+    nome: string;
+    slug: string;
+    status: Status;
+    plano?: string | null;
+    data_inicio: string;
+    data_renovacao?: string | null;
+    instancia_url?: string | null;
+    provisionamento_solicitado: boolean;
+    notas?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+  }
+  export interface Create {
+    nome: string;
+    slug: string;
+    status?: Status;
+    plano?: string | null;
+    data_inicio: string;
+    data_renovacao?: string | null;
+    instancia_url?: string | null;
+    notas?: string | null;
+  }
+  export type Update = Partial<Create>;
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3484,6 +3484,11 @@ export const saasClientes = {
     api<SaasClientes.Cliente>(`/saas/clientes/${id}/suspender`, { method: 'POST' }),
   reativar: (id: number) =>
     api<SaasClientes.Cliente>(`/saas/clientes/${id}/reativar`, { method: 'POST' }),
+  renovar: (id: number, data?: { dias?: number; nova_data?: string }) =>
+    api<SaasClientes.Cliente>(`/saas/clientes/${id}/renovar`, {
+      method: 'POST',
+      body: JSON.stringify(data ?? { dias: 30 }),
+    }),
   registrarInstancia: (id: number, data: { instancia_url: string }) =>
     api<SaasClientes.Cliente>(`/saas/clientes/${id}/registrar-instancia`, {
       method: 'POST',
@@ -3493,8 +3498,36 @@ export const saasClientes = {
     api<SaasClientes.Cliente>(`/saas/clientes/${id}/solicitar-provisionamento`, { method: 'POST' }),
 };
 
+export const saasPublic = {
+  trial: (data: SaasPublic.TrialCreate) =>
+    publicApi<SaasPublic.TrialRead>('/saas/public/trial', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+};
+
+export namespace SaasPublic {
+  export interface TrialCreate {
+    empresa: string;
+    slug: string;
+    contato_nome: string;
+    contato_email: string;
+    notas?: string | null;
+    solicitar_provisionamento?: boolean;
+  }
+  export interface TrialRead {
+    id: number;
+    nome: string;
+    slug: string;
+    status: string;
+    data_renovacao?: string | null;
+    mensagem: string;
+  }
+}
+
 export namespace SaasClientes {
   export type Status = 'trial' | 'ativo' | 'suspenso' | 'churn';
+  export type ProvisionamentoStatus = 'pendente' | 'em_progresso' | 'aguardando_ops' | 'sucesso' | 'falha';
   export interface Cliente {
     id: number;
     nome: string;
@@ -3504,7 +3537,14 @@ export namespace SaasClientes {
     data_inicio: string;
     data_renovacao?: string | null;
     instancia_url?: string | null;
+    contato_email?: string | null;
+    contato_nome?: string | null;
+    api_port?: number | null;
     provisionamento_solicitado: boolean;
+    provisionamento_status?: ProvisionamentoStatus | null;
+    provisionamento_mensagem?: string | null;
+    provisionamento_atualizado_em?: string | null;
+    dias_para_renovacao?: number | null;
     notas?: string | null;
     created_at?: string | null;
     updated_at?: string | null;
@@ -3517,6 +3557,8 @@ export namespace SaasClientes {
     data_inicio: string;
     data_renovacao?: string | null;
     instancia_url?: string | null;
+    contato_email?: string | null;
+    contato_nome?: string | null;
     notas?: string | null;
   }
   export type Update = Partial<Create>;

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -71,6 +71,16 @@ const icons: Record<string, React.ReactNode> = {
       />
     </svg>
   ),
+  saas: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z"
+      />
+    </svg>
+  ),
   tiposNegocio: (
     <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
       <path
@@ -204,6 +214,8 @@ interface NavLink {
   label: string
   icon: string
   adminOnly?: boolean
+  /** Só na instância comercial (control-plane SaaS). */
+  saasOnly?: boolean
 }
 
 interface NavGroup {
@@ -212,6 +224,7 @@ interface NavGroup {
   label: string
   icon: string
   adminOnly?: boolean
+  saasOnly?: boolean
   /** Ex.: conversa aberta `/whatsapp/c/:id` mantém o grupo Chat ativo */
   extraActivePrefixes?: string[]
   children: NavLink[]
@@ -225,6 +238,7 @@ interface NavItemLink {
   /** Mantém o item ativo em rotas filhas (ex.: `/chat/c/:id`) */
   activePrefix?: string
   adminOnly?: boolean
+  saasOnly?: boolean
 }
 
 type NavItem = NavItemLink | NavGroup
@@ -252,6 +266,16 @@ const navStructure: NavItem[] = [
       { to: '/empresas', label: 'Empresas', icon: 'empresas' },
       { to: '/funcionarios-rede', label: 'Funcionários da rede', icon: 'funcionarios' },
     ],
+  },
+  {
+    type: 'group',
+    id: 'saas',
+    label: 'SaaS DeskRudder',
+    icon: 'saas',
+    adminOnly: true,
+    saasOnly: true,
+    extraActivePrefixes: ['/saas/'],
+    children: [{ to: '/saas/licencas', label: 'Licenças', icon: 'saas' }],
   },
   {
     type: 'group',
@@ -297,8 +321,12 @@ function navGroupMatchesPath(pathname: string, group: NavGroup): boolean {
   return group.extraActivePrefixes?.some((prefix) => pathname.startsWith(prefix)) ?? false
 }
 
-function navChildrenVisible(children: NavLink[], isAdmin: boolean): NavLink[] {
-  return children.filter((child) => !child.adminOnly || isAdmin)
+function navChildrenVisible(children: NavLink[], isAdmin: boolean, saasEnabled: boolean): NavLink[] {
+  return children.filter((child) => {
+    if (child.adminOnly && !isAdmin) return false
+    if (child.saasOnly && !saasEnabled) return false
+    return true
+  })
 }
 
 interface SidebarProps {
@@ -332,13 +360,16 @@ export function Sidebar({
       (import.meta.env.VITE_APP_VERSION as string | undefined)?.trim()
     return fromEnv ? (fromEnv.startsWith('v') ? fromEnv : `v${fromEnv}`) : null
   })
+  const [saasEnabled, setSaasEnabled] = useState(false)
 
   useEffect(() => {
     let cancelled = false
     system
       .info()
       .then((info) => {
-        if (!cancelled && info.version_display) setVersionLabel(info.version_display)
+        if (cancelled) return
+        if (info.version_display) setVersionLabel(info.version_display)
+        setSaasEnabled(Boolean(info.saas_control_plane))
       })
       .catch(() => {
         /* fallback: env ou oculto */
@@ -367,6 +398,7 @@ export function Sidebar({
 
   const items = navStructure.filter((item) => {
     if ('adminOnly' in item && item.adminOnly && !isAdmin) return false
+    if ('saasOnly' in item && item.saasOnly && !saasEnabled) return false
     return true
   }) as NavItem[]
 
@@ -374,7 +406,7 @@ export function Sidebar({
   useEffect(() => {
     for (const item of navStructure) {
       if (item.type === 'group') {
-        if (!item.adminOnly || isAdmin) {
+        if ((!item.adminOnly || isAdmin) && (!item.saasOnly || saasEnabled)) {
           if (navGroupMatchesPath(location.pathname, item)) {
             setOpenGroup(item.id)
             return
@@ -382,7 +414,7 @@ export function Sidebar({
         }
       }
     }
-  }, [location.pathname, isAdmin])
+  }, [location.pathname, isAdmin, saasEnabled])
 
   // No drawer mobile usamos acordeão (não flyout); evita estado do flyout “preso”
   useEffect(() => {
@@ -438,7 +470,7 @@ export function Sidebar({
               }}
               role="menu"
             >
-              {navChildrenVisible(openFlyoutGroup.children, isAdmin).map((child) => (
+              {navChildrenVisible(openFlyoutGroup.children, isAdmin, saasEnabled).map((child) => (
                 <li key={child.to} role="none">
                   <Link
                     to={child.to}
@@ -543,7 +575,7 @@ export function Sidebar({
                       className={`min-w-0 overflow-hidden transition-all duration-200 ${open ? 'max-h-[500px] opacity-100' : 'max-h-0 opacity-0'}`}
                       role="group"
                     >
-                      {navChildrenVisible(group.children, isAdmin).map((child) => (
+                      {navChildrenVisible(group.children, isAdmin, saasEnabled).map((child) => (
                         <li key={child.to} className="min-w-0 pl-4">
                           <Link
                             to={child.to}

--- a/frontend/src/lib/saasControlPlane.ts
+++ b/frontend/src/lib/saasControlPlane.ts
@@ -19,6 +19,30 @@ export function labelStatusClienteSaaS(status: string): string {
   return STATUS_CLIENTE_SAAS.find((s) => s.value === status)?.label ?? status
 }
 
+export function labelProvisionamento(status: string | null | undefined): string {
+  switch (status) {
+    case 'pendente':
+      return 'Pendente'
+    case 'em_progresso':
+      return 'Em progresso'
+    case 'aguardando_ops':
+      return 'Aguardando ops'
+    case 'sucesso':
+      return 'Sucesso'
+    case 'falha':
+      return 'Falha'
+    default:
+      return '—'
+  }
+}
+
+export function renovacaoAlerta(dias: number | null | undefined): 'ok' | 'risco' | 'vencido' | null {
+  if (dias == null) return null
+  if (dias < 0) return 'vencido'
+  if (dias <= 14) return 'risco'
+  return 'ok'
+}
+
 export function badgeClassStatusClienteSaaS(status: string): string {
   switch (status) {
     case 'ativo':

--- a/frontend/src/lib/saasControlPlane.ts
+++ b/frontend/src/lib/saasControlPlane.ts
@@ -1,0 +1,43 @@
+/** Flag Vite para atalhos públicos (landing) do control-plane SaaS. */
+export function isSaasControlPlaneFrontend(): boolean {
+  const raw = (import.meta.env.VITE_SAAS_CONTROL_PLANE as string | undefined)?.trim().toLowerCase()
+  return raw === '1' || raw === 'true' || raw === 'yes'
+}
+
+export const SAAS_LICENCAS_PATH = '/saas/licencas'
+
+export const STATUS_CLIENTE_SAAS = [
+  { value: 'trial', label: 'Trial' },
+  { value: 'ativo', label: 'Ativo' },
+  { value: 'suspenso', label: 'Suspenso' },
+  { value: 'churn', label: 'Churn' },
+] as const
+
+export type StatusClienteSaaS = (typeof STATUS_CLIENTE_SAAS)[number]['value']
+
+export function labelStatusClienteSaaS(status: string): string {
+  return STATUS_CLIENTE_SAAS.find((s) => s.value === status)?.label ?? status
+}
+
+export function badgeClassStatusClienteSaaS(status: string): string {
+  switch (status) {
+    case 'ativo':
+      return 'bg-emerald-50 text-emerald-800 ring-1 ring-emerald-600/15 dark:bg-emerald-950/40 dark:text-emerald-300 dark:ring-emerald-600/30'
+    case 'trial':
+      return 'bg-sky-50 text-sky-800 ring-1 ring-sky-600/15 dark:bg-sky-950/40 dark:text-sky-300 dark:ring-sky-600/30'
+    case 'suspenso':
+      return 'bg-amber-50 text-amber-900 ring-1 ring-amber-600/20 dark:bg-amber-950/40 dark:text-amber-200 dark:ring-amber-600/30'
+    case 'churn':
+      return 'bg-slate-100 text-slate-600 ring-1 ring-slate-300/60 dark:bg-slate-800 dark:text-slate-400 dark:ring-slate-600/40'
+    default:
+      return 'bg-slate-100 text-slate-600 ring-1 ring-slate-300/60 dark:bg-slate-800 dark:text-slate-400'
+  }
+}
+
+/** Normaliza URL para abrir em nova aba. */
+export function hrefInstanciaCliente(url: string | null | undefined): string | null {
+  const raw = (url || '').trim()
+  if (!raw) return null
+  if (/^https?:\/\//i.test(raw)) return raw
+  return `https://${raw}`
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
@@ -43,6 +43,18 @@ export function Login() {
   const { login } = useAuth()
   const { showError, showSuccess } = useToast()
   const navigate = useNavigate()
+  const location = useLocation()
+  const [searchParams] = useSearchParams()
+
+  function destinoAposLogin(): string {
+    const next = (searchParams.get('next') || '').trim()
+    if (next.startsWith('/') && !next.startsWith('//')) return next
+    const from = (location.state as { from?: { pathname?: string; search?: string } } | null)?.from
+    if (from?.pathname && from.pathname !== '/login') {
+      return `${from.pathname}${from.search || ''}`
+    }
+    return '/'
+  }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -68,7 +80,7 @@ export function Login() {
         /* storage indisponível */
       }
       showSuccess('Login realizado com sucesso. Redirecionando...')
-      navigate('/', { replace: true })
+      navigate(destinoAposLogin(), { replace: true })
     } catch (err) {
       showError(mensagemFalhaParaToast(err, 'Falha no login. Verifique suas credenciais e tente novamente.'))
     } finally {

--- a/frontend/src/pages/marketing/LandingPage.tsx
+++ b/frontend/src/pages/marketing/LandingPage.tsx
@@ -144,12 +144,20 @@ export function LandingPage() {
               {landingHero.ctaSecondary}
             </Link>
             {isSaasControlPlaneFrontend() ? (
-              <Link
-                to={`/login?next=${encodeURIComponent(SAAS_LICENCAS_PATH)}`}
-                className="rounded-full border border-sky-400/35 bg-sky-400/10 px-3 py-2 text-sm font-semibold text-sky-100 transition hover:border-sky-300/50 hover:bg-sky-400/20"
-              >
-                Painel de licenças
-              </Link>
+              <>
+                <Link
+                  to="/trial"
+                  className="rounded-full px-3 py-2 text-sm font-semibold text-cyan-200 transition hover:bg-white/5 hover:text-cyan-100"
+                >
+                  Pedir trial
+                </Link>
+                <Link
+                  to={`/login?next=${encodeURIComponent(SAAS_LICENCAS_PATH)}`}
+                  className="rounded-full border border-sky-400/35 bg-sky-400/10 px-3 py-2 text-sm font-semibold text-sky-100 transition hover:border-sky-300/50 hover:bg-sky-400/20"
+                >
+                  Painel de licenças
+                </Link>
+              </>
             ) : null}
             <LandingContactSlot
               variant="hero"

--- a/frontend/src/pages/marketing/LandingPage.tsx
+++ b/frontend/src/pages/marketing/LandingPage.tsx
@@ -18,6 +18,7 @@ import {
   landingShowcases,
   landingShots,
 } from '../../content/landing'
+import { isSaasControlPlaneFrontend, SAAS_LICENCAS_PATH } from '../../lib/saasControlPlane'
 import { MarketingLayout } from './MarketingLayout'
 
 function SecondaryLink({ to, children }: { to: string; children: ReactNode }) {
@@ -142,6 +143,14 @@ export function LandingPage() {
             >
               {landingHero.ctaSecondary}
             </Link>
+            {isSaasControlPlaneFrontend() ? (
+              <Link
+                to={`/login?next=${encodeURIComponent(SAAS_LICENCAS_PATH)}`}
+                className="rounded-full border border-sky-400/35 bg-sky-400/10 px-3 py-2 text-sm font-semibold text-sky-100 transition hover:border-sky-300/50 hover:bg-sky-400/20"
+              >
+                Painel de licenças
+              </Link>
+            ) : null}
             <LandingContactSlot
               variant="hero"
               label="Ver demonstração"

--- a/frontend/src/pages/marketing/TrialPage.tsx
+++ b/frontend/src/pages/marketing/TrialPage.tsx
@@ -1,0 +1,157 @@
+import { useState, type FormEvent } from 'react'
+import { Link } from 'react-router-dom'
+import { BrandLogo } from '../../brand'
+import { saasPublic } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { isSaasControlPlaneFrontend } from '../../lib/saasControlPlane'
+import { MarketingLayout } from './MarketingLayout'
+
+export function TrialPage() {
+  const enabled = isSaasControlPlaneFrontend()
+  const [empresa, setEmpresa] = useState('')
+  const [slug, setSlug] = useState('')
+  const [contatoNome, setContatoNome] = useState('')
+  const [contatoEmail, setContatoEmail] = useState('')
+  const [notas, setNotas] = useState('')
+  const [solicitarProv, setSolicitarProv] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [erro, setErro] = useState<string | null>(null)
+  const [okMsg, setOkMsg] = useState<string | null>(null)
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault()
+    setErro(null)
+    setOkMsg(null)
+    setSaving(true)
+    try {
+      const res = await saasPublic.trial({
+        empresa: empresa.trim(),
+        slug: slug.trim().toLowerCase(),
+        contato_nome: contatoNome.trim(),
+        contato_email: contatoEmail.trim(),
+        notas: notas.trim() || null,
+        solicitar_provisionamento: solicitarProv,
+      })
+      setOkMsg(res.mensagem)
+      setEmpresa('')
+      setSlug('')
+      setContatoNome('')
+      setContatoEmail('')
+      setNotas('')
+      setSolicitarProv(false)
+    } catch (err) {
+      setErro(mensagemFalhaParaToast(err, 'Não foi possível enviar o pedido de trial.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <MarketingLayout>
+      <header className="border-b border-white/5 bg-[#071826]/85 backdrop-blur-xl">
+        <div className="mx-auto flex w-full max-w-3xl items-center justify-between gap-4 px-5 py-4 sm:px-8">
+          <Link to="/">
+            <BrandLogo variant="full" size="md" markVariant="onDark" />
+          </Link>
+          <Link to="/" className="text-sm font-medium text-sky-300 hover:text-sky-200">
+            Voltar à landing
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-3xl px-5 py-12 sm:px-8">
+        <h1 className="text-3xl font-bold tracking-tight text-white">Pedir trial DeskRudder</h1>
+        <p className="mt-3 text-slate-300">
+          Preencha os dados da sua empresa de suporte. A equipa DeskRudder analisa o pedido e entra em
+          contacto.
+        </p>
+
+        {!enabled ? (
+          <p className="mt-8 rounded-2xl border border-amber-400/30 bg-amber-400/10 px-4 py-3 text-sm text-amber-100">
+            O formulário de trial só está ativo na instância comercial DeskRudder.
+          </p>
+        ) : (
+          <form onSubmit={onSubmit} className="mt-8 space-y-5 rounded-2xl border border-white/10 bg-white/5 p-6">
+            {erro ? (
+              <p className="rounded-xl border border-red-400/30 bg-red-500/10 px-3 py-2 text-sm text-red-100">
+                {erro}
+              </p>
+            ) : null}
+            {okMsg ? (
+              <p className="rounded-xl border border-emerald-400/30 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-100">
+                {okMsg}
+              </p>
+            ) : null}
+
+            <label className="block space-y-1.5">
+              <span className="text-sm font-medium text-slate-200">Empresa</span>
+              <input
+                required
+                value={empresa}
+                onChange={(e) => setEmpresa(e.target.value)}
+                className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2.5 text-sm text-white placeholder:text-slate-500 focus:border-sky-400/50 focus:outline-none focus:ring-2 focus:ring-sky-400/25"
+              />
+            </label>
+            <label className="block space-y-1.5">
+              <span className="text-sm font-medium text-slate-200">Slug desejado</span>
+              <input
+                required
+                value={slug}
+                onChange={(e) => setSlug(e.target.value)}
+                placeholder="ex.: minha-empresa"
+                className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2.5 font-mono text-sm text-white placeholder:text-slate-500 focus:border-sky-400/50 focus:outline-none focus:ring-2 focus:ring-sky-400/25"
+              />
+              <span className="text-xs text-slate-400">Letras minúsculas, números e hífens.</span>
+            </label>
+            <div className="grid gap-5 sm:grid-cols-2">
+              <label className="block space-y-1.5">
+                <span className="text-sm font-medium text-slate-200">O seu nome</span>
+                <input
+                  required
+                  value={contatoNome}
+                  onChange={(e) => setContatoNome(e.target.value)}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2.5 text-sm text-white focus:border-sky-400/50 focus:outline-none focus:ring-2 focus:ring-sky-400/25"
+                />
+              </label>
+              <label className="block space-y-1.5">
+                <span className="text-sm font-medium text-slate-200">E-mail</span>
+                <input
+                  required
+                  type="email"
+                  value={contatoEmail}
+                  onChange={(e) => setContatoEmail(e.target.value)}
+                  className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2.5 text-sm text-white focus:border-sky-400/50 focus:outline-none focus:ring-2 focus:ring-sky-400/25"
+                />
+              </label>
+            </div>
+            <label className="block space-y-1.5">
+              <span className="text-sm font-medium text-slate-200">Notas (opcional)</span>
+              <textarea
+                rows={3}
+                value={notas}
+                onChange={(e) => setNotas(e.target.value)}
+                className="w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2.5 text-sm text-white focus:border-sky-400/50 focus:outline-none focus:ring-2 focus:ring-sky-400/25"
+              />
+            </label>
+            <label className="flex items-center gap-2 text-sm text-slate-300">
+              <input
+                type="checkbox"
+                checked={solicitarProv}
+                onChange={(e) => setSolicitarProv(e.target.checked)}
+                className="rounded border-white/20"
+              />
+              Solicitar provisionamento da instância (fila para a equipa)
+            </label>
+            <button
+              type="submit"
+              disabled={saving}
+              className="inline-flex items-center justify-center rounded-2xl bg-gradient-to-r from-sky-500 via-sky-400 to-cyan-400 px-6 py-3 text-sm font-semibold text-white shadow-lg disabled:opacity-60"
+            >
+              {saving ? 'A enviar…' : 'Enviar pedido de trial'}
+            </button>
+          </form>
+        )}
+      </main>
+    </MarketingLayout>
+  )
+}

--- a/frontend/src/pages/saas/SaasLicencaDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasLicencaDetalhe.tsx
@@ -12,7 +12,9 @@ import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/
 import {
   badgeClassStatusClienteSaaS,
   hrefInstanciaCliente,
+  labelProvisionamento,
   labelStatusClienteSaaS,
+  renovacaoAlerta,
 } from '../../lib/saasControlPlane'
 
 function formatDate(iso: string | null | undefined): string {
@@ -154,6 +156,13 @@ export function SaasLicencaDetalhe() {
           <Button variant="secondary" disabled={acting} onClick={() => navigate(`/saas/licencas/${item.id}/editar`)}>
             Editar
           </Button>
+          <Button
+            variant="secondary"
+            disabled={acting}
+            onClick={() => runAction(() => saasClientes.renovar(item.id, { dias: 30 }), 'Licença renovada por 30 dias.')}
+          >
+            Renovar (+30 dias)
+          </Button>
           {item.status !== 'suspenso' ? (
             <Button
               variant="secondary"
@@ -171,35 +180,63 @@ export function SaasLicencaDetalhe() {
               Reativar
             </Button>
           )}
-          {!item.provisionamento_solicitado ? (
+          {item.provisionamento_status !== 'sucesso' && item.provisionamento_status !== 'em_progresso' ? (
             <Button
               variant="secondary"
               disabled={acting}
               onClick={() =>
                 runAction(
                   () => saasClientes.solicitarProvisionamento(item.id),
-                  'Provisionamento solicitado (fila manual).',
+                  'Provisionamento enfileirado.',
                 )
               }
             >
-              Solicitar provisionamento
+              {item.provisionamento_solicitado ? 'Reenviar à fila' : 'Solicitar provisionamento'}
             </Button>
           ) : null}
         </div>
       </header>
+
+      {(() => {
+        const alerta = renovacaoAlerta(item.dias_para_renovacao)
+        if (!alerta || alerta === 'ok') return null
+        return (
+          <div
+            className={`rounded-2xl border px-4 py-3 text-sm ${
+              alerta === 'vencido'
+                ? 'border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-700/50 dark:bg-amber-950/40 dark:text-amber-100'
+                : 'border-sky-300 bg-sky-50 text-sky-900 dark:border-sky-700/50 dark:bg-sky-950/40 dark:text-sky-100'
+            }`}
+          >
+            {alerta === 'vencido'
+              ? `Licença vencida há ${Math.abs(item.dias_para_renovacao ?? 0)} dia(s). Renove ou mantenha suspensa.`
+              : `Renovação em ${item.dias_para_renovacao} dia(s) (${formatDate(item.data_renovacao)}).`}
+          </div>
+        )
+      })()}
 
       <Card title="Dados da licença">
         <dl>
           <DetailRow label="ID" value={String(item.id)} mono />
           <DetailRow label="Slug" value={item.slug} mono />
           <DetailRow label="Plano" value={item.plano || '—'} />
+          <DetailRow label="Contacto" value={item.contato_nome || '—'} />
+          <DetailRow label="E-mail" value={item.contato_email || '—'} />
           <DetailRow label="Início" value={formatDate(item.data_inicio)} />
-          <DetailRow label="Renovação" value={formatDate(item.data_renovacao)} />
-          <DetailRow label="Instância" value={item.instancia_url || '—'} />
           <DetailRow
-            label="Provisionamento"
-            value={item.provisionamento_solicitado ? 'Solicitado' : 'Não solicitado'}
+            label="Renovação"
+            value={
+              item.data_renovacao
+                ? `${formatDate(item.data_renovacao)}${
+                    item.dias_para_renovacao != null ? ` (${item.dias_para_renovacao} dia(s))` : ''
+                  }`
+                : '—'
+            }
           />
+          <DetailRow label="Instância" value={item.instancia_url || '—'} />
+          <DetailRow label="Porta API" value={item.api_port != null ? String(item.api_port) : '—'} mono />
+          <DetailRow label="Provisionamento" value={labelProvisionamento(item.provisionamento_status)} />
+          <DetailRow label="Detalhe da fila" value={item.provisionamento_mensagem || '—'} />
           <DetailRow label="Notas" value={item.notas || '—'} />
         </dl>
       </Card>

--- a/frontend/src/pages/saas/SaasLicencaDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasLicencaDetalhe.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ApiError, saasClientes } from '../../api/client'
+import { Card } from '../../components/ui/Card'
+import { Button } from '../../components/ui/Button'
+import { DetailRow } from '../../components/ui/DetailRow'
+import { useToast } from '../../components/ui/Toast'
+import { useVoltarAnterior } from '../../hooks/useVoltarAnterior'
+import { SemPermissao } from '../SemPermissao'
+import { CarregamentoFalhou } from '../../components/ui/CarregamentoFalhou'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/errorMessage'
+import {
+  badgeClassStatusClienteSaaS,
+  hrefInstanciaCliente,
+  labelStatusClienteSaaS,
+} from '../../lib/saasControlPlane'
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const d = iso.slice(0, 10)
+  const [y, m, day] = d.split('-')
+  if (!y || !m || !day) return iso
+  return `${day}/${m}/${y}`
+}
+
+export function SaasLicencaDetalhe() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const voltarAnterior = useVoltarAnterior('/saas/licencas')
+  const clienteId = id ? parseInt(id, 10) : NaN
+
+  const [loading, setLoading] = useState(true)
+  const [acting, setActing] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [indisponivel, setIndisponivel] = useState(false)
+  const [falha, setFalha] = useState<{ titulo: string; detalhe?: string } | null>(null)
+  const [item, setItem] = useState<Awaited<ReturnType<typeof saasClientes.get>> | null>(null)
+
+  function carregar() {
+    if (!id || Number.isNaN(clienteId)) {
+      setFalha({ titulo: 'Licença não encontrada.', detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setForbidden(false)
+    setIndisponivel(false)
+    setFalha(null)
+    saasClientes
+      .get(clienteId)
+      .then((c) => setItem(c))
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          const detail =
+            typeof err.body === 'object' && err.body && 'detail' in err.body
+              ? String((err.body as { detail?: unknown }).detail ?? '')
+              : ''
+          if (detail.toLowerCase().includes('não disponível')) {
+            setIndisponivel(true)
+          } else {
+            setFalha(interpretarFalhaCarregamento(err, 'Licença não encontrada.'))
+          }
+          return
+        }
+        setFalha(interpretarFalhaCarregamento(err, 'Licença não encontrada.'))
+      })
+      .finally(() => setLoading(false))
+  }
+
+  useEffect(() => {
+    carregar()
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- recarrega só quando muda o id
+  }, [id, clienteId])
+
+  async function runAction(
+    action: () => Promise<Awaited<ReturnType<typeof saasClientes.get>>>,
+    okMsg: string,
+  ) {
+    setActing(true)
+    try {
+      const updated = await action()
+      setItem(updated)
+      toast.showSuccess(okMsg)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível concluir a ação.'))
+    } finally {
+      setActing(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+        <div className="h-40 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </div>
+    )
+  }
+
+  if (indisponivel) {
+    return (
+      <SemPermissao
+        title="Painel de licenças não disponível nesta instância."
+        voltarPara="/"
+        voltarLabel="Voltar para o Dashboard"
+      />
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para acessar esta licença."
+        voltarPara="/saas/licencas"
+        voltarLabel="Voltar para Licenças"
+      />
+    )
+  }
+
+  if (falha) {
+    return <CarregamentoFalhou titulo={falha.titulo} detalhe={falha.detalhe} onVoltar={voltarAnterior} />
+  }
+
+  if (!item) return null
+
+  const href = hrefInstanciaCliente(item.instancia_url)
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <button
+        type="button"
+        onClick={voltarAnterior}
+        className="inline-flex items-center gap-1 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100"
+      >
+        <span aria-hidden>←</span> Voltar
+      </button>
+
+      <header className="flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 space-y-2">
+          <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">
+            {item.nome}
+          </h1>
+          <span
+            className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${badgeClassStatusClienteSaaS(item.status)}`}
+          >
+            {labelStatusClienteSaaS(item.status)}
+          </span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="secondary" disabled={acting} onClick={() => navigate(`/saas/licencas/${item.id}/editar`)}>
+            Editar
+          </Button>
+          {item.status !== 'suspenso' ? (
+            <Button
+              variant="secondary"
+              disabled={acting}
+              onClick={() => runAction(() => saasClientes.suspender(item.id), 'Cliente suspenso.')}
+            >
+              Suspender
+            </Button>
+          ) : (
+            <Button
+              variant="secondary"
+              disabled={acting}
+              onClick={() => runAction(() => saasClientes.reativar(item.id), 'Cliente reativado.')}
+            >
+              Reativar
+            </Button>
+          )}
+          {!item.provisionamento_solicitado ? (
+            <Button
+              variant="secondary"
+              disabled={acting}
+              onClick={() =>
+                runAction(
+                  () => saasClientes.solicitarProvisionamento(item.id),
+                  'Provisionamento solicitado (fila manual).',
+                )
+              }
+            >
+              Solicitar provisionamento
+            </Button>
+          ) : null}
+        </div>
+      </header>
+
+      <Card title="Dados da licença">
+        <dl>
+          <DetailRow label="ID" value={String(item.id)} mono />
+          <DetailRow label="Slug" value={item.slug} mono />
+          <DetailRow label="Plano" value={item.plano || '—'} />
+          <DetailRow label="Início" value={formatDate(item.data_inicio)} />
+          <DetailRow label="Renovação" value={formatDate(item.data_renovacao)} />
+          <DetailRow label="Instância" value={item.instancia_url || '—'} />
+          <DetailRow
+            label="Provisionamento"
+            value={item.provisionamento_solicitado ? 'Solicitado' : 'Não solicitado'}
+          />
+          <DetailRow label="Notas" value={item.notas || '—'} />
+        </dl>
+      </Card>
+      {href ? (
+        <Card title="Acesso à instância">
+          <a
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium text-sky-600 hover:underline dark:text-sky-400"
+          >
+            Abrir {item.instancia_url}
+          </a>
+        </Card>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/pages/saas/SaasLicencaForm.tsx
+++ b/frontend/src/pages/saas/SaasLicencaForm.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ApiError, saasClientes } from '../../api/client'
+import { Card } from '../../components/ui/Card'
+import { Input } from '../../components/ui/Input'
+import { Select } from '../../components/ui/Select'
+import { useToast } from '../../components/ui/Toast'
+import { useVoltarAnterior } from '../../hooks/useVoltarAnterior'
+import { FormSection } from '../../components/ui/FormSection'
+import { InlineCadastroFooter } from '../../components/ui/InlineCadastroPanel'
+import { CadastroFormPageShell } from '../../components/ui/CadastroFormPageShell'
+import { SemPermissao } from '../SemPermissao'
+import { CarregamentoFalhou } from '../../components/ui/CarregamentoFalhou'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/errorMessage'
+import { STATUS_CLIENTE_SAAS, type StatusClienteSaaS } from '../../lib/saasControlPlane'
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+export function SaasLicencaForm() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const voltarAnterior = useVoltarAnterior('/saas/licencas')
+
+  const clienteId = id ? parseInt(id, 10) : NaN
+  const isEdit = id != null
+
+  const [loading, setLoading] = useState(isEdit)
+  const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [indisponivel, setIndisponivel] = useState(false)
+  const [inexistente, setInexistente] = useState<{ detalhe?: string } | null>(null)
+
+  const [nome, setNome] = useState('')
+  const [slug, setSlug] = useState('')
+  const [status, setStatus] = useState<StatusClienteSaaS>('trial')
+  const [plano, setPlano] = useState('')
+  const [dataInicio, setDataInicio] = useState(todayIso)
+  const [dataRenovacao, setDataRenovacao] = useState('')
+  const [instanciaUrl, setInstanciaUrl] = useState('')
+  const [notas, setNotas] = useState('')
+
+  useEffect(() => {
+    if (!isEdit) return
+    if (!id || Number.isNaN(clienteId)) {
+      setInexistente({ detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setIndisponivel(false)
+    setInexistente(null)
+    saasClientes
+      .get(clienteId)
+      .then((c) => {
+        if (cancelled) return
+        setNome(c.nome)
+        setSlug(c.slug)
+        setStatus(c.status)
+        setPlano(c.plano ?? '')
+        setDataInicio(c.data_inicio.slice(0, 10))
+        setDataRenovacao(c.data_renovacao ? c.data_renovacao.slice(0, 10) : '')
+        setInstanciaUrl(c.instancia_url ?? '')
+        setNotas(c.notas ?? '')
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          const detail =
+            typeof err.body === 'object' && err.body && 'detail' in err.body
+              ? String((err.body as { detail?: unknown }).detail ?? '')
+              : ''
+          if (detail.toLowerCase().includes('não disponível')) {
+            setIndisponivel(true)
+          } else {
+            setInexistente({})
+          }
+          return
+        }
+        const m = interpretarFalhaCarregamento(err, 'Licença não encontrada.')
+        toast.showWarning([m.titulo, m.detalhe].filter(Boolean).join(' '))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [clienteId, id, isEdit, toast])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setSaving(true)
+    try {
+      const payload = {
+        nome: nome.trim(),
+        slug: slug.trim().toLowerCase(),
+        status,
+        plano: plano.trim() || null,
+        data_inicio: dataInicio,
+        data_renovacao: dataRenovacao.trim() || null,
+        instancia_url: instanciaUrl.trim() || null,
+        notas: notas.trim() || null,
+      }
+      if (isEdit && !Number.isNaN(clienteId)) {
+        await saasClientes.update(clienteId, payload)
+        toast.showSuccess('Licença atualizada.')
+        navigate(`/saas/licencas/${clienteId}`, { replace: true })
+      } else {
+        const created = await saasClientes.create(payload)
+        toast.showSuccess('Licença cadastrada.')
+        navigate(`/saas/licencas/${created.id}`, { replace: true })
+      }
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a licença.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <CadastroFormPageShell onVoltar={voltarAnterior}>
+        <div className="h-48 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </CadastroFormPageShell>
+    )
+  }
+
+  if (indisponivel) {
+    return (
+      <SemPermissao
+        title="Painel de licenças não disponível nesta instância."
+        voltarPara="/"
+        voltarLabel="Voltar para o Dashboard"
+      />
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para editar licenças SaaS."
+        voltarPara="/saas/licencas"
+        voltarLabel="Voltar para Licenças"
+      />
+    )
+  }
+
+  if (inexistente) {
+    return (
+      <CarregamentoFalhou
+        className="mx-auto max-w-5xl space-y-4 pb-10"
+        titulo="Licença não encontrada."
+        detalhe={inexistente.detalhe}
+        onVoltar={voltarAnterior}
+      />
+    )
+  }
+
+  return (
+    <CadastroFormPageShell onVoltar={voltarAnterior}>
+      <Card title={isEdit ? 'Editar licença' : 'Nova licença SaaS'}>
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-6">
+            <FormSection title="Cliente">
+              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
+              <Input
+                label="Slug"
+                value={slug}
+                onChange={(e) => setSlug(e.target.value)}
+                required
+                hint="Subdomínio / identificador único (ex.: duplex-soft)"
+              />
+              <Select
+                label="Status"
+                value={status}
+                onChange={(v) => setStatus(String(v) as StatusClienteSaaS)}
+                options={STATUS_CLIENTE_SAAS.map((s) => ({ value: s.value, label: s.label }))}
+              />
+              <Input
+                label="Plano"
+                value={plano}
+                onChange={(e) => setPlano(e.target.value)}
+                hint="Texto livre (ex.: profissional, enterprise)"
+              />
+            </FormSection>
+            <FormSection title="Vigência e instância">
+              <Input
+                label="Data de início"
+                type="date"
+                value={dataInicio}
+                onChange={(e) => setDataInicio(e.target.value)}
+                required
+              />
+              <Input
+                label="Data de renovação"
+                type="date"
+                value={dataRenovacao}
+                onChange={(e) => setDataRenovacao(e.target.value)}
+              />
+              <Input
+                label="URL da instância"
+                value={instanciaUrl}
+                onChange={(e) => setInstanciaUrl(e.target.value)}
+                hint="Ex.: cliente01.deskrudder.com.br"
+              />
+              <label className="block space-y-1.5">
+                <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Notas</span>
+                <textarea
+                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-sky-400 focus:outline-none focus:ring-2 focus:ring-sky-400/30 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+                  rows={3}
+                  value={notas}
+                  onChange={(e) => setNotas(e.target.value)}
+                />
+              </label>
+            </FormSection>
+          </div>
+          <InlineCadastroFooter onCancel={voltarAnterior} saving={saving} />
+        </form>
+      </Card>
+    </CadastroFormPageShell>
+  )
+}

--- a/frontend/src/pages/saas/SaasLicencas.tsx
+++ b/frontend/src/pages/saas/SaasLicencas.tsx
@@ -1,0 +1,260 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { CabecalhoOrdenavel } from '../../components/ui/CabecalhoOrdenavel'
+import { useOrdenacaoLista } from '../../hooks/useOrdenacaoLista'
+import { ApiError, saasClientes, type SaasClientes } from '../../api/client'
+import { Card } from '../../components/ui/Card'
+import { Button } from '../../components/ui/Button'
+import { Select } from '../../components/ui/Select'
+import { ListaAcoesVerEditar } from '../../components/ui/ListaAcoesVerEditar'
+import { useToast } from '../../components/ui/Toast'
+import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../../components/ui/BarraBuscaPaginacao'
+import { ConfigListPageShell } from '../../components/config/ConfigListPageShell'
+import { SemPermissao } from '../SemPermissao'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import {
+  STATUS_CLIENTE_SAAS,
+  badgeClassStatusClienteSaaS,
+  hrefInstanciaCliente,
+  labelStatusClienteSaaS,
+} from '../../lib/saasControlPlane'
+
+type Coluna = 'nome' | 'slug' | 'status' | 'data_renovacao'
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const d = iso.slice(0, 10)
+  const [y, m, day] = d.split('-')
+  if (!y || !m || !day) return iso
+  return `${day}/${m}/${y}`
+}
+
+export function SaasLicencas({ embedded = false }: { embedded?: boolean }) {
+  const navigate = useNavigate()
+  const toast = useToast()
+  const { ordenarPor, ordem, aoOrdenarColuna, sortParams } = useOrdenacaoLista<Coluna>()
+  const [list, setList] = useState<SaasClientes.Cliente[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [busca, setBusca] = useState('')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+  const [statusFiltro, setStatusFiltro] = useState<string>('')
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [indisponivel, setIndisponivel] = useState(false)
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
+    return () => clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    setPage(1)
+  }, [debouncedBusca, statusFiltro, ordenarPor, ordem])
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    setIndisponivel(false)
+    saasClientes
+      .list({
+        busca: debouncedBusca || undefined,
+        status: statusFiltro || undefined,
+        ...sortParams,
+        offset: (page - 1) * PAGE_SIZE_PADRAO,
+        limit: PAGE_SIZE_PADRAO,
+      })
+      .then(({ items, total: t }) => {
+        setList(items)
+        setTotal(t)
+      })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          setTotal(0)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setIndisponivel(true)
+          setList([])
+          setTotal(0)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não encontramos a lista de licenças.'))
+        setList([])
+        setTotal(0)
+      })
+      .finally(() => setLoading(false))
+  }, [debouncedBusca, page, sortParams, statusFiltro, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  if (indisponivel) {
+    return (
+      <SemPermissao
+        title="Painel de licenças não disponível nesta instância."
+        detail="Este módulo só existe na instância comercial DeskRudder (control-plane)."
+        voltarPara="/"
+        voltarLabel="Voltar para o Dashboard"
+      />
+    )
+  }
+
+  const denied = (
+    <SemPermissao
+      title="Você não tem permissão para gerir licenças SaaS."
+      detail="Peça a um administrador acesso ao painel comercial."
+      voltarPara="/"
+      voltarLabel="Voltar para o Dashboard"
+    />
+  )
+
+  return (
+    <ConfigListPageShell
+      embedded={embedded}
+      forbidden={forbidden}
+      denied={denied}
+      title="Licenças SaaS"
+      actions={<Button onClick={() => navigate('/saas/licencas/novo')}>Nova licença</Button>}
+    >
+      <Card>
+        <BarraBuscaPaginacao
+          busca={busca}
+          onBuscaChange={setBusca}
+          placeholder="Buscar por nome ou slug…"
+          page={page}
+          total={total}
+          onPageChange={setPage}
+          disabled={loading}
+          extra={
+            <div className="min-w-[10rem]">
+              <Select
+                label="Status"
+                labelStyle="overline"
+                value={statusFiltro}
+                onChange={(v) => setStatusFiltro(String(v))}
+                options={STATUS_CLIENTE_SAAS.map((s) => ({ value: s.value, label: s.label }))}
+                includeEmpty
+                emptyLabel="Todos"
+                placeholder="Todos"
+              />
+            </div>
+          }
+        />
+        {loading ? (
+          <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
+        ) : list.length === 0 ? (
+          <p className="text-slate-500 dark:text-slate-400">Nenhuma licença cadastrada.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[720px] text-left text-sm">
+              <thead>
+                <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+                  <CabecalhoOrdenavel
+                    coluna="nome"
+                    rotulo="Cliente"
+                    ordenarPor={ordenarPor}
+                    ordem={ordem}
+                    aoOrdenar={aoOrdenarColuna}
+                  />
+                  <CabecalhoOrdenavel
+                    coluna="slug"
+                    rotulo="Slug"
+                    ordenarPor={ordenarPor}
+                    ordem={ordem}
+                    aoOrdenar={aoOrdenarColuna}
+                  />
+                  <CabecalhoOrdenavel
+                    coluna="status"
+                    rotulo="Status"
+                    ordenarPor={ordenarPor}
+                    ordem={ordem}
+                    aoOrdenar={aoOrdenarColuna}
+                  />
+                  <CabecalhoOrdenavel
+                    coluna="data_renovacao"
+                    rotulo="Renovação"
+                    ordenarPor={ordenarPor}
+                    ordem={ordem}
+                    aoOrdenar={aoOrdenarColuna}
+                  />
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
+                    Instância
+                  </th>
+                  <th className="w-px px-4 py-3 text-right text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
+                    <span className="sr-only">Ações</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                {list.map((item) => {
+                  const href = hrefInstanciaCliente(item.instancia_url)
+                  return (
+                    <tr
+                      key={item.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => navigate(`/saas/licencas/${item.id}`)}
+                      onKeyDown={(ev) => {
+                        if (ev.key === 'Enter' || ev.key === ' ') {
+                          ev.preventDefault()
+                          navigate(`/saas/licencas/${item.id}`)
+                        }
+                      }}
+                      className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/50 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
+                    >
+                      <td className="px-4 py-3.5 sm:px-6">
+                        <span className="font-medium text-slate-800 dark:text-slate-100">{item.nome}</span>
+                        {item.plano ? (
+                          <span className="mt-0.5 block text-xs text-slate-500">{item.plano}</span>
+                        ) : null}
+                      </td>
+                      <td className="px-4 py-3.5 font-mono text-xs text-slate-600 sm:px-6 dark:text-slate-300">
+                        {item.slug}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3.5 sm:px-6">
+                        <span
+                          className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${badgeClassStatusClienteSaaS(item.status)}`}
+                        >
+                          {labelStatusClienteSaaS(item.status)}
+                        </span>
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-300">
+                        {formatDate(item.data_renovacao)}
+                      </td>
+                      <td className="px-4 py-3.5 sm:px-6" onClick={(ev) => ev.stopPropagation()}>
+                        {href ? (
+                          <a
+                            href={href}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-sky-600 hover:underline dark:text-sky-400"
+                          >
+                            Abrir
+                          </a>
+                        ) : (
+                          <span className="text-slate-400">—</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3.5 text-right sm:px-6" onClick={(ev) => ev.stopPropagation()}>
+                        <ListaAcoesVerEditar
+                          onVer={() => navigate(`/saas/licencas/${item.id}`)}
+                          onEditar={() => navigate(`/saas/licencas/${item.id}/editar`)}
+                          verLabel="Visualizar licença"
+                          editarLabel="Editar licença"
+                        />
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </ConfigListPageShell>
+  )
+}

--- a/frontend/src/pages/saas/SaasLicencas.tsx
+++ b/frontend/src/pages/saas/SaasLicencas.tsx
@@ -17,6 +17,7 @@ import {
   badgeClassStatusClienteSaaS,
   hrefInstanciaCliente,
   labelStatusClienteSaaS,
+  renovacaoAlerta,
 } from '../../lib/saasControlPlane'
 
 type Coluna = 'nome' | 'slug' | 'status' | 'data_renovacao'
@@ -223,7 +224,22 @@ export function SaasLicencas({ embedded = false }: { embedded?: boolean }) {
                         </span>
                       </td>
                       <td className="whitespace-nowrap px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-300">
-                        {formatDate(item.data_renovacao)}
+                        <span>{formatDate(item.data_renovacao)}</span>
+                        {(() => {
+                          const alerta = renovacaoAlerta(item.dias_para_renovacao)
+                          if (!alerta || alerta === 'ok') return null
+                          return (
+                            <span
+                              className={`mt-1 block text-xs font-medium ${
+                                alerta === 'vencido' ? 'text-amber-700 dark:text-amber-300' : 'text-sky-700 dark:text-sky-300'
+                              }`}
+                            >
+                              {alerta === 'vencido'
+                                ? `Vencida há ${Math.abs(item.dias_para_renovacao ?? 0)}d`
+                                : `Vence em ${item.dias_para_renovacao}d`}
+                            </span>
+                          )
+                        })()}
                       </td>
                       <td className="px-4 py-3.5 sm:px-6" onClick={(ev) => ev.stopPropagation()}>
                         {href ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumo

Lote completo do épico SaaS DeskRudder (#519) no control-plane comercial:

### DR-F2 (já no PR)
- **#521 / DR-01** — modelo `ClienteSaaS` + migration
- **#522 / DR-02** — API `/v1/saas/clientes` gated por `SAAS_CONTROL_PLANE`
- **#523 / DR-03** — UI `/saas/licencas` + menu + atalho na landing

### DR-F3 (esta iteração)
- **DR-04** — fila de provisionamento (`pendente` → `aguardando_ops` / `sucesso` / `falha`), worker, execução opcional de `provision-client.sh` / `stack-client.sh` quando `SAAS_PROVISION_EXEC_ENABLED=true`
- **DR-07** — `POST /v1/saas/public/trial` + página pública `/trial` + notificação à equipa
- **DR-08** — worker de renovações (alerta na janela + suspensão automática), ação **Renovar**, destaques na lista/detalhe

Docs: `docs/SAAS_CONTROL_PLANE.md`

Closes #521  
Closes #522  
Closes #523  

## Ativar (instância comercial)

```bash
SAAS_CONTROL_PLANE=true
SAAS_NOTIFY_EMAIL=comercial@deskrudder.com.br
SAAS_PROVISION_BASE_DOMAIN=deskrudder.com.br
VITE_SAAS_CONTROL_PLANE=true
# opcional no host de deploy:
# SAAS_PROVISION_EXEC_ENABLED=true
```

## Test plan

- [x] `pytest tests/test_saas_clientes.py tests/test_saas_fase3.py` (12 passed)
- [x] `alembic heads` → `079_saas_provision_trial_renovacao`
- [x] `npm run build`
- [ ] Control-plane on: CRUD + provisionar (fila `aguardando_ops` sem exec)
- [ ] `/trial` cria licença `trial` visível no painel
- [ ] Renovar (+30d) e worker suspende vencidos
- [ ] Landing mostra «Pedir trial» e «Painel de licenças»
- [ ] Instância cliente sem flag: API 404 / menu oculto
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4f48ad3-48af-46bc-9554-9af8023b5314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4f48ad3-48af-46bc-9554-9af8023b5314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

