### PR TITLE
feat(whatsapp): prefixo setor, lightbox, foto de perfil (#628 #629 #630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- WhatsApp (#628): no WhatsApp do cliente, mensagens do atendente saem com prefixo **setor do atendimento + nome** e o texto na linha de baixo (ex.: `[ Suporte - Ana ]:`); ao assumir, 1 setor é gravado automaticamente e vários setores pedem escolha no painel
+- WhatsApp (#629): no lightbox de imagens da conversa, dá para navegar entre as fotos (botões e setas ←/→) com contador e legenda atualizada; Esc continua a fechar só a visualização
+- WhatsApp (#630): foto de perfil do contacto no header e nas listas Atendendo/Aguardando (com cache e fallback para a inicial do nome)
+- WhatsApp: no header da conversa, o chip da empresa abre a página de detalhe da empresa (Voltar regressa ao chat); alterar empresa multi-empresa continua no menu ⋮
 - Chat (#626): ícone de som junto a **Aguardando** para silenciar/reativar o alerta contínuo da fila (WhatsApp + portal); preferência guardada no browser — não afeta alertas de ticket nem do chat interno
 - Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário
 - Portal (#600, #601): cadastro de funcionário pelo modal da Rede permite definir senha do portal na criação; sócio cadastra sem escolher empresas (escopo automático em toda a rede)

--- a/backend/alembic/versions/078_wpp_foto_perfil.py
+++ b/backend/alembic/versions/078_wpp_foto_perfil.py
@@ -1,0 +1,41 @@
+"""WhatsApp: foto de perfil do contacto (URL em cache).
+
+Revision ID: 078_wpp_foto_perfil
+Revises: 077_wpp_avaliacao_janela
+Create Date: 2026-08-01
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "078_wpp_foto_perfil"
+down_revision = "077_wpp_avaliacao_janela"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "foto_perfil_url" not in cols:
+        op.add_column("whatsapp_chats", sa.Column("foto_perfil_url", sa.Text(), nullable=True))
+    if "foto_perfil_atualizada_em" not in cols:
+        op.add_column(
+            "whatsapp_chats",
+            sa.Column("foto_perfil_atualizada_em", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "foto_perfil_atualizada_em" in cols:
+        op.drop_column("whatsapp_chats", "foto_perfil_atualizada_em")
+    if "foto_perfil_url" in cols:
+        op.drop_column("whatsapp_chats", "foto_perfil_url")

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -217,10 +217,34 @@ def _rotulo_midia_outbound(tipo_db: str) -> str:
     }.get(tipo_db, "[Ficheiro enviado]")
 
 
+def _prefixo_assinatura_whatsapp(
+    db: Session,
+    chat: WhatsappChat,
+    atendente: Atendente | None,
+) -> str:
+    """Prefixo visível no WhatsApp do cliente: «[ Setor - Nome ]:» (#628)."""
+    nome = (atendente.nome if atendente else "").strip()
+    if not nome:
+        return ""
+    setor_nome: str | None = None
+    if chat.setor_id:
+        rel = getattr(chat, "setor", None)
+        if rel and (rel.nome or "").strip():
+            setor_nome = rel.nome.strip()
+        else:
+            s = db.query(Setor).filter(Setor.id == chat.setor_id).first()
+            if s and (s.nome or "").strip():
+                setor_nome = s.nome.strip()
+    if setor_nome:
+        return f"[ {setor_nome} - {nome} ]:"
+    return f"[ Atendimento - {nome} ]:"
+
+
 def _corpo_e_caption_midia_outbound(
     tipo_db: str,
     caption: str | None,
-    nome_atendente: str | None,
+    *,
+    prefixo: str | None = None,
 ) -> tuple[str, str]:
     """
     Retorna (corpo_db, caption_evolution).
@@ -231,9 +255,71 @@ def _corpo_e_caption_midia_outbound(
     cap = (caption or "").strip()
     if not cap:
         return "", ""
-    nome = (nome_atendente or "").strip()
-    texto = f"[ {nome} ]: {cap}" if nome else cap
+    pref = (prefixo or "").strip()
+    texto = f"{pref}\n{cap}" if pref else cap
     return texto, texto
+
+
+def _aplicar_setor_ao_assumir(
+    db: Session,
+    chat: WhatsappChat,
+    atendente: Atendente,
+    setor_id: int | None,
+) -> None:
+    """Opção 1 (#628): 1 setor → auto; vários → obrigatório; admin sem setores pode omitir."""
+    if chat.setor_id is not None:
+        return
+    setores_atendente = list(getattr(atendente, "setores", None) or [])
+    if setor_id is not None:
+        if atendente.role != "admin":
+            ids = {s.id for s in setores_atendente}
+            if setor_id not in ids:
+                raise HTTPException(status_code=403, detail="Sem permissão para este setor")
+        else:
+            s = db.query(Setor).filter(Setor.id == setor_id, Setor.ativo.is_(True)).first()
+            if not s:
+                raise HTTPException(status_code=400, detail="Setor inválido ou inativo")
+        chat.setor_id = setor_id
+        return
+    if len(setores_atendente) == 1:
+        chat.setor_id = setores_atendente[0].id
+        return
+    if len(setores_atendente) > 1:
+        raise HTTPException(
+            status_code=400,
+            detail="Selecione o setor deste atendimento (atendente com vários setores).",
+        )
+
+
+FOTO_PERFIL_TTL_SEC = 7 * 24 * 3600
+
+
+def _maybe_refresh_foto_perfil(db: Session, chat: WhatsappChat, *, force: bool = False) -> bool:
+    """Atualiza cache da foto via Evolution. Retorna True se gravou alteração."""
+    now = datetime.now(timezone.utc)
+    if not force:
+        url = getattr(chat, "foto_perfil_url", None)
+        atualizada = getattr(chat, "foto_perfil_atualizada_em", None)
+        if url and atualizada is not None:
+            ts = atualizada if atualizada.tzinfo else atualizada.replace(tzinfo=timezone.utc)
+            if (now - ts).total_seconds() < FOTO_PERFIL_TTL_SEC:
+                return False
+    st = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
+    if not st or not _evolution_configurada(st):
+        return False
+    ok, profile_url, err = evolution_api.evolution_fetch_profile_picture_url(
+        st.evolution_base_url or "",
+        st.evolution_instance_name or "",
+        st.evolution_api_key or "",
+        chat.wa_id,
+    )
+    if not ok:
+        logger.info("Foto perfil Evolution falhou (chat=%s): %s", chat.protocolo, err)
+        chat.foto_perfil_atualizada_em = now
+        return True
+    chat.foto_perfil_url = profile_url
+    chat.foto_perfil_atualizada_em = now
+    return True
 
 
 def _sanitizar_nome_ficheiro(name: str | None, fallback: str) -> str:
@@ -289,16 +375,15 @@ def _enviar_texto_whatsapp(
     texto_eff = (texto or "").strip()
     if not texto_eff:
         raise HTTPException(status_code=400, detail="Mensagem vazia")
-    # Quando o atendente envia manualmente pelo DX Connect, prefixa o nome no texto
-    # para ficar visível no WhatsApp do cliente (padrão: "[ Nome ]: mensagem").
-    # A saudação ao assumir o chat usa o mesmo prefixo do atendente (não BOT).
+    # Prefixo no WhatsApp do cliente: "[ Setor - Nome ]:\nmensagem" (#628).
+    # A saudação ao assumir usa o mesmo prefixo do atendente (não BOT).
     if atendente is not None and evento_sistema in (None, "auto_assumido"):
-        nome = (atendente.nome or "").strip()
-        if nome and not texto_eff.startswith("["):
-            texto_eff = f"[ {nome} ]: {texto_eff}"
+        prefixo = _prefixo_assinatura_whatsapp(db, chat, atendente)
+        if prefixo and not texto_eff.startswith("["):
+            texto_eff = f"{prefixo}\n{texto_eff}"
     elif evento_sistema is not None:
         if not texto_eff.startswith("["):
-            texto_eff = f"[ BOT ]: {texto_eff}"
+            texto_eff = f"[ BOT ]:\n{texto_eff}"
     if evento_sistema:
         exist = (
             db.query(WhatsappMensagem)
@@ -576,6 +661,8 @@ def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False)
         inatividade_pausada=bool(getattr(c, "inatividade_pausada", False)),
         inatividade_retomada_em=getattr(c, "inatividade_retomada_em", None),
         classificacao_demanda_pendente=bool(getattr(c, "classificacao_demanda_pendente", False)),
+        foto_perfil_url=getattr(c, "foto_perfil_url", None),
+        foto_perfil_atualizada_em=getattr(c, "foto_perfil_atualizada_em", None),
     )
 
 
@@ -1256,6 +1343,32 @@ def obter(
         raise HTTPException(status_code=404, detail="Chat não encontrado")
     if not _pode_ver_chat(db, atendente, c):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    if _maybe_refresh_foto_perfil(db, c, force=False):
+        db.commit()
+        db.refresh(c)
+    return _chat_read(db, c)
+
+
+@router.post("/{chat_id}/foto-perfil", response_model=WhatsappChatRead)
+def atualizar_foto_perfil(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Força refresh da foto de perfil do contacto via Evolution (#630)."""
+    c = (
+        db.query(WhatsappChat)
+        .options(*_CHAT_LOAD_OPTIONS)
+        .filter(WhatsappChat.id == chat_id)
+        .first()
+    )
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    _maybe_refresh_foto_perfil(db, c, force=True)
+    db.commit()
+    db.refresh(c)
     return _chat_read(db, c)
 
 
@@ -1428,6 +1541,11 @@ def assumir(
         ge=1,
         description="Empresa de contexto opcional (pode ser definida depois na conversa).",
     ),
+    setor_id: int | None = Query(
+        None,
+        ge=1,
+        description="Setor do atendimento — obrigatório se o atendente tem vários setores e o chat ainda não tem setor (#628).",
+    ),
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
@@ -1441,6 +1559,7 @@ def assumir(
     if c.estado != "aguardando_atendente":
         raise HTTPException(status_code=400, detail="Só é possível assumir chats na fila de espera")
     _aplicar_empresa_contexto_chat(db, atendente, c, empresa_id)
+    _aplicar_setor_ao_assumir(db, c, atendente, setor_id)
     estado_anterior = c.estado
     c.estado = "em_atendimento"
     c.atendente_id = atendente.id
@@ -1627,8 +1746,9 @@ async def enviar_mensagem_midia(
         raise HTTPException(status_code=500, detail="Não foi possível guardar o ficheiro em disco.")
 
     cap = (caption or "").strip()
+    prefixo = _prefixo_assinatura_whatsapp(db, c, atendente) if cap else None
     corpo_eff, legenda_whatsapp = _corpo_e_caption_midia_outbound(
-        tipo_db, cap, atendente.nome
+        tipo_db, cap, prefixo=prefixo
     )
     b64 = base64.b64encode(data).decode("ascii")
     st = _settings_envio(db)

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -76,6 +76,9 @@ class WhatsappChat(Base):
     inatividade_retomada_em = Column(DateTime(timezone=True), nullable=True)
     # Após encerramento por inatividade: responsável deve registar (ou confirmar sem) demanda.
     classificacao_demanda_pendente = Column(Boolean, nullable=False, default=False, server_default="false")
+    # Cache da foto de perfil WhatsApp do contacto (#630 lote 1).
+    foto_perfil_url = Column(Text, nullable=True)
+    foto_perfil_atualizada_em = Column(DateTime(timezone=True), nullable=True)
 
     atendente = relationship("Atendente", backref="whatsapp_chats_atendidos")
     setor = relationship("Setor", backref="whatsapp_chats")

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -56,6 +56,8 @@ class WhatsappChatRead(BaseModel):
     inatividade_pausada: bool = False
     inatividade_retomada_em: datetime | None = None
     classificacao_demanda_pendente: bool = False
+    foto_perfil_url: str | None = None
+    foto_perfil_atualizada_em: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -219,6 +219,45 @@ def evolution_mark_messages_as_read(
     return False, f"HTTP {code}"
 
 
+def evolution_fetch_profile_picture_url(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    number_digits: str,
+) -> tuple[bool, str | None, str | None]:
+    """POST /chat/fetchProfilePictureUrl/{instance} → (ok, url | None, err)."""
+    import re
+
+    digits = re.sub(r"\D", "", number_digits or "")
+    if not digits:
+        return False, None, "Número inválido"
+    base = base_url.rstrip("/")
+    url = f"{base}/chat/fetchProfilePictureUrl/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body = {"number": digits}
+    code, data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=30)
+    if code not in (200, 201):
+        if err:
+            return False, None, err[:800]
+        return False, None, f"HTTP {code}"
+    profile_url: str | None = None
+    if isinstance(data, dict):
+        for key in ("profilePictureUrl", "profilePicUrl", "url", "picture"):
+            raw = data.get(key)
+            if isinstance(raw, str) and raw.strip().startswith(("http://", "https://")):
+                profile_url = raw.strip()
+                break
+        if profile_url is None:
+            nested = data.get("data")
+            if isinstance(nested, dict):
+                for key in ("profilePictureUrl", "profilePicUrl", "url", "picture"):
+                    raw = nested.get(key)
+                    if isinstance(raw, str) and raw.strip().startswith(("http://", "https://")):
+                        profile_url = raw.strip()
+                        break
+    return True, profile_url, None
+
+
 def evolution_send_text(
     base_url: str,
     instance: str,

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -1277,3 +1277,161 @@ def test_webhook_mensagens_paralelas_mesmo_wa_id_um_chat(client, seed_base, auth
         .all()
     )
     assert len(abertos) == 1
+
+
+def test_assumir_define_setor_unico_e_prefixo_mensagem(client, seed_base, auth_headers, monkeypatch):
+    """#628 — 1 setor auto ao assumir; prefixo «[ Setor - Nome ]:» + texto na linha de baixo."""
+    sent: list[str] = []
+
+    def fake_send(*_a, **kwargs):
+        text = kwargs.get("text")
+        if text is None and len(_a) > 4:
+            text = _a[4]
+        sent.append(text or "")
+        return True, None, f"wa-pfx-{len(sent)}"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "pfx-628",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "pfx-628"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511999000628", msg_id="pfx-628-1"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    r_ass = client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    assert r_ass.status_code == 200
+    assert r_ass.json()["setor_id"] == seed_base["setor1"].id
+
+    r_msg = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Olá, em que posso ajudar?"},
+        headers=auth_headers["a1"],
+    )
+    assert r_msg.status_code == 201
+    corpo = r_msg.json()["corpo"]
+    assert corpo.startswith("[ Suporte - Atendente 1 ]:\n")
+    assert "Olá, em que posso ajudar?" in corpo
+    assert sent and sent[-1].startswith("[ Suporte - Atendente 1 ]:\n")
+
+
+def test_assumir_multi_setor_exige_setor_id(client, seed_base, auth_headers, db_session):
+    """#628 — atendente com vários setores precisa informar setor_id ao assumir."""
+    a1 = seed_base["a1"]
+    a1.setores.append(seed_base["setor2"])
+    db_session.commit()
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "multi-628"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "multi-628"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511999000629", msg_id="multi-628-1"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+
+    sem = client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    assert sem.status_code == 400
+    assert "setor" in (sem.json().get("detail") or "").lower()
+
+    ok = client.post(
+        f"/v1/whatsapp/chats/{cid}/assumir",
+        params={"setor_id": seed_base["setor2"].id},
+        headers=auth_headers["a1"],
+    )
+    assert ok.status_code == 200
+    assert ok.json()["setor_id"] == seed_base["setor2"].id
+
+
+def test_prefixo_apos_transferencia_usa_novo_setor(client, seed_base, auth_headers, monkeypatch):
+    """#628 — após transferir, novas mensagens usam o setor novo do chat."""
+    sent: list[str] = []
+
+    def fake_send(*_a, **kwargs):
+        text = kwargs.get("text")
+        if text is None and len(_a) > 4:
+            text = _a[4]
+        sent.append(text or "")
+        return True, None, f"wa-tr-{len(sent)}"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "tr-pfx",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "tr-pfx"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511999000630", msg_id="tr-pfx-1"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    tr = client.post(
+        f"/v1/whatsapp/chats/{cid}/transferir",
+        json={"setor_id": seed_base["setor2"].id, "atendente_id": None},
+        headers=auth_headers["a1"],
+    )
+    assert tr.status_code == 200
+    assert tr.json()["setor_id"] == seed_base["setor2"].id
+    ass2 = client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a2"])
+    assert ass2.status_code == 200
+    r_msg = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Sou do Financeiro"},
+        headers=auth_headers["a2"],
+    )
+    assert r_msg.status_code == 201
+    assert r_msg.json()["corpo"].startswith("[ Financeiro - Atendente 2 ]:\n")
+
+
+def test_chat_read_inclui_foto_perfil_campos(client, seed_base, auth_headers, db_session):
+    """#630 lote 1 — schema expõe foto_perfil_url / foto_perfil_atualizada_em."""
+    from datetime import datetime, timezone
+
+    from app.models import WhatsappChat
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "foto-630"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "foto-630"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511999000631", msg_id="foto-630-1"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    chat = db_session.query(WhatsappChat).filter(WhatsappChat.id == cid).first()
+    assert chat is not None
+    chat.foto_perfil_url = "https://example.test/foto.jpg"
+    chat.foto_perfil_atualizada_em = datetime.now(timezone.utc)
+    db_session.commit()
+
+    r = client.get(f"/v1/whatsapp/chats/{cid}", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["foto_perfil_url"] == "https://example.test/foto.jpg"
+    assert body.get("foto_perfil_atualizada_em")

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -909,6 +909,8 @@ export namespace WhatsappChats {
   inatividade_pausada?: boolean
   inatividade_retomada_em?: string | null
   classificacao_demanda_pendente?: boolean
+  foto_perfil_url?: string | null
+  foto_perfil_atualizada_em?: string | null
   }
   export interface EmpresaOpcao {
     id: number
@@ -1174,13 +1176,19 @@ export const whatsappChats = {
       method: 'PATCH',
       body: JSON.stringify(data),
     }),
-  assumir: (id: number, data?: { empresa_id?: number | null }) => {
-    const qs =
-      data?.empresa_id != null && data.empresa_id !== undefined
-        ? `?empresa_id=${encodeURIComponent(String(data.empresa_id))}`
-        : ''
+  assumir: (id: number, data?: { empresa_id?: number | null; setor_id?: number | null }) => {
+    const params = new URLSearchParams()
+    if (data?.empresa_id != null && data.empresa_id !== undefined) {
+      params.set('empresa_id', String(data.empresa_id))
+    }
+    if (data?.setor_id != null && data.setor_id !== undefined) {
+      params.set('setor_id', String(data.setor_id))
+    }
+    const qs = params.toString() ? `?${params.toString()}` : ''
     return api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/assumir${qs}`, { method: 'POST' })
   },
+  atualizarFotoPerfil: (id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/foto-perfil`, { method: 'POST' }),
   definirEmpresaContexto: (id: number, empresa_id: number) =>
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/empresa-contexto`, {
       method: 'POST',

--- a/frontend/src/components/chat/AssumirWhatsappSetorModal.tsx
+++ b/frontend/src/components/chat/AssumirWhatsappSetorModal.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useState } from 'react'
+import { setores, type Setores } from '../../api/client'
+import { Button } from '../ui/Button'
+import { Select } from '../ui/Select'
+
+type Props = {
+  open: boolean
+  setorIds: number[]
+  loading?: boolean
+  onClose: () => void
+  onConfirm: (setorId: number) => void
+}
+
+/** Modal para escolher o setor ao assumir WhatsApp com atendente multi-setor (#628). */
+export function AssumirWhatsappSetorModal({
+  open,
+  setorIds,
+  loading = false,
+  onClose,
+  onConfirm,
+}: Props) {
+  const [lista, setLista] = useState<Setores.Setor[]>([])
+  const [setorId, setSetorId] = useState<number | ''>('')
+  const [carregando, setCarregando] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    setSetorId('')
+    setCarregando(true)
+    void setores
+      .list({ limit: 200 })
+      .then((page) => setLista(page.items || []))
+      .catch(() => setLista([]))
+      .finally(() => setCarregando(false))
+  }, [open])
+
+  const opcoes = useMemo(() => {
+    const ids = new Set(setorIds)
+    return lista
+      .filter((s) => ids.has(s.id) && s.ativo !== false)
+      .map((s) => ({ value: s.id, label: s.nome }))
+  }, [lista, setorIds])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-[180] flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+      role="dialog"
+      aria-modal
+      aria-labelledby="assumir-setor-titulo"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-2xl bg-white p-5 shadow-xl dark:bg-slate-900"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="assumir-setor-titulo" className="text-lg font-bold text-slate-900 dark:text-white">
+          Escolher setor
+        </h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Você atende em mais de um setor. Selecione o setor deste atendimento — ele aparece no
+          prefixo das mensagens no WhatsApp do cliente.
+        </p>
+        <div className="mt-4">
+          <Select
+            label="Setor"
+            value={setorId}
+            onChange={(v) => setSetorId(v === '' ? '' : Number(v))}
+            options={opcoes}
+            placeholder={carregando ? 'Carregando…' : 'Selecione o setor'}
+            includeEmpty
+            emptyLabel="Selecione…"
+            disabled={carregando || loading}
+          />
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <Button type="button" variant="secondary" onClick={onClose} disabled={loading}>
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            loading={loading}
+            disabled={setorId === '' || carregando}
+            onClick={() => {
+              if (setorId === '') return
+              onConfirm(setorId)
+            }}
+          >
+            Atender
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/WhatsappAvatar.tsx
+++ b/frontend/src/components/chat/WhatsappAvatar.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+
+type Props = {
+  nome?: string | null
+  fotoUrl?: string | null
+  className?: string
+  /** Classes do círculo quando só há inicial */
+  fallbackClassName?: string
+}
+
+/** Avatar do contacto WhatsApp com fallback para inicial (#630). */
+export function WhatsappAvatar({
+  nome,
+  fotoUrl,
+  className = 'h-10 w-10',
+  fallbackClassName = 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-200',
+}: Props) {
+  const [broke, setBroke] = useState(false)
+  const inicial = (nome || '?').trim().charAt(0).toUpperCase() || '?'
+  if (fotoUrl && !broke) {
+    return (
+      <img
+        src={fotoUrl}
+        alt=""
+        className={`${className} shrink-0 rounded-full object-cover`}
+        referrerPolicy="no-referrer"
+        onError={() => setBroke(true)}
+      />
+    )
+  }
+  return (
+    <div
+      className={`${className} flex shrink-0 items-center justify-center rounded-full text-sm font-bold ${fallbackClassName}`}
+      aria-hidden
+    >
+      {inicial}
+    </div>
+  )
+}

--- a/frontend/src/lib/assumirWhatsappSetor.ts
+++ b/frontend/src/lib/assumirWhatsappSetor.ts
@@ -1,0 +1,10 @@
+import type { Atendentes } from '../api/client'
+
+/** Atendente com vários setores precisa escolher ao assumir chat sem setor (#628). */
+export function precisaEscolherSetorAoAssumir(
+  user: Atendentes.Atendente | null | undefined,
+  chatJaTemSetor?: boolean,
+): boolean {
+  if (chatJaTemSetor) return false
+  return (user?.setor_ids?.length ?? 0) > 1
+}

--- a/frontend/src/lib/chatHubLista.ts
+++ b/frontend/src/lib/chatHubLista.ts
@@ -17,6 +17,7 @@ export type ChatHubItem = {
   atendente_id?: number | null
   atendente_nome?: string | null
   ultima_mensagem_preview?: string | null
+  foto_perfil_url?: string | null
 }
 
 export function mapWhatsappChat(c: WhatsappChats.Chat): ChatHubItem {
@@ -32,6 +33,7 @@ export function mapWhatsappChat(c: WhatsappChats.Chat): ChatHubItem {
     estado: c.estado,
     atendente_id: c.atendente_id,
     atendente_nome: c.atendente_nome,
+    foto_perfil_url: c.foto_perfil_url,
   }
 }
 

--- a/frontend/src/pages/chat/ChatListaAtendendo.tsx
+++ b/frontend/src/pages/chat/ChatListaAtendendo.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { Link, useMatch } from 'react-router-dom'
 import { portalChats, whatsappChats } from '../../api/client'
 import { ChatCanalBadge } from '../../components/chat/ChatCanalBadge'
+import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
 import { useAuth } from '../../contexts/AuthContext'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { useEventStream } from '../../contexts/EventStreamContext'
@@ -64,13 +65,13 @@ function ChatAtendendoItem({
           variant === 'outro' ? 'border-l-2 border-slate-300 pl-[10px] dark:border-slate-600' : ''
         }`}
       >
-        <div
-          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold ${
+        <WhatsappAvatar
+          nome={item.nome}
+          fotoUrl={item.canal === 'whatsapp' ? item.foto_perfil_url : null}
+          fallbackClassName={
             ativo ? 'bg-cyan-600 text-white' : 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-200'
-          }`}
-        >
-          {item.nome.charAt(0)?.toUpperCase() || '?'}
-        </div>
+          }
+        />
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-2">
             <div className="flex min-w-0 flex-1 items-center gap-1.5">

--- a/frontend/src/pages/chat/ChatListaEspera.tsx
+++ b/frontend/src/pages/chat/ChatListaEspera.tsx
@@ -1,12 +1,16 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { ApiError, portalChats, whatsappChats } from '../../api/client'
+import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsappSetorModal'
 import { ChatCanalBadge } from '../../components/chat/ChatCanalBadge'
+import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
 import { Button } from '../../components/ui/Button'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useAuth } from '../../contexts/AuthContext'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { useEventStream } from '../../contexts/EventStreamContext'
+import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import {
   chatHubItemKey,
@@ -51,12 +55,14 @@ type Props = {
 
 export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerChat }: Props = {}) {
   const toast = useToast()
+  const { user } = useAuth()
   const navigate = useNavigate()
   const { busca, refreshContagens } = useChatHub()
   const { subscribe, useFallback } = useEventStream()
   const [fila, setFila] = useState<ChatHubItem[]>([])
   const [loading, setLoading] = useState(true)
   const [assumindoKey, setAssumindoKey] = useState<string | null>(null)
+  const [pendenteSetor, setPendenteSetor] = useState<ChatHubItem | null>(null)
 
   const load = useCallback(async () => {
     try {
@@ -88,17 +94,18 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
     }
   }, [subscribe, load])
 
-  async function assumir(item: ChatHubItem) {
+  async function executarAssumir(item: ChatHubItem, setorId?: number) {
     const key = chatHubItemKey(item)
     setAssumindoKey(key)
     try {
       if (item.canal === 'whatsapp') {
-        await whatsappChats.assumir(item.id)
+        await whatsappChats.assumir(item.id, setorId != null ? { setor_id: setorId } : undefined)
         toast.showSuccess('Chat assumido.')
       } else {
         await portalChats.assumir(item.id)
         toast.showSuccess('Chat assumido.')
       }
+      setPendenteSetor(null)
       await load()
       void refreshContagens()
       void refetchPendenciasResumo()
@@ -118,6 +125,17 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
     }
   }
 
+  function assumir(item: ChatHubItem) {
+    if (
+      item.canal === 'whatsapp' &&
+      precisaEscolherSetorAoAssumir(user, Boolean(item.setor_nome))
+    ) {
+      setPendenteSetor(item)
+      return
+    }
+    void executarAssumir(item)
+  }
+
   const lista = ignorarBusca ? fila : filtrarChatHubPorBusca(fila, busca)
 
   if (loading) {
@@ -133,13 +151,16 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
   }
 
   return (
+    <>
     <ul className="divide-y divide-slate-100 dark:divide-slate-800">
       {lista.map((c) => (
         <li key={chatHubItemKey(c)} className="px-3 py-3">
           <div className="flex gap-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-amber-100 text-sm font-bold text-amber-800 dark:bg-amber-950/50 dark:text-amber-200">
-              {c.nome.charAt(0)?.toUpperCase() || '?'}
-            </div>
+            <WhatsappAvatar
+              nome={c.nome}
+              fotoUrl={c.canal === 'whatsapp' ? c.foto_perfil_url : null}
+              fallbackClassName="bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-200"
+            />
             <div className="min-w-0 flex-1">
               <div className="flex items-start justify-between gap-2">
                 <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">{c.nome}</p>
@@ -176,5 +197,16 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
         </li>
       ))}
     </ul>
+    <AssumirWhatsappSetorModal
+      open={pendenteSetor != null}
+      setorIds={user?.setor_ids || []}
+      loading={pendenteSetor != null && assumindoKey === chatHubItemKey(pendenteSetor)}
+      onClose={() => setPendenteSetor(null)}
+      onConfirm={(setorId) => {
+        if (!pendenteSetor) return
+        void executarAssumir(pendenteSetor, setorId)
+      }}
+    />
+    </>
   )
 }

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -1,8 +1,12 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { ApiError, whatsappChats, type WhatsappChats } from '../../api/client'
+import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsappSetorModal'
+import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
 import { whatsappConversaLink, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
+import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
+import { useAuth } from '../../contexts/AuthContext'
 import { useEventStream } from '../../contexts/EventStreamContext'
 import { Card } from '../../components/ui/Card'
 import { Button } from '../../components/ui/Button'
@@ -40,10 +44,13 @@ function TempoEspera({ data }: { data?: string | null }) {
 
 export function WhatsappAtendendo() {
   const toast = useToast()
+  const { user } = useAuth()
   const { subscribe, useFallback } = useEventStream()
   const [fila, setFila] = useState<WhatsappChats.Chat[]>([])
   const [meus, setMeus] = useState<WhatsappChats.Chat[]>([])
   const [loading, setLoading] = useState(true)
+  const [assumindoId, setAssumindoId] = useState<number | null>(null)
+  const [pendenteSetor, setPendenteSetor] = useState<WhatsappChats.Chat | null>(null)
   const isFirstLoad = useRef(true)
   const prevFilaCount = useRef(0)
 
@@ -90,9 +97,11 @@ export function WhatsappAtendendo() {
     prevFilaCount.current = fila.length
   }, [fila.length])
 
-  async function assumir(id: number) {
+  async function executarAssumir(chat: WhatsappChats.Chat, setorId?: number) {
+    setAssumindoId(chat.id)
     try {
-      await whatsappChats.assumir(id)
+      await whatsappChats.assumir(chat.id, setorId != null ? { setor_id: setorId } : undefined)
+      setPendenteSetor(null)
       toast.showSuccess('Chat assumido com sucesso!')
       await load(true)
       void refetchPendenciasResumo()
@@ -102,7 +111,17 @@ export function WhatsappAtendendo() {
           ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'
           : mensagemFalhaParaToast(err)
       toast.showWarning(msg)
+    } finally {
+      setAssumindoId(null)
     }
+  }
+
+  function assumir(chat: WhatsappChats.Chat) {
+    if (precisaEscolherSetorAoAssumir(user, Boolean(chat.setor_id || chat.setor_nome))) {
+      setPendenteSetor(chat)
+      return
+    }
+    void executarAssumir(chat)
   }
 
   const meusAtivos = meus.filter((c) => c.estado === 'em_atendimento')
@@ -162,8 +181,14 @@ export function WhatsappAtendendo() {
               fila.map((c) => (
                 <Card key={c.id} className="border-none p-4 shadow-sm ring-1 ring-slate-200 dark:ring-slate-800">
                   <div className="flex flex-col gap-4">
-                    <div className="flex items-start justify-between">
-                      <div className="min-w-0">
+                    <div className="flex items-start justify-between gap-3">
+                      <WhatsappAvatar
+                        nome={c.cliente_nome}
+                        fotoUrl={c.foto_perfil_url}
+                        className="h-10 w-10"
+                        fallbackClassName="bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-200"
+                      />
+                      <div className="min-w-0 flex-1">
                         <div className="mb-1 flex items-center gap-2">
                           <span
                             className="min-w-0 truncate font-mono text-[10px] font-bold text-cyan-600"
@@ -204,7 +229,8 @@ export function WhatsappAtendendo() {
                         Visualizar
                       </Link>
                       <Button
-                        onClick={() => void assumir(c.id)}
+                        loading={assumindoId === c.id}
+                        onClick={() => assumir(c)}
                         className="flex-1 bg-amber-500 text-white hover:bg-amber-600"
                       >
                         Atender
@@ -323,6 +349,16 @@ export function WhatsappAtendendo() {
           </div>
         </section>
       </div>
+      <AssumirWhatsappSetorModal
+        open={pendenteSetor != null}
+        setorIds={user?.setor_ids || []}
+        loading={pendenteSetor != null && assumindoId === pendenteSetor.id}
+        onClose={() => setPendenteSetor(null)}
+        onConfirm={(setorId) => {
+          if (!pendenteSetor) return
+          void executarAssumir(pendenteSetor, setorId)
+        }}
+      />
     </div>
   )
 }

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useRef, type MouseEvent } from 'react'
+import { useCallback, useEffect, useMemo, useState, useRef, type MouseEvent } from 'react'
 
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
@@ -28,6 +28,9 @@ import {
   scrollWhatsappToBottom,
 } from '../../lib/whatsappScrollMemory'
 import { MensagemRodapeMeta } from '../../components/chat/MensagemRodapeMeta'
+import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsappSetorModal'
+import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
+import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
 
 import { Card } from '../../components/ui/Card'
 import { TEXTAREA_FIELD_CLASS } from '../../components/ui/Input'
@@ -106,7 +109,15 @@ function TextoComLinks({ texto }: { texto: string }) {
   )
 }
 
-function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number; m: WhatsappChats.Mensagem; onImageClick: (url: string, caption: string | null) => void }) {
+function ConteudoMensagemWhatsApp({
+  chatId,
+  m,
+  onImageClick,
+}: {
+  chatId: number
+  m: WhatsappChats.Mensagem
+  onImageClick: (msgId: number) => void
+}) {
 
   const tipo = (m.tipo_midia || 'texto').toLowerCase()
 
@@ -183,7 +194,7 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
           src={url}
           alt=""
           className={`${mediaClass} cursor-zoom-in transition-transform duration-200 hover:scale-[1.02]`}
-          onClick={() => onImageClick(url, legenda)}
+          onClick={() => onImageClick(m.id)}
         />
         {legenda ? <TextoComLinks texto={legenda} /> : null}
       </div>
@@ -218,6 +229,141 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 }
 
 
+
+/** Lightbox com galeria só de imagens (#629). */
+function WhatsappZoomLightbox({
+  chatId,
+  msgs,
+  zoomMsgId,
+  onClose,
+  onChangeMsgId,
+}: {
+  chatId: number
+  msgs: WhatsappChats.Mensagem[]
+  zoomMsgId: number
+  onClose: () => void
+  onChangeMsgId: (msgId: number) => void
+}) {
+  const galeria = useMemo(
+    () =>
+      msgs.filter(
+        (m) => (m.tipo_midia || '').toLowerCase() === 'imagem' && m.midia_disponivel,
+      ),
+    [msgs],
+  )
+  const index = galeria.findIndex((m) => m.id === zoomMsgId)
+  const msgAtiva = msgs.find((m) => m.id === zoomMsgId) || null
+  const caption = msgAtiva ? legendaMidiaVisivel(msgAtiva.corpo) : null
+  const [url, setUrl] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setUrl(null)
+    void resolveWhatsappMidiaObjectUrl(chatId, zoomMsgId, () => fetchWhatsAppMidiaBlob(chatId, zoomMsgId))
+      .then((u) => {
+        if (!cancelled) setUrl(u)
+      })
+      .catch(() => {
+        if (!cancelled) setUrl(null)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [chatId, zoomMsgId])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
+      if (index < 0 || galeria.length <= 1) return
+      e.preventDefault()
+      e.stopPropagation()
+      if (e.key === 'ArrowLeft' && index > 0) onChangeMsgId(galeria[index - 1].id)
+      if (e.key === 'ArrowRight' && index < galeria.length - 1) onChangeMsgId(galeria[index + 1].id)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [galeria, index, onChangeMsgId])
+
+  const podePrev = index > 0
+  const podeNext = index >= 0 && index < galeria.length - 1
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex flex-col items-center justify-center bg-black/90 p-4 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={onClose}
+    >
+      <button
+        type="button"
+        className="absolute top-4 right-4 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white/10 text-3xl font-bold text-white transition-colors touch-manipulation hover:bg-white/20"
+        onClick={onClose}
+        aria-label="Fechar"
+      >
+        &times;
+      </button>
+      {index >= 0 && galeria.length > 1 && (
+        <p className="absolute top-5 left-1/2 -translate-x-1/2 text-sm font-medium text-white/80">
+          {index + 1} / {galeria.length}
+        </p>
+      )}
+      {podePrev && (
+        <button
+          type="button"
+          className="absolute left-3 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 text-2xl text-white hover:bg-white/20 sm:left-6"
+          onClick={(e) => {
+            e.stopPropagation()
+            onChangeMsgId(galeria[index - 1].id)
+          }}
+          aria-label="Imagem anterior"
+        >
+          ‹
+        </button>
+      )}
+      {podeNext && (
+        <button
+          type="button"
+          className="absolute right-3 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 text-2xl text-white hover:bg-white/20 sm:right-6"
+          onClick={(e) => {
+            e.stopPropagation()
+            onChangeMsgId(galeria[index + 1].id)
+          }}
+          aria-label="Próxima imagem"
+        >
+          ›
+        </button>
+      )}
+      {loading || !url ? (
+        <p className="text-sm text-white/70 animate-pulse">Carregando imagem…</p>
+      ) : (
+        <img
+          src={url}
+          alt=""
+          className="max-h-[85vh] max-w-full rounded-lg object-contain shadow-2xl animate-in zoom-in-95 duration-200"
+          onClick={(e) => e.stopPropagation()}
+        />
+      )}
+      {caption && (
+        <p className="mt-4 max-w-2xl rounded-xl bg-black/40 px-4 py-2 text-center text-sm text-white backdrop-blur-md">
+          {caption}
+        </p>
+      )}
+      {url && (
+        <a
+          href={url}
+          download="whatsapp-imagem.jpg"
+          className="absolute bottom-4 right-4 flex items-center gap-2 rounded-xl bg-cyan-600 px-4 py-2.5 text-xs font-bold text-white shadow-lg shadow-cyan-600/30 transition-all hover:scale-105 hover:bg-cyan-700"
+          onClick={(e) => e.stopPropagation()}
+        >
+          📥 Baixar Imagem
+        </a>
+      )}
+    </div>
+  )
+}
 
 // --- Componente Principal ---
 
@@ -279,9 +425,9 @@ export function WhatsappConversa() {
   // Estados de WhatsApp Clone (Citação e Zoom)
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
   const [focoComposerEm, setFocoComposerEm] = useState(0)
-  const [activeZoomImage, setActiveZoomImage] = useState<string | null>(null)
-  const [activeZoomImageCaption, setActiveZoomImageCaption] = useState<string | null>(null)
+  const [zoomMsgId, setZoomMsgId] = useState<number | null>(null)
   const [modoInterno, setModoInterno] = useState(false)
+  const [modalAssumirSetor, setModalAssumirSetor] = useState(false)
 
   // Transferência
   const [modalTransferir, setModalTransferir] = useState(false)
@@ -324,11 +470,10 @@ export function WhatsappConversa() {
       if (e.key !== 'Escape' || e.defaultPrevented || modalEncerrar) return
       const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase()
       if (tag === 'input' || tag === 'textarea' || tag === 'select') return
-      if (activeZoomImage) {
+      if (zoomMsgId != null) {
         e.preventDefault()
         e.stopPropagation()
-        setActiveZoomImage(null)
-        setActiveZoomImageCaption(null)
+        setZoomMsgId(null)
         return
       }
       if (arquivoPendente) {
@@ -341,7 +486,7 @@ export function WhatsappConversa() {
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [voltarLista, modalEncerrar, activeZoomImage, arquivoPendente])
+  }, [voltarLista, modalEncerrar, zoomMsgId, arquivoPendente])
 
   useEffect(() => {
     if (!menuMobileAberto) return
@@ -854,12 +999,16 @@ useEffect(() => {
     }
   }
 
-  async function assumirChat() {
+  async function executarAssumirChat(setorId?: number) {
     if (!chat || chat.estado !== 'aguardando_atendente' || assumindo) return
     setAssumindo(true)
     try {
-      const atualizado = await whatsappChats.assumir(chat.id)
+      const atualizado = await whatsappChats.assumir(
+        chat.id,
+        setorId != null ? { setor_id: setorId } : undefined,
+      )
       setChat((prev) => mergeWhatsappChat(prev, atualizado))
+      setModalAssumirSetor(false)
       void refreshContagens()
       void refetchPendenciasResumo()
       toast.showSuccess('Chat assumido.')
@@ -873,6 +1022,15 @@ useEffect(() => {
     } finally {
       setAssumindo(false)
     }
+  }
+
+  function assumirChat() {
+    if (!chat || chat.estado !== 'aguardando_atendente' || assumindo) return
+    if (precisaEscolherSetorAoAssumir(user, Boolean(chat.setor_id || chat.setor_nome))) {
+      setModalAssumirSetor(true)
+      return
+    }
+    void executarAssumirChat()
   }
 
   async function enviarFigurinha(file: File) {
@@ -1050,13 +1208,16 @@ useEffect(() => {
 
             >
 
-              <div className={`h-8 w-8 shrink-0 rounded-full flex items-center justify-center text-xs font-bold shadow-sm
-
-                ${c.id === id ? 'bg-cyan-600 text-white' : 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-300'}`}>
-
-                {c.cliente_nome?.charAt(0) || '?'}
-
-              </div>
+              <WhatsappAvatar
+                nome={c.cliente_nome}
+                fotoUrl={c.foto_perfil_url}
+                className="h-8 w-8 text-xs shadow-sm"
+                fallbackClassName={
+                  c.id === id
+                    ? 'bg-cyan-600 text-white'
+                    : 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
+                }
+              />
 
               {sidebarAberta && (
 
@@ -1125,6 +1286,12 @@ useEffect(() => {
               <span className="hidden sm:inline"> Voltar</span>
             </Button>
 
+            <WhatsappAvatar
+              nome={chat?.cliente_nome}
+              fotoUrl={chat?.foto_perfil_url}
+              className="h-9 w-9 text-sm"
+              fallbackClassName="bg-cyan-100 text-cyan-800 dark:bg-cyan-950/50 dark:text-cyan-200"
+            />
             <div className="min-w-0 flex-1">
               <h1 className="truncate font-bold text-slate-900 dark:text-white">
                 {chat?.cliente_nome || 'Atendimento'}
@@ -1319,21 +1486,15 @@ useEffect(() => {
                   {chat.funcionario_nome}
                   {chat.funcionario_tipo ? ` · ${chat.funcionario_tipo}` : ''}
                 </Link>
-                {chat.empresa_nome ? (
-                  podeDefinirEmpresa && (chat.empresas_opcoes?.length ?? 0) > 1 ? (
-                    <button
-                      type="button"
-                      onClick={abrirModalEmpresaContexto}
-                      className="inline-flex max-w-full truncate rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 transition-colors hover:border-cyan-400 hover:text-cyan-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300"
-                      title="Alterar empresa do atendimento"
-                    >
-                      {chat.empresa_nome}
-                    </button>
-                  ) : (
-                    <span className="inline-flex max-w-full truncate rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
-                      {chat.empresa_nome}
-                    </span>
-                  )
+                {chat.empresa_nome && chat.empresa_id ? (
+                  <Link
+                    to={`/empresas/${chat.empresa_id}`}
+                    state={{ voltarPara: `${location.pathname}${location.search}` }}
+                    className="inline-flex max-w-full truncate rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 transition-colors hover:border-cyan-400 hover:text-cyan-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:hover:border-cyan-600 dark:hover:text-cyan-300"
+                    title="Ver detalhe da empresa"
+                  >
+                    {chat.empresa_nome}
+                  </Link>
                 ) : podeDefinirEmpresa ? (
                   <button
                     type="button"
@@ -1539,10 +1700,11 @@ useEffect(() => {
                       </div>
                     )}
 
-                    <ConteudoMensagemWhatsApp chatId={id} m={m} onImageClick={(url, caption) => {
-                      setActiveZoomImage(url)
-                      setActiveZoomImageCaption(caption)
-                    }} />
+                    <ConteudoMensagemWhatsApp
+                      chatId={id}
+                      m={m}
+                      onImageClick={(msgId) => setZoomMsgId(msgId)}
+                    />
 
                     {!isSystem && (
                       <MensagemRodapeMeta
@@ -1863,45 +2025,23 @@ useEffect(() => {
         />
       )}
 
-      {/* Modal Zoom de Imagem */}
-      {activeZoomImage && (
-        <div 
-          className="fixed inset-0 z-[200] flex flex-col items-center justify-center bg-black/90 backdrop-blur-sm p-4 animate-in fade-in duration-200"
-          onClick={() => {
-            setActiveZoomImage(null)
-            setActiveZoomImageCaption(null)
-          }}
-        >
-          <button 
-            className="absolute top-4 right-4 text-white text-3xl font-bold bg-white/10 hover:bg-white/20 w-12 h-12 rounded-full flex items-center justify-center transition-colors touch-manipulation cursor-pointer"
-            onClick={() => {
-              setActiveZoomImage(null)
-              setActiveZoomImageCaption(null)
-            }}
-          >
-            &times;
-          </button>
-          <img 
-            src={activeZoomImage} 
-            alt="" 
-            className="max-h-[85vh] max-w-full rounded-lg shadow-2xl object-contain animate-in zoom-in-95 duration-200" 
-            onClick={(e) => e.stopPropagation()} 
-          />
-          {activeZoomImageCaption && (
-            <p className="mt-4 text-white text-sm max-w-2xl text-center bg-black/40 px-4 py-2 rounded-xl backdrop-blur-md">
-              {activeZoomImageCaption}
-            </p>
-          )}
-          <a 
-            href={activeZoomImage} 
-            download="whatsapp-imagem.jpg" 
-            className="absolute bottom-4 right-4 bg-cyan-600 hover:bg-cyan-700 text-white font-bold text-xs px-4 py-2.5 rounded-xl flex items-center gap-2 shadow-lg shadow-cyan-600/30 transition-all hover:scale-105" 
-            onClick={(e) => e.stopPropagation()}
-          >
-            📥 Baixar Imagem
-          </a>
-        </div>
+      {zoomMsgId != null && (
+        <WhatsappZoomLightbox
+          chatId={id}
+          msgs={msgs}
+          zoomMsgId={zoomMsgId}
+          onClose={() => setZoomMsgId(null)}
+          onChangeMsgId={setZoomMsgId}
+        />
       )}
+
+      <AssumirWhatsappSetorModal
+        open={modalAssumirSetor}
+        setorIds={user?.setor_ids || []}
+        loading={assumindo}
+        onClose={() => setModalAssumirSetor(false)}
+        onConfirm={(setorId) => void executarAssumirChat(setorId)}
+      />
 
       {modoHub && (
         <ChatFilaAguardandoSheet


### PR DESCRIPTION
## Summary

- Closes #628 — prefixo no WhatsApp do cliente com **setor do atendimento + nome**, texto na linha de baixo; ao assumir, 1 setor grava automaticamente e vários pedem escolha no painel
- Closes #629 — lightbox de imagens com navegação (botões + ←/→), contador e legenda; Esc mantém fechar só o zoom
- Partial #630 (lote 1) — foto de perfil do contacto (cache Evolution, avatar no header/listas, fallback para inicial)
- Chip da empresa no header da conversa abre o detalhe da empresa (Voltar regressa ao chat)

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] Pytest: `test_assumir_define_setor_unico_e_prefixo_mensagem`, multi-setor, prefixo pós-transferência, campos `foto_perfil_*`, `test_fila_e_assumir`
- [x] `npm run build` (frontend)
- [ ] Smoke: assumir com 1 setor e com vários (modal)
- [ ] Smoke: lightbox com ≥2 imagens (setas / contador / Esc)
- [ ] Smoke: avatar com foto e sem foto; chip empresa → detalhe → Voltar

## Follow-ups / backlog

- [x] #630 permanece aberto como épico — lotes 2–3 (reações, editar/apagar) fora deste PR; issues filhas a abrir após merge se ainda não existirem
- [ ] Higiene: fechar épico #545 (Presença) — filhas #546/#547 já fechadas (sem código neste PR)
