### PR TITLE
feat(whatsapp): reações, editar e apagar mensagens (#630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - WhatsApp (#628): no WhatsApp do cliente, mensagens do atendente saem com prefixo **setor do atendimento + nome** e o texto na linha de baixo (ex.: `[ Suporte - Ana ]:`); ao assumir, 1 setor é gravado automaticamente e vários setores pedem escolha no painel
 - WhatsApp (#629): no lightbox de imagens da conversa, dá para navegar entre as fotos (botões e setas ←/→) com contador e legenda atualizada; Esc continua a fechar só a visualização
 - WhatsApp (#630): foto de perfil do contacto no header e nas listas Atendendo/Aguardando (com cache e fallback para a inicial do nome)
+- WhatsApp (#630): reações no chat com o cliente — ver emoji do cliente no balão e o atendente responsável pode reagir (👍 ❤️ 😂 😮 😢 🙏); clique de novo remove
+- WhatsApp (#630): editar (até 15 min) e apagar para todos (até 48 h) mensagens de texto enviadas pelo responsável; também sincroniza quando o cliente edita ou apaga
 - WhatsApp: no header da conversa, o chip da empresa abre a página de detalhe da empresa (Voltar regressa ao chat); alterar empresa multi-empresa continua no menu ⋮
 - Chat (#626): ícone de som junto a **Aguardando** para silenciar/reativar o alerta contínuo da fila (WhatsApp + portal); preferência guardada no browser — não afeta alertas de ticket nem do chat interno
 - Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário

--- a/backend/alembic/versions/079_wpp_reacoes.py
+++ b/backend/alembic/versions/079_wpp_reacoes.py
@@ -1,0 +1,52 @@
+"""WhatsApp: reações em mensagens do chat com o cliente (#630 lote 2).
+
+Revision ID: 079_wpp_reacoes
+Revises: 078_wpp_foto_perfil
+Create Date: 2026-08-01
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "079_wpp_reacoes"
+down_revision = "078_wpp_foto_perfil"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_mensagens"):
+        return
+    if insp.has_table("whatsapp_mensagem_reacoes"):
+        return
+    op.create_table(
+        "whatsapp_mensagem_reacoes",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "mensagem_id",
+            sa.Integer(),
+            sa.ForeignKey("whatsapp_mensagens.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("origem", sa.String(20), nullable=False),
+        sa.Column("emoji", sa.String(16), nullable=False),
+        sa.Column(
+            "atendente_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("mensagem_id", "origem", name="uq_whatsapp_mensagem_reacoes_mensagem_origem"),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("whatsapp_mensagem_reacoes"):
+        op.drop_table("whatsapp_mensagem_reacoes")

--- a/backend/alembic/versions/080_wpp_edicao_apagar.py
+++ b/backend/alembic/versions/080_wpp_edicao_apagar.py
@@ -1,0 +1,44 @@
+"""WhatsApp: editar e apagar para todos (#630 lote 3).
+
+Revision ID: 080_wpp_edicao_apagar
+Revises: 079_wpp_reacoes
+Create Date: 2026-08-01
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "080_wpp_edicao_apagar"
+down_revision = "079_wpp_reacoes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_mensagens"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_mensagens")}
+    if "editada_em" not in cols:
+        op.add_column(
+            "whatsapp_mensagens",
+            sa.Column("editada_em", sa.DateTime(timezone=True), nullable=True),
+        )
+    if "apagada_em" not in cols:
+        op.add_column(
+            "whatsapp_mensagens",
+            sa.Column("apagada_em", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_mensagens"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_mensagens")}
+    if "apagada_em" in cols:
+        op.drop_column("whatsapp_mensagens", "apagada_em")
+    if "editada_em" in cols:
+        op.drop_column("whatsapp_mensagens", "editada_em")

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -32,6 +32,9 @@ from app.schemas.whatsapp_chat import (
     WhatsappEmpresaContextoBody,
     WhatsappIniciarChatBody,
     WhatsappMensagemRead,
+    WhatsappMensagemUpdate,
+    WhatsappReacaoCreate,
+    WhatsappReacaoRead,
     WhatsappTransferirChatBody,
     WhatsappVincularFuncionarioBody,
     WhatsappCadastrarFuncionarioBody,
@@ -63,6 +66,8 @@ from app.services.ticket_distribuicao import pos_criar_ticket_na_fila
 from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.whatsapp_wa_id_lock import lock_wa_id_para_chat, unlock_wa_id_para_chat
 from app.services.audit_operacional import audit_whatsapp_chat
+from app.services import whatsapp_reacoes as wpp_reacoes
+from app.services import whatsapp_edicao as wpp_edicao
 
 router = APIRouter(prefix="/whatsapp/chats", tags=["whatsapp-chats"])
 
@@ -735,17 +740,33 @@ def _pode_ver_chat(db: Session, atendente: Atendente, c: WhatsappChat) -> bool:
     return False
 
 
-def _mensagem_read(m: WhatsappMensagem) -> WhatsappMensagemRead:
+def _mensagem_read(
+    m: WhatsappMensagem,
+    *,
+    viewer_id: int | None = None,
+    is_responsavel: bool = False,
+) -> WhatsappMensagemRead:
     midia_ok = bool(m.midia_nome_arquivo and str(m.midia_nome_arquivo).strip())
     status = m.status_entrega if m.direcao == "outbound" and not m.evento_sistema else None
+    reacoes = [
+        WhatsappReacaoRead(
+            emoji=r.emoji,
+            count=r.count,
+            reagiu_eu=r.reagiu_eu,
+            atendente_ids=r.atendente_ids,
+            tem_cliente=r.tem_cliente,
+        )
+        for r in wpp_reacoes.agregar_reacoes(m, viewer_id)
+    ]
+    apagada = wpp_edicao.mensagem_apagada(m)
     return WhatsappMensagemRead(
         id=m.id,
         chat_id=m.chat_id,
         direcao=m.direcao,
-        corpo=m.corpo,
+        corpo=wpp_edicao.CORPO_MENSAGEM_APAGADA if apagada else m.corpo,
         tipo_midia=m.tipo_midia,
         mimetype=m.mimetype,
-        midia_disponivel=midia_ok,
+        midia_disponivel=False if apagada else midia_ok,
         evento_sistema=getattr(m, "evento_sistema", None),
         wa_message_id=m.wa_message_id,
         quoted_wa_message_id=getattr(m, "quoted_wa_message_id", None),
@@ -754,6 +775,12 @@ def _mensagem_read(m: WhatsappMensagem) -> WhatsappMensagemRead:
         atendente_nome=m.atendente.nome if m.atendente else None,
         status_entrega=status,
         created_at=m.created_at,
+        reacoes=[] if apagada else reacoes,
+        editada=wpp_edicao.mensagem_editada(m),
+        editada_em=getattr(m, "editada_em", None),
+        apagada=apagada,
+        pode_editar=wpp_edicao.pode_editar_mensagem(m, is_responsavel=is_responsavel),
+        pode_apagar_para_todos=wpp_edicao.pode_apagar_para_todos(m, is_responsavel=is_responsavel),
     )
 
 
@@ -1412,13 +1439,266 @@ def listar_mensagens(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
     rows = (
         db.query(WhatsappMensagem)
-        .options(joinedload(WhatsappMensagem.atendente))
+        .options(
+            joinedload(WhatsappMensagem.atendente),
+            joinedload(WhatsappMensagem.reacoes),
+        )
         .filter(WhatsappMensagem.chat_id == chat_id)
         .order_by(WhatsappMensagem.created_at.asc())
         .all()
     )
     visiveis = [m for m in rows if not mensagem_oculta_na_conversa(getattr(m, "evento_sistema", None))]
-    return [_mensagem_read(m) for m in visiveis]
+    is_resp = c.atendente_id == atendente.id
+    return [_mensagem_read(m, viewer_id=atendente.id, is_responsavel=is_resp) for m in visiveis]
+
+
+@router.patch("/{chat_id}/mensagens/{mensagem_id}", response_model=WhatsappMensagemRead)
+def editar_mensagem_whatsapp(
+    chat_id: int,
+    mensagem_id: int,
+    body: WhatsappMensagemUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Edita texto outbound no WhatsApp do cliente (#630 lote 3)."""
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    _exigir_responsavel_envio_cliente(c, atendente)
+
+    m = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id, WhatsappMensagem.chat_id == chat_id)
+        .first()
+    )
+    if not m:
+        raise HTTPException(status_code=404, detail="Mensagem não encontrada")
+    if not wpp_edicao.pode_editar_mensagem(m, is_responsavel=True):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Não é possível editar (só texto próprio, até {wpp_edicao.JANELA_EDICAO_MINUTOS} min).",
+        )
+
+    texto_novo = (body.texto or "").strip()
+    if not texto_novo:
+        raise HTTPException(status_code=400, detail="Mensagem vazia")
+    prefixo = _prefixo_assinatura_whatsapp(db, c, atendente)
+    texto_eff = f"{prefixo}\n{texto_novo}" if prefixo and not texto_novo.startswith("[") else texto_novo
+
+    st = _settings_envio(db)
+    ok, err = evolution_api.evolution_update_message(
+        st.evolution_base_url or "",
+        st.evolution_instance_name or "",
+        st.evolution_api_key or "",
+        number_digits=c.wa_id,
+        message_id=m.wa_message_id or "",
+        text=texto_eff,
+        remote_jid=f"{c.wa_id}@s.whatsapp.net",
+    )
+    if not ok:
+        raise HTTPException(status_code=502, detail=err or "Falha ao editar na Evolution API")
+
+    m.corpo = texto_eff
+    m.editada_em = datetime.now(timezone.utc)
+    db.commit()
+    m2 = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id)
+        .first()
+    )
+    assert m2 is not None
+    emit_chat_mensagem_from_models(db, c, m2, exclude_atendente_id=atendente.id)
+    return _mensagem_read(m2, viewer_id=atendente.id, is_responsavel=True)
+
+
+@router.delete("/{chat_id}/mensagens/{mensagem_id}", response_model=WhatsappMensagemRead)
+def apagar_mensagem_whatsapp_para_todos(
+    chat_id: int,
+    mensagem_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Apaga mensagem outbound para todos no WhatsApp do cliente (#630 lote 3)."""
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    _exigir_responsavel_envio_cliente(c, atendente)
+
+    m = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id, WhatsappMensagem.chat_id == chat_id)
+        .first()
+    )
+    if not m:
+        raise HTTPException(status_code=404, detail="Mensagem não encontrada")
+    if not wpp_edicao.pode_apagar_para_todos(m, is_responsavel=True):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Não é possível apagar para todos (só outbound próprio, até {wpp_edicao.JANELA_APAGAR_TODOS_HORAS} h).",
+        )
+
+    st = _settings_envio(db)
+    ok, err = evolution_api.evolution_delete_message_for_everyone(
+        st.evolution_base_url or "",
+        st.evolution_instance_name or "",
+        st.evolution_api_key or "",
+        message_id=m.wa_message_id or "",
+        remote_jid=f"{c.wa_id}@s.whatsapp.net",
+        from_me=True,
+    )
+    if not ok:
+        raise HTTPException(status_code=502, detail=err or "Falha ao apagar na Evolution API")
+
+    m.corpo = wpp_edicao.CORPO_MENSAGEM_APAGADA
+    m.apagada_em = datetime.now(timezone.utc)
+    m.midia_nome_arquivo = None
+    db.commit()
+    m2 = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id)
+        .first()
+    )
+    assert m2 is not None
+    emit_chat_mensagem_from_models(db, c, m2, exclude_atendente_id=atendente.id)
+    return _mensagem_read(m2, viewer_id=atendente.id, is_responsavel=True)
+
+
+@router.put("/{chat_id}/mensagens/{mensagem_id}/reacoes", response_model=WhatsappMensagemRead)
+def definir_reacao_mensagem(
+    chat_id: int,
+    mensagem_id: int,
+    body: WhatsappReacaoCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Atendente responsável reage a uma mensagem no WhatsApp do cliente (#630)."""
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    _exigir_responsavel_envio_cliente(c, atendente)
+    if c.estado not in ("em_atendimento", "aguardando_avaliacao"):
+        raise HTTPException(status_code=400, detail="Só é possível reagir em chat em atendimento")
+
+    m = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id, WhatsappMensagem.chat_id == chat_id)
+        .first()
+    )
+    if not m:
+        raise HTTPException(status_code=404, detail="Mensagem não encontrada")
+    if m.evento_sistema:
+        raise HTTPException(status_code=400, detail="Não é possível reagir a mensagem interna/sistema")
+    if not m.wa_message_id:
+        raise HTTPException(status_code=400, detail="Mensagem sem identificador WhatsApp")
+
+    try:
+        emoji = wpp_reacoes.validar_emoji_reacao(body.emoji)
+    except wpp_reacoes.WhatsappReacaoErro as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Toggle: mesmo emoji remove
+    atual = next(
+        (r for r in (m.reacoes or []) if r.origem == wpp_reacoes.ORIGEM_ATENDENTE),
+        None,
+    )
+    remover = bool(atual and atual.emoji == emoji)
+    st = _settings_envio(db)
+    from_me = m.direcao == "outbound"
+    ok, err = evolution_api.evolution_send_reaction(
+        st.evolution_base_url or "",
+        st.evolution_instance_name or "",
+        st.evolution_api_key or "",
+        remote_jid=c.wa_id,
+        from_me=from_me,
+        message_id=m.wa_message_id,
+        reaction="" if remover else emoji,
+    )
+    if not ok:
+        raise HTTPException(status_code=502, detail=err or "Falha ao enviar reação pela Evolution API")
+
+    wpp_reacoes.aplicar_reacao(
+        db,
+        m,
+        origem=wpp_reacoes.ORIGEM_ATENDENTE,
+        emoji=None if remover else emoji,
+        atendente_id=None if remover else atendente.id,
+    )
+    db.commit()
+    m2 = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id)
+        .first()
+    )
+    assert m2 is not None
+    emit_chat_mensagem_from_models(db, c, m2, exclude_atendente_id=atendente.id)
+    return _mensagem_read(m2, viewer_id=atendente.id, is_responsavel=True)
+
+
+@router.delete("/{chat_id}/mensagens/{mensagem_id}/reacoes", response_model=WhatsappMensagemRead)
+def remover_reacao_mensagem(
+    chat_id: int,
+    mensagem_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Remove a reação do atendente na mensagem (#630)."""
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    _exigir_responsavel_envio_cliente(c, atendente)
+
+    m = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id, WhatsappMensagem.chat_id == chat_id)
+        .first()
+    )
+    if not m:
+        raise HTTPException(status_code=404, detail="Mensagem não encontrada")
+    if not m.wa_message_id:
+        raise HTTPException(status_code=400, detail="Mensagem sem identificador WhatsApp")
+
+    st = _settings_envio(db)
+    from_me = m.direcao == "outbound"
+    ok, err = evolution_api.evolution_send_reaction(
+        st.evolution_base_url or "",
+        st.evolution_instance_name or "",
+        st.evolution_api_key or "",
+        remote_jid=c.wa_id,
+        from_me=from_me,
+        message_id=m.wa_message_id,
+        reaction="",
+    )
+    if not ok:
+        raise HTTPException(status_code=502, detail=err or "Falha ao remover reação pela Evolution API")
+
+    wpp_reacoes.aplicar_reacao(
+        db, m, origem=wpp_reacoes.ORIGEM_ATENDENTE, emoji=None, atendente_id=None
+    )
+    db.commit()
+    m2 = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id)
+        .first()
+    )
+    assert m2 is not None
+    emit_chat_mensagem_from_models(db, c, m2, exclude_atendente_id=atendente.id)
+    return _mensagem_read(m2, viewer_id=atendente.id, is_responsavel=True)
 
 
 @router.get("/{chat_id}/demandas", response_model=list[WhatsappChatDemandaRead])
@@ -1701,9 +1981,14 @@ def enviar_mensagem(
         evento_sistema=None,
         quoted_wa_message_id=data.quoted_wa_message_id,
     )
-    m = db.query(WhatsappMensagem).options(joinedload(WhatsappMensagem.atendente)).filter(WhatsappMensagem.id == m.id).first()
+    m = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == m.id)
+        .first()
+    )
     assert m is not None
-    return _mensagem_read(m)
+    return _mensagem_read(m, viewer_id=atendente.id, is_responsavel=True)
 
 
 @router.post("/{chat_id}/mensagens/midia", response_model=WhatsappMensagemRead, status_code=201)
@@ -1826,13 +2111,13 @@ async def enviar_mensagem_midia(
     db.commit()
     m2 = (
         db.query(WhatsappMensagem)
-        .options(joinedload(WhatsappMensagem.atendente))
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
         .filter(WhatsappMensagem.id == m.id)
         .first()
     )
     assert m2 is not None
     emit_chat_mensagem_from_models(db, c, m2, exclude_atendente_id=atendente.id)
-    return _mensagem_read(m2)
+    return _mensagem_read(m2, viewer_id=atendente.id, is_responsavel=True)
 
 
 @router.post("/{chat_id}/comentarios-internos", response_model=WhatsappMensagemRead, status_code=201)

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -9,7 +9,16 @@ from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem, WhatsappSet
 from app.services import evolution_api
 from app.services.whatsapp_contato_match import funcionario_por_wa_id
 from app.services.protocolo_mensal import gerar_protocolo_chat
-from app.services.evolution_inbound import iter_inbound_whatsapp_messages, iter_message_status_updates
+from app.services.evolution_inbound import (
+    iter_inbound_edits,
+    iter_inbound_reactions,
+    iter_inbound_revokes,
+    iter_inbound_whatsapp_messages,
+    iter_message_status_updates,
+)
+from app.services import whatsapp_reacoes as wpp_reacoes
+from app.services import whatsapp_edicao as wpp_edicao
+from app.services.realtime_emit import emit_chat_mensagem_from_models
 from app.services.whatsapp_media_storage import gravar_base64_em_disco
 from app.services.whatsapp_wa_id_lock import lock_wa_id_para_chat, unlock_wa_id_para_chat
 from app.services.whatsapp_auto_messages import (
@@ -18,7 +27,7 @@ from app.services.whatsapp_auto_messages import (
     resolver_nome_empresa_para_template,
 )
 from app.core.business_calendar import is_feriado_nacional_br as _is_feriado_nacional_br
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import json
 
@@ -395,6 +404,33 @@ def evolution_webhook(
 
     st_media = st
     processados = 0
+    reacoes = 0
+    revokes = 0
+    edits = 0
+    for item in iter_inbound_revokes(body):
+        wa_id = item["wa_id"]
+        lock_wa_id_para_chat(db, wa_id)
+        try:
+            revokes += _processar_revoke_inbound(db, item=item)
+        finally:
+            unlock_wa_id_para_chat(db, wa_id)
+
+    for item in iter_inbound_edits(body):
+        wa_id = item["wa_id"]
+        lock_wa_id_para_chat(db, wa_id)
+        try:
+            edits += _processar_edit_inbound(db, item=item)
+        finally:
+            unlock_wa_id_para_chat(db, wa_id)
+
+    for item in iter_inbound_reactions(body):
+        wa_id = item["wa_id"]
+        lock_wa_id_para_chat(db, wa_id)
+        try:
+            reacoes += _processar_reacao_inbound(db, item=item)
+        finally:
+            unlock_wa_id_para_chat(db, wa_id)
+
     for item in iter_inbound_whatsapp_messages(body):
         wa_id = item["wa_id"]
         lock_wa_id_para_chat(db, wa_id)
@@ -408,7 +444,134 @@ def evolution_webhook(
         finally:
             unlock_wa_id_para_chat(db, wa_id)
 
-    return {"ok": True, "processados": processados}
+    return {
+        "ok": True,
+        "processados": processados,
+        "reacoes": reacoes,
+        "revokes": revokes,
+        "edits": edits,
+    }
+
+
+def _chat_recente_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
+    return (
+        db.query(WhatsappChat)
+        .filter(
+            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.estado.in_(
+                ("aguardando_atendente", "em_atendimento", "aguardando_avaliacao", "encerrado")
+            ),
+        )
+        .order_by(WhatsappChat.id.desc())
+        .first()
+    )
+
+
+def _mensagem_alvo(db: Session, chat: WhatsappChat, target_id: str) -> WhatsappMensagem | None:
+    return (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(
+            WhatsappMensagem.chat_id == chat.id,
+            WhatsappMensagem.wa_message_id == str(target_id),
+        )
+        .first()
+    )
+
+
+def _emit_mensagem_atualizada(db: Session, chat: WhatsappChat, mensagem_id: int) -> None:
+    alvo2 = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id)
+        .first()
+    )
+    if alvo2:
+        emit_chat_mensagem_from_models(db, chat, alvo2)
+
+
+def _processar_revoke_inbound(db: Session, *, item: dict) -> int:
+    """Cliente ou mesa apagou mensagem para todos (#630 lote 3)."""
+    wa_id = item["wa_id"]
+    target_id = item.get("target_wa_message_id")
+    if not target_id:
+        return 0
+    chat = _chat_recente_por_wa_id(db, wa_id)
+    if not chat:
+        return 0
+    alvo = _mensagem_alvo(db, chat, str(target_id))
+    if not alvo or alvo.evento_sistema or wpp_edicao.mensagem_apagada(alvo):
+        return 0
+    try:
+        alvo.corpo = wpp_edicao.CORPO_MENSAGEM_APAGADA
+        alvo.apagada_em = datetime.now(timezone.utc)
+        alvo.midia_nome_arquivo = None
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception("Falha ao aplicar revoke inbound (chat=%s target=%s)", chat.protocolo, target_id)
+        return 0
+    _emit_mensagem_atualizada(db, chat, alvo.id)
+    return 1
+
+
+def _processar_edit_inbound(db: Session, *, item: dict) -> int:
+    """Cliente editou mensagem (#630 lote 3)."""
+    wa_id = item["wa_id"]
+    target_id = item.get("target_wa_message_id")
+    texto = (item.get("texto") or "").strip()
+    if not target_id or not texto:
+        return 0
+    chat = _chat_recente_por_wa_id(db, wa_id)
+    if not chat:
+        return 0
+    alvo = _mensagem_alvo(db, chat, str(target_id))
+    if not alvo or alvo.evento_sistema or wpp_edicao.mensagem_apagada(alvo):
+        return 0
+    try:
+        alvo.corpo = texto
+        alvo.editada_em = datetime.now(timezone.utc)
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception("Falha ao aplicar edit inbound (chat=%s target=%s)", chat.protocolo, target_id)
+        return 0
+    _emit_mensagem_atualizada(db, chat, alvo.id)
+    return 1
+
+
+def _processar_reacao_inbound(db: Session, *, item: dict) -> int:
+    """Aplica reação do cliente (ou eco fromMe) na mensagem alvo (#630)."""
+    wa_id = item["wa_id"]
+    target_id = item.get("target_wa_message_id")
+    if not target_id:
+        return 0
+    chat = _chat_recente_por_wa_id(db, wa_id)
+    if not chat:
+        return 0
+    alvo = _mensagem_alvo(db, chat, str(target_id))
+    if not alvo or alvo.evento_sistema:
+        return 0
+
+    from_me = bool(item.get("from_me"))
+    origem = wpp_reacoes.ORIGEM_ATENDENTE if from_me else wpp_reacoes.ORIGEM_CLIENTE
+    emoji = item.get("emoji")
+    try:
+        wpp_reacoes.aplicar_reacao(
+            db,
+            alvo,
+            origem=origem,
+            emoji=emoji,
+            atendente_id=chat.atendente_id if from_me else None,
+        )
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception("Falha ao aplicar reação inbound (chat=%s target=%s)", chat.protocolo, target_id)
+        return 0
+
+    _emit_mensagem_atualizada(db, chat, alvo.id)
+    return 1
 
 
 def _processar_mensagem_inbound(

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,7 +13,13 @@ from app.models.whatsapp_chat_read import WhatsappChatRead
 from app.models.audit_log import AuditLog
 from app.models.ibge_municipio import IbgeMunicipio
 from app.models.app_cache_meta import AppCacheMeta
-from app.models.whatsapp_chat import WhatsappChat, WhatsappChatTicket, WhatsappMensagem, WhatsappSettings
+from app.models.whatsapp_chat import (
+    WhatsappChat,
+    WhatsappChatTicket,
+    WhatsappMensagem,
+    WhatsappMensagemReacao,
+    WhatsappSettings,
+)
 from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
 from app.models.empresa_sistema import EmpresaSistema
 from app.models.email_settings import EmailSettings
@@ -69,6 +75,7 @@ __all__ = [
     "WhatsappSettings",
     "WhatsappChat",
     "WhatsappMensagem",
+    "WhatsappMensagemReacao",
     "WhatsappChatTicket",
     "WhatsappChatDemanda",
     "EmpresaSistema",

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -119,11 +119,41 @@ class WhatsappMensagem(Base):
     # pendente | enviada | entregue | lida | erro — apenas outbound ao cliente
     status_entrega = Column(String(20), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+    # #630 lote 3 — editar / apagar para todos (timestamps; corpo vira placeholder ao apagar)
+    editada_em = Column(DateTime(timezone=True), nullable=True)
+    apagada_em = Column(DateTime(timezone=True), nullable=True)
 
     chat = relationship("WhatsappChat", back_populates="mensagens")
     atendente = relationship("Atendente", backref="whatsapp_mensagens_enviadas")
+    reacoes = relationship(
+        "WhatsappMensagemReacao",
+        back_populates="mensagem",
+        cascade="all, delete-orphan",
+    )
 
     __table_args__ = (UniqueConstraint("wa_message_id", name="uq_whatsapp_mensagens_wa_message_id"),)
+
+
+class WhatsappMensagemReacao(Base):
+    """Uma reação por origem (cliente ou mesa) na mensagem alvo (#630 lote 2)."""
+
+    __tablename__ = "whatsapp_mensagem_reacoes"
+    __table_args__ = (
+        UniqueConstraint("mensagem_id", "origem", name="uq_whatsapp_mensagem_reacoes_mensagem_origem"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    mensagem_id = Column(
+        Integer, ForeignKey("whatsapp_mensagens.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # cliente | atendente
+    origem = Column(String(20), nullable=False)
+    emoji = Column(String(16), nullable=False)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    mensagem = relationship("WhatsappMensagem", back_populates="reacoes")
+    atendente = relationship("Atendente", backref="whatsapp_mensagem_reacoes")
 
 
 class WhatsappChatTicket(Base):

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -3,6 +3,22 @@ from datetime import datetime
 from pydantic import BaseModel, Field, field_validator
 
 
+class WhatsappReacaoRead(BaseModel):
+    emoji: str
+    count: int
+    reagiu_eu: bool = False
+    atendente_ids: list[int] = Field(default_factory=list)
+    tem_cliente: bool = False
+
+
+class WhatsappReacaoCreate(BaseModel):
+    emoji: str = Field(..., min_length=1, max_length=16)
+
+
+class WhatsappMensagemUpdate(BaseModel):
+    texto: str = Field(..., min_length=1, max_length=4000)
+
+
 class WhatsappMensagemRead(BaseModel):
     id: int
     chat_id: int
@@ -19,6 +35,12 @@ class WhatsappMensagemRead(BaseModel):
     atendente_nome: str | None = None
     status_entrega: str | None = None
     created_at: datetime | None = None
+    reacoes: list[WhatsappReacaoRead] = Field(default_factory=list)
+    editada: bool = False
+    editada_em: datetime | None = None
+    apagada: bool = False
+    pode_editar: bool = False
+    pode_apagar_para_todos: bool = False
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -219,6 +219,96 @@ def evolution_mark_messages_as_read(
     return False, f"HTTP {code}"
 
 
+def evolution_send_reaction(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    *,
+    remote_jid: str,
+    from_me: bool,
+    message_id: str,
+    reaction: str,
+) -> tuple[bool, str | None]:
+    """POST /message/sendReaction/{instance} — reaction='' remove. Retorna (ok, err)."""
+    mid = (message_id or "").strip()
+    if not mid:
+        return False, "ID da mensagem inválido"
+    jid = remote_jid if "@" in (remote_jid or "") else f"{remote_jid}@s.whatsapp.net"
+    base = base_url.rstrip("/")
+    url = f"{base}/message/sendReaction/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body: dict[str, Any] = {
+        "key": {"remoteJid": jid, "fromMe": bool(from_me), "id": mid},
+        "reaction": reaction if reaction is not None else "",
+    }
+    code, _data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=30)
+    if code in (200, 201):
+        return True, None
+    if err:
+        return False, err[:800]
+    return False, f"HTTP {code}"
+
+
+def evolution_update_message(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    *,
+    number_digits: str,
+    message_id: str,
+    text: str,
+    remote_jid: str | None = None,
+) -> tuple[bool, str | None]:
+    """POST /chat/updateMessage/{instance} — edita mensagem outbound (texto)."""
+    import re
+
+    digits = re.sub(r"\D", "", number_digits or "")
+    mid = (message_id or "").strip()
+    if not digits or not mid:
+        return False, "Número ou ID da mensagem inválido"
+    jid = remote_jid if remote_jid and "@" in remote_jid else f"{digits}@s.whatsapp.net"
+    base = base_url.rstrip("/")
+    url = f"{base}/chat/updateMessage/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body: dict[str, Any] = {
+        "number": digits,
+        "text": text,
+        "key": {"remoteJid": jid, "fromMe": True, "id": mid},
+    }
+    code, _data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=30)
+    if code in (200, 201):
+        return True, None
+    if err:
+        return False, err[:800]
+    return False, f"HTTP {code}"
+
+
+def evolution_delete_message_for_everyone(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    *,
+    message_id: str,
+    remote_jid: str,
+    from_me: bool = True,
+) -> tuple[bool, str | None]:
+    """DELETE /chat/deleteMessageForEveryone/{instance}."""
+    mid = (message_id or "").strip()
+    if not mid:
+        return False, "ID da mensagem inválido"
+    jid = remote_jid if "@" in (remote_jid or "") else f"{remote_jid}@s.whatsapp.net"
+    base = base_url.rstrip("/")
+    url = f"{base}/chat/deleteMessageForEveryone/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body: dict[str, Any] = {"id": mid, "remoteJid": jid, "fromMe": bool(from_me)}
+    code, _data, err = _request_json_with_retry("DELETE", url, headers=headers, body=body, timeout=30)
+    if code in (200, 201):
+        return True, None
+    if err:
+        return False, err[:800]
+    return False, f"HTTP {code}"
+
+
 def evolution_fetch_profile_picture_url(
     base_url: str,
     instance: str,

--- a/backend/app/services/evolution_inbound.py
+++ b/backend/app/services/evolution_inbound.py
@@ -370,3 +370,143 @@ def iter_inbound_text_messages(webhook_body: dict[str, Any]) -> Iterator[dict[st
             "wa_message_id": item.get("wa_message_id"),
             "push_name": item.get("push_name"),
         }
+
+
+def _reaction_payload_from_inner(inner: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Retorna (target_wa_message_id, emoji_ou_vazio)."""
+    react = inner.get("reactionMessage") or inner.get("ReactionMessage")
+    if not isinstance(react, dict):
+        return None, None
+    key = react.get("key") or react.get("Key") or {}
+    if not isinstance(key, dict):
+        return None, None
+    mid = key.get("id") or key.get("Id")
+    target_id = str(mid).strip() if mid else None
+    text = react.get("text") if "text" in react else react.get("Text")
+    emoji = "" if text is None else str(text)
+    return target_id or None, emoji
+
+
+def iter_inbound_revokes(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """
+    Apagar para todos (protocolMessage type REVOKE) em messages.upsert.
+
+    Yields: wa_id, target_wa_message_id
+    """
+    event = webhook_body.get("event") or webhook_body.get("Event") or ""
+    ev = str(event).lower()
+    if "messages" not in ev:
+        return
+    data = webhook_body.get("data") or webhook_body.get("Data")
+    for m in _iter_message_dicts(data):
+        key = m.get("key") or m.get("Key") or {}
+        if not isinstance(key, dict):
+            continue
+        rjid = key.get("remoteJid") or key.get("RemoteJid")
+        rjid_s = str(rjid) if rjid else ""
+        if "@g.us" in rjid_s:
+            continue
+        wa_id = _only_digits_jid(rjid_s)
+        if not wa_id:
+            continue
+        inner = m.get("message") or m.get("Message")
+        if not isinstance(inner, dict):
+            continue
+        proto = inner.get("protocolMessage") or inner.get("ProtocolMessage")
+        if not isinstance(proto, dict):
+            continue
+        ptype = str(proto.get("type") or proto.get("Type") or "").upper()
+        if ptype not in ("REVOKE", "14"):
+            continue
+        pkey = proto.get("key") or proto.get("Key") or {}
+        if not isinstance(pkey, dict):
+            continue
+        mid = pkey.get("id") or pkey.get("Id")
+        target = str(mid).strip() if mid else None
+        if not target:
+            continue
+        yield {"wa_id": wa_id, "target_wa_message_id": target}
+
+
+def iter_inbound_edits(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """
+    Edição de mensagem (editedMessage) em messages.upsert.
+
+    Yields: wa_id, target_wa_message_id, texto
+    """
+    event = webhook_body.get("event") or webhook_body.get("Event") or ""
+    ev = str(event).lower()
+    if "messages" not in ev and "edit" not in ev:
+        return
+    data = webhook_body.get("data") or webhook_body.get("Data")
+    for m in _iter_message_dicts(data):
+        key = m.get("key") or m.get("Key") or {}
+        if not isinstance(key, dict):
+            continue
+        rjid = key.get("remoteJid") or key.get("RemoteJid")
+        rjid_s = str(rjid) if rjid else ""
+        if "@g.us" in rjid_s:
+            continue
+        wa_id = _only_digits_jid(rjid_s)
+        if not wa_id:
+            continue
+        inner = m.get("message") or m.get("Message")
+        if not isinstance(inner, dict):
+            continue
+        edited = inner.get("editedMessage") or inner.get("EditedMessage")
+        if not isinstance(edited, dict):
+            continue
+        # editedMessage.message.{conversation|extendedTextMessage}
+        nested = edited.get("message") or edited.get("Message") or edited
+        if not isinstance(nested, dict):
+            continue
+        texto = _text_from_inner(nested)
+        if not texto:
+            continue
+        # alvo: key do envelope ou editedMessage.key
+        ekey = edited.get("key") or edited.get("Key") or key
+        if not isinstance(ekey, dict):
+            ekey = key
+        mid = ekey.get("id") or ekey.get("Id")
+        target = str(mid).strip() if mid else None
+        if not target:
+            continue
+        yield {"wa_id": wa_id, "target_wa_message_id": target, "texto": texto}
+
+
+def iter_inbound_reactions(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """
+    Reações (cliente ou eco fromMe) em messages.upsert com reactionMessage.
+
+    Yields:
+      wa_id, target_wa_message_id, emoji ('' = remover), from_me
+    """
+    event = webhook_body.get("event") or webhook_body.get("Event") or ""
+    ev = str(event).lower()
+    if "messages" not in ev:
+        return
+    data = webhook_body.get("data") or webhook_body.get("Data")
+    for m in _iter_message_dicts(data):
+        key = m.get("key") or m.get("Key") or {}
+        if not isinstance(key, dict):
+            continue
+        rjid = key.get("remoteJid") or key.get("RemoteJid")
+        rjid_s = str(rjid) if rjid else ""
+        if "@g.us" in rjid_s:
+            continue
+        wa_id = _only_digits_jid(rjid_s)
+        if not wa_id:
+            continue
+        inner = m.get("message") or m.get("Message")
+        if not isinstance(inner, dict):
+            continue
+        target_id, emoji = _reaction_payload_from_inner(inner)
+        if not target_id:
+            continue
+        from_me = bool(key.get("fromMe") or key.get("FromMe"))
+        yield {
+            "wa_id": wa_id,
+            "target_wa_message_id": target_id,
+            "emoji": emoji if emoji is not None else "",
+            "from_me": from_me,
+        }

--- a/backend/app/services/realtime_emit.py
+++ b/backend/app/services/realtime_emit.py
@@ -285,10 +285,15 @@ def emit_chat_mensagem_from_models(
 ) -> None:
     from app.api.whatsapp_chats import _mensagem_read
 
+    # Flags de permissão são por visualizador — omitir no broadcast SSE
+    # para não sobrescrever pode_editar / pode_apagar no cliente do responsável.
+    payload = _mensagem_read(mensagem).model_dump(mode="json")
+    payload.pop("pode_editar", None)
+    payload.pop("pode_apagar_para_todos", None)
     emit_chat_mensagem(
         db,
         chat,
-        _mensagem_read(mensagem).model_dump(mode="json"),
+        payload,
         exclude_atendente_id=exclude_atendente_id,
     )
 

--- a/backend/app/services/whatsapp_edicao.py
+++ b/backend/app/services/whatsapp_edicao.py
@@ -1,0 +1,80 @@
+"""Editar / apagar para todos em mensagens WhatsApp (#630 lote 3)."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+
+from app.models.whatsapp_chat import WhatsappMensagem
+
+CORPO_MENSAGEM_APAGADA = "Mensagem apagada"
+# Limites alinhados à experiência típica do WhatsApp / Evolution (documentar em WHATSAPP_EVOLUTION.md).
+JANELA_EDICAO_MINUTOS = 15
+JANELA_APAGAR_TODOS_HORAS = 48
+
+_PREFIXO_ASSINATURA = re.compile(r"^\[\s*[^\]]+\s*\]:\s*\n?", re.MULTILINE)
+
+
+class WhatsappEdicaoErro(ValueError):
+    """Validação de edição/apagamento WhatsApp."""
+
+
+def corpo_sem_prefixo(corpo: str | None) -> str:
+    t = (corpo or "").strip()
+    return _PREFIXO_ASSINATURA.sub("", t, count=1).strip()
+
+
+def mensagem_apagada(m: WhatsappMensagem) -> bool:
+    return getattr(m, "apagada_em", None) is not None
+
+
+def mensagem_editada(m: WhatsappMensagem) -> bool:
+    return getattr(m, "editada_em", None) is not None
+
+
+def _created_aware(m: WhatsappMensagem) -> datetime | None:
+    ts = m.created_at
+    if ts is None:
+        return None
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=timezone.utc)
+    return ts
+
+
+def dentro_janela_edicao(m: WhatsappMensagem, *, agora: datetime | None = None) -> bool:
+    ts = _created_aware(m)
+    if ts is None:
+        return False
+    now = agora or datetime.now(timezone.utc)
+    return now - ts <= timedelta(minutes=JANELA_EDICAO_MINUTOS)
+
+
+def dentro_janela_apagar_todos(m: WhatsappMensagem, *, agora: datetime | None = None) -> bool:
+    ts = _created_aware(m)
+    if ts is None:
+        return False
+    now = agora or datetime.now(timezone.utc)
+    return now - ts <= timedelta(hours=JANELA_APAGAR_TODOS_HORAS)
+
+
+def pode_editar_mensagem(m: WhatsappMensagem, *, is_responsavel: bool) -> bool:
+    if not is_responsavel or mensagem_apagada(m):
+        return False
+    if m.direcao != "outbound" or m.evento_sistema:
+        return False
+    if not m.wa_message_id:
+        return False
+    tipo = (m.tipo_midia or "texto").lower()
+    if tipo not in ("texto", ""):
+        return False  # legenda de mídia fora de escopo v1
+    return dentro_janela_edicao(m)
+
+
+def pode_apagar_para_todos(m: WhatsappMensagem, *, is_responsavel: bool) -> bool:
+    if not is_responsavel or mensagem_apagada(m):
+        return False
+    if m.direcao != "outbound" or m.evento_sistema:
+        return False
+    if not m.wa_message_id:
+        return False
+    return dentro_janela_apagar_todos(m)

--- a/backend/app/services/whatsapp_reacoes.py
+++ b/backend/app/services/whatsapp_reacoes.py
@@ -1,0 +1,116 @@
+"""Reações em mensagens WhatsApp do chat com o cliente (#630 lote 2)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.models.whatsapp_chat import WhatsappMensagem, WhatsappMensagemReacao
+
+ORIGEM_CLIENTE = "cliente"
+ORIGEM_ATENDENTE = "atendente"
+EMOJIS_REACAO_PERMITIDOS = frozenset({"👍", "❤️", "😂", "😮", "😢", "🙏"})
+
+
+class WhatsappReacaoErro(ValueError):
+    """Validação de reação WhatsApp."""
+
+
+@dataclass
+class ReacaoAgregada:
+    emoji: str
+    count: int
+    reagiu_eu: bool
+    atendente_ids: list[int]
+    tem_cliente: bool
+
+
+def validar_emoji_reacao(emoji: str) -> str:
+    valor = (emoji or "").strip()
+    if valor not in EMOJIS_REACAO_PERMITIDOS:
+        raise WhatsappReacaoErro("Emoji de reação inválido.")
+    return valor
+
+
+def aplicar_reacao(
+    db: Session,
+    mensagem: WhatsappMensagem,
+    *,
+    origem: str,
+    emoji: str | None,
+    atendente_id: int | None = None,
+) -> WhatsappMensagem:
+    """Upsert ou remove reação da origem. emoji None/'' remove."""
+    if origem not in (ORIGEM_CLIENTE, ORIGEM_ATENDENTE):
+        raise WhatsappReacaoErro("Origem de reação inválida.")
+    if mensagem.evento_sistema:
+        raise WhatsappReacaoErro("Não é possível reagir a mensagem de sistema.")
+
+    row = (
+        db.query(WhatsappMensagemReacao)
+        .filter(
+            WhatsappMensagemReacao.mensagem_id == mensagem.id,
+            WhatsappMensagemReacao.origem == origem,
+        )
+        .first()
+    )
+    texto = (emoji or "").strip()
+    if not texto:
+        if row:
+            db.delete(row)
+            db.flush()
+        db.refresh(mensagem)
+        return mensagem
+
+    if origem == ORIGEM_ATENDENTE:
+        texto = validar_emoji_reacao(texto)
+    # Cliente: aceitar qualquer emoji Unicode curto (WhatsApp livre)
+    elif len(texto) > 16:
+        texto = texto[:16]
+
+    if row:
+        row.emoji = texto
+        row.atendente_id = atendente_id if origem == ORIGEM_ATENDENTE else None
+    else:
+        db.add(
+            WhatsappMensagemReacao(
+                mensagem_id=mensagem.id,
+                origem=origem,
+                emoji=texto,
+                atendente_id=atendente_id if origem == ORIGEM_ATENDENTE else None,
+            )
+        )
+    db.flush()
+    db.refresh(mensagem)
+    return mensagem
+
+
+def agregar_reacoes(
+    mensagem: WhatsappMensagem,
+    viewer_id: int | None = None,
+) -> list[ReacaoAgregada]:
+    rows = list(getattr(mensagem, "reacoes", None) or [])
+    por_emoji: dict[str, dict] = {}
+    for row in rows:
+        bucket = por_emoji.setdefault(
+            row.emoji,
+            {"count": 0, "reagiu_eu": False, "atendente_ids": [], "tem_cliente": False},
+        )
+        bucket["count"] = int(bucket["count"]) + 1
+        if row.origem == ORIGEM_CLIENTE:
+            bucket["tem_cliente"] = True
+        if row.origem == ORIGEM_ATENDENTE and row.atendente_id is not None:
+            bucket["atendente_ids"].append(int(row.atendente_id))
+            if viewer_id is not None and row.atendente_id == viewer_id:
+                bucket["reagiu_eu"] = True
+    return [
+        ReacaoAgregada(
+            emoji=emoji,
+            count=int(data["count"]),
+            reagiu_eu=bool(data["reagiu_eu"]),
+            atendente_ids=list(data["atendente_ids"]),
+            tem_cliente=bool(data["tem_cliente"]),
+        )
+        for emoji, data in sorted(por_emoji.items(), key=lambda item: (-int(item[1]["count"]), item[0]))
+    ]

--- a/backend/tests/test_whatsapp_edicao_apagar.py
+++ b/backend/tests/test_whatsapp_edicao_apagar.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+
+def _webhook_body(wa_id: str = "5511999999999", msg_id: str = "mid1", text: str = "Olá"):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": msg_id,
+                    },
+                    "message": {"conversation": text},
+                }
+            ]
+        },
+    }
+
+
+def _webhook_revoke(wa_id: str, *, target_id: str, revoke_msg_id: str = "rev-1"):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "key": {
+                "remoteJid": f"{wa_id}@s.whatsapp.net",
+                "fromMe": False,
+                "id": revoke_msg_id,
+            },
+            "message": {
+                "protocolMessage": {
+                    "type": "REVOKE",
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": target_id,
+                    },
+                }
+            },
+        },
+    }
+
+
+def _webhook_edit(wa_id: str, *, target_id: str, texto: str, edit_msg_id: str = "edit-1"):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "key": {
+                "remoteJid": f"{wa_id}@s.whatsapp.net",
+                "fromMe": False,
+                "id": target_id,
+            },
+            "message": {
+                "editedMessage": {
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": target_id,
+                    },
+                    "message": {"conversation": texto},
+                }
+            },
+        },
+    }
+
+
+def _chat_em_atendimento(client, auth_headers, wa_id="5511999000801", msg_id="edit-base-1"):
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "edit-630",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+            "auto_msg_assumido_ativa": False,
+            "auto_msg_espera_ativa": False,
+        },
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "edit-630"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id=wa_id, msg_id=msg_id),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    return cid, h
+
+
+def test_editar_mensagem_via_api(client, seed_base, auth_headers, monkeypatch):
+    n = {"i": 0}
+    updated: list[dict] = []
+
+    def fake_send(*_a, **_k):
+        n["i"] += 1
+        return True, None, f"wa-out-edit-{n['i']}"
+
+    def fake_update(*_a, **kwargs):
+        updated.append(kwargs)
+        return True, None
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_update_message",
+        fake_update,
+    )
+
+    cid, _h = _chat_em_atendimento(client, auth_headers)
+    r_msg = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Texto original"},
+        headers=auth_headers["a1"],
+    )
+    assert r_msg.status_code == 201
+    mid = r_msg.json()["id"]
+    assert r_msg.json().get("pode_editar") is True
+
+    ok = client.patch(
+        f"/v1/whatsapp/chats/{cid}/mensagens/{mid}",
+        json={"texto": "Texto corrigido"},
+        headers=auth_headers["a1"],
+    )
+    assert ok.status_code == 200
+    body = ok.json()
+    assert body["editada"] is True
+    assert "Texto corrigido" in body["corpo"]
+    assert updated and "Texto corrigido" in (updated[-1].get("text") or "")
+
+
+def test_apagar_mensagem_via_api(client, seed_base, auth_headers, monkeypatch):
+    n = {"i": 0}
+    deleted: list[dict] = []
+
+    def fake_send(*_a, **_k):
+        n["i"] += 1
+        return True, None, f"wa-out-del-{n['i']}"
+
+    def fake_delete(*_a, **kwargs):
+        deleted.append(kwargs)
+        return True, None
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_delete_message_for_everyone",
+        fake_delete,
+    )
+
+    cid, _h = _chat_em_atendimento(
+        client, auth_headers, wa_id="5511999000802", msg_id="del-base-2"
+    )
+    r_msg = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Vai sumir"},
+        headers=auth_headers["a1"],
+    )
+    assert r_msg.status_code == 201
+    mid = r_msg.json()["id"]
+    assert r_msg.json().get("pode_apagar_para_todos") is True
+
+    ok = client.delete(
+        f"/v1/whatsapp/chats/{cid}/mensagens/{mid}",
+        headers=auth_headers["a1"],
+    )
+    assert ok.status_code == 200
+    body = ok.json()
+    assert body["apagada"] is True
+    assert body["corpo"] == "Mensagem apagada"
+    assert body["pode_editar"] is False
+    assert deleted
+
+
+def test_webhook_revoke_marca_apagada(client, seed_base, auth_headers, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-rev"),
+    )
+    cid, h = _chat_em_atendimento(
+        client, auth_headers, wa_id="5511999000803", msg_id="rev-in-3"
+    )
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    inbound = next(m for m in msgs if m["direcao"] == "inbound")
+    target = inbound["wa_message_id"]
+
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_revoke("5511999000803", target_id=target),
+        headers=h,
+    )
+    assert r.status_code == 200
+    assert r.json().get("revokes", 0) >= 1
+
+    msgs2 = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    alvo = next(m for m in msgs2 if m["id"] == inbound["id"])
+    assert alvo["apagada"] is True
+    assert alvo["corpo"] == "Mensagem apagada"
+
+
+def test_webhook_edit_atualiza_corpo(client, seed_base, auth_headers, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-edw"),
+    )
+    cid, h = _chat_em_atendimento(
+        client, auth_headers, wa_id="5511999000804", msg_id="edit-in-4"
+    )
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    inbound = next(m for m in msgs if m["direcao"] == "inbound")
+    target = inbound["wa_message_id"]
+
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_edit("5511999000804", target_id=target, texto="Texto editado pelo cliente"),
+        headers=h,
+    )
+    assert r.status_code == 200
+    assert r.json().get("edits", 0) >= 1
+
+    msgs2 = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    alvo = next(m for m in msgs2 if m["id"] == inbound["id"])
+    assert alvo["editada"] is True
+    assert alvo["corpo"] == "Texto editado pelo cliente"
+
+
+def test_editar_exige_responsavel(client, seed_base, auth_headers, monkeypatch):
+    n = {"i": 0}
+
+    def fake_send(*_a, **_k):
+        n["i"] += 1
+        return True, None, f"wa-out-deny-{n['i']}"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_update_message",
+        lambda *_a, **_k: (True, None),
+    )
+    cid, _h = _chat_em_atendimento(
+        client, auth_headers, wa_id="5511999000805", msg_id="deny-5"
+    )
+    r_msg = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Só o responsável"},
+        headers=auth_headers["a1"],
+    )
+    mid = r_msg.json()["id"]
+    denied = client.patch(
+        f"/v1/whatsapp/chats/{cid}/mensagens/{mid}",
+        json={"texto": "Hack"},
+        headers=auth_headers["a2"],
+    )
+    assert denied.status_code == 403

--- a/backend/tests/test_whatsapp_reacoes.py
+++ b/backend/tests/test_whatsapp_reacoes.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+
+def _webhook_body(wa_id: str = "5511999999999", msg_id: str = "mid1", text: str = "Olá"):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": msg_id,
+                    },
+                    "message": {"conversation": text},
+                }
+            ]
+        },
+    }
+
+
+def _webhook_reaction(
+    wa_id: str,
+    *,
+    target_id: str,
+    emoji: str,
+    from_me: bool = False,
+    reaction_msg_id: str = "react-1",
+):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "key": {
+                "remoteJid": f"{wa_id}@s.whatsapp.net",
+                "fromMe": from_me,
+                "id": reaction_msg_id,
+            },
+            "message": {
+                "reactionMessage": {
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": True,
+                        "id": target_id,
+                    },
+                    "text": emoji,
+                }
+            },
+        },
+    }
+
+
+def _chat_em_atendimento(client, auth_headers, wa_id="5511999000701", msg_id="reac-base-1"):
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "reac-630",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+            "auto_msg_assumido_ativa": False,
+            "auto_msg_espera_ativa": False,
+        },
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "reac-630"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id=wa_id, msg_id=msg_id),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    return cid, h
+
+
+def test_webhook_reacao_cliente_aparece_na_mensagem(client, seed_base, auth_headers, monkeypatch):
+    n = {"i": 0}
+
+    def fake_send(*_a, **_k):
+        n["i"] += 1
+        return True, None, f"wa-out-{n['i']}"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+    cid, h = _chat_em_atendimento(client, auth_headers)
+    # Mensagem outbound do atendente
+    r_msg = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Olá!"},
+        headers=auth_headers["a1"],
+    )
+    assert r_msg.status_code == 201
+    target = r_msg.json()["wa_message_id"]
+    assert target
+
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_reaction("5511999000701", target_id=target, emoji="👍"),
+        headers=h,
+    )
+    assert r.status_code == 200
+    assert r.json().get("reacoes", 0) >= 1
+
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    alvo = next(m for m in msgs if m["wa_message_id"] == target)
+    assert any(r["emoji"] == "👍" and r.get("tem_cliente") for r in alvo.get("reacoes") or [])
+
+
+def test_atendente_reage_via_api(client, seed_base, auth_headers, monkeypatch):
+    sent: list[dict] = []
+    n = {"i": 0}
+
+    def fake_send(*_a, **_k):
+        n["i"] += 1
+        return True, None, f"wa-out-reac-{n['i']}"
+
+    def fake_reaction(*_a, **kwargs):
+        sent.append(kwargs)
+        return True, None
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_reaction",
+        fake_reaction,
+    )
+
+    cid, _h = _chat_em_atendimento(client, auth_headers, wa_id="5511999000702", msg_id="reac-in-2")
+    inbound_id = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()[0]["id"]
+
+    ok = client.put(
+        f"/v1/whatsapp/chats/{cid}/mensagens/{inbound_id}/reacoes",
+        json={"emoji": "❤️"},
+        headers=auth_headers["a1"],
+    )
+    assert ok.status_code == 200
+    body = ok.json()
+    assert any(r["emoji"] == "❤️" and r["reagiu_eu"] for r in body.get("reacoes") or [])
+    assert sent and sent[-1].get("reaction") == "❤️"
+
+    # Toggle remove
+    rem = client.put(
+        f"/v1/whatsapp/chats/{cid}/mensagens/{inbound_id}/reacoes",
+        json={"emoji": "❤️"},
+        headers=auth_headers["a1"],
+    )
+    assert rem.status_code == 200
+    assert not any(r["emoji"] == "❤️" for r in rem.json().get("reacoes") or [])
+    assert sent[-1].get("reaction") == ""
+
+
+def test_reacao_exige_responsavel(client, seed_base, auth_headers, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_reaction",
+        lambda *_a, **_k: (True, None),
+    )
+    cid, _h = _chat_em_atendimento(client, auth_headers, wa_id="5511999000703", msg_id="reac-in-3")
+    mid = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()[0]["id"]
+    denied = client.put(
+        f"/v1/whatsapp/chats/{cid}/mensagens/{mid}/reacoes",
+        json={"emoji": "👍"},
+        headers=auth_headers["a2"],
+    )
+    assert denied.status_code == 403

--- a/docs/WHATSAPP_EVOLUTION.md
+++ b/docs/WHATSAPP_EVOLUTION.md
@@ -71,10 +71,22 @@ Campos persistidos em `whatsapp_settings` (via **Configurações → WhatsApp**,
 3. **Encerrar** → `encerrado`, `encerramento_at`.
 4. Nova mensagem do mesmo cliente **após encerramento** → **novo** chat e novo protocolo.
 
+## Reações, editar e apagar (#630)
+
+| Ação | Endpoint Evolution (v2 típico) | Limite no DX Connect |
+|------|-------------------------------|----------------------|
+| Reagir | `POST /message/sendReaction/{instance}` | Whitelist 👍❤️😂😮😢🙏; só responsável do chat |
+| Editar texto | `POST /chat/updateMessage/{instance}` | Só outbound texto; **15 minutos** após envio |
+| Apagar para todos | `DELETE /chat/deleteMessageForEveryone/{instance}` | Só outbound; **48 horas** após envio |
+
+- Webhook inbound: `reactionMessage`, `protocolMessage` tipo `REVOKE`, e `editedMessage` atualizam a mensagem e emitem SSE `chat.mensagem`.
+- Editar legenda de mídia fica fora do escopo v1.
+- O prefixo de assinatura `[ Setor - Nome ]:` é reaplicado ao editar (ver #628).
+
 ## Riscos e limitações
 
 - Comportamento e payloads podem variar entre **versões** da Evolution; ajustar o parser em `app/services/evolution_inbound.py` ou a chamada a `getBase64FromMediaMessage` se necessário.
-- Políticas e limitações do **WhatsApp** aplicam-se ao número conectado na Evolution.
+- Políticas e limitações do **WhatsApp** aplicam-se ao número conectado na Evolution (janelas de edição/apagamento podem ser mais restritas que as do DX Connect).
 - **Localização** e **templates** não são tratados nesta versão.
 - Ficheiros muito grandes respeitam `WHATSAPP_MEDIA_MAX_BYTES` (por defeito 25 MB).
 - **Contacto** e **localização** inbound aparecem como texto legível (`[Contacto]`, `[Localização]` + link Google Maps).

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -959,6 +959,13 @@ export namespace WhatsappChats {
     encerramento_at?: string | null
     sem_avaliacao: boolean
   }
+  export interface ReacaoMensagem {
+    emoji: string
+    count: number
+    reagiu_eu: boolean
+    atendente_ids?: number[]
+    tem_cliente?: boolean
+  }
   export interface Mensagem {
     id: number
     chat_id: number
@@ -975,6 +982,12 @@ export namespace WhatsappChats {
     atendente_nome?: string | null
     status_entrega?: 'pendente' | 'enviada' | 'entregue' | 'lida' | 'erro' | null
     created_at?: string | null
+    reacoes?: ReacaoMensagem[]
+    editada?: boolean
+    editada_em?: string | null
+    apagada?: boolean
+    pode_editar?: boolean
+    pode_apagar_para_todos?: boolean
   }
   export interface Demanda {
     id: number
@@ -1206,6 +1219,24 @@ export const whatsappChats = {
     api<WhatsappChats.Mensagem>(`/whatsapp/chats/${id}/comentarios-internos`, {
       method: 'POST',
       body: JSON.stringify({ texto }),
+    }),
+  definirReacao: (chatId: number, mensagemId: number, emoji: string) =>
+    api<WhatsappChats.Mensagem>(`/whatsapp/chats/${chatId}/mensagens/${mensagemId}/reacoes`, {
+      method: 'PUT',
+      body: JSON.stringify({ emoji }),
+    }),
+  removerReacao: (chatId: number, mensagemId: number) =>
+    api<WhatsappChats.Mensagem>(`/whatsapp/chats/${chatId}/mensagens/${mensagemId}/reacoes`, {
+      method: 'DELETE',
+    }),
+  editarMensagem: (chatId: number, mensagemId: number, texto: string) =>
+    api<WhatsappChats.Mensagem>(`/whatsapp/chats/${chatId}/mensagens/${mensagemId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ texto }),
+    }),
+  apagarMensagem: (chatId: number, mensagemId: number) =>
+    api<WhatsappChats.Mensagem>(`/whatsapp/chats/${chatId}/mensagens/${mensagemId}`, {
+      method: 'DELETE',
     }),
   marcarVisto: (id: number) => api<void>(`/whatsapp/chats/${id}/visto`, { method: 'POST' }),
   pausarInatividade: (id: number) =>

--- a/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
+++ b/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react'
+import type { WhatsappChats } from '../../api/client'
+import { ConfirmDialog } from '../ui/ConfirmDialog'
+import { TEXTAREA_FIELD_CLASS } from '../ui/Input'
+
+/** Remove prefixo `[ Setor - Nome ]:` gravado no corpo (#628 / #630). */
+export function corpoWhatsappSemPrefixo(corpo: string | null | undefined): string {
+  const t = (corpo || '').trim()
+  return t.replace(/^\[\s*[^\]]+\s*\]:\s*\n?/, '').trim()
+}
+
+type Props = {
+  mensagem: WhatsappChats.Mensagem
+  onEditar: (novoCorpo: string) => Promise<void>
+  onApagar: () => Promise<void>
+  alinhamento?: 'start' | 'end'
+}
+
+/** Editar / apagar para todos no chat WhatsApp (#630 lote 3). */
+export function WhatsappMensagemAcoes({
+  mensagem,
+  onEditar,
+  onApagar,
+  alinhamento = 'end',
+}: Props) {
+  const [editando, setEditando] = useState(false)
+  const [texto, setTexto] = useState(() => corpoWhatsappSemPrefixo(mensagem.corpo))
+  const [salvando, setSalvando] = useState(false)
+  const [confirmarApagar, setConfirmarApagar] = useState(false)
+  const [apagando, setApagando] = useState(false)
+
+  const podeEditar = Boolean(mensagem.pode_editar)
+  const podeApagarTodos = Boolean(mensagem.pode_apagar_para_todos)
+  const temAcoes = podeEditar || podeApagarTodos
+
+  useEffect(() => {
+    if (!editando) setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
+  }, [mensagem, editando])
+
+  if (mensagem.apagada || !temAcoes) return null
+
+  if (editando && podeEditar) {
+    return (
+      <div className="mt-1 w-full min-w-[min(100%,18rem)] space-y-2">
+        <textarea
+          value={texto}
+          onChange={(e) => setTexto(e.target.value)}
+          rows={3}
+          className={TEXTAREA_FIELD_CLASS}
+        />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            disabled={salvando || !texto.trim()}
+            onClick={() => {
+              setSalvando(true)
+              void onEditar(texto.trim())
+                .then(() => setEditando(false))
+                .finally(() => setSalvando(false))
+            }}
+            className="rounded-lg bg-cyan-600 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+          >
+            Salvar
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
+              setEditando(false)
+            }}
+            className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50 dark:border-slate-500 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const btnAcaoClass =
+    'rounded-full bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-100 dark:ring-slate-600 dark:hover:bg-slate-700'
+
+  return (
+    <>
+      <div
+        className={`pointer-events-none absolute bottom-full z-20 flex flex-col ${
+          alinhamento === 'end' ? 'right-0 items-end' : 'left-0 items-start'
+        }`}
+      >
+        <div
+          className={`flex gap-1 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 ${
+            alinhamento === 'end' ? 'justify-end' : 'justify-start'
+          }`}
+        >
+          {podeEditar && (
+            <button
+              type="button"
+              onClick={() => {
+                setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
+                setEditando(true)
+              }}
+              className={btnAcaoClass}
+            >
+              Editar
+            </button>
+          )}
+          {podeApagarTodos && (
+            <button type="button" onClick={() => setConfirmarApagar(true)} className={btnAcaoClass}>
+              Apagar
+            </button>
+          )}
+        </div>
+        <div
+          className="h-2 w-full min-w-[8rem] group-hover:pointer-events-auto group-focus-within:pointer-events-auto"
+          aria-hidden
+        />
+      </div>
+      <ConfirmDialog
+        open={confirmarApagar}
+        title="Apagar mensagem?"
+        message="A mensagem será apagada para todos no WhatsApp do cliente (até 48 h após o envio)."
+        confirmLabel="Apagar para todos"
+        cancelLabel="Cancelar"
+        variant="danger"
+        loading={apagando}
+        onCancel={() => setConfirmarApagar(false)}
+        onConfirm={() => {
+          setApagando(true)
+          void onApagar()
+            .then(() => setConfirmarApagar(false))
+            .finally(() => setApagando(false))
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/chat/WhatsappReacoesBar.tsx
+++ b/frontend/src/components/chat/WhatsappReacoesBar.tsx
@@ -1,0 +1,81 @@
+import type { WhatsappChats } from '../../api/client'
+import { EMOJIS_REACAO_CHAT_INTERNO } from '../../lib/chatInternoReacoes'
+
+type Props = {
+  reacoes: WhatsappChats.ReacaoMensagem[]
+  onReagir?: (emoji: string) => void
+  /** false = só chips (cliente reagiu; atendente sem permissão) */
+  podeReagir?: boolean
+  alinhamento?: 'start' | 'end'
+}
+
+/** Reações no chat WhatsApp com o cliente (#630 lote 2). */
+export function WhatsappReacoesBar({
+  reacoes,
+  onReagir,
+  podeReagir = false,
+  alinhamento = 'end',
+}: Props) {
+  const temReacoes = reacoes.length > 0
+  const alignEnd = alinhamento === 'end'
+
+  return (
+    <>
+      {podeReagir && onReagir ? (
+        <div
+          className={`pointer-events-none absolute top-full z-20 flex flex-col ${
+            alignEnd ? 'right-0 items-end' : 'left-0 items-start'
+          }`}
+        >
+          <div
+            className="h-2 w-full min-w-[10rem] group-hover:pointer-events-auto group-focus-within:pointer-events-auto"
+            aria-hidden
+          />
+          <div className="opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+            <div className="flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
+              {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
+                <button
+                  key={emoji}
+                  type="button"
+                  onClick={() => onReagir(emoji)}
+                  className="rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
+                  aria-label={`Reagir com ${emoji}`}
+                >
+                  {emoji}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {temReacoes ? (
+        <div
+          className={`relative z-[1] mt-1 flex flex-wrap gap-1 ${
+            alignEnd ? 'justify-end' : 'justify-start'
+          }`}
+        >
+          {reacoes.map((r) => (
+            <button
+              key={r.emoji}
+              type="button"
+              disabled={!podeReagir || !onReagir}
+              onClick={() => onReagir?.(r.emoji)}
+              className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] shadow-sm transition ${
+                r.reagiu_eu
+                  ? 'border-cyan-400/60 bg-white text-slate-800 dark:bg-slate-800 dark:text-slate-100'
+                  : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 disabled:hover:bg-white dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200'
+              } ${!podeReagir ? 'cursor-default' : ''}`}
+              title={
+                r.reagiu_eu ? 'Remover sua reação' : podeReagir ? 'Reagir' : r.tem_cliente ? 'Cliente' : 'Reação'
+              }
+            >
+              <span>{r.emoji}</span>
+              <span className="font-medium tabular-nums">{r.count}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -30,6 +30,8 @@ import {
 import { MensagemRodapeMeta } from '../../components/chat/MensagemRodapeMeta'
 import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsappSetorModal'
 import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
+import { WhatsappMensagemAcoes } from '../../components/chat/WhatsappMensagemAcoes'
+import { WhatsappReacoesBar } from '../../components/chat/WhatsappReacoesBar'
 import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
 
 import { Card } from '../../components/ui/Card'
@@ -83,6 +85,20 @@ function legendaMidiaVisivel(corpo: string | null | undefined): string | null {
   return t
 }
 
+function normalizarReacoesMensagem(
+  msg: WhatsappChats.Mensagem,
+  viewerId?: number | null,
+): WhatsappChats.Mensagem {
+  if (!msg.reacoes?.length || viewerId == null) return msg
+  return {
+    ...msg,
+    reacoes: msg.reacoes.map((r) => ({
+      ...r,
+      reagiu_eu: Boolean(r.reagiu_eu || r.atendente_ids?.includes(viewerId)),
+    })),
+  }
+}
+
 
 // --- Subcomponente de Renderização de Mídia ---
 
@@ -131,7 +147,7 @@ function ConteudoMensagemWhatsApp({
 
   useEffect(() => {
 
-    if (!m.midia_disponivel || tipo === 'texto') {
+    if (m.apagada || !m.midia_disponivel || tipo === 'texto') {
 
       setUrl(null)
 
@@ -165,9 +181,13 @@ function ConteudoMensagemWhatsApp({
 
     }
 
-  }, [chatId, m.id, m.midia_disponivel, tipo])
+  }, [chatId, m.id, m.midia_disponivel, m.apagada, tipo])
 
 
+
+  if (m.apagada) {
+    return <p className="text-sm italic opacity-70">Mensagem apagada</p>
+  }
 
   const legenda = legendaMidiaVisivel(m.corpo)
 
@@ -719,20 +739,36 @@ export function WhatsappConversa() {
     const chatId = Number(id)
     const unsubMsg = subscribe('chat.mensagem', (payload) => {
       if (Number(payload.chat_id) !== chatId) return
-      const msg = payload.mensagem as WhatsappChats.Mensagem | undefined
-      if (!msg) return
+      const msg = normalizarReacoesMensagem(
+        payload.mensagem as WhatsappChats.Mensagem,
+        userIdRef.current,
+      )
+      if (!msg?.id) return
       setMsgs((prev) => {
+        const mergeMsg = (prevRow: WhatsappChats.Mensagem, incoming: WhatsappChats.Mensagem) => {
+          const merged = { ...prevRow, ...incoming }
+          // SSE omite flags por visualizador; preservar as já conhecidas
+          if (incoming.pode_editar === undefined) merged.pode_editar = prevRow.pode_editar
+          if (incoming.pode_apagar_para_todos === undefined) {
+            merged.pode_apagar_para_todos = prevRow.pode_apagar_para_todos
+          }
+          if (merged.apagada) {
+            merged.pode_editar = false
+            merged.pode_apagar_para_todos = false
+          }
+          return merged
+        }
         const idx = prev.findIndex((m) => m.id === msg.id)
         if (idx >= 0) {
           const next = [...prev]
-          next[idx] = { ...next[idx], ...msg }
+          next[idx] = mergeMsg(next[idx], msg)
           return next
         }
         if (msg.wa_message_id && prev.some((m) => m.wa_message_id === msg.wa_message_id)) {
           const widx = prev.findIndex((m) => m.wa_message_id === msg.wa_message_id)
           if (widx >= 0) {
             const next = [...prev]
-            next[widx] = { ...next[widx], ...msg }
+            next[widx] = mergeMsg(next[widx], msg)
             return next
           }
         }
@@ -1109,6 +1145,52 @@ useEffect(() => {
     isResponsavel &&
     !encerrado &&
     !chat?.classificacao_demanda_pendente
+
+  const podeReagir = Boolean(podeEnviar)
+
+  async function reagirMensagem(m: WhatsappChats.Mensagem, emoji: string) {
+    if (!chat || !podeReagir || m.evento_sistema || m.apagada) return
+    try {
+      const atualizada = await whatsappChats.definirReacao(chat.id, m.id, emoji)
+      setMsgs((prev) =>
+        prev.map((row) =>
+          row.id === atualizada.id ? normalizarReacoesMensagem(atualizada, user?.id) : row,
+        ),
+      )
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao reagir'))
+    }
+  }
+
+  async function editarMensagemWhatsapp(m: WhatsappChats.Mensagem, texto: string) {
+    if (!chat) return
+    try {
+      const atualizada = await whatsappChats.editarMensagem(chat.id, m.id, texto)
+      setMsgs((prev) =>
+        prev.map((row) =>
+          row.id === atualizada.id ? normalizarReacoesMensagem(atualizada, user?.id) : row,
+        ),
+      )
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao editar mensagem'))
+      throw err
+    }
+  }
+
+  async function apagarMensagemWhatsapp(m: WhatsappChats.Mensagem) {
+    if (!chat) return
+    try {
+      const atualizada = await whatsappChats.apagarMensagem(chat.id, m.id)
+      setMsgs((prev) =>
+        prev.map((row) =>
+          row.id === atualizada.id ? normalizarReacoesMensagem(atualizada, user?.id) : row,
+        ),
+      )
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao apagar mensagem'))
+      throw err
+    }
+  }
 
   const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && (isResponsavel || isAdmin)
 
@@ -1644,7 +1726,7 @@ useEffect(() => {
                 onDoubleClick={(e) => duploCliqueResponder(e, m, isSystem)}
                 className={`flex w-full group cursor-default items-center gap-2 transition-all ${isInbound ? 'justify-start' : 'justify-end'}`}
               >
-                {!isInbound && !isSystem && (
+                {!isInbound && !isSystem && !m.apagada && (
                   <button
                     onClick={() => iniciarResposta(m)}
                     className="opacity-25 group-hover:opacity-100 md:opacity-0 transition-opacity p-1.5 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 cursor-pointer shrink-0"
@@ -1654,7 +1736,9 @@ useEffect(() => {
                   </button>
                 )}
 
-                <div className={`max-w-[85%] sm:max-w-[70%] space-y-1 ${isInbound ? 'items-start' : 'items-end'}`}>
+                <div
+                  className={`relative max-w-[85%] space-y-1 sm:max-w-[70%] ${isInbound ? 'items-start' : 'items-end'}`}
+                >
 
                   {isSystem && (
                     <span className="text-[9px] font-bold uppercase px-2 text-amber-600">
@@ -1662,7 +1746,14 @@ useEffect(() => {
                     </span>
                   )}
 
-                 
+                  {!isSystem && !isInbound && (
+                    <WhatsappMensagemAcoes
+                      mensagem={m}
+                      onEditar={(texto) => editarMensagemWhatsapp(m, texto)}
+                      onApagar={() => apagarMensagemWhatsapp(m)}
+                      alinhamento="end"
+                    />
+                  )}
 
                   <div className={`
 
@@ -1676,7 +1767,7 @@ useEffect(() => {
 
                   `}>
 
-                    {m.quoted_wa_message_id && (
+                    {m.quoted_wa_message_id && !m.apagada && (
                       <div 
                         onClick={() => {
                           const el = document.getElementById(`msg-${m.quoted_wa_message_id}`);
@@ -1713,15 +1804,25 @@ useEffect(() => {
                         direcao={m.direcao}
                         eventoSistema={m.evento_sistema}
                         variant={isInbound ? 'escuro' : 'claro'}
+                        editada={m.editada}
                         className={isInbound ? 'text-slate-400' : ''}
                       />
                     )}
 
                   </div>
 
+                  {!isSystem && !m.apagada && (
+                    <WhatsappReacoesBar
+                      reacoes={m.reacoes || []}
+                      podeReagir={podeReagir}
+                      onReagir={podeReagir ? (emoji) => void reagirMensagem(m, emoji) : undefined}
+                      alinhamento={isInbound ? 'start' : 'end'}
+                    />
+                  )}
+
                 </div>
 
-                {isInbound && !isSystem && (
+                {isInbound && !isSystem && !m.apagada && (
                   <button
                     onClick={() => iniciarResposta(m)}
                     className="opacity-25 group-hover:opacity-100 md:opacity-0 transition-opacity p-1.5 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 cursor-pointer shrink-0"


### PR DESCRIPTION
## Summary

- WhatsApp (#630 lote 2): reações no chat com o cliente — ver emoji do cliente e o responsável pode reagir (👍 ❤️ 😂 😮 😢 🙏); clique de novo remove
- WhatsApp (#630 lote 3): editar texto outbound (até 15 min) e apagar para todos (até 48 h); sync quando o cliente edita ou apaga via webhook Evolution
- Migrations `079` (reações) e `080` (editada_em / apagada_em); docs em `WHATSAPP_EVOLUTION.md`

Closes #630

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest` — `tests/test_whatsapp_reacoes.py` + `tests/test_whatsapp_edicao_apagar.py` (8 passed)
- [ ] Em chat em atendimento como responsável: reagir a mensagem inbound; ver reação do cliente após webhook
- [ ] Editar mensagem de texto própria dentro de 15 min; conferir rótulo «editada» e prefixo de setor reaplicado
- [ ] Apagar para todos mensagem outbound dentro de 48 h; UI mostra «Mensagem apagada»
- [ ] Atendente não responsável: 403 em reagir/editar/apagar
- [ ] `alembic heads` → único head `080_wpp_edicao_apagar`

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Editar legenda de mídia fica fora do escopo v1 (documentado em `docs/WHATSAPP_EVOLUTION.md`)
- [ ] Se ainda faltarem itens do épico #630 após este merge, abrir follow-ups explícitos no comentário de fechamento
