### PR TITLE
fix(chat): fila Aguardando — Atender, Enter no anexo e mute (#625–#627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Chat (#626): ícone de som junto a **Aguardando** para silenciar/reativar o alerta contínuo da fila (WhatsApp + portal); preferência guardada no browser — não afeta alertas de ticket nem do chat interno
 - Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário
 - Portal (#600, #601): cadastro de funcionário pelo modal da Rede permite definir senha do portal na criação; sócio cadastra sem escolher empresas (escopo automático em toda a rede)
 - Portal (#604): RBAC por papel — colaborador vê só os próprios chamados; supervisor vê todos das empresas vinculadas; sócio vê toda a rede
@@ -35,6 +36,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- Chat (#625): ao **Ver** um chat da fila Aguardando, a lista com **Atender** permanece na lateral; na conversa há CTA **Atender** (WhatsApp e portal) para assumir sem voltar à lista
+- WhatsApp (#627): com anexo pendente, **Enter** na legenda (ou no painel, em áudio) envia o anexo — equivalente a «Enviar anexo»
 - WhatsApp (#608): duas mensagens inbound seguidas do mesmo contacto deixam de abrir dois chats/protocolos — lock por `wa_id` no webhook e uma única sequência de auto-mensagens por sessão
 - WhatsApp (#598): após encerrar com avaliação, janela de ~30 min (configurável) para a nota; se o cliente mandar outro texto, abre atendimento novo com essa mensagem; sem resposta, finaliza sozinho
 - WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** (somente leitura) até registar, manter demandas existentes ou confirmar sem demanda; nova mensagem do mesmo cliente abre chat novo na fila

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -66,6 +66,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -281,6 +282,7 @@
       "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -292,6 +294,7 @@
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -997,9 +1000,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1017,9 +1017,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1037,9 +1034,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1057,9 +1051,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1097,27 +1088,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -1348,6 +1318,7 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1355,6 +1326,7 @@
     "node_modules/@types/react": {
       "version": "19.2.17",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1424,6 +1396,7 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -1658,6 +1631,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1720,16 +1694,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1752,6 +1726,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1861,18 +1836,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2139,6 +2107,7 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3627,7 +3596,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3752,6 +3723,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3807,7 +3779,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -3825,7 +3799,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3869,6 +3843,7 @@
     "node_modules/react": {
       "version": "19.2.7",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3878,6 +3853,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3924,6 +3900,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3943,20 +3920,19 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -3965,12 +3941,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -4014,7 +3990,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4111,12 +4088,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4284,6 +4255,7 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4514,6 +4486,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4630,6 +4603,7 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,5 +36,8 @@
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.63.0",
     "vite": "^8.0.16"
+  },
+  "overrides": {
+    "react-router": "8.3.0"
   }
 }

--- a/frontend/src/components/chat/ChatFilaAguardandoSheet.tsx
+++ b/frontend/src/components/chat/ChatFilaAguardandoSheet.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ChatListaEspera } from '../../pages/chat/ChatListaEspera'
+import { ChatFilaSomToggle } from './ChatFilaSomToggle'
 
 type Props = {
   open: boolean
@@ -45,9 +46,12 @@ export function ChatFilaAguardandoSheet({ open, onClose }: Props) {
         className="absolute inset-x-0 bottom-0 flex max-h-[min(85vh,32rem)] flex-col rounded-t-2xl bg-white shadow-2xl outline-none dark:bg-slate-950"
       >
         <div className="flex shrink-0 items-center justify-between border-b border-slate-200 px-4 py-3 dark:border-slate-800">
-          <h2 id={titleId} className="text-base font-bold text-slate-900 dark:text-white">
-            Aguardando
-          </h2>
+          <div className="flex items-center gap-1">
+            <h2 id={titleId} className="text-base font-bold text-slate-900 dark:text-white">
+              Aguardando
+            </h2>
+            <ChatFilaSomToggle size="md" />
+          </div>
           <button
             type="button"
             className="rounded-lg px-2 py-1 text-2xl leading-none text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-100"

--- a/frontend/src/components/chat/ChatFilaSomToggle.tsx
+++ b/frontend/src/components/chat/ChatFilaSomToggle.tsx
@@ -1,0 +1,51 @@
+import {
+  setFilaAguardandoMuted,
+  useFilaAguardandoMuted,
+} from '../../hooks/useAlertaFilaSemResponsavel'
+
+type Props = {
+  className?: string
+  /** Compacto para caber no header mobile / tabs */
+  size?: 'sm' | 'md'
+}
+
+export function ChatFilaSomToggle({ className = '', size = 'sm' }: Props) {
+  const muted = useFilaAguardandoMuted()
+  const dim = size === 'md' ? 'h-8 w-8' : 'h-7 w-7'
+  const icon = size === 'md' ? 18 : 16
+
+  return (
+    <button
+      type="button"
+      aria-pressed={muted}
+      aria-label={
+        muted
+          ? 'Ativar alerta sonoro da fila Aguardando'
+          : 'Silenciar alerta sonoro da fila Aguardando'
+      }
+      title={muted ? 'Alerta da fila silenciado — clique para ativar' : 'Silenciar alerta da fila'}
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        setFilaAguardandoMuted(!muted)
+      }}
+      className={`inline-flex ${dim} shrink-0 items-center justify-center rounded-lg text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100 ${
+        muted ? 'text-amber-600 dark:text-amber-400' : ''
+      } ${className}`}
+    >
+      {muted ? (
+        <svg xmlns="http://www.w3.org/2000/svg" width={icon} height={icon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <path d="M11 5 6 9H2v6h4l5 4V5z" />
+          <line x1="23" y1="9" x2="17" y2="15" />
+          <line x1="17" y1="9" x2="23" y2="15" />
+        </svg>
+      ) : (
+        <svg xmlns="http://www.w3.org/2000/svg" width={icon} height={icon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+          <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+          <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+        </svg>
+      )}
+    </button>
+  )
+}

--- a/frontend/src/components/chat/ChatHubTabs.tsx
+++ b/frontend/src/components/chat/ChatHubTabs.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from 'react-router-dom'
 import { useChatInterno } from '../../contexts/ChatInternoContext'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { CHAT_HUB_PATHS, chatHubModoDePath } from '../../lib/chatHubPaths'
+import { ChatFilaSomToggle } from './ChatFilaSomToggle'
 
 type TabDef = {
   id: keyof typeof CHAT_HUB_PATHS
@@ -12,8 +13,8 @@ type TabDef = {
 }
 
 export function ChatHubTabs() {
-  const { pathname } = useLocation()
-  const modo = chatHubModoDePath(pathname)
+  const { pathname, search } = useLocation()
+  const modo = chatHubModoDePath(pathname, search)
   const { filaCount, atendendoCount } = useChatHub()
   const { conversas } = useChatInterno()
   const internoNaoLidas = conversas.reduce((acc, c) => acc + c.nao_lidas_count, 0)
@@ -73,17 +74,33 @@ export function ChatHubTabs() {
     <nav className="flex shrink-0 border-b border-slate-200 dark:border-slate-800" aria-label="Modos de chat">
       {tabs.map((tab) => {
         const ativo = modo === tab.id
+        const tabClass = `relative flex flex-1 flex-col items-center gap-1 border-b-2 px-0.5 py-2.5 text-[10px] font-semibold transition-colors ${
+          ativo
+            ? 'border-cyan-500 text-cyan-600 dark:text-cyan-400'
+            : 'border-transparent text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'
+        }`
+
+        if (tab.id === 'espera') {
+          return (
+            <div key={tab.id} className="relative flex flex-1 items-stretch">
+              <Link to={tab.to} title={tab.label} className={tabClass}>
+                <span className={ativo ? 'text-cyan-600 dark:text-cyan-400' : ''}>{tab.icon}</span>
+                <span className="hidden sm:inline">{tab.label}</span>
+                {tab.badge != null && tab.badge > 0 && (
+                  <span className="absolute right-5 top-1 min-w-[1rem] rounded-full bg-cyan-600 px-1 text-center text-[9px] font-bold leading-4 text-white sm:right-6">
+                    {tab.badge > 99 ? '99+' : tab.badge}
+                  </span>
+                )}
+              </Link>
+              <div className="absolute right-0 top-1/2 z-10 -translate-y-1/2 pr-0.5">
+                <ChatFilaSomToggle />
+              </div>
+            </div>
+          )
+        }
+
         return (
-          <Link
-            key={tab.id}
-            to={tab.to}
-            title={tab.label}
-            className={`relative flex flex-1 flex-col items-center gap-1 border-b-2 px-0.5 py-2.5 text-[10px] font-semibold transition-colors ${
-              ativo
-                ? 'border-cyan-500 text-cyan-600 dark:text-cyan-400'
-                : 'border-transparent text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'
-            }`}
-          >
+          <Link key={tab.id} to={tab.to} title={tab.label} className={tabClass}>
             <span className={ativo ? 'text-cyan-600 dark:text-cyan-400' : ''}>{tab.icon}</span>
             <span className="hidden sm:inline">{tab.label}</span>
             {tab.badge != null && tab.badge > 0 && (

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -10,6 +10,8 @@ const LS_KEY_LAST_WPP_RESP = 'dxconnect.notificacoes.last_wpp_resp'
 const LS_KEY_LAST_PORTAL_FILA = 'dxconnect.notificacoes.last_portal_fila'
 const LS_KEY_LAST_PORTAL_RESP = 'dxconnect.notificacoes.last_portal_resp'
 const LS_KEY_LAST_CHAT_INTERNO = 'dxconnect.notificacoes.last_chat_interno'
+/** Preferência local: silenciar loop/pulse da fila Aguardando (WPP + portal). */
+const LS_KEY_FILA_AGUARDANDO_MUTED = 'dxconnect.notificacoes.fila_aguardando_muted'
 const POLL_MS = 10_000
 /** Fallback de segurança quando SSE está ativo (#266). */
 const POLL_SSE_SAFETY_MS = 60_000
@@ -65,6 +67,20 @@ const mutedChatInternoIds = new Set<number>()
 let chatInternoUserId: number | null = null
 let activeChatInternoConversaId: number | null = null
 
+type ListenerFilaMuted = (muted: boolean) => void
+const listenersFilaMuted = new Set<ListenerFilaMuted>()
+
+function readFilaAguardandoMuted(): boolean {
+  try {
+    if (typeof localStorage === 'undefined') return false
+    return localStorage.getItem(LS_KEY_FILA_AGUARDANDO_MUTED) === '1'
+  } catch {
+    return false
+  }
+}
+
+let filaAguardandoMuted = readFilaAguardandoMuted()
+
 let wppFilaLoopInterval: number | null = null
 let wppFilaLoopAudio: HTMLAudioElement | null = null
 let pollTimerId: number | null = null
@@ -91,6 +107,36 @@ export function syncChatInternoMutedIds(ids: Iterable<number>) {
 export function setChatInternoMuted(conversaId: number, muted: boolean) {
   if (muted) mutedChatInternoIds.add(conversaId)
   else mutedChatInternoIds.delete(conversaId)
+}
+
+export function isFilaAguardandoMuted() {
+  return filaAguardandoMuted
+}
+
+/** Silencia/reativa só o alerta contínuo (e pulses) da fila Aguardando — não afeta tickets nem chat interno. */
+export function setFilaAguardandoMuted(muted: boolean) {
+  filaAguardandoMuted = muted
+  try {
+    localStorage.setItem(LS_KEY_FILA_AGUARDANDO_MUTED, muted ? '1' : '0')
+  } catch {
+    // ignore
+  }
+  const filaCount = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
+  syncWppFilaBeep(filaCount)
+  for (const l of listenersFilaMuted) l(muted)
+}
+
+export function useFilaAguardandoMuted(): boolean {
+  const [muted, setMuted] = useState(filaAguardandoMuted)
+  useEffect(() => {
+    const listener: ListenerFilaMuted = (m) => setMuted(m)
+    listenersFilaMuted.add(listener)
+    setMuted(filaAguardandoMuted)
+    return () => {
+      listenersFilaMuted.delete(listener)
+    }
+  }, [])
+  return muted
 }
 
 function shouldPlayChatInternoSound(payload: Record<string, unknown>): boolean {
@@ -350,7 +396,7 @@ function ensureWppFilaLoop() {
 }
 
 function syncWppFilaBeep(wppFilaCount: number) {
-  if (wppFilaCount > 0) {
+  if (wppFilaCount > 0 && !filaAguardandoMuted) {
     ensureWppFilaLoop()
   } else {
     stopWppFilaLoop()
@@ -413,11 +459,17 @@ function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean, source: 'sse
       for (let i = 0; i < delta; i++) enqueueAlert('ticket_fila')
     }
 
-    if (shouldEnqueueCounterAlert('wpp_fila_pulse', prevWppFilaValue, r.wpp_fila_count)) {
+    if (
+      !filaAguardandoMuted &&
+      shouldEnqueueCounterAlert('wpp_fila_pulse', prevWppFilaValue, r.wpp_fila_count)
+    ) {
       enqueueAlert('wpp_fila_pulse')
     }
 
-    if (shouldEnqueueCounterAlert('wpp_fila_pulse', prevPortalFilaValue, r.portal_fila_count)) {
+    if (
+      !filaAguardandoMuted &&
+      shouldEnqueueCounterAlert('wpp_fila_pulse', prevPortalFilaValue, r.portal_fila_count)
+    ) {
       enqueueAlert('wpp_fila_pulse')
     }
 

--- a/frontend/src/lib/chatHubLista.ts
+++ b/frontend/src/lib/chatHubLista.ts
@@ -53,7 +53,9 @@ export function mapPortalChat(c: PortalChats.Chat): ChatHubItem {
 }
 
 export function chatHubItemLink(item: ChatHubItem, from?: ChatHubModo) {
-  if (item.canal === 'portal') return chatPortalLink(item.id)
+  if (item.canal === 'portal') {
+    return chatPortalLink(item.id, from === 'espera' ? 'espera' : undefined)
+  }
   return chatWhatsappLink(item.id, from === 'espera' ? 'espera' : 'atendendo')
 }
 

--- a/frontend/src/lib/chatHubPaths.ts
+++ b/frontend/src/lib/chatHubPaths.ts
@@ -7,10 +7,20 @@ export const CHAT_HUB_PATHS = {
 
 export type ChatHubModo = keyof typeof CHAT_HUB_PATHS
 
-export function chatHubModoDePath(pathname: string): ChatHubModo {
+/** `search` opcional (ex. `?from=espera`) — ao visualizar chat da fila, mantém modo Aguardando (#625). */
+export function chatHubModoDePath(pathname: string, search?: string): ChatHubModo {
   if (pathname.startsWith('/chat/interno') || pathname === CHAT_HUB_PATHS.interno) return 'interno'
   if (pathname.startsWith('/chat/espera')) return 'espera'
   if (pathname.startsWith('/chat/contatos')) return 'contatos'
+  const from = search
+    ? new URLSearchParams(search.startsWith('?') ? search.slice(1) : search).get('from')
+    : null
+  if (
+    from === 'espera' &&
+    (pathname.startsWith('/chat/c/') || pathname.startsWith('/chat/portal/'))
+  ) {
+    return 'espera'
+  }
   return 'atendendo'
 }
 
@@ -21,8 +31,11 @@ export function chatWhatsappLink(chatId: number, from?: ChatHubModo) {
   }
 }
 
-export function chatPortalLink(chatId: number) {
-  return `/chat/portal/${chatId}`
+export function chatPortalLink(chatId: number, from?: ChatHubModo) {
+  return {
+    pathname: `/chat/portal/${chatId}`,
+    search: from ? `?from=${from}` : '',
+  }
 }
 
 export function chatInternoLink(conversaId: number) {

--- a/frontend/src/pages/chat/ChatHubLayout.tsx
+++ b/frontend/src/pages/chat/ChatHubLayout.tsx
@@ -8,8 +8,8 @@ import { ChatListaEspera } from './ChatListaEspera'
 import { ChatListaContatos } from './ChatListaContatos'
 
 function ChatHubLista() {
-  const { pathname } = useLocation()
-  const modo = chatHubModoDePath(pathname)
+  const { pathname, search } = useLocation()
+  const modo = chatHubModoDePath(pathname, search)
 
   switch (modo) {
     case 'espera':
@@ -24,8 +24,8 @@ function ChatHubLista() {
 }
 
 export function ChatHubLayout() {
-  const { pathname } = useLocation()
-  const modo = chatHubModoDePath(pathname)
+  const { pathname, search } = useLocation()
+  const modo = chatHubModoDePath(pathname, search)
   const emConversa =
     /\/chat\/c\/\d+/.test(pathname) ||
     /\/chat\/portal\/\d+/.test(pathname) ||

--- a/frontend/src/pages/chat/PortalConversa.tsx
+++ b/frontend/src/pages/chat/PortalConversa.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
-import { fetchPortalMidiaBlob, portalChats, type PortalChats } from '../../api/client'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { ApiError, fetchPortalMidiaBlob, portalChats, type PortalChats } from '../../api/client'
 import { ChatCanalBadge } from '../../components/chat/ChatCanalBadge'
 import { ChatDemandasPanel } from '../../components/chat/ChatDemandasPanel'
 import { ChatEncerrarModal } from '../../components/chat/ChatEncerrarModal'
 import { ChatFilaAguardandoSheet } from '../../components/chat/ChatFilaAguardandoSheet'
+import { ChatFilaSomToggle } from '../../components/chat/ChatFilaSomToggle'
 import { ChatMensagemMidia } from '../../components/chat/ChatMensagemMidia'
 import { ChatTransferModal } from '../../components/chat/ChatTransferModal'
 import { Button } from '../../components/ui/Button'
@@ -16,7 +17,7 @@ import { useEventStream } from '../../contexts/EventStreamContext'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
 import { portalDemandasApi, type ChatDemanda } from '../../lib/chatDemandasApi'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
-import { CHAT_HUB_PATHS } from '../../lib/chatHubPaths'
+import { CHAT_HUB_PATHS, chatPortalLink } from '../../lib/chatHubPaths'
 import { mensagemTransferenciaSucesso, rotuloEstadoChat, rotuloResponsavelChat } from '../../lib/whatsappChatMeta'
 import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
 import { WhatsappDemandaTimelineMarco } from '../whatsapp/WhatsappDemandaTimelineMarco'
@@ -61,6 +62,8 @@ export function PortalConversa() {
   const { chatId: chatIdParam } = useParams()
   const chatId = Number(chatIdParam)
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const fromEspera = searchParams.get('from') === 'espera'
   const toast = useToast()
   const { user } = useAuth()
   const { subscribe, useFallback } = useEventStream()
@@ -71,6 +74,7 @@ export function PortalConversa() {
   const [texto, setTexto] = useState('')
   const [loading, setLoading] = useState(true)
   const [enviando, setEnviando] = useState(false)
+  const [assumindo, setAssumindo] = useState(false)
   const [modalEncerrar, setModalEncerrar] = useState(false)
   const [modalTransferir, setModalTransferir] = useState(false)
   const [transferindo, setTransferindo] = useState(false)
@@ -219,9 +223,30 @@ export function PortalConversa() {
     if (fileInputRef.current) fileInputRef.current.value = ''
   }
 
+  async function assumirChat() {
+    if (!chat || chat.estado !== 'aguardando_atendente' || assumindo) return
+    setAssumindo(true)
+    try {
+      const atualizado = await portalChats.assumir(chat.id)
+      setChat(atualizado)
+      void refreshContagens()
+      void refetchPendenciasResumo()
+      toast.showSuccess('Chat assumido.')
+      navigate(chatPortalLink(chat.id), { replace: true })
+    } catch (err) {
+      const msg =
+        err instanceof ApiError && err.status === 400
+          ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'
+          : mensagemFalhaParaToast(err)
+      toast.showWarning(msg)
+    } finally {
+      setAssumindo(false)
+    }
+  }
+
   async function confirmarEnvioMidia() {
     const responsavel = chat?.estado === 'em_atendimento' && chat.atendente_id === user?.id
-    if (!arquivoPendente || !Number.isFinite(chatId) || !responsavel) return
+    if (!arquivoPendente || !Number.isFinite(chatId) || !responsavel || enviando) return
     setEnviando(true)
     try {
       const msg = await portalChats.enviarMidia(chatId, arquivoPendente, legendaMidia.trim())
@@ -319,7 +344,10 @@ export function PortalConversa() {
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-white dark:bg-slate-950">
       <header className="flex shrink-0 items-center justify-between gap-3 border-b border-slate-200 bg-white px-4 py-3 dark:border-slate-800 dark:bg-slate-950">
         <div className="min-w-0">
-          <Link to={CHAT_HUB_PATHS.atendendo} className="text-xs text-cyan-600 hover:underline md:hidden">
+          <Link
+            to={fromEspera ? CHAT_HUB_PATHS.espera : CHAT_HUB_PATHS.atendendo}
+            className="text-xs text-cyan-600 hover:underline md:hidden"
+          >
             ← Voltar
           </Link>
           <div className="mt-0.5 flex flex-wrap items-center gap-2">
@@ -339,20 +367,35 @@ export function PortalConversa() {
         </div>
 
         <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant="secondary"
-            className="relative h-8 shrink-0 px-2.5 text-xs font-semibold md:hidden"
-            onClick={() => setFilaAguardandoAberta(true)}
-            aria-label={filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'}
-          >
-            Aguardando
-            {filaCount > 0 && (
-              <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
-                {filaCount > 99 ? '99+' : filaCount}
-              </span>
-            )}
-          </Button>
+          <div className="flex items-center gap-0.5 md:hidden">
+            <Button
+              type="button"
+              variant="secondary"
+              className="relative h-8 shrink-0 px-2.5 text-xs font-semibold"
+              onClick={() => setFilaAguardandoAberta(true)}
+              aria-label={filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'}
+            >
+              Aguardando
+              {filaCount > 0 && (
+                <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
+                  {filaCount > 99 ? '99+' : filaCount}
+                </span>
+              )}
+            </Button>
+            <ChatFilaSomToggle />
+          </div>
+
+          {chat.estado === 'aguardando_atendente' && (
+            <Button
+              type="button"
+              variant="primary"
+              className="h-8 shrink-0 px-3 text-xs font-semibold"
+              loading={assumindo}
+              onClick={() => void assumirChat()}
+            >
+              Atender
+            </Button>
+          )}
 
           {!encerrado && (
             <>
@@ -496,13 +539,33 @@ export function PortalConversa() {
             : 'Este atendimento foi encerrado.'}
         </p>
       ) : chat.estado === 'aguardando_atendente' ? (
-        <p className="shrink-0 border-t border-slate-200 bg-amber-50 px-4 py-3 text-center text-sm text-amber-800 dark:border-slate-800 dark:bg-amber-950/30 dark:text-amber-200">
-          Assuma o chat na lista para responder.
-        </p>
+        <div className="flex shrink-0 flex-col items-center gap-2 border-t border-slate-200 bg-amber-50 px-4 py-3 dark:border-slate-800 dark:bg-amber-950/30">
+          <p className="text-center text-sm text-amber-800 dark:text-amber-200">
+            Este chat está na fila. Assuma para responder ao visitante.
+          </p>
+          <Button
+            type="button"
+            variant="primary"
+            className="h-9 px-4 text-sm font-semibold"
+            loading={assumindo}
+            onClick={() => void assumirChat()}
+          >
+            Atender
+          </Button>
+        </div>
       ) : (
         <div className="shrink-0 border-t border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-950">
           {arquivoPendente ? (
-            <div className="mb-2 rounded-xl border border-cyan-200 bg-cyan-50/80 p-3 dark:border-cyan-900/40 dark:bg-cyan-950/20">
+            <div
+              className="mb-2 rounded-xl border border-cyan-200 bg-cyan-50/80 p-3 dark:border-cyan-900/40 dark:bg-cyan-950/20"
+              tabIndex={arquivoPendente.type.startsWith('audio/') ? 0 : undefined}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey && !enviando && podeEnviar) {
+                  e.preventDefault()
+                  void confirmarEnvioMidia()
+                }
+              }}
+            >
               <div className="flex flex-wrap items-start justify-between gap-2">
                 <div className="min-w-0 flex-1">
                   <p className="text-xs font-bold text-cyan-800 dark:text-cyan-300">Anexo selecionado</p>
@@ -526,6 +589,12 @@ export function PortalConversa() {
                   type="text"
                   value={legendaMidia}
                   onChange={(e) => setLegendaMidia(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                      e.preventDefault()
+                      if (!enviando && podeEnviar) void confirmarEnvioMidia()
+                    }
+                  }}
                   placeholder="Legenda opcional"
                   className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900"
                 />

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -3,22 +3,15 @@ import { useCallback, useEffect, useState, useRef, type MouseEvent } from 'react
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
 import {
-
-
+  ApiError,
   atendentes,
   tickets,
   whatsappChats,
-
   fetchWhatsAppMidiaBlob,
-
-
   type Setores,
-
   type Atendentes,
-
   type Tickets,
   type WhatsappChats,
-
 } from '../../api/client'
 
 import { resolveWhatsappMidiaObjectUrl, revokeWhatsappMidiaForChat } from '../../lib/whatsappMidiaCache'
@@ -70,6 +63,8 @@ import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
 import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { ChatFilaAguardandoSheet } from '../../components/chat/ChatFilaAguardandoSheet'
+import { ChatFilaSomToggle } from '../../components/chat/ChatFilaSomToggle'
+import { chatWhatsappLink } from '../../lib/chatHubPaths'
 import { WhatsappInatividadeControle } from './WhatsappInatividadeControle'
 import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
 import { rotuloDownloadArquivo, visualTipoArquivo } from '../../lib/fileTypeIcon'
@@ -312,7 +307,8 @@ export function WhatsappConversa() {
   const [menuMobileAberto, setMenuMobileAberto] = useState(false)
   const menuMobileRef = useRef<HTMLDivElement>(null)
   const [filaAguardandoAberta, setFilaAguardandoAberta] = useState(false)
-  const { filaCount } = useChatHub()
+  const [assumindo, setAssumindo] = useState(false)
+  const { filaCount, refreshContagens } = useChatHub()
   const navigate = useNavigate()
   const location = useLocation()
   const [searchParams] = useSearchParams()
@@ -836,7 +832,7 @@ useEffect(() => {
   }
 
   async function confirmarEnvioMidia() {
-    if (!arquivoPendente || !chat || !podeEnviar) return
+    if (!arquivoPendente || !chat || !podeEnviar || enviando) return
     setEnviando(true)
     try {
       await whatsappChats.enviarMidia(
@@ -855,6 +851,27 @@ useEffect(() => {
       toast.showError(mensagemFalhaParaToast(err, 'Falha no envio do anexo'))
     } finally {
       setEnviando(false)
+    }
+  }
+
+  async function assumirChat() {
+    if (!chat || chat.estado !== 'aguardando_atendente' || assumindo) return
+    setAssumindo(true)
+    try {
+      const atualizado = await whatsappChats.assumir(chat.id)
+      setChat((prev) => mergeWhatsappChat(prev, atualizado))
+      void refreshContagens()
+      void refetchPendenciasResumo()
+      toast.showSuccess('Chat assumido.')
+      navigate(chatWhatsappLink(chat.id, 'atendendo'), { replace: true })
+    } catch (err) {
+      const msg =
+        err instanceof ApiError && err.status === 400
+          ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'
+          : mensagemFalhaParaToast(err)
+      toast.showWarning(msg)
+    } finally {
+      setAssumindo(false)
     }
   }
 
@@ -1117,19 +1134,34 @@ useEffect(() => {
             <div className="flex shrink-0 items-center gap-1 sm:gap-2">
 
               {modoHub && (
+                <div className="flex items-center gap-0.5 md:hidden">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    className="relative h-8 shrink-0 px-2.5 text-xs font-semibold"
+                    onClick={() => setFilaAguardandoAberta(true)}
+                    aria-label={filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'}
+                  >
+                    Aguardando
+                    {filaCount > 0 && (
+                      <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
+                        {filaCount > 99 ? '99+' : filaCount}
+                      </span>
+                    )}
+                  </Button>
+                  <ChatFilaSomToggle />
+                </div>
+              )}
+
+              {chat?.estado === 'aguardando_atendente' && (
                 <Button
                   type="button"
-                  variant="secondary"
-                  className="relative h-8 shrink-0 px-2.5 text-xs font-semibold md:hidden"
-                  onClick={() => setFilaAguardandoAberta(true)}
-                  aria-label={filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'}
+                  variant="primary"
+                  className="h-8 shrink-0 px-3 text-xs font-semibold"
+                  loading={assumindo}
+                  onClick={() => void assumirChat()}
                 >
-                  Aguardando
-                  {filaCount > 0 && (
-                    <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
-                      {filaCount > 99 ? '99+' : filaCount}
-                    </span>
-                  )}
+                  Atender
                 </Button>
               )}
 
@@ -1583,7 +1615,16 @@ useEffect(() => {
           )}
 
           {arquivoPendente && (
-            <div className="mb-2 rounded-xl border border-cyan-200 bg-cyan-50/80 p-3 dark:border-cyan-900/40 dark:bg-cyan-950/20">
+            <div
+              className="mb-2 rounded-xl border border-cyan-200 bg-cyan-50/80 p-3 dark:border-cyan-900/40 dark:bg-cyan-950/20"
+              tabIndex={arquivoPendente.type.startsWith('audio/') ? 0 : undefined}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey && !enviando && podeEnviar) {
+                  e.preventDefault()
+                  void confirmarEnvioMidia()
+                }
+              }}
+            >
               <div className="flex flex-wrap items-start justify-between gap-2">
                 <div className="min-w-0 flex-1">
                   <p className="text-xs font-bold text-cyan-800 dark:text-cyan-300">Anexo selecionado</p>
@@ -1607,6 +1648,12 @@ useEffect(() => {
                   type="text"
                   value={legendaMidia}
                   onChange={(e) => setLegendaMidia(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                      e.preventDefault()
+                      if (!enviando && podeEnviar) void confirmarEnvioMidia()
+                    }
+                  }}
                   placeholder="Legenda opcional (visível no WhatsApp)"
                   className={`mt-2 ${TEXTAREA_FIELD_CLASS}`}
                   autoFocus


### PR DESCRIPTION
## Summary

- **#625**: ao **Ver** um chat da fila Aguardando, a lista com **Atender** permanece (`?from=espera`); CTA **Atender** na própria conversa (WhatsApp e portal)
- **#627**: com anexo pendente, **Enter** na legenda (ou no painel de áudio) envia o anexo
- **#626**: ícone de som junto a **Aguardando** para silenciar/reativar o alerta contínuo da fila (preferência em `localStorage`; não afeta tickets nem chat interno)

Closes #625
Closes #626
Closes #627

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções)

## Test plan

- [x] Build frontend (`npm run build`)
- [x] Smoke UI local: login, hub Chat, mute da fila (#626), modo `?from=espera` mantém tab Aguardando (#625)
- [ ] Com chat real na fila: Ver → lista permanece + CTA Atender na conversa; após assumir, some da fila
- [ ] Com anexo pendente em atendimento: Enter envia; Esc continua a cancelar
- [ ] Mute: com fila > 0 o loop para; desmutar restaura; persiste após reload

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens fora do escopo — Enter no anexo do portal incluído por paridade UX (mesmo padrão); sem issue nova necessária
- [x] Sem stubs/nullable neste lote
- [x] Sem follow-ups abertos neste PR
