### PR TITLE
feat(whatsapp): UX da mesa e nome original de ficheiros (#679–#684)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,16 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 - CRM (#322 / #336–#344): perfil comercial, funil, leads e negociações multi-CNPJ (API + UI — lista/Kanban, detalhe com custos/margem e timeline); configuração dos estágios em Cadastros; simulação e leitura do catálogo de custos para comercial (CRUD do catálogo continua só admin)
 - Sobre: as notas de atualização passam a mostrar só o que mudou no helpdesk nesta instância; melhorias do painel SaaS deixam de aparecer misturadas (#672 / #674)
+- WhatsApp (#684): número do contacto visível no header da conversa (com copiar)
+- WhatsApp (#681): clique na foto do contacto abre a imagem em tela cheia
+- WhatsApp (#682): no telemóvel, dá para ocultar detalhes (protocolo, tags, demandas) e ver mais o chat
+- WhatsApp (#680): vídeos da conversa abrem em overlay ampliado, com opção de tela cheia nativa
+- WhatsApp (#679): documentos mostram e descarregam com o **nome original** do ficheiro (envio e recebimento)
 
 #### Correções
 
 - Login (#677): em subdomínio do cliente, **Voltar ao site** abre a landing DeskRudder (apex) em vez de voltar ao próprio login
+- WhatsApp (#683): envio de mensagem/áudio/anexo já não mostra toast verde que cobria o botão de enviar (erros continuam)
 
 ### SaaS Control Plane
 

--- a/backend/alembic/versions/094_wpp_midia_nome_original.py
+++ b/backend/alembic/versions/094_wpp_midia_nome_original.py
@@ -1,0 +1,33 @@
+"""WhatsApp: midia_nome_original nas mensagens (#679).
+
+Revision ID: 094_wpp_midia_nome_original
+Revises: 093_crm_leads_negociacao
+Create Date: 2026-08-14
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "094_wpp_midia_nome_original"
+down_revision = "093_crm_leads_negociacao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = {c["name"] for c in insp.get_columns("whatsapp_mensagens")}
+    if "midia_nome_original" not in cols:
+        op.add_column(
+            "whatsapp_mensagens",
+            sa.Column("midia_nome_original", sa.String(length=255), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    cols = {c["name"] for c in insp.get_columns("whatsapp_mensagens")}
+    if "midia_nome_original" in cols:
+        op.drop_column("whatsapp_mensagens", "midia_nome_original")

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -767,6 +767,7 @@ def _mensagem_read(
         tipo_midia=m.tipo_midia,
         mimetype=m.mimetype,
         midia_disponivel=False if apagada else midia_ok,
+        midia_nome_original=None if apagada else (getattr(m, "midia_nome_original", None) or None),
         evento_sistema=getattr(m, "evento_sistema", None),
         wa_message_id=m.wa_message_id,
         quoted_wa_message_id=getattr(m, "quoted_wa_message_id", None),
@@ -1416,7 +1417,8 @@ def obter_midia_da_mensagem(
     if not path:
         raise HTTPException(status_code=404, detail="Ficheiro não encontrado em disco")
     media_type = m.mimetype or "application/octet-stream"
-    return FileResponse(path, media_type=media_type, filename=path.name)
+    download_name = (getattr(m, "midia_nome_original", None) or "").strip() or path.name
+    return FileResponse(path, media_type=media_type, filename=download_name)
 
 
 @router.get("/{chat_id}/mensagens", response_model=list[WhatsappMensagemRead])
@@ -2092,6 +2094,7 @@ async def enviar_mensagem_midia(
         tipo_midia=tipo_db,
         mimetype=mime,
         midia_nome_arquivo=nome_guardado,
+        midia_nome_original=fname,
         wa_message_id=sent_wa_id,
         quoted_wa_message_id=q_wa,
         quoted_corpo_preview=q_prev,

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -580,6 +580,11 @@ def _processar_mensagem_inbound(
 
     tipo_midia = tipo
     mimetype_val = item.get("mimetype")
+    midia_nome_original = item.get("file_name")
+    if isinstance(midia_nome_original, str):
+        midia_nome_original = midia_nome_original.strip()[:255] or None
+    else:
+        midia_nome_original = None
     midia_nome = _baixar_midia_inbound(
         item=item,
         st_media=st_media,
@@ -611,6 +616,7 @@ def _processar_mensagem_inbound(
                     tipo_midia=tipo_midia,
                     mimetype=mimetype_val,
                     midia_nome_arquivo=midia_nome,
+                    midia_nome_original=midia_nome_original,
                     wa_message_id=wa_mid,
                     quoted_wa_message_id=item.get("quoted_wa_message_id"),
                     quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
@@ -687,6 +693,7 @@ def _processar_mensagem_inbound(
         tipo_midia=tipo_midia,
         mimetype=mimetype_val,
         midia_nome_arquivo=midia_nome,
+        midia_nome_original=midia_nome_original,
         wa_message_id=wa_mid,
         quoted_wa_message_id=item.get("quoted_wa_message_id"),
         quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -109,6 +109,8 @@ class WhatsappMensagem(Base):
     mimetype = Column(String(128), nullable=True)
     # Nome do ficheiro dentro de WHATSAPP_MEDIA_DIR (apenas inbound com mídia obtida da Evolution)
     midia_nome_arquivo = Column(String(500), nullable=True)
+    # Nome amigável para UI/download (#679); storage em disco continua com UUID
+    midia_nome_original = Column(String(255), nullable=True)
     # Identifica mensagens automáticas disparadas pelo sistema (evita duplicação e ajuda auditoria).
     evento_sistema = Column(String(40), nullable=True, index=True)
     wa_message_id = Column(String(128), nullable=True, index=True)

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -27,6 +27,7 @@ class WhatsappMensagemRead(BaseModel):
     tipo_midia: str | None = None
     mimetype: str | None = None
     midia_disponivel: bool = False
+    midia_nome_original: str | None = None
     evento_sistema: str | None = None
     wa_message_id: str | None = None
     quoted_wa_message_id: str | None = None

--- a/backend/app/services/evolution_inbound.py
+++ b/backend/app/services/evolution_inbound.py
@@ -160,6 +160,20 @@ def _mimetype_de_obj_midia(obj: dict[str, Any]) -> str | None:
     return None
 
 
+def _file_name_de_obj_midia(obj: dict[str, Any]) -> str | None:
+    """Nome original do documento/mídia (Baileys/Evolution) (#679)."""
+    for k in ("fileName", "filename", "FileName", "title", "Title", "name", "Name"):
+        v = obj.get(k)
+        if v and str(v).strip():
+            # Evita path traversal e caracteres de controlo
+            raw = str(v).strip().replace("\\", "/").split("/")[-1]
+            safe = "".join(ch for ch in raw if ch.isprintable() and ch not in '<>:"|?*')
+            safe = safe.strip().strip(".")
+            if safe:
+                return safe[:200]
+    return None
+
+
 def _caption_de_obj_midia(obj: dict[str, Any]) -> str | None:
     for k in ("caption", "Caption"):
         v = obj.get(k)
@@ -292,6 +306,7 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
             kind, obj = media
             mime = _mimetype_de_obj_midia(obj)
             cap = _caption_de_obj_midia(obj)
+            file_name = _file_name_de_obj_midia(obj)
             corpo = cap if cap else _ROTULO_TIPO.get(kind, "[Mídia]")
             yield {
                 "wa_id": wa_id,
@@ -300,6 +315,7 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
                 "tipo": kind,
                 "corpo": corpo,
                 "mimetype": mime,
+                "file_name": file_name,
                 "raw_envelope": m,
                 "quoted_wa_message_id": q_wid,
                 "quoted_corpo_preview": q_prev,

--- a/backend/tests/test_evolution_inbound_especiais.py
+++ b/backend/tests/test_evolution_inbound_especiais.py
@@ -46,6 +46,44 @@ def test_inbound_localizacao():
     assert "maps.google.com" in item["corpo"]
 
 
+def test_inbound_documento_com_file_name():
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "key": {"remoteJid": "5511999999999@s.whatsapp.net", "fromMe": False, "id": "doc1"},
+            "message": {
+                "documentMessage": {
+                    "fileName": "SPED_Fiscal_2026.txt",
+                    "mimetype": "text/plain",
+                    "caption": "Segue SPED",
+                }
+            },
+        },
+    }
+    item = _one(body)
+    assert item["tipo"] == "documento"
+    assert item["file_name"] == "SPED_Fiscal_2026.txt"
+    assert item["corpo"] == "Segue SPED"
+    assert item["mimetype"] == "text/plain"
+
+
+def test_inbound_documento_sanitiza_path_no_file_name():
+    body = {
+        "event": "messages.upsert",
+        "data": {
+            "key": {"remoteJid": "5511999999999@s.whatsapp.net", "fromMe": False, "id": "doc2"},
+            "message": {
+                "documentMessage": {
+                    "fileName": "../../etc/passwd.pdf",
+                    "mimetype": "application/pdf",
+                }
+            },
+        },
+    }
+    item = _one(body)
+    assert item["file_name"] == "passwd.pdf"
+
+
 def test_inbound_resolve_lid_via_sender_pn():
     body = {
         "event": "messages.upsert",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -974,6 +974,7 @@ export namespace WhatsappChats {
     tipo_midia?: string | null
     mimetype?: string | null
     midia_disponivel?: boolean
+    midia_nome_original?: string | null
     evento_sistema?: string | null
     wa_message_id?: string | null
     quoted_wa_message_id?: string | null

--- a/frontend/src/components/chat/WhatsappAvatar.tsx
+++ b/frontend/src/components/chat/WhatsappAvatar.tsx
@@ -6,6 +6,8 @@ type Props = {
   className?: string
   /** Classes do círculo quando só há inicial */
   fallbackClassName?: string
+  /** Clique na foto (só quando há URL válida) — ex. lightbox (#681). */
+  onFotoClick?: () => void
 }
 
 /** Avatar do contacto WhatsApp com fallback para inicial (#630). */
@@ -14,19 +16,33 @@ export function WhatsappAvatar({
   fotoUrl,
   className = 'h-10 w-10',
   fallbackClassName = 'bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-200',
+  onFotoClick,
 }: Props) {
   const [broke, setBroke] = useState(false)
   const inicial = (nome || '?').trim().charAt(0).toUpperCase() || '?'
   if (fotoUrl && !broke) {
-    return (
+    const img = (
       <img
         src={fotoUrl}
         alt=""
-        className={`${className} shrink-0 rounded-full object-cover`}
+        className={`${className} shrink-0 rounded-full object-cover ${onFotoClick ? 'cursor-zoom-in' : ''}`}
         referrerPolicy="no-referrer"
         onError={() => setBroke(true)}
       />
     )
+    if (onFotoClick) {
+      return (
+        <button
+          type="button"
+          onClick={onFotoClick}
+          className="shrink-0 rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400"
+          aria-label="Ver foto do contacto"
+        >
+          {img}
+        </button>
+      )
+    }
+    return img
   }
   return (
     <div

--- a/frontend/src/lib/fileTypeIcon.ts
+++ b/frontend/src/lib/fileTypeIcon.ts
@@ -76,6 +76,11 @@ export function rotuloDownloadArquivo(
   tipoMidia?: string | null,
 ): string {
   const tipo = (tipoMidia ?? '').toLowerCase()
+  const nomeLimpo = (nome ?? '').trim()
+  if (nomeLimpo) {
+    const v = visualTipoArquivo(nomeLimpo, mime)
+    return `${v.emoji} ${nomeLimpo}`
+  }
   if (tipo === 'audio') return '🔊 Baixar áudio'
   if (tipo === 'video') return '🎬 Baixar vídeo'
   if (tipo === 'imagem' || tipo === 'figurinha') return '📷 Baixar imagem'

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -34,6 +34,7 @@ import { ImageLightboxViewer } from '../../components/chat/ImageLightboxViewer'
 import { WhatsappMensagemAcoes } from '../../components/chat/WhatsappMensagemAcoes'
 import { WhatsappReacoesBar } from '../../components/chat/WhatsappReacoesBar'
 import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
+import { formatWaIdExibicao } from '../../utils/masks'
 
 import { Card } from '../../components/ui/Card'
 import { TEXTAREA_FIELD_CLASS } from '../../components/ui/Input'
@@ -130,10 +131,12 @@ function ConteudoMensagemWhatsApp({
   chatId,
   m,
   onImageClick,
+  onVideoClick,
 }: {
   chatId: number
   m: WhatsappChats.Mensagem
   onImageClick: (msgId: number) => void
+  onVideoClick: (msgId: number) => void
 }) {
 
   const tipo = (m.tipo_midia || 'texto').toLowerCase()
@@ -227,22 +230,32 @@ function ConteudoMensagemWhatsApp({
   if (tipo === 'video') {
     return (
       <div className="space-y-1">
-        <video controls src={url} className={mediaClass} />
+        <div className="relative inline-block max-w-full">
+          <video controls src={url} className={mediaClass} />
+          <button
+            type="button"
+            className="absolute bottom-2 right-2 rounded-md bg-black/65 px-2.5 py-1.5 text-[11px] font-semibold text-white shadow-sm backdrop-blur-sm transition hover:bg-black/80"
+            onClick={() => onVideoClick(m.id)}
+          >
+            Expandir
+          </button>
+        </div>
         {legenda ? <TextoComLinks texto={legenda} /> : null}
       </div>
     )
   }
 
-  const downloadLabel = rotuloDownloadArquivo(null, m.mimetype, tipo)
-  const fileVisual = visualTipoArquivo(null, m.mimetype)
+  const downloadLabel = rotuloDownloadArquivo(m.midia_nome_original, m.mimetype, tipo)
+  const fileVisual = visualTipoArquivo(m.midia_nome_original, m.mimetype)
+  const downloadName = (m.midia_nome_original || '').trim() || undefined
 
   return (
     <div className="space-y-1">
-      <a href={url} download className="flex items-center gap-2 text-xs font-bold underline">
+      <a href={url} download={downloadName} className="flex items-center gap-2 text-xs font-bold underline">
         <span className="text-base" aria-hidden>
           {fileVisual.emoji}
         </span>
-        <span>{downloadLabel.replace(/^\S+\s*/, '')}</span>
+        <span className="min-w-0 break-all">{downloadLabel.replace(/^\S+\s*/, '')}</span>
       </a>
       {legenda ? <TextoComLinks texto={legenda} /> : null}
     </div>
@@ -384,6 +397,139 @@ function WhatsappZoomLightbox({
   )
 }
 
+/** Overlay ampliado para vídeos da mesa (#680). */
+function WhatsappVideoLightbox({
+  chatId,
+  msgId,
+  caption,
+  onClose,
+}: {
+  chatId: number
+  msgId: number
+  caption: string | null
+  onClose: () => void
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const [url, setUrl] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setUrl(null)
+    void resolveWhatsappMidiaObjectUrl(chatId, msgId, () => fetchWhatsAppMidiaBlob(chatId, msgId))
+      .then((u) => {
+        if (!cancelled) setUrl(u)
+      })
+      .catch(() => {
+        if (!cancelled) setUrl(null)
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [chatId, msgId])
+
+  async function entrarTelaCheia() {
+    const el = videoRef.current
+    if (!el) return
+    try {
+      if (el.requestFullscreen) await el.requestFullscreen()
+      else if ('webkitRequestFullscreen' in el) {
+        await (el as HTMLVideoElement & { webkitRequestFullscreen: () => Promise<void> }).webkitRequestFullscreen()
+      }
+    } catch {
+      /* browser bloqueou — overlay já é o fallback */
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex flex-col items-center justify-center bg-black/90 p-4 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={onClose}
+    >
+      <button
+        type="button"
+        className="absolute top-4 right-4 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white/10 text-3xl font-bold text-white transition-colors touch-manipulation hover:bg-white/20"
+        onClick={onClose}
+        aria-label="Fechar"
+      >
+        &times;
+      </button>
+      {loading || !url ? (
+        <p className="animate-pulse text-sm text-white/70">Carregando vídeo…</p>
+      ) : (
+        <div className="flex max-h-[90vh] w-full max-w-5xl flex-col items-center gap-3" onClick={(e) => e.stopPropagation()}>
+          <video
+            ref={videoRef}
+            controls
+            autoPlay
+            src={url}
+            className="max-h-[min(80vh,48rem)] w-full rounded-xl bg-black shadow-2xl"
+          />
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <button
+              type="button"
+              className="rounded-xl bg-white/15 px-4 py-2 text-xs font-semibold text-white transition hover:bg-white/25"
+              onClick={() => void entrarTelaCheia()}
+            >
+              Tela cheia
+            </button>
+            <a
+              href={url}
+              download="whatsapp-video.mp4"
+              className="rounded-xl bg-cyan-600 px-4 py-2 text-xs font-bold text-white transition hover:bg-cyan-700"
+            >
+              Baixar vídeo
+            </a>
+          </div>
+          {caption ? (
+            <p className="max-w-2xl rounded-xl bg-black/40 px-4 py-2 text-center text-sm text-white backdrop-blur-md">
+              {caption}
+            </p>
+          ) : null}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Foto do contacto em overlay (#681). */
+function WhatsappFotoPerfilLightbox({ src, nome, onClose }: { src: string; nome?: string | null; onClose: () => void }) {
+  return (
+    <div
+      className="fixed inset-0 z-[200] flex flex-col items-center justify-center bg-black/90 p-4 backdrop-blur-sm animate-in fade-in duration-200"
+      onClick={onClose}
+      role="presentation"
+    >
+      <button
+        type="button"
+        className="absolute top-4 right-4 flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white/10 text-3xl font-bold text-white transition-colors touch-manipulation hover:bg-white/20"
+        onClick={onClose}
+        aria-label="Fechar"
+      >
+        &times;
+      </button>
+      <img
+        src={src}
+        alt={nome ? `Foto de ${nome}` : 'Foto do contacto'}
+        className="max-h-[85vh] max-w-full rounded-2xl object-contain shadow-2xl"
+        referrerPolicy="no-referrer"
+        onClick={(e) => e.stopPropagation()}
+      />
+      {nome ? (
+        <p className="mt-4 text-sm font-medium text-white/90" onClick={(e) => e.stopPropagation()}>
+          {nome}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+const WA_DETALHES_SESSION_KEY = 'deskrudder-wa-conversa-detalhes'
+
 // --- Componente Principal ---
 
 export function WhatsappConversa() {
@@ -446,6 +592,16 @@ export function WhatsappConversa() {
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
   const [focoComposerEm, setFocoComposerEm] = useState(0)
   const [zoomMsgId, setZoomMsgId] = useState<number | null>(null)
+  const [videoZoomMsgId, setVideoZoomMsgId] = useState<number | null>(null)
+  const [fotoPerfilAberta, setFotoPerfilAberta] = useState(false)
+  const [numeroCopiado, setNumeroCopiado] = useState(false)
+  const [detalhesMobileAbertos, setDetalhesMobileAbertos] = useState(() => {
+    try {
+      return sessionStorage.getItem(WA_DETALHES_SESSION_KEY) !== '0'
+    } catch {
+      return true
+    }
+  })
   const [modoInterno, setModoInterno] = useState(false)
   const [modalAssumirSetor, setModalAssumirSetor] = useState(false)
 
@@ -497,6 +653,18 @@ export function WhatsappConversa() {
         setZoomMsgId(null)
         return
       }
+      if (videoZoomMsgId != null) {
+        e.preventDefault()
+        e.stopPropagation()
+        setVideoZoomMsgId(null)
+        return
+      }
+      if (fotoPerfilAberta) {
+        e.preventDefault()
+        e.stopPropagation()
+        setFotoPerfilAberta(false)
+        return
+      }
       if (arquivoPendente) {
         e.preventDefault()
         setArquivoPendente(null)
@@ -523,6 +691,8 @@ export function WhatsappConversa() {
     sairParaListaSegura,
     modalEncerrar,
     zoomMsgId,
+    videoZoomMsgId,
+    fotoPerfilAberta,
     arquivoPendente,
     filaAguardandoAberta,
     menuMobileAberto,
@@ -934,10 +1104,8 @@ useEffect(() => {
     try {
       if (modoInterno) {
         await whatsappChats.comentarInterno(chat.id, texto.trim())
-        toast.showSuccess('Comentário interno registrado.')
       } else {
         await whatsappChats.enviar(chat.id, texto.trim(), msgRespondida?.wa_message_id || null)
-        toast.showSuccess('Mensagem enviada.')
       }
 
       setTexto('')
@@ -1012,7 +1180,6 @@ useEffect(() => {
         msgRespondida?.wa_message_id || null,
       )
       setMsgRespondida(null)
-      toast.showSuccess('Áudio enviado.')
       stickToBottomRef.current = true
       await carregar()
     } catch (err) {
@@ -1047,7 +1214,6 @@ useEffect(() => {
       setMsgRespondida(null)
       setArquivoPendente(null)
       setLegendaMidia('')
-      toast.showSuccess('Anexo enviado!')
       stickToBottomRef.current = true
       await carregar()
     } catch (err) {
@@ -1098,7 +1264,6 @@ useEffect(() => {
     try {
       await whatsappChats.enviarFigurinha(chat.id, file, msgRespondida?.wa_message_id || null)
       setMsgRespondida(null)
-      toast.showSuccess('Figurinha enviada!')
       stickToBottomRef.current = true
       await carregar()
     } catch (err) {
@@ -1396,12 +1561,53 @@ useEffect(() => {
               fotoUrl={chat?.foto_perfil_url}
               className="h-9 w-9 text-sm"
               fallbackClassName="bg-cyan-100 text-cyan-800 dark:bg-cyan-950/50 dark:text-cyan-200"
+              onFotoClick={
+                chat?.foto_perfil_url ? () => setFotoPerfilAberta(true) : undefined
+              }
             />
             <div className="min-w-0 flex-1">
               <h1 className="truncate font-bold text-slate-900 dark:text-white">
                 {chat?.cliente_nome || 'Atendimento'}
               </h1>
+              {chat?.wa_id ? (
+                <button
+                  type="button"
+                  className="mt-0.5 max-w-full truncate font-mono text-[11px] text-slate-500 transition hover:text-cyan-700 dark:text-slate-400 dark:hover:text-cyan-300"
+                  title={numeroCopiado ? 'Copiado' : 'Clique para copiar o número'}
+                  onClick={() => {
+                    const raw = chat.wa_id
+                    void navigator.clipboard?.writeText(raw).then(() => {
+                      setNumeroCopiado(true)
+                      window.setTimeout(() => setNumeroCopiado(false), 1500)
+                    })
+                  }}
+                >
+                  {numeroCopiado ? 'Copiado!' : formatWaIdExibicao(chat.wa_id)}
+                </button>
+              ) : null}
             </div>
+
+            <button
+              type="button"
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 md:hidden dark:hover:bg-slate-800 dark:hover:text-slate-100"
+              aria-expanded={detalhesMobileAbertos}
+              aria-label={detalhesMobileAbertos ? 'Ocultar detalhes' : 'Mostrar detalhes'}
+              onClick={() => {
+                setDetalhesMobileAbertos((aberto) => {
+                  const next = !aberto
+                  try {
+                    sessionStorage.setItem(WA_DETALHES_SESSION_KEY, next ? '1' : '0')
+                  } catch {
+                    /* ignore */
+                  }
+                  return next
+                })
+              }}
+            >
+              <span className="text-lg leading-none" aria-hidden>
+                {detalhesMobileAbertos ? '▴' : '▾'}
+              </span>
+            </button>
 
             <div className="flex shrink-0 items-center gap-1 sm:gap-2">
 
@@ -1538,7 +1744,9 @@ useEffect(() => {
 
           </div>
 
-          <div className="space-y-1.5 px-3 pb-2 sm:px-4 sm:pb-3">
+          <div
+            className={`space-y-1.5 px-3 pb-2 sm:px-4 sm:pb-3 ${detalhesMobileAbertos ? '' : 'hidden md:block'}`}
+          >
 
             <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[10px]">
               <span className="min-w-0 truncate font-mono font-bold text-cyan-600" title={exibirProtocolo(chat?.protocolo)}>
@@ -1678,12 +1886,14 @@ useEffect(() => {
 
 
         {chat && chat.estado === 'em_atendimento' && (
-          <WhatsappDemandasPanel
-            key={chat.id}
-            chatId={chat.id}
-            podeRegistrar={isResponsavel || isAdmin}
-            onDemandasChange={refrescarTimelineDemandas}
-          />
+          <div className={detalhesMobileAbertos ? '' : 'hidden md:block'}>
+            <WhatsappDemandasPanel
+              key={chat.id}
+              chatId={chat.id}
+              podeRegistrar={isResponsavel || isAdmin}
+              onDemandasChange={refrescarTimelineDemandas}
+            />
+          </div>
         )}
 
 
@@ -1819,6 +2029,7 @@ useEffect(() => {
                       chatId={id}
                       m={m}
                       onImageClick={(msgId) => setZoomMsgId(msgId)}
+                      onVideoClick={(msgId) => setVideoZoomMsgId(msgId)}
                     />
 
                     {!isSystem && (
@@ -2165,6 +2376,28 @@ useEffect(() => {
           onChangeMsgId={setZoomMsgId}
         />
       )}
+
+      {videoZoomMsgId != null && (
+        <WhatsappVideoLightbox
+          chatId={id}
+          msgId={videoZoomMsgId}
+          caption={
+            (() => {
+              const m = msgs.find((x) => x.id === videoZoomMsgId)
+              return m ? legendaMidiaVisivel(m.corpo) : null
+            })()
+          }
+          onClose={() => setVideoZoomMsgId(null)}
+        />
+      )}
+
+      {fotoPerfilAberta && chat?.foto_perfil_url ? (
+        <WhatsappFotoPerfilLightbox
+          src={chat.foto_perfil_url}
+          nome={chat.cliente_nome}
+          onClose={() => setFotoPerfilAberta(false)}
+        />
+      ) : null}
 
       <AssumirWhatsappSetorModal
         open={modalAssumirSetor}

--- a/frontend/src/utils/masks.ts
+++ b/frontend/src/utils/masks.ts
@@ -26,6 +26,25 @@ export function formatTelefoneBrExibicao(value: string | null | undefined): stri
   return maskTelefoneBr(value)
 }
 
+/**
+ * Formata `wa_id` WhatsApp para exibição na mesa (#684).
+ * Ex.: `5511987654321` → `+55 (11) 98765-4321`
+ */
+export function formatWaIdExibicao(waId: string | null | undefined): string {
+  if (!waId?.trim()) return ''
+  const raw = waId.trim().split('@')[0] || waId.trim()
+  const digits = raw.replace(/\D/g, '')
+  if (digits.startsWith('55') && (digits.length === 12 || digits.length === 13)) {
+    const local = formatTelefoneBrExibicao(digits.slice(2))
+    return local ? `+55 ${local}` : `+${digits}`
+  }
+  if (digits.length >= 10 && digits.length <= 11) {
+    return formatTelefoneBrExibicao(digits)
+  }
+  if (raw.startsWith('+')) return raw
+  return digits ? `+${digits}` : raw
+}
+
 /** IE alfanumérica comum (apenas letras e números, máx. 20). */
 export function maskInscricaoEstadual(value: string): string {
   return value.replace(/[^a-zA-Z0-9]/g, '').slice(0, 20).toUpperCase()


### PR DESCRIPTION
## Summary

Lote de UX da mesa WhatsApp: número do contacto no header, foto e vídeo em tela cheia, detalhes recolhíveis no mobile, remoção dos toasts verdes no envio, e documentos com nome original (BE + FE + migration).

Closes #683, #684, #681, #682, #680, #679

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest` (suite completa com mount do repo) — 529 + 22 passed
- [x] `npm run build` (com `VITE_API_URL` de CI)
- [ ] Manual: enviar mensagem/áudio/anexo — sem toast verde; erros ainda aparecem
- [ ] Manual: copiar número formatado no header
- [ ] Manual: clicar foto do contacto → lightbox
- [ ] Manual (mobile): ▾/▴ oculta detalhes do chat
- [ ] Manual: Expandir vídeo → overlay / tela cheia
- [ ] Manual: documento inbound/outbound mostra e descarrega com nome original

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — #654/#655 (URLs fixas), #685 (scroll funcionários) e higiene DR/#519/#321 ficam fora deste lote
- [x] Stubs/campos nullable: `midia_nome_original` nullable de propósito (mensagens antigas sem nome)
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados
