### PR TITLE
feat(deskrudder): login por conta e hosts DeskRudder

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,24 +17,24 @@ LOG_LEVEL=INFO
 # --- Tenant (produção comercial: single-tenant por instância / Postgres dedicado) ---
 # DX_CONNECT_MULTI_TENANT=false   # padrão; true só em dev legado (vários clientes no mesmo Postgres)
 # DEFAULT_TENANT_ID=1
-# CLIENT_APP_HOST=duplexsoft.connect.duplexsoft.com.br   # URL pública do painel (GET /tenant/atual)
+# CLIENT_APP_HOST=cliente01.deskrudder.com.br   # URL pública do painel (GET /tenant/atual)
 # PASSWORD_RESET_TOKEN_EXPIRE_HOURS=1   # validade do link «esqueci minha senha»
 #
 # --- Multi-tenant legado (só se DX_CONNECT_MULTI_TENANT=true) ---
-# CONNECT_APP_BASE_DOMAIN=connect.duplexsoft.com.br
-# INBOUND_EMAIL_DOMAIN=notify.duplexsoft.com.br
+# CONNECT_APP_BASE_DOMAIN=deskrudder.com.br
+# INBOUND_EMAIL_DOMAIN=notify.deskrudder.com.br
 
 # --- E-mail transaccional (plataforma / Resend HTTP API) ---
-# Uma conta Resend (ou equivalente) da operação DX Connect — o cliente final NÃO configura API key no painel.
+# Uma conta Resend (ou equivalente) da operação — o cliente final NÃO configura API key no painel.
 # RESEND_API_KEY=re_...
-# TRANSACTIONAL_FROM_EMAIL=noreply@notify.duplexsoft.com.br
-# TRANSACTIONAL_FROM_NAME=DX Connect
-# SUPPORT_REPLY_TO_EMAIL=suporte@duplexsoft.com.br
+# TRANSACTIONAL_FROM_EMAIL=noreply@notify.deskrudder.com.br
+# TRANSACTIONAL_FROM_NAME=DeskRudder
+# SUPPORT_REPLY_TO_EMAIL=suporte@suaempresa.com.br
 #
 # --- Ingestão inbound (encaminhamento → tickets) ---
 # EMAIL_INBOUND_WEBHOOK_SECRET=...
 # RESEND_WEBHOOK_SECRET=whsec_...   # webhook Resend email.received → POST /v1/webhooks/resend-inbound
-# INBOUND_EMAIL_DOMAIN=notify.duplexsoft.com.br
+# INBOUND_EMAIL_DOMAIN=notify.deskrudder.com.br
 # EMAIL_INBOUND_DEFAULT_EMPRESA_ID=1   # omitir = ticket sem empresa até triagem
 # EMAIL_INBOUND_DEFAULT_SETOR_ID=1
 
@@ -42,7 +42,7 @@ LOG_LEVEL=INFO
 # API em network_mode: host chama a Evolution em 127.0.0.1:8080 (porta publicada pelo contentor).
 # EVOLUTION_INTERNAL_BASE_URL=http://127.0.0.1:8080
 # EVOLUTION_GLOBAL_API_KEY=<mesmo valor de AUTHENTICATION_API_KEY da Evolution; mín. 32 caracteres>
-# DX_CONNECT_WEBHOOK_BASE_URL=https://api.seudominio.com
+# DX_CONNECT_WEBHOOK_BASE_URL=https://api-cliente01.deskrudder.com.br
 # EVOLUTION_POSTGRES_PASSWORD=<senha forte para o Postgres dedicado da Evolution>
 # EVOLUTION_POSTGRES_USER=evolution
 # EVOLUTION_POSTGRES_DB=evolution

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -76,17 +76,17 @@ class Settings(BaseSettings):
     # Modo legado: vários clientes no mesmo Postgres (subdomínio numérico + coluna tenant_id).
     # Produção comercial: manter False (um Postgres por cliente / deploy).
     DX_CONNECT_MULTI_TENANT: bool = False
-    # URL pública do painel em single-tenant (ex.: duplexsoft.connect.duplexsoft.com.br).
+    # URL pública do painel em single-tenant (ex.: cliente01.deskrudder.com.br).
     # Se vazio, GET /tenant/atual usa {tenant_id}.CONNECT_APP_BASE_DOMAIN só em multi-tenant.
     CLIENT_APP_HOST: str | None = None
     # Validade do link de redefinição de senha (#105).
     PASSWORD_RESET_TOKEN_EXPIRE_HOURS: int = 1
 
-    # Multi-tenant: subdomínio {tenant_id}.CONNECT_APP_BASE_DOMAIN e endereços {local}@INBOUND_EMAIL_DOMAIN
-    CONNECT_APP_BASE_DOMAIN: str = "connect.duplexsoft.com.br"
-    # Domínio Resend com Receiving (ex.: notify.duplexsoft.com.br). Endereços: {setor}.t{tenant}@domínio.
-    INBOUND_EMAIL_DOMAIN: str = "notify.duplexsoft.com.br"
-    # Host sem subdomínio (ex.: connect.duplexsoft.com.br) ou dev local sem header.
+    # Multi-tenant legado: subdomínio {tenant_id}.CONNECT_APP_BASE_DOMAIN e endereços {local}@INBOUND_EMAIL_DOMAIN
+    CONNECT_APP_BASE_DOMAIN: str = "deskrudder.com.br"
+    # Domínio Resend com Receiving (ex.: notify.deskrudder.com.br). Endereços: {setor}.t{tenant}@domínio.
+    INBOUND_EMAIL_DOMAIN: str = "notify.deskrudder.com.br"
+    # Host sem subdomínio (ex.: deskrudder.com.br) ou dev local sem header.
     DEFAULT_TENANT_ID: int = 1
 
     # Webhook de ingestão de e-mail (padrão SaaS). Sem segredo, o endpoint responde 503.
@@ -101,7 +101,7 @@ class Settings(BaseSettings):
     RESEND_WEBHOOK_SECRET: str | None = None
     TRANSACTIONAL_FROM_EMAIL: str | None = None
     TRANSACTIONAL_FROM_NAME: str | None = None
-    # Respostas ao cliente: Reply-To público (ex. suporte@duplexsoft.com.br) enquanto From usa @notify na Resend.
+    # Respostas ao cliente: Reply-To público (ex. suporte@suaempresa.com.br) enquanto From usa @notify na Resend.
     SUPPORT_REPLY_TO_EMAIL: str | None = None
 
     # Diretório para logo da empresa do sistema (caminho relativo ao cwd ou absoluto).

--- a/deploy/clients/README.md
+++ b/deploy/clients/README.md
@@ -30,7 +30,7 @@ Na **raiz do repositório** (Linux/macOS/Git Bash no Windows):
 ```bash
 bash deploy/scripts/provision-client.sh \
   --slug duplexsoft \
-  --base-domain connect.duplexsoft.com.br \
+  --base-domain deskrudder.com.br \
   --api-port 8001
 ```
 

--- a/deploy/clients/_template/client.env.example
+++ b/deploy/clients/_template/client.env.example
@@ -1,4 +1,5 @@
 # Copiado para client.env pelo provision-client.sh — ajuste antes do primeiro up.
+# Hosts DeskRudder: {slug}.deskrudder.com.br + api-{slug}.deskrudder.com.br
 
 CLIENT_SLUG=exemplo
 CLIENT_API_PORT=8001
@@ -14,26 +15,27 @@ ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 
 # Origem do SPA (HTTPS em produção)
-CORS_ORIGINS=https://exemplo.connect.duplexsoft.com.br
+CORS_ORIGINS=https://exemplo.deskrudder.com.br
 
 # Hostnames que a API aceita (TrustedHostMiddleware)
-ALLOWED_HOSTS=api-exemplo.connect.duplexsoft.com.br,127.0.0.1,localhost
+ALLOWED_HOSTS=api-exemplo.deskrudder.com.br,127.0.0.1,localhost
 
 LOG_LEVEL=INFO
 
 # Single-tenant por instância (um Postgres por cliente)
 DX_CONNECT_MULTI_TENANT=false
 DEFAULT_TENANT_ID=1
-CLIENT_APP_HOST=exemplo.connect.duplexsoft.com.br
-CONNECT_APP_BASE_DOMAIN=connect.duplexsoft.com.br
-INBOUND_EMAIL_DOMAIN=notify.duplexsoft.com.br
+CLIENT_APP_HOST=exemplo.deskrudder.com.br
+CONNECT_APP_BASE_DOMAIN=deskrudder.com.br
+INBOUND_EMAIL_DOMAIN=notify.deskrudder.com.br
 
 # Resend / e-mail transaccional (preencher por cliente)
 # RESEND_API_KEY=re_...
-# TRANSACTIONAL_FROM_EMAIL=noreply@notify.duplexsoft.com.br
-# TRANSACTIONAL_FROM_NAME=DX Connect
-# SUPPORT_REPLY_TO_EMAIL=suporte@duplexsoft.com.br
+# TRANSACTIONAL_FROM_EMAIL=noreply@notify.deskrudder.com.br
+# TRANSACTIONAL_FROM_NAME=DeskRudder
+# SUPPORT_REPLY_TO_EMAIL=suporte@suaempresa.com.br
 # RESEND_WEBHOOK_SECRET=whsec_...
+# DX_CONNECT_WEBHOOK_BASE_URL=https://api-exemplo.deskrudder.com.br
 
 # Seed inicial (produção) — após primeiro up: docker compose ... exec backend python -m app.seed
 SEED_ADMIN_EMAIL=admin@email.com

--- a/deploy/clients/_template/frontend.env.production.example
+++ b/deploy/clients/_template/frontend.env.production.example
@@ -3,7 +3,8 @@
 #   cd ../../../frontend && npm ci && npm run build
 #   rsync dist/ para FRONTEND_DIST no VPS (ver nginx.site.conf.example)
 
-VITE_API_URL=https://api-CLIENT_SLUG.connect.BASE_DOMAIN
+VITE_API_URL=https://api-CLIENT_SLUG.BASE_DOMAIN
+VITE_MARKETING_SITE_URL=https://deskrudder.com.br
 VITE_DEFAULT_TENANT_ID=1
-VITE_CLIENT_APP_HOST=CLIENT_SLUG.connect.BASE_DOMAIN
+VITE_CLIENT_APP_HOST=CLIENT_SLUG.BASE_DOMAIN
 # VITE_MULTI_TENANT=false

--- a/deploy/clients/_template/nginx.site.conf.example
+++ b/deploy/clients/_template/nginx.site.conf.example
@@ -1,4 +1,5 @@
 # Nginx — um cliente (app + API em subdomínios distintos).
+# Padrão DeskRudder: {slug}.deskrudder.com.br + api-{slug}.deskrudder.com.br
 # Copiar para /etc/nginx/sites-available/dx-connect-CLIENT_SLUG e ativar.
 #
 # Pré-requisitos:
@@ -13,7 +14,7 @@ upstream dx_connect_api_CLIENT_SLUG {
 server {
     listen 80;
     listen [::]:80;
-    server_name api-CLIENT_SLUG.connect.BASE_DOMAIN;
+    server_name api-CLIENT_SLUG.BASE_DOMAIN;
 
     client_max_body_size 25M;
 
@@ -34,7 +35,7 @@ server {
 server {
     listen 80;
     listen [::]:80;
-    server_name CLIENT_SLUG.connect.BASE_DOMAIN;
+    server_name CLIENT_SLUG.BASE_DOMAIN;
 
     root FRONTEND_DIST;
     index index.html;

--- a/deploy/nginx/README.md
+++ b/deploy/nginx/README.md
@@ -2,57 +2,18 @@
 
 O **backend** já envia logs corretamente atrás de proxy (Gunicorn com `forwarded_allow_ips`). Estes ficheiros **não** são aplicados automaticamente: copie-os para o VPS e ajuste domínios e caminhos.
 
-## DeskRudder / domínio legado
+## DeskRudder — hosts
 
-| Ficheiro | Uso |
-|----------|-----|
-| [`connect-duplexsoft-redirect.conf.example`](connect-duplexsoft-redirect.conf.example) | `connect.duplexsoft.com.br` → `301` `https://deskrudder.com.br$request_uri` |
-| App do cliente | `https://duplexsoft.deskrudder.com.br` |
-| API legada (manter) | `https://api.connect.duplexsoft.com.br` |
+| Host | Função |
+|------|--------|
+| `deskrudder.com.br` | Landing / site comercial |
+| `{slug}.deskrudder.com.br` | Painel do cliente (ex.: `duplexsoft.deskrudder.com.br`) |
+| `api-{slug}.deskrudder.com.br` | API do cliente (ex.: `api-duplexsoft.deskrudder.com.br`) |
+
+Exemplos: [`deskrudder-landing.conf.example`](deskrudder-landing.conf.example), [`deskrudder-duplexsoft.conf.example`](deskrudder-duplexsoft.conf.example) (se presentes), template em [`../clients/_template/nginx.site.conf.example`](../clients/_template/nginx.site.conf.example).
+
+### Domínios legados (`*.duplexsoft.com.br`)
+
+[`connect-duplexsoft-redirect.conf.example`](connect-duplexsoft-redirect.conf.example) — `301` de `connect.` / `api.connect.` para os hosts DeskRudder do cliente piloto.
 
 ## Requisitos no VPS
-
-1. Backend a escutar **só em localhost** (ex.: `127.0.0.1:8000` — padrão do `docker compose` ao mapear `8000:8000` continua acessível no host; para fechar à internet deixe o `-p` apenas se usar rede interna; o mais comum é `ports: - "127.0.0.1:8000:8000"` no compose de produção).
-2. Variáveis do app: `CORS_ORIGINS` deve incluir a origem do frontend (ex.: `http://app.seudominio.com` durante testes HTTP, depois `https://...`).
-
-## Instalação rápida (Debian/Ubuntu)
-
-```bash
-sudo apt update && sudo apt install -y nginx
-sudo cp api.http.conf.example /etc/nginx/sites-available/dx-connect-api
-sudo cp frontend.http.conf.example /etc/nginx/sites-available/dx-connect-app
-# Editar server_name e root
-sudo ln -sf /etc/nginx/sites-available/dx-connect-api /etc/nginx/sites-enabled/
-sudo ln -sf /etc/nginx/sites-available/dx-connect-app /etc/nginx/sites-enabled/
-sudo nginx -t && sudo systemctl reload nginx
-```
-
-## Testar em HTTP
-
-- API: `curl -sS http://api.seudominio.com/health`
-- App: abrir `http://app.seudominio.com` no browser e fazer login.
-
-Depois ative **HTTPS** (Certbot ou certificado do painel) e atualize `CORS_ORIGINS`, `VITE_API_URL` e redirecionamentos `80 → 443`.
-
-## Um domínio só (API + SPA)
-
-Se quiser tudo no mesmo `server_name`, pode servir o `dist/` em `/` e fazer `location /api/` com `proxy_pass` — **neste projeto** a API não usa o prefixo `/api` nas rotas, seria preciso alinhar `proxy_pass` e o `VITE_API_URL`. O arranjo mais simples é **dois nomes**: `app.` e `api.`.
-
-## Cabeçalhos de segurança (HTTPS + SPA)
-
-Checklist ao colocar o site em produção:
-
-1. **TLS**: redirecionar `80 → 443`; certificados válidos (ex.: Certbot).
-2. **HSTS** no `server` HTTPS: `add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`
-3. **HTML estático** (`index.html` e assets): `Content-Security-Policy` alinhada ao que o bundle carrega (scripts, estilos, `connect-src` para a URL da API); `X-Frame-Options: DENY` ou `frame-ancestors 'none'` na CSP.
-4. **Complementar a API**: a aplicação FastAPI já envia `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` e `Strict-Transport-Security` quando `X-Forwarded-Proto` é `https` — o proxy deve repassar `X-Forwarded-Proto` e `X-Forwarded-For`.
-5. **Login (força bruta)**: além do limite na API, pode usar `limit_req` no Nginx em `POST` para `/auth/login` (ex.: `limit_req_zone` por `$binary_remote_addr`).
-
-Exemplo mínimo de bloco TLS + cabeçalhos no `server` do frontend (ajuste CSP ao seu build):
-
-```nginx
-add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-add_header X-Content-Type-Options "nosniff" always;
-add_header X-Frame-Options "DENY" always;
-add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-```

--- a/deploy/nginx/README.md
+++ b/deploy/nginx/README.md
@@ -2,6 +2,14 @@
 
 O **backend** já envia logs corretamente atrás de proxy (Gunicorn com `forwarded_allow_ips`). Estes ficheiros **não** são aplicados automaticamente: copie-os para o VPS e ajuste domínios e caminhos.
 
+## DeskRudder / domínio legado
+
+| Ficheiro | Uso |
+|----------|-----|
+| [`connect-duplexsoft-redirect.conf.example`](connect-duplexsoft-redirect.conf.example) | `connect.duplexsoft.com.br` → `301` `https://deskrudder.com.br$request_uri` |
+| App do cliente | `https://duplexsoft.deskrudder.com.br` |
+| API legada (manter) | `https://api.connect.duplexsoft.com.br` |
+
 ## Requisitos no VPS
 
 1. Backend a escutar **só em localhost** (ex.: `127.0.0.1:8000` — padrão do `docker compose` ao mapear `8000:8000` continua acessível no host; para fechar à internet deixe o `-p` apenas se usar rede interna; o mais comum é `ports: - "127.0.0.1:8000:8000"` no compose de produção).

--- a/deploy/nginx/connect-duplexsoft-redirect.conf.example
+++ b/deploy/nginx/connect-duplexsoft-redirect.conf.example
@@ -1,0 +1,24 @@
+# Domínio legado connect.duplexsoft.com.br → landing DeskRudder.
+# A API (api.connect.duplexsoft.com.br) permanece no site dx-connect-api.
+#
+# App do cliente DuplexSoft: https://duplexsoft.deskrudder.com.br
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name connect.duplexsoft.com.br;
+
+    ssl_certificate /etc/letsencrypt/live/connect.duplexsoft.com.br/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/connect.duplexsoft.com.br/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    return 301 https://deskrudder.com.br$request_uri;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name connect.duplexsoft.com.br;
+    return 301 https://deskrudder.com.br$request_uri;
+}

--- a/deploy/nginx/connect-duplexsoft-redirect.conf.example
+++ b/deploy/nginx/connect-duplexsoft-redirect.conf.example
@@ -1,7 +1,8 @@
-# Domínio legado connect.duplexsoft.com.br → landing DeskRudder.
-# A API (api.connect.duplexsoft.com.br) permanece no site dx-connect-api.
+# Domínios legados DuplexSoft → DeskRudder (cliente piloto).
+# App:  connect.duplexsoft.com.br → duplexsoft.deskrudder.com.br
+# API:  api.connect.duplexsoft.com.br → api-duplexsoft.deskrudder.com.br
 #
-# App do cliente DuplexSoft: https://duplexsoft.deskrudder.com.br
+# Certificados Let's Encrypt dos hosts legados podem permanecer só para o TLS do redirect.
 
 server {
     listen 443 ssl;
@@ -13,12 +14,32 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-    return 301 https://deskrudder.com.br$request_uri;
+    return 301 https://duplexsoft.deskrudder.com.br$request_uri;
 }
 
 server {
     listen 80;
     listen [::]:80;
     server_name connect.duplexsoft.com.br;
-    return 301 https://deskrudder.com.br$request_uri;
+    return 301 https://duplexsoft.deskrudder.com.br$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name api.connect.duplexsoft.com.br;
+
+    ssl_certificate /etc/letsencrypt/live/connect.duplexsoft.com.br/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/connect.duplexsoft.com.br/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    return 301 https://api-duplexsoft.deskrudder.com.br$request_uri;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name api.connect.duplexsoft.com.br;
+    return 301 https://api-duplexsoft.deskrudder.com.br$request_uri;
 }

--- a/deploy/scripts/provision-client.sh
+++ b/deploy/scripts/provision-client.sh
@@ -10,8 +10,10 @@ BASE_DOMAIN=""
 API_PORT=""
 
 usage() {
-  echo "Uso: $0 --slug <slug> --base-domain <connect.example.com> --api-port <porta>"
-  echo "Ex.: $0 --slug duplexsoft --base-domain connect.duplexsoft.com.br --api-port 8001"
+  echo "Uso: $0 --slug <slug> --base-domain <deskrudder.com.br> --api-port <porta>"
+  echo "Ex.: $0 --slug cliente01 --base-domain deskrudder.com.br --api-port 8001"
+  echo "  App:  https://cliente01.deskrudder.com.br"
+  echo "  API:  https://api-cliente01.deskrudder.com.br"
   exit 1
 }
 
@@ -90,7 +92,7 @@ sed -e "s/^CLIENT_SLUG=.*/CLIENT_SLUG=$SLUG/" \
     -e "s/^CONNECT_APP_BASE_DOMAIN=.*/CONNECT_APP_BASE_DOMAIN=$BASE_DOMAIN/" \
     -e "s/^SEED_ADMIN_PASSWORD=.*/SEED_ADMIN_PASSWORD=$ADMIN_PASS/" \
     -e "s/exemplo/${SLUG}/g" \
-    -e "s/connect\.duplexsoft\.com\.br/${BASE_DOMAIN}/g" \
+    -e "s/deskrudder\.com\.br/${BASE_DOMAIN}/g" \
     "$TEMPLATE/client.env.example" >"$DEST/client.env"
 
 substitute "$TEMPLATE/nginx.site.conf.example" "$DEST/nginx.site.conf"

--- a/docs/DEPLOYMENT_ARCHITECTURE.md
+++ b/docs/DEPLOYMENT_ARCHITECTURE.md
@@ -7,7 +7,7 @@
 | Aspecto | Direção |
 |---------|---------|
 | Infra | Mesma **VPS** (ou cluster) para vários clientes |
-| URL | **Subdomínio** por cliente (ex.: `duplexsoft.connect.duplexsoft.com.br`, `clienteb.connect.duplexsoft.com.br`) |
+| URL | **Subdomínio** por cliente (ex.: `duplexsoft.deskrudder.com.br`, `cliente02.deskrudder.com.br`) |
 | Dados | **Um PostgreSQL por cliente** (`DATABASE_URL` distinta por deploy) |
 | API | **Um container Docker por cliente** (modelo adotado — ver abaixo) |
 | Código | Tratar cada deploy como **single-tenant**: sem filtrar “outro cliente” na mesma base |

--- a/docs/EMAIL_SETTINGS.md
+++ b/docs/EMAIL_SETTINGS.md
@@ -53,7 +53,7 @@ Fluxo: caixa do cliente (`suporte@duplexsoft.com.br`) → **encaminhamento** →
 | 1 | Resend → Domains | Domínio **`notify.duplexsoft.com.br`** com **Enable Receiving** e MX **Verified** |
 | 2 | Painel Connect | **Empresa → E-mail** → **Atualizar lista** → copiar ex.: `suporte.t1@notify.duplexsoft.com.br` |
 | 3 | Outlook / M365 | Encaminhar `suporte@` para o endereço da tabela (não o antigo `@inbound...`) |
-| 4 | Resend → Webhooks | Evento **`email.received`**, URL `POST https://api.connect.duplexsoft.com.br/v1/webhooks/resend-inbound` |
+| 4 | Resend → Webhooks | Evento **`email.received`**, URL `POST https://api-{slug}.deskrudder.com.br/v1/webhooks/resend-inbound` |
 | 5 | VPS `backend/.env` | Ver variáveis abaixo + rebuild do container API |
 
 Variáveis no servidor:

--- a/docs/MOBILE_APP_BRIEF.md
+++ b/docs/MOBILE_APP_BRIEF.md
@@ -26,7 +26,7 @@ Documento para equipes/ferramentas que **não têm acesso ao GitHub**. Descreve 
 ### Base URL
 
 - **Desenvolvimento:** `http://localhost:8000/v1`
-- **Produção:** configurar por build (ex.: `https://api.connect.duplexsoft.com.br/v1`)
+- **Produção:** configurar por build (ex.: `https://api-duplexsoft.deskrudder.com.br/v1`)
 
 ### Login
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -8,6 +8,8 @@
 
 # Landing comercial (mailto do CTA «Fale conosco» — #515 / #516)
 # VITE_LANDING_CONTACT_EMAIL=contato@deskrudder.com.br
+# URL absoluta do site comercial («Voltar ao site» no login dos painéis de cliente)
+# VITE_MARKETING_SITE_URL=https://deskrudder.com.br
 
 # Single-tenant (produção por cliente): padrão — não envia X-Dx-Tenant-Id
 # VITE_DEFAULT_TENANT_ID=1

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -8,13 +8,12 @@
 
 # Landing comercial (mailto do CTA «Fale conosco» — #515 / #516)
 # VITE_LANDING_CONTACT_EMAIL=contato@deskrudder.com.br
-# URL absoluta do site comercial («Voltar ao site» no login dos painéis de cliente)
 # VITE_MARKETING_SITE_URL=https://deskrudder.com.br
 
 # Single-tenant (produção por cliente): padrão — não envia X-Dx-Tenant-Id
 # VITE_DEFAULT_TENANT_ID=1
-# VITE_CLIENT_APP_HOST=duplexsoft.connect.duplexsoft.com.br
+# VITE_CLIENT_APP_HOST=cliente01.deskrudder.com.br
 #
 # Multi-tenant legado (dev com vários clientes no mesmo Postgres):
 # VITE_MULTI_TENANT=true
-# VITE_CONNECT_APP_BASE_DOMAIN=connect.duplexsoft.com.br
+# VITE_CONNECT_APP_BASE_DOMAIN=deskrudder.com.br

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { ThemeProvider } from './contexts/ThemeContext'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
 import { Layout } from './components/Layout'
 import { Login } from './pages/Login'
+import { AuthSessao } from './pages/AuthSessao'
 import { EsqueciSenha } from './pages/EsqueciSenha'
 import { RedefinirSenha } from './pages/RedefinirSenha'
 import { AvaliarTicket } from './pages/AvaliarTicket'
@@ -90,9 +91,11 @@ import { PortalEquipeForm } from './pages/portal/PortalEquipeForm'
 import { ToastProvider } from './components/ui/Toast'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { PageLoading } from './components/ui/PageLoading'
+import { isMarketingHost } from './lib/marketingHost'
 
 /**
- * `/` anônimo → landing pública; demais rotas do shell exigem login.
+ * Apex comercial (`deskrudder.com.br`): `/` anônimo → landing.
+ * Subdomínio de cliente: `/` anônimo → login do painel.
  * Autenticado → Layout + painel (index = Dashboard).
  */
 function LayoutOrLanding() {
@@ -102,7 +105,7 @@ function LayoutOrLanding() {
     return <PageLoading fullscreen label="Carregando sessão…" />
   }
   if (!user) {
-    if (location.pathname === '/' || location.pathname === '') {
+    if ((location.pathname === '/' || location.pathname === '') && isMarketingHost()) {
       return <LandingPage />
     }
     return <Navigate to="/login" replace state={{ from: location }} />
@@ -144,6 +147,7 @@ function AppRoutes() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
+      <Route path="/auth/sessao" element={<AuthSessao />} />
       <Route path="/esqueci-senha" element={<EsqueciSenha />} />
       <Route path="/redefinir-senha" element={<RedefinirSenha />} />
       <Route path="/avaliar-ticket" element={<AvaliarTicket />} />

--- a/frontend/src/brand/index.ts
+++ b/frontend/src/brand/index.ts
@@ -1,4 +1,15 @@
-export { APP_NAME, APP_TAGLINE, APP_DESCRIPTION, BRAND_ASSET_VERSION, brandColors, brandGradients, brandAssets, brandLightSurfaces, brandWordmarkOnDark } from './tokens'
+export {
+  APP_NAME,
+  APP_TAGLINE,
+  APP_DESCRIPTION,
+  MARKETING_SITE_URL,
+  BRAND_ASSET_VERSION,
+  brandColors,
+  brandGradients,
+  brandAssets,
+  brandLightSurfaces,
+  brandWordmarkOnDark,
+} from './tokens'
 export {
   THEME_STORAGE_KEY,
   THEME_STORAGE_KEY_LEGACY,

--- a/frontend/src/brand/tokens.ts
+++ b/frontend/src/brand/tokens.ts
@@ -9,6 +9,15 @@ export const APP_TAGLINE = 'Organize. Foque. Direcione'
 export const APP_DESCRIPTION =
   'Plataforma de atendimento multicanal — tickets, WhatsApp e e-mail com fila, roteamento e SLA.'
 
+/**
+ * Site comercial (landing em deskrudder.com.br).
+ * Nos subdomínios de cliente, «Voltar ao site» aponta para cá — não para `/` do painel.
+ */
+export const MARKETING_SITE_URL = (
+  (import.meta.env.VITE_MARKETING_SITE_URL as string | undefined)?.trim() ||
+  'https://deskrudder.com.br'
+).replace(/\/$/, '')
+
 export const brandColors = {
   /** Profundidade / confiança — fundos escuros, gradientes. */
   navy: '#0B2D4A',

--- a/frontend/src/lib/marketingHost.ts
+++ b/frontend/src/lib/marketingHost.ts
@@ -1,0 +1,132 @@
+import { MARKETING_SITE_URL } from '../brand/tokens'
+import { mensagemErroApi } from '../api/errorMessage'
+
+const RESERVED_SLUGS = new Set([
+  'www',
+  'api',
+  'mail',
+  'ftp',
+  'cdn',
+  'static',
+  'app',
+  'admin',
+  'status',
+  'portal',
+])
+
+const SLUG_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/
+
+export const LOGIN_ACCOUNT_STORAGE_KEY = 'deskrudder-login-account'
+
+/** Hostname do site comercial (sem www). */
+export function marketingApexHost(): string {
+  try {
+    return new URL(MARKETING_SITE_URL).hostname.replace(/^www\./i, '').toLowerCase()
+  } catch {
+    return 'deskrudder.com.br'
+  }
+}
+
+/** True na landing comercial (apex / www), não em subdomínio de cliente. */
+export function isMarketingHost(hostname = typeof window !== 'undefined' ? window.location.hostname : ''): boolean {
+  const host = hostname.toLowerCase()
+  const apex = marketingApexHost()
+  return host === apex || host === `www.${apex}`
+}
+
+/** Normaliza e valida slug da conta (subdomínio). Retorna null se inválido. */
+export function normalizeClientSlug(raw: string): string | null {
+  const slug = raw.trim().toLowerCase()
+  if (!slug || !SLUG_RE.test(slug) || RESERVED_SLUGS.has(slug)) return null
+  return slug
+}
+
+/** Origem HTTPS do painel do cliente: https://{slug}.deskrudder.com.br */
+export function clientAppOrigin(slug: string): string {
+  const normalized = normalizeClientSlug(slug)
+  if (!normalized) {
+    throw new Error('Conta inválida')
+  }
+  return `https://${normalized}.${marketingApexHost()}`
+}
+
+/** API da instância: https://api-{slug}.deskrudder.com.br */
+export function clientApiOrigin(slug: string): string {
+  const normalized = normalizeClientSlug(slug)
+  if (!normalized) {
+    throw new Error('Conta inválida')
+  }
+  return `https://api-${normalized}.${marketingApexHost()}`
+}
+
+export type ClientLoginTokens = {
+  access_token: string
+  refresh_token?: string | null
+  must_change_password?: boolean
+}
+
+/** Autentica na API do cliente a partir da apex (CORS). */
+export async function loginAgainstClientInstance(
+  slug: string,
+  email: string,
+  senha: string,
+): Promise<ClientLoginTokens> {
+  const apiOrigin = clientApiOrigin(slug)
+  let res: Response
+  try {
+    res = await fetch(`${apiOrigin}/v1/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ email, senha }),
+    })
+  } catch {
+    throw new Error(
+      'Não foi possível contactar o painel desta conta. Verifique o identificador ou tente mais tarde.',
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    let msg = mensagemErroApi(body, res.status)
+    if (res.status === 401 || msg.startsWith('Não foi possível concluir')) {
+      msg = 'E-mail ou senha inválidos.'
+    }
+    if (res.status === 404 || res.status >= 502) {
+      msg = 'Conta não encontrada ou temporariamente indisponível.'
+    }
+    throw new Error(msg)
+  }
+  if (!body || typeof (body as ClientLoginTokens).access_token !== 'string') {
+    throw new Error('Resposta de login inválida.')
+  }
+  return body as ClientLoginTokens
+}
+
+/** URL no subdomínio que recebe a sessão via fragmento (não vai para logs do servidor). */
+export function buildSessionHandoffUrl(
+  slug: string,
+  tokens: ClientLoginTokens,
+  lembrarMe: boolean,
+): string {
+  const params = new URLSearchParams()
+  params.set('access_token', tokens.access_token)
+  if (tokens.refresh_token) params.set('refresh_token', tokens.refresh_token)
+  params.set('lembrar', lembrarMe ? '1' : '0')
+  if (tokens.must_change_password) params.set('must_change_password', '1')
+  return `${clientAppOrigin(slug)}/auth/sessao#${params.toString()}`
+}
+
+export function readRememberedAccount(): string {
+  try {
+    return localStorage.getItem(LOGIN_ACCOUNT_STORAGE_KEY) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+export function writeRememberedAccount(slug: string): void {
+  try {
+    localStorage.setItem(LOGIN_ACCOUNT_STORAGE_KEY, slug)
+  } catch {
+    /* storage indisponível */
+  }
+}

--- a/frontend/src/pages/AuthSessao.tsx
+++ b/frontend/src/pages/AuthSessao.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { clearAuthToken } from '../api/client'
+import { PageLoading } from '../components/ui/PageLoading'
+import { isMarketingHost } from '../lib/marketingHost'
+
+const TOKEN_KEY = 'token'
+const REFRESH_TOKEN_KEY = 'refresh_token'
+
+/**
+ * Recebe tokens no hash após login na apex comercial e grava a sessão no subdomínio do cliente.
+ * O fragmento não é enviado ao servidor; limpamos da URL logo após ler.
+ */
+export function AuthSessao() {
+  const navigate = useNavigate()
+  const [erro, setErro] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (isMarketingHost()) {
+      navigate('/login', { replace: true })
+      return
+    }
+
+    const raw = window.location.hash.replace(/^#/, '')
+    if (!raw) {
+      setErro('Sessão inválida ou expirada. Faça login novamente.')
+      return
+    }
+
+    const params = new URLSearchParams(raw)
+    const access = params.get('access_token')
+    const refresh = params.get('refresh_token')
+    const lembrar = params.get('lembrar') !== '0'
+
+    window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}`)
+
+    if (!access) {
+      setErro('Sessão inválida ou expirada. Faça login novamente.')
+      return
+    }
+
+    clearAuthToken()
+    const store = lembrar ? localStorage : sessionStorage
+    store.setItem(TOKEN_KEY, access)
+    if (refresh) store.setItem(REFRESH_TOKEN_KEY, refresh)
+
+    // Full reload para o AuthProvider ler os tokens no boot.
+    window.location.replace('/')
+  }, [navigate])
+
+  if (erro) {
+    return (
+      <div className="flex min-h-dvh flex-col items-center justify-center gap-4 bg-[#050810] px-4 text-center text-slate-200">
+        <p className="max-w-sm text-sm text-slate-400">{erro}</p>
+        <a href="/login" className="text-sm font-medium text-cyan-400 hover:text-cyan-300">
+          Ir para o login
+        </a>
+      </div>
+    )
+  }
+
+  return <PageLoading fullscreen label="Entrando no painel…" />
+}

--- a/frontend/src/pages/ConfigEmpresaEmail.tsx
+++ b/frontend/src/pages/ConfigEmpresaEmail.tsx
@@ -597,7 +597,7 @@ export function ConfigEmpresaEmail({ embedded = false, section }: ConfigEmpresaE
                     <p className="text-xs opacity-90">
                       Reply-To não definido — defina{' '}
                       <span className="font-mono">SUPPORT_REPLY_TO_EMAIL</span> no servidor (ex.{' '}
-                      <span className="font-mono">suporte@duplexsoft.com.br</span>) para as respostas do cliente
+                      <span className="font-mono">suporte@suaempresa.com.br</span>) para as respostas do cliente
                       voltarem à caixa de suporte.
                     </p>
                   )}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -4,7 +4,13 @@ import { useAuth } from '../contexts/AuthContext'
 import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
-import { BrandLogo, LOGIN_EMAIL_STORAGE_KEY, LOGIN_EMAIL_STORAGE_KEY_LEGACY, brandAssets } from '../brand'
+import {
+  BrandLogo,
+  LOGIN_EMAIL_STORAGE_KEY,
+  LOGIN_EMAIL_STORAGE_KEY_LEGACY,
+  MARKETING_SITE_URL,
+  brandAssets,
+} from '../brand'
 
 const fieldClass =
   'w-full rounded-xl border border-white/10 bg-white/[0.06] px-3.5 py-3 text-[0.9375rem] text-slate-100 placeholder:text-slate-500 shadow-inner shadow-black/20 backdrop-blur-sm transition-colors focus:border-cyan-400/50 focus:outline-none focus:ring-2 focus:ring-cyan-400/25'
@@ -179,12 +185,12 @@ export function Login() {
             Use o usuário cadastrado pelo administrador. Problemas para acessar? Contate o suporte interno.
           </p>
           <p className="text-center">
-            <Link
-              to="/"
+            <a
+              href={MARKETING_SITE_URL}
               className="inline-flex items-center gap-1.5 rounded-lg border border-white/15 bg-white/[0.06] px-4 py-2.5 text-sm font-medium text-sky-300 transition hover:border-sky-400/40 hover:bg-white/10 hover:text-sky-200"
             >
               ← Voltar ao site
-            </Link>
+            </a>
           </p>
         </div>
       </main>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -11,9 +11,21 @@ import {
   MARKETING_SITE_URL,
   brandAssets,
 } from '../brand'
+import { landingMailtoHref } from '../content/landing'
+import {
+  buildSessionHandoffUrl,
+  isMarketingHost,
+  loginAgainstClientInstance,
+  normalizeClientSlug,
+  readRememberedAccount,
+  writeRememberedAccount,
+} from '../lib/marketingHost'
 
 const fieldClass =
   'w-full rounded-xl border border-white/10 bg-white/[0.06] px-3.5 py-3 text-[0.9375rem] text-slate-100 placeholder:text-slate-500 shadow-inner shadow-black/20 backdrop-blur-sm transition-colors focus:border-cyan-400/50 focus:outline-none focus:ring-2 focus:ring-cyan-400/25'
+
+const secondaryLinkClass =
+  'inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-white/15 bg-white/[0.06] px-4 py-2.5 text-sm font-medium transition hover:border-sky-400/40 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/40'
 
 function readRememberedEmail(): string {
   try {
@@ -40,7 +52,209 @@ function LoginBackground() {
   )
 }
 
-export function Login() {
+function LoginShell({ children, footer }: { children: React.ReactNode; footer: React.ReactNode }) {
+  return (
+    <div
+      className="relative min-h-dvh font-sans text-slate-100 antialiased"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+    >
+      <LoginBackground />
+      <main className="relative flex min-h-dvh flex-col items-center justify-center px-4 py-10 sm:px-8">
+        <div className="w-full max-w-[400px] space-y-8 sm:space-y-10">
+          <header className="flex w-full justify-center">
+            <BrandLogo
+              variant="full"
+              size="lg"
+              markVariant="onDark"
+              className="flex-col items-center gap-4 sm:flex-row sm:items-center sm:justify-center sm:gap-5"
+            />
+          </header>
+          <div className="rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 shadow-2xl shadow-black/40 backdrop-blur-md sm:p-6">
+            {children}
+          </div>
+          {footer}
+        </div>
+      </main>
+    </div>
+  )
+}
+
+function PasswordToggle({
+  mostrarSenha,
+  onToggle,
+}: {
+  mostrarSenha: boolean
+  onToggle: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="absolute right-1.5 top-1/2 flex size-10 -translate-y-1/2 items-center justify-center rounded-lg text-cyan-400/85 transition-colors hover:bg-white/5 hover:text-cyan-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/40"
+      aria-label={mostrarSenha ? 'Ocultar senha' : 'Mostrar senha'}
+      aria-pressed={mostrarSenha}
+    >
+      {mostrarSenha ? (
+        <svg className="size-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+        </svg>
+      ) : (
+        <svg className="size-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        </svg>
+      )}
+    </button>
+  )
+}
+
+/** Apex comercial: conta + e-mail + senha → autentica na API do cliente e entra no painel. */
+function LoginConta() {
+  const [conta, setConta] = useState(readRememberedAccount)
+  const [email, setEmail] = useState(readRememberedEmail)
+  const [senha, setSenha] = useState('')
+  const [lembrarMe, setLembrarMe] = useState(() => !!readRememberedEmail())
+  const [mostrarSenha, setMostrarSenha] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const { showError } = useToast()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const slug = normalizeClientSlug(conta)
+    if (!slug) {
+      showError('Informe a conta da empresa (ex.: suaempresa), só letras minúsculas, números e hífen.')
+      return
+    }
+    if (!email.trim() || !senha.trim()) {
+      showError('Informe e-mail e senha.')
+      return
+    }
+    if (!email.includes('@')) {
+      showError('Informe um e-mail válido.')
+      return
+    }
+
+    setLoading(true)
+    try {
+      const tokens = await loginAgainstClientInstance(slug, email.trim(), senha)
+      writeRememberedAccount(slug)
+      try {
+        if (lembrarMe) {
+          localStorage.setItem(LOGIN_EMAIL_STORAGE_KEY, email.trim())
+        } else {
+          localStorage.removeItem(LOGIN_EMAIL_STORAGE_KEY)
+          localStorage.removeItem(LOGIN_EMAIL_STORAGE_KEY_LEGACY)
+        }
+      } catch {
+        /* storage indisponível */
+      }
+      window.location.assign(buildSessionHandoffUrl(slug, tokens, lembrarMe))
+    } catch (err) {
+      showError(mensagemFalhaParaToast(err, 'Falha no login. Verifique conta, e-mail e senha.'))
+      setLoading(false)
+    }
+  }
+
+  return (
+    <LoginShell
+      footer={
+        <div className="space-y-4">
+          <p className="text-center text-xs leading-relaxed text-slate-500">
+            Após validar, você entra direto no painel da sua empresa.
+          </p>
+          <div className="flex flex-col gap-2.5 sm:flex-row sm:justify-center">
+            <a href={MARKETING_SITE_URL} className={`${secondaryLinkClass} text-sky-300 hover:text-sky-200 sm:w-auto`}>
+              ← Voltar ao site
+            </a>
+            <a
+              href={landingMailtoHref()}
+              className={`${secondaryLinkClass} text-cyan-300 hover:text-cyan-200 sm:w-auto`}
+            >
+              Solicitar uma demonstração
+            </a>
+          </div>
+        </div>
+      }
+    >
+      <form onSubmit={handleSubmit} className="space-y-5" noValidate>
+        <div>
+          <label htmlFor="login-conta" className="mb-1.5 block text-sm font-medium text-slate-300">
+            Conta da empresa
+          </label>
+          <input
+            id="login-conta"
+            type="text"
+            value={conta}
+            onChange={(e) => setConta(e.target.value.toLowerCase())}
+            autoComplete="organization"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            placeholder="ex.: suaempresa"
+            className={fieldClass}
+          />
+          <p className="mt-2 text-xs leading-relaxed text-slate-500">
+            Sem espaços. Em geral é o nome curto da empresa (o mesmo do subdomínio).
+          </p>
+        </div>
+
+        <div>
+          <label htmlFor="login-email-apex" className="mb-1.5 block text-sm font-medium text-slate-300">
+            E-mail
+          </label>
+          <input
+            id="login-email-apex"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+            placeholder="nome@empresa.com"
+            className={fieldClass}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="login-senha-apex" className="mb-1.5 block text-sm font-medium text-slate-300">
+            Senha
+          </label>
+          <div className="relative">
+            <input
+              id="login-senha-apex"
+              type={mostrarSenha ? 'text' : 'password'}
+              value={senha}
+              onChange={(e) => setSenha(e.target.value)}
+              autoComplete="current-password"
+              placeholder="••••••••"
+              className={`${fieldClass} pr-12`}
+            />
+            <PasswordToggle mostrarSenha={mostrarSenha} onToggle={() => setMostrarSenha((v) => !v)} />
+          </div>
+        </div>
+
+        <label className="flex cursor-pointer items-start gap-3 text-sm text-slate-400">
+          <input
+            type="checkbox"
+            checked={lembrarMe}
+            onChange={(e) => setLembrarMe(e.target.checked)}
+            className="mt-0.5 size-4 shrink-0 rounded border-white/20 bg-white/[0.06] text-cyan-500 accent-cyan-500 focus:ring-2 focus:ring-cyan-400/30"
+          />
+          <span>Lembrar-me neste dispositivo</span>
+        </label>
+
+        <Button
+          type="submit"
+          className="w-full rounded-xl py-3 text-base font-semibold shadow-lg shadow-cyan-500/25 focus-visible:ring-offset-[#050810] disabled:opacity-60"
+          loading={loading}
+        >
+          Entrar
+        </Button>
+      </form>
+    </LoginShell>
+  )
+}
+
+/** Subdomínio do cliente: e-mail + senha na API da instância. */
+function LoginCredenciais() {
   const [email, setEmail] = useState(readRememberedEmail)
   const [senha, setSenha] = useState('')
   const [lembrarMe, setLembrarMe] = useState(() => !!readRememberedEmail())
@@ -83,117 +297,85 @@ export function Login() {
   }
 
   return (
-    <div
-      className="relative min-h-dvh font-sans text-slate-100 antialiased"
-      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
-    >
-      <LoginBackground />
-
-      <main className="relative flex min-h-dvh flex-col items-center justify-center px-4 py-10 sm:px-8">
-        <div className="w-full max-w-[400px] space-y-8 sm:space-y-10">
-          <header className="flex w-full justify-center">
-            <BrandLogo
-              variant="full"
-              size="lg"
-              markVariant="onDark"
-              className="flex-col items-center gap-4 sm:flex-row sm:items-center sm:justify-center sm:gap-5"
-            />
-          </header>
-
-          <div className="rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 shadow-2xl shadow-black/40 backdrop-blur-md sm:p-6">
-            <form onSubmit={handleSubmit} className="space-y-5" noValidate>
-              <div>
-                <label htmlFor="login-email" className="mb-1.5 block text-sm font-medium text-slate-300">
-                  E-mail
-                </label>
-                <input
-                  id="login-email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  autoComplete="email"
-                  placeholder="nome@empresa.com"
-                  className={fieldClass}
-                />
-              </div>
-
-              <div>
-                <label htmlFor="login-senha" className="mb-1.5 block text-sm font-medium text-slate-300">
-                  Senha
-                </label>
-                <div className="relative">
-                  <input
-                    id="login-senha"
-                    type={mostrarSenha ? 'text' : 'password'}
-                    value={senha}
-                    onChange={(e) => setSenha(e.target.value)}
-                    autoComplete="current-password"
-                    placeholder="••••••••"
-                    className={`${fieldClass} pr-12`}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setMostrarSenha((v) => !v)}
-                    className="absolute right-1.5 top-1/2 flex size-10 -translate-y-1/2 items-center justify-center rounded-lg text-cyan-400/85 transition-colors hover:bg-white/5 hover:text-cyan-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/40"
-                    aria-label={mostrarSenha ? 'Ocultar senha' : 'Mostrar senha'}
-                    aria-pressed={mostrarSenha}
-                  >
-                    {mostrarSenha ? (
-                      <svg className="size-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
-                      </svg>
-                    ) : (
-                      <svg className="size-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                      </svg>
-                    )}
-                  </button>
-                </div>
-              </div>
-
-              <div className="text-right">
-                <Link
-                  to="/esqueci-senha"
-                  className="text-sm text-cyan-400/90 transition-colors hover:text-cyan-300"
-                >
-                  Esqueci minha senha
-                </Link>
-              </div>
-
-              <label className="flex cursor-pointer items-start gap-3 text-sm text-slate-400">
-                <input
-                  type="checkbox"
-                  checked={lembrarMe}
-                  onChange={(e) => setLembrarMe(e.target.checked)}
-                  className="mt-0.5 size-4 shrink-0 rounded border-white/20 bg-white/[0.06] text-cyan-500 accent-cyan-500 focus:ring-2 focus:ring-cyan-400/30"
-                />
-                <span>Lembrar-me neste dispositivo</span>
-              </label>
-
-              <Button
-                type="submit"
-                className="w-full rounded-xl py-3 text-base font-semibold shadow-lg shadow-cyan-500/25 focus-visible:ring-offset-[#050810] disabled:opacity-60"
-                loading={loading}
-              >
-                Entrar
-              </Button>
-            </form>
-          </div>
-
+    <LoginShell
+      footer={
+        <>
           <p className="text-center text-xs leading-relaxed text-slate-500">
             Use o usuário cadastrado pelo administrador. Problemas para acessar? Contate o suporte interno.
           </p>
           <p className="text-center">
-            <a
-              href={MARKETING_SITE_URL}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-white/15 bg-white/[0.06] px-4 py-2.5 text-sm font-medium text-sky-300 transition hover:border-sky-400/40 hover:bg-white/10 hover:text-sky-200"
-            >
+            <a href={MARKETING_SITE_URL} className={`${secondaryLinkClass} text-sky-300 hover:text-sky-200`}>
               ← Voltar ao site
             </a>
           </p>
+        </>
+      }
+    >
+      <form onSubmit={handleSubmit} className="space-y-5" noValidate>
+        <div>
+          <label htmlFor="login-email" className="mb-1.5 block text-sm font-medium text-slate-300">
+            E-mail
+          </label>
+          <input
+            id="login-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+            placeholder="nome@empresa.com"
+            className={fieldClass}
+          />
         </div>
-      </main>
-    </div>
+
+        <div>
+          <label htmlFor="login-senha" className="mb-1.5 block text-sm font-medium text-slate-300">
+            Senha
+          </label>
+          <div className="relative">
+            <input
+              id="login-senha"
+              type={mostrarSenha ? 'text' : 'password'}
+              value={senha}
+              onChange={(e) => setSenha(e.target.value)}
+              autoComplete="current-password"
+              placeholder="••••••••"
+              className={`${fieldClass} pr-12`}
+            />
+            <PasswordToggle mostrarSenha={mostrarSenha} onToggle={() => setMostrarSenha((v) => !v)} />
+          </div>
+        </div>
+
+        <div className="text-right">
+          <Link to="/esqueci-senha" className="text-sm text-cyan-400/90 transition-colors hover:text-cyan-300">
+            Esqueci minha senha
+          </Link>
+        </div>
+
+        <label className="flex cursor-pointer items-start gap-3 text-sm text-slate-400">
+          <input
+            type="checkbox"
+            checked={lembrarMe}
+            onChange={(e) => setLembrarMe(e.target.checked)}
+            className="mt-0.5 size-4 shrink-0 rounded border-white/20 bg-white/[0.06] text-cyan-500 accent-cyan-500 focus:ring-2 focus:ring-cyan-400/30"
+          />
+          <span>Lembrar-me neste dispositivo</span>
+        </label>
+
+        <Button
+          type="submit"
+          className="w-full rounded-xl py-3 text-base font-semibold shadow-lg shadow-cyan-500/25 focus-visible:ring-offset-[#050810] disabled:opacity-60"
+          loading={loading}
+        >
+          Entrar
+        </Button>
+      </form>
+    </LoginShell>
   )
+}
+
+export function Login() {
+  if (isMarketingHost()) {
+    return <LoginConta />
+  }
+  return <LoginCredenciais />
 }


### PR DESCRIPTION
## Summary
- Login na apex (deskrudder.com.br): conta + e-mail + senha → autentica em pi-{slug}.deskrudder.com.br e entra no painel do cliente já autenticado.
- Subdomínio do cliente: / anônimo vai para /login (sem landing); login só com e-mail/senha.
- Hosts padrão DeskRudder ({slug}.deskrudder.com.br / pi-{slug}...); templates, docs e exemplos atualizados.
- Legado connect.duplexsoft.com.br → 301 para duplexsoft.deskrudder.com.br; API legada permanece como alias.

## Test plan
- [ ] https://deskrudder.com.br/ → landing
- [ ] https://deskrudder.com.br/login → 3 campos; login com conta piloto leva a duplexsoft.deskrudder.com.br autenticado
- [ ] https://duplexsoft.deskrudder.com.br/ → redirect para /login
- [ ] https://connect.duplexsoft.com.br/ → 301 para painel DeskRudder do piloto
- [ ] https://api-duplexsoft.deskrudder.com.br/health → 200
- [ ] Hard refresh / Ctrl+F5 após deploy do dist

Closes domain cutover parcial (piloto DuplexSoft em DeskRudder).