### PR TITLE
feat(comercial): TEF/posto e motor com snapshot (#321 lote B)

### DIFF
--- a/.github/planning-issue-bodies/analises/321-lote-b-tef-tier-motor.md
+++ b/.github/planning-issue-bodies/analises/321-lote-b-tef-tier-motor.md
@@ -1,0 +1,163 @@
+# Plano — Catálogo de custos lote B (#331 / #332 / #335)
+
+**Épico:** [#321](https://github.com/lgustavoss/dx-connect/issues/321)  
+**Branch:** `feat/comercial-custos-regras-331-332-335`  
+**Base:** `main` com lote A (#656 mergeado)  
+**Status:** plano **revisado** e **implementado** na branch `feat/comercial-custos-regras-331-332-335` (2026-08-08)
+
+---
+
+## Resumo
+
+Completar CM01-F2 com o fluxo real do comercial: catálogo traz **valores padrão**; na proposta/simulação o admin **escolhe** desconto de posto (&lt;100k) e **sobrescreve** TEF (custo interno + valor ao cliente); o motor devolve **snapshot** para uso futuro em contrato. Controlo do desconto após os 3 meses é **manual** — sem ecrã pesado de validação.
+
+---
+
+## Regras de negócio (confirmadas)
+
+### Posto &lt;100k L (#332)
+
+1. Cliente **declara** que o posto vende menos de 100k L/mês.
+2. Comercial **ativa o desconto** (custo a **20% SM** em vez de 30%).
+3. Nos **3 primeiros meses** de uso do sistema: se em **qualquer** mês passar de 100k L → **perde o desconto** (volta a 30%).
+4. Depois disso (ou a qualquer momento), o desconto pode ser **aplicado ou removido manualmente** — não depende de ecrã automático rígido.
+
+### TEF (#331)
+
+1. Catálogo guarda só os **valores padrão** (base 1º PDV + adicional).
+2. Oferta do fornecedor muda caso a caso → **não** há “promoção cadastrada com vigência” no catálogo.
+3. No momento da **proposta/contrato**, o comercial informa:
+   - **custo promocional** (o que a DeskRudder paga / usa no custo interno), e/ou
+   - **valor ao cliente** (com ou sem promoção de venda).
+4. O snapshot grava o que foi usado naquela proposta.
+
+### Ecrã de validação
+
+Não é prioridade: o controlo é interno e manual. Neste lote **não** há UI rica de volumes/congelamento; no máximo campos simples na simulação + API mínima se ajudar o motor.
+
+---
+
+## Escopo do lote B
+
+### Dentro
+
+| Issue | Entrega |
+|-------|---------|
+| **#331** | Catálogo TEF = padrão; simulação/motor aceita **override** opcional `tef_custo_base` / `tef_custo_adicional` (e opcional `tef_valor_cliente_*` para registo no snapshot). Sem campos promo no item do catálogo. |
+| **#332** | Itens `% SM` com flag `aplica_tier_posto`; na simulação: `desconto_posto_100k: true\|false` (true → 20%, false/omitido → usa % do catálogo ou 30% default do item). Sem tabela elaborada de avaliação nem job automático. Doc da regra no código. |
+| **#335** | `calcular_custo_pacote` + snapshot JSON imutável; `simular` como fachada; testes com override TEF + desconto posto. |
+| **UI** | Aba Simular: checkbox «desconto posto &lt;100k»; campos opcionais de override TEF (custo e valor cliente); mostrar snapshot/resumo. Formulário de item **sem** promo. |
+
+### Fora (follow-ups)
+
+- Persistência do snapshot em negociação/contrato (#322+)
+- Tela na empresa para anotar volumes dos 3 meses (opcional, depois)
+- Integração automática com implantação / retaguarda de litros
+- Cadastro de promoções TEF no catálogo com vigência (descartado para o fluxo actual)
+- SSE
+
+---
+
+## Desenho técnico
+
+### TEF no motor
+
+```text
+valores_efetivos =
+  override da request, se enviado
+  senão tef_base / tef_adicional do catálogo
+
+custo_linha = base + max(0, pdvs-1) * adicional
+```
+
+Valor ao cliente (se informado) entra só no **snapshot** / metadados — não soma no `total` de **custo** interno (o total continua sendo custo DeskRudder).
+
+### Tier posto no motor
+
+```text
+se item.aplica_tier_posto:
+  percentual = 20 se desconto_posto_100k else (item.percentual_sm ou 30)
+senão:
+  percentual = item.percentual_sm
+```
+
+Default recomendado no catálogo: item “Posto” com `percentual_sm=30` e `aplica_tier_posto=true`; o checkbox na simulação aplica o 20%.
+
+### Snapshot (exemplo)
+
+```json
+{
+  "versao": 1,
+  "calculado_em": "...",
+  "data_referencia": "...",
+  "salario_minimo": {"id": 1, "valor": "1518.00"},
+  "desconto_posto_100k": true,
+  "quantidade_pdvs": 3,
+  "itens": [
+    {
+      "id": 1, "slug": "posto", "tipo": "percentual_sm",
+      "percentual_usado": "20", "valor": "303.60",
+      "aplica_tier_posto": true
+    },
+    {
+      "id": 10, "slug": "tef", "tipo": "composto_tef",
+      "tef_base_catalogo": "100.00", "tef_adicional_catalogo": "30.00",
+      "tef_base_usado": "80.00", "tef_adicional_usado": "25.00",
+      "override_custo": true,
+      "tef_valor_cliente_base": "120.00",
+      "tef_valor_cliente_adicional": "40.00",
+      "valor_custo": "130.00"
+    }
+  ],
+  "total_custo": "..."
+}
+```
+
+### RBAC
+
+Só admin (`exigir_admin`). Sem SSE.
+
+---
+
+## Mapa de arquivos
+
+| Ação | Caminho |
+|------|---------|
+| alterar | `backend/app/models/comercial_custo.py` (`aplica_tier_posto`) |
+| criar | `backend/alembic/versions/083_*.py` |
+| alterar | `backend/app/schemas/comercial_custo.py` |
+| alterar | `backend/app/services/comercial_custo.py` |
+| alterar | `backend/app/api/comercial_custos.py` |
+| alterar | `backend/tests/test_comercial_custos.py` |
+| alterar | `frontend/src/api/client.ts` |
+| alterar | `frontend/src/pages/ConfigComercialCustos.tsx` |
+| alterar | `CHANGELOG.md` |
+
+---
+
+## Ordem de implementação
+
+1. Migration: `aplica_tier_posto` em `custo_catalogo_itens`
+2. Schemas: request de simular com `desconto_posto_100k`, overrides TEF, response com snapshot
+3. `calcular_custo_pacote` + refatorar `simular_custo`
+4. Testes (#331 fórmula + override; #332 20 vs 30 / qualquer mês &gt;100k só documentado; #335 snapshot estável)
+5. UI simulador
+6. CHANGELOG; pytest; build frontend
+
+---
+
+## Testes (aceite)
+
+- [ ] TEF sem override = valores do catálogo (1, 2, N PDVs)
+- [ ] TEF com override = usa override; snapshot marca `override_custo`
+- [ ] Valor cliente no snapshot não altera `total_custo`
+- [ ] `desconto_posto_100k=true` em item `aplica_tier_posto` → 20% SM
+- [ ] Sem desconto → percentual do catálogo (ex. 30%)
+- [ ] Snapshot não muda se SM/catálogo forem alterados depois (objecto já devolvido)
+- [ ] Atendente → 403
+
+---
+
+## Próximo passo
+
+Implementar neste branch `feat/comercial-custos-regras-331-332-335` conforme este plano revisado.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Melhorias
 
+- Comercial (#321 / #331–#335): simulador com desconto posto &lt;100k L (20% SM), override de custo/valor TEF só na proposta e snapshot imutável do pacote (catálogo TEF continua com valores padrão)
 - Comercial (#321 / #329–#334): catálogo de custos — salário mínimo com histórico por vigência (atualizar valor sem reescrever o passado), itens (% SM, valor fixo, TEF) e simulador em Cadastros → Catálogo de custos (admin)
 - Dashboard (#599): filtros de período Hoje | Esta semana (seg–dom) | Este mês | Mês passado | Personalizado no geral, tickets e WhatsApp (substitui 7/30/90); CSAT do geral respeita o intervalo
 - WhatsApp (#594): análise de demandas no dashboard — drill-down por natureza/motivo, ranking por empresa, insights (erro → atualização; dúvida → treinamento) e sugestão de novo motivo a partir de «Outros» repetido

--- a/backend/alembic/versions/083_comercial_custos_tier_posto.py
+++ b/backend/alembic/versions/083_comercial_custos_tier_posto.py
@@ -1,0 +1,42 @@
+"""Catálogo comercial: flag aplica_tier_posto nos itens (#332).
+
+Revision ID: 083_comercial_custos_tier_posto
+Revises: 082_comercial_catalogo_custos
+Create Date: 2026-08-08
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "083_comercial_custos_tier_posto"
+down_revision = "082_comercial_catalogo_custos"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("custo_catalogo_itens"):
+        return
+    cols = {c["name"] for c in insp.get_columns("custo_catalogo_itens")}
+    if "aplica_tier_posto" not in cols:
+        op.add_column(
+            "custo_catalogo_itens",
+            sa.Column(
+                "aplica_tier_posto",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("custo_catalogo_itens"):
+        return
+    cols = {c["name"] for c in insp.get_columns("custo_catalogo_itens")}
+    if "aplica_tier_posto" in cols:
+        op.drop_column("custo_catalogo_itens", "aplica_tier_posto")

--- a/backend/app/api/comercial_custos.py
+++ b/backend/app/api/comercial_custos.py
@@ -227,9 +227,12 @@ def simular_custo(
     db: Session = Depends(get_db),
     _: Atendente = Depends(exigir_admin),
 ):
+    """Simula pacote de custos; devolve também snapshot imutável (#331/#332/#335)."""
     return svc.simular_custo(
         db,
         item_ids=body.item_ids,
         quantidade_pdvs=body.quantidade_pdvs,
         data_referencia=body.data_referencia,
+        desconto_posto_100k=body.desconto_posto_100k,
+        tef_override=body.tef_override,
     )

--- a/backend/app/models/comercial_custo.py
+++ b/backend/app/models/comercial_custo.py
@@ -1,4 +1,4 @@
-"""Catálogo comercial de custos e salário mínimo (#321 / #329–#330)."""
+"""Catálogo comercial de custos e salário mínimo (#321 / #329–#335)."""
 
 from __future__ import annotations
 
@@ -52,6 +52,8 @@ class CustoCatalogoItem(Base):
     valor_fixo = Column(Numeric(12, 2), nullable=True)
     tef_base = Column(Numeric(12, 2), nullable=True)
     tef_adicional = Column(Numeric(12, 2), nullable=True)
+    # Itens % SM de posto: na simulação, desconto_posto_100k aplica 20% em vez do % do catálogo (#332)
+    aplica_tier_posto = Column(Boolean, default=False, nullable=False)
     ordem = Column(Integer, default=0, nullable=False)
     ativo = Column(Boolean, default=True, nullable=False)
     vigencia_inicio = Column(Date, nullable=True)

--- a/backend/app/schemas/comercial_custo.py
+++ b/backend/app/schemas/comercial_custo.py
@@ -1,10 +1,10 @@
-"""Schemas do catálogo comercial de custos (#321)."""
+"""Schemas do catálogo comercial de custos (#321 / #329–#335)."""
 
 from __future__ import annotations
 
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -56,6 +56,7 @@ class CustoCatalogoItemCreate(BaseModel):
     valor_fixo: Decimal | None = Field(None, ge=0)
     tef_base: Decimal | None = Field(None, ge=0)
     tef_adicional: Decimal | None = Field(None, ge=0)
+    aplica_tier_posto: bool = False
     ordem: int = 0
     ativo: bool = True
     vigencia_inicio: date | None = None
@@ -80,9 +81,13 @@ class CustoCatalogoItemCreate(BaseModel):
         elif self.tipo == "valor_fixo":
             if self.valor_fixo is None:
                 raise ValueError("valor_fixo é obrigatório para tipo valor_fixo")
+            if self.aplica_tier_posto:
+                raise ValueError("aplica_tier_posto só se aplica a itens percentual_sm")
         elif self.tipo == "composto_tef":
             if self.tef_base is None or self.tef_adicional is None:
                 raise ValueError("tef_base e tef_adicional são obrigatórios para composto_tef")
+            if self.aplica_tier_posto:
+                raise ValueError("aplica_tier_posto só se aplica a itens percentual_sm")
         return self
 
 
@@ -95,6 +100,7 @@ class CustoCatalogoItemUpdate(BaseModel):
     valor_fixo: Decimal | None = Field(None, ge=0)
     tef_base: Decimal | None = Field(None, ge=0)
     tef_adicional: Decimal | None = Field(None, ge=0)
+    aplica_tier_posto: bool | None = None
     ordem: int | None = None
     ativo: bool | None = None
     vigencia_inicio: date | None = None
@@ -111,6 +117,7 @@ class CustoCatalogoItemRead(BaseModel):
     valor_fixo: Decimal | None = None
     tef_base: Decimal | None = None
     tef_adicional: Decimal | None = None
+    aplica_tier_posto: bool = False
     ordem: int
     ativo: bool
     vigencia_inicio: date | None = None
@@ -121,10 +128,35 @@ class CustoCatalogoItemRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class CustoTefOverride(BaseModel):
+    """Override pontual na proposta: custo interno e/ou valor ao cliente (#331)."""
+
+    tef_custo_base: Decimal | None = Field(None, ge=0)
+    tef_custo_adicional: Decimal | None = Field(None, ge=0)
+    tef_valor_cliente_base: Decimal | None = Field(None, ge=0)
+    tef_valor_cliente_adicional: Decimal | None = Field(None, ge=0)
+
+    @model_validator(mode="after")
+    def _pares(self):
+        custo_parcial = (self.tef_custo_base is None) != (self.tef_custo_adicional is None)
+        if custo_parcial:
+            raise ValueError("Informe tef_custo_base e tef_custo_adicional juntos, ou nenhum.")
+        cliente_parcial = (self.tef_valor_cliente_base is None) != (self.tef_valor_cliente_adicional is None)
+        if cliente_parcial:
+            raise ValueError(
+                "Informe tef_valor_cliente_base e tef_valor_cliente_adicional juntos, ou nenhum."
+            )
+        return self
+
+
 class CustoSimularRequest(BaseModel):
     item_ids: list[int] = Field(..., min_length=1)
     quantidade_pdvs: int = Field(1, ge=1, le=500)
     data_referencia: date | None = None
+    # True = cliente declarou <100k L → aplica 20% SM nos itens com aplica_tier_posto (#332)
+    desconto_posto_100k: bool = False
+    # Override TEF na proposta (não altera o catálogo) (#331)
+    tef_override: CustoTefOverride | None = None
 
 
 class CustoSimularLinha(BaseModel):
@@ -133,6 +165,9 @@ class CustoSimularLinha(BaseModel):
     slug: str
     tipo: str
     valor: Decimal
+    percentual_usado: Decimal | None = None
+    override_custo: bool = False
+    tef_valor_cliente: Decimal | None = None
 
 
 class CustoSimularResponse(BaseModel):
@@ -140,5 +175,8 @@ class CustoSimularResponse(BaseModel):
     salario_minimo: Decimal | None
     salario_minimo_id: int | None
     quantidade_pdvs: int
+    desconto_posto_100k: bool = False
     linhas: list[CustoSimularLinha]
-    total: Decimal
+    total: Decimal  # compat lote A (= total_custo)
+    total_custo: Decimal
+    snapshot: dict[str, Any]

--- a/backend/app/services/comercial_custo.py
+++ b/backend/app/services/comercial_custo.py
@@ -1,8 +1,15 @@
-"""Serviço do catálogo comercial de custos (#321)."""
+"""Serviço do catálogo comercial de custos (#321 / #329–#335).
+
+Regras de negócio (lote B):
+- TEF no catálogo = valores padrão; na proposta pode haver override de custo e valor ao cliente (#331).
+- Desconto posto <100k L: ativado manualmente (desconto_posto_100k); nos 3 primeiros meses,
+  se em algum mês passar de 100k o comercial remove o desconto — controlo interno, sem job (#332).
+- calcular_custo_pacote devolve snapshot serializável imutável para gravar em contrato depois (#335).
+"""
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 
 from fastapi import HTTPException
@@ -22,10 +29,14 @@ from app.schemas.comercial_custo import (
     CustoCatalogoItemUpdate,
     CustoSimularLinha,
     CustoSimularResponse,
+    CustoTefOverride,
     SalarioMinimoAtualizarValor,
     SalarioMinimoCreate,
     SalarioMinimoUpdate,
 )
+
+# Percentual SM quando o comercial ativa o desconto declarado pelo cliente (<100k L/mês).
+PERCENTUAL_DESCONTO_POSTO_100K = Decimal("20")
 
 
 def _ranges_overlap(
@@ -108,7 +119,6 @@ def atualizar_valor_sm(db: Session, data: SalarioMinimoAtualizarValor) -> Salari
     """
     aberto = obter_sm_vigente_aberto(db)
     if aberto is None:
-        # Sem histórico: primeiro cadastro
         if db.query(SalarioMinimoReferencia).count() == 0:
             return criar_sm(
                 db,
@@ -135,7 +145,6 @@ def atualizar_valor_sm(db: Session, data: SalarioMinimoAtualizarValor) -> Salari
             detail="Intervalo inválido ao encerrar o SM vigente.",
         )
 
-    # Fecha o vigente (passado intacto) e abre o novo
     aberto.vigencia_fim = fim_anterior
     db.flush()
 
@@ -164,7 +173,15 @@ def atualizar_sm(db: Session, row: SalarioMinimoReferencia, data: SalarioMinimoU
     return row
 
 
-def _validar_campos_item(tipo: str, *, percentual_sm, valor_fixo, tef_base, tef_adicional) -> None:
+def _validar_campos_item(
+    tipo: str,
+    *,
+    percentual_sm,
+    valor_fixo,
+    tef_base,
+    tef_adicional,
+    aplica_tier_posto: bool,
+) -> None:
     if tipo not in TIPOS_CUSTO_CATALOGO:
         raise HTTPException(status_code=400, detail=f"tipo inválido: {tipo}")
     if tipo == TIPO_PERCENTUAL_SM and percentual_sm is None:
@@ -173,6 +190,8 @@ def _validar_campos_item(tipo: str, *, percentual_sm, valor_fixo, tef_base, tef_
         raise HTTPException(status_code=400, detail="valor_fixo é obrigatório para valor_fixo")
     if tipo == TIPO_COMPOSTO_TEF and (tef_base is None or tef_adicional is None):
         raise HTTPException(status_code=400, detail="tef_base e tef_adicional são obrigatórios para composto_tef")
+    if aplica_tier_posto and tipo != TIPO_PERCENTUAL_SM:
+        raise HTTPException(status_code=400, detail="aplica_tier_posto só se aplica a itens percentual_sm")
 
 
 def criar_item(db: Session, data: CustoCatalogoItemCreate) -> CustoCatalogoItem:
@@ -184,6 +203,7 @@ def criar_item(db: Session, data: CustoCatalogoItemCreate) -> CustoCatalogoItem:
         valor_fixo=data.valor_fixo,
         tef_base=data.tef_base,
         tef_adicional=data.tef_adicional,
+        aplica_tier_posto=data.aplica_tier_posto,
     )
     row = CustoCatalogoItem(**data.model_dump())
     db.add(row)
@@ -208,12 +228,14 @@ def atualizar_item(db: Session, row: CustoCatalogoItem, data: CustoCatalogoItemU
     valor_fixo = payload.get("valor_fixo", row.valor_fixo)
     tef_base = payload.get("tef_base", row.tef_base)
     tef_adicional = payload.get("tef_adicional", row.tef_adicional)
+    aplica_tier = payload.get("aplica_tier_posto", row.aplica_tier_posto)
     _validar_campos_item(
         tipo,
         percentual_sm=percentual,
         valor_fixo=valor_fixo,
         tef_base=tef_base,
         tef_adicional=tef_adicional,
+        aplica_tier_posto=bool(aplica_tier),
     )
     for k, v in payload.items():
         setattr(row, k, v)
@@ -229,32 +251,56 @@ def _item_vigente_em(item: CustoCatalogoItem, ref: date) -> bool:
     return True
 
 
-def _valor_linha(item: CustoCatalogoItem, sm: Decimal | None, quantidade_pdvs: int) -> Decimal:
-    if item.tipo == TIPO_PERCENTUAL_SM:
-        if sm is None:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Item «{item.nome}» exige salário mínimo vigente na data de referência.",
-            )
-        pct = Decimal(item.percentual_sm or 0)
-        return (sm * pct / Decimal("100")).quantize(Decimal("0.01"))
-    if item.tipo == TIPO_VALOR_FIXO:
-        return Decimal(item.valor_fixo or 0).quantize(Decimal("0.01"))
-    if item.tipo == TIPO_COMPOSTO_TEF:
-        base = Decimal(item.tef_base or 0)
-        adicional = Decimal(item.tef_adicional or 0)
-        extras = max(0, quantidade_pdvs - 1)
-        return (base + adicional * extras).quantize(Decimal("0.01"))
-    raise HTTPException(status_code=400, detail=f"Tipo de item não suportado: {item.tipo}")
+def _dec(v) -> Decimal:
+    return Decimal(v).quantize(Decimal("0.01"))
 
 
-def simular_custo(
+def _percentual_efetivo(item: CustoCatalogoItem, desconto_posto_100k: bool) -> Decimal:
+    """
+    Itens com aplica_tier_posto: desconto_posto_100k=True → 20% SM (cliente declarou <100k).
+    Sem desconto → percentual do catálogo (tipicamente 30%).
+    Controlo após os 3 meses / perda do desconto se passar 100k em algum mês = manual (#332).
+    """
+    if item.aplica_tier_posto and desconto_posto_100k:
+        return PERCENTUAL_DESCONTO_POSTO_100K
+    return Decimal(item.percentual_sm or 0)
+
+
+def _tef_custo_efetivo(
+    item: CustoCatalogoItem,
+    override: CustoTefOverride | None,
+) -> tuple[Decimal, Decimal, bool]:
+    """Retorna (base, adicional, usou_override) para o custo interno."""
+    if override and override.tef_custo_base is not None and override.tef_custo_adicional is not None:
+        return Decimal(override.tef_custo_base), Decimal(override.tef_custo_adicional), True
+    return Decimal(item.tef_base or 0), Decimal(item.tef_adicional or 0), False
+
+
+def _tef_valor_cliente(
+    override: CustoTefOverride | None,
+    quantidade_pdvs: int,
+) -> Decimal | None:
+    if not override or override.tef_valor_cliente_base is None:
+        return None
+    base = Decimal(override.tef_valor_cliente_base)
+    adicional = Decimal(override.tef_valor_cliente_adicional or 0)
+    extras = max(0, quantidade_pdvs - 1)
+    return (base + adicional * extras).quantize(Decimal("0.01"))
+
+
+def calcular_custo_pacote(
     db: Session,
     *,
     item_ids: list[int],
     quantidade_pdvs: int = 1,
     data_referencia: date | None = None,
+    desconto_posto_100k: bool = False,
+    tef_override: CustoTefOverride | None = None,
 ) -> CustoSimularResponse:
+    """
+    Motor canónico (#335): linhas de custo + total + snapshot JSON.
+    Valor ao cliente do TEF (se informado) entra só no snapshot — não soma em total_custo.
+    """
     ref = data_referencia or date.today()
     sm_row = obter_sm_na_data(db, ref)
     sm_valor = Decimal(sm_row.valor) if sm_row else None
@@ -270,8 +316,18 @@ def simular_custo(
     if faltando:
         raise HTTPException(status_code=400, detail=f"Itens inexistentes ou inativos: {faltando}")
 
+    if tef_override is not None:
+        tem_tef = any(by_id[i].tipo == TIPO_COMPOSTO_TEF for i in ids_unicos)
+        if not tem_tef:
+            raise HTTPException(
+                status_code=400,
+                detail="tef_override só pode ser usado quando há um item composto_tef no pacote.",
+            )
+
     linhas: list[CustoSimularLinha] = []
+    snapshot_itens: list[dict] = []
     total = Decimal("0.00")
+
     for iid in ids_unicos:
         item = by_id[iid]
         if not _item_vigente_em(item, ref):
@@ -279,7 +335,60 @@ def simular_custo(
                 status_code=400,
                 detail=f"Item «{item.nome}» fora da vigência em {ref.isoformat()}.",
             )
-        valor = _valor_linha(item, sm_valor, quantidade_pdvs)
+
+        percentual_usado: Decimal | None = None
+        override_custo = False
+        tef_valor_cli: Decimal | None = None
+        snap: dict = {
+            "id": item.id,
+            "slug": item.slug,
+            "nome": item.nome,
+            "tipo": item.tipo,
+            "aplica_tier_posto": bool(item.aplica_tier_posto),
+        }
+
+        if item.tipo == TIPO_PERCENTUAL_SM:
+            if sm_valor is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Item «{item.nome}» exige salário mínimo vigente na data de referência.",
+                )
+            percentual_usado = _percentual_efetivo(item, desconto_posto_100k)
+            valor = (sm_valor * percentual_usado / Decimal("100")).quantize(Decimal("0.01"))
+            snap["percentual_catalogo"] = str(Decimal(item.percentual_sm or 0))
+            snap["percentual_usado"] = str(percentual_usado)
+            snap["valor"] = str(valor)
+
+        elif item.tipo == TIPO_VALOR_FIXO:
+            valor = _dec(item.valor_fixo or 0)
+            snap["valor"] = str(valor)
+
+        elif item.tipo == TIPO_COMPOSTO_TEF:
+            base_cat = Decimal(item.tef_base or 0)
+            adic_cat = Decimal(item.tef_adicional or 0)
+            base, adicional, override_custo = _tef_custo_efetivo(item, tef_override)
+            extras = max(0, quantidade_pdvs - 1)
+            valor = (base + adicional * extras).quantize(Decimal("0.01"))
+            tef_valor_cli = _tef_valor_cliente(tef_override, quantidade_pdvs)
+            snap.update(
+                {
+                    "tef_base_catalogo": str(_dec(base_cat)),
+                    "tef_adicional_catalogo": str(_dec(adic_cat)),
+                    "tef_base_usado": str(_dec(base)),
+                    "tef_adicional_usado": str(_dec(adicional)),
+                    "override_custo": override_custo,
+                    "valor_custo": str(valor),
+                }
+            )
+            if tef_override and tef_override.tef_valor_cliente_base is not None:
+                snap["tef_valor_cliente_base"] = str(_dec(tef_override.tef_valor_cliente_base))
+                snap["tef_valor_cliente_adicional"] = str(
+                    _dec(tef_override.tef_valor_cliente_adicional or 0)
+                )
+                snap["tef_valor_cliente"] = str(tef_valor_cli) if tef_valor_cli is not None else None
+        else:
+            raise HTTPException(status_code=400, detail=f"Tipo de item não suportado: {item.tipo}")
+
         linhas.append(
             CustoSimularLinha(
                 item_id=item.id,
@@ -287,15 +396,56 @@ def simular_custo(
                 slug=item.slug,
                 tipo=item.tipo,
                 valor=valor,
+                percentual_usado=percentual_usado,
+                override_custo=override_custo,
+                tef_valor_cliente=tef_valor_cli,
             )
         )
+        snapshot_itens.append(snap)
         total += valor
+
+    total_q = total.quantize(Decimal("0.01"))
+    snapshot = {
+        "versao": 1,
+        "calculado_em": datetime.now(timezone.utc).isoformat(),
+        "data_referencia": ref.isoformat(),
+        "salario_minimo": (
+            {"id": sm_row.id, "valor": str(_dec(sm_valor))} if sm_row and sm_valor is not None else None
+        ),
+        "desconto_posto_100k": desconto_posto_100k,
+        "quantidade_pdvs": quantidade_pdvs,
+        "itens": snapshot_itens,
+        "total_custo": str(total_q),
+    }
 
     return CustoSimularResponse(
         data_referencia=ref,
         salario_minimo=sm_valor,
         salario_minimo_id=sm_row.id if sm_row else None,
         quantidade_pdvs=quantidade_pdvs,
+        desconto_posto_100k=desconto_posto_100k,
         linhas=linhas,
-        total=total.quantize(Decimal("0.01")),
+        total=total_q,
+        total_custo=total_q,
+        snapshot=snapshot,
+    )
+
+
+def simular_custo(
+    db: Session,
+    *,
+    item_ids: list[int],
+    quantidade_pdvs: int = 1,
+    data_referencia: date | None = None,
+    desconto_posto_100k: bool = False,
+    tef_override: CustoTefOverride | None = None,
+) -> CustoSimularResponse:
+    """Fachada da API — delega ao motor (#335)."""
+    return calcular_custo_pacote(
+        db,
+        item_ids=item_ids,
+        quantidade_pdvs=quantidade_pdvs,
+        data_referencia=data_referencia,
+        desconto_posto_100k=desconto_posto_100k,
+        tef_override=tef_override,
     )

--- a/backend/tests/test_comercial_custos.py
+++ b/backend/tests/test_comercial_custos.py
@@ -1,4 +1,4 @@
-"""Testes do catálogo comercial de custos (#321 / #329–#333)."""
+"""Testes do catálogo comercial de custos (#321 / #329–#335)."""
 
 from __future__ import annotations
 
@@ -23,7 +23,6 @@ def test_sm_crud_e_na_data(client, auth_headers):
     )
     assert r2.status_code == 201, r2.text
 
-    # Sobreposição rejeitada
     r_dup = client.post(
         "/v1/comercial/salario-minimo",
         headers=h,
@@ -65,17 +64,14 @@ def test_sm_atualizar_valor_preserva_passado(client, auth_headers):
     assert r1.json()["vigencia_inicio"] == "2025-01-01"
     assert r1.json()["vigencia_fim"] is None
 
-    # Passado intacto
     ant = client.get("/v1/comercial/salario-minimo/na-data", headers=h, params={"data": "2024-06-01"})
     assert ant.status_code == 200
     assert Decimal(ant.json()["valor"]) == Decimal("1412.00")
     assert ant.json()["vigencia_fim"] == "2024-12-31"
 
-    # Presente usa novo
     hoje = client.get("/v1/comercial/salario-minimo/na-data", headers=h, params={"data": "2025-06-01"})
     assert Decimal(hoje.json()["valor"]) == Decimal("1518.00")
 
-    # Não permite data <= início do vigente
     bad = client.post(
         "/v1/comercial/salario-minimo/atualizar-valor",
         headers=h,
@@ -89,28 +85,25 @@ def test_sm_somente_admin(client, auth_headers):
     assert r.status_code == 403
 
 
-def test_item_crud_e_simular(client, auth_headers):
-    h = auth_headers["admin"]
+def _seed_sm_e_itens(client, h):
     client.post(
         "/v1/comercial/salario-minimo",
         headers=h,
         json={"valor": "1000.00", "vigencia_inicio": "2020-01-01", "vigencia_fim": None},
     )
-
     pct = client.post(
         "/v1/comercial/custos/itens",
         headers=h,
         json={
-            "nome": "Posto bandeira branca",
-            "slug": "posto-bb",
+            "nome": "Posto",
+            "slug": "posto",
             "tipo": "percentual_sm",
-            "percentual_sm": "20",
+            "percentual_sm": "30",
+            "aplica_tier_posto": True,
             "ordem": 1,
         },
     )
     assert pct.status_code == 201, pct.text
-    item_pct = pct.json()
-
     fixo = client.post(
         "/v1/comercial/custos/itens",
         headers=h,
@@ -123,8 +116,6 @@ def test_item_crud_e_simular(client, auth_headers):
         },
     )
     assert fixo.status_code == 201, fixo.text
-    item_fixo = fixo.json()
-
     tef = client.post(
         "/v1/comercial/custos/itens",
         headers=h,
@@ -138,16 +129,21 @@ def test_item_crud_e_simular(client, auth_headers):
         },
     )
     assert tef.status_code == 201, tef.text
-    item_tef = tef.json()
+    return pct.json(), fixo.json(), tef.json()
 
-    # slug duplicado
+
+def test_item_crud_e_simular(client, auth_headers):
+    h = auth_headers["admin"]
+    item_pct, item_fixo, item_tef = _seed_sm_e_itens(client, h)
+
     dup = client.post(
         "/v1/comercial/custos/itens",
         headers=h,
-        json={"nome": "X", "slug": "posto-bb", "tipo": "valor_fixo", "valor_fixo": "1"},
+        json={"nome": "X", "slug": "posto", "tipo": "valor_fixo", "valor_fixo": "1"},
     )
     assert dup.status_code == 400
 
+    # Sem desconto: 30% de 1000 = 300; fixo 50; TEF 100+2*30=160 → 510
     sim = client.post(
         "/v1/comercial/custos/simular",
         headers=h,
@@ -159,10 +155,14 @@ def test_item_crud_e_simular(client, auth_headers):
     )
     assert sim.status_code == 200, sim.text
     body = sim.json()
-    # 20% de 1000 = 200; fixo 50; TEF 100 + 2*30 = 160 → total 410
-    assert Decimal(body["total"]) == Decimal("410.00")
+    assert Decimal(body["total"]) == Decimal("510.00")
+    assert Decimal(body["total_custo"]) == Decimal("510.00")
     assert Decimal(body["salario_minimo"]) == Decimal("1000.00")
     assert len(body["linhas"]) == 3
+    assert "snapshot" in body
+    assert body["snapshot"]["versao"] == 1
+    assert body["snapshot"]["total_custo"] == "510.00"
+    assert body["desconto_posto_100k"] is False
 
     patch = client.patch(
         f"/v1/comercial/custos/itens/{item_fixo['id']}",
@@ -172,7 +172,6 @@ def test_item_crud_e_simular(client, auth_headers):
     assert patch.status_code == 200
     assert patch.json()["ativo"] is False
 
-    # item inativo não entra na simulação
     sim2 = client.post(
         "/v1/comercial/custos/simular",
         headers=h,
@@ -181,11 +180,133 @@ def test_item_crud_e_simular(client, auth_headers):
     assert sim2.status_code == 400
 
 
+def test_desconto_posto_100k_aplica_20_pct(client, auth_headers):
+    """#332 — cliente declarou <100k → comercial ativa desconto (20% SM)."""
+    h = auth_headers["admin"]
+    item_pct, _, _ = _seed_sm_e_itens(client, h)
+    assert item_pct["aplica_tier_posto"] is True
+
+    sem = client.post(
+        "/v1/comercial/custos/simular",
+        headers=h,
+        json={"item_ids": [item_pct["id"]], "quantidade_pdvs": 1},
+    )
+    assert Decimal(sem.json()["total"]) == Decimal("300.00")  # 30%
+
+    com = client.post(
+        "/v1/comercial/custos/simular",
+        headers=h,
+        json={
+            "item_ids": [item_pct["id"]],
+            "quantidade_pdvs": 1,
+            "desconto_posto_100k": True,
+        },
+    )
+    assert com.status_code == 200, com.text
+    body = com.json()
+    assert Decimal(body["total"]) == Decimal("200.00")  # 20%
+    assert body["desconto_posto_100k"] is True
+    assert Decimal(body["linhas"][0]["percentual_usado"]) == Decimal("20")
+    assert body["snapshot"]["itens"][0]["percentual_usado"] == "20"
+
+
+def test_tef_pdvs_e_override(client, auth_headers):
+    """#331 — fórmula PDVs + override de custo/valor cliente na proposta."""
+    h = auth_headers["admin"]
+    _, _, item_tef = _seed_sm_e_itens(client, h)
+
+    um = client.post(
+        "/v1/comercial/custos/simular",
+        headers=h,
+        json={"item_ids": [item_tef["id"]], "quantidade_pdvs": 1},
+    )
+    assert Decimal(um.json()["total"]) == Decimal("100.00")
+
+    dois = client.post(
+        "/v1/comercial/custos/simular",
+        headers=h,
+        json={"item_ids": [item_tef["id"]], "quantidade_pdvs": 2},
+    )
+    assert Decimal(dois.json()["total"]) == Decimal("130.00")
+
+    n = client.post(
+        "/v1/comercial/custos/simular",
+        headers=h,
+        json={"item_ids": [item_tef["id"]], "quantidade_pdvs": 5},
+    )
+    assert Decimal(n.json()["total"]) == Decimal("220.00")  # 100 + 4*30
+
+    over = client.post(
+        "/v1/comercial/custos/simular",
+        headers=h,
+        json={
+            "item_ids": [item_tef["id"]],
+            "quantidade_pdvs": 3,
+            "tef_override": {
+                "tef_custo_base": "80.00",
+                "tef_custo_adicional": "25.00",
+                "tef_valor_cliente_base": "120.00",
+                "tef_valor_cliente_adicional": "40.00",
+            },
+        },
+    )
+    assert over.status_code == 200, over.text
+    body = over.json()
+    # custo: 80 + 2*25 = 130; valor cliente NÃO entra no total
+    assert Decimal(body["total"]) == Decimal("130.00")
+    assert body["linhas"][0]["override_custo"] is True
+    assert Decimal(body["linhas"][0]["tef_valor_cliente"]) == Decimal("200.00")  # 120+2*40
+    snap = body["snapshot"]["itens"][0]
+    assert snap["override_custo"] is True
+    assert snap["tef_base_catalogo"] == "100.00"
+    assert snap["tef_base_usado"] == "80.00"
+    assert snap["tef_valor_cliente"] == "200.00"
+
+
+def test_snapshot_imutavel_apos_alterar_sm(client, auth_headers):
+    """#335 — snapshot já calculado não muda se o catálogo/SM mudarem depois."""
+    h = auth_headers["admin"]
+    item_pct, _, _ = _seed_sm_e_itens(client, h)
+    sim = client.post(
+        "/v1/comercial/custos/simular",
+        headers=h,
+        json={"item_ids": [item_pct["id"]], "quantidade_pdvs": 1, "desconto_posto_100k": True},
+    )
+    snap = sim.json()["snapshot"]
+    total_antes = snap["total_custo"]
+
+    client.post(
+        "/v1/comercial/salario-minimo/atualizar-valor",
+        headers=h,
+        json={"valor": "2000.00", "vigencia_inicio": "2026-01-01"},
+    )
+    # Objecto snapshot já devolvido permanece igual
+    assert snap["total_custo"] == total_antes
+    assert snap["salario_minimo"]["valor"] == "1000.00"
+
+
 def test_item_exige_campos_por_tipo(client, auth_headers):
     h = auth_headers["admin"]
     r = client.post(
         "/v1/comercial/custos/itens",
         headers=h,
         json={"nome": "Sem %", "slug": "sem-pct", "tipo": "percentual_sm"},
+    )
+    assert r.status_code == 422
+
+
+def test_aplica_tier_posto_so_percentual(client, auth_headers):
+    h = auth_headers["admin"]
+    r = client.post(
+        "/v1/comercial/custos/itens",
+        headers=h,
+        json={
+            "nome": "TEF bad",
+            "slug": "tef-bad",
+            "tipo": "composto_tef",
+            "tef_base": "1",
+            "tef_adicional": "1",
+            "aplica_tier_posto": True,
+        },
     )
     assert r.status_code == 422

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.ux-screenshots/

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2868,6 +2868,7 @@ export namespace ComercialCustos {
     valor_fixo?: string | null;
     tef_base?: string | null;
     tef_adicional?: string | null;
+    aplica_tier_posto?: boolean;
     ordem: number;
     ativo: boolean;
     vigencia_inicio?: string | null;
@@ -2884,6 +2885,7 @@ export namespace ComercialCustos {
     valor_fixo?: string | number | null;
     tef_base?: string | number | null;
     tef_adicional?: string | number | null;
+    aplica_tier_posto?: boolean;
     ordem?: number;
     ativo?: boolean;
     vigencia_inicio?: string | null;
@@ -2898,16 +2900,25 @@ export namespace ComercialCustos {
     valor_fixo?: string | number | null;
     tef_base?: string | number | null;
     tef_adicional?: string | number | null;
+    aplica_tier_posto?: boolean;
     ordem?: number;
     ativo?: boolean;
     vigencia_inicio?: string | null;
     vigencia_fim?: string | null;
   }
 
+  export interface TefOverride {
+    tef_custo_base?: string | number | null;
+    tef_custo_adicional?: string | number | null;
+    tef_valor_cliente_base?: string | number | null;
+    tef_valor_cliente_adicional?: string | number | null;
+  }
   export interface SimularRequest {
     item_ids: number[];
     quantidade_pdvs?: number;
     data_referencia?: string | null;
+    desconto_posto_100k?: boolean;
+    tef_override?: TefOverride | null;
   }
   export interface SimularLinha {
     item_id: number;
@@ -2915,14 +2926,20 @@ export namespace ComercialCustos {
     slug: string;
     tipo: string;
     valor: string;
+    percentual_usado?: string | null;
+    override_custo?: boolean;
+    tef_valor_cliente?: string | null;
   }
   export interface SimularResponse {
     data_referencia: string;
     salario_minimo: string | null;
     salario_minimo_id: number | null;
     quantidade_pdvs: number;
+    desconto_posto_100k?: boolean;
     linhas: SimularLinha[];
     total: string;
+    total_custo?: string;
+    snapshot?: Record<string, unknown>;
   }
 }
 

--- a/frontend/src/pages/ConfigComercialCustos.tsx
+++ b/frontend/src/pages/ConfigComercialCustos.tsx
@@ -46,6 +46,7 @@ const emptyItem = (): ComercialCustos.ItemCreate => ({
   valor_fixo: '',
   tef_base: '',
   tef_adicional: '',
+  aplica_tier_posto: false,
   ordem: 0,
   ativo: true,
 })
@@ -119,9 +120,21 @@ export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean
   const [simSelected, setSimSelected] = useState<number[]>([])
   const [simPdvs, setSimPdvs] = useState('1')
   const [simData, setSimData] = useState(() => new Date().toISOString().slice(0, 10))
+  const [simDescontoPosto, setSimDescontoPosto] = useState(false)
+  const [simTefCustoBase, setSimTefCustoBase] = useState('')
+  const [simTefCustoAdic, setSimTefCustoAdic] = useState('')
+  const [simTefCliBase, setSimTefCliBase] = useState('')
+  const [simTefCliAdic, setSimTefCliAdic] = useState('')
   const [simResult, setSimResult] = useState<ComercialCustos.SimularResponse | null>(null)
   const [simLoading, setSimLoading] = useState(false)
   const [simCatalogLoading, setSimCatalogLoading] = useState(false)
+
+  const simTemTefSelecionado = simItens.some(
+    (i) => simSelected.includes(i.id) && i.tipo === 'composto_tef',
+  )
+  const simTemPostoTier = simItens.some(
+    (i) => simSelected.includes(i.id) && i.aplica_tier_posto,
+  )
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -285,6 +298,7 @@ export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean
         valor_fixo: itemForm.tipo === 'valor_fixo' ? itemForm.valor_fixo : null,
         tef_base: itemForm.tipo === 'composto_tef' ? itemForm.tef_base : null,
         tef_adicional: itemForm.tipo === 'composto_tef' ? itemForm.tef_adicional : null,
+        aplica_tier_posto: itemForm.tipo === 'percentual_sm' ? !!itemForm.aplica_tier_posto : false,
         vigencia_inicio: itemForm.vigencia_inicio || null,
         vigencia_fim: itemForm.vigencia_fim || null,
       }
@@ -323,13 +337,43 @@ export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean
       return
     }
     const pdvs = Number(simPdvs) || 1
+    const temCustoOverride = simTefCustoBase.trim() !== '' || simTefCustoAdic.trim() !== ''
+    const temClienteOverride = simTefCliBase.trim() !== '' || simTefCliAdic.trim() !== ''
+    if (temCustoOverride && (simTefCustoBase.trim() === '' || simTefCustoAdic.trim() === '')) {
+      toast.showWarning('Informe base e adicional do custo TEF promocional, ou deixe ambos vazios.')
+      return
+    }
+    if (temClienteOverride && (simTefCliBase.trim() === '' || simTefCliAdic.trim() === '')) {
+      toast.showWarning('Informe base e adicional do valor TEF ao cliente, ou deixe ambos vazios.')
+      return
+    }
+    if ((temCustoOverride || temClienteOverride) && !simTemTefSelecionado) {
+      toast.showWarning('Inclua um item TEF na simulação para usar override.')
+      return
+    }
     setSimLoading(true)
     setSimResult(null)
     try {
+      const tef_override =
+        temCustoOverride || temClienteOverride
+          ? {
+              ...(temCustoOverride
+                ? { tef_custo_base: simTefCustoBase, tef_custo_adicional: simTefCustoAdic }
+                : {}),
+              ...(temClienteOverride
+                ? {
+                    tef_valor_cliente_base: simTefCliBase,
+                    tef_valor_cliente_adicional: simTefCliAdic,
+                  }
+                : {}),
+            }
+          : null
       const res = await comercialCustosItens.simular({
         item_ids: simSelected,
         quantidade_pdvs: pdvs,
         data_referencia: simData || null,
+        desconto_posto_100k: simDescontoPosto,
+        tef_override,
       })
       setSimResult(res)
     } catch (err) {
@@ -592,7 +636,9 @@ export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean
                       </td>
                       <td className="px-4 py-3.5 tabular-nums text-slate-600 dark:text-slate-300 sm:px-6">
                         {item.tipo === 'percentual_sm'
-                          ? fmtPercentual(item.percentual_sm)
+                          ? `${fmtPercentual(item.percentual_sm)}${
+                              item.aplica_tier_posto ? ' · elegível desconto volume' : ''
+                            }`
                           : item.tipo === 'valor_fixo'
                             ? fmtMoney(item.valor_fixo)
                             : `${fmtMoney(item.tef_base)} + ${fmtMoney(item.tef_adicional)}/PDV`}
@@ -629,6 +675,7 @@ export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean
                                 valor_fixo: item.valor_fixo ?? '',
                                 tef_base: item.tef_base ?? '',
                                 tef_adicional: item.tef_adicional ?? '',
+                                aplica_tier_posto: !!item.aplica_tier_posto,
                                 ordem: item.ordem,
                                 ativo: item.ativo,
                                 vigencia_inicio: item.vigencia_inicio ?? null,
@@ -663,7 +710,8 @@ export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean
         <Card>
           <div className="space-y-4">
           <p className="text-sm text-slate-600 dark:text-slate-400">
-            Selecione perfis/módulos e a quantidade de PDVs para estimar o custo interno (não é preço de venda).
+            Selecione perfis/módulos e a quantidade de PDVs para estimar o custo interno. TEF promocional e valor ao
+            cliente são overrides só desta simulação (não alteram o catálogo).
           </p>
           <div className="grid gap-4 sm:grid-cols-2">
             <Input
@@ -710,6 +758,7 @@ export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean
                           <span className="font-medium text-slate-800 dark:text-slate-100">{item.nome}</span>
                           <span className="ml-2 text-xs text-slate-500" aria-hidden>
                             · {tipoLabel}
+                            {item.aplica_tier_posto ? ' · elegível desconto volume' : ''}
                           </span>
                         </span>
                       </label>
@@ -719,6 +768,72 @@ export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean
               </ul>
             )}
           </fieldset>
+          {simTemPostoTier ? (
+            <Switch
+              bare
+              checked={simDescontoPosto}
+              onCheckedChange={setSimDescontoPosto}
+              label="Desconto posto menos de 100k L (20% SM)"
+              description="Só altera itens marcados como «elegível desconto volume». Se o posto passar de 100k em algum dos 3 primeiros meses, desative."
+              showStatusPill
+              statusOnText="Ativo"
+              statusOffText="Off"
+            />
+          ) : null}
+          {simTemTefSelecionado ? (
+            <div className="space-y-3 rounded-lg border border-slate-200 p-3 dark:border-slate-700">
+              <p className="text-sm font-medium text-slate-800 dark:text-slate-100">
+                TEF na proposta (opcional)
+              </p>
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                Deixe vazio para usar o padrão do catálogo. Preencha ao ativar oferta do fornecedor ou valor ao cliente.
+              </p>
+              {simItens.filter((i) => simSelected.includes(i.id) && i.tipo === 'composto_tef').length > 1 ? (
+                <p className="rounded-md bg-amber-50 px-2.5 py-1.5 text-xs text-amber-900 dark:bg-amber-950/40 dark:text-amber-200">
+                  Há mais de um item TEF selecionado — o custo/valor informados abaixo aplicam-se a todos. Em
+                  propostas reais, selecione só um TEF.
+                </p>
+              ) : null}
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Input
+                  id="sim-tef-custo-base"
+                  label="Custo TEF base (1º PDV)"
+                  type="number"
+                  step="0.01"
+                  min={0}
+                  value={simTefCustoBase}
+                  onChange={(e) => setSimTefCustoBase(e.target.value)}
+                />
+                <Input
+                  id="sim-tef-custo-adic"
+                  label="Custo TEF adicional/PDV"
+                  type="number"
+                  step="0.01"
+                  min={0}
+                  value={simTefCustoAdic}
+                  onChange={(e) => setSimTefCustoAdic(e.target.value)}
+                />
+                <Input
+                  id="sim-tef-cli-base"
+                  label="Valor cliente TEF base"
+                  type="number"
+                  step="0.01"
+                  min={0}
+                  value={simTefCliBase}
+                  onChange={(e) => setSimTefCliBase(e.target.value)}
+                />
+                <Input
+                  id="sim-tef-cli-adic"
+                  label="Valor cliente TEF adicional/PDV"
+                  type="number"
+                  step="0.01"
+                  min={0}
+                  value={simTefCliAdic}
+                  onChange={(e) => setSimTefCliAdic(e.target.value)}
+                />
+              </div>
+            </div>
+          ) : null}
           <Button type="button" loading={simLoading} onClick={() => void executarSimulacao()}>
             Calcular estimado
           </Button>
@@ -726,18 +841,43 @@ export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean
             <div className="rounded-lg border border-slate-200 bg-slate-50/80 p-4 dark:border-slate-700 dark:bg-slate-900/40">
               <p className="text-sm text-slate-600 dark:text-slate-400">
                 SM na data: {fmtMoney(simResult.salario_minimo)} · PDVs: {simResult.quantidade_pdvs}
+                {simResult.desconto_posto_100k ? ' · desconto volume ativo' : ''}
               </p>
+              {simResult.desconto_posto_100k ? (
+                <p className="mt-1 text-xs text-slate-500">
+                  20% SM só nos itens elegíveis a desconto volume; os demais mantêm o % do catálogo.
+                </p>
+              ) : null}
               <ul className="mt-3 space-y-1 text-sm">
                 {simResult.linhas.map((l) => (
-                  <li key={l.item_id} className="flex justify-between gap-4">
-                    <span>{l.nome}</span>
-                    <span className="tabular-nums font-medium">{fmtMoney(l.valor)}</span>
+                  <li key={l.item_id} className="flex flex-col gap-0.5">
+                    <div className="flex justify-between gap-4">
+                      <span>
+                        {l.nome}
+                        {l.percentual_usado != null ? (
+                          <span className="ml-1 text-xs text-slate-500">
+                            ({fmtPercentual(l.percentual_usado)})
+                          </span>
+                        ) : null}
+                        {l.override_custo ? (
+                          <span className="ml-1 rounded bg-amber-50 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-amber-800 dark:bg-amber-950/50 dark:text-amber-300">
+                            custo promo
+                          </span>
+                        ) : null}
+                      </span>
+                      <span className="tabular-nums font-medium">{fmtMoney(l.valor)}</span>
+                    </div>
+                    {l.tef_valor_cliente != null ? (
+                      <p className="text-xs text-slate-500">
+                        Valor ao cliente (TEF): {fmtMoney(l.tef_valor_cliente)} — não entra no total de custo
+                      </p>
+                    ) : null}
                   </li>
                 ))}
               </ul>
               <p className="mt-3 flex justify-between border-t border-slate-200 pt-3 text-base font-semibold dark:border-slate-700">
-                <span>Total estimado</span>
-                <span className="tabular-nums">{fmtMoney(simResult.total)}</span>
+                <span>Total custo estimado</span>
+                <span className="tabular-nums">{fmtMoney(simResult.total_custo ?? simResult.total)}</span>
               </p>
             </div>
           ) : null}
@@ -858,25 +998,37 @@ export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean
                 ]}
               />
               {itemForm.tipo === 'percentual_sm' ? (
-                <Input
-                  id="item-pct"
-                  label="Percentual do SM (%)"
-                  type="number"
-                  step="1"
-                  min={0}
-                  hint="Somente números inteiros (ex.: 20)."
-                  value={String(itemForm.percentual_sm ?? '')}
-                  onChange={(e) => {
-                    const raw = e.target.value
-                    if (raw === '') {
-                      setItemForm((f) => ({ ...f, percentual_sm: '' }))
-                      return
-                    }
-                    const n = Math.round(Number(raw))
-                    if (!Number.isNaN(n)) setItemForm((f) => ({ ...f, percentual_sm: String(n) }))
-                  }}
-                  required
-                />
+                <>
+                  <Input
+                    id="item-pct"
+                    label="Percentual do SM (%)"
+                    type="number"
+                    step="1"
+                    min={0}
+                    hint="Somente números inteiros (ex.: 30). Com desconto <100k na simulação, passa a 20%."
+                    value={String(itemForm.percentual_sm ?? '')}
+                    onChange={(e) => {
+                      const raw = e.target.value
+                      if (raw === '') {
+                        setItemForm((f) => ({ ...f, percentual_sm: '' }))
+                        return
+                      }
+                      const n = Math.round(Number(raw))
+                      if (!Number.isNaN(n)) setItemForm((f) => ({ ...f, percentual_sm: String(n) }))
+                    }}
+                    required
+                  />
+                  <Switch
+                    bare
+                    checked={!!itemForm.aplica_tier_posto}
+                    onCheckedChange={(aplica_tier_posto) => setItemForm((f) => ({ ...f, aplica_tier_posto }))}
+                    label="Elegível a desconto posto <100k L"
+                    description="Marque em itens de posto: na simulação dá para ativar 20% SM quando o cliente declara volume baixo."
+                    showStatusPill
+                    statusOnText="Sim"
+                    statusOffText="Não"
+                  />
+                </>
               ) : null}
               {itemForm.tipo === 'valor_fixo' ? (
                 <Input


### PR DESCRIPTION
## Summary

- Lote B do catálogo de custos (#321): desconto posto &lt;100k L (20% SM) nos itens elegíveis, override de custo/valor TEF só na simulação/proposta, motor `calcular_custo_pacote` com **snapshot** JSON imutável
- Migration `083` (`aplica_tier_posto`) + UI do simulador (avisos multi-TEF, labels mais claros)
- Plano de produto em `.github/planning-issue-bodies/analises/321-lote-b-tef-tier-motor.md`

Closes #331  
Closes #332  
Closes #335  

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest` `tests/test_comercial_custos.py` (9 passed)
- [x] Suite backend (ignore scripts release sem mount): 481 passed
- [x] `npm run build`
- [x] Smoke UX Playwright: login → cadastro item elegível → simular desconto + override TEF
- [ ] CI verde (changelog + backend + frontend)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Persistência do snapshot em negociação/contrato: épicos #322 / #323 / #324 (ainda não implementados)
- [x] Precificação de venda / margem: fora de escopo do #321
- [ ] Comentário no épico #321 após merge listando follow-ups
