### PR TITLE
release: main → staging

### DIFF
--- a/.cursor/commands/criar-pr.md
+++ b/.cursor/commands/criar-pr.md
@@ -4,11 +4,14 @@ Finalize a feature, abra Pull Request para **`main`**, acompanhe o CI, aprove e 
 
 > **`main` é branch de testes** neste repo — após CI verde, merge automático é o comportamento padrão do `/criar-pr`.
 > Para **só abrir PR sem merge**, o usuário deve pedir explicitamente: `/criar-pr sem merge`.
+>
+> **Este comando NÃO serve para `staging`.** Release para produção = `/release-staging` (abre PR `main → staging` e **para**; o utilizador mergeia no GitHub). **Nunca** `gh pr merge` com base `staging`.
 
 ## Pré-requisitos
 
 - Feature implementada e revisada (`/revisar-e-testar` recomendado)
 - Branch **não** é `main` nem `staging`
+- Base do PR será **`main`** (nunca `staging`)
 - Testes passando localmente
 - `gh` autenticado (`gh auth status`)
 

--- a/.cursor/commands/release-staging.md
+++ b/.cursor/commands/release-staging.md
@@ -1,0 +1,52 @@
+# Release staging
+
+Abre Pull Request **`main` → `staging`** para o utilizador **analisar e aprovar no GitHub**.
+
+> **`staging` = produção.** O agente **NUNCA** faz `gh pr merge` neste fluxo — nem com CI verde, nem “para facilitar”.
+
+## Pré-requisitos
+
+- Lote testado na `main`
+- `CHANGELOG.md` → `[Unreleased]` com o lote a publicar
+- `gh` autenticado
+
+## Passo 1 — Diagnóstico
+
+```bash
+git fetch origin
+git log origin/staging..origin/main --oneline
+gh pr list --base staging --head main --state open
+```
+
+Se já existir PR aberto `main` → `staging`, **reutilize** (não duplique).
+
+## Passo 2 — Conflitos?
+
+Se `gh pr create` / GitHub indicar conflito:
+
+1. Branch a partir de `origin/staging`: `merge/main-into-staging-YYYYMMDD`
+2. `git merge origin/main` e resolver (código da `main`; `[Unreleased]` = só o que ainda não foi publicado na staging)
+3. Push da branch e **um** PR → `staging`
+4. **Pare** — entregue o URL; **não** mergeie
+
+Não manter dois PRs de release abertos sem explicar; preferir **um** PR mergeável.
+
+## Passo 3 — Criar PR (sem merge)
+
+```bash
+gh pr create --base staging --head main --title "release: main → staging" --body-file .cursor/pr-body-temp.md
+```
+
+Corpo: Summary do lote (`[Unreleased]`), test plan, nota **“Merge apenas após aprovação manual (staging = produção)”**.
+
+## Passo 4 — Entrega
+
+Reporte só:
+
+| Item | Valor |
+|------|-------|
+| URL do PR | ... |
+| Base | staging |
+| Merge pelo agente | ❌ proibido — aguarda aprovação no GitHub |
+
+**Não** executar: `gh pr merge`, `gh pr review --approve` seguido de merge, push para `staging`.

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,16 +1,16 @@
-{
-  "version": 1,
-  "hooks": {
-    "beforeShellExecution": [
-      {
-        "command": "python .cursor/hooks/block_main_branch.py",
-        "matcher": "git "
-      }
-    ],
-    "afterFileEdit": [
-      {
-        "command": "python .cursor/hooks/format_frontend.py"
-      }
-    ]
-  }
-}
+{
+  "version": 1,
+  "hooks": {
+    "beforeShellExecution": [
+      {
+        "command": "py -3 .cursor/hooks/block_main_branch.py",
+        "matcher": "git |gh "
+      }
+    ],
+    "afterFileEdit": [
+      {
+        "command": "py -3 .cursor/hooks/format_frontend.py"
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/block_main_branch.py
+++ b/.cursor/hooks/block_main_branch.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Bloqueia git commit/push perigosos em main/staging."""
+"""Bloqueia git/gh perigosos em main/staging (staging = produção)."""
 
 import json
 import re
@@ -29,11 +29,45 @@ def deny(msg: str) -> None:
             {
                 "permission": "deny",
                 "user_message": msg,
-                "agent_message": "Hook block_main_branch bloqueou comando git em branch protegida.",
+                "agent_message": "Hook block_main_branch bloqueou comando em branch protegida / staging.",
             }
         )
     )
     sys.exit(0)
+
+
+def _pr_base_ref(pr_selector: str | None) -> str | None:
+    """baseRefName do PR (número ou PR da branch atual)."""
+    args = ["gh", "pr", "view", "--json", "baseRefName"]
+    if pr_selector:
+        args.insert(3, pr_selector)
+    try:
+        r = subprocess.run(args, capture_output=True, text=True, timeout=15)
+        if r.returncode != 0:
+            return None
+        data = json.loads(r.stdout or "{}")
+        return data.get("baseRefName")
+    except (subprocess.SubprocessError, OSError, json.JSONDecodeError):
+        return None
+
+
+def _blocks_staging_merge(command: str) -> bool:
+    """Impede merge de PR cuja base é staging (produção)."""
+    if not re.search(r"\bgh\s+pr\s+merge\b", command):
+        return False
+
+    m = re.search(r"\bgh\s+pr\s+merge\s+(\d+)\b", command)
+    pr_num = m.group(1) if m else None
+    base = _pr_base_ref(pr_num)
+    if base == "staging":
+        return True
+    if base is None and ("staging" in command.lower() or "main-into-staging" in command.lower()):
+        return True
+    # Sem número e sem API: se a branch atual é de merge para staging, bloquear
+    branch = current_branch()
+    if pr_num is None and branch and re.search(r"main-into-staging|merge/.*staging", branch, re.I):
+        return True
+    return False
 
 
 def main() -> None:
@@ -44,6 +78,17 @@ def main() -> None:
         return
 
     command = payload.get("command") or ""
+
+    # --- gh: nunca mergear PR cuja base é staging ---
+    if re.search(r"\bgh\b", command):
+        if _blocks_staging_merge(command):
+            deny(
+                "Merge de PR para staging bloqueado (staging = produção). "
+                "Abra/atualize o PR e peça aprovação/merge manual no GitHub."
+            )
+        print(json.dumps({"permission": "allow"}))
+        return
+
     if not re.search(r"\bgit\b", command):
         print(json.dumps({"permission": "allow"}))
         return
@@ -56,7 +101,9 @@ def main() -> None:
             r"HEAD:(main|staging)", command
         ):
             deny(
-                "Push para main/staging bloqueado. Abra PR com /criar-pr a partir de uma branch de feature."
+                "Push para main/staging bloqueado. "
+                "Feature → PR para main (/criar-pr). "
+                "Release → PR main→staging (/release-staging) sem merge pelo agente."
             )
 
     # Operações destrutivas na branch atual protegida

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -1,5 +1,5 @@
 ---
-description: Fluxo Git — branch por feature, PR para main, convenções do time
+description: Fluxo Git — branch por feature, PR para main, release staging só com aprovação humana
 alwaysApply: true
 ---
 
@@ -11,7 +11,8 @@ alwaysApply: true
 - **Sempre** criar branch nova antes de codar
 - **Uma feature/lote = uma branch = um PR** para `main`
 - `main` é **branch de testes** — `/criar-pr` mergeia automaticamente após CI verde
-- Não push direto em `main` (sempre via PR)
+- **`staging` é produção** — release só via PR `main → staging`; o agente **nunca** faz o merge
+- Não push direto em `main` nem `staging` (sempre via PR)
 
 ## Após merge na `main` (obrigatório)
 
@@ -49,22 +50,39 @@ git checkout -b feat/minha-feature-123
 
 Use `/iniciar-feature` para automatizar este passo.
 
+## Após merge na `main` (obrigatório)
+
+Quando o PR do lote for **mergeado** e o desenvolvimento daquele lote estiver **fechado para testes** na `main`:
+
+1. **Não** continuar a codar na branch já mergeada
+2. **Sempre** abrir **branch nova** a partir de `main` atualizada antes do próximo trabalho
+3. Usar `/iniciar-feature` — mesmo se o próximo lote for polish ou issues pequenas
+
+Exceção: hotfix urgente na mesma linha só se o PR ainda **não** tiver sido mergeado.
+
 ## Commits
 
 - Mensagens claras, foco no **porquê**
 - Estilo do repo: `feat(tickets): ...`, `fix(frontend): ...`, `chore(deps): ...`
 - **Não commitar** sem pedido explícito do usuário
-- **Não** `--no-verify`, `--force`, `push --force` em `main`
+- **Não** `--no-verify`, `--force`, `push --force` em `main`/`staging`
 
-## Finalização
+## Finalização (feature → main)
 
 1. `/revisar-e-testar` — qualidade + testes
 2. `/criar-pr` — commit (se pendente), push, PR, CI, approve e **merge em main**
 
-## PR
+## PR → main
 
 - Base: **`main`**
 - Corpo: resumo, test plan, link da issue
 - Aguardar CI (pytest + build frontend)
 - `/criar-pr` faz merge automático quando CI passa (main = testes)
-- Para staging/produção: fluxo separado (`main → staging`)
+
+## Release → staging (produção)
+
+- Comando: **`/release-staging`**
+- Abre (ou atualiza) PR **`main` → `staging`**
+- **PROIBIDO** ao agente: `gh pr merge`, push para `staging`, “mergear para facilitar”
+- O utilizador **analisa, aprova e mergeia no GitHub**
+- Rule: `.cursor/rules/staging-release-approval.mdc`

--- a/.cursor/rules/main-pr-batch-delivery.mdc
+++ b/.cursor/rules/main-pr-batch-delivery.mdc
@@ -27,6 +27,7 @@ feature/feat/<lote>  →  PR  →  main  →  (acumular)  →  PR main → stagi
 
 - **`main → staging`**: só quando houver **release** para produção (várias melhorias no `[Unreleased]`), não a cada merge na `main`.
 - **Nunca** commit direto na `main`.
+- **`staging` = produção**: o agente só **abre** o PR (`/release-staging`); **nunca** executa `gh pr merge` — aprovação e merge são **só do utilizador no GitHub**.
 
 ## Nomenclatura de branch
 
@@ -51,4 +52,4 @@ feature/feat/<lote>  →  PR  →  main  →  (acumular)  →  PR main → stagi
 ## Referências
 
 - Encerramento de issues: `.cursor/rules/issue-closure-backlog.mdc`, `docs/ISSUE_CLOSURE.md`
-- Deploy: PR `main → staging`; ver `docs/RELEASES.md` se existir
+- Deploy: `/release-staging` (PR sem merge pelo agente); ver `docs/RELEASES.md` e rule `staging-release-approval`

--- a/.cursor/rules/project-core.mdc
+++ b/.cursor/rules/project-core.mdc
@@ -13,6 +13,7 @@ Sistema interno de helpdesk para redes de postos (tickets, WhatsApp, e-mail, SSE
 - Mudanças **mínimas**: só o necessário para a tarefa; não refatorar código adjacente.
 - **Não commitar** nem sugerir commit/push sem pedido explícito do usuário.
 - Git: branch nova por feature, PR para `main` — ver rule `git-workflow`.
+- **`staging` = produção**: só PR `main → staging` (`/release-staging`); agente **nunca** mergeia — ver `staging-release-approval`.
 
 ## Onde está a verdade
 

--- a/.cursor/rules/staging-release-approval.mdc
+++ b/.cursor/rules/staging-release-approval.mdc
@@ -1,0 +1,35 @@
+---
+description: staging = produção — PR obrigatório e merge só com aprovação humana
+alwaysApply: true
+---
+
+# Release para staging (produção)
+
+## Verdade do deploy
+
+- **`staging` = branch em produção** (deploy/CalVer).
+- **`main` = branch de testes** (CI + validação do time).
+
+## Proibido ao agente (sem exceção “para facilitar”)
+
+1. **`gh pr merge`** de qualquer PR com base **`staging`**
+2. **`git push`** para `staging` / `HEAD:staging` / `origin staging`
+3. **`git merge` / `commit` / `reset`** em cima da branch local `staging` para “empurrar” release
+4. Merge automático após abrir PR **`main → staging`** — mesmo se o utilizador pediu “fazer o deploy”, “facilitar” ou “já está verde”
+5. Criar **segundo PR** paralelo e mergeá-lo no lugar do release sem o utilizador ter **aprovado explicitamente no GitHub** (botão Approve / merge por ele)
+
+## Obrigatório
+
+1. Release = **um único PR** `main` → `staging` (abrir com `/release-staging` ou pedido explícito)
+2. Se houver conflito: resolver numa branch `merge/…`, abrir **um** PR para `staging`, **parar** e entregar o URL
+3. O utilizador (Luis) **analisa e aprova/mergeia no GitHub** — o agente **não** corre `gh pr merge` nesse PR
+4. Após merge humano: deploy/CalVer segue o workflow do repo (`docs/RELEASES.md`)
+
+## Se o utilizador pedir merge em staging
+
+Responder: o PR está pronto no URL; **merge só no GitHub por ti** (staging = produção). Não executar `gh pr merge`.
+
+## Relação com `/criar-pr`
+
+- `/criar-pr` → só **`→ main`** (testes); merge automático CI verde **permitido**
+- `/release-staging` → só **abre** PR `main → staging`; **nunca** mergeia

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "20"
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,13 +21,14 @@ Guia para desenvolvimento assistido por IA no Cursor (time 2–3 devs).
 | `rbac-setor-scope` | `backend/app/api/**`, `backend/app/core/**` |
 | `alembic-migrations` | `backend/alembic/**` |
 | `git-workflow` | Sempre — branch por feature, PR para `main` |
+| `staging-release-approval` | Sempre — staging = produção; merge só humano |
 | `sse-realtime` | Arquivos SSE/realtime (backend + frontend) |
 
 ## Hooks
 
 | Hook | Evento | Função |
 |------|--------|--------|
-| `block_main_branch.py` | `beforeShellExecution` | Bloqueia commit/push em `main`/`staging` |
+| `block_main_branch.py` | `beforeShellExecution` (`git` / `gh`) | Bloqueia commit/push em `main`/`staging` e **`gh pr merge` com base staging** |
 | `format_frontend.py` | `afterFileEdit` | ESLint `--fix` em `.ts/.tsx` do frontend |
 
 Config: `.cursor/hooks.json`
@@ -43,7 +44,8 @@ Config: `.cursor/hooks.json`
 | `/revisar-e-testar` | Revisão pré-merge com testes |
 | `/subir-local` | Subir Docker, migrations, API e frontend em dev |
 | `/testar-ui` | Smoke test no navegador integrado (login, rotas, console) |
-| `/criar-pr` | PR → watch CI → approve → **merge automático em main** |
+| `/criar-pr` | PR → watch CI → approve → **merge automático em main** (nunca staging) |
+| `/release-staging` | Abre PR `main → staging`; **não mergeia** (aprovação humana) |
 
 ## Subagents (Task tool)
 
@@ -70,6 +72,8 @@ Use subagents para **paralelizar** ou **isolar** trabalho:
 ```
 
 O `/criar-pr` monitora Actions, aprova e **mergeia em `main`** quando CI passa (main = branch de testes). Em falha, corrige e re-monitora (skill **babysit**). Opt-out: pedir `/criar-pr sem merge`.
+
+Release para produção: `/release-staging` — **só abre** o PR; merge em `staging` é **sempre** manual no GitHub.
 
 Para desenvolvimento local: `/subir-local` → `/testar-ui` (navegador integrado).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - WhatsApp (#628): no WhatsApp do cliente, mensagens do atendente saem com prefixo **setor do atendimento + nome** e o texto na linha de baixo (ex.: `[ Suporte - Ana ]:`); ao assumir, 1 setor é gravado automaticamente e vários setores pedem escolha no painel
 - WhatsApp (#629): no lightbox de imagens da conversa, dá para navegar entre as fotos (botões e setas ←/→) com contador e legenda atualizada; Esc continua a fechar só a visualização
 - WhatsApp (#630): foto de perfil do contacto no header e nas listas Atendendo/Aguardando (com cache e fallback para a inicial do nome)
+- WhatsApp (#630): reações no chat com o cliente — ver emoji do cliente no balão e o atendente responsável pode reagir (👍 ❤️ 😂 😮 😢 🙏); clique de novo remove
+- WhatsApp (#630): editar (até 15 min) e apagar para todos (até 48 h) mensagens de texto enviadas pelo responsável; também sincroniza quando o cliente edita ou apaga
 - WhatsApp: no header da conversa, o chip da empresa abre a página de detalhe da empresa (Voltar regressa ao chat); alterar empresa multi-empresa continua no menu ⋮
 - Chat (#626): ícone de som junto a **Aguardando** para silenciar/reativar o alerta contínuo da fila (WhatsApp + portal); preferência guardada no browser — não afeta alertas de ticket nem do chat interno
 - Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- WhatsApp (#628): no WhatsApp do cliente, mensagens do atendente saem com prefixo **setor do atendimento + nome** e o texto na linha de baixo (ex.: `[ Suporte - Ana ]:`); ao assumir, 1 setor é gravado automaticamente e vários setores pedem escolha no painel
+- WhatsApp (#629): no lightbox de imagens da conversa, dá para navegar entre as fotos (botões e setas ←/→) com contador e legenda atualizada; Esc continua a fechar só a visualização
+- WhatsApp (#630): foto de perfil do contacto no header e nas listas Atendendo/Aguardando (com cache e fallback para a inicial do nome)
+- WhatsApp: no header da conversa, o chip da empresa abre a página de detalhe da empresa (Voltar regressa ao chat); alterar empresa multi-empresa continua no menu ⋮
 - Chat (#626): ícone de som junto a **Aguardando** para silenciar/reativar o alerta contínuo da fila (WhatsApp + portal); preferência guardada no browser — não afeta alertas de ticket nem do chat interno
 - Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário
 - Portal (#600, #601): cadastro de funcionário pelo modal da Rede permite definir senha do portal na criação; sócio cadastra sem escolher empresas (escopo automático em toda a rede)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Chat (#626): ícone de som junto a **Aguardando** para silenciar/reativar o alerta contínuo da fila (WhatsApp + portal); preferência guardada no browser — não afeta alertas de ticket nem do chat interno
 - Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário
 - Portal (#600, #601): cadastro de funcionário pelo modal da Rede permite definir senha do portal na criação; sócio cadastra sem escolher empresas (escopo automático em toda a rede)
 - Portal (#604): RBAC por papel — colaborador vê só os próprios chamados; supervisor vê todos das empresas vinculadas; sócio vê toda a rede
@@ -35,6 +36,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Correções
 
+- Chat (#625): ao **Ver** um chat da fila Aguardando, a lista com **Atender** permanece na lateral; na conversa há CTA **Atender** (WhatsApp e portal) para assumir sem voltar à lista
+- WhatsApp (#627): com anexo pendente, **Enter** na legenda (ou no painel, em áudio) envia o anexo — equivalente a «Enviar anexo»
 - WhatsApp (#608): duas mensagens inbound seguidas do mesmo contacto deixam de abrir dois chats/protocolos — lock por `wa_id` no webhook e uma única sequência de auto-mensagens por sessão
 - WhatsApp (#598): após encerrar com avaliação, janela de ~30 min (configurável) para a nota; se o cliente mandar outro texto, abre atendimento novo com essa mensagem; sem resposta, finaliza sozinho
 - WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** (somente leitura) até registar, manter demandas existentes ou confirmar sem demanda; nova mensagem do mesmo cliente abre chat novo na fila

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,24 +17,24 @@ LOG_LEVEL=INFO
 # --- Tenant (produção comercial: single-tenant por instância / Postgres dedicado) ---
 # DX_CONNECT_MULTI_TENANT=false   # padrão; true só em dev legado (vários clientes no mesmo Postgres)
 # DEFAULT_TENANT_ID=1
-# CLIENT_APP_HOST=duplexsoft.connect.duplexsoft.com.br   # URL pública do painel (GET /tenant/atual)
+# CLIENT_APP_HOST=cliente01.deskrudder.com.br   # URL pública do painel (GET /tenant/atual)
 # PASSWORD_RESET_TOKEN_EXPIRE_HOURS=1   # validade do link «esqueci minha senha»
 #
 # --- Multi-tenant legado (só se DX_CONNECT_MULTI_TENANT=true) ---
-# CONNECT_APP_BASE_DOMAIN=connect.duplexsoft.com.br
-# INBOUND_EMAIL_DOMAIN=notify.duplexsoft.com.br
+# CONNECT_APP_BASE_DOMAIN=deskrudder.com.br
+# INBOUND_EMAIL_DOMAIN=notify.deskrudder.com.br
 
 # --- E-mail transaccional (plataforma / Resend HTTP API) ---
-# Uma conta Resend (ou equivalente) da operação DX Connect — o cliente final NÃO configura API key no painel.
+# Uma conta Resend (ou equivalente) da operação — o cliente final NÃO configura API key no painel.
 # RESEND_API_KEY=re_...
-# TRANSACTIONAL_FROM_EMAIL=noreply@notify.duplexsoft.com.br
-# TRANSACTIONAL_FROM_NAME=DX Connect
-# SUPPORT_REPLY_TO_EMAIL=suporte@duplexsoft.com.br
+# TRANSACTIONAL_FROM_EMAIL=noreply@notify.deskrudder.com.br
+# TRANSACTIONAL_FROM_NAME=DeskRudder
+# SUPPORT_REPLY_TO_EMAIL=suporte@suaempresa.com.br
 #
 # --- Ingestão inbound (encaminhamento → tickets) ---
 # EMAIL_INBOUND_WEBHOOK_SECRET=...
 # RESEND_WEBHOOK_SECRET=whsec_...   # webhook Resend email.received → POST /v1/webhooks/resend-inbound
-# INBOUND_EMAIL_DOMAIN=notify.duplexsoft.com.br
+# INBOUND_EMAIL_DOMAIN=notify.deskrudder.com.br
 # EMAIL_INBOUND_DEFAULT_EMPRESA_ID=1   # omitir = ticket sem empresa até triagem
 # EMAIL_INBOUND_DEFAULT_SETOR_ID=1
 
@@ -42,7 +42,7 @@ LOG_LEVEL=INFO
 # API em network_mode: host chama a Evolution em 127.0.0.1:8080 (porta publicada pelo contentor).
 # EVOLUTION_INTERNAL_BASE_URL=http://127.0.0.1:8080
 # EVOLUTION_GLOBAL_API_KEY=<mesmo valor de AUTHENTICATION_API_KEY da Evolution; mín. 32 caracteres>
-# DX_CONNECT_WEBHOOK_BASE_URL=https://api.seudominio.com
+# DX_CONNECT_WEBHOOK_BASE_URL=https://api-cliente01.deskrudder.com.br
 # EVOLUTION_POSTGRES_PASSWORD=<senha forte para o Postgres dedicado da Evolution>
 # EVOLUTION_POSTGRES_USER=evolution
 # EVOLUTION_POSTGRES_DB=evolution

--- a/backend/alembic/versions/078_wpp_foto_perfil.py
+++ b/backend/alembic/versions/078_wpp_foto_perfil.py
@@ -1,0 +1,41 @@
+"""WhatsApp: foto de perfil do contacto (URL em cache).
+
+Revision ID: 078_wpp_foto_perfil
+Revises: 077_wpp_avaliacao_janela
+Create Date: 2026-08-01
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "078_wpp_foto_perfil"
+down_revision = "077_wpp_avaliacao_janela"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "foto_perfil_url" not in cols:
+        op.add_column("whatsapp_chats", sa.Column("foto_perfil_url", sa.Text(), nullable=True))
+    if "foto_perfil_atualizada_em" not in cols:
+        op.add_column(
+            "whatsapp_chats",
+            sa.Column("foto_perfil_atualizada_em", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_chats"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_chats")}
+    if "foto_perfil_atualizada_em" in cols:
+        op.drop_column("whatsapp_chats", "foto_perfil_atualizada_em")
+    if "foto_perfil_url" in cols:
+        op.drop_column("whatsapp_chats", "foto_perfil_url")

--- a/backend/alembic/versions/079_wpp_reacoes.py
+++ b/backend/alembic/versions/079_wpp_reacoes.py
@@ -1,0 +1,52 @@
+"""WhatsApp: reações em mensagens do chat com o cliente (#630 lote 2).
+
+Revision ID: 079_wpp_reacoes
+Revises: 078_wpp_foto_perfil
+Create Date: 2026-08-01
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "079_wpp_reacoes"
+down_revision = "078_wpp_foto_perfil"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_mensagens"):
+        return
+    if insp.has_table("whatsapp_mensagem_reacoes"):
+        return
+    op.create_table(
+        "whatsapp_mensagem_reacoes",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "mensagem_id",
+            sa.Integer(),
+            sa.ForeignKey("whatsapp_mensagens.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("origem", sa.String(20), nullable=False),
+        sa.Column("emoji", sa.String(16), nullable=False),
+        sa.Column(
+            "atendente_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.UniqueConstraint("mensagem_id", "origem", name="uq_whatsapp_mensagem_reacoes_mensagem_origem"),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("whatsapp_mensagem_reacoes"):
+        op.drop_table("whatsapp_mensagem_reacoes")

--- a/backend/alembic/versions/080_wpp_edicao_apagar.py
+++ b/backend/alembic/versions/080_wpp_edicao_apagar.py
@@ -1,0 +1,44 @@
+"""WhatsApp: editar e apagar para todos (#630 lote 3).
+
+Revision ID: 080_wpp_edicao_apagar
+Revises: 079_wpp_reacoes
+Create Date: 2026-08-01
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "080_wpp_edicao_apagar"
+down_revision = "079_wpp_reacoes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_mensagens"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_mensagens")}
+    if "editada_em" not in cols:
+        op.add_column(
+            "whatsapp_mensagens",
+            sa.Column("editada_em", sa.DateTime(timezone=True), nullable=True),
+        )
+    if "apagada_em" not in cols:
+        op.add_column(
+            "whatsapp_mensagens",
+            sa.Column("apagada_em", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_mensagens"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_mensagens")}
+    if "apagada_em" in cols:
+        op.drop_column("whatsapp_mensagens", "apagada_em")
+    if "editada_em" in cols:
+        op.drop_column("whatsapp_mensagens", "editada_em")

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -32,6 +32,9 @@ from app.schemas.whatsapp_chat import (
     WhatsappEmpresaContextoBody,
     WhatsappIniciarChatBody,
     WhatsappMensagemRead,
+    WhatsappMensagemUpdate,
+    WhatsappReacaoCreate,
+    WhatsappReacaoRead,
     WhatsappTransferirChatBody,
     WhatsappVincularFuncionarioBody,
     WhatsappCadastrarFuncionarioBody,
@@ -63,6 +66,8 @@ from app.services.ticket_distribuicao import pos_criar_ticket_na_fila
 from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.whatsapp_wa_id_lock import lock_wa_id_para_chat, unlock_wa_id_para_chat
 from app.services.audit_operacional import audit_whatsapp_chat
+from app.services import whatsapp_reacoes as wpp_reacoes
+from app.services import whatsapp_edicao as wpp_edicao
 
 router = APIRouter(prefix="/whatsapp/chats", tags=["whatsapp-chats"])
 
@@ -735,17 +740,33 @@ def _pode_ver_chat(db: Session, atendente: Atendente, c: WhatsappChat) -> bool:
     return False
 
 
-def _mensagem_read(m: WhatsappMensagem) -> WhatsappMensagemRead:
+def _mensagem_read(
+    m: WhatsappMensagem,
+    *,
+    viewer_id: int | None = None,
+    is_responsavel: bool = False,
+) -> WhatsappMensagemRead:
     midia_ok = bool(m.midia_nome_arquivo and str(m.midia_nome_arquivo).strip())
     status = m.status_entrega if m.direcao == "outbound" and not m.evento_sistema else None
+    reacoes = [
+        WhatsappReacaoRead(
+            emoji=r.emoji,
+            count=r.count,
+            reagiu_eu=r.reagiu_eu,
+            atendente_ids=r.atendente_ids,
+            tem_cliente=r.tem_cliente,
+        )
+        for r in wpp_reacoes.agregar_reacoes(m, viewer_id)
+    ]
+    apagada = wpp_edicao.mensagem_apagada(m)
     return WhatsappMensagemRead(
         id=m.id,
         chat_id=m.chat_id,
         direcao=m.direcao,
-        corpo=m.corpo,
+        corpo=wpp_edicao.CORPO_MENSAGEM_APAGADA if apagada else m.corpo,
         tipo_midia=m.tipo_midia,
         mimetype=m.mimetype,
-        midia_disponivel=midia_ok,
+        midia_disponivel=False if apagada else midia_ok,
         evento_sistema=getattr(m, "evento_sistema", None),
         wa_message_id=m.wa_message_id,
         quoted_wa_message_id=getattr(m, "quoted_wa_message_id", None),
@@ -754,6 +775,12 @@ def _mensagem_read(m: WhatsappMensagem) -> WhatsappMensagemRead:
         atendente_nome=m.atendente.nome if m.atendente else None,
         status_entrega=status,
         created_at=m.created_at,
+        reacoes=[] if apagada else reacoes,
+        editada=wpp_edicao.mensagem_editada(m),
+        editada_em=getattr(m, "editada_em", None),
+        apagada=apagada,
+        pode_editar=wpp_edicao.pode_editar_mensagem(m, is_responsavel=is_responsavel),
+        pode_apagar_para_todos=wpp_edicao.pode_apagar_para_todos(m, is_responsavel=is_responsavel),
     )
 
 
@@ -1412,13 +1439,266 @@ def listar_mensagens(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
     rows = (
         db.query(WhatsappMensagem)
-        .options(joinedload(WhatsappMensagem.atendente))
+        .options(
+            joinedload(WhatsappMensagem.atendente),
+            joinedload(WhatsappMensagem.reacoes),
+        )
         .filter(WhatsappMensagem.chat_id == chat_id)
         .order_by(WhatsappMensagem.created_at.asc())
         .all()
     )
     visiveis = [m for m in rows if not mensagem_oculta_na_conversa(getattr(m, "evento_sistema", None))]
-    return [_mensagem_read(m) for m in visiveis]
+    is_resp = c.atendente_id == atendente.id
+    return [_mensagem_read(m, viewer_id=atendente.id, is_responsavel=is_resp) for m in visiveis]
+
+
+@router.patch("/{chat_id}/mensagens/{mensagem_id}", response_model=WhatsappMensagemRead)
+def editar_mensagem_whatsapp(
+    chat_id: int,
+    mensagem_id: int,
+    body: WhatsappMensagemUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Edita texto outbound no WhatsApp do cliente (#630 lote 3)."""
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    _exigir_responsavel_envio_cliente(c, atendente)
+
+    m = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id, WhatsappMensagem.chat_id == chat_id)
+        .first()
+    )
+    if not m:
+        raise HTTPException(status_code=404, detail="Mensagem não encontrada")
+    if not wpp_edicao.pode_editar_mensagem(m, is_responsavel=True):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Não é possível editar (só texto próprio, até {wpp_edicao.JANELA_EDICAO_MINUTOS} min).",
+        )
+
+    texto_novo = (body.texto or "").strip()
+    if not texto_novo:
+        raise HTTPException(status_code=400, detail="Mensagem vazia")
+    prefixo = _prefixo_assinatura_whatsapp(db, c, atendente)
+    texto_eff = f"{prefixo}\n{texto_novo}" if prefixo and not texto_novo.startswith("[") else texto_novo
+
+    st = _settings_envio(db)
+    ok, err = evolution_api.evolution_update_message(
+        st.evolution_base_url or "",
+        st.evolution_instance_name or "",
+        st.evolution_api_key or "",
+        number_digits=c.wa_id,
+        message_id=m.wa_message_id or "",
+        text=texto_eff,
+        remote_jid=f"{c.wa_id}@s.whatsapp.net",
+    )
+    if not ok:
+        raise HTTPException(status_code=502, detail=err or "Falha ao editar na Evolution API")
+
+    m.corpo = texto_eff
+    m.editada_em = datetime.now(timezone.utc)
+    db.commit()
+    m2 = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id)
+        .first()
+    )
+    assert m2 is not None
+    emit_chat_mensagem_from_models(db, c, m2, exclude_atendente_id=atendente.id)
+    return _mensagem_read(m2, viewer_id=atendente.id, is_responsavel=True)
+
+
+@router.delete("/{chat_id}/mensagens/{mensagem_id}", response_model=WhatsappMensagemRead)
+def apagar_mensagem_whatsapp_para_todos(
+    chat_id: int,
+    mensagem_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Apaga mensagem outbound para todos no WhatsApp do cliente (#630 lote 3)."""
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    _exigir_responsavel_envio_cliente(c, atendente)
+
+    m = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id, WhatsappMensagem.chat_id == chat_id)
+        .first()
+    )
+    if not m:
+        raise HTTPException(status_code=404, detail="Mensagem não encontrada")
+    if not wpp_edicao.pode_apagar_para_todos(m, is_responsavel=True):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Não é possível apagar para todos (só outbound próprio, até {wpp_edicao.JANELA_APAGAR_TODOS_HORAS} h).",
+        )
+
+    st = _settings_envio(db)
+    ok, err = evolution_api.evolution_delete_message_for_everyone(
+        st.evolution_base_url or "",
+        st.evolution_instance_name or "",
+        st.evolution_api_key or "",
+        message_id=m.wa_message_id or "",
+        remote_jid=f"{c.wa_id}@s.whatsapp.net",
+        from_me=True,
+    )
+    if not ok:
+        raise HTTPException(status_code=502, detail=err or "Falha ao apagar na Evolution API")
+
+    m.corpo = wpp_edicao.CORPO_MENSAGEM_APAGADA
+    m.apagada_em = datetime.now(timezone.utc)
+    m.midia_nome_arquivo = None
+    db.commit()
+    m2 = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id)
+        .first()
+    )
+    assert m2 is not None
+    emit_chat_mensagem_from_models(db, c, m2, exclude_atendente_id=atendente.id)
+    return _mensagem_read(m2, viewer_id=atendente.id, is_responsavel=True)
+
+
+@router.put("/{chat_id}/mensagens/{mensagem_id}/reacoes", response_model=WhatsappMensagemRead)
+def definir_reacao_mensagem(
+    chat_id: int,
+    mensagem_id: int,
+    body: WhatsappReacaoCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Atendente responsável reage a uma mensagem no WhatsApp do cliente (#630)."""
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    _exigir_responsavel_envio_cliente(c, atendente)
+    if c.estado not in ("em_atendimento", "aguardando_avaliacao"):
+        raise HTTPException(status_code=400, detail="Só é possível reagir em chat em atendimento")
+
+    m = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id, WhatsappMensagem.chat_id == chat_id)
+        .first()
+    )
+    if not m:
+        raise HTTPException(status_code=404, detail="Mensagem não encontrada")
+    if m.evento_sistema:
+        raise HTTPException(status_code=400, detail="Não é possível reagir a mensagem interna/sistema")
+    if not m.wa_message_id:
+        raise HTTPException(status_code=400, detail="Mensagem sem identificador WhatsApp")
+
+    try:
+        emoji = wpp_reacoes.validar_emoji_reacao(body.emoji)
+    except wpp_reacoes.WhatsappReacaoErro as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # Toggle: mesmo emoji remove
+    atual = next(
+        (r for r in (m.reacoes or []) if r.origem == wpp_reacoes.ORIGEM_ATENDENTE),
+        None,
+    )
+    remover = bool(atual and atual.emoji == emoji)
+    st = _settings_envio(db)
+    from_me = m.direcao == "outbound"
+    ok, err = evolution_api.evolution_send_reaction(
+        st.evolution_base_url or "",
+        st.evolution_instance_name or "",
+        st.evolution_api_key or "",
+        remote_jid=c.wa_id,
+        from_me=from_me,
+        message_id=m.wa_message_id,
+        reaction="" if remover else emoji,
+    )
+    if not ok:
+        raise HTTPException(status_code=502, detail=err or "Falha ao enviar reação pela Evolution API")
+
+    wpp_reacoes.aplicar_reacao(
+        db,
+        m,
+        origem=wpp_reacoes.ORIGEM_ATENDENTE,
+        emoji=None if remover else emoji,
+        atendente_id=None if remover else atendente.id,
+    )
+    db.commit()
+    m2 = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id)
+        .first()
+    )
+    assert m2 is not None
+    emit_chat_mensagem_from_models(db, c, m2, exclude_atendente_id=atendente.id)
+    return _mensagem_read(m2, viewer_id=atendente.id, is_responsavel=True)
+
+
+@router.delete("/{chat_id}/mensagens/{mensagem_id}/reacoes", response_model=WhatsappMensagemRead)
+def remover_reacao_mensagem(
+    chat_id: int,
+    mensagem_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Remove a reação do atendente na mensagem (#630)."""
+    c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == chat_id).first()
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    _exigir_responsavel_envio_cliente(c, atendente)
+
+    m = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id, WhatsappMensagem.chat_id == chat_id)
+        .first()
+    )
+    if not m:
+        raise HTTPException(status_code=404, detail="Mensagem não encontrada")
+    if not m.wa_message_id:
+        raise HTTPException(status_code=400, detail="Mensagem sem identificador WhatsApp")
+
+    st = _settings_envio(db)
+    from_me = m.direcao == "outbound"
+    ok, err = evolution_api.evolution_send_reaction(
+        st.evolution_base_url or "",
+        st.evolution_instance_name or "",
+        st.evolution_api_key or "",
+        remote_jid=c.wa_id,
+        from_me=from_me,
+        message_id=m.wa_message_id,
+        reaction="",
+    )
+    if not ok:
+        raise HTTPException(status_code=502, detail=err or "Falha ao remover reação pela Evolution API")
+
+    wpp_reacoes.aplicar_reacao(
+        db, m, origem=wpp_reacoes.ORIGEM_ATENDENTE, emoji=None, atendente_id=None
+    )
+    db.commit()
+    m2 = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id)
+        .first()
+    )
+    assert m2 is not None
+    emit_chat_mensagem_from_models(db, c, m2, exclude_atendente_id=atendente.id)
+    return _mensagem_read(m2, viewer_id=atendente.id, is_responsavel=True)
 
 
 @router.get("/{chat_id}/demandas", response_model=list[WhatsappChatDemandaRead])
@@ -1701,9 +1981,14 @@ def enviar_mensagem(
         evento_sistema=None,
         quoted_wa_message_id=data.quoted_wa_message_id,
     )
-    m = db.query(WhatsappMensagem).options(joinedload(WhatsappMensagem.atendente)).filter(WhatsappMensagem.id == m.id).first()
+    m = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == m.id)
+        .first()
+    )
     assert m is not None
-    return _mensagem_read(m)
+    return _mensagem_read(m, viewer_id=atendente.id, is_responsavel=True)
 
 
 @router.post("/{chat_id}/mensagens/midia", response_model=WhatsappMensagemRead, status_code=201)
@@ -1826,13 +2111,13 @@ async def enviar_mensagem_midia(
     db.commit()
     m2 = (
         db.query(WhatsappMensagem)
-        .options(joinedload(WhatsappMensagem.atendente))
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
         .filter(WhatsappMensagem.id == m.id)
         .first()
     )
     assert m2 is not None
     emit_chat_mensagem_from_models(db, c, m2, exclude_atendente_id=atendente.id)
-    return _mensagem_read(m2)
+    return _mensagem_read(m2, viewer_id=atendente.id, is_responsavel=True)
 
 
 @router.post("/{chat_id}/comentarios-internos", response_model=WhatsappMensagemRead, status_code=201)

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -217,10 +217,34 @@ def _rotulo_midia_outbound(tipo_db: str) -> str:
     }.get(tipo_db, "[Ficheiro enviado]")
 
 
+def _prefixo_assinatura_whatsapp(
+    db: Session,
+    chat: WhatsappChat,
+    atendente: Atendente | None,
+) -> str:
+    """Prefixo visível no WhatsApp do cliente: «[ Setor - Nome ]:» (#628)."""
+    nome = (atendente.nome if atendente else "").strip()
+    if not nome:
+        return ""
+    setor_nome: str | None = None
+    if chat.setor_id:
+        rel = getattr(chat, "setor", None)
+        if rel and (rel.nome or "").strip():
+            setor_nome = rel.nome.strip()
+        else:
+            s = db.query(Setor).filter(Setor.id == chat.setor_id).first()
+            if s and (s.nome or "").strip():
+                setor_nome = s.nome.strip()
+    if setor_nome:
+        return f"[ {setor_nome} - {nome} ]:"
+    return f"[ Atendimento - {nome} ]:"
+
+
 def _corpo_e_caption_midia_outbound(
     tipo_db: str,
     caption: str | None,
-    nome_atendente: str | None,
+    *,
+    prefixo: str | None = None,
 ) -> tuple[str, str]:
     """
     Retorna (corpo_db, caption_evolution).
@@ -231,9 +255,71 @@ def _corpo_e_caption_midia_outbound(
     cap = (caption or "").strip()
     if not cap:
         return "", ""
-    nome = (nome_atendente or "").strip()
-    texto = f"[ {nome} ]: {cap}" if nome else cap
+    pref = (prefixo or "").strip()
+    texto = f"{pref}\n{cap}" if pref else cap
     return texto, texto
+
+
+def _aplicar_setor_ao_assumir(
+    db: Session,
+    chat: WhatsappChat,
+    atendente: Atendente,
+    setor_id: int | None,
+) -> None:
+    """Opção 1 (#628): 1 setor → auto; vários → obrigatório; admin sem setores pode omitir."""
+    if chat.setor_id is not None:
+        return
+    setores_atendente = list(getattr(atendente, "setores", None) or [])
+    if setor_id is not None:
+        if atendente.role != "admin":
+            ids = {s.id for s in setores_atendente}
+            if setor_id not in ids:
+                raise HTTPException(status_code=403, detail="Sem permissão para este setor")
+        else:
+            s = db.query(Setor).filter(Setor.id == setor_id, Setor.ativo.is_(True)).first()
+            if not s:
+                raise HTTPException(status_code=400, detail="Setor inválido ou inativo")
+        chat.setor_id = setor_id
+        return
+    if len(setores_atendente) == 1:
+        chat.setor_id = setores_atendente[0].id
+        return
+    if len(setores_atendente) > 1:
+        raise HTTPException(
+            status_code=400,
+            detail="Selecione o setor deste atendimento (atendente com vários setores).",
+        )
+
+
+FOTO_PERFIL_TTL_SEC = 7 * 24 * 3600
+
+
+def _maybe_refresh_foto_perfil(db: Session, chat: WhatsappChat, *, force: bool = False) -> bool:
+    """Atualiza cache da foto via Evolution. Retorna True se gravou alteração."""
+    now = datetime.now(timezone.utc)
+    if not force:
+        url = getattr(chat, "foto_perfil_url", None)
+        atualizada = getattr(chat, "foto_perfil_atualizada_em", None)
+        if url and atualizada is not None:
+            ts = atualizada if atualizada.tzinfo else atualizada.replace(tzinfo=timezone.utc)
+            if (now - ts).total_seconds() < FOTO_PERFIL_TTL_SEC:
+                return False
+    st = db.query(WhatsappSettings).order_by(WhatsappSettings.id.asc()).first()
+    if not st or not _evolution_configurada(st):
+        return False
+    ok, profile_url, err = evolution_api.evolution_fetch_profile_picture_url(
+        st.evolution_base_url or "",
+        st.evolution_instance_name or "",
+        st.evolution_api_key or "",
+        chat.wa_id,
+    )
+    if not ok:
+        logger.info("Foto perfil Evolution falhou (chat=%s): %s", chat.protocolo, err)
+        chat.foto_perfil_atualizada_em = now
+        return True
+    chat.foto_perfil_url = profile_url
+    chat.foto_perfil_atualizada_em = now
+    return True
 
 
 def _sanitizar_nome_ficheiro(name: str | None, fallback: str) -> str:
@@ -289,16 +375,15 @@ def _enviar_texto_whatsapp(
     texto_eff = (texto or "").strip()
     if not texto_eff:
         raise HTTPException(status_code=400, detail="Mensagem vazia")
-    # Quando o atendente envia manualmente pelo DX Connect, prefixa o nome no texto
-    # para ficar visível no WhatsApp do cliente (padrão: "[ Nome ]: mensagem").
-    # A saudação ao assumir o chat usa o mesmo prefixo do atendente (não BOT).
+    # Prefixo no WhatsApp do cliente: "[ Setor - Nome ]:\nmensagem" (#628).
+    # A saudação ao assumir usa o mesmo prefixo do atendente (não BOT).
     if atendente is not None and evento_sistema in (None, "auto_assumido"):
-        nome = (atendente.nome or "").strip()
-        if nome and not texto_eff.startswith("["):
-            texto_eff = f"[ {nome} ]: {texto_eff}"
+        prefixo = _prefixo_assinatura_whatsapp(db, chat, atendente)
+        if prefixo and not texto_eff.startswith("["):
+            texto_eff = f"{prefixo}\n{texto_eff}"
     elif evento_sistema is not None:
         if not texto_eff.startswith("["):
-            texto_eff = f"[ BOT ]: {texto_eff}"
+            texto_eff = f"[ BOT ]:\n{texto_eff}"
     if evento_sistema:
         exist = (
             db.query(WhatsappMensagem)
@@ -576,6 +661,8 @@ def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False)
         inatividade_pausada=bool(getattr(c, "inatividade_pausada", False)),
         inatividade_retomada_em=getattr(c, "inatividade_retomada_em", None),
         classificacao_demanda_pendente=bool(getattr(c, "classificacao_demanda_pendente", False)),
+        foto_perfil_url=getattr(c, "foto_perfil_url", None),
+        foto_perfil_atualizada_em=getattr(c, "foto_perfil_atualizada_em", None),
     )
 
 
@@ -1256,6 +1343,32 @@ def obter(
         raise HTTPException(status_code=404, detail="Chat não encontrado")
     if not _pode_ver_chat(db, atendente, c):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    if _maybe_refresh_foto_perfil(db, c, force=False):
+        db.commit()
+        db.refresh(c)
+    return _chat_read(db, c)
+
+
+@router.post("/{chat_id}/foto-perfil", response_model=WhatsappChatRead)
+def atualizar_foto_perfil(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Força refresh da foto de perfil do contacto via Evolution (#630)."""
+    c = (
+        db.query(WhatsappChat)
+        .options(*_CHAT_LOAD_OPTIONS)
+        .filter(WhatsappChat.id == chat_id)
+        .first()
+    )
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    _maybe_refresh_foto_perfil(db, c, force=True)
+    db.commit()
+    db.refresh(c)
     return _chat_read(db, c)
 
 
@@ -1428,6 +1541,11 @@ def assumir(
         ge=1,
         description="Empresa de contexto opcional (pode ser definida depois na conversa).",
     ),
+    setor_id: int | None = Query(
+        None,
+        ge=1,
+        description="Setor do atendimento — obrigatório se o atendente tem vários setores e o chat ainda não tem setor (#628).",
+    ),
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
@@ -1441,6 +1559,7 @@ def assumir(
     if c.estado != "aguardando_atendente":
         raise HTTPException(status_code=400, detail="Só é possível assumir chats na fila de espera")
     _aplicar_empresa_contexto_chat(db, atendente, c, empresa_id)
+    _aplicar_setor_ao_assumir(db, c, atendente, setor_id)
     estado_anterior = c.estado
     c.estado = "em_atendimento"
     c.atendente_id = atendente.id
@@ -1627,8 +1746,9 @@ async def enviar_mensagem_midia(
         raise HTTPException(status_code=500, detail="Não foi possível guardar o ficheiro em disco.")
 
     cap = (caption or "").strip()
+    prefixo = _prefixo_assinatura_whatsapp(db, c, atendente) if cap else None
     corpo_eff, legenda_whatsapp = _corpo_e_caption_midia_outbound(
-        tipo_db, cap, atendente.nome
+        tipo_db, cap, prefixo=prefixo
     )
     b64 = base64.b64encode(data).decode("ascii")
     st = _settings_envio(db)

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -9,7 +9,16 @@ from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem, WhatsappSet
 from app.services import evolution_api
 from app.services.whatsapp_contato_match import funcionario_por_wa_id
 from app.services.protocolo_mensal import gerar_protocolo_chat
-from app.services.evolution_inbound import iter_inbound_whatsapp_messages, iter_message_status_updates
+from app.services.evolution_inbound import (
+    iter_inbound_edits,
+    iter_inbound_reactions,
+    iter_inbound_revokes,
+    iter_inbound_whatsapp_messages,
+    iter_message_status_updates,
+)
+from app.services import whatsapp_reacoes as wpp_reacoes
+from app.services import whatsapp_edicao as wpp_edicao
+from app.services.realtime_emit import emit_chat_mensagem_from_models
 from app.services.whatsapp_media_storage import gravar_base64_em_disco
 from app.services.whatsapp_wa_id_lock import lock_wa_id_para_chat, unlock_wa_id_para_chat
 from app.services.whatsapp_auto_messages import (
@@ -18,7 +27,7 @@ from app.services.whatsapp_auto_messages import (
     resolver_nome_empresa_para_template,
 )
 from app.core.business_calendar import is_feriado_nacional_br as _is_feriado_nacional_br
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 import json
 
@@ -395,6 +404,33 @@ def evolution_webhook(
 
     st_media = st
     processados = 0
+    reacoes = 0
+    revokes = 0
+    edits = 0
+    for item in iter_inbound_revokes(body):
+        wa_id = item["wa_id"]
+        lock_wa_id_para_chat(db, wa_id)
+        try:
+            revokes += _processar_revoke_inbound(db, item=item)
+        finally:
+            unlock_wa_id_para_chat(db, wa_id)
+
+    for item in iter_inbound_edits(body):
+        wa_id = item["wa_id"]
+        lock_wa_id_para_chat(db, wa_id)
+        try:
+            edits += _processar_edit_inbound(db, item=item)
+        finally:
+            unlock_wa_id_para_chat(db, wa_id)
+
+    for item in iter_inbound_reactions(body):
+        wa_id = item["wa_id"]
+        lock_wa_id_para_chat(db, wa_id)
+        try:
+            reacoes += _processar_reacao_inbound(db, item=item)
+        finally:
+            unlock_wa_id_para_chat(db, wa_id)
+
     for item in iter_inbound_whatsapp_messages(body):
         wa_id = item["wa_id"]
         lock_wa_id_para_chat(db, wa_id)
@@ -408,7 +444,134 @@ def evolution_webhook(
         finally:
             unlock_wa_id_para_chat(db, wa_id)
 
-    return {"ok": True, "processados": processados}
+    return {
+        "ok": True,
+        "processados": processados,
+        "reacoes": reacoes,
+        "revokes": revokes,
+        "edits": edits,
+    }
+
+
+def _chat_recente_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
+    return (
+        db.query(WhatsappChat)
+        .filter(
+            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.estado.in_(
+                ("aguardando_atendente", "em_atendimento", "aguardando_avaliacao", "encerrado")
+            ),
+        )
+        .order_by(WhatsappChat.id.desc())
+        .first()
+    )
+
+
+def _mensagem_alvo(db: Session, chat: WhatsappChat, target_id: str) -> WhatsappMensagem | None:
+    return (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(
+            WhatsappMensagem.chat_id == chat.id,
+            WhatsappMensagem.wa_message_id == str(target_id),
+        )
+        .first()
+    )
+
+
+def _emit_mensagem_atualizada(db: Session, chat: WhatsappChat, mensagem_id: int) -> None:
+    alvo2 = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.reacoes), joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.id == mensagem_id)
+        .first()
+    )
+    if alvo2:
+        emit_chat_mensagem_from_models(db, chat, alvo2)
+
+
+def _processar_revoke_inbound(db: Session, *, item: dict) -> int:
+    """Cliente ou mesa apagou mensagem para todos (#630 lote 3)."""
+    wa_id = item["wa_id"]
+    target_id = item.get("target_wa_message_id")
+    if not target_id:
+        return 0
+    chat = _chat_recente_por_wa_id(db, wa_id)
+    if not chat:
+        return 0
+    alvo = _mensagem_alvo(db, chat, str(target_id))
+    if not alvo or alvo.evento_sistema or wpp_edicao.mensagem_apagada(alvo):
+        return 0
+    try:
+        alvo.corpo = wpp_edicao.CORPO_MENSAGEM_APAGADA
+        alvo.apagada_em = datetime.now(timezone.utc)
+        alvo.midia_nome_arquivo = None
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception("Falha ao aplicar revoke inbound (chat=%s target=%s)", chat.protocolo, target_id)
+        return 0
+    _emit_mensagem_atualizada(db, chat, alvo.id)
+    return 1
+
+
+def _processar_edit_inbound(db: Session, *, item: dict) -> int:
+    """Cliente editou mensagem (#630 lote 3)."""
+    wa_id = item["wa_id"]
+    target_id = item.get("target_wa_message_id")
+    texto = (item.get("texto") or "").strip()
+    if not target_id or not texto:
+        return 0
+    chat = _chat_recente_por_wa_id(db, wa_id)
+    if not chat:
+        return 0
+    alvo = _mensagem_alvo(db, chat, str(target_id))
+    if not alvo or alvo.evento_sistema or wpp_edicao.mensagem_apagada(alvo):
+        return 0
+    try:
+        alvo.corpo = texto
+        alvo.editada_em = datetime.now(timezone.utc)
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception("Falha ao aplicar edit inbound (chat=%s target=%s)", chat.protocolo, target_id)
+        return 0
+    _emit_mensagem_atualizada(db, chat, alvo.id)
+    return 1
+
+
+def _processar_reacao_inbound(db: Session, *, item: dict) -> int:
+    """Aplica reação do cliente (ou eco fromMe) na mensagem alvo (#630)."""
+    wa_id = item["wa_id"]
+    target_id = item.get("target_wa_message_id")
+    if not target_id:
+        return 0
+    chat = _chat_recente_por_wa_id(db, wa_id)
+    if not chat:
+        return 0
+    alvo = _mensagem_alvo(db, chat, str(target_id))
+    if not alvo or alvo.evento_sistema:
+        return 0
+
+    from_me = bool(item.get("from_me"))
+    origem = wpp_reacoes.ORIGEM_ATENDENTE if from_me else wpp_reacoes.ORIGEM_CLIENTE
+    emoji = item.get("emoji")
+    try:
+        wpp_reacoes.aplicar_reacao(
+            db,
+            alvo,
+            origem=origem,
+            emoji=emoji,
+            atendente_id=chat.atendente_id if from_me else None,
+        )
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception("Falha ao aplicar reação inbound (chat=%s target=%s)", chat.protocolo, target_id)
+        return 0
+
+    _emit_mensagem_atualizada(db, chat, alvo.id)
+    return 1
 
 
 def _processar_mensagem_inbound(

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -76,17 +76,17 @@ class Settings(BaseSettings):
     # Modo legado: vários clientes no mesmo Postgres (subdomínio numérico + coluna tenant_id).
     # Produção comercial: manter False (um Postgres por cliente / deploy).
     DX_CONNECT_MULTI_TENANT: bool = False
-    # URL pública do painel em single-tenant (ex.: duplexsoft.connect.duplexsoft.com.br).
+    # URL pública do painel em single-tenant (ex.: cliente01.deskrudder.com.br).
     # Se vazio, GET /tenant/atual usa {tenant_id}.CONNECT_APP_BASE_DOMAIN só em multi-tenant.
     CLIENT_APP_HOST: str | None = None
     # Validade do link de redefinição de senha (#105).
     PASSWORD_RESET_TOKEN_EXPIRE_HOURS: int = 1
 
-    # Multi-tenant: subdomínio {tenant_id}.CONNECT_APP_BASE_DOMAIN e endereços {local}@INBOUND_EMAIL_DOMAIN
-    CONNECT_APP_BASE_DOMAIN: str = "connect.duplexsoft.com.br"
-    # Domínio Resend com Receiving (ex.: notify.duplexsoft.com.br). Endereços: {setor}.t{tenant}@domínio.
-    INBOUND_EMAIL_DOMAIN: str = "notify.duplexsoft.com.br"
-    # Host sem subdomínio (ex.: connect.duplexsoft.com.br) ou dev local sem header.
+    # Multi-tenant legado: subdomínio {tenant_id}.CONNECT_APP_BASE_DOMAIN e endereços {local}@INBOUND_EMAIL_DOMAIN
+    CONNECT_APP_BASE_DOMAIN: str = "deskrudder.com.br"
+    # Domínio Resend com Receiving (ex.: notify.deskrudder.com.br). Endereços: {setor}.t{tenant}@domínio.
+    INBOUND_EMAIL_DOMAIN: str = "notify.deskrudder.com.br"
+    # Host sem subdomínio (ex.: deskrudder.com.br) ou dev local sem header.
     DEFAULT_TENANT_ID: int = 1
 
     # Webhook de ingestão de e-mail (padrão SaaS). Sem segredo, o endpoint responde 503.
@@ -101,7 +101,7 @@ class Settings(BaseSettings):
     RESEND_WEBHOOK_SECRET: str | None = None
     TRANSACTIONAL_FROM_EMAIL: str | None = None
     TRANSACTIONAL_FROM_NAME: str | None = None
-    # Respostas ao cliente: Reply-To público (ex. suporte@duplexsoft.com.br) enquanto From usa @notify na Resend.
+    # Respostas ao cliente: Reply-To público (ex. suporte@suaempresa.com.br) enquanto From usa @notify na Resend.
     SUPPORT_REPLY_TO_EMAIL: str | None = None
 
     # Diretório para logo da empresa do sistema (caminho relativo ao cwd ou absoluto).

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,7 +13,13 @@ from app.models.whatsapp_chat_read import WhatsappChatRead
 from app.models.audit_log import AuditLog
 from app.models.ibge_municipio import IbgeMunicipio
 from app.models.app_cache_meta import AppCacheMeta
-from app.models.whatsapp_chat import WhatsappChat, WhatsappChatTicket, WhatsappMensagem, WhatsappSettings
+from app.models.whatsapp_chat import (
+    WhatsappChat,
+    WhatsappChatTicket,
+    WhatsappMensagem,
+    WhatsappMensagemReacao,
+    WhatsappSettings,
+)
 from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
 from app.models.empresa_sistema import EmpresaSistema
 from app.models.email_settings import EmailSettings
@@ -69,6 +75,7 @@ __all__ = [
     "WhatsappSettings",
     "WhatsappChat",
     "WhatsappMensagem",
+    "WhatsappMensagemReacao",
     "WhatsappChatTicket",
     "WhatsappChatDemanda",
     "EmpresaSistema",

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -119,11 +119,41 @@ class WhatsappMensagem(Base):
     # pendente | enviada | entregue | lida | erro — apenas outbound ao cliente
     status_entrega = Column(String(20), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+    # #630 lote 3 — editar / apagar para todos (timestamps; corpo vira placeholder ao apagar)
+    editada_em = Column(DateTime(timezone=True), nullable=True)
+    apagada_em = Column(DateTime(timezone=True), nullable=True)
 
     chat = relationship("WhatsappChat", back_populates="mensagens")
     atendente = relationship("Atendente", backref="whatsapp_mensagens_enviadas")
+    reacoes = relationship(
+        "WhatsappMensagemReacao",
+        back_populates="mensagem",
+        cascade="all, delete-orphan",
+    )
 
     __table_args__ = (UniqueConstraint("wa_message_id", name="uq_whatsapp_mensagens_wa_message_id"),)
+
+
+class WhatsappMensagemReacao(Base):
+    """Uma reação por origem (cliente ou mesa) na mensagem alvo (#630 lote 2)."""
+
+    __tablename__ = "whatsapp_mensagem_reacoes"
+    __table_args__ = (
+        UniqueConstraint("mensagem_id", "origem", name="uq_whatsapp_mensagem_reacoes_mensagem_origem"),
+    )
+
+    id = Column(Integer, primary_key=True, index=True)
+    mensagem_id = Column(
+        Integer, ForeignKey("whatsapp_mensagens.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    # cliente | atendente
+    origem = Column(String(20), nullable=False)
+    emoji = Column(String(16), nullable=False)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    mensagem = relationship("WhatsappMensagem", back_populates="reacoes")
+    atendente = relationship("Atendente", backref="whatsapp_mensagem_reacoes")
 
 
 class WhatsappChatTicket(Base):

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -76,6 +76,9 @@ class WhatsappChat(Base):
     inatividade_retomada_em = Column(DateTime(timezone=True), nullable=True)
     # Após encerramento por inatividade: responsável deve registar (ou confirmar sem) demanda.
     classificacao_demanda_pendente = Column(Boolean, nullable=False, default=False, server_default="false")
+    # Cache da foto de perfil WhatsApp do contacto (#630 lote 1).
+    foto_perfil_url = Column(Text, nullable=True)
+    foto_perfil_atualizada_em = Column(DateTime(timezone=True), nullable=True)
 
     atendente = relationship("Atendente", backref="whatsapp_chats_atendidos")
     setor = relationship("Setor", backref="whatsapp_chats")

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -56,6 +56,8 @@ class WhatsappChatRead(BaseModel):
     inatividade_pausada: bool = False
     inatividade_retomada_em: datetime | None = None
     classificacao_demanda_pendente: bool = False
+    foto_perfil_url: str | None = None
+    foto_perfil_atualizada_em: datetime | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -3,6 +3,22 @@ from datetime import datetime
 from pydantic import BaseModel, Field, field_validator
 
 
+class WhatsappReacaoRead(BaseModel):
+    emoji: str
+    count: int
+    reagiu_eu: bool = False
+    atendente_ids: list[int] = Field(default_factory=list)
+    tem_cliente: bool = False
+
+
+class WhatsappReacaoCreate(BaseModel):
+    emoji: str = Field(..., min_length=1, max_length=16)
+
+
+class WhatsappMensagemUpdate(BaseModel):
+    texto: str = Field(..., min_length=1, max_length=4000)
+
+
 class WhatsappMensagemRead(BaseModel):
     id: int
     chat_id: int
@@ -19,6 +35,12 @@ class WhatsappMensagemRead(BaseModel):
     atendente_nome: str | None = None
     status_entrega: str | None = None
     created_at: datetime | None = None
+    reacoes: list[WhatsappReacaoRead] = Field(default_factory=list)
+    editada: bool = False
+    editada_em: datetime | None = None
+    apagada: bool = False
+    pode_editar: bool = False
+    pode_apagar_para_todos: bool = False
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -219,6 +219,45 @@ def evolution_mark_messages_as_read(
     return False, f"HTTP {code}"
 
 
+def evolution_fetch_profile_picture_url(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    number_digits: str,
+) -> tuple[bool, str | None, str | None]:
+    """POST /chat/fetchProfilePictureUrl/{instance} → (ok, url | None, err)."""
+    import re
+
+    digits = re.sub(r"\D", "", number_digits or "")
+    if not digits:
+        return False, None, "Número inválido"
+    base = base_url.rstrip("/")
+    url = f"{base}/chat/fetchProfilePictureUrl/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body = {"number": digits}
+    code, data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=30)
+    if code not in (200, 201):
+        if err:
+            return False, None, err[:800]
+        return False, None, f"HTTP {code}"
+    profile_url: str | None = None
+    if isinstance(data, dict):
+        for key in ("profilePictureUrl", "profilePicUrl", "url", "picture"):
+            raw = data.get(key)
+            if isinstance(raw, str) and raw.strip().startswith(("http://", "https://")):
+                profile_url = raw.strip()
+                break
+        if profile_url is None:
+            nested = data.get("data")
+            if isinstance(nested, dict):
+                for key in ("profilePictureUrl", "profilePicUrl", "url", "picture"):
+                    raw = nested.get(key)
+                    if isinstance(raw, str) and raw.strip().startswith(("http://", "https://")):
+                        profile_url = raw.strip()
+                        break
+    return True, profile_url, None
+
+
 def evolution_send_text(
     base_url: str,
     instance: str,

--- a/backend/app/services/evolution_api.py
+++ b/backend/app/services/evolution_api.py
@@ -219,6 +219,96 @@ def evolution_mark_messages_as_read(
     return False, f"HTTP {code}"
 
 
+def evolution_send_reaction(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    *,
+    remote_jid: str,
+    from_me: bool,
+    message_id: str,
+    reaction: str,
+) -> tuple[bool, str | None]:
+    """POST /message/sendReaction/{instance} — reaction='' remove. Retorna (ok, err)."""
+    mid = (message_id or "").strip()
+    if not mid:
+        return False, "ID da mensagem inválido"
+    jid = remote_jid if "@" in (remote_jid or "") else f"{remote_jid}@s.whatsapp.net"
+    base = base_url.rstrip("/")
+    url = f"{base}/message/sendReaction/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body: dict[str, Any] = {
+        "key": {"remoteJid": jid, "fromMe": bool(from_me), "id": mid},
+        "reaction": reaction if reaction is not None else "",
+    }
+    code, _data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=30)
+    if code in (200, 201):
+        return True, None
+    if err:
+        return False, err[:800]
+    return False, f"HTTP {code}"
+
+
+def evolution_update_message(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    *,
+    number_digits: str,
+    message_id: str,
+    text: str,
+    remote_jid: str | None = None,
+) -> tuple[bool, str | None]:
+    """POST /chat/updateMessage/{instance} — edita mensagem outbound (texto)."""
+    import re
+
+    digits = re.sub(r"\D", "", number_digits or "")
+    mid = (message_id or "").strip()
+    if not digits or not mid:
+        return False, "Número ou ID da mensagem inválido"
+    jid = remote_jid if remote_jid and "@" in remote_jid else f"{digits}@s.whatsapp.net"
+    base = base_url.rstrip("/")
+    url = f"{base}/chat/updateMessage/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body: dict[str, Any] = {
+        "number": digits,
+        "text": text,
+        "key": {"remoteJid": jid, "fromMe": True, "id": mid},
+    }
+    code, _data, err = _request_json_with_retry("POST", url, headers=headers, body=body, timeout=30)
+    if code in (200, 201):
+        return True, None
+    if err:
+        return False, err[:800]
+    return False, f"HTTP {code}"
+
+
+def evolution_delete_message_for_everyone(
+    base_url: str,
+    instance: str,
+    api_key: str,
+    *,
+    message_id: str,
+    remote_jid: str,
+    from_me: bool = True,
+) -> tuple[bool, str | None]:
+    """DELETE /chat/deleteMessageForEveryone/{instance}."""
+    mid = (message_id or "").strip()
+    if not mid:
+        return False, "ID da mensagem inválido"
+    jid = remote_jid if "@" in (remote_jid or "") else f"{remote_jid}@s.whatsapp.net"
+    base = base_url.rstrip("/")
+    url = f"{base}/chat/deleteMessageForEveryone/{instance}"
+    headers = {"apikey": api_key, "Content-Type": "application/json", "Accept": "application/json"}
+    body: dict[str, Any] = {"id": mid, "remoteJid": jid, "fromMe": bool(from_me)}
+    code, _data, err = _request_json_with_retry("DELETE", url, headers=headers, body=body, timeout=30)
+    if code in (200, 201):
+        return True, None
+    if err:
+        return False, err[:800]
+    return False, f"HTTP {code}"
+
+
 def evolution_fetch_profile_picture_url(
     base_url: str,
     instance: str,

--- a/backend/app/services/evolution_inbound.py
+++ b/backend/app/services/evolution_inbound.py
@@ -370,3 +370,143 @@ def iter_inbound_text_messages(webhook_body: dict[str, Any]) -> Iterator[dict[st
             "wa_message_id": item.get("wa_message_id"),
             "push_name": item.get("push_name"),
         }
+
+
+def _reaction_payload_from_inner(inner: dict[str, Any]) -> tuple[str | None, str | None]:
+    """Retorna (target_wa_message_id, emoji_ou_vazio)."""
+    react = inner.get("reactionMessage") or inner.get("ReactionMessage")
+    if not isinstance(react, dict):
+        return None, None
+    key = react.get("key") or react.get("Key") or {}
+    if not isinstance(key, dict):
+        return None, None
+    mid = key.get("id") or key.get("Id")
+    target_id = str(mid).strip() if mid else None
+    text = react.get("text") if "text" in react else react.get("Text")
+    emoji = "" if text is None else str(text)
+    return target_id or None, emoji
+
+
+def iter_inbound_revokes(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """
+    Apagar para todos (protocolMessage type REVOKE) em messages.upsert.
+
+    Yields: wa_id, target_wa_message_id
+    """
+    event = webhook_body.get("event") or webhook_body.get("Event") or ""
+    ev = str(event).lower()
+    if "messages" not in ev:
+        return
+    data = webhook_body.get("data") or webhook_body.get("Data")
+    for m in _iter_message_dicts(data):
+        key = m.get("key") or m.get("Key") or {}
+        if not isinstance(key, dict):
+            continue
+        rjid = key.get("remoteJid") or key.get("RemoteJid")
+        rjid_s = str(rjid) if rjid else ""
+        if "@g.us" in rjid_s:
+            continue
+        wa_id = _only_digits_jid(rjid_s)
+        if not wa_id:
+            continue
+        inner = m.get("message") or m.get("Message")
+        if not isinstance(inner, dict):
+            continue
+        proto = inner.get("protocolMessage") or inner.get("ProtocolMessage")
+        if not isinstance(proto, dict):
+            continue
+        ptype = str(proto.get("type") or proto.get("Type") or "").upper()
+        if ptype not in ("REVOKE", "14"):
+            continue
+        pkey = proto.get("key") or proto.get("Key") or {}
+        if not isinstance(pkey, dict):
+            continue
+        mid = pkey.get("id") or pkey.get("Id")
+        target = str(mid).strip() if mid else None
+        if not target:
+            continue
+        yield {"wa_id": wa_id, "target_wa_message_id": target}
+
+
+def iter_inbound_edits(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """
+    Edição de mensagem (editedMessage) em messages.upsert.
+
+    Yields: wa_id, target_wa_message_id, texto
+    """
+    event = webhook_body.get("event") or webhook_body.get("Event") or ""
+    ev = str(event).lower()
+    if "messages" not in ev and "edit" not in ev:
+        return
+    data = webhook_body.get("data") or webhook_body.get("Data")
+    for m in _iter_message_dicts(data):
+        key = m.get("key") or m.get("Key") or {}
+        if not isinstance(key, dict):
+            continue
+        rjid = key.get("remoteJid") or key.get("RemoteJid")
+        rjid_s = str(rjid) if rjid else ""
+        if "@g.us" in rjid_s:
+            continue
+        wa_id = _only_digits_jid(rjid_s)
+        if not wa_id:
+            continue
+        inner = m.get("message") or m.get("Message")
+        if not isinstance(inner, dict):
+            continue
+        edited = inner.get("editedMessage") or inner.get("EditedMessage")
+        if not isinstance(edited, dict):
+            continue
+        # editedMessage.message.{conversation|extendedTextMessage}
+        nested = edited.get("message") or edited.get("Message") or edited
+        if not isinstance(nested, dict):
+            continue
+        texto = _text_from_inner(nested)
+        if not texto:
+            continue
+        # alvo: key do envelope ou editedMessage.key
+        ekey = edited.get("key") or edited.get("Key") or key
+        if not isinstance(ekey, dict):
+            ekey = key
+        mid = ekey.get("id") or ekey.get("Id")
+        target = str(mid).strip() if mid else None
+        if not target:
+            continue
+        yield {"wa_id": wa_id, "target_wa_message_id": target, "texto": texto}
+
+
+def iter_inbound_reactions(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    """
+    Reações (cliente ou eco fromMe) em messages.upsert com reactionMessage.
+
+    Yields:
+      wa_id, target_wa_message_id, emoji ('' = remover), from_me
+    """
+    event = webhook_body.get("event") or webhook_body.get("Event") or ""
+    ev = str(event).lower()
+    if "messages" not in ev:
+        return
+    data = webhook_body.get("data") or webhook_body.get("Data")
+    for m in _iter_message_dicts(data):
+        key = m.get("key") or m.get("Key") or {}
+        if not isinstance(key, dict):
+            continue
+        rjid = key.get("remoteJid") or key.get("RemoteJid")
+        rjid_s = str(rjid) if rjid else ""
+        if "@g.us" in rjid_s:
+            continue
+        wa_id = _only_digits_jid(rjid_s)
+        if not wa_id:
+            continue
+        inner = m.get("message") or m.get("Message")
+        if not isinstance(inner, dict):
+            continue
+        target_id, emoji = _reaction_payload_from_inner(inner)
+        if not target_id:
+            continue
+        from_me = bool(key.get("fromMe") or key.get("FromMe"))
+        yield {
+            "wa_id": wa_id,
+            "target_wa_message_id": target_id,
+            "emoji": emoji if emoji is not None else "",
+            "from_me": from_me,
+        }

--- a/backend/app/services/realtime_emit.py
+++ b/backend/app/services/realtime_emit.py
@@ -285,10 +285,15 @@ def emit_chat_mensagem_from_models(
 ) -> None:
     from app.api.whatsapp_chats import _mensagem_read
 
+    # Flags de permissão são por visualizador — omitir no broadcast SSE
+    # para não sobrescrever pode_editar / pode_apagar no cliente do responsável.
+    payload = _mensagem_read(mensagem).model_dump(mode="json")
+    payload.pop("pode_editar", None)
+    payload.pop("pode_apagar_para_todos", None)
     emit_chat_mensagem(
         db,
         chat,
-        _mensagem_read(mensagem).model_dump(mode="json"),
+        payload,
         exclude_atendente_id=exclude_atendente_id,
     )
 

--- a/backend/app/services/whatsapp_edicao.py
+++ b/backend/app/services/whatsapp_edicao.py
@@ -1,0 +1,80 @@
+"""Editar / apagar para todos em mensagens WhatsApp (#630 lote 3)."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+
+from app.models.whatsapp_chat import WhatsappMensagem
+
+CORPO_MENSAGEM_APAGADA = "Mensagem apagada"
+# Limites alinhados à experiência típica do WhatsApp / Evolution (documentar em WHATSAPP_EVOLUTION.md).
+JANELA_EDICAO_MINUTOS = 15
+JANELA_APAGAR_TODOS_HORAS = 48
+
+_PREFIXO_ASSINATURA = re.compile(r"^\[\s*[^\]]+\s*\]:\s*\n?", re.MULTILINE)
+
+
+class WhatsappEdicaoErro(ValueError):
+    """Validação de edição/apagamento WhatsApp."""
+
+
+def corpo_sem_prefixo(corpo: str | None) -> str:
+    t = (corpo or "").strip()
+    return _PREFIXO_ASSINATURA.sub("", t, count=1).strip()
+
+
+def mensagem_apagada(m: WhatsappMensagem) -> bool:
+    return getattr(m, "apagada_em", None) is not None
+
+
+def mensagem_editada(m: WhatsappMensagem) -> bool:
+    return getattr(m, "editada_em", None) is not None
+
+
+def _created_aware(m: WhatsappMensagem) -> datetime | None:
+    ts = m.created_at
+    if ts is None:
+        return None
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=timezone.utc)
+    return ts
+
+
+def dentro_janela_edicao(m: WhatsappMensagem, *, agora: datetime | None = None) -> bool:
+    ts = _created_aware(m)
+    if ts is None:
+        return False
+    now = agora or datetime.now(timezone.utc)
+    return now - ts <= timedelta(minutes=JANELA_EDICAO_MINUTOS)
+
+
+def dentro_janela_apagar_todos(m: WhatsappMensagem, *, agora: datetime | None = None) -> bool:
+    ts = _created_aware(m)
+    if ts is None:
+        return False
+    now = agora or datetime.now(timezone.utc)
+    return now - ts <= timedelta(hours=JANELA_APAGAR_TODOS_HORAS)
+
+
+def pode_editar_mensagem(m: WhatsappMensagem, *, is_responsavel: bool) -> bool:
+    if not is_responsavel or mensagem_apagada(m):
+        return False
+    if m.direcao != "outbound" or m.evento_sistema:
+        return False
+    if not m.wa_message_id:
+        return False
+    tipo = (m.tipo_midia or "texto").lower()
+    if tipo not in ("texto", ""):
+        return False  # legenda de mídia fora de escopo v1
+    return dentro_janela_edicao(m)
+
+
+def pode_apagar_para_todos(m: WhatsappMensagem, *, is_responsavel: bool) -> bool:
+    if not is_responsavel or mensagem_apagada(m):
+        return False
+    if m.direcao != "outbound" or m.evento_sistema:
+        return False
+    if not m.wa_message_id:
+        return False
+    return dentro_janela_apagar_todos(m)

--- a/backend/app/services/whatsapp_reacoes.py
+++ b/backend/app/services/whatsapp_reacoes.py
@@ -1,0 +1,116 @@
+"""Reações em mensagens WhatsApp do chat com o cliente (#630 lote 2)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy.orm import Session
+
+from app.models.whatsapp_chat import WhatsappMensagem, WhatsappMensagemReacao
+
+ORIGEM_CLIENTE = "cliente"
+ORIGEM_ATENDENTE = "atendente"
+EMOJIS_REACAO_PERMITIDOS = frozenset({"👍", "❤️", "😂", "😮", "😢", "🙏"})
+
+
+class WhatsappReacaoErro(ValueError):
+    """Validação de reação WhatsApp."""
+
+
+@dataclass
+class ReacaoAgregada:
+    emoji: str
+    count: int
+    reagiu_eu: bool
+    atendente_ids: list[int]
+    tem_cliente: bool
+
+
+def validar_emoji_reacao(emoji: str) -> str:
+    valor = (emoji or "").strip()
+    if valor not in EMOJIS_REACAO_PERMITIDOS:
+        raise WhatsappReacaoErro("Emoji de reação inválido.")
+    return valor
+
+
+def aplicar_reacao(
+    db: Session,
+    mensagem: WhatsappMensagem,
+    *,
+    origem: str,
+    emoji: str | None,
+    atendente_id: int | None = None,
+) -> WhatsappMensagem:
+    """Upsert ou remove reação da origem. emoji None/'' remove."""
+    if origem not in (ORIGEM_CLIENTE, ORIGEM_ATENDENTE):
+        raise WhatsappReacaoErro("Origem de reação inválida.")
+    if mensagem.evento_sistema:
+        raise WhatsappReacaoErro("Não é possível reagir a mensagem de sistema.")
+
+    row = (
+        db.query(WhatsappMensagemReacao)
+        .filter(
+            WhatsappMensagemReacao.mensagem_id == mensagem.id,
+            WhatsappMensagemReacao.origem == origem,
+        )
+        .first()
+    )
+    texto = (emoji or "").strip()
+    if not texto:
+        if row:
+            db.delete(row)
+            db.flush()
+        db.refresh(mensagem)
+        return mensagem
+
+    if origem == ORIGEM_ATENDENTE:
+        texto = validar_emoji_reacao(texto)
+    # Cliente: aceitar qualquer emoji Unicode curto (WhatsApp livre)
+    elif len(texto) > 16:
+        texto = texto[:16]
+
+    if row:
+        row.emoji = texto
+        row.atendente_id = atendente_id if origem == ORIGEM_ATENDENTE else None
+    else:
+        db.add(
+            WhatsappMensagemReacao(
+                mensagem_id=mensagem.id,
+                origem=origem,
+                emoji=texto,
+                atendente_id=atendente_id if origem == ORIGEM_ATENDENTE else None,
+            )
+        )
+    db.flush()
+    db.refresh(mensagem)
+    return mensagem
+
+
+def agregar_reacoes(
+    mensagem: WhatsappMensagem,
+    viewer_id: int | None = None,
+) -> list[ReacaoAgregada]:
+    rows = list(getattr(mensagem, "reacoes", None) or [])
+    por_emoji: dict[str, dict] = {}
+    for row in rows:
+        bucket = por_emoji.setdefault(
+            row.emoji,
+            {"count": 0, "reagiu_eu": False, "atendente_ids": [], "tem_cliente": False},
+        )
+        bucket["count"] = int(bucket["count"]) + 1
+        if row.origem == ORIGEM_CLIENTE:
+            bucket["tem_cliente"] = True
+        if row.origem == ORIGEM_ATENDENTE and row.atendente_id is not None:
+            bucket["atendente_ids"].append(int(row.atendente_id))
+            if viewer_id is not None and row.atendente_id == viewer_id:
+                bucket["reagiu_eu"] = True
+    return [
+        ReacaoAgregada(
+            emoji=emoji,
+            count=int(data["count"]),
+            reagiu_eu=bool(data["reagiu_eu"]),
+            atendente_ids=list(data["atendente_ids"]),
+            tem_cliente=bool(data["tem_cliente"]),
+        )
+        for emoji, data in sorted(por_emoji.items(), key=lambda item: (-int(item[1]["count"]), item[0]))
+    ]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 # Necessário para `Form()` / `UploadFile` (envio de mídia WhatsApp, etc.).
 python-multipart==0.0.32
-fastapi==0.139.2
+fastapi==0.141.1
 starlette==1.3.1
 uvicorn[standard]==0.51.0
 gunicorn==26.0.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,4 +12,4 @@ pydantic-settings==2.14.2
 PyJWT[crypto]==2.13.0
 cryptography>=49.0.0
 bcrypt>=5.0.0,<6
-svix>=1.98.0
+svix>=1.99.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,7 @@
 python-multipart==0.0.32
 fastapi==0.139.2
 starlette==1.3.1
-uvicorn[standard]==0.51.0
+uvicorn[standard]==0.52.0
 gunicorn==26.0.0
 sqlalchemy==2.0.51
 psycopg2-binary==2.9.12

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -1277,3 +1277,161 @@ def test_webhook_mensagens_paralelas_mesmo_wa_id_um_chat(client, seed_base, auth
         .all()
     )
     assert len(abertos) == 1
+
+
+def test_assumir_define_setor_unico_e_prefixo_mensagem(client, seed_base, auth_headers, monkeypatch):
+    """#628 — 1 setor auto ao assumir; prefixo «[ Setor - Nome ]:» + texto na linha de baixo."""
+    sent: list[str] = []
+
+    def fake_send(*_a, **kwargs):
+        text = kwargs.get("text")
+        if text is None and len(_a) > 4:
+            text = _a[4]
+        sent.append(text or "")
+        return True, None, f"wa-pfx-{len(sent)}"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "pfx-628",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "pfx-628"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511999000628", msg_id="pfx-628-1"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    r_ass = client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    assert r_ass.status_code == 200
+    assert r_ass.json()["setor_id"] == seed_base["setor1"].id
+
+    r_msg = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Olá, em que posso ajudar?"},
+        headers=auth_headers["a1"],
+    )
+    assert r_msg.status_code == 201
+    corpo = r_msg.json()["corpo"]
+    assert corpo.startswith("[ Suporte - Atendente 1 ]:\n")
+    assert "Olá, em que posso ajudar?" in corpo
+    assert sent and sent[-1].startswith("[ Suporte - Atendente 1 ]:\n")
+
+
+def test_assumir_multi_setor_exige_setor_id(client, seed_base, auth_headers, db_session):
+    """#628 — atendente com vários setores precisa informar setor_id ao assumir."""
+    a1 = seed_base["a1"]
+    a1.setores.append(seed_base["setor2"])
+    db_session.commit()
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "multi-628"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "multi-628"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511999000629", msg_id="multi-628-1"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+
+    sem = client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    assert sem.status_code == 400
+    assert "setor" in (sem.json().get("detail") or "").lower()
+
+    ok = client.post(
+        f"/v1/whatsapp/chats/{cid}/assumir",
+        params={"setor_id": seed_base["setor2"].id},
+        headers=auth_headers["a1"],
+    )
+    assert ok.status_code == 200
+    assert ok.json()["setor_id"] == seed_base["setor2"].id
+
+
+def test_prefixo_apos_transferencia_usa_novo_setor(client, seed_base, auth_headers, monkeypatch):
+    """#628 — após transferir, novas mensagens usam o setor novo do chat."""
+    sent: list[str] = []
+
+    def fake_send(*_a, **kwargs):
+        text = kwargs.get("text")
+        if text is None and len(_a) > 4:
+            text = _a[4]
+        sent.append(text or "")
+        return True, None, f"wa-tr-{len(sent)}"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "tr-pfx",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+        },
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "tr-pfx"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511999000630", msg_id="tr-pfx-1"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    tr = client.post(
+        f"/v1/whatsapp/chats/{cid}/transferir",
+        json={"setor_id": seed_base["setor2"].id, "atendente_id": None},
+        headers=auth_headers["a1"],
+    )
+    assert tr.status_code == 200
+    assert tr.json()["setor_id"] == seed_base["setor2"].id
+    ass2 = client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a2"])
+    assert ass2.status_code == 200
+    r_msg = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Sou do Financeiro"},
+        headers=auth_headers["a2"],
+    )
+    assert r_msg.status_code == 201
+    assert r_msg.json()["corpo"].startswith("[ Financeiro - Atendente 2 ]:\n")
+
+
+def test_chat_read_inclui_foto_perfil_campos(client, seed_base, auth_headers, db_session):
+    """#630 lote 1 — schema expõe foto_perfil_url / foto_perfil_atualizada_em."""
+    from datetime import datetime, timezone
+
+    from app.models import WhatsappChat
+
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "foto-630"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "foto-630"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511999000631", msg_id="foto-630-1"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    chat = db_session.query(WhatsappChat).filter(WhatsappChat.id == cid).first()
+    assert chat is not None
+    chat.foto_perfil_url = "https://example.test/foto.jpg"
+    chat.foto_perfil_atualizada_em = datetime.now(timezone.utc)
+    db_session.commit()
+
+    r = client.get(f"/v1/whatsapp/chats/{cid}", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["foto_perfil_url"] == "https://example.test/foto.jpg"
+    assert body.get("foto_perfil_atualizada_em")

--- a/backend/tests/test_whatsapp_edicao_apagar.py
+++ b/backend/tests/test_whatsapp_edicao_apagar.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+
+def _webhook_body(wa_id: str = "5511999999999", msg_id: str = "mid1", text: str = "Olá"):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": msg_id,
+                    },
+                    "message": {"conversation": text},
+                }
+            ]
+        },
+    }
+
+
+def _webhook_revoke(wa_id: str, *, target_id: str, revoke_msg_id: str = "rev-1"):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "key": {
+                "remoteJid": f"{wa_id}@s.whatsapp.net",
+                "fromMe": False,
+                "id": revoke_msg_id,
+            },
+            "message": {
+                "protocolMessage": {
+                    "type": "REVOKE",
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": target_id,
+                    },
+                }
+            },
+        },
+    }
+
+
+def _webhook_edit(wa_id: str, *, target_id: str, texto: str, edit_msg_id: str = "edit-1"):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "key": {
+                "remoteJid": f"{wa_id}@s.whatsapp.net",
+                "fromMe": False,
+                "id": target_id,
+            },
+            "message": {
+                "editedMessage": {
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": target_id,
+                    },
+                    "message": {"conversation": texto},
+                }
+            },
+        },
+    }
+
+
+def _chat_em_atendimento(client, auth_headers, wa_id="5511999000801", msg_id="edit-base-1"):
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "edit-630",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+            "auto_msg_assumido_ativa": False,
+            "auto_msg_espera_ativa": False,
+        },
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "edit-630"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id=wa_id, msg_id=msg_id),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    return cid, h
+
+
+def test_editar_mensagem_via_api(client, seed_base, auth_headers, monkeypatch):
+    n = {"i": 0}
+    updated: list[dict] = []
+
+    def fake_send(*_a, **_k):
+        n["i"] += 1
+        return True, None, f"wa-out-edit-{n['i']}"
+
+    def fake_update(*_a, **kwargs):
+        updated.append(kwargs)
+        return True, None
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_update_message",
+        fake_update,
+    )
+
+    cid, _h = _chat_em_atendimento(client, auth_headers)
+    r_msg = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Texto original"},
+        headers=auth_headers["a1"],
+    )
+    assert r_msg.status_code == 201
+    mid = r_msg.json()["id"]
+    assert r_msg.json().get("pode_editar") is True
+
+    ok = client.patch(
+        f"/v1/whatsapp/chats/{cid}/mensagens/{mid}",
+        json={"texto": "Texto corrigido"},
+        headers=auth_headers["a1"],
+    )
+    assert ok.status_code == 200
+    body = ok.json()
+    assert body["editada"] is True
+    assert "Texto corrigido" in body["corpo"]
+    assert updated and "Texto corrigido" in (updated[-1].get("text") or "")
+
+
+def test_apagar_mensagem_via_api(client, seed_base, auth_headers, monkeypatch):
+    n = {"i": 0}
+    deleted: list[dict] = []
+
+    def fake_send(*_a, **_k):
+        n["i"] += 1
+        return True, None, f"wa-out-del-{n['i']}"
+
+    def fake_delete(*_a, **kwargs):
+        deleted.append(kwargs)
+        return True, None
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_delete_message_for_everyone",
+        fake_delete,
+    )
+
+    cid, _h = _chat_em_atendimento(
+        client, auth_headers, wa_id="5511999000802", msg_id="del-base-2"
+    )
+    r_msg = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Vai sumir"},
+        headers=auth_headers["a1"],
+    )
+    assert r_msg.status_code == 201
+    mid = r_msg.json()["id"]
+    assert r_msg.json().get("pode_apagar_para_todos") is True
+
+    ok = client.delete(
+        f"/v1/whatsapp/chats/{cid}/mensagens/{mid}",
+        headers=auth_headers["a1"],
+    )
+    assert ok.status_code == 200
+    body = ok.json()
+    assert body["apagada"] is True
+    assert body["corpo"] == "Mensagem apagada"
+    assert body["pode_editar"] is False
+    assert deleted
+
+
+def test_webhook_revoke_marca_apagada(client, seed_base, auth_headers, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-rev"),
+    )
+    cid, h = _chat_em_atendimento(
+        client, auth_headers, wa_id="5511999000803", msg_id="rev-in-3"
+    )
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    inbound = next(m for m in msgs if m["direcao"] == "inbound")
+    target = inbound["wa_message_id"]
+
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_revoke("5511999000803", target_id=target),
+        headers=h,
+    )
+    assert r.status_code == 200
+    assert r.json().get("revokes", 0) >= 1
+
+    msgs2 = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    alvo = next(m for m in msgs2 if m["id"] == inbound["id"])
+    assert alvo["apagada"] is True
+    assert alvo["corpo"] == "Mensagem apagada"
+
+
+def test_webhook_edit_atualiza_corpo(client, seed_base, auth_headers, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-edw"),
+    )
+    cid, h = _chat_em_atendimento(
+        client, auth_headers, wa_id="5511999000804", msg_id="edit-in-4"
+    )
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    inbound = next(m for m in msgs if m["direcao"] == "inbound")
+    target = inbound["wa_message_id"]
+
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_edit("5511999000804", target_id=target, texto="Texto editado pelo cliente"),
+        headers=h,
+    )
+    assert r.status_code == 200
+    assert r.json().get("edits", 0) >= 1
+
+    msgs2 = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    alvo = next(m for m in msgs2 if m["id"] == inbound["id"])
+    assert alvo["editada"] is True
+    assert alvo["corpo"] == "Texto editado pelo cliente"
+
+
+def test_editar_exige_responsavel(client, seed_base, auth_headers, monkeypatch):
+    n = {"i": 0}
+
+    def fake_send(*_a, **_k):
+        n["i"] += 1
+        return True, None, f"wa-out-deny-{n['i']}"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_update_message",
+        lambda *_a, **_k: (True, None),
+    )
+    cid, _h = _chat_em_atendimento(
+        client, auth_headers, wa_id="5511999000805", msg_id="deny-5"
+    )
+    r_msg = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Só o responsável"},
+        headers=auth_headers["a1"],
+    )
+    mid = r_msg.json()["id"]
+    denied = client.patch(
+        f"/v1/whatsapp/chats/{cid}/mensagens/{mid}",
+        json={"texto": "Hack"},
+        headers=auth_headers["a2"],
+    )
+    assert denied.status_code == 403

--- a/backend/tests/test_whatsapp_reacoes.py
+++ b/backend/tests/test_whatsapp_reacoes.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+
+def _webhook_body(wa_id: str = "5511999999999", msg_id: str = "mid1", text: str = "Olá"):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": msg_id,
+                    },
+                    "message": {"conversation": text},
+                }
+            ]
+        },
+    }
+
+
+def _webhook_reaction(
+    wa_id: str,
+    *,
+    target_id: str,
+    emoji: str,
+    from_me: bool = False,
+    reaction_msg_id: str = "react-1",
+):
+    return {
+        "event": "messages.upsert",
+        "data": {
+            "key": {
+                "remoteJid": f"{wa_id}@s.whatsapp.net",
+                "fromMe": from_me,
+                "id": reaction_msg_id,
+            },
+            "message": {
+                "reactionMessage": {
+                    "key": {
+                        "remoteJid": f"{wa_id}@s.whatsapp.net",
+                        "fromMe": True,
+                        "id": target_id,
+                    },
+                    "text": emoji,
+                }
+            },
+        },
+    }
+
+
+def _chat_em_atendimento(client, auth_headers, wa_id="5511999000701", msg_id="reac-base-1"):
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={
+            "webhook_secret": "reac-630",
+            "evolution_base_url": "http://evolution.test",
+            "evolution_instance_name": "inst",
+            "evolution_api_key": "key-test",
+            "auto_msg_assumido_ativa": False,
+            "auto_msg_espera_ativa": False,
+        },
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "reac-630"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id=wa_id, msg_id=msg_id),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"])
+    return cid, h
+
+
+def test_webhook_reacao_cliente_aparece_na_mensagem(client, seed_base, auth_headers, monkeypatch):
+    n = {"i": 0}
+
+    def fake_send(*_a, **_k):
+        n["i"] += 1
+        return True, None, f"wa-out-{n['i']}"
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+    cid, h = _chat_em_atendimento(client, auth_headers)
+    # Mensagem outbound do atendente
+    r_msg = client.post(
+        f"/v1/whatsapp/chats/{cid}/mensagens",
+        json={"texto": "Olá!"},
+        headers=auth_headers["a1"],
+    )
+    assert r_msg.status_code == 201
+    target = r_msg.json()["wa_message_id"]
+    assert target
+
+    r = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_reaction("5511999000701", target_id=target, emoji="👍"),
+        headers=h,
+    )
+    assert r.status_code == 200
+    assert r.json().get("reacoes", 0) >= 1
+
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    alvo = next(m for m in msgs if m["wa_message_id"] == target)
+    assert any(r["emoji"] == "👍" and r.get("tem_cliente") for r in alvo.get("reacoes") or [])
+
+
+def test_atendente_reage_via_api(client, seed_base, auth_headers, monkeypatch):
+    sent: list[dict] = []
+    n = {"i": 0}
+
+    def fake_send(*_a, **_k):
+        n["i"] += 1
+        return True, None, f"wa-out-reac-{n['i']}"
+
+    def fake_reaction(*_a, **kwargs):
+        sent.append(kwargs)
+        return True, None
+
+    monkeypatch.setattr("app.api.whatsapp_chats.evolution_api.evolution_send_text", fake_send)
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_reaction",
+        fake_reaction,
+    )
+
+    cid, _h = _chat_em_atendimento(client, auth_headers, wa_id="5511999000702", msg_id="reac-in-2")
+    inbound_id = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()[0]["id"]
+
+    ok = client.put(
+        f"/v1/whatsapp/chats/{cid}/mensagens/{inbound_id}/reacoes",
+        json={"emoji": "❤️"},
+        headers=auth_headers["a1"],
+    )
+    assert ok.status_code == 200
+    body = ok.json()
+    assert any(r["emoji"] == "❤️" and r["reagiu_eu"] for r in body.get("reacoes") or [])
+    assert sent and sent[-1].get("reaction") == "❤️"
+
+    # Toggle remove
+    rem = client.put(
+        f"/v1/whatsapp/chats/{cid}/mensagens/{inbound_id}/reacoes",
+        json={"emoji": "❤️"},
+        headers=auth_headers["a1"],
+    )
+    assert rem.status_code == 200
+    assert not any(r["emoji"] == "❤️" for r in rem.json().get("reacoes") or [])
+    assert sent[-1].get("reaction") == ""
+
+
+def test_reacao_exige_responsavel(client, seed_base, auth_headers, monkeypatch):
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_reaction",
+        lambda *_a, **_k: (True, None),
+    )
+    cid, _h = _chat_em_atendimento(client, auth_headers, wa_id="5511999000703", msg_id="reac-in-3")
+    mid = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()[0]["id"]
+    denied = client.put(
+        f"/v1/whatsapp/chats/{cid}/mensagens/{mid}/reacoes",
+        json={"emoji": "👍"},
+        headers=auth_headers["a2"],
+    )
+    assert denied.status_code == 403

--- a/deploy/clients/README.md
+++ b/deploy/clients/README.md
@@ -30,7 +30,7 @@ Na **raiz do repositório** (Linux/macOS/Git Bash no Windows):
 ```bash
 bash deploy/scripts/provision-client.sh \
   --slug duplexsoft \
-  --base-domain connect.duplexsoft.com.br \
+  --base-domain deskrudder.com.br \
   --api-port 8001
 ```
 

--- a/deploy/clients/_template/client.env.example
+++ b/deploy/clients/_template/client.env.example
@@ -1,4 +1,5 @@
 # Copiado para client.env pelo provision-client.sh — ajuste antes do primeiro up.
+# Hosts DeskRudder: {slug}.deskrudder.com.br + api-{slug}.deskrudder.com.br
 
 CLIENT_SLUG=exemplo
 CLIENT_API_PORT=8001
@@ -14,26 +15,27 @@ ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 
 # Origem do SPA (HTTPS em produção)
-CORS_ORIGINS=https://exemplo.connect.duplexsoft.com.br
+CORS_ORIGINS=https://exemplo.deskrudder.com.br
 
 # Hostnames que a API aceita (TrustedHostMiddleware)
-ALLOWED_HOSTS=api-exemplo.connect.duplexsoft.com.br,127.0.0.1,localhost
+ALLOWED_HOSTS=api-exemplo.deskrudder.com.br,127.0.0.1,localhost
 
 LOG_LEVEL=INFO
 
 # Single-tenant por instância (um Postgres por cliente)
 DX_CONNECT_MULTI_TENANT=false
 DEFAULT_TENANT_ID=1
-CLIENT_APP_HOST=exemplo.connect.duplexsoft.com.br
-CONNECT_APP_BASE_DOMAIN=connect.duplexsoft.com.br
-INBOUND_EMAIL_DOMAIN=notify.duplexsoft.com.br
+CLIENT_APP_HOST=exemplo.deskrudder.com.br
+CONNECT_APP_BASE_DOMAIN=deskrudder.com.br
+INBOUND_EMAIL_DOMAIN=notify.deskrudder.com.br
 
 # Resend / e-mail transaccional (preencher por cliente)
 # RESEND_API_KEY=re_...
-# TRANSACTIONAL_FROM_EMAIL=noreply@notify.duplexsoft.com.br
-# TRANSACTIONAL_FROM_NAME=DX Connect
-# SUPPORT_REPLY_TO_EMAIL=suporte@duplexsoft.com.br
+# TRANSACTIONAL_FROM_EMAIL=noreply@notify.deskrudder.com.br
+# TRANSACTIONAL_FROM_NAME=DeskRudder
+# SUPPORT_REPLY_TO_EMAIL=suporte@suaempresa.com.br
 # RESEND_WEBHOOK_SECRET=whsec_...
+# DX_CONNECT_WEBHOOK_BASE_URL=https://api-exemplo.deskrudder.com.br
 
 # Seed inicial (produção) — após primeiro up: docker compose ... exec backend python -m app.seed
 SEED_ADMIN_EMAIL=admin@email.com

--- a/deploy/clients/_template/frontend.env.production.example
+++ b/deploy/clients/_template/frontend.env.production.example
@@ -3,7 +3,8 @@
 #   cd ../../../frontend && npm ci && npm run build
 #   rsync dist/ para FRONTEND_DIST no VPS (ver nginx.site.conf.example)
 
-VITE_API_URL=https://api-CLIENT_SLUG.connect.BASE_DOMAIN
+VITE_API_URL=https://api-CLIENT_SLUG.BASE_DOMAIN
+VITE_MARKETING_SITE_URL=https://deskrudder.com.br
 VITE_DEFAULT_TENANT_ID=1
-VITE_CLIENT_APP_HOST=CLIENT_SLUG.connect.BASE_DOMAIN
+VITE_CLIENT_APP_HOST=CLIENT_SLUG.BASE_DOMAIN
 # VITE_MULTI_TENANT=false

--- a/deploy/clients/_template/nginx.site.conf.example
+++ b/deploy/clients/_template/nginx.site.conf.example
@@ -1,4 +1,5 @@
 # Nginx — um cliente (app + API em subdomínios distintos).
+# Padrão DeskRudder: {slug}.deskrudder.com.br + api-{slug}.deskrudder.com.br
 # Copiar para /etc/nginx/sites-available/dx-connect-CLIENT_SLUG e ativar.
 #
 # Pré-requisitos:
@@ -13,7 +14,7 @@ upstream dx_connect_api_CLIENT_SLUG {
 server {
     listen 80;
     listen [::]:80;
-    server_name api-CLIENT_SLUG.connect.BASE_DOMAIN;
+    server_name api-CLIENT_SLUG.BASE_DOMAIN;
 
     client_max_body_size 25M;
 
@@ -34,7 +35,7 @@ server {
 server {
     listen 80;
     listen [::]:80;
-    server_name CLIENT_SLUG.connect.BASE_DOMAIN;
+    server_name CLIENT_SLUG.BASE_DOMAIN;
 
     root FRONTEND_DIST;
     index index.html;

--- a/deploy/nginx/README.md
+++ b/deploy/nginx/README.md
@@ -2,57 +2,18 @@
 
 O **backend** já envia logs corretamente atrás de proxy (Gunicorn com `forwarded_allow_ips`). Estes ficheiros **não** são aplicados automaticamente: copie-os para o VPS e ajuste domínios e caminhos.
 
-## DeskRudder / domínio legado
+## DeskRudder — hosts
 
-| Ficheiro | Uso |
-|----------|-----|
-| [`connect-duplexsoft-redirect.conf.example`](connect-duplexsoft-redirect.conf.example) | `connect.duplexsoft.com.br` → `301` `https://deskrudder.com.br$request_uri` |
-| App do cliente | `https://duplexsoft.deskrudder.com.br` |
-| API legada (manter) | `https://api.connect.duplexsoft.com.br` |
+| Host | Função |
+|------|--------|
+| `deskrudder.com.br` | Landing / site comercial |
+| `{slug}.deskrudder.com.br` | Painel do cliente (ex.: `duplexsoft.deskrudder.com.br`) |
+| `api-{slug}.deskrudder.com.br` | API do cliente (ex.: `api-duplexsoft.deskrudder.com.br`) |
+
+Exemplos: [`deskrudder-landing.conf.example`](deskrudder-landing.conf.example), [`deskrudder-duplexsoft.conf.example`](deskrudder-duplexsoft.conf.example) (se presentes), template em [`../clients/_template/nginx.site.conf.example`](../clients/_template/nginx.site.conf.example).
+
+### Domínios legados (`*.duplexsoft.com.br`)
+
+[`connect-duplexsoft-redirect.conf.example`](connect-duplexsoft-redirect.conf.example) — `301` de `connect.` / `api.connect.` para os hosts DeskRudder do cliente piloto.
 
 ## Requisitos no VPS
-
-1. Backend a escutar **só em localhost** (ex.: `127.0.0.1:8000` — padrão do `docker compose` ao mapear `8000:8000` continua acessível no host; para fechar à internet deixe o `-p` apenas se usar rede interna; o mais comum é `ports: - "127.0.0.1:8000:8000"` no compose de produção).
-2. Variáveis do app: `CORS_ORIGINS` deve incluir a origem do frontend (ex.: `http://app.seudominio.com` durante testes HTTP, depois `https://...`).
-
-## Instalação rápida (Debian/Ubuntu)
-
-```bash
-sudo apt update && sudo apt install -y nginx
-sudo cp api.http.conf.example /etc/nginx/sites-available/dx-connect-api
-sudo cp frontend.http.conf.example /etc/nginx/sites-available/dx-connect-app
-# Editar server_name e root
-sudo ln -sf /etc/nginx/sites-available/dx-connect-api /etc/nginx/sites-enabled/
-sudo ln -sf /etc/nginx/sites-available/dx-connect-app /etc/nginx/sites-enabled/
-sudo nginx -t && sudo systemctl reload nginx
-```
-
-## Testar em HTTP
-
-- API: `curl -sS http://api.seudominio.com/health`
-- App: abrir `http://app.seudominio.com` no browser e fazer login.
-
-Depois ative **HTTPS** (Certbot ou certificado do painel) e atualize `CORS_ORIGINS`, `VITE_API_URL` e redirecionamentos `80 → 443`.
-
-## Um domínio só (API + SPA)
-
-Se quiser tudo no mesmo `server_name`, pode servir o `dist/` em `/` e fazer `location /api/` com `proxy_pass` — **neste projeto** a API não usa o prefixo `/api` nas rotas, seria preciso alinhar `proxy_pass` e o `VITE_API_URL`. O arranjo mais simples é **dois nomes**: `app.` e `api.`.
-
-## Cabeçalhos de segurança (HTTPS + SPA)
-
-Checklist ao colocar o site em produção:
-
-1. **TLS**: redirecionar `80 → 443`; certificados válidos (ex.: Certbot).
-2. **HSTS** no `server` HTTPS: `add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;`
-3. **HTML estático** (`index.html` e assets): `Content-Security-Policy` alinhada ao que o bundle carrega (scripts, estilos, `connect-src` para a URL da API); `X-Frame-Options: DENY` ou `frame-ancestors 'none'` na CSP.
-4. **Complementar a API**: a aplicação FastAPI já envia `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` e `Strict-Transport-Security` quando `X-Forwarded-Proto` é `https` — o proxy deve repassar `X-Forwarded-Proto` e `X-Forwarded-For`.
-5. **Login (força bruta)**: além do limite na API, pode usar `limit_req` no Nginx em `POST` para `/auth/login` (ex.: `limit_req_zone` por `$binary_remote_addr`).
-
-Exemplo mínimo de bloco TLS + cabeçalhos no `server` do frontend (ajuste CSP ao seu build):
-
-```nginx
-add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-add_header X-Content-Type-Options "nosniff" always;
-add_header X-Frame-Options "DENY" always;
-add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-```

--- a/deploy/nginx/README.md
+++ b/deploy/nginx/README.md
@@ -2,6 +2,14 @@
 
 O **backend** já envia logs corretamente atrás de proxy (Gunicorn com `forwarded_allow_ips`). Estes ficheiros **não** são aplicados automaticamente: copie-os para o VPS e ajuste domínios e caminhos.
 
+## DeskRudder / domínio legado
+
+| Ficheiro | Uso |
+|----------|-----|
+| [`connect-duplexsoft-redirect.conf.example`](connect-duplexsoft-redirect.conf.example) | `connect.duplexsoft.com.br` → `301` `https://deskrudder.com.br$request_uri` |
+| App do cliente | `https://duplexsoft.deskrudder.com.br` |
+| API legada (manter) | `https://api.connect.duplexsoft.com.br` |
+
 ## Requisitos no VPS
 
 1. Backend a escutar **só em localhost** (ex.: `127.0.0.1:8000` — padrão do `docker compose` ao mapear `8000:8000` continua acessível no host; para fechar à internet deixe o `-p` apenas se usar rede interna; o mais comum é `ports: - "127.0.0.1:8000:8000"` no compose de produção).

--- a/deploy/nginx/connect-duplexsoft-redirect.conf.example
+++ b/deploy/nginx/connect-duplexsoft-redirect.conf.example
@@ -1,0 +1,24 @@
+# Domínio legado connect.duplexsoft.com.br → landing DeskRudder.
+# A API (api.connect.duplexsoft.com.br) permanece no site dx-connect-api.
+#
+# App do cliente DuplexSoft: https://duplexsoft.deskrudder.com.br
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name connect.duplexsoft.com.br;
+
+    ssl_certificate /etc/letsencrypt/live/connect.duplexsoft.com.br/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/connect.duplexsoft.com.br/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    return 301 https://deskrudder.com.br$request_uri;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name connect.duplexsoft.com.br;
+    return 301 https://deskrudder.com.br$request_uri;
+}

--- a/deploy/nginx/connect-duplexsoft-redirect.conf.example
+++ b/deploy/nginx/connect-duplexsoft-redirect.conf.example
@@ -1,7 +1,8 @@
-# Domínio legado connect.duplexsoft.com.br → landing DeskRudder.
-# A API (api.connect.duplexsoft.com.br) permanece no site dx-connect-api.
+# Domínios legados DuplexSoft → DeskRudder (cliente piloto).
+# App:  connect.duplexsoft.com.br → duplexsoft.deskrudder.com.br
+# API:  api.connect.duplexsoft.com.br → api-duplexsoft.deskrudder.com.br
 #
-# App do cliente DuplexSoft: https://duplexsoft.deskrudder.com.br
+# Certificados Let's Encrypt dos hosts legados podem permanecer só para o TLS do redirect.
 
 server {
     listen 443 ssl;
@@ -13,12 +14,32 @@ server {
     include /etc/letsencrypt/options-ssl-nginx.conf;
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
-    return 301 https://deskrudder.com.br$request_uri;
+    return 301 https://duplexsoft.deskrudder.com.br$request_uri;
 }
 
 server {
     listen 80;
     listen [::]:80;
     server_name connect.duplexsoft.com.br;
-    return 301 https://deskrudder.com.br$request_uri;
+    return 301 https://duplexsoft.deskrudder.com.br$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    server_name api.connect.duplexsoft.com.br;
+
+    ssl_certificate /etc/letsencrypt/live/connect.duplexsoft.com.br/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/connect.duplexsoft.com.br/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    return 301 https://api-duplexsoft.deskrudder.com.br$request_uri;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name api.connect.duplexsoft.com.br;
+    return 301 https://api-duplexsoft.deskrudder.com.br$request_uri;
 }

--- a/deploy/scripts/provision-client.sh
+++ b/deploy/scripts/provision-client.sh
@@ -10,8 +10,10 @@ BASE_DOMAIN=""
 API_PORT=""
 
 usage() {
-  echo "Uso: $0 --slug <slug> --base-domain <connect.example.com> --api-port <porta>"
-  echo "Ex.: $0 --slug duplexsoft --base-domain connect.duplexsoft.com.br --api-port 8001"
+  echo "Uso: $0 --slug <slug> --base-domain <deskrudder.com.br> --api-port <porta>"
+  echo "Ex.: $0 --slug cliente01 --base-domain deskrudder.com.br --api-port 8001"
+  echo "  App:  https://cliente01.deskrudder.com.br"
+  echo "  API:  https://api-cliente01.deskrudder.com.br"
   exit 1
 }
 
@@ -90,7 +92,7 @@ sed -e "s/^CLIENT_SLUG=.*/CLIENT_SLUG=$SLUG/" \
     -e "s/^CONNECT_APP_BASE_DOMAIN=.*/CONNECT_APP_BASE_DOMAIN=$BASE_DOMAIN/" \
     -e "s/^SEED_ADMIN_PASSWORD=.*/SEED_ADMIN_PASSWORD=$ADMIN_PASS/" \
     -e "s/exemplo/${SLUG}/g" \
-    -e "s/connect\.duplexsoft\.com\.br/${BASE_DOMAIN}/g" \
+    -e "s/deskrudder\.com\.br/${BASE_DOMAIN}/g" \
     "$TEMPLATE/client.env.example" >"$DEST/client.env"
 
 substitute "$TEMPLATE/nginx.site.conf.example" "$DEST/nginx.site.conf"

--- a/docs/DEPLOYMENT_ARCHITECTURE.md
+++ b/docs/DEPLOYMENT_ARCHITECTURE.md
@@ -7,7 +7,7 @@
 | Aspecto | Direção |
 |---------|---------|
 | Infra | Mesma **VPS** (ou cluster) para vários clientes |
-| URL | **Subdomínio** por cliente (ex.: `duplexsoft.connect.duplexsoft.com.br`, `clienteb.connect.duplexsoft.com.br`) |
+| URL | **Subdomínio** por cliente (ex.: `duplexsoft.deskrudder.com.br`, `cliente02.deskrudder.com.br`) |
 | Dados | **Um PostgreSQL por cliente** (`DATABASE_URL` distinta por deploy) |
 | API | **Um container Docker por cliente** (modelo adotado — ver abaixo) |
 | Código | Tratar cada deploy como **single-tenant**: sem filtrar “outro cliente” na mesma base |

--- a/docs/EMAIL_SETTINGS.md
+++ b/docs/EMAIL_SETTINGS.md
@@ -53,7 +53,7 @@ Fluxo: caixa do cliente (`suporte@duplexsoft.com.br`) → **encaminhamento** →
 | 1 | Resend → Domains | Domínio **`notify.duplexsoft.com.br`** com **Enable Receiving** e MX **Verified** |
 | 2 | Painel Connect | **Empresa → E-mail** → **Atualizar lista** → copiar ex.: `suporte.t1@notify.duplexsoft.com.br` |
 | 3 | Outlook / M365 | Encaminhar `suporte@` para o endereço da tabela (não o antigo `@inbound...`) |
-| 4 | Resend → Webhooks | Evento **`email.received`**, URL `POST https://api.connect.duplexsoft.com.br/v1/webhooks/resend-inbound` |
+| 4 | Resend → Webhooks | Evento **`email.received`**, URL `POST https://api-{slug}.deskrudder.com.br/v1/webhooks/resend-inbound` |
 | 5 | VPS `backend/.env` | Ver variáveis abaixo + rebuild do container API |
 
 Variáveis no servidor:

--- a/docs/MOBILE_APP_BRIEF.md
+++ b/docs/MOBILE_APP_BRIEF.md
@@ -26,7 +26,7 @@ Documento para equipes/ferramentas que **não têm acesso ao GitHub**. Descreve 
 ### Base URL
 
 - **Desenvolvimento:** `http://localhost:8000/v1`
-- **Produção:** configurar por build (ex.: `https://api.connect.duplexsoft.com.br/v1`)
+- **Produção:** configurar por build (ex.: `https://api-duplexsoft.deskrudder.com.br/v1`)
 
 ### Login
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -14,12 +14,13 @@ Bump automático no **deploy de `staging`** (fuso `America/Sao_Paulo`).
 ## Fluxo do time
 
 ```
-feature → PR main (+ CHANGELOG) → PR main → staging → deploy → /sobre
+feature → PR main (+ CHANGELOG) → PR main → staging (aprovação humana) → deploy → /sobre
 ```
 
 1. **Cada PR para `main`** com mudança de produto: inclua bullet(s) em `CHANGELOG.md` → `## [Unreleased]`
 2. **PR `main → staging`**: o `[Unreleased]` descreve **todo o lote** que será publicado
-3. **Deploy em `staging`**: consome `[Unreleased]`, gera nova CalVer, append em `docs/releases/manifest.json`, zera `[Unreleased]`
+3. **Merge em `staging`**: **só após análise e aprovação humana no GitHub** (`staging` = produção). Agentes/CI **não** mergeiam este PR automaticamente — usar `/release-staging` para abrir o PR e parar.
+4. **Deploy em `staging`**: consome `[Unreleased]`, gera nova CalVer, append em `docs/releases/manifest.json`, zera `[Unreleased]`
 
 ## Requisito de PR (obrigatório)
 
@@ -73,6 +74,7 @@ Após cada deploy, o workflow commita `VERSION`, `CHANGELOG.md`, `manifest.json`
 
 - [ ] `[Unreleased]` lista **todas** as entregas do lote
 - [ ] Revisão de redação (sem «deploy», «branch», «commit»)
+- [ ] **Aprovação e merge manuais** no GitHub (agente não executa `gh pr merge`)
 
 ## Desenvolvimento local
 

--- a/docs/WHATSAPP_EVOLUTION.md
+++ b/docs/WHATSAPP_EVOLUTION.md
@@ -71,10 +71,22 @@ Campos persistidos em `whatsapp_settings` (via **Configurações → WhatsApp**,
 3. **Encerrar** → `encerrado`, `encerramento_at`.
 4. Nova mensagem do mesmo cliente **após encerramento** → **novo** chat e novo protocolo.
 
+## Reações, editar e apagar (#630)
+
+| Ação | Endpoint Evolution (v2 típico) | Limite no DX Connect |
+|------|-------------------------------|----------------------|
+| Reagir | `POST /message/sendReaction/{instance}` | Whitelist 👍❤️😂😮😢🙏; só responsável do chat |
+| Editar texto | `POST /chat/updateMessage/{instance}` | Só outbound texto; **15 minutos** após envio |
+| Apagar para todos | `DELETE /chat/deleteMessageForEveryone/{instance}` | Só outbound; **48 horas** após envio |
+
+- Webhook inbound: `reactionMessage`, `protocolMessage` tipo `REVOKE`, e `editedMessage` atualizam a mensagem e emitem SSE `chat.mensagem`.
+- Editar legenda de mídia fica fora do escopo v1.
+- O prefixo de assinatura `[ Setor - Nome ]:` é reaplicado ao editar (ver #628).
+
 ## Riscos e limitações
 
 - Comportamento e payloads podem variar entre **versões** da Evolution; ajustar o parser em `app/services/evolution_inbound.py` ou a chamada a `getBase64FromMediaMessage` se necessário.
-- Políticas e limitações do **WhatsApp** aplicam-se ao número conectado na Evolution.
+- Políticas e limitações do **WhatsApp** aplicam-se ao número conectado na Evolution (janelas de edição/apagamento podem ser mais restritas que as do DX Connect).
 - **Localização** e **templates** não são tratados nesta versão.
 - Ficheiros muito grandes respeitam `WHATSAPP_MEDIA_MAX_BYTES` (por defeito 25 MB).
 - **Contacto** e **localização** inbound aparecem como texto legível (`[Contacto]`, `[Localização]` + link Google Maps).

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -8,6 +8,8 @@
 
 # Landing comercial (mailto do CTA «Fale conosco» — #515 / #516)
 # VITE_LANDING_CONTACT_EMAIL=contato@deskrudder.com.br
+# URL absoluta do site comercial («Voltar ao site» no login dos painéis de cliente)
+# VITE_MARKETING_SITE_URL=https://deskrudder.com.br
 
 # Single-tenant (produção por cliente): padrão — não envia X-Dx-Tenant-Id
 # VITE_DEFAULT_TENANT_ID=1

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -8,13 +8,12 @@
 
 # Landing comercial (mailto do CTA «Fale conosco» — #515 / #516)
 # VITE_LANDING_CONTACT_EMAIL=contato@deskrudder.com.br
-# URL absoluta do site comercial («Voltar ao site» no login dos painéis de cliente)
 # VITE_MARKETING_SITE_URL=https://deskrudder.com.br
 
 # Single-tenant (produção por cliente): padrão — não envia X-Dx-Tenant-Id
 # VITE_DEFAULT_TENANT_ID=1
-# VITE_CLIENT_APP_HOST=duplexsoft.connect.duplexsoft.com.br
+# VITE_CLIENT_APP_HOST=cliente01.deskrudder.com.br
 #
 # Multi-tenant legado (dev com vários clientes no mesmo Postgres):
 # VITE_MULTI_TENANT=true
-# VITE_CONNECT_APP_BASE_DOMAIN=connect.duplexsoft.com.br
+# VITE_CONNECT_APP_BASE_DOMAIN=deskrudder.com.br

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,7 +23,7 @@
         "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@vitejs/plugin-react": "^6.0.3",
+        "@vitejs/plugin-react": "^6.0.4",
         "eslint": "^10.5.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
@@ -1596,9 +1596,9 @@
       "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.3.tgz",
-      "integrity": "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.4.tgz",
+      "integrity": "sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "qrcode.react": "^4.2.0",
-        "react": "19.2.7",
+        "react": "19.2.8",
         "react-dom": "19.2.7",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.18.1",
@@ -66,7 +66,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -282,7 +281,6 @@
       "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -294,7 +292,6 @@
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1318,7 +1315,6 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1326,7 +1322,6 @@
     "node_modules/@types/react": {
       "version": "19.2.17",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1396,7 +1391,6 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -1631,7 +1625,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1726,7 +1719,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2107,7 +2099,6 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3723,7 +3714,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3841,9 +3831,10 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3853,7 +3844,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3900,7 +3890,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3990,8 +3979,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4255,7 +4243,6 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4486,7 +4473,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4603,7 +4589,6 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,7 @@
         "playwright": "^1.61.1",
         "tailwindcss": "^4.3.3",
         "typescript": "~6.0.3",
-        "typescript-eslint": "^8.63.0",
+        "typescript-eslint": "^8.65.0",
         "vite": "^8.0.16"
       }
     },
@@ -66,7 +66,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -282,7 +281,6 @@
       "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -294,7 +292,6 @@
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1318,7 +1315,6 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1326,7 +1322,6 @@
     "node_modules/@types/react": {
       "version": "19.2.17",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1352,17 +1347,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
-      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/type-utils": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1375,7 +1370,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.63.0",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1391,17 +1386,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
-      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1417,14 +1411,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
-      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.63.0",
-        "@typescript-eslint/types": "^8.63.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1439,14 +1433,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
-      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1457,9 +1451,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
-      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1474,15 +1468,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
-      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1499,9 +1493,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
-      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1513,16 +1507,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
-      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.63.0",
-        "@typescript-eslint/tsconfig-utils": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/visitor-keys": "8.63.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1554,16 +1548,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
-      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.63.0",
-        "@typescript-eslint/types": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1578,13 +1572,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
-      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1631,7 +1625,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1726,7 +1719,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2107,7 +2099,6 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3723,7 +3714,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3843,7 +3833,6 @@
     "node_modules/react": {
       "version": "19.2.7",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3853,7 +3842,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3900,7 +3888,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3990,8 +3977,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4255,7 +4241,6 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4265,16 +4250,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.63.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
-      "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.63.0",
-        "@typescript-eslint/parser": "8.63.0",
-        "@typescript-eslint/typescript-estree": "8.63.0",
-        "@typescript-eslint/utils": "8.63.0"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4486,7 +4471,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4603,7 +4587,6 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "recharts": "^3.9.2"
       },
       "devDependencies": {
-        "@emnapi/core": "^1.11.2",
+        "@emnapi/core": "^1.11.3",
         "@emnapi/runtime": "^1.11.3",
         "@eslint/js": "^9.39.1",
         "@tailwindcss/vite": "^4.3.3",
@@ -276,13 +276,13 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
+        "@emnapi/wasi-threads": "1.2.3",
         "tslib": "^2.4.0"
       }
     },
@@ -297,9 +297,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@emnapi/core": "^1.11.2",
-        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/runtime": "^1.11.3",
         "@eslint/js": "^9.39.1",
         "@tailwindcss/vite": "^4.3.3",
         "@types/node": "^26.1.1",
@@ -66,7 +66,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -282,19 +281,17 @@
       "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1318,7 +1315,6 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1326,7 +1322,6 @@
     "node_modules/@types/react": {
       "version": "19.2.17",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1396,7 +1391,6 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -1631,7 +1625,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1726,7 +1719,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2107,7 +2099,6 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3723,7 +3714,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3843,7 +3833,6 @@
     "node_modules/react": {
       "version": "19.2.7",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3853,7 +3842,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3900,7 +3888,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3990,8 +3977,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4255,7 +4241,6 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4486,7 +4471,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4603,7 +4587,6 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -66,6 +66,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -281,6 +282,7 @@
       "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -292,6 +294,7 @@
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -997,9 +1000,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1017,9 +1017,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1037,9 +1034,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1057,9 +1051,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1097,27 +1088,6 @@
       },
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
@@ -1348,6 +1318,7 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1355,6 +1326,7 @@
     "node_modules/@types/react": {
       "version": "19.2.17",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1424,6 +1396,7 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -1658,6 +1631,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1720,16 +1694,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1752,6 +1726,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1861,18 +1836,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2139,6 +2107,7 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3627,7 +3596,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -3752,6 +3723,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3807,7 +3779,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -3825,7 +3799,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3869,6 +3843,7 @@
     "node_modules/react": {
       "version": "19.2.7",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3878,6 +3853,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3924,6 +3900,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3943,20 +3920,19 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
@@ -3965,12 +3941,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -4014,7 +3990,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4111,12 +4088,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -4284,6 +4255,7 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4514,6 +4486,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4630,6 +4603,7 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "recharts": "^3.9.2"
   },
   "devDependencies": {
-    "@emnapi/core": "^1.11.2",
+    "@emnapi/core": "^1.11.3",
     "@emnapi/runtime": "^1.11.3",
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.3.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,7 +34,7 @@
     "playwright": "^1.61.1",
     "tailwindcss": "^4.3.3",
     "typescript": "~6.0.3",
-    "typescript-eslint": "^8.63.0",
+    "typescript-eslint": "^8.65.0",
     "vite": "^8.0.16"
   },
   "overrides": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "qrcode.react": "^4.2.0",
-    "react": "19.2.7",
+    "react": "19.2.8",
     "react-dom": "19.2.7",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.18.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^6.0.3",
+    "@vitejs/plugin-react": "^6.0.4",
     "eslint": "^10.5.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@emnapi/core": "^1.11.2",
-    "@emnapi/runtime": "^1.11.1",
+    "@emnapi/runtime": "^1.11.3",
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/node": "^26.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,5 +36,8 @@
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.63.0",
     "vite": "^8.0.16"
+  },
+  "overrides": {
+    "react-router": "8.3.0"
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { ThemeProvider } from './contexts/ThemeContext'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
 import { Layout } from './components/Layout'
 import { Login } from './pages/Login'
+import { AuthSessao } from './pages/AuthSessao'
 import { EsqueciSenha } from './pages/EsqueciSenha'
 import { RedefinirSenha } from './pages/RedefinirSenha'
 import { AvaliarTicket } from './pages/AvaliarTicket'
@@ -90,9 +91,11 @@ import { PortalEquipeForm } from './pages/portal/PortalEquipeForm'
 import { ToastProvider } from './components/ui/Toast'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { PageLoading } from './components/ui/PageLoading'
+import { isMarketingHost } from './lib/marketingHost'
 
 /**
- * `/` anônimo → landing pública; demais rotas do shell exigem login.
+ * Apex comercial (`deskrudder.com.br`): `/` anônimo → landing.
+ * Subdomínio de cliente: `/` anônimo → login do painel.
  * Autenticado → Layout + painel (index = Dashboard).
  */
 function LayoutOrLanding() {
@@ -102,7 +105,7 @@ function LayoutOrLanding() {
     return <PageLoading fullscreen label="Carregando sessão…" />
   }
   if (!user) {
-    if (location.pathname === '/' || location.pathname === '') {
+    if ((location.pathname === '/' || location.pathname === '') && isMarketingHost()) {
       return <LandingPage />
     }
     return <Navigate to="/login" replace state={{ from: location }} />
@@ -144,6 +147,7 @@ function AppRoutes() {
   return (
     <Routes>
       <Route path="/login" element={<Login />} />
+      <Route path="/auth/sessao" element={<AuthSessao />} />
       <Route path="/esqueci-senha" element={<EsqueciSenha />} />
       <Route path="/redefinir-senha" element={<RedefinirSenha />} />
       <Route path="/avaliar-ticket" element={<AvaliarTicket />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -909,6 +909,8 @@ export namespace WhatsappChats {
   inatividade_pausada?: boolean
   inatividade_retomada_em?: string | null
   classificacao_demanda_pendente?: boolean
+  foto_perfil_url?: string | null
+  foto_perfil_atualizada_em?: string | null
   }
   export interface EmpresaOpcao {
     id: number
@@ -1174,13 +1176,19 @@ export const whatsappChats = {
       method: 'PATCH',
       body: JSON.stringify(data),
     }),
-  assumir: (id: number, data?: { empresa_id?: number | null }) => {
-    const qs =
-      data?.empresa_id != null && data.empresa_id !== undefined
-        ? `?empresa_id=${encodeURIComponent(String(data.empresa_id))}`
-        : ''
+  assumir: (id: number, data?: { empresa_id?: number | null; setor_id?: number | null }) => {
+    const params = new URLSearchParams()
+    if (data?.empresa_id != null && data.empresa_id !== undefined) {
+      params.set('empresa_id', String(data.empresa_id))
+    }
+    if (data?.setor_id != null && data.setor_id !== undefined) {
+      params.set('setor_id', String(data.setor_id))
+    }
+    const qs = params.toString() ? `?${params.toString()}` : ''
     return api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/assumir${qs}`, { method: 'POST' })
   },
+  atualizarFotoPerfil: (id: number) =>
+    api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/foto-perfil`, { method: 'POST' }),
   definirEmpresaContexto: (id: number, empresa_id: number) =>
     api<WhatsappChats.Chat>(`/whatsapp/chats/${id}/empresa-contexto`, {
       method: 'POST',

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -959,6 +959,13 @@ export namespace WhatsappChats {
     encerramento_at?: string | null
     sem_avaliacao: boolean
   }
+  export interface ReacaoMensagem {
+    emoji: string
+    count: number
+    reagiu_eu: boolean
+    atendente_ids?: number[]
+    tem_cliente?: boolean
+  }
   export interface Mensagem {
     id: number
     chat_id: number
@@ -975,6 +982,12 @@ export namespace WhatsappChats {
     atendente_nome?: string | null
     status_entrega?: 'pendente' | 'enviada' | 'entregue' | 'lida' | 'erro' | null
     created_at?: string | null
+    reacoes?: ReacaoMensagem[]
+    editada?: boolean
+    editada_em?: string | null
+    apagada?: boolean
+    pode_editar?: boolean
+    pode_apagar_para_todos?: boolean
   }
   export interface Demanda {
     id: number
@@ -1206,6 +1219,24 @@ export const whatsappChats = {
     api<WhatsappChats.Mensagem>(`/whatsapp/chats/${id}/comentarios-internos`, {
       method: 'POST',
       body: JSON.stringify({ texto }),
+    }),
+  definirReacao: (chatId: number, mensagemId: number, emoji: string) =>
+    api<WhatsappChats.Mensagem>(`/whatsapp/chats/${chatId}/mensagens/${mensagemId}/reacoes`, {
+      method: 'PUT',
+      body: JSON.stringify({ emoji }),
+    }),
+  removerReacao: (chatId: number, mensagemId: number) =>
+    api<WhatsappChats.Mensagem>(`/whatsapp/chats/${chatId}/mensagens/${mensagemId}/reacoes`, {
+      method: 'DELETE',
+    }),
+  editarMensagem: (chatId: number, mensagemId: number, texto: string) =>
+    api<WhatsappChats.Mensagem>(`/whatsapp/chats/${chatId}/mensagens/${mensagemId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ texto }),
+    }),
+  apagarMensagem: (chatId: number, mensagemId: number) =>
+    api<WhatsappChats.Mensagem>(`/whatsapp/chats/${chatId}/mensagens/${mensagemId}`, {
+      method: 'DELETE',
     }),
   marcarVisto: (id: number) => api<void>(`/whatsapp/chats/${id}/visto`, { method: 'POST' }),
   pausarInatividade: (id: number) =>

--- a/frontend/src/brand/index.ts
+++ b/frontend/src/brand/index.ts
@@ -1,4 +1,15 @@
-export { APP_NAME, APP_TAGLINE, APP_DESCRIPTION, BRAND_ASSET_VERSION, brandColors, brandGradients, brandAssets, brandLightSurfaces, brandWordmarkOnDark } from './tokens'
+export {
+  APP_NAME,
+  APP_TAGLINE,
+  APP_DESCRIPTION,
+  MARKETING_SITE_URL,
+  BRAND_ASSET_VERSION,
+  brandColors,
+  brandGradients,
+  brandAssets,
+  brandLightSurfaces,
+  brandWordmarkOnDark,
+} from './tokens'
 export {
   THEME_STORAGE_KEY,
   THEME_STORAGE_KEY_LEGACY,

--- a/frontend/src/brand/tokens.ts
+++ b/frontend/src/brand/tokens.ts
@@ -9,6 +9,15 @@ export const APP_TAGLINE = 'Organize. Foque. Direcione'
 export const APP_DESCRIPTION =
   'Plataforma de atendimento multicanal — tickets, WhatsApp e e-mail com fila, roteamento e SLA.'
 
+/**
+ * Site comercial (landing em deskrudder.com.br).
+ * Nos subdomínios de cliente, «Voltar ao site» aponta para cá — não para `/` do painel.
+ */
+export const MARKETING_SITE_URL = (
+  (import.meta.env.VITE_MARKETING_SITE_URL as string | undefined)?.trim() ||
+  'https://deskrudder.com.br'
+).replace(/\/$/, '')
+
 export const brandColors = {
   /** Profundidade / confiança — fundos escuros, gradientes. */
   navy: '#0B2D4A',

--- a/frontend/src/components/chat/AssumirWhatsappSetorModal.tsx
+++ b/frontend/src/components/chat/AssumirWhatsappSetorModal.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useState } from 'react'
+import { setores, type Setores } from '../../api/client'
+import { Button } from '../ui/Button'
+import { Select } from '../ui/Select'
+
+type Props = {
+  open: boolean
+  setorIds: number[]
+  loading?: boolean
+  onClose: () => void
+  onConfirm: (setorId: number) => void
+}
+
+/** Modal para escolher o setor ao assumir WhatsApp com atendente multi-setor (#628). */
+export function AssumirWhatsappSetorModal({
+  open,
+  setorIds,
+  loading = false,
+  onClose,
+  onConfirm,
+}: Props) {
+  const [lista, setLista] = useState<Setores.Setor[]>([])
+  const [setorId, setSetorId] = useState<number | ''>('')
+  const [carregando, setCarregando] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    setSetorId('')
+    setCarregando(true)
+    void setores
+      .list({ limit: 200 })
+      .then((page) => setLista(page.items || []))
+      .catch(() => setLista([]))
+      .finally(() => setCarregando(false))
+  }, [open])
+
+  const opcoes = useMemo(() => {
+    const ids = new Set(setorIds)
+    return lista
+      .filter((s) => ids.has(s.id) && s.ativo !== false)
+      .map((s) => ({ value: s.id, label: s.nome }))
+  }, [lista, setorIds])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-[180] flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+      role="dialog"
+      aria-modal
+      aria-labelledby="assumir-setor-titulo"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md rounded-2xl bg-white p-5 shadow-xl dark:bg-slate-900"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 id="assumir-setor-titulo" className="text-lg font-bold text-slate-900 dark:text-white">
+          Escolher setor
+        </h2>
+        <p className="mt-1 text-sm text-slate-500">
+          Você atende em mais de um setor. Selecione o setor deste atendimento — ele aparece no
+          prefixo das mensagens no WhatsApp do cliente.
+        </p>
+        <div className="mt-4">
+          <Select
+            label="Setor"
+            value={setorId}
+            onChange={(v) => setSetorId(v === '' ? '' : Number(v))}
+            options={opcoes}
+            placeholder={carregando ? 'Carregando…' : 'Selecione o setor'}
+            includeEmpty
+            emptyLabel="Selecione…"
+            disabled={carregando || loading}
+          />
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <Button type="button" variant="secondary" onClick={onClose} disabled={loading}>
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            loading={loading}
+            disabled={setorId === '' || carregando}
+            onClick={() => {
+              if (setorId === '') return
+              onConfirm(setorId)
+            }}
+          >
+            Atender
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/ChatFilaAguardandoSheet.tsx
+++ b/frontend/src/components/chat/ChatFilaAguardandoSheet.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ChatListaEspera } from '../../pages/chat/ChatListaEspera'
+import { ChatFilaSomToggle } from './ChatFilaSomToggle'
 
 type Props = {
   open: boolean
@@ -45,9 +46,12 @@ export function ChatFilaAguardandoSheet({ open, onClose }: Props) {
         className="absolute inset-x-0 bottom-0 flex max-h-[min(85vh,32rem)] flex-col rounded-t-2xl bg-white shadow-2xl outline-none dark:bg-slate-950"
       >
         <div className="flex shrink-0 items-center justify-between border-b border-slate-200 px-4 py-3 dark:border-slate-800">
-          <h2 id={titleId} className="text-base font-bold text-slate-900 dark:text-white">
-            Aguardando
-          </h2>
+          <div className="flex items-center gap-1">
+            <h2 id={titleId} className="text-base font-bold text-slate-900 dark:text-white">
+              Aguardando
+            </h2>
+            <ChatFilaSomToggle size="md" />
+          </div>
           <button
             type="button"
             className="rounded-lg px-2 py-1 text-2xl leading-none text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-100"

--- a/frontend/src/components/chat/ChatFilaSomToggle.tsx
+++ b/frontend/src/components/chat/ChatFilaSomToggle.tsx
@@ -1,0 +1,51 @@
+import {
+  setFilaAguardandoMuted,
+  useFilaAguardandoMuted,
+} from '../../hooks/useAlertaFilaSemResponsavel'
+
+type Props = {
+  className?: string
+  /** Compacto para caber no header mobile / tabs */
+  size?: 'sm' | 'md'
+}
+
+export function ChatFilaSomToggle({ className = '', size = 'sm' }: Props) {
+  const muted = useFilaAguardandoMuted()
+  const dim = size === 'md' ? 'h-8 w-8' : 'h-7 w-7'
+  const icon = size === 'md' ? 18 : 16
+
+  return (
+    <button
+      type="button"
+      aria-pressed={muted}
+      aria-label={
+        muted
+          ? 'Ativar alerta sonoro da fila Aguardando'
+          : 'Silenciar alerta sonoro da fila Aguardando'
+      }
+      title={muted ? 'Alerta da fila silenciado — clique para ativar' : 'Silenciar alerta da fila'}
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        setFilaAguardandoMuted(!muted)
+      }}
+      className={`inline-flex ${dim} shrink-0 items-center justify-center rounded-lg text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100 ${
+        muted ? 'text-amber-600 dark:text-amber-400' : ''
+      } ${className}`}
+    >
+      {muted ? (
+        <svg xmlns="http://www.w3.org/2000/svg" width={icon} height={icon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <path d="M11 5 6 9H2v6h4l5 4V5z" />
+          <line x1="23" y1="9" x2="17" y2="15" />
+          <line x1="17" y1="9" x2="23" y2="15" />
+        </svg>
+      ) : (
+        <svg xmlns="http://www.w3.org/2000/svg" width={icon} height={icon} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+          <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+          <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+          <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+        </svg>
+      )}
+    </button>
+  )
+}

--- a/frontend/src/components/chat/ChatHubTabs.tsx
+++ b/frontend/src/components/chat/ChatHubTabs.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation } from 'react-router-dom'
 import { useChatInterno } from '../../contexts/ChatInternoContext'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { CHAT_HUB_PATHS, chatHubModoDePath } from '../../lib/chatHubPaths'
+import { ChatFilaSomToggle } from './ChatFilaSomToggle'
 
 type TabDef = {
   id: keyof typeof CHAT_HUB_PATHS
@@ -12,8 +13,8 @@ type TabDef = {
 }
 
 export function ChatHubTabs() {
-  const { pathname } = useLocation()
-  const modo = chatHubModoDePath(pathname)
+  const { pathname, search } = useLocation()
+  const modo = chatHubModoDePath(pathname, search)
   const { filaCount, atendendoCount } = useChatHub()
   const { conversas } = useChatInterno()
   const internoNaoLidas = conversas.reduce((acc, c) => acc + c.nao_lidas_count, 0)
@@ -73,17 +74,33 @@ export function ChatHubTabs() {
     <nav className="flex shrink-0 border-b border-slate-200 dark:border-slate-800" aria-label="Modos de chat">
       {tabs.map((tab) => {
         const ativo = modo === tab.id
+        const tabClass = `relative flex flex-1 flex-col items-center gap-1 border-b-2 px-0.5 py-2.5 text-[10px] font-semibold transition-colors ${
+          ativo
+            ? 'border-cyan-500 text-cyan-600 dark:text-cyan-400'
+            : 'border-transparent text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'
+        }`
+
+        if (tab.id === 'espera') {
+          return (
+            <div key={tab.id} className="relative flex flex-1 items-stretch">
+              <Link to={tab.to} title={tab.label} className={tabClass}>
+                <span className={ativo ? 'text-cyan-600 dark:text-cyan-400' : ''}>{tab.icon}</span>
+                <span className="hidden sm:inline">{tab.label}</span>
+                {tab.badge != null && tab.badge > 0 && (
+                  <span className="absolute right-5 top-1 min-w-[1rem] rounded-full bg-cyan-600 px-1 text-center text-[9px] font-bold leading-4 text-white sm:right-6">
+                    {tab.badge > 99 ? '99+' : tab.badge}
+                  </span>
+                )}
+              </Link>
+              <div className="absolute right-0 top-1/2 z-10 -translate-y-1/2 pr-0.5">
+                <ChatFilaSomToggle />
+              </div>
+            </div>
+          )
+        }
+
         return (
-          <Link
-            key={tab.id}
-            to={tab.to}
-            title={tab.label}
-            className={`relative flex flex-1 flex-col items-center gap-1 border-b-2 px-0.5 py-2.5 text-[10px] font-semibold transition-colors ${
-              ativo
-                ? 'border-cyan-500 text-cyan-600 dark:text-cyan-400'
-                : 'border-transparent text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'
-            }`}
-          >
+          <Link key={tab.id} to={tab.to} title={tab.label} className={tabClass}>
             <span className={ativo ? 'text-cyan-600 dark:text-cyan-400' : ''}>{tab.icon}</span>
             <span className="hidden sm:inline">{tab.label}</span>
             {tab.badge != null && tab.badge > 0 && (

--- a/frontend/src/components/chat/WhatsappAvatar.tsx
+++ b/frontend/src/components/chat/WhatsappAvatar.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+
+type Props = {
+  nome?: string | null
+  fotoUrl?: string | null
+  className?: string
+  /** Classes do círculo quando só há inicial */
+  fallbackClassName?: string
+}
+
+/** Avatar do contacto WhatsApp com fallback para inicial (#630). */
+export function WhatsappAvatar({
+  nome,
+  fotoUrl,
+  className = 'h-10 w-10',
+  fallbackClassName = 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-200',
+}: Props) {
+  const [broke, setBroke] = useState(false)
+  const inicial = (nome || '?').trim().charAt(0).toUpperCase() || '?'
+  if (fotoUrl && !broke) {
+    return (
+      <img
+        src={fotoUrl}
+        alt=""
+        className={`${className} shrink-0 rounded-full object-cover`}
+        referrerPolicy="no-referrer"
+        onError={() => setBroke(true)}
+      />
+    )
+  }
+  return (
+    <div
+      className={`${className} flex shrink-0 items-center justify-center rounded-full text-sm font-bold ${fallbackClassName}`}
+      aria-hidden
+    >
+      {inicial}
+    </div>
+  )
+}

--- a/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
+++ b/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from 'react'
+import type { WhatsappChats } from '../../api/client'
+import { ConfirmDialog } from '../ui/ConfirmDialog'
+import { TEXTAREA_FIELD_CLASS } from '../ui/Input'
+
+/** Remove prefixo `[ Setor - Nome ]:` gravado no corpo (#628 / #630). */
+export function corpoWhatsappSemPrefixo(corpo: string | null | undefined): string {
+  const t = (corpo || '').trim()
+  return t.replace(/^\[\s*[^\]]+\s*\]:\s*\n?/, '').trim()
+}
+
+type Props = {
+  mensagem: WhatsappChats.Mensagem
+  onEditar: (novoCorpo: string) => Promise<void>
+  onApagar: () => Promise<void>
+  alinhamento?: 'start' | 'end'
+}
+
+/** Editar / apagar para todos no chat WhatsApp (#630 lote 3). */
+export function WhatsappMensagemAcoes({
+  mensagem,
+  onEditar,
+  onApagar,
+  alinhamento = 'end',
+}: Props) {
+  const [editando, setEditando] = useState(false)
+  const [texto, setTexto] = useState(() => corpoWhatsappSemPrefixo(mensagem.corpo))
+  const [salvando, setSalvando] = useState(false)
+  const [confirmarApagar, setConfirmarApagar] = useState(false)
+  const [apagando, setApagando] = useState(false)
+
+  const podeEditar = Boolean(mensagem.pode_editar)
+  const podeApagarTodos = Boolean(mensagem.pode_apagar_para_todos)
+  const temAcoes = podeEditar || podeApagarTodos
+
+  useEffect(() => {
+    if (!editando) setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
+  }, [mensagem, editando])
+
+  if (mensagem.apagada || !temAcoes) return null
+
+  if (editando && podeEditar) {
+    return (
+      <div className="mt-1 w-full min-w-[min(100%,18rem)] space-y-2">
+        <textarea
+          value={texto}
+          onChange={(e) => setTexto(e.target.value)}
+          rows={3}
+          className={TEXTAREA_FIELD_CLASS}
+        />
+        <div className="flex gap-2">
+          <button
+            type="button"
+            disabled={salvando || !texto.trim()}
+            onClick={() => {
+              setSalvando(true)
+              void onEditar(texto.trim())
+                .then(() => setEditando(false))
+                .finally(() => setSalvando(false))
+            }}
+            className="rounded-lg bg-cyan-600 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+          >
+            Salvar
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
+              setEditando(false)
+            }}
+            className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50 dark:border-slate-500 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
+          >
+            Cancelar
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  const btnAcaoClass =
+    'rounded-full bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-100 dark:ring-slate-600 dark:hover:bg-slate-700'
+
+  return (
+    <>
+      <div
+        className={`pointer-events-none absolute bottom-full z-20 flex flex-col ${
+          alinhamento === 'end' ? 'right-0 items-end' : 'left-0 items-start'
+        }`}
+      >
+        <div
+          className={`flex gap-1 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 ${
+            alinhamento === 'end' ? 'justify-end' : 'justify-start'
+          }`}
+        >
+          {podeEditar && (
+            <button
+              type="button"
+              onClick={() => {
+                setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
+                setEditando(true)
+              }}
+              className={btnAcaoClass}
+            >
+              Editar
+            </button>
+          )}
+          {podeApagarTodos && (
+            <button type="button" onClick={() => setConfirmarApagar(true)} className={btnAcaoClass}>
+              Apagar
+            </button>
+          )}
+        </div>
+        <div
+          className="h-2 w-full min-w-[8rem] group-hover:pointer-events-auto group-focus-within:pointer-events-auto"
+          aria-hidden
+        />
+      </div>
+      <ConfirmDialog
+        open={confirmarApagar}
+        title="Apagar mensagem?"
+        message="A mensagem será apagada para todos no WhatsApp do cliente (até 48 h após o envio)."
+        confirmLabel="Apagar para todos"
+        cancelLabel="Cancelar"
+        variant="danger"
+        loading={apagando}
+        onCancel={() => setConfirmarApagar(false)}
+        onConfirm={() => {
+          setApagando(true)
+          void onApagar()
+            .then(() => setConfirmarApagar(false))
+            .finally(() => setApagando(false))
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/chat/WhatsappReacoesBar.tsx
+++ b/frontend/src/components/chat/WhatsappReacoesBar.tsx
@@ -1,0 +1,81 @@
+import type { WhatsappChats } from '../../api/client'
+import { EMOJIS_REACAO_CHAT_INTERNO } from '../../lib/chatInternoReacoes'
+
+type Props = {
+  reacoes: WhatsappChats.ReacaoMensagem[]
+  onReagir?: (emoji: string) => void
+  /** false = só chips (cliente reagiu; atendente sem permissão) */
+  podeReagir?: boolean
+  alinhamento?: 'start' | 'end'
+}
+
+/** Reações no chat WhatsApp com o cliente (#630 lote 2). */
+export function WhatsappReacoesBar({
+  reacoes,
+  onReagir,
+  podeReagir = false,
+  alinhamento = 'end',
+}: Props) {
+  const temReacoes = reacoes.length > 0
+  const alignEnd = alinhamento === 'end'
+
+  return (
+    <>
+      {podeReagir && onReagir ? (
+        <div
+          className={`pointer-events-none absolute top-full z-20 flex flex-col ${
+            alignEnd ? 'right-0 items-end' : 'left-0 items-start'
+          }`}
+        >
+          <div
+            className="h-2 w-full min-w-[10rem] group-hover:pointer-events-auto group-focus-within:pointer-events-auto"
+            aria-hidden
+          />
+          <div className="opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+            <div className="flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
+              {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
+                <button
+                  key={emoji}
+                  type="button"
+                  onClick={() => onReagir(emoji)}
+                  className="rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
+                  aria-label={`Reagir com ${emoji}`}
+                >
+                  {emoji}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {temReacoes ? (
+        <div
+          className={`relative z-[1] mt-1 flex flex-wrap gap-1 ${
+            alignEnd ? 'justify-end' : 'justify-start'
+          }`}
+        >
+          {reacoes.map((r) => (
+            <button
+              key={r.emoji}
+              type="button"
+              disabled={!podeReagir || !onReagir}
+              onClick={() => onReagir?.(r.emoji)}
+              className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] shadow-sm transition ${
+                r.reagiu_eu
+                  ? 'border-cyan-400/60 bg-white text-slate-800 dark:bg-slate-800 dark:text-slate-100'
+                  : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 disabled:hover:bg-white dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200'
+              } ${!podeReagir ? 'cursor-default' : ''}`}
+              title={
+                r.reagiu_eu ? 'Remover sua reação' : podeReagir ? 'Reagir' : r.tem_cliente ? 'Cliente' : 'Reação'
+              }
+            >
+              <span>{r.emoji}</span>
+              <span className="font-medium tabular-nums">{r.count}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -10,6 +10,8 @@ const LS_KEY_LAST_WPP_RESP = 'dxconnect.notificacoes.last_wpp_resp'
 const LS_KEY_LAST_PORTAL_FILA = 'dxconnect.notificacoes.last_portal_fila'
 const LS_KEY_LAST_PORTAL_RESP = 'dxconnect.notificacoes.last_portal_resp'
 const LS_KEY_LAST_CHAT_INTERNO = 'dxconnect.notificacoes.last_chat_interno'
+/** Preferência local: silenciar loop/pulse da fila Aguardando (WPP + portal). */
+const LS_KEY_FILA_AGUARDANDO_MUTED = 'dxconnect.notificacoes.fila_aguardando_muted'
 const POLL_MS = 10_000
 /** Fallback de segurança quando SSE está ativo (#266). */
 const POLL_SSE_SAFETY_MS = 60_000
@@ -65,6 +67,20 @@ const mutedChatInternoIds = new Set<number>()
 let chatInternoUserId: number | null = null
 let activeChatInternoConversaId: number | null = null
 
+type ListenerFilaMuted = (muted: boolean) => void
+const listenersFilaMuted = new Set<ListenerFilaMuted>()
+
+function readFilaAguardandoMuted(): boolean {
+  try {
+    if (typeof localStorage === 'undefined') return false
+    return localStorage.getItem(LS_KEY_FILA_AGUARDANDO_MUTED) === '1'
+  } catch {
+    return false
+  }
+}
+
+let filaAguardandoMuted = readFilaAguardandoMuted()
+
 let wppFilaLoopInterval: number | null = null
 let wppFilaLoopAudio: HTMLAudioElement | null = null
 let pollTimerId: number | null = null
@@ -91,6 +107,36 @@ export function syncChatInternoMutedIds(ids: Iterable<number>) {
 export function setChatInternoMuted(conversaId: number, muted: boolean) {
   if (muted) mutedChatInternoIds.add(conversaId)
   else mutedChatInternoIds.delete(conversaId)
+}
+
+export function isFilaAguardandoMuted() {
+  return filaAguardandoMuted
+}
+
+/** Silencia/reativa só o alerta contínuo (e pulses) da fila Aguardando — não afeta tickets nem chat interno. */
+export function setFilaAguardandoMuted(muted: boolean) {
+  filaAguardandoMuted = muted
+  try {
+    localStorage.setItem(LS_KEY_FILA_AGUARDANDO_MUTED, muted ? '1' : '0')
+  } catch {
+    // ignore
+  }
+  const filaCount = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
+  syncWppFilaBeep(filaCount)
+  for (const l of listenersFilaMuted) l(muted)
+}
+
+export function useFilaAguardandoMuted(): boolean {
+  const [muted, setMuted] = useState(filaAguardandoMuted)
+  useEffect(() => {
+    const listener: ListenerFilaMuted = (m) => setMuted(m)
+    listenersFilaMuted.add(listener)
+    setMuted(filaAguardandoMuted)
+    return () => {
+      listenersFilaMuted.delete(listener)
+    }
+  }, [])
+  return muted
 }
 
 function shouldPlayChatInternoSound(payload: Record<string, unknown>): boolean {
@@ -350,7 +396,7 @@ function ensureWppFilaLoop() {
 }
 
 function syncWppFilaBeep(wppFilaCount: number) {
-  if (wppFilaCount > 0) {
+  if (wppFilaCount > 0 && !filaAguardandoMuted) {
     ensureWppFilaLoop()
   } else {
     stopWppFilaLoop()
@@ -413,11 +459,17 @@ function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean, source: 'sse
       for (let i = 0; i < delta; i++) enqueueAlert('ticket_fila')
     }
 
-    if (shouldEnqueueCounterAlert('wpp_fila_pulse', prevWppFilaValue, r.wpp_fila_count)) {
+    if (
+      !filaAguardandoMuted &&
+      shouldEnqueueCounterAlert('wpp_fila_pulse', prevWppFilaValue, r.wpp_fila_count)
+    ) {
       enqueueAlert('wpp_fila_pulse')
     }
 
-    if (shouldEnqueueCounterAlert('wpp_fila_pulse', prevPortalFilaValue, r.portal_fila_count)) {
+    if (
+      !filaAguardandoMuted &&
+      shouldEnqueueCounterAlert('wpp_fila_pulse', prevPortalFilaValue, r.portal_fila_count)
+    ) {
       enqueueAlert('wpp_fila_pulse')
     }
 

--- a/frontend/src/lib/assumirWhatsappSetor.ts
+++ b/frontend/src/lib/assumirWhatsappSetor.ts
@@ -1,0 +1,10 @@
+import type { Atendentes } from '../api/client'
+
+/** Atendente com vários setores precisa escolher ao assumir chat sem setor (#628). */
+export function precisaEscolherSetorAoAssumir(
+  user: Atendentes.Atendente | null | undefined,
+  chatJaTemSetor?: boolean,
+): boolean {
+  if (chatJaTemSetor) return false
+  return (user?.setor_ids?.length ?? 0) > 1
+}

--- a/frontend/src/lib/chatHubLista.ts
+++ b/frontend/src/lib/chatHubLista.ts
@@ -17,6 +17,7 @@ export type ChatHubItem = {
   atendente_id?: number | null
   atendente_nome?: string | null
   ultima_mensagem_preview?: string | null
+  foto_perfil_url?: string | null
 }
 
 export function mapWhatsappChat(c: WhatsappChats.Chat): ChatHubItem {
@@ -32,6 +33,7 @@ export function mapWhatsappChat(c: WhatsappChats.Chat): ChatHubItem {
     estado: c.estado,
     atendente_id: c.atendente_id,
     atendente_nome: c.atendente_nome,
+    foto_perfil_url: c.foto_perfil_url,
   }
 }
 

--- a/frontend/src/lib/chatHubLista.ts
+++ b/frontend/src/lib/chatHubLista.ts
@@ -53,7 +53,9 @@ export function mapPortalChat(c: PortalChats.Chat): ChatHubItem {
 }
 
 export function chatHubItemLink(item: ChatHubItem, from?: ChatHubModo) {
-  if (item.canal === 'portal') return chatPortalLink(item.id)
+  if (item.canal === 'portal') {
+    return chatPortalLink(item.id, from === 'espera' ? 'espera' : undefined)
+  }
   return chatWhatsappLink(item.id, from === 'espera' ? 'espera' : 'atendendo')
 }
 

--- a/frontend/src/lib/chatHubPaths.ts
+++ b/frontend/src/lib/chatHubPaths.ts
@@ -7,10 +7,20 @@ export const CHAT_HUB_PATHS = {
 
 export type ChatHubModo = keyof typeof CHAT_HUB_PATHS
 
-export function chatHubModoDePath(pathname: string): ChatHubModo {
+/** `search` opcional (ex. `?from=espera`) — ao visualizar chat da fila, mantém modo Aguardando (#625). */
+export function chatHubModoDePath(pathname: string, search?: string): ChatHubModo {
   if (pathname.startsWith('/chat/interno') || pathname === CHAT_HUB_PATHS.interno) return 'interno'
   if (pathname.startsWith('/chat/espera')) return 'espera'
   if (pathname.startsWith('/chat/contatos')) return 'contatos'
+  const from = search
+    ? new URLSearchParams(search.startsWith('?') ? search.slice(1) : search).get('from')
+    : null
+  if (
+    from === 'espera' &&
+    (pathname.startsWith('/chat/c/') || pathname.startsWith('/chat/portal/'))
+  ) {
+    return 'espera'
+  }
   return 'atendendo'
 }
 
@@ -21,8 +31,11 @@ export function chatWhatsappLink(chatId: number, from?: ChatHubModo) {
   }
 }
 
-export function chatPortalLink(chatId: number) {
-  return `/chat/portal/${chatId}`
+export function chatPortalLink(chatId: number, from?: ChatHubModo) {
+  return {
+    pathname: `/chat/portal/${chatId}`,
+    search: from ? `?from=${from}` : '',
+  }
 }
 
 export function chatInternoLink(conversaId: number) {

--- a/frontend/src/lib/marketingHost.ts
+++ b/frontend/src/lib/marketingHost.ts
@@ -1,0 +1,132 @@
+import { MARKETING_SITE_URL } from '../brand/tokens'
+import { mensagemErroApi } from '../api/errorMessage'
+
+const RESERVED_SLUGS = new Set([
+  'www',
+  'api',
+  'mail',
+  'ftp',
+  'cdn',
+  'static',
+  'app',
+  'admin',
+  'status',
+  'portal',
+])
+
+const SLUG_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/
+
+export const LOGIN_ACCOUNT_STORAGE_KEY = 'deskrudder-login-account'
+
+/** Hostname do site comercial (sem www). */
+export function marketingApexHost(): string {
+  try {
+    return new URL(MARKETING_SITE_URL).hostname.replace(/^www\./i, '').toLowerCase()
+  } catch {
+    return 'deskrudder.com.br'
+  }
+}
+
+/** True na landing comercial (apex / www), não em subdomínio de cliente. */
+export function isMarketingHost(hostname = typeof window !== 'undefined' ? window.location.hostname : ''): boolean {
+  const host = hostname.toLowerCase()
+  const apex = marketingApexHost()
+  return host === apex || host === `www.${apex}`
+}
+
+/** Normaliza e valida slug da conta (subdomínio). Retorna null se inválido. */
+export function normalizeClientSlug(raw: string): string | null {
+  const slug = raw.trim().toLowerCase()
+  if (!slug || !SLUG_RE.test(slug) || RESERVED_SLUGS.has(slug)) return null
+  return slug
+}
+
+/** Origem HTTPS do painel do cliente: https://{slug}.deskrudder.com.br */
+export function clientAppOrigin(slug: string): string {
+  const normalized = normalizeClientSlug(slug)
+  if (!normalized) {
+    throw new Error('Conta inválida')
+  }
+  return `https://${normalized}.${marketingApexHost()}`
+}
+
+/** API da instância: https://api-{slug}.deskrudder.com.br */
+export function clientApiOrigin(slug: string): string {
+  const normalized = normalizeClientSlug(slug)
+  if (!normalized) {
+    throw new Error('Conta inválida')
+  }
+  return `https://api-${normalized}.${marketingApexHost()}`
+}
+
+export type ClientLoginTokens = {
+  access_token: string
+  refresh_token?: string | null
+  must_change_password?: boolean
+}
+
+/** Autentica na API do cliente a partir da apex (CORS). */
+export async function loginAgainstClientInstance(
+  slug: string,
+  email: string,
+  senha: string,
+): Promise<ClientLoginTokens> {
+  const apiOrigin = clientApiOrigin(slug)
+  let res: Response
+  try {
+    res = await fetch(`${apiOrigin}/v1/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ email, senha }),
+    })
+  } catch {
+    throw new Error(
+      'Não foi possível contactar o painel desta conta. Verifique o identificador ou tente mais tarde.',
+    )
+  }
+  const body = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    let msg = mensagemErroApi(body, res.status)
+    if (res.status === 401 || msg.startsWith('Não foi possível concluir')) {
+      msg = 'E-mail ou senha inválidos.'
+    }
+    if (res.status === 404 || res.status >= 502) {
+      msg = 'Conta não encontrada ou temporariamente indisponível.'
+    }
+    throw new Error(msg)
+  }
+  if (!body || typeof (body as ClientLoginTokens).access_token !== 'string') {
+    throw new Error('Resposta de login inválida.')
+  }
+  return body as ClientLoginTokens
+}
+
+/** URL no subdomínio que recebe a sessão via fragmento (não vai para logs do servidor). */
+export function buildSessionHandoffUrl(
+  slug: string,
+  tokens: ClientLoginTokens,
+  lembrarMe: boolean,
+): string {
+  const params = new URLSearchParams()
+  params.set('access_token', tokens.access_token)
+  if (tokens.refresh_token) params.set('refresh_token', tokens.refresh_token)
+  params.set('lembrar', lembrarMe ? '1' : '0')
+  if (tokens.must_change_password) params.set('must_change_password', '1')
+  return `${clientAppOrigin(slug)}/auth/sessao#${params.toString()}`
+}
+
+export function readRememberedAccount(): string {
+  try {
+    return localStorage.getItem(LOGIN_ACCOUNT_STORAGE_KEY) ?? ''
+  } catch {
+    return ''
+  }
+}
+
+export function writeRememberedAccount(slug: string): void {
+  try {
+    localStorage.setItem(LOGIN_ACCOUNT_STORAGE_KEY, slug)
+  } catch {
+    /* storage indisponível */
+  }
+}

--- a/frontend/src/pages/AuthSessao.tsx
+++ b/frontend/src/pages/AuthSessao.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { clearAuthToken } from '../api/client'
+import { PageLoading } from '../components/ui/PageLoading'
+import { isMarketingHost } from '../lib/marketingHost'
+
+const TOKEN_KEY = 'token'
+const REFRESH_TOKEN_KEY = 'refresh_token'
+
+/**
+ * Recebe tokens no hash após login na apex comercial e grava a sessão no subdomínio do cliente.
+ * O fragmento não é enviado ao servidor; limpamos da URL logo após ler.
+ */
+export function AuthSessao() {
+  const navigate = useNavigate()
+  const [erro, setErro] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (isMarketingHost()) {
+      navigate('/login', { replace: true })
+      return
+    }
+
+    const raw = window.location.hash.replace(/^#/, '')
+    if (!raw) {
+      setErro('Sessão inválida ou expirada. Faça login novamente.')
+      return
+    }
+
+    const params = new URLSearchParams(raw)
+    const access = params.get('access_token')
+    const refresh = params.get('refresh_token')
+    const lembrar = params.get('lembrar') !== '0'
+
+    window.history.replaceState(null, '', `${window.location.pathname}${window.location.search}`)
+
+    if (!access) {
+      setErro('Sessão inválida ou expirada. Faça login novamente.')
+      return
+    }
+
+    clearAuthToken()
+    const store = lembrar ? localStorage : sessionStorage
+    store.setItem(TOKEN_KEY, access)
+    if (refresh) store.setItem(REFRESH_TOKEN_KEY, refresh)
+
+    // Full reload para o AuthProvider ler os tokens no boot.
+    window.location.replace('/')
+  }, [navigate])
+
+  if (erro) {
+    return (
+      <div className="flex min-h-dvh flex-col items-center justify-center gap-4 bg-[#050810] px-4 text-center text-slate-200">
+        <p className="max-w-sm text-sm text-slate-400">{erro}</p>
+        <a href="/login" className="text-sm font-medium text-cyan-400 hover:text-cyan-300">
+          Ir para o login
+        </a>
+      </div>
+    )
+  }
+
+  return <PageLoading fullscreen label="Entrando no painel…" />
+}

--- a/frontend/src/pages/ConfigEmpresaEmail.tsx
+++ b/frontend/src/pages/ConfigEmpresaEmail.tsx
@@ -597,7 +597,7 @@ export function ConfigEmpresaEmail({ embedded = false, section }: ConfigEmpresaE
                     <p className="text-xs opacity-90">
                       Reply-To não definido — defina{' '}
                       <span className="font-mono">SUPPORT_REPLY_TO_EMAIL</span> no servidor (ex.{' '}
-                      <span className="font-mono">suporte@duplexsoft.com.br</span>) para as respostas do cliente
+                      <span className="font-mono">suporte@suaempresa.com.br</span>) para as respostas do cliente
                       voltarem à caixa de suporte.
                     </p>
                   )}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -4,7 +4,13 @@ import { useAuth } from '../contexts/AuthContext'
 import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
-import { BrandLogo, LOGIN_EMAIL_STORAGE_KEY, LOGIN_EMAIL_STORAGE_KEY_LEGACY, brandAssets } from '../brand'
+import {
+  BrandLogo,
+  LOGIN_EMAIL_STORAGE_KEY,
+  LOGIN_EMAIL_STORAGE_KEY_LEGACY,
+  MARKETING_SITE_URL,
+  brandAssets,
+} from '../brand'
 
 const fieldClass =
   'w-full rounded-xl border border-white/10 bg-white/[0.06] px-3.5 py-3 text-[0.9375rem] text-slate-100 placeholder:text-slate-500 shadow-inner shadow-black/20 backdrop-blur-sm transition-colors focus:border-cyan-400/50 focus:outline-none focus:ring-2 focus:ring-cyan-400/25'
@@ -179,12 +185,12 @@ export function Login() {
             Use o usuário cadastrado pelo administrador. Problemas para acessar? Contate o suporte interno.
           </p>
           <p className="text-center">
-            <Link
-              to="/"
+            <a
+              href={MARKETING_SITE_URL}
               className="inline-flex items-center gap-1.5 rounded-lg border border-white/15 bg-white/[0.06] px-4 py-2.5 text-sm font-medium text-sky-300 transition hover:border-sky-400/40 hover:bg-white/10 hover:text-sky-200"
             >
               ← Voltar ao site
-            </Link>
+            </a>
           </p>
         </div>
       </main>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -11,9 +11,21 @@ import {
   MARKETING_SITE_URL,
   brandAssets,
 } from '../brand'
+import { landingMailtoHref } from '../content/landing'
+import {
+  buildSessionHandoffUrl,
+  isMarketingHost,
+  loginAgainstClientInstance,
+  normalizeClientSlug,
+  readRememberedAccount,
+  writeRememberedAccount,
+} from '../lib/marketingHost'
 
 const fieldClass =
   'w-full rounded-xl border border-white/10 bg-white/[0.06] px-3.5 py-3 text-[0.9375rem] text-slate-100 placeholder:text-slate-500 shadow-inner shadow-black/20 backdrop-blur-sm transition-colors focus:border-cyan-400/50 focus:outline-none focus:ring-2 focus:ring-cyan-400/25'
+
+const secondaryLinkClass =
+  'inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-white/15 bg-white/[0.06] px-4 py-2.5 text-sm font-medium transition hover:border-sky-400/40 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/40'
 
 function readRememberedEmail(): string {
   try {
@@ -40,7 +52,209 @@ function LoginBackground() {
   )
 }
 
-export function Login() {
+function LoginShell({ children, footer }: { children: React.ReactNode; footer: React.ReactNode }) {
+  return (
+    <div
+      className="relative min-h-dvh font-sans text-slate-100 antialiased"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+    >
+      <LoginBackground />
+      <main className="relative flex min-h-dvh flex-col items-center justify-center px-4 py-10 sm:px-8">
+        <div className="w-full max-w-[400px] space-y-8 sm:space-y-10">
+          <header className="flex w-full justify-center">
+            <BrandLogo
+              variant="full"
+              size="lg"
+              markVariant="onDark"
+              className="flex-col items-center gap-4 sm:flex-row sm:items-center sm:justify-center sm:gap-5"
+            />
+          </header>
+          <div className="rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 shadow-2xl shadow-black/40 backdrop-blur-md sm:p-6">
+            {children}
+          </div>
+          {footer}
+        </div>
+      </main>
+    </div>
+  )
+}
+
+function PasswordToggle({
+  mostrarSenha,
+  onToggle,
+}: {
+  mostrarSenha: boolean
+  onToggle: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="absolute right-1.5 top-1/2 flex size-10 -translate-y-1/2 items-center justify-center rounded-lg text-cyan-400/85 transition-colors hover:bg-white/5 hover:text-cyan-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/40"
+      aria-label={mostrarSenha ? 'Ocultar senha' : 'Mostrar senha'}
+      aria-pressed={mostrarSenha}
+    >
+      {mostrarSenha ? (
+        <svg className="size-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+        </svg>
+      ) : (
+        <svg className="size-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+        </svg>
+      )}
+    </button>
+  )
+}
+
+/** Apex comercial: conta + e-mail + senha → autentica na API do cliente e entra no painel. */
+function LoginConta() {
+  const [conta, setConta] = useState(readRememberedAccount)
+  const [email, setEmail] = useState(readRememberedEmail)
+  const [senha, setSenha] = useState('')
+  const [lembrarMe, setLembrarMe] = useState(() => !!readRememberedEmail())
+  const [mostrarSenha, setMostrarSenha] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const { showError } = useToast()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    const slug = normalizeClientSlug(conta)
+    if (!slug) {
+      showError('Informe a conta da empresa (ex.: suaempresa), só letras minúsculas, números e hífen.')
+      return
+    }
+    if (!email.trim() || !senha.trim()) {
+      showError('Informe e-mail e senha.')
+      return
+    }
+    if (!email.includes('@')) {
+      showError('Informe um e-mail válido.')
+      return
+    }
+
+    setLoading(true)
+    try {
+      const tokens = await loginAgainstClientInstance(slug, email.trim(), senha)
+      writeRememberedAccount(slug)
+      try {
+        if (lembrarMe) {
+          localStorage.setItem(LOGIN_EMAIL_STORAGE_KEY, email.trim())
+        } else {
+          localStorage.removeItem(LOGIN_EMAIL_STORAGE_KEY)
+          localStorage.removeItem(LOGIN_EMAIL_STORAGE_KEY_LEGACY)
+        }
+      } catch {
+        /* storage indisponível */
+      }
+      window.location.assign(buildSessionHandoffUrl(slug, tokens, lembrarMe))
+    } catch (err) {
+      showError(mensagemFalhaParaToast(err, 'Falha no login. Verifique conta, e-mail e senha.'))
+      setLoading(false)
+    }
+  }
+
+  return (
+    <LoginShell
+      footer={
+        <div className="space-y-4">
+          <p className="text-center text-xs leading-relaxed text-slate-500">
+            Após validar, você entra direto no painel da sua empresa.
+          </p>
+          <div className="flex flex-col gap-2.5 sm:flex-row sm:justify-center">
+            <a href={MARKETING_SITE_URL} className={`${secondaryLinkClass} text-sky-300 hover:text-sky-200 sm:w-auto`}>
+              ← Voltar ao site
+            </a>
+            <a
+              href={landingMailtoHref()}
+              className={`${secondaryLinkClass} text-cyan-300 hover:text-cyan-200 sm:w-auto`}
+            >
+              Solicitar uma demonstração
+            </a>
+          </div>
+        </div>
+      }
+    >
+      <form onSubmit={handleSubmit} className="space-y-5" noValidate>
+        <div>
+          <label htmlFor="login-conta" className="mb-1.5 block text-sm font-medium text-slate-300">
+            Conta da empresa
+          </label>
+          <input
+            id="login-conta"
+            type="text"
+            value={conta}
+            onChange={(e) => setConta(e.target.value.toLowerCase())}
+            autoComplete="organization"
+            autoCapitalize="none"
+            autoCorrect="off"
+            spellCheck={false}
+            placeholder="ex.: suaempresa"
+            className={fieldClass}
+          />
+          <p className="mt-2 text-xs leading-relaxed text-slate-500">
+            Sem espaços. Em geral é o nome curto da empresa (o mesmo do subdomínio).
+          </p>
+        </div>
+
+        <div>
+          <label htmlFor="login-email-apex" className="mb-1.5 block text-sm font-medium text-slate-300">
+            E-mail
+          </label>
+          <input
+            id="login-email-apex"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+            placeholder="nome@empresa.com"
+            className={fieldClass}
+          />
+        </div>
+
+        <div>
+          <label htmlFor="login-senha-apex" className="mb-1.5 block text-sm font-medium text-slate-300">
+            Senha
+          </label>
+          <div className="relative">
+            <input
+              id="login-senha-apex"
+              type={mostrarSenha ? 'text' : 'password'}
+              value={senha}
+              onChange={(e) => setSenha(e.target.value)}
+              autoComplete="current-password"
+              placeholder="••••••••"
+              className={`${fieldClass} pr-12`}
+            />
+            <PasswordToggle mostrarSenha={mostrarSenha} onToggle={() => setMostrarSenha((v) => !v)} />
+          </div>
+        </div>
+
+        <label className="flex cursor-pointer items-start gap-3 text-sm text-slate-400">
+          <input
+            type="checkbox"
+            checked={lembrarMe}
+            onChange={(e) => setLembrarMe(e.target.checked)}
+            className="mt-0.5 size-4 shrink-0 rounded border-white/20 bg-white/[0.06] text-cyan-500 accent-cyan-500 focus:ring-2 focus:ring-cyan-400/30"
+          />
+          <span>Lembrar-me neste dispositivo</span>
+        </label>
+
+        <Button
+          type="submit"
+          className="w-full rounded-xl py-3 text-base font-semibold shadow-lg shadow-cyan-500/25 focus-visible:ring-offset-[#050810] disabled:opacity-60"
+          loading={loading}
+        >
+          Entrar
+        </Button>
+      </form>
+    </LoginShell>
+  )
+}
+
+/** Subdomínio do cliente: e-mail + senha na API da instância. */
+function LoginCredenciais() {
   const [email, setEmail] = useState(readRememberedEmail)
   const [senha, setSenha] = useState('')
   const [lembrarMe, setLembrarMe] = useState(() => !!readRememberedEmail())
@@ -83,117 +297,85 @@ export function Login() {
   }
 
   return (
-    <div
-      className="relative min-h-dvh font-sans text-slate-100 antialiased"
-      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
-    >
-      <LoginBackground />
-
-      <main className="relative flex min-h-dvh flex-col items-center justify-center px-4 py-10 sm:px-8">
-        <div className="w-full max-w-[400px] space-y-8 sm:space-y-10">
-          <header className="flex w-full justify-center">
-            <BrandLogo
-              variant="full"
-              size="lg"
-              markVariant="onDark"
-              className="flex-col items-center gap-4 sm:flex-row sm:items-center sm:justify-center sm:gap-5"
-            />
-          </header>
-
-          <div className="rounded-2xl border border-white/[0.08] bg-white/[0.03] p-5 shadow-2xl shadow-black/40 backdrop-blur-md sm:p-6">
-            <form onSubmit={handleSubmit} className="space-y-5" noValidate>
-              <div>
-                <label htmlFor="login-email" className="mb-1.5 block text-sm font-medium text-slate-300">
-                  E-mail
-                </label>
-                <input
-                  id="login-email"
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  autoComplete="email"
-                  placeholder="nome@empresa.com"
-                  className={fieldClass}
-                />
-              </div>
-
-              <div>
-                <label htmlFor="login-senha" className="mb-1.5 block text-sm font-medium text-slate-300">
-                  Senha
-                </label>
-                <div className="relative">
-                  <input
-                    id="login-senha"
-                    type={mostrarSenha ? 'text' : 'password'}
-                    value={senha}
-                    onChange={(e) => setSenha(e.target.value)}
-                    autoComplete="current-password"
-                    placeholder="••••••••"
-                    className={`${fieldClass} pr-12`}
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setMostrarSenha((v) => !v)}
-                    className="absolute right-1.5 top-1/2 flex size-10 -translate-y-1/2 items-center justify-center rounded-lg text-cyan-400/85 transition-colors hover:bg-white/5 hover:text-cyan-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/40"
-                    aria-label={mostrarSenha ? 'Ocultar senha' : 'Mostrar senha'}
-                    aria-pressed={mostrarSenha}
-                  >
-                    {mostrarSenha ? (
-                      <svg className="size-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
-                      </svg>
-                    ) : (
-                      <svg className="size-5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" aria-hidden>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                      </svg>
-                    )}
-                  </button>
-                </div>
-              </div>
-
-              <div className="text-right">
-                <Link
-                  to="/esqueci-senha"
-                  className="text-sm text-cyan-400/90 transition-colors hover:text-cyan-300"
-                >
-                  Esqueci minha senha
-                </Link>
-              </div>
-
-              <label className="flex cursor-pointer items-start gap-3 text-sm text-slate-400">
-                <input
-                  type="checkbox"
-                  checked={lembrarMe}
-                  onChange={(e) => setLembrarMe(e.target.checked)}
-                  className="mt-0.5 size-4 shrink-0 rounded border-white/20 bg-white/[0.06] text-cyan-500 accent-cyan-500 focus:ring-2 focus:ring-cyan-400/30"
-                />
-                <span>Lembrar-me neste dispositivo</span>
-              </label>
-
-              <Button
-                type="submit"
-                className="w-full rounded-xl py-3 text-base font-semibold shadow-lg shadow-cyan-500/25 focus-visible:ring-offset-[#050810] disabled:opacity-60"
-                loading={loading}
-              >
-                Entrar
-              </Button>
-            </form>
-          </div>
-
+    <LoginShell
+      footer={
+        <>
           <p className="text-center text-xs leading-relaxed text-slate-500">
             Use o usuário cadastrado pelo administrador. Problemas para acessar? Contate o suporte interno.
           </p>
           <p className="text-center">
-            <a
-              href={MARKETING_SITE_URL}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-white/15 bg-white/[0.06] px-4 py-2.5 text-sm font-medium text-sky-300 transition hover:border-sky-400/40 hover:bg-white/10 hover:text-sky-200"
-            >
+            <a href={MARKETING_SITE_URL} className={`${secondaryLinkClass} text-sky-300 hover:text-sky-200`}>
               ← Voltar ao site
             </a>
           </p>
+        </>
+      }
+    >
+      <form onSubmit={handleSubmit} className="space-y-5" noValidate>
+        <div>
+          <label htmlFor="login-email" className="mb-1.5 block text-sm font-medium text-slate-300">
+            E-mail
+          </label>
+          <input
+            id="login-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+            placeholder="nome@empresa.com"
+            className={fieldClass}
+          />
         </div>
-      </main>
-    </div>
+
+        <div>
+          <label htmlFor="login-senha" className="mb-1.5 block text-sm font-medium text-slate-300">
+            Senha
+          </label>
+          <div className="relative">
+            <input
+              id="login-senha"
+              type={mostrarSenha ? 'text' : 'password'}
+              value={senha}
+              onChange={(e) => setSenha(e.target.value)}
+              autoComplete="current-password"
+              placeholder="••••••••"
+              className={`${fieldClass} pr-12`}
+            />
+            <PasswordToggle mostrarSenha={mostrarSenha} onToggle={() => setMostrarSenha((v) => !v)} />
+          </div>
+        </div>
+
+        <div className="text-right">
+          <Link to="/esqueci-senha" className="text-sm text-cyan-400/90 transition-colors hover:text-cyan-300">
+            Esqueci minha senha
+          </Link>
+        </div>
+
+        <label className="flex cursor-pointer items-start gap-3 text-sm text-slate-400">
+          <input
+            type="checkbox"
+            checked={lembrarMe}
+            onChange={(e) => setLembrarMe(e.target.checked)}
+            className="mt-0.5 size-4 shrink-0 rounded border-white/20 bg-white/[0.06] text-cyan-500 accent-cyan-500 focus:ring-2 focus:ring-cyan-400/30"
+          />
+          <span>Lembrar-me neste dispositivo</span>
+        </label>
+
+        <Button
+          type="submit"
+          className="w-full rounded-xl py-3 text-base font-semibold shadow-lg shadow-cyan-500/25 focus-visible:ring-offset-[#050810] disabled:opacity-60"
+          loading={loading}
+        >
+          Entrar
+        </Button>
+      </form>
+    </LoginShell>
   )
+}
+
+export function Login() {
+  if (isMarketingHost()) {
+    return <LoginConta />
+  }
+  return <LoginCredenciais />
 }

--- a/frontend/src/pages/chat/ChatHubLayout.tsx
+++ b/frontend/src/pages/chat/ChatHubLayout.tsx
@@ -8,8 +8,8 @@ import { ChatListaEspera } from './ChatListaEspera'
 import { ChatListaContatos } from './ChatListaContatos'
 
 function ChatHubLista() {
-  const { pathname } = useLocation()
-  const modo = chatHubModoDePath(pathname)
+  const { pathname, search } = useLocation()
+  const modo = chatHubModoDePath(pathname, search)
 
   switch (modo) {
     case 'espera':
@@ -24,8 +24,8 @@ function ChatHubLista() {
 }
 
 export function ChatHubLayout() {
-  const { pathname } = useLocation()
-  const modo = chatHubModoDePath(pathname)
+  const { pathname, search } = useLocation()
+  const modo = chatHubModoDePath(pathname, search)
   const emConversa =
     /\/chat\/c\/\d+/.test(pathname) ||
     /\/chat\/portal\/\d+/.test(pathname) ||

--- a/frontend/src/pages/chat/ChatListaAtendendo.tsx
+++ b/frontend/src/pages/chat/ChatListaAtendendo.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState, type ReactNode } from 'react'
 import { Link, useMatch } from 'react-router-dom'
 import { portalChats, whatsappChats } from '../../api/client'
 import { ChatCanalBadge } from '../../components/chat/ChatCanalBadge'
+import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
 import { useAuth } from '../../contexts/AuthContext'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { useEventStream } from '../../contexts/EventStreamContext'
@@ -64,13 +65,13 @@ function ChatAtendendoItem({
           variant === 'outro' ? 'border-l-2 border-slate-300 pl-[10px] dark:border-slate-600' : ''
         }`}
       >
-        <div
-          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold ${
+        <WhatsappAvatar
+          nome={item.nome}
+          fotoUrl={item.canal === 'whatsapp' ? item.foto_perfil_url : null}
+          fallbackClassName={
             ativo ? 'bg-cyan-600 text-white' : 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-200'
-          }`}
-        >
-          {item.nome.charAt(0)?.toUpperCase() || '?'}
-        </div>
+          }
+        />
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-2">
             <div className="flex min-w-0 flex-1 items-center gap-1.5">

--- a/frontend/src/pages/chat/ChatListaEspera.tsx
+++ b/frontend/src/pages/chat/ChatListaEspera.tsx
@@ -1,12 +1,16 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { ApiError, portalChats, whatsappChats } from '../../api/client'
+import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsappSetorModal'
 import { ChatCanalBadge } from '../../components/chat/ChatCanalBadge'
+import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
 import { Button } from '../../components/ui/Button'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useAuth } from '../../contexts/AuthContext'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { useEventStream } from '../../contexts/EventStreamContext'
+import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import {
   chatHubItemKey,
@@ -51,12 +55,14 @@ type Props = {
 
 export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerChat }: Props = {}) {
   const toast = useToast()
+  const { user } = useAuth()
   const navigate = useNavigate()
   const { busca, refreshContagens } = useChatHub()
   const { subscribe, useFallback } = useEventStream()
   const [fila, setFila] = useState<ChatHubItem[]>([])
   const [loading, setLoading] = useState(true)
   const [assumindoKey, setAssumindoKey] = useState<string | null>(null)
+  const [pendenteSetor, setPendenteSetor] = useState<ChatHubItem | null>(null)
 
   const load = useCallback(async () => {
     try {
@@ -88,17 +94,18 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
     }
   }, [subscribe, load])
 
-  async function assumir(item: ChatHubItem) {
+  async function executarAssumir(item: ChatHubItem, setorId?: number) {
     const key = chatHubItemKey(item)
     setAssumindoKey(key)
     try {
       if (item.canal === 'whatsapp') {
-        await whatsappChats.assumir(item.id)
+        await whatsappChats.assumir(item.id, setorId != null ? { setor_id: setorId } : undefined)
         toast.showSuccess('Chat assumido.')
       } else {
         await portalChats.assumir(item.id)
         toast.showSuccess('Chat assumido.')
       }
+      setPendenteSetor(null)
       await load()
       void refreshContagens()
       void refetchPendenciasResumo()
@@ -118,6 +125,17 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
     }
   }
 
+  function assumir(item: ChatHubItem) {
+    if (
+      item.canal === 'whatsapp' &&
+      precisaEscolherSetorAoAssumir(user, Boolean(item.setor_nome))
+    ) {
+      setPendenteSetor(item)
+      return
+    }
+    void executarAssumir(item)
+  }
+
   const lista = ignorarBusca ? fila : filtrarChatHubPorBusca(fila, busca)
 
   if (loading) {
@@ -133,13 +151,16 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
   }
 
   return (
+    <>
     <ul className="divide-y divide-slate-100 dark:divide-slate-800">
       {lista.map((c) => (
         <li key={chatHubItemKey(c)} className="px-3 py-3">
           <div className="flex gap-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-amber-100 text-sm font-bold text-amber-800 dark:bg-amber-950/50 dark:text-amber-200">
-              {c.nome.charAt(0)?.toUpperCase() || '?'}
-            </div>
+            <WhatsappAvatar
+              nome={c.nome}
+              fotoUrl={c.canal === 'whatsapp' ? c.foto_perfil_url : null}
+              fallbackClassName="bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-200"
+            />
             <div className="min-w-0 flex-1">
               <div className="flex items-start justify-between gap-2">
                 <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">{c.nome}</p>
@@ -176,5 +197,16 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
         </li>
       ))}
     </ul>
+    <AssumirWhatsappSetorModal
+      open={pendenteSetor != null}
+      setorIds={user?.setor_ids || []}
+      loading={pendenteSetor != null && assumindoKey === chatHubItemKey(pendenteSetor)}
+      onClose={() => setPendenteSetor(null)}
+      onConfirm={(setorId) => {
+        if (!pendenteSetor) return
+        void executarAssumir(pendenteSetor, setorId)
+      }}
+    />
+    </>
   )
 }

--- a/frontend/src/pages/chat/PortalConversa.tsx
+++ b/frontend/src/pages/chat/PortalConversa.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
-import { fetchPortalMidiaBlob, portalChats, type PortalChats } from '../../api/client'
+import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { ApiError, fetchPortalMidiaBlob, portalChats, type PortalChats } from '../../api/client'
 import { ChatCanalBadge } from '../../components/chat/ChatCanalBadge'
 import { ChatDemandasPanel } from '../../components/chat/ChatDemandasPanel'
 import { ChatEncerrarModal } from '../../components/chat/ChatEncerrarModal'
 import { ChatFilaAguardandoSheet } from '../../components/chat/ChatFilaAguardandoSheet'
+import { ChatFilaSomToggle } from '../../components/chat/ChatFilaSomToggle'
 import { ChatMensagemMidia } from '../../components/chat/ChatMensagemMidia'
 import { ChatTransferModal } from '../../components/chat/ChatTransferModal'
 import { Button } from '../../components/ui/Button'
@@ -16,7 +17,7 @@ import { useEventStream } from '../../contexts/EventStreamContext'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
 import { portalDemandasApi, type ChatDemanda } from '../../lib/chatDemandasApi'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
-import { CHAT_HUB_PATHS } from '../../lib/chatHubPaths'
+import { CHAT_HUB_PATHS, chatPortalLink } from '../../lib/chatHubPaths'
 import { mensagemTransferenciaSucesso, rotuloEstadoChat, rotuloResponsavelChat } from '../../lib/whatsappChatMeta'
 import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
 import { WhatsappDemandaTimelineMarco } from '../whatsapp/WhatsappDemandaTimelineMarco'
@@ -61,6 +62,8 @@ export function PortalConversa() {
   const { chatId: chatIdParam } = useParams()
   const chatId = Number(chatIdParam)
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const fromEspera = searchParams.get('from') === 'espera'
   const toast = useToast()
   const { user } = useAuth()
   const { subscribe, useFallback } = useEventStream()
@@ -71,6 +74,7 @@ export function PortalConversa() {
   const [texto, setTexto] = useState('')
   const [loading, setLoading] = useState(true)
   const [enviando, setEnviando] = useState(false)
+  const [assumindo, setAssumindo] = useState(false)
   const [modalEncerrar, setModalEncerrar] = useState(false)
   const [modalTransferir, setModalTransferir] = useState(false)
   const [transferindo, setTransferindo] = useState(false)
@@ -219,9 +223,30 @@ export function PortalConversa() {
     if (fileInputRef.current) fileInputRef.current.value = ''
   }
 
+  async function assumirChat() {
+    if (!chat || chat.estado !== 'aguardando_atendente' || assumindo) return
+    setAssumindo(true)
+    try {
+      const atualizado = await portalChats.assumir(chat.id)
+      setChat(atualizado)
+      void refreshContagens()
+      void refetchPendenciasResumo()
+      toast.showSuccess('Chat assumido.')
+      navigate(chatPortalLink(chat.id), { replace: true })
+    } catch (err) {
+      const msg =
+        err instanceof ApiError && err.status === 400
+          ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'
+          : mensagemFalhaParaToast(err)
+      toast.showWarning(msg)
+    } finally {
+      setAssumindo(false)
+    }
+  }
+
   async function confirmarEnvioMidia() {
     const responsavel = chat?.estado === 'em_atendimento' && chat.atendente_id === user?.id
-    if (!arquivoPendente || !Number.isFinite(chatId) || !responsavel) return
+    if (!arquivoPendente || !Number.isFinite(chatId) || !responsavel || enviando) return
     setEnviando(true)
     try {
       const msg = await portalChats.enviarMidia(chatId, arquivoPendente, legendaMidia.trim())
@@ -319,7 +344,10 @@ export function PortalConversa() {
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-white dark:bg-slate-950">
       <header className="flex shrink-0 items-center justify-between gap-3 border-b border-slate-200 bg-white px-4 py-3 dark:border-slate-800 dark:bg-slate-950">
         <div className="min-w-0">
-          <Link to={CHAT_HUB_PATHS.atendendo} className="text-xs text-cyan-600 hover:underline md:hidden">
+          <Link
+            to={fromEspera ? CHAT_HUB_PATHS.espera : CHAT_HUB_PATHS.atendendo}
+            className="text-xs text-cyan-600 hover:underline md:hidden"
+          >
             ← Voltar
           </Link>
           <div className="mt-0.5 flex flex-wrap items-center gap-2">
@@ -339,20 +367,35 @@ export function PortalConversa() {
         </div>
 
         <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant="secondary"
-            className="relative h-8 shrink-0 px-2.5 text-xs font-semibold md:hidden"
-            onClick={() => setFilaAguardandoAberta(true)}
-            aria-label={filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'}
-          >
-            Aguardando
-            {filaCount > 0 && (
-              <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
-                {filaCount > 99 ? '99+' : filaCount}
-              </span>
-            )}
-          </Button>
+          <div className="flex items-center gap-0.5 md:hidden">
+            <Button
+              type="button"
+              variant="secondary"
+              className="relative h-8 shrink-0 px-2.5 text-xs font-semibold"
+              onClick={() => setFilaAguardandoAberta(true)}
+              aria-label={filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'}
+            >
+              Aguardando
+              {filaCount > 0 && (
+                <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
+                  {filaCount > 99 ? '99+' : filaCount}
+                </span>
+              )}
+            </Button>
+            <ChatFilaSomToggle />
+          </div>
+
+          {chat.estado === 'aguardando_atendente' && (
+            <Button
+              type="button"
+              variant="primary"
+              className="h-8 shrink-0 px-3 text-xs font-semibold"
+              loading={assumindo}
+              onClick={() => void assumirChat()}
+            >
+              Atender
+            </Button>
+          )}
 
           {!encerrado && (
             <>
@@ -496,13 +539,33 @@ export function PortalConversa() {
             : 'Este atendimento foi encerrado.'}
         </p>
       ) : chat.estado === 'aguardando_atendente' ? (
-        <p className="shrink-0 border-t border-slate-200 bg-amber-50 px-4 py-3 text-center text-sm text-amber-800 dark:border-slate-800 dark:bg-amber-950/30 dark:text-amber-200">
-          Assuma o chat na lista para responder.
-        </p>
+        <div className="flex shrink-0 flex-col items-center gap-2 border-t border-slate-200 bg-amber-50 px-4 py-3 dark:border-slate-800 dark:bg-amber-950/30">
+          <p className="text-center text-sm text-amber-800 dark:text-amber-200">
+            Este chat está na fila. Assuma para responder ao visitante.
+          </p>
+          <Button
+            type="button"
+            variant="primary"
+            className="h-9 px-4 text-sm font-semibold"
+            loading={assumindo}
+            onClick={() => void assumirChat()}
+          >
+            Atender
+          </Button>
+        </div>
       ) : (
         <div className="shrink-0 border-t border-slate-200 bg-white p-3 dark:border-slate-800 dark:bg-slate-950">
           {arquivoPendente ? (
-            <div className="mb-2 rounded-xl border border-cyan-200 bg-cyan-50/80 p-3 dark:border-cyan-900/40 dark:bg-cyan-950/20">
+            <div
+              className="mb-2 rounded-xl border border-cyan-200 bg-cyan-50/80 p-3 dark:border-cyan-900/40 dark:bg-cyan-950/20"
+              tabIndex={arquivoPendente.type.startsWith('audio/') ? 0 : undefined}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey && !enviando && podeEnviar) {
+                  e.preventDefault()
+                  void confirmarEnvioMidia()
+                }
+              }}
+            >
               <div className="flex flex-wrap items-start justify-between gap-2">
                 <div className="min-w-0 flex-1">
                   <p className="text-xs font-bold text-cyan-800 dark:text-cyan-300">Anexo selecionado</p>
@@ -526,6 +589,12 @@ export function PortalConversa() {
                   type="text"
                   value={legendaMidia}
                   onChange={(e) => setLegendaMidia(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                      e.preventDefault()
+                      if (!enviando && podeEnviar) void confirmarEnvioMidia()
+                    }
+                  }}
                   placeholder="Legenda opcional"
                   className="mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900"
                 />

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -1,8 +1,12 @@
 import { useCallback, useEffect, useState, useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { ApiError, whatsappChats, type WhatsappChats } from '../../api/client'
+import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsappSetorModal'
+import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
 import { whatsappConversaLink, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
+import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
+import { useAuth } from '../../contexts/AuthContext'
 import { useEventStream } from '../../contexts/EventStreamContext'
 import { Card } from '../../components/ui/Card'
 import { Button } from '../../components/ui/Button'
@@ -40,10 +44,13 @@ function TempoEspera({ data }: { data?: string | null }) {
 
 export function WhatsappAtendendo() {
   const toast = useToast()
+  const { user } = useAuth()
   const { subscribe, useFallback } = useEventStream()
   const [fila, setFila] = useState<WhatsappChats.Chat[]>([])
   const [meus, setMeus] = useState<WhatsappChats.Chat[]>([])
   const [loading, setLoading] = useState(true)
+  const [assumindoId, setAssumindoId] = useState<number | null>(null)
+  const [pendenteSetor, setPendenteSetor] = useState<WhatsappChats.Chat | null>(null)
   const isFirstLoad = useRef(true)
   const prevFilaCount = useRef(0)
 
@@ -90,9 +97,11 @@ export function WhatsappAtendendo() {
     prevFilaCount.current = fila.length
   }, [fila.length])
 
-  async function assumir(id: number) {
+  async function executarAssumir(chat: WhatsappChats.Chat, setorId?: number) {
+    setAssumindoId(chat.id)
     try {
-      await whatsappChats.assumir(id)
+      await whatsappChats.assumir(chat.id, setorId != null ? { setor_id: setorId } : undefined)
+      setPendenteSetor(null)
       toast.showSuccess('Chat assumido com sucesso!')
       await load(true)
       void refetchPendenciasResumo()
@@ -102,7 +111,17 @@ export function WhatsappAtendendo() {
           ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'
           : mensagemFalhaParaToast(err)
       toast.showWarning(msg)
+    } finally {
+      setAssumindoId(null)
     }
+  }
+
+  function assumir(chat: WhatsappChats.Chat) {
+    if (precisaEscolherSetorAoAssumir(user, Boolean(chat.setor_id || chat.setor_nome))) {
+      setPendenteSetor(chat)
+      return
+    }
+    void executarAssumir(chat)
   }
 
   const meusAtivos = meus.filter((c) => c.estado === 'em_atendimento')
@@ -162,8 +181,14 @@ export function WhatsappAtendendo() {
               fila.map((c) => (
                 <Card key={c.id} className="border-none p-4 shadow-sm ring-1 ring-slate-200 dark:ring-slate-800">
                   <div className="flex flex-col gap-4">
-                    <div className="flex items-start justify-between">
-                      <div className="min-w-0">
+                    <div className="flex items-start justify-between gap-3">
+                      <WhatsappAvatar
+                        nome={c.cliente_nome}
+                        fotoUrl={c.foto_perfil_url}
+                        className="h-10 w-10"
+                        fallbackClassName="bg-amber-100 text-amber-800 dark:bg-amber-950/50 dark:text-amber-200"
+                      />
+                      <div className="min-w-0 flex-1">
                         <div className="mb-1 flex items-center gap-2">
                           <span
                             className="min-w-0 truncate font-mono text-[10px] font-bold text-cyan-600"
@@ -204,7 +229,8 @@ export function WhatsappAtendendo() {
                         Visualizar
                       </Link>
                       <Button
-                        onClick={() => void assumir(c.id)}
+                        loading={assumindoId === c.id}
+                        onClick={() => assumir(c)}
                         className="flex-1 bg-amber-500 text-white hover:bg-amber-600"
                       >
                         Atender
@@ -323,6 +349,16 @@ export function WhatsappAtendendo() {
           </div>
         </section>
       </div>
+      <AssumirWhatsappSetorModal
+        open={pendenteSetor != null}
+        setorIds={user?.setor_ids || []}
+        loading={pendenteSetor != null && assumindoId === pendenteSetor.id}
+        onClose={() => setPendenteSetor(null)}
+        onConfirm={(setorId) => {
+          if (!pendenteSetor) return
+          void executarAssumir(pendenteSetor, setorId)
+        }}
+      />
     </div>
   )
 }

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useRef, type MouseEvent } from 'react'
+import { useCallback, useEffect, useMemo, useState, useRef, type MouseEvent } from 'react'
 
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
@@ -28,6 +28,9 @@ import {
   scrollWhatsappToBottom,
 } from '../../lib/whatsappScrollMemory'
 import { MensagemRodapeMeta } from '../../components/chat/MensagemRodapeMeta'
+import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsappSetorModal'
+import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
+import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
 
 import { Card } from '../../components/ui/Card'
 import { TEXTAREA_FIELD_CLASS } from '../../components/ui/Input'
@@ -106,7 +109,15 @@ function TextoComLinks({ texto }: { texto: string }) {
   )
 }
 
-function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number; m: WhatsappChats.Mensagem; onImageClick: (url: string, caption: string | null) => void }) {
+function ConteudoMensagemWhatsApp({
+  chatId,
+  m,
+  onImageClick,
+}: {
+  chatId: number
+  m: WhatsappChats.Mensagem
+  onImageClick: (msgId: number) => void
+}) {
 
   const tipo = (m.tipo_midia || 'texto').toLowerCase()
 
@@ -183,7 +194,7 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
           src={url}
           alt=""
           className={`${mediaClass} cursor-zoom-in transition-transform duration-200 hover:scale-[1.02]`}
-          onClick={() => onImageClick(url, legenda)}
+          onClick={() => onImageClick(m.id)}
         />
         {legenda ? <TextoComLinks texto={legenda} /> : null}
       </div>
@@ -218,6 +229,141 @@ function ConteudoMensagemWhatsApp({ chatId, m, onImageClick }: { chatId: number;
 }
 
 
+
+/** Lightbox com galeria só de imagens (#629). */
+function WhatsappZoomLightbox({
+  chatId,
+  msgs,
+  zoomMsgId,
+  onClose,
+  onChangeMsgId,
+}: {
+  chatId: number
+  msgs: WhatsappChats.Mensagem[]
+  zoomMsgId: number
+  onClose: () => void
+  onChangeMsgId: (msgId: number) => void
+}) {
+  const galeria = useMemo(
+    () =>
+      msgs.filter(
+        (m) => (m.tipo_midia || '').toLowerCase() === 'imagem' && m.midia_disponivel,
+      ),
+    [msgs],
+  )
+  const index = galeria.findIndex((m) => m.id === zoomMsgId)
+  const msgAtiva = msgs.find((m) => m.id === zoomMsgId) || null
+  const caption = msgAtiva ? legendaMidiaVisivel(msgAtiva.corpo) : null
+  const [url, setUrl] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setUrl(null)
+    void resolveWhatsappMidiaObjectUrl(chatId, zoomMsgId, () => fetchWhatsAppMidiaBlob(chatId, zoomMsgId))
+      .then((u) => {
+        if (!cancelled) setUrl(u)
+      })
+      .catch(() => {
+        if (!cancelled) setUrl(null)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [chatId, zoomMsgId])
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
+      if (index < 0 || galeria.length <= 1) return
+      e.preventDefault()
+      e.stopPropagation()
+      if (e.key === 'ArrowLeft' && index > 0) onChangeMsgId(galeria[index - 1].id)
+      if (e.key === 'ArrowRight' && index < galeria.length - 1) onChangeMsgId(galeria[index + 1].id)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [galeria, index, onChangeMsgId])
+
+  const podePrev = index > 0
+  const podeNext = index >= 0 && index < galeria.length - 1
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex flex-col items-center justify-center bg-black/90 p-4 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={onClose}
+    >
+      <button
+        type="button"
+        className="absolute top-4 right-4 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white/10 text-3xl font-bold text-white transition-colors touch-manipulation hover:bg-white/20"
+        onClick={onClose}
+        aria-label="Fechar"
+      >
+        &times;
+      </button>
+      {index >= 0 && galeria.length > 1 && (
+        <p className="absolute top-5 left-1/2 -translate-x-1/2 text-sm font-medium text-white/80">
+          {index + 1} / {galeria.length}
+        </p>
+      )}
+      {podePrev && (
+        <button
+          type="button"
+          className="absolute left-3 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 text-2xl text-white hover:bg-white/20 sm:left-6"
+          onClick={(e) => {
+            e.stopPropagation()
+            onChangeMsgId(galeria[index - 1].id)
+          }}
+          aria-label="Imagem anterior"
+        >
+          ‹
+        </button>
+      )}
+      {podeNext && (
+        <button
+          type="button"
+          className="absolute right-3 top-1/2 z-10 flex h-12 w-12 -translate-y-1/2 items-center justify-center rounded-full bg-white/10 text-2xl text-white hover:bg-white/20 sm:right-6"
+          onClick={(e) => {
+            e.stopPropagation()
+            onChangeMsgId(galeria[index + 1].id)
+          }}
+          aria-label="Próxima imagem"
+        >
+          ›
+        </button>
+      )}
+      {loading || !url ? (
+        <p className="text-sm text-white/70 animate-pulse">Carregando imagem…</p>
+      ) : (
+        <img
+          src={url}
+          alt=""
+          className="max-h-[85vh] max-w-full rounded-lg object-contain shadow-2xl animate-in zoom-in-95 duration-200"
+          onClick={(e) => e.stopPropagation()}
+        />
+      )}
+      {caption && (
+        <p className="mt-4 max-w-2xl rounded-xl bg-black/40 px-4 py-2 text-center text-sm text-white backdrop-blur-md">
+          {caption}
+        </p>
+      )}
+      {url && (
+        <a
+          href={url}
+          download="whatsapp-imagem.jpg"
+          className="absolute bottom-4 right-4 flex items-center gap-2 rounded-xl bg-cyan-600 px-4 py-2.5 text-xs font-bold text-white shadow-lg shadow-cyan-600/30 transition-all hover:scale-105 hover:bg-cyan-700"
+          onClick={(e) => e.stopPropagation()}
+        >
+          📥 Baixar Imagem
+        </a>
+      )}
+    </div>
+  )
+}
 
 // --- Componente Principal ---
 
@@ -279,9 +425,9 @@ export function WhatsappConversa() {
   // Estados de WhatsApp Clone (Citação e Zoom)
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
   const [focoComposerEm, setFocoComposerEm] = useState(0)
-  const [activeZoomImage, setActiveZoomImage] = useState<string | null>(null)
-  const [activeZoomImageCaption, setActiveZoomImageCaption] = useState<string | null>(null)
+  const [zoomMsgId, setZoomMsgId] = useState<number | null>(null)
   const [modoInterno, setModoInterno] = useState(false)
+  const [modalAssumirSetor, setModalAssumirSetor] = useState(false)
 
   // Transferência
   const [modalTransferir, setModalTransferir] = useState(false)
@@ -324,11 +470,10 @@ export function WhatsappConversa() {
       if (e.key !== 'Escape' || e.defaultPrevented || modalEncerrar) return
       const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase()
       if (tag === 'input' || tag === 'textarea' || tag === 'select') return
-      if (activeZoomImage) {
+      if (zoomMsgId != null) {
         e.preventDefault()
         e.stopPropagation()
-        setActiveZoomImage(null)
-        setActiveZoomImageCaption(null)
+        setZoomMsgId(null)
         return
       }
       if (arquivoPendente) {
@@ -341,7 +486,7 @@ export function WhatsappConversa() {
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [voltarLista, modalEncerrar, activeZoomImage, arquivoPendente])
+  }, [voltarLista, modalEncerrar, zoomMsgId, arquivoPendente])
 
   useEffect(() => {
     if (!menuMobileAberto) return
@@ -854,12 +999,16 @@ useEffect(() => {
     }
   }
 
-  async function assumirChat() {
+  async function executarAssumirChat(setorId?: number) {
     if (!chat || chat.estado !== 'aguardando_atendente' || assumindo) return
     setAssumindo(true)
     try {
-      const atualizado = await whatsappChats.assumir(chat.id)
+      const atualizado = await whatsappChats.assumir(
+        chat.id,
+        setorId != null ? { setor_id: setorId } : undefined,
+      )
       setChat((prev) => mergeWhatsappChat(prev, atualizado))
+      setModalAssumirSetor(false)
       void refreshContagens()
       void refetchPendenciasResumo()
       toast.showSuccess('Chat assumido.')
@@ -873,6 +1022,15 @@ useEffect(() => {
     } finally {
       setAssumindo(false)
     }
+  }
+
+  function assumirChat() {
+    if (!chat || chat.estado !== 'aguardando_atendente' || assumindo) return
+    if (precisaEscolherSetorAoAssumir(user, Boolean(chat.setor_id || chat.setor_nome))) {
+      setModalAssumirSetor(true)
+      return
+    }
+    void executarAssumirChat()
   }
 
   async function enviarFigurinha(file: File) {
@@ -1050,13 +1208,16 @@ useEffect(() => {
 
             >
 
-              <div className={`h-8 w-8 shrink-0 rounded-full flex items-center justify-center text-xs font-bold shadow-sm
-
-                ${c.id === id ? 'bg-cyan-600 text-white' : 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-300'}`}>
-
-                {c.cliente_nome?.charAt(0) || '?'}
-
-              </div>
+              <WhatsappAvatar
+                nome={c.cliente_nome}
+                fotoUrl={c.foto_perfil_url}
+                className="h-8 w-8 text-xs shadow-sm"
+                fallbackClassName={
+                  c.id === id
+                    ? 'bg-cyan-600 text-white'
+                    : 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-300'
+                }
+              />
 
               {sidebarAberta && (
 
@@ -1125,6 +1286,12 @@ useEffect(() => {
               <span className="hidden sm:inline"> Voltar</span>
             </Button>
 
+            <WhatsappAvatar
+              nome={chat?.cliente_nome}
+              fotoUrl={chat?.foto_perfil_url}
+              className="h-9 w-9 text-sm"
+              fallbackClassName="bg-cyan-100 text-cyan-800 dark:bg-cyan-950/50 dark:text-cyan-200"
+            />
             <div className="min-w-0 flex-1">
               <h1 className="truncate font-bold text-slate-900 dark:text-white">
                 {chat?.cliente_nome || 'Atendimento'}
@@ -1319,21 +1486,15 @@ useEffect(() => {
                   {chat.funcionario_nome}
                   {chat.funcionario_tipo ? ` · ${chat.funcionario_tipo}` : ''}
                 </Link>
-                {chat.empresa_nome ? (
-                  podeDefinirEmpresa && (chat.empresas_opcoes?.length ?? 0) > 1 ? (
-                    <button
-                      type="button"
-                      onClick={abrirModalEmpresaContexto}
-                      className="inline-flex max-w-full truncate rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 transition-colors hover:border-cyan-400 hover:text-cyan-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300"
-                      title="Alterar empresa do atendimento"
-                    >
-                      {chat.empresa_nome}
-                    </button>
-                  ) : (
-                    <span className="inline-flex max-w-full truncate rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300">
-                      {chat.empresa_nome}
-                    </span>
-                  )
+                {chat.empresa_nome && chat.empresa_id ? (
+                  <Link
+                    to={`/empresas/${chat.empresa_id}`}
+                    state={{ voltarPara: `${location.pathname}${location.search}` }}
+                    className="inline-flex max-w-full truncate rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-slate-700 transition-colors hover:border-cyan-400 hover:text-cyan-700 dark:border-slate-800 dark:bg-slate-900 dark:text-slate-300 dark:hover:border-cyan-600 dark:hover:text-cyan-300"
+                    title="Ver detalhe da empresa"
+                  >
+                    {chat.empresa_nome}
+                  </Link>
                 ) : podeDefinirEmpresa ? (
                   <button
                     type="button"
@@ -1539,10 +1700,11 @@ useEffect(() => {
                       </div>
                     )}
 
-                    <ConteudoMensagemWhatsApp chatId={id} m={m} onImageClick={(url, caption) => {
-                      setActiveZoomImage(url)
-                      setActiveZoomImageCaption(caption)
-                    }} />
+                    <ConteudoMensagemWhatsApp
+                      chatId={id}
+                      m={m}
+                      onImageClick={(msgId) => setZoomMsgId(msgId)}
+                    />
 
                     {!isSystem && (
                       <MensagemRodapeMeta
@@ -1863,45 +2025,23 @@ useEffect(() => {
         />
       )}
 
-      {/* Modal Zoom de Imagem */}
-      {activeZoomImage && (
-        <div 
-          className="fixed inset-0 z-[200] flex flex-col items-center justify-center bg-black/90 backdrop-blur-sm p-4 animate-in fade-in duration-200"
-          onClick={() => {
-            setActiveZoomImage(null)
-            setActiveZoomImageCaption(null)
-          }}
-        >
-          <button 
-            className="absolute top-4 right-4 text-white text-3xl font-bold bg-white/10 hover:bg-white/20 w-12 h-12 rounded-full flex items-center justify-center transition-colors touch-manipulation cursor-pointer"
-            onClick={() => {
-              setActiveZoomImage(null)
-              setActiveZoomImageCaption(null)
-            }}
-          >
-            &times;
-          </button>
-          <img 
-            src={activeZoomImage} 
-            alt="" 
-            className="max-h-[85vh] max-w-full rounded-lg shadow-2xl object-contain animate-in zoom-in-95 duration-200" 
-            onClick={(e) => e.stopPropagation()} 
-          />
-          {activeZoomImageCaption && (
-            <p className="mt-4 text-white text-sm max-w-2xl text-center bg-black/40 px-4 py-2 rounded-xl backdrop-blur-md">
-              {activeZoomImageCaption}
-            </p>
-          )}
-          <a 
-            href={activeZoomImage} 
-            download="whatsapp-imagem.jpg" 
-            className="absolute bottom-4 right-4 bg-cyan-600 hover:bg-cyan-700 text-white font-bold text-xs px-4 py-2.5 rounded-xl flex items-center gap-2 shadow-lg shadow-cyan-600/30 transition-all hover:scale-105" 
-            onClick={(e) => e.stopPropagation()}
-          >
-            📥 Baixar Imagem
-          </a>
-        </div>
+      {zoomMsgId != null && (
+        <WhatsappZoomLightbox
+          chatId={id}
+          msgs={msgs}
+          zoomMsgId={zoomMsgId}
+          onClose={() => setZoomMsgId(null)}
+          onChangeMsgId={setZoomMsgId}
+        />
       )}
+
+      <AssumirWhatsappSetorModal
+        open={modalAssumirSetor}
+        setorIds={user?.setor_ids || []}
+        loading={assumindo}
+        onClose={() => setModalAssumirSetor(false)}
+        onConfirm={(setorId) => void executarAssumirChat(setorId)}
+      />
 
       {modoHub && (
         <ChatFilaAguardandoSheet

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -30,6 +30,8 @@ import {
 import { MensagemRodapeMeta } from '../../components/chat/MensagemRodapeMeta'
 import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsappSetorModal'
 import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
+import { WhatsappMensagemAcoes } from '../../components/chat/WhatsappMensagemAcoes'
+import { WhatsappReacoesBar } from '../../components/chat/WhatsappReacoesBar'
 import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
 
 import { Card } from '../../components/ui/Card'
@@ -83,6 +85,20 @@ function legendaMidiaVisivel(corpo: string | null | undefined): string | null {
   return t
 }
 
+function normalizarReacoesMensagem(
+  msg: WhatsappChats.Mensagem,
+  viewerId?: number | null,
+): WhatsappChats.Mensagem {
+  if (!msg.reacoes?.length || viewerId == null) return msg
+  return {
+    ...msg,
+    reacoes: msg.reacoes.map((r) => ({
+      ...r,
+      reagiu_eu: Boolean(r.reagiu_eu || r.atendente_ids?.includes(viewerId)),
+    })),
+  }
+}
+
 
 // --- Subcomponente de Renderização de Mídia ---
 
@@ -131,7 +147,7 @@ function ConteudoMensagemWhatsApp({
 
   useEffect(() => {
 
-    if (!m.midia_disponivel || tipo === 'texto') {
+    if (m.apagada || !m.midia_disponivel || tipo === 'texto') {
 
       setUrl(null)
 
@@ -165,9 +181,13 @@ function ConteudoMensagemWhatsApp({
 
     }
 
-  }, [chatId, m.id, m.midia_disponivel, tipo])
+  }, [chatId, m.id, m.midia_disponivel, m.apagada, tipo])
 
 
+
+  if (m.apagada) {
+    return <p className="text-sm italic opacity-70">Mensagem apagada</p>
+  }
 
   const legenda = legendaMidiaVisivel(m.corpo)
 
@@ -719,20 +739,36 @@ export function WhatsappConversa() {
     const chatId = Number(id)
     const unsubMsg = subscribe('chat.mensagem', (payload) => {
       if (Number(payload.chat_id) !== chatId) return
-      const msg = payload.mensagem as WhatsappChats.Mensagem | undefined
-      if (!msg) return
+      const msg = normalizarReacoesMensagem(
+        payload.mensagem as WhatsappChats.Mensagem,
+        userIdRef.current,
+      )
+      if (!msg?.id) return
       setMsgs((prev) => {
+        const mergeMsg = (prevRow: WhatsappChats.Mensagem, incoming: WhatsappChats.Mensagem) => {
+          const merged = { ...prevRow, ...incoming }
+          // SSE omite flags por visualizador; preservar as já conhecidas
+          if (incoming.pode_editar === undefined) merged.pode_editar = prevRow.pode_editar
+          if (incoming.pode_apagar_para_todos === undefined) {
+            merged.pode_apagar_para_todos = prevRow.pode_apagar_para_todos
+          }
+          if (merged.apagada) {
+            merged.pode_editar = false
+            merged.pode_apagar_para_todos = false
+          }
+          return merged
+        }
         const idx = prev.findIndex((m) => m.id === msg.id)
         if (idx >= 0) {
           const next = [...prev]
-          next[idx] = { ...next[idx], ...msg }
+          next[idx] = mergeMsg(next[idx], msg)
           return next
         }
         if (msg.wa_message_id && prev.some((m) => m.wa_message_id === msg.wa_message_id)) {
           const widx = prev.findIndex((m) => m.wa_message_id === msg.wa_message_id)
           if (widx >= 0) {
             const next = [...prev]
-            next[widx] = { ...next[widx], ...msg }
+            next[widx] = mergeMsg(next[widx], msg)
             return next
           }
         }
@@ -1109,6 +1145,52 @@ useEffect(() => {
     isResponsavel &&
     !encerrado &&
     !chat?.classificacao_demanda_pendente
+
+  const podeReagir = Boolean(podeEnviar)
+
+  async function reagirMensagem(m: WhatsappChats.Mensagem, emoji: string) {
+    if (!chat || !podeReagir || m.evento_sistema || m.apagada) return
+    try {
+      const atualizada = await whatsappChats.definirReacao(chat.id, m.id, emoji)
+      setMsgs((prev) =>
+        prev.map((row) =>
+          row.id === atualizada.id ? normalizarReacoesMensagem(atualizada, user?.id) : row,
+        ),
+      )
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao reagir'))
+    }
+  }
+
+  async function editarMensagemWhatsapp(m: WhatsappChats.Mensagem, texto: string) {
+    if (!chat) return
+    try {
+      const atualizada = await whatsappChats.editarMensagem(chat.id, m.id, texto)
+      setMsgs((prev) =>
+        prev.map((row) =>
+          row.id === atualizada.id ? normalizarReacoesMensagem(atualizada, user?.id) : row,
+        ),
+      )
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao editar mensagem'))
+      throw err
+    }
+  }
+
+  async function apagarMensagemWhatsapp(m: WhatsappChats.Mensagem) {
+    if (!chat) return
+    try {
+      const atualizada = await whatsappChats.apagarMensagem(chat.id, m.id)
+      setMsgs((prev) =>
+        prev.map((row) =>
+          row.id === atualizada.id ? normalizarReacoesMensagem(atualizada, user?.id) : row,
+        ),
+      )
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao apagar mensagem'))
+      throw err
+    }
+  }
 
   const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && (isResponsavel || isAdmin)
 
@@ -1644,7 +1726,7 @@ useEffect(() => {
                 onDoubleClick={(e) => duploCliqueResponder(e, m, isSystem)}
                 className={`flex w-full group cursor-default items-center gap-2 transition-all ${isInbound ? 'justify-start' : 'justify-end'}`}
               >
-                {!isInbound && !isSystem && (
+                {!isInbound && !isSystem && !m.apagada && (
                   <button
                     onClick={() => iniciarResposta(m)}
                     className="opacity-25 group-hover:opacity-100 md:opacity-0 transition-opacity p-1.5 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 cursor-pointer shrink-0"
@@ -1654,7 +1736,9 @@ useEffect(() => {
                   </button>
                 )}
 
-                <div className={`max-w-[85%] sm:max-w-[70%] space-y-1 ${isInbound ? 'items-start' : 'items-end'}`}>
+                <div
+                  className={`relative max-w-[85%] space-y-1 sm:max-w-[70%] ${isInbound ? 'items-start' : 'items-end'}`}
+                >
 
                   {isSystem && (
                     <span className="text-[9px] font-bold uppercase px-2 text-amber-600">
@@ -1662,7 +1746,14 @@ useEffect(() => {
                     </span>
                   )}
 
-                 
+                  {!isSystem && !isInbound && (
+                    <WhatsappMensagemAcoes
+                      mensagem={m}
+                      onEditar={(texto) => editarMensagemWhatsapp(m, texto)}
+                      onApagar={() => apagarMensagemWhatsapp(m)}
+                      alinhamento="end"
+                    />
+                  )}
 
                   <div className={`
 
@@ -1676,7 +1767,7 @@ useEffect(() => {
 
                   `}>
 
-                    {m.quoted_wa_message_id && (
+                    {m.quoted_wa_message_id && !m.apagada && (
                       <div 
                         onClick={() => {
                           const el = document.getElementById(`msg-${m.quoted_wa_message_id}`);
@@ -1713,15 +1804,25 @@ useEffect(() => {
                         direcao={m.direcao}
                         eventoSistema={m.evento_sistema}
                         variant={isInbound ? 'escuro' : 'claro'}
+                        editada={m.editada}
                         className={isInbound ? 'text-slate-400' : ''}
                       />
                     )}
 
                   </div>
 
+                  {!isSystem && !m.apagada && (
+                    <WhatsappReacoesBar
+                      reacoes={m.reacoes || []}
+                      podeReagir={podeReagir}
+                      onReagir={podeReagir ? (emoji) => void reagirMensagem(m, emoji) : undefined}
+                      alinhamento={isInbound ? 'start' : 'end'}
+                    />
+                  )}
+
                 </div>
 
-                {isInbound && !isSystem && (
+                {isInbound && !isSystem && !m.apagada && (
                   <button
                     onClick={() => iniciarResposta(m)}
                     className="opacity-25 group-hover:opacity-100 md:opacity-0 transition-opacity p-1.5 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 cursor-pointer shrink-0"

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -3,22 +3,15 @@ import { useCallback, useEffect, useState, useRef, type MouseEvent } from 'react
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
 import {
-
-
+  ApiError,
   atendentes,
   tickets,
   whatsappChats,
-
   fetchWhatsAppMidiaBlob,
-
-
   type Setores,
-
   type Atendentes,
-
   type Tickets,
   type WhatsappChats,
-
 } from '../../api/client'
 
 import { resolveWhatsappMidiaObjectUrl, revokeWhatsappMidiaForChat } from '../../lib/whatsappMidiaCache'
@@ -70,6 +63,8 @@ import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
 import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { ChatFilaAguardandoSheet } from '../../components/chat/ChatFilaAguardandoSheet'
+import { ChatFilaSomToggle } from '../../components/chat/ChatFilaSomToggle'
+import { chatWhatsappLink } from '../../lib/chatHubPaths'
 import { WhatsappInatividadeControle } from './WhatsappInatividadeControle'
 import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
 import { rotuloDownloadArquivo, visualTipoArquivo } from '../../lib/fileTypeIcon'
@@ -312,7 +307,8 @@ export function WhatsappConversa() {
   const [menuMobileAberto, setMenuMobileAberto] = useState(false)
   const menuMobileRef = useRef<HTMLDivElement>(null)
   const [filaAguardandoAberta, setFilaAguardandoAberta] = useState(false)
-  const { filaCount } = useChatHub()
+  const [assumindo, setAssumindo] = useState(false)
+  const { filaCount, refreshContagens } = useChatHub()
   const navigate = useNavigate()
   const location = useLocation()
   const [searchParams] = useSearchParams()
@@ -836,7 +832,7 @@ useEffect(() => {
   }
 
   async function confirmarEnvioMidia() {
-    if (!arquivoPendente || !chat || !podeEnviar) return
+    if (!arquivoPendente || !chat || !podeEnviar || enviando) return
     setEnviando(true)
     try {
       await whatsappChats.enviarMidia(
@@ -855,6 +851,27 @@ useEffect(() => {
       toast.showError(mensagemFalhaParaToast(err, 'Falha no envio do anexo'))
     } finally {
       setEnviando(false)
+    }
+  }
+
+  async function assumirChat() {
+    if (!chat || chat.estado !== 'aguardando_atendente' || assumindo) return
+    setAssumindo(true)
+    try {
+      const atualizado = await whatsappChats.assumir(chat.id)
+      setChat((prev) => mergeWhatsappChat(prev, atualizado))
+      void refreshContagens()
+      void refetchPendenciasResumo()
+      toast.showSuccess('Chat assumido.')
+      navigate(chatWhatsappLink(chat.id, 'atendendo'), { replace: true })
+    } catch (err) {
+      const msg =
+        err instanceof ApiError && err.status === 400
+          ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'
+          : mensagemFalhaParaToast(err)
+      toast.showWarning(msg)
+    } finally {
+      setAssumindo(false)
     }
   }
 
@@ -1117,19 +1134,34 @@ useEffect(() => {
             <div className="flex shrink-0 items-center gap-1 sm:gap-2">
 
               {modoHub && (
+                <div className="flex items-center gap-0.5 md:hidden">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    className="relative h-8 shrink-0 px-2.5 text-xs font-semibold"
+                    onClick={() => setFilaAguardandoAberta(true)}
+                    aria-label={filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'}
+                  >
+                    Aguardando
+                    {filaCount > 0 && (
+                      <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
+                        {filaCount > 99 ? '99+' : filaCount}
+                      </span>
+                    )}
+                  </Button>
+                  <ChatFilaSomToggle />
+                </div>
+              )}
+
+              {chat?.estado === 'aguardando_atendente' && (
                 <Button
                   type="button"
-                  variant="secondary"
-                  className="relative h-8 shrink-0 px-2.5 text-xs font-semibold md:hidden"
-                  onClick={() => setFilaAguardandoAberta(true)}
-                  aria-label={filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'}
+                  variant="primary"
+                  className="h-8 shrink-0 px-3 text-xs font-semibold"
+                  loading={assumindo}
+                  onClick={() => void assumirChat()}
                 >
-                  Aguardando
-                  {filaCount > 0 && (
-                    <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
-                      {filaCount > 99 ? '99+' : filaCount}
-                    </span>
-                  )}
+                  Atender
                 </Button>
               )}
 
@@ -1583,7 +1615,16 @@ useEffect(() => {
           )}
 
           {arquivoPendente && (
-            <div className="mb-2 rounded-xl border border-cyan-200 bg-cyan-50/80 p-3 dark:border-cyan-900/40 dark:bg-cyan-950/20">
+            <div
+              className="mb-2 rounded-xl border border-cyan-200 bg-cyan-50/80 p-3 dark:border-cyan-900/40 dark:bg-cyan-950/20"
+              tabIndex={arquivoPendente.type.startsWith('audio/') ? 0 : undefined}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey && !enviando && podeEnviar) {
+                  e.preventDefault()
+                  void confirmarEnvioMidia()
+                }
+              }}
+            >
               <div className="flex flex-wrap items-start justify-between gap-2">
                 <div className="min-w-0 flex-1">
                   <p className="text-xs font-bold text-cyan-800 dark:text-cyan-300">Anexo selecionado</p>
@@ -1607,6 +1648,12 @@ useEffect(() => {
                   type="text"
                   value={legendaMidia}
                   onChange={(e) => setLegendaMidia(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                      e.preventDefault()
+                      if (!enviando && podeEnviar) void confirmarEnvioMidia()
+                    }
+                  }}
                   placeholder="Legenda opcional (visível no WhatsApp)"
                   className={`mt-2 ${TEXTAREA_FIELD_CLASS}`}
                   autoFocus


### PR DESCRIPTION
## Summary

Release **`main` → `staging`** (produção). Inclui o lote acumulado em `[Unreleased]`, com destaque recente:

- WhatsApp (#628–#630): prefixo setor+nome, lightbox com galeria, foto de perfil, reações, editar (15 min) e apagar para todos (48 h); chip da empresa abre o detalhe
- Chat (#625–#627): CTA Atender na conversa da fila, mute do alerta em Aguardando, Enter envia anexo
- Portal do cliente, WhatsApp (empresa/contatos/inatividade), chat interno e demais itens já listados no CHANGELOG `[Unreleased]`

Ver bullets completos em `CHANGELOG.md` → **`[Unreleased]`**.

## CHANGELOG

- [x] `[Unreleased]` descreve o lote a publicar (consumido no deploy CalVer)

## Test plan

- [ ] Smoke pós-deploy: login, fila WhatsApp, assumir, enviar texto, reagir, editar/apagar (janelas)
- [ ] Foto de perfil / lightbox / prefixo de assinatura
- [ ] Portal e chat interno sem regressão óbvia
- [ ] `/sobre` após deploy mostra a nova CalVer e as notas do lote

## Merge

**Merge apenas após aprovação manual no GitHub** (`staging` = produção). O agente **não** mergeia este PR.
