### PR TITLE
feat(crm): leads, Kanban, funil e perfil comercial (#322)

### DIFF
--- a/.cursor/commands/implementar-issue.md
+++ b/.cursor/commands/implementar-issue.md
@@ -6,7 +6,9 @@ Implemente a issue ou épico indicado pelo usuário seguindo o padrão do DX Con
 
 Se o usuário não passou issue, peça:
 - número/link da issue GitHub **ou**
-- caminho do body em `.github/planning-issue-bodies/`
+- descrição do lote (ex.: «lote A do #322»)
+
+Ler o body com `gh issue view` (e issues filhas do lote). **Não** depender de ficheiros locais em `.github/planning-issue-bodies/` para o corpo da issue.
 
 Leia o body completo antes de codar. Respeite **fora de escopo** e **critérios de aceite**.
 

--- a/.cursor/commands/iniciar-feature.md
+++ b/.cursor/commands/iniciar-feature.md
@@ -58,7 +58,7 @@ Informe:
 Sugira próximo passo:
 
 ```
-/implementar-issue @<arquivo-da-issue.md>
+/implementar-issue #<número-da-issue-ou-lote>
 ```
 
 **Não** escreva código de feature neste comando — só preparar Git.

--- a/.cursor/commands/planejar-feature.md
+++ b/.cursor/commands/planejar-feature.md
@@ -5,27 +5,28 @@ Planeje uma feature **antes** de implementar. Use a skill `design-feature` como 
 ## Entrada
 
 Se o usuário não passou referência, peça:
-- caminho do body em `.github/planning-issue-bodies/` **ou**
-- número/link da issue GitHub **ou**
+- número/link da **issue GitHub** (preferido) **ou**
 - descrição livre da feature
+
+Não peça caminho de `.md` local em `.github/planning-issue-bodies/` — a verdade está no GitHub.
 
 ## Fluxo
 
 ### 1. Contexto
 
-- Ler issue/épico completo
+- Ler issue/épico completo com `gh issue view`
 - Ler código existente relacionado (use subagent `explore` se o domínio for grande)
 - Identificar padrões vizinhos no repo (api/services/models similares)
 
 ### 2. Plano (skill design-feature)
 
-Produzir plano com:
+Produzir plano **no chat** (não gravar ficheiro local) com:
 - Escopo dentro/fora
 - Mapa de arquivos (criar vs alterar)
-- Decisões RBAC (admin vs atendente, setor_scope, casos 403)
+- Decisões RBAC (admin vs atendente/comercial, setor_scope, casos 403)
 - SSE e notificações (se aplicável)
 - Migration Alembic (se aplicável)
-- Ordem de implementação em etapas
+- Ordem de implementação em etapas / lotes
 - Testes mínimos
 - Riscos e dúvidas em aberto
 
@@ -34,15 +35,24 @@ Produzir plano com:
 - Apresente o plano completo
 - Se houver ambiguidade de produto, **pare e pergunte** antes de seguir
 - Não escreva código nesta fase
+- **Não** criar `.md` em `planning-issue-bodies/` ou `analises/`
 
-### 4. Handoff
+### 4. Persistir decisões (obrigatório se há issue)
 
-Encerre com:
+Quando o utilizador confirmar decisões de produto:
+
+```bash
+gh issue comment <número> --body "..."
+```
+
+Incluir no comentário: decisões fechadas, fora de escopo, ordem de lotes/PRs.
+
+### 5. Handoff
 
 ```
 Plano pronto. Próximos passos:
 /iniciar-feature
-/implementar-issue @<arquivo-da-issue.md>
+/implementar-issue #<número-da-issue-ou-lote>
 ```
 
-**Não** commitar, criar arquivos de código nem abrir PR nesta fase — só o plano.
+**Não** commitar, criar ficheiros de código nem abrir PR nesta fase — só o plano no chat + comentário na issue.

--- a/.cursor/rules/issue-closure-backlog.mdc
+++ b/.cursor/rules/issue-closure-backlog.mdc
@@ -11,8 +11,8 @@ Ao **fechar** uma issue ou épico (merge do PR + fechamento no GitHub):
 
 1. **Escopo da issue atual** — só o que estava nos critérios de aceite; não expandir no mesmo PR.
 2. **Identificar lacunas** — stubs, «fora de escopo v1», melhorias descobertas na implementação, débito explícito.
-3. **Abrir issues novas** — uma issue por follow-up, com corpo em `.github/planning-issue-bodies/followups/` quando fizer sentido.
-4. **Referenciar origem** — seção «Origem» no corpo: issue/épico que motivou o follow-up.
+3. **Abrir issues novas** — uma issue por follow-up via `gh issue create` (corpo no GitHub; **não** gravar em `.github/planning-issue-bodies/followups/`).
+4. **Referenciar origem** — seção «Origem» no corpo da issue: issue/épico que motivou o follow-up.
 5. **Comentário ao fechar** — no PR ou na issue fechada, listar links `#NNN` dos follow-ups criados.
 
 ## Checklist (obrigatório antes de fechar)

--- a/.cursor/rules/planning-github-source.mdc
+++ b/.cursor/rules/planning-github-source.mdc
@@ -1,0 +1,34 @@
+---
+description: Planejamento e issues — GitHub é a fonte da verdade; não acumular .md locais
+alwaysApply: true
+---
+
+# Planejamento — sem lixo local
+
+## Fonte da verdade
+
+- **Issues / épicos / aceite / decisões de produto** → **GitHub** (`gh issue view`, `gh issue comment`, `gh issue create`)
+- **Índice de números** (opcional) → `.github/planning-issue-bodies/ISSUES_CRIADAS.md` (só links, sem duplicar corpo)
+
+## Proibido ao agente (padrão)
+
+1. Criar ou atualizar ficheiros em `.github/planning-issue-bodies/` para planos, spikes ou corpos de issue **só porque estamos a planear no chat**
+2. Commitar rascunhos de planeamento «para não perder» — usar comentário na issue
+3. Pedir commit de `.md` de análise quando a decisão já pode ir no GitHub
+
+## O que fazer em `/planejar-feature`
+
+1. Ler a issue/épico no GitHub
+2. Apresentar o plano **no chat**
+3. Quando o utilizador confirmar decisões → `gh issue comment <n>` com o resumo (decisões, escopo, ordem de lotes)
+4. **Não** gravar `analises/*.md` nem `followups/*.md` locais
+
+## Follow-ups ao fechar issue
+
+- Abrir com `gh issue create` (corpo no comando / ficheiro temp apagado a seguir)
+- Comentar na issue/PR fechada com os `#NNN`
+- **Não** exigir body em `.github/planning-issue-bodies/followups/`
+
+## Exceção (rara)
+
+Só escrever/commitar em `analises/` se o utilizador pedir **explicitamente** um doc durável no repo (ex.: decisão arquitectónica multi-épico que não cabe num comentário). Preferir sempre comentário ou issue dedicada.

--- a/.cursor/rules/project-core.mdc
+++ b/.cursor/rules/project-core.mdc
@@ -21,7 +21,7 @@ Sistema interno de helpdesk para redes de postos (tickets, WhatsApp, e-mail, SSE
 - SSE: `docs/REALTIME_SSE.md`
 - Migrations: `docs/ALEMBIC_MIGRATIONS.md`
 - Deploy: `docs/DEPLOYMENT_ARCHITECTURE.md`
-- Planejamento: `.github/planning-issue-bodies/`
+- Planejamento: issues no **GitHub** (ver rule `planning-github-source`); índice opcional em `.github/planning-issue-bodies/ISSUES_CRIADAS.md`
 
 ## Dev e testes (Docker-first)
 

--- a/.cursor/skills/design-feature/SKILL.md
+++ b/.cursor/skills/design-feature/SKILL.md
@@ -5,29 +5,31 @@ description: Planeja features do DX Connect — camadas, RBAC, SSE, migrations e
 
 # Design Feature — DX Connect
 
-Playbook para **planejar** antes de implementar. Não escreva código nesta fase — produza um plano revisável.
+Playbook para **planear** antes de implementar. Não escreva código nesta fase — produza um plano revisável **no chat**.
 
 ## Quando usar
 
-- Épico ou issue nova em `.github/planning-issue-bodies/`
+- Épico ou issue no **GitHub** (`gh issue view`)
 - Feature que cruza backend + frontend + tempo real
 - Dúvida sobre onde colocar lógica ou como aplicar RBAC
 
+**Não** criar ficheiros em `.github/planning-issue-bodies/` para o plano — ver rule `planning-github-source`.
+
 ## Fase 1 — Ler e delimitar
 
-1. Ler body completo da issue/épico
+1. Ler body completo da issue/épico no GitHub
 2. Extrair:
    - **Objetivo** (1 frase)
    - **Dentro do escopo** / **Fora do escopo**
    - **Dependências** (issues bloqueantes)
    - **Critérios de aceite**
-3. Identificar bounded context: tickets, chats, notificações, cadastro, WhatsApp, etc.
+3. Identificar bounded context: tickets, chats, notificações, cadastro, WhatsApp, comercial, etc.
 
 Se faltar escopo, pergunte uma vez com opções — não assuma.
 
 ## Fase 2 — Mapa técnico
 
-Preencha mentalmente (e no output) esta tabela:
+Preencha mentalmente (e no output do chat) esta tabela:
 
 | Camada | Arquivos prováveis | Necessário? |
 |--------|-------------------|-------------|
@@ -47,28 +49,26 @@ Consultar e aplicar:
 
 | Tema | Onde decidir | Pergunta-chave |
 |------|--------------|----------------|
-| RBAC | `docs/BACKEND_RBAC.md`, `setor_scope` | Admin-only ou escopo por setor? |
+| RBAC | `docs/BACKEND_RBAC.md`, `setor_scope` | Admin-only, comercial, ou escopo por setor? |
 | SSE | `docs/REALTIME_SSE.md` | Quem recebe o evento? Payload? |
 | Deploy | `docs/DEPLOYMENT_ARCHITECTURE.md` | Afeta multi-cliente / migration? |
 | Tenant | `project-core` rule | Não modelar em cima de `tenant_id` legado |
 
 ### Checklist RBAC
 
-- [ ] Rotas de cadastro usam `exigir_admin`
-- [ ] Operação usa `obter_atendente_atual` + `setor_scope`
+- [ ] Rotas de cadastro usam `exigir_admin` (ou papel adequado)
+- [ ] Operação usa `obter_atendente_atual` + `setor_scope` quando aplicável
 - [ ] Homônimos considerados (não filtrar só no frontend)
 - [ ] Testes 403 documentados
 
 ### Checklist tempo real
 
-- [ ] Tipo de evento definido (`chat.mensagem`, `ticket.fila`, etc.)
+- [ ] Tipo de evento definido
 - [ ] Publicação **após commit** DB
 - [ ] Destinatários filtrados por RBAC
-- [ ] Frontend consome via `EventStreamContext` (sem SSE duplicado)
+- [ ] Frontend via `EventStreamContext` (sem SSE duplicado)
 
 ## Fase 4 — Ordem de implementação
-
-Ordem padrão para features full-stack:
 
 ```
 1. Model + migration (alembic heads único)
@@ -83,11 +83,11 @@ Ordem padrão para features full-stack:
 10. Build frontend
 ```
 
-Quebrar em **issues/sub-PRs** quando possível (ex.: IC-01 → IC-02 → IC-03).
+Agrupar em **lotes/PRs** conforme `main-pr-batch-delivery` (não micro-PR por issue).
 
 ## Fase 5 — Output do plano
 
-Entregar neste formato:
+Entregar **no chat**. Após confirmação do utilizador → `gh issue comment` na issue/épico.
 
 ```markdown
 ## Resumo
@@ -105,27 +105,23 @@ Entregar neste formato:
 
 ## RBAC
 - Admin: ...
-- Atendente: ...
+- Atendente / comercial: ...
 - Casos 403: ...
 
 ## SSE (se houver)
-- Tipo: ...
-- Payload: ...
-- Quem recebe: ...
+- ...
 
 ## Ordem de implementação
 1. ...
-2. ...
 
 ## Testes
-- [ ] ...
 - [ ] ...
 
 ## Riscos / dúvidas
 - ...
 
 ## Próximo passo
-→ `/implementar-issue @<arquivo-da-issue.md>`
+→ `/iniciar-feature` + `/implementar-issue #<issue-ou-lote>`
 ```
 
 ## Referências
@@ -133,4 +129,4 @@ Entregar neste formato:
 - `docs/BACKEND_RBAC.md`
 - `docs/REALTIME_SSE.md`
 - `docs/ALEMBIC_MIGRATIONS.md`
-- `.github/planning-issue-bodies/`
+- Issues no GitHub (não cópias locais de bodies)

--- a/.github/planning-issue-bodies/README.md
+++ b/.github/planning-issue-bodies/README.md
@@ -4,22 +4,26 @@
 
 | Tipo | Onde |
 |------|------|
-| Issues abertas (texto, aceite, comentários) | **GitHub** — fonte da verdade |
-| Índice de épicos e números | [`ISSUES_CRIADAS.md`](ISSUES_CRIADAS.md) |
-| Análises / spikes de viabilidade | [`analises/`](analises/) — inclui SaaS vs produto |
+| Issues, aceite, decisões, comentários de plano | **GitHub** — fonte da verdade |
+| Índice opcional de épicos/números | [`ISSUES_CRIADAS.md`](ISSUES_CRIADAS.md) (só links — sem duplicar corpo) |
+| Análises antigas (legado) | [`analises/`](analises/) — **não criar novos** por defeito; preferir comentário/issue no GitHub |
 
 Épico SaaS DeskRudder (licenças/instâncias): [#519](https://github.com/lgustavoss/dx-connect/issues/519).
 
-Não mantemos cópias locais do **corpo** de issues já publicadas no GitHub. Isso evita divergência entre repositório e o que o time revisa na issue.
+Não mantemos cópias locais do **corpo** de issues nem planos de feature em `.md`. Isso evita divergência e acumulação de rascunhos.
 
 ## Como abrir issues novas
 
 1. Criar direto no GitHub ou com `gh issue create`.
 2. Usar labels e vincular ao épico/meta-issue relevante ([#16](https://github.com/lgustavoss/dx-connect/issues/16) para melhorias de produto).
-3. Se fizer parte de um lote planejado, adicionar uma linha em [`ISSUES_CRIADAS.md`](ISSUES_CRIADAS.md) (só link e título — sem duplicar o corpo).
+3. Se fizer parte de um lote, opcionalmente uma linha em [`ISSUES_CRIADAS.md`](ISSUES_CRIADAS.md) (só link e título).
 
-Para issues recorrentes (bug, feature), considere no futuro templates em `.github/ISSUE_TEMPLATE/` — padrão comum da comunidade para **orientar quem abre**, não para armazenar specs fechadas.
+## Como planear (`/planejar-feature`)
+
+1. Plano no **chat**.
+2. Decisões confirmadas → `gh issue comment` na issue/épico.
+3. Sem ficheiro local em `analises/` ou `followups/`.
 
 ## Histórico
 
-Antes desta pasta continha rascunhos `.md` + scripts (`create_planning_issues.py`, `create_commercial_planning_issues.py`) usados para criar issues em lote. Após criação e revisão no GitHub (#256–#308, #321–#375, etc.), os rascunhos foram removidos; permanecem apenas o índice e análises.
+Antes havia rascunhos `.md` + scripts para criar issues em lote. Após publicação no GitHub, os corpos locais foram removidos. A pasta `analises/` ainda tem docs legados; novos planos vão para o GitHub.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Guia para desenvolvimento assistido por IA no Cursor (time 2–3 devs).
 | Rule | Quando |
 |------|--------|
 | `project-core` | Sempre |
+| `planning-github-source` | Sempre — planos/decisões no GitHub, sem `.md` locais de rascunho |
 | `backend-fastapi` | Arquivos em `backend/**` |
 | `frontend-react` | Arquivos em `frontend/**` |
 | `rbac-setor-scope` | `backend/app/api/**`, `backend/app/core/**` |
@@ -63,10 +64,10 @@ Use subagents para **paralelizar** ou **isolar** trabalho:
 ### Padrão recomendado por feature
 
 ```
-1. /planejar-feature @IC-02-backend-api-chat-interno.md
-2. revisar plano (RBAC, SSE, migrations)
-3. /iniciar-feature                    → branch feat/chat-interno-api-ic02
-4. /implementar-issue @IC-02-backend-api-chat-interno.md
+1. /planejar-feature #322
+2. revisar plano (RBAC, SSE, migrations) — decisões → comentário na issue
+3. /iniciar-feature                    → branch feat/...
+4. /implementar-issue #336-340         → lote
 5. /revisar-e-testar
 6. /criar-pr                           → PR + CI + approve + merge em main
 ```
@@ -95,4 +96,5 @@ Skills futuras sugeridas:
 - `docs/REALTIME_SSE.md`
 - `docs/ALEMBIC_MIGRATIONS.md`
 - `docs/DEPLOYMENT_ARCHITECTURE.md`
-- `.github/planning-issue-bodies/`
+- Issues e decisões de produto no **GitHub**
+- Índice opcional: `.github/planning-issue-bodies/ISSUES_CRIADAS.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### Adicionado
 
-- CRM (#322 / #336–#340): perfil `comercial`, funil configurável, leads e negociações multi-CNPJ (API `/v1/crm`), timeline de atividades e simulação de custos liberada para comercial (CRUD do catálogo continua só admin)
+- CRM (#322 / #336–#344): perfil `comercial`, funil, leads e negociações multi-CNPJ (API + UI — lista/Kanban com scrollbar discreta, reordenação e rename de colunas no board para admin, detalhe com custos/margem e timeline); configuração dos estágios do funil em Cadastros; simulação e leitura do catálogo de custos para comercial (CRUD do catálogo continua só admin)
 
 ### Corrigido
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ## [Unreleased]
 
+### Adicionado
+
+- CRM (#322 / #336–#340): perfil `comercial`, funil configurável, leads e negociações multi-CNPJ (API `/v1/crm`), timeline de atividades e simulação de custos liberada para comercial (CRUD do catálogo continua só admin)
+
 ### Corrigido
 
 - Chat: duplo clique **dentro** do balão já não inicia resposta (dá para selecionar/copiar o texto); responder com duplo clique fica só **ao lado** do balão

--- a/backend/alembic/versions/084_crm_leads_negociacao.py
+++ b/backend/alembic/versions/084_crm_leads_negociacao.py
@@ -1,0 +1,166 @@
+"""CRM — funil, leads e negociações (#322 / #083 → #084).
+
+Revision ID: 084_crm_leads_negociacao
+Revises: 083_comercial_custos_tier_posto
+Create Date: 2026-08-10
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "084_crm_leads_negociacao"
+down_revision = "083_comercial_custos_tier_posto"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if not insp.has_table("crm_funil_estagios"):
+        op.create_table(
+            "crm_funil_estagios",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("slug", sa.String(50), nullable=False),
+            sa.Column("nome", sa.String(120), nullable=False),
+            sa.Column("ordem", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("tipo", sa.String(20), nullable=False, server_default="aberto"),
+            sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+            sa.UniqueConstraint("slug", name="uq_crm_funil_estagio_slug"),
+        )
+        op.create_index("ix_crm_funil_estagios_slug", "crm_funil_estagios", ["slug"])
+        op.create_index("ix_crm_funil_estagios_ordem", "crm_funil_estagios", ["ordem"])
+
+    if not insp.has_table("crm_leads"):
+        op.create_table(
+            "crm_leads",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("nome", sa.String(255), nullable=False),
+            sa.Column("telefone", sa.String(40), nullable=True),
+            sa.Column("email", sa.String(255), nullable=True),
+            sa.Column("empresa_texto", sa.String(255), nullable=True),
+            sa.Column("origem", sa.String(80), nullable=True),
+            sa.Column("notas", sa.Text(), nullable=True),
+            sa.Column("responsavel_id", sa.Integer(), sa.ForeignKey("atendentes.id", ondelete="RESTRICT"), nullable=False),
+            sa.Column(
+                "estagio_id",
+                sa.Integer(),
+                sa.ForeignKey("crm_funil_estagios.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column("perdido_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.create_index("ix_crm_leads_responsavel_id", "crm_leads", ["responsavel_id"])
+        op.create_index("ix_crm_leads_estagio_id", "crm_leads", ["estagio_id"])
+
+    if not insp.has_table("crm_negociacoes"):
+        op.create_table(
+            "crm_negociacoes",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("lead_id", sa.Integer(), sa.ForeignKey("crm_leads.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("responsavel_id", sa.Integer(), sa.ForeignKey("atendentes.id", ondelete="RESTRICT"), nullable=False),
+            sa.Column(
+                "estagio_id",
+                sa.Integer(),
+                sa.ForeignKey("crm_funil_estagios.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column("ativa", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("titulo", sa.String(255), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.create_index("ix_crm_negociacoes_lead_id", "crm_negociacoes", ["lead_id"])
+        op.create_index("ix_crm_negociacoes_responsavel_id", "crm_negociacoes", ["responsavel_id"])
+        op.create_index("ix_crm_negociacoes_estagio_id", "crm_negociacoes", ["estagio_id"])
+        op.create_index("ix_crm_negociacoes_ativa", "crm_negociacoes", ["ativa"])
+
+    if not insp.has_table("crm_negociacao_cnpj_linhas"):
+        op.create_table(
+            "crm_negociacao_cnpj_linhas",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "negociacao_id",
+                sa.Integer(),
+                sa.ForeignKey("crm_negociacoes.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("cnpj", sa.String(18), nullable=True),
+            sa.Column("razao_social", sa.String(255), nullable=True),
+            sa.Column("item_ids", sa.JSON(), nullable=False),
+            sa.Column("quantidade_pdvs", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("desconto_posto_100k", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+            sa.Column("tef_override", sa.JSON(), nullable=True),
+            sa.Column("valor_negociado", sa.Numeric(14, 2), nullable=False, server_default="0"),
+            sa.Column("snapshot_custo", sa.JSON(), nullable=True),
+            sa.Column("total_custo", sa.Numeric(14, 2), nullable=True),
+            sa.Column("margem_calculada", sa.Numeric(14, 2), nullable=True),
+            sa.Column("empresa_id", sa.Integer(), sa.ForeignKey("empresas.id", ondelete="SET NULL"), nullable=True),
+            sa.Column("ordem", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.create_index("ix_crm_negociacao_cnpj_linhas_negociacao_id", "crm_negociacao_cnpj_linhas", ["negociacao_id"])
+        op.create_index("ix_crm_negociacao_cnpj_linhas_cnpj", "crm_negociacao_cnpj_linhas", ["cnpj"])
+
+    if not insp.has_table("crm_negociacao_atividades"):
+        op.create_table(
+            "crm_negociacao_atividades",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "negociacao_id",
+                sa.Integer(),
+                sa.ForeignKey("crm_negociacoes.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("autor_id", sa.Integer(), sa.ForeignKey("atendentes.id", ondelete="RESTRICT"), nullable=False),
+            sa.Column("tipo", sa.String(40), nullable=False, server_default="nota"),
+            sa.Column("texto", sa.Text(), nullable=False),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        )
+        op.create_index(
+            "ix_crm_negociacao_atividades_negociacao_id", "crm_negociacao_atividades", ["negociacao_id"]
+        )
+        op.create_index("ix_crm_negociacao_atividades_created_at", "crm_negociacao_atividades", ["created_at"])
+
+    # Seed funil padrão se vazio
+    conn = op.get_bind()
+    count = conn.execute(sa.text("SELECT COUNT(*) FROM crm_funil_estagios")).scalar()
+    if not count:
+        rows = [
+            ("lead", "Lead", 10, "aberto"),
+            ("em_negociacao", "Em negociação", 20, "aberto"),
+            ("documentacao", "Documentação", 30, "aberto"),
+            ("proposta_enviada", "Proposta enviada", 40, "aberto"),
+            ("contrato_assinado", "Contrato assinado", 50, "ganho"),
+            ("implantacao", "Implantação", 60, "ganho"),
+            ("perdido", "Perdido", 90, "perdido"),
+        ]
+        for slug, nome, ordem, tipo in rows:
+            conn.execute(
+                sa.text(
+                    "INSERT INTO crm_funil_estagios (slug, nome, ordem, tipo, ativo) "
+                    "VALUES (:slug, :nome, :ordem, :tipo, true)"
+                ),
+                {"slug": slug, "nome": nome, "ordem": ordem, "tipo": tipo},
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    for table in (
+        "crm_negociacao_atividades",
+        "crm_negociacao_cnpj_linhas",
+        "crm_negociacoes",
+        "crm_leads",
+        "crm_funil_estagios",
+    ):
+        if insp.has_table(table):
+            op.drop_table(table)

--- a/backend/alembic/versions/093_crm_leads_negociacao.py
+++ b/backend/alembic/versions/093_crm_leads_negociacao.py
@@ -1,15 +1,15 @@
-"""CRM — funil, leads e negociações (#322 / #083 → #084).
+"""CRM — funil, leads e negociações (#322 / #093).
 
-Revision ID: 084_crm_leads_negociacao
-Revises: 083_comercial_custos_tier_posto
+Revision ID: 093_crm_leads_negociacao
+Revises: 092_saas_licenca_completa
 Create Date: 2026-08-10
 """
 
 import sqlalchemy as sa
 from alembic import op
 
-revision = "084_crm_leads_negociacao"
-down_revision = "083_comercial_custos_tier_posto"
+revision = "093_crm_leads_negociacao"
+down_revision = "092_saas_licenca_completa"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -10,7 +10,7 @@ from app.models import Atendente, Setor
 from app.schemas.atendente import AtendenteCreate, AtendenteRead, AtendenteUpdate, TrocaSenhaPropria
 from app.schemas.ticket_csat import AtendenteAvaliacoesRead, AvaliacaoResumoRead
 from app.schemas.lista_paginada import ListaPaginada
-from app.core.auth import exigir_admin, obter_atendente_atual
+from app.core.auth import exigir_admin, obter_atendente_atual, validar_role
 from app.services.atendente_avaliacoes import calcular_avaliacoes_atendente
 from app.core.setor_scope import ids_setores_mesmo_nome, ids_setores_visiveis_atendente
 from app.core.security import hash_senha, verificar_senha
@@ -93,12 +93,13 @@ def criar_atendente(
         .first()
     ):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="E-mail já cadastrado")
+    role = validar_role(data.role)
     atendente = Atendente(
         tenant_id=atendente_logado.tenant_id,
         email=data.email,
         nome=data.nome,
         senha_hash=hash_senha(data.senha),
-        role=data.role,
+        role=role,
         ativo=data.ativo,
     )
     db.add(atendente)
@@ -220,6 +221,8 @@ def atualizar_atendente(
     if "senha" in update and update["senha"]:
         atendente.senha_hash = hash_senha(update.pop("senha"))
         atendente.must_change_password = False
+    if "role" in update and update["role"] is not None:
+        update["role"] = validar_role(update["role"])
     if "setor_ids" in update:
         setor_ids = update.pop("setor_ids")
         atendente.setores.clear()

--- a/backend/app/api/comercial_custos.py
+++ b/backend/app/api/comercial_custos.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
-from app.core.auth import exigir_admin
+from app.core.auth import exigir_admin, exigir_comercial_ou_admin
 from app.core.audit import registrar_audit
 from app.core.ordenacao_lista import OrdemLista, expr_ordem
 from app.database import get_db
@@ -225,9 +225,9 @@ def excluir_item_custo(
 def simular_custo(
     body: CustoSimularRequest,
     db: Session = Depends(get_db),
-    _: Atendente = Depends(exigir_admin),
+    _: Atendente = Depends(exigir_comercial_ou_admin),
 ):
-    """Simula pacote de custos; devolve também snapshot imutável (#331/#332/#335)."""
+    """Simula pacote de custos; devolve também snapshot imutável (#331/#332/#335). Comercial + admin (#336)."""
     return svc.simular_custo(
         db,
         item_ids=body.item_ids,

--- a/backend/app/api/comercial_custos.py
+++ b/backend/app/api/comercial_custos.py
@@ -151,8 +151,9 @@ def listar_itens_custo(
     ordenar_por: OrdenarItem | None = Query(OrdenarItem.ordem),
     ordem: OrdemLista = Query(OrdemLista.asc),
     db: Session = Depends(get_db),
-    _: Atendente = Depends(exigir_admin),
+    _: Atendente = Depends(exigir_comercial_ou_admin),
 ):
+    """Lista itens do catálogo — leitura para montar pacote na negociação (#343). Mutações continuam admin."""
     q = db.query(CustoCatalogoItem)
     if not incluir_inativos:
         q = q.filter(CustoCatalogoItem.ativo.is_(True))

--- a/backend/app/api/crm.py
+++ b/backend/app/api/crm.py
@@ -1,0 +1,322 @@
+"""API CRM — leads, funil e negociações (#322 / #336–#340)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.core.auth import exigir_admin, exigir_comercial_ou_admin
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.models.crm import CrmNegociacaoCnpjLinha
+from app.schemas.crm import (
+    CrmAtividadeCreate,
+    CrmAtividadeRead,
+    CrmLeadCreate,
+    CrmLeadRead,
+    CrmLeadUpdate,
+    CrmLinhaCreate,
+    CrmLinhaRead,
+    CrmLinhaUpdate,
+    CrmMoverEstagioRequest,
+    CrmNegociacaoCreate,
+    CrmNegociacaoRead,
+    CrmNegociacaoUpdate,
+    FunilEstagioCreate,
+    FunilEstagioRead,
+    FunilEstagioUpdate,
+)
+from app.schemas.lista_paginada import ListaPaginada
+from app.services import crm as svc
+
+router = APIRouter(prefix="/crm", tags=["crm"])
+
+_MAX_PAGE = 100
+_DEFAULT_PAGE = 50
+
+
+@router.get("/funil-estagios", response_model=list[FunilEstagioRead])
+def listar_funil(
+    incluir_inativos: bool = Query(False),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    return svc.listar_estagios(db, incluir_inativos=incluir_inativos)
+
+
+@router.post("/funil-estagios", response_model=FunilEstagioRead, status_code=201)
+def criar_funil_estagio(
+    data: FunilEstagioCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = svc.criar_estagio(db, data)
+    registrar_audit(db, "crm_funil_estagio", row.id, "create", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.patch("/funil-estagios/{estagio_id}", response_model=FunilEstagioRead)
+def atualizar_funil_estagio(
+    estagio_id: int,
+    data: FunilEstagioUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = svc.obter_estagio(db, estagio_id=estagio_id, apenas_ativos=False)
+    row = svc.atualizar_estagio(db, row, data)
+    registrar_audit(db, "crm_funil_estagio", row.id, "update", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.get("/leads", response_model=ListaPaginada[CrmLeadRead])
+def listar_leads(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    q: str | None = Query(None),
+    responsavel_id: int | None = Query(None),
+    estagio_id: int | None = Query(None),
+    so_minhas: bool = Query(False, description="Filtra só leads do utilizador logado"),
+    ativo: bool | None = Query(True),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    rows, total = svc.listar_leads(
+        db,
+        offset=offset,
+        limit=limit,
+        q=q,
+        responsavel_id=responsavel_id,
+        estagio_id=estagio_id,
+        so_minhas=so_minhas,
+        ator_id=atendente.id,
+        ativo=ativo,
+    )
+    return ListaPaginada(items=[CrmLeadRead(**svc.lead_to_read(db, r)) for r in rows], total=total)
+
+
+@router.post("/leads", response_model=CrmLeadRead, status_code=201)
+def criar_lead(
+    data: CrmLeadCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    lead = svc.criar_lead(db, data, atendente)
+    registrar_audit(db, "crm_lead", lead.id, "create", atendente.id)
+    db.commit()
+    lead = svc.obter_lead(db, lead.id)
+    return CrmLeadRead(**svc.lead_to_read(db, lead))
+
+
+@router.get("/leads/{lead_id}", response_model=CrmLeadRead)
+def obter_lead(
+    lead_id: int,
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    lead = svc.obter_lead(db, lead_id)
+    return CrmLeadRead(**svc.lead_to_read(db, lead))
+
+
+@router.patch("/leads/{lead_id}", response_model=CrmLeadRead)
+def atualizar_lead(
+    lead_id: int,
+    data: CrmLeadUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    lead = svc.obter_lead(db, lead_id)
+    lead = svc.atualizar_lead(db, lead, data)
+    registrar_audit(db, "crm_lead", lead.id, "update", atendente.id)
+    db.commit()
+    lead = svc.obter_lead(db, lead.id)
+    return CrmLeadRead(**svc.lead_to_read(db, lead))
+
+
+@router.get("/negociacoes", response_model=ListaPaginada[CrmNegociacaoRead])
+def listar_negociacoes(
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    lead_id: int | None = Query(None),
+    responsavel_id: int | None = Query(None),
+    estagio_id: int | None = Query(None),
+    ativa: bool | None = Query(True),
+    q: str | None = Query(None),
+    so_minhas: bool = Query(False),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    rows, total = svc.listar_negociacoes(
+        db,
+        offset=offset,
+        limit=limit,
+        lead_id=lead_id,
+        responsavel_id=responsavel_id,
+        estagio_id=estagio_id,
+        ativa=ativa,
+        q=q,
+        so_minhas=so_minhas,
+        ator_id=atendente.id,
+    )
+    return ListaPaginada(
+        items=[CrmNegociacaoRead(**svc.negociacao_to_read(r)) for r in rows],
+        total=total,
+    )
+
+
+@router.post("/negociacoes", response_model=CrmNegociacaoRead, status_code=201)
+def criar_negociacao(
+    data: CrmNegociacaoCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    neg = svc.criar_negociacao(db, data, atendente)
+    registrar_audit(db, "crm_negociacao", neg.id, "create", atendente.id)
+    db.commit()
+    neg = svc.obter_negociacao(db, neg.id)
+    return CrmNegociacaoRead(**svc.negociacao_to_read(neg))
+
+
+@router.get("/negociacoes/{negociacao_id}", response_model=CrmNegociacaoRead)
+def obter_negociacao(
+    negociacao_id: int,
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    neg = svc.obter_negociacao(db, negociacao_id)
+    return CrmNegociacaoRead(**svc.negociacao_to_read(neg))
+
+
+@router.patch("/negociacoes/{negociacao_id}", response_model=CrmNegociacaoRead)
+def atualizar_negociacao(
+    negociacao_id: int,
+    data: CrmNegociacaoUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    neg = svc.obter_negociacao(db, negociacao_id)
+    neg = svc.atualizar_negociacao(db, neg, data)
+    registrar_audit(db, "crm_negociacao", neg.id, "update", atendente.id)
+    db.commit()
+    neg = svc.obter_negociacao(db, neg.id)
+    return CrmNegociacaoRead(**svc.negociacao_to_read(neg))
+
+
+@router.post("/negociacoes/{negociacao_id}/mover-estagio", response_model=CrmNegociacaoRead)
+def mover_estagio(
+    negociacao_id: int,
+    body: CrmMoverEstagioRequest,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    neg = svc.obter_negociacao(db, negociacao_id)
+    neg = svc.mover_estagio(
+        db,
+        neg,
+        ator=atendente,
+        estagio_id=body.estagio_id,
+        estagio_slug=body.estagio_slug,
+        nota=body.nota,
+    )
+    registrar_audit(db, "crm_negociacao", neg.id, "mover_estagio", atendente.id)
+    db.commit()
+    neg = svc.obter_negociacao(db, neg.id)
+    return CrmNegociacaoRead(**svc.negociacao_to_read(neg))
+
+
+@router.post(
+    "/negociacoes/{negociacao_id}/linhas",
+    response_model=CrmLinhaRead,
+    status_code=201,
+)
+def adicionar_linha(
+    negociacao_id: int,
+    data: CrmLinhaCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    neg = svc.obter_negociacao(db, negociacao_id)
+    linha = svc.add_linha(db, neg, data)
+    registrar_audit(db, "crm_negociacao_linha", linha.id, "create", atendente.id)
+    db.commit()
+    db.refresh(linha)
+    return linha
+
+
+@router.patch("/negociacoes/{negociacao_id}/linhas/{linha_id}", response_model=CrmLinhaRead)
+def atualizar_linha(
+    negociacao_id: int,
+    linha_id: int,
+    data: CrmLinhaUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    linha = (
+        db.query(CrmNegociacaoCnpjLinha)
+        .filter(CrmNegociacaoCnpjLinha.id == linha_id, CrmNegociacaoCnpjLinha.negociacao_id == negociacao_id)
+        .first()
+    )
+    if not linha:
+        raise HTTPException(status_code=404, detail="Linha CNPJ não encontrada.")
+    linha = svc.atualizar_linha(db, linha, data)
+    registrar_audit(db, "crm_negociacao_linha", linha.id, "update", atendente.id)
+    db.commit()
+    db.refresh(linha)
+    return linha
+
+
+@router.delete("/negociacoes/{negociacao_id}/linhas/{linha_id}", status_code=204)
+def excluir_linha(
+    negociacao_id: int,
+    linha_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    linha = (
+        db.query(CrmNegociacaoCnpjLinha)
+        .filter(CrmNegociacaoCnpjLinha.id == linha_id, CrmNegociacaoCnpjLinha.negociacao_id == negociacao_id)
+        .first()
+    )
+    if not linha:
+        raise HTTPException(status_code=404, detail="Linha CNPJ não encontrada.")
+    svc.excluir_linha(db, linha)
+    registrar_audit(db, "crm_negociacao_linha", linha_id, "delete", atendente.id)
+    db.commit()
+    return None
+
+
+@router.get(
+    "/negociacoes/{negociacao_id}/atividades",
+    response_model=ListaPaginada[CrmAtividadeRead],
+)
+def listar_atividades(
+    negociacao_id: int,
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    rows, total = svc.listar_atividades(db, negociacao_id, offset=offset, limit=limit)
+    return ListaPaginada(items=rows, total=total)
+
+
+@router.post(
+    "/negociacoes/{negociacao_id}/atividades",
+    response_model=CrmAtividadeRead,
+    status_code=201,
+)
+def criar_atividade(
+    negociacao_id: int,
+    data: CrmAtividadeCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    row = svc.criar_atividade(db, negociacao_id, data, atendente)
+    registrar_audit(db, "crm_negociacao_atividade", row.id, "create", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -110,3 +110,26 @@ def exigir_admin(atendente: Atendente = Depends(obter_atendente_atual)) -> Atend
     if atendente.role != "admin":
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Acesso restrito a administradores")
     return atendente
+
+
+def exigir_comercial_ou_admin(atendente: Atendente = Depends(obter_atendente_atual)) -> Atendente:
+    """CRM e simulação de custos (#336 / #322): admin ou perfil comercial."""
+    if atendente.role not in ("admin", "comercial"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Acesso restrito a perfil comercial ou administrador",
+        )
+    return atendente
+
+
+ROLES_ATENDENTE = frozenset({"admin", "atendente", "comercial"})
+
+
+def validar_role(role: str) -> str:
+    r = (role or "").strip().lower()
+    if r not in ROLES_ATENDENTE:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"role inválido: use admin, atendente ou comercial",
+        )
+    return r

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,6 +40,7 @@ from app.api import (
     ticket_catalogos,
     empresa_pdvs,
     comercial_custos,
+    crm,
     system_settings,
     tenant,
     public_csat,
@@ -455,6 +456,7 @@ app.include_router(respostas_prontas.router, prefix=API_V1_PREFIX)
 app.include_router(pdv_catalogos.router, prefix=API_V1_PREFIX)
 app.include_router(ticket_catalogos.router, prefix=API_V1_PREFIX)
 app.include_router(comercial_custos.router, prefix=API_V1_PREFIX)
+app.include_router(crm.router, prefix=API_V1_PREFIX)
 app.include_router(empresa_pdvs.router, prefix=API_V1_PREFIX)
 app.include_router(system_settings.router, prefix=API_V1_PREFIX)
 app.include_router(tenant.router, prefix=API_V1_PREFIX)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -53,6 +53,13 @@ from app.models.chat_interno import (
     MensagemInternaReacao,
     MensagemInternaOculta,
 )
+from app.models.crm import (
+    CrmLead,
+    CrmNegociacao,
+    CrmNegociacaoAtividade,
+    CrmNegociacaoCnpjLinha,
+    FunilEstagio,
+)
 
 __all__ = [
     "Rede",
@@ -122,4 +129,9 @@ __all__ = [
     "MensagemInternaReacao",
     "MensagemInternaOculta",
     "ConversaInternaLeitura",
+    "FunilEstagio",
+    "CrmLead",
+    "CrmNegociacao",
+    "CrmNegociacaoCnpjLinha",
+    "CrmNegociacaoAtividade",
 ]

--- a/backend/app/models/atendente.py
+++ b/backend/app/models/atendente.py
@@ -14,7 +14,7 @@ atendente_setor = Table(
 
 
 class Atendente(Base):
-    """Usuário interno: admin ou atendente. Atendente vê apenas tickets do(s) seu(s) setor(es)."""
+    """Usuário interno: admin, atendente ou comercial."""
 
     __tablename__ = "atendentes"
     __table_args__ = (UniqueConstraint("tenant_id", "email", name="uq_atendentes_tenant_email"),)
@@ -24,7 +24,7 @@ class Atendente(Base):
     email = Column(String(255), nullable=False, index=True)
     senha_hash = Column(String(255), nullable=False)
     nome = Column(String(255), nullable=False)
-    role = Column(String(20), nullable=False, default="atendente")  # admin | atendente
+    role = Column(String(20), nullable=False, default="atendente")  # admin | atendente | comercial
     ativo = Column(Boolean, default=True)
     must_change_password = Column(Boolean, nullable=False, default=False)
     # Presença online (#546+): heartbeat gravado no DB (funciona com Gunicorn N>1).

--- a/backend/app/models/crm.py
+++ b/backend/app/models/crm.py
@@ -1,0 +1,156 @@
+"""CRM — leads, funil, negociação multi-CNPJ (#322 / #337–#339 / #344)."""
+
+from __future__ import annotations
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from sqlalchemy.types import JSON
+
+from app.database import Base
+
+# Tipos de estágio do funil
+FUNIL_TIPO_ABERTO = "aberto"
+FUNIL_TIPO_GANHO = "ganho"
+FUNIL_TIPO_PERDIDO = "perdido"
+FUNIL_TIPOS = frozenset({FUNIL_TIPO_ABERTO, FUNIL_TIPO_GANHO, FUNIL_TIPO_PERDIDO})
+
+# Atividades
+ATIVIDADE_NOTA = "nota"
+ATIVIDADE_LIGACAO = "ligacao"
+ATIVIDADE_REUNIAO = "reuniao"
+ATIVIDADE_MUDANCA_ESTAGIO = "mudanca_estagio"
+ATIVIDADE_DOCUMENTO = "documento_anexado"
+ATIVIDADE_TIPOS = frozenset(
+    {ATIVIDADE_NOTA, ATIVIDADE_LIGACAO, ATIVIDADE_REUNIAO, ATIVIDADE_MUDANCA_ESTAGIO, ATIVIDADE_DOCUMENTO}
+)
+
+# Seed padrão do funil (#339)
+FUNIL_SEED = (
+    ("lead", "Lead", 10, FUNIL_TIPO_ABERTO),
+    ("em_negociacao", "Em negociação", 20, FUNIL_TIPO_ABERTO),
+    ("documentacao", "Documentação", 30, FUNIL_TIPO_ABERTO),
+    ("proposta_enviada", "Proposta enviada", 40, FUNIL_TIPO_ABERTO),
+    ("contrato_assinado", "Contrato assinado", 50, FUNIL_TIPO_GANHO),
+    ("implantacao", "Implantação", 60, FUNIL_TIPO_GANHO),
+    ("perdido", "Perdido", 90, FUNIL_TIPO_PERDIDO),
+)
+
+SLUG_DOCUMENTACAO = "documentacao"
+
+
+class FunilEstagio(Base):
+    __tablename__ = "crm_funil_estagios"
+    __table_args__ = (UniqueConstraint("slug", name="uq_crm_funil_estagio_slug"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    slug = Column(String(50), nullable=False, index=True)
+    nome = Column(String(120), nullable=False)
+    ordem = Column(Integer, nullable=False, default=0, index=True)
+    tipo = Column(String(20), nullable=False, default=FUNIL_TIPO_ABERTO)
+    ativo = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+
+class CrmLead(Base):
+    __tablename__ = "crm_leads"
+
+    id = Column(Integer, primary_key=True, index=True)
+    nome = Column(String(255), nullable=False)
+    telefone = Column(String(40), nullable=True)
+    email = Column(String(255), nullable=True)
+    empresa_texto = Column(String(255), nullable=True)
+    origem = Column(String(80), nullable=True)
+    notas = Column(Text, nullable=True)
+    responsavel_id = Column(Integer, ForeignKey("atendentes.id", ondelete="RESTRICT"), nullable=False, index=True)
+    estagio_id = Column(Integer, ForeignKey("crm_funil_estagios.id", ondelete="RESTRICT"), nullable=False, index=True)
+    perdido_em = Column(DateTime(timezone=True), nullable=True)
+    ativo = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    responsavel = relationship("Atendente", foreign_keys=[responsavel_id])
+    estagio = relationship("FunilEstagio")
+    negociacoes = relationship("CrmNegociacao", back_populates="lead", cascade="all, delete-orphan")
+
+
+class CrmNegociacao(Base):
+    __tablename__ = "crm_negociacoes"
+
+    id = Column(Integer, primary_key=True, index=True)
+    lead_id = Column(Integer, ForeignKey("crm_leads.id", ondelete="CASCADE"), nullable=False, index=True)
+    responsavel_id = Column(Integer, ForeignKey("atendentes.id", ondelete="RESTRICT"), nullable=False, index=True)
+    estagio_id = Column(Integer, ForeignKey("crm_funil_estagios.id", ondelete="RESTRICT"), nullable=False, index=True)
+    # True = negociação ativa do lead (no máximo uma por lead)
+    ativa = Column(Boolean, nullable=False, default=True, index=True)
+    titulo = Column(String(255), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    lead = relationship("CrmLead", back_populates="negociacoes")
+    responsavel = relationship("Atendente", foreign_keys=[responsavel_id])
+    estagio = relationship("FunilEstagio")
+    linhas = relationship(
+        "CrmNegociacaoCnpjLinha",
+        back_populates="negociacao",
+        cascade="all, delete-orphan",
+    )
+    atividades = relationship(
+        "CrmNegociacaoAtividade",
+        back_populates="negociacao",
+        cascade="all, delete-orphan",
+    )
+
+
+class CrmNegociacaoCnpjLinha(Base):
+    __tablename__ = "crm_negociacao_cnpj_linhas"
+
+    id = Column(Integer, primary_key=True, index=True)
+    negociacao_id = Column(
+        Integer, ForeignKey("crm_negociacoes.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    cnpj = Column(String(18), nullable=True, index=True)
+    razao_social = Column(String(255), nullable=True)
+    # Composição do pacote + overrides usados no motor de custos
+    item_ids = Column(JSON, nullable=False, default=lambda: [])
+    quantidade_pdvs = Column(Integer, nullable=False, default=1)
+    desconto_posto_100k = Column(Boolean, nullable=False, default=False)
+    tef_override = Column(JSON, nullable=True)
+    valor_negociado = Column(Numeric(14, 2), nullable=False, default=0)
+    snapshot_custo = Column(JSON, nullable=True)
+    total_custo = Column(Numeric(14, 2), nullable=True)
+    margem_calculada = Column(Numeric(14, 2), nullable=True)
+    # Preenchido pós-contrato (#324)
+    empresa_id = Column(Integer, ForeignKey("empresas.id", ondelete="SET NULL"), nullable=True)
+    ordem = Column(Integer, nullable=False, default=0)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    negociacao = relationship("CrmNegociacao", back_populates="linhas")
+
+
+class CrmNegociacaoAtividade(Base):
+    __tablename__ = "crm_negociacao_atividades"
+
+    id = Column(Integer, primary_key=True, index=True)
+    negociacao_id = Column(
+        Integer, ForeignKey("crm_negociacoes.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    autor_id = Column(Integer, ForeignKey("atendentes.id", ondelete="RESTRICT"), nullable=False)
+    tipo = Column(String(40), nullable=False, default=ATIVIDADE_NOTA)
+    texto = Column(Text, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)
+
+    negociacao = relationship("CrmNegociacao", back_populates="atividades")
+    autor = relationship("Atendente", foreign_keys=[autor_id])

--- a/backend/app/schemas/atendente.py
+++ b/backend/app/schemas/atendente.py
@@ -5,7 +5,7 @@ from datetime import datetime
 class AtendenteBase(BaseModel):
     email: EmailStr
     nome: str
-    role: str = "atendente"  # admin | atendente
+    role: str = "atendente"  # admin | atendente | comercial
     ativo: bool = True
 
 

--- a/backend/app/schemas/crm.py
+++ b/backend/app/schemas/crm.py
@@ -1,0 +1,199 @@
+"""Schemas CRM — leads, funil, negociações (#322 / #336–#340)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.schemas.comercial_custo import CustoTefOverride
+
+
+def _normalizar_cnpj_opcional(v: str | None) -> str | None:
+    if v is None:
+        return None
+    digits = "".join(c for c in str(v) if c.isdigit())
+    if not digits:
+        return None
+    if len(digits) != 14:
+        raise ValueError("CNPJ deve ter 14 dígitos.")
+    return digits
+
+
+class FunilEstagioRead(BaseModel):
+    id: int
+    slug: str
+    nome: str
+    ordem: int
+    tipo: str
+    ativo: bool
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FunilEstagioCreate(BaseModel):
+    slug: str = Field(..., min_length=2, max_length=50)
+    nome: str = Field(..., min_length=1, max_length=120)
+    ordem: int = 0
+    tipo: str = "aberto"
+    ativo: bool = True
+
+
+class FunilEstagioUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=120)
+    ordem: int | None = None
+    tipo: str | None = None
+    ativo: bool | None = None
+
+
+class CrmLeadCreate(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=255)
+    telefone: str | None = Field(None, max_length=40)
+    email: str | None = Field(None, max_length=255)
+    empresa_texto: str | None = Field(None, max_length=255)
+    origem: str | None = Field(None, max_length=80)
+    notas: str | None = None
+    responsavel_id: int | None = None  # default = utilizador logado
+    criar_negociacao: bool = True
+    titulo_negociacao: str | None = Field(None, max_length=255)
+
+
+class CrmLeadUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=255)
+    telefone: str | None = Field(None, max_length=40)
+    email: str | None = Field(None, max_length=255)
+    empresa_texto: str | None = Field(None, max_length=255)
+    origem: str | None = Field(None, max_length=80)
+    notas: str | None = None
+    responsavel_id: int | None = None
+    ativo: bool | None = None
+
+
+class CrmLeadRead(BaseModel):
+    id: int
+    nome: str
+    telefone: str | None = None
+    email: str | None = None
+    empresa_texto: str | None = None
+    origem: str | None = None
+    notas: str | None = None
+    responsavel_id: int
+    estagio_id: int
+    estagio_slug: str | None = None
+    estagio_nome: str | None = None
+    perdido_em: datetime | None = None
+    ativo: bool
+    negociacao_ativa_id: int | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CrmLinhaCreate(BaseModel):
+    cnpj: str | None = None
+    razao_social: str | None = Field(None, max_length=255)
+    item_ids: list[int] = Field(default_factory=list)
+    quantidade_pdvs: int = Field(1, ge=1, le=500)
+    desconto_posto_100k: bool = False
+    tef_override: CustoTefOverride | None = None
+    valor_negociado: Decimal = Field(Decimal("0"), ge=0)
+    ordem: int = 0
+
+    @field_validator("cnpj", mode="before")
+    @classmethod
+    def _cnpj(cls, v):
+        return _normalizar_cnpj_opcional(v)
+
+
+class CrmLinhaUpdate(BaseModel):
+    cnpj: str | None = None
+    razao_social: str | None = Field(None, max_length=255)
+    item_ids: list[int] | None = None
+    quantidade_pdvs: int | None = Field(None, ge=1, le=500)
+    desconto_posto_100k: bool | None = None
+    tef_override: CustoTefOverride | None = None
+    valor_negociado: Decimal | None = Field(None, ge=0)
+    ordem: int | None = None
+    # True = limpar override TEF
+    limpar_tef_override: bool = False
+
+    @field_validator("cnpj", mode="before")
+    @classmethod
+    def _cnpj(cls, v):
+        if v is None:
+            return None
+        return _normalizar_cnpj_opcional(v)
+
+
+class CrmLinhaRead(BaseModel):
+    id: int
+    negociacao_id: int
+    cnpj: str | None = None
+    razao_social: str | None = None
+    item_ids: list[int] = Field(default_factory=list)
+    quantidade_pdvs: int
+    desconto_posto_100k: bool
+    tef_override: dict[str, Any] | None = None
+    valor_negociado: Decimal
+    snapshot_custo: dict[str, Any] | None = None
+    total_custo: Decimal | None = None
+    margem_calculada: Decimal | None = None
+    empresa_id: int | None = None
+    ordem: int
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CrmNegociacaoCreate(BaseModel):
+    lead_id: int
+    titulo: str | None = Field(None, max_length=255)
+    responsavel_id: int | None = None
+    linhas: list[CrmLinhaCreate] = Field(default_factory=list)
+
+
+class CrmNegociacaoUpdate(BaseModel):
+    titulo: str | None = Field(None, max_length=255)
+    responsavel_id: int | None = None
+
+
+class CrmNegociacaoRead(BaseModel):
+    id: int
+    lead_id: int
+    responsavel_id: int
+    estagio_id: int
+    estagio_slug: str | None = None
+    estagio_nome: str | None = None
+    ativa: bool
+    titulo: str | None = None
+    linhas: list[CrmLinhaRead] = Field(default_factory=list)
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class CrmMoverEstagioRequest(BaseModel):
+    estagio_id: int | None = None
+    estagio_slug: str | None = None
+    nota: str | None = None
+
+
+class CrmAtividadeCreate(BaseModel):
+    tipo: str = "nota"
+    texto: str = Field(..., min_length=1)
+
+
+class CrmAtividadeRead(BaseModel):
+    id: int
+    negociacao_id: int
+    autor_id: int
+    tipo: str
+    texto: str
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -99,6 +99,29 @@ def run_seed():
             )
             db.commit()
             print("Usuário admin criado (desenvolvimento): admin@email.com / admin123 — não use em produção.")
+
+        # Demo opcional perfil comercial (#336) — só desenvolvimento
+        if not settings.is_production:
+            if not db.query(Atendente).filter(func.lower(Atendente.email) == "comercial@email.com").first():
+                db.add(
+                    Atendente(
+                        tenant_id=1,
+                        email="comercial@email.com",
+                        nome="Comercial",
+                        senha_hash=_hash_senha("comercial123"),
+                        role="comercial",
+                        ativo=True,
+                        must_change_password=False,
+                    )
+                )
+                db.commit()
+                print(
+                    "Usuário comercial criado (desenvolvimento): comercial@email.com / comercial123 — não use em produção."
+                )
+            from app.services.crm import ensure_funil_padrao
+
+            ensure_funil_padrao(db)
+            db.commit()
     finally:
         db.close()
 

--- a/backend/app/services/crm.py
+++ b/backend/app/services/crm.py
@@ -1,0 +1,601 @@
+"""Serviço CRM — funil, leads e negociações (#322 / #336–#340)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from fastapi import HTTPException
+from sqlalchemy import or_
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.atendente import Atendente
+from app.models.crm import (
+    ATIVIDADE_MUDANCA_ESTAGIO,
+    ATIVIDADE_TIPOS,
+    FUNIL_SEED,
+    FUNIL_TIPOS,
+    FUNIL_TIPO_PERDIDO,
+    SLUG_DOCUMENTACAO,
+    CrmLead,
+    CrmNegociacao,
+    CrmNegociacaoAtividade,
+    CrmNegociacaoCnpjLinha,
+    FunilEstagio,
+)
+from app.schemas.comercial_custo import CustoTefOverride
+from app.schemas.crm import (
+    CrmAtividadeCreate,
+    CrmLeadCreate,
+    CrmLeadUpdate,
+    CrmLinhaCreate,
+    CrmLinhaUpdate,
+    CrmNegociacaoCreate,
+    CrmNegociacaoUpdate,
+    FunilEstagioCreate,
+    FunilEstagioUpdate,
+)
+from app.services import comercial_custo as custo_svc
+
+
+def ensure_funil_padrao(db: Session) -> None:
+    """Garante estágios do funil (migration ou create_all em testes)."""
+    if db.query(FunilEstagio).count() > 0:
+        return
+    for slug, nome, ordem, tipo in FUNIL_SEED:
+        db.add(FunilEstagio(slug=slug, nome=nome, ordem=ordem, tipo=tipo, ativo=True))
+    db.flush()
+
+
+def obter_estagio(
+    db: Session,
+    *,
+    estagio_id: int | None = None,
+    slug: str | None = None,
+    apenas_ativos: bool = True,
+) -> FunilEstagio:
+    ensure_funil_padrao(db)
+    q = db.query(FunilEstagio)
+    if apenas_ativos:
+        q = q.filter(FunilEstagio.ativo.is_(True))
+    if estagio_id is not None:
+        row = q.filter(FunilEstagio.id == estagio_id).first()
+    elif slug:
+        row = q.filter(FunilEstagio.slug == slug).first()
+    else:
+        raise HTTPException(status_code=400, detail="Informe estagio_id ou estagio_slug.")
+    if not row:
+        raise HTTPException(status_code=404, detail="Estágio do funil não encontrado.")
+    return row
+
+
+def estagio_inicial(db: Session) -> FunilEstagio:
+    ensure_funil_padrao(db)
+    row = (
+        db.query(FunilEstagio)
+        .filter(FunilEstagio.ativo.is_(True), FunilEstagio.tipo != FUNIL_TIPO_PERDIDO)
+        .order_by(FunilEstagio.ordem.asc())
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=500, detail="Funil sem estágios ativos.")
+    return row
+
+
+def listar_estagios(db: Session, *, incluir_inativos: bool = False) -> list[FunilEstagio]:
+    ensure_funil_padrao(db)
+    q = db.query(FunilEstagio)
+    if not incluir_inativos:
+        q = q.filter(FunilEstagio.ativo.is_(True))
+    return q.order_by(FunilEstagio.ordem.asc(), FunilEstagio.id.asc()).all()
+
+
+def criar_estagio(db: Session, data: FunilEstagioCreate) -> FunilEstagio:
+    ensure_funil_padrao(db)
+    tipo = (data.tipo or "").strip().lower()
+    if tipo not in FUNIL_TIPOS:
+        raise HTTPException(status_code=400, detail=f"tipo inválido: use {', '.join(sorted(FUNIL_TIPOS))}")
+    slug = data.slug.strip().lower().replace(" ", "_")
+    if db.query(FunilEstagio).filter(FunilEstagio.slug == slug).first():
+        raise HTTPException(status_code=400, detail="Já existe estágio com este slug.")
+    row = FunilEstagio(slug=slug, nome=data.nome.strip(), ordem=data.ordem, tipo=tipo, ativo=data.ativo)
+    db.add(row)
+    db.flush()
+    return row
+
+
+def atualizar_estagio(db: Session, row: FunilEstagio, data: FunilEstagioUpdate) -> FunilEstagio:
+    payload = data.model_dump(exclude_unset=True)
+    if "tipo" in payload:
+        tipo = str(payload["tipo"]).strip().lower()
+        if tipo not in FUNIL_TIPOS:
+            raise HTTPException(status_code=400, detail=f"tipo inválido: use {', '.join(sorted(FUNIL_TIPOS))}")
+        payload["tipo"] = tipo
+    if "nome" in payload and payload["nome"] is not None:
+        payload["nome"] = str(payload["nome"]).strip()
+    for k, v in payload.items():
+        setattr(row, k, v)
+    db.flush()
+    return row
+
+
+def _estagio_exige_cnpj(db: Session, estagio: FunilEstagio) -> bool:
+    """CNPJ obrigatório a partir de Documentação (#322)."""
+    ensure_funil_padrao(db)
+    doc = db.query(FunilEstagio).filter(FunilEstagio.slug == SLUG_DOCUMENTACAO).first()
+    if not doc:
+        return estagio.slug == SLUG_DOCUMENTACAO
+    return estagio.ordem >= doc.ordem and estagio.tipo != FUNIL_TIPO_PERDIDO
+
+
+def _validar_transicao(origem: FunilEstagio, destino: FunilEstagio) -> None:
+    if origem.id == destino.id:
+        raise HTTPException(status_code=400, detail="Negociação já está neste estágio.")
+    if not destino.ativo:
+        raise HTTPException(status_code=400, detail="Estágio de destino inativo.")
+    # Grafo simples: qualquer estágio ativo → outro ativo (reabrir perdido permitido)
+    # Bloqueio: não saltar de aberto para implantacao sem passar contrato? — v1 permissivo por ordem livre.
+
+
+def _negociacao_ativa_do_lead(db: Session, lead_id: int) -> CrmNegociacao | None:
+    return (
+        db.query(CrmNegociacao)
+        .filter(CrmNegociacao.lead_id == lead_id, CrmNegociacao.ativa.is_(True))
+        .first()
+    )
+
+
+def _tef_override_dict(ov: CustoTefOverride | None) -> dict | None:
+    if ov is None:
+        return None
+    return {k: str(v) if v is not None else None for k, v in ov.model_dump().items()}
+
+
+def _tef_from_json(raw: dict | None) -> CustoTefOverride | None:
+    if not raw:
+        return None
+    cleaned = {k: v for k, v in raw.items() if v is not None}
+    if not cleaned:
+        return None
+    return CustoTefOverride(**cleaned)
+
+
+def recalcular_linha(db: Session, linha: CrmNegociacaoCnpjLinha) -> None:
+    """Atualiza snapshot_custo, total_custo e margem (#338)."""
+    ids = list(linha.item_ids or [])
+    if not ids:
+        linha.snapshot_custo = None
+        linha.total_custo = Decimal("0.00")
+        linha.margem_calculada = Decimal(linha.valor_negociado or 0)
+        return
+    ov = _tef_from_json(linha.tef_override if isinstance(linha.tef_override, dict) else None)
+    result = custo_svc.calcular_custo_pacote(
+        db,
+        item_ids=ids,
+        quantidade_pdvs=int(linha.quantidade_pdvs or 1),
+        desconto_posto_100k=bool(linha.desconto_posto_100k),
+        tef_override=ov,
+    )
+    linha.snapshot_custo = result.snapshot
+    linha.total_custo = result.total_custo
+    linha.margem_calculada = (Decimal(linha.valor_negociado or 0) - Decimal(result.total_custo)).quantize(
+        Decimal("0.01")
+    )
+
+
+def _validar_cnpjs_obrigatorios(db: Session, negociacao: CrmNegociacao, estagio: FunilEstagio) -> None:
+    if not _estagio_exige_cnpj(db, estagio):
+        return
+    linhas = (
+        db.query(CrmNegociacaoCnpjLinha).filter(CrmNegociacaoCnpjLinha.negociacao_id == negociacao.id).all()
+    )
+    if not linhas:
+        raise HTTPException(
+            status_code=400,
+            detail="A partir de Documentação é obrigatório ter ao menos uma linha com CNPJ.",
+        )
+    for ln in linhas:
+        if not ln.cnpj or len("".join(c for c in str(ln.cnpj) if c.isdigit())) != 14:
+            raise HTTPException(
+                status_code=400,
+                detail="CNPJ obrigatório em todas as linhas a partir do estágio Documentação.",
+            )
+
+
+def _assert_responsavel_comercial(db: Session, responsavel_id: int) -> Atendente:
+    a = db.query(Atendente).filter(Atendente.id == responsavel_id, Atendente.ativo.is_(True)).first()
+    if not a:
+        raise HTTPException(status_code=400, detail="Responsável não encontrado ou inativo.")
+    if a.role not in ("admin", "comercial"):
+        raise HTTPException(status_code=400, detail="Responsável deve ter perfil comercial ou admin.")
+    return a
+
+
+def lead_to_read(db: Session, lead: CrmLead) -> dict:
+    est = lead.estagio
+    neg = _negociacao_ativa_do_lead(db, lead.id)
+    return {
+        "id": lead.id,
+        "nome": lead.nome,
+        "telefone": lead.telefone,
+        "email": lead.email,
+        "empresa_texto": lead.empresa_texto,
+        "origem": lead.origem,
+        "notas": lead.notas,
+        "responsavel_id": lead.responsavel_id,
+        "estagio_id": lead.estagio_id,
+        "estagio_slug": est.slug if est else None,
+        "estagio_nome": est.nome if est else None,
+        "perdido_em": lead.perdido_em,
+        "ativo": lead.ativo,
+        "negociacao_ativa_id": neg.id if neg else None,
+        "created_at": lead.created_at,
+        "updated_at": lead.updated_at,
+    }
+
+
+def negociacao_to_read(neg: CrmNegociacao) -> dict:
+    est = neg.estagio
+    linhas = sorted(neg.linhas or [], key=lambda x: (x.ordem, x.id))
+    return {
+        "id": neg.id,
+        "lead_id": neg.lead_id,
+        "responsavel_id": neg.responsavel_id,
+        "estagio_id": neg.estagio_id,
+        "estagio_slug": est.slug if est else None,
+        "estagio_nome": est.nome if est else None,
+        "ativa": neg.ativa,
+        "titulo": neg.titulo,
+        "linhas": linhas,
+        "created_at": neg.created_at,
+        "updated_at": neg.updated_at,
+    }
+
+
+def listar_leads(
+    db: Session,
+    *,
+    offset: int = 0,
+    limit: int = 50,
+    q: str | None = None,
+    responsavel_id: int | None = None,
+    estagio_id: int | None = None,
+    so_minhas: bool = False,
+    ator_id: int | None = None,
+    ativo: bool | None = True,
+) -> tuple[list[CrmLead], int]:
+    ensure_funil_padrao(db)
+    query = db.query(CrmLead).options(joinedload(CrmLead.estagio))
+    if ativo is not None:
+        query = query.filter(CrmLead.ativo.is_(ativo))
+    if so_minhas and ator_id is not None:
+        query = query.filter(CrmLead.responsavel_id == ator_id)
+    elif responsavel_id is not None:
+        query = query.filter(CrmLead.responsavel_id == responsavel_id)
+    if estagio_id is not None:
+        query = query.filter(CrmLead.estagio_id == estagio_id)
+    if q:
+        term = f"%{q.strip()}%"
+        query = query.filter(
+            or_(
+                CrmLead.nome.ilike(term),
+                CrmLead.telefone.ilike(term),
+                CrmLead.email.ilike(term),
+                CrmLead.empresa_texto.ilike(term),
+            )
+        )
+    total = query.count()
+    rows = query.order_by(CrmLead.id.desc()).offset(offset).limit(limit).all()
+    return rows, total
+
+
+def criar_lead(db: Session, data: CrmLeadCreate, ator: Atendente) -> CrmLead:
+    ensure_funil_padrao(db)
+    responsavel_id = data.responsavel_id or ator.id
+    _assert_responsavel_comercial(db, responsavel_id)
+    est = estagio_inicial(db)
+    lead = CrmLead(
+        nome=data.nome.strip(),
+        telefone=(data.telefone or None),
+        email=(data.email or None),
+        empresa_texto=(data.empresa_texto or None),
+        origem=(data.origem or None),
+        notas=data.notas,
+        responsavel_id=responsavel_id,
+        estagio_id=est.id,
+        ativo=True,
+    )
+    db.add(lead)
+    db.flush()
+    if data.criar_negociacao:
+        neg = CrmNegociacao(
+            lead_id=lead.id,
+            responsavel_id=responsavel_id,
+            estagio_id=est.id,
+            ativa=True,
+            titulo=data.titulo_negociacao or f"Negociação — {lead.nome}",
+        )
+        db.add(neg)
+        db.flush()
+        db.add(
+            CrmNegociacaoAtividade(
+                negociacao_id=neg.id,
+                autor_id=ator.id,
+                tipo=ATIVIDADE_MUDANCA_ESTAGIO,
+                texto=f"Negociação criada no estágio «{est.nome}».",
+            )
+        )
+    db.flush()
+    return lead
+
+
+def atualizar_lead(db: Session, lead: CrmLead, data: CrmLeadUpdate) -> CrmLead:
+    payload = data.model_dump(exclude_unset=True)
+    if "responsavel_id" in payload and payload["responsavel_id"] is not None:
+        _assert_responsavel_comercial(db, payload["responsavel_id"])
+    if "nome" in payload and payload["nome"]:
+        payload["nome"] = str(payload["nome"]).strip()
+    for k, v in payload.items():
+        setattr(lead, k, v)
+    db.flush()
+    return lead
+
+
+def obter_lead(db: Session, lead_id: int) -> CrmLead:
+    lead = (
+        db.query(CrmLead)
+        .options(joinedload(CrmLead.estagio))
+        .filter(CrmLead.id == lead_id)
+        .first()
+    )
+    if not lead:
+        raise HTTPException(status_code=404, detail="Lead não encontrado.")
+    return lead
+
+
+def listar_negociacoes(
+    db: Session,
+    *,
+    offset: int = 0,
+    limit: int = 50,
+    lead_id: int | None = None,
+    responsavel_id: int | None = None,
+    estagio_id: int | None = None,
+    ativa: bool | None = True,
+    q: str | None = None,
+    so_minhas: bool = False,
+    ator_id: int | None = None,
+) -> tuple[list[CrmNegociacao], int]:
+    ensure_funil_padrao(db)
+    query = db.query(CrmNegociacao).options(
+        joinedload(CrmNegociacao.estagio),
+        joinedload(CrmNegociacao.linhas),
+    )
+    if lead_id is not None:
+        query = query.filter(CrmNegociacao.lead_id == lead_id)
+    if ativa is not None:
+        query = query.filter(CrmNegociacao.ativa.is_(ativa))
+    if so_minhas and ator_id is not None:
+        query = query.filter(CrmNegociacao.responsavel_id == ator_id)
+    elif responsavel_id is not None:
+        query = query.filter(CrmNegociacao.responsavel_id == responsavel_id)
+    if estagio_id is not None:
+        query = query.filter(CrmNegociacao.estagio_id == estagio_id)
+    if q:
+        term = f"%{q.strip()}%"
+        query = query.outerjoin(CrmNegociacaoCnpjLinha).filter(
+            or_(
+                CrmNegociacao.titulo.ilike(term),
+                CrmNegociacaoCnpjLinha.cnpj.ilike(term),
+                CrmNegociacaoCnpjLinha.razao_social.ilike(term),
+            )
+        )
+    total = query.distinct().count()
+    rows = (
+        query.distinct()
+        .order_by(CrmNegociacao.id.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+    return rows, total
+
+
+def obter_negociacao(db: Session, negociacao_id: int) -> CrmNegociacao:
+    neg = (
+        db.query(CrmNegociacao)
+        .options(joinedload(CrmNegociacao.estagio), joinedload(CrmNegociacao.linhas))
+        .filter(CrmNegociacao.id == negociacao_id)
+        .first()
+    )
+    if not neg:
+        raise HTTPException(status_code=404, detail="Negociação não encontrada.")
+    return neg
+
+
+def criar_negociacao(db: Session, data: CrmNegociacaoCreate, ator: Atendente) -> CrmNegociacao:
+    lead = obter_lead(db, data.lead_id)
+    if _negociacao_ativa_do_lead(db, lead.id):
+        raise HTTPException(
+            status_code=400,
+            detail="Já existe uma negociação ativa para este lead. Encerre a atual antes de criar outra.",
+        )
+    responsavel_id = data.responsavel_id or lead.responsavel_id
+    _assert_responsavel_comercial(db, responsavel_id)
+    est = estagio_inicial(db)
+    neg = CrmNegociacao(
+        lead_id=lead.id,
+        responsavel_id=responsavel_id,
+        estagio_id=est.id,
+        ativa=True,
+        titulo=data.titulo or f"Negociação — {lead.nome}",
+    )
+    db.add(neg)
+    db.flush()
+    # Sincroniza estágio do lead com a nova negociação
+    lead.estagio_id = est.id
+    lead.perdido_em = None
+    for ln_data in data.linhas:
+        add_linha(db, neg, ln_data)
+    db.add(
+        CrmNegociacaoAtividade(
+            negociacao_id=neg.id,
+            autor_id=ator.id,
+            tipo=ATIVIDADE_MUDANCA_ESTAGIO,
+            texto=f"Negociação criada no estágio «{est.nome}».",
+        )
+    )
+    db.flush()
+    return obter_negociacao(db, neg.id)
+
+
+def atualizar_negociacao(db: Session, neg: CrmNegociacao, data: CrmNegociacaoUpdate) -> CrmNegociacao:
+    payload = data.model_dump(exclude_unset=True)
+    if "responsavel_id" in payload and payload["responsavel_id"] is not None:
+        _assert_responsavel_comercial(db, payload["responsavel_id"])
+    for k, v in payload.items():
+        setattr(neg, k, v)
+    db.flush()
+    return obter_negociacao(db, neg.id)
+
+
+def add_linha(db: Session, neg: CrmNegociacao, data: CrmLinhaCreate) -> CrmNegociacaoCnpjLinha:
+    est = obter_estagio(db, estagio_id=neg.estagio_id)
+    if _estagio_exige_cnpj(db, est) and not data.cnpj:
+        raise HTTPException(status_code=400, detail="CNPJ obrigatório neste estágio do funil.")
+    linha = CrmNegociacaoCnpjLinha(
+        negociacao_id=neg.id,
+        cnpj=data.cnpj,
+        razao_social=data.razao_social,
+        item_ids=list(data.item_ids or []),
+        quantidade_pdvs=data.quantidade_pdvs,
+        desconto_posto_100k=data.desconto_posto_100k,
+        tef_override=_tef_override_dict(data.tef_override),
+        valor_negociado=data.valor_negociado,
+        ordem=data.ordem,
+    )
+    db.add(linha)
+    db.flush()
+    recalcular_linha(db, linha)
+    db.flush()
+    return linha
+
+
+def atualizar_linha(db: Session, linha: CrmNegociacaoCnpjLinha, data: CrmLinhaUpdate) -> CrmNegociacaoCnpjLinha:
+    neg = obter_negociacao(db, linha.negociacao_id)
+    est = obter_estagio(db, estagio_id=neg.estagio_id)
+    payload = data.model_dump(exclude_unset=True, exclude={"limpar_tef_override", "tef_override"})
+    if data.limpar_tef_override:
+        linha.tef_override = None
+    elif data.tef_override is not None:
+        linha.tef_override = _tef_override_dict(data.tef_override)
+    for k, v in payload.items():
+        setattr(linha, k, v)
+    if _estagio_exige_cnpj(db, est) and not linha.cnpj:
+        raise HTTPException(status_code=400, detail="CNPJ obrigatório neste estágio do funil.")
+    recalcular_linha(db, linha)
+    db.flush()
+    return linha
+
+
+def excluir_linha(db: Session, linha: CrmNegociacaoCnpjLinha) -> None:
+    neg = obter_negociacao(db, linha.negociacao_id)
+    est = obter_estagio(db, estagio_id=neg.estagio_id)
+    restantes = [
+        r
+        for r in db.query(CrmNegociacaoCnpjLinha)
+        .filter(CrmNegociacaoCnpjLinha.negociacao_id == neg.id)
+        .all()
+        if r.id != linha.id
+    ]
+    if _estagio_exige_cnpj(db, est):
+        if not restantes or any(not r.cnpj for r in restantes):
+            raise HTTPException(
+                status_code=400,
+                detail="Não é possível remover: neste estágio todas as linhas precisam de CNPJ.",
+            )
+    db.delete(linha)
+    db.flush()
+
+
+def mover_estagio(
+    db: Session,
+    neg: CrmNegociacao,
+    *,
+    ator: Atendente,
+    estagio_id: int | None = None,
+    estagio_slug: str | None = None,
+    nota: str | None = None,
+) -> CrmNegociacao:
+    origem = obter_estagio(db, estagio_id=neg.estagio_id)
+    destino = obter_estagio(db, estagio_id=estagio_id, slug=estagio_slug)
+    _validar_transicao(origem, destino)
+    _validar_cnpjs_obrigatorios(db, neg, destino)
+
+    neg.estagio_id = destino.id
+    lead = obter_lead(db, neg.lead_id)
+    lead.estagio_id = destino.id
+    if destino.tipo == FUNIL_TIPO_PERDIDO:
+        lead.perdido_em = datetime.now(timezone.utc)
+        # Mantém histórico; soft-archive via perdido_em (lead continua ativo=True)
+        neg.ativa = False
+    else:
+        lead.perdido_em = None
+        if not neg.ativa:
+            # Reabrir: só se não houver outra ativa
+            outra = _negociacao_ativa_do_lead(db, lead.id)
+            if outra and outra.id != neg.id:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Já existe outra negociação ativa neste lead.",
+                )
+            neg.ativa = True
+
+    texto = f"Estágio: «{origem.nome}» → «{destino.nome}»."
+    if nota:
+        texto = f"{texto} {nota.strip()}"
+    db.add(
+        CrmNegociacaoAtividade(
+            negociacao_id=neg.id,
+            autor_id=ator.id,
+            tipo=ATIVIDADE_MUDANCA_ESTAGIO,
+            texto=texto,
+        )
+    )
+    db.flush()
+    return obter_negociacao(db, neg.id)
+
+
+def listar_atividades(
+    db: Session, negociacao_id: int, *, offset: int = 0, limit: int = 50
+) -> tuple[list[CrmNegociacaoAtividade], int]:
+    obter_negociacao(db, negociacao_id)
+    q = db.query(CrmNegociacaoAtividade).filter(CrmNegociacaoAtividade.negociacao_id == negociacao_id)
+    total = q.count()
+    rows = q.order_by(CrmNegociacaoAtividade.created_at.desc(), CrmNegociacaoAtividade.id.desc()).offset(
+        offset
+    ).limit(limit).all()
+    return rows, total
+
+
+def criar_atividade(
+    db: Session, negociacao_id: int, data: CrmAtividadeCreate, ator: Atendente
+) -> CrmNegociacaoAtividade:
+    obter_negociacao(db, negociacao_id)
+    tipo = (data.tipo or "nota").strip().lower()
+    if tipo not in ATIVIDADE_TIPOS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"tipo inválido: use {', '.join(sorted(ATIVIDADE_TIPOS))}",
+        )
+    if tipo == ATIVIDADE_MUDANCA_ESTAGIO:
+        raise HTTPException(status_code=400, detail="Use POST .../mover-estagio para mudança de estágio.")
+    row = CrmNegociacaoAtividade(
+        negociacao_id=negociacao_id,
+        autor_id=ator.id,
+        tipo=tipo,
+        texto=data.texto.strip(),
+    )
+    db.add(row)
+    db.flush()
+    return row

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -109,7 +109,16 @@ def seed_base(db_session):
         ativo=True,
         must_change_password=False,
     )
-    db_session.add_all([admin, a1, a2])
+    comercial = Atendente(
+        tenant_id=1,
+        email="comercial@test.local",
+        nome="Comercial",
+        senha_hash=hash_senha("com123"),
+        role="comercial",
+        ativo=True,
+        must_change_password=False,
+    )
+    db_session.add_all([admin, a1, a2, comercial])
     db_session.flush()
 
     # Vínculos de setor (admin sem setores; atendentes em setores distintos)
@@ -127,6 +136,7 @@ def seed_base(db_session):
         "admin": admin,
         "a1": a1,
         "a2": a2,
+        "comercial": comercial,
     }
 
 
@@ -146,4 +156,5 @@ def auth_headers(seed_base):
         "admin": headers_for(seed_base["admin"].email),
         "a1": headers_for(seed_base["a1"].email),
         "a2": headers_for(seed_base["a2"].email),
+        "comercial": headers_for(seed_base["comercial"].email),
     }

--- a/backend/tests/test_crm.py
+++ b/backend/tests/test_crm.py
@@ -166,6 +166,10 @@ def test_comercial_pode_simular_custos(client, auth_headers):
     )
     assert item.status_code == 201, item.text
 
+    lst = client.get("/v1/comercial/custos/itens", headers=h_com)
+    assert lst.status_code == 200, lst.text
+    assert lst.json()["total"] >= 1
+
     sim = client.post(
         "/v1/comercial/custos/simular",
         headers=h_com,

--- a/backend/tests/test_crm.py
+++ b/backend/tests/test_crm.py
@@ -1,0 +1,185 @@
+"""CRM — leads, funil e negociações (#322 / #336–#340)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+
+def test_atendente_403_crm_e_comercial_ok(client, auth_headers):
+    r = client.get("/v1/crm/leads", headers=auth_headers["a1"])
+    assert r.status_code == 403
+
+    r2 = client.get("/v1/crm/funil-estagios", headers=auth_headers["comercial"])
+    assert r2.status_code == 200
+    assert len(r2.json()) >= 5
+    assert any(e["slug"] == "lead" for e in r2.json())
+
+
+def test_comercial_403_cadastros_admin(client, auth_headers):
+    h = auth_headers["comercial"]
+    assert client.get("/v1/redes", headers=h).status_code == 403
+    assert client.get("/v1/audit", headers=h).status_code == 403
+    assert client.get("/v1/comercial/salario-minimo", headers=h).status_code == 403
+    assert client.post("/v1/crm/funil-estagios", headers=h, json={
+        "slug": "x",
+        "nome": "X",
+        "ordem": 1,
+        "tipo": "aberto",
+    }).status_code == 403
+
+
+def test_fluxo_lead_negociacao_estagio_e_cnpj(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    comercial_id = seed_base["comercial"].id
+
+    # Cria lead (+ negociação ativa)
+    r = client.post(
+        "/v1/crm/leads",
+        headers=h,
+        json={"nome": "Posto Alpha", "telefone": "11999990000", "origem": "whatsapp"},
+    )
+    assert r.status_code == 201, r.text
+    lead = r.json()
+    assert lead["responsavel_id"] == comercial_id
+    assert lead["estagio_slug"] == "lead"
+    assert lead["negociacao_ativa_id"] is not None
+    neg_id = lead["negociacao_ativa_id"]
+
+    # Segunda negociação ativa bloqueada
+    r2 = client.post(
+        "/v1/crm/negociacoes",
+        headers=h,
+        json={"lead_id": lead["id"]},
+    )
+    assert r2.status_code == 400
+
+    # Linha sem CNPJ (ok no início)
+    ln = client.post(
+        f"/v1/crm/negociacoes/{neg_id}/linhas",
+        headers=h,
+        json={"razao_social": "Alpha LTDA", "valor_negociado": "500.00", "item_ids": []},
+    )
+    assert ln.status_code == 201, ln.text
+    assert ln.json()["cnpj"] is None
+    assert Decimal(ln.json()["margem_calculada"]) == Decimal("500.00")
+
+    # Avança para em_negociacao
+    mv = client.post(
+        f"/v1/crm/negociacoes/{neg_id}/mover-estagio",
+        headers=h,
+        json={"estagio_slug": "em_negociacao", "nota": "Cliente interessado"},
+    )
+    assert mv.status_code == 200, mv.text
+    assert mv.json()["estagio_slug"] == "em_negociacao"
+
+    # Documentação exige CNPJ
+    bad = client.post(
+        f"/v1/crm/negociacoes/{neg_id}/mover-estagio",
+        headers=h,
+        json={"estagio_slug": "documentacao"},
+    )
+    assert bad.status_code == 400
+    assert "CNPJ" in bad.json()["detail"]
+
+    # Preenche CNPJ e avança
+    up = client.patch(
+        f"/v1/crm/negociacoes/{neg_id}/linhas/{ln.json()['id']}",
+        headers=h,
+        json={"cnpj": "12.345.678/0001-95"},
+    )
+    assert up.status_code == 200, up.text
+    assert up.json()["cnpj"] == "12345678000195"
+
+    ok = client.post(
+        f"/v1/crm/negociacoes/{neg_id}/mover-estagio",
+        headers=h,
+        json={"estagio_slug": "documentacao"},
+    )
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["estagio_slug"] == "documentacao"
+
+    # Timeline
+    acts = client.get(f"/v1/crm/negociacoes/{neg_id}/atividades", headers=h)
+    assert acts.status_code == 200
+    assert acts.json()["total"] >= 2
+
+    nota = client.post(
+        f"/v1/crm/negociacoes/{neg_id}/atividades",
+        headers=h,
+        json={"tipo": "nota", "texto": "Enviar docs por e-mail"},
+    )
+    assert nota.status_code == 201
+
+    # Perdido arquiva negociação
+    perd = client.post(
+        f"/v1/crm/negociacoes/{neg_id}/mover-estagio",
+        headers=h,
+        json={"estagio_slug": "perdido", "nota": "Sem retorno"},
+    )
+    assert perd.status_code == 200
+    assert perd.json()["ativa"] is False
+    lead2 = client.get(f"/v1/crm/leads/{lead['id']}", headers=h)
+    assert lead2.json()["perdido_em"] is not None
+
+
+def test_admin_ve_todas_e_filtro_so_minhas(client, auth_headers, seed_base):
+    h_com = auth_headers["comercial"]
+    h_adm = auth_headers["admin"]
+
+    client.post("/v1/crm/leads", headers=h_com, json={"nome": "Lead Comercial"})
+    client.post(
+        "/v1/crm/leads",
+        headers=h_adm,
+        json={"nome": "Lead Admin", "responsavel_id": seed_base["admin"].id},
+    )
+
+    todas = client.get("/v1/crm/leads", headers=h_com)
+    assert todas.status_code == 200
+    assert todas.json()["total"] == 2
+
+    minhas = client.get("/v1/crm/leads", headers=h_com, params={"so_minhas": True})
+    assert minhas.json()["total"] == 1
+    assert minhas.json()["items"][0]["nome"] == "Lead Comercial"
+
+
+def test_comercial_pode_simular_custos(client, auth_headers):
+    h_adm = auth_headers["admin"]
+    h_com = auth_headers["comercial"]
+
+    client.post(
+        "/v1/comercial/salario-minimo",
+        headers=h_adm,
+        json={"valor": "1518.00", "vigencia_inicio": "2025-01-01", "vigencia_fim": None},
+    )
+    item = client.post(
+        "/v1/comercial/custos/itens",
+        headers=h_adm,
+        json={
+            "nome": "Licença",
+            "slug": "licenca-crm-test",
+            "tipo": "percentual_sm",
+            "percentual_sm": "10",
+            "aplica_tier_posto": False,
+            "ordem": 1,
+            "ativo": True,
+        },
+    )
+    assert item.status_code == 201, item.text
+
+    sim = client.post(
+        "/v1/comercial/custos/simular",
+        headers=h_com,
+        json={"item_ids": [item.json()["id"]], "quantidade_pdvs": 1},
+    )
+    assert sim.status_code == 200, sim.text
+    assert "snapshot" in sim.json()
+
+    # Atendente continua bloqueado
+    assert (
+        client.post(
+            "/v1/comercial/custos/simular",
+            headers=auth_headers["a1"],
+            json={"item_ids": [item.json()["id"]]},
+        ).status_code
+        == 403
+    )

--- a/docs/BACKEND_RBAC.md
+++ b/docs/BACKEND_RBAC.md
@@ -31,8 +31,9 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 | Tipos de negócio (detalhe / mutação) | `GET/POST/PATCH/DELETE /v1/tipos-negocio/{id}`, `POST /v1/tipos-negocio` |
 | Auditoria | `GET /v1/audit` |
 | Cadastro auxiliar (IBGE) | `POST /v1/cadastro-aux/municipios/sincronizar` |
-| Catálogo comercial (CRUD) | `GET/POST/PATCH/DELETE /v1/comercial/salario-minimo*`, `GET/POST/PATCH/DELETE /v1/comercial/custos/itens*` |
-| Funil CRM (mutação) | `POST/PATCH /v1/crm/funil-estagios` |
+| Catálogo comercial (CRUD) | `POST/PATCH/DELETE /v1/comercial/salario-minimo*`, `POST/PATCH/DELETE /v1/comercial/custos/itens*` |
+| Catálogo comercial (leitura itens) | `GET /v1/comercial/custos/itens` — também comercial (montar pacote na negociação) |
+| Funil CRM (mutação) | `POST/PATCH /v1/crm/funil-estagios` — UI em Configurações → Cadastros → Funil CRM |
 
 ## Comercial ou administrador (`exigir_comercial_ou_admin`)
 
@@ -40,7 +41,8 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 |---------|----------------|
 | **CRM** | `GET/POST/PATCH /v1/crm/leads`, `GET/POST/PATCH /v1/crm/negociacoes*`, atividades, mover estágio. Listagem vê **todas** as leads/negociações; filtro opcional `so_minhas=true`. |
 | **Funil (leitura)** | `GET /v1/crm/funil-estagios` |
-| **Simular custos** | `POST /v1/comercial/custos/simular` (CRUD do catálogo continua só admin) |
+| **Simular custos** | `POST /v1/comercial/custos/simular` |
+| **Listar itens catálogo** | `GET /v1/comercial/custos/itens` (mutações continuam só admin) |
 
 ## Autenticado com escopo de setor (`obter_atendente_atual`)
 
@@ -68,4 +70,4 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 - **Rotas**: páginas de cadastro usam `AdminRoute` em `App.tsx` — atendente vê `AcessoNegado` se aceder por URL.
 - **Tickets / novo ticket**: listas de **setores** e **empresas** seguem o filtro da API; não se recorta setor no cliente por `setor_ids` do `/me` (homônimos). Quando o atendente ainda não tem empresas no escopo, o UI explica o critério da rede com ticket nos setores dele.
 - **403**: mensagens vêm do corpo da API (`api/client` + `errorMessage.ts`).
-- **CRM UI** (#341–#344): ainda não entregue — lote B do épico #322.
+- **CRM UI** (#341–#344): menu **CRM** e rotas `/crm/leads`, `/crm/negociacoes/:id` para `admin` e `comercial`.

--- a/docs/BACKEND_RBAC.md
+++ b/docs/BACKEND_RBAC.md
@@ -1,6 +1,16 @@
 # RBAC no backend (API v1)
 
-Política alinhada à issue **#38**: perfis **admin** e **atendente**, com escopo por **setor** (inclui setores homônimos — ver `app.core.setor_scope`).
+Política alinhada à issue **#38** (admin / atendente + setor) e **#336** (perfil **comercial** para CRM).
+
+## Perfis
+
+| Role | Uso |
+|------|-----|
+| `admin` | Cadastros, configuração, visão total, CRM e catálogo de custos. |
+| `atendente` | Tickets / chats no escopo de setor; **sem** CRM nem catálogo de custos. |
+| `comercial` | CRM (leads/negociações) + `POST /v1/comercial/custos/simular`; **sem** CRUD de catálogo nem cadastros admin. |
+
+Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 
 ## Autenticação
 
@@ -21,6 +31,16 @@ Política alinhada à issue **#38**: perfis **admin** e **atendente**, com escop
 | Tipos de negócio (detalhe / mutação) | `GET/POST/PATCH/DELETE /v1/tipos-negocio/{id}`, `POST /v1/tipos-negocio` |
 | Auditoria | `GET /v1/audit` |
 | Cadastro auxiliar (IBGE) | `POST /v1/cadastro-aux/municipios/sincronizar` |
+| Catálogo comercial (CRUD) | `GET/POST/PATCH/DELETE /v1/comercial/salario-minimo*`, `GET/POST/PATCH/DELETE /v1/comercial/custos/itens*` |
+| Funil CRM (mutação) | `POST/PATCH /v1/crm/funil-estagios` |
+
+## Comercial ou administrador (`exigir_comercial_ou_admin`)
+
+| Recurso | Comportamento |
+|---------|----------------|
+| **CRM** | `GET/POST/PATCH /v1/crm/leads`, `GET/POST/PATCH /v1/crm/negociacoes*`, atividades, mover estágio. Listagem vê **todas** as leads/negociações; filtro opcional `so_minhas=true`. |
+| **Funil (leitura)** | `GET /v1/crm/funil-estagios` |
+| **Simular custos** | `POST /v1/comercial/custos/simular` (CRUD do catálogo continua só admin) |
 
 ## Autenticado com escopo de setor (`obter_atendente_atual`)
 
@@ -38,9 +58,9 @@ Política alinhada à issue **#38**: perfis **admin** e **atendente**, com escop
 
 ## Referência de código
 
-- `app.core.auth`: `obter_atendente_atual`, `exigir_admin`.
+- `app.core.auth`: `obter_atendente_atual`, `exigir_admin`, `exigir_comercial_ou_admin`, `validar_role`.
 - `app.core.setor_scope`: `ids_setores_visiveis_atendente`, `ids_setores_mesmo_nome`, `responsavel_elegivel_para_setor_do_ticket`, `select_rede_ids_com_ticket_nos_setores`.
-- Testes: `backend/tests/test_rbac_tickets.py`, `test_rbac_catalogos.py`, `test_rbac_admin_only.py`.
+- Testes: `backend/tests/test_rbac_tickets.py`, `test_rbac_catalogos.py`, `test_rbac_admin_only.py`, `test_crm.py`.
 
 ## Frontend (alinhamento)
 
@@ -48,3 +68,4 @@ Política alinhada à issue **#38**: perfis **admin** e **atendente**, com escop
 - **Rotas**: páginas de cadastro usam `AdminRoute` em `App.tsx` — atendente vê `AcessoNegado` se aceder por URL.
 - **Tickets / novo ticket**: listas de **setores** e **empresas** seguem o filtro da API; não se recorta setor no cliente por `setor_ids` do `/me` (homônimos). Quando o atendente ainda não tem empresas no escopo, o UI explica o critério da rede com ticket nos setores dele.
 - **403**: mensagens vêm do corpo da API (`api/client` + `errorMessage.ts`).
+- **CRM UI** (#341–#344): ainda não entregue — lote B do épico #322.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,9 @@ import { PresencaOnline } from './pages/PresencaOnline'
 import { Tickets } from './pages/Tickets'
 import { TicketNovo } from './pages/TicketNovo'
 import { TicketDetalhe } from './pages/TicketDetalhe'
+import { CrmLeads } from './pages/CrmLeads'
+import { CrmNegociacaoDetalhe } from './pages/CrmNegociacaoDetalhe'
+import { ConfigCrmFunil } from './pages/ConfigCrmFunil'
 import { Redes } from './pages/Redes'
 import { RedeDetalhe } from './pages/RedeDetalhe'
 import { RedeForm } from './pages/RedeForm'
@@ -124,6 +127,25 @@ function AdminRoute({ children }: { children: React.ReactNode }) {
   }
   if (user.role !== 'admin') {
     return <AcessoNegado />
+  }
+  return <>{children}</>
+}
+
+function ComercialOuAdminRoute({ children }: { children: React.ReactNode }) {
+  const { user, loading } = useAuth()
+  if (loading) {
+    return <PageLoading fullscreen label="Carregando sessão…" />
+  }
+  if (!user) {
+    return <Navigate to="/login" replace />
+  }
+  if (user.role !== 'admin' && user.role !== 'comercial') {
+    return (
+      <AcessoNegado
+        title="Área exclusiva para comercial ou administradores"
+        detail="Você está autenticado, mas esta página só pode ser acessada por usuários com perfil comercial ou administrador."
+      />
+    )
   }
   return <>{children}</>
 }
@@ -245,6 +267,22 @@ function AppRoutes() {
         <Route path="tickets" element={<Tickets />} />
         <Route path="tickets/novo" element={<TicketNovo />} />
         <Route path="tickets/:id" element={<TicketDetalhe />} />
+        <Route
+          path="crm/leads"
+          element={
+            <ComercialOuAdminRoute>
+              <CrmLeads />
+            </ComercialOuAdminRoute>
+          }
+        />
+        <Route
+          path="crm/negociacoes/:id"
+          element={
+            <ComercialOuAdminRoute>
+              <CrmNegociacaoDetalhe />
+            </ComercialOuAdminRoute>
+          }
+        />
         <Route path="chat" element={<ChatHubShell />}>
           <Route element={<ChatHubLayout />}>
             <Route index element={<Navigate to="atendendo" replace />} />
@@ -574,6 +612,7 @@ function AppRoutes() {
           <Route path="tipos-negocio" element={<TiposNegocio embedded />} />
           <Route path="pdv" element={<ConfigPdvCatalogos embedded />} />
           <Route path="custos" element={<ConfigComercialCustos embedded />} />
+          <Route path="funil-crm" element={<ConfigCrmFunil embedded />} />
         </Route>
         <Route
           path="configuracoes/sistema"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2943,6 +2943,233 @@ export namespace ComercialCustos {
   }
 }
 
+export const crmFunil = {
+  list: (params?: { incluir_inativos?: boolean }) =>
+    api<Crm.FunilEstagio[]>(withParams('/crm/funil-estagios', params)),
+  create: (data: Crm.FunilEstagioCreate) =>
+    api<Crm.FunilEstagio>('/crm/funil-estagios', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id: number, data: Crm.FunilEstagioUpdate) =>
+    api<Crm.FunilEstagio>(`/crm/funil-estagios/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+};
+
+export const crmLeads = {
+  list: (params?: {
+    offset?: number;
+    limit?: number;
+    q?: string;
+    responsavel_id?: number;
+    estagio_id?: number;
+    so_minhas?: boolean;
+    ativo?: boolean;
+  }) => listPaginated<Crm.Lead>('/crm/leads', params),
+  get: (id: number) => api<Crm.Lead>(`/crm/leads/${id}`),
+  create: (data: Crm.LeadCreate) =>
+    api<Crm.Lead>('/crm/leads', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id: number, data: Crm.LeadUpdate) =>
+    api<Crm.Lead>(`/crm/leads/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+};
+
+export const crmNegociacoes = {
+  list: (params?: {
+    offset?: number;
+    limit?: number;
+    lead_id?: number;
+    responsavel_id?: number;
+    estagio_id?: number;
+    ativa?: boolean;
+    q?: string;
+    so_minhas?: boolean;
+  }) => listPaginated<Crm.Negociacao>('/crm/negociacoes', params),
+  get: (id: number) => api<Crm.Negociacao>(`/crm/negociacoes/${id}`),
+  create: (data: Crm.NegociacaoCreate) =>
+    api<Crm.Negociacao>('/crm/negociacoes', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id: number, data: Crm.NegociacaoUpdate) =>
+    api<Crm.Negociacao>(`/crm/negociacoes/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  moverEstagio: (id: number, data: Crm.MoverEstagioRequest) =>
+    api<Crm.Negociacao>(`/crm/negociacoes/${id}/mover-estagio`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  addLinha: (negociacaoId: number, data: Crm.LinhaCreate) =>
+    api<Crm.Linha>(`/crm/negociacoes/${negociacaoId}/linhas`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  updateLinha: (negociacaoId: number, linhaId: number, data: Crm.LinhaUpdate) =>
+    api<Crm.Linha>(`/crm/negociacoes/${negociacaoId}/linhas/${linhaId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+  deleteLinha: (negociacaoId: number, linhaId: number) =>
+    api<void>(`/crm/negociacoes/${negociacaoId}/linhas/${linhaId}`, { method: 'DELETE' }),
+  listAtividades: (negociacaoId: number, params?: { offset?: number; limit?: number }) =>
+    listPaginated<Crm.Atividade>(`/crm/negociacoes/${negociacaoId}/atividades`, params),
+  addAtividade: (negociacaoId: number, data: Crm.AtividadeCreate) =>
+    api<Crm.Atividade>(`/crm/negociacoes/${negociacaoId}/atividades`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+};
+
+export namespace Crm {
+  export interface FunilEstagio {
+    id: number;
+    slug: string;
+    nome: string;
+    ordem: number;
+    tipo: string;
+    ativo: boolean;
+  }
+
+  export interface FunilEstagioCreate {
+    slug: string;
+    nome: string;
+    ordem?: number;
+    tipo?: string;
+    ativo?: boolean;
+  }
+
+  export interface FunilEstagioUpdate {
+    nome?: string;
+    ordem?: number;
+    tipo?: string;
+    ativo?: boolean;
+  }
+
+  export interface Lead {
+    id: number;
+    nome: string;
+    telefone?: string | null;
+    email?: string | null;
+    empresa_texto?: string | null;
+    origem?: string | null;
+    notas?: string | null;
+    responsavel_id: number;
+    estagio_id: number;
+    estagio_slug?: string | null;
+    estagio_nome?: string | null;
+    perdido_em?: string | null;
+    ativo: boolean;
+    negociacao_ativa_id?: number | null;
+    created_at?: string | null;
+    updated_at?: string | null;
+  }
+
+  export interface LeadCreate {
+    nome: string;
+    telefone?: string | null;
+    email?: string | null;
+    empresa_texto?: string | null;
+    origem?: string | null;
+    notas?: string | null;
+    responsavel_id?: number | null;
+    criar_negociacao?: boolean;
+    titulo_negociacao?: string | null;
+  }
+
+  export interface LeadUpdate {
+    nome?: string;
+    telefone?: string | null;
+    email?: string | null;
+    empresa_texto?: string | null;
+    origem?: string | null;
+    notas?: string | null;
+    responsavel_id?: number | null;
+    ativo?: boolean;
+  }
+
+  export interface Linha {
+    id: number;
+    negociacao_id: number;
+    cnpj?: string | null;
+    razao_social?: string | null;
+    item_ids: number[];
+    quantidade_pdvs: number;
+    desconto_posto_100k: boolean;
+    tef_override?: Record<string, unknown> | null;
+    valor_negociado: string;
+    snapshot_custo?: Record<string, unknown> | null;
+    total_custo?: string | null;
+    margem_calculada?: string | null;
+    empresa_id?: number | null;
+    ordem: number;
+    created_at?: string | null;
+    updated_at?: string | null;
+  }
+
+  export interface LinhaCreate {
+    cnpj?: string | null;
+    razao_social?: string | null;
+    item_ids?: number[];
+    quantidade_pdvs?: number;
+    desconto_posto_100k?: boolean;
+    tef_override?: ComercialCustos.TefOverride | null;
+    valor_negociado?: string | number;
+    ordem?: number;
+  }
+
+  export interface LinhaUpdate {
+    cnpj?: string | null;
+    razao_social?: string | null;
+    item_ids?: number[];
+    quantidade_pdvs?: number;
+    desconto_posto_100k?: boolean;
+    tef_override?: ComercialCustos.TefOverride | null;
+    limpar_tef_override?: boolean;
+    valor_negociado?: string | number;
+    ordem?: number;
+  }
+
+  export interface Negociacao {
+    id: number;
+    lead_id: number;
+    responsavel_id: number;
+    estagio_id: number;
+    estagio_slug?: string | null;
+    estagio_nome?: string | null;
+    ativa: boolean;
+    titulo?: string | null;
+    linhas: Linha[];
+    created_at?: string | null;
+    updated_at?: string | null;
+  }
+
+  export interface NegociacaoCreate {
+    lead_id: number;
+    titulo?: string | null;
+    responsavel_id?: number | null;
+    linhas?: LinhaCreate[];
+  }
+
+  export interface NegociacaoUpdate {
+    titulo?: string | null;
+    responsavel_id?: number | null;
+  }
+
+  export interface MoverEstagioRequest {
+    estagio_id?: number | null;
+    estagio_slug?: string | null;
+    nota?: string | null;
+  }
+
+  export interface Atividade {
+    id: number;
+    negociacao_id: number;
+    autor_id: number;
+    tipo: string;
+    texto: string;
+    created_at?: string | null;
+  }
+
+  export interface AtividadeCreate {
+    tipo?: string;
+    texto: string;
+  }
+}
+
 export const pdvRotulos = {
   list: (params?: { incluir_inativos?: boolean; busca?: string; offset?: number; limit?: number }) =>
     listPaginated<PdvCatalogo.Item>('/pdv-rotulos', params),

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -12,6 +12,7 @@ import { useTheme } from '../contexts/ThemeContext'
 function perfilExibicao(role: string | undefined): string {
   if (role === 'admin') return 'Administrador'
   if (role === 'atendente') return 'Atendente'
+  if (role === 'comercial') return 'Comercial'
   return role?.trim() || '—'
 }
 
@@ -22,7 +23,7 @@ const menuIcon = (
 )
 
 function LayoutInner() {
-  const { user, logout, isAdmin } = useAuth()
+  const { user, logout, isAdmin, isComercialOuAdmin } = useAuth()
   const { subscribe } = useEventStream()
   const location = useLocation()
   const [sidebarExpanded, setSidebarExpanded] = useState(true)
@@ -69,6 +70,7 @@ function LayoutInner() {
         mobileOpen={sidebarMobileOpen}
         onMobileClose={() => setSidebarMobileOpen(false)}
         isAdmin={isAdmin ?? false}
+        isComercialOuAdmin={isComercialOuAdmin ?? false}
         userNome={user?.nome ?? ''}
         userRole={perfilExibicao(user?.role)}
         onLogout={logout}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -204,6 +204,10 @@ interface NavLink {
   label: string
   icon: string
   adminOnly?: boolean
+  /** Visível para admin ou comercial (CRM). */
+  comercialOuAdmin?: boolean
+  /** Mantém o item ativo em rotas filhas (ex.: `/crm/negociacoes/:id`) */
+  activePrefix?: string
 }
 
 interface NavGroup {
@@ -212,6 +216,7 @@ interface NavGroup {
   label: string
   icon: string
   adminOnly?: boolean
+  comercialOuAdmin?: boolean
   /** Ex.: conversa aberta `/whatsapp/c/:id` mantém o grupo Chat ativo */
   extraActivePrefixes?: string[]
   children: NavLink[]
@@ -225,6 +230,7 @@ interface NavItemLink {
   /** Mantém o item ativo em rotas filhas (ex.: `/chat/c/:id`) */
   activePrefix?: string
   adminOnly?: boolean
+  comercialOuAdmin?: boolean
 }
 
 type NavItem = NavItemLink | NavGroup
@@ -239,6 +245,23 @@ const navStructure: NavItem[] = [
     adminOnly: true,
   },
   { type: 'link', to: '/tickets', label: 'Tickets', icon: 'tickets' },
+  {
+    type: 'group',
+    id: 'comercial',
+    label: 'Comercial',
+    icon: 'tiposNegocio',
+    comercialOuAdmin: true,
+    extraActivePrefixes: ['/crm/'],
+    children: [
+      {
+        to: '/crm/leads',
+        label: 'CRM',
+        icon: 'tiposNegocio',
+        comercialOuAdmin: true,
+        activePrefix: '/crm/',
+      },
+    ],
+  },
   { type: 'link', to: '/chat/atendendo', label: 'Chat', icon: 'chat', activePrefix: '/chat/' },
   { type: 'link', to: '/whatsapp/historico', label: 'Atendimentos', icon: 'chatHistory' },
   {
@@ -297,8 +320,22 @@ function navGroupMatchesPath(pathname: string, group: NavGroup): boolean {
   return group.extraActivePrefixes?.some((prefix) => pathname.startsWith(prefix)) ?? false
 }
 
-function navChildrenVisible(children: NavLink[], isAdmin: boolean): NavLink[] {
-  return children.filter((child) => !child.adminOnly || isAdmin)
+function navItemVisivel(
+  item: { adminOnly?: boolean; comercialOuAdmin?: boolean },
+  isAdmin: boolean,
+  isComercialOuAdmin: boolean,
+): boolean {
+  if (item.adminOnly && !isAdmin) return false
+  if (item.comercialOuAdmin && !isComercialOuAdmin) return false
+  return true
+}
+
+function navChildrenVisible(
+  children: NavLink[],
+  isAdmin: boolean,
+  isComercialOuAdmin: boolean,
+): NavLink[] {
+  return children.filter((child) => navItemVisivel(child, isAdmin, isComercialOuAdmin))
 }
 
 interface SidebarProps {
@@ -306,6 +343,7 @@ interface SidebarProps {
   mobileOpen: boolean
   onMobileClose: () => void
   isAdmin: boolean
+  isComercialOuAdmin: boolean
   userNome: string
   userRole: string
   onLogout: () => void
@@ -316,6 +354,7 @@ export function Sidebar({
   mobileOpen,
   onMobileClose,
   isAdmin,
+  isComercialOuAdmin,
   userNome,
   userRole,
   onLogout,
@@ -365,16 +404,15 @@ export function Sidebar({
     [closeFlyout, openFlyout]
   )
 
-  const items = navStructure.filter((item) => {
-    if ('adminOnly' in item && item.adminOnly && !isAdmin) return false
-    return true
-  }) as NavItem[]
+  const items = navStructure.filter((item) =>
+    navItemVisivel(item, isAdmin, isComercialOuAdmin),
+  ) as NavItem[]
 
   // Abrir grupo automaticamente quando a rota pertence a ele
   useEffect(() => {
     for (const item of navStructure) {
       if (item.type === 'group') {
-        if (!item.adminOnly || isAdmin) {
+        if (navItemVisivel(item, isAdmin, isComercialOuAdmin)) {
           if (navGroupMatchesPath(location.pathname, item)) {
             setOpenGroup(item.id)
             return
@@ -382,7 +420,7 @@ export function Sidebar({
         }
       }
     }
-  }, [location.pathname, isAdmin])
+  }, [location.pathname, isAdmin, isComercialOuAdmin])
 
   // No drawer mobile usamos acordeão (não flyout); evita estado do flyout “preso”
   useEffect(() => {
@@ -438,7 +476,7 @@ export function Sidebar({
               }}
               role="menu"
             >
-              {navChildrenVisible(openFlyoutGroup.children, isAdmin).map((child) => (
+              {navChildrenVisible(openFlyoutGroup.children, isAdmin, isComercialOuAdmin).map((child) => (
                 <li key={child.to} role="none">
                   <Link
                     to={child.to}
@@ -513,6 +551,7 @@ export function Sidebar({
             const group = item
             const open = isGroupOpen(group.id)
             const active = navGroupMatchesPath(location.pathname, group)
+            const childActive = group.children.some((c) => isLinkActive(c.to, c.activePrefix))
 
             const menuExpandido = expanded || mobileOpen
 
@@ -525,9 +564,11 @@ export function Sidebar({
                       type="button"
                       onClick={() => setOpenGroup(open ? null : group.id)}
                       className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors touch-manipulation min-h-[44px] ${
-                        active
+                        active && !childActive
                           ? 'bg-cyan-50/80 text-slate-900 ring-1 ring-cyan-200/50 dark:bg-cyan-950/30 dark:text-slate-100 dark:ring-cyan-800/40'
-                          : 'text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800/80'
+                          : active && childActive
+                            ? 'text-slate-800 dark:text-slate-100'
+                            : 'text-slate-600 hover:bg-slate-100 dark:text-slate-400 dark:hover:bg-slate-800/80'
                       }`}
                       aria-expanded={open}
                       aria-controls={`nav-group-${group.id}`}
@@ -540,15 +581,17 @@ export function Sidebar({
                     </button>
                     <ul
                       id={`nav-group-${group.id}`}
-                      className={`min-w-0 overflow-hidden transition-all duration-200 ${open ? 'max-h-[500px] opacity-100' : 'max-h-0 opacity-0'}`}
+                      className={`min-w-0 space-y-0.5 overflow-hidden transition-all duration-200 ${
+                        open ? 'mt-1 max-h-[500px] opacity-100' : 'max-h-0 opacity-0'
+                      }`}
                       role="group"
                     >
-                      {navChildrenVisible(group.children, isAdmin).map((child) => (
-                        <li key={child.to} className="min-w-0 pl-4">
+                      {navChildrenVisible(group.children, isAdmin, isComercialOuAdmin).map((child) => (
+                        <li key={child.to} className="min-w-0 border-l border-slate-200 pl-3 ml-4 dark:border-slate-700">
                           <Link
                             to={child.to}
                             onClick={onMobileClose}
-                            className={linkClass(child.to, 'flex')}
+                            className={linkClass(child.to, child.activePrefix)}
                           >
                             {icons[child.icon]}
                             <span className="truncate">{child.label}</span>

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -17,10 +17,18 @@ const variants: Record<Variant, string> = {
     'bg-transparent text-slate-700 hover:bg-slate-100 focus:ring-slate-400 dark:text-slate-300 dark:hover:bg-slate-800',
 }
 
-export function Button({ variant = 'primary', loading, className = '', disabled, children, ...props }: ButtonProps) {
+export function Button({
+  variant = 'primary',
+  loading,
+  className = '',
+  disabled,
+  children,
+  type = 'button',
+  ...props
+}: ButtonProps) {
   return (
     <button
-      type="button"
+      type={type}
       className={`
         inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium
         focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -8,6 +8,7 @@ interface AuthContextValue {
   logout: () => void
   refreshUser: () => Promise<void>
   isAdmin: boolean
+  isComercialOuAdmin: boolean
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
@@ -73,6 +74,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     logout,
     refreshUser,
     isAdmin: user?.role === 'admin',
+    isComercialOuAdmin: user?.role === 'admin' || user?.role === 'comercial',
   }
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -161,3 +161,46 @@
   @apply border-slate-200;
 }
 
+/* Scrollbar discreta (Kanban CRM e listas horizontais) — evita a barra nativa do Windows */
+.dx-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rgb(148 163 184 / 0.55) transparent;
+}
+
+.dark .dx-scrollbar {
+  scrollbar-color: rgb(100 116 139 / 0.7) transparent;
+}
+
+.dx-scrollbar::-webkit-scrollbar {
+  height: 6px;
+  width: 6px;
+}
+
+.dx-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+  margin-inline: 4px;
+}
+
+.dx-scrollbar::-webkit-scrollbar-thumb {
+  background: rgb(148 163 184 / 0.55);
+  border-radius: 9999px;
+}
+
+.dx-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: rgb(100 116 139 / 0.75);
+}
+
+.dark .dx-scrollbar::-webkit-scrollbar-thumb {
+  background: rgb(100 116 139 / 0.7);
+}
+
+.dark .dx-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: rgb(148 163 184 / 0.55);
+}
+
+.dx-scrollbar::-webkit-scrollbar-button {
+  display: none;
+  width: 0;
+  height: 0;
+}
+

--- a/frontend/src/pages/AcessoNegado.tsx
+++ b/frontend/src/pages/AcessoNegado.tsx
@@ -1,14 +1,17 @@
 import { Link } from 'react-router-dom'
 
-export function AcessoNegado() {
+export function AcessoNegado({
+  title = 'Área exclusiva para administradores',
+  detail = 'Você está autenticado, mas esta página só pode ser acessada por usuários com perfil de administrador. Se precisar de acesso, solicite ao gestor da equipe.',
+}: {
+  title?: string
+  detail?: string
+} = {}) {
   return (
     <div className="mx-auto max-w-lg rounded-2xl border border-amber-200/80 bg-amber-50/90 p-6 text-amber-950 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
       <p className="text-sm font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-300">403 — Acesso restrito</p>
-      <h1 className="mt-2 text-lg font-semibold text-slate-900 dark:text-slate-100">Área exclusiva para administradores</h1>
-      <p className="mt-3 text-sm leading-relaxed text-slate-700 dark:text-slate-300">
-        Você está autenticado, mas esta página só pode ser acessada por usuários com perfil de administrador. Se precisar
-        de acesso, solicite ao gestor da equipe.
-      </p>
+      <h1 className="mt-2 text-lg font-semibold text-slate-900 dark:text-slate-100">{title}</h1>
+      <p className="mt-3 text-sm leading-relaxed text-slate-700 dark:text-slate-300">{detail}</p>
       <div className="mt-6 flex flex-wrap gap-3">
         <Link
           to="/"

--- a/frontend/src/pages/AtendenteDetalhe.tsx
+++ b/frontend/src/pages/AtendenteDetalhe.tsx
@@ -11,7 +11,11 @@ import { SemPermissao } from './SemPermissao'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 import { interpretarFalhaCarregamento } from '../api/errorMessage'
 
-const roleLabel: Record<string, string> = { admin: 'Administrador', atendente: 'Atendente' }
+const roleLabel: Record<string, string> = {
+  admin: 'Administrador',
+  atendente: 'Atendente',
+  comercial: 'Comercial',
+}
 
 function fmtMediaAvaliacao(media: number | null): string {
   if (media == null) return '—'

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -35,7 +35,7 @@ export function AtendenteForm() {
   const [nome, setNome] = useState('')
   const [senha, setSenha] = useState('')
   const [mostrarSenha, setMostrarSenha] = useState(false)
-  const [role, setRole] = useState<'admin' | 'atendente'>('atendente')
+  const [role, setRole] = useState<'admin' | 'atendente' | 'comercial'>('atendente')
   const [ativo, setAtivo] = useState(true)
   const [setorIds, setSetorIds] = useState<number[]>([])
 
@@ -64,7 +64,7 @@ export function AtendenteForm() {
         setNome(a.nome)
         setSenha('')
         setMostrarSenha(false)
-        setRole((a.role as 'admin') || 'atendente')
+        setRole((a.role as 'admin' | 'atendente' | 'comercial') || 'atendente')
         setAtivo(a.ativo)
         setSetorIds(a.setor_ids ?? [])
       })
@@ -186,9 +186,12 @@ export function AtendenteForm() {
               <Select
                 label="Perfil"
                 value={role}
-                onChange={(v) => setRole(v === 'admin' ? 'admin' : 'atendente')}
+                onChange={(v) =>
+                  setRole(v === 'admin' ? 'admin' : v === 'comercial' ? 'comercial' : 'atendente')
+                }
                 options={[
                   { value: 'atendente', label: 'Atendente' },
+                  { value: 'comercial', label: 'Comercial' },
                   { value: 'admin', label: 'Administrador' },
                 ]}
               />

--- a/frontend/src/pages/Atendentes.tsx
+++ b/frontend/src/pages/Atendentes.tsx
@@ -15,7 +15,11 @@ import { mensagemFalhaParaToast } from '../api/errorMessage'
 
 type ColunaAtendente = 'nome' | 'email' | 'role'
 
-const roleLabel: Record<string, string> = { admin: 'Administrador', atendente: 'Atendente' }
+const roleLabel: Record<string, string> = {
+  admin: 'Administrador',
+  atendente: 'Atendente',
+  comercial: 'Comercial',
+}
 
 export function Atendentes({ embedded = false }: { embedded?: boolean }) {
   const navigate = useNavigate()

--- a/frontend/src/pages/ConfigComercialCustos.tsx
+++ b/frontend/src/pages/ConfigComercialCustos.tsx
@@ -386,7 +386,7 @@ export function ConfigComercialCustos({ embedded = false }: { embedded?: boolean
   if (forbidden) {
     return (
       <SemPermissao
-        title="Apenas administradores podem gerir o catálogo comercial de custos."
+        title="Apenas administradores podem gerenciar o catálogo comercial de custos."
         voltarPara="/"
         voltarLabel="Voltar"
       />

--- a/frontend/src/pages/ConfigCrmFunil.tsx
+++ b/frontend/src/pages/ConfigCrmFunil.tsx
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ApiError, crmFunil, type Crm } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Button } from '../components/ui/Button'
+import { Card } from '../components/ui/Card'
+import { Input } from '../components/ui/Input'
+import { Select } from '../components/ui/Select'
+import { Switch } from '../components/ui/Switch'
+import { FiltroInativos } from '../components/ui/FiltroInativos'
+import { IconPencil } from '../components/ui/IconPencil'
+import { useToast } from '../components/ui/Toast'
+import { ConfigListPageShell } from '../components/config/ConfigListPageShell'
+import { SemPermissao } from './SemPermissao'
+
+const TIPO_OPTIONS = [
+  { value: 'aberto', label: 'Aberto (em andamento)' },
+  { value: 'ganho', label: 'Ganho' },
+  { value: 'perdido', label: 'Perdido' },
+]
+
+const TIPO_LABEL: Record<string, string> = {
+  aberto: 'Aberto',
+  ganho: 'Ganho',
+  perdido: 'Perdido',
+}
+
+function slugify(nome: string): string {
+  return nome
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '')
+    .slice(0, 50)
+}
+
+type FormState = {
+  nome: string
+  slug: string
+  ordem: string
+  tipo: string
+  ativo: boolean
+}
+
+const emptyForm = (): FormState => ({
+  nome: '',
+  slug: '',
+  ordem: '100',
+  tipo: 'aberto',
+  ativo: true,
+})
+
+export function ConfigCrmFunil({ embedded = false }: { embedded?: boolean }) {
+  const toast = useToast()
+  const [list, setList] = useState<Crm.FunilEstagio[]>([])
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [incluirInativos, setIncluirInativos] = useState(false)
+  const [modal, setModal] = useState<'create' | Crm.FunilEstagio | null>(null)
+  const [form, setForm] = useState<FormState>(emptyForm())
+  const [saving, setSaving] = useState(false)
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    crmFunil
+      .list({ incluir_inativos: incluirInativos })
+      .then(setList)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar o funil.'))
+        setList([])
+      })
+      .finally(() => setLoading(false))
+  }, [incluirInativos, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  function openCreate() {
+    const maxOrdem = list.reduce((m, e) => Math.max(m, e.ordem), 0)
+    setForm({ ...emptyForm(), ordem: String(maxOrdem + 10) })
+    setModal('create')
+  }
+
+  function openEdit(row: Crm.FunilEstagio) {
+    setForm({
+      nome: row.nome,
+      slug: row.slug,
+      ordem: String(row.ordem),
+      tipo: row.tipo,
+      ativo: row.ativo,
+    })
+    setModal(row)
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    if (!form.nome.trim()) {
+      toast.showWarning('Informe o nome do estágio.')
+      return
+    }
+    setSaving(true)
+    try {
+      if (modal === 'create') {
+        const slug = form.slug.trim() || slugify(form.nome)
+        if (!slug) {
+          toast.showWarning('Não foi possível gerar o identificador (slug). Ajuste o nome.')
+          return
+        }
+        await crmFunil.create({
+          nome: form.nome.trim(),
+          slug,
+          ordem: parseInt(form.ordem, 10) || 0,
+          tipo: form.tipo,
+          ativo: form.ativo,
+        })
+        toast.showSuccess('Estágio criado.')
+      } else if (modal && typeof modal === 'object') {
+        await crmFunil.update(modal.id, {
+          nome: form.nome.trim(),
+          ordem: parseInt(form.ordem, 10) || 0,
+          tipo: form.tipo,
+          ativo: form.ativo,
+        })
+        toast.showSuccess('Estágio atualizado.')
+      }
+      setModal(null)
+      load()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o estágio.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const denied = (
+    <SemPermissao
+      title="Você não tem permissão para configurar o funil CRM."
+      detail="Apenas administradores gerem os estágios do funil."
+      voltarPara="/"
+      voltarLabel="Voltar para o Dashboard"
+    />
+  )
+
+  return (
+    <ConfigListPageShell
+      embedded={embedded}
+      forbidden={forbidden}
+      denied={denied}
+      title="Funil CRM"
+      actions={<Button onClick={openCreate}>Novo estágio</Button>}
+    >
+      <p className="mb-3 text-sm text-slate-500 dark:text-slate-400">
+        Os estágios padrão (Lead, Em negociação, Documentação…) já vêm no sistema. Aqui você pode renomear, reordenar,
+        desativar ou criar novos — o Kanban e a lista do CRM usam esta configuração.
+      </p>
+      <Card>
+        <div className="mb-3">
+          <FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />
+        </div>
+        {loading ? (
+          <p className="text-slate-500">Carregando…</p>
+        ) : list.length === 0 ? (
+          <p className="text-slate-500">Nenhum estágio encontrado.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[560px] text-left text-sm">
+              <thead>
+                <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Ordem</th>
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Nome</th>
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Tipo</th>
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Identificador</th>
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Ativo</th>
+                  <th className="px-3 py-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {list.map((row) => (
+                  <tr key={row.id} className="border-b border-slate-100 dark:border-slate-800/80">
+                    <td className="px-3 py-2.5 text-slate-600">{row.ordem}</td>
+                    <td className="px-3 py-2.5 font-medium text-slate-900 dark:text-slate-100">{row.nome}</td>
+                    <td className="px-3 py-2.5 text-slate-600">{TIPO_LABEL[row.tipo] || row.tipo}</td>
+                    <td className="px-3 py-2.5 font-mono text-xs text-slate-500">{row.slug}</td>
+                    <td className="px-3 py-2.5">{row.ativo ? 'Sim' : 'Não'}</td>
+                    <td className="px-3 py-2.5 text-right">
+                      <button
+                        type="button"
+                        onClick={() => openEdit(row)}
+                        className="inline-flex size-8 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
+                        aria-label={`Editar ${row.nome}`}
+                      >
+                        <IconPencil />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+
+      {modal ? (
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-0 sm:items-center sm:p-4">
+          <div className="max-h-[92vh] w-full overflow-y-auto rounded-t-2xl bg-white p-5 shadow-xl dark:bg-slate-900 sm:max-w-md sm:rounded-2xl">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              {modal === 'create' ? 'Novo estágio' : 'Editar estágio'}
+            </h2>
+            <form onSubmit={handleSave} className="mt-4 space-y-3">
+              <Input
+                label="Nome"
+                value={form.nome}
+                onChange={(e) => {
+                  const nome = e.target.value
+                  setForm((p) => ({
+                    ...p,
+                    nome,
+                    slug: modal === 'create' ? slugify(nome) : p.slug,
+                  }))
+                }}
+                required
+              />
+              {modal === 'create' ? (
+                <Input
+                  label="Identificador (slug)"
+                  value={form.slug}
+                  onChange={(e) => setForm((p) => ({ ...p, slug: e.target.value }))}
+                  hint="Usado internamente; gerado a partir do nome."
+                />
+              ) : (
+                <p className="text-xs text-slate-500">
+                  Identificador: <span className="font-mono">{form.slug}</span> (não editável)
+                </p>
+              )}
+              <Input
+                label="Ordem"
+                value={form.ordem}
+                onChange={(e) => setForm((p) => ({ ...p, ordem: e.target.value }))}
+              />
+              <Select
+                label="Tipo"
+                value={form.tipo}
+                onChange={(v) => setForm((p) => ({ ...p, tipo: String(v) }))}
+                options={TIPO_OPTIONS}
+              />
+              <Switch
+                bare
+                checked={form.ativo}
+                onCheckedChange={(ativo) => setForm((p) => ({ ...p, ativo }))}
+                label="Estágio ativo"
+                description="Inativos deixam de aparecer no funil e no Kanban."
+                showStatusPill
+                statusOnText="Ativo"
+                statusOffText="Inativo"
+              />
+              <div className="flex flex-wrap justify-end gap-2 pt-2">
+                <Button type="button" variant="secondary" onClick={() => setModal(null)} disabled={saving}>
+                  Cancelar
+                </Button>
+                <Button type="submit" disabled={saving}>
+                  {saving ? 'Salvando…' : 'Salvar'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </ConfigListPageShell>
+  )
+}

--- a/frontend/src/pages/CrmLeads.tsx
+++ b/frontend/src/pages/CrmLeads.tsx
@@ -1,0 +1,799 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import {
+  ApiError,
+  atendentes,
+  crmFunil,
+  crmLeads,
+  crmNegociacoes,
+  type Atendentes,
+  type Crm,
+} from '../api/client'
+import { coletarTodasPaginas } from '../api/collectPages'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Button } from '../components/ui/Button'
+import { Card } from '../components/ui/Card'
+import { Input } from '../components/ui/Input'
+import { Select } from '../components/ui/Select'
+import { IconPencil } from '../components/ui/IconPencil'
+import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../components/ui/BarraBuscaPaginacao'
+import { useToast } from '../components/ui/Toast'
+import { useAuth } from '../contexts/AuthContext'
+import { SemPermissao } from './SemPermissao'
+
+const DND_LEAD = 'application/x-crm-lead'
+const DND_COL = 'application/x-crm-estagio'
+
+type VistaCrm = 'lista' | 'kanban'
+
+const VISTA_KEY = 'dx-crm-vista'
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString('pt-BR')
+}
+
+function lerVistaInicial(): VistaCrm {
+  try {
+    const v = localStorage.getItem(VISTA_KEY)
+    return v === 'kanban' ? 'kanban' : 'lista'
+  } catch {
+    return 'lista'
+  }
+}
+
+export function CrmLeads() {
+  const navigate = useNavigate()
+  const toast = useToast()
+  const { user, isAdmin } = useAuth()
+
+  const [vista, setVista] = useState<VistaCrm>(lerVistaInicial)
+  const [estagios, setEstagios] = useState<Crm.FunilEstagio[]>([])
+  const [contagens, setContagens] = useState<Record<number, number>>({})
+  const [list, setList] = useState<Crm.Lead[]>([])
+  const [kanbanLeads, setKanbanLeads] = useState<Crm.Lead[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [busca, setBusca] = useState('')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+  const [estagioId, setEstagioId] = useState<number | ''>('')
+  const [soMinhas, setSoMinhas] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [draggingId, setDraggingId] = useState<number | null>(null)
+  const [draggingColId, setDraggingColId] = useState<number | null>(null)
+  const [dropColId, setDropColId] = useState<number | null>(null)
+  const [moving, setMoving] = useState(false)
+  const [reorderingCols, setReorderingCols] = useState(false)
+  const [editingColId, setEditingColId] = useState<number | null>(null)
+  const [editingNome, setEditingNome] = useState('')
+  const [savingCol, setSavingCol] = useState(false)
+  const cancelEditColRef = useRef(false)
+
+  const [modalOpen, setModalOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [nome, setNome] = useState('')
+  const [telefone, setTelefone] = useState('')
+  const [email, setEmail] = useState('')
+  const [empresaTexto, setEmpresaTexto] = useState('')
+  const [origem, setOrigem] = useState('')
+  const [notas, setNotas] = useState('')
+  const [responsavelId, setResponsavelId] = useState<number | ''>('')
+  const [responsaveis, setResponsaveis] = useState<Atendentes.Atendente[]>([])
+  const loadGenRef = useRef(0)
+
+  function mudarVista(v: VistaCrm) {
+    if (v === vista) return
+    setLoading(true)
+    setVista(v)
+    try {
+      localStorage.setItem(VISTA_KEY, v)
+    } catch {
+      /* ignore */
+    }
+  }
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
+    return () => clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    setPage(1)
+  }, [debouncedBusca, estagioId, soMinhas, vista])
+
+  const loadEstagios = useCallback(() => {
+    crmFunil
+      .list()
+      .then(setEstagios)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) setForbidden(true)
+        else toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar o funil.'))
+      })
+  }, [toast])
+
+  useEffect(() => {
+    loadEstagios()
+  }, [loadEstagios])
+
+  useEffect(() => {
+    if (!isAdmin) return
+    atendentes
+      .list({ limit: 100, offset: 0 })
+      .then(({ items }) => {
+        setResponsaveis(items.filter((a) => a.ativo && (a.role === 'comercial' || a.role === 'admin')))
+      })
+      .catch(() => setResponsaveis([]))
+  }, [isAdmin])
+
+  const loadContagens = useCallback(async (stages: Crm.FunilEstagio[]) => {
+    if (!stages.length) return
+    try {
+      const pairs = await Promise.all(
+        stages.map(async (e) => {
+          const { total: t } = await crmLeads.list({
+            estagio_id: e.id,
+            limit: 1,
+            offset: 0,
+            so_minhas: soMinhas || undefined,
+            ativo: true,
+            q: debouncedBusca || undefined,
+          })
+          return [e.id, t] as const
+        }),
+      )
+      setContagens(Object.fromEntries(pairs))
+    } catch {
+      /* contadores auxiliares */
+    }
+  }, [soMinhas, debouncedBusca])
+
+  useEffect(() => {
+    if (estagios.length) void loadContagens(estagios)
+  }, [estagios, loadContagens])
+
+  const loadLista = useCallback(() => {
+    const gen = ++loadGenRef.current
+    setLoading(true)
+    setForbidden(false)
+    crmLeads
+      .list({
+        q: debouncedBusca || undefined,
+        estagio_id: estagioId === '' ? undefined : estagioId,
+        so_minhas: soMinhas || undefined,
+        ativo: true,
+        offset: (page - 1) * PAGE_SIZE_PADRAO,
+        limit: PAGE_SIZE_PADRAO,
+      })
+      .then(({ items, total: t }) => {
+        if (gen !== loadGenRef.current) return
+        setList(items)
+        setTotal(t)
+      })
+      .catch((err) => {
+        if (gen !== loadGenRef.current) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          setTotal(0)
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar as leads.'))
+        setList([])
+        setTotal(0)
+      })
+      .finally(() => {
+        if (gen === loadGenRef.current) setLoading(false)
+      })
+  }, [debouncedBusca, estagioId, soMinhas, page, toast])
+
+  const loadKanban = useCallback(() => {
+    const gen = ++loadGenRef.current
+    setLoading(true)
+    setForbidden(false)
+    coletarTodasPaginas<Crm.Lead>(
+      (offset, limit) =>
+        crmLeads.list({
+          q: debouncedBusca || undefined,
+          so_minhas: soMinhas || undefined,
+          ativo: true,
+          offset,
+          limit,
+        }),
+      100,
+      300,
+    )
+      .then((items) => {
+        if (gen !== loadGenRef.current) return
+        setKanbanLeads(items)
+        setTotal(items.length)
+      })
+      .catch((err) => {
+        if (gen !== loadGenRef.current) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setKanbanLeads([])
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar o Kanban.'))
+        setKanbanLeads([])
+      })
+      .finally(() => {
+        if (gen === loadGenRef.current) setLoading(false)
+      })
+  }, [debouncedBusca, soMinhas, toast])
+
+  useEffect(() => {
+    if (vista === 'kanban') loadKanban()
+    else loadLista()
+  }, [vista, loadKanban, loadLista])
+
+  const porEstagio = useMemo(() => {
+    const map = new Map<number, Crm.Lead[]>()
+    for (const e of estagios) map.set(e.id, [])
+    for (const lead of kanbanLeads) {
+      const bucket = map.get(lead.estagio_id)
+      if (bucket) bucket.push(lead)
+      else map.set(lead.estagio_id, [lead])
+    }
+    return map
+  }, [estagios, kanbanLeads])
+
+  function openModal() {
+    setNome('')
+    setTelefone('')
+    setEmail('')
+    setEmpresaTexto('')
+    setOrigem('')
+    setNotas('')
+    setResponsavelId(user?.id ?? '')
+    setModalOpen(true)
+  }
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault()
+    if (!nome.trim()) {
+      toast.showWarning('Informe o nome do contato.')
+      return
+    }
+    setSaving(true)
+    try {
+      const lead = await crmLeads.create({
+        nome: nome.trim(),
+        telefone: telefone.trim() || null,
+        email: email.trim() || null,
+        empresa_texto: empresaTexto.trim() || null,
+        origem: origem.trim() || null,
+        notas: notas.trim() || null,
+        responsavel_id: responsavelId === '' ? undefined : Number(responsavelId),
+        criar_negociacao: true,
+      })
+      toast.showSuccess('Lead criada.')
+      setModalOpen(false)
+      if (lead.negociacao_ativa_id) {
+        navigate(`/crm/negociacoes/${lead.negociacao_ativa_id}`)
+      } else {
+        if (vista === 'kanban') loadKanban()
+        else loadLista()
+        void loadContagens(estagios)
+      }
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível criar a lead.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function abrirNegociacao(lead: Crm.Lead) {
+    if (lead.negociacao_ativa_id) {
+      navigate(`/crm/negociacoes/${lead.negociacao_ativa_id}`)
+      return
+    }
+    toast.showWarning('Esta lead não tem negociação ativa.')
+  }
+
+  async function moverLeadParaEstagio(lead: Crm.Lead, destinoId: number) {
+    if (!lead.negociacao_ativa_id) {
+      toast.showWarning('Esta lead não tem negociação ativa para mover.')
+      return
+    }
+    if (lead.estagio_id === destinoId) return
+    setMoving(true)
+    try {
+      await crmNegociacoes.moverEstagio(lead.negociacao_ativa_id, { estagio_id: destinoId })
+      toast.showSuccess('Estágio atualizado.')
+      loadKanban()
+      void loadContagens(estagios)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível mover a lead.'))
+    } finally {
+      setMoving(false)
+      setDraggingId(null)
+      setDropColId(null)
+    }
+  }
+
+  function iniciarEdicaoColuna(col: Crm.FunilEstagio) {
+    cancelEditColRef.current = false
+    setEditingColId(col.id)
+    setEditingNome(col.nome)
+  }
+
+  async function salvarNomeColuna() {
+    if (cancelEditColRef.current) {
+      cancelEditColRef.current = false
+      return
+    }
+    if (editingColId == null) return
+    const nomeNovo = editingNome.trim()
+    if (!nomeNovo) {
+      toast.showWarning('Informe o nome do estágio.')
+      return
+    }
+    const atual = estagios.find((e) => e.id === editingColId)
+    if (atual && atual.nome === nomeNovo) {
+      setEditingColId(null)
+      return
+    }
+    setSavingCol(true)
+    try {
+      await crmFunil.update(editingColId, { nome: nomeNovo })
+      toast.showSuccess('Nome do estágio atualizado.')
+      setEditingColId(null)
+      loadEstagios()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível renomear o estágio.'))
+    } finally {
+      setSavingCol(false)
+    }
+  }
+
+  async function reordenarColunas(dragId: number, targetId: number) {
+    if (!isAdmin || dragId === targetId || reorderingCols) return
+    const ordered = [...estagios].sort((a, b) => a.ordem - b.ordem || a.id - b.id)
+    const dragged = ordered.find((e) => e.id === dragId)
+    if (!dragged) return
+    const without = ordered.filter((e) => e.id !== dragId)
+    const targetIdx = without.findIndex((e) => e.id === targetId)
+    if (targetIdx < 0) return
+    without.splice(targetIdx, 0, dragged)
+    const next = without.map((e, i) => ({ ...e, ordem: (i + 1) * 10 }))
+    const changed = next.filter((e) => {
+      const prev = estagios.find((p) => p.id === e.id)
+      return !prev || prev.ordem !== e.ordem
+    })
+    if (!changed.length) return
+    setEstagios(next)
+    setReorderingCols(true)
+    try {
+      await Promise.all(changed.map((e) => crmFunil.update(e.id, { ordem: e.ordem })))
+      toast.showSuccess('Ordem das colunas atualizada.')
+      loadEstagios()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível reordenar as colunas.'))
+      loadEstagios()
+    } finally {
+      setReorderingCols(false)
+      setDraggingColId(null)
+      setDropColId(null)
+    }
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para acessar o CRM."
+        detail="Esta área é para perfil comercial ou administrador."
+        voltarPara="/"
+        voltarLabel="Voltar para o Dashboard"
+      />
+    )
+  }
+
+  const toggleVista = (
+    <div className="inline-flex rounded-lg border border-slate-200 p-0.5 dark:border-slate-700">
+      <button
+        type="button"
+        onClick={() => mudarVista('lista')}
+        className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
+          vista === 'lista'
+            ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900'
+            : 'text-slate-600 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-800'
+        }`}
+      >
+        Lista
+      </button>
+      <button
+        type="button"
+        onClick={() => mudarVista('kanban')}
+        className={`rounded-md px-3 py-1.5 text-xs font-medium transition ${
+          vista === 'kanban'
+            ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900'
+            : 'text-slate-600 hover:bg-slate-50 dark:text-slate-300 dark:hover:bg-slate-800'
+        }`}
+      >
+        Kanban
+      </button>
+    </div>
+  )
+
+  return (
+    <div className={`mx-auto space-y-4 pb-10 ${vista === 'kanban' ? 'max-w-[100%]' : 'max-w-6xl'}`}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">CRM — Leads</h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Funil comercial: contatos, negociações e estágios.
+            {isAdmin ? (
+              <>
+                {' '}
+                <Link
+                  to="/configuracoes/cadastros/funil-crm"
+                  className="font-medium text-cyan-700 hover:underline dark:text-cyan-400"
+                >
+                  Configurar funil
+                </Link>
+              </>
+            ) : null}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {toggleVista}
+          <Button type="button" onClick={openModal}>
+            Criar Lead
+          </Button>
+        </div>
+      </div>
+
+      {vista === 'lista' ? (
+        <>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => setEstagioId('')}
+              className={`rounded-lg px-3 py-1.5 text-xs font-medium transition ${
+                estagioId === ''
+                  ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900'
+                  : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200'
+              }`}
+            >
+              Todas
+              {Object.values(contagens).length > 0
+                ? ` (${Object.values(contagens).reduce((a, b) => a + b, 0)})`
+                : ''}
+            </button>
+            {estagios.map((e) => (
+              <button
+                key={e.id}
+                type="button"
+                onClick={() => setEstagioId(e.id)}
+                className={`rounded-lg px-3 py-1.5 text-xs font-medium transition ${
+                  estagioId === e.id
+                    ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900'
+                    : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200'
+                }`}
+              >
+                {e.nome}
+                {contagens[e.id] != null ? ` (${contagens[e.id]})` : ''}
+              </button>
+            ))}
+          </div>
+
+          <Card>
+            <BarraBuscaPaginacao
+              busca={busca}
+              onBuscaChange={setBusca}
+              placeholder="Buscar por nome, telefone, e-mail…"
+              page={page}
+              total={total}
+              onPageChange={setPage}
+              disabled={loading}
+              extra={
+                <div className="flex flex-wrap items-center gap-3">
+                  <Select
+                    label="Estágio"
+                    labelStyle="overline"
+                    value={estagioId === '' ? '' : estagioId}
+                    onChange={(v) => setEstagioId(v === '' ? '' : Number(v))}
+                    options={estagios.map((e) => ({
+                      value: e.id,
+                      label: contagens[e.id] != null ? `${e.nome} (${contagens[e.id]})` : e.nome,
+                    }))}
+                    includeEmpty
+                    emptyLabel="Todos os estágios"
+                  />
+                  <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                    <input
+                      type="checkbox"
+                      checked={soMinhas}
+                      onChange={(ev) => setSoMinhas(ev.target.checked)}
+                      className="size-4 rounded border-slate-300"
+                    />
+                    Só as minhas
+                  </label>
+                </div>
+              }
+            />
+
+            {loading ? (
+              <p className="text-slate-500 dark:text-slate-400">Carregando…</p>
+            ) : list.length === 0 ? (
+              <p className="text-slate-500 dark:text-slate-400">Nenhuma lead encontrada.</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[640px] text-left text-sm">
+                  <thead>
+                    <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+                      <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Lead</th>
+                      <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Estágio</th>
+                      <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Contato</th>
+                      <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Criada</th>
+                      <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {list.map((lead) => (
+                      <tr key={lead.id} className="border-b border-slate-100 dark:border-slate-800/80">
+                        <td className="px-3 py-2.5">
+                          <div className="font-medium text-slate-900 dark:text-slate-100">{lead.nome}</div>
+                          {lead.empresa_texto ? (
+                            <div className="text-xs text-slate-500">{lead.empresa_texto}</div>
+                          ) : null}
+                          {lead.origem ? (
+                            <div className="text-xs text-slate-400">Origem: {lead.origem}</div>
+                          ) : null}
+                        </td>
+                        <td className="px-3 py-2.5 text-slate-700 dark:text-slate-300">
+                          {lead.estagio_nome || '—'}
+                        </td>
+                        <td className="px-3 py-2.5 text-slate-600 dark:text-slate-400">
+                          <div>{lead.telefone || '—'}</div>
+                          <div className="text-xs">{lead.email || ''}</div>
+                        </td>
+                        <td className="px-3 py-2.5 text-slate-500">{formatDate(lead.created_at)}</td>
+                        <td className="px-3 py-2.5 text-right">
+                          <Button variant="secondary" onClick={() => abrirNegociacao(lead)}>
+                            Abrir
+                          </Button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </Card>
+        </>
+      ) : (
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="min-w-[240px] flex-1 max-w-sm">
+              <input
+                type="search"
+                value={busca}
+                onChange={(e) => setBusca(e.target.value)}
+                placeholder="Buscar por nome, telefone, e-mail…"
+                aria-label="Buscar leads"
+                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500 dark:border-slate-600 dark:bg-slate-900/50 dark:text-slate-100"
+              />
+            </div>
+            <label className="inline-flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={soMinhas}
+                onChange={(ev) => setSoMinhas(ev.target.checked)}
+                className="size-4 rounded border-slate-300"
+              />
+              Só as minhas
+            </label>
+            {moving || reorderingCols ? (
+              <span className="text-xs text-slate-500">Atualizando…</span>
+            ) : null}
+            <p className="text-xs text-slate-500">
+              Arraste os cartões entre colunas
+              {isAdmin ? ' · ≡ no cabeçalho reordena · lápis renomeia' : ''}.
+            </p>
+          </div>
+
+          {loading ? (
+            <p className="text-slate-500">Carregando Kanban…</p>
+          ) : (
+            <div className="dx-scrollbar -mx-1 flex gap-3 overflow-x-auto px-1 pb-3">
+              {estagios.map((col) => {
+                const cards = porEstagio.get(col.id) || []
+                const isDropTarget = dropColId === col.id && (draggingId != null || draggingColId != null)
+                const editing = editingColId === col.id
+                return (
+                  <div
+                    key={col.id}
+                    className={`flex w-72 shrink-0 flex-col rounded-xl border bg-slate-50/80 transition dark:bg-slate-900/50 ${
+                      isDropTarget
+                        ? 'border-cyan-400/80 ring-1 ring-cyan-400/40 dark:border-cyan-500/70'
+                        : 'border-slate-200/90 dark:border-slate-700/80'
+                    } ${draggingColId === col.id ? 'opacity-60' : ''}`}
+                    onDragOver={(e) => {
+                      e.preventDefault()
+                      const isCol = e.dataTransfer.types.includes(DND_COL)
+                      const isLead =
+                        e.dataTransfer.types.includes(DND_LEAD) || e.dataTransfer.types.includes('text/plain')
+                      if (isCol || isLead) {
+                        e.dataTransfer.dropEffect = 'move'
+                        setDropColId(col.id)
+                      }
+                    }}
+                    onDragLeave={() => {
+                      setDropColId((cur) => (cur === col.id ? null : cur))
+                    }}
+                    onDrop={(e) => {
+                      e.preventDefault()
+                      setDropColId(null)
+                      const colRaw = e.dataTransfer.getData(DND_COL)
+                      if (colRaw && isAdmin) {
+                        void reordenarColunas(Number(colRaw), col.id)
+                        return
+                      }
+                      const leadRaw = e.dataTransfer.getData(DND_LEAD) || e.dataTransfer.getData('text/plain')
+                      const leadId = Number(leadRaw)
+                      const lead = kanbanLeads.find((l) => l.id === leadId)
+                      if (lead) void moverLeadParaEstagio(lead, col.id)
+                    }}
+                  >
+                    <div className="flex items-center gap-1.5 border-b border-slate-200/80 px-2 py-2 dark:border-slate-700/80">
+                      {isAdmin ? (
+                        <button
+                          type="button"
+                          draggable={!reorderingCols && !editing}
+                          onDragStart={(e) => {
+                            setDraggingColId(col.id)
+                            e.dataTransfer.setData(DND_COL, String(col.id))
+                            e.dataTransfer.effectAllowed = 'move'
+                          }}
+                          onDragEnd={() => {
+                            setDraggingColId(null)
+                            setDropColId(null)
+                          }}
+                          className="cursor-grab rounded px-1 py-0.5 text-slate-400 hover:bg-slate-200/70 hover:text-slate-600 active:cursor-grabbing dark:hover:bg-slate-800 dark:hover:text-slate-200"
+                          aria-label={`Reordenar coluna ${col.nome}`}
+                          title="Arrastar para reordenar"
+                        >
+                          ≡
+                        </button>
+                      ) : null}
+                      <div className="min-w-0 flex-1">
+                        {editing ? (
+                          <input
+                            autoFocus
+                            value={editingNome}
+                            disabled={savingCol}
+                            onChange={(e) => setEditingNome(e.target.value)}
+                            onBlur={() => void salvarNomeColuna()}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') {
+                                e.preventDefault()
+                                void salvarNomeColuna()
+                              }
+                              if (e.key === 'Escape') {
+                                cancelEditColRef.current = true
+                                setEditingColId(null)
+                              }
+                            }}
+                            className="w-full rounded-md border border-cyan-500/60 bg-white px-1.5 py-0.5 text-sm font-semibold text-slate-900 focus:outline-none dark:bg-slate-950 dark:text-slate-100"
+                            aria-label="Nome do estágio"
+                          />
+                        ) : (
+                          <h2 className="truncate text-sm font-semibold text-slate-800 dark:text-slate-100">
+                            {col.nome}
+                          </h2>
+                        )}
+                      </div>
+                      <span className="shrink-0 rounded-md bg-slate-200/80 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-slate-600 dark:bg-slate-800 dark:text-slate-300">
+                        {contagens[col.id] ?? cards.length}
+                      </span>
+                      {isAdmin && !editing ? (
+                        <button
+                          type="button"
+                          onClick={() => iniciarEdicaoColuna(col)}
+                          className="rounded p-1 text-slate-400 hover:bg-slate-200/70 hover:text-slate-700 dark:hover:bg-slate-800 dark:hover:text-slate-200"
+                          aria-label={`Editar nome de ${col.nome}`}
+                          title="Renomear estágio"
+                        >
+                          <IconPencil className="size-3.5" />
+                        </button>
+                      ) : null}
+                    </div>
+                    <div className="dx-scrollbar flex max-h-[min(70vh,560px)] flex-col gap-2 overflow-y-auto p-2">
+                      {cards.length === 0 ? (
+                        <div className="rounded-lg border border-dashed border-slate-200 px-2 py-8 text-center text-xs text-slate-400 dark:border-slate-700">
+                          Sem leads
+                        </div>
+                      ) : (
+                        cards.map((lead) => (
+                          <button
+                            key={lead.id}
+                            type="button"
+                            draggable={!moving && !reorderingCols}
+                            onDragStart={(e) => {
+                              setDraggingId(lead.id)
+                              e.dataTransfer.setData(DND_LEAD, String(lead.id))
+                              e.dataTransfer.setData('text/plain', String(lead.id))
+                              e.dataTransfer.effectAllowed = 'move'
+                            }}
+                            onDragEnd={() => {
+                              setDraggingId(null)
+                              setDropColId(null)
+                            }}
+                            onClick={() => abrirNegociacao(lead)}
+                            className={`rounded-lg border border-slate-200/90 bg-white p-3 text-left shadow-sm transition hover:border-cyan-400/50 hover:shadow dark:border-slate-600/80 dark:bg-slate-800/90 ${
+                              draggingId === lead.id ? 'opacity-50' : ''
+                            }`}
+                          >
+                            <div className="font-medium text-slate-900 dark:text-slate-100">{lead.nome}</div>
+                            {lead.empresa_texto ? (
+                              <div className="mt-0.5 truncate text-xs text-slate-500">{lead.empresa_texto}</div>
+                            ) : null}
+                            <div className="mt-2 flex flex-wrap gap-2 text-xs text-slate-500">
+                              {lead.telefone ? <span>{lead.telefone}</span> : null}
+                              {lead.origem ? <span>· {lead.origem}</span> : null}
+                            </div>
+                            <div className="mt-1 text-[11px] text-slate-400">{formatDate(lead.created_at)}</div>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {modalOpen ? (
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-0 sm:items-center sm:p-4">
+          <div className="max-h-[92vh] w-full overflow-y-auto rounded-t-2xl bg-white p-5 shadow-xl dark:bg-slate-900 sm:max-w-lg sm:rounded-2xl">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Criar Lead</h2>
+            <p className="mt-1 text-sm text-slate-500">Cria também a negociação inicial automaticamente.</p>
+            <form onSubmit={handleCreate} className="mt-4 space-y-3">
+              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
+              <Input label="Telefone" value={telefone} onChange={(e) => setTelefone(e.target.value)} />
+              <Input label="E-mail" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+              <Input
+                label="Empresa / prospecto"
+                value={empresaTexto}
+                onChange={(e) => setEmpresaTexto(e.target.value)}
+              />
+              <Input
+                label="Origem"
+                value={origem}
+                onChange={(e) => setOrigem(e.target.value)}
+                placeholder="WhatsApp, indicação…"
+              />
+              <Input label="Observações" value={notas} onChange={(e) => setNotas(e.target.value)} />
+              {isAdmin && responsaveis.length > 0 ? (
+                <Select
+                  label="Responsável"
+                  value={responsavelId === '' ? '' : String(responsavelId)}
+                  onChange={(v) => setResponsavelId(v === '' ? '' : Number(v))}
+                  options={[
+                    { value: '', label: 'Eu (usuário atual)' },
+                    ...responsaveis.map((a) => ({ value: String(a.id), label: a.nome })),
+                  ]}
+                />
+              ) : null}
+              <div className="flex flex-wrap justify-end gap-2 pt-2">
+                <Button type="button" variant="secondary" onClick={() => setModalOpen(false)} disabled={saving}>
+                  Cancelar
+                </Button>
+                <Button type="submit" disabled={saving}>
+                  {saving ? 'Salvando…' : 'Criar e abrir negociação'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/frontend/src/pages/CrmNegociacaoDetalhe.tsx
+++ b/frontend/src/pages/CrmNegociacaoDetalhe.tsx
@@ -1,0 +1,577 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import {
+  ApiError,
+  comercialCustosItens,
+  crmFunil,
+  crmLeads,
+  crmNegociacoes,
+  type ComercialCustos,
+  type Crm,
+} from '../api/client'
+import { coletarTodasPaginas } from '../api/collectPages'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
+import { Button } from '../components/ui/Button'
+import { Card } from '../components/ui/Card'
+import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+import { ConfirmDialog } from '../components/ui/ConfirmDialog'
+import { Input } from '../components/ui/Input'
+import { Select } from '../components/ui/Select'
+import { useToast } from '../components/ui/Toast'
+import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
+import { SemPermissao } from './SemPermissao'
+
+const TIPO_ATIVIDADE_LABEL: Record<string, string> = {
+  nota: 'Nota',
+  ligacao: 'Ligação',
+  reuniao: 'Reunião',
+  mudanca_estagio: 'Estágio',
+  documento_anexado: 'Documento',
+}
+
+const TIPO_CUSTO_LABEL: Record<string, string> = {
+  percentual_sm: '% salário mínimo',
+  valor_fixo: 'Valor fixo',
+  composto_tef: 'TEF (base + adicional)',
+}
+
+function rotuloItemCusto(item: ComercialCustos.Item): string {
+  const tipo = TIPO_CUSTO_LABEL[item.tipo] || null
+  return tipo ? `${item.nome} · ${tipo}` : item.nome
+}
+
+function money(v: string | number | null | undefined): string {
+  if (v == null || v === '') return '—'
+  const n = typeof v === 'number' ? v : Number(v)
+  if (Number.isNaN(n)) return String(v)
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })
+}
+
+function margemBaixa(linha: Crm.Linha): boolean {
+  const valor = Number(linha.valor_negociado || 0)
+  const margem = Number(linha.margem_calculada ?? NaN)
+  if (Number.isNaN(margem)) return false
+  if (margem < 0) return true
+  if (valor > 0 && margem / valor < 0.1) return true
+  return false
+}
+
+function formatDateTime(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
+}
+
+type LinhaForm = {
+  cnpj: string
+  razao_social: string
+  valor_negociado: string
+  quantidade_pdvs: string
+  desconto_posto_100k: boolean
+  item_ids: number[]
+}
+
+const emptyLinhaForm = (): LinhaForm => ({
+  cnpj: '',
+  razao_social: '',
+  valor_negociado: '0',
+  quantidade_pdvs: '1',
+  desconto_posto_100k: false,
+  item_ids: [],
+})
+
+export function CrmNegociacaoDetalhe() {
+  const { id } = useParams<{ id: string }>()
+  const negociacaoId = id ? parseInt(id, 10) : NaN
+  const voltar = useVoltarAnterior('/crm/leads')
+  const toast = useToast()
+
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [falha, setFalha] = useState<{ titulo: string; detalhe?: string } | null>(null)
+  const [neg, setNeg] = useState<Crm.Negociacao | null>(null)
+  const [lead, setLead] = useState<Crm.Lead | null>(null)
+  const [estagios, setEstagios] = useState<Crm.FunilEstagio[]>([])
+  const [itensCatalogo, setItensCatalogo] = useState<ComercialCustos.Item[]>([])
+  const [atividades, setAtividades] = useState<Crm.Atividade[]>([])
+
+  const [destinoEstagio, setDestinoEstagio] = useState<number | ''>('')
+  const [notaEstagio, setNotaEstagio] = useState('')
+  const [movendo, setMovendo] = useState(false)
+
+  const [linhaModal, setLinhaModal] = useState<'create' | Crm.Linha | null>(null)
+  const [linhaForm, setLinhaForm] = useState<LinhaForm>(emptyLinhaForm)
+  const [savingLinha, setSavingLinha] = useState(false)
+  const [deleteLinhaId, setDeleteLinhaId] = useState<number | null>(null)
+
+  const [notaTexto, setNotaTexto] = useState('')
+  const [savingNota, setSavingNota] = useState(false)
+
+  const load = useCallback(async () => {
+    if (!id || Number.isNaN(negociacaoId)) {
+      setFalha({ titulo: 'Negociação não encontrada.', detalhe: 'Identificador inválido na URL.' })
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setForbidden(false)
+    setFalha(null)
+    try {
+      const n = await crmNegociacoes.get(negociacaoId)
+      setNeg(n)
+      setDestinoEstagio('')
+      const [l, funil, acts] = await Promise.all([
+        crmLeads.get(n.lead_id),
+        crmFunil.list(),
+        crmNegociacoes.listAtividades(negociacaoId, { limit: 50, offset: 0 }),
+      ])
+      setLead(l)
+      setEstagios(funil)
+      setAtividades(acts.items)
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        setForbidden(true)
+        return
+      }
+      const m = interpretarFalhaCarregamento(err, 'Negociação não encontrada.')
+      setFalha({ titulo: m.titulo, detalhe: m.detalhe })
+    } finally {
+      setLoading(false)
+    }
+  }, [id, negociacaoId])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  useEffect(() => {
+    coletarTodasPaginas<ComercialCustos.Item>((offset, limit) =>
+      comercialCustosItens.list({ offset, limit, incluir_inativos: false }),
+    )
+      .then((items) =>
+        // Oculta cadastros de teste gerados em QA (ex.: "Posto UX 182304")
+        setItensCatalogo(items.filter((i) => !/\bUX\s*\d{5,}\b/i.test(i.nome))),
+      )
+      .catch(() => setItensCatalogo([]))
+  }, [])
+
+  const totais = useMemo(() => {
+    const linhas = neg?.linhas ?? []
+    let valor = 0
+    let custo = 0
+    for (const ln of linhas) {
+      valor += Number(ln.valor_negociado || 0)
+      custo += Number(ln.total_custo || 0)
+    }
+    return { valor, custo, margem: valor - custo }
+  }, [neg])
+
+  function openCreateLinha() {
+    setLinhaForm(emptyLinhaForm())
+    setLinhaModal('create')
+  }
+
+  function openEditLinha(ln: Crm.Linha) {
+    setLinhaForm({
+      cnpj: ln.cnpj || '',
+      razao_social: ln.razao_social || '',
+      valor_negociado: String(ln.valor_negociado ?? '0'),
+      quantidade_pdvs: String(ln.quantidade_pdvs ?? 1),
+      desconto_posto_100k: Boolean(ln.desconto_posto_100k),
+      item_ids: [...(ln.item_ids || [])],
+    })
+    setLinhaModal(ln)
+  }
+
+  function toggleItem(itemId: number) {
+    setLinhaForm((prev) => ({
+      ...prev,
+      item_ids: prev.item_ids.includes(itemId)
+        ? prev.item_ids.filter((x) => x !== itemId)
+        : [...prev.item_ids, itemId],
+    }))
+  }
+
+  async function saveLinha(e: React.FormEvent) {
+    e.preventDefault()
+    if (!neg) return
+    setSavingLinha(true)
+    try {
+      const payload = {
+        cnpj: linhaForm.cnpj.trim() || null,
+        razao_social: linhaForm.razao_social.trim() || null,
+        valor_negociado: linhaForm.valor_negociado || '0',
+        quantidade_pdvs: Math.max(1, parseInt(linhaForm.quantidade_pdvs, 10) || 1),
+        desconto_posto_100k: linhaForm.desconto_posto_100k,
+        item_ids: linhaForm.item_ids,
+      }
+      if (linhaModal === 'create') {
+        await crmNegociacoes.addLinha(neg.id, payload)
+        toast.showSuccess('Linha CNPJ adicionada.')
+      } else if (linhaModal && typeof linhaModal === 'object') {
+        await crmNegociacoes.updateLinha(neg.id, linhaModal.id, payload)
+        toast.showSuccess('Linha atualizada (custo/margem recalculados).')
+      }
+      setLinhaModal(null)
+      await load()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a linha.'))
+    } finally {
+      setSavingLinha(false)
+    }
+  }
+
+  async function confirmDeleteLinha() {
+    if (!neg || deleteLinhaId == null) return
+    try {
+      await crmNegociacoes.deleteLinha(neg.id, deleteLinhaId)
+      toast.showSuccess('Linha removida.')
+      setDeleteLinhaId(null)
+      await load()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível remover a linha.'))
+    }
+  }
+
+  async function handleMoverEstagio() {
+    if (!neg || destinoEstagio === '') {
+      toast.showWarning('Escolha o estágio de destino.')
+      return
+    }
+    setMovendo(true)
+    try {
+      await crmNegociacoes.moverEstagio(neg.id, {
+        estagio_id: Number(destinoEstagio),
+        nota: notaEstagio.trim() || null,
+      })
+      toast.showSuccess('Estágio atualizado.')
+      setNotaEstagio('')
+      await load()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível mover o estágio.'))
+    } finally {
+      setMovendo(false)
+    }
+  }
+
+  async function handleAddNota(e: React.FormEvent) {
+    e.preventDefault()
+    if (!neg || !notaTexto.trim()) return
+    setSavingNota(true)
+    try {
+      await crmNegociacoes.addAtividade(neg.id, { tipo: 'nota', texto: notaTexto.trim() })
+      setNotaTexto('')
+      toast.showSuccess('Nota registrada.')
+      const acts = await crmNegociacoes.listAtividades(neg.id, { limit: 50, offset: 0 })
+      setAtividades(acts.items)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a nota.'))
+    } finally {
+      setSavingNota(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-5xl pb-10">
+        <div className="h-72 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
+      </div>
+    )
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para ver esta negociação."
+        voltarPara="/crm/leads"
+        voltarLabel="Voltar para CRM"
+      />
+    )
+  }
+
+  if (falha || !neg) {
+    return (
+      <CarregamentoFalhou
+        className="mx-auto max-w-5xl space-y-4 pb-10"
+        titulo={falha?.titulo || 'Negociação não encontrada.'}
+        detalhe={falha?.detalhe}
+        onVoltar={voltar}
+      />
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-4 pb-10">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <button
+            type="button"
+            onClick={voltar}
+            className="text-sm text-slate-500 hover:text-slate-800 dark:hover:text-slate-200"
+          >
+            ← Voltar
+          </button>
+          <h1 className="mt-1 text-xl font-semibold text-slate-900 dark:text-slate-100">
+            {neg.titulo || `Negociação #${neg.id}`}
+          </h1>
+          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+            Lead:{' '}
+            <span className="font-medium text-slate-700 dark:text-slate-200">{lead?.nome || `#${neg.lead_id}`}</span>
+            {' · '}
+            Estágio: <span className="font-medium">{neg.estagio_nome || '—'}</span>
+            {!neg.ativa ? ' · encerrada' : null}
+          </p>
+        </div>
+        <Link
+          to="/crm/leads"
+          className="text-sm font-medium text-cyan-700 hover:underline dark:text-cyan-400"
+        >
+          Lista de leads
+        </Link>
+      </div>
+
+      <Card title="Avançar estágio">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="min-w-[200px] flex-1">
+            <Select
+              label="Novo estágio"
+              value={destinoEstagio}
+              onChange={(v) => setDestinoEstagio(v === '' ? '' : Number(v))}
+              options={estagios
+                .filter((e) => e.id !== neg.estagio_id)
+                .map((e) => ({ value: e.id, label: e.nome }))}
+              includeEmpty
+              emptyLabel="Selecionar…"
+              disabled={!neg.ativa && neg.estagio_slug === 'perdido' ? false : !neg.ativa}
+            />
+          </div>
+          <div className="flex-1">
+            <Input
+              label="Nota (opcional)"
+              value={notaEstagio}
+              onChange={(e) => setNotaEstagio(e.target.value)}
+            />
+          </div>
+          <Button onClick={handleMoverEstagio} disabled={movendo || destinoEstagio === ''}>
+            {movendo ? 'Movendo…' : 'Mover'}
+          </Button>
+        </div>
+        <p className="mt-2 text-xs text-slate-500">
+          A partir de Documentação, o CNPJ é obrigatório em todas as linhas. Sem CNPJ válido, o avanço para esse estágio
+          (e posteriores) fica bloqueado.
+        </p>
+      </Card>
+
+      <Card title="Linhas por CNPJ">
+        <div className="mb-3 flex justify-end">
+          <Button variant="secondary" onClick={openCreateLinha}>
+            Adicionar linha
+          </Button>
+        </div>
+        <div className="mb-3 grid gap-2 rounded-xl bg-slate-50 p-3 text-sm dark:bg-slate-800/50 sm:grid-cols-3">
+          <div>
+            <div className="text-xs text-slate-500">Valor negociado</div>
+            <div className="font-semibold text-slate-900 dark:text-slate-100">{money(totais.valor)}</div>
+          </div>
+          <div>
+            <div className="text-xs text-slate-500">Custo estimado (interno)</div>
+            <div className="font-semibold text-slate-900 dark:text-slate-100">{money(totais.custo)}</div>
+          </div>
+          <div>
+            <div className="text-xs text-slate-500">Margem total</div>
+            <div
+              className={`font-semibold ${
+                totais.margem < 0 || (totais.valor > 0 && totais.margem / totais.valor < 0.1)
+                  ? 'text-amber-700 dark:text-amber-300'
+                  : 'text-emerald-700 dark:text-emerald-300'
+              }`}
+            >
+              {money(totais.margem)}
+            </div>
+          </div>
+        </div>
+
+        {(neg.linhas || []).length === 0 ? (
+          <p className="text-sm text-slate-500">Nenhuma linha CNPJ ainda.</p>
+        ) : (
+          <div className="space-y-3">
+            {(neg.linhas || []).map((ln) => (
+              <div
+                key={ln.id}
+                className={`rounded-xl border p-3 ${
+                  margemBaixa(ln)
+                    ? 'border-amber-300 bg-amber-50/60 dark:border-amber-800 dark:bg-amber-950/30'
+                    : 'border-slate-200 dark:border-slate-700'
+                }`}
+              >
+                <div className="flex flex-wrap items-start justify-between gap-2">
+                  <div>
+                    <div className="font-medium text-slate-900 dark:text-slate-100">
+                      {ln.razao_social || 'Sem razão social'}
+                    </div>
+                    <div className="text-xs text-slate-500">
+                      CNPJ: {ln.cnpj || '— (opcional até Documentação)'} · PDVs: {ln.quantidade_pdvs}
+                      {ln.desconto_posto_100k ? ' · desconto posto <100k' : ''}
+                    </div>
+                    <div className="mt-1 text-xs text-slate-500">
+                      Pacote:{' '}
+                      {ln.item_ids?.length
+                        ? ln.item_ids
+                            .map((iid) => itensCatalogo.find((i) => i.id === iid)?.nome || `#${iid}`)
+                            .join(', ')
+                        : '—'}
+                    </div>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button variant="ghost" onClick={() => openEditLinha(ln)}>
+                      Editar
+                    </Button>
+                    <Button variant="ghost" onClick={() => setDeleteLinhaId(ln.id)}>
+                      Remover
+                    </Button>
+                  </div>
+                </div>
+                <div className="mt-2 grid gap-2 text-sm sm:grid-cols-3">
+                  <div>
+                    Valor: <strong>{money(ln.valor_negociado)}</strong>
+                  </div>
+                  <div>
+                    Custo: <strong>{money(ln.total_custo)}</strong>
+                  </div>
+                  <div className={margemBaixa(ln) ? 'text-amber-800 dark:text-amber-200' : ''}>
+                    Margem: <strong>{money(ln.margem_calculada)}</strong>
+                    {margemBaixa(ln) ? ' · margem baixa' : ''}
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+
+      <Card title="Histórico">
+        <form onSubmit={handleAddNota} className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end">
+          <div className="flex-1">
+            <Input
+              label="Nova nota"
+              value={notaTexto}
+              onChange={(e) => setNotaTexto(e.target.value)}
+              placeholder="Registrar contato, reunião…"
+            />
+          </div>
+          <Button type="submit" disabled={savingNota || !notaTexto.trim()}>
+            {savingNota ? 'Salvando…' : 'Adicionar'}
+          </Button>
+        </form>
+        {atividades.length === 0 ? (
+          <p className="text-sm text-slate-500">Sem atividades ainda.</p>
+        ) : (
+          <ul className="space-y-3">
+            {atividades.map((a) => (
+              <li
+                key={a.id}
+                className="border-l-2 border-slate-200 pl-3 dark:border-slate-700"
+              >
+                <div className="flex flex-wrap items-baseline gap-2 text-xs text-slate-500">
+                  <span className="font-semibold uppercase tracking-wide text-slate-600 dark:text-slate-300">
+                    {TIPO_ATIVIDADE_LABEL[a.tipo] || a.tipo}
+                  </span>
+                  <span>{formatDateTime(a.created_at)}</span>
+                </div>
+                <p className="mt-0.5 text-sm text-slate-800 dark:text-slate-200 whitespace-pre-wrap">{a.texto}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      {linhaModal ? (
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-0 sm:items-center sm:p-4">
+          <div className="max-h-[92vh] w-full overflow-y-auto rounded-t-2xl bg-white p-5 shadow-xl dark:bg-slate-900 sm:max-w-lg sm:rounded-2xl">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              {linhaModal === 'create' ? 'Nova linha CNPJ' : 'Editar linha'}
+            </h2>
+            <form onSubmit={saveLinha} className="mt-4 space-y-3">
+              <Input
+                label="CNPJ"
+                value={linhaForm.cnpj}
+                onChange={(e) => setLinhaForm((p) => ({ ...p, cnpj: e.target.value }))}
+                placeholder="Opcional até Documentação"
+              />
+              <Input
+                label="Razão social"
+                value={linhaForm.razao_social}
+                onChange={(e) => setLinhaForm((p) => ({ ...p, razao_social: e.target.value }))}
+              />
+              <Input
+                label="Valor negociado (R$)"
+                value={linhaForm.valor_negociado}
+                onChange={(e) => setLinhaForm((p) => ({ ...p, valor_negociado: e.target.value }))}
+              />
+              <Input
+                label="Quantidade de PDVs"
+                value={linhaForm.quantidade_pdvs}
+                onChange={(e) => setLinhaForm((p) => ({ ...p, quantidade_pdvs: e.target.value }))}
+              />
+              <label className="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+                <input
+                  type="checkbox"
+                  checked={linhaForm.desconto_posto_100k}
+                  onChange={(e) =>
+                    setLinhaForm((p) => ({ ...p, desconto_posto_100k: e.target.checked }))
+                  }
+                  className="size-4 rounded border-slate-300"
+                />
+                Desconto posto &lt;100k L (20% SM)
+              </label>
+              <div>
+                <p className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-300">Composição do pacote</p>
+                {itensCatalogo.length === 0 ? (
+                  <p className="text-xs text-slate-500">
+                    Nenhum item no catálogo (ou sem permissão de leitura). Peça ao admin para cadastrar custos.
+                  </p>
+                ) : (
+                  <div className="max-h-40 space-y-1 overflow-auto rounded-lg border border-slate-200 p-2 dark:border-slate-700">
+                    {itensCatalogo.map((item) => (
+                      <label
+                        key={item.id}
+                        className="flex cursor-pointer items-center gap-2 rounded px-1 py-1 text-sm hover:bg-slate-50 dark:hover:bg-slate-800"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={linhaForm.item_ids.includes(item.id)}
+                          onChange={() => toggleItem(item.id)}
+                          className="size-4 rounded border-slate-300"
+                        />
+                        <span className="min-w-0 flex-1">{rotuloItemCusto(item)}</span>
+                      </label>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="flex flex-wrap justify-end gap-2 pt-2">
+                <Button type="button" variant="secondary" onClick={() => setLinhaModal(null)} disabled={savingLinha}>
+                  Cancelar
+                </Button>
+                <Button type="submit" disabled={savingLinha}>
+                  {savingLinha ? 'Salvando…' : 'Salvar'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+
+      <ConfirmDialog
+        open={deleteLinhaId != null}
+        title="Remover linha CNPJ?"
+        message="Esta ação não apaga o histórico da negociação, só esta linha."
+        confirmLabel="Remover"
+        variant="danger"
+        onConfirm={confirmDeleteLinha}
+        onCancel={() => setDeleteLinhaId(null)}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/config/ConfigCadastrosLayout.tsx
+++ b/frontend/src/pages/config/ConfigCadastrosLayout.tsx
@@ -6,12 +6,14 @@ const TABS = [
   { to: '/configuracoes/cadastros/tipos-negocio', label: 'Tipos de negócio' },
   { to: '/configuracoes/cadastros/pdv', label: 'Catálogos PDV' },
   { to: '/configuracoes/cadastros/custos', label: 'Catálogo de custos' },
+  { to: '/configuracoes/cadastros/funil-crm', label: 'Funil CRM' },
 ] as const
 
 const TAB_HINTS: Record<string, string> = {
   'tipos-negocio': 'Classificação das empresas (posto, conveniência, restaurante…).',
   pdv: 'Rótulos de dispositivo e tipos de acesso remoto usados no cadastro de PDVs por empresa.',
   custos: 'Salário mínimo com vigência, perfis/módulos de custo e simulador estimado para negociação.',
+  'funil-crm': 'Estágios do funil comercial (Lead, Em negociação…). Usados na lista e no Kanban do CRM.',
 }
 
 function abaAtiva(pathname: string): string {
@@ -25,7 +27,7 @@ export function ConfigCadastrosLayout() {
 
   return (
     <PageContainer>
-      <PageHeader title="Cadastros" subtitle="Tipos de negócio, catálogos de PDV e custos comerciais." />
+      <PageHeader title="Cadastros" subtitle="Tipos de negócio, catálogos de PDV, custos comerciais e funil CRM." />
       <ConfigSectionTabs tabs={[...TABS]} ariaLabel="Seções de cadastros" />
       {hint ? <p className="text-sm text-slate-600 dark:text-slate-400">{hint}</p> : null}
       <Outlet />


### PR DESCRIPTION
## Summary

- Fecha o lote CRM do épico #322: API + UI de leads/negociações multi-CNPJ, funil configurável e perfil `comercial`.
- UI: lista/Kanban (drag de cards, reordenação/rename de colunas para admin), detalhe com pacote de custos/margem e timeline; Funil CRM em Cadastros.
- RBAC: comercial lê catálogo e simula custos; mutações do catálogo e do funil continuam admin.

Closes #336
Closes #337
Closes #338
Closes #339
Closes #340
Closes #341
Closes #342
Closes #343
Closes #344

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest` CRM + suite backend (486 passed local, scripts externos ignorados no Docker mount)
- [x] `npm run build` frontend
- [ ] Login como admin: menu Comercial → CRM; criar lead; mover no Kanban até Implantação
- [ ] Login como comercial: ver leads, simular/montar pacote; sem CRUD de funil/catálogo
- [ ] Cadastros → Funil CRM: criar/renomear/reordenar estágios (admin)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [ ] Revisei itens **fora do escopo** desta issue — cada um virou issue `#___` ou está documentado como wontfix
- [ ] Stubs/campos nullable têm issue de conclusão, se aplicável
- [ ] Comentário na issue fechada ou no PR lista links dos follow-ups criados
