### PR TITLE
fix(frontend): alinha react-dom a 19.2.8 (hotfix produção)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ## [Unreleased]
 
+### Corrigido
+
+- Frontend: alinhamento de `react` e `react-dom` em **19.2.8** (o Dependabot tinha subido só o `react`, o que gerava tela preta com React error #527 em produção)
+
 ### Melhorias
 
 - WhatsApp (#628): no WhatsApp do cliente, mensagens do atendente saem com prefixo **setor do atendimento + nome** e o texto na linha de baixo (ex.: `[ Suporte - Ana ]:`); ao assumir, 1 setor é gravado automaticamente e vários setores pedem escolha no painel

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "qrcode.react": "^4.2.0",
         "react": "19.2.8",
-        "react-dom": "19.2.7",
+        "react-dom": "19.2.8",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.18.1",
         "recharts": "^3.9.2"
@@ -3840,15 +3840,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "qrcode.react": "^4.2.0",
     "react": "19.2.8",
-    "react-dom": "19.2.7",
+    "react-dom": "19.2.8",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.18.1",
     "recharts": "^3.9.2"


### PR DESCRIPTION
## Summary
- Hotfix: Dependabot #624 atualizou `react` para 19.2.8 e deixou `react-dom` em 19.2.7.
- React 19 exige a mesma versão → Minified error #527 e tela preta em produção.
- Alinha ambos em 19.2.8.

## Test plan
- [x] `npm run build` local com versões alinhadas (só 19.2.8 no bundle)
- [ ] CI verde
- [ ] Após merge + release staging: login em duplexsoft.deskrudder.com.br sem tela preta

## Nota
Hotfix urgente — produção quebrada.

Made with [Cursor](https://cursor.com)