### PR TITLE
feat(chat): zoom, rotação e pan no lightbox de imagens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- WhatsApp: na visualização ampliada de imagens, dá para fazer zoom (+/−, scroll e duplo clique), rodar e arrastar; repor volta à vista normal (também no chat interno)
 - WhatsApp (#628): no WhatsApp do cliente, mensagens do atendente saem com prefixo **setor do atendimento + nome** e o texto na linha de baixo (ex.: `[ Suporte - Ana ]:`); ao assumir, 1 setor é gravado automaticamente e vários setores pedem escolha no painel
 - WhatsApp (#629): no lightbox de imagens da conversa, dá para navegar entre as fotos (botões e setas ←/→) com contador e legenda atualizada; Esc continua a fechar só a visualização
 - WhatsApp (#630): foto de perfil do contacto no header e nas listas Atendendo/Aguardando (com cache e fallback para a inicial do nome)

--- a/frontend/src/components/chat-interno/ChatInternoConteudoMensagem.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoConteudoMensagem.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { fetchChatInternoMidiaBlob, type ChatInterno } from '../../api/client'
 import { segmentarCorpoComMencoes } from '../../lib/chatInternoMencoes'
 import { useAuth } from '../../contexts/AuthContext'
+import { ImageLightboxViewer } from '../chat/ImageLightboxViewer'
 
 const ROTULO_SEM_LEGENDA = /^(📷 Imagem|🎬 Vídeo|🎵 Áudio|📄 Documento)$/
 
@@ -205,14 +206,12 @@ export function ChatInternoConteudoMensagem({
               >
                 &times;
               </button>
-              <img
-                src={url}
-                alt=""
-                className="max-h-[85vh] max-w-full rounded-lg object-contain shadow-2xl animate-in zoom-in-95 duration-200"
-                onClick={(e) => e.stopPropagation()}
-              />
+              <ImageLightboxViewer src={url} />
               {legenda ? (
-                <p className="mt-4 max-w-2xl rounded-xl bg-black/40 px-4 py-2 text-center text-sm text-white backdrop-blur-md">
+                <p
+                  className="mt-4 max-w-2xl rounded-xl bg-black/40 px-4 py-2 text-center text-sm text-white backdrop-blur-md"
+                  onClick={(e) => e.stopPropagation()}
+                >
                   {legenda}
                 </p>
               ) : null}

--- a/frontend/src/components/chat/ImageLightboxViewer.tsx
+++ b/frontend/src/components/chat/ImageLightboxViewer.tsx
@@ -1,0 +1,175 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
+
+const SCALE_MIN = 0.5
+const SCALE_MAX = 5
+const SCALE_STEP = 0.25
+
+type Props = {
+  src: string
+  alt?: string
+}
+
+function clampScale(n: number) {
+  return Math.min(SCALE_MAX, Math.max(SCALE_MIN, n))
+}
+
+/** Visualização de imagem no lightbox: zoom, rotação e arrastar. */
+export function ImageLightboxViewer({ src, alt = '' }: Props) {
+  const [scale, setScale] = useState(1)
+  const [rotation, setRotation] = useState(0)
+  const [offset, setOffset] = useState({ x: 0, y: 0 })
+  const [dragging, setDragging] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const dragRef = useRef<{ pointerId: number; startX: number; startY: number; originX: number; originY: number } | null>(
+    null,
+  )
+  const scaleRef = useRef(scale)
+  scaleRef.current = scale
+
+  useEffect(() => {
+    setScale(1)
+    setRotation(0)
+    setOffset({ x: 0, y: 0 })
+    setDragging(false)
+    dragRef.current = null
+  }, [src])
+
+  useEffect(() => {
+    const el = rootRef.current
+    if (!el) return
+    const onWheel = (e: WheelEvent) => {
+      e.preventDefault()
+      e.stopPropagation()
+      const delta = e.deltaY < 0 ? SCALE_STEP : -SCALE_STEP
+      setScale((s) => clampScale(Number((s + delta).toFixed(2))))
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [])
+
+  function zoomBy(delta: number) {
+    setScale((s) => clampScale(Number((s + delta).toFixed(2))))
+  }
+
+  function resetView() {
+    setScale(1)
+    setRotation(0)
+    setOffset({ x: 0, y: 0 })
+  }
+
+  function onPointerDown(e: ReactPointerEvent<HTMLImageElement>) {
+    if (e.button !== 0) return
+    e.preventDefault()
+    e.stopPropagation()
+    e.currentTarget.setPointerCapture(e.pointerId)
+    dragRef.current = {
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      originX: offset.x,
+      originY: offset.y,
+    }
+    setDragging(true)
+  }
+
+  function onPointerMove(e: ReactPointerEvent<HTMLImageElement>) {
+    const drag = dragRef.current
+    if (!drag || drag.pointerId !== e.pointerId) return
+    e.preventDefault()
+    setOffset({
+      x: drag.originX + (e.clientX - drag.startX),
+      y: drag.originY + (e.clientY - drag.startY),
+    })
+  }
+
+  function onPointerUp(e: ReactPointerEvent<HTMLImageElement>) {
+    if (dragRef.current?.pointerId === e.pointerId) {
+      dragRef.current = null
+      setDragging(false)
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId)
+      } catch {
+        /* já libertado */
+      }
+    }
+  }
+
+  const btnClass =
+    'flex h-10 w-10 items-center justify-center rounded-full bg-white/15 text-lg font-semibold text-white transition-colors hover:bg-white/25'
+
+  return (
+    <div
+      ref={rootRef}
+      className="relative flex max-h-[85vh] max-w-full flex-col items-center gap-3"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="flex max-h-[calc(85vh-3.5rem)] max-w-full items-center justify-center overflow-hidden">
+        <img
+          src={src}
+          alt={alt}
+          draggable={false}
+          className="max-h-[calc(85vh-3.5rem)] max-w-full touch-none select-none object-contain shadow-2xl"
+          style={{
+            transform: `translate(${offset.x}px, ${offset.y}px) scale(${scale}) rotate(${rotation}deg)`,
+            cursor: dragging ? 'grabbing' : scale > 1 || offset.x !== 0 || offset.y !== 0 ? 'grab' : 'zoom-in',
+            transition: dragging ? undefined : 'transform 120ms ease-out',
+          }}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          onDoubleClick={(e) => {
+            e.stopPropagation()
+            if (scaleRef.current > 1.01) {
+              resetView()
+            } else {
+              setScale(2)
+              setOffset({ x: 0, y: 0 })
+            }
+          }}
+        />
+      </div>
+      <div
+        className="flex flex-wrap items-center justify-center gap-1.5 rounded-full bg-black/50 px-2 py-1.5 backdrop-blur-md"
+        role="toolbar"
+        aria-label="Controles da imagem"
+      >
+        <button type="button" className={btnClass} onClick={() => zoomBy(-SCALE_STEP)} aria-label="Diminuir zoom" title="Diminuir zoom">
+          −
+        </button>
+        <button type="button" className={btnClass} onClick={() => zoomBy(SCALE_STEP)} aria-label="Aumentar zoom" title="Aumentar zoom">
+          +
+        </button>
+        <button
+          type="button"
+          className={btnClass}
+          onClick={() => setRotation((r) => r - 90)}
+          aria-label="Rodar para a esquerda"
+          title="Rodar à esquerda"
+        >
+          ↺
+        </button>
+        <button
+          type="button"
+          className={btnClass}
+          onClick={() => setRotation((r) => r + 90)}
+          aria-label="Rodar para a direita"
+          title="Rodar à direita"
+        >
+          ↻
+        </button>
+        <button type="button" className={btnClass} onClick={resetView} aria-label="Repor vista" title="Repor">
+          ⟲
+        </button>
+        <span className="min-w-[3.25rem] px-1 text-center text-xs tabular-nums text-white/80">
+          {Math.round(scale * 100)}%
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -30,6 +30,7 @@ import {
 import { MensagemRodapeMeta } from '../../components/chat/MensagemRodapeMeta'
 import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsappSetorModal'
 import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
+import { ImageLightboxViewer } from '../../components/chat/ImageLightboxViewer'
 import { WhatsappMensagemAcoes } from '../../components/chat/WhatsappMensagemAcoes'
 import { WhatsappReacoesBar } from '../../components/chat/WhatsappReacoesBar'
 import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
@@ -359,15 +360,13 @@ function WhatsappZoomLightbox({
       {loading || !url ? (
         <p className="text-sm text-white/70 animate-pulse">Carregando imagem…</p>
       ) : (
-        <img
-          src={url}
-          alt=""
-          className="max-h-[85vh] max-w-full rounded-lg object-contain shadow-2xl animate-in zoom-in-95 duration-200"
-          onClick={(e) => e.stopPropagation()}
-        />
+        <ImageLightboxViewer src={url} />
       )}
       {caption && (
-        <p className="mt-4 max-w-2xl rounded-xl bg-black/40 px-4 py-2 text-center text-sm text-white backdrop-blur-md">
+        <p
+          className="mt-4 max-w-2xl rounded-xl bg-black/40 px-4 py-2 text-center text-sm text-white backdrop-blur-md"
+          onClick={(e) => e.stopPropagation()}
+        >
           {caption}
         </p>
       )}


### PR DESCRIPTION
## Summary

- Lightbox de imagens com zoom (+/−, scroll, duplo clique), rotação e arrastar
- Componente partilhado `ImageLightboxViewer` no WhatsApp e no chat interno
- Repor vista restaura escala/rotação/posição

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**

## Test plan

- [ ] WhatsApp: abrir imagem → zoom +/− e scroll; rodar ↺/↻; arrastar com zoom; duplo clique 2× / repor
- [ ] Navegar ←/→ na galeria reinicia a vista na imagem seguinte
- [ ] Esc / clique fora continua a fechar; Baixar funciona
- [ ] Chat interno: mesmas ações no zoom da imagem

## Follow-ups / backlog

- [x] N/A (melhoria de UX do lightbox #629)
