### PR TITLE
feat(releases): notas por produto + fixes LP/login (#672)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,180 +5,29 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ## [Unreleased]
 
-### Corrigido
+### DeskRudder
 
-- WhatsApp: ao iniciar conversa com número avulso e o cliente responder, deixa de abrir chat novo na fila (alerta de «novo atendimento») quando o `wa_id` chega em variante (DDI / nono dígito BR) ou como `@lid` com `senderPn` / `remoteJidAlt`
-- WhatsApp (#667): em Atendimentos (e Avaliações), **Próxima** / **Anterior** deixam de voltar sozinhas para a página 1; o `offset` da URL é respeitado ao abrir/recarregar
-- Chat (#651): **Silenciar** na fila Aguardando corta o alerta na hora (loop + pulse); o toque passa a tocar completo e a reiniciar em sequência, sem intervalo de silêncio
-- WhatsApp (#653): **Esc** na conversa já não percorre o histórico do browser (evita reabrir chat encerrado); fecha overlays locais e, ao sair, vai à lista de origem (Atendendo / Aguardando / etc.)
-- Chat (#652): com a aba em segundo plano, novo chat na fila dispara notificação do sistema (se permitida) e o áudio é desbloqueado no primeiro clique; ao voltar à aba o alerta retoma de imediato
-- Chat (#652): banner no painel pede permissão de notificações («Ativar alertas») para avisar novos chats na fila mesmo com outra aba ou o navegador minimizado
-- Chat: duplo clique **dentro** do balão já não inicia resposta (dá para selecionar/copiar o texto); responder com duplo clique fica só **ao lado** do balão
-- WhatsApp: menu com seta no canto do balão para Editar/Apagar (em vez de botões flutuantes que saltavam para a mensagem de cima)
-- WhatsApp: Enter na legenda do anexo deixava de enviar a imagem **duas vezes** (o evento subia ao painel e disparava o envio de novo)
-- WhatsApp (#628): ao atender com vários setores, o modal «Escolher setor» voltava vazio (pedido com `limit` acima do máximo da API); a lista passa a carregar com paginação válida
-- Frontend: alinhamento de `react` e `react-dom` em **19.2.8** (o Dependabot tinha subido só o `react`, o que gerava tela preta com React error #527 em produção)
+#### Melhorias
 
-### Melhorias
+- Sobre: as notas de atualização passam a mostrar só o que mudou no helpdesk nesta instância; melhorias do painel SaaS deixam de aparecer misturadas (#672 / #674)
 
-- SaaS: **controle de licenças** — histórico/timeline na ficha, snapshot de módulos + limites na licença, preço/limites nos planos, e-mail de entrega com plano/módulos/acesso, conversão de lead com plano, `SAAS_MODULOS` no provisionamento e lista de instâncias no resumo
-- SaaS: catálogo comercial de **planos e módulos** (CRUD, activar/desactivar, seed Trial/Profissional/Enterprise); licença escolhe plano em vez de texto livre
-- SaaS: lista de licenças com **filtros** (plano, aprovação, provisionamento, renovação), cartões do resumo clicáveis e **escolha de plano** ao aprovar go-live
-- SaaS: após aprovar trial, em local Windows use `./deploy/scripts/saas-drain-queue.sh` para criar a base no host (a API no Docker não tem Docker socket)
-- SaaS: URL da instância deixa de ser campo livre — só o **nome da base (slug)**; URL = `https://{slug}.{domínio}/`; em local o «Abrir» usa a porta API (DNS público não resolve)
-- SaaS: trial só **pede aprovação**; **Aprovar e criar base** enfileira a criação da instância/Postgres
-- SaaS: **entrega pós-health** ao contacto (`entrega_notificada_em` + `reenviar-entrega`)
-- SaaS: lead → licença com **vínculo persistido** (`POST …/leads/{id}/converter` + `lead_id` no formulário)
-- SaaS: **suspender/reativar** pede (ou executa) `stack-client.sh down|up` e confirmação ops
-- SaaS: trial público entra com **aprovação pendente**; painel com **Aprovar go-live** / **Rejeitar** (`aprovacao_status`)
-- SaaS DeskRudder (#519 / #516 / #521–#528): painel de **licenças** (contactos, resumo ops, renovação flexível, lead→licença); **leads comerciais** da landing (formulário «Fale conosco», inbox `/saas/leads` — sem reutilizar o chat `/kb`); **provisionamento** em fila; **trial** em `/trial`; **renovações** com alertas e suspensão ao vencer
-- Comercial (#321 / #331–#335): simulador com desconto posto &lt;100k L (20% SM), override de custo/valor TEF só na proposta e snapshot imutável do pacote (catálogo TEF continua com valores padrão)
-- Comercial (#321 / #329–#334): catálogo de custos — salário mínimo com histórico por vigência (atualizar valor sem reescrever o passado), itens (% SM, valor fixo, TEF) e simulador em Cadastros → Catálogo de custos (admin)
-- Dashboard (#599): filtros de período Hoje | Esta semana (seg–dom) | Este mês | Mês passado | Personalizado no geral, tickets e WhatsApp (substitui 7/30/90); CSAT do geral respeita o intervalo
-- WhatsApp (#594): análise de demandas no dashboard — drill-down por natureza/motivo, ranking por empresa, insights (erro → atualização; dúvida → treinamento) e sugestão de novo motivo a partir de «Outros» repetido
-- Rede e Empresa (#595): aba Análises com tickets + demandas WhatsApp no período, insights e ranking (reutiliza #594/#599)
-- WhatsApp: na visualização ampliada de imagens, dá para fazer zoom (+/−, scroll e duplo clique), rodar e arrastar; repor volta à vista normal (também no chat interno)
-- WhatsApp (#628): no WhatsApp do cliente, mensagens do atendente saem com prefixo **setor do atendimento + nome** e o texto na linha de baixo (ex.: `[ Suporte - Ana ]:`); ao assumir, 1 setor é gravado automaticamente e vários setores pedem escolha no painel
-- WhatsApp (#629): no lightbox de imagens da conversa, dá para navegar entre as fotos (botões e setas ←/→) com contador e legenda atualizada; Esc continua a fechar só a visualização
-- WhatsApp (#630): foto de perfil do contacto no header e nas listas Atendendo/Aguardando (com cache e fallback para a inicial do nome)
-- WhatsApp (#630): reações no chat com o cliente — ver emoji do cliente no balão e o atendente responsável pode reagir (👍 ❤️ 😂 😮 😢 🙏); clique de novo remove
-- WhatsApp (#630): editar (até 15 min) e apagar para todos (até 48 h) mensagens de texto enviadas pelo responsável; também sincroniza quando o cliente edita ou apaga
-- WhatsApp: no header da conversa, o chip da empresa abre a página de detalhe da empresa (Voltar regressa ao chat); alterar empresa multi-empresa continua no menu ⋮
-- Chat (#626): ícone de som junto a **Aguardando** para silenciar/reativar o alerta contínuo da fila (WhatsApp + portal); preferência guardada no browser — não afeta alertas de ticket nem do chat interno
-- Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário
-- Portal (#600, #601): cadastro de funcionário pelo modal da Rede permite definir senha do portal na criação; sócio cadastra sem escolher empresas (escopo automático em toda a rede)
-- Portal (#604): RBAC por papel — colaborador vê só os próprios chamados; supervisor vê todos das empresas vinculadas; sócio vê toda a rede
-- Portal (#603): listagem e detalhe de atendimentos WhatsApp no `/portal` (somente leitura), com o mesmo escopo por papel e sem comentários internos da equipe
-- Portal (#602): sócio gere a equipa no `/portal` — cadastro e edição de colaboradores e supervisores (empresas, senha do portal); outros sócios listados com edição limitada; colaborador/supervisor recebem 403
-- Portal (#605): branding white-label no `/portal` — logo e cores da instância (mesmas configurações de Configurações → Base de conhecimento); login e shell aplicam a identidade do contratante, não a marca DeskRudder
-- Portal: shell alinhado ao painel DeskRudder (menu lateral com usuário/Sair, navbar com expandir/recolher); cor do menu lateral configurável (padrão = navbar); chat ao vivo no `/portal` (mesmo canal da `/kb`, isolado por instância); login com logo em destaque, ícone de olho na senha e fundo minimalista; título do portal independente da central `/kb`
-- WhatsApp (#593): ao **cadastrar** contacto no chat, o sistema sugere funcionários com nome semelhante para vincular (evita duplicados); o atendente pode ignorar e criar novo
-- WhatsApp (#591): no detalhe da **Empresa**, nova aba **Chats** com atendimentos filtrados por aquela empresa (busca, paginação, abrir conversa / retomar)
-- WhatsApp (#592): com funcionário em **mais de uma empresa**, o atendimento pode começar sem empresa; o atendente pergunta ao cliente e vincula (ou altera) a qualquer momento antes de encerrar — 1 empresa continua automática
-- WhatsApp (#590): na listagem **Atendimentos**, cada card mostra a **empresa** do contacto (ou «Sem empresa» quando não houver vínculo)
-- WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown (até o aviso e, após o aviso, até encerrar); enviar mensagem sai da pausa automaticamente
-- WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel
-- PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)
-- Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)
-- Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima
-- Equipe online: lista funciona com vários workers do servidor (presença gravada no banco); admin pode **Forçar saída** de um atendente conectado
-- Chat interno: balões mais próximos — opções/reações só no hover; em grupos, avatar e cor por pessoa para distinguir quem fala
-- Equipe online (#545–#547): administradores veem quem está com o painel aberto e desde quando (menu **Equipe online**), para coordenar atendimento de chats e tickets
-- Chat interno: no grupo, clique no nome na barra superior para ver participantes e administradores; admins promovidos também podem gerenciar membros
-- WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homónimos
-- WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos
-- WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede
-- Chat (#607): na aba **Atendendo**, secções **Comigo** e **Outros atendentes** quando o admin acompanha colegas; badge «Você» e destaque visual nos seus; nome do responsável legível nos de outros
-- WhatsApp (#606): conversa mais utilizável no **mobile** — composer com campo largo e botão de manuais só ícone; menu **⋮** com Transferir/Tickets; metadados em linha separada; painel de demandas colapsável; `safe-area` no composer
+#### Correções
 
-### Correções
+- Login (#677): em subdomínio do cliente, **Voltar ao site** abre a landing DeskRudder (apex) em vez de voltar ao próprio login
 
-- Chat (#625): ao **Ver** um chat da fila Aguardando, a lista com **Atender** permanece na lateral; na conversa há CTA **Atender** (WhatsApp e portal) para assumir sem voltar à lista
-- WhatsApp (#627): com anexo pendente, **Enter** na legenda (ou no painel, em áudio) envia o anexo — equivalente a «Enviar anexo»
-- WhatsApp (#608): duas mensagens inbound seguidas do mesmo contacto deixam de abrir dois chats/protocolos — lock por `wa_id` no webhook e uma única sequência de auto-mensagens por sessão
-- WhatsApp (#598): após encerrar com avaliação, janela de ~30 min (configurável) para a nota; se o cliente mandar outro texto, abre atendimento novo com essa mensagem; sem resposta, finaliza sozinho
-- WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** (somente leitura) até registar, manter demandas existentes ou confirmar sem demanda; nova mensagem do mesmo cliente abre chat novo na fila
-- WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat
-- WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)
-- WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda
-- WhatsApp (#571): Esc no zoom da imagem fecha só a visualização, sem sair do chat
-- WhatsApp (#576): cancelar gravação de áudio já não envia o ficheiro
-- WhatsApp (#573): ao reabrir o chat, o scroll volta à última posição vista (não salta para o início)
-- WhatsApp (#570): contacto já vinculado é reconhecido em chats novos do mesmo número
-- Modo escuro: texto digitado nos campos de pesquisa (listagens e chat interno) volta a ficar legível
-- Equipe online: «0 online» mesmo com painel aberto (lista lia só a memória do worker errado)
-- Chat interno: espaço excessivo entre mensagens após colocar ações/reações fora do balão
-- WhatsApp: o feed deixa de puxar sozinho para o fim enquanto você lê mensagens acima; ao reabrir a conversa, retoma a posição em que parou
-- Chat interno: ações (Responder/Editar/Apagar) e reações ficam fora do balão da mensagem
-- Chat interno: clique na imagem abre visualização em tela cheia (antes só tinha o cursor de zoom, sem ação)
-- Anexos de ticket: ficheiros deixam de desaparecer após atualização do sistema; se o arquivo já tiver sido perdido, o aviso deixa isso claro
-- WhatsApp: removido botão duplicado «Identificar contato» no header — fica só o do banner enquanto o contacto não está vinculado; após vincular o CTA some
-- WhatsApp: encerramento por inatividade só conta a partir da última mensagem do cliente quando o chat já está em atendimento e o atendente já enviou mensagem humana (auto_assumido/BOT não disparam o timer)
-- WhatsApp: Ctrl+V no composer cola imagem/ficheiro do clipboard (pré-visualização antes de enviar), como no chat interno
-- Chat: removida a borda branca de foco no campo de mensagem e nos demais inputs/textareas (outline nativo + alinhamento ao design system)
-- Chat interno: contraste no hover de Responder/Editar/Apagar; duplo clique na mensagem (ou ao lado do balão) inicia resposta e foca o composer — também no WhatsApp
-- WhatsApp / modais: ao digitar na descrição da demanda no **Encerrar atendimento**, o campo perdia o foco a cada atualização da conversa — diálogo já não refoca o painel; formulário não é limpo pelo poll
-- Sons de alerta: toque de **abertura de ticket** e de **novo chat** (fila WhatsApp/Portal) estavam trocados — ticket usa `notification.mp3` e chat na fila usa `alerta.mp3`
-- WhatsApp: conversa em atendimento disparava loop de pedidos a `/demandas` (e esgotava recursos do browser com `ERR_INSUFFICIENT_RESOURCES`) — o painel de demandas já não notifica o pai no carregamento inicial
-- WhatsApp (#473): modal de encerramento deixava de carregar demandas — polling da conversa refazia o fetch e mantinha «A carregar demandas…» em loop; demanda passa a ser opcional quando o chat encerra por inatividade
-- WhatsApp (#472): banner «contato não identificado» persistia após vincular/cadastrar — polling/SSE com snapshot antigo sobrescrevia o vínculo; sidebar e header atualizam na hora
-- WhatsApp (#471): cache de mídia por mensagem reduz refetch de blobs e mitiga `ERR_INSUFFICIENT_RESOURCES` no carregamento de anexos
-- WhatsApp: aviso de inatividade duplicado quando vários workers processavam o mesmo chat em paralelo (Gunicorn)
-- WhatsApp (#443/#454): painel de emoji e envio de figurinhas no composer; Histórico e Avaliações preservam posição de scroll ao voltar da conversa
-- WhatsApp (#449): corrigido link do Histórico/Avaliações para conversa — query `?from=` separada do `pathname` (React Router v7)
-- Notificações (#452): pendências de mensagem não lida abrem o ticket ou chat concreto (`/tickets/{id}`, `/whatsapp/c/{id}`) — removido fallback genérico para listagens
-- WhatsApp (#447): terminologia «contato do cliente» no chat e tickets — distingue colaborador da rede de atendente interno
-- WhatsApp (#453): ícones por tipo de ficheiro (PDF, Word, Excel, etc.) nas mensagens de documento
-- WhatsApp (#446): marco «Demanda registada» na timeline via evento interno + SSE em tempo real; removido ao excluir demanda
-- WhatsApp (#455): Histórico lista chats em atendimento — colegas do setor consultam e comentam internamente; ordenação e filtros de data corrigidos
-- WhatsApp (#443): barra de composição estilo WhatsApp Web (+ anexos, emoji e figurinhas, microfone à direita)
-- WhatsApp (#445): modal de encerramento substitui `confirm()` nativo — registo/edição de demandas, aviso quando houve conversa após última demanda, marco na timeline e `ConfirmDialog` reutilizável
-- WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape
-- WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)
-- WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais
-- WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker
-- WhatsApp (#441): áudio gravado pelo atendente enviado como nota de voz via `sendWhatsAppAudio` (encoding Evolution); falha explícita se a API não confirmar entrega
-- WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível
-- WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional
-- WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile
-- WhatsApp: mensagens de contacto e localização recebidas passam a aparecer como texto legível no chat
-- Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)
+### SaaS Control Plane
 
-### Melhorias
+#### Melhorias
 
-- Chat interno (IC-F1): API backend para conversas diretas entre atendentes e canal de comunicados por setor — inbox, mensagens, leitura (`/v1/chat-interno`); conversas diretas privadas (admin não vê conversas de terceiros)
-- Chat interno (IC-F2): mensagens internas no sino de notificações e evento SSE `chat.interno.mensagem`; contador `chat_interno_nao_lidas_count` no badge do navbar
-- Chat interno (IC-F3): inbox unificada, conversas diretas e canais de setor no menu Chat interno; comunicados com visual distinto; link no detalhe do setor; layout com lista lateral fixa para alternar conversas e ver não lidas
-- Chat interno (#495): anexos e mídia — upload, download, pré-visualização no painel e colar imagem (Ctrl+V) no composer
-- Chat operacional: hub unificado em `/chat` com abas Atendendo, Aguardando e Interno; tela **Atendimentos** no menu para consulta de chats abertos e encerrados (#485)
-- WhatsApp (#484): aba **Aguardando** no hub; no mobile, atalho na conversa abre a fila para assumir chats sem voltar à lista
-- Chat interno e WhatsApp: indicadores de envio, entrega e leitura nas mensagens (✓ / ✓✓)
-- Notificações: pendência do chat interno abre direto em `/chat/interno/{id}`
-- Chat interno (#503): editar e apagar mensagens de texto — autor ou admin; exclusão lógica com «Mensagem apagada»
-- Chat interno (#502): reações rápidas (👍 ❤️ 😂 😮 😢 🙏) em conversas diretas e canais de setor
-- Chat interno: editar e apagar para todos só nos primeiros 5 minutos; depois «apagar para mim»; opção de limpar conversa só para você
-- Chat interno: ao ler o histórico o scroll não volta sozinho para o fim; ao reabrir a conversa retoma na última mensagem visualizada
-- Chat interno (#505): paginação infinita — carrega mensagens recentes e busca histórico ao rolar para cima (50 por vez)
-- Chat interno (#506): editar legenda de mensagens com mídia (mesma janela de 5 minutos)
-- Chat interno (#507): grupos personalizados com até 50 atendentes; criador e admins promovidos gerenciam membros
-- WhatsApp (#470): áudio gravado na barra de composição é enviado automaticamente ao terminar a gravação (estilo WhatsApp Web)
-- Identidade visual (#434): marca DeskRudder no login e em todo o painel
-- WhatsApp (#485): menu «Atendimentos» unifica chats abertos e encerrados com filtro por status
-- Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp
-- Base de conhecimento (#465/#466): portal público `/kb` com logo e nome da empresa (Configurações → Empresa); listagem, busca e leitura de artigos sem login
-- Base de conhecimento (#467): personalização do portal em Configurações → Sistema → Base de conhecimento (cores da navbar, textos, links); menu lateral de categorias/subcategorias expansível no /kb; navbar com título centralizado, logo sem fundo branco e menu hamburger
-- Base de conhecimento (#469): visitantes do portal `/kb` avaliam manuais como úteis ou não; admin vê totais no artigo e pode ligar/desligar a avaliação nas configurações do portal
-- Base de conhecimento (#468): chat ao vivo no portal `/kb` — widget para visitantes; atendimento na mesma inbox WhatsApp (abas Aguardando/Atendendo) com badge Portal; protocolo unificado `#C`; mensagens automáticas, avaliação ao encerrar, anexos e áudio como no WhatsApp; transferência, demandas e encerramento com revisão
-- Base de conhecimento (#293–#299): menu **Ajuda** para consultar manuais durante o atendimento; gestão de categorias e artigos (admin); consulta integrada em tickets e WhatsApp; manuais «só para a equipe»; imagens no texto; histórico de versões; reordenar categorias arrastando; manuais consultados ficam disponíveis offline neste computador
-- Auditoria (#290–#292): trail expandido com payload, IP, request-id e user-agent; registro de atribuição, transferência, fechamento e reabertura de tickets, ações em chats WhatsApp, envio de e-mail ao cliente, visualização de credencial PDV e exportação de relatórios
-- Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id
-- Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)
-- Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável
-- Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats; edição via `PATCH`, marco na timeline e fluxo completo no modal de encerramento (#445)
-- SLA (#418): pausa automática da contagem quando o ticket está em status configurado (flag `pausa_sla`; «Aguardando cliente» ativado por padrão)
-- SLA: políticas opcionais por natureza do ticket; filtro «em risco» e dashboard usam o motor completo (calendário + pausa); prazo efetivo no card SLA
-- SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets
-- SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket
-- SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta
-- SLA (#280): painel admin em Configurações → Atendimento → SLA para CRUD de políticas por setor/prioridade
-- SLA (#281): badges e filtros na listagem de tickets e card de SLA no detalhe com countdown
-- Dashboard geral: card com quantidade de tickets abertos em violação de SLA, com atalho para a listagem filtrada (#416)
-- Dashboard geral: card com tickets abertos em risco de SLA, com atalho para a listagem filtrada
-- SLA (#417): CRUD de calendários comerciais em Configurações → Atendimento → SLA → Calendários (horário semanal e feriados nacionais)
-- Configurações WhatsApp: editor de horário semanal reutilizado (mesmo componente dos calendários SLA)
-- Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets
-- Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime
-- `aplicar_roteamento` restrito a administradores para sobrescrever setor explícito
-- UI em Configurações → Atendimento → Roteamento com simulador de teste seco
-- Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)
-- CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)
+- Painel SaaS: página **Sobre / Novidades** com o histórico só de entregas do control-plane (licenças, planos, provisionamento) (#672 / #675)
+- Release notes: CHANGELOG e API separam DeskRudder e SaaS no mesmo deploy CalVer (#672 / #673 / #676)
 
-### Interno / Infra
+#### Correções
 
-- Persistência do manifest de releases após cada deploy em staging
-- Deploy: volume Docker `backend_data` → `/app/data` (anexos, mídia WhatsApp/chat interno, KB e logos) no compose de produção e no template por cliente
+- Landing (#668): modal «Quero ver uma demonstração» fica centrado na tela, com scroll se o formulário for alto (deixa de cortar Nome/E-mail)
 
-<!-- Adicione bullets aqui a cada PR para main. Texto para o usuário final, não mensagem de commit. -->
+<!-- Adicione bullets sob ### DeskRudder ou ### SaaS Control Plane. Ver docs/RELEASES.md. -->
+
 
 ## [26.06.001] - 2026-06-22
 

--- a/backend/app/api/saas.py
+++ b/backend/app/api/saas.py
@@ -36,11 +36,13 @@ from app.schemas.saas import (
     SaasResumoRead,
     SaasTimelineEvent,
 )
+from app.schemas.system import ReleaseNotesRead
 from app.services import saas_aprovacao
 from app.services import saas_catalogo
 from app.services import saas_clientes as svc
 from app.services import saas_renovacoes
 from app.services.saas_resumo import obter_resumo
+from app.services.system_release import PRODUCT_SAAS, release_notes_payload
 
 router = APIRouter(prefix="/saas", tags=["saas"])
 
@@ -61,6 +63,15 @@ def exigir_saas_control_plane() -> None:
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Painel SaaS não disponível nesta instância",
         )
+
+
+@router.get("/release-notes", response_model=ReleaseNotesRead)
+def obter_saas_release_notes(
+    _: None = Depends(exigir_saas_control_plane),
+    __: Atendente = Depends(exigir_saas_ops),
+):
+    """Notas do control-plane SaaS — só bullets product=saas (#675)."""
+    return ReleaseNotesRead(**release_notes_payload(product=PRODUCT_SAAS))
 
 
 def _http_from_saas(exc: svc.SaasErro) -> HTTPException:

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -17,4 +17,5 @@ def obter_system_info(_: Atendente = Depends(obter_atendente_atual)):
 
 @router.get("/release-notes", response_model=ReleaseNotesRead)
 def obter_release_notes(_: Atendente = Depends(obter_atendente_atual)):
-    return ReleaseNotesRead(**release_notes_payload())
+    """Notas do DeskRudder (helpdesk na instância) — exclui bullets SaaS."""
+    return ReleaseNotesRead(**release_notes_payload(product="deskrudder"))

--- a/backend/app/data/release_notes.json
+++ b/backend/app/data/release_notes.json
@@ -1,39 +1,101 @@
 {
-  "current_version": "26.06.001",
-  "current_version_display": "v26.06.001",
+  "current_version": "26.08.006",
+  "current_version_display": "v26.08.006",
   "current": {
-    "version": "26.06.001",
-    "version_display": "v26.06.001",
-    "date": "2026-06-22",
+    "version": "26.08.006",
+    "version_display": "v26.08.006",
+    "date": "2026-08-12",
     "status": "published",
     "changes": [
       {
         "category": "melhorias",
-        "text": "Versão e notas de atualização no painel (página Sobre) (#404)"
+        "text": "WhatsApp: ao iniciar conversa com número avulso e o cliente responder, deixa de abrir chat novo na fila (alerta de «novo atendimento») quando o `wa_id` chega em variante (DDI / nono dígito BR) ou como `@lid` com `senderPn` / `remoteJidAlt`",
+        "product": "deskrudder"
       },
       {
         "category": "melhorias",
-        "text": "Distribuição automática de tickets na fila — modos manual, após timeout e imediato; estratégias round-robin e menor carga (#399)"
+        "text": "WhatsApp (#667): em Atendimentos (e Avaliações), **Próxima** / **Anterior** deixam de voltar sozinhas para a página 1; o `offset` da URL é respeitado ao abrir/recarregar",
+        "product": "deskrudder"
       },
       {
         "category": "melhorias",
-        "text": "Exibição do solicitante no detalhe do ticket e reconciliação inbound pós-cadastro (#392)"
+        "text": "Chat (#651): **Silenciar** na fila Aguardando corta o alerta na hora (loop + pulse); o toque passa a tocar completo e a reiniciar em sequência, sem intervalo de silêncio",
+        "product": "deskrudder"
       },
       {
         "category": "melhorias",
-        "text": "Relatórios de tickets e chats WhatsApp com exportação CSV (#390)"
+        "text": "WhatsApp (#653): **Esc** na conversa já não percorre o histórico do browser (evita reabrir chat encerrado); fecha overlays locais e, ao sair, vai à lista de origem (Atendendo / Aguardando / etc.)",
+        "product": "deskrudder"
       },
       {
-        "category": "correcoes",
-        "text": "E-mail de resposta ao cliente no Postgres (worker de outbox com timezone) (#397)"
+        "category": "melhorias",
+        "text": "Chat (#652): com a aba em segundo plano, novo chat na fila dispara notificação do sistema (se permitida) e o áudio é desbloqueado no primeiro clique; ao voltar à aba o alerta retoma de imediato",
+        "product": "deskrudder"
       },
       {
-        "category": "correcoes",
-        "text": "Notificações: paridade entre badge e itens do dropdown (#395)"
+        "category": "melhorias",
+        "text": "Chat (#652): banner no painel pede permissão de notificações («Ativar alertas») para avisar novos chats na fila mesmo com outra aba ou o navegador minimizado",
+        "product": "deskrudder"
       },
       {
-        "category": "correcoes",
-        "text": "Health check e capabilities com FastAPI 0.137+ (#394)"
+        "category": "melhorias",
+        "text": "SaaS: **controle de licenças** — histórico/timeline na ficha, snapshot de módulos + limites na licença, preço/limites nos planos, e-mail de entrega com plano/módulos/acesso, conversão de lead com plano, `SAAS_MODULOS` no provisionamento e lista de instâncias no resumo",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: catálogo comercial de **planos e módulos** (CRUD, activar/desactivar, seed Trial/Profissional/Enterprise); licença escolhe plano em vez de texto livre",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: lista de licenças com **filtros** (plano, aprovação, provisionamento, renovação), cartões do resumo clicáveis e **escolha de plano** ao aprovar go-live",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: URL da instância deixa de ser campo livre — só o **nome da base (slug)**; URL = `https://{slug}.{domínio}/`; em local o «Abrir» usa a porta API (DNS público não resolve)",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: trial só **pede aprovação**; **Aprovar e criar base** enfileira a criação da instância/Postgres",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: **entrega pós-health** ao contacto (`entrega_notificada_em` + `reenviar-entrega`)",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: lead → licença com **vínculo persistido** (`POST ./leads/{id}/converter` + `lead_id` no formulário)",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: **suspender/reativar** pede (ou executa) `stack-client.sh down|up` e confirmação ops",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: trial público entra com **aprovação pendente**; painel com **Aprovar go-live** / **Rejeitar** (`aprovacao_status`)",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS DeskRudder (#519 / #516 / #521–#528): painel de **licenças** (contactos, resumo ops, renovação flexível, lead→licença); **leads comerciais** da landing (formulário «Fale conosco», inbox `/saas/leads`); **provisionamento** em fila; **trial** em `/trial`; **renovações** com alertas e suspensão ao vencer",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "Comercial (#321 / #331–#335): simulador com desconto posto <100k L (20% SM), override de custo/valor TEF só na proposta e snapshot imutável do pacote (catálogo TEF continua com valores padrão)",
+        "product": "deskrudder"
+      },
+      {
+        "category": "melhorias",
+        "text": "Comercial (#321 / #329–#334): catálogo de custos — salário mínimo com histórico por vigência (atualizar valor sem reescrever o passado), itens (% SM, valor fixo, TEF) e simulador em Cadastros → Catálogo de custos (admin)",
+        "product": "deskrudder"
       }
     ]
   },
@@ -46,31 +108,1499 @@
       "changes": [
         {
           "category": "melhorias",
-          "text": "Versão e notas de atualização no painel (página Sobre) (#404)"
+          "text": "Versão e notas de atualização no painel (página Sobre) (#404)",
+          "product": "deskrudder"
         },
         {
           "category": "melhorias",
-          "text": "Distribuição automática de tickets na fila — modos manual, após timeout e imediato; estratégias round-robin e menor carga (#399)"
+          "text": "Distribuição automática de tickets na fila — modos manual, após timeout e imediato; estratégias round-robin e menor carga (#399)",
+          "product": "deskrudder"
         },
         {
           "category": "melhorias",
-          "text": "Exibição do solicitante no detalhe do ticket e reconciliação inbound pós-cadastro (#392)"
+          "text": "Exibição do solicitante no detalhe do ticket e reconciliação inbound pós-cadastro (#392)",
+          "product": "deskrudder"
         },
         {
           "category": "melhorias",
-          "text": "Relatórios de tickets e chats WhatsApp com exportação CSV (#390)"
+          "text": "Relatórios de tickets e chats WhatsApp com exportação CSV (#390)",
+          "product": "deskrudder"
         },
         {
           "category": "correcoes",
-          "text": "E-mail de resposta ao cliente no Postgres (worker de outbox com timezone) (#397)"
+          "text": "E-mail de resposta ao cliente no Postgres (worker de outbox com timezone) (#397)",
+          "product": "deskrudder"
         },
         {
           "category": "correcoes",
-          "text": "Notificações: paridade entre badge e itens do dropdown (#395)"
+          "text": "Notificações: paridade entre badge e itens do dropdown (#395)",
+          "product": "deskrudder"
         },
         {
           "category": "correcoes",
-          "text": "Health check e capabilities com FastAPI 0.137+ (#394)"
+          "text": "Health check e capabilities com FastAPI 0.137+ (#394)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.002",
+      "version_display": "v26.06.002",
+      "date": "2026-06-22",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Persistência do manifest de releases após cada deploy em staging",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.003",
+      "version_display": "v26.06.003",
+      "date": "2026-06-23",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#280): painel admin em Configurações → Atendimento → SLA para CRUD de políticas por setor/prioridade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#281): badges e filtros na listagem de tickets e card de SLA no detalhe com countdown",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "`aplicar_roteamento` restrito a administradores para sobrescrever setor explícito",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "UI em Configurações → Atendimento → Roteamento com simulador de teste seco",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Persistência do manifest de releases após cada deploy em staging",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.004",
+      "version_display": "v26.06.004",
+      "date": "2026-06-25",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#293–#299): menu **Ajuda** para consultar manuais durante o atendimento; gestão de categorias e artigos (admin); consulta integrada em tickets e WhatsApp; manuais «só para a equipe»; imagens no texto; histórico de versões; reordenar categorias arrastando; manuais consultados ficam disponíveis offline neste computador",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria (#290–#292): registro detalhado de ações no sistema (atribuição e transferência de tickets, chats WhatsApp, e-mails ao cliente, credenciais PDV e exportações)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do registro",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#418): pausa automática da contagem quando o ticket está em status «Aguardando cliente» (ativado por padrão)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA: políticas opcionais por natureza do ticket; filtro «em risco» e dashboard usam calendário comercial e pausa; prazo efetivo no card SLA",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com quantidade de tickets abertos em violação de SLA, com atalho para a listagem filtrada (#416)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com tickets abertos em risco de SLA, com atalho para a listagem filtrada",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#417): calendários comerciais em Configurações → Atendimento → SLA (horário semanal e feriados nacionais)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Configurações WhatsApp: editor de horário semanal reutilizado (mesmo componente dos calendários SLA)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.005",
+      "version_display": "v26.06.005",
+      "date": "2026-06-27",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: mensagens de contacto e localização recebidas passam a aparecer como texto legível no chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Identidade visual DeskRudder no painel (logos, login, favicon e componentes de marca)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.006",
+      "version_display": "v26.06.006",
+      "date": "2026-06-28",
+      "status": "published",
+      "changes": [
+        {
+          "category": "interno",
+          "text": "Atualização do sistema",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.007",
+      "version_display": "v26.06.007",
+      "date": "2026-06-28",
+      "status": "published",
+      "changes": [
+        {
+          "category": "interno",
+          "text": "Atualização do sistema",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.008",
+      "version_display": "v26.06.008",
+      "date": "2026-06-29",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#473): modal de encerramento deixava de carregar demandas — polling da conversa refazia o fetch e mantinha «A carregar demandas…» em loop; demanda passa a ser opcional quando o chat encerra por inatividade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#472): banner «contato não identificado» persistia após vincular/cadastrar — polling/SSE com snapshot antigo sobrescrevia o vínculo; sidebar e header atualizam na hora",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#471): cache de mídia por mensagem reduz refetch de blobs e mitiga `ERR_INSUFFICIENT_RESOURCES` no carregamento de anexos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: aviso de inatividade duplicado quando vários workers processavam o mesmo chat em paralelo (Gunicorn)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#443/#454): painel de emoji e envio de figurinhas no composer; Histórico e Avaliações preservam posição de scroll ao voltar da conversa",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#449): corrigido link do Histórico/Avaliações para conversa — query `?from=` separada do `pathname` (React Router v7)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Notificações (#452): pendências de mensagem não lida abrem o ticket ou chat concreto (`/tickets/{id}`, `/whatsapp/c/{id}`) — removido fallback genérico para listagens",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#447): terminologia «contato do cliente» no chat e tickets — distingue colaborador da rede de atendente interno",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#453): ícones por tipo de ficheiro (PDF, Word, Excel, etc.) nas mensagens de documento",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#446): marco «Demanda registada» na timeline via evento interno + SSE em tempo real; removido ao excluir demanda",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#455): Histórico lista chats em atendimento — colegas do setor consultam e comentam internamente; ordenação e filtros de data corrigidos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#443): barra de composição estilo WhatsApp Web (+ anexos, emoji e figurinhas, microfone à direita)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#445): modal de encerramento substitui `confirm()` nativo — registo/edição de demandas, aviso quando houve conversa após última demanda, marco na timeline e `ConfirmDialog` reutilizável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#441): áudio gravado pelo atendente enviado como nota de voz via `sendWhatsAppAudio` (encoding Evolution); falha explícita se a API não confirmar entrega",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: mensagens de contacto e localização recebidas passam a aparecer como texto legível no chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#470): áudio gravado na barra de composição é enviado automaticamente ao terminar a gravação (estilo WhatsApp Web)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Identidade visual (#434): painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#465/#466): portal público `/kb` com logo e nome da empresa (Configurações → Empresa); listagem, busca e leitura de artigos sem login",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#467): personalização do portal em Configurações → Sistema → Base de conhecimento (cores da navbar, textos, links); menu lateral de categorias/subcategorias expansível no /kb; navbar com título centralizado, logo sem fundo branco e menu hamburger",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#293–#299): menu **Ajuda** para consultar manuais durante o atendimento; gestão de categorias e artigos (admin); consulta integrada em tickets e WhatsApp; manuais «só para a equipe»; imagens no texto; histórico de versões; reordenar categorias arrastando; manuais consultados ficam disponíveis offline neste computador",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria (#290–#292): trail expandido com payload, IP, request-id e user-agent; registro de atribuição, transferência, fechamento e reabertura de tickets, ações em chats WhatsApp, envio de e-mail ao cliente, visualização de credencial PDV e exportação de relatórios",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats; edição via `PATCH`, marco na timeline e fluxo completo no modal de encerramento (#445)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#418): pausa automática da contagem quando o ticket está em status configurado (flag `pausa_sla`; «Aguardando cliente» ativado por padrão)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA: políticas opcionais por natureza do ticket; filtro «em risco» e dashboard usam o motor completo (calendário + pausa); prazo efetivo no card SLA",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#280): painel admin em Configurações → Atendimento → SLA para CRUD de políticas por setor/prioridade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#281): badges e filtros na listagem de tickets e card de SLA no detalhe com countdown",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com quantidade de tickets abertos em violação de SLA, com atalho para a listagem filtrada (#416)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com tickets abertos em risco de SLA, com atalho para a listagem filtrada",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#417): CRUD de calendários comerciais em Configurações → Atendimento → SLA → Calendários (horário semanal e feriados nacionais)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Configurações WhatsApp: editor de horário semanal reutilizado (mesmo componente dos calendários SLA)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "`aplicar_roteamento` restrito a administradores para sobrescrever setor explícito",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "UI em Configurações → Atendimento → Roteamento com simulador de teste seco",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Persistência do manifest de releases após cada deploy em staging",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.001",
+      "version_display": "v26.07.001",
+      "date": "2026-07-11",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#473): modal de encerramento deixava de carregar demandas — polling da conversa refazia o fetch e mantinha «A carregar demandas…» em loop; demanda passa a ser opcional quando o chat encerra por inatividade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#472): banner «contato não identificado» persistia após vincular/cadastrar — polling/SSE com snapshot antigo sobrescrevia o vínculo; sidebar e header atualizam na hora",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#471): cache de mídia por mensagem reduz refetch de blobs e mitiga `ERR_INSUFFICIENT_RESOURCES` no carregamento de anexos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: aviso de inatividade duplicado quando vários workers processavam o mesmo chat em paralelo (Gunicorn)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#443/#454): painel de emoji e envio de figurinhas no composer; Histórico e Avaliações preservam posição de scroll ao voltar da conversa",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#449): corrigido link do Histórico/Avaliações para conversa — query `?from=` separada do `pathname` (React Router v7)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Notificações (#452): pendências de mensagem não lida abrem o ticket ou chat concreto (`/tickets/{id}`, `/whatsapp/c/{id}`) — removido fallback genérico para listagens",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#447): terminologia «contato do cliente» no chat e tickets — distingue colaborador da rede de atendente interno",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#453): ícones por tipo de ficheiro (PDF, Word, Excel, etc.) nas mensagens de documento",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#446): marco «Demanda registada» na timeline via evento interno + SSE em tempo real; removido ao excluir demanda",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#455): Histórico lista chats em atendimento — colegas do setor consultam e comentam internamente; ordenação e filtros de data corrigidos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#443): barra de composição estilo WhatsApp Web (+ anexos, emoji e figurinhas, microfone à direita)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#445): modal de encerramento substitui `confirm()` nativo — registo/edição de demandas, aviso quando houve conversa após última demanda, marco na timeline e `ConfirmDialog` reutilizável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#441): áudio gravado pelo atendente enviado como nota de voz via `sendWhatsAppAudio` (encoding Evolution); falha explícita se a API não confirmar entrega",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: mensagens de contacto e localização recebidas passam a aparecer como texto legível no chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (IC-F1): API backend para conversas diretas entre atendentes e canal de comunicados por setor — inbox, mensagens, leitura (`/v1/chat-interno`); conversas diretas privadas (admin não vê conversas de terceiros)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (IC-F2): mensagens internas no sino de notificações e evento SSE `chat.interno.mensagem`; contador `chat_interno_nao_lidas_count` no badge do navbar",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (IC-F3): inbox unificada, conversas diretas e canais de setor no menu Chat interno; comunicados com visual distinto; link no detalhe do setor; layout com lista lateral fixa para alternar conversas e ver não lidas",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#495): anexos e mídia — upload, download, pré-visualização no painel e colar imagem (Ctrl+V) no composer",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat operacional: hub unificado em `/chat` com abas Atendendo, Espera e Interno; Histórico permanece em menu separado",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno e WhatsApp: indicadores de envio, entrega e leitura nas mensagens (✓ / ✓✓)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Notificações: pendência do chat interno abre direto em `/chat/interno/{id}`",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#503): editar e apagar mensagens de texto — autor ou admin; exclusão lógica com «Mensagem apagada»",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#502): reações rápidas (👍 ❤️ 😂 😮 😢 🙏) em conversas diretas e canais de setor",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: editar e apagar para todos só nos primeiros 5 minutos; depois «apagar para mim»; opção de limpar conversa só para você",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: ao ler o histórico o scroll não volta sozinho para o fim; ao reabrir a conversa retoma na última mensagem visualizada",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#505): paginação infinita — carrega mensagens recentes e busca histórico ao rolar para cima (50 por vez)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#506): editar legenda de mensagens com mídia (mesma janela de 5 minutos)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#507): grupos personalizados com até 50 atendentes; criador e admins promovidos gerenciam membros",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#470): áudio gravado na barra de composição é enviado automaticamente ao terminar a gravação (estilo WhatsApp Web)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Identidade visual (#434): painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#465/#466): portal público `/kb` com logo e nome da empresa (Configurações → Empresa); listagem, busca e leitura de artigos sem login",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#467): personalização do portal em Configurações → Sistema → Base de conhecimento (cores da navbar, textos, links); menu lateral de categorias/subcategorias expansível no /kb; navbar com título centralizado, logo sem fundo branco e menu hamburger",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#293–#299): menu **Ajuda** para consultar manuais durante o atendimento; gestão de categorias e artigos (admin); consulta integrada em tickets e WhatsApp; manuais «só para a equipe»; imagens no texto; histórico de versões; reordenar categorias arrastando; manuais consultados ficam disponíveis offline neste computador",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria (#290–#292): trail expandido com payload, IP, request-id e user-agent; registro de atribuição, transferência, fechamento e reabertura de tickets, ações em chats WhatsApp, envio de e-mail ao cliente, visualização de credencial PDV e exportação de relatórios",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats; edição via `PATCH`, marco na timeline e fluxo completo no modal de encerramento (#445)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#418): pausa automática da contagem quando o ticket está em status configurado (flag `pausa_sla`; «Aguardando cliente» ativado por padrão)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA: políticas opcionais por natureza do ticket; filtro «em risco» e dashboard usam o motor completo (calendário + pausa); prazo efetivo no card SLA",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#280): painel admin em Configurações → Atendimento → SLA para CRUD de políticas por setor/prioridade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#281): badges e filtros na listagem de tickets e card de SLA no detalhe com countdown",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com quantidade de tickets abertos em violação de SLA, com atalho para a listagem filtrada (#416)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com tickets abertos em risco de SLA, com atalho para a listagem filtrada",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#417): CRUD de calendários comerciais em Configurações → Atendimento → SLA → Calendários (horário semanal e feriados nacionais)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Configurações WhatsApp: editor de horário semanal reutilizado (mesmo componente dos calendários SLA)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "`aplicar_roteamento` restrito a administradores para sobrescrever setor explícito",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "UI em Configurações → Atendimento → Roteamento com simulador de teste seco",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Persistência do manifest de releases após cada deploy em staging",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.002",
+      "version_display": "v26.07.002",
+      "date": "2026-07-11",
+      "status": "published",
+      "changes": [
+        {
+          "category": "interno",
+          "text": "Atualização do sistema",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.003",
+      "version_display": "v26.07.003",
+      "date": "2026-07-14",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: conversa em atendimento disparava loop de pedidos a `/demandas` (e esgotava recursos do browser com `ERR_INSUFFICIENT_RESOURCES`) — o painel de demandas já não notifica o pai no carregamento inicial",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#468): chat ao vivo no portal `/kb` — widget para visitantes; atendimento na mesma inbox WhatsApp (abas Aguardando/Atendendo) com badge Portal; protocolo unificado `#C`; mensagens automáticas, avaliação ao encerrar, anexos e áudio como no WhatsApp; transferência, demandas e encerramento com revisão",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.004",
+      "version_display": "v26.07.004",
+      "date": "2026-07-15",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Sons de alerta: toque de **abertura de ticket** e de **novo chat** (fila WhatsApp/Portal) estavam trocados — ticket usa `notification.mp3` e chat na fila usa `alerta.mp3`",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.005",
+      "version_display": "v26.07.005",
+      "date": "2026-07-15",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.006",
+      "version_display": "v26.07.006",
+      "date": "2026-07-15",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Chat (#539): após enviar mensagem (WhatsApp e chat interno), o cursor permanece no campo de texto; painel de emoji fica aberto ao escolher vários; **Responder** mensagem no chat interno (direta, equipe e grupo)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homônimos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp / modais: ao digitar na descrição da demanda no **Encerrar atendimento**, o campo perdia o foco a cada atualização da conversa — diálogo já não refoca o painel; formulário não é limpo pelo poll",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.007",
+      "version_display": "v26.07.007",
+      "date": "2026-07-16",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: removido botão duplicado «Identificar contato» no header — fica só o do banner enquanto o contacto não está vinculado; após vincular o CTA some",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: encerramento por inatividade só conta a partir da última mensagem do cliente quando o chat já está em atendimento e o atendente já enviou mensagem humana (auto_assumido/BOT não disparam o timer)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: Ctrl+V no composer cola imagem/ficheiro do clipboard (pré-visualização antes de enviar), como no chat interno",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat: removida a borda branca de foco no campo de mensagem e nos demais inputs/textareas (outline nativo + alinhamento ao design system)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: contraste no hover de Responder/Editar/Apagar; duplo clique na mensagem (ou ao lado do balão) inicia resposta e foca o composer — também no WhatsApp",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.008",
+      "version_display": "v26.07.008",
+      "date": "2026-07-16",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Equipe online (#545–#547): administradores veem quem está com o painel aberto e desde quando (menu **Equipe online**), para coordenar atendimento de chats e tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#539): após enviar mensagem (WhatsApp e chat interno), o cursor permanece no campo de texto; painel de emoji fica aberto ao escolher vários; **Responder** mensagem no chat interno (direta, equipe e grupo)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homónimos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: o feed deixa de puxar sozinho para o fim enquanto você lê mensagens acima; ao reabrir a conversa, retoma a posição em que parou",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: ações (Responder/Editar/Apagar) e reações ficam fora do balão da mensagem",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: clique na imagem abre visualização em tela cheia (antes só tinha o cursor de zoom, sem ação)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Anexos de ticket: ficheiros deixam de desaparecer após atualização do sistema; se o arquivo já tiver sido perdido, o aviso deixa isso claro",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.009",
+      "version_display": "v26.07.009",
+      "date": "2026-07-16",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Chat interno (grupos/canal): menções com `@` — autocomplete de participantes e `@all` (todos); destaque visual na mensagem",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Equipe online: lista funciona com vários workers do servidor (presença gravada no banco); admin pode **Forçar saída** de um atendente conectado",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: balões mais próximos — opções/reações só no hover; em grupos, avatar e cor por pessoa para distinguir quem fala",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Equipe online: «0 online» mesmo com painel aberto (lista lia só a memória do worker errado)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: espaço excessivo entre mensagens após colocar ações/reações fora do balão",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.010",
+      "version_display": "v26.07.010",
+      "date": "2026-07-17",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.011",
+      "version_display": "v26.07.011",
+      "date": "2026-07-17",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Modo escuro: texto digitado nos campos de pesquisa (listagens e chat interno) volta a ficar legível",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.012",
+      "version_display": "v26.07.012",
+      "date": "2026-07-18",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown no chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#571): Esc no zoom da imagem fecha só a visualização, sem sair do chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#576): cancelar gravação de áudio já não envia o ficheiro",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#573): ao reabrir o chat, o scroll volta à última posição vista (não salta para o início)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#570): contacto já vinculado é reconhecido em chats novos do mesmo número",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.013",
+      "version_display": "v26.07.013",
+      "date": "2026-07-18",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#577): countdown até o aviso e, após o aviso, até encerrar; enviar mensagem (ou o cliente falar) sai automaticamente da pausa",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** (somente leitura) até registar, manter demandas existentes ou confirmar sem demanda; nova mensagem do mesmo cliente abre chat novo na fila",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.014",
+      "version_display": "v26.07.014",
+      "date": "2026-07-22",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#600, #601): cadastro de funcionário pelo modal da Rede permite definir senha do portal na criação; sócio cadastra sem escolher empresas (escopo automático em toda a rede)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#604): RBAC por papel — colaborador vê só os próprios chamados; supervisor vê todos das empresas vinculadas; sócio vê toda a rede",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#603): listagem e detalhe de atendimentos WhatsApp no `/portal` (somente leitura), com o mesmo escopo por papel e sem comentários internos da equipe",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#602): sócio gere a equipa no `/portal` — cadastro e edição de colaboradores e supervisores (empresas, senha do portal); outros sócios listados com edição limitada; colaborador/supervisor recebem 403",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#605): branding white-label no `/portal` — logo e cores da instância (mesmas configurações de Configurações → Base de conhecimento); login e shell aplicam a identidade do contratante, não a marca DeskRudder",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal: shell alinhado ao painel DeskRudder (menu lateral com usuário/Sair, navbar com expandir/recolher); cor do menu lateral configurável (padrão = navbar); chat ao vivo no `/portal` (mesmo canal da `/kb`, isolado por instância); login com logo em destaque, ícone de olho na senha e fundo minimalista; título do portal independente da central `/kb`",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#593): ao **cadastrar** contacto no chat, o sistema sugere funcionários com nome semelhante para vincular (evita duplicados); o atendente pode ignorar e criar novo",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#591): no detalhe da **Empresa**, nova aba **Chats** com atendimentos filtrados por aquela empresa (busca, paginação, abrir conversa / retomar)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#592): com funcionário em **mais de uma empresa**, o atendimento pode começar sem empresa; o atendente pergunta ao cliente e vincula (ou altera) a qualquer momento antes de encerrar — 1 empresa continua automática",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#590): na listagem **Atendimentos**, cada card mostra a **empresa** do contacto (ou «Sem empresa» quando não houver vínculo)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#607): na aba **Atendendo**, secções **Comigo** e **Outros atendentes** quando o admin acompanha colegas; badge «Você» e destaque visual nos seus; nome do responsável legível nos de outros",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#606): conversa mais utilizável no **mobile** — composer com campo largo e botão de manuais só ícone; menu **⋮** com Transferir/Tickets; metadados em linha separada; painel de demandas colapsável; `safe-area` no composer",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#608): duas mensagens inbound seguidas do mesmo contacto deixam de abrir dois chats/protocolos — lock por `wa_id` no webhook e uma única sequência de auto-mensagens por sessão",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#598): após encerrar com avaliação, janela de ~30 min (configurável) para a nota; se o cliente mandar outro texto, abre atendimento novo com essa mensagem; sem resposta, finaliza sozinho",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.001",
+      "version_display": "v26.08.001",
+      "date": "2026-08-02",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#628): no WhatsApp do cliente, mensagens do atendente saem com prefixo **setor do atendimento + nome** e o texto na linha de baixo (ex.: `[ Suporte - Ana ]:`); ao assumir, 1 setor é gravado automaticamente e vários setores pedem escolha no painel",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#629): no lightbox de imagens da conversa, dá para navegar entre as fotos (botões e setas ←/→) com contador e legenda atualizada; Esc continua a fechar só a visualização",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#630): foto de perfil do contacto no header e nas listas Atendendo/Aguardando (com cache e fallback para a inicial do nome)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#630): reações no chat com o cliente — ver emoji do cliente no balão e o atendente responsável pode reagir (👍 ❤️ 😂 😮 😢 🙏); clique de novo remove",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#630): editar (até 15 min) e apagar para todos (até 48 h) mensagens de texto enviadas pelo responsável; também sincroniza quando o cliente edita ou apaga",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: no header da conversa, o chip da empresa abre a página de detalhe da empresa (Voltar regressa ao chat); alterar empresa multi-empresa continua no menu ⋮",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#626): ícone de som junto a **Aguardando** para silenciar/reativar o alerta contínuo da fila (WhatsApp + portal); preferência guardada no browser — não afeta alertas de ticket nem do chat interno",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#625): ao **Ver** um chat da fila Aguardando, a lista com **Atender** permanece na lateral; na conversa há CTA **Atender** (WhatsApp e portal) para assumir sem voltar à lista",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#627): com anexo pendente, **Enter** na legenda (ou no painel, em áudio) envia o anexo — equivalente a «Enviar anexo»",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Login / site: «Voltar ao site» e hosts DeskRudder apontam para deskrudder.com.br (redirect da apex connect)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.002",
+      "version_display": "v26.08.002",
+      "date": "2026-08-02",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Frontend: alinhamento de `react` e `react-dom` em **19.2.8** (o Dependabot tinha subido só o `react`, o que gerava tela preta com React error #527 em produção)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.003",
+      "version_display": "v26.08.003",
+      "date": "2026-08-02",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#628): ao atender com vários setores, o modal «Escolher setor» voltava vazio (pedido com `limit` acima do máximo da API); a lista passa a carregar com paginação válida",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.004",
+      "version_display": "v26.08.004",
+      "date": "2026-08-02",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: na visualização ampliada de imagens, dá para fazer zoom (+/−, scroll e duplo clique), rodar e arrastar; repor volta à vista normal (também no chat interno)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat: duplo clique **dentro** do balão já não inicia resposta (dá para selecionar/copiar o texto); responder com duplo clique fica só **ao lado** do balão",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: menu com seta no canto do balão para Editar/Apagar (em vez de botões flutuantes que saltavam para a mensagem de cima)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: Enter na legenda do anexo deixava de enviar a imagem **duas vezes** (o evento subia ao painel e disparava o envio de novo)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.005",
+      "version_display": "v26.08.005",
+      "date": "2026-08-03",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Dashboard (#599): filtros de período Hoje | Esta semana (seg–dom) | Este mês | Mês passado | Personalizado no geral, tickets e WhatsApp (substitui 7/30/90); CSAT do geral respeita o intervalo",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#594): análise de demandas no dashboard — drill-down por natureza/motivo, ranking por empresa, insights (erro → atualização; dúvida → treinamento) e sugestão de novo motivo a partir de «Outros» repetido",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Rede e Empresa (#595): aba Análises com tickets + demandas WhatsApp no período, insights e ranking (reutiliza #594/#599)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.006",
+      "version_display": "v26.08.006",
+      "date": "2026-08-12",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: ao iniciar conversa com número avulso e o cliente responder, deixa de abrir chat novo na fila (alerta de «novo atendimento») quando o `wa_id` chega em variante (DDI / nono dígito BR) ou como `@lid` com `senderPn` / `remoteJidAlt`",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#667): em Atendimentos (e Avaliações), **Próxima** / **Anterior** deixam de voltar sozinhas para a página 1; o `offset` da URL é respeitado ao abrir/recarregar",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#651): **Silenciar** na fila Aguardando corta o alerta na hora (loop + pulse); o toque passa a tocar completo e a reiniciar em sequência, sem intervalo de silêncio",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#653): **Esc** na conversa já não percorre o histórico do browser (evita reabrir chat encerrado); fecha overlays locais e, ao sair, vai à lista de origem (Atendendo / Aguardando / etc.)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#652): com a aba em segundo plano, novo chat na fila dispara notificação do sistema (se permitida) e o áudio é desbloqueado no primeiro clique; ao voltar à aba o alerta retoma de imediato",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#652): banner no painel pede permissão de notificações («Ativar alertas») para avisar novos chats na fila mesmo com outra aba ou o navegador minimizado",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: **controle de licenças** — histórico/timeline na ficha, snapshot de módulos + limites na licença, preço/limites nos planos, e-mail de entrega com plano/módulos/acesso, conversão de lead com plano, `SAAS_MODULOS` no provisionamento e lista de instâncias no resumo",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: catálogo comercial de **planos e módulos** (CRUD, activar/desactivar, seed Trial/Profissional/Enterprise); licença escolhe plano em vez de texto livre",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: lista de licenças com **filtros** (plano, aprovação, provisionamento, renovação), cartões do resumo clicáveis e **escolha de plano** ao aprovar go-live",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: URL da instância deixa de ser campo livre — só o **nome da base (slug)**; URL = `https://{slug}.{domínio}/`; em local o «Abrir» usa a porta API (DNS público não resolve)",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: trial só **pede aprovação**; **Aprovar e criar base** enfileira a criação da instância/Postgres",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: **entrega pós-health** ao contacto (`entrega_notificada_em` + `reenviar-entrega`)",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: lead → licença com **vínculo persistido** (`POST ./leads/{id}/converter` + `lead_id` no formulário)",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: **suspender/reativar** pede (ou executa) `stack-client.sh down|up` e confirmação ops",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: trial público entra com **aprovação pendente**; painel com **Aprovar go-live** / **Rejeitar** (`aprovacao_status`)",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS DeskRudder (#519 / #516 / #521–#528): painel de **licenças** (contactos, resumo ops, renovação flexível, lead→licença); **leads comerciais** da landing (formulário «Fale conosco», inbox `/saas/leads`); **provisionamento** em fila; **trial** em `/trial`; **renovações** com alertas e suspensão ao vencer",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "Comercial (#321 / #331–#335): simulador com desconto posto <100k L (20% SM), override de custo/valor TEF só na proposta e snapshot imutável do pacote (catálogo TEF continua com valores padrão)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Comercial (#321 / #329–#334): catálogo de custos — salário mínimo com histórico por vigência (atualizar valor sem reescrever o passado), itens (% SM, valor fixo, TEF) e simulador em Cadastros → Catálogo de custos (admin)",
+          "product": "deskrudder"
         }
       ]
     }

--- a/backend/app/schemas/system.py
+++ b/backend/app/schemas/system.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict
 class ReleaseChangeRead(BaseModel):
     category: str
     text: str
+    product: str | None = None
 
 
 class ReleaseRead(BaseModel):

--- a/backend/app/services/system_release.py
+++ b/backend/app/services/system_release.py
@@ -1,4 +1,4 @@
-"""Versão CalVer e release notes (#401)."""
+"""Versão CalVer e release notes (#401 / #673)."""
 
 from __future__ import annotations
 
@@ -13,6 +13,10 @@ from app.config import settings
 
 _DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 _REPO_ROOT = Path(__file__).resolve().parents[3]
+
+PRODUCT_DESKRUDDER = "deskrudder"
+PRODUCT_SAAS = "saas"
+VALID_PRODUCTS = frozenset({PRODUCT_DESKRUDDER, PRODUCT_SAAS})
 
 _LEGACY_BRAND_RE = re.compile(r"DX/Duplexsoft|Duplexsoft|DX Connect|DX-Connect", re.IGNORECASE)
 
@@ -86,10 +90,48 @@ def reload_release_notes_cache() -> None:
     _load_release_notes_raw.cache_clear()
 
 
-def release_notes_payload(*, version_override: str | None = None) -> dict[str, Any]:
+def _change_product(ch: dict[str, Any]) -> str:
+    raw = ch.get("product")
+    if isinstance(raw, str) and raw.strip().lower() in VALID_PRODUCTS:
+        return raw.strip().lower()
+    return PRODUCT_DESKRUDDER
+
+
+def _filter_release_for_product(rel: dict[str, Any], product: str) -> dict[str, Any] | None:
+    changes = []
+    for ch in rel.get("changes") or []:
+        if not isinstance(ch, dict):
+            continue
+        if _change_product(ch) != product:
+            continue
+        item = dict(ch)
+        item["product"] = product
+        changes.append(item)
+    if not changes:
+        return None
+    out = dict(rel)
+    out["changes"] = changes
+    return out
+
+
+def release_notes_payload(
+    *,
+    version_override: str | None = None,
+    product: str = PRODUCT_DESKRUDDER,
+) -> dict[str, Any]:
+    product_key = (product or PRODUCT_DESKRUDDER).strip().lower()
+    if product_key not in VALID_PRODUCTS:
+        product_key = PRODUCT_DESKRUDDER
+
     raw = _load_release_notes_raw()
     version = version_override or resolve_app_version()
-    releases: list[dict[str, Any]] = [_sanitize_release(r) or r for r in (raw.get("releases") or [])]
+    releases_all: list[dict[str, Any]] = [_sanitize_release(r) or r for r in (raw.get("releases") or [])]
+
+    releases: list[dict[str, Any]] = []
+    for rel in releases_all:
+        filtered = _filter_release_for_product(rel, product_key)
+        if filtered is not None:
+            releases.append(filtered)
 
     current = None
     if version:
@@ -97,6 +139,13 @@ def release_notes_payload(*, version_override: str | None = None) -> dict[str, A
             if rel.get("version") == version:
                 current = rel
                 break
+        if current is None:
+            # Versão atual pode não ter bullets deste produto — ainda assim
+            # tente achar a release bruta só para metadados (sem misturar produtos).
+            for rel in releases_all:
+                if rel.get("version") == version:
+                    current = _filter_release_for_product(rel, product_key)
+                    break
         if current is None and releases:
             current = releases[-1]
 

--- a/backend/tests/test_check_changelog.py
+++ b/backend/tests/test_check_changelog.py
@@ -1,22 +1,33 @@
-"""Testes do validador de CHANGELOG (#400)."""
+"""Testes do validador de CHANGELOG (#400 / #673)."""
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS = ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
-from check_changelog import parse_unreleased_bullets, requires_changelog  # noqa: E402
+from check_changelog import (  # noqa: E402
+    is_saas_path,
+    parse_unreleased_bullets,
+    products_required_by_paths,
+    requires_changelog,
+)
+from prepare_release import parse_changelog_unreleased  # noqa: E402
 
 
 def test_parse_unreleased_bullets():
     text = """## [Unreleased]
 
-### Melhorias
+### DeskRudder
+
+#### Melhorias
 
 - Item A (#1)
 
@@ -27,17 +38,68 @@ def test_parse_unreleased_bullets():
     assert parse_unreleased_bullets(text) == ["Item A (#1)"]
 
 
+def test_parse_changelog_com_produtos():
+    text = """## [Unreleased]
+
+### DeskRudder
+
+#### Correções
+
+- Fix chat (#1)
+
+### SaaS Control Plane
+
+#### Melhorias
+
+- Licenças (#2)
+"""
+    changes = parse_changelog_unreleased(text, warn_legacy=False)
+    assert len(changes) == 2
+    assert changes[0] == {"product": "deskrudder", "category": "correcoes", "text": "Fix chat (#1)"}
+    assert changes[1] == {"product": "saas", "category": "melhorias", "text": "Licenças (#2)"}
+
+
+def test_parse_changelog_legado_vira_deskrudder():
+    text = """## [Unreleased]
+
+### Corrigido
+
+- Algo antigo (#9)
+"""
+    changes = parse_changelog_unreleased(text, warn_legacy=False)
+    assert changes == [{"product": "deskrudder", "category": "correcoes", "text": "Algo antigo (#9)"}]
+
+
 def test_requires_changelog_product_paths():
     assert requires_changelog(["frontend/src/pages/Foo.tsx"]) is True
     assert requires_changelog(["docs/RELEASES.md"]) is False
     assert requires_changelog(["CHANGELOG.md"]) is False
 
 
+def test_saas_path_heuristic():
+    assert is_saas_path("frontend/src/pages/saas/SaasSobre.tsx") is True
+    assert is_saas_path("backend/app/api/saas.py") is True
+    assert is_saas_path("backend/app/services/saas_clientes.py") is True
+    assert is_saas_path("frontend/src/pages/Sobre.tsx") is False
+
+
+def test_products_required_by_paths_misto():
+    needed = products_required_by_paths(
+        [
+            "frontend/src/pages/saas/SaasSobre.tsx",
+            "frontend/src/pages/Sobre.tsx",
+        ]
+    )
+    assert needed == {"deskrudder", "saas"}
+
+
 def test_check_changelog_script_ok_without_product_diff():
+    if shutil.which("git") is None:
+        pytest.skip("git não está na PATH (imagem backend sem git; CI tem)")
     r = subprocess.run(
         [sys.executable, str(SCRIPTS / "check_changelog.py"), "--base", "HEAD", "--head", "HEAD"],
         cwd=ROOT,
         capture_output=True,
         text=True,
     )
-    assert r.returncode == 0
+    assert r.returncode == 0, r.stderr or r.stdout

--- a/backend/tests/test_migrate_release_notes_product.py
+++ b/backend/tests/test_migrate_release_notes_product.py
@@ -1,0 +1,44 @@
+"""Testes do migrador de product no manifest (#676)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from migrate_release_notes_product import classify_product, migrate_manifest  # noqa: E402
+
+
+def test_classify_saas_prefix():
+    assert classify_product("SaaS: licenças") == "saas"
+    assert classify_product("SaaS DeskRudder (#519): painel") == "saas"
+    assert classify_product("WhatsApp: fila") == "deskrudder"
+    assert classify_product("Comercial (#321): simulador") == "deskrudder"
+
+
+def test_migrate_manifest_idempotent():
+    data = {
+        "releases": [
+            {
+                "version": "26.08.006",
+                "changes": [
+                    {"category": "melhorias", "text": "SaaS: planos"},
+                    {"category": "correcoes", "text": "Chat (#651)"},
+                    {"product": "saas", "category": "melhorias", "text": "SaaS: já tagueado"},
+                ],
+            }
+        ]
+    }
+    migrated, stats = migrate_manifest(data)
+    changes = migrated["releases"][0]["changes"]
+    assert changes[0]["product"] == "saas"
+    assert changes[1]["product"] == "deskrudder"
+    assert changes[2]["product"] == "saas"
+    assert stats["saas"] == 2
+    assert stats["deskrudder"] == 1
+    again, stats2 = migrate_manifest(migrated)
+    assert again == migrated
+    assert stats2["kept"] == 3

--- a/backend/tests/test_system_release.py
+++ b/backend/tests/test_system_release.py
@@ -180,6 +180,77 @@ def test_system_release_notes_sanitize_legacy_brand(client, auth_headers, monkey
     assert "DeskRudder" in text
 
 
+def test_system_release_notes_filters_by_product(client, auth_headers, monkeypatch, tmp_path):
+    data_path = tmp_path / "release_notes.json"
+    payload = {
+        "current_version": "26.08.006",
+        "current_version_display": "v26.08.006",
+        "releases": [
+            {
+                "version": "26.08.006",
+                "version_display": "v26.08.006",
+                "date": "2026-08-13",
+                "status": "published",
+                "changes": [
+                    {"product": "deskrudder", "category": "correcoes", "text": "Chat fila"},
+                    {"product": "saas", "category": "melhorias", "text": "SaaS: licenças"},
+                ],
+            }
+        ],
+        "upcoming": [],
+    }
+    data_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    import app.services.system_release as sr
+
+    monkeypatch.setattr(sr, "_DATA_DIR", tmp_path)
+    reload_release_notes_cache()
+    monkeypatch.setenv("DX_CONNECT_VERSION", "26.08.006")
+
+    body = client.get("/v1/system/release-notes", headers=auth_headers["admin"]).json()
+    texts = [c["text"] for c in body["current"]["changes"]]
+    assert texts == ["Chat fila"]
+    assert all(c.get("product") == "deskrudder" for c in body["current"]["changes"])
+
+
+def test_saas_release_notes_rbac_and_filter(client, auth_headers, monkeypatch, tmp_path):
+    from app.config import settings
+
+    data_path = tmp_path / "release_notes.json"
+    payload = {
+        "current_version": "26.08.006",
+        "releases": [
+            {
+                "version": "26.08.006",
+                "version_display": "v26.08.006",
+                "date": "2026-08-13",
+                "status": "published",
+                "changes": [
+                    {"product": "deskrudder", "category": "correcoes", "text": "Chat fila"},
+                    {"product": "saas", "category": "melhorias", "text": "SaaS: licenças"},
+                ],
+            }
+        ],
+        "upcoming": [],
+    }
+    data_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    import app.services.system_release as sr
+
+    monkeypatch.setattr(sr, "_DATA_DIR", tmp_path)
+    reload_release_notes_cache()
+    monkeypatch.setenv("DX_CONNECT_VERSION", "26.08.006")
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+
+    assert client.get("/v1/saas/release-notes", headers=auth_headers["a1"]).status_code == 403
+    assert client.get("/v1/saas/release-notes", headers=auth_headers["admin"]).status_code == 403
+
+    ok = client.get("/v1/saas/release-notes", headers=auth_headers["ops"])
+    assert ok.status_code == 200, ok.text
+    texts = [c["text"] for c in ok.json()["current"]["changes"]]
+    assert texts == ["SaaS: licenças"]
+
+
 def test_health_includes_version(client, monkeypatch):
     monkeypatch.setenv("DX_CONNECT_VERSION", "26.06.000")
     r = client.get("/health")

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,6 +1,6 @@
-# Releases — DX Connect (#400)
+# Releases — DX Connect (#400 / #672)
 
-Guia de versionamento, CHANGELOG e o que o usuário vê em **Sobre** (`/sobre`).
+Guia de versionamento, CHANGELOG e o que o usuário vê em **Sobre**.
 
 ## CalVer (`YY.MM.NNN`)
 
@@ -11,43 +11,80 @@ Guia de versionamento, CHANGELOG e o que o usuário vê em **Sobre** (`/sobre`).
 
 Bump automático no **deploy de `staging`** (fuso `America/Sao_Paulo`).
 
+## Dois produtos, um deploy
+
+Uma CalVer por merge `main → staging`, mas **dois feeds** de notas:
+
+| Produto | Código no manifest | Onde o usuário vê | API |
+|---------|--------------------|-------------------|-----|
+| DeskRudder (helpdesk na instância) | `deskrudder` | `/sobre` | `GET /v1/system/release-notes` |
+| SaaS Control Plane | `saas` | `/saas/sobre` | `GET /v1/saas/release-notes` (RBAC `saas_ops`) |
+
+- **Comercial** (CM/FN, simulador, custos) = DeskRudder (roda no cliente).
+- **Landing / trial / leads B2B / licenças / planos** = SaaS.
+
 ## Fluxo do time
 
 ```
-feature → PR main (+ CHANGELOG) → PR main → staging (aprovação humana) → deploy → /sobre
+feature → PR main (+ CHANGELOG por produto) → PR main → staging (aprovação humana) → deploy → /sobre e /saas/sobre
 ```
 
-1. **Cada PR para `main`** com mudança de produto: inclua bullet(s) em `CHANGELOG.md` → `## [Unreleased]`
+1. **Cada PR para `main`** com mudança de produto: bullets em `CHANGELOG.md` → `## [Unreleased]` na **subseção do produto** certo
 2. **PR `main → staging`**: o `[Unreleased]` descreve **todo o lote** que será publicado
 3. **Merge em `staging`**: **só após análise e aprovação humana no GitHub** (`staging` = produção). Agentes/CI **não** mergeiam este PR automaticamente — usar `/release-staging` para abrir o PR e parar.
-4. **Deploy em `staging`**: consome `[Unreleased]`, gera nova CalVer, append em `docs/releases/manifest.json`, zera `[Unreleased]`
+4. **Deploy em `staging`**: consome `[Unreleased]`, gera nova CalVer, append em `docs/releases/manifest.json` (cada bullet com `product`), zera `[Unreleased]`
+
+## Formato do CHANGELOG
+
+```markdown
+## [Unreleased]
+
+### DeskRudder
+
+#### Melhorias
+
+- Descrição curta para o atendente/admin (#123)
+
+#### Correções
+
+- …
+
+### SaaS Control Plane
+
+#### Melhorias
+
+- Descrição curta para a equipe ops (#456)
+```
+
+Compatibilidade: bullets só com `### Melhorias` / `### Corrigido` (sem produto) → tratados como **DeskRudder** + warning no pipeline.
 
 ## Requisito de PR (obrigatório)
 
-Se o PR altera código de produto (`backend/`, `frontend/src/`, etc.), **`CHANGELOG.md` deve ter bullets em `[Unreleased]`**.
+Se o PR altera código de produto, **`CHANGELOG.md` deve ter bullets em `[Unreleased]`** na subseção correta:
 
-- Texto para o **usuário final** (curto, claro)
-- Agrupe em `### Melhorias`, `### Correções` ou `### Interno / Infra`
-- Um bullet por entrega relevante; referência `(#issue)` opcional
+| Paths (heurística CI) | Subseção exigida |
+|-----------------------|------------------|
+| `frontend/src/pages/saas/`, `backend/app/api/saas*`, `backend/app/services/saas_*`, … | `### SaaS Control Plane` |
+| Demais `backend/`, `frontend/src/`, … | `### DeskRudder` |
+| Diff misto | **ambas** as subseções |
 
 O CI executa `scripts/check_changelog.py` e **bloqueia merge** se faltar.
 
 Isento (sem exigir CHANGELOG): só docs internos, planning, artefatos de release gerados, etc.
 
-## O que o usuário vê em `/sobre`
+## O que o usuário vê
+
+### `/sobre` (DeskRudder)
 
 | Seção | Conteúdo |
 |-------|----------|
-| **Versão atual** | CalVer em produção (`v26.06.002`) |
-| **O que há de novo nesta versão** | Bullets publicados na **última** release |
-| **Histórico** | Releases anteriores (`v26.06.001`, …) com os **mesmos bullets** de quando foram publicadas |
+| **Versão atual** | CalVer do deploy |
+| **O que há de novo** | Só bullets `product=deskrudder` da release atual |
+| **Histórico** | Releases anteriores **sem** cards que só tinham itens SaaS |
 
-Exemplo após publicar `v26.06.002`:
+### `/saas/sobre` (ops)
 
-- **O que há de novo** → itens do lote de `.002`
-- **Histórico** → card `v26.06.001` com o texto que estava em «O que há de novo» antes
-
-O histórico vem de `docs/releases/manifest.json`, append a cada deploy (nunca sobrescreve releases antigas).
+Mesma CalVer; só bullets `product=saas` (licenças, planos, provisionamento, leads).
 
 ## Arquivos
 
@@ -55,24 +92,26 @@ O histórico vem de `docs/releases/manifest.json`, append a cada deploy (nunca s
 |---------|--------|
 | `CHANGELOG.md` | Fonte editada pelo time; `[Unreleased]` → próxima release |
 | `VERSION` | Versão publicada (sem `v`) |
-| `docs/releases/manifest.json` | Histórico estruturado de todas as releases |
+| `docs/releases/manifest.json` | Histórico estruturado (`product` por bullet) |
 | `backend/app/data/release_notes.json` | Payload da API (gerado no deploy) |
+| `scripts/migrate_release_notes_product.py` | One-off / idempotente para taguear histórico (#676) |
 
 Após cada deploy, o workflow commita `VERSION`, `CHANGELOG.md`, `manifest.json` e JSONs em `staging` (mensagem com `[skip ci]` para não redeployar).
 
 ## API (autenticada)
 
 - `GET /v1/system/info` — versão em execução
-- `GET /v1/system/release-notes` — release atual + array `releases` (histórico)
+- `GET /v1/system/release-notes` — feed DeskRudder
+- `GET /v1/saas/release-notes` — feed SaaS (`saas_ops` + control plane ligado)
 
 ## Checklist — PR para `main`
 
-- [ ] Bullets em `CHANGELOG.md` → `[Unreleased]` (se mudou produto)
-- [ ] Texto compreensível para atendente/admin, não jargão de dev
+- [ ] Bullets em `CHANGELOG.md` → `[Unreleased]` na subseção do produto (se mudou produto)
+- [ ] Texto compreensível para o público certo (atendente vs ops), não jargão de dev
 
 ## Checklist — PR `main → staging`
 
-- [ ] `[Unreleased]` lista **todas** as entregas do lote
+- [ ] `[Unreleased]` lista **todas** as entregas do lote (por produto)
 - [ ] Revisão de redação (sem «deploy», «branch», «commit»)
 - [ ] **Aprovação e merge manuais** no GitHub (agente não executa `gh pr merge`)
 
@@ -88,4 +127,10 @@ Simular publicação (cuidado — altera arquivos):
 
 ```bash
 python scripts/prepare_release.py --deploy
+```
+
+Reclassificar histórico do manifest:
+
+```bash
+python scripts/migrate_release_notes_product.py
 ```

--- a/docs/releases/manifest.json
+++ b/docs/releases/manifest.json
@@ -8,31 +8,1499 @@
       "changes": [
         {
           "category": "melhorias",
-          "text": "Versão e notas de atualização no painel (página Sobre) (#404)"
+          "text": "Versão e notas de atualização no painel (página Sobre) (#404)",
+          "product": "deskrudder"
         },
         {
           "category": "melhorias",
-          "text": "Distribuição automática de tickets na fila — modos manual, após timeout e imediato; estratégias round-robin e menor carga (#399)"
+          "text": "Distribuição automática de tickets na fila — modos manual, após timeout e imediato; estratégias round-robin e menor carga (#399)",
+          "product": "deskrudder"
         },
         {
           "category": "melhorias",
-          "text": "Exibição do solicitante no detalhe do ticket e reconciliação inbound pós-cadastro (#392)"
+          "text": "Exibição do solicitante no detalhe do ticket e reconciliação inbound pós-cadastro (#392)",
+          "product": "deskrudder"
         },
         {
           "category": "melhorias",
-          "text": "Relatórios de tickets e chats WhatsApp com exportação CSV (#390)"
+          "text": "Relatórios de tickets e chats WhatsApp com exportação CSV (#390)",
+          "product": "deskrudder"
         },
         {
           "category": "correcoes",
-          "text": "E-mail de resposta ao cliente no Postgres (worker de outbox com timezone) (#397)"
+          "text": "E-mail de resposta ao cliente no Postgres (worker de outbox com timezone) (#397)",
+          "product": "deskrudder"
         },
         {
           "category": "correcoes",
-          "text": "Notificações: paridade entre badge e itens do dropdown (#395)"
+          "text": "Notificações: paridade entre badge e itens do dropdown (#395)",
+          "product": "deskrudder"
         },
         {
           "category": "correcoes",
-          "text": "Health check e capabilities com FastAPI 0.137+ (#394)"
+          "text": "Health check e capabilities com FastAPI 0.137+ (#394)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.002",
+      "version_display": "v26.06.002",
+      "date": "2026-06-22",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Persistência do manifest de releases após cada deploy em staging",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.003",
+      "version_display": "v26.06.003",
+      "date": "2026-06-23",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#280): painel admin em Configurações → Atendimento → SLA para CRUD de políticas por setor/prioridade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#281): badges e filtros na listagem de tickets e card de SLA no detalhe com countdown",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "`aplicar_roteamento` restrito a administradores para sobrescrever setor explícito",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "UI em Configurações → Atendimento → Roteamento com simulador de teste seco",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Persistência do manifest de releases após cada deploy em staging",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.004",
+      "version_display": "v26.06.004",
+      "date": "2026-06-25",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#293–#299): menu **Ajuda** para consultar manuais durante o atendimento; gestão de categorias e artigos (admin); consulta integrada em tickets e WhatsApp; manuais «só para a equipe»; imagens no texto; histórico de versões; reordenar categorias arrastando; manuais consultados ficam disponíveis offline neste computador",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria (#290–#292): registro detalhado de ações no sistema (atribuição e transferência de tickets, chats WhatsApp, e-mails ao cliente, credenciais PDV e exportações)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do registro",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#418): pausa automática da contagem quando o ticket está em status «Aguardando cliente» (ativado por padrão)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA: políticas opcionais por natureza do ticket; filtro «em risco» e dashboard usam calendário comercial e pausa; prazo efetivo no card SLA",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com quantidade de tickets abertos em violação de SLA, com atalho para a listagem filtrada (#416)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com tickets abertos em risco de SLA, com atalho para a listagem filtrada",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#417): calendários comerciais em Configurações → Atendimento → SLA (horário semanal e feriados nacionais)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Configurações WhatsApp: editor de horário semanal reutilizado (mesmo componente dos calendários SLA)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.005",
+      "version_display": "v26.06.005",
+      "date": "2026-06-27",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: mensagens de contacto e localização recebidas passam a aparecer como texto legível no chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Identidade visual DeskRudder no painel (logos, login, favicon e componentes de marca)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.006",
+      "version_display": "v26.06.006",
+      "date": "2026-06-28",
+      "status": "published",
+      "changes": [
+        {
+          "category": "interno",
+          "text": "Atualização do sistema",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.007",
+      "version_display": "v26.06.007",
+      "date": "2026-06-28",
+      "status": "published",
+      "changes": [
+        {
+          "category": "interno",
+          "text": "Atualização do sistema",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.008",
+      "version_display": "v26.06.008",
+      "date": "2026-06-29",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#473): modal de encerramento deixava de carregar demandas — polling da conversa refazia o fetch e mantinha «A carregar demandas…» em loop; demanda passa a ser opcional quando o chat encerra por inatividade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#472): banner «contato não identificado» persistia após vincular/cadastrar — polling/SSE com snapshot antigo sobrescrevia o vínculo; sidebar e header atualizam na hora",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#471): cache de mídia por mensagem reduz refetch de blobs e mitiga `ERR_INSUFFICIENT_RESOURCES` no carregamento de anexos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: aviso de inatividade duplicado quando vários workers processavam o mesmo chat em paralelo (Gunicorn)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#443/#454): painel de emoji e envio de figurinhas no composer; Histórico e Avaliações preservam posição de scroll ao voltar da conversa",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#449): corrigido link do Histórico/Avaliações para conversa — query `?from=` separada do `pathname` (React Router v7)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Notificações (#452): pendências de mensagem não lida abrem o ticket ou chat concreto (`/tickets/{id}`, `/whatsapp/c/{id}`) — removido fallback genérico para listagens",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#447): terminologia «contato do cliente» no chat e tickets — distingue colaborador da rede de atendente interno",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#453): ícones por tipo de ficheiro (PDF, Word, Excel, etc.) nas mensagens de documento",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#446): marco «Demanda registada» na timeline via evento interno + SSE em tempo real; removido ao excluir demanda",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#455): Histórico lista chats em atendimento — colegas do setor consultam e comentam internamente; ordenação e filtros de data corrigidos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#443): barra de composição estilo WhatsApp Web (+ anexos, emoji e figurinhas, microfone à direita)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#445): modal de encerramento substitui `confirm()` nativo — registo/edição de demandas, aviso quando houve conversa após última demanda, marco na timeline e `ConfirmDialog` reutilizável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#441): áudio gravado pelo atendente enviado como nota de voz via `sendWhatsAppAudio` (encoding Evolution); falha explícita se a API não confirmar entrega",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: mensagens de contacto e localização recebidas passam a aparecer como texto legível no chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#470): áudio gravado na barra de composição é enviado automaticamente ao terminar a gravação (estilo WhatsApp Web)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Identidade visual (#434): painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#465/#466): portal público `/kb` com logo e nome da empresa (Configurações → Empresa); listagem, busca e leitura de artigos sem login",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#467): personalização do portal em Configurações → Sistema → Base de conhecimento (cores da navbar, textos, links); menu lateral de categorias/subcategorias expansível no /kb; navbar com título centralizado, logo sem fundo branco e menu hamburger",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#293–#299): menu **Ajuda** para consultar manuais durante o atendimento; gestão de categorias e artigos (admin); consulta integrada em tickets e WhatsApp; manuais «só para a equipe»; imagens no texto; histórico de versões; reordenar categorias arrastando; manuais consultados ficam disponíveis offline neste computador",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria (#290–#292): trail expandido com payload, IP, request-id e user-agent; registro de atribuição, transferência, fechamento e reabertura de tickets, ações em chats WhatsApp, envio de e-mail ao cliente, visualização de credencial PDV e exportação de relatórios",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats; edição via `PATCH`, marco na timeline e fluxo completo no modal de encerramento (#445)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#418): pausa automática da contagem quando o ticket está em status configurado (flag `pausa_sla`; «Aguardando cliente» ativado por padrão)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA: políticas opcionais por natureza do ticket; filtro «em risco» e dashboard usam o motor completo (calendário + pausa); prazo efetivo no card SLA",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#280): painel admin em Configurações → Atendimento → SLA para CRUD de políticas por setor/prioridade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#281): badges e filtros na listagem de tickets e card de SLA no detalhe com countdown",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com quantidade de tickets abertos em violação de SLA, com atalho para a listagem filtrada (#416)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com tickets abertos em risco de SLA, com atalho para a listagem filtrada",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#417): CRUD de calendários comerciais em Configurações → Atendimento → SLA → Calendários (horário semanal e feriados nacionais)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Configurações WhatsApp: editor de horário semanal reutilizado (mesmo componente dos calendários SLA)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "`aplicar_roteamento` restrito a administradores para sobrescrever setor explícito",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "UI em Configurações → Atendimento → Roteamento com simulador de teste seco",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Persistência do manifest de releases após cada deploy em staging",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.001",
+      "version_display": "v26.07.001",
+      "date": "2026-07-11",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#473): modal de encerramento deixava de carregar demandas — polling da conversa refazia o fetch e mantinha «A carregar demandas…» em loop; demanda passa a ser opcional quando o chat encerra por inatividade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#472): banner «contato não identificado» persistia após vincular/cadastrar — polling/SSE com snapshot antigo sobrescrevia o vínculo; sidebar e header atualizam na hora",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#471): cache de mídia por mensagem reduz refetch de blobs e mitiga `ERR_INSUFFICIENT_RESOURCES` no carregamento de anexos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: aviso de inatividade duplicado quando vários workers processavam o mesmo chat em paralelo (Gunicorn)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#443/#454): painel de emoji e envio de figurinhas no composer; Histórico e Avaliações preservam posição de scroll ao voltar da conversa",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#449): corrigido link do Histórico/Avaliações para conversa — query `?from=` separada do `pathname` (React Router v7)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Notificações (#452): pendências de mensagem não lida abrem o ticket ou chat concreto (`/tickets/{id}`, `/whatsapp/c/{id}`) — removido fallback genérico para listagens",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#447): terminologia «contato do cliente» no chat e tickets — distingue colaborador da rede de atendente interno",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#453): ícones por tipo de ficheiro (PDF, Word, Excel, etc.) nas mensagens de documento",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#446): marco «Demanda registada» na timeline via evento interno + SSE em tempo real; removido ao excluir demanda",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#455): Histórico lista chats em atendimento — colegas do setor consultam e comentam internamente; ordenação e filtros de data corrigidos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#443): barra de composição estilo WhatsApp Web (+ anexos, emoji e figurinhas, microfone à direita)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#445): modal de encerramento substitui `confirm()` nativo — registo/edição de demandas, aviso quando houve conversa após última demanda, marco na timeline e `ConfirmDialog` reutilizável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#441): áudio gravado pelo atendente enviado como nota de voz via `sendWhatsAppAudio` (encoding Evolution); falha explícita se a API não confirmar entrega",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: mensagens de contacto e localização recebidas passam a aparecer como texto legível no chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (IC-F1): API backend para conversas diretas entre atendentes e canal de comunicados por setor — inbox, mensagens, leitura (`/v1/chat-interno`); conversas diretas privadas (admin não vê conversas de terceiros)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (IC-F2): mensagens internas no sino de notificações e evento SSE `chat.interno.mensagem`; contador `chat_interno_nao_lidas_count` no badge do navbar",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (IC-F3): inbox unificada, conversas diretas e canais de setor no menu Chat interno; comunicados com visual distinto; link no detalhe do setor; layout com lista lateral fixa para alternar conversas e ver não lidas",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#495): anexos e mídia — upload, download, pré-visualização no painel e colar imagem (Ctrl+V) no composer",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat operacional: hub unificado em `/chat` com abas Atendendo, Espera e Interno; Histórico permanece em menu separado",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno e WhatsApp: indicadores de envio, entrega e leitura nas mensagens (✓ / ✓✓)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Notificações: pendência do chat interno abre direto em `/chat/interno/{id}`",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#503): editar e apagar mensagens de texto — autor ou admin; exclusão lógica com «Mensagem apagada»",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#502): reações rápidas (👍 ❤️ 😂 😮 😢 🙏) em conversas diretas e canais de setor",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: editar e apagar para todos só nos primeiros 5 minutos; depois «apagar para mim»; opção de limpar conversa só para você",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: ao ler o histórico o scroll não volta sozinho para o fim; ao reabrir a conversa retoma na última mensagem visualizada",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#505): paginação infinita — carrega mensagens recentes e busca histórico ao rolar para cima (50 por vez)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#506): editar legenda de mensagens com mídia (mesma janela de 5 minutos)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#507): grupos personalizados com até 50 atendentes; criador e admins promovidos gerenciam membros",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#470): áudio gravado na barra de composição é enviado automaticamente ao terminar a gravação (estilo WhatsApp Web)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Identidade visual (#434): painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#465/#466): portal público `/kb` com logo e nome da empresa (Configurações → Empresa); listagem, busca e leitura de artigos sem login",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#467): personalização do portal em Configurações → Sistema → Base de conhecimento (cores da navbar, textos, links); menu lateral de categorias/subcategorias expansível no /kb; navbar com título centralizado, logo sem fundo branco e menu hamburger",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#293–#299): menu **Ajuda** para consultar manuais durante o atendimento; gestão de categorias e artigos (admin); consulta integrada em tickets e WhatsApp; manuais «só para a equipe»; imagens no texto; histórico de versões; reordenar categorias arrastando; manuais consultados ficam disponíveis offline neste computador",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria (#290–#292): trail expandido com payload, IP, request-id e user-agent; registro de atribuição, transferência, fechamento e reabertura de tickets, ações em chats WhatsApp, envio de e-mail ao cliente, visualização de credencial PDV e exportação de relatórios",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats; edição via `PATCH`, marco na timeline e fluxo completo no modal de encerramento (#445)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#418): pausa automática da contagem quando o ticket está em status configurado (flag `pausa_sla`; «Aguardando cliente» ativado por padrão)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA: políticas opcionais por natureza do ticket; filtro «em risco» e dashboard usam o motor completo (calendário + pausa); prazo efetivo no card SLA",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#280): painel admin em Configurações → Atendimento → SLA para CRUD de políticas por setor/prioridade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#281): badges e filtros na listagem de tickets e card de SLA no detalhe com countdown",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com quantidade de tickets abertos em violação de SLA, com atalho para a listagem filtrada (#416)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com tickets abertos em risco de SLA, com atalho para a listagem filtrada",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#417): CRUD de calendários comerciais em Configurações → Atendimento → SLA → Calendários (horário semanal e feriados nacionais)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Configurações WhatsApp: editor de horário semanal reutilizado (mesmo componente dos calendários SLA)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "`aplicar_roteamento` restrito a administradores para sobrescrever setor explícito",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "UI em Configurações → Atendimento → Roteamento com simulador de teste seco",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Persistência do manifest de releases após cada deploy em staging",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.002",
+      "version_display": "v26.07.002",
+      "date": "2026-07-11",
+      "status": "published",
+      "changes": [
+        {
+          "category": "interno",
+          "text": "Atualização do sistema",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.003",
+      "version_display": "v26.07.003",
+      "date": "2026-07-14",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: conversa em atendimento disparava loop de pedidos a `/demandas` (e esgotava recursos do browser com `ERR_INSUFFICIENT_RESOURCES`) — o painel de demandas já não notifica o pai no carregamento inicial",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#468): chat ao vivo no portal `/kb` — widget para visitantes; atendimento na mesma inbox WhatsApp (abas Aguardando/Atendendo) com badge Portal; protocolo unificado `#C`; mensagens automáticas, avaliação ao encerrar, anexos e áudio como no WhatsApp; transferência, demandas e encerramento com revisão",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.004",
+      "version_display": "v26.07.004",
+      "date": "2026-07-15",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Sons de alerta: toque de **abertura de ticket** e de **novo chat** (fila WhatsApp/Portal) estavam trocados — ticket usa `notification.mp3` e chat na fila usa `alerta.mp3`",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.005",
+      "version_display": "v26.07.005",
+      "date": "2026-07-15",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.006",
+      "version_display": "v26.07.006",
+      "date": "2026-07-15",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Chat (#539): após enviar mensagem (WhatsApp e chat interno), o cursor permanece no campo de texto; painel de emoji fica aberto ao escolher vários; **Responder** mensagem no chat interno (direta, equipe e grupo)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homônimos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp / modais: ao digitar na descrição da demanda no **Encerrar atendimento**, o campo perdia o foco a cada atualização da conversa — diálogo já não refoca o painel; formulário não é limpo pelo poll",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.007",
+      "version_display": "v26.07.007",
+      "date": "2026-07-16",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: removido botão duplicado «Identificar contato» no header — fica só o do banner enquanto o contacto não está vinculado; após vincular o CTA some",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: encerramento por inatividade só conta a partir da última mensagem do cliente quando o chat já está em atendimento e o atendente já enviou mensagem humana (auto_assumido/BOT não disparam o timer)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: Ctrl+V no composer cola imagem/ficheiro do clipboard (pré-visualização antes de enviar), como no chat interno",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat: removida a borda branca de foco no campo de mensagem e nos demais inputs/textareas (outline nativo + alinhamento ao design system)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: contraste no hover de Responder/Editar/Apagar; duplo clique na mensagem (ou ao lado do balão) inicia resposta e foca o composer — também no WhatsApp",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.008",
+      "version_display": "v26.07.008",
+      "date": "2026-07-16",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Equipe online (#545–#547): administradores veem quem está com o painel aberto e desde quando (menu **Equipe online**), para coordenar atendimento de chats e tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#539): após enviar mensagem (WhatsApp e chat interno), o cursor permanece no campo de texto; painel de emoji fica aberto ao escolher vários; **Responder** mensagem no chat interno (direta, equipe e grupo)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homónimos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: o feed deixa de puxar sozinho para o fim enquanto você lê mensagens acima; ao reabrir a conversa, retoma a posição em que parou",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: ações (Responder/Editar/Apagar) e reações ficam fora do balão da mensagem",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: clique na imagem abre visualização em tela cheia (antes só tinha o cursor de zoom, sem ação)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Anexos de ticket: ficheiros deixam de desaparecer após atualização do sistema; se o arquivo já tiver sido perdido, o aviso deixa isso claro",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.009",
+      "version_display": "v26.07.009",
+      "date": "2026-07-16",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Chat interno (grupos/canal): menções com `@` — autocomplete de participantes e `@all` (todos); destaque visual na mensagem",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Equipe online: lista funciona com vários workers do servidor (presença gravada no banco); admin pode **Forçar saída** de um atendente conectado",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: balões mais próximos — opções/reações só no hover; em grupos, avatar e cor por pessoa para distinguir quem fala",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Equipe online: «0 online» mesmo com painel aberto (lista lia só a memória do worker errado)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: espaço excessivo entre mensagens após colocar ações/reações fora do balão",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.010",
+      "version_display": "v26.07.010",
+      "date": "2026-07-17",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.011",
+      "version_display": "v26.07.011",
+      "date": "2026-07-17",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Modo escuro: texto digitado nos campos de pesquisa (listagens e chat interno) volta a ficar legível",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.012",
+      "version_display": "v26.07.012",
+      "date": "2026-07-18",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown no chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#571): Esc no zoom da imagem fecha só a visualização, sem sair do chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#576): cancelar gravação de áudio já não envia o ficheiro",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#573): ao reabrir o chat, o scroll volta à última posição vista (não salta para o início)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#570): contacto já vinculado é reconhecido em chats novos do mesmo número",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.013",
+      "version_display": "v26.07.013",
+      "date": "2026-07-18",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#577): countdown até o aviso e, após o aviso, até encerrar; enviar mensagem (ou o cliente falar) sai automaticamente da pausa",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** (somente leitura) até registar, manter demandas existentes ou confirmar sem demanda; nova mensagem do mesmo cliente abre chat novo na fila",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.014",
+      "version_display": "v26.07.014",
+      "date": "2026-07-22",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#600, #601): cadastro de funcionário pelo modal da Rede permite definir senha do portal na criação; sócio cadastra sem escolher empresas (escopo automático em toda a rede)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#604): RBAC por papel — colaborador vê só os próprios chamados; supervisor vê todos das empresas vinculadas; sócio vê toda a rede",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#603): listagem e detalhe de atendimentos WhatsApp no `/portal` (somente leitura), com o mesmo escopo por papel e sem comentários internos da equipe",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#602): sócio gere a equipa no `/portal` — cadastro e edição de colaboradores e supervisores (empresas, senha do portal); outros sócios listados com edição limitada; colaborador/supervisor recebem 403",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#605): branding white-label no `/portal` — logo e cores da instância (mesmas configurações de Configurações → Base de conhecimento); login e shell aplicam a identidade do contratante, não a marca DeskRudder",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal: shell alinhado ao painel DeskRudder (menu lateral com usuário/Sair, navbar com expandir/recolher); cor do menu lateral configurável (padrão = navbar); chat ao vivo no `/portal` (mesmo canal da `/kb`, isolado por instância); login com logo em destaque, ícone de olho na senha e fundo minimalista; título do portal independente da central `/kb`",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#593): ao **cadastrar** contacto no chat, o sistema sugere funcionários com nome semelhante para vincular (evita duplicados); o atendente pode ignorar e criar novo",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#591): no detalhe da **Empresa**, nova aba **Chats** com atendimentos filtrados por aquela empresa (busca, paginação, abrir conversa / retomar)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#592): com funcionário em **mais de uma empresa**, o atendimento pode começar sem empresa; o atendente pergunta ao cliente e vincula (ou altera) a qualquer momento antes de encerrar — 1 empresa continua automática",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#590): na listagem **Atendimentos**, cada card mostra a **empresa** do contacto (ou «Sem empresa» quando não houver vínculo)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#607): na aba **Atendendo**, secções **Comigo** e **Outros atendentes** quando o admin acompanha colegas; badge «Você» e destaque visual nos seus; nome do responsável legível nos de outros",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#606): conversa mais utilizável no **mobile** — composer com campo largo e botão de manuais só ícone; menu **⋮** com Transferir/Tickets; metadados em linha separada; painel de demandas colapsável; `safe-area` no composer",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#608): duas mensagens inbound seguidas do mesmo contacto deixam de abrir dois chats/protocolos — lock por `wa_id` no webhook e uma única sequência de auto-mensagens por sessão",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#598): após encerrar com avaliação, janela de ~30 min (configurável) para a nota; se o cliente mandar outro texto, abre atendimento novo com essa mensagem; sem resposta, finaliza sozinho",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.001",
+      "version_display": "v26.08.001",
+      "date": "2026-08-02",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#628): no WhatsApp do cliente, mensagens do atendente saem com prefixo **setor do atendimento + nome** e o texto na linha de baixo (ex.: `[ Suporte - Ana ]:`); ao assumir, 1 setor é gravado automaticamente e vários setores pedem escolha no painel",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#629): no lightbox de imagens da conversa, dá para navegar entre as fotos (botões e setas ←/→) com contador e legenda atualizada; Esc continua a fechar só a visualização",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#630): foto de perfil do contacto no header e nas listas Atendendo/Aguardando (com cache e fallback para a inicial do nome)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#630): reações no chat com o cliente — ver emoji do cliente no balão e o atendente responsável pode reagir (👍 ❤️ 😂 😮 😢 🙏); clique de novo remove",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#630): editar (até 15 min) e apagar para todos (até 48 h) mensagens de texto enviadas pelo responsável; também sincroniza quando o cliente edita ou apaga",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: no header da conversa, o chip da empresa abre a página de detalhe da empresa (Voltar regressa ao chat); alterar empresa multi-empresa continua no menu ⋮",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#626): ícone de som junto a **Aguardando** para silenciar/reativar o alerta contínuo da fila (WhatsApp + portal); preferência guardada no browser — não afeta alertas de ticket nem do chat interno",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#625): ao **Ver** um chat da fila Aguardando, a lista com **Atender** permanece na lateral; na conversa há CTA **Atender** (WhatsApp e portal) para assumir sem voltar à lista",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#627): com anexo pendente, **Enter** na legenda (ou no painel, em áudio) envia o anexo — equivalente a «Enviar anexo»",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Login / site: «Voltar ao site» e hosts DeskRudder apontam para deskrudder.com.br (redirect da apex connect)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.002",
+      "version_display": "v26.08.002",
+      "date": "2026-08-02",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Frontend: alinhamento de `react` e `react-dom` em **19.2.8** (o Dependabot tinha subido só o `react`, o que gerava tela preta com React error #527 em produção)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.003",
+      "version_display": "v26.08.003",
+      "date": "2026-08-02",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#628): ao atender com vários setores, o modal «Escolher setor» voltava vazio (pedido com `limit` acima do máximo da API); a lista passa a carregar com paginação válida",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.004",
+      "version_display": "v26.08.004",
+      "date": "2026-08-02",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: na visualização ampliada de imagens, dá para fazer zoom (+/−, scroll e duplo clique), rodar e arrastar; repor volta à vista normal (também no chat interno)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat: duplo clique **dentro** do balão já não inicia resposta (dá para selecionar/copiar o texto); responder com duplo clique fica só **ao lado** do balão",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: menu com seta no canto do balão para Editar/Apagar (em vez de botões flutuantes que saltavam para a mensagem de cima)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: Enter na legenda do anexo deixava de enviar a imagem **duas vezes** (o evento subia ao painel e disparava o envio de novo)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.005",
+      "version_display": "v26.08.005",
+      "date": "2026-08-03",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Dashboard (#599): filtros de período Hoje | Esta semana (seg–dom) | Este mês | Mês passado | Personalizado no geral, tickets e WhatsApp (substitui 7/30/90); CSAT do geral respeita o intervalo",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#594): análise de demandas no dashboard — drill-down por natureza/motivo, ranking por empresa, insights (erro → atualização; dúvida → treinamento) e sugestão de novo motivo a partir de «Outros» repetido",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Rede e Empresa (#595): aba Análises com tickets + demandas WhatsApp no período, insights e ranking (reutiliza #594/#599)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.006",
+      "version_display": "v26.08.006",
+      "date": "2026-08-12",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: ao iniciar conversa com número avulso e o cliente responder, deixa de abrir chat novo na fila (alerta de «novo atendimento») quando o `wa_id` chega em variante (DDI / nono dígito BR) ou como `@lid` com `senderPn` / `remoteJidAlt`",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#667): em Atendimentos (e Avaliações), **Próxima** / **Anterior** deixam de voltar sozinhas para a página 1; o `offset` da URL é respeitado ao abrir/recarregar",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#651): **Silenciar** na fila Aguardando corta o alerta na hora (loop + pulse); o toque passa a tocar completo e a reiniciar em sequência, sem intervalo de silêncio",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#653): **Esc** na conversa já não percorre o histórico do browser (evita reabrir chat encerrado); fecha overlays locais e, ao sair, vai à lista de origem (Atendendo / Aguardando / etc.)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#652): com a aba em segundo plano, novo chat na fila dispara notificação do sistema (se permitida) e o áudio é desbloqueado no primeiro clique; ao voltar à aba o alerta retoma de imediato",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#652): banner no painel pede permissão de notificações («Ativar alertas») para avisar novos chats na fila mesmo com outra aba ou o navegador minimizado",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: **controle de licenças** — histórico/timeline na ficha, snapshot de módulos + limites na licença, preço/limites nos planos, e-mail de entrega com plano/módulos/acesso, conversão de lead com plano, `SAAS_MODULOS` no provisionamento e lista de instâncias no resumo",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: catálogo comercial de **planos e módulos** (CRUD, activar/desactivar, seed Trial/Profissional/Enterprise); licença escolhe plano em vez de texto livre",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: lista de licenças com **filtros** (plano, aprovação, provisionamento, renovação), cartões do resumo clicáveis e **escolha de plano** ao aprovar go-live",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: URL da instância deixa de ser campo livre — só o **nome da base (slug)**; URL = `https://{slug}.{domínio}/`; em local o «Abrir» usa a porta API (DNS público não resolve)",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: trial só **pede aprovação**; **Aprovar e criar base** enfileira a criação da instância/Postgres",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: **entrega pós-health** ao contacto (`entrega_notificada_em` + `reenviar-entrega`)",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: lead → licença com **vínculo persistido** (`POST ./leads/{id}/converter` + `lead_id` no formulário)",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: **suspender/reativar** pede (ou executa) `stack-client.sh down|up` e confirmação ops",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: trial público entra com **aprovação pendente**; painel com **Aprovar go-live** / **Rejeitar** (`aprovacao_status`)",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS DeskRudder (#519 / #516 / #521–#528): painel de **licenças** (contactos, resumo ops, renovação flexível, lead→licença); **leads comerciais** da landing (formulário «Fale conosco», inbox `/saas/leads`); **provisionamento** em fila; **trial** em `/trial`; **renovações** com alertas e suspensão ao vencer",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "Comercial (#321 / #331–#335): simulador com desconto posto <100k L (20% SM), override de custo/valor TEF só na proposta e snapshot imutável do pacote (catálogo TEF continua com valores padrão)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Comercial (#321 / #329–#334): catálogo de custos — salário mínimo com histórico por vigência (atualizar valor sem reescrever o passado), itens (% SM, valor fixo, TEF) e simulador em Cadastros → Catálogo de custos (admin)",
+          "product": "deskrudder"
         }
       ]
     }

--- a/frontend/public/release-notes.json
+++ b/frontend/public/release-notes.json
@@ -1,39 +1,101 @@
 {
-  "current_version": "26.06.001",
-  "current_version_display": "v26.06.001",
+  "current_version": "26.08.006",
+  "current_version_display": "v26.08.006",
   "current": {
-    "version": "26.06.001",
-    "version_display": "v26.06.001",
-    "date": "2026-06-22",
+    "version": "26.08.006",
+    "version_display": "v26.08.006",
+    "date": "2026-08-12",
     "status": "published",
     "changes": [
       {
         "category": "melhorias",
-        "text": "Versão e notas de atualização no painel (página Sobre) (#404)"
+        "text": "WhatsApp: ao iniciar conversa com número avulso e o cliente responder, deixa de abrir chat novo na fila (alerta de «novo atendimento») quando o `wa_id` chega em variante (DDI / nono dígito BR) ou como `@lid` com `senderPn` / `remoteJidAlt`",
+        "product": "deskrudder"
       },
       {
         "category": "melhorias",
-        "text": "Distribuição automática de tickets na fila — modos manual, após timeout e imediato; estratégias round-robin e menor carga (#399)"
+        "text": "WhatsApp (#667): em Atendimentos (e Avaliações), **Próxima** / **Anterior** deixam de voltar sozinhas para a página 1; o `offset` da URL é respeitado ao abrir/recarregar",
+        "product": "deskrudder"
       },
       {
         "category": "melhorias",
-        "text": "Exibição do solicitante no detalhe do ticket e reconciliação inbound pós-cadastro (#392)"
+        "text": "Chat (#651): **Silenciar** na fila Aguardando corta o alerta na hora (loop + pulse); o toque passa a tocar completo e a reiniciar em sequência, sem intervalo de silêncio",
+        "product": "deskrudder"
       },
       {
         "category": "melhorias",
-        "text": "Relatórios de tickets e chats WhatsApp com exportação CSV (#390)"
+        "text": "WhatsApp (#653): **Esc** na conversa já não percorre o histórico do browser (evita reabrir chat encerrado); fecha overlays locais e, ao sair, vai à lista de origem (Atendendo / Aguardando / etc.)",
+        "product": "deskrudder"
       },
       {
-        "category": "correcoes",
-        "text": "E-mail de resposta ao cliente no Postgres (worker de outbox com timezone) (#397)"
+        "category": "melhorias",
+        "text": "Chat (#652): com a aba em segundo plano, novo chat na fila dispara notificação do sistema (se permitida) e o áudio é desbloqueado no primeiro clique; ao voltar à aba o alerta retoma de imediato",
+        "product": "deskrudder"
       },
       {
-        "category": "correcoes",
-        "text": "Notificações: paridade entre badge e itens do dropdown (#395)"
+        "category": "melhorias",
+        "text": "Chat (#652): banner no painel pede permissão de notificações («Ativar alertas») para avisar novos chats na fila mesmo com outra aba ou o navegador minimizado",
+        "product": "deskrudder"
       },
       {
-        "category": "correcoes",
-        "text": "Health check e capabilities com FastAPI 0.137+ (#394)"
+        "category": "melhorias",
+        "text": "SaaS: **controle de licenças** — histórico/timeline na ficha, snapshot de módulos + limites na licença, preço/limites nos planos, e-mail de entrega com plano/módulos/acesso, conversão de lead com plano, `SAAS_MODULOS` no provisionamento e lista de instâncias no resumo",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: catálogo comercial de **planos e módulos** (CRUD, activar/desactivar, seed Trial/Profissional/Enterprise); licença escolhe plano em vez de texto livre",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: lista de licenças com **filtros** (plano, aprovação, provisionamento, renovação), cartões do resumo clicáveis e **escolha de plano** ao aprovar go-live",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: URL da instância deixa de ser campo livre — só o **nome da base (slug)**; URL = `https://{slug}.{domínio}/`; em local o «Abrir» usa a porta API (DNS público não resolve)",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: trial só **pede aprovação**; **Aprovar e criar base** enfileira a criação da instância/Postgres",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: **entrega pós-health** ao contacto (`entrega_notificada_em` + `reenviar-entrega`)",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: lead → licença com **vínculo persistido** (`POST ./leads/{id}/converter` + `lead_id` no formulário)",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: **suspender/reativar** pede (ou executa) `stack-client.sh down|up` e confirmação ops",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS: trial público entra com **aprovação pendente**; painel com **Aprovar go-live** / **Rejeitar** (`aprovacao_status`)",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "SaaS DeskRudder (#519 / #516 / #521–#528): painel de **licenças** (contactos, resumo ops, renovação flexível, lead→licença); **leads comerciais** da landing (formulário «Fale conosco», inbox `/saas/leads`); **provisionamento** em fila; **trial** em `/trial`; **renovações** com alertas e suspensão ao vencer",
+        "product": "saas"
+      },
+      {
+        "category": "melhorias",
+        "text": "Comercial (#321 / #331–#335): simulador com desconto posto <100k L (20% SM), override de custo/valor TEF só na proposta e snapshot imutável do pacote (catálogo TEF continua com valores padrão)",
+        "product": "deskrudder"
+      },
+      {
+        "category": "melhorias",
+        "text": "Comercial (#321 / #329–#334): catálogo de custos — salário mínimo com histórico por vigência (atualizar valor sem reescrever o passado), itens (% SM, valor fixo, TEF) e simulador em Cadastros → Catálogo de custos (admin)",
+        "product": "deskrudder"
       }
     ]
   },
@@ -46,31 +108,1499 @@
       "changes": [
         {
           "category": "melhorias",
-          "text": "Versão e notas de atualização no painel (página Sobre) (#404)"
+          "text": "Versão e notas de atualização no painel (página Sobre) (#404)",
+          "product": "deskrudder"
         },
         {
           "category": "melhorias",
-          "text": "Distribuição automática de tickets na fila — modos manual, após timeout e imediato; estratégias round-robin e menor carga (#399)"
+          "text": "Distribuição automática de tickets na fila — modos manual, após timeout e imediato; estratégias round-robin e menor carga (#399)",
+          "product": "deskrudder"
         },
         {
           "category": "melhorias",
-          "text": "Exibição do solicitante no detalhe do ticket e reconciliação inbound pós-cadastro (#392)"
+          "text": "Exibição do solicitante no detalhe do ticket e reconciliação inbound pós-cadastro (#392)",
+          "product": "deskrudder"
         },
         {
           "category": "melhorias",
-          "text": "Relatórios de tickets e chats WhatsApp com exportação CSV (#390)"
+          "text": "Relatórios de tickets e chats WhatsApp com exportação CSV (#390)",
+          "product": "deskrudder"
         },
         {
           "category": "correcoes",
-          "text": "E-mail de resposta ao cliente no Postgres (worker de outbox com timezone) (#397)"
+          "text": "E-mail de resposta ao cliente no Postgres (worker de outbox com timezone) (#397)",
+          "product": "deskrudder"
         },
         {
           "category": "correcoes",
-          "text": "Notificações: paridade entre badge e itens do dropdown (#395)"
+          "text": "Notificações: paridade entre badge e itens do dropdown (#395)",
+          "product": "deskrudder"
         },
         {
           "category": "correcoes",
-          "text": "Health check e capabilities com FastAPI 0.137+ (#394)"
+          "text": "Health check e capabilities com FastAPI 0.137+ (#394)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.002",
+      "version_display": "v26.06.002",
+      "date": "2026-06-22",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Persistência do manifest de releases após cada deploy em staging",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.003",
+      "version_display": "v26.06.003",
+      "date": "2026-06-23",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#280): painel admin em Configurações → Atendimento → SLA para CRUD de políticas por setor/prioridade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#281): badges e filtros na listagem de tickets e card de SLA no detalhe com countdown",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "`aplicar_roteamento` restrito a administradores para sobrescrever setor explícito",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "UI em Configurações → Atendimento → Roteamento com simulador de teste seco",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Persistência do manifest de releases após cada deploy em staging",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.004",
+      "version_display": "v26.06.004",
+      "date": "2026-06-25",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#293–#299): menu **Ajuda** para consultar manuais durante o atendimento; gestão de categorias e artigos (admin); consulta integrada em tickets e WhatsApp; manuais «só para a equipe»; imagens no texto; histórico de versões; reordenar categorias arrastando; manuais consultados ficam disponíveis offline neste computador",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria (#290–#292): registro detalhado de ações no sistema (atribuição e transferência de tickets, chats WhatsApp, e-mails ao cliente, credenciais PDV e exportações)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do registro",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#418): pausa automática da contagem quando o ticket está em status «Aguardando cliente» (ativado por padrão)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA: políticas opcionais por natureza do ticket; filtro «em risco» e dashboard usam calendário comercial e pausa; prazo efetivo no card SLA",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com quantidade de tickets abertos em violação de SLA, com atalho para a listagem filtrada (#416)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com tickets abertos em risco de SLA, com atalho para a listagem filtrada",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#417): calendários comerciais em Configurações → Atendimento → SLA (horário semanal e feriados nacionais)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Configurações WhatsApp: editor de horário semanal reutilizado (mesmo componente dos calendários SLA)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.005",
+      "version_display": "v26.06.005",
+      "date": "2026-06-27",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: mensagens de contacto e localização recebidas passam a aparecer como texto legível no chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Identidade visual DeskRudder no painel (logos, login, favicon e componentes de marca)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.006",
+      "version_display": "v26.06.006",
+      "date": "2026-06-28",
+      "status": "published",
+      "changes": [
+        {
+          "category": "interno",
+          "text": "Atualização do sistema",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.007",
+      "version_display": "v26.06.007",
+      "date": "2026-06-28",
+      "status": "published",
+      "changes": [
+        {
+          "category": "interno",
+          "text": "Atualização do sistema",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.06.008",
+      "version_display": "v26.06.008",
+      "date": "2026-06-29",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#473): modal de encerramento deixava de carregar demandas — polling da conversa refazia o fetch e mantinha «A carregar demandas…» em loop; demanda passa a ser opcional quando o chat encerra por inatividade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#472): banner «contato não identificado» persistia após vincular/cadastrar — polling/SSE com snapshot antigo sobrescrevia o vínculo; sidebar e header atualizam na hora",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#471): cache de mídia por mensagem reduz refetch de blobs e mitiga `ERR_INSUFFICIENT_RESOURCES` no carregamento de anexos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: aviso de inatividade duplicado quando vários workers processavam o mesmo chat em paralelo (Gunicorn)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#443/#454): painel de emoji e envio de figurinhas no composer; Histórico e Avaliações preservam posição de scroll ao voltar da conversa",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#449): corrigido link do Histórico/Avaliações para conversa — query `?from=` separada do `pathname` (React Router v7)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Notificações (#452): pendências de mensagem não lida abrem o ticket ou chat concreto (`/tickets/{id}`, `/whatsapp/c/{id}`) — removido fallback genérico para listagens",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#447): terminologia «contato do cliente» no chat e tickets — distingue colaborador da rede de atendente interno",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#453): ícones por tipo de ficheiro (PDF, Word, Excel, etc.) nas mensagens de documento",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#446): marco «Demanda registada» na timeline via evento interno + SSE em tempo real; removido ao excluir demanda",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#455): Histórico lista chats em atendimento — colegas do setor consultam e comentam internamente; ordenação e filtros de data corrigidos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#443): barra de composição estilo WhatsApp Web (+ anexos, emoji e figurinhas, microfone à direita)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#445): modal de encerramento substitui `confirm()` nativo — registo/edição de demandas, aviso quando houve conversa após última demanda, marco na timeline e `ConfirmDialog` reutilizável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#441): áudio gravado pelo atendente enviado como nota de voz via `sendWhatsAppAudio` (encoding Evolution); falha explícita se a API não confirmar entrega",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: mensagens de contacto e localização recebidas passam a aparecer como texto legível no chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#470): áudio gravado na barra de composição é enviado automaticamente ao terminar a gravação (estilo WhatsApp Web)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Identidade visual (#434): painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#465/#466): portal público `/kb` com logo e nome da empresa (Configurações → Empresa); listagem, busca e leitura de artigos sem login",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#467): personalização do portal em Configurações → Sistema → Base de conhecimento (cores da navbar, textos, links); menu lateral de categorias/subcategorias expansível no /kb; navbar com título centralizado, logo sem fundo branco e menu hamburger",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#293–#299): menu **Ajuda** para consultar manuais durante o atendimento; gestão de categorias e artigos (admin); consulta integrada em tickets e WhatsApp; manuais «só para a equipe»; imagens no texto; histórico de versões; reordenar categorias arrastando; manuais consultados ficam disponíveis offline neste computador",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria (#290–#292): trail expandido com payload, IP, request-id e user-agent; registro de atribuição, transferência, fechamento e reabertura de tickets, ações em chats WhatsApp, envio de e-mail ao cliente, visualização de credencial PDV e exportação de relatórios",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats; edição via `PATCH`, marco na timeline e fluxo completo no modal de encerramento (#445)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#418): pausa automática da contagem quando o ticket está em status configurado (flag `pausa_sla`; «Aguardando cliente» ativado por padrão)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA: políticas opcionais por natureza do ticket; filtro «em risco» e dashboard usam o motor completo (calendário + pausa); prazo efetivo no card SLA",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#280): painel admin em Configurações → Atendimento → SLA para CRUD de políticas por setor/prioridade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#281): badges e filtros na listagem de tickets e card de SLA no detalhe com countdown",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com quantidade de tickets abertos em violação de SLA, com atalho para a listagem filtrada (#416)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com tickets abertos em risco de SLA, com atalho para a listagem filtrada",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#417): CRUD de calendários comerciais em Configurações → Atendimento → SLA → Calendários (horário semanal e feriados nacionais)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Configurações WhatsApp: editor de horário semanal reutilizado (mesmo componente dos calendários SLA)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "`aplicar_roteamento` restrito a administradores para sobrescrever setor explícito",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "UI em Configurações → Atendimento → Roteamento com simulador de teste seco",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Persistência do manifest de releases após cada deploy em staging",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.001",
+      "version_display": "v26.07.001",
+      "date": "2026-07-11",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#473): modal de encerramento deixava de carregar demandas — polling da conversa refazia o fetch e mantinha «A carregar demandas…» em loop; demanda passa a ser opcional quando o chat encerra por inatividade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#472): banner «contato não identificado» persistia após vincular/cadastrar — polling/SSE com snapshot antigo sobrescrevia o vínculo; sidebar e header atualizam na hora",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#471): cache de mídia por mensagem reduz refetch de blobs e mitiga `ERR_INSUFFICIENT_RESOURCES` no carregamento de anexos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: aviso de inatividade duplicado quando vários workers processavam o mesmo chat em paralelo (Gunicorn)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#443/#454): painel de emoji e envio de figurinhas no composer; Histórico e Avaliações preservam posição de scroll ao voltar da conversa",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#449): corrigido link do Histórico/Avaliações para conversa — query `?from=` separada do `pathname` (React Router v7)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Notificações (#452): pendências de mensagem não lida abrem o ticket ou chat concreto (`/tickets/{id}`, `/whatsapp/c/{id}`) — removido fallback genérico para listagens",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#447): terminologia «contato do cliente» no chat e tickets — distingue colaborador da rede de atendente interno",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#453): ícones por tipo de ficheiro (PDF, Word, Excel, etc.) nas mensagens de documento",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#446): marco «Demanda registada» na timeline via evento interno + SSE em tempo real; removido ao excluir demanda",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#455): Histórico lista chats em atendimento — colegas do setor consultam e comentam internamente; ordenação e filtros de data corrigidos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#443): barra de composição estilo WhatsApp Web (+ anexos, emoji e figurinhas, microfone à direita)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#445): modal de encerramento substitui `confirm()` nativo — registo/edição de demandas, aviso quando houve conversa após última demanda, marco na timeline e `ConfirmDialog` reutilizável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#449): botão Voltar na conversa regressa à lista de origem (Atendimento, Histórico ou Avaliações), com filtros na URL e atalho Escape",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#448): abas Histórico e Avaliações — filtros coerentes (finalizados incluem aguardando avaliação; avaliações só com nota respondida)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#444): cadastro de funcionário no chat com e-mail opcional; erros de validação visíveis dentro do modal (não atrás do overlay); toasts acima de modais",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#442): mensagens inbound passam a aparecer sem reload — polling de segurança na conversa e na fila, complementando SSE em deploy multi-worker",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#441): áudio gravado pelo atendente enviado como nota de voz via `sendWhatsAppAudio` (encoding Evolution); falha explícita se a API não confirmar entrega",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#431): mídia recebida (imagem, áudio, vídeo, documento, figurinha) gravada corretamente no webhook; fallback e retry na Evolution API; UI deixa de ficar presa em «Carregando mídia…» quando o ficheiro não está disponível",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#432): barra de anexos com ações visíveis (imagem, vídeo, áudio, documento, gravar áudio), pré-visualização antes do envio e legenda opcional",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#433): banner e badge «Sem vínculo» para contactos não cadastrados; botão vincular visível em mobile",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: mensagens de contacto e localização recebidas passam a aparecer como texto legível no chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Som de ticket novo na fila sem responsável tocava múltiplas vezes por emissões SSE duplicadas e hook de alerta montado em mais de um componente (#406)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (IC-F1): API backend para conversas diretas entre atendentes e canal de comunicados por setor — inbox, mensagens, leitura (`/v1/chat-interno`); conversas diretas privadas (admin não vê conversas de terceiros)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (IC-F2): mensagens internas no sino de notificações e evento SSE `chat.interno.mensagem`; contador `chat_interno_nao_lidas_count` no badge do navbar",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (IC-F3): inbox unificada, conversas diretas e canais de setor no menu Chat interno; comunicados com visual distinto; link no detalhe do setor; layout com lista lateral fixa para alternar conversas e ver não lidas",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#495): anexos e mídia — upload, download, pré-visualização no painel e colar imagem (Ctrl+V) no composer",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat operacional: hub unificado em `/chat` com abas Atendendo, Espera e Interno; Histórico permanece em menu separado",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno e WhatsApp: indicadores de envio, entrega e leitura nas mensagens (✓ / ✓✓)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Notificações: pendência do chat interno abre direto em `/chat/interno/{id}`",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#503): editar e apagar mensagens de texto — autor ou admin; exclusão lógica com «Mensagem apagada»",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#502): reações rápidas (👍 ❤️ 😂 😮 😢 🙏) em conversas diretas e canais de setor",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: editar e apagar para todos só nos primeiros 5 minutos; depois «apagar para mim»; opção de limpar conversa só para você",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: ao ler o histórico o scroll não volta sozinho para o fim; ao reabrir a conversa retoma na última mensagem visualizada",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#505): paginação infinita — carrega mensagens recentes e busca histórico ao rolar para cima (50 por vez)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#506): editar legenda de mensagens com mídia (mesma janela de 5 minutos)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno (#507): grupos personalizados com até 50 atendentes; criador e admins promovidos gerenciam membros",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#470): áudio gravado na barra de composição é enviado automaticamente ao terminar a gravação (estilo WhatsApp Web)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Identidade visual (#434): painel lateral do login e assets legados DX/Duplexsoft removidos — marca DeskRudder em todo o painel",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#296): admin vincula manuais a natureza/motivo; até 5 sugestões na classificação de tickets e demandas WhatsApp",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#465/#466): portal público `/kb` com logo e nome da empresa (Configurações → Empresa); listagem, busca e leitura de artigos sem login",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#467): personalização do portal em Configurações → Sistema → Base de conhecimento (cores da navbar, textos, links); menu lateral de categorias/subcategorias expansível no /kb; navbar com título centralizado, logo sem fundo branco e menu hamburger",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#293–#299): menu **Ajuda** para consultar manuais durante o atendimento; gestão de categorias e artigos (admin); consulta integrada em tickets e WhatsApp; manuais «só para a equipe»; imagens no texto; histórico de versões; reordenar categorias arrastando; manuais consultados ficam disponíveis offline neste computador",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria (#290–#292): trail expandido com payload, IP, request-id e user-agent; registro de atribuição, transferência, fechamento e reabertura de tickets, ações em chats WhatsApp, envio de e-mail ao cliente, visualização de credencial PDV e exportação de relatórios",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Auditoria: filtros por ação, período e atendente; exportação CSV; painel com detalhes do payload e request-id",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Página Sobre: badges de categoria (Melhorias, Correções, etc.) com texto centralizado e alinhamento uniforme na lista (#426)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#403): administradores acompanham chats alheios apenas com comentário interno; envio ao cliente restrito ao operador responsável",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat WhatsApp (#423): registro de demandas por sessão (natureza/motivo), auto-registro ao abrir ticket e agregação no dashboard de chats; edição via `PATCH`, marco na timeline e fluxo completo no modal de encerramento (#445)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#418): pausa automática da contagem quando o ticket está em status configurado (flag `pausa_sla`; «Aguardando cliente» ativado por padrão)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA: políticas opcionais por natureza do ticket; filtro «em risco» e dashboard usam o motor completo (calendário + pausa); prazo efetivo no card SLA",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#277): políticas por setor e prioridade, calendário comercial compartilhado e snapshot de metas na criação de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#278): cálculo com horário comercial, estados dentro/em risco/violado, worker periódico e endpoint de detalhe do SLA por ticket",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#279): alertas de SLA em risco e violado por e-mail e SSE, com preferências opt-in/out e debounce por ticket/meta",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#280): painel admin em Configurações → Atendimento → SLA para CRUD de políticas por setor/prioridade",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#281): badges e filtros na listagem de tickets e card de SLA no detalhe com countdown",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com quantidade de tickets abertos em violação de SLA, com atalho para a listagem filtrada (#416)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Dashboard geral: card com tickets abertos em risco de SLA, com atalho para a listagem filtrada",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SLA (#417): CRUD de calendários comerciais em Configurações → Atendimento → SLA → Calendários (horário semanal e feriados nacionais)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Configurações WhatsApp: editor de horário semanal reutilizado (mesmo componente dos calendários SLA)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Motor de roteamento automático: regras configuráveis por admin (setor, prioridade, natureza, motivo, atendente) com avaliação em e-mail inbound e criação manual de tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Audit log e histórico do ticket quando uma regra de roteamento é aplicada em runtime",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "`aplicar_roteamento` restrito a administradores para sobrescrever setor explícito",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "UI em Configurações → Atendimento → Roteamento com simulador de teste seco",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Histórico completo de atualizações no painel Sobre (versões anteriores permanecem visíveis)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "CHANGELOG obrigatório em PRs com mudança de produto (validação automática no CI)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Persistência do manifest de releases após cada deploy em staging",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.002",
+      "version_display": "v26.07.002",
+      "date": "2026-07-11",
+      "status": "published",
+      "changes": [
+        {
+          "category": "interno",
+          "text": "Atualização do sistema",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.003",
+      "version_display": "v26.07.003",
+      "date": "2026-07-14",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: conversa em atendimento disparava loop de pedidos a `/demandas` (e esgotava recursos do browser com `ERR_INSUFFICIENT_RESOURCES`) — o painel de demandas já não notifica o pai no carregamento inicial",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Base de conhecimento (#468): chat ao vivo no portal `/kb` — widget para visitantes; atendimento na mesma inbox WhatsApp (abas Aguardando/Atendendo) com badge Portal; protocolo unificado `#C`; mensagens automáticas, avaliação ao encerrar, anexos e áudio como no WhatsApp; transferência, demandas e encerramento com revisão",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.004",
+      "version_display": "v26.07.004",
+      "date": "2026-07-15",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Sons de alerta: toque de **abertura de ticket** e de **novo chat** (fila WhatsApp/Portal) estavam trocados — ticket usa `notification.mp3` e chat na fila usa `alerta.mp3`",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.005",
+      "version_display": "v26.07.005",
+      "date": "2026-07-15",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.006",
+      "version_display": "v26.07.006",
+      "date": "2026-07-15",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Chat (#539): após enviar mensagem (WhatsApp e chat interno), o cursor permanece no campo de texto; painel de emoji fica aberto ao escolher vários; **Responder** mensagem no chat interno (direta, equipe e grupo)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homônimos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp / modais: ao digitar na descrição da demanda no **Encerrar atendimento**, o campo perdia o foco a cada atualização da conversa — diálogo já não refoca o painel; formulário não é limpo pelo poll",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.007",
+      "version_display": "v26.07.007",
+      "date": "2026-07-16",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: removido botão duplicado «Identificar contato» no header — fica só o do banner enquanto o contacto não está vinculado; após vincular o CTA some",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: encerramento por inatividade só conta a partir da última mensagem do cliente quando o chat já está em atendimento e o atendente já enviou mensagem humana (auto_assumido/BOT não disparam o timer)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: Ctrl+V no composer cola imagem/ficheiro do clipboard (pré-visualização antes de enviar), como no chat interno",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat: removida a borda branca de foco no campo de mensagem e nos demais inputs/textareas (outline nativo + alinhamento ao design system)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: contraste no hover de Responder/Editar/Apagar; duplo clique na mensagem (ou ao lado do balão) inicia resposta e foca o composer — também no WhatsApp",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.008",
+      "version_display": "v26.07.008",
+      "date": "2026-07-16",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Equipe online (#545–#547): administradores veem quem está com o painel aberto e desde quando (menu **Equipe online**), para coordenar atendimento de chats e tickets",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#539): após enviar mensagem (WhatsApp e chat interno), o cursor permanece no campo de texto; painel de emoji fica aberto ao escolher vários; **Responder** mensagem no chat interno (direta, equipe e grupo)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: na busca «Vincular existente», cada resultado mostra **rede** e **empresa(s)** para distinguir homónimos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#534): identificar/cadastrar contato do cliente também em atendimento **encerrado** (Histórico); o número do WhatsApp passa a ser gravado no telefone do cadastro para retomar pela aba Contatos",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#531): aba **Contatos** no hub de chat — lista funcionários com empresa e telefone; iniciar conversa (ou número avulso / retomar no Histórico); chat já fica em atendimento com o iniciador; telefone no cadastro do funcionário da rede",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: o feed deixa de puxar sozinho para o fim enquanto você lê mensagens acima; ao reabrir a conversa, retoma a posição em que parou",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: ações (Responder/Editar/Apagar) e reações ficam fora do balão da mensagem",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: clique na imagem abre visualização em tela cheia (antes só tinha o cursor de zoom, sem ação)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Anexos de ticket: ficheiros deixam de desaparecer após atualização do sistema; se o arquivo já tiver sido perdido, o aviso deixa isso claro",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.009",
+      "version_display": "v26.07.009",
+      "date": "2026-07-16",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Chat interno (grupos/canal): menções com `@` — autocomplete de participantes e `@all` (todos); destaque visual na mensagem",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Equipe online: lista funciona com vários workers do servidor (presença gravada no banco); admin pode **Forçar saída** de um atendente conectado",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: balões mais próximos — opções/reações só no hover; em grupos, avatar e cor por pessoa para distinguir quem fala",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Equipe online: «0 online» mesmo com painel aberto (lista lia só a memória do worker errado)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: espaço excessivo entre mensagens após colocar ações/reações fora do balão",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.010",
+      "version_display": "v26.07.010",
+      "date": "2026-07-17",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Chat interno: alerta sonoro ao receber nova mensagem; em grupos, opção de **Silenciar** / **Ativar som** (preferência por pessoa)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat interno: ao passar o mouse em mensagens próximas, as opções (Responder/Editar/Apagar) e reações não “saltam” mais para a mensagem de cima",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.011",
+      "version_display": "v26.07.011",
+      "date": "2026-07-17",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "PDVs: código editável na edição (ex.: 001 ↔ 002 ao trocar equipamento); listagem mostra só o código, sem prefixo «PDV»; colunas separadas de acesso remoto, ID e senha (copiar ID/senha; revelar senha com o olho)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Modo escuro: texto digitado nos campos de pesquisa (listagens e chat interno) volta a ficar legível",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.012",
+      "version_display": "v26.07.012",
+      "date": "2026-07-18",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#577): encerramento por inatividade conta desde a **última mensagem** (cliente ou atendente); botão **Pausar/Retomar** com countdown no chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#575): ✓✓ azul no WhatsApp do cliente só quando o **atendente responsável** abre o chat no painel",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#568): ao anexar imagem, só o campo de legenda fica visível (sem o composer por baixo)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#569/#572/#574): legenda de mídia com a mesma fonte do texto; PDF/vídeo mostram legenda; sem placeholder «[Imagem enviada]» quando não há legenda",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#571): Esc no zoom da imagem fecha só a visualização, sem sair do chat",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#576): cancelar gravação de áudio já não envia o ficheiro",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#573): ao reabrir o chat, o scroll volta à última posição vista (não salta para o início)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#570): contacto já vinculado é reconhecido em chats novos do mesmo número",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.013",
+      "version_display": "v26.07.013",
+      "date": "2026-07-18",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#577): countdown até o aviso e, após o aviso, até encerrar; enviar mensagem (ou o cliente falar) sai automaticamente da pausa",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: após encerramento por inatividade, o chat fica em **A classificar demanda** (somente leitura) até registar, manter demandas existentes ou confirmar sem demanda; nova mensagem do mesmo cliente abre chat novo na fila",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#575): ticks de entrega/leitura no painel passam a atualizar (✓✓ / ✓✓ azul) — o webhook da Evolution com `keyId` + `DELIVERY_ACK`/`READ` era ignorado; mark-as-read no WhatsApp do cliente também quando chega mensagem nova com o responsável no chat",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.07.014",
+      "version_display": "v26.07.014",
+      "date": "2026-07-22",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Portal do cliente (#263 / #300–#308): funcionários da rede fazem login em **/portal**, abrem e acompanham chamados da sua empresa, respondem no fio público, anexam ficheiros, consultam a base de ajuda e recebem e-mail quando a equipe responde; o admin define a senha do portal no cadastro do funcionário",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#600, #601): cadastro de funcionário pelo modal da Rede permite definir senha do portal na criação; sócio cadastra sem escolher empresas (escopo automático em toda a rede)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#604): RBAC por papel — colaborador vê só os próprios chamados; supervisor vê todos das empresas vinculadas; sócio vê toda a rede",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#603): listagem e detalhe de atendimentos WhatsApp no `/portal` (somente leitura), com o mesmo escopo por papel e sem comentários internos da equipe",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#602): sócio gere a equipa no `/portal` — cadastro e edição de colaboradores e supervisores (empresas, senha do portal); outros sócios listados com edição limitada; colaborador/supervisor recebem 403",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal (#605): branding white-label no `/portal` — logo e cores da instância (mesmas configurações de Configurações → Base de conhecimento); login e shell aplicam a identidade do contratante, não a marca DeskRudder",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Portal: shell alinhado ao painel DeskRudder (menu lateral com usuário/Sair, navbar com expandir/recolher); cor do menu lateral configurável (padrão = navbar); chat ao vivo no `/portal` (mesmo canal da `/kb`, isolado por instância); login com logo em destaque, ícone de olho na senha e fundo minimalista; título do portal independente da central `/kb`",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#593): ao **cadastrar** contacto no chat, o sistema sugere funcionários com nome semelhante para vincular (evita duplicados); o atendente pode ignorar e criar novo",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#591): no detalhe da **Empresa**, nova aba **Chats** com atendimentos filtrados por aquela empresa (busca, paginação, abrir conversa / retomar)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#592): com funcionário em **mais de uma empresa**, o atendimento pode começar sem empresa; o atendente pergunta ao cliente e vincula (ou altera) a qualquer momento antes de encerrar — 1 empresa continua automática",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#590): na listagem **Atendimentos**, cada card mostra a **empresa** do contacto (ou «Sem empresa» quando não houver vínculo)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#607): na aba **Atendendo**, secções **Comigo** e **Outros atendentes** quando o admin acompanha colegas; badge «Você» e destaque visual nos seus; nome do responsável legível nos de outros",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#606): conversa mais utilizável no **mobile** — composer com campo largo e botão de manuais só ícone; menu **⋮** com Transferir/Tickets; metadados em linha separada; painel de demandas colapsável; `safe-area` no composer",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#608): duas mensagens inbound seguidas do mesmo contacto deixam de abrir dois chats/protocolos — lock por `wa_id` no webhook e uma única sequência de auto-mensagens por sessão",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#598): após encerrar com avaliação, janela de ~30 min (configurável) para a nota; se o cliente mandar outro texto, abre atendimento novo com essa mensagem; sem resposta, finaliza sozinho",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.001",
+      "version_display": "v26.08.001",
+      "date": "2026-08-02",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#628): no WhatsApp do cliente, mensagens do atendente saem com prefixo **setor do atendimento + nome** e o texto na linha de baixo (ex.: `[ Suporte - Ana ]:`); ao assumir, 1 setor é gravado automaticamente e vários setores pedem escolha no painel",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#629): no lightbox de imagens da conversa, dá para navegar entre as fotos (botões e setas ←/→) com contador e legenda atualizada; Esc continua a fechar só a visualização",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#630): foto de perfil do contacto no header e nas listas Atendendo/Aguardando (com cache e fallback para a inicial do nome)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#630): reações no chat com o cliente — ver emoji do cliente no balão e o atendente responsável pode reagir (👍 ❤️ 😂 😮 😢 🙏); clique de novo remove",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#630): editar (até 15 min) e apagar para todos (até 48 h) mensagens de texto enviadas pelo responsável; também sincroniza quando o cliente edita ou apaga",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: no header da conversa, o chip da empresa abre a página de detalhe da empresa (Voltar regressa ao chat); alterar empresa multi-empresa continua no menu ⋮",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#626): ícone de som junto a **Aguardando** para silenciar/reativar o alerta contínuo da fila (WhatsApp + portal); preferência guardada no browser — não afeta alertas de ticket nem do chat interno",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#625): ao **Ver** um chat da fila Aguardando, a lista com **Atender** permanece na lateral; na conversa há CTA **Atender** (WhatsApp e portal) para assumir sem voltar à lista",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#627): com anexo pendente, **Enter** na legenda (ou no painel, em áudio) envia o anexo — equivalente a «Enviar anexo»",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Login / site: «Voltar ao site» e hosts DeskRudder apontam para deskrudder.com.br (redirect da apex connect)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.002",
+      "version_display": "v26.08.002",
+      "date": "2026-08-02",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Frontend: alinhamento de `react` e `react-dom` em **19.2.8** (o Dependabot tinha subido só o `react`, o que gerava tela preta com React error #527 em produção)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.003",
+      "version_display": "v26.08.003",
+      "date": "2026-08-02",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#628): ao atender com vários setores, o modal «Escolher setor» voltava vazio (pedido com `limit` acima do máximo da API); a lista passa a carregar com paginação válida",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.004",
+      "version_display": "v26.08.004",
+      "date": "2026-08-02",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: na visualização ampliada de imagens, dá para fazer zoom (+/−, scroll e duplo clique), rodar e arrastar; repor volta à vista normal (também no chat interno)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat: duplo clique **dentro** do balão já não inicia resposta (dá para selecionar/copiar o texto); responder com duplo clique fica só **ao lado** do balão",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: menu com seta no canto do balão para Editar/Apagar (em vez de botões flutuantes que saltavam para a mensagem de cima)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: Enter na legenda do anexo deixava de enviar a imagem **duas vezes** (o evento subia ao painel e disparava o envio de novo)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.005",
+      "version_display": "v26.08.005",
+      "date": "2026-08-03",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "Dashboard (#599): filtros de período Hoje | Esta semana (seg–dom) | Este mês | Mês passado | Personalizado no geral, tickets e WhatsApp (substitui 7/30/90); CSAT do geral respeita o intervalo",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#594): análise de demandas no dashboard — drill-down por natureza/motivo, ranking por empresa, insights (erro → atualização; dúvida → treinamento) e sugestão de novo motivo a partir de «Outros» repetido",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Rede e Empresa (#595): aba Análises com tickets + demandas WhatsApp no período, insights e ranking (reutiliza #594/#599)",
+          "product": "deskrudder"
+        }
+      ]
+    },
+    {
+      "version": "26.08.006",
+      "version_display": "v26.08.006",
+      "date": "2026-08-12",
+      "status": "published",
+      "changes": [
+        {
+          "category": "melhorias",
+          "text": "WhatsApp: ao iniciar conversa com número avulso e o cliente responder, deixa de abrir chat novo na fila (alerta de «novo atendimento») quando o `wa_id` chega em variante (DDI / nono dígito BR) ou como `@lid` com `senderPn` / `remoteJidAlt`",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#667): em Atendimentos (e Avaliações), **Próxima** / **Anterior** deixam de voltar sozinhas para a página 1; o `offset` da URL é respeitado ao abrir/recarregar",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#651): **Silenciar** na fila Aguardando corta o alerta na hora (loop + pulse); o toque passa a tocar completo e a reiniciar em sequência, sem intervalo de silêncio",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "WhatsApp (#653): **Esc** na conversa já não percorre o histórico do browser (evita reabrir chat encerrado); fecha overlays locais e, ao sair, vai à lista de origem (Atendendo / Aguardando / etc.)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#652): com a aba em segundo plano, novo chat na fila dispara notificação do sistema (se permitida) e o áudio é desbloqueado no primeiro clique; ao voltar à aba o alerta retoma de imediato",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Chat (#652): banner no painel pede permissão de notificações («Ativar alertas») para avisar novos chats na fila mesmo com outra aba ou o navegador minimizado",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: **controle de licenças** — histórico/timeline na ficha, snapshot de módulos + limites na licença, preço/limites nos planos, e-mail de entrega com plano/módulos/acesso, conversão de lead com plano, `SAAS_MODULOS` no provisionamento e lista de instâncias no resumo",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: catálogo comercial de **planos e módulos** (CRUD, activar/desactivar, seed Trial/Profissional/Enterprise); licença escolhe plano em vez de texto livre",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: lista de licenças com **filtros** (plano, aprovação, provisionamento, renovação), cartões do resumo clicáveis e **escolha de plano** ao aprovar go-live",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: URL da instância deixa de ser campo livre — só o **nome da base (slug)**; URL = `https://{slug}.{domínio}/`; em local o «Abrir» usa a porta API (DNS público não resolve)",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: trial só **pede aprovação**; **Aprovar e criar base** enfileira a criação da instância/Postgres",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: **entrega pós-health** ao contacto (`entrega_notificada_em` + `reenviar-entrega`)",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: lead → licença com **vínculo persistido** (`POST ./leads/{id}/converter` + `lead_id` no formulário)",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: **suspender/reativar** pede (ou executa) `stack-client.sh down|up` e confirmação ops",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS: trial público entra com **aprovação pendente**; painel com **Aprovar go-live** / **Rejeitar** (`aprovacao_status`)",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "SaaS DeskRudder (#519 / #516 / #521–#528): painel de **licenças** (contactos, resumo ops, renovação flexível, lead→licença); **leads comerciais** da landing (formulário «Fale conosco», inbox `/saas/leads`); **provisionamento** em fila; **trial** em `/trial`; **renovações** com alertas e suspensão ao vencer",
+          "product": "saas"
+        },
+        {
+          "category": "melhorias",
+          "text": "Comercial (#321 / #331–#335): simulador com desconto posto <100k L (20% SM), override de custo/valor TEF só na proposta e snapshot imutável do pacote (catálogo TEF continua com valores padrão)",
+          "product": "deskrudder"
+        },
+        {
+          "category": "melhorias",
+          "text": "Comercial (#321 / #329–#334): catálogo de custos — salário mínimo com histórico por vigência (atualizar valor sem reescrever o passado), itens (% SM, valor fixo, TEF) e simulador em Cadastros → Catálogo de custos (admin)",
+          "product": "deskrudder"
         }
       ]
     }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -84,6 +84,7 @@ import { SaasModulos } from './pages/saas/SaasModulos'
 import { SaasLeads } from './pages/saas/SaasLeads'
 import { SaasLeadDetalhe } from './pages/saas/SaasLeadDetalhe'
 import { SaasLayout } from './pages/saas/SaasLayout'
+import { SaasSobre } from './pages/saas/SaasSobre'
 import { KbPublicLayout } from './pages/kb-public/KbPublicLayout'
 import { KbPublicHome } from './pages/kb-public/KbPublicHome'
 import { KbPublicArtigo } from './pages/kb-public/KbPublicArtigo'
@@ -205,6 +206,7 @@ function AppRoutes() {
         <Route path="modulos" element={<SaasModulos />} />
         <Route path="leads/:id" element={<SaasLeadDetalhe />} />
         <Route path="leads" element={<SaasLeads />} />
+        <Route path="sobre" element={<SaasSobre />} />
       </Route>
       <Route
         path="/"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3723,6 +3723,7 @@ export namespace System {
   export interface ReleaseChange {
     category: string;
     text: string;
+    product?: string | null;
   }
   export interface Release {
     version: string;
@@ -3743,6 +3744,11 @@ export namespace System {
 export const system = {
   info: () => api<System.Info>('/system/info'),
   releaseNotes: () => api<System.ReleaseNotes>('/system/release-notes'),
+};
+
+/** Release notes do control-plane (RBAC saas_ops). */
+export const saasReleaseNotes = {
+  get: () => api<System.ReleaseNotes>('/saas/release-notes'),
 };
 
 export const saasClientes = {

--- a/frontend/src/components/marketing/LandingContactSlot.tsx
+++ b/frontend/src/components/marketing/LandingContactSlot.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useState, type FormEvent } from 'react'
+import { createPortal } from 'react-dom'
 import { saasPublic } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { landingMailtoHref } from '../../content/landing'
@@ -81,8 +82,13 @@ function ContatoComercialModal({ titleId, onClose }: { titleId: string; onClose:
     function onKey(e: KeyboardEvent) {
       if (e.key === 'Escape') onClose()
     }
+    const prevOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
     window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
+    return () => {
+      document.body.style.overflow = prevOverflow
+      window.removeEventListener('keydown', onKey)
+    }
   }, [onClose])
 
   async function onSubmit(e: FormEvent) {
@@ -112,9 +118,9 @@ function ContatoComercialModal({ titleId, onClose }: { titleId: string; onClose:
   const field =
     'w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2.5 text-sm text-white placeholder:text-slate-500 focus:border-sky-400/50 focus:outline-none focus:ring-2 focus:ring-sky-400/25'
 
-  return (
+  return createPortal(
     <div
-      className="fixed inset-0 z-[100] flex items-end justify-center bg-black/70 p-4 backdrop-blur-sm sm:items-center"
+      className="fixed inset-0 z-[100] flex items-center justify-center overflow-y-auto bg-black/70 p-4 backdrop-blur-sm"
       role="presentation"
       onClick={onClose}
     >
@@ -122,7 +128,7 @@ function ContatoComercialModal({ titleId, onClose }: { titleId: string; onClose:
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
-        className="w-full max-w-lg rounded-2xl border border-white/10 bg-[#0b1c2b] p-5 shadow-2xl sm:p-6"
+        className="my-auto max-h-[min(90vh,40rem)] w-full max-w-lg overflow-y-auto rounded-2xl border border-white/10 bg-[#0b1c2b] p-5 shadow-2xl sm:p-6"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start justify-between gap-3">
@@ -199,6 +205,7 @@ function ContatoComercialModal({ titleId, onClose }: { titleId: string; onClose:
           </div>
         </form>
       </div>
-    </div>
+    </div>,
+    document.body,
   )
 }

--- a/frontend/src/components/release/ReleaseNotesView.tsx
+++ b/frontend/src/components/release/ReleaseNotesView.tsx
@@ -1,0 +1,153 @@
+import { Link } from 'react-router-dom'
+import type { System } from '../../api/client'
+import { Card } from '../../components/ui/Card'
+import { BrandLogo } from '../../brand'
+
+const CATEGORY_LABEL: Record<string, string> = {
+  melhorias: 'Melhorias',
+  correcoes: 'Correções',
+  interno: 'Interno / Infra',
+}
+
+function categoryClass(category: string): string {
+  if (category === 'correcoes') {
+    return 'bg-amber-50 text-amber-900 ring-amber-200/70 dark:bg-amber-950/40 dark:text-amber-100 dark:ring-amber-800/50'
+  }
+  if (category === 'interno') {
+    return 'bg-slate-100 text-slate-700 ring-slate-200/80 dark:bg-slate-800/60 dark:text-slate-200 dark:ring-slate-700/60'
+  }
+  return 'bg-cyan-50 text-cyan-900 ring-cyan-200/70 dark:bg-cyan-950/40 dark:text-cyan-100 dark:ring-cyan-800/50'
+}
+
+function formatDate(value: string): string {
+  const d = value.slice(0, 10)
+  const [y, m, day] = d.split('-')
+  if (!y || !m || !day) return value
+  return `${day}/${m}/${y}`
+}
+
+function ChangeList({ items }: { items: System.ReleaseChange[] }) {
+  if (!items.length) {
+    return <p className="text-sm text-slate-500 dark:text-slate-400">Nenhum item registrado.</p>
+  }
+  return (
+    <ul className="space-y-3">
+      {items.map((item, idx) => (
+        <li key={`${item.category}-${idx}`} className="flex items-start gap-3 text-sm leading-relaxed">
+          <span
+            className={`inline-flex min-w-[5.5rem] shrink-0 items-center justify-center self-start rounded-md px-2.5 py-1 text-center text-xs font-medium leading-none ring-1 ring-inset ${categoryClass(item.category)}`}
+          >
+            {CATEGORY_LABEL[item.category] ?? item.category}
+          </span>
+          <span className="min-w-0 flex-1 text-slate-700 dark:text-slate-200">{item.text}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function ReleaseBlock({ release }: { release: System.Release }) {
+  return (
+    <Card className="space-y-4 p-5">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">{release.version_display}</h2>
+        <time className="text-sm text-slate-500 dark:text-slate-400" dateTime={String(release.date)}>
+          {formatDate(String(release.date))}
+        </time>
+      </div>
+      <ChangeList items={release.changes} />
+    </Card>
+  )
+}
+
+export type ReleaseNotesViewProps = {
+  backTo: string
+  backLabel?: string
+  title: string
+  description: string
+  brandCaption?: string
+  versionLabel: string | null
+  notes: System.ReleaseNotes | null
+  loading?: boolean
+  showBrandLogo?: boolean
+}
+
+/** Lista partilhada de versão + histórico filtrado por produto (#674 / #675). */
+export function ReleaseNotesView({
+  backTo,
+  backLabel = 'Voltar',
+  title,
+  description,
+  brandCaption,
+  versionLabel,
+  notes,
+  loading = false,
+  showBrandLogo = true,
+}: ReleaseNotesViewProps) {
+  const pastReleases = (notes?.releases ?? []).filter((r) => r.version !== notes?.current?.version)
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-3xl">
+        <div className="h-56 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-8 pb-10">
+      <div>
+        <Link
+          to={backTo}
+          className="inline-flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-100"
+        >
+          <span aria-hidden>←</span> {backLabel}
+        </Link>
+        <h1 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">{title}</h1>
+        {showBrandLogo ? (
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <BrandLogo variant="full" size="md" />
+          </div>
+        ) : null}
+        {brandCaption ? <p className="mt-3 text-sm text-slate-600 dark:text-slate-400">{brandCaption}</p> : null}
+        <p className={`text-sm text-slate-600 dark:text-slate-400 ${brandCaption || showBrandLogo ? 'mt-2' : 'mt-3'}`}>
+          {description}
+        </p>
+      </div>
+
+      <Card className="space-y-2 p-5">
+        <p className="text-sm font-medium text-slate-500 dark:text-slate-400">Versão atual</p>
+        <p className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">
+          {versionLabel ?? '—'}
+        </p>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          CalVer do último deploy (mesma versão nos painéis DeskRudder e SaaS).
+        </p>
+      </Card>
+
+      {notes?.current ? (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">O que há de novo nesta versão</h2>
+          <ReleaseBlock release={notes.current} />
+        </section>
+      ) : null}
+
+      {pastReleases.length > 0 ? (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">Histórico</h2>
+          <p className="text-sm text-slate-600 dark:text-slate-400">
+            Atualizações publicadas em versões anteriores, do mais recente ao mais antigo.
+          </p>
+          <div className="space-y-4">
+            {pastReleases
+              .slice()
+              .reverse()
+              .map((release) => (
+                <ReleaseBlock key={release.version} release={release} />
+              ))}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/lib/marketingHost.ts
+++ b/frontend/src/lib/marketingHost.ts
@@ -34,6 +34,21 @@ export function isMarketingHost(hostname = typeof window !== 'undefined' ? windo
   return host === apex || host === `www.${apex}`
 }
 
+/**
+ * Destino de «Voltar ao site» (#677).
+ * Em apex/www/localhost o `/` já é a LP → SPA.
+ * Em subdomínio de cliente → URL absoluta da apex (evita loop `/` → `/login`).
+ */
+export function marketingHomeHref(
+  hostname = typeof window !== 'undefined' ? window.location.hostname : '',
+): { mode: 'spa'; to: '/' } | { mode: 'external'; href: string } {
+  const host = hostname.toLowerCase()
+  if (isMarketingHost(host) || host === 'localhost' || host === '127.0.0.1') {
+    return { mode: 'spa', to: '/' }
+  }
+  return { mode: 'external', href: `${MARKETING_SITE_URL}/` }
+}
+
 /** Normaliza e valida slug da conta (subdomínio). Retorna null se inválido. */
 export function normalizeClientSlug(raw: string): string | null {
   const slug = raw.trim().toLowerCase()

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -15,6 +15,7 @@ import {
   buildSessionHandoffUrl,
   isMarketingHost,
   loginAgainstClientInstance,
+  marketingHomeHref,
   normalizeClientSlug,
   readRememberedAccount,
   writeRememberedAccount,
@@ -26,6 +27,23 @@ const fieldClass =
 
 const secondaryLinkClass =
   'inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-white/15 bg-white/[0.06] px-4 py-2.5 text-sm font-medium transition hover:border-sky-400/40 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/40'
+
+/** «Voltar ao site» — LP na apex; em tenant aponta para a apex absoluta (#677). */
+function VoltarAoSiteLink({ className }: { className: string }) {
+  const dest = marketingHomeHref()
+  if (dest.mode === 'spa') {
+    return (
+      <Link to={dest.to} className={className}>
+        ← Voltar ao site
+      </Link>
+    )
+  }
+  return (
+    <a href={dest.href} className={className}>
+      ← Voltar ao site
+    </a>
+  )
+}
 
 function readRememberedEmail(): string {
   try {
@@ -172,9 +190,7 @@ function LoginConta() {
             Após validar, você entra direto no painel da sua empresa.
           </p>
           <div className="flex flex-col gap-2.5 sm:flex-row sm:justify-center">
-            <Link to="/" className={`${secondaryLinkClass} text-sky-300 hover:text-sky-200 sm:w-auto`}>
-              ← Voltar ao site
-            </Link>
+            <VoltarAoSiteLink className={`${secondaryLinkClass} text-sky-300 hover:text-sky-200 sm:w-auto`} />
             <a
               href={landingMailtoHref()}
               className={`${secondaryLinkClass} text-cyan-300 hover:text-cyan-200 sm:w-auto`}
@@ -362,9 +378,7 @@ function LoginCredenciais({ variant = 'tenant' }: { variant?: 'tenant' | 'ops' }
               </p>
             ) : null}
             <p className="text-center">
-              <Link to="/" className={`${secondaryLinkClass} text-sky-300 hover:text-sky-200`}>
-                ← Voltar ao site
-              </Link>
+              <VoltarAoSiteLink className={`${secondaryLinkClass} text-sky-300 hover:text-sky-200`} />
             </p>
           </div>
         </>

--- a/frontend/src/pages/saas/SaasLayout.tsx
+++ b/frontend/src/pages/saas/SaasLayout.tsx
@@ -146,6 +146,9 @@ export function SaasLayout() {
           <NavLink to="/saas/leads" className={navLinkClass}>
             <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Leads comerciais' : 'Leads'}</span>
           </NavLink>
+          <NavLink to="/saas/sobre" className={navLinkClass}>
+            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Sobre' : 'Info'}</span>
+          </NavLink>
         </nav>
         <div className="border-t border-slate-200 p-3 dark:border-slate-800">
           {sidebarExpanded || sidebarMobileOpen ? (

--- a/frontend/src/pages/saas/SaasSobre.tsx
+++ b/frontend/src/pages/saas/SaasSobre.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react'
-import { system, type System } from '../api/client'
-import { mensagemFalhaParaToast } from '../api/errorMessage'
-import { APP_DESCRIPTION, APP_NAME } from '../brand'
-import { ReleaseNotesView } from '../components/release/ReleaseNotesView'
-import { useToast } from '../components/ui/Toast'
+import { saasReleaseNotes, system, type System } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { ReleaseNotesView } from '../../components/release/ReleaseNotesView'
+import { useToast } from '../../components/ui/Toast'
+import { SAAS_LICENCAS_PATH } from '../../lib/saasControlPlane'
 
-/** Página Sobre do DeskRudder — só notas product=deskrudder (#674). */
-export function Sobre() {
+/** Novidades do control-plane SaaS (#675). */
+export function SaasSobre() {
   const toast = useToast()
   const [loading, setLoading] = useState(true)
   const [info, setInfo] = useState<System.Info | null>(null)
@@ -15,7 +15,7 @@ export function Sobre() {
   useEffect(() => {
     let cancelled = false
     setLoading(true)
-    Promise.all([system.info(), system.releaseNotes()])
+    Promise.all([system.info(), saasReleaseNotes.get()])
       .then(([i, n]) => {
         if (!cancelled) {
           setInfo(i)
@@ -24,7 +24,7 @@ export function Sobre() {
       })
       .catch((err) => {
         if (!cancelled) {
-          toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar informações da versão.'))
+          toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar as novidades do SaaS.'))
         }
       })
       .finally(() => {
@@ -44,13 +44,15 @@ export function Sobre() {
 
   return (
     <ReleaseNotesView
-      backTo="/"
-      title="Sobre"
-      brandCaption={APP_DESCRIPTION}
-      description={`Consulte a versão em uso e o que mudou nas atualizações do ${APP_NAME} nesta instância (helpdesk). Melhorias do painel SaaS não aparecem aqui.`}
+      backTo={SAAS_LICENCAS_PATH}
+      backLabel="Voltar às licenças"
+      title="Sobre / Novidades"
+      brandCaption="Painel admin SaaS — licenças, planos e provisionamento."
+      description="Atualizações do control-plane DeskRudder (ops). Notas do helpdesk nas instâncias dos clientes ficam em Sobre no painel de atendimento."
       versionLabel={versionLabel}
       notes={notes}
       loading={loading}
+      showBrandLogo
     />
   )
 }

--- a/scripts/check_changelog.py
+++ b/scripts/check_changelog.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Valida CHANGELOG [Unreleased] em PRs com mudanças de produto (#400)."""
+"""Valida CHANGELOG [Unreleased] em PRs com mudanças de produto (#400 / #673)."""
 
 from __future__ import annotations
 
@@ -11,6 +11,15 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CHANGELOG = ROOT / "CHANGELOG.md"
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+from prepare_release import (  # noqa: E402
+    PRODUCT_DESKRUDDER,
+    PRODUCT_SAAS,
+    parse_changelog_unreleased,
+)
 
 PRODUCT_PREFIXES = (
     "backend/app/",
@@ -27,6 +36,21 @@ SKIP_PREFIXES = (
     "docs/releases/",
     "backend/app/data/release_notes.json",
     "frontend/public/release_notes.json",
+    "frontend/public/release-notes.json",
+)
+
+# Paths tipicamente do control-plane SaaS (#673)
+SAAS_PATH_MARKERS = (
+    "frontend/src/pages/saas/",
+    "frontend/src/lib/saasControlPlane",
+    "backend/app/api/saas",
+    "backend/app/services/saas_",
+    "backend/app/models/cliente_saas",
+    "backend/app/models/saas_",
+    "backend/app/schemas/saas",
+    "backend/tests/test_saas",
+    "deploy/scripts/saas-",
+    "deploy/scripts/stack-client",
 )
 
 
@@ -59,16 +83,41 @@ def requires_changelog(paths: list[str]) -> bool:
     return product
 
 
+def is_saas_path(path: str) -> bool:
+    p = path.replace("\\", "/")
+    return any(p.startswith(m) or m in p for m in SAAS_PATH_MARKERS)
+
+
+def products_required_by_paths(paths: list[str]) -> set[str]:
+    """Heurística: paths SaaS → saas; demais de produto → deskrudder."""
+    needed: set[str] = set()
+    for p in paths:
+        if any(p.startswith(s) for s in SKIP_PREFIXES):
+            continue
+        is_product = (
+            any(p.startswith(prefix) for prefix in PRODUCT_PREFIXES)
+            or p.startswith("backend/")
+            or p.startswith("frontend/")
+            or (p.startswith("scripts/") and "check_changelog" not in p)
+        )
+        if not is_product:
+            continue
+        if is_saas_path(p):
+            needed.add(PRODUCT_SAAS)
+        else:
+            needed.add(PRODUCT_DESKRUDDER)
+    return needed
+
+
 def parse_unreleased_bullets(text: str) -> list[str]:
-    m = re.search(r"## \[Unreleased\](.*?)(?=\n## \[|\Z)", text, re.DOTALL | re.IGNORECASE)
-    if not m:
-        return []
-    bullets: list[str] = []
-    for line in m.group(1).splitlines():
-        bullet = re.match(r"^-\s+(.+)$", line.strip())
-        if bullet:
-            bullets.append(bullet.group(1).strip())
-    return bullets
+    return [c["text"] for c in parse_changelog_unreleased(text, warn_legacy=False)]
+
+
+def bullets_by_product(text: str) -> dict[str, list[str]]:
+    out: dict[str, list[str]] = {PRODUCT_DESKRUDDER: [], PRODUCT_SAAS: []}
+    for c in parse_changelog_unreleased(text, warn_legacy=False):
+        out.setdefault(c["product"], []).append(c["text"])
+    return out
 
 
 def main() -> int:
@@ -93,27 +142,46 @@ def main() -> int:
         print("Arquivos:", ", ".join(paths[:12]) + ("…" if len(paths) > 12 else ""))
         return 0
 
-    # CHANGELOG na revisão do PR (head)
     try:
         text = _run("git", "show", f"{args.head}:{args.changelog.relative_to(ROOT).as_posix()}")
     except RuntimeError:
         text = args.changelog.read_text(encoding="utf-8") if args.changelog.is_file() else ""
 
     bullets = parse_unreleased_bullets(text)
-    if bullets:
-        print(f"OK: CHANGELOG [Unreleased] com {len(bullets)} item(ns) de produto.")
-        return 0
+    if not bullets:
+        print(
+            "::error::Este PR altera código de produto, mas CHANGELOG.md não tem bullets em ## [Unreleased].\n"
+            "Adicione entregas sob ### DeskRudder e/ou ### SaaS Control Plane, ex.:\n"
+            "  ### DeskRudder\n"
+            "  #### Melhorias\n"
+            "  - Descrição curta da funcionalidade (#123)\n"
+            "Veja docs/RELEASES.md",
+            file=sys.stderr,
+        )
+        print("Arquivos de produto no diff:", ", ".join(paths[:20]), file=sys.stderr)
+        return 1
 
-    print(
-        "::error::Este PR altera código de produto, mas CHANGELOG.md não tem bullets em ## [Unreleased].\n"
-        "Adicione uma linha por entrega (texto para o usuário final), ex.:\n"
-        "  ### Melhorias\n"
-        "  - Descrição curta da funcionalidade (#123)\n"
-        "Veja docs/RELEASES.md",
-        file=sys.stderr,
-    )
-    print("Arquivos de produto no diff:", ", ".join(paths[:20]), file=sys.stderr)
-    return 1
+    needed = products_required_by_paths(paths)
+    by_prod = bullets_by_product(text)
+    missing = [p for p in sorted(needed) if not by_prod.get(p)]
+    if missing:
+        labels = {
+            PRODUCT_DESKRUDDER: "### DeskRudder",
+            PRODUCT_SAAS: "### SaaS Control Plane",
+        }
+        want = ", ".join(labels[p] for p in missing)
+        print(
+            f"::error::Este PR altera código de {', '.join(missing)}, mas CHANGELOG [Unreleased] "
+            f"não tem bullets na(s) subseção(ões) {want}.\n"
+            "Separe notas por produto (docs/RELEASES.md — «Dois produtos, um deploy»).",
+            file=sys.stderr,
+        )
+        print("Arquivos no diff:", ", ".join(paths[:20]), file=sys.stderr)
+        return 1
+
+    parts = [f"{p}={len(by_prod.get(p, []))}" for p in sorted(needed or by_prod.keys())]
+    print(f"OK: CHANGELOG [Unreleased] com {len(bullets)} item(ns) ({', '.join(parts)}).")
+    return 0
 
 
 if __name__ == "__main__":

--- a/scripts/migrate_release_notes_product.py
+++ b/scripts/migrate_release_notes_product.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Migra docs/releases/manifest.json com campo product por bullet (#676).
+
+Idempotente: bullets já com product válido são preservados.
+Heurística: texto que começa com «SaaS» → saas; resto → deskrudder.
+
+Uso:
+  python scripts/migrate_release_notes_product.py
+  python scripts/migrate_release_notes_product.py --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parent
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from prepare_release import (  # noqa: E402
+    PRODUCT_DESKRUDDER,
+    PRODUCT_SAAS,
+    ROOT,
+    build_payload,
+    write_release_notes,
+)
+
+MANIFEST_FILE = ROOT / "docs" / "releases" / "manifest.json"
+VERSION_FILE = ROOT / "VERSION"
+
+_SAAS_PREFIX = re.compile(r"(?i)^saas\b")
+
+
+def classify_product(text: str) -> str:
+    if _SAAS_PREFIX.match((text or "").strip()):
+        return PRODUCT_SAAS
+    return PRODUCT_DESKRUDDER
+
+
+def migrate_manifest(data: dict) -> tuple[dict, dict[str, int]]:
+    stats = {"saas": 0, "deskrudder": 0, "kept": 0, "total": 0}
+    releases = []
+    for rel in data.get("releases") or []:
+        entry = dict(rel)
+        changes = []
+        for ch in entry.get("changes") or []:
+            if not isinstance(ch, dict):
+                changes.append(ch)
+                continue
+            item = dict(ch)
+            stats["total"] += 1
+            existing = item.get("product")
+            if existing in (PRODUCT_DESKRUDDER, PRODUCT_SAAS):
+                stats["kept"] += 1
+                stats[existing] += 1
+            else:
+                product = classify_product(str(item.get("text") or ""))
+                item["product"] = product
+                stats[product] += 1
+            changes.append(item)
+        entry["changes"] = changes
+        releases.append(entry)
+    return {"releases": releases}, stats
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Classifica bullets do manifest com product (#676)")
+    ap.add_argument("--dry-run", action="store_true", help="Só imprime estatísticas")
+    ap.add_argument("--no-write-json", action="store_true", help="Não regenera release_notes.json")
+    args = ap.parse_args()
+
+    if not MANIFEST_FILE.is_file():
+        print(f"::error::{MANIFEST_FILE} não encontrado", file=sys.stderr)
+        return 1
+
+    raw = json.loads(MANIFEST_FILE.read_text(encoding="utf-8"))
+    migrated, stats = migrate_manifest(raw)
+    print(
+        f"Bullets: total={stats['total']} deskrudder={stats['deskrudder']} "
+        f"saas={stats['saas']} (já tinham product={stats['kept']})"
+    )
+
+    if args.dry_run:
+        return 0
+
+    MANIFEST_FILE.write_text(json.dumps(migrated, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(f"Atualizado: {MANIFEST_FILE.relative_to(ROOT)}")
+
+    if not args.no_write_json:
+        version = VERSION_FILE.read_text(encoding="utf-8").strip() if VERSION_FILE.is_file() else None
+        payload = build_payload(current_version=version or None, manifest=migrated, upcoming=[])
+        write_release_notes(payload)
+        print("Regenerados: backend/app/data/release_notes.json e frontend/public/release-notes.json")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
-Prepara manifest de releases e release-notes.json (#401).
+Prepara manifest de releases e release-notes.json (#401 / #673).
 
 Modo --deploy: bump CalVer, consome seção [Unreleased] do CHANGELOG e atualiza artefatos.
+Suporta subseções por produto (DeskRudder vs SaaS Control Plane).
 """
 
 from __future__ import annotations
@@ -28,18 +29,42 @@ MANIFEST_FILE = ROOT / "docs" / "releases" / "manifest.json"
 BACKEND_DATA = ROOT / "backend" / "app" / "data" / "release_notes.json"
 FRONTEND_PUBLIC = ROOT / "frontend" / "public" / "release-notes.json"
 
+PRODUCT_DESKRUDDER = "deskrudder"
+PRODUCT_SAAS = "saas"
+
+PRODUCT_MAP = {
+    "deskrudder": PRODUCT_DESKRUDDER,
+    "saas control plane": PRODUCT_SAAS,
+    "saas": PRODUCT_SAAS,
+}
+
+PRODUCT_TITLE = {
+    PRODUCT_DESKRUDDER: "DeskRudder",
+    PRODUCT_SAAS: "SaaS Control Plane",
+}
+
 CATEGORY_MAP = {
     "melhorias": "melhorias",
     "melhoria": "melhorias",
     "added": "melhorias",
+    "changed": "melhorias",
     "correcoes": "correcoes",
+    "correções": "correcoes",
     "correção": "correcoes",
     "correcao": "correcoes",
+    "corrigido": "correcoes",
+    "corrigidos": "correcoes",
     "fixed": "correcoes",
     "interno": "interno",
+    "interno / infra": "interno",
     "infra": "interno",
     "internal": "interno",
-    "changed": "melhorias",
+}
+
+CATEGORY_TITLE = {
+    "melhorias": "Melhorias",
+    "correcoes": "Correções",
+    "interno": "Interno / Infra",
 }
 
 _LEGACY_BRAND_RE = re.compile(r"DX/Duplexsoft|Duplexsoft|DX Connect|DX-Connect", re.IGNORECASE)
@@ -83,49 +108,123 @@ def _save_manifest(data: dict) -> None:
     MANIFEST_FILE.write_text(json.dumps(data, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
-def parse_changelog_unreleased(text: str) -> list[dict[str, str]]:
-    """Extrai bullets da seção [Unreleased] agrupados por ### categoria."""
+def _norm_header(raw: str) -> str:
+    return re.sub(r"\s+", " ", raw.strip().lower())
+
+
+def _is_product_header(title: str) -> str | None:
+    return PRODUCT_MAP.get(_norm_header(title))
+
+
+def _is_category_header(title: str) -> str | None:
+    key = _norm_header(title)
+    if key in CATEGORY_MAP:
+        return CATEGORY_MAP[key]
+    return None
+
+
+def parse_changelog_unreleased(
+    text: str,
+    *,
+    warn_legacy: bool = True,
+) -> list[dict[str, str]]:
+    """Extrai bullets de [Unreleased] com product + category.
+
+    Formato preferido (#673)::
+
+        ### DeskRudder
+        #### Melhorias
+        - …
+
+        ### SaaS Control Plane
+        #### Correções
+        - …
+
+    Legado (só ### Melhorias / ### Corrigido): product=deskrudder + warning.
+    """
     m = re.search(r"## \[Unreleased\](.*?)(?=\n## \[|\Z)", text, re.DOTALL | re.IGNORECASE)
     if not m:
         return []
     body = m.group(1)
     changes: list[dict[str, str]] = []
+    current_product: str | None = None
     current_cat = "melhorias"
+    saw_legacy_category = False
     for line in body.splitlines():
-        hdr = re.match(r"^###\s+(.+)$", line.strip())
-        if hdr:
-            key = hdr.group(1).strip().lower()
-            current_cat = CATEGORY_MAP.get(key, "melhorias")
+        stripped = line.strip()
+        h4 = re.match(r"^####\s+(.+)$", stripped)
+        if h4:
+            cat = _is_category_header(h4.group(1))
+            current_cat = cat or "melhorias"
             continue
-        bullet = re.match(r"^-\s+(.+)$", line.strip())
+        h3 = re.match(r"^###\s+(.+)$", stripped)
+        if h3:
+            title = h3.group(1)
+            product = _is_product_header(title)
+            if product is not None:
+                current_product = product
+                continue
+            cat = _is_category_header(title)
+            if cat is not None:
+                current_cat = cat
+                if current_product is None:
+                    saw_legacy_category = True
+                continue
+            # Cabeçalho desconhecido sob produto ativo → trata como categoria genérica
+            if current_product is not None:
+                current_cat = "melhorias"
+            else:
+                saw_legacy_category = True
+                current_cat = "melhorias"
+            continue
+        bullet = re.match(r"^-\s+(.+)$", stripped)
         if bullet:
+            product = current_product or PRODUCT_DESKRUDDER
             changes.append(
-                {"category": current_cat, "text": sanitize_release_text(bullet.group(1).strip())}
+                {
+                    "product": product,
+                    "category": current_cat,
+                    "text": sanitize_release_text(bullet.group(1).strip()),
+                }
             )
+    if warn_legacy and saw_legacy_category and any(c["product"] == PRODUCT_DESKRUDDER for c in changes):
+        print(
+            "::warning::CHANGELOG [Unreleased] sem subseção de produto — "
+            "bullets legados tratados como DeskRudder. "
+            "Use ### DeskRudder / ### SaaS Control Plane (docs/RELEASES.md).",
+            file=sys.stderr,
+        )
     return changes
 
 
 def finalize_changelog_release(text: str, version: str, date: str) -> str:
-    """Move [Unreleased] para [version] e recria [Unreleased] vazio."""
-    unreleased = parse_changelog_unreleased(text)
+    """Move [Unreleased] para [version] (com produtos) e recria [Unreleased] vazio."""
+    unreleased = parse_changelog_unreleased(text, warn_legacy=False)
     if not unreleased:
         return text
+
     block_lines = [f"## [{version}] - {date}", ""]
-    by_cat: dict[str, list[str]] = {}
+    # Mantém ordem DeskRudder → SaaS; categorias na ordem de aparição
+    by_product: dict[str, dict[str, list[str]]] = {}
+    product_order: list[str] = []
     for c in unreleased:
-        label = c["category"]
-        cat_title = {
-            "melhorias": "Melhorias",
-            "correcoes": "Correções",
-            "interno": "Interno / Infra",
-        }.get(label, "Melhorias")
-        by_cat.setdefault(cat_title, []).append(c["text"])
-    for cat_title, items in by_cat.items():
-        block_lines.append(f"### {cat_title}")
+        prod = c["product"]
+        if prod not in by_product:
+            by_product[prod] = {}
+            product_order.append(prod)
+        cat_title = CATEGORY_TITLE.get(c["category"], "Melhorias")
+        by_product[prod].setdefault(cat_title, []).append(c["text"])
+
+    for prod in product_order:
+        block_lines.append(f"### {PRODUCT_TITLE.get(prod, prod)}")
         block_lines.append("")
-        for item in items:
-            block_lines.append(f"- {item}")
-        block_lines.append("")
+        for cat_title, items in by_product[prod].items():
+            block_lines.append(f"#### {cat_title}")
+            block_lines.append("")
+            for item in items:
+                block_lines.append(f"- {item}")
+            block_lines.append("")
+
     new_block = "\n".join(block_lines).rstrip() + "\n"
 
     without_unreleased = re.sub(
@@ -135,7 +234,6 @@ def finalize_changelog_release(text: str, version: str, date: str) -> str:
         count=1,
         flags=re.DOTALL | re.IGNORECASE,
     )
-    # Insere release após cabeçalho Unreleased
     parts = without_unreleased.split("## [Unreleased]", 1)
     if len(parts) != 2:
         return text


### PR DESCRIPTION
## Summary
- Separa release notes DeskRudder vs SaaS Control Plane (CHANGELOG, manifest com `product`, APIs `/system/release-notes` e `/saas/release-notes`, `/sobre` e `/saas/sobre`) — épico #672 e filhas #673–#676
- Login (#677): «Voltar ao site» no subdomínio do cliente abre a landing apex (`VITE_MARKETING_SITE_URL`)
- Landing (#668): modal de demonstração centrado com scroll (portal no `body`)

Closes #672
Closes #673
Closes #674
Closes #675
Closes #676
Closes #677
Closes #668

## Test plan
- [ ] `docker compose run --rm --no-deps -v ${PWD}:/workspace -w /workspace/backend backend pytest -q tests/test_system_release.py tests/test_check_changelog.py tests/test_migrate_release_notes_product.py`
- [ ] CI: changelog + pytest + build frontend
- [ ] `/sobre`: sem bullets «SaaS:» (ex. histórico v26.08.006)
- [ ] `/saas/sobre` (ops + control-plane): só notas SaaS
- [ ] Login em host de cliente: «Voltar ao site» → apex LP
- [ ] LP: abrir «Quero ver uma demonstração» — modal centrado, campos visíveis / scroll
