### PR TITLE
fix(whatsapp): Enter na legenda não envia imagem duas vezes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Corrigido
 
+- WhatsApp: Enter na legenda do anexo deixava de enviar a imagem **duas vezes** (o evento subia ao painel e disparava o envio de novo)
 - WhatsApp (#628): ao atender com vários setores, o modal «Escolher setor» voltava vazio (pedido com `limit` acima do máximo da API); a lista passa a carregar com paginação válida
 - Frontend: alinhamento de `react` e `react-dom` em **19.2.8** (o Dependabot tinha subido só o `react`, o que gerava tela preta com React error #527 em produção)
 

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -441,6 +441,7 @@ export function WhatsappConversa() {
   const [texto, setTexto] = useState('')
 
   const [enviando, setEnviando] = useState(false)
+  const enviandoMidiaRef = useRef(false)
 
   // Estados de WhatsApp Clone (Citação e Zoom)
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
@@ -1013,7 +1014,8 @@ useEffect(() => {
   }
 
   async function confirmarEnvioMidia() {
-    if (!arquivoPendente || !chat || !podeEnviar || enviando) return
+    if (!arquivoPendente || !chat || !podeEnviar || enviando || enviandoMidiaRef.current) return
+    enviandoMidiaRef.current = true
     setEnviando(true)
     try {
       await whatsappChats.enviarMidia(
@@ -1031,6 +1033,7 @@ useEffect(() => {
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha no envio do anexo'))
     } finally {
+      enviandoMidiaRef.current = false
       setEnviando(false)
     }
   }
@@ -1881,12 +1884,17 @@ useEffect(() => {
             <div
               className="mb-2 rounded-xl border border-cyan-200 bg-cyan-50/80 p-3 dark:border-cyan-900/40 dark:bg-cyan-950/20"
               tabIndex={arquivoPendente.type.startsWith('audio/') ? 0 : undefined}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey && !enviando && podeEnviar) {
-                  e.preventDefault()
-                  void confirmarEnvioMidia()
-                }
-              }}
+              onKeyDown={
+                arquivoPendente.type.startsWith('audio/')
+                  ? (e) => {
+                      if (e.key === 'Enter' && !e.shiftKey && !enviando && podeEnviar) {
+                        e.preventDefault()
+                        e.stopPropagation()
+                        void confirmarEnvioMidia()
+                      }
+                    }
+                  : undefined
+              }
             >
               <div className="flex flex-wrap items-start justify-between gap-2">
                 <div className="min-w-0 flex-1">
@@ -1914,6 +1922,7 @@ useEffect(() => {
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' && !e.shiftKey) {
                       e.preventDefault()
+                      e.stopPropagation()
                       if (!enviando && podeEnviar) void confirmarEnvioMidia()
                     }
                   }}


### PR DESCRIPTION
## Summary

- Corrige envio **duplicado** de imagem/anexo no WhatsApp ao pressionar Enter na legenda
- Causa: regressão #627 — handlers de Enter no input e no painel pai disparavam juntos (`enviando` ainda falso)
- Lock síncrono + Enter no painel só para áudio; `stopPropagation` na legenda

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**

## Test plan

- [x] Anexar imagem → Enter na legenda → **uma** mensagem no painel e no WhatsApp do cliente
- [x] Botão «Enviar anexo» continua a enviar uma vez
- [x] Áudio pendente: Enter no painel ainda envia uma vez

## Follow-ups / backlog

- [x] Hotfix isolado (produção)
