### PR TITLE
feat(comercial): catálogo de custos e SM com histórico (#321 lote A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Comercial (#321 / #329–#334): catálogo de custos — salário mínimo com histórico por vigência (atualizar valor sem reescrever o passado), itens (% SM, valor fixo, TEF) e simulador em Cadastros → Catálogo de custos (admin)
 - Dashboard (#599): filtros de período Hoje | Esta semana (seg–dom) | Este mês | Mês passado | Personalizado no geral, tickets e WhatsApp (substitui 7/30/90); CSAT do geral respeita o intervalo
 - WhatsApp (#594): análise de demandas no dashboard — drill-down por natureza/motivo, ranking por empresa, insights (erro → atualização; dúvida → treinamento) e sugestão de novo motivo a partir de «Outros» repetido
 - Rede e Empresa (#595): aba Análises com tickets + demandas WhatsApp no período, insights e ranking (reutiliza #594/#599)

--- a/backend/alembic/versions/082_comercial_catalogo_custos.py
+++ b/backend/alembic/versions/082_comercial_catalogo_custos.py
@@ -1,0 +1,81 @@
+"""Catálogo comercial: salário mínimo e itens de custo (#321).
+
+Revision ID: 082_comercial_catalogo_custos
+Revises: 081_wpp_demanda_motivo_sugestoes
+Create Date: 2026-08-03
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "082_comercial_catalogo_custos"
+down_revision = "081_wpp_demanda_motivo_sugestoes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("salario_minimo_referencia"):
+        op.create_table(
+            "salario_minimo_referencia",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("valor", sa.Numeric(12, 2), nullable=False),
+            sa.Column("vigencia_inicio", sa.Date(), nullable=False),
+            sa.Column("vigencia_fim", sa.Date(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.create_index(
+            "ix_salario_minimo_referencia_vigencia_inicio",
+            "salario_minimo_referencia",
+            ["vigencia_inicio"],
+        )
+        op.create_index(
+            "ix_salario_minimo_referencia_vigencia_fim",
+            "salario_minimo_referencia",
+            ["vigencia_fim"],
+        )
+
+    if not insp.has_table("custo_catalogo_itens"):
+        op.create_table(
+            "custo_catalogo_itens",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("nome", sa.String(120), nullable=False),
+            sa.Column("slug", sa.String(50), nullable=False),
+            sa.Column("descricao", sa.Text(), nullable=True),
+            sa.Column("tipo", sa.String(24), nullable=False),
+            sa.Column("percentual_sm", sa.Numeric(8, 4), nullable=True),
+            sa.Column("valor_fixo", sa.Numeric(12, 2), nullable=True),
+            sa.Column("tef_base", sa.Numeric(12, 2), nullable=True),
+            sa.Column("tef_adicional", sa.Numeric(12, 2), nullable=True),
+            sa.Column("ordem", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("vigencia_inicio", sa.Date(), nullable=True),
+            sa.Column("vigencia_fim", sa.Date(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("now()"),
+                nullable=False,
+            ),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+            sa.UniqueConstraint("slug", name="uq_custo_catalogo_item_slug"),
+        )
+        op.create_index("ix_custo_catalogo_itens_slug", "custo_catalogo_itens", ["slug"])
+        op.create_index("ix_custo_catalogo_itens_tipo", "custo_catalogo_itens", ["tipo"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("custo_catalogo_itens"):
+        op.drop_table("custo_catalogo_itens")
+    if insp.has_table("salario_minimo_referencia"):
+        op.drop_table("salario_minimo_referencia")

--- a/backend/app/api/comercial_custos.py
+++ b/backend/app/api/comercial_custos.py
@@ -1,0 +1,235 @@
+"""API admin do catálogo comercial de custos (#321 / #333)."""
+
+from __future__ import annotations
+
+from datetime import date
+from enum import Enum
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from app.core.auth import exigir_admin
+from app.core.audit import registrar_audit
+from app.core.ordenacao_lista import OrdemLista, expr_ordem
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.models.comercial_custo import CustoCatalogoItem, SalarioMinimoReferencia
+from app.schemas.comercial_custo import (
+    CustoCatalogoItemCreate,
+    CustoCatalogoItemRead,
+    CustoCatalogoItemUpdate,
+    CustoSimularRequest,
+    CustoSimularResponse,
+    SalarioMinimoAtualizarValor,
+    SalarioMinimoCreate,
+    SalarioMinimoRead,
+    SalarioMinimoUpdate,
+)
+from app.schemas.lista_paginada import ListaPaginada
+from app.services import comercial_custo as svc
+
+router = APIRouter(prefix="/comercial", tags=["comercial-custos"])
+
+_MAX_PAGE = 100
+_DEFAULT_PAGE = 50
+
+
+class OrdenarSm(str, Enum):
+    vigencia_inicio = "vigencia_inicio"
+    valor = "valor"
+    id = "id"
+
+
+class OrdenarItem(str, Enum):
+    nome = "nome"
+    slug = "slug"
+    ordem = "ordem"
+    tipo = "tipo"
+    ativo = "ativo"
+
+
+@router.get("/salario-minimo", response_model=ListaPaginada[SalarioMinimoRead])
+def listar_salario_minimo(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    ordenar_por: OrdenarSm | None = Query(OrdenarSm.vigencia_inicio),
+    ordem: OrdemLista = Query(OrdemLista.desc),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_admin),
+):
+    q = db.query(SalarioMinimoReferencia)
+    total = q.count()
+    if ordenar_por == OrdenarSm.valor:
+        cols = [expr_ordem(SalarioMinimoReferencia.valor, ordem), expr_ordem(SalarioMinimoReferencia.id, ordem)]
+    elif ordenar_por == OrdenarSm.id:
+        cols = [expr_ordem(SalarioMinimoReferencia.id, ordem)]
+    else:
+        cols = [
+            expr_ordem(SalarioMinimoReferencia.vigencia_inicio, ordem),
+            expr_ordem(SalarioMinimoReferencia.id, ordem),
+        ]
+    items = q.order_by(*cols).offset(offset).limit(limit).all()
+    return ListaPaginada(items=items, total=total)
+
+
+@router.get("/salario-minimo/na-data", response_model=SalarioMinimoRead | None)
+def salario_minimo_na_data(
+    data: date = Query(..., description="Data de referência"),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_admin),
+):
+    return svc.obter_sm_na_data(db, data)
+
+
+@router.post("/salario-minimo", response_model=SalarioMinimoRead, status_code=201)
+def criar_salario_minimo(
+    data: SalarioMinimoCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = svc.criar_sm(db, data)
+    registrar_audit(db, "salario_minimo", row.id, "create", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.post("/salario-minimo/atualizar-valor", response_model=SalarioMinimoRead, status_code=201)
+def atualizar_valor_salario_minimo(
+    data: SalarioMinimoAtualizarValor,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    """Novo valor a partir de uma data: fecha o vigente e mantém o histórico intacto."""
+    row = svc.atualizar_valor_sm(db, data)
+    registrar_audit(db, "salario_minimo", row.id, "atualizar_valor", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.patch("/salario-minimo/{sm_id}", response_model=SalarioMinimoRead)
+def atualizar_salario_minimo(
+    sm_id: int,
+    data: SalarioMinimoUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = db.query(SalarioMinimoReferencia).filter(SalarioMinimoReferencia.id == sm_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Salário mínimo não encontrado.")
+    row = svc.atualizar_sm(db, row, data)
+    registrar_audit(db, "salario_minimo", row.id, "update", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.delete("/salario-minimo/{sm_id}", status_code=204)
+def excluir_salario_minimo(
+    sm_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = db.query(SalarioMinimoReferencia).filter(SalarioMinimoReferencia.id == sm_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Salário mínimo não encontrado.")
+    registrar_audit(db, "salario_minimo", row.id, "delete", atendente.id)
+    db.delete(row)
+    db.commit()
+    return None
+
+
+@router.get("/custos/itens", response_model=ListaPaginada[CustoCatalogoItemRead])
+def listar_itens_custo(
+    incluir_inativos: bool = Query(False),
+    busca: str | None = Query(None),
+    tipo: str | None = Query(None),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    ordenar_por: OrdenarItem | None = Query(OrdenarItem.ordem),
+    ordem: OrdemLista = Query(OrdemLista.asc),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_admin),
+):
+    q = db.query(CustoCatalogoItem)
+    if not incluir_inativos:
+        q = q.filter(CustoCatalogoItem.ativo.is_(True))
+    if tipo:
+        q = q.filter(CustoCatalogoItem.tipo == tipo)
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter(or_(CustoCatalogoItem.nome.ilike(term), CustoCatalogoItem.slug.ilike(term)))
+    total = q.count()
+    if ordenar_por == OrdenarItem.nome:
+        cols = [expr_ordem(CustoCatalogoItem.nome, ordem), expr_ordem(CustoCatalogoItem.id, ordem)]
+    elif ordenar_por == OrdenarItem.slug:
+        cols = [expr_ordem(CustoCatalogoItem.slug, ordem), expr_ordem(CustoCatalogoItem.id, ordem)]
+    elif ordenar_por == OrdenarItem.tipo:
+        cols = [expr_ordem(CustoCatalogoItem.tipo, ordem), expr_ordem(CustoCatalogoItem.ordem, ordem)]
+    elif ordenar_por == OrdenarItem.ativo:
+        cols = [expr_ordem(CustoCatalogoItem.ativo, ordem), expr_ordem(CustoCatalogoItem.ordem, ordem)]
+    else:
+        cols = [expr_ordem(CustoCatalogoItem.ordem, ordem), expr_ordem(CustoCatalogoItem.nome, ordem)]
+    items = q.order_by(*cols).offset(offset).limit(limit).all()
+    return ListaPaginada(items=items, total=total)
+
+
+@router.post("/custos/itens", response_model=CustoCatalogoItemRead, status_code=201)
+def criar_item_custo(
+    data: CustoCatalogoItemCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = svc.criar_item(db, data)
+    registrar_audit(db, "custo_catalogo_item", row.id, "create", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.patch("/custos/itens/{item_id}", response_model=CustoCatalogoItemRead)
+def atualizar_item_custo(
+    item_id: int,
+    data: CustoCatalogoItemUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = db.query(CustoCatalogoItem).filter(CustoCatalogoItem.id == item_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Item de custo não encontrado.")
+    row = svc.atualizar_item(db, row, data)
+    registrar_audit(db, "custo_catalogo_item", row.id, "update", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.delete("/custos/itens/{item_id}", status_code=204)
+def excluir_item_custo(
+    item_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = db.query(CustoCatalogoItem).filter(CustoCatalogoItem.id == item_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Item de custo não encontrado.")
+    registrar_audit(db, "custo_catalogo_item", row.id, "delete", atendente.id)
+    db.delete(row)
+    db.commit()
+    return None
+
+
+@router.post("/custos/simular", response_model=CustoSimularResponse)
+def simular_custo(
+    body: CustoSimularRequest,
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_admin),
+):
+    return svc.simular_custo(
+        db,
+        item_ids=body.item_ids,
+        quantidade_pdvs=body.quantidade_pdvs,
+        data_referencia=body.data_referencia,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -39,6 +39,7 @@ from app.api import (
     pdv_catalogos,
     ticket_catalogos,
     empresa_pdvs,
+    comercial_custos,
     system_settings,
     tenant,
     public_csat,
@@ -453,6 +454,7 @@ app.include_router(resend_inbound_webhook.router, prefix=API_V1_PREFIX)
 app.include_router(respostas_prontas.router, prefix=API_V1_PREFIX)
 app.include_router(pdv_catalogos.router, prefix=API_V1_PREFIX)
 app.include_router(ticket_catalogos.router, prefix=API_V1_PREFIX)
+app.include_router(comercial_custos.router, prefix=API_V1_PREFIX)
 app.include_router(empresa_pdvs.router, prefix=API_V1_PREFIX)
 app.include_router(system_settings.router, prefix=API_V1_PREFIX)
 app.include_router(tenant.router, prefix=API_V1_PREFIX)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -22,6 +22,7 @@ from app.models.whatsapp_chat import (
 )
 from app.models.whatsapp_chat_demanda import WhatsappChatDemanda
 from app.models.whatsapp_demanda_motivo_sugestao import WhatsappDemandaMotivoSugestao
+from app.models.comercial_custo import CustoCatalogoItem, SalarioMinimoReferencia
 from app.models.empresa_sistema import EmpresaSistema
 from app.models.email_settings import EmailSettings
 from app.models.protocol_sequence import ProtocolSequence
@@ -80,6 +81,8 @@ __all__ = [
     "WhatsappChatTicket",
     "WhatsappChatDemanda",
     "WhatsappDemandaMotivoSugestao",
+    "SalarioMinimoReferencia",
+    "CustoCatalogoItem",
     "EmpresaSistema",
     "EmailSettings",
     "ProtocolSequence",

--- a/backend/app/models/comercial_custo.py
+++ b/backend/app/models/comercial_custo.py
@@ -1,0 +1,60 @@
+"""Catálogo comercial de custos e salário mínimo (#321 / #329–#330)."""
+
+from __future__ import annotations
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+# Tipos de item do catálogo (lote A; composto_tef usado no motor/simular)
+TIPO_PERCENTUAL_SM = "percentual_sm"
+TIPO_VALOR_FIXO = "valor_fixo"
+TIPO_COMPOSTO_TEF = "composto_tef"
+TIPOS_CUSTO_CATALOGO = frozenset({TIPO_PERCENTUAL_SM, TIPO_VALOR_FIXO, TIPO_COMPOSTO_TEF})
+
+
+class SalarioMinimoReferencia(Base):
+    """Salário mínimo com vigência — contratos futuros usam snapshot, não recalculam (#329)."""
+
+    __tablename__ = "salario_minimo_referencia"
+
+    id = Column(Integer, primary_key=True, index=True)
+    valor = Column(Numeric(12, 2), nullable=False)
+    vigencia_inicio = Column(Date, nullable=False, index=True)
+    vigencia_fim = Column(Date, nullable=True, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+
+class CustoCatalogoItem(Base):
+    """Perfil/módulo de custo cadastrável (#330)."""
+
+    __tablename__ = "custo_catalogo_itens"
+    __table_args__ = (UniqueConstraint("slug", name="uq_custo_catalogo_item_slug"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    nome = Column(String(120), nullable=False)
+    slug = Column(String(50), nullable=False, index=True)
+    descricao = Column(Text, nullable=True)
+    tipo = Column(String(24), nullable=False, index=True)
+    percentual_sm = Column(Numeric(8, 4), nullable=True)
+    valor_fixo = Column(Numeric(12, 2), nullable=True)
+    tef_base = Column(Numeric(12, 2), nullable=True)
+    tef_adicional = Column(Numeric(12, 2), nullable=True)
+    ordem = Column(Integer, default=0, nullable=False)
+    ativo = Column(Boolean, default=True, nullable=False)
+    vigencia_inicio = Column(Date, nullable=True)
+    vigencia_fim = Column(Date, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/app/schemas/comercial_custo.py
+++ b/backend/app/schemas/comercial_custo.py
@@ -1,0 +1,144 @@
+"""Schemas do catálogo comercial de custos (#321)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+TipoCusto = Literal["percentual_sm", "valor_fixo", "composto_tef"]
+
+
+class SalarioMinimoCreate(BaseModel):
+    valor: Decimal = Field(..., gt=0)
+    vigencia_inicio: date
+    vigencia_fim: date | None = None
+
+    @model_validator(mode="after")
+    def _vigencia(self):
+        if self.vigencia_fim is not None and self.vigencia_fim < self.vigencia_inicio:
+            raise ValueError("vigencia_fim deve ser >= vigencia_inicio")
+        return self
+
+
+class SalarioMinimoUpdate(BaseModel):
+    valor: Decimal | None = Field(None, gt=0)
+    vigencia_inicio: date | None = None
+    vigencia_fim: date | None = None
+
+
+class SalarioMinimoAtualizarValor(BaseModel):
+    """Novo valor a partir de uma data — fecha o vigente e preserva o histórico."""
+
+    valor: Decimal = Field(..., gt=0)
+    vigencia_inicio: date = Field(..., description="Data a partir da qual o novo valor passa a valer")
+
+
+class SalarioMinimoRead(BaseModel):
+    id: int
+    valor: Decimal
+    vigencia_inicio: date
+    vigencia_fim: date | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CustoCatalogoItemCreate(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=120)
+    slug: str = Field(..., min_length=1, max_length=50)
+    descricao: str | None = None
+    tipo: TipoCusto
+    percentual_sm: Decimal | None = Field(None, ge=0, le=1000)
+    valor_fixo: Decimal | None = Field(None, ge=0)
+    tef_base: Decimal | None = Field(None, ge=0)
+    tef_adicional: Decimal | None = Field(None, ge=0)
+    ordem: int = 0
+    ativo: bool = True
+    vigencia_inicio: date | None = None
+    vigencia_fim: date | None = None
+
+    @field_validator("slug")
+    @classmethod
+    def _slug(cls, v: str) -> str:
+        s = v.strip().lower()
+        if not s:
+            raise ValueError("slug inválido")
+        return s
+
+    @model_validator(mode="after")
+    def _campos_por_tipo(self):
+        if self.vigencia_fim is not None and self.vigencia_inicio is not None:
+            if self.vigencia_fim < self.vigencia_inicio:
+                raise ValueError("vigencia_fim deve ser >= vigencia_inicio")
+        if self.tipo == "percentual_sm":
+            if self.percentual_sm is None:
+                raise ValueError("percentual_sm é obrigatório para tipo percentual_sm")
+        elif self.tipo == "valor_fixo":
+            if self.valor_fixo is None:
+                raise ValueError("valor_fixo é obrigatório para tipo valor_fixo")
+        elif self.tipo == "composto_tef":
+            if self.tef_base is None or self.tef_adicional is None:
+                raise ValueError("tef_base e tef_adicional são obrigatórios para composto_tef")
+        return self
+
+
+class CustoCatalogoItemUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=120)
+    slug: str | None = Field(None, min_length=1, max_length=50)
+    descricao: str | None = None
+    tipo: TipoCusto | None = None
+    percentual_sm: Decimal | None = Field(None, ge=0, le=1000)
+    valor_fixo: Decimal | None = Field(None, ge=0)
+    tef_base: Decimal | None = Field(None, ge=0)
+    tef_adicional: Decimal | None = Field(None, ge=0)
+    ordem: int | None = None
+    ativo: bool | None = None
+    vigencia_inicio: date | None = None
+    vigencia_fim: date | None = None
+
+
+class CustoCatalogoItemRead(BaseModel):
+    id: int
+    nome: str
+    slug: str
+    descricao: str | None = None
+    tipo: str
+    percentual_sm: Decimal | None = None
+    valor_fixo: Decimal | None = None
+    tef_base: Decimal | None = None
+    tef_adicional: Decimal | None = None
+    ordem: int
+    ativo: bool
+    vigencia_inicio: date | None = None
+    vigencia_fim: date | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CustoSimularRequest(BaseModel):
+    item_ids: list[int] = Field(..., min_length=1)
+    quantidade_pdvs: int = Field(1, ge=1, le=500)
+    data_referencia: date | None = None
+
+
+class CustoSimularLinha(BaseModel):
+    item_id: int
+    nome: str
+    slug: str
+    tipo: str
+    valor: Decimal
+
+
+class CustoSimularResponse(BaseModel):
+    data_referencia: date
+    salario_minimo: Decimal | None
+    salario_minimo_id: int | None
+    quantidade_pdvs: int
+    linhas: list[CustoSimularLinha]
+    total: Decimal

--- a/backend/app/services/comercial_custo.py
+++ b/backend/app/services/comercial_custo.py
@@ -1,0 +1,301 @@
+"""Serviço do catálogo comercial de custos (#321)."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+from fastapi import HTTPException
+from sqlalchemy import or_
+from sqlalchemy.orm import Session
+
+from app.models.comercial_custo import (
+    TIPO_COMPOSTO_TEF,
+    TIPO_PERCENTUAL_SM,
+    TIPO_VALOR_FIXO,
+    TIPOS_CUSTO_CATALOGO,
+    CustoCatalogoItem,
+    SalarioMinimoReferencia,
+)
+from app.schemas.comercial_custo import (
+    CustoCatalogoItemCreate,
+    CustoCatalogoItemUpdate,
+    CustoSimularLinha,
+    CustoSimularResponse,
+    SalarioMinimoAtualizarValor,
+    SalarioMinimoCreate,
+    SalarioMinimoUpdate,
+)
+
+
+def _ranges_overlap(
+    a_ini: date,
+    a_fim: date | None,
+    b_ini: date,
+    b_fim: date | None,
+) -> bool:
+    """Intervalos inclusivos; fim null = aberto."""
+    if a_fim is not None and a_fim < b_ini:
+        return False
+    if b_fim is not None and b_fim < a_ini:
+        return False
+    return True
+
+
+def validar_vigencia_sm(
+    db: Session,
+    *,
+    vigencia_inicio: date,
+    vigencia_fim: date | None,
+    exclude_id: int | None = None,
+) -> None:
+    q = db.query(SalarioMinimoReferencia)
+    if exclude_id is not None:
+        q = q.filter(SalarioMinimoReferencia.id != exclude_id)
+    for row in q.all():
+        if _ranges_overlap(vigencia_inicio, vigencia_fim, row.vigencia_inicio, row.vigencia_fim):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Vigência sobrepõe outro salário mínimo "
+                    f"(id={row.id}, {row.vigencia_inicio}–{row.vigencia_fim or 'vigente'})."
+                ),
+            )
+
+
+def obter_sm_na_data(db: Session, ref: date) -> SalarioMinimoReferencia | None:
+    return (
+        db.query(SalarioMinimoReferencia)
+        .filter(
+            SalarioMinimoReferencia.vigencia_inicio <= ref,
+            or_(
+                SalarioMinimoReferencia.vigencia_fim.is_(None),
+                SalarioMinimoReferencia.vigencia_fim >= ref,
+            ),
+        )
+        .order_by(SalarioMinimoReferencia.vigencia_inicio.desc())
+        .first()
+    )
+
+
+def criar_sm(db: Session, data: SalarioMinimoCreate) -> SalarioMinimoReferencia:
+    validar_vigencia_sm(db, vigencia_inicio=data.vigencia_inicio, vigencia_fim=data.vigencia_fim)
+    row = SalarioMinimoReferencia(
+        valor=data.valor,
+        vigencia_inicio=data.vigencia_inicio,
+        vigencia_fim=data.vigencia_fim,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def obter_sm_vigente_aberto(db: Session) -> SalarioMinimoReferencia | None:
+    """Último SM com vigência aberta (fim null)."""
+    return (
+        db.query(SalarioMinimoReferencia)
+        .filter(SalarioMinimoReferencia.vigencia_fim.is_(None))
+        .order_by(SalarioMinimoReferencia.vigencia_inicio.desc())
+        .first()
+    )
+
+
+def atualizar_valor_sm(db: Session, data: SalarioMinimoAtualizarValor) -> SalarioMinimoReferencia:
+    """
+    Altera o SM a partir de `vigencia_inicio` sem reescrever o passado:
+    fecha o registro vigente no dia anterior e cria um novo (histórico).
+    Se ainda não houver nenhum SM, cria o primeiro.
+    """
+    aberto = obter_sm_vigente_aberto(db)
+    if aberto is None:
+        # Sem histórico: primeiro cadastro
+        if db.query(SalarioMinimoReferencia).count() == 0:
+            return criar_sm(
+                db,
+                SalarioMinimoCreate(valor=data.valor, vigencia_inicio=data.vigencia_inicio, vigencia_fim=None),
+            )
+        raise HTTPException(
+            status_code=400,
+            detail="Não há salário mínimo vigente aberto. Corrija o histórico ou cadastre um SM com vigência aberta.",
+        )
+
+    if data.vigencia_inicio <= aberto.vigencia_inicio:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "A data do novo valor deve ser posterior ao início do SM vigente "
+                f"({aberto.vigencia_inicio.isoformat()})."
+            ),
+        )
+
+    fim_anterior = data.vigencia_inicio - timedelta(days=1)
+    if fim_anterior < aberto.vigencia_inicio:
+        raise HTTPException(
+            status_code=400,
+            detail="Intervalo inválido ao encerrar o SM vigente.",
+        )
+
+    # Fecha o vigente (passado intacto) e abre o novo
+    aberto.vigencia_fim = fim_anterior
+    db.flush()
+
+    novo = SalarioMinimoReferencia(
+        valor=data.valor,
+        vigencia_inicio=data.vigencia_inicio,
+        vigencia_fim=None,
+    )
+    db.add(novo)
+    db.flush()
+    return novo
+
+
+def atualizar_sm(db: Session, row: SalarioMinimoReferencia, data: SalarioMinimoUpdate) -> SalarioMinimoReferencia:
+    payload = data.model_dump(exclude_unset=True)
+    inicio = payload.get("vigencia_inicio", row.vigencia_inicio)
+    fim = payload.get("vigencia_fim", row.vigencia_fim) if "vigencia_fim" in payload else row.vigencia_fim
+    if "vigencia_fim" in payload and payload["vigencia_fim"] is None:
+        fim = None
+    if fim is not None and fim < inicio:
+        raise HTTPException(status_code=400, detail="vigencia_fim deve ser >= vigencia_inicio")
+    validar_vigencia_sm(db, vigencia_inicio=inicio, vigencia_fim=fim, exclude_id=row.id)
+    for k, v in payload.items():
+        setattr(row, k, v)
+    db.flush()
+    return row
+
+
+def _validar_campos_item(tipo: str, *, percentual_sm, valor_fixo, tef_base, tef_adicional) -> None:
+    if tipo not in TIPOS_CUSTO_CATALOGO:
+        raise HTTPException(status_code=400, detail=f"tipo inválido: {tipo}")
+    if tipo == TIPO_PERCENTUAL_SM and percentual_sm is None:
+        raise HTTPException(status_code=400, detail="percentual_sm é obrigatório para percentual_sm")
+    if tipo == TIPO_VALOR_FIXO and valor_fixo is None:
+        raise HTTPException(status_code=400, detail="valor_fixo é obrigatório para valor_fixo")
+    if tipo == TIPO_COMPOSTO_TEF and (tef_base is None or tef_adicional is None):
+        raise HTTPException(status_code=400, detail="tef_base e tef_adicional são obrigatórios para composto_tef")
+
+
+def criar_item(db: Session, data: CustoCatalogoItemCreate) -> CustoCatalogoItem:
+    if db.query(CustoCatalogoItem).filter(CustoCatalogoItem.slug == data.slug).first():
+        raise HTTPException(status_code=400, detail="Slug de item de custo já existe.")
+    _validar_campos_item(
+        data.tipo,
+        percentual_sm=data.percentual_sm,
+        valor_fixo=data.valor_fixo,
+        tef_base=data.tef_base,
+        tef_adicional=data.tef_adicional,
+    )
+    row = CustoCatalogoItem(**data.model_dump())
+    db.add(row)
+    db.flush()
+    return row
+
+
+def atualizar_item(db: Session, row: CustoCatalogoItem, data: CustoCatalogoItemUpdate) -> CustoCatalogoItem:
+    payload = data.model_dump(exclude_unset=True)
+    if "slug" in payload:
+        slug = str(payload["slug"]).strip().lower()
+        payload["slug"] = slug
+        dup = (
+            db.query(CustoCatalogoItem)
+            .filter(CustoCatalogoItem.slug == slug, CustoCatalogoItem.id != row.id)
+            .first()
+        )
+        if dup:
+            raise HTTPException(status_code=400, detail="Slug de item de custo já existe.")
+    tipo = payload.get("tipo", row.tipo)
+    percentual = payload.get("percentual_sm", row.percentual_sm)
+    valor_fixo = payload.get("valor_fixo", row.valor_fixo)
+    tef_base = payload.get("tef_base", row.tef_base)
+    tef_adicional = payload.get("tef_adicional", row.tef_adicional)
+    _validar_campos_item(
+        tipo,
+        percentual_sm=percentual,
+        valor_fixo=valor_fixo,
+        tef_base=tef_base,
+        tef_adicional=tef_adicional,
+    )
+    for k, v in payload.items():
+        setattr(row, k, v)
+    db.flush()
+    return row
+
+
+def _item_vigente_em(item: CustoCatalogoItem, ref: date) -> bool:
+    if item.vigencia_inicio and item.vigencia_inicio > ref:
+        return False
+    if item.vigencia_fim and item.vigencia_fim < ref:
+        return False
+    return True
+
+
+def _valor_linha(item: CustoCatalogoItem, sm: Decimal | None, quantidade_pdvs: int) -> Decimal:
+    if item.tipo == TIPO_PERCENTUAL_SM:
+        if sm is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Item «{item.nome}» exige salário mínimo vigente na data de referência.",
+            )
+        pct = Decimal(item.percentual_sm or 0)
+        return (sm * pct / Decimal("100")).quantize(Decimal("0.01"))
+    if item.tipo == TIPO_VALOR_FIXO:
+        return Decimal(item.valor_fixo or 0).quantize(Decimal("0.01"))
+    if item.tipo == TIPO_COMPOSTO_TEF:
+        base = Decimal(item.tef_base or 0)
+        adicional = Decimal(item.tef_adicional or 0)
+        extras = max(0, quantidade_pdvs - 1)
+        return (base + adicional * extras).quantize(Decimal("0.01"))
+    raise HTTPException(status_code=400, detail=f"Tipo de item não suportado: {item.tipo}")
+
+
+def simular_custo(
+    db: Session,
+    *,
+    item_ids: list[int],
+    quantidade_pdvs: int = 1,
+    data_referencia: date | None = None,
+) -> CustoSimularResponse:
+    ref = data_referencia or date.today()
+    sm_row = obter_sm_na_data(db, ref)
+    sm_valor = Decimal(sm_row.valor) if sm_row else None
+
+    ids_unicos = list(dict.fromkeys(item_ids))
+    itens = (
+        db.query(CustoCatalogoItem)
+        .filter(CustoCatalogoItem.id.in_(ids_unicos), CustoCatalogoItem.ativo.is_(True))
+        .all()
+    )
+    by_id = {i.id: i for i in itens}
+    faltando = [i for i in ids_unicos if i not in by_id]
+    if faltando:
+        raise HTTPException(status_code=400, detail=f"Itens inexistentes ou inativos: {faltando}")
+
+    linhas: list[CustoSimularLinha] = []
+    total = Decimal("0.00")
+    for iid in ids_unicos:
+        item = by_id[iid]
+        if not _item_vigente_em(item, ref):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Item «{item.nome}» fora da vigência em {ref.isoformat()}.",
+            )
+        valor = _valor_linha(item, sm_valor, quantidade_pdvs)
+        linhas.append(
+            CustoSimularLinha(
+                item_id=item.id,
+                nome=item.nome,
+                slug=item.slug,
+                tipo=item.tipo,
+                valor=valor,
+            )
+        )
+        total += valor
+
+    return CustoSimularResponse(
+        data_referencia=ref,
+        salario_minimo=sm_valor,
+        salario_minimo_id=sm_row.id if sm_row else None,
+        quantidade_pdvs=quantidade_pdvs,
+        linhas=linhas,
+        total=total.quantize(Decimal("0.01")),
+    )

--- a/backend/tests/test_comercial_custos.py
+++ b/backend/tests/test_comercial_custos.py
@@ -1,0 +1,191 @@
+"""Testes do catálogo comercial de custos (#321 / #329–#333)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+
+def test_sm_crud_e_na_data(client, auth_headers):
+    h = auth_headers["admin"]
+    r = client.post(
+        "/v1/comercial/salario-minimo",
+        headers=h,
+        json={"valor": "1412.00", "vigencia_inicio": "2024-01-01", "vigencia_fim": "2024-12-31"},
+    )
+    assert r.status_code == 201, r.text
+    sm1 = r.json()
+    assert Decimal(sm1["valor"]) == Decimal("1412.00")
+
+    r2 = client.post(
+        "/v1/comercial/salario-minimo",
+        headers=h,
+        json={"valor": "1518.00", "vigencia_inicio": "2025-01-01", "vigencia_fim": None},
+    )
+    assert r2.status_code == 201, r2.text
+
+    # Sobreposição rejeitada
+    r_dup = client.post(
+        "/v1/comercial/salario-minimo",
+        headers=h,
+        json={"valor": "1500.00", "vigencia_inicio": "2024-06-01", "vigencia_fim": "2024-08-01"},
+    )
+    assert r_dup.status_code == 400
+    assert "sobrepõe" in r_dup.json()["detail"].lower() or "sobrepoe" in r_dup.json()["detail"].lower()
+
+    na = client.get("/v1/comercial/salario-minimo/na-data", headers=h, params={"data": "2024-07-15"})
+    assert na.status_code == 200
+    assert na.json()["id"] == sm1["id"]
+
+    na2 = client.get("/v1/comercial/salario-minimo/na-data", headers=h, params={"data": "2025-03-01"})
+    assert na2.status_code == 200
+    assert Decimal(na2.json()["valor"]) == Decimal("1518.00")
+
+    lst = client.get("/v1/comercial/salario-minimo", headers=h)
+    assert lst.status_code == 200
+    assert lst.json()["total"] == 2
+
+
+def test_sm_atualizar_valor_preserva_passado(client, auth_headers):
+    h = auth_headers["admin"]
+    r0 = client.post(
+        "/v1/comercial/salario-minimo/atualizar-valor",
+        headers=h,
+        json={"valor": "1412.00", "vigencia_inicio": "2024-01-01"},
+    )
+    assert r0.status_code == 201, r0.text
+    assert r0.json()["vigencia_fim"] is None
+
+    r1 = client.post(
+        "/v1/comercial/salario-minimo/atualizar-valor",
+        headers=h,
+        json={"valor": "1518.00", "vigencia_inicio": "2025-01-01"},
+    )
+    assert r1.status_code == 201, r1.text
+    assert Decimal(r1.json()["valor"]) == Decimal("1518.00")
+    assert r1.json()["vigencia_inicio"] == "2025-01-01"
+    assert r1.json()["vigencia_fim"] is None
+
+    # Passado intacto
+    ant = client.get("/v1/comercial/salario-minimo/na-data", headers=h, params={"data": "2024-06-01"})
+    assert ant.status_code == 200
+    assert Decimal(ant.json()["valor"]) == Decimal("1412.00")
+    assert ant.json()["vigencia_fim"] == "2024-12-31"
+
+    # Presente usa novo
+    hoje = client.get("/v1/comercial/salario-minimo/na-data", headers=h, params={"data": "2025-06-01"})
+    assert Decimal(hoje.json()["valor"]) == Decimal("1518.00")
+
+    # Não permite data <= início do vigente
+    bad = client.post(
+        "/v1/comercial/salario-minimo/atualizar-valor",
+        headers=h,
+        json={"valor": "1600.00", "vigencia_inicio": "2025-01-01"},
+    )
+    assert bad.status_code == 400
+
+
+def test_sm_somente_admin(client, auth_headers):
+    r = client.get("/v1/comercial/salario-minimo", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+
+def test_item_crud_e_simular(client, auth_headers):
+    h = auth_headers["admin"]
+    client.post(
+        "/v1/comercial/salario-minimo",
+        headers=h,
+        json={"valor": "1000.00", "vigencia_inicio": "2020-01-01", "vigencia_fim": None},
+    )
+
+    pct = client.post(
+        "/v1/comercial/custos/itens",
+        headers=h,
+        json={
+            "nome": "Posto bandeira branca",
+            "slug": "posto-bb",
+            "tipo": "percentual_sm",
+            "percentual_sm": "20",
+            "ordem": 1,
+        },
+    )
+    assert pct.status_code == 201, pct.text
+    item_pct = pct.json()
+
+    fixo = client.post(
+        "/v1/comercial/custos/itens",
+        headers=h,
+        json={
+            "nome": "Módulo fiscal",
+            "slug": "mod-fiscal",
+            "tipo": "valor_fixo",
+            "valor_fixo": "50.00",
+            "ordem": 2,
+        },
+    )
+    assert fixo.status_code == 201, fixo.text
+    item_fixo = fixo.json()
+
+    tef = client.post(
+        "/v1/comercial/custos/itens",
+        headers=h,
+        json={
+            "nome": "TEF",
+            "slug": "tef",
+            "tipo": "composto_tef",
+            "tef_base": "100.00",
+            "tef_adicional": "30.00",
+            "ordem": 3,
+        },
+    )
+    assert tef.status_code == 201, tef.text
+    item_tef = tef.json()
+
+    # slug duplicado
+    dup = client.post(
+        "/v1/comercial/custos/itens",
+        headers=h,
+        json={"nome": "X", "slug": "posto-bb", "tipo": "valor_fixo", "valor_fixo": "1"},
+    )
+    assert dup.status_code == 400
+
+    sim = client.post(
+        "/v1/comercial/custos/simular",
+        headers=h,
+        json={
+            "item_ids": [item_pct["id"], item_fixo["id"], item_tef["id"]],
+            "quantidade_pdvs": 3,
+            "data_referencia": "2025-06-01",
+        },
+    )
+    assert sim.status_code == 200, sim.text
+    body = sim.json()
+    # 20% de 1000 = 200; fixo 50; TEF 100 + 2*30 = 160 → total 410
+    assert Decimal(body["total"]) == Decimal("410.00")
+    assert Decimal(body["salario_minimo"]) == Decimal("1000.00")
+    assert len(body["linhas"]) == 3
+
+    patch = client.patch(
+        f"/v1/comercial/custos/itens/{item_fixo['id']}",
+        headers=h,
+        json={"ativo": False},
+    )
+    assert patch.status_code == 200
+    assert patch.json()["ativo"] is False
+
+    # item inativo não entra na simulação
+    sim2 = client.post(
+        "/v1/comercial/custos/simular",
+        headers=h,
+        json={"item_ids": [item_fixo["id"]], "quantidade_pdvs": 1},
+    )
+    assert sim2.status_code == 400
+
+
+def test_item_exige_campos_por_tipo(client, auth_headers):
+    h = auth_headers["admin"]
+    r = client.post(
+        "/v1/comercial/custos/itens",
+        headers=h,
+        json={"nome": "Sem %", "slug": "sem-pct", "tipo": "percentual_sm"},
+    )
+    assert r.status_code == 422

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -66,6 +66,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -281,6 +282,7 @@
       "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.3",
         "tslib": "^2.4.0"
@@ -292,6 +294,7 @@
       "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1315,6 +1318,7 @@
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1322,6 +1326,7 @@
     "node_modules/@types/react": {
       "version": "19.2.17",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1391,6 +1396,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -1625,6 +1631,7 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1719,6 +1726,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2099,6 +2107,7 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3587,9 +3596,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -3714,6 +3723,7 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3835,6 +3845,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3844,6 +3855,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3890,6 +3902,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -3979,7 +3992,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -4243,6 +4257,7 @@
       "version": "6.0.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4473,6 +4488,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4589,6 +4605,7 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,6 +55,7 @@ import { TipoNegocioForm } from './pages/TipoNegocioForm'
 import { TipoNegocioDetalhe } from './pages/TipoNegocioDetalhe'
 import { ConfigWhatsapp } from './pages/ConfigWhatsapp'
 import { ConfigPdvCatalogos } from './pages/ConfigPdvCatalogos'
+import { ConfigComercialCustos } from './pages/ConfigComercialCustos'
 import { ConfigEmpresaEmail } from './pages/ConfigEmpresaEmail'
 import { ConfigAtendimentoLayout } from './pages/config/ConfigAtendimentoLayout'
 import { ConfigCadastrosLayout } from './pages/config/ConfigCadastrosLayout'
@@ -572,6 +573,7 @@ function AppRoutes() {
           <Route index element={<Navigate to="tipos-negocio" replace />} />
           <Route path="tipos-negocio" element={<TiposNegocio embedded />} />
           <Route path="pdv" element={<ConfigPdvCatalogos embedded />} />
+          <Route path="custos" element={<ConfigComercialCustos embedded />} />
         </Route>
         <Route
           path="configuracoes/sistema"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2785,6 +2785,147 @@ export namespace TicketClassificacao {
   }
 }
 
+export const comercialSalarioMinimo = {
+  list: (params?: {
+    offset?: number;
+    limit?: number;
+    ordenar_por?: 'vigencia_inicio' | 'valor' | 'id';
+    ordem?: 'asc' | 'desc';
+  }) => listPaginated<ComercialCustos.SalarioMinimo>('/comercial/salario-minimo', params),
+  naData: (data: string) =>
+    api<ComercialCustos.SalarioMinimo | null>(withParams('/comercial/salario-minimo/na-data', { data })),
+  create: (data: ComercialCustos.SalarioMinimoCreate) =>
+    api<ComercialCustos.SalarioMinimo>('/comercial/salario-minimo', { method: 'POST', body: JSON.stringify(data) }),
+  /** Fecha o vigente e cria novo valor a partir da data (histórico preservado). */
+  atualizarValor: (data: ComercialCustos.SalarioMinimoAtualizarValor) =>
+    api<ComercialCustos.SalarioMinimo>('/comercial/salario-minimo/atualizar-valor', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  update: (id: number, data: ComercialCustos.SalarioMinimoUpdate) =>
+    api<ComercialCustos.SalarioMinimo>(`/comercial/salario-minimo/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+  delete: (id: number) => api<void>(`/comercial/salario-minimo/${id}`, { method: 'DELETE' }),
+};
+
+export const comercialCustosItens = {
+  list: (params?: {
+    incluir_inativos?: boolean;
+    busca?: string;
+    tipo?: string;
+    offset?: number;
+    limit?: number;
+    ordenar_por?: 'nome' | 'slug' | 'ordem' | 'tipo' | 'ativo';
+    ordem?: 'asc' | 'desc';
+  }) => listPaginated<ComercialCustos.Item>('/comercial/custos/itens', params),
+  create: (data: ComercialCustos.ItemCreate) =>
+    api<ComercialCustos.Item>('/comercial/custos/itens', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id: number, data: ComercialCustos.ItemUpdate) =>
+    api<ComercialCustos.Item>(`/comercial/custos/itens/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  delete: (id: number) => api<void>(`/comercial/custos/itens/${id}`, { method: 'DELETE' }),
+  simular: (data: ComercialCustos.SimularRequest) =>
+    api<ComercialCustos.SimularResponse>('/comercial/custos/simular', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+};
+
+export namespace ComercialCustos {
+  export type Tipo = 'percentual_sm' | 'valor_fixo' | 'composto_tef';
+
+  export interface SalarioMinimo {
+    id: number;
+    valor: string;
+    vigencia_inicio: string;
+    vigencia_fim?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+  }
+  export interface SalarioMinimoCreate {
+    valor: string | number;
+    vigencia_inicio: string;
+    vigencia_fim?: string | null;
+  }
+  export interface SalarioMinimoAtualizarValor {
+    valor: string | number;
+    vigencia_inicio: string;
+  }
+  export interface SalarioMinimoUpdate {
+    valor?: string | number;
+    vigencia_inicio?: string;
+    vigencia_fim?: string | null;
+  }
+
+  export interface Item {
+    id: number;
+    nome: string;
+    slug: string;
+    descricao?: string | null;
+    tipo: Tipo | string;
+    percentual_sm?: string | null;
+    valor_fixo?: string | null;
+    tef_base?: string | null;
+    tef_adicional?: string | null;
+    ordem: number;
+    ativo: boolean;
+    vigencia_inicio?: string | null;
+    vigencia_fim?: string | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+  }
+  export interface ItemCreate {
+    nome: string;
+    slug: string;
+    descricao?: string | null;
+    tipo: Tipo;
+    percentual_sm?: string | number | null;
+    valor_fixo?: string | number | null;
+    tef_base?: string | number | null;
+    tef_adicional?: string | number | null;
+    ordem?: number;
+    ativo?: boolean;
+    vigencia_inicio?: string | null;
+    vigencia_fim?: string | null;
+  }
+  export interface ItemUpdate {
+    nome?: string;
+    slug?: string;
+    descricao?: string | null;
+    tipo?: Tipo;
+    percentual_sm?: string | number | null;
+    valor_fixo?: string | number | null;
+    tef_base?: string | number | null;
+    tef_adicional?: string | number | null;
+    ordem?: number;
+    ativo?: boolean;
+    vigencia_inicio?: string | null;
+    vigencia_fim?: string | null;
+  }
+
+  export interface SimularRequest {
+    item_ids: number[];
+    quantidade_pdvs?: number;
+    data_referencia?: string | null;
+  }
+  export interface SimularLinha {
+    item_id: number;
+    nome: string;
+    slug: string;
+    tipo: string;
+    valor: string;
+  }
+  export interface SimularResponse {
+    data_referencia: string;
+    salario_minimo: string | null;
+    salario_minimo_id: number | null;
+    quantidade_pdvs: number;
+    linhas: SimularLinha[];
+    total: string;
+  }
+}
+
 export const pdvRotulos = {
   list: (params?: { incluir_inativos?: boolean; busca?: string; offset?: number; limit?: number }) =>
     listPaginated<PdvCatalogo.Item>('/pdv-rotulos', params),

--- a/frontend/src/pages/ConfigComercialCustos.tsx
+++ b/frontend/src/pages/ConfigComercialCustos.tsx
@@ -1,0 +1,955 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ApiError,
+  comercialCustosItens,
+  comercialSalarioMinimo,
+  type ComercialCustos,
+} from '../api/client'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { Input } from '../components/ui/Input'
+import { Switch } from '../components/ui/Switch'
+import { Select } from '../components/ui/Select'
+import { FiltroInativos } from '../components/ui/FiltroInativos'
+import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
+import { IconPencil } from '../components/ui/IconPencil'
+import { IconTrash } from '../components/ui/IconTrash'
+import { ConfirmDialog } from '../components/ui/ConfirmDialog'
+import { useToast } from '../components/ui/Toast'
+import { SemPermissao } from './SemPermissao'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { MODAL_PANEL_COMPACT } from '../lib/modalPanel'
+import { PageContainer, PageHeader } from '../components/ui/PageContainer'
+
+type Aba = 'sm' | 'itens' | 'simular'
+
+type PendingDelete =
+  | { kind: 'sm'; id: number; rotulo: string }
+  | { kind: 'item'; id: number; rotulo: string }
+
+const TIPO_LABEL: Record<string, string> = {
+  percentual_sm: '% salário mínimo',
+  valor_fixo: 'Valor fixo',
+  composto_tef: 'TEF (base + adicional)',
+}
+
+const emptySmForm = (): ComercialCustos.SalarioMinimoAtualizarValor => ({
+  valor: '',
+  vigencia_inicio: new Date().toISOString().slice(0, 10),
+})
+
+const emptyItem = (): ComercialCustos.ItemCreate => ({
+  nome: '',
+  slug: '',
+  tipo: 'percentual_sm',
+  percentual_sm: '',
+  valor_fixo: '',
+  tef_base: '',
+  tef_adicional: '',
+  ordem: 0,
+  ativo: true,
+})
+
+/** Identificador técnico interno — gerado a partir do nome; não aparece na UI. */
+function slugify(nome: string): string {
+  const base = nome
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 40)
+  return base || 'item'
+}
+
+function fmtMoney(v: string | number | null | undefined): string {
+  if (v == null || v === '') return '—'
+  const n = Number(v)
+  if (Number.isNaN(n)) return String(v)
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })
+}
+
+function fmtPercentual(v: string | number | null | undefined): string {
+  if (v == null || v === '') return '—'
+  const n = Math.round(Number(v))
+  if (Number.isNaN(n)) return String(v)
+  return `${n}% SM`
+}
+
+function fmtDataIso(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const [y, m, d] = iso.split('-')
+  if (!y || !m || !d) return iso
+  return `${d}/${m}/${y}`
+}
+
+export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean }) {
+  const toast = useToast()
+  const [forbidden, setForbidden] = useState(false)
+  const [aba, setAba] = useState<Aba>('sm')
+
+  // —— SM ——
+  const [smItems, setSmItems] = useState<ComercialCustos.SalarioMinimo[]>([])
+  const [smTotal, setSmTotal] = useState(0)
+  const [smPage, setSmPage] = useState(1)
+  const [smLoading, setSmLoading] = useState(true)
+  const [smModal, setSmModal] = useState(false)
+  const [smForm, setSmForm] = useState(emptySmForm())
+  const [smSaving, setSmSaving] = useState(false)
+  const smVigente = smItems.find((r) => r.vigencia_fim == null) ?? null
+  const smTemHistorico = smTotal > 0
+
+  // —— Itens ——
+  const [itens, setItens] = useState<ComercialCustos.Item[]>([])
+  const [itensTotal, setItensTotal] = useState(0)
+  const [itensPage, setItensPage] = useState(1)
+  const [busca, setBusca] = useState('')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+  const [incluirInativos, setIncluirInativos] = useState(false)
+  const [itensLoading, setItensLoading] = useState(true)
+  const [itemModal, setItemModal] = useState(false)
+  const [itemEditId, setItemEditId] = useState<number | null>(null)
+  const [itemForm, setItemForm] = useState(emptyItem())
+  const [itemSaving, setItemSaving] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<PendingDelete | null>(null)
+  const [deleteLoading, setDeleteLoading] = useState(false)
+
+  // —— Simular ——
+  const [simItens, setSimItens] = useState<ComercialCustos.Item[]>([])
+  const [simSelected, setSimSelected] = useState<number[]>([])
+  const [simPdvs, setSimPdvs] = useState('1')
+  const [simData, setSimData] = useState(() => new Date().toISOString().slice(0, 10))
+  const [simResult, setSimResult] = useState<ComercialCustos.SimularResponse | null>(null)
+  const [simLoading, setSimLoading] = useState(false)
+  const [simCatalogLoading, setSimCatalogLoading] = useState(false)
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
+    return () => clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    setItensPage(1)
+  }, [debouncedBusca, incluirInativos])
+
+  const loadSm = useCallback(() => {
+    setSmLoading(true)
+    setForbidden(false)
+    comercialSalarioMinimo
+      .list({
+        offset: (smPage - 1) * PAGE_SIZE_PADRAO,
+        limit: PAGE_SIZE_PADRAO,
+        ordenar_por: 'vigencia_inicio',
+        ordem: 'desc',
+      })
+      .then(({ items, total }) => {
+        setSmItems(items)
+        setSmTotal(total)
+      })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar o salário mínimo.'))
+        setSmItems([])
+        setSmTotal(0)
+      })
+      .finally(() => setSmLoading(false))
+  }, [smPage, toast])
+
+  const loadItens = useCallback(() => {
+    setItensLoading(true)
+    setForbidden(false)
+    comercialCustosItens
+      .list({
+        incluir_inativos: incluirInativos,
+        busca: debouncedBusca || undefined,
+        offset: (itensPage - 1) * PAGE_SIZE_PADRAO,
+        limit: PAGE_SIZE_PADRAO,
+      })
+      .then(({ items, total }) => {
+        setItens(items)
+        setItensTotal(total)
+      })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar os itens de custo.'))
+        setItens([])
+        setItensTotal(0)
+      })
+      .finally(() => setItensLoading(false))
+  }, [debouncedBusca, incluirInativos, itensPage, toast])
+
+  const loadSimCatalogo = useCallback(() => {
+    setSimCatalogLoading(true)
+    comercialCustosItens
+      .list({ incluir_inativos: false, limit: 100, ordenar_por: 'ordem', ordem: 'asc' })
+      .then(({ items }) => setSimItens(items))
+      .catch((err) => {
+        setSimItens([])
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar os itens para simular.'))
+      })
+      .finally(() => setSimCatalogLoading(false))
+  }, [toast])
+
+  useEffect(() => {
+    if (aba === 'sm') loadSm()
+    else if (aba === 'itens') loadItens()
+    else loadSimCatalogo()
+  }, [aba, loadSm, loadItens, loadSimCatalogo])
+
+  async function salvarSm() {
+    const valor = String(smForm.valor).trim()
+    if (!valor || Number(valor) <= 0) {
+      toast.showWarning('Informe um valor de salário mínimo válido.')
+      return
+    }
+    if (!smForm.vigencia_inicio) {
+      toast.showWarning('Informe a data a partir da qual o valor passa a valer.')
+      return
+    }
+    setSmSaving(true)
+    try {
+      await comercialSalarioMinimo.atualizarValor({
+        valor,
+        vigencia_inicio: smForm.vigencia_inicio,
+      })
+      toast.showSuccess(smTemHistorico ? 'Salário mínimo atualizado. Histórico preservado.' : 'Salário mínimo definido.')
+      setSmModal(false)
+      setSmForm(emptySmForm())
+      loadSm()
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
+    } finally {
+      setSmSaving(false)
+    }
+  }
+
+  async function confirmarExclusao() {
+    if (!pendingDelete) return
+    setDeleteLoading(true)
+    try {
+      if (pendingDelete.kind === 'sm') {
+        await comercialSalarioMinimo.delete(pendingDelete.id)
+        toast.showSuccess('Salário mínimo excluído.')
+        loadSm()
+      } else {
+        await comercialCustosItens.delete(pendingDelete.id)
+        toast.showSuccess('Item excluído.')
+        loadItens()
+        setSimSelected((prev) => prev.filter((id) => id !== pendingDelete.id))
+      }
+      setPendingDelete(null)
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível excluir.'))
+    } finally {
+      setDeleteLoading(false)
+    }
+  }
+
+  async function salvarItem() {
+    const nome = itemForm.nome.trim()
+    if (!nome) {
+      toast.showWarning('Informe o nome.')
+      return
+    }
+    if (itemForm.tipo === 'percentual_sm' && (itemForm.percentual_sm === '' || itemForm.percentual_sm == null)) {
+      toast.showWarning('Informe o percentual do salário mínimo.')
+      return
+    }
+    if (itemForm.tipo === 'valor_fixo' && (itemForm.valor_fixo === '' || itemForm.valor_fixo == null)) {
+      toast.showWarning('Informe o valor fixo.')
+      return
+    }
+    if (
+      itemForm.tipo === 'composto_tef' &&
+      (itemForm.tef_base === '' || itemForm.tef_base == null || itemForm.tef_adicional === '' || itemForm.tef_adicional == null)
+    ) {
+      toast.showWarning('Informe TEF base e adicional por PDV.')
+      return
+    }
+    setItemSaving(true)
+    try {
+      const percentual =
+        itemForm.tipo === 'percentual_sm' ? String(Math.round(Number(itemForm.percentual_sm))) : null
+      const basePayload = {
+        nome,
+        descricao: itemForm.descricao || null,
+        tipo: itemForm.tipo,
+        ativo: itemForm.ativo ?? true,
+        percentual_sm: percentual,
+        valor_fixo: itemForm.tipo === 'valor_fixo' ? itemForm.valor_fixo : null,
+        tef_base: itemForm.tipo === 'composto_tef' ? itemForm.tef_base : null,
+        tef_adicional: itemForm.tipo === 'composto_tef' ? itemForm.tef_adicional : null,
+        vigencia_inicio: itemForm.vigencia_inicio || null,
+        vigencia_fim: itemForm.vigencia_fim || null,
+      }
+      if (itemEditId != null) {
+        await comercialCustosItens.update(itemEditId, basePayload)
+        toast.showSuccess('Item atualizado.')
+      } else {
+        let slug = slugify(nome)
+        try {
+          await comercialCustosItens.create({ ...basePayload, slug, ordem: 0 })
+        } catch (err) {
+          const detail = err instanceof ApiError ? String((err.body as { detail?: unknown })?.detail ?? err.message) : ''
+          if (err instanceof ApiError && err.status === 400 && /slug/i.test(detail)) {
+            slug = `${slugify(nome)}-${Date.now().toString(36).slice(-5)}`
+            await comercialCustosItens.create({ ...basePayload, slug, ordem: 0 })
+          } else {
+            throw err
+          }
+        }
+        toast.showSuccess('Item cadastrado.')
+      }
+      setItemModal(false)
+      setItemEditId(null)
+      setItemForm(emptyItem())
+      loadItens()
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
+    } finally {
+      setItemSaving(false)
+    }
+  }
+
+  async function executarSimulacao() {
+    if (simSelected.length === 0) {
+      toast.showWarning('Selecione ao menos um item de custo.')
+      return
+    }
+    const pdvs = Number(simPdvs) || 1
+    setSimLoading(true)
+    setSimResult(null)
+    try {
+      const res = await comercialCustosItens.simular({
+        item_ids: simSelected,
+        quantidade_pdvs: pdvs,
+        data_referencia: simData || null,
+      })
+      setSimResult(res)
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível simular.'))
+    } finally {
+      setSimLoading(false)
+    }
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Apenas administradores podem gerir o catálogo comercial de custos."
+        voltarPara="/"
+        voltarLabel="Voltar"
+      />
+    )
+  }
+
+  const tabBtn = (id: Aba, rotulo: string) => (
+    <button
+      type="button"
+      onClick={() => setAba(id)}
+      aria-current={aba === id ? 'page' : undefined}
+      className={
+        aba === id
+          ? 'border-b-2 border-sky-500 px-3 py-2.5 text-sm font-semibold text-slate-900 dark:border-sky-400 dark:text-white'
+          : 'border-b-2 border-transparent px-3 py-2.5 text-sm font-medium text-slate-500 transition-colors hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200'
+      }
+    >
+      {rotulo}
+    </button>
+  )
+
+  const actionsBtn =
+    aba === 'sm' ? (
+      <Button
+        type="button"
+        onClick={() => {
+          setSmForm(emptySmForm())
+          setSmModal(true)
+        }}
+      >
+        {smTemHistorico ? 'Atualizar valor' : 'Definir SM'}
+      </Button>
+    ) : aba === 'itens' ? (
+      <Button
+        type="button"
+        onClick={() => {
+          setItemEditId(null)
+          setItemForm(emptyItem())
+          setItemModal(true)
+        }}
+      >
+        Novo item
+      </Button>
+    ) : null
+
+  const conteudo = (
+    <>
+      {embedded ? (
+        actionsBtn ? <div className="flex justify-end">{actionsBtn}</div> : null
+      ) : (
+        <PageHeader
+          title="Catálogo de custos"
+          subtitle="Salário mínimo com vigência, perfis de custo e simulador estimado."
+          actions={actionsBtn}
+        />
+      )}
+
+      <div className="border-b border-slate-200 dark:border-slate-800">
+        <nav className="-mb-px flex gap-1" aria-label="Seções do catálogo de custos">
+          {tabBtn('sm', 'Salário mínimo')}
+          {tabBtn('itens', 'Itens de custo')}
+          {tabBtn('simular', 'Simular')}
+        </nav>
+      </div>
+
+      {aba === 'sm' ? (
+        <div className="space-y-4">
+          <Card>
+            {smLoading ? (
+              <p className="py-8 text-center text-sm text-slate-500">Carregando…</p>
+            ) : !smVigente ? (
+              <div className="py-10 text-center">
+                <p className="text-sm text-slate-500">Nenhum salário mínimo definido ainda.</p>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="mt-4"
+                  onClick={() => {
+                    setSmForm(emptySmForm())
+                    setSmModal(true)
+                  }}
+                >
+                  Definir SM
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Valor vigente
+                </p>
+                <p className="text-3xl font-semibold tabular-nums text-slate-900 dark:text-slate-50">
+                  {fmtMoney(smVigente.valor)}
+                </p>
+                <p className="text-sm text-slate-600 dark:text-slate-300">
+                  Em vigor desde {fmtDataIso(smVigente.vigencia_inicio)}
+                </p>
+                <p className="text-xs leading-relaxed text-slate-500 dark:text-slate-400">
+                  Ao atualizar, o valor anterior fica no histórico (não reescreve o passado). Simulações e custos usam o SM
+                  da data de referência. A mensalidade do cliente só muda no reajuste do contrato — entre o novo SM e o
+                  aniversário do contrato a margem pode apertar.
+                </p>
+              </div>
+            )}
+          </Card>
+
+          {smTemHistorico ? (
+            <Card>
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                <h3 className="text-sm font-semibold text-slate-800 dark:text-slate-100">Histórico de alterações</h3>
+                <div className="flex flex-wrap items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                  <span className="whitespace-nowrap">
+                    {smTotal > 0
+                      ? `${(smPage - 1) * PAGE_SIZE_PADRAO + 1}–${Math.min(smPage * PAGE_SIZE_PADRAO, smTotal)} de ${smTotal}`
+                      : '0'}
+                  </span>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    disabled={smLoading || smPage <= 1}
+                    onClick={() => setSmPage((p) => p - 1)}
+                    className="px-2 py-1 text-xs"
+                  >
+                    Anterior
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    disabled={smLoading || smPage >= Math.max(1, Math.ceil(smTotal / PAGE_SIZE_PADRAO))}
+                    onClick={() => setSmPage((p) => p + 1)}
+                    className="px-2 py-1 text-xs"
+                  >
+                    Próxima
+                  </Button>
+                </div>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[520px] text-left text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-100 bg-slate-50/60 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-800 dark:bg-slate-800/40 dark:text-slate-400">
+                      <th className="px-4 py-3 sm:px-6">Valor</th>
+                      <th className="px-4 py-3 sm:px-6">Período</th>
+                      <th className="w-px px-4 py-3 text-right sm:px-6">
+                        <span className="sr-only">Ações</span>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                    {smItems.map((row) => {
+                      const vigente = row.vigencia_fim == null
+                      return (
+                        <tr key={row.id} className="transition-colors hover:bg-slate-50/80 dark:hover:bg-white/40">
+                          <td className="px-4 py-3.5 font-medium tabular-nums text-slate-800 dark:text-slate-100 sm:px-6">
+                            {fmtMoney(row.valor)}
+                            {vigente ? (
+                              <span className="ml-2 inline-flex rounded-full bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700 ring-1 ring-emerald-600/15 dark:bg-emerald-950/40 dark:text-emerald-300">
+                                Vigente
+                              </span>
+                            ) : null}
+                          </td>
+                          <td className="px-4 py-3.5 text-slate-600 dark:text-slate-300 sm:px-6">
+                            {fmtDataIso(row.vigencia_inicio)}
+                            {' → '}
+                            {row.vigencia_fim ? fmtDataIso(row.vigencia_fim) : 'hoje'}
+                          </td>
+                          <td className="px-4 py-3.5 text-right sm:px-6">
+                            {!vigente ? (
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                className="!px-2 !py-2"
+                                aria-label="Excluir registro do histórico"
+                                onClick={() =>
+                                  setPendingDelete({
+                                    kind: 'sm',
+                                    id: row.id,
+                                    rotulo: `${fmtMoney(row.valor)} (${fmtDataIso(row.vigencia_inicio)} → ${fmtDataIso(row.vigencia_fim)})`,
+                                  })
+                                }
+                              >
+                                <IconTrash ariaHidden={false} />
+                              </Button>
+                            ) : (
+                              <span className="sr-only">Sem exclusão do vigente — use Atualizar valor</span>
+                            )}
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </Card>
+          ) : null}
+        </div>
+      ) : null}
+
+      {aba === 'itens' ? (
+        <Card>
+          <BarraBuscaPaginacao
+            busca={busca}
+            onBuscaChange={setBusca}
+            placeholder="Buscar por nome…"
+            page={itensPage}
+            total={itensTotal}
+            onPageChange={setItensPage}
+            disabled={itensLoading}
+            extra={<FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />}
+          />
+          {itensLoading ? (
+            <p className="py-8 text-center text-sm text-slate-500">Carregando…</p>
+          ) : itens.length === 0 ? (
+            <div className="py-10 text-center">
+              <p className="text-sm text-slate-500">Nenhum item de custo cadastrado.</p>
+              <Button
+                type="button"
+                variant="secondary"
+                className="mt-4"
+                onClick={() => {
+                  setItemEditId(null)
+                  setItemForm(emptyItem())
+                  setItemModal(true)
+                }}
+              >
+                Novo item
+              </Button>
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[640px] text-left text-sm">
+                <thead>
+                  <tr className="border-b border-slate-100 bg-slate-50/60 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:border-slate-800 dark:bg-slate-800/40 dark:text-slate-400">
+                    <th className="px-4 py-3 sm:px-6">Nome</th>
+                    <th className="px-4 py-3 sm:px-6">Tipo</th>
+                    <th className="px-4 py-3 sm:px-6">Parâmetros</th>
+                    <th className="w-28 px-4 py-3 sm:px-6">Situação</th>
+                    <th className="w-px px-4 py-3 text-right sm:px-6">
+                      <span className="sr-only">Ações</span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                  {itens.map((item) => (
+                    <tr key={item.id} className="transition-colors hover:bg-slate-50/80 dark:hover:bg-white/40">
+                      <td className="px-4 py-3.5 font-medium text-slate-800 dark:text-slate-100 sm:px-6">{item.nome}</td>
+                      <td className="px-4 py-3.5 text-slate-600 dark:text-slate-300 sm:px-6">
+                        {TIPO_LABEL[item.tipo] ?? item.tipo}
+                      </td>
+                      <td className="px-4 py-3.5 tabular-nums text-slate-600 dark:text-slate-300 sm:px-6">
+                        {item.tipo === 'percentual_sm'
+                          ? fmtPercentual(item.percentual_sm)
+                          : item.tipo === 'valor_fixo'
+                            ? fmtMoney(item.valor_fixo)
+                            : `${fmtMoney(item.tef_base)} + ${fmtMoney(item.tef_adicional)}/PDV`}
+                      </td>
+                      <td className="px-4 py-3.5 sm:px-6">
+                        <span
+                          className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                            item.ativo
+                              ? 'bg-emerald-50 text-emerald-700 ring-1 ring-emerald-600/15 dark:bg-emerald-950/40 dark:text-emerald-300'
+                              : 'bg-slate-100 text-slate-500 ring-1 ring-slate-300/60 dark:bg-slate-800 dark:text-slate-400'
+                          }`}
+                        >
+                          {item.ativo ? 'Ativo' : 'Inativo'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3.5 text-right sm:px-6">
+                        <div className="flex justify-end gap-1">
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            className="!px-2 !py-2"
+                            aria-label={`Editar ${item.nome}`}
+                            onClick={() => {
+                              setItemEditId(item.id)
+                              setItemForm({
+                                nome: item.nome,
+                                slug: item.slug,
+                                descricao: item.descricao ?? null,
+                                tipo: (item.tipo as ComercialCustos.Tipo) || 'percentual_sm',
+                                percentual_sm:
+                                  item.percentual_sm != null && item.percentual_sm !== ''
+                                    ? String(Math.round(Number(item.percentual_sm)))
+                                    : '',
+                                valor_fixo: item.valor_fixo ?? '',
+                                tef_base: item.tef_base ?? '',
+                                tef_adicional: item.tef_adicional ?? '',
+                                ordem: item.ordem,
+                                ativo: item.ativo,
+                                vigencia_inicio: item.vigencia_inicio ?? null,
+                                vigencia_fim: item.vigencia_fim ?? null,
+                              })
+                              setItemModal(true)
+                            }}
+                          >
+                            <IconPencil ariaHidden={false} />
+                          </Button>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            className="!px-2 !py-2"
+                            aria-label={`Excluir ${item.nome}`}
+                            onClick={() => setPendingDelete({ kind: 'item', id: item.id, rotulo: item.nome })}
+                          >
+                            <IconTrash ariaHidden={false} />
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
+      ) : null}
+
+      {aba === 'simular' ? (
+        <Card>
+          <div className="space-y-4">
+          <p className="text-sm text-slate-600 dark:text-slate-400">
+            Selecione perfis/módulos e a quantidade de PDVs para estimar o custo interno (não é preço de venda).
+          </p>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Input
+              id="sim-pdvs"
+              label="Quantidade de PDVs"
+              type="number"
+              min={1}
+              value={simPdvs}
+              onChange={(e) => setSimPdvs(e.target.value)}
+            />
+            <Input
+              id="sim-data"
+              label="Data de referência"
+              type="date"
+              value={simData}
+              onChange={(e) => setSimData(e.target.value)}
+            />
+          </div>
+          <fieldset>
+            <legend className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-200">Itens</legend>
+            {simCatalogLoading ? (
+              <p className="text-sm text-slate-500">Carregando itens…</p>
+            ) : simItens.length === 0 ? (
+              <p className="text-sm text-slate-500">Cadastre itens ativos na aba «Itens de custo».</p>
+            ) : (
+              <ul className="max-h-64 space-y-2 overflow-y-auto rounded-lg border border-slate-200 p-3 dark:border-slate-700">
+                {simItens.map((item) => {
+                  const checked = simSelected.includes(item.id)
+                  const tipoLabel = TIPO_LABEL[item.tipo] ?? item.tipo
+                  return (
+                    <li key={item.id}>
+                      <label className="flex cursor-pointer items-start gap-2 text-sm">
+                        <input
+                          type="checkbox"
+                          className="mt-0.5"
+                          checked={checked}
+                          onChange={() =>
+                            setSimSelected((prev) =>
+                              checked ? prev.filter((id) => id !== item.id) : [...prev, item.id],
+                            )
+                          }
+                        />
+                        <span>
+                          <span className="font-medium text-slate-800 dark:text-slate-100">{item.nome}</span>
+                          <span className="ml-2 text-xs text-slate-500" aria-hidden>
+                            · {tipoLabel}
+                          </span>
+                        </span>
+                      </label>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </fieldset>
+          <Button type="button" loading={simLoading} onClick={() => void executarSimulacao()}>
+            Calcular estimado
+          </Button>
+          {simResult ? (
+            <div className="rounded-lg border border-slate-200 bg-slate-50/80 p-4 dark:border-slate-700 dark:bg-slate-900/40">
+              <p className="text-sm text-slate-600 dark:text-slate-400">
+                SM na data: {fmtMoney(simResult.salario_minimo)} · PDVs: {simResult.quantidade_pdvs}
+              </p>
+              <ul className="mt-3 space-y-1 text-sm">
+                {simResult.linhas.map((l) => (
+                  <li key={l.item_id} className="flex justify-between gap-4">
+                    <span>{l.nome}</span>
+                    <span className="tabular-nums font-medium">{fmtMoney(l.valor)}</span>
+                  </li>
+                ))}
+              </ul>
+              <p className="mt-3 flex justify-between border-t border-slate-200 pt-3 text-base font-semibold dark:border-slate-700">
+                <span>Total estimado</span>
+                <span className="tabular-nums">{fmtMoney(simResult.total)}</span>
+              </p>
+            </div>
+          ) : null}
+          </div>
+        </Card>
+      ) : null}
+
+      {smModal ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4 backdrop-blur-[2px]"
+          role="presentation"
+          onClick={() => setSmModal(false)}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="sm-modal-title"
+            className={MODAL_PANEL_COMPACT}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 id="sm-modal-title" className="text-lg font-semibold text-slate-900 dark:text-slate-50">
+              {smTemHistorico ? 'Atualizar salário mínimo' : 'Definir salário mínimo'}
+            </h3>
+            <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+              {smTemHistorico
+                ? 'O valor atual continua no histórico até o dia anterior à data informada. O passado não é reescrito.'
+                : 'Primeiro valor de referência. Depois, use «Atualizar valor» quando o SM oficial mudar.'}
+            </p>
+            <form
+              className="mt-5 space-y-4"
+              onSubmit={(e) => {
+                e.preventDefault()
+                void salvarSm()
+              }}
+            >
+              <Input
+                id="sm-valor"
+                label="Novo valor (R$)"
+                type="number"
+                step="0.01"
+                min={0.01}
+                value={String(smForm.valor)}
+                onChange={(e) => setSmForm((f) => ({ ...f, valor: e.target.value }))}
+                required
+                autoFocus
+              />
+              <Input
+                id="sm-inicio"
+                label="Válido a partir de"
+                type="date"
+                hint={
+                  smVigente
+                    ? `Deve ser depois de ${fmtDataIso(smVigente.vigencia_inicio)} (início do valor vigente).`
+                    : 'Normalmente 1º de janeiro do ano do reajuste.'
+                }
+                value={smForm.vigencia_inicio}
+                onChange={(e) => setSmForm((f) => ({ ...f, vigencia_inicio: e.target.value }))}
+                required
+              />
+              <div className="flex justify-end gap-2 border-t border-slate-200 pt-4 dark:border-slate-800">
+                <Button type="button" variant="secondary" onClick={() => setSmModal(false)}>
+                  Cancelar
+                </Button>
+                <Button type="submit" loading={smSaving}>
+                  {smTemHistorico ? 'Atualizar' : 'Definir'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+
+      {itemModal ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4 backdrop-blur-[2px]"
+          role="presentation"
+          onClick={() => setItemModal(false)}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="item-modal-title"
+            className={`${MODAL_PANEL_COMPACT} max-h-[90vh] overflow-y-auto`}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 id="item-modal-title" className="text-lg font-semibold text-slate-900 dark:text-slate-50">
+              {itemEditId != null ? 'Editar item de custo' : 'Novo item de custo'}
+            </h3>
+            <form
+              className="mt-5 space-y-4"
+              onSubmit={(e) => {
+                e.preventDefault()
+                void salvarItem()
+              }}
+            >
+              <Input
+                id="item-nome"
+                label="Nome"
+                value={itemForm.nome}
+                onChange={(e) => setItemForm((f) => ({ ...f, nome: e.target.value }))}
+                required
+                autoFocus
+              />
+              <Select
+                id="item-tipo"
+                label="Tipo"
+                value={itemForm.tipo}
+                onChange={(v) =>
+                  setItemForm((f) => ({
+                    ...f,
+                    tipo: (String(v) as ComercialCustos.Tipo) || 'percentual_sm',
+                  }))
+                }
+                options={[
+                  { value: 'percentual_sm', label: TIPO_LABEL.percentual_sm },
+                  { value: 'valor_fixo', label: TIPO_LABEL.valor_fixo },
+                  { value: 'composto_tef', label: TIPO_LABEL.composto_tef },
+                ]}
+              />
+              {itemForm.tipo === 'percentual_sm' ? (
+                <Input
+                  id="item-pct"
+                  label="Percentual do SM (%)"
+                  type="number"
+                  step="1"
+                  min={0}
+                  hint="Somente números inteiros (ex.: 20)."
+                  value={String(itemForm.percentual_sm ?? '')}
+                  onChange={(e) => {
+                    const raw = e.target.value
+                    if (raw === '') {
+                      setItemForm((f) => ({ ...f, percentual_sm: '' }))
+                      return
+                    }
+                    const n = Math.round(Number(raw))
+                    if (!Number.isNaN(n)) setItemForm((f) => ({ ...f, percentual_sm: String(n) }))
+                  }}
+                  required
+                />
+              ) : null}
+              {itemForm.tipo === 'valor_fixo' ? (
+                <Input
+                  id="item-fixo"
+                  label="Valor fixo (R$)"
+                  type="number"
+                  step="0.01"
+                  min={0}
+                  value={String(itemForm.valor_fixo ?? '')}
+                  onChange={(e) => setItemForm((f) => ({ ...f, valor_fixo: e.target.value }))}
+                  required
+                />
+              ) : null}
+              {itemForm.tipo === 'composto_tef' ? (
+                <>
+                  <Input
+                    id="item-tef-base"
+                    label="TEF base (1º PDV)"
+                    type="number"
+                    step="0.01"
+                    min={0}
+                    value={String(itemForm.tef_base ?? '')}
+                    onChange={(e) => setItemForm((f) => ({ ...f, tef_base: e.target.value }))}
+                    required
+                  />
+                  <Input
+                    id="item-tef-adic"
+                    label="TEF adicional por PDV"
+                    type="number"
+                    step="0.01"
+                    min={0}
+                    value={String(itemForm.tef_adicional ?? '')}
+                    onChange={(e) => setItemForm((f) => ({ ...f, tef_adicional: e.target.value }))}
+                    required
+                  />
+                </>
+              ) : null}
+              <Switch
+                bare
+                checked={itemForm.ativo ?? true}
+                onCheckedChange={(ativo) => setItemForm((f) => ({ ...f, ativo }))}
+                label="Ativo"
+                showStatusPill
+              />
+              <div className="flex justify-end gap-2 border-t border-slate-200 pt-4 dark:border-slate-800">
+                <Button type="button" variant="secondary" onClick={() => setItemModal(false)}>
+                  Cancelar
+                </Button>
+                <Button type="submit" loading={itemSaving}>
+                  Salvar
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+
+      <ConfirmDialog
+        open={pendingDelete != null}
+        title={pendingDelete?.kind === 'sm' ? 'Excluir salário mínimo?' : 'Excluir item de custo?'}
+        message={
+          pendingDelete?.kind === 'sm'
+            ? `Remover ${pendingDelete.rotulo} do histórico. Só use para corrigir cadastro errado — o normal é só atualizar o valor vigente.`
+            : `Remover «${pendingDelete?.rotulo ?? ''}» do catálogo e do simulador.`
+        }
+        confirmLabel="Excluir"
+        variant="danger"
+        loading={deleteLoading}
+        onConfirm={() => void confirmarExclusao()}
+        onCancel={() => setPendingDelete(null)}
+      />
+    </>
+  )
+
+  return embedded ? conteudo : <PageContainer>{conteudo}</PageContainer>
+}

--- a/frontend/src/pages/config/ConfigCadastrosLayout.tsx
+++ b/frontend/src/pages/config/ConfigCadastrosLayout.tsx
@@ -5,11 +5,13 @@ import { ConfigSectionTabs } from '../../components/config/ConfigSectionTabs'
 const TABS = [
   { to: '/configuracoes/cadastros/tipos-negocio', label: 'Tipos de negócio' },
   { to: '/configuracoes/cadastros/pdv', label: 'Catálogos PDV' },
+  { to: '/configuracoes/cadastros/custos', label: 'Catálogo de custos' },
 ] as const
 
 const TAB_HINTS: Record<string, string> = {
   'tipos-negocio': 'Classificação das empresas (posto, conveniência, restaurante…).',
   pdv: 'Rótulos de dispositivo e tipos de acesso remoto usados no cadastro de PDVs por empresa.',
+  custos: 'Salário mínimo com vigência, perfis/módulos de custo e simulador estimado para negociação.',
 }
 
 function abaAtiva(pathname: string): string {
@@ -23,7 +25,7 @@ export function ConfigCadastrosLayout() {
 
   return (
     <PageContainer>
-      <PageHeader title="Cadastros" subtitle="Tipos de negócio e catálogos globais de PDV." />
+      <PageHeader title="Cadastros" subtitle="Tipos de negócio, catálogos de PDV e custos comerciais." />
       <ConfigSectionTabs tabs={[...TABS]} ariaLabel="Seções de cadastros" />
       {hint ? <p className="text-sm text-slate-600 dark:text-slate-400">{hint}</p> : null}
       <Outlet />


### PR DESCRIPTION
## Summary

- Catálogo comercial de custos (lote A do épico #321): salário mínimo com **atualização por vigência** (histórico preservado; passado não é reescrito), itens de custo (% SM, valor fixo, TEF) e simulador estimado
- API admin sob `/v1/comercial/...` + migration `082`
- UI em **Configurações → Cadastros → Catálogo de custos** (só admin)

Closes #329  
Closes #330  
Closes #333  
Closes #334  

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest` `tests/test_comercial_custos.py` (5 passed)
- [x] Migration `082` aplicada no Docker local
- [x] Smoke UI: login admin → Cadastros → Catálogo de custos → definir/atualizar SM, CRUD itens, simular
- [ ] CI verde (changelog + backend + frontend)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Lote B do épico #321 (ainda aberto): #331 TEF promo/snapshot, #332 tier posto 20%/30% + janela 3 meses, #335 motor com snapshot imutável para negociação/contrato
- [x] Snapshot em contrato / CRM (#322+) fica fora deste PR — depende do motor (#335)
- [ ] Comentário no épico #321 listando follow-ups após merge
