### PR TITLE
feat(dashboard): analytics operacional (#599, #594, #595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Dashboard (#599): filtros de período Hoje | Esta semana (seg–dom) | Este mês | Mês passado | Personalizado no geral, tickets e WhatsApp (substitui 7/30/90); CSAT do geral respeita o intervalo
+- WhatsApp (#594): análise de demandas no dashboard — drill-down por natureza/motivo, ranking por empresa, insights (erro → atualização; dúvida → treinamento) e sugestão de novo motivo a partir de «Outros» repetido
+- Rede e Empresa (#595): aba Análises com tickets + demandas WhatsApp no período, insights e ranking (reutiliza #594/#599)
 - WhatsApp: na visualização ampliada de imagens, dá para fazer zoom (+/−, scroll e duplo clique), rodar e arrastar; repor volta à vista normal (também no chat interno)
 - WhatsApp (#628): no WhatsApp do cliente, mensagens do atendente saem com prefixo **setor do atendimento + nome** e o texto na linha de baixo (ex.: `[ Suporte - Ana ]:`); ao assumir, 1 setor é gravado automaticamente e vários setores pedem escolha no painel
 - WhatsApp (#629): no lightbox de imagens da conversa, dá para navegar entre as fotos (botões e setas ←/→) com contador e legenda atualizada; Esc continua a fechar só a visualização

--- a/backend/alembic/versions/081_wpp_demanda_motivo_sugestoes.py
+++ b/backend/alembic/versions/081_wpp_demanda_motivo_sugestoes.py
@@ -1,0 +1,75 @@
+"""Decisões de sugestão de motivo a partir de «Outros» nas demandas WA (#594).
+
+Revision ID: 081_wpp_demanda_motivo_sugestoes
+Revises: 080_wpp_edicao_apagar
+Create Date: 2026-08-02
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "081_wpp_demanda_motivo_sugestoes"
+down_revision = "080_wpp_edicao_apagar"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("whatsapp_demanda_motivo_sugestoes"):
+        return
+    op.create_table(
+        "whatsapp_demanda_motivo_sugestoes",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "natureza_id",
+            sa.Integer(),
+            sa.ForeignKey("ticket_naturezas.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("texto_normalizado", sa.String(500), nullable=False),
+        sa.Column("texto_exemplo", sa.String(500), nullable=False),
+        sa.Column("status", sa.String(16), nullable=False),
+        sa.Column(
+            "motivo_criado_id",
+            sa.Integer(),
+            sa.ForeignKey("ticket_motivos.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "decidido_por_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "decidido_em",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "natureza_id",
+            "texto_normalizado",
+            name="uq_wpp_demanda_motivo_sugestao_nat_texto",
+        ),
+    )
+    op.create_index(
+        "ix_wpp_demanda_motivo_sugestoes_natureza_id",
+        "whatsapp_demanda_motivo_sugestoes",
+        ["natureza_id"],
+    )
+    op.create_index(
+        "ix_wpp_demanda_motivo_sugestoes_status",
+        "whatsapp_demanda_motivo_sugestoes",
+        ["status"],
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_demanda_motivo_sugestoes"):
+        return
+    op.drop_table("whatsapp_demanda_motivo_sugestoes")

--- a/backend/app/api/dashboard.py
+++ b/backend/app/api/dashboard.py
@@ -17,14 +17,26 @@ from app.schemas.dashboard import (
     DashboardResumo,
     DashboardTicketsResponse,
     DashboardChatsResponse,
+    DemandaDrillItem,
     StatusCount,
+    SugestaoMotivoOutrosAcao,
 )
+from app.schemas.lista_paginada import ListaPaginada
+from app.schemas.ticket_classificacao import TicketMotivoRead
 from app.services.dashboard_geral import obter_dashboard_geral as montar_dashboard_geral
 from app.services.dashboard_tickets import obter_dashboard_tickets as montar_dashboard_tickets
-from app.services.dashboard_chats import obter_dashboard_chats as montar_dashboard_chats
-from app.services.ticket_dashboard_filters import normalizar_prioridade
+from app.services.dashboard_chats import (
+    clear_dashboard_chats_cache,
+    obter_dashboard_chats as montar_dashboard_chats,
+)
+from app.services.dashboard_demandas_analise import (
+    aceitar_sugestao_motivo_outros,
+    ignorar_sugestao_motivo_outros,
+    listar_demandas_drilldown,
+)
+from app.services.ticket_dashboard_filters import normalizar_prioridade, resolve_period
 from app.schemas.ticket import TicketRead
-from app.core.auth import obter_atendente_atual
+from app.core.auth import exigir_admin, obter_atendente_atual
 from app.api.tickets import _ticket_para_read
 from app.core.setor_scope import ids_setores_visiveis_atendente
 
@@ -171,12 +183,20 @@ def obter_dashboard(
     )
 
 
-@router.get("/geral", response_model=DashboardGeralResponse)
+@router.get(
+    "/geral",
+    response_model=DashboardGeralResponse,
+    summary="Dashboard geral (filas + CSAT)",
+    description="Filas e SLA são situação atual. CSAT respeita o período (`de`/`ate`; "
+    "default sem parâmetros: últimos 7 dias inclusive).",
+)
 def obter_dashboard_geral(
+    de: date | None = Query(None, description="Início do período do CSAT"),
+    ate: date | None = Query(None, description="Fim do período do CSAT (default: hoje)"),
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
-    return montar_dashboard_geral(db, atendente)
+    return montar_dashboard_geral(db, atendente, de=de, ate=ate)
 
 
 @router.get(
@@ -252,3 +272,81 @@ def obter_dashboard_chats(
         drill_valor=drill_valor,
         atendente_filtro_id=atendente_filtro_id,
     )
+
+
+@router.get(
+    "/chats/demandas",
+    response_model=ListaPaginada[DemandaDrillItem],
+    summary="Drill-down de demandas WhatsApp",
+    description="Lista demandas (itens) filtradas por período, natureza, motivo, empresa e rede (#594).",
+)
+def listar_dashboard_chats_demandas(
+    de: date | None = Query(None),
+    ate: date | None = Query(None),
+    setor_id: int | None = Query(None, ge=1),
+    empresa_id: int | None = Query(None, ge=1),
+    rede_id: int | None = Query(None, ge=1),
+    natureza_id: int | None = Query(None, ge=1),
+    motivo_id: int | None = Query(None, ge=1),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=100),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    inicio, fim = resolve_period(de, ate)
+    return listar_demandas_drilldown(
+        db,
+        atendente,
+        de=inicio,
+        ate=fim,
+        setor_id=setor_id,
+        empresa_id=empresa_id,
+        rede_id=rede_id,
+        natureza_id=natureza_id,
+        motivo_id=motivo_id,
+        skip=skip,
+        limit=limit,
+    )
+
+
+@router.post(
+    "/chats/demandas/sugestoes-motivo/aceitar",
+    response_model=TicketMotivoRead,
+    summary="Aceitar sugestão de motivo a partir de Outros",
+)
+def aceitar_sugestao_motivo_demanda(
+    body: SugestaoMotivoOutrosAcao,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    motivo = aceitar_sugestao_motivo_outros(
+        db,
+        atendente,
+        natureza_id=body.natureza_id,
+        texto_normalizado=body.texto_normalizado,
+        nome=body.nome,
+        slug=body.slug,
+    )
+    clear_dashboard_chats_cache()
+    return motivo
+
+
+@router.post(
+    "/chats/demandas/sugestoes-motivo/ignorar",
+    status_code=204,
+    summary="Ignorar sugestão de motivo a partir de Outros",
+)
+def ignorar_sugestao_motivo_demanda(
+    body: SugestaoMotivoOutrosAcao,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    ignorar_sugestao_motivo_outros(
+        db,
+        atendente,
+        natureza_id=body.natureza_id,
+        texto_normalizado=body.texto_normalizado,
+        texto_exemplo=body.texto_exemplo,
+    )
+    clear_dashboard_chats_cache()
+    return None

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -21,6 +21,7 @@ from app.models.whatsapp_chat import (
     WhatsappSettings,
 )
 from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
+from app.models.whatsapp_demanda_motivo_sugestao import WhatsappDemandaMotivoSugestao
 from app.models.empresa_sistema import EmpresaSistema
 from app.models.email_settings import EmailSettings
 from app.models.protocol_sequence import ProtocolSequence
@@ -78,6 +79,7 @@ __all__ = [
     "WhatsappMensagemReacao",
     "WhatsappChatTicket",
     "WhatsappChatDemanda",
+    "WhatsappDemandaMotivoSugestao",
     "EmpresaSistema",
     "EmailSettings",
     "ProtocolSequence",

--- a/backend/app/models/whatsapp_demanda_motivo_sugestao.py
+++ b/backend/app/models/whatsapp_demanda_motivo_sugestao.py
@@ -1,0 +1,39 @@
+"""Decisões admin sobre sugestões de motivo a partir de «Outros» (#594)."""
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+STATUS_ACEITA = "aceita"
+STATUS_IGNORADA = "ignorada"
+STATUS_SUGESTAO = frozenset({STATUS_ACEITA, STATUS_IGNORADA})
+
+
+class WhatsappDemandaMotivoSugestao(Base):
+    __tablename__ = "whatsapp_demanda_motivo_sugestoes"
+    __table_args__ = (
+        UniqueConstraint(
+            "natureza_id",
+            "texto_normalizado",
+            name="uq_wpp_demanda_motivo_sugestao_nat_texto",
+        ),
+    )
+
+    id = Column(Integer, primary_key=True)
+    natureza_id = Column(
+        Integer, ForeignKey("ticket_naturezas.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    texto_normalizado = Column(String(500), nullable=False)
+    texto_exemplo = Column(String(500), nullable=False)
+    status = Column(String(16), nullable=False, index=True)
+    motivo_criado_id = Column(
+        Integer, ForeignKey("ticket_motivos.id", ondelete="SET NULL"), nullable=True
+    )
+    decidido_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    decidido_em = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    natureza = relationship("TicketNatureza")
+    motivo_criado = relationship("TicketMotivo")
+    decidido_por = relationship("Atendente")

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -59,6 +59,8 @@ class DashboardGeralResponse(BaseModel):
     csat_chats: CsAtMediaResumo
     sla_violacoes_abertas: int = Field(ge=0)
     sla_em_risco_abertas: int = Field(ge=0)
+    de: date
+    ate: date
     gerado_em: datetime
     cache_ttl_segundos: int = Field(ge=0)
 
@@ -129,6 +131,58 @@ class SnapshotCanais(BaseModel):
     chats_em_atendimento: int = Field(ge=0)
 
 
+class DemandaEmpresaRanking(BaseModel):
+    empresa_id: int | None = None
+    empresa_nome: str
+    total: int = Field(ge=0)
+    natureza_dominante_id: int | None = None
+    natureza_dominante_nome: str | None = None
+    natureza_dominante_slug: str | None = None
+
+
+class DemandaInsight(BaseModel):
+    tipo: str
+    titulo: str
+    detalhe: str
+    natureza_id: int | None = None
+    motivo_id: int | None = None
+    total: int = Field(ge=0)
+    limiar: int = Field(ge=1)
+
+
+class SugestaoMotivoOutros(BaseModel):
+    natureza_id: int
+    natureza_nome: str
+    texto_normalizado: str
+    texto_exemplo: str
+    ocorrencias: int = Field(ge=0)
+    limiar: int = Field(ge=1)
+
+
+class DemandaDrillItem(BaseModel):
+    demanda_id: int
+    chat_id: int
+    protocolo: str
+    cliente_nome: str | None = None
+    empresa_id: int | None = None
+    empresa_nome: str | None = None
+    natureza_id: int
+    natureza_nome: str
+    motivo_id: int | None = None
+    motivo_nome: str | None = None
+    desfecho: str
+    descricao_curta: str | None = None
+    created_at: datetime
+
+
+class SugestaoMotivoOutrosAcao(BaseModel):
+    natureza_id: int = Field(ge=1)
+    texto_normalizado: str = Field(min_length=1, max_length=500)
+    nome: str | None = Field(None, min_length=1, max_length=120)
+    slug: str | None = Field(None, min_length=1, max_length=50)
+    texto_exemplo: str | None = Field(None, max_length=500)
+
+
 class DashboardChatsResponse(BaseModel):
     de: date
     ate: date
@@ -142,6 +196,10 @@ class DashboardChatsResponse(BaseModel):
     por_estado_atual: list[ContagemRotulo]
     demandas_por_natureza: list[ContagemIdNome] = Field(default_factory=list)
     demandas_por_motivo: list[ContagemIdNome] = Field(default_factory=list)
+    demandas_por_empresa: list[DemandaEmpresaRanking] = Field(default_factory=list)
+    demanda_maior: ContagemIdNome | None = None
+    insights_demandas: list[DemandaInsight] = Field(default_factory=list)
+    sugestoes_motivo_outros: list[SugestaoMotivoOutros] = Field(default_factory=list)
     snapshot: SnapshotCanais
     gerado_em: datetime
     cache_ttl_segundos: int = Field(ge=0)

--- a/backend/app/services/dashboard_chats.py
+++ b/backend/app/services/dashboard_chats.py
@@ -19,6 +19,12 @@ from app.schemas.dashboard import (
     SnapshotCanais,
 )
 from app.services.chat_dashboard_filters import apply_chat_dashboard_filters, period_bounds, resolve_period
+from app.services.dashboard_demandas_analise import (
+    gerar_insights_demandas,
+    maior_demanda_global,
+    ranking_demandas_por_empresa,
+    sugerir_motivos_outros,
+)
 from app.services.dashboard_drilldown import ChatDrillDown, apply_chat_drill_down
 from app.services.whatsapp_chat_demandas import agregar_demandas_por_motivo, agregar_demandas_por_natureza
 
@@ -357,6 +363,10 @@ def _compute(
         empresa_id=empresa_id,
         rede_id=rede_id,
     )
+    por_natureza = agregar_demandas_por_natureza(db, atendente, **filtros_demanda)
+    sugestoes = (
+        sugerir_motivos_outros(db, atendente, **filtros_demanda) if atendente.role == "admin" else []
+    )
     return DashboardChatsResponse(
         de=de,
         ate=ate,
@@ -370,8 +380,12 @@ def _compute(
         pct_com_ticket_vinculado=_pct_com_ticket_vinculado(db, atendente, de_dt, ate_dt, setor_id, drill),
         por_atendente=_por_atendente(db, atendente, de_dt, ate_dt, setor_id, drill),
         por_estado_atual=_por_estado_atual(db, atendente, setor_id, drill),
-        demandas_por_natureza=agregar_demandas_por_natureza(db, atendente, **filtros_demanda),
+        demandas_por_natureza=por_natureza,
         demandas_por_motivo=agregar_demandas_por_motivo(db, atendente, **filtros_demanda),
+        demandas_por_empresa=ranking_demandas_por_empresa(db, atendente, **filtros_demanda),
+        demanda_maior=maior_demanda_global(por_natureza),
+        insights_demandas=gerar_insights_demandas(db, atendente, **filtros_demanda),
+        sugestoes_motivo_outros=sugestoes,
         snapshot=_snapshot_canais(db, atendente),
         gerado_em=agora,
         cache_ttl_segundos=CACHE_TTL_SECONDS,

--- a/backend/app/services/dashboard_demandas_analise.py
+++ b/backend/app/services/dashboard_demandas_analise.py
@@ -1,0 +1,605 @@
+"""Análise operacional de demandas WhatsApp (#594).
+
+Limiares (documentados; v1 fixos):
+- LIMIAR_INSIGHT_ERRO: natureza `erro` com total ≥ N → sugerir avaliar atualização/bug
+- LIMIAR_INSIGHT_DUVIDA: natureza `duvida` + mesmo motivo ≥ N → sugerir treinamento/KB
+- LIMIAR_SUGESTAO_OUTROS: motivo slug `outros` + mesma descrição normalizada ≥ N → sugerir novo motivo
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from datetime import date, datetime, timezone
+
+from fastapi import HTTPException
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.atendente import Atendente
+from app.models.empresa import Empresa
+from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+from app.models.whatsapp_chat import WhatsappChat
+from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
+from app.models.whatsapp_demanda_motivo_sugestao import (
+    STATUS_ACEITA,
+    STATUS_IGNORADA,
+    WhatsappDemandaMotivoSugestao,
+)
+from app.schemas.dashboard import (
+    ContagemIdNome,
+    DemandaDrillItem,
+    DemandaEmpresaRanking,
+    DemandaInsight,
+    SugestaoMotivoOutros,
+)
+from app.schemas.lista_paginada import ListaPaginada
+from app.schemas.ticket_classificacao import TicketMotivoRead
+from app.services.chat_dashboard_filters import apply_chat_dashboard_filters, period_bounds
+from app.services.kb import slugify
+from app.services.ticket_classificacao_rules import MOTIVO_OUTROS_SLUG
+
+LIMIAR_INSIGHT_ERRO = 5
+LIMIAR_INSIGHT_DUVIDA = 5
+LIMIAR_SUGESTAO_OUTROS = 3
+RANKING_EMPRESAS_TOP = 15
+
+
+def normalizar_descricao_demanda(valor: str | None) -> str | None:
+    if valor is None:
+        return None
+    t = valor.strip().lower()
+    t = unicodedata.normalize("NFKD", t)
+    t = "".join(ch for ch in t if not unicodedata.combining(ch))
+    t = re.sub(r"\s+", " ", t)
+    return t or None
+
+
+def _base_demandas_stmt(
+    *,
+    de: date,
+    ate: date,
+    natureza_id: int | None = None,
+    motivo_id: int | None = None,
+    empresa_id: int | None = None,
+    rede_id: int | None = None,
+):
+    de_dt, ate_dt = period_bounds(de, ate)
+    stmt = (
+        select(WhatsappChatDemanda)
+        .join(WhatsappChat, WhatsappChat.id == WhatsappChatDemanda.chat_id)
+        .where(
+            WhatsappChatDemanda.created_at >= de_dt,
+            WhatsappChatDemanda.created_at < ate_dt,
+        )
+    )
+    if natureza_id is not None:
+        stmt = stmt.where(WhatsappChatDemanda.natureza_id == natureza_id)
+    if motivo_id is not None:
+        stmt = stmt.where(WhatsappChatDemanda.motivo_id == motivo_id)
+    if empresa_id is not None:
+        stmt = stmt.where(WhatsappChat.empresa_id == empresa_id)
+    if rede_id is not None:
+        stmt = stmt.join(Empresa, Empresa.id == WhatsappChat.empresa_id).where(Empresa.rede_id == rede_id)
+    return stmt
+
+
+def listar_demandas_drilldown(
+    db: Session,
+    atendente: Atendente,
+    *,
+    de: date,
+    ate: date,
+    setor_id: int | None = None,
+    empresa_id: int | None = None,
+    rede_id: int | None = None,
+    natureza_id: int | None = None,
+    motivo_id: int | None = None,
+    skip: int = 0,
+    limit: int = 50,
+) -> ListaPaginada[DemandaDrillItem]:
+    de_dt, ate_dt = period_bounds(de, ate)
+    count_stmt = (
+        select(func.count(WhatsappChatDemanda.id))
+        .select_from(WhatsappChatDemanda)
+        .join(WhatsappChat, WhatsappChat.id == WhatsappChatDemanda.chat_id)
+        .where(
+            WhatsappChatDemanda.created_at >= de_dt,
+            WhatsappChatDemanda.created_at < ate_dt,
+        )
+    )
+    if natureza_id is not None:
+        count_stmt = count_stmt.where(WhatsappChatDemanda.natureza_id == natureza_id)
+    if motivo_id is not None:
+        count_stmt = count_stmt.where(WhatsappChatDemanda.motivo_id == motivo_id)
+    if empresa_id is not None:
+        count_stmt = count_stmt.where(WhatsappChat.empresa_id == empresa_id)
+    if rede_id is not None:
+        count_stmt = count_stmt.join(Empresa, Empresa.id == WhatsappChat.empresa_id).where(
+            Empresa.rede_id == rede_id
+        )
+    count_stmt = apply_chat_dashboard_filters(count_stmt, db, atendente, setor_id=setor_id)
+    total = int(db.execute(count_stmt).scalar_one())
+
+    stmt = _base_demandas_stmt(
+        de=de,
+        ate=ate,
+        natureza_id=natureza_id,
+        motivo_id=motivo_id,
+        empresa_id=empresa_id,
+        rede_id=rede_id,
+    )
+    stmt = apply_chat_dashboard_filters(stmt, db, atendente, setor_id=setor_id)
+    stmt = (
+        stmt.options(
+            joinedload(WhatsappChatDemanda.chat).joinedload(WhatsappChat.empresa),
+            joinedload(WhatsappChatDemanda.natureza),
+            joinedload(WhatsappChatDemanda.motivo),
+        )
+        .order_by(WhatsappChatDemanda.created_at.desc(), WhatsappChatDemanda.id.desc())
+        .offset(max(skip, 0))
+        .limit(min(max(limit, 1), 100))
+    )
+    rows = db.execute(stmt).unique().scalars().all()
+    items = [
+        DemandaDrillItem(
+            demanda_id=r.id,
+            chat_id=r.chat_id,
+            protocolo=r.chat.protocolo if r.chat else "",
+            cliente_nome=r.chat.cliente_nome if r.chat else None,
+            empresa_id=r.chat.empresa_id if r.chat else None,
+            empresa_nome=r.chat.empresa.nome if r.chat and r.chat.empresa else None,
+            natureza_id=r.natureza_id,
+            natureza_nome=r.natureza.nome if r.natureza else "",
+            motivo_id=r.motivo_id,
+            motivo_nome=r.motivo.nome if r.motivo else None,
+            desfecho=r.desfecho,
+            descricao_curta=r.descricao_curta,
+            created_at=r.created_at,
+        )
+        for r in rows
+    ]
+    return ListaPaginada(items=items, total=total)
+
+
+def ranking_demandas_por_empresa(
+    db: Session,
+    atendente: Atendente,
+    *,
+    de: date,
+    ate: date,
+    setor_id: int | None = None,
+    empresa_id: int | None = None,
+    rede_id: int | None = None,
+    top: int = RANKING_EMPRESAS_TOP,
+) -> list[DemandaEmpresaRanking]:
+    de_dt, ate_dt = period_bounds(de, ate)
+    stmt = (
+        select(
+            WhatsappChat.empresa_id,
+            func.coalesce(Empresa.nome, "Sem empresa").label("empresa_nome"),
+            func.count().label("total"),
+        )
+        .select_from(WhatsappChatDemanda)
+        .join(WhatsappChat, WhatsappChat.id == WhatsappChatDemanda.chat_id)
+        .outerjoin(Empresa, Empresa.id == WhatsappChat.empresa_id)
+        .where(
+            WhatsappChatDemanda.created_at >= de_dt,
+            WhatsappChatDemanda.created_at < ate_dt,
+        )
+        .group_by(WhatsappChat.empresa_id, Empresa.nome)
+        .order_by(func.count().desc(), func.coalesce(Empresa.nome, "Sem empresa").asc())
+        .limit(top)
+    )
+    if empresa_id is not None:
+        stmt = stmt.where(WhatsappChat.empresa_id == empresa_id)
+    if rede_id is not None:
+        stmt = stmt.where(Empresa.rede_id == rede_id)
+    stmt = apply_chat_dashboard_filters(stmt, db, atendente, setor_id=setor_id)
+
+    ranking: list[DemandaEmpresaRanking] = []
+    for eid, nome, total in db.execute(stmt):
+        nat_id, nat_nome, nat_slug = _natureza_dominante_empresa(
+            db,
+            atendente,
+            de=de,
+            ate=ate,
+            setor_id=setor_id,
+            empresa_id=int(eid) if eid is not None else None,
+            rede_id=rede_id,
+            sem_empresa=eid is None,
+        )
+        ranking.append(
+            DemandaEmpresaRanking(
+                empresa_id=int(eid) if eid is not None else None,
+                empresa_nome=str(nome),
+                total=int(total),
+                natureza_dominante_id=nat_id,
+                natureza_dominante_nome=nat_nome,
+                natureza_dominante_slug=nat_slug,
+            )
+        )
+    return ranking
+
+
+def _natureza_dominante_empresa(
+    db: Session,
+    atendente: Atendente,
+    *,
+    de: date,
+    ate: date,
+    setor_id: int | None,
+    empresa_id: int | None,
+    rede_id: int | None,
+    sem_empresa: bool,
+) -> tuple[int | None, str | None, str | None]:
+    de_dt, ate_dt = period_bounds(de, ate)
+    stmt = (
+        select(TicketNatureza.id, TicketNatureza.nome, TicketNatureza.slug, func.count())
+        .select_from(WhatsappChatDemanda)
+        .join(WhatsappChat, WhatsappChat.id == WhatsappChatDemanda.chat_id)
+        .join(TicketNatureza, TicketNatureza.id == WhatsappChatDemanda.natureza_id)
+        .where(
+            WhatsappChatDemanda.created_at >= de_dt,
+            WhatsappChatDemanda.created_at < ate_dt,
+        )
+        .group_by(TicketNatureza.id, TicketNatureza.nome, TicketNatureza.slug)
+        .order_by(func.count().desc(), TicketNatureza.nome.asc())
+        .limit(1)
+    )
+    if sem_empresa:
+        stmt = stmt.where(WhatsappChat.empresa_id.is_(None))
+    elif empresa_id is not None:
+        stmt = stmt.where(WhatsappChat.empresa_id == empresa_id)
+    if rede_id is not None:
+        stmt = stmt.join(Empresa, Empresa.id == WhatsappChat.empresa_id).where(Empresa.rede_id == rede_id)
+    stmt = apply_chat_dashboard_filters(stmt, db, atendente, setor_id=setor_id)
+    row = db.execute(stmt).first()
+    if not row:
+        return None, None, None
+    return int(row[0]), str(row[1]), str(row[2])
+
+
+def maior_demanda_global(por_natureza: list[ContagemIdNome]) -> ContagemIdNome | None:
+    if not por_natureza:
+        return None
+    return max(por_natureza, key=lambda x: (x.total, -x.id))
+
+
+def gerar_insights_demandas(
+    db: Session,
+    atendente: Atendente,
+    *,
+    de: date,
+    ate: date,
+    setor_id: int | None = None,
+    empresa_id: int | None = None,
+    rede_id: int | None = None,
+) -> list[DemandaInsight]:
+    de_dt, ate_dt = period_bounds(de, ate)
+    insights: list[DemandaInsight] = []
+
+    stmt_nat = (
+        select(TicketNatureza.id, TicketNatureza.nome, TicketNatureza.slug, func.count())
+        .select_from(WhatsappChatDemanda)
+        .join(WhatsappChat, WhatsappChat.id == WhatsappChatDemanda.chat_id)
+        .join(TicketNatureza, TicketNatureza.id == WhatsappChatDemanda.natureza_id)
+        .where(
+            WhatsappChatDemanda.created_at >= de_dt,
+            WhatsappChatDemanda.created_at < ate_dt,
+            TicketNatureza.slug == "erro",
+        )
+        .group_by(TicketNatureza.id, TicketNatureza.nome, TicketNatureza.slug)
+    )
+    if empresa_id is not None:
+        stmt_nat = stmt_nat.where(WhatsappChat.empresa_id == empresa_id)
+    if rede_id is not None:
+        stmt_nat = stmt_nat.join(Empresa, Empresa.id == WhatsappChat.empresa_id).where(
+            Empresa.rede_id == rede_id
+        )
+    stmt_nat = apply_chat_dashboard_filters(stmt_nat, db, atendente, setor_id=setor_id)
+    for nid, nome, _slug, total in db.execute(stmt_nat):
+        total_i = int(total)
+        if total_i >= LIMIAR_INSIGHT_ERRO:
+            insights.append(
+                DemandaInsight(
+                    tipo="avaliar_atualizacao",
+                    titulo="Erros recorrentes no período",
+                    detalhe=(
+                        f"Há {total_i} demandas de «{nome}». Avalie correção de produto "
+                        f"ou atualização (limiar: {LIMIAR_INSIGHT_ERRO})."
+                    ),
+                    natureza_id=int(nid),
+                    motivo_id=None,
+                    total=total_i,
+                    limiar=LIMIAR_INSIGHT_ERRO,
+                )
+            )
+
+    stmt_mot = (
+        select(
+            TicketMotivo.id,
+            TicketMotivo.nome,
+            TicketNatureza.id,
+            TicketNatureza.nome,
+            func.count(),
+        )
+        .select_from(WhatsappChatDemanda)
+        .join(WhatsappChat, WhatsappChat.id == WhatsappChatDemanda.chat_id)
+        .join(TicketMotivo, TicketMotivo.id == WhatsappChatDemanda.motivo_id)
+        .join(TicketNatureza, TicketNatureza.id == WhatsappChatDemanda.natureza_id)
+        .where(
+            WhatsappChatDemanda.created_at >= de_dt,
+            WhatsappChatDemanda.created_at < ate_dt,
+            TicketNatureza.slug == "duvida",
+            WhatsappChatDemanda.motivo_id.isnot(None),
+        )
+        .group_by(TicketMotivo.id, TicketMotivo.nome, TicketNatureza.id, TicketNatureza.nome)
+        .having(func.count() >= LIMIAR_INSIGHT_DUVIDA)
+        .order_by(func.count().desc())
+    )
+    if empresa_id is not None:
+        stmt_mot = stmt_mot.where(WhatsappChat.empresa_id == empresa_id)
+    if rede_id is not None:
+        stmt_mot = stmt_mot.join(Empresa, Empresa.id == WhatsappChat.empresa_id).where(
+            Empresa.rede_id == rede_id
+        )
+    stmt_mot = apply_chat_dashboard_filters(stmt_mot, db, atendente, setor_id=setor_id)
+    for mid, mnome, nid, nnome, total in db.execute(stmt_mot):
+        total_i = int(total)
+        insights.append(
+            DemandaInsight(
+                tipo="sugerir_treinamento",
+                titulo="Dúvidas repetidas no mesmo motivo",
+                detalhe=(
+                    f"«{mnome}» ({nnome}) apareceu {total_i} vezes. "
+                    f"Considere treinamento ou material na base de ajuda "
+                    f"(limiar: {LIMIAR_INSIGHT_DUVIDA})."
+                ),
+                natureza_id=int(nid),
+                motivo_id=int(mid),
+                total=total_i,
+                limiar=LIMIAR_INSIGHT_DUVIDA,
+            )
+        )
+
+    return insights
+
+
+def sugerir_motivos_outros(
+    db: Session,
+    atendente: Atendente,
+    *,
+    de: date,
+    ate: date,
+    setor_id: int | None = None,
+    empresa_id: int | None = None,
+    rede_id: int | None = None,
+) -> list[SugestaoMotivoOutros]:
+    """Agrupa descrições em motivo `outros`; exclui já aceitas/ignoradas."""
+    de_dt, ate_dt = period_bounds(de, ate)
+    stmt = (
+        select(
+            TicketNatureza.id,
+            TicketNatureza.nome,
+            WhatsappChatDemanda.descricao_curta,
+        )
+        .select_from(WhatsappChatDemanda)
+        .join(WhatsappChat, WhatsappChat.id == WhatsappChatDemanda.chat_id)
+        .join(TicketMotivo, TicketMotivo.id == WhatsappChatDemanda.motivo_id)
+        .join(TicketNatureza, TicketNatureza.id == WhatsappChatDemanda.natureza_id)
+        .where(
+            WhatsappChatDemanda.created_at >= de_dt,
+            WhatsappChatDemanda.created_at < ate_dt,
+            TicketMotivo.slug == MOTIVO_OUTROS_SLUG,
+            WhatsappChatDemanda.descricao_curta.isnot(None),
+        )
+    )
+    if empresa_id is not None:
+        stmt = stmt.where(WhatsappChat.empresa_id == empresa_id)
+    if rede_id is not None:
+        stmt = stmt.join(Empresa, Empresa.id == WhatsappChat.empresa_id).where(Empresa.rede_id == rede_id)
+    stmt = apply_chat_dashboard_filters(stmt, db, atendente, setor_id=setor_id)
+
+    buckets: dict[tuple[int, str], dict] = {}
+    for nid, nnome, desc in db.execute(stmt):
+        norm = normalizar_descricao_demanda(desc)
+        if not norm:
+            continue
+        key = (int(nid), norm)
+        if key not in buckets:
+            buckets[key] = {
+                "natureza_id": int(nid),
+                "natureza_nome": str(nnome),
+                "texto_normalizado": norm,
+                "texto_exemplo": (desc or "").strip()[:500],
+                "ocorrencias": 0,
+            }
+        buckets[key]["ocorrencias"] += 1
+
+    if not buckets:
+        return []
+
+    decididas = {
+        (int(r.natureza_id), r.texto_normalizado)
+        for r in db.query(WhatsappDemandaMotivoSugestao)
+        .filter(WhatsappDemandaMotivoSugestao.status.in_([STATUS_ACEITA, STATUS_IGNORADA]))
+        .all()
+    }
+
+    out: list[SugestaoMotivoOutros] = []
+    for key, data in buckets.items():
+        if key in decididas:
+            continue
+        if data["ocorrencias"] < LIMIAR_SUGESTAO_OUTROS:
+            continue
+        out.append(
+            SugestaoMotivoOutros(
+                natureza_id=data["natureza_id"],
+                natureza_nome=data["natureza_nome"],
+                texto_normalizado=data["texto_normalizado"],
+                texto_exemplo=data["texto_exemplo"],
+                ocorrencias=data["ocorrencias"],
+                limiar=LIMIAR_SUGESTAO_OUTROS,
+            )
+        )
+    out.sort(key=lambda s: (-s.ocorrencias, s.natureza_nome, s.texto_normalizado))
+    return out
+
+
+def _motivo_para_read(row: TicketMotivo) -> TicketMotivoRead:
+    return TicketMotivoRead(
+        id=row.id,
+        natureza_id=row.natureza_id,
+        nome=row.nome,
+        slug=row.slug,
+        ordem=row.ordem,
+        ativo=row.ativo,
+        natureza_nome=row.natureza.nome if row.natureza else None,
+    )
+
+
+def aceitar_sugestao_motivo_outros(
+    db: Session,
+    atendente: Atendente,
+    *,
+    natureza_id: int,
+    texto_normalizado: str,
+    nome: str | None = None,
+    slug: str | None = None,
+) -> TicketMotivoRead:
+    if atendente.role != "admin":
+        raise HTTPException(status_code=403, detail="Apenas administradores podem aceitar sugestões.")
+    norm = normalizar_descricao_demanda(texto_normalizado)
+    if not norm:
+        raise HTTPException(status_code=400, detail="Texto da sugestão inválido.")
+    natureza = db.query(TicketNatureza).filter(TicketNatureza.id == natureza_id).first()
+    if not natureza:
+        raise HTTPException(status_code=404, detail="Natureza não encontrada.")
+
+    existente = (
+        db.query(WhatsappDemandaMotivoSugestao)
+        .filter(
+            WhatsappDemandaMotivoSugestao.natureza_id == natureza_id,
+            WhatsappDemandaMotivoSugestao.texto_normalizado == norm,
+        )
+        .first()
+    )
+    if existente and existente.status == STATUS_ACEITA and existente.motivo_criado_id:
+        row = (
+            db.query(TicketMotivo)
+            .options(joinedload(TicketMotivo.natureza))
+            .filter(TicketMotivo.id == existente.motivo_criado_id)
+            .first()
+        )
+        if row:
+            return _motivo_para_read(row)
+
+    nome_motivo = (nome or norm).strip()[:120]
+    if not nome_motivo:
+        raise HTTPException(status_code=400, detail="Nome do motivo inválido.")
+    slug_base = (slug or slugify(nome_motivo))[:50]
+    candidato = slug_base or "motivo"
+    sufixo = 2
+    while (
+        db.query(TicketMotivo.id)
+        .filter(TicketMotivo.natureza_id == natureza_id, TicketMotivo.slug == candidato)
+        .first()
+        is not None
+    ):
+        candidato = f"{slug_base[:40]}-{sufixo}"
+        sufixo += 1
+
+    ordem_max = (
+        db.execute(
+            select(func.coalesce(func.max(TicketMotivo.ordem), 0)).where(
+                TicketMotivo.natureza_id == natureza_id,
+                TicketMotivo.slug != MOTIVO_OUTROS_SLUG,
+            )
+        ).scalar_one()
+    )
+    row = TicketMotivo(
+        natureza_id=natureza_id,
+        nome=nome_motivo,
+        slug=candidato,
+        ordem=int(ordem_max) + 1,
+        ativo=True,
+    )
+    db.add(row)
+    db.flush()
+
+    agora = datetime.now(timezone.utc)
+    if existente:
+        existente.status = STATUS_ACEITA
+        existente.motivo_criado_id = row.id
+        existente.decidido_por_id = atendente.id
+        existente.decidido_em = agora
+        existente.texto_exemplo = nome_motivo[:500]
+    else:
+        db.add(
+            WhatsappDemandaMotivoSugestao(
+                natureza_id=natureza_id,
+                texto_normalizado=norm,
+                texto_exemplo=nome_motivo[:500],
+                status=STATUS_ACEITA,
+                motivo_criado_id=row.id,
+                decidido_por_id=atendente.id,
+                decidido_em=agora,
+            )
+        )
+    db.commit()
+    row = (
+        db.query(TicketMotivo)
+        .options(joinedload(TicketMotivo.natureza))
+        .filter(TicketMotivo.id == row.id)
+        .first()
+    )
+    assert row is not None
+    return _motivo_para_read(row)
+
+
+def ignorar_sugestao_motivo_outros(
+    db: Session,
+    atendente: Atendente,
+    *,
+    natureza_id: int,
+    texto_normalizado: str,
+    texto_exemplo: str | None = None,
+) -> None:
+    if atendente.role != "admin":
+        raise HTTPException(status_code=403, detail="Apenas administradores podem ignorar sugestões.")
+    norm = normalizar_descricao_demanda(texto_normalizado)
+    if not norm:
+        raise HTTPException(status_code=400, detail="Texto da sugestão inválido.")
+    natureza = db.query(TicketNatureza).filter(TicketNatureza.id == natureza_id).first()
+    if not natureza:
+        raise HTTPException(status_code=404, detail="Natureza não encontrada.")
+
+    agora = datetime.now(timezone.utc)
+    existente = (
+        db.query(WhatsappDemandaMotivoSugestao)
+        .filter(
+            WhatsappDemandaMotivoSugestao.natureza_id == natureza_id,
+            WhatsappDemandaMotivoSugestao.texto_normalizado == norm,
+        )
+        .first()
+    )
+    exemplo = (texto_exemplo or norm).strip()[:500]
+    if existente:
+        existente.status = STATUS_IGNORADA
+        existente.motivo_criado_id = None
+        existente.decidido_por_id = atendente.id
+        existente.decidido_em = agora
+        existente.texto_exemplo = exemplo
+    else:
+        db.add(
+            WhatsappDemandaMotivoSugestao(
+                natureza_id=natureza_id,
+                texto_normalizado=norm,
+                texto_exemplo=exemplo,
+                status=STATUS_IGNORADA,
+                decidido_por_id=atendente.id,
+                decidido_em=agora,
+            )
+        )
+    db.commit()

--- a/backend/app/services/dashboard_geral.py
+++ b/backend/app/services/dashboard_geral.py
@@ -1,8 +1,8 @@
-"""Métricas consolidadas do dashboard geral (#282)."""
+"""Métricas consolidadas do dashboard geral (#282, #599)."""
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 from sqlalchemy import func, or_, select
 from sqlalchemy.orm import Session
@@ -13,11 +13,17 @@ from app.models.atendente import Atendente
 from app.models.ticket_avaliacao import TicketAvaliacao
 from app.models.whatsapp_chat import WhatsappChat
 from app.schemas.dashboard import CsAtMediaResumo, DashboardGeralResponse
+from app.services.ticket_dashboard_filters import (
+    period_bounds,
+    period_days_inclusive,
+    resolve_period,
+)
 
 CACHE_TTL_SECONDS = 60
+# Compat API sem `de`/`ate`: CSAT nos últimos 7 dias (inclusive).
 CSAT_PERIOD_DAYS = 7
 
-_cache: dict[tuple[int, str], tuple[datetime, DashboardGeralResponse]] = {}
+_cache: dict[tuple, tuple[datetime, DashboardGeralResponse]] = {}
 
 
 def clear_dashboard_geral_cache() -> None:
@@ -82,7 +88,9 @@ def _count_chats_por_estado(db: Session, atendente: Atendente, estado: str) -> i
     return int(db.execute(stmt).scalar_one())
 
 
-def _csat_tickets(db: Session, atendente: Atendente, desde: datetime) -> CsAtMediaResumo:
+def _csat_tickets(
+    db: Session, atendente: Atendente, desde: datetime, ate_exclusivo: datetime, periodo_dias: int
+) -> CsAtMediaResumo:
     stmt = (
         select(
             func.avg(TicketAvaliacao.nota),
@@ -90,7 +98,10 @@ def _csat_tickets(db: Session, atendente: Atendente, desde: datetime) -> CsAtMed
         )
         .select_from(TicketAvaliacao)
         .join(Ticket, Ticket.id == TicketAvaliacao.ticket_id)
-        .where(TicketAvaliacao.respondida_em >= desde)
+        .where(
+            TicketAvaliacao.respondida_em >= desde,
+            TicketAvaliacao.respondida_em < ate_exclusivo,
+        )
     )
     stmt = _ticket_scope(stmt, db, atendente)
     media, total = db.execute(stmt).one()
@@ -98,11 +109,13 @@ def _csat_tickets(db: Session, atendente: Atendente, desde: datetime) -> CsAtMed
     return CsAtMediaResumo(
         media=round(float(media), 2) if media is not None and total_int > 0 else None,
         total_avaliacoes=total_int,
-        periodo_dias=CSAT_PERIOD_DAYS,
+        periodo_dias=periodo_dias,
     )
 
 
-def _csat_chats(db: Session, atendente: Atendente, desde: datetime) -> CsAtMediaResumo:
+def _csat_chats(
+    db: Session, atendente: Atendente, desde: datetime, ate_exclusivo: datetime, periodo_dias: int
+) -> CsAtMediaResumo:
     stmt = (
         select(
             func.avg(WhatsappChat.avaliacao_nota),
@@ -113,6 +126,7 @@ def _csat_chats(db: Session, atendente: Atendente, desde: datetime) -> CsAtMedia
             WhatsappChat.avaliacao_nota.isnot(None),
             WhatsappChat.avaliacao_respondida_at.isnot(None),
             WhatsappChat.avaliacao_respondida_at >= desde,
+            WhatsappChat.avaliacao_respondida_at < ate_exclusivo,
         )
     )
     stmt = _whatsapp_scope(stmt, db, atendente)
@@ -121,35 +135,60 @@ def _csat_chats(db: Session, atendente: Atendente, desde: datetime) -> CsAtMedia
     return CsAtMediaResumo(
         media=round(float(media), 2) if media is not None and total_int > 0 else None,
         total_avaliacoes=total_int,
-        periodo_dias=CSAT_PERIOD_DAYS,
+        periodo_dias=periodo_dias,
     )
 
 
-def _compute_dashboard_geral(db: Session, atendente: Atendente) -> DashboardGeralResponse:
+def _resolve_csat_period(de: date | None, ate: date | None) -> tuple[date, date]:
+    if de is None and ate is None:
+        fim = date.today()
+        inicio = fim - timedelta(days=CSAT_PERIOD_DAYS - 1)
+        return inicio, fim
+    return resolve_period(de, ate)
+
+
+def _compute_dashboard_geral(
+    db: Session,
+    atendente: Atendente,
+    *,
+    de: date | None = None,
+    ate: date | None = None,
+) -> DashboardGeralResponse:
+    inicio, fim = _resolve_csat_period(de, ate)
+    desde, ate_exclusivo = period_bounds(inicio, fim)
+    periodo_dias = period_days_inclusive(inicio, fim)
     agora = datetime.now(timezone.utc)
-    desde = agora - timedelta(days=CSAT_PERIOD_DAYS)
     return DashboardGeralResponse(
         tickets_abertos=_count_tickets_abertos(db, atendente),
         tickets_sem_responsavel=_count_tickets_sem_responsavel(db, atendente),
         chats_aguardando_atendente=_count_chats_por_estado(db, atendente, "aguardando_atendente"),
         chats_em_atendimento=_count_chats_por_estado(db, atendente, "em_atendimento"),
-        csat_tickets=_csat_tickets(db, atendente, desde),
-        csat_chats=_csat_chats(db, atendente, desde),
+        csat_tickets=_csat_tickets(db, atendente, desde, ate_exclusivo, periodo_dias),
+        csat_chats=_csat_chats(db, atendente, desde, ate_exclusivo, periodo_dias),
         sla_violacoes_abertas=_count_sla_violacoes_abertas(db, atendente),
         sla_em_risco_abertas=_count_sla_em_risco_abertas(db, atendente),
+        de=inicio,
+        ate=fim,
         gerado_em=agora,
         cache_ttl_segundos=CACHE_TTL_SECONDS,
     )
 
 
-def obter_dashboard_geral(db: Session, atendente: Atendente) -> DashboardGeralResponse:
-    chave = (atendente.id, atendente.role)
+def obter_dashboard_geral(
+    db: Session,
+    atendente: Atendente,
+    *,
+    de: date | None = None,
+    ate: date | None = None,
+) -> DashboardGeralResponse:
+    inicio, fim = _resolve_csat_period(de, ate)
+    chave = (atendente.id, atendente.role, inicio.isoformat(), fim.isoformat())
     agora = datetime.now(timezone.utc)
     em_cache = _cache.get(chave)
     if em_cache is not None:
         gerado_em, resposta = em_cache
         if (agora - gerado_em).total_seconds() < CACHE_TTL_SECONDS:
             return resposta
-    resposta = _compute_dashboard_geral(db, atendente)
+    resposta = _compute_dashboard_geral(db, atendente, de=inicio, ate=fim)
     _cache[chave] = (agora, resposta)
     return resposta

--- a/backend/app/services/ticket_dashboard_filters.py
+++ b/backend/app/services/ticket_dashboard_filters.py
@@ -14,6 +14,12 @@ from app.models.atendente import Atendente
 DEFAULT_PERIOD_DAYS = 30
 MAX_PERIOD_DAYS = 366
 
+# Presets de calendário (#599). Semana = segunda → domingo (ISO weekday).
+PRESET_HOJE = "hoje"
+PRESET_ESTA_SEMANA = "esta_semana"
+PRESET_ESTE_MES = "este_mes"
+PRESET_MES_PASSADO = "mes_passado"
+
 
 def period_bounds(de: date, ate: date) -> tuple[datetime, datetime]:
     de_dt = datetime.combine(de, time.min, tzinfo=timezone.utc)
@@ -29,6 +35,50 @@ def resolve_period(de: date | None, ate: date | None) -> tuple[date, date]:
     if (fim - inicio).days > MAX_PERIOD_DAYS:
         inicio = fim - timedelta(days=MAX_PERIOD_DAYS)
     return inicio, fim
+
+
+def bounds_hoje(ref: date | None = None) -> tuple[date, date]:
+    d = ref or date.today()
+    return d, d
+
+
+def bounds_esta_semana(ref: date | None = None) -> tuple[date, date]:
+    """Segunda → domingo; se a semana ainda não acabou, o fim é `ref` (hoje)."""
+    d = ref or date.today()
+    inicio = d - timedelta(days=d.weekday())
+    fim_semana = inicio + timedelta(days=6)
+    fim = min(fim_semana, d)
+    return inicio, fim
+
+
+def bounds_este_mes(ref: date | None = None) -> tuple[date, date]:
+    d = ref or date.today()
+    return d.replace(day=1), d
+
+
+def bounds_mes_passado(ref: date | None = None) -> tuple[date, date]:
+    d = ref or date.today()
+    primeiro_este = d.replace(day=1)
+    ultimo_passado = primeiro_este - timedelta(days=1)
+    return ultimo_passado.replace(day=1), ultimo_passado
+
+
+def bounds_for_preset(preset: str, ref: date | None = None) -> tuple[date, date]:
+    """Calcula `de`/`ate` para presets de calendário (#599)."""
+    key = (preset or "").strip().lower()
+    if key == PRESET_HOJE:
+        return bounds_hoje(ref)
+    if key == PRESET_ESTA_SEMANA:
+        return bounds_esta_semana(ref)
+    if key == PRESET_ESTE_MES:
+        return bounds_este_mes(ref)
+    if key == PRESET_MES_PASSADO:
+        return bounds_mes_passado(ref)
+    raise ValueError(f"preset de período inválido: {preset}")
+
+
+def period_days_inclusive(de: date, ate: date) -> int:
+    return (ate - de).days + 1
 
 
 def normalizar_prioridade(prioridade: str | None) -> str | None:

--- a/backend/tests/test_dashboard_demandas_analise.py
+++ b/backend/tests/test_dashboard_demandas_analise.py
@@ -1,0 +1,205 @@
+"""Análise operacional de demandas WhatsApp (#594)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+from app.models.whatsapp_chat import WhatsappChat
+from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
+from app.services.dashboard_chats import clear_dashboard_chats_cache
+from app.services.dashboard_demandas_analise import (
+    LIMIAR_INSIGHT_DUVIDA,
+    LIMIAR_INSIGHT_ERRO,
+    LIMIAR_SUGESTAO_OUTROS,
+    normalizar_descricao_demanda,
+)
+
+
+def _nat_motivo(db_session, *, nat_slug: str, nat_nome: str, mot_slug: str, mot_nome: str):
+    nat = TicketNatureza(nome=nat_nome, slug=nat_slug, ordem=1, ativo=True)
+    db_session.add(nat)
+    db_session.flush()
+    mot = TicketMotivo(
+        natureza_id=nat.id, nome=mot_nome, slug=mot_slug, ordem=1, ativo=True
+    )
+    db_session.add(mot)
+    db_session.commit()
+    return nat, mot
+
+
+def _chat(db_session, seed_base, *, empresa_id=None, setor_id=None, suf="x"):
+    c = WhatsappChat(
+        protocolo=f"W-{suf}-{datetime.now().timestamp()}",
+        wa_id=f"5511888{suf}",
+        estado="encerrado",
+        setor_id=setor_id or seed_base["setor1"].id,
+        empresa_id=empresa_id if empresa_id is not None else seed_base["empresa"].id,
+        cliente_nome=f"Cliente {suf}",
+    )
+    db_session.add(c)
+    db_session.commit()
+    db_session.refresh(c)
+    return c
+
+
+def _demanda(db_session, chat, nat, mot=None, *, desc=None):
+    d = WhatsappChatDemanda(
+        chat_id=chat.id,
+        natureza_id=nat.id,
+        motivo_id=mot.id if mot else None,
+        desfecho="resolvido_sessao",
+        descricao_curta=desc,
+        created_at=datetime.now(timezone.utc),
+    )
+    db_session.add(d)
+    db_session.commit()
+    return d
+
+
+def test_normalizar_descricao_demanda():
+    assert normalizar_descricao_demanda("  Foo   BAR ") == "foo bar"
+    assert normalizar_descricao_demanda("   ") is None
+
+
+def test_drilldown_e_ranking_por_empresa(client, seed_base, auth_headers, db_session):
+    clear_dashboard_chats_cache()
+    nat, mot = _nat_motivo(
+        db_session, nat_slug="erro", nat_nome="Erro", mot_slug="bug-x", mot_nome="Bug X"
+    )
+    c1 = _chat(db_session, seed_base, suf="r1")
+    c2 = _chat(db_session, seed_base, suf="r2")
+    _demanda(db_session, c1, nat, mot)
+    _demanda(db_session, c2, nat, mot)
+
+    hoje = date.today().isoformat()
+    lista = client.get(
+        f"/v1/dashboard/chats/demandas?de={hoje}&ate={hoje}&natureza_id={nat.id}",
+        headers=auth_headers["admin"],
+    )
+    assert lista.status_code == 200
+    body = lista.json()
+    assert body["total"] == 2
+    assert len(body["items"]) == 2
+    assert {i["chat_id"] for i in body["items"]} == {c1.id, c2.id}
+
+    dash = client.get(
+        f"/v1/dashboard/chats?de={hoje}&ate={hoje}",
+        headers=auth_headers["admin"],
+    ).json()
+    assert dash["demanda_maior"]["id"] == nat.id
+    assert dash["demanda_maior"]["total"] == 2
+    assert any(e["empresa_id"] == seed_base["empresa"].id and e["total"] >= 2 for e in dash["demandas_por_empresa"])
+
+
+def test_insights_erro_e_duvida(client, seed_base, auth_headers, db_session):
+    clear_dashboard_chats_cache()
+    nat_erro, mot_erro = _nat_motivo(
+        db_session, nat_slug="erro", nat_nome="Erro", mot_slug="falha", mot_nome="Falha"
+    )
+    nat_duv, mot_duv = _nat_motivo(
+        db_session, nat_slug="duvida", nat_nome="Dúvida", mot_slug="login", mot_nome="Login"
+    )
+    for i in range(LIMIAR_INSIGHT_ERRO):
+        c = _chat(db_session, seed_base, suf=f"e{i}")
+        _demanda(db_session, c, nat_erro, mot_erro)
+    for i in range(LIMIAR_INSIGHT_DUVIDA):
+        c = _chat(db_session, seed_base, suf=f"d{i}")
+        _demanda(db_session, c, nat_duv, mot_duv)
+
+    hoje = date.today().isoformat()
+    dash = client.get(
+        f"/v1/dashboard/chats?de={hoje}&ate={hoje}",
+        headers=auth_headers["admin"],
+    ).json()
+    tipos = {i["tipo"] for i in dash["insights_demandas"]}
+    assert "avaliar_atualizacao" in tipos
+    assert "sugerir_treinamento" in tipos
+
+
+def test_sugestao_outros_aceitar_e_ignorar(client, seed_base, auth_headers, db_session):
+    clear_dashboard_chats_cache()
+    nat, _ = _nat_motivo(
+        db_session, nat_slug="solicitacao", nat_nome="Solicitação", mot_slug="x", mot_nome="X"
+    )
+    outros = TicketMotivo(
+        natureza_id=nat.id, nome="Outros", slug="outros", ordem=99, ativo=True
+    )
+    db_session.add(outros)
+    db_session.commit()
+
+    texto = "Precisa emitir 2ª via do boleto"
+    for i in range(LIMIAR_SUGESTAO_OUTROS):
+        c = _chat(db_session, seed_base, suf=f"o{i}")
+        _demanda(db_session, c, nat, outros, desc=texto if i % 2 == 0 else f"  {texto.upper()}  ")
+
+    hoje = date.today().isoformat()
+    dash = client.get(
+        f"/v1/dashboard/chats?de={hoje}&ate={hoje}",
+        headers=auth_headers["admin"],
+    ).json()
+    sugs = dash["sugestoes_motivo_outros"]
+    assert len(sugs) >= 1
+    sug = next(s for s in sugs if "boleto" in s["texto_normalizado"])
+    assert sug["ocorrencias"] >= LIMIAR_SUGESTAO_OUTROS
+
+    aceitar = client.post(
+        "/v1/dashboard/chats/demandas/sugestoes-motivo/aceitar",
+        json={
+            "natureza_id": sug["natureza_id"],
+            "texto_normalizado": sug["texto_normalizado"],
+            "nome": "2ª via de boleto",
+        },
+        headers=auth_headers["admin"],
+    )
+    assert aceitar.status_code == 200
+    assert aceitar.json()["nome"] == "2ª via de boleto"
+    assert aceitar.json()["natureza_id"] == nat.id
+
+    dash2 = client.get(
+        f"/v1/dashboard/chats?de={hoje}&ate={hoje}",
+        headers=auth_headers["admin"],
+    ).json()
+    assert not any(s["texto_normalizado"] == sug["texto_normalizado"] for s in dash2["sugestoes_motivo_outros"])
+
+    # segunda descrição para ignorar
+    texto2 = "Relatório mensal customizado"
+    for i in range(LIMIAR_SUGESTAO_OUTROS):
+        c = _chat(db_session, seed_base, suf=f"ig{i}")
+        _demanda(db_session, c, nat, outros, desc=texto2)
+
+    clear_dashboard_chats_cache()
+    dash3 = client.get(
+        f"/v1/dashboard/chats?de={hoje}&ate={hoje}",
+        headers=auth_headers["admin"],
+    ).json()
+    sug2 = next(s for s in dash3["sugestoes_motivo_outros"] if "relatorio" in s["texto_normalizado"])
+    ign = client.post(
+        "/v1/dashboard/chats/demandas/sugestoes-motivo/ignorar",
+        json={
+            "natureza_id": sug2["natureza_id"],
+            "texto_normalizado": sug2["texto_normalizado"],
+            "texto_exemplo": sug2["texto_exemplo"],
+        },
+        headers=auth_headers["admin"],
+    )
+    assert ign.status_code == 204
+
+    clear_dashboard_chats_cache()
+    dash4 = client.get(
+        f"/v1/dashboard/chats?de={hoje}&ate={hoje}",
+        headers=auth_headers["admin"],
+    ).json()
+    assert not any(s["texto_normalizado"] == sug2["texto_normalizado"] for s in dash4["sugestoes_motivo_outros"])
+
+
+def test_atendente_nao_aceita_sugestao(client, seed_base, auth_headers, db_session):
+    nat, _ = _nat_motivo(
+        db_session, nat_slug="solicitacao-a", nat_nome="Sol A", mot_slug="xa", mot_nome="Xa"
+    )
+    r = client.post(
+        "/v1/dashboard/chats/demandas/sugestoes-motivo/aceitar",
+        json={"natureza_id": nat.id, "texto_normalizado": "algo"},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 403

--- a/backend/tests/test_dashboard_geral.py
+++ b/backend/tests/test_dashboard_geral.py
@@ -69,6 +69,9 @@ def test_dashboard_geral_admin_ve_global(client, seed_base, auth_headers, db_ses
     assert body["cache_ttl_segundos"] == CACHE_TTL_SECONDS
     assert body["csat_tickets"]["total_avaliacoes"] == 0
     assert body["csat_tickets"]["media"] is None
+    assert body["de"]
+    assert body["ate"]
+    assert body["csat_tickets"]["periodo_dias"] == 7
 
 
 def test_dashboard_geral_atendente_escopo_setor(client, seed_base, auth_headers, db_session):
@@ -110,6 +113,45 @@ def test_dashboard_geral_csat_7_dias(client, seed_base, auth_headers, db_session
     assert body["csat_tickets"]["media"] == 5.0
     assert body["csat_chats"]["total_avaliacoes"] == 1
     assert body["csat_chats"]["media"] == 4.0
+    assert body["csat_tickets"]["periodo_dias"] == 7
+
+
+def test_dashboard_geral_csat_respeita_periodo(client, seed_base, auth_headers, db_session):
+    from datetime import date
+
+    t = _criar_ticket(db_session, seed_base, setor_id=seed_base["setor1"].id, fechado=True)
+    db_session.add(
+        TicketAvaliacao(
+            ticket_id=t.id,
+            atendente_id=seed_base["admin"].id,
+            nota=5,
+            respondida_em=datetime.now(timezone.utc) - timedelta(days=10),
+        )
+    )
+    db_session.commit()
+
+    hoje = date.today()
+    r_hoje = client.get(
+        f"/v1/dashboard/geral?de={hoje.isoformat()}&ate={hoje.isoformat()}",
+        headers=auth_headers["admin"],
+    )
+    assert r_hoje.status_code == 200
+    body_hoje = r_hoje.json()
+    assert body_hoje["csat_tickets"]["total_avaliacoes"] == 0
+    assert body_hoje["de"] == hoje.isoformat()
+    assert body_hoje["ate"] == hoje.isoformat()
+    assert body_hoje["csat_tickets"]["periodo_dias"] == 1
+
+    de = (hoje - timedelta(days=14)).isoformat()
+    ate = hoje.isoformat()
+    r_amp = client.get(
+        f"/v1/dashboard/geral?de={de}&ate={ate}",
+        headers=auth_headers["admin"],
+    )
+    assert r_amp.status_code == 200
+    body_amp = r_amp.json()
+    assert body_amp["csat_tickets"]["total_avaliacoes"] == 1
+    assert body_amp["csat_tickets"]["media"] == 5.0
 
 
 def test_dashboard_geral_requer_autenticacao(client):

--- a/backend/tests/test_dashboard_isolamento_cliente.py
+++ b/backend/tests/test_dashboard_isolamento_cliente.py
@@ -1,0 +1,79 @@
+"""Isolamento de análises por rede/empresa (#595)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from app.models.empresa import Empresa
+from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+from app.models.whatsapp_chat import WhatsappChat
+from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
+from app.services.dashboard_chats import clear_dashboard_chats_cache
+
+
+def test_demandas_filtradas_por_empresa_nao_vazam(client, seed_base, auth_headers, db_session):
+    clear_dashboard_chats_cache()
+    emp_a = seed_base["empresa"]
+    emp_b = Empresa(
+        tenant_id=1,
+        rede_id=emp_a.rede_id,
+        nome="Empresa B isolamento",
+        cnpj_cpf="00000000000191",
+        ativo=True,
+    )
+    db_session.add(emp_b)
+    db_session.flush()
+
+    nat = TicketNatureza(nome="Iso Nat", slug="iso-nat-595", ordem=1, ativo=True)
+    db_session.add(nat)
+    db_session.flush()
+    mot = TicketMotivo(natureza_id=nat.id, nome="Iso Mot", slug="iso-mot-595", ordem=1, ativo=True)
+    db_session.add(mot)
+    db_session.commit()
+
+    for emp, suf in ((emp_a, "a"), (emp_b, "b")):
+        chat = WhatsappChat(
+            protocolo=f"W-iso-{suf}-{datetime.now().timestamp()}",
+            wa_id=f"5511777{suf}",
+            estado="encerrado",
+            setor_id=seed_base["setor1"].id,
+            empresa_id=emp.id,
+        )
+        db_session.add(chat)
+        db_session.flush()
+        db_session.add(
+            WhatsappChatDemanda(
+                chat_id=chat.id,
+                natureza_id=nat.id,
+                motivo_id=mot.id,
+                desfecho="resolvido_sessao",
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+    db_session.commit()
+
+    hoje = date.today().isoformat()
+    r_a = client.get(
+        f"/v1/dashboard/chats?de={hoje}&ate={hoje}&empresa_id={emp_a.id}",
+        headers=auth_headers["admin"],
+    )
+    assert r_a.status_code == 200
+    body_a = r_a.json()
+    assert body_a["demanda_maior"]["total"] == 1
+    assert all(e["empresa_id"] == emp_a.id for e in body_a["demandas_por_empresa"])
+
+    r_b = client.get(
+        f"/v1/dashboard/chats?de={hoje}&ate={hoje}&empresa_id={emp_b.id}",
+        headers=auth_headers["admin"],
+    )
+    assert r_b.status_code == 200
+    body_b = r_b.json()
+    assert body_b["demanda_maior"]["total"] == 1
+    assert all(e["empresa_id"] == emp_b.id for e in body_b["demandas_por_empresa"])
+
+    lista = client.get(
+        f"/v1/dashboard/chats/demandas?de={hoje}&ate={hoje}&empresa_id={emp_a.id}",
+        headers=auth_headers["admin"],
+    ).json()
+    assert lista["total"] == 1
+    assert lista["items"][0]["empresa_id"] == emp_a.id

--- a/backend/tests/test_period_bounds.py
+++ b/backend/tests/test_period_bounds.py
@@ -1,0 +1,64 @@
+"""Limites de período de calendário do dashboard (#599)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from app.services.ticket_dashboard_filters import (
+    bounds_esta_semana,
+    bounds_este_mes,
+    bounds_for_preset,
+    bounds_hoje,
+    bounds_mes_passado,
+    period_days_inclusive,
+)
+
+
+def test_bounds_hoje():
+    assert bounds_hoje(date(2026, 7, 19)) == (date(2026, 7, 19), date(2026, 7, 19))
+
+
+def test_bounds_esta_semana_meio_da_semana():
+    # quarta 15/07/2026 → seg 13/07 até quarta 15/07
+    assert bounds_esta_semana(date(2026, 7, 15)) == (date(2026, 7, 13), date(2026, 7, 15))
+
+
+def test_bounds_esta_semana_domingo_completo():
+    # domingo 19/07/2026 → seg 13/07 até dom 19/07
+    assert bounds_esta_semana(date(2026, 7, 19)) == (date(2026, 7, 13), date(2026, 7, 19))
+
+
+def test_bounds_esta_semana_segunda():
+    assert bounds_esta_semana(date(2026, 7, 13)) == (date(2026, 7, 13), date(2026, 7, 13))
+
+
+def test_bounds_este_mes():
+    assert bounds_este_mes(date(2026, 7, 19)) == (date(2026, 7, 1), date(2026, 7, 19))
+
+
+def test_bounds_mes_passado():
+    assert bounds_mes_passado(date(2026, 7, 19)) == (date(2026, 6, 1), date(2026, 6, 30))
+
+
+def test_bounds_mes_passado_em_janeiro():
+    assert bounds_mes_passado(date(2026, 1, 5)) == (date(2025, 12, 1), date(2025, 12, 31))
+
+
+def test_bounds_for_preset_aliases():
+    ref = date(2026, 8, 2)
+    assert bounds_for_preset("hoje", ref) == bounds_hoje(ref)
+    assert bounds_for_preset("esta_semana", ref) == bounds_esta_semana(ref)
+    assert bounds_for_preset("este_mes", ref) == bounds_este_mes(ref)
+    assert bounds_for_preset("mes_passado", ref) == bounds_mes_passado(ref)
+
+
+def test_bounds_for_preset_invalido():
+    with pytest.raises(ValueError, match="preset"):
+        bounds_for_preset("7dias")
+
+
+def test_period_days_inclusive():
+    assert period_days_inclusive(date(2026, 7, 1), date(2026, 7, 1)) == 1
+    assert period_days_inclusive(date(2026, 7, 1), date(2026, 7, 7)) == 7

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1409,7 +1409,8 @@ export const tickets = {
 
 export const dashboard = {
   get: () => api<Dashboard.Response>('/dashboard'),
-  getGeral: () => api<Dashboard.GeralResponse>('/dashboard/geral'),
+  getGeral: (params?: { de?: string; ate?: string }) =>
+    api<Dashboard.GeralResponse>(withParams('/dashboard/geral', params)),
   getTickets: (params?: {
     de?: string;
     ate?: string;
@@ -1430,6 +1431,37 @@ export const dashboard = {
     drill_tipo?: string;
     drill_valor?: string;
   }) => api<Dashboard.ChatsResponse>(withParams('/dashboard/chats', params)),
+  getChatsDemandas: (params?: {
+    de?: string;
+    ate?: string;
+    setor_id?: number;
+    empresa_id?: number;
+    rede_id?: number;
+    natureza_id?: number;
+    motivo_id?: number;
+    skip?: number;
+    limit?: number;
+  }) =>
+    api<Dashboard.DemandasDrillResponse>(withParams('/dashboard/chats/demandas', params)),
+  aceitarSugestaoMotivoOutros: (body: {
+    natureza_id: number;
+    texto_normalizado: string;
+    nome?: string;
+    slug?: string;
+  }) =>
+    api<TicketClassificacao.Motivo>('/dashboard/chats/demandas/sugestoes-motivo/aceitar', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  ignorarSugestaoMotivoOutros: (body: {
+    natureza_id: number;
+    texto_normalizado: string;
+    texto_exemplo?: string;
+  }) =>
+    api<void>('/dashboard/chats/demandas/sugestoes-motivo/ignorar', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
 };
 
 export const relatorios = {
@@ -1780,6 +1812,8 @@ export namespace Dashboard {
     csat_chats: CsatResumo;
     sla_violacoes_abertas: number;
     sla_em_risco_abertas: number;
+    de: string;
+    ate: string;
     gerado_em: string;
     cache_ttl_segundos: number;
   }
@@ -1840,6 +1874,50 @@ export namespace Dashboard {
     rotulo: string;
     total: number;
   }
+  export interface DemandaEmpresaRanking {
+    empresa_id: number | null;
+    empresa_nome: string;
+    total: number;
+    natureza_dominante_id: number | null;
+    natureza_dominante_nome: string | null;
+    natureza_dominante_slug: string | null;
+  }
+  export interface DemandaInsight {
+    tipo: string;
+    titulo: string;
+    detalhe: string;
+    natureza_id: number | null;
+    motivo_id: number | null;
+    total: number;
+    limiar: number;
+  }
+  export interface SugestaoMotivoOutros {
+    natureza_id: number;
+    natureza_nome: string;
+    texto_normalizado: string;
+    texto_exemplo: string;
+    ocorrencias: number;
+    limiar: number;
+  }
+  export interface DemandaDrillItem {
+    demanda_id: number;
+    chat_id: number;
+    protocolo: string;
+    cliente_nome: string | null;
+    empresa_id: number | null;
+    empresa_nome: string | null;
+    natureza_id: number;
+    natureza_nome: string;
+    motivo_id: number | null;
+    motivo_nome: string | null;
+    desfecho: string;
+    descricao_curta: string | null;
+    created_at: string;
+  }
+  export interface DemandasDrillResponse {
+    items: DemandaDrillItem[];
+    total: number;
+  }
   export interface ChatsResponse {
     de: string;
     ate: string;
@@ -1853,6 +1931,10 @@ export namespace Dashboard {
     por_estado_atual: ContagemRotulo[];
     demandas_por_natureza: ContagemIdNome[];
     demandas_por_motivo: ContagemIdNome[];
+    demandas_por_empresa: DemandaEmpresaRanking[];
+    demanda_maior: ContagemIdNome | null;
+    insights_demandas: DemandaInsight[];
+    sugestoes_motivo_outros: SugestaoMotivoOutros[];
     snapshot: SnapshotCanais;
     gerado_em: string;
     cache_ttl_segundos: number;

--- a/frontend/src/components/dashboard/DashboardDemandasAnalise.tsx
+++ b/frontend/src/components/dashboard/DashboardDemandasAnalise.tsx
@@ -1,0 +1,402 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { dashboard, type Dashboard } from '../../api/client'
+import { useToast } from '../ui/Toast'
+import { Button } from '../ui/Button'
+import { Card } from '../ui/Card'
+import { barClickableProps, chartTooltipProps } from './dashboardChartUtils'
+import { corDrill } from './useDashboardDrilldown'
+import { exibirProtocolo } from '../../lib/exibirProtocolo'
+
+type FiltroDemanda = {
+  naturezaId: number | null
+  naturezaNome: string | null
+  motivoId: number | null
+  motivoNome: string | null
+}
+
+type Props = {
+  data: Dashboard.ChatsResponse
+  de: string
+  ate: string
+  setorId: number | ''
+  redeId?: number
+  empresaId?: number
+  isAdmin: boolean
+  onRecarregar: () => void
+}
+
+function rotuloDesfecho(d: string): string {
+  if (d === 'resolvido_sessao') return 'Resolvido na sessão'
+  if (d === 'escalado_ticket') return 'Escalado para ticket'
+  return d
+}
+
+export function DashboardDemandasAnalise({
+  data,
+  de,
+  ate,
+  setorId,
+  redeId,
+  empresaId,
+  isAdmin,
+  onRecarregar,
+}: Props) {
+  const toast = useToast()
+  const [filtro, setFiltro] = useState<FiltroDemanda>({
+    naturezaId: null,
+    naturezaNome: null,
+    motivoId: null,
+    motivoNome: null,
+  })
+  const [itens, setItens] = useState<Dashboard.DemandaDrillItem[]>([])
+  const [total, setTotal] = useState(0)
+  const [loadingLista, setLoadingLista] = useState(false)
+  const [acaoKey, setAcaoKey] = useState<string | null>(null)
+
+  const temFiltro = filtro.naturezaId != null || filtro.motivoId != null
+
+  useEffect(() => {
+    if (!temFiltro) {
+      setItens([])
+      setTotal(0)
+      return
+    }
+    setLoadingLista(true)
+    dashboard
+      .getChatsDemandas({
+        de,
+        ate,
+        setor_id: setorId === '' ? undefined : setorId,
+        rede_id: redeId,
+        empresa_id: empresaId,
+        natureza_id: filtro.naturezaId ?? undefined,
+        motivo_id: filtro.motivoId ?? undefined,
+        limit: 40,
+      })
+      .then((res) => {
+        setItens(res.items)
+        setTotal(res.total)
+      })
+      .catch(() => {
+        setItens([])
+        setTotal(0)
+        toast.showError('Não foi possível carregar as demandas filtradas.')
+      })
+      .finally(() => setLoadingLista(false))
+  }, [temFiltro, de, ate, setorId, redeId, empresaId, filtro.naturezaId, filtro.motivoId, toast])
+
+  const naturezaChart = (data.demandas_por_natureza ?? []).map((d) => ({
+    id: d.id,
+    nome: d.nome,
+    total: d.total,
+  }))
+  const motivoChart = (data.demandas_por_motivo ?? []).map((d) => ({
+    id: d.id,
+    nome: d.nome,
+    total: d.total,
+  }))
+
+  const limparFiltro = () =>
+    setFiltro({ naturezaId: null, naturezaNome: null, motivoId: null, motivoNome: null })
+
+  const aceitar = async (s: Dashboard.SugestaoMotivoOutros) => {
+    const key = `${s.natureza_id}:${s.texto_normalizado}`
+    setAcaoKey(key)
+    try {
+      await dashboard.aceitarSugestaoMotivoOutros({
+        natureza_id: s.natureza_id,
+        texto_normalizado: s.texto_normalizado,
+        nome: s.texto_exemplo.slice(0, 120),
+      })
+      toast.showSuccess('Motivo criado no catálogo a partir da sugestão.')
+      onRecarregar()
+    } catch {
+      toast.showError('Não foi possível criar o motivo.')
+    } finally {
+      setAcaoKey(null)
+    }
+  }
+
+  const ignorar = async (s: Dashboard.SugestaoMotivoOutros) => {
+    const key = `${s.natureza_id}:${s.texto_normalizado}`
+    setAcaoKey(key)
+    try {
+      await dashboard.ignorarSugestaoMotivoOutros({
+        natureza_id: s.natureza_id,
+        texto_normalizado: s.texto_normalizado,
+        texto_exemplo: s.texto_exemplo,
+      })
+      toast.showSuccess('Sugestão ignorada.')
+      onRecarregar()
+    } catch {
+      toast.showError('Não foi possível ignorar a sugestão.')
+    } finally {
+      setAcaoKey(null)
+    }
+  }
+
+  return (
+    <div className="mt-6 space-y-6">
+      {data.demanda_maior ? (
+        <Card className="border-l-4 border-l-violet-500">
+          <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Maior demanda no período</p>
+          <p className="mt-1 text-xl font-bold text-slate-800 dark:text-slate-100">
+            {data.demanda_maior.nome}{' '}
+            <span className="text-base font-semibold text-violet-600 dark:text-violet-400">
+              ({data.demanda_maior.total})
+            </span>
+          </p>
+        </Card>
+      ) : null}
+
+      {(data.insights_demandas ?? []).length > 0 ? (
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+          {data.insights_demandas.map((ins) => (
+            <Card
+              key={`${ins.tipo}-${ins.natureza_id}-${ins.motivo_id}`}
+              className={
+                ins.tipo === 'avaliar_atualizacao'
+                  ? 'border-l-4 border-l-amber-500'
+                  : 'border-l-4 border-l-sky-500'
+              }
+            >
+              <p className="text-sm font-semibold text-slate-800 dark:text-slate-100">{ins.titulo}</p>
+              <p className="mt-1 text-sm text-slate-600 dark:text-slate-400">{ins.detalhe}</p>
+              {ins.natureza_id != null ? (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="mt-3"
+                  onClick={() =>
+                    setFiltro({
+                      naturezaId: ins.natureza_id,
+                      naturezaNome: null,
+                      motivoId: ins.motivo_id,
+                      motivoNome: null,
+                    })
+                  }
+                >
+                  Ver demandas
+                </Button>
+              ) : null}
+            </Card>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-2">
+        <Card
+          title="Demandas por natureza"
+          description="Clique numa barra para listar os chats dessa natureza"
+        >
+          <div className="h-72">
+            {naturezaChart.length === 0 ? (
+              <p className="text-slate-500 dark:text-slate-400">Nenhuma demanda registrada no período.</p>
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={naturezaChart}>
+                  <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                  <XAxis dataKey="nome" tick={{ fontSize: 11 }} />
+                  <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                  <Tooltip {...chartTooltipProps} />
+                  <Bar
+                    dataKey="total"
+                    name="Demandas"
+                    radius={[4, 4, 0, 0]}
+                    {...barClickableProps}
+                    onClick={(bar) => {
+                      const p = bar?.payload as { id?: number; nome?: string }
+                      if (p?.id != null && p.nome) {
+                        setFiltro({
+                          naturezaId: p.id,
+                          naturezaNome: p.nome,
+                          motivoId: null,
+                          motivoNome: null,
+                        })
+                      }
+                    }}
+                  >
+                    {naturezaChart.map((entry) => (
+                      <Cell
+                        key={entry.id}
+                        fill={corDrill(
+                          '#8b5cf6',
+                          filtro.naturezaId === entry.id && filtro.motivoId == null,
+                          temFiltro,
+                        )}
+                      />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </Card>
+
+        <Card title="Demandas por motivo" description="Clique numa barra para listar os chats desse motivo">
+          <div className="h-72">
+            {motivoChart.length === 0 ? (
+              <p className="text-slate-500 dark:text-slate-400">Nenhum motivo registrado no período.</p>
+            ) : (
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={motivoChart}>
+                  <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
+                  <XAxis dataKey="nome" tick={{ fontSize: 11 }} />
+                  <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+                  <Tooltip {...chartTooltipProps} />
+                  <Bar
+                    dataKey="total"
+                    name="Demandas"
+                    radius={[4, 4, 0, 0]}
+                    {...barClickableProps}
+                    onClick={(bar) => {
+                      const p = bar?.payload as { id?: number; nome?: string }
+                      if (p?.id != null && p.nome) {
+                        setFiltro({
+                          naturezaId: null,
+                          naturezaNome: null,
+                          motivoId: p.id,
+                          motivoNome: p.nome,
+                        })
+                      }
+                    }}
+                  >
+                    {motivoChart.map((entry) => (
+                      <Cell
+                        key={entry.id}
+                        fill={corDrill('#a855f7', filtro.motivoId === entry.id, temFiltro)}
+                      />
+                    ))}
+                  </Bar>
+                </BarChart>
+              </ResponsiveContainer>
+            )}
+          </div>
+        </Card>
+      </div>
+
+      <Card
+        title="Ranking por empresa"
+        description="Volume de demandas no período e natureza dominante de cada cliente"
+      >
+        {(data.demandas_por_empresa ?? []).length === 0 ? (
+          <p className="text-slate-500 dark:text-slate-400">Sem demandas com empresa no período.</p>
+        ) : (
+          <ul className="divide-y divide-slate-200 dark:divide-slate-700">
+            {data.demandas_por_empresa.map((e) => (
+              <li key={`${e.empresa_id ?? 'none'}-${e.empresa_nome}`} className="flex flex-wrap items-center justify-between gap-2 py-2.5 text-sm">
+                <div>
+                  <p className="font-medium text-slate-800 dark:text-slate-100">{e.empresa_nome}</p>
+                  {e.natureza_dominante_nome ? (
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      Dominante: {e.natureza_dominante_nome}
+                    </p>
+                  ) : null}
+                </div>
+                <span className="font-semibold text-slate-700 dark:text-slate-200">{e.total}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      {temFiltro ? (
+        <Card
+          title="Demandas filtradas"
+          description={
+            filtro.motivoNome
+              ? `Motivo: ${filtro.motivoNome}`
+              : filtro.naturezaNome
+                ? `Natureza: ${filtro.naturezaNome}`
+                : 'Filtro ativo'
+          }
+        >
+          <div className="mb-3">
+            <Button type="button" variant="secondary" onClick={limparFiltro}>
+              Limpar filtro
+            </Button>
+          </div>
+          {loadingLista ? (
+            <p className="text-slate-500 dark:text-slate-400">A carregar…</p>
+          ) : itens.length === 0 ? (
+            <p className="text-slate-500 dark:text-slate-400">Nenhuma demanda neste filtro.</p>
+          ) : (
+            <>
+              <p className="mb-3 text-xs text-slate-500 dark:text-slate-400">
+                {total} resultado{total === 1 ? '' : 's'} (a mostrar até {itens.length})
+              </p>
+              <ul className="divide-y divide-slate-200 dark:divide-slate-700">
+                {itens.map((item) => (
+                  <li key={item.demanda_id} className="flex flex-wrap items-center justify-between gap-2 py-2.5 text-sm">
+                    <div className="min-w-0">
+                      <Link
+                        to={`/chat/c/${item.chat_id}`}
+                        className="font-medium text-cyan-700 hover:text-cyan-800 dark:text-cyan-400"
+                      >
+                        {exibirProtocolo(item.protocolo)}
+                      </Link>
+                      <p className="text-slate-600 dark:text-slate-400">
+                        {[item.cliente_nome, item.empresa_nome].filter(Boolean).join(' · ') || '—'}
+                      </p>
+                      <p className="text-xs text-slate-500 dark:text-slate-500">
+                        {item.natureza_nome}
+                        {item.motivo_nome ? ` · ${item.motivo_nome}` : ''} · {rotuloDesfecho(item.desfecho)}
+                        {item.descricao_curta ? ` · ${item.descricao_curta}` : ''}
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </Card>
+      ) : null}
+
+      {isAdmin && (data.sugestoes_motivo_outros ?? []).length > 0 ? (
+        <Card
+          title="Sugestões de novo motivo (a partir de «Outros»)"
+          description="Mesma descrição repetida várias vezes — aceite para criar no catálogo ou ignore"
+        >
+          <ul className="space-y-3">
+            {data.sugestoes_motivo_outros.map((s) => {
+              const key = `${s.natureza_id}:${s.texto_normalizado}`
+              const busy = acaoKey === key
+              return (
+                <li
+                  key={key}
+                  className="flex flex-col gap-2 rounded-lg border border-slate-200 p-3 dark:border-slate-700 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div>
+                    <p className="font-medium text-slate-800 dark:text-slate-100">{s.texto_exemplo}</p>
+                    <p className="text-xs text-slate-500 dark:text-slate-400">
+                      {s.natureza_nome} · {s.ocorrencias} ocorrências (limiar {s.limiar})
+                    </p>
+                  </div>
+                  <div className="flex flex-wrap gap-2">
+                    <Button type="button" disabled={busy} onClick={() => void aceitar(s)}>
+                      Criar motivo
+                    </Button>
+                    <Button type="button" variant="secondary" disabled={busy} onClick={() => void ignorar(s)}>
+                      Ignorar
+                    </Button>
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        </Card>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/DashboardPeriodoFiltro.tsx
+++ b/frontend/src/components/dashboard/DashboardPeriodoFiltro.tsx
@@ -1,0 +1,68 @@
+import { Button } from '../ui/Button'
+import { PRESET_OPCOES, type PresetPeriodo } from './dashboardMetrics'
+
+type Props = {
+  preset: PresetPeriodo
+  de: string
+  ate: string
+  onPreset: (p: Exclude<PresetPeriodo, 'custom'>) => void
+  onCustom: () => void
+  onDeChange: (v: string) => void
+  onAteChange: (v: string) => void
+}
+
+/**
+ * Filtro de período reutilizável (#599).
+ * Semana = segunda → domingo (até hoje se a semana ainda não acabou).
+ */
+export function DashboardPeriodoFiltro({
+  preset,
+  de,
+  ate,
+  onPreset,
+  onCustom,
+  onDeChange,
+  onAteChange,
+}: Props) {
+  return (
+    <>
+      <div className="flex flex-wrap gap-2" role="group" aria-label="Período">
+        {PRESET_OPCOES.map((op) => (
+          <Button
+            key={op.id}
+            type="button"
+            variant={preset === op.id ? 'primary' : 'secondary'}
+            onClick={() => onPreset(op.id)}
+          >
+            {op.label}
+          </Button>
+        ))}
+        <Button type="button" variant={preset === 'custom' ? 'primary' : 'secondary'} onClick={onCustom}>
+          Personalizado
+        </Button>
+      </div>
+      {preset === 'custom' ? (
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+            De
+            <input
+              type="date"
+              value={de}
+              onChange={(e) => onDeChange(e.target.value)}
+              className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
+            Até
+            <input
+              type="date"
+              value={ate}
+              onChange={(e) => onAteChange(e.target.value)}
+              className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
+            />
+          </label>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/frontend/src/components/dashboard/PainelAnalisesCliente.tsx
+++ b/frontend/src/components/dashboard/PainelAnalisesCliente.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ApiError, dashboard, type Dashboard } from '../../api/client'
+import { useDashboardPeriodo } from '../../hooks/useDashboardPeriodo'
+import { useToast } from '../ui/Toast'
+import { Button } from '../ui/Button'
+import { Card } from '../ui/Card'
+import { DashboardPeriodoFiltro } from './DashboardPeriodoFiltro'
+import { DashboardDemandasAnalise } from './DashboardDemandasAnalise'
+import { formatarIntervaloPeriodo, MetricCard } from './dashboardMetrics'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/errorMessage'
+
+type Props = {
+  /** Escopo da rede (agrega todas as empresas). */
+  redeId?: number
+  /** Escopo de uma empresa. */
+  empresaId?: number
+  /** Navegação para listagens no mesmo contexto (aba ou rota). */
+  onVerTickets?: () => void
+  onVerChats?: () => void
+  hrefTickets?: string
+  hrefChats?: string
+}
+
+/**
+ * Painel de análises no detalhe Rede/Empresa (#595).
+ * Reutiliza APIs de dashboard + análise de demandas (#594) e filtro de período (#599).
+ */
+export function PainelAnalisesCliente({
+  redeId,
+  empresaId,
+  onVerTickets,
+  onVerChats,
+  hrefTickets,
+  hrefChats,
+}: Props) {
+  const toast = useToast()
+  const { preset, de, ate, aplicarPreset, marcarCustom, onDeChange, onAteChange } =
+    useDashboardPeriodo('este_mes')
+  const [ticketsDash, setTicketsDash] = useState<Dashboard.TicketsResponse | null>(null)
+  const [chatsDash, setChatsDash] = useState<Dashboard.ChatsResponse | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
+
+  useEffect(() => {
+    if (redeId == null && empresaId == null) return
+    setLoading(true)
+    setError(null)
+    const ticketsParams: Parameters<typeof dashboard.getTickets>[0] = { de, ate }
+    if (redeId != null) ticketsParams.rede_id = redeId
+    if (empresaId != null) {
+      ticketsParams.drill_tipo = 'empresa'
+      ticketsParams.drill_valor = String(empresaId)
+    }
+    const chatsParams: Parameters<typeof dashboard.getChats>[0] = { de, ate }
+    if (redeId != null) chatsParams.rede_id = redeId
+    if (empresaId != null) chatsParams.empresa_id = empresaId
+
+    Promise.all([dashboard.getTickets(ticketsParams), dashboard.getChats(chatsParams)])
+      .then(([t, c]) => {
+        setTicketsDash(t)
+        setChatsDash(c)
+      })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setError('Sem permissão para ver estas análises.')
+          return
+        }
+        const m = interpretarFalhaCarregamento(err, 'Não encontramos as análises deste cliente.')
+        setError(m.titulo)
+        toast.showError(mensagemFalhaParaToast(m))
+      })
+      .finally(() => setLoading(false))
+  }, [redeId, empresaId, de, ate, reloadKey, toast])
+
+  if (loading && !ticketsDash && !chatsDash) {
+    return (
+      <div className="space-y-4">
+        <div className="h-12 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-24 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (error && !ticketsDash) {
+    return (
+      <div className="flex flex-col items-center gap-3 py-12 text-center">
+        <p className="text-slate-600 dark:text-slate-300">{error}</p>
+        <Button type="button" onClick={() => setReloadKey((k) => k + 1)}>
+          Tentar novamente
+        </Button>
+      </div>
+    )
+  }
+
+  const abertosPeriodo = ticketsDash?.volume_por_dia.reduce((s, d) => s + d.abertos, 0) ?? 0
+  const fechadosPeriodo = ticketsDash?.volume_por_dia.reduce((s, d) => s + d.fechados, 0) ?? 0
+  const chatsAbertos = chatsDash?.volume_por_dia.reduce((s, d) => s + d.abertos, 0) ?? 0
+  const totalDemandas = (chatsDash?.demandas_por_natureza ?? []).reduce((s, d) => s + d.total, 0)
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap lg:items-end lg:justify-between">
+          <DashboardPeriodoFiltro
+            preset={preset}
+            de={de}
+            ate={ate}
+            onPreset={aplicarPreset}
+            onCustom={marcarCustom}
+            onDeChange={onDeChange}
+            onAteChange={onAteChange}
+          />
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Período: {formatarIntervaloPeriodo(de, ate)}
+          </p>
+        </div>
+      </Card>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <MetricCard
+          label="Tickets abertos no período"
+          value={String(abertosPeriodo)}
+          borderClass="border-l-4 border-l-slate-400"
+        />
+        <MetricCard
+          label="Tickets fechados no período"
+          value={String(fechadosPeriodo)}
+          borderClass="border-l-4 border-l-emerald-400"
+        />
+        <MetricCard
+          label="Chats iniciados"
+          value={String(chatsAbertos)}
+          borderClass="border-l-4 border-l-cyan-500"
+        />
+        <MetricCard
+          label="Demandas registradas"
+          value={String(totalDemandas)}
+          borderClass="border-l-4 border-l-violet-500"
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {onVerTickets ? (
+          <Button type="button" variant="secondary" onClick={onVerTickets}>
+            Ver tickets deste contexto
+          </Button>
+        ) : hrefTickets ? (
+          <Link to={hrefTickets}>
+            <Button variant="secondary">Ver tickets deste contexto</Button>
+          </Link>
+        ) : null}
+        {onVerChats ? (
+          <Button type="button" variant="secondary" onClick={onVerChats}>
+            Ver chats deste contexto
+          </Button>
+        ) : hrefChats ? (
+          <Link to={hrefChats}>
+            <Button variant="secondary">Ver chats deste contexto</Button>
+          </Link>
+        ) : null}
+        <Link to="/dashboard/chats">
+          <Button variant="secondary">Dashboard WhatsApp global</Button>
+        </Link>
+      </div>
+
+      {ticketsDash && (ticketsDash.por_motivo?.length ?? 0) > 0 ? (
+        <Card title="Tickets — top motivos" description="No período selecionado">
+          <ul className="space-y-1">
+            {ticketsDash.por_motivo.slice(0, 8).map((m) => (
+              <li key={m.id} className="flex justify-between text-sm">
+                <span className="text-slate-600 dark:text-slate-400">{m.nome}</span>
+                <span className="font-medium text-slate-800 dark:text-slate-100">{m.total}</span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      ) : null}
+
+      {redeId != null && ticketsDash && (ticketsDash.por_empresa?.length ?? 0) > 0 ? (
+        <Card title="Tickets — ranking de empresas da rede" description="Volume no período">
+          <ul className="space-y-1">
+            {ticketsDash.por_empresa.slice(0, 10).map((e) => (
+              <li key={e.id} className="flex justify-between text-sm">
+                <span className="text-slate-600 dark:text-slate-400">{e.nome}</span>
+                <span className="font-medium text-slate-800 dark:text-slate-100">{e.total}</span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      ) : null}
+
+      {chatsDash ? (
+        <DashboardDemandasAnalise
+          data={chatsDash}
+          de={de}
+          ate={ate}
+          setorId=""
+          redeId={redeId}
+          empresaId={empresaId}
+          isAdmin
+          onRecarregar={() => setReloadKey((k) => k + 1)}
+        />
+      ) : (
+        <p className="text-slate-500 dark:text-slate-400">Sem dados de chats/demandas no período.</p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/dashboard/dashboardMetrics.tsx
+++ b/frontend/src/components/dashboard/dashboardMetrics.tsx
@@ -58,6 +58,20 @@ export function formatarDiaCurto(iso: string): string {
   return `${day}/${m}`
 }
 
+export function formatarDiaCompleto(iso: string): string {
+  const [y, m, day] = iso.split('-')
+  return `${day}/${m}/${y}`
+}
+
+/** Intervalo efetivo para subtítulo do dashboard (#599). */
+export function formatarIntervaloPeriodo(deIso: string, ateIso: string): string {
+  if (deIso === ateIso) return formatarDiaCompleto(deIso)
+  const [dy] = deIso.split('-')
+  const [ay] = ateIso.split('-')
+  if (dy === ay) return `${formatarDiaCurto(deIso)}–${formatarDiaCompleto(ateIso)}`
+  return `${formatarDiaCompleto(deIso)}–${formatarDiaCompleto(ateIso)}`
+}
+
 export function formatarCsatMedia(media: number | null): string {
   if (media == null) return '—'
   return `${media.toFixed(1).replace('.', ',')} ★`
@@ -68,20 +82,57 @@ export function formatarPct(valor: number | null): string {
   return `${valor.toFixed(1).replace('.', ',')}%`
 }
 
-export type PresetPeriodo = '7' | '30' | '90' | 'custom'
+/** Presets de calendário (#599). Semana = segunda → domingo. */
+export type PresetPeriodo = 'hoje' | 'esta_semana' | 'este_mes' | 'mes_passado' | 'custom'
 
-export const PRESET_DIAS: Record<Exclude<PresetPeriodo, 'custom'>, number> = {
-  '7': 7,
-  '30': 30,
-  '90': 90,
-}
+export const PRESET_OPCOES: { id: Exclude<PresetPeriodo, 'custom'>; label: string }[] = [
+  { id: 'hoje', label: 'Hoje' },
+  { id: 'esta_semana', label: 'Esta semana' },
+  { id: 'este_mes', label: 'Este mês' },
+  { id: 'mes_passado', label: 'Mês passado' },
+]
 
+/** Data civil local (YYYY-MM-DD) — evita deslocamento UTC de toISOString(). */
 export function isoDate(d: Date): string {
-  return d.toISOString().slice(0, 10)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
 }
 
 export function addDays(base: Date, dias: number): Date {
-  const d = new Date(base)
+  const d = new Date(base.getFullYear(), base.getMonth(), base.getDate())
   d.setDate(d.getDate() + dias)
   return d
+}
+
+export function parseIsoDateLocal(iso: string): Date {
+  const [y, m, d] = iso.split('-').map(Number)
+  return new Date(y, m - 1, d)
+}
+
+export function boundsForPreset(
+  preset: Exclude<PresetPeriodo, 'custom'>,
+  ref: Date = new Date(),
+): { de: string; ate: string } {
+  const hoje = new Date(ref.getFullYear(), ref.getMonth(), ref.getDate())
+  if (preset === 'hoje') {
+    const iso = isoDate(hoje)
+    return { de: iso, ate: iso }
+  }
+  if (preset === 'esta_semana') {
+    // Monday = 0 in ISO; getDay() Sunday=0 → convert
+    const weekday = (hoje.getDay() + 6) % 7
+    const inicio = addDays(hoje, -weekday)
+    return { de: isoDate(inicio), ate: isoDate(hoje) }
+  }
+  if (preset === 'este_mes') {
+    const inicio = new Date(hoje.getFullYear(), hoje.getMonth(), 1)
+    return { de: isoDate(inicio), ate: isoDate(hoje) }
+  }
+  // mes_passado
+  const primeiroEste = new Date(hoje.getFullYear(), hoje.getMonth(), 1)
+  const ultimoPassado = addDays(primeiroEste, -1)
+  const primeiroPassado = new Date(ultimoPassado.getFullYear(), ultimoPassado.getMonth(), 1)
+  return { de: isoDate(primeiroPassado), ate: isoDate(ultimoPassado) }
 }

--- a/frontend/src/hooks/useDashboardPeriodo.ts
+++ b/frontend/src/hooks/useDashboardPeriodo.ts
@@ -1,0 +1,46 @@
+import { useCallback, useState } from 'react'
+import {
+  boundsForPreset,
+  type PresetPeriodo,
+} from '../components/dashboard/dashboardMetrics'
+
+const DEFAULT_PRESET: Exclude<PresetPeriodo, 'custom'> = 'este_mes'
+
+/** Estado partilhado do filtro de período dos dashboards (#599). */
+export function useDashboardPeriodo(initial: Exclude<PresetPeriodo, 'custom'> = DEFAULT_PRESET) {
+  const inicial = boundsForPreset(initial)
+  const [preset, setPreset] = useState<PresetPeriodo>(initial)
+  const [de, setDe] = useState(inicial.de)
+  const [ate, setAte] = useState(inicial.ate)
+
+  const aplicarPreset = useCallback((p: Exclude<PresetPeriodo, 'custom'>) => {
+    setPreset(p)
+    const b = boundsForPreset(p)
+    setDe(b.de)
+    setAte(b.ate)
+  }, [])
+
+  const marcarCustom = useCallback(() => {
+    setPreset('custom')
+  }, [])
+
+  const onDeChange = useCallback((v: string) => {
+    setPreset('custom')
+    setDe(v)
+  }, [])
+
+  const onAteChange = useCallback((v: string) => {
+    setPreset('custom')
+    setAte(v)
+  }, [])
+
+  return {
+    preset,
+    de,
+    ate,
+    aplicarPreset,
+    marcarCustom,
+    onDeChange,
+    onAteChange,
+  }
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -13,7 +13,10 @@ import { exibirProtocolo } from '../lib/exibirProtocolo'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { DashboardCanalComparativo, snapshotFromGeral } from '../components/dashboard/DashboardCanalComparativo'
 import { DashboardNav } from '../components/dashboard/DashboardNav'
+import { DashboardPeriodoFiltro } from '../components/dashboard/DashboardPeriodoFiltro'
+import { formatarIntervaloPeriodo } from '../components/dashboard/dashboardMetrics'
 import { NotaEstrelasMedia } from '../components/ui/NotaEstrelasMedia'
+import { useDashboardPeriodo } from '../hooks/useDashboardPeriodo'
 
 type ColunaUltimos = 'protocolo' | 'empresa' | 'assunto' | 'status'
 
@@ -80,6 +83,8 @@ function MetricCard({
 export function Dashboard() {
   const toast = useToast()
   const { ordenarPor, ordem, aoOrdenarColuna } = useOrdenacaoLista<ColunaUltimos>()
+  const { preset, de, ate, aplicarPreset, marcarCustom, onDeChange, onAteChange } =
+    useDashboardPeriodo('este_mes')
   const [geral, setGeral] = useState<Dashboard.GeralResponse | null>(null)
   const [data, setData] = useState<Awaited<ReturnType<typeof dashboard.get>> | null>(null)
   const [loading, setLoading] = useState(true)
@@ -91,7 +96,7 @@ export function Dashboard() {
     setLoading(true)
     setError(null)
     setForbidden(false)
-    Promise.all([dashboard.getGeral(), dashboard.get()])
+    Promise.all([dashboard.getGeral({ de, ate }), dashboard.get()])
       .then(([geralRes, dashRes]) => {
         setGeral(geralRes)
         setData(dashRes)
@@ -108,8 +113,8 @@ export function Dashboard() {
         toast.showError(mensagemFalhaParaToast(err, msg))
       })
       .finally(() => setLoading(false))
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- recarrega só quando reloadKey muda
-  }, [reloadKey])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- toast estável; recarrega com período/reload
+  }, [reloadKey, de, ate])
 
   const ultimos_tickets = useMemo(() => data?.ultimos_tickets ?? [], [data?.ultimos_tickets])
 
@@ -164,7 +169,10 @@ export function Dashboard() {
 
   return (
     <PageContainer>
-      <PageHeader title="Dashboard" />
+      <PageHeader
+        title="Dashboard"
+        subtitle={`CSAT e indicadores · ${formatarIntervaloPeriodo(geral.de, geral.ate)}`}
+      />
 
       <DashboardNav
         actions={
@@ -178,6 +186,23 @@ export function Dashboard() {
           </>
         }
       />
+
+      <Card className="mb-6">
+        <div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap lg:items-end">
+          <DashboardPeriodoFiltro
+            preset={preset}
+            de={de}
+            ate={ate}
+            onPreset={aplicarPreset}
+            onCustom={marcarCustom}
+            onDeChange={onDeChange}
+            onAteChange={onAteChange}
+          />
+          <p className="text-xs text-slate-500 dark:text-slate-400 lg:max-w-xs">
+            Filas e SLA são situação atual. O período aplica-se à satisfação (CSAT).
+          </p>
+        </div>
+      </Card>
 
       {geral ? <DashboardCanalComparativo snapshot={snapshotFromGeral(geral)} /> : null}
 
@@ -229,7 +254,7 @@ export function Dashboard() {
         <MetricCard
           label="Satisfação — tickets"
           borderClass="border-l-4 border-l-violet-400"
-          hint={`últimos ${geral.csat_tickets.periodo_dias} dias · ${geral.csat_tickets.total_avaliacoes} avaliações`}
+          hint={`${formatarIntervaloPeriodo(geral.de, geral.ate)} · ${geral.csat_tickets.total_avaliacoes} avaliações`}
         >
           <div className="mt-2">
             <NotaEstrelasMedia media={geral.csat_tickets.media} size="lg" />
@@ -238,7 +263,7 @@ export function Dashboard() {
         <MetricCard
           label="Satisfação — WhatsApp"
           borderClass="border-l-4 border-l-pink-400"
-          hint={`últimos ${geral.csat_chats.periodo_dias} dias · ${geral.csat_chats.total_avaliacoes} avaliações`}
+          hint={`${formatarIntervaloPeriodo(geral.de, geral.ate)} · ${geral.csat_chats.total_avaliacoes} avaliações`}
         >
           <div className="mt-2">
             <NotaEstrelasMedia media={geral.csat_chats.media} size="lg" />

--- a/frontend/src/pages/DashboardChats.tsx
+++ b/frontend/src/pages/DashboardChats.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import {
   Bar,
@@ -29,16 +29,16 @@ import { DashboardNav } from '../components/dashboard/DashboardNav'
 import { barClickableProps, chartTooltipProps } from '../components/dashboard/dashboardChartUtils'
 import { corDrill, useDashboardDrilldown } from '../components/dashboard/useDashboardDrilldown'
 import { NotaEstrelasMedia } from '../components/ui/NotaEstrelasMedia'
+import { DashboardDemandasAnalise } from '../components/dashboard/DashboardDemandasAnalise'
+import { DashboardPeriodoFiltro } from '../components/dashboard/DashboardPeriodoFiltro'
 import {
   MetricCard,
-  PRESET_DIAS,
-  addDays,
   formatarDiaCurto,
   formatarHoras,
+  formatarIntervaloPeriodo,
   formatarPct,
-  isoDate,
-  type PresetPeriodo,
 } from '../components/dashboard/dashboardMetrics'
+import { useDashboardPeriodo } from '../hooks/useDashboardPeriodo'
 
 const CORES_ENCERRAMENTO = ['#06b6d4', '#94a3b8']
 
@@ -59,10 +59,8 @@ function DashboardChatsSkeleton() {
 export function DashboardChats() {
   const toast = useToast()
   const { user } = useAuth()
-  const hoje = useMemo(() => new Date(), [])
-  const [preset, setPreset] = useState<PresetPeriodo>('30')
-  const [de, setDe] = useState(() => isoDate(addDays(hoje, -30)))
-  const [ate, setAte] = useState(() => isoDate(hoje))
+  const { preset, de, ate, aplicarPreset, marcarCustom, onDeChange, onAteChange } =
+    useDashboardPeriodo('este_mes')
   const [setorId, setSetorId] = useState<number | ''>('')
   const [data, setData] = useState<Dashboard.ChatsResponse | null>(null)
   const [setoresLista, setSetoresLista] = useState<Setores.Setor[]>([])
@@ -80,13 +78,6 @@ export function DashboardChats() {
     const qs = params.toString()
     return qs ? `/relatorios/chats?${qs}` : '/relatorios/chats'
   }, [de, ate, setorId])
-
-  const aplicarPreset = useCallback((p: Exclude<PresetPeriodo, 'custom'>) => {
-    setPreset(p)
-    const fim = new Date()
-    setAte(isoDate(fim))
-    setDe(isoDate(addDays(fim, -PRESET_DIAS[p])))
-  }, [])
 
   useEffect(() => {
     setores
@@ -148,16 +139,6 @@ export function DashboardChats() {
     [data],
   )
 
-  const demandasNaturezaChart = useMemo(
-    () =>
-      (data?.demandas_por_natureza ?? []).map((d) => ({
-        id: d.id,
-        nome: d.nome,
-        total: d.total,
-      })),
-    [data],
-  )
-
   const estadoChart = useMemo(
     () =>
       (data?.por_estado_atual ?? []).map((e) => ({
@@ -206,7 +187,7 @@ export function DashboardChats() {
     <PageContainer>
       <PageHeader
         title="Dashboard — WhatsApp"
-        subtitle={`Indicadores de atendimento · ${formatarDiaCurto(data.de)} a ${formatarDiaCurto(data.ate)}`}
+        subtitle={`Indicadores de atendimento · ${formatarIntervaloPeriodo(data.de, data.ate)}`}
       />
 
       <DashboardNav
@@ -235,47 +216,15 @@ export function DashboardChats() {
 
       <Card className="mb-6">
         <div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap lg:items-end">
-          <div className="flex flex-wrap gap-2">
-            {(['7', '30', '90'] as const).map((p) => (
-              <Button
-                key={p}
-                type="button"
-                variant={preset === p ? 'primary' : 'secondary'}
-                onClick={() => aplicarPreset(p)}
-              >
-                {p} dias
-              </Button>
-            ))}
-            <Button
-              type="button"
-              variant={preset === 'custom' ? 'primary' : 'secondary'}
-              onClick={() => setPreset('custom')}
-            >
-              Personalizado
-            </Button>
-          </div>
-          {preset === 'custom' ? (
-            <div className="flex flex-wrap items-center gap-3">
-              <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
-                De
-                <input
-                  type="date"
-                  value={de}
-                  onChange={(e) => setDe(e.target.value)}
-                  className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
-                Até
-                <input
-                  type="date"
-                  value={ate}
-                  onChange={(e) => setAte(e.target.value)}
-                  className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
-                />
-              </label>
-            </div>
-          ) : null}
+          <DashboardPeriodoFiltro
+            preset={preset}
+            de={de}
+            ate={ate}
+            onPreset={aplicarPreset}
+            onCustom={marcarCustom}
+            onDeChange={onDeChange}
+            onAteChange={onAteChange}
+          />
           <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
             Setor
             <select
@@ -475,27 +424,6 @@ export function DashboardChats() {
             </div>
           </Card>
 
-          <Card
-            title="Demandas registradas na sessão"
-            description="Naturezas informadas pelos atendentes ao resolver assuntos no chat (não inclui apenas transcript)"
-          >
-            <div className="h-72">
-              {demandasNaturezaChart.length === 0 ? (
-                <p className="text-slate-500 dark:text-slate-400">Nenhuma demanda registrada no período.</p>
-              ) : (
-                <ResponsiveContainer width="100%" height="100%">
-                  <BarChart data={demandasNaturezaChart}>
-                    <CartesianGrid strokeDasharray="3 3" className="stroke-slate-200 dark:stroke-slate-700" />
-                    <XAxis dataKey="nome" tick={{ fontSize: 11 }} />
-                    <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
-                    <Tooltip {...chartTooltipProps} />
-                    <Bar dataKey="total" name="Demandas" fill="#8b5cf6" radius={[4, 4, 0, 0]} />
-                  </BarChart>
-                </ResponsiveContainer>
-              )}
-            </div>
-          </Card>
-
           {user?.role === 'admin' && atendentesChart.length > 0 ? (
             <Card
               title="Atendentes com mais chats assumidos"
@@ -537,6 +465,15 @@ export function DashboardChats() {
           ) : null}
         </div>
       )}
+
+      <DashboardDemandasAnalise
+        data={data}
+        de={de}
+        ate={ate}
+        setorId={setorId}
+        isAdmin={user?.role === 'admin'}
+        onRecarregar={() => setReloadKey((k) => k + 1)}
+      />
     </PageContainer>
   )
 }

--- a/frontend/src/pages/DashboardTickets.tsx
+++ b/frontend/src/pages/DashboardTickets.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import {
   Bar,
@@ -35,15 +35,14 @@ import { DashboardNav } from '../components/dashboard/DashboardNav'
 import { barClickableProps, chartTooltipProps } from '../components/dashboard/dashboardChartUtils'
 import { corDrill, useDashboardDrilldown } from '../components/dashboard/useDashboardDrilldown'
 import { NotaEstrelasMedia } from '../components/ui/NotaEstrelasMedia'
+import { DashboardPeriodoFiltro } from '../components/dashboard/DashboardPeriodoFiltro'
 import {
   MetricCard,
-  PRESET_DIAS,
-  addDays,
   formatarDiaCurto,
   formatarHoras,
-  isoDate,
-  type PresetPeriodo,
+  formatarIntervaloPeriodo,
 } from '../components/dashboard/dashboardMetrics'
+import { useDashboardPeriodo } from '../hooks/useDashboardPeriodo'
 
 const CORES_PRIORIDADE: Record<string, string> = {
   baixa: '#94a3b8',
@@ -87,10 +86,8 @@ function DashboardTicketsSkeleton() {
 export function DashboardTickets() {
   const toast = useToast()
   const { user } = useAuth()
-  const hoje = useMemo(() => new Date(), [])
-  const [preset, setPreset] = useState<PresetPeriodo>('30')
-  const [de, setDe] = useState(() => isoDate(addDays(hoje, -30)))
-  const [ate, setAte] = useState(() => isoDate(hoje))
+  const { preset, de, ate, aplicarPreset, marcarCustom, onDeChange, onAteChange } =
+    useDashboardPeriodo('este_mes')
   const [redeId, setRedeId] = useState<number | ''>('')
   const [setorId, setSetorId] = useState<number | ''>('')
   const [prioridade, setPrioridade] = useState('')
@@ -103,16 +100,6 @@ export function DashboardTickets() {
   const [error, setError] = useState<string | null>(null)
   const drill = useDashboardDrilldown()
   const [reloadKey, setReloadKey] = useState(0)
-
-  const aplicarPreset = useCallback(
-    (p: Exclude<PresetPeriodo, 'custom'>) => {
-      setPreset(p)
-      const fim = new Date()
-      setAte(isoDate(fim))
-      setDe(isoDate(addDays(fim, -PRESET_DIAS[p])))
-    },
-    [],
-  )
 
   useEffect(() => {
     Promise.all([
@@ -129,8 +116,11 @@ export function DashboardTickets() {
   }, [])
 
   useEffect(() => {
-    dashboard.getGeral().then((g) => setSnapshot(snapshotFromGeral(g))).catch(() => undefined)
-  }, [reloadKey])
+    dashboard
+      .getGeral({ de, ate })
+      .then((g) => setSnapshot(snapshotFromGeral(g)))
+      .catch(() => undefined)
+  }, [de, ate, reloadKey])
 
   useEffect(() => {
     setLoading(true)
@@ -269,7 +259,7 @@ export function DashboardTickets() {
     <PageContainer>
       <PageHeader
         title="Dashboard — Tickets"
-        subtitle={`Indicadores de atendimento · ${formatarDiaCurto(data.de)} a ${formatarDiaCurto(data.ate)}`}
+        subtitle={`Indicadores de atendimento · ${formatarIntervaloPeriodo(data.de, data.ate)}`}
       />
 
       <DashboardNav
@@ -295,47 +285,15 @@ export function DashboardTickets() {
 
       <Card className="mb-6">
         <div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap lg:items-end">
-          <div className="flex flex-wrap gap-2">
-            {(['7', '30', '90'] as const).map((p) => (
-              <Button
-                key={p}
-                type="button"
-                variant={preset === p ? 'primary' : 'secondary'}
-                onClick={() => aplicarPreset(p)}
-              >
-                {p} dias
-              </Button>
-            ))}
-            <Button
-              type="button"
-              variant={preset === 'custom' ? 'primary' : 'secondary'}
-              onClick={() => setPreset('custom')}
-            >
-              Personalizado
-            </Button>
-          </div>
-          {preset === 'custom' ? (
-            <div className="flex flex-wrap items-center gap-3">
-              <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
-                De
-                <input
-                  type="date"
-                  value={de}
-                  onChange={(e) => setDe(e.target.value)}
-                  className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
-                />
-              </label>
-              <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
-                Até
-                <input
-                  type="date"
-                  value={ate}
-                  onChange={(e) => setAte(e.target.value)}
-                  className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-slate-800 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100"
-                />
-              </label>
-            </div>
-          ) : null}
+          <DashboardPeriodoFiltro
+            preset={preset}
+            de={de}
+            ate={ate}
+            onPreset={aplicarPreset}
+            onCustom={marcarCustom}
+            onDeChange={onDeChange}
+            onAteChange={onAteChange}
+          />
           <label className="flex flex-col gap-1 text-sm text-slate-600 dark:text-slate-400">
             Rede
             <select

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -23,8 +23,9 @@ import { TicketsTabelaContexto } from '../components/TicketsTabelaContexto'
 import { FuncionariosEmpresaLista } from '../components/FuncionariosEmpresaLista'
 import { EmpresaPdvsPanel } from '../components/EmpresaPdvsPanel'
 import { EmpresaChatsPanel } from '../components/EmpresaChatsPanel'
+import { PainelAnalisesCliente } from '../components/dashboard/PainelAnalisesCliente'
 import { SemPermissao } from './SemPermissao'
-type Aba = 'geral' | 'tickets' | 'chats' | 'funcionarios' | 'pdvs'
+type Aba = 'geral' | 'tickets' | 'chats' | 'funcionarios' | 'pdvs' | 'analises'
 
 function DetailRow({ label, value }: { label: string; value: string | null | undefined }) {
   const v = value?.trim()
@@ -313,6 +314,7 @@ export function EmpresaDetalhe() {
         <div className="border-b border-slate-200 dark:border-slate-600">
           <nav className="flex flex-wrap gap-1 sm:gap-2" aria-label="Seções da empresa">
             {tabBtn('geral', 'Geral')}
+            {tabBtn('analises', 'Análises')}
             {tabBtn('tickets', 'Tickets')}
             {tabBtn('chats', 'Chats')}
             {tabBtn('funcionarios', 'Funcionários')}
@@ -406,6 +408,20 @@ export function EmpresaDetalhe() {
             </dl>
           </section>
         </div>
+      )}
+
+      {aba === 'analises' && (
+        <section className="rounded-2xl border border-slate-200/90 bg-white p-5 shadow-sm dark:border-slate-800/80 dark:bg-slate-900/70 dark:shadow-none sm:p-7">
+          <p className="mb-4 text-sm text-slate-500 dark:text-slate-400">
+            Estatísticas de tickets e demandas WhatsApp só desta empresa — use o período para treinar, priorizar
+            atualizações e evoluir o catálogo de motivos.
+          </p>
+          <PainelAnalisesCliente
+            empresaId={empresa.id}
+            onVerTickets={() => setAba('tickets')}
+            onVerChats={() => setAba('chats')}
+          />
+        </section>
       )}
 
       {aba === 'tickets' && (

--- a/frontend/src/pages/RedeDetalhe.tsx
+++ b/frontend/src/pages/RedeDetalhe.tsx
@@ -54,7 +54,9 @@ import { SemPermissao } from './SemPermissao'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 
-type Aba = 'empresas' | 'funcionarios' | 'tickets'
+import { PainelAnalisesCliente } from '../components/dashboard/PainelAnalisesCliente'
+
+type Aba = 'empresas' | 'funcionarios' | 'tickets' | 'analises'
 type AbaModalEmpresa = 'geral' | 'tickets' | 'funcionarios' | 'pdvs'
 type TipoFuncionario = 'socio' | 'supervisor' | 'colaborador'
 const tipoLabel: Record<string, string> = { socio: 'Sócio', supervisor: 'Supervisor', colaborador: 'Colaborador' }
@@ -910,6 +912,18 @@ export function RedeDetalhe() {
             </button>
             <button
               type="button"
+              onClick={() => setAba('analises')}
+              aria-current={aba === 'analises' ? 'page' : undefined}
+              className={
+                aba === 'analises'
+                  ? 'border-b-2 border-sky-500 px-3 py-2 text-sm font-semibold text-slate-900 dark:border-sky-400 dark:bg-slate-800/50 dark:text-white'
+                  : 'border-b-2 border-transparent px-3 py-2 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:bg-white/30 dark:hover:text-slate-200'
+              }
+            >
+              Análises
+            </button>
+            <button
+              type="button"
               onClick={() => setAba('tickets')}
               aria-current={aba === 'tickets' ? 'page' : undefined}
               className={
@@ -1593,6 +1607,21 @@ export function RedeDetalhe() {
           )}
         </Card>
       )}
+
+      {aba === 'analises' && !modalEmpresa && !modalFuncionario && Number.isFinite(redeId) ? (
+        <Card>
+          <div className="mb-4">
+            <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">Análises da rede</h2>
+            <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+              Agregados de tickets e demandas WhatsApp de todas as empresas desta rede.
+            </p>
+          </div>
+          <PainelAnalisesCliente
+            redeId={redeId}
+            onVerTickets={() => setAba('tickets')}
+          />
+        </Card>
+      ) : null}
 
       {aba === 'tickets' && !modalEmpresa && !modalFuncionario && (
         <Card>


### PR DESCRIPTION
## Summary

Lote de analytics operacional:

- **#599** — Filtros de período (Hoje / Esta semana seg–dom / Este mês / Mês passado / Personalizado) no dashboard geral, tickets e WhatsApp; CSAT do geral respeita `de`/`ate`
- **#594** — Análise de demandas WhatsApp: drill-down, ranking por empresa, insights (erro → atualização; dúvida → treinamento) e sugestão de motivo a partir de «Outros»
- **#595** — Aba **Análises** em Rede e Empresa (reutiliza APIs/período/insights)
- Higiene: épico **#545** (Presença) fechado no GitHub (filhas já entregues)

Closes #599
Closes #594
Closes #595

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias)

## Test plan

- [x] `pytest` — `test_period_bounds`, `test_dashboard_geral`, `test_dashboard_demandas_analise`, `test_dashboard_isolamento_cliente`, `test_dashboard_chats`
- [x] `npm run build` (frontend)
- [ ] Smoke UI: presets de período nos 3 dashboards; drill de demandas; aba Análises em Rede/Empresa
- [ ] Migration `081_wpp_demanda_motivo_sugestoes` em ambiente local/staging no deploy

## Follow-ups / backlog

- [x] #545 fechado com fora de escopo v1 documentado (sem issue nova obrigatória)
- [x] Comparativo período atual vs anterior (#599) continua fora de escopo
- [x] NLP / criação automática de motivo sem confirmação (#594) continua fora de escopo
