### PR TITLE
fix(chat): duplo clique e menu de ações no balão WhatsApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Corrigido
 
+- Chat: duplo clique **dentro** do balão já não inicia resposta (dá para selecionar/copiar o texto); responder com duplo clique fica só **ao lado** do balão
+- WhatsApp: menu com seta no canto do balão para Editar/Apagar (em vez de botões flutuantes que saltavam para a mensagem de cima)
 - WhatsApp: Enter na legenda do anexo deixava de enviar a imagem **duas vezes** (o evento subia ao painel e disparava o envio de novo)
 - WhatsApp (#628): ao atender com vários setores, o modal «Escolher setor» voltava vazio (pedido com `limit` acima do máximo da API); a lista passa a carregar com paginação válida
 - Frontend: alinhamento de `react` e `react-dom` em **19.2.8** (o Dependabot tinha subido só o `react`, o que gerava tela preta com React error #527 em produção)

--- a/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
+++ b/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { WhatsappChats } from '../../api/client'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { TEXTAREA_FIELD_CLASS } from '../ui/Input'
@@ -13,21 +13,17 @@ type Props = {
   mensagem: WhatsappChats.Mensagem
   onEditar: (novoCorpo: string) => Promise<void>
   onApagar: () => Promise<void>
-  alinhamento?: 'start' | 'end'
 }
 
-/** Editar / apagar para todos no chat WhatsApp (#630 lote 3). */
-export function WhatsappMensagemAcoes({
-  mensagem,
-  onEditar,
-  onApagar,
-  alinhamento = 'end',
-}: Props) {
+/** Menu de ações no canto do balão (editar / apagar) — #630. */
+export function WhatsappMensagemAcoes({ mensagem, onEditar, onApagar }: Props) {
   const [editando, setEditando] = useState(false)
   const [texto, setTexto] = useState(() => corpoWhatsappSemPrefixo(mensagem.corpo))
   const [salvando, setSalvando] = useState(false)
+  const [menuAberto, setMenuAberto] = useState(false)
   const [confirmarApagar, setConfirmarApagar] = useState(false)
   const [apagando, setApagando] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
 
   const podeEditar = Boolean(mensagem.pode_editar)
   const podeApagarTodos = Boolean(mensagem.pode_apagar_para_todos)
@@ -37,84 +33,134 @@ export function WhatsappMensagemAcoes({
     if (!editando) setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
   }, [mensagem, editando])
 
+  useEffect(() => {
+    if (!menuAberto) return
+    const onDoc = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setMenuAberto(false)
+    }
+    document.addEventListener('mousedown', onDoc)
+    return () => document.removeEventListener('mousedown', onDoc)
+  }, [menuAberto])
+
   if (mensagem.apagada || !temAcoes) return null
 
-  if (editando && podeEditar) {
-    return (
-      <div className="mt-1 w-full min-w-[min(100%,18rem)] space-y-2">
-        <textarea
-          value={texto}
-          onChange={(e) => setTexto(e.target.value)}
-          rows={3}
-          className={TEXTAREA_FIELD_CLASS}
-        />
-        <div className="flex gap-2">
-          <button
-            type="button"
-            disabled={salvando || !texto.trim()}
-            onClick={() => {
-              setSalvando(true)
-              void onEditar(texto.trim())
-                .then(() => setEditando(false))
-                .finally(() => setSalvando(false))
-            }}
-            className="rounded-lg bg-cyan-600 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
-          >
-            Salvar
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
-              setEditando(false)
-            }}
-            className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50 dark:border-slate-500 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
-          >
-            Cancelar
-          </button>
-        </div>
-      </div>
-    )
-  }
-
-  const btnAcaoClass =
-    'rounded-full bg-white px-2.5 py-1 text-[11px] font-medium text-slate-700 shadow-sm ring-1 ring-slate-200 hover:bg-slate-100 dark:bg-slate-800 dark:text-slate-100 dark:ring-slate-600 dark:hover:bg-slate-700'
+  const itemClass =
+    'block w-full px-3 py-1.5 text-left text-xs font-medium text-slate-700 hover:bg-slate-100 dark:text-slate-100 dark:hover:bg-slate-700'
 
   return (
     <>
       <div
-        className={`pointer-events-none absolute bottom-full z-20 flex flex-col ${
-          alinhamento === 'end' ? 'right-0 items-end' : 'left-0 items-start'
-        }`}
+        ref={rootRef}
+        data-msg-acoes
+        className="absolute top-1 right-1 z-20"
+        onClick={(e) => e.stopPropagation()}
+        onDoubleClick={(e) => e.stopPropagation()}
       >
-        <div
-          className={`flex gap-1 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 ${
-            alinhamento === 'end' ? 'justify-end' : 'justify-start'
+        <button
+          type="button"
+          aria-label="Ações da mensagem"
+          aria-expanded={menuAberto}
+          aria-haspopup="menu"
+          title="Ações"
+          className={`flex h-6 w-6 items-center justify-center rounded-full text-white transition-opacity ${
+            menuAberto
+              ? 'bg-black/30 opacity-100'
+              : 'bg-black/15 opacity-0 group-hover/bubble:opacity-100 group-focus-within/bubble:opacity-100 hover:bg-black/25'
           }`}
+          onClick={() => setMenuAberto((o) => !o)}
         >
-          {podeEditar && (
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
+        {menuAberto && !editando && (
+          <div
+            role="menu"
+            className="absolute right-0 top-full mt-1 min-w-[8rem] overflow-hidden rounded-lg bg-white py-1 shadow-lg ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-600"
+          >
+            {podeEditar && (
+              <button
+                type="button"
+                role="menuitem"
+                className={itemClass}
+                onClick={() => {
+                  setMenuAberto(false)
+                  setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
+                  setEditando(true)
+                }}
+              >
+                Editar
+              </button>
+            )}
+            {podeApagarTodos && (
+              <button
+                type="button"
+                role="menuitem"
+                className={`${itemClass} text-rose-600 hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-950/40`}
+                onClick={() => {
+                  setMenuAberto(false)
+                  setConfirmarApagar(true)
+                }}
+              >
+                Apagar
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {editando && podeEditar && (
+        <div
+          className="relative z-10 mt-2 w-full min-w-[min(100%,18rem)] space-y-2 rounded-lg bg-white/95 p-2 text-slate-900 shadow-md dark:bg-slate-900 dark:text-slate-100"
+          onClick={(e) => e.stopPropagation()}
+          onDoubleClick={(e) => e.stopPropagation()}
+        >
+          <textarea
+            value={texto}
+            onChange={(e) => setTexto(e.target.value)}
+            rows={3}
+            className={TEXTAREA_FIELD_CLASS}
+            autoFocus
+          />
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={salvando || !texto.trim()}
+              onClick={() => {
+                setSalvando(true)
+                void onEditar(texto.trim())
+                  .then(() => setEditando(false))
+                  .finally(() => setSalvando(false))
+              }}
+              className="rounded-lg bg-cyan-600 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50"
+            >
+              Salvar
+            </button>
             <button
               type="button"
               onClick={() => {
                 setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
-                setEditando(true)
+                setEditando(false)
               }}
-              className={btnAcaoClass}
+              className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 shadow-sm hover:bg-slate-50 dark:border-slate-500 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700"
             >
-              Editar
+              Cancelar
             </button>
-          )}
-          {podeApagarTodos && (
-            <button type="button" onClick={() => setConfirmarApagar(true)} className={btnAcaoClass}>
-              Apagar
-            </button>
-          )}
+          </div>
         </div>
-        <div
-          className="h-2 w-full min-w-[8rem] group-hover:pointer-events-auto group-focus-within:pointer-events-auto"
-          aria-hidden
-        />
-      </div>
+      )}
+
       <ConfirmDialog
         open={confirmarApagar}
         title="Apagar mensagem?"

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -419,7 +419,8 @@ export function ChatInternoThread() {
 
   function duploCliqueResponder(e: MouseEvent, m: ChatInterno.Mensagem) {
     const t = e.target as HTMLElement
-    if (t.closest('button, a, input, textarea, [role="dialog"]')) return
+    // Só ao lado do balão — dentro do balão permite selecionar/copiar texto
+    if (t.closest('[data-msg-bubble], button, a, input, textarea, [role="dialog"]')) return
     iniciarResposta(m)
   }
 
@@ -633,6 +634,7 @@ export function ChatInternoThread() {
                   data-chat-msg-id={m.id}
                   onMouseEnter={() => trancarHoverMensagem(m.id)}
                   onMouseLeave={() => liberarHoverMensagem(m.id)}
+                  onDoubleClick={(e) => duploCliqueResponder(e, m)}
                 >
                 <ChatInternoMensagemAcoes
                   mensagem={m}
@@ -642,7 +644,7 @@ export function ChatInternoThread() {
                   alinhamento="start"
                 />
                 <article
-                  onDoubleClick={(e) => duploCliqueResponder(e, m)}
+                  data-msg-bubble
                   className="w-full min-w-0 overflow-hidden rounded-2xl border border-amber-200/80 bg-amber-50/95 p-5 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40"
                 >
                   <div className="mb-2 flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-200">
@@ -730,6 +732,7 @@ export function ChatInternoThread() {
                       alinhamento={propria ? 'end' : 'start'}
                     />
                     <div
+                      data-msg-bubble
                       className={`relative w-fit max-w-full rounded-lg px-[9px] py-[6px] text-sm shadow-sm ring-1 ring-inset ${
                         propria
                           ? 'rounded-tr-none bg-cyan-600 text-white ring-cyan-500/30'

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -900,7 +900,8 @@ useEffect(() => {
   function duploCliqueResponder(e: MouseEvent, m: WhatsappChats.Mensagem, isSystem: boolean) {
     if (isSystem || encerrado || !podeEnviar || modoInterno) return
     const t = e.target as HTMLElement
-    if (t.closest('button, a, input, textarea, video, audio')) return
+    // Só ao lado do balão — dentro do balão permite selecionar/copiar texto
+    if (t.closest('[data-msg-bubble], button, a, input, textarea, video, audio')) return
     iniciarResposta(m)
   }
 
@@ -1748,16 +1749,9 @@ useEffect(() => {
                     </span>
                   )}
 
-                  {!isSystem && !isInbound && (
-                    <WhatsappMensagemAcoes
-                      mensagem={m}
-                      onEditar={(texto) => editarMensagemWhatsapp(m, texto)}
-                      onApagar={() => apagarMensagemWhatsapp(m)}
-                      alinhamento="end"
-                    />
-                  )}
-
-                  <div className={`
+                  <div
+                    data-msg-bubble
+                    className={`
 
                     rounded-2xl px-4 py-2 text-sm shadow-sm relative group/bubble
 
@@ -1765,9 +1759,17 @@ useEffect(() => {
 
                       isInbound ? 'bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 rounded-tl-none ring-1 ring-slate-100 dark:ring-slate-700' :
 
-                      'bg-cyan-600 text-white rounded-tr-none'}
+                      'bg-cyan-600 text-white rounded-tr-none pr-8'}
 
                   `}>
+
+                    {!isSystem && !isInbound && (
+                      <WhatsappMensagemAcoes
+                        mensagem={m}
+                        onEditar={(texto) => editarMensagemWhatsapp(m, texto)}
+                        onApagar={() => apagarMensagemWhatsapp(m)}
+                      />
+                    )}
 
                     {m.quoted_wa_message_id && !m.apagada && (
                       <div 


### PR DESCRIPTION
## Summary

- Duplo clique **dentro** do balão não inicia mais resposta (permite selecionar/copiar); resposta com duplo clique só **ao lado** do balão (WhatsApp + chat interno)
- WhatsApp: Editar/Apagar passam para menu com seta no canto superior direito do balão — evita botões flutuantes que saltavam para a mensagem de cima

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**

## Test plan

- [ ] Duplo clique no texto do balão: seleciona palavra / não abre “responder”
- [ ] Duplo clique na área ao lado do balão: inicia resposta
- [ ] Hover em mensagem outbound própria: seta ▾ no canto → Editar / Apagar funcionam
- [ ] Confirmar apagar; editar e salvar ainda reaplicam prefixo de setor

## Follow-ups / backlog

- [x] N/A (UX hotfix)
