### PR TITLE
fix(whatsapp): bugs produção — fila outbound, paginação, alerta e Esc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Corrigido
 
+- WhatsApp: ao iniciar conversa com número avulso e o cliente responder, deixa de abrir chat novo na fila (alerta de «novo atendimento») quando o `wa_id` chega em variante (DDI / nono dígito BR) ou como `@lid` com `senderPn` / `remoteJidAlt`
+- WhatsApp (#667): em Atendimentos (e Avaliações), **Próxima** / **Anterior** deixam de voltar sozinhas para a página 1; o `offset` da URL é respeitado ao abrir/recarregar
+- Chat (#651): **Silenciar** na fila Aguardando corta o alerta na hora (loop + pulse); o toque passa a tocar completo e a reiniciar em sequência, sem intervalo de silêncio
+- WhatsApp (#653): **Esc** na conversa já não percorre o histórico do browser (evita reabrir chat encerrado); fecha overlays locais e, ao sair, vai à lista de origem (Atendendo / Aguardando / etc.)
+- Chat (#652): com a aba em segundo plano, novo chat na fila dispara notificação do sistema (se permitida) e o áudio é desbloqueado no primeiro clique; ao voltar à aba o alerta retoma de imediato
+- Chat (#652): banner no painel pede permissão de notificações («Ativar alertas») para avisar novos chats na fila mesmo com outra aba ou o navegador minimizado
 - Chat: duplo clique **dentro** do balão já não inicia resposta (dá para selecionar/copiar o texto); responder com duplo clique fica só **ao lado** do balão
 - WhatsApp: menu com seta no canto do balão para Editar/Apagar (em vez de botões flutuantes que saltavam para a mensagem de cima)
 - WhatsApp: Enter na legenda do anexo deixava de enviar a imagem **duas vezes** (o evento subia ao painel e disparava o envio de novo)

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -1140,16 +1140,9 @@ def _preencher_telefone_do_chat(func: FuncionarioRede, wa_id: str | None) -> Non
 
 
 def _chat_aberto_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
-    return (
-        db.query(WhatsappChat)
-        .options(*_CHAT_LOAD_OPTIONS)
-        .filter(
-            WhatsappChat.wa_id == wa_id,
-            WhatsappChat.estado.in_(("aguardando_atendente", "em_atendimento")),
-        )
-        .order_by(WhatsappChat.id.desc())
-        .first()
-    )
+    from app.services.whatsapp_contato_match import chat_aberto_por_wa_id as _find
+
+    return _find(db, wa_id, load_options=_CHAT_LOAD_OPTIONS)
 
 
 @router.get("/contatos", response_model=ListaPaginada[WhatsappContatoRead])

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -7,7 +7,12 @@ from sqlalchemy.orm import Session, joinedload
 from app.database import get_db
 from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem, WhatsappSettings
 from app.services import evolution_api
-from app.services.whatsapp_contato_match import funcionario_por_wa_id
+from app.services.whatsapp_contato_match import (
+    chat_aberto_por_wa_id,
+    chat_aguardando_avaliacao_por_wa_id,
+    funcionario_por_wa_id,
+    variantes_wa_id,
+)
 from app.services.protocolo_mensal import gerar_protocolo_chat
 from app.services.evolution_inbound import (
     iter_inbound_edits,
@@ -101,28 +106,11 @@ def _baixar_midia_inbound(
 
 def _chat_aberto_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
     """Chat ativo para conversa (fila ou em atendimento). Não inclui pós-inatividade a classificar."""
-    return (
-        db.query(WhatsappChat)
-        .filter(
-            WhatsappChat.wa_id == wa_id,
-            WhatsappChat.estado.in_(("aguardando_atendente", "em_atendimento")),
-            WhatsappChat.classificacao_demanda_pendente.is_(False),
-        )
-        .order_by(WhatsappChat.id.desc())
-        .first()
-    )
+    return chat_aberto_por_wa_id(db, wa_id, excluir_classificacao_pendente=True)
 
 
 def _chat_aguardando_avaliacao_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
-    return (
-        db.query(WhatsappChat)
-        .filter(
-            WhatsappChat.wa_id == wa_id,
-            WhatsappChat.estado == "aguardando_avaliacao",
-        )
-        .order_by(WhatsappChat.id.desc())
-        .first()
-    )
+    return chat_aguardando_avaliacao_por_wa_id(db, wa_id)
 
 
 def _fmt_data_abertura(dt: datetime | None, tz: ZoneInfo) -> str:
@@ -454,10 +442,13 @@ def evolution_webhook(
 
 
 def _chat_recente_por_wa_id(db: Session, wa_id: str) -> WhatsappChat | None:
+    targets = variantes_wa_id(wa_id)
+    if not targets:
+        return None
     return (
         db.query(WhatsappChat)
         .filter(
-            WhatsappChat.wa_id == wa_id,
+            WhatsappChat.wa_id.in_(targets),
             WhatsappChat.estado.in_(
                 ("aguardando_atendente", "em_atendimento", "aguardando_avaliacao", "encerrado")
             ),

--- a/backend/app/services/evolution_inbound.py
+++ b/backend/app/services/evolution_inbound.py
@@ -35,6 +35,41 @@ def _only_digits_jid(jid: str | None) -> str | None:
     return digits or None
 
 
+def _wa_id_from_message_key(key: dict[str, Any], envelope: dict[str, Any]) -> str | None:
+    """
+    Extrai wa_id (só dígitos) do key da mensagem.
+
+    Quando remoteJid é @lid (WhatsApp Linked ID), prefere remoteJidAlt / senderPn
+    com o número real — senão o inbound não casa com chats abertos por telefone.
+    """
+    rjid = key.get("remoteJid") or key.get("RemoteJid")
+    rjid_s = str(rjid) if rjid else ""
+    if not rjid_s:
+        return None
+    if "@g.us" in rjid_s:
+        return None
+
+    if "@lid" in rjid_s.lower():
+        for src in (key, envelope):
+            for alt_key in (
+                "remoteJidAlt",
+                "RemoteJidAlt",
+                "senderPn",
+                "SenderPn",
+                "participantPn",
+                "ParticipantPn",
+            ):
+                alt = src.get(alt_key)
+                if alt:
+                    digits = _only_digits_jid(str(alt))
+                    if digits:
+                        return digits
+        # Sem telefone alternativo: LID opaco (último recurso)
+        return _only_digits_jid(rjid_s)
+
+    return _only_digits_jid(rjid_s)
+
+
 def _text_from_inner(inner: dict[str, Any]) -> str | None:
     if "conversation" in inner:
         v = inner.get("conversation")
@@ -236,11 +271,7 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
             continue
         if key.get("fromMe") or key.get("FromMe"):
             continue
-        rjid = key.get("remoteJid") or key.get("RemoteJid")
-        rjid_s = str(rjid) if rjid else ""
-        if "@g.us" in rjid_s:
-            continue
-        wa_id = _only_digits_jid(rjid_s)
+        wa_id = _wa_id_from_message_key(key, m)
         if not wa_id:
             continue
         mid = key.get("id") or key.get("Id")
@@ -402,11 +433,7 @@ def iter_inbound_revokes(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any
         key = m.get("key") or m.get("Key") or {}
         if not isinstance(key, dict):
             continue
-        rjid = key.get("remoteJid") or key.get("RemoteJid")
-        rjid_s = str(rjid) if rjid else ""
-        if "@g.us" in rjid_s:
-            continue
-        wa_id = _only_digits_jid(rjid_s)
+        wa_id = _wa_id_from_message_key(key, m)
         if not wa_id:
             continue
         inner = m.get("message") or m.get("Message")
@@ -443,11 +470,7 @@ def iter_inbound_edits(webhook_body: dict[str, Any]) -> Iterator[dict[str, Any]]
         key = m.get("key") or m.get("Key") or {}
         if not isinstance(key, dict):
             continue
-        rjid = key.get("remoteJid") or key.get("RemoteJid")
-        rjid_s = str(rjid) if rjid else ""
-        if "@g.us" in rjid_s:
-            continue
-        wa_id = _only_digits_jid(rjid_s)
+        wa_id = _wa_id_from_message_key(key, m)
         if not wa_id:
             continue
         inner = m.get("message") or m.get("Message")
@@ -490,11 +513,7 @@ def iter_inbound_reactions(webhook_body: dict[str, Any]) -> Iterator[dict[str, A
         key = m.get("key") or m.get("Key") or {}
         if not isinstance(key, dict):
             continue
-        rjid = key.get("remoteJid") or key.get("RemoteJid")
-        rjid_s = str(rjid) if rjid else ""
-        if "@g.us" in rjid_s:
-            continue
-        wa_id = _only_digits_jid(rjid_s)
+        wa_id = _wa_id_from_message_key(key, m)
         if not wa_id:
             continue
         inner = m.get("message") or m.get("Message")

--- a/backend/app/services/whatsapp_contato_match.py
+++ b/backend/app/services/whatsapp_contato_match.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import re
 
+from collections.abc import Sequence
+from typing import Any
+
 from sqlalchemy.orm import Session
 
 from app.models.funcionario_rede import FuncionarioRede
+from app.models.whatsapp_chat import WhatsappChat
 
 
 def digits_wa(raw: str | None) -> str:
@@ -14,20 +18,52 @@ def digits_wa(raw: str | None) -> str:
 
 
 def variantes_wa_id(wa_id: str | None) -> set[str]:
+    """
+    Variantes do mesmo contacto WhatsApp.
+
+    Cobre DDI 55 com/sem prefixo e o nono dígito BR em telemóveis
+    (ex.: 5511988776655 ↔ 551188776655 ↔ 11988776655).
+    """
     digits = digits_wa(wa_id)
     out: set[str] = set()
     if not digits:
         return out
-    out.add(digits)
-    if digits.startswith("55") and len(digits) >= 12:
-        out.add(digits[2:])
-    elif len(digits) in (10, 11):
-        out.add("55" + digits)
+
+    def add_with_ddi(d: str) -> None:
+        if not d:
+            return
+        out.add(d)
+        if d.startswith("55") and len(d) >= 12:
+            out.add(d[2:])
+        elif len(d) in (10, 11) and not d.startswith("55"):
+            out.add("55" + d)
+
+    add_with_ddi(digits)
+
+    local = digits[2:] if digits.startswith("55") and len(digits) >= 12 else digits
+
+    # Telemóvel BR: DDD(2) + 9 + 8 dígitos ↔ DDD(2) + 8 dígitos (legado)
+    if len(local) == 11 and local[2] == "9":
+        add_with_ddi(local[:2] + local[3:])
+    elif len(local) == 10:
+        add_with_ddi(local[:2] + "9" + local[2:])
+
     return out
 
 
+def canonical_wa_id_para_lock(wa_id: str | None) -> str:
+    """Representante estável entre variantes — mesmo lock para o mesmo contacto."""
+    variants = variantes_wa_id(wa_id)
+    if not variants:
+        return digits_wa(wa_id) or (wa_id or "").strip()
+    with_55 = [v for v in variants if v.startswith("55")]
+    pool = with_55 or list(variants)
+    # Preferir forma mais completa (com 55 + nono dígito quando existir)
+    return max(pool, key=lambda v: (len(v), v))
+
+
 def funcionario_por_wa_id(db: Session, wa_id: str | None) -> FuncionarioRede | None:
-    """Encontra funcionário ativo cujo telefone corresponde ao wa_id (com/sem DDI 55)."""
+    """Encontra funcionário ativo cujo telefone corresponde ao wa_id (com/sem DDI 55 / nono dígito)."""
     targets = variantes_wa_id(wa_id)
     if not targets:
         return None
@@ -52,7 +88,42 @@ def funcionario_por_wa_id(db: Session, wa_id: str | None) -> FuncionarioRede | N
             continue
         if f_digits in targets or targets & variantes_wa_id(f_digits):
             return func
-        # Últimos 11 dígitos (BR sem/com 9 extra)
-        if len(f_digits) >= 11 and len(sample) >= 11 and f_digits[-11:] == sample[-11:]:
-            return func
     return None
+
+
+def chat_aberto_por_wa_id(
+    db: Session,
+    wa_id: str | None,
+    *,
+    excluir_classificacao_pendente: bool = False,
+    load_options: Sequence[Any] | None = None,
+) -> WhatsappChat | None:
+    """Chat ativo (fila ou em atendimento) para o contacto, tolerando variantes de wa_id."""
+    targets = variantes_wa_id(wa_id)
+    if not targets:
+        return None
+    q = db.query(WhatsappChat)
+    if load_options:
+        q = q.options(*load_options)
+    q = q.filter(
+        WhatsappChat.wa_id.in_(targets),
+        WhatsappChat.estado.in_(("aguardando_atendente", "em_atendimento")),
+    )
+    if excluir_classificacao_pendente:
+        q = q.filter(WhatsappChat.classificacao_demanda_pendente.is_(False))
+    return q.order_by(WhatsappChat.id.desc()).first()
+
+
+def chat_aguardando_avaliacao_por_wa_id(db: Session, wa_id: str | None) -> WhatsappChat | None:
+    targets = variantes_wa_id(wa_id)
+    if not targets:
+        return None
+    return (
+        db.query(WhatsappChat)
+        .filter(
+            WhatsappChat.wa_id.in_(targets),
+            WhatsappChat.estado == "aguardando_avaliacao",
+        )
+        .order_by(WhatsappChat.id.desc())
+        .first()
+    )

--- a/backend/app/services/whatsapp_wa_id_lock.py
+++ b/backend/app/services/whatsapp_wa_id_lock.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import threading
+
 from sqlalchemy import text
 from sqlalchemy.orm import Session
+
+from app.services.whatsapp_contato_match import canonical_wa_id_para_lock
 
 _WA_LOCK_NS = 608608
 _wa_thread_locks: dict[str, threading.Lock] = {}
@@ -24,10 +27,10 @@ def lock_wa_id_para_chat(db: Session, wa_id: str) -> None:
     """
     Garante uma única criação de chat aberto por contacto.
 
-    PostgreSQL: advisory lock transacional (liberta no commit/rollback).
-    SQLite (testes): lock in-process por wa_id.
+    Usa forma canónica (DDI/nono dígito) para o mesmo contacto não passar
+    por locks diferentes. PostgreSQL: advisory lock transacional; SQLite: in-process.
     """
-    wa = (wa_id or "").strip()
+    wa = canonical_wa_id_para_lock(wa_id)
     if not wa:
         return
     bind = db.get_bind()
@@ -42,7 +45,7 @@ def lock_wa_id_para_chat(db: Session, wa_id: str) -> None:
 
 def unlock_wa_id_para_chat(db: Session, wa_id: str) -> None:
     """Liberta lock in-process (SQLite). No-op em PostgreSQL."""
-    wa = (wa_id or "").strip()
+    wa = canonical_wa_id_para_lock(wa_id)
     if not wa:
         return
     if db.get_bind().dialect.name != "postgresql":

--- a/backend/tests/test_evolution_inbound_especiais.py
+++ b/backend/tests/test_evolution_inbound_especiais.py
@@ -44,3 +44,42 @@ def test_inbound_localizacao():
     assert item["tipo"] == "texto"
     assert "[Localização]" in item["corpo"]
     assert "maps.google.com" in item["corpo"]
+
+
+def test_inbound_resolve_lid_via_sender_pn():
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "key": {
+                "remoteJid": "11122233344455@lid",
+                "fromMe": False,
+                "id": "lid1",
+                "senderPn": "5511987654321@s.whatsapp.net",
+            },
+            "message": {"conversation": "oi"},
+        },
+    }
+    item = _one(body)
+    assert item["wa_id"] == "5511987654321"
+    assert item["corpo"] == "oi"
+
+
+def test_inbound_resolve_lid_via_remote_jid_alt():
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {
+                        "remoteJid": "99988877766655@lid",
+                        "remoteJidAlt": "5511888777666@s.whatsapp.net",
+                        "fromMe": False,
+                        "id": "lid2",
+                    },
+                    "message": {"conversation": "alt"},
+                }
+            ]
+        },
+    }
+    item = _one(body)
+    assert item["wa_id"] == "5511888777666"

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -1009,6 +1009,102 @@ def test_iniciar_chat_409_outro_responsavel(client, seed_base, auth_headers, mon
     assert r2.status_code == 409
 
 
+def test_inbound_apos_outbound_nao_abre_fila_com_variante_wa_id(
+    client, seed_base, auth_headers, monkeypatch
+):
+    """
+    Atendente inicia com número digitado; cliente responde com variante (sem nono dígito).
+    Não deve criar chat novo em aguardando_atendente (alerta de fila).
+    """
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-var"),
+    )
+    _evolution_settings(client, auth_headers, "iniciar-var")
+
+    r = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"telefone": "11988770011", "mensagem_inicial": "Olá"},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    chat = r.json()
+    assert chat["estado"] == "em_atendimento"
+    assert chat["wa_id"] == "5511988770011"
+    cid = chat["id"]
+
+    h = {"X-Dx-Webhook-Secret": "iniciar-var"}
+    # Evolution / WhatsApp pode devolver sem o nono dígito
+    wr = client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="551188770011", msg_id="reply-var-1", text="Oi, recebi"),
+        headers=h,
+    )
+    assert wr.status_code == 200
+    assert wr.json().get("processados", 0) >= 1
+
+    fila = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()
+    assert not any(c["wa_id"] in ("5511988770011", "551188770011") for c in fila), fila
+
+    detalhe = client.get(f"/v1/whatsapp/chats/{cid}", headers=auth_headers["a1"])
+    assert detalhe.status_code == 200
+    assert detalhe.json()["estado"] == "em_atendimento"
+
+    msgs = client.get(f"/v1/whatsapp/chats/{cid}/mensagens", headers=auth_headers["a1"]).json()
+    corpos = [m["corpo"] for m in (msgs if isinstance(msgs, list) else msgs.get("items", []))]
+    assert any("Oi, recebi" in (c or "") for c in corpos), msgs
+
+
+def test_inbound_apos_outbound_resolve_lid_com_sender_pn(
+    client, seed_base, auth_headers, monkeypatch
+):
+    """Resposta com remoteJid @lid + senderPn deve reutilizar o chat outbound."""
+    monkeypatch.setattr(
+        "app.api.whatsapp_chats.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-lid"),
+    )
+    _evolution_settings(client, auth_headers, "iniciar-lid")
+
+    r = client.post(
+        "/v1/whatsapp/chats/iniciar",
+        json={"telefone": "5511999000044", "mensagem_inicial": "Retorno"},
+        headers=auth_headers["a1"],
+    )
+    assert r.status_code == 200
+    cid = r.json()["id"]
+
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "messages": [
+                {
+                    "key": {
+                        "remoteJid": "98765432109876@lid",
+                        "fromMe": False,
+                        "id": "reply-lid-1",
+                        "senderPn": "5511999000044@s.whatsapp.net",
+                    },
+                    "message": {"conversation": "Resposta via LID"},
+                }
+            ]
+        },
+    }
+    wr = client.post(
+        "/v1/webhooks/evolution",
+        json=body,
+        headers={"X-Dx-Webhook-Secret": "iniciar-lid"},
+    )
+    assert wr.status_code == 200
+    assert wr.json().get("processados", 0) >= 1
+
+    fila = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()
+    assert not any(c["id"] == cid or c.get("wa_id") == "5511999000044" for c in fila), fila
+    assert not any(c.get("wa_id") == "98765432109876" for c in fila), fila
+
+    detalhe = client.get(f"/v1/whatsapp/chats/{cid}", headers=auth_headers["a1"])
+    assert detalhe.json()["estado"] == "em_atendimento"
+
+
 def test_iniciar_chat_funcionario_sem_telefone_exige_numero(client, seed_base, auth_headers, db_session, monkeypatch):
     monkeypatch.setattr(
         "app.api.whatsapp_chats.evolution_api.evolution_send_text",

--- a/backend/tests/test_whatsapp_wa_id_match.py
+++ b/backend/tests/test_whatsapp_wa_id_match.py
@@ -1,0 +1,33 @@
+"""Match de wa_id WhatsApp — variantes DDI / nono dígito BR e chat aberto."""
+
+from __future__ import annotations
+
+from app.services.whatsapp_contato_match import (
+    canonical_wa_id_para_lock,
+    variantes_wa_id,
+)
+
+
+def test_variantes_wa_id_ddi_e_nono_digito():
+    v = variantes_wa_id("5511988776655")
+    assert "5511988776655" in v
+    assert "11988776655" in v
+    assert "551188776655" in v
+    assert "1188776655" in v
+
+    v2 = variantes_wa_id("551188776655")
+    assert "5511988776655" in v2
+    assert "551188776655" in v2
+
+
+def test_variantes_wa_id_sem_ddi():
+    v = variantes_wa_id("11988776655")
+    assert "5511988776655" in v
+    assert "11988776655" in v
+
+
+def test_canonical_lock_estavel_entre_variantes():
+    a = canonical_wa_id_para_lock("11988776655")
+    b = canonical_wa_id_para_lock("551188776655")
+    c = canonical_wa_id_para_lock("5511988776655")
+    assert a == b == c

--- a/frontend/public/sons/LEIA-ME.txt
+++ b/frontend/public/sons/LEIA-ME.txt
@@ -6,7 +6,7 @@ Cada evento usa um arquivo distinto para não se misturar na reprodução:
   ticket-mensagem.mp3 — nova mensagem em ticket já atribuído
                         (fallback: notification.mp3, se faltar o ficheiro)
   alerta.mp3         — cliente aguardando na fila WhatsApp / Portal
-                        (loop enquanto houver fila — «novo chat»)
+                        (toca completo e reinicia em sequência enquanto houver fila)
   wpp-mensagem.mp3   — nova mensagem do cliente em chat em atendimento
                         (fallback: notification.mp3)
 

--- a/frontend/src/components/AlertaDesktopPermissaoBanner.tsx
+++ b/frontend/src/components/AlertaDesktopPermissaoBanner.tsx
@@ -1,0 +1,128 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ativarAlertasEmSegundoPlano,
+  getNotificationPermission,
+  type AlertasDesktopResultado,
+} from '../hooks/useAlertaFilaSemResponsavel'
+import { Button } from './ui/Button'
+
+const LS_DISMISS = 'dxconnect.notificacoes.desktop_prompt_dismissed'
+
+function readDismissed(): boolean {
+  try {
+    return localStorage.getItem(LS_DISMISS) === '1'
+  } catch {
+    return false
+  }
+}
+
+function writeDismissed() {
+  try {
+    localStorage.setItem(LS_DISMISS, '1')
+  } catch {
+    // ignore
+  }
+}
+
+type Props = {
+  enabled: boolean
+}
+
+/**
+ * Pede permissão de notificações do SO para alertar fila com aba em 2º plano (#652).
+ * O clique em «Ativar» é o gesto que desbloqueia áudio + permission prompt do browser.
+ */
+export function AlertaDesktopPermissaoBanner({ enabled }: Props) {
+  const [perm, setPerm] = useState<AlertasDesktopResultado>(() => getNotificationPermission())
+  const [dismissed, setDismissed] = useState(readDismissed)
+  const [busy, setBusy] = useState(false)
+  const [feedback, setFeedback] = useState<'ok' | 'denied' | null>(null)
+
+  useEffect(() => {
+    if (!enabled) return
+    setPerm(getNotificationPermission())
+  }, [enabled])
+
+  const ativar = useCallback(async () => {
+    setBusy(true)
+    setFeedback(null)
+    try {
+      const result = await ativarAlertasEmSegundoPlano()
+      setPerm(result)
+      if (result === 'granted') {
+        setFeedback('ok')
+        writeDismissed()
+        setDismissed(true)
+        window.setTimeout(() => setFeedback(null), 5000)
+      } else if (result === 'denied') {
+        setFeedback('denied')
+      }
+    } finally {
+      setBusy(false)
+    }
+  }, [])
+
+  const agoraNao = useCallback(() => {
+    writeDismissed()
+    setDismissed(true)
+  }, [])
+
+  if (!enabled) return null
+  if (perm === 'unsupported') return null
+  if (perm === 'granted' && feedback !== 'ok') return null
+  if (dismissed && feedback !== 'ok' && feedback !== 'denied') return null
+  // Já pediu e foi negado no browser — só mostra se o utilizador acabou de negar neste clique
+  if (perm === 'denied' && feedback !== 'denied') return null
+  if (perm === 'granted' && feedback === 'ok') {
+    return (
+      <div
+        role="status"
+        className="shrink-0 border-b border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm text-emerald-900 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-100"
+      >
+        Alertas do sistema activos — vais ser avisado mesmo com a aba em segundo plano ou o navegador minimizado.
+      </div>
+    )
+  }
+
+  if (feedback === 'denied' || perm === 'denied') {
+    return (
+      <div
+        role="status"
+        className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-amber-200 bg-amber-50 px-4 py-2.5 text-sm text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100"
+      >
+        <p className="min-w-0 flex-1">
+          Notificações bloqueadas neste browser. Para receber alertas com a aba em segundo plano, permita
+          notificações nas definições do site.
+        </p>
+        <Button type="button" variant="ghost" className="h-8 shrink-0 px-2 text-xs" onClick={agoraNao}>
+          Fechar
+        </Button>
+      </div>
+    )
+  }
+
+  // permission === 'default' e ainda não dispensado
+  return (
+    <div
+      role="region"
+      aria-label="Ativar alertas em segundo plano"
+      className="flex shrink-0 flex-col gap-2 border-b border-cyan-200 bg-cyan-50 px-4 py-3 text-sm text-slate-800 dark:border-cyan-900/40 dark:bg-cyan-950/30 dark:text-slate-100 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div className="min-w-0 space-y-0.5">
+        <p className="font-semibold text-slate-900 dark:text-white">Ativar alertas fora desta aba?</p>
+        <p className="text-xs text-slate-600 dark:text-slate-300 sm:text-sm">
+          Com a permissão do browser, o DeskRudder avisa novos chats na fila mesmo com outra aba aberta ou o
+          navegador minimizado.
+        </p>
+      </div>
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <Button type="button" variant="ghost" className="h-9 px-3" onClick={agoraNao} disabled={busy}>
+          Agora não
+        </Button>
+        <Button type="button" variant="primary" className="h-9 px-4" loading={busy} onClick={() => void ativar()}>
+          Ativar alertas
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -8,6 +8,7 @@ import { useAlertaFilaSemResponsavel, setChatInternoAlertUserId } from '../hooks
 import { EventStreamProvider, useEventStream } from '../contexts/EventStreamContext'
 import { BrandLogo } from '../brand'
 import { useTheme } from '../contexts/ThemeContext'
+import { AlertaDesktopPermissaoBanner } from './AlertaDesktopPermissaoBanner'
 
 function perfilExibicao(role: string | undefined): string {
   if (role === 'admin') return 'Administrador'
@@ -104,6 +105,8 @@ function LayoutInner() {
               <p className="truncate text-xs text-slate-500 dark:text-slate-400">{perfilExibicao(user?.role)}</p>
             </div>
           </header>
+
+          {notificacoesEnabled ? <AlertaDesktopPermissaoBanner enabled /> : null}
 
           <main className="min-h-0 flex-1 overflow-hidden">
             <div

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -814,7 +814,6 @@ function notifyFilaDesktop(filaCount: number) {
     const n = new Notification(APP_NAME, {
       body,
       tag: 'dx-connect-fila-aguardando',
-      renotify: true,
       silent: false,
     })
     n.onclick = () => {

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -81,8 +81,15 @@ function readFilaAguardandoMuted(): boolean {
 
 let filaAguardandoMuted = readFilaAguardandoMuted()
 
-let wppFilaLoopInterval: number | null = null
 let wppFilaLoopAudio: HTMLAudioElement | null = null
+/** Loop contínuo activo (fila > 0 e não silenciado). */
+let wppFilaLoopWanted = false
+let wppFilaLoopEndedHandler: (() => void) | null = null
+let wppFilaLoopRetryTimer: number | null = null
+/** Áudio «desbloqueado» por gesto do utilizador — melhora play em aba em background (#652). */
+let audioUnlocked = false
+let audioUnlockInstalled = false
+let lastFilaDesktopNotifyAt = 0
 let pollTimerId: number | null = null
 let sseSlowPollMode = false
 let sseListenerCount = 0
@@ -121,8 +128,14 @@ export function setFilaAguardandoMuted(muted: boolean) {
   } catch {
     // ignore
   }
-  const filaCount = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
-  syncWppFilaBeep(filaCount)
+  if (muted) {
+    // Corta na hora: loop + pulse one-shot na fila de alertas (#651)
+    stopWppFilaLoop()
+    stopWppFilaOneShots()
+  } else {
+    const filaCount = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
+    syncWppFilaBeep(filaCount)
+  }
   for (const l of listenersFilaMuted) l(muted)
 }
 
@@ -357,42 +370,124 @@ async function drainAlertQueue() {
   while (alertQueue.length > 0) {
     const kind = alertQueue.shift()
     if (!kind) continue
+    if (kind === 'wpp_fila_pulse' && (filaAguardandoMuted || wppFilaLoopWanted)) continue
     await playAlertKind(kind)
     await new Promise((r) => window.setTimeout(r, 180))
   }
   drainingAlerts = false
+  // One-shot pode ter adiado o loop da fila — retoma se ainda houver pendências
+  if (wppFilaLoopWanted && !filaAguardandoMuted) {
+    ensureWppFilaLoop()
+  }
 }
 
-function playWppFilaLoopPulse() {
-  if (oneShotPlaying) return
+function clearWppFilaLoopRetry() {
+  if (wppFilaLoopRetryTimer != null) {
+    window.clearTimeout(wppFilaLoopRetryTimer)
+    wppFilaLoopRetryTimer = null
+  }
+}
 
+function getWppFilaLoopAudio(): HTMLAudioElement {
   const src = SOUND_WPP_FILA
   if (!wppFilaLoopAudio) {
     wppFilaLoopAudio = getAudioElement(audioKey('wpp_fila_loop', src), src)
   }
-  const audio = wppFilaLoopAudio
-  audio.pause()
-  audio.currentTime = 0
+  return wppFilaLoopAudio
+}
+
+function startFilaLoopPlayback() {
+  if (!wppFilaLoopWanted || filaAguardandoMuted) return
+  if (oneShotPlaying) {
+    clearWppFilaLoopRetry()
+    wppFilaLoopRetryTimer = window.setTimeout(() => {
+      wppFilaLoopRetryTimer = null
+      startFilaLoopPlayback()
+    }, 250)
+    return
+  }
+
+  const audio = getWppFilaLoopAudio()
+  try {
+    audio.pause()
+    audio.currentTime = 0
+  } catch {
+    // ignore
+  }
   audio.volume = 0.38
-  audio.play().catch(() => {
-    if (!oneShotPlaying) synthForKind('wpp_fila_pulse')
-  })
+  const playPromise = audio.play()
+  if (playPromise && typeof playPromise.then === 'function') {
+    playPromise.catch(() => {
+      if (!wppFilaLoopWanted || filaAguardandoMuted || oneShotPlaying) return
+      // Em aba oculta o browser bloqueia play — notifica no SO e retenta ao voltar (#652)
+      const filaCount = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
+      notifyFilaDesktop(filaCount)
+      if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+        synthForKind('wpp_fila_pulse')
+        clearWppFilaLoopRetry()
+        wppFilaLoopRetryTimer = window.setTimeout(() => {
+          wppFilaLoopRetryTimer = null
+          if (wppFilaLoopWanted && !filaAguardandoMuted) startFilaLoopPlayback()
+        }, 400)
+      }
+    })
+  }
+}
+
+function onFilaLoopEnded() {
+  if (!wppFilaLoopWanted || filaAguardandoMuted) return
+  // Recomeça na sequência, sem intervalo fixo (sem silêncio artificial)
+  startFilaLoopPlayback()
+}
+
+/** Remove pulses enfileirados e corta o one-shot da fila que estiver a tocar. */
+function stopWppFilaOneShots() {
+  for (let i = alertQueue.length - 1; i >= 0; i--) {
+    if (alertQueue[i] === 'wpp_fila_pulse') alertQueue.splice(i, 1)
+  }
+  const pulseKey = audioKey('wpp_fila_pulse', SOUND_WPP_FILA)
+  const pulseAudio = audioByKey.get(pulseKey)
+  if (pulseAudio && !pulseAudio.paused) {
+    pulseAudio.pause()
+    try {
+      pulseAudio.currentTime = 0
+    } catch {
+      // ignore
+    }
+    // Liberta playSrcOnce que espera 'ended'
+    pulseAudio.dispatchEvent(new Event('ended'))
+  }
 }
 
 function stopWppFilaLoop() {
-  if (wppFilaLoopInterval != null) {
-    window.clearInterval(wppFilaLoopInterval)
-    wppFilaLoopInterval = null
+  wppFilaLoopWanted = false
+  clearWppFilaLoopRetry()
+  const audio = wppFilaLoopAudio
+  if (audio && wppFilaLoopEndedHandler) {
+    audio.removeEventListener('ended', wppFilaLoopEndedHandler)
+    wppFilaLoopEndedHandler = null
   }
-  wppFilaLoopAudio?.pause()
+  if (audio) {
+    audio.pause()
+    try {
+      audio.currentTime = 0
+    } catch {
+      // ignore
+    }
+  }
 }
 
 function ensureWppFilaLoop() {
-  if (wppFilaLoopInterval != null) return
-  playWppFilaLoopPulse()
-  wppFilaLoopInterval = window.setInterval(() => {
-    playWppFilaLoopPulse()
-  }, 5200)
+  if (filaAguardandoMuted) return
+  wppFilaLoopWanted = true
+  const audio = getWppFilaLoopAudio()
+  if (!wppFilaLoopEndedHandler) {
+    wppFilaLoopEndedHandler = onFilaLoopEnded
+    audio.addEventListener('ended', wppFilaLoopEndedHandler)
+  }
+  // Já a tocar até ao fim — não reinicia a meio (deixa o 'ended' encadear)
+  if (!audio.paused && !audio.ended) return
+  startFilaLoopPlayback()
 }
 
 function syncWppFilaBeep(wppFilaCount: number) {
@@ -463,14 +558,22 @@ function applyResumo(r: Notificacoes.Resumo, atualizarSom: boolean, source: 'sse
       !filaAguardandoMuted &&
       shouldEnqueueCounterAlert('wpp_fila_pulse', prevWppFilaValue, r.wpp_fila_count)
     ) {
-      enqueueAlert('wpp_fila_pulse')
+      // Loop contínuo já cobre o alerta; pulse só se o loop ainda não estiver activo
+      if (!wppFilaLoopWanted) enqueueAlert('wpp_fila_pulse')
     }
 
     if (
       !filaAguardandoMuted &&
       shouldEnqueueCounterAlert('wpp_fila_pulse', prevPortalFilaValue, r.portal_fila_count)
     ) {
-      enqueueAlert('wpp_fila_pulse')
+      if (!wppFilaLoopWanted) enqueueAlert('wpp_fila_pulse')
+    }
+
+    const filaTotal = r.wpp_fila_count + r.portal_fila_count
+    const prevFilaTotal = (prevWppFilaValue ?? 0) + (prevPortalFilaValue ?? 0)
+    if (!filaAguardandoMuted && filaTotal > prevFilaTotal) {
+      // Aba em 2º plano: garantir alerta via Notification do SO (#652)
+      notifyFilaDesktop(filaTotal)
     }
 
     if (shouldEnqueueCounterAlert('ticket_mensagem', prevNao, r.nao_lidas_count)) {
@@ -580,6 +683,153 @@ function preloadSounds() {
   }
 }
 
+/** Desbloqueia reprodução após gesto do utilizador (autoplay / aba em background). */
+export function unlockAlertAudio() {
+  if (audioUnlocked) return
+  audioUnlocked = true
+  const sources = [
+    SOUND_TICKET_FILA,
+    SOUND_TICKET_MENSAGEM,
+    SOUND_WPP_FILA,
+    SOUND_WPP_MENSAGEM,
+    SOUND_CHAT_INTERNO,
+  ]
+  for (const src of sources) {
+    const audio = getAudioElement(`preload:${src}`, src)
+    const wasMuted = audio.muted
+    audio.muted = true
+    void audio
+      .play()
+      .then(() => {
+        audio.pause()
+        try {
+          audio.currentTime = 0
+        } catch {
+          // ignore
+        }
+        audio.muted = wasMuted
+      })
+      .catch(() => {
+        audio.muted = wasMuted
+      })
+  }
+  try {
+    const Ctx =
+      window.AudioContext ||
+      (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext
+    if (Ctx) {
+      const ctx = new Ctx()
+      void ctx.resume().finally(() => {
+        void ctx.close().catch(() => {})
+      })
+    }
+  } catch {
+    // ignore
+  }
+}
+
+export type AlertasDesktopResultado = 'granted' | 'denied' | 'default' | 'unsupported'
+
+/**
+ * Pedido explícito (gesto do utilizador no banner): desbloqueia áudio + permissão
+ * de notificação do SO para alertar com aba em 2º plano / browser minimizado (#652).
+ */
+export async function ativarAlertasEmSegundoPlano(): Promise<AlertasDesktopResultado> {
+  unlockAlertAudio()
+  if (typeof Notification === 'undefined') return 'unsupported'
+  if (Notification.permission === 'granted') {
+    // Confirmação curta — o utilizador acabou de autorizar / já tinha
+    try {
+      const n = new Notification(APP_NAME, {
+        body: 'Alertas activos mesmo com a aba em segundo plano.',
+        tag: 'dx-connect-fila-perm-ok',
+        silent: false,
+      })
+      window.setTimeout(() => n.close(), 4000)
+    } catch {
+      // ignore
+    }
+    return 'granted'
+  }
+  if (Notification.permission === 'denied') return 'denied'
+  try {
+    const p = await Notification.requestPermission()
+    if (p === 'granted') {
+      try {
+        const n = new Notification(APP_NAME, {
+          body: 'Alertas activos mesmo com a aba em segundo plano.',
+          tag: 'dx-connect-fila-perm-ok',
+          silent: false,
+        })
+        window.setTimeout(() => n.close(), 4000)
+      } catch {
+        // ignore
+      }
+      return 'granted'
+    }
+    return p === 'denied' ? 'denied' : 'default'
+  } catch {
+    return 'denied'
+  }
+}
+
+export function getNotificationPermission(): AlertasDesktopResultado {
+  if (typeof Notification === 'undefined') return 'unsupported'
+  const p = Notification.permission
+  if (p === 'granted' || p === 'denied' || p === 'default') return p
+  return 'unsupported'
+}
+
+function installAudioUnlockListeners() {
+  if (audioUnlockInstalled || typeof window === 'undefined') return
+  audioUnlockInstalled = true
+  const onGesture = () => {
+    unlockAlertAudio()
+    window.removeEventListener('pointerdown', onGesture)
+    window.removeEventListener('keydown', onGesture)
+    window.removeEventListener('touchstart', onGesture)
+  }
+  window.addEventListener('pointerdown', onGesture, { passive: true })
+  window.addEventListener('keydown', onGesture)
+  window.addEventListener('touchstart', onGesture, { passive: true })
+}
+
+/**
+ * Notificação do SO quando a aba está oculta — browsers bloqueiam audio.play() em background.
+ * Respeita silenciar da fila. Dedup ~4s para não spammar.
+ */
+function notifyFilaDesktop(filaCount: number) {
+  if (filaAguardandoMuted || filaCount <= 0) return
+  if (typeof document === 'undefined' || document.visibilityState === 'visible') return
+  if (typeof Notification === 'undefined') return
+  if (Notification.permission !== 'granted') return
+  const now = Date.now()
+  if (now - lastFilaDesktopNotifyAt < 4000) return
+  lastFilaDesktopNotifyAt = now
+  try {
+    const body =
+      filaCount === 1
+        ? 'Há 1 chat aguardando atendimento'
+        : `Há ${filaCount} chats aguardando atendimento`
+    const n = new Notification(APP_NAME, {
+      body,
+      tag: 'dx-connect-fila-aguardando',
+      renotify: true,
+      silent: false,
+    })
+    n.onclick = () => {
+      try {
+        window.focus()
+      } catch {
+        // ignore
+      }
+      n.close()
+    }
+  } catch {
+    // ignore
+  }
+}
+
 function ensureStarted() {
   if (started) return
   started = true
@@ -592,12 +842,16 @@ function ensureStarted() {
   prevChatInterno = getStoredNumber(LS_KEY_LAST_CHAT_INTERNO)
 
   preloadSounds()
+  installAudioUnlockListeners()
 
   void poll()
   restartPollTimer()
 
   const onFocusOrVisible = () => {
     if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return
+    // Retoma o loop imediatamente ao voltar à aba (#652), sem esperar o poll
+    const fila = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
+    syncWppFilaBeep(fila)
     void poll()
   }
   window.addEventListener('focus', onFocusOrVisible)

--- a/frontend/src/hooks/useWhatsappVoltarLista.ts
+++ b/frontend/src/hooks/useWhatsappVoltarLista.ts
@@ -3,22 +3,38 @@ import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 
 import { resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../lib/whatsappListReturn'
 
+type VoltarListaApi = {
+  /** Botão Voltar (#449): history.back no SPA quando possível; senão lista segura. */
+  voltarLista: () => void
+  /**
+   * Esc / sair sem percorrer pilha de chats (#653): sempre lista de origem
+   * (state / ?from= / Atendendo) — nunca navigate(-1).
+   */
+  sairParaListaSegura: () => void
+}
+
 /**
- * Volta à lista WhatsApp de origem (#449): history.back() no SPA quando possível;
- * senão state whatsappListReturn, query ?from= ou atendimento.
+ * Navegação de saída da conversa WhatsApp.
+ * Voltar UI pode usar histórico; Esc deve ir à lista segura (#653).
  */
-export function useWhatsappVoltarLista(fallbackPath = WHATSAPP_LIST_PATHS.atendendo) {
+export function useWhatsappVoltarLista(fallbackPath = WHATSAPP_LIST_PATHS.atendendo): VoltarListaApi {
   const navigate = useNavigate()
   const location = useLocation()
   const [searchParams] = useSearchParams()
 
-  return useCallback(() => {
-    if (typeof window !== 'undefined' && window.history.length > 1) {
-      navigate(-1)
-      return
-    }
+  const sairParaListaSegura = useCallback(() => {
     navigate(
       resolveWhatsappListFallback(location.state, searchParams.get('from'), fallbackPath),
     )
   }, [navigate, location.state, searchParams, fallbackPath])
+
+  const voltarLista = useCallback(() => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      navigate(-1)
+      return
+    }
+    sairParaListaSegura()
+  }, [navigate, sairParaListaSegura])
+
+  return { voltarLista, sairParaListaSegura }
 }

--- a/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
@@ -102,9 +102,12 @@ export function WhatsappAvaliacoes() {
 
   useWhatsappListScrollRestore('avaliacoes', avaliacoesReturnPath, !loading)
 
+  // Carga inicial (respeita ?offset=). Paginação e «Filtrar» chamam load() explicitamente —
+  // mesmo padrão de #667 (Atendimentos).
   useEffect(() => {
-    void load(0)
-  }, [load])
+    void load(offset)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- só mount
+  }, [])
 
   useEffect(() => {
     void atendentes

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -478,7 +478,7 @@ export function WhatsappConversa() {
   const navigate = useNavigate()
   const location = useLocation()
   const [searchParams] = useSearchParams()
-  const voltarLista = useWhatsappVoltarLista()
+  const { voltarLista, sairParaListaSegura } = useWhatsappVoltarLista()
   const listaRetorno = resolveWhatsappListFallback(
     location.state,
     searchParams.get('from'),
@@ -490,6 +490,7 @@ export function WhatsappConversa() {
       if (e.key !== 'Escape' || e.defaultPrevented || modalEncerrar) return
       const tag = (e.target as HTMLElement | null)?.tagName?.toLowerCase()
       if (tag === 'input' || tag === 'textarea' || tag === 'select') return
+      // Overlays locais primeiro — não sair da conversa (#571 / #653)
       if (zoomMsgId != null) {
         e.preventDefault()
         e.stopPropagation()
@@ -502,11 +503,30 @@ export function WhatsappConversa() {
         setLegendaMidia('')
         return
       }
-      voltarLista()
+      if (filaAguardandoAberta) {
+        e.preventDefault()
+        setFilaAguardandoAberta(false)
+        return
+      }
+      if (menuMobileAberto) {
+        e.preventDefault()
+        setMenuMobileAberto(false)
+        return
+      }
+      // Sai para lista segura — nunca history.back pela pilha de chats (#653)
+      e.preventDefault()
+      sairParaListaSegura()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [voltarLista, modalEncerrar, zoomMsgId, arquivoPendente])
+  }, [
+    sairParaListaSegura,
+    modalEncerrar,
+    zoomMsgId,
+    arquivoPendente,
+    filaAguardandoAberta,
+    menuMobileAberto,
+  ])
 
   useEffect(() => {
     if (!menuMobileAberto) return

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -100,9 +100,12 @@ export function WhatsappHistorico() {
 
   useWhatsappListScrollRestore('historico', historicoReturnPath, !loading)
 
+  // Carga inicial (respeita ?offset=). Paginação e «Filtrar» chamam load() explicitamente —
+  // não reagir a [load], senão Próxima volta à página 1 (#667).
   useEffect(() => {
-    void load(0)
-  }, [load])
+    void load(offset)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- só mount
+  }, [])
 
   useEffect(() => {
     void atendentes


### PR DESCRIPTION
## Summary

Lote de correções WhatsApp/chat operacionais em produção:

- **Outbound + resposta**: deixa de abrir chat novo na fila (falso alerta de «novo atendimento») quando o `wa_id` chega em variante (DDI / nono dígito BR) ou como `@lid` com `senderPn` / `remoteJidAlt`
- **#667**: paginação de Atendimentos (e Avaliações) deixa de voltar sozinha para a página 1; `?offset=` respeitado
- **#651**: Silenciar corta o alerta na hora; loop toca o áudio completo e reinicia em sequência (sem gap de 5,2s)
- **#653**: Esc não usa `history.back` (não reabre chat encerrado); overlays locais primeiro; saída para lista segura
- **#652**: banner «Ativar alertas» pede permissão de notificações; com permissão, alerta via SO com aba em 2º plano / browser minimizado; áudio desbloqueado no gesto

Closes #667
Closes #651
Closes #653
Closes #652

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] Iniciar chat com número avulso → cliente responde (mesmo com variante de número / LID) → **não** entra na fila Aguardando nem toca alerta de fila; mensagem fica no chat `em_atendimento`
- [ ] Atendimentos: com >15 registos, **Próxima** permanece na página 2; recarregar com `?offset=15` mantém a página
- [ ] Fila com chat: alerta toca completo e reinicia sem silêncio; **Silenciar** corta na hora
- [ ] Esc: fecha lightbox/anexo/menu; sem overlay vai à lista de origem (não a chat encerrado da pilha); botão Voltar mantém history.back
- [ ] Banner «Ativar alertas» → Aceitar no browser → com aba em 2º plano, novo chat na fila gera notificação do SO
- [ ] `docker compose run --rm --no-deps backend pytest -q tests/test_whatsapp_wa_id_match.py tests/test_evolution_inbound_especiais.py tests/test_whatsapp_chats.py::test_inbound_apos_outbound_nao_abre_fila_com_variante_wa_id tests/test_whatsapp_chats.py::test_inbound_apos_outbound_resolve_lid_com_sender_pn`

## Follow-ups / backlog

- [x] **#652** limitado por política de autoplay do browser — notificação do SO é o caminho fiável em background (documentado no CHANGELOG / banner)
- [ ] #668 (LP modal) e #654/#655 (URLs) ficam fora deste lote
