### PR TITLE
feat(frontend): URLs fixas na mesa/tickets e scroll de funcionários (#654, #655, #685)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,14 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - WhatsApp (#682): no telemóvel, dá para ocultar detalhes (protocolo, tags, demandas) e ver mais o chat
 - WhatsApp (#680): vídeos da conversa abrem em overlay ampliado, com opção de tela cheia nativa
 - WhatsApp (#679): documentos mostram e descarregam com o **nome original** do ficheiro (envio e recebimento)
+- Chat (#654): a mesa de atendimento fica sempre no mesmo endereço (`/chat/atendendo`, `/chat/espera`, `/chat/interno`) — o número da conversa deixa de aparecer na barra do navegador e a conversa aberta continua no painel ao trocar de aba
+- Tickets (#655): abrir um chamado mantém o endereço `/tickets`, sem o número do ticket na barra do navegador; ao voltar, a lista preserva filtros e página
 
 #### Correções
 
 - Login (#677): em subdomínio do cliente, **Voltar ao site** abre a landing DeskRudder (apex) em vez de voltar ao próprio login
+- Funcionários da rede (#685): ao editar/criar, o formulário volta a mostrar o topo e a rolar até ao fim — sem espaço vazio abaixo dos botões nem conteúdo preso fora do ecrã
+- Links antigos (#654 / #655): endereços com número (chat da fila, conversa do WhatsApp, notificações de ticket) continuam a funcionar e abrem o item certo no novo formato
 - WhatsApp (#683): envio de mensagem/áudio/anexo já não mostra toast verde que cobria o botão de enviar (erros continuam)
 
 ### SaaS Control Plane

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,7 +17,6 @@ import { RelatoriosChats } from './pages/RelatoriosChats'
 import { PresencaOnline } from './pages/PresencaOnline'
 import { Tickets } from './pages/Tickets'
 import { TicketNovo } from './pages/TicketNovo'
-import { TicketDetalhe } from './pages/TicketDetalhe'
 import { CrmLeads } from './pages/CrmLeads'
 import { CrmNegociacaoDetalhe } from './pages/CrmNegociacaoDetalhe'
 import { ConfigCrmFunil } from './pages/ConfigCrmFunil'
@@ -67,13 +66,11 @@ import { ConfigSistemaLayout } from './pages/config/ConfigSistemaLayout'
 import { WhatsappLayout } from './pages/whatsapp/WhatsappLayout'
 import { WhatsappHistorico } from './pages/whatsapp/WhatsappHistorico'
 import { WhatsappAvaliacoes } from './pages/whatsapp/WhatsappAvaliacoes'
-import { WhatsappConversa } from './pages/whatsapp/WhatsappConversa'
-import { ChatInternoThread } from './pages/chat-interno/ChatInternoThread'
 import { ChatInternoSetorCanal } from './pages/chat-interno/ChatInternoSetorCanal'
 import { ChatHubShell } from './pages/chat/ChatHubShell'
 import { ChatHubLayout } from './pages/chat/ChatHubLayout'
+import { ChatHubPainel } from './pages/chat/ChatHubPainel'
 import { ChatHubPlaceholder } from './pages/chat/ChatHubPlaceholder'
-import { PortalConversa } from './pages/chat/PortalConversa'
 import { AlterarSenha } from './pages/AlterarSenha'
 import { NotificacoesPreferencias } from './pages/NotificacoesPreferencias'
 import { Sobre } from './pages/Sobre'
@@ -108,6 +105,9 @@ import { ErrorBoundary } from './components/ErrorBoundary'
 import { PageLoading } from './components/ui/PageLoading'
 import { isMarketingHost } from './lib/marketingHost'
 import { isSaasControlPlaneFrontend } from './lib/saasControlPlane'
+import { gravarChatAtivoSession, type ChatAtivoCanal } from './lib/chatAtivo'
+import { chatHubModoDePath, chatHubPathParaModo } from './lib/chatHubPaths'
+import { gravarTicketAtivoSession } from './lib/ticketAtivo'
 
 /**
  * Apex comercial (`deskrudder.com.br`): `/` anônimo → landing.
@@ -176,9 +176,32 @@ function RedirectKbArtigoEditar() {
   return <Navigate to={`/ajuda/artigos/${id}/editar`} replace />
 }
 
-function RedirectWhatsappConversa() {
-  const { chatId } = useParams<{ chatId: string }>()
-  return <Navigate to={`/chat/c/${chatId}`} replace />
+/**
+ * Rotas legadas com id na URL (`/chat/c/:id`, `/whatsapp/c/:id`, notificações):
+ * guardam a conversa como ativa e caem na aba fixa do hub (#654).
+ */
+function RedirectChatConversa({ canal }: { canal: ChatAtivoCanal }) {
+  const params = useParams<{ chatId?: string; conversaId?: string }>()
+  const location = useLocation()
+  const id = Number(params.chatId ?? params.conversaId)
+  if (Number.isFinite(id) && id > 0) {
+    gravarChatAtivoSession({ canal, id })
+  }
+  const destino = chatHubPathParaModo(chatHubModoDePath(location.pathname, location.search))
+  return (
+    <Navigate to={{ pathname: destino, search: location.search }} replace state={location.state} />
+  )
+}
+
+/** `/tickets/:id` deixa de existir: id vai para a sessão e a URL fica `/tickets` (#655). */
+function RedirectTicketDetalhe() {
+  const { id } = useParams<{ id: string }>()
+  const location = useLocation()
+  const ticketId = Number(id)
+  if (Number.isFinite(ticketId) && ticketId > 0) {
+    gravarTicketAtivoSession(ticketId)
+  }
+  return <Navigate to="/tickets" replace state={location.state} />
 }
 
 function RedirectLegacyChatInterno() {
@@ -303,7 +326,7 @@ function AppRoutes() {
         <Route path="sobre" element={<Sobre />} />
         <Route path="tickets" element={<Tickets />} />
         <Route path="tickets/novo" element={<TicketNovo />} />
-        <Route path="tickets/:id" element={<TicketDetalhe />} />
+        <Route path="tickets/:id" element={<RedirectTicketDetalhe />} />
         <Route
           path="crm/leads"
           element={
@@ -326,44 +349,60 @@ function AppRoutes() {
             <Route
               path="atendendo"
               element={
-                <ChatHubPlaceholder
-                  titulo="Atendendo"
-                  subtitulo="Selecione um dos seus chats em atendimento na lista ao lado."
+                <ChatHubPainel
+                  placeholder={
+                    <ChatHubPlaceholder
+                      titulo="Atendendo"
+                      subtitulo="Selecione um dos seus chats em atendimento na lista ao lado."
+                    />
+                  }
                 />
               }
             />
             <Route
               path="espera"
               element={
-                <ChatHubPlaceholder
-                  titulo="Aguardando"
-                  subtitulo="Chats na fila — assuma um novo atendimento."
+                <ChatHubPainel
+                  placeholder={
+                    <ChatHubPlaceholder
+                      titulo="Aguardando"
+                      subtitulo="Chats na fila — assuma um novo atendimento."
+                    />
+                  }
                 />
               }
             />
             <Route
               path="contatos"
               element={
-                <ChatHubPlaceholder
-                  titulo="Contatos"
-                  subtitulo="Escolha um contacto ou número avulso para iniciar conversa no WhatsApp."
+                <ChatHubPainel
+                  placeholder={
+                    <ChatHubPlaceholder
+                      titulo="Contatos"
+                      subtitulo="Escolha um contacto ou número avulso para iniciar conversa no WhatsApp."
+                    />
+                  }
                 />
               }
             />
             <Route path="portal" element={<Navigate to="/chat/espera" replace />} />
-            <Route path="portal/:chatId" element={<PortalConversa />} />
+            <Route path="portal/:chatId" element={<RedirectChatConversa canal="portal" />} />
             <Route
               path="interno"
               element={
-                <ChatHubPlaceholder
-                  titulo="Chat interno"
-                  subtitulo="Converse com colegas ou acesse o canal do seu setor."
+                <ChatHubPainel
+                  placeholder={
+                    <ChatHubPlaceholder
+                      titulo="Chat interno"
+                      subtitulo="Converse com colegas ou acesse o canal do seu setor."
+                    />
+                  }
                 />
               }
             />
             <Route path="interno/setor/:setorId" element={<ChatInternoSetorCanal />} />
-            <Route path="interno/:conversaId" element={<ChatInternoThread />} />
-            <Route path="c/:chatId" element={<WhatsappConversa />} />
+            <Route path="interno/:conversaId" element={<RedirectChatConversa canal="interno" />} />
+            <Route path="c/:chatId" element={<RedirectChatConversa canal="whatsapp" />} />
           </Route>
         </Route>
         <Route path="chat/historico" element={<Navigate to="/whatsapp/historico" replace />} />
@@ -373,7 +412,7 @@ function AppRoutes() {
           <Route path="historico" element={<WhatsappHistorico />} />
           <Route path="fila" element={<Navigate to="/chat/espera" replace />} />
           <Route path="meus" element={<Navigate to="/chat/atendendo" replace />} />
-          <Route path="c/:chatId" element={<RedirectWhatsappConversa />} />
+          <Route path="c/:chatId" element={<RedirectChatConversa canal="whatsapp" />} />
           <Route
             path="avaliacoes"
             element={

--- a/frontend/src/components/EmpresaChatsPanel.tsx
+++ b/frontend/src/components/EmpresaChatsPanel.tsx
@@ -9,7 +9,7 @@ import { useToast } from './ui/Toast'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { exibirProtocolo } from '../lib/exibirProtocolo'
 import { rotuloEstadoChat } from '../lib/whatsappChatMeta'
-import { whatsappConversaLink } from '../lib/whatsappListReturn'
+import { marcarWhatsappChatAtivo, whatsappConversaLink } from '../lib/whatsappListReturn'
 import { ChatIniciarConversaModal } from './chat/ChatIniciarConversaModal'
 
 type Props = {
@@ -183,7 +183,8 @@ export function EmpresaChatsPanel({ empresaId }: Props) {
                     </div>
                   </div>
                   <Link
-                    to={whatsappConversaLink(c.id, returnPath)}
+                    to={whatsappConversaLink(returnPath)}
+                    onClick={() => marcarWhatsappChatAtivo(c.id)}
                     className="rounded-full bg-slate-100 p-2 text-slate-400 transition-all hover:bg-cyan-600 hover:text-white dark:bg-slate-800 dark:hover:bg-cyan-700"
                     title="Ver conversa"
                   >

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -9,6 +9,7 @@ import { EventStreamProvider, useEventStream } from '../contexts/EventStreamCont
 import { BrandLogo } from '../brand'
 import { useTheme } from '../contexts/ThemeContext'
 import { AlertaDesktopPermissaoBanner } from './AlertaDesktopPermissaoBanner'
+import { lerTicketAtivoSession, TICKET_ATIVO_EVENT } from '../lib/ticketAtivo'
 
 function perfilExibicao(role: string | undefined): string {
   if (role === 'admin') return 'Administrador'
@@ -53,9 +54,23 @@ function LayoutInner() {
 
   const sidebarW = sidebarExpanded ? '280px' : '80px'
   const isChatHub = location.pathname.startsWith('/chat')
+  const naListaTickets = location.pathname === '/tickets' || location.pathname === '/tickets/'
+  const [ticketDetalheAberto, setTicketDetalheAberto] = useState(
+    () => naListaTickets && lerTicketAtivoSession() != null,
+  )
+  useEffect(() => {
+    const sync = () => {
+      const naLista = location.pathname === '/tickets' || location.pathname === '/tickets/'
+      setTicketDetalheAberto(naLista && lerTicketAtivoSession() != null)
+    }
+    sync()
+    window.addEventListener(TICKET_ATIVO_EVENT, sync)
+    return () => window.removeEventListener(TICKET_ATIVO_EVENT, sync)
+  }, [location.pathname])
   const scrollInternoNaPagina =
     /^\/tickets\/\d+\/?$/.test(location.pathname) ||
     location.pathname === '/tickets/novo' ||
+    ticketDetalheAberto ||
     isChatHub
 
   return (

--- a/frontend/src/components/TicketsTabelaContexto.tsx
+++ b/frontend/src/components/TicketsTabelaContexto.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import type { Tickets } from '../api/client'
 import { exibirProtocolo } from '../lib/exibirProtocolo'
+import { marcarTicketAtivo, TICKETS_PATH } from '../lib/ticketAtivo'
 import { Button } from './ui/Button'
 import { IconEye } from './ui/IconEye'
 
@@ -81,7 +82,11 @@ export function TicketsTabelaContexto({
                 {t.atendente_nome ?? '—'}
               </td>
               <td className="px-4 py-3 text-right sm:px-6">
-                <Link to={`/tickets/${t.id}`} aria-label={`Ver ticket ${exibirProtocolo(t.protocolo)}`}>
+                <Link
+                  to={TICKETS_PATH}
+                  onClick={() => marcarTicketAtivo(t.id)}
+                  aria-label={`Ver ticket ${exibirProtocolo(t.protocolo)}`}
+                >
                   <Button
                     type="button"
                     variant="ghost"

--- a/frontend/src/components/chat-interno/ChatInternoLista.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoLista.tsx
@@ -1,19 +1,17 @@
 import { useMemo, useState } from 'react'
-import { Link, useMatch } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { Button } from '../ui/Button'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { useChatInterno } from '../../contexts/ChatInternoContext'
 import { formatarHoraRelativa, previewTexto } from '../../lib/chatInternoUtils'
-import { chatInternoLink } from '../../lib/chatHubPaths'
+import { CHAT_HUB_PATHS, chatAtivoIgual } from '../../lib/chatHubPaths'
 import { ChatInternoNovaConversaModal } from './ChatInternoNovaConversaModal'
 import { CHAT_INTERNO_FILTRO_VAZIO, ChatInternoFiltroTipo } from './ChatInternoFiltroTipo'
 
 export function ChatInternoLista() {
   const { filtradas, filtro, loading, erro, carregar } = useChatInterno()
-  const { busca } = useChatHub()
+  const { busca, chatAtivo, abrirChat } = useChatHub()
   const [modalAberto, setModalAberto] = useState(false)
-  const match = useMatch('/chat/interno/:conversaId')
-  const conversaAtivaId = match?.params.conversaId ? Number(match.params.conversaId) : null
 
   const lista = useMemo(() => {
     const q = busca.trim().toLowerCase()
@@ -54,11 +52,12 @@ export function ChatInternoLista() {
         ) : (
           <ul className="divide-y divide-slate-100 dark:divide-slate-800">
             {lista.map((c) => {
-              const ativa = conversaAtivaId === c.id
+              const ativa = chatAtivoIgual(chatAtivo, 'interno', c.id)
               return (
                 <li key={c.id}>
                   <Link
-                    to={chatInternoLink(c.id)}
+                    to={CHAT_HUB_PATHS.interno}
+                    onClick={() => abrirChat('interno', c.id)}
                     className={`flex gap-3 px-3 py-3 transition-colors hover:bg-slate-50 dark:hover:bg-slate-900/50 ${
                       ativa ? 'bg-cyan-50/80 dark:bg-cyan-950/30' : ''
                     }`}

--- a/frontend/src/components/chat-interno/ChatInternoNovaConversaModal.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoNovaConversaModal.tsx
@@ -7,6 +7,7 @@ import { useChatInterno } from '../../contexts/ChatInternoContext'
 import { Button } from '../ui/Button'
 import { INPUT_FIELD_CLASS } from '../ui/Input'
 import { useToast } from '../ui/Toast'
+import { chatInternoLink } from '../../lib/chatHubPaths'
 import { MODAL_OVERLAY, MODAL_PANEL_COMPACT } from '../../lib/modalPanel'
 
 type Props = {
@@ -67,7 +68,7 @@ export function ChatInternoNovaConversaModal({ open, onClose }: Props) {
       const conv = await chatInterno.criarDireta(atendenteId)
       onClose()
       await carregar(true)
-      navigate(`/chat/interno/${conv.id}`)
+      navigate(chatInternoLink(conv.id))
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível iniciar a conversa.'))
     } finally {
@@ -83,7 +84,7 @@ export function ChatInternoNovaConversaModal({ open, onClose }: Props) {
       const conv = await chatInterno.criarGrupo(titulo, selecionados)
       onClose()
       await carregar(true)
-      navigate(`/chat/interno/${conv.id}`)
+      navigate(chatInternoLink(conv.id))
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível criar o grupo.'))
     } finally {

--- a/frontend/src/components/chat/ChatFilaAguardandoSheet.tsx
+++ b/frontend/src/components/chat/ChatFilaAguardandoSheet.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ChatListaEspera } from '../../pages/chat/ChatListaEspera'
+import { chatPortalLink, chatWhatsappLink } from '../../lib/chatHubPaths'
 import { ChatFilaSomToggle } from './ChatFilaSomToggle'
 
 type Props = {
@@ -65,7 +66,11 @@ export function ChatFilaAguardandoSheet({ open, onClose }: Props) {
           <ChatListaEspera
             ignorarBusca
             onChatAssumido={(canal, chatId) => {
-              navigate(canal === 'portal' ? `/chat/portal/${chatId}` : `/chat/c/${chatId}`)
+              navigate(
+                canal === 'portal'
+                  ? chatPortalLink(chatId, 'atendendo')
+                  : chatWhatsappLink(chatId, 'atendendo'),
+              )
               onClose()
             }}
             onVerChat={onClose}

--- a/frontend/src/components/dashboard/DashboardDemandasAnalise.tsx
+++ b/frontend/src/components/dashboard/DashboardDemandasAnalise.tsx
@@ -17,6 +17,8 @@ import { Card } from '../ui/Card'
 import { barClickableProps, chartTooltipProps } from './dashboardChartUtils'
 import { corDrill } from './useDashboardDrilldown'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
+import { CHAT_HUB_PATHS } from '../../lib/chatHubPaths'
+import { marcarWhatsappChatAtivo } from '../../lib/whatsappListReturn'
 
 type FiltroDemanda = {
   naturezaId: number | null
@@ -341,7 +343,8 @@ export function DashboardDemandasAnalise({
                   <li key={item.demanda_id} className="flex flex-wrap items-center justify-between gap-2 py-2.5 text-sm">
                     <div className="min-w-0">
                       <Link
-                        to={`/chat/c/${item.chat_id}`}
+                        to={CHAT_HUB_PATHS.atendendo}
+                        onClick={() => marcarWhatsappChatAtivo(item.chat_id)}
                         className="font-medium text-cyan-700 hover:text-cyan-800 dark:text-cyan-400"
                       >
                         {exibirProtocolo(item.protocolo)}

--- a/frontend/src/components/tickets/TicketFilhosMassaPanel.tsx
+++ b/frontend/src/components/tickets/TicketFilhosMassaPanel.tsx
@@ -6,6 +6,7 @@ import { CheckboxField } from '../ui/CheckboxField'
 import { Input } from '../ui/Input'
 import { useToast } from '../ui/Toast'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
+import { marcarTicketAtivo, TICKETS_PATH } from '../../lib/ticketAtivo'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 
 interface Props {
@@ -174,7 +175,8 @@ export function TicketFilhosMassaPanel({ ticketId, disabled, onCriados }: Props)
           {ultimosCriados.map((c) => (
             <li key={c.id}>
               <Link
-                to={`/tickets/${c.id}`}
+                to={TICKETS_PATH}
+                onClick={() => marcarTicketAtivo(c.id)}
                 className="font-medium text-emerald-800 underline hover:text-emerald-950 dark:text-emerald-300 dark:hover:text-emerald-200"
               >
                 {exibirProtocolo(c.protocolo)}

--- a/frontend/src/contexts/ChatHubContext.tsx
+++ b/frontend/src/contexts/ChatHubContext.tsx
@@ -1,150 +1,114 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
-
+import { useLocation } from 'react-router-dom'
 import { portalChats, whatsappChats } from '../api/client'
-
+import {
+  gravarChatAtivoSession,
+  lerChatAtivoSession,
+  type ChatAtivo,
+  type ChatAtivoCanal,
+} from '../lib/chatAtivo'
 import { useEventStream } from './EventStreamContext'
 
-
-
 type ChatHubContextValue = {
-
   busca: string
-
   setBusca: (v: string) => void
-
   filaCount: number
-
   atendendoCount: number
-
   refreshContagens: () => Promise<void>
-
+  /** Conversa aberta no painel (sem id na URL) (#654). */
+  chatAtivo: ChatAtivo | null
+  abrirChat: (canal: ChatAtivoCanal, id: number) => void
+  fecharChat: () => void
 }
-
-
 
 const ChatHubContext = createContext<ChatHubContextValue | null>(null)
 
-
-
 export function ChatHubProvider({ children }: { children: ReactNode }) {
-
   const { subscribe, useFallback } = useEventStream()
-
+  const location = useLocation()
   const [busca, setBusca] = useState('')
-
   const [filaCount, setFilaCount] = useState(0)
-
   const [atendendoCount, setAtendendoCount] = useState(0)
+  const [chatAtivo, setChatAtivo] = useState<ChatAtivo | null>(() => lerChatAtivoSession())
 
-
-
-  const refreshContagens = useCallback(async () => {
-
-    try {
-
-      const [fila, meus, portalFila, portalMeus] = await Promise.all([
-
-        whatsappChats.fila(),
-
-        whatsappChats.meus(),
-
-        portalChats.fila(),
-
-        portalChats.meus(),
-
-      ])
-
-      setFilaCount(fila.length + portalFila.length)
-
-      setAtendendoCount(meus.length + portalMeus.length)
-
-    } catch {
-
-      /* silencioso — badges são auxiliares */
-
-    }
-
+  const abrirChat = useCallback((canal: ChatAtivoCanal, id: number) => {
+    if (!Number.isFinite(id) || id <= 0) return
+    const next = { canal, id }
+    gravarChatAtivoSession(next)
+    setChatAtivo(next)
   }, [])
 
+  const fecharChat = useCallback(() => {
+    gravarChatAtivoSession(null)
+    setChatAtivo(null)
+  }, [])
 
+  /** Sync após navigate com `chatWhatsappLink` (grava sessão antes do path) (#654). */
+  useEffect(() => {
+    if (!location.pathname.startsWith('/chat')) return
+    setChatAtivo(lerChatAtivoSession())
+  }, [location.pathname, location.key])
+
+  const refreshContagens = useCallback(async () => {
+    try {
+      const [fila, meus, portalFila, portalMeus] = await Promise.all([
+        whatsappChats.fila(),
+        whatsappChats.meus(),
+        portalChats.fila(),
+        portalChats.meus(),
+      ])
+      setFilaCount(fila.length + portalFila.length)
+      setAtendendoCount(meus.length + portalMeus.length)
+    } catch {
+      /* silencioso — badges são auxiliares */
+    }
+  }, [])
 
   useEffect(() => {
-
     void refreshContagens()
-
     const intervalMs = useFallback ? 12_000 : 8_000
-
     const timer = setInterval(() => void refreshContagens(), intervalMs)
-
     return () => clearInterval(timer)
-
   }, [refreshContagens, useFallback])
 
-
-
   useEffect(() => {
-
     const refresh = () => void refreshContagens()
-
     const u1 = subscribe('chat.fila', refresh)
-
     const u2 = subscribe('chat.mensagem', refresh)
-
     const u3 = subscribe('portal.chat.fila', refresh)
-
     const u4 = subscribe('portal.chat.mensagem', refresh)
-
     return () => {
-
       u1()
-
       u2()
-
       u3()
-
       u4()
-
     }
-
   }, [subscribe, refreshContagens])
 
-
-
   const value = useMemo(
-
     () => ({
-
       busca,
-
       setBusca,
-
       filaCount,
-
       atendendoCount,
-
       refreshContagens,
-
+      chatAtivo,
+      abrirChat,
+      fecharChat,
     }),
-
-    [busca, filaCount, atendendoCount, refreshContagens],
-
+    [busca, filaCount, atendendoCount, refreshContagens, chatAtivo, abrirChat, fecharChat],
   )
 
-
-
   return <ChatHubContext.Provider value={value}>{children}</ChatHubContext.Provider>
-
 }
-
-
 
 export function useChatHub() {
-
   const ctx = useContext(ChatHubContext)
-
   if (!ctx) throw new Error('useChatHub deve ser usado dentro de ChatHubProvider')
-
   return ctx
-
 }
 
+/** Para telas que também rodam fora do hub (ex.: histórico WhatsApp). */
+export function useChatHubOpcional() {
+  return useContext(ChatHubContext)
+}

--- a/frontend/src/hooks/useWhatsappVoltarLista.ts
+++ b/frontend/src/hooks/useWhatsappVoltarLista.ts
@@ -1,10 +1,16 @@
 import { useCallback } from 'react'
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom'
 
-import { resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../lib/whatsappListReturn'
+import { useChatHubOpcional } from '../contexts/ChatHubContext'
+import { CHAT_HUB_PATHS } from '../lib/chatHubPaths'
+import {
+  resolveWhatsappListFallback,
+  WHATSAPP_LIST_PATHS,
+  type WhatsappListReturnState,
+} from '../lib/whatsappListReturn'
 
 type VoltarListaApi = {
-  /** Botão Voltar (#449): history.back no SPA quando possível; senão lista segura. */
+  /** Botão Voltar: fecha o painel; se veio de Histórico/etc., regressa a essa lista. */
   voltarLista: () => void
   /**
    * Esc / sair sem percorrer pilha de chats (#653): sempre lista de origem
@@ -13,28 +19,43 @@ type VoltarListaApi = {
   sairParaListaSegura: () => void
 }
 
+function estaNaAbaDoHub(pathname: string): boolean {
+  return (Object.values(CHAT_HUB_PATHS) as string[]).some(
+    (p) => pathname === p || pathname.startsWith(`${p}/`),
+  )
+}
+
 /**
  * Navegação de saída da conversa WhatsApp.
- * Voltar UI pode usar histórico; Esc deve ir à lista segura (#653).
+ * Com URL fixa (#654) o pathname já é a aba: Voltar só fecha o painel, senão
+ * o history.back saía do módulo chat.
  */
 export function useWhatsappVoltarLista(fallbackPath = WHATSAPP_LIST_PATHS.atendendo): VoltarListaApi {
   const navigate = useNavigate()
   const location = useLocation()
   const [searchParams] = useSearchParams()
+  const hub = useChatHubOpcional()
+  const fecharChat = hub?.fecharChat
 
   const sairParaListaSegura = useCallback(() => {
-    navigate(
-      resolveWhatsappListFallback(location.state, searchParams.get('from'), fallbackPath),
-    )
-  }, [navigate, location.state, searchParams, fallbackPath])
-
-  const voltarLista = useCallback(() => {
-    if (typeof window !== 'undefined' && window.history.length > 1) {
-      navigate(-1)
+    fecharChat?.()
+    const destino = resolveWhatsappListFallback(location.state, searchParams.get('from'), fallbackPath)
+    if (destino === location.pathname || (estaNaAbaDoHub(location.pathname) && destino.startsWith('/chat/'))) {
       return
     }
+    navigate(destino)
+  }, [fecharChat, navigate, location.state, location.pathname, searchParams, fallbackPath])
+
+  const voltarLista = useCallback(() => {
+    fecharChat?.()
+    const returnPath = (location.state as WhatsappListReturnState | null)?.whatsappListReturn?.trim()
+    if (returnPath && returnPath !== location.pathname) {
+      navigate(returnPath)
+      return
+    }
+    if (estaNaAbaDoHub(location.pathname)) return
     sairParaListaSegura()
-  }, [navigate, sairParaListaSegura])
+  }, [fecharChat, location.pathname, location.state, navigate, sairParaListaSegura])
 
   return { voltarLista, sairParaListaSegura }
 }

--- a/frontend/src/lib/chatAtivo.ts
+++ b/frontend/src/lib/chatAtivo.ts
@@ -1,0 +1,41 @@
+/** Chat ativo na mesa — só estado/API, sem id na URL do browser (#654). */
+
+export type ChatAtivoCanal = 'whatsapp' | 'portal' | 'interno'
+
+export type ChatAtivo = {
+  canal: ChatAtivoCanal
+  id: number
+}
+
+export const CHAT_ATIVO_SESSION_KEY = 'deskrudder-chat-ativo'
+
+export function lerChatAtivoSession(): ChatAtivo | null {
+  try {
+    const raw = sessionStorage.getItem(CHAT_ATIVO_SESSION_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<ChatAtivo>
+    if (
+      (parsed.canal === 'whatsapp' || parsed.canal === 'portal' || parsed.canal === 'interno') &&
+      typeof parsed.id === 'number' &&
+      Number.isFinite(parsed.id) &&
+      parsed.id > 0
+    ) {
+      return { canal: parsed.canal, id: parsed.id }
+    }
+  } catch {
+    /* ignore */
+  }
+  return null
+}
+
+export function gravarChatAtivoSession(ativo: ChatAtivo | null): void {
+  try {
+    if (!ativo) {
+      sessionStorage.removeItem(CHAT_ATIVO_SESSION_KEY)
+      return
+    }
+    sessionStorage.setItem(CHAT_ATIVO_SESSION_KEY, JSON.stringify(ativo))
+  } catch {
+    /* ignore */
+  }
+}

--- a/frontend/src/lib/chatHubLista.ts
+++ b/frontend/src/lib/chatHubLista.ts
@@ -1,5 +1,5 @@
 import type { PortalChats, WhatsappChats } from '../api/client'
-import { chatPortalLink, chatWhatsappLink, type ChatHubModo } from './chatHubPaths'
+import { chatHubPathParaModo, type ChatHubModo } from './chatHubPaths'
 import { rotuloResponsavelChat } from './whatsappChatMeta'
 
 export type ChatHubCanal = 'whatsapp' | 'portal'
@@ -54,11 +54,11 @@ export function mapPortalChat(c: PortalChats.Chat): ChatHubItem {
   }
 }
 
-export function chatHubItemLink(item: ChatHubItem, from?: ChatHubModo) {
-  if (item.canal === 'portal') {
-    return chatPortalLink(item.id, from === 'espera' ? 'espera' : undefined)
-  }
-  return chatWhatsappLink(item.id, from === 'espera' ? 'espera' : 'atendendo')
+/** Só o path da aba — gravar chat ativo no onClick via `abrirChat` (#654). */
+export function chatHubItemLink(from?: ChatHubModo) {
+  const modo: ChatHubModo =
+    from === 'espera' ? 'espera' : from === 'contatos' ? 'contatos' : 'atendendo'
+  return { pathname: chatHubPathParaModo(modo), search: '' }
 }
 
 export function chatHubItemKey(item: ChatHubItem) {

--- a/frontend/src/lib/chatHubPaths.ts
+++ b/frontend/src/lib/chatHubPaths.ts
@@ -1,3 +1,5 @@
+import { gravarChatAtivoSession, type ChatAtivoCanal } from './chatAtivo'
+
 export const CHAT_HUB_PATHS = {
   atendendo: '/chat/atendendo',
   espera: '/chat/espera',
@@ -7,7 +9,18 @@ export const CHAT_HUB_PATHS = {
 
 export type ChatHubModo = keyof typeof CHAT_HUB_PATHS
 
-/** `search` opcional (ex. `?from=espera`) — ao visualizar chat da fila, mantém modo Aguardando (#625). */
+/** Path da aba do hub — sem id de conversa (#654). */
+export function chatHubPathParaModo(from?: ChatHubModo | null): string {
+  if (from === 'espera') return CHAT_HUB_PATHS.espera
+  if (from === 'contatos') return CHAT_HUB_PATHS.contatos
+  if (from === 'interno') return CHAT_HUB_PATHS.interno
+  return CHAT_HUB_PATHS.atendendo
+}
+
+/**
+ * Modo da aba a partir do path.
+ * `?from=` em rotas legadas `/chat/c/:id` ainda é lido nos redirects.
+ */
 export function chatHubModoDePath(pathname: string, search?: string): ChatHubModo {
   if (pathname.startsWith('/chat/interno') || pathname === CHAT_HUB_PATHS.interno) return 'interno'
   if (pathname.startsWith('/chat/espera')) return 'espera'
@@ -15,29 +28,41 @@ export function chatHubModoDePath(pathname: string, search?: string): ChatHubMod
   const from = search
     ? new URLSearchParams(search.startsWith('?') ? search.slice(1) : search).get('from')
     : null
-  if (
-    from === 'espera' &&
-    (pathname.startsWith('/chat/c/') || pathname.startsWith('/chat/portal/'))
-  ) {
-    return 'espera'
-  }
+  if (from === 'espera') return 'espera'
+  if (from === 'contatos') return 'contatos'
+  if (from === 'interno') return 'interno'
   return 'atendendo'
 }
 
+/**
+ * Abre WhatsApp no hub: grava id na sessão e devolve path estável (#654).
+ * Chamar no click / navigate (não em render de lista).
+ */
 export function chatWhatsappLink(chatId: number, from?: ChatHubModo) {
+  gravarChatAtivoSession({ canal: 'whatsapp', id: chatId })
   return {
-    pathname: `/chat/c/${chatId}`,
-    search: from ? `?from=${from}` : '',
+    pathname: chatHubPathParaModo(from),
+    search: '',
   }
 }
 
 export function chatPortalLink(chatId: number, from?: ChatHubModo) {
+  gravarChatAtivoSession({ canal: 'portal', id: chatId })
   return {
-    pathname: `/chat/portal/${chatId}`,
-    search: from ? `?from=${from}` : '',
+    pathname: chatHubPathParaModo(from === 'espera' ? 'espera' : 'atendendo'),
+    search: '',
   }
 }
 
 export function chatInternoLink(conversaId: number) {
-  return `/chat/interno/${conversaId}`
+  gravarChatAtivoSession({ canal: 'interno', id: conversaId })
+  return CHAT_HUB_PATHS.interno
+}
+
+export function chatAtivoIgual(
+  ativo: { canal: ChatAtivoCanal; id: number } | null | undefined,
+  canal: ChatAtivoCanal,
+  id: number,
+): boolean {
+  return Boolean(ativo && ativo.canal === canal && ativo.id === id)
 }

--- a/frontend/src/lib/ticketAtivo.ts
+++ b/frontend/src/lib/ticketAtivo.ts
@@ -1,0 +1,56 @@
+/** Ticket aberto na listagem — sem id na URL do browser (#655). */
+
+import { useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+export const TICKETS_PATH = '/tickets'
+
+export const TICKET_ATIVO_SESSION_KEY = 'deskrudder-ticket-ativo'
+
+export function lerTicketAtivoSession(): number | null {
+  try {
+    const raw = sessionStorage.getItem(TICKET_ATIVO_SESSION_KEY)
+    if (!raw) return null
+    const id = Number(raw)
+    return Number.isFinite(id) && id > 0 ? id : null
+  } catch {
+    return null
+  }
+}
+
+export function gravarTicketAtivoSession(id: number | null): void {
+  try {
+    if (id == null || !Number.isFinite(id) || id <= 0) {
+      sessionStorage.removeItem(TICKET_ATIVO_SESSION_KEY)
+    } else {
+      sessionStorage.setItem(TICKET_ATIVO_SESSION_KEY, String(id))
+    }
+  } catch {
+    /* quota / modo privado */
+  }
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(TICKET_ATIVO_EVENT))
+  }
+}
+
+export const TICKET_ATIVO_EVENT = 'deskrudder-ticket-ativo'
+
+/**
+ * Marca o ticket como aberto antes de navegar. Usar no `onClick` do link —
+ * nunca no render da lista.
+ */
+export function marcarTicketAtivo(id: number): void {
+  gravarTicketAtivoSession(id)
+}
+
+/** Abre o ticket na listagem: guarda o id e mantém a URL em `/tickets`. */
+export function useAbrirTicket() {
+  const navigate = useNavigate()
+  return useCallback(
+    (id: number) => {
+      gravarTicketAtivoSession(id)
+      navigate(TICKETS_PATH)
+    },
+    [navigate],
+  )
+}

--- a/frontend/src/lib/whatsappListReturn.ts
+++ b/frontend/src/lib/whatsappListReturn.ts
@@ -1,3 +1,5 @@
+import { gravarChatAtivoSession } from './chatAtivo'
+
 export const WHATSAPP_LIST_PATHS = {
   atendendo: '/chat/atendendo',
   historico: '/whatsapp/historico',
@@ -41,9 +43,18 @@ export function whatsappConversaState(returnPath: string): WhatsappListReturnSta
   return { whatsappListReturn: returnPath }
 }
 
-export function whatsappConversaLink(chatId: number, returnPath: string, from?: WhatsappListOrigin) {
+/**
+ * Marca a conversa como ativa na mesa. Chamar no `onClick` do link — nunca no
+ * render da lista, senão o último item renderizado ganharia o painel (#654).
+ */
+export function marcarWhatsappChatAtivo(chatId: number): void {
+  gravarChatAtivoSession({ canal: 'whatsapp', id: chatId })
+}
+
+/** Aba fixa do hub + caminho de retorno; o id da conversa vai na sessão (#654). */
+export function whatsappConversaLink(returnPath: string, from?: WhatsappListOrigin) {
   return {
-    pathname: `/chat/c/${chatId}`,
+    pathname: WHATSAPP_LIST_PATHS.atendendo,
     search: from ? `?from=${from}` : '',
     state: whatsappConversaState(returnPath),
   }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -10,6 +10,9 @@ import { useToast } from '../components/ui/Toast'
 import { SemPermissao } from './SemPermissao'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { exibirProtocolo } from '../lib/exibirProtocolo'
+import { CHAT_HUB_PATHS } from '../lib/chatHubPaths'
+import { marcarTicketAtivo, TICKETS_PATH } from '../lib/ticketAtivo'
+import { marcarWhatsappChatAtivo } from '../lib/whatsappListReturn'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { DashboardCanalComparativo, snapshotFromGeral } from '../components/dashboard/DashboardCanalComparativo'
 import { DashboardNav } from '../components/dashboard/DashboardNav'
@@ -390,7 +393,8 @@ export function Dashboard() {
                     <td className="py-3 pr-4">{t.status_nome ?? t.status_id}</td>
                     <td className="py-3">
                       <Link
-                        to={`/tickets/${t.id}`}
+                        to={TICKETS_PATH}
+                        onClick={() => marcarTicketAtivo(t.id)}
                         aria-label="Ver ticket"
                         className="inline-flex shrink-0"
                       >
@@ -437,7 +441,10 @@ export function Dashboard() {
                       <td className="py-3 pr-4">{c.cliente_nome ?? '—'}</td>
                       <td className="py-3 pr-4">{rotuloEstadoChat(c.estado)}</td>
                       <td className="py-3">
-                        <Link to={`/chat/c/${c.id}`}>
+                        <Link
+                          to={CHAT_HUB_PATHS.atendendo}
+                          onClick={() => marcarWhatsappChatAtivo(c.id)}
+                        >
                           <Button type="button" variant="ghost" className="text-sm">
                             Abrir
                           </Button>

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { ApiError, funcionariosRede, redes, empresas, type FuncionariosRede, type Redes, type Empresas } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
@@ -30,6 +30,7 @@ export function FuncionarioRedeForm() {
   const navigate = useNavigate()
   const toast = useToast()
   const voltarAnterior = useVoltarAnterior('/funcionarios-rede')
+  const topoRef = useRef<HTMLDivElement>(null)
 
   const funcionarioId = id ? parseInt(id, 10) : NaN
   const isEdit = id != null
@@ -146,6 +147,17 @@ export function FuncionarioRedeForm() {
     }
   }, [id, isEdit, funcionarioId, toast, empresasList])
 
+  /** #685: após carregar, garantir topo visível no scroll do Layout (sem sticky a “roubar” o viewport). */
+  useEffect(() => {
+    if (loading) return
+    const root = topoRef.current
+    if (!root) return
+    const scrollParent = root.closest('.overflow-y-auto')
+    if (scrollParent instanceof HTMLElement) {
+      scrollParent.scrollTop = 0
+    }
+  }, [loading, id])
+
   const empresasDaRede = useMemo(
     () => empresasList.filter((em) => em.rede_id === Number(redeId) && (em.ativo || em.id === empresaId || empresaIds.includes(em.id))),
     [empresasList, redeId, empresaId, empresaIds],
@@ -259,7 +271,7 @@ export function FuncionarioRedeForm() {
   }
 
   return (
-    <div className="mx-auto max-w-5xl space-y-6 pb-10">
+    <div ref={topoRef} className="mx-auto max-w-5xl space-y-6 pb-10">
       <div className="flex items-center justify-between gap-3">
         <button
           type="button"
@@ -443,7 +455,7 @@ export function FuncionarioRedeForm() {
             </FormSection>
           </div>
 
-          <div className="sticky bottom-0 -mx-6 mt-6 border-t border-slate-200 bg-white px-6 py-4 dark:border-slate-800 dark:bg-slate-900">
+          <div className="mt-6 border-t border-slate-200 pt-4 dark:border-slate-800">
             <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
               <Button type="button" variant="secondary" onClick={voltarAnterior} className="w-full sm:w-auto">
                 Cancelar

--- a/frontend/src/pages/SemPermissao.tsx
+++ b/frontend/src/pages/SemPermissao.tsx
@@ -5,12 +5,17 @@ export function SemPermissao({
   detail = 'Se isso estiver incorreto, solicite ao administrador o ajuste de setor/perfil.',
   voltarPara = '/tickets',
   voltarLabel = 'Ver tickets',
+  onVoltar,
 }: {
   title?: string
   detail?: string
   voltarPara?: string
   voltarLabel?: string
+  /** Telas sem rota própria (ex.: ticket aberto na lista) voltam por estado. */
+  onVoltar?: () => void
 }) {
+  const classeVoltar =
+    'inline-flex rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800'
   return (
     <div className="mx-auto max-w-lg rounded-2xl border border-amber-200/80 bg-amber-50/90 p-6 text-amber-950 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
       <p className="text-sm font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-300">403 — Sem permissão</p>
@@ -23,12 +28,15 @@ export function SemPermissao({
         >
           Ir para o início
         </Link>
-        <Link
-          to={voltarPara}
-          className="inline-flex rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800"
-        >
-          {voltarLabel}
-        </Link>
+        {onVoltar ? (
+          <button type="button" onClick={onVoltar} className={classeVoltar}>
+            {voltarLabel}
+          </button>
+        ) : (
+          <Link to={voltarPara} className={classeVoltar}>
+            {voltarLabel}
+          </Link>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -34,6 +34,9 @@ import { SemPermissao } from './SemPermissao'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 import { exibirProtocolo } from '../lib/exibirProtocolo'
+import { CHAT_HUB_PATHS } from '../lib/chatHubPaths'
+import { marcarTicketAtivo, TICKETS_PATH } from '../lib/ticketAtivo'
+import { marcarWhatsappChatAtivo } from '../lib/whatsappListReturn'
 import { MODAL_PANEL_COMPACT, MODAL_PANEL_SCROLLABLE } from '../lib/modalPanel'
 import { autorRodapeMensagem, corpoMensagemEmailVisivel } from '../lib/ticketMensagemEmail'
 import { mensagemEmFilaEmail } from '../lib/ticketMensagemEmailOutbox'
@@ -199,10 +202,19 @@ function TicketCsatEstrelas({ nota }: { nota: number }) {
   )
 }
 
-export function TicketDetalhe() {
-  const { id } = useParams<{ id: string }>()
+type TicketDetalheProps = {
+  /** Ticket aberto pela listagem (sem id na URL) (#655). */
+  ticketIdProp?: number
+  /** Fechar o detalhe e voltar à lista quando aberto sem rota própria. */
+  onVoltar?: () => void
+}
+
+export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {}) {
+  const { id: idParam } = useParams<{ id: string }>()
+  const id = ticketIdProp != null ? String(ticketIdProp) : idParam
   const navigate = useNavigate()
-  const voltarAnterior = useVoltarAnterior('/tickets')
+  const voltarPadrao = useVoltarAnterior('/tickets')
+  const voltarAnterior = onVoltar ?? voltarPadrao
   const toast = useToast()
   const { isAdmin, user } = useAuth()
   const [atribuindo, setAtribuindo] = useState(false)
@@ -1232,6 +1244,7 @@ export function TicketDetalhe() {
           detail="Este chamado pertence a um setor fora do seu escopo. Se precisar, peça ao administrador para ajustar seus vínculos de setor."
           voltarPara="/tickets"
           voltarLabel="Voltar para Tickets"
+          onVoltar={onVoltar}
         />
       </div>
     )
@@ -1607,7 +1620,8 @@ export function TicketDetalhe() {
                 {chatsWhatsapp.map((c) => (
                   <Link
                     key={c.id}
-                    to={`/chat/c/${c.id}`}
+                    to={CHAT_HUB_PATHS.atendendo}
+                    onClick={() => marcarWhatsappChatAtivo(c.id)}
                     className="inline-flex rounded-full border border-slate-200 bg-slate-50 px-2 py-0.5 text-[10px] font-medium text-cyan-700 sm:text-xs dark:border-slate-800 dark:bg-slate-900/40 dark:text-cyan-400"
                   >
                     WA {exibirProtocolo(c.protocolo)}
@@ -1638,7 +1652,8 @@ export function TicketDetalhe() {
                     <p className="mt-0.5 text-slate-500 dark:text-slate-400">Nenhum.</p>
                   ) : (
                     <Link
-                      to={`/tickets/${ticket.parent_ticket_id}`}
+                      to={TICKETS_PATH}
+                      onClick={() => marcarTicketAtivo(ticket.parent_ticket_id as number)}
                       className="mt-0.5 inline-block font-medium text-cyan-700 underline hover:text-cyan-900 dark:text-cyan-400 dark:hover:text-cyan-300"
                     >
                       {ticket.parent
@@ -1656,7 +1671,8 @@ export function TicketDetalhe() {
                       {ticket.children.map((c) => (
                         <li key={c.id}>
                           <Link
-                            to={`/tickets/${c.id}`}
+                            to={TICKETS_PATH}
+                            onClick={() => marcarTicketAtivo(c.id)}
                             className="font-medium text-cyan-700 underline hover:text-cyan-900 dark:text-cyan-400 dark:hover:text-cyan-300"
                           >
                             {exibirProtocolo(c.protocolo)}
@@ -2118,9 +2134,12 @@ export function TicketDetalhe() {
                   ) : (
                     <div className="mt-2 flex flex-wrap items-center gap-2">
                       <Link
-                        to={`/tickets/${ticket.parent_ticket_id}`}
+                        to={TICKETS_PATH}
                         className="font-medium text-cyan-700 underline hover:text-cyan-900 dark:text-cyan-400 dark:hover:text-cyan-300"
-                        onClick={() => setModalGerirAberto(false)}
+                        onClick={() => {
+                          marcarTicketAtivo(ticket.parent_ticket_id as number)
+                          setModalGerirAberto(false)
+                        }}
                       >
                         {ticket.parent
                           ? `${exibirProtocolo(ticket.parent.protocolo)} — ${ticket.parent.assunto}`
@@ -2153,9 +2172,12 @@ export function TicketDetalhe() {
                         <li key={c.id} className="flex flex-wrap items-center justify-between gap-2 px-3 py-2">
                           <div className="min-w-0">
                             <Link
-                              to={`/tickets/${c.id}`}
+                              to={TICKETS_PATH}
                               className="font-medium text-cyan-700 underline hover:text-cyan-900 dark:text-cyan-400 dark:hover:text-cyan-300"
-                              onClick={() => setModalGerirAberto(false)}
+                              onClick={() => {
+                                marcarTicketAtivo(c.id)
+                                setModalGerirAberto(false)
+                              }}
                             >
                               {exibirProtocolo(c.protocolo)}
                             </Link>
@@ -2274,9 +2296,12 @@ export function TicketDetalhe() {
                           <div className="min-w-0">
                             <span className="text-xs font-medium text-slate-500 dark:text-slate-400">{v.rotulo}</span>
                             <Link
-                              to={`/tickets/${v.outro_ticket.id}`}
+                              to={TICKETS_PATH}
                               className="ml-2 font-medium text-cyan-700 underline hover:text-cyan-900 dark:text-cyan-400 dark:hover:text-cyan-300"
-                              onClick={() => setModalGerirAberto(false)}
+                              onClick={() => {
+                                marcarTicketAtivo(v.outro_ticket.id)
+                                setModalGerirAberto(false)
+                              }}
                             >
                               {exibirProtocolo(v.outro_ticket.protocolo)} — {v.outro_ticket.assunto}
                             </Link>

--- a/frontend/src/pages/TicketNovo.tsx
+++ b/frontend/src/pages/TicketNovo.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
-import { useNavigate, useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom'
 import { ApiError, tickets, empresas, setores, redes, type Empresas, type Setores, type Redes, type Tickets } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
@@ -15,13 +15,14 @@ import { CheckboxField } from '../components/ui/CheckboxField'
 import { SemPermissao } from './SemPermissao'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { PRIORIDADE_OPCOES, type PrioridadeTicket } from '../lib/ticketPrioridade'
+import { useAbrirTicket } from '../lib/ticketAtivo'
 const MAX_ANEXO_BYTES = 25 * 1024 * 1024
 const MAX_ANEXOS_COUNT = 10
 
 export function TicketNovo() {
   const { isAdmin } = useAuth()
   const toast = useToast()
-  const navigate = useNavigate()
+  const abrirTicket = useAbrirTicket()
   const [searchParams] = useSearchParams()
   const voltarAnterior = useVoltarAnterior('/tickets')
   const [forbidden, setForbidden] = useState(false)
@@ -223,7 +224,7 @@ export function TicketNovo() {
       } else {
         toast.showSuccess('Ticket criado.')
       }
-      navigate(`/tickets/${created.id}`)
+      abrirTicket(created.id)
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível localizar os dados para criar o ticket.'))
     } finally {

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useId, useCallback } from 'react'
-import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { Link, useLocation, useSearchParams } from 'react-router-dom'
 import {
   tickets,
   statusTicket,
@@ -27,6 +27,8 @@ import { exibirProtocolo } from '../lib/exibirProtocolo'
 import { rotuloPrioridade, classeBadgePrioridade } from '../lib/ticketPrioridade'
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { SlaBadge } from '../components/tickets/SlaBadge'
+import { TicketDetalhe } from './TicketDetalhe'
+import { gravarTicketAtivoSession, lerTicketAtivoSession } from '../lib/ticketAtivo'
 
 type ColunaOrdenacao =
   | 'protocolo'
@@ -107,11 +109,27 @@ function IndicadoresFilaTicket({ ticket, className = '' }: { ticket: Tickets.Tic
 }
 
 export function Tickets() {
-  const navigate = useNavigate()
+  const location = useLocation()
   const [searchParams, setSearchParams] = useSearchParams()
   const toast = useToast()
   const { isAdmin } = useAuth()
   const [forbidden, setForbidden] = useState(false)
+  /** Ticket aberto no lugar da lista — a URL continua `/tickets` (#655). */
+  const [ticketAtivoId, setTicketAtivoId] = useState<number | null>(() => lerTicketAtivoSession())
+
+  useEffect(() => {
+    setTicketAtivoId(lerTicketAtivoSession())
+  }, [location.key])
+
+  const abrirTicket = useCallback((id: number) => {
+    gravarTicketAtivoSession(id)
+    setTicketAtivoId(id)
+  }, [])
+
+  const fecharTicket = useCallback(() => {
+    gravarTicketAtivoSession(null)
+    setTicketAtivoId(null)
+  }, [])
 
   const situacao = useMemo<'abertos' | 'fechados'>(() => {
     const s = searchParams.get('situacao')
@@ -362,6 +380,10 @@ export function Tickets() {
     sortParamsEfetivos,
     toast,
   ])
+
+  if (ticketAtivoId != null) {
+    return <TicketDetalhe ticketIdProp={ticketAtivoId} onVoltar={fecharTicket} />
+  }
 
   if (forbidden) {
     return (
@@ -735,7 +757,7 @@ export function Tickets() {
                   <button
                     key={t.id}
                     type="button"
-                    onClick={() => navigate(`/tickets/${t.id}`)}
+                    onClick={() => abrirTicket(t.id)}
                     className={`w-full px-4 py-4 text-left transition-colors hover:bg-slate-50/80 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/40 dark:focus-visible:bg-slate-800/60 ${
                       proximoAuto
                         ? 'bg-amber-50/70 ring-1 ring-inset ring-amber-200/70 dark:bg-amber-950/25 dark:ring-amber-800/40'
@@ -945,11 +967,11 @@ export function Tickets() {
                     key={t.id}
                     role="button"
                     tabIndex={0}
-                    onClick={() => navigate(`/tickets/${t.id}`)}
+                    onClick={() => abrirTicket(t.id)}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault()
-                        navigate(`/tickets/${t.id}`)
+                        abrirTicket(t.id)
                       }
                     }}
                     className={`cursor-pointer transition-colors hover:bg-slate-50/90 focus:outline-none focus-visible:bg-slate-100/80 dark:hover:bg-white/50 dark:focus-visible:bg-slate-800/60 ${

--- a/frontend/src/pages/chat-interno/ChatInternoSetorCanal.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoSetorCanal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ApiError, chatInterno } from '../../api/client'
+import { chatInternoLink } from '../../lib/chatHubPaths'
 import { SemPermissao } from '../SemPermissao'
 
 export function ChatInternoSetorCanal() {
@@ -18,7 +19,7 @@ export function ChatInternoSetorCanal() {
     ;(async () => {
       try {
         const canal = await chatInterno.obterCanalSetor(setorId)
-        if (!cancelled) navigate(`/chat/interno/${canal.id}`, { replace: true })
+        if (!cancelled) navigate(chatInternoLink(canal.id), { replace: true })
       } catch (err) {
         if (!cancelled && err instanceof ApiError && err.status === 403) {
           setForbidden(true)

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState, type MouseEvent } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { ApiError, atendentes, chatInterno, type ChatInterno } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { ChatInternoComposerBar } from '../../components/chat-interno/ChatInternoComposerBar'
@@ -8,6 +8,7 @@ import { ChatInternoConteudoMensagem } from '../../components/chat-interno/ChatI
 import { ChatInternoMensagemAcoes } from '../../components/chat-interno/ChatInternoMensagemAcoes'
 import { ChatInternoReacoesBar } from '../../components/chat-interno/ChatInternoReacoesBar'
 import { MensagemRodapeMeta } from '../../components/chat/MensagemRodapeMeta'
+import { useChatHub } from '../../contexts/ChatHubContext'
 import { useChatInterno } from '../../contexts/ChatInternoContext'
 import { useToast } from '../../components/ui/Toast'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
@@ -39,13 +40,19 @@ function formatarHoraMensagem(iso: string): string {
   return d.toLocaleString('pt-BR', { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit' })
 }
 
-export function ChatInternoThread() {
+type ChatInternoThreadProps = {
+  /** Conversa aberta pelo hub (sem id na URL) (#654). */
+  conversaIdProp?: number
+}
+
+export function ChatInternoThread({ conversaIdProp }: ChatInternoThreadProps = {}) {
   const { conversaId: conversaIdParam } = useParams()
-  const conversaId = Number(conversaIdParam)
+  const conversaId = conversaIdProp ?? Number(conversaIdParam)
   const navigate = useNavigate()
   const toast = useToast()
   const { user } = useAuth()
   const { subscribe, useFallback } = useEventStream()
+  const { fecharChat } = useChatHub()
   const { obterConversa, carregar: refreshInbox } = useChatInterno()
 
   const meta = obterConversa(conversaId)
@@ -176,6 +183,7 @@ export function ChatInternoThread() {
 
   useEffect(() => {
     if (!Number.isFinite(conversaId) || conversaId <= 0) {
+      fecharChat()
       navigate('/chat/interno', { replace: true })
       return
     }
@@ -184,7 +192,7 @@ export function ChatInternoThread() {
     setTemMaisAntigas(false)
     setLoading(true)
     void carregar()
-  }, [conversaId, carregar, navigate])
+  }, [conversaId, carregar, navigate, fecharChat])
 
   useEffect(() => {
     if (loading || mensagens.length === 0 || initialScrollRestoredRef.current) return
@@ -396,6 +404,7 @@ export function ChatInternoThread() {
       setMensagens([])
       setTemMaisAntigas(false)
       void refreshInbox(true)
+      fecharChat()
       navigate('/chat/interno', { replace: true })
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível limpar a conversa.'))
@@ -512,15 +521,16 @@ export function ChatInternoThread() {
   return (
     <div className="relative flex h-full min-h-0 flex-col overflow-hidden">
       <header className="flex shrink-0 items-center gap-3 border-b border-slate-200 bg-white px-4 py-3 dark:border-slate-800 dark:bg-slate-900 md:px-6 lg:px-8">
-        <Link
-          to="/chat/interno"
+        <button
+          type="button"
+          onClick={fecharChat}
           className="rounded-lg p-2 text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800 md:hidden"
           aria-label="Voltar à lista"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
             <path d="M15 18l-6-6 6-6" />
           </svg>
-        </Link>
+        </button>
         <div
           className={`hidden h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white md:flex ${
             isSetor ? 'bg-amber-500' : isGrupo ? 'bg-violet-600' : 'bg-cyan-600'

--- a/frontend/src/pages/chat/ChatHubLayout.tsx
+++ b/frontend/src/pages/chat/ChatHubLayout.tsx
@@ -2,6 +2,7 @@ import { Outlet, useLocation } from 'react-router-dom'
 import { ChatHubTabs } from '../../components/chat/ChatHubTabs'
 import { ChatHubSearch } from '../../components/chat/ChatHubSearch'
 import { ChatInternoLista } from '../../components/chat-interno/ChatInternoLista'
+import { useChatHub } from '../../contexts/ChatHubContext'
 import { chatHubModoDePath } from '../../lib/chatHubPaths'
 import { ChatListaAtendendo } from './ChatListaAtendendo'
 import { ChatListaEspera } from './ChatListaEspera'
@@ -25,12 +26,10 @@ function ChatHubLista() {
 
 export function ChatHubLayout() {
   const { pathname, search } = useLocation()
+  const { chatAtivo } = useChatHub()
   const modo = chatHubModoDePath(pathname, search)
-  const emConversa =
-    /\/chat\/c\/\d+/.test(pathname) ||
-    /\/chat\/portal\/\d+/.test(pathname) ||
-    /\/chat\/interno\/\d+/.test(pathname) ||
-    /\/chat\/interno\/setor\/\d+/.test(pathname)
+  /** Conversa aberta vem do estado, não da URL (#654). */
+  const emConversa = Boolean(chatAtivo) || /\/chat\/interno\/setor\/\d+/.test(pathname)
 
   return (
     <div className="flex h-full min-h-0 w-full overflow-hidden bg-slate-50 dark:bg-slate-950">

--- a/frontend/src/pages/chat/ChatHubPainel.tsx
+++ b/frontend/src/pages/chat/ChatHubPainel.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react'
+import { WhatsappConversa } from '../whatsapp/WhatsappConversa'
+import { ChatInternoThread } from '../chat-interno/ChatInternoThread'
+import { useChatHub } from '../../contexts/ChatHubContext'
+import { PortalConversa } from './PortalConversa'
+
+type Props = {
+  placeholder: ReactNode
+}
+
+/** Painel direito do hub: conversa ativa via estado, sem id na URL (#654). */
+export function ChatHubPainel({ placeholder }: Props) {
+  const { chatAtivo } = useChatHub()
+  if (chatAtivo?.canal === 'whatsapp') {
+    return <WhatsappConversa chatIdProp={chatAtivo.id} />
+  }
+  if (chatAtivo?.canal === 'portal') {
+    return <PortalConversa chatIdProp={chatAtivo.id} />
+  }
+  if (chatAtivo?.canal === 'interno') {
+    return <ChatInternoThread conversaIdProp={chatAtivo.id} />
+  }
+  return <>{placeholder}</>
+}

--- a/frontend/src/pages/chat/ChatListaAtendendo.tsx
+++ b/frontend/src/pages/chat/ChatListaAtendendo.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState, type ReactNode } from 'react'
-import { Link, useMatch } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { portalChats, whatsappChats } from '../../api/client'
 import { ChatCanalBadge } from '../../components/chat/ChatCanalBadge'
 import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
@@ -51,6 +51,7 @@ function ChatAtendendoItem({
   variant: ItemVariant
   usuarioId?: number | null
 }) {
+  const { abrirChat } = useChatHub()
   const key = chatHubItemKey(item)
   const responsavel =
     item.atendente_nome?.trim() || (item.atendente_id != null ? `Atendente #${item.atendente_id}` : 'Sem responsável')
@@ -58,7 +59,8 @@ function ChatAtendendoItem({
   return (
     <li key={key}>
       <Link
-        to={chatHubItemLink(item, 'atendendo')}
+        to={chatHubItemLink('atendendo')}
+        onClick={() => abrirChat(item.canal, item.id)}
         className={`flex gap-3 px-3 py-3 transition-colors hover:bg-slate-50 dark:hover:bg-slate-900/50 ${
           ativo ? 'bg-cyan-50/80 dark:bg-cyan-950/30' : ''
         } ${variant === 'proprio' ? 'border-l-2 border-cyan-500 pl-[10px]' : ''} ${
@@ -115,18 +117,11 @@ function ChatAtendendoItem({
 
 export function ChatListaAtendendo() {
   const { user } = useAuth()
-  const { busca } = useChatHub()
+  const { busca, chatAtivo } = useChatHub()
   const { subscribe, useFallback } = useEventStream()
   const [meus, setMeus] = useState<ChatHubItem[]>([])
   const [loading, setLoading] = useState(true)
-  const matchWpp = useMatch('/chat/c/:chatId')
-  const matchPortal = useMatch('/chat/portal/:chatId')
-  const chatAtivoKey =
-    matchWpp?.params.chatId != null
-      ? `whatsapp-${matchWpp.params.chatId}`
-      : matchPortal?.params.chatId != null
-        ? `portal-${matchPortal.params.chatId}`
-        : null
+  const chatAtivoKey = chatAtivo ? `${chatAtivo.canal}-${chatAtivo.id}` : null
 
   const load = useCallback(async () => {
     try {

--- a/frontend/src/pages/chat/ChatListaEspera.tsx
+++ b/frontend/src/pages/chat/ChatListaEspera.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '../../contexts/AuthContext'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { useEventStream } from '../../contexts/EventStreamContext'
 import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
+import { chatAtivoIgual } from '../../lib/chatHubPaths'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import {
   chatHubItemKey,
@@ -57,7 +58,7 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
   const toast = useToast()
   const { user } = useAuth()
   const navigate = useNavigate()
-  const { busca, refreshContagens } = useChatHub()
+  const { busca, refreshContagens, chatAtivo, abrirChat } = useChatHub()
   const { subscribe, useFallback } = useEventStream()
   const [fila, setFila] = useState<ChatHubItem[]>([])
   const [loading, setLoading] = useState(true)
@@ -111,8 +112,9 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
       void refetchPendenciasResumo()
       if (onChatAssumido) {
         onChatAssumido(item.canal, item.id)
-      } else if (item.canal === 'portal') {
-        navigate(chatHubItemLink(item, 'atendendo'))
+      } else {
+        abrirChat(item.canal, item.id)
+        navigate(chatHubItemLink('atendendo'))
       }
     } catch (err) {
       const msg =
@@ -154,7 +156,12 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
     <>
     <ul className="divide-y divide-slate-100 dark:divide-slate-800">
       {lista.map((c) => (
-        <li key={chatHubItemKey(c)} className="px-3 py-3">
+        <li
+          key={chatHubItemKey(c)}
+          className={`px-3 py-3 ${
+            chatAtivoIgual(chatAtivo, c.canal, c.id) ? 'bg-cyan-50/80 dark:bg-cyan-950/30' : ''
+          }`}
+        >
           <div className="flex gap-3">
             <WhatsappAvatar
               nome={c.nome}
@@ -177,8 +184,11 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
               {c.setor_nome && <p className="text-[11px] text-slate-400">Setor {c.setor_nome}</p>}
               <div className="mt-2 flex gap-2">
                 <Link
-                  to={chatHubItemLink(c, 'espera')}
-                  onClick={() => onVerChat?.()}
+                  to={chatHubItemLink('espera')}
+                  onClick={() => {
+                    abrirChat(c.canal, c.id)
+                    onVerChat?.()
+                  }}
                   className="flex-1 rounded-lg border border-slate-200 py-1.5 text-center text-xs font-semibold text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
                 >
                   Ver

--- a/frontend/src/pages/chat/PortalConversa.tsx
+++ b/frontend/src/pages/chat/PortalConversa.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { ApiError, fetchPortalMidiaBlob, portalChats, type PortalChats } from '../../api/client'
 import { ChatCanalBadge } from '../../components/chat/ChatCanalBadge'
 import { ChatDemandasPanel } from '../../components/chat/ChatDemandasPanel'
@@ -58,16 +58,19 @@ function formatarHora(iso?: string | null) {
   })
 }
 
-export function PortalConversa() {
+type PortalConversaProps = {
+  /** Conversa aberta pelo hub (sem id na URL) (#654). */
+  chatIdProp?: number
+}
+
+export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
   const { chatId: chatIdParam } = useParams()
-  const chatId = Number(chatIdParam)
+  const chatId = chatIdProp ?? Number(chatIdParam)
   const navigate = useNavigate()
-  const [searchParams] = useSearchParams()
-  const fromEspera = searchParams.get('from') === 'espera'
   const toast = useToast()
   const { user } = useAuth()
   const { subscribe, useFallback } = useEventStream()
-  const { refreshContagens, filaCount } = useChatHub()
+  const { refreshContagens, filaCount, fecharChat } = useChatHub()
   const [chat, setChat] = useState<PortalChats.Chat | null>(null)
   const [mensagens, setMensagens] = useState<PortalChats.Mensagem[]>([])
   const [demandasTimeline, setDemandasTimeline] = useState<ChatDemanda[]>([])
@@ -300,6 +303,7 @@ export function PortalConversa() {
       void refetchPendenciasResumo()
       toast.showSuccess(mensagemTransferenciaSucesso(atualizado))
       if (atualizado.atendente_id !== user?.id && atualizado.estado === 'em_atendimento') {
+        fecharChat()
         navigate(CHAT_HUB_PATHS.atendendo)
       }
     } catch (err) {
@@ -318,6 +322,7 @@ export function PortalConversa() {
       return
     }
     toast.showSuccess('Atendimento encerrado.')
+    fecharChat()
     navigate(CHAT_HUB_PATHS.atendendo)
   }
 
@@ -344,12 +349,13 @@ export function PortalConversa() {
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-white dark:bg-slate-950">
       <header className="flex shrink-0 items-center justify-between gap-3 border-b border-slate-200 bg-white px-4 py-3 dark:border-slate-800 dark:bg-slate-950">
         <div className="min-w-0">
-          <Link
-            to={fromEspera ? CHAT_HUB_PATHS.espera : CHAT_HUB_PATHS.atendendo}
+          <button
+            type="button"
+            onClick={fecharChat}
             className="text-xs text-cyan-600 hover:underline md:hidden"
           >
             ← Voltar
-          </Link>
+          </button>
           <div className="mt-0.5 flex flex-wrap items-center gap-2">
             <h1 className="truncate text-base font-semibold text-slate-900 dark:text-slate-100">
               {chat.visitante_nome}

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { ApiError, whatsappChats, type WhatsappChats } from '../../api/client'
 import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsappSetorModal'
 import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
-import { whatsappConversaLink, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
+import { marcarWhatsappChatAtivo, whatsappConversaLink, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
 import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
 import { useAuth } from '../../contexts/AuthContext'
@@ -223,7 +223,8 @@ export function WhatsappAtendendo() {
 
                     <div className="flex items-center gap-2 border-t pt-3 dark:border-slate-800">
                       <Link
-                        to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
+                        to={whatsappConversaLink(WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
+                        onClick={() => marcarWhatsappChatAtivo(c.id)}
                         className="flex-1 rounded-lg bg-slate-100 py-2 text-center text-xs font-bold text-slate-600 transition-colors hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-300 dark:hover:bg-slate-700"
                       >
                         Visualizar
@@ -253,7 +254,8 @@ export function WhatsappAtendendo() {
                 {meusAClassificar.map((c) => (
                   <Link
                     key={c.id}
-                    to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
+                    to={whatsappConversaLink(WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
+                    onClick={() => marcarWhatsappChatAtivo(c.id)}
                     className="group"
                   >
                     <Card className="h-full border-none p-5 shadow-sm ring-1 ring-amber-300 transition-all group-hover:ring-amber-500 dark:ring-amber-800">
@@ -305,7 +307,8 @@ export function WhatsappAtendendo() {
                 meusAtivos.map((c) => (
                   <Link
                     key={c.id}
-                    to={whatsappConversaLink(c.id, WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
+                    to={whatsappConversaLink(WHATSAPP_LIST_PATHS.atendendo, 'atendendo')}
+                    onClick={() => marcarWhatsappChatAtivo(c.id)}
                     className="group"
                   >
                     <Card className="h-full border-none p-5 shadow-sm ring-1 ring-slate-200 transition-all group-hover:ring-cyan-500 dark:ring-slate-800">

--- a/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAvaliacoes.tsx
@@ -9,7 +9,12 @@ import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { rotuloAvaliacaoChat } from '../../lib/whatsappChatMeta'
-import { buildAvaliacoesReturnPath, saveWhatsappListScroll, whatsappConversaLink } from '../../lib/whatsappListReturn'
+import {
+  buildAvaliacoesReturnPath,
+  marcarWhatsappChatAtivo,
+  saveWhatsappListScroll,
+  whatsappConversaLink,
+} from '../../lib/whatsappListReturn'
 import { useWhatsappListScrollRestore } from '../../hooks/useWhatsappListScrollRestore'
 import { CheckboxField } from '../../components/ui/CheckboxField'
 
@@ -200,8 +205,11 @@ export function WhatsappAvaliacoes() {
                       : '—'}
                   </p>
                   <Link
-                    to={whatsappConversaLink(a.chat_id, avaliacoesReturnPath, 'avaliacoes')}
-                    onClick={() => saveWhatsappListScroll('avaliacoes', avaliacoesReturnPath)}
+                    to={whatsappConversaLink(avaliacoesReturnPath, 'avaliacoes')}
+                    onClick={() => {
+                      marcarWhatsappChatAtivo(a.chat_id)
+                      saveWhatsappListScroll('avaliacoes', avaliacoesReturnPath)
+                    }}
                     className="mt-1 inline-block text-xs font-medium text-cyan-600 hover:underline dark:text-cyan-400"
                   >
                     Ver conversa

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -67,11 +67,17 @@ import { ACCEPT_ANEXO, type TipoAnexoPicker } from './WhatsappBarraAnexos'
 import { WhatsappComposerBar } from './WhatsappComposerBar'
 import { WhatsappPreviaAnexo } from './WhatsappPreviaAnexo'
 import { useWhatsappVoltarLista } from '../../hooks/useWhatsappVoltarLista'
-import { whatsappConversaLink, resolveWhatsappListFallback, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
+import {
+  marcarWhatsappChatAtivo,
+  whatsappConversaLink,
+  resolveWhatsappListFallback,
+  WHATSAPP_LIST_PATHS,
+} from '../../lib/whatsappListReturn'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { ChatFilaAguardandoSheet } from '../../components/chat/ChatFilaAguardandoSheet'
 import { ChatFilaSomToggle } from '../../components/chat/ChatFilaSomToggle'
 import { chatWhatsappLink } from '../../lib/chatHubPaths'
+import { marcarTicketAtivo, TICKETS_PATH } from '../../lib/ticketAtivo'
 import { WhatsappInatividadeControle } from './WhatsappInatividadeControle'
 import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
 import { rotuloDownloadArquivo, visualTipoArquivo } from '../../lib/fileTypeIcon'
@@ -532,11 +538,16 @@ const WA_DETALHES_SESSION_KEY = 'deskrudder-wa-conversa-detalhes'
 
 // --- Componente Principal ---
 
-export function WhatsappConversa() {
+type WhatsappConversaProps = {
+  /** Conversa aberta pelo hub (sem id na URL) (#654). */
+  chatIdProp?: number
+}
+
+export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
 
   const { chatId } = useParams<{ chatId: string }>()
 
-  const id = Number(chatId)
+  const id = chatIdProp ?? Number(chatId)
 
   const toast = useToast()
 
@@ -1416,7 +1427,7 @@ useEffect(() => {
           ? `Este chat está com ${chat.atendente_nome || 'outro atendente'}.`
           : undefined
 
-  const modoHub = location.pathname.startsWith('/chat/c/')
+  const modoHub = chatIdProp != null || location.pathname.startsWith('/chat/')
 
   return (
 
@@ -1472,7 +1483,9 @@ useEffect(() => {
 
               key={c.id}
 
-              to={whatsappConversaLink(c.id, listaRetorno)}
+              to={whatsappConversaLink(listaRetorno)}
+
+              onClick={() => marcarWhatsappChatAtivo(c.id)}
 
               className={`flex items-center p-4 gap-3 transition-colors ${c.id === id ? 'bg-white shadow-sm dark:bg-slate-800' : 'hover:bg-white/40 dark:hover:bg-slate-900/50'}`}
 
@@ -1779,7 +1792,8 @@ useEffect(() => {
                 {ticketsVinculados.map((t) => (
                   <Link
                     key={t.id}
-                    to={`/tickets/${t.id}`}
+                    to={TICKETS_PATH}
+                    onClick={() => marcarTicketAtivo(t.id)}
                     className="inline-flex rounded-full border border-cyan-200/80 bg-cyan-50 px-2 py-0.5 text-[10px] font-medium text-cyan-800 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-300"
                     title={t.assunto}
                   >

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -10,7 +10,12 @@ import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { AvaliacaoEstrelas } from '../../components/ui/AvaliacaoEstrelas'
 import { rotuloEstadoChat } from '../../lib/whatsappChatMeta'
-import { buildHistoricoReturnPath, saveWhatsappListScroll, whatsappConversaLink } from '../../lib/whatsappListReturn'
+import {
+  buildHistoricoReturnPath,
+  marcarWhatsappChatAtivo,
+  saveWhatsappListScroll,
+  whatsappConversaLink,
+} from '../../lib/whatsappListReturn'
 import { useWhatsappListScrollRestore } from '../../hooks/useWhatsappListScrollRestore'
 import { ChatIniciarConversaModal } from '../../components/chat/ChatIniciarConversaModal'
 
@@ -275,8 +280,11 @@ export function WhatsappHistorico() {
                     </div>
 
                     <Link
-                      to={whatsappConversaLink(c.id, historicoReturnPath, 'historico')}
-                      onClick={() => saveWhatsappListScroll('historico', historicoReturnPath)}
+                      to={whatsappConversaLink(historicoReturnPath, 'historico')}
+                      onClick={() => {
+                        marcarWhatsappChatAtivo(c.id)
+                        saveWhatsappListScroll('historico', historicoReturnPath)
+                      }}
                       className="rounded-full bg-slate-100 p-2 text-slate-400 transition-all hover:bg-cyan-600 hover:text-white dark:bg-slate-800 dark:hover:bg-cyan-700"
                       title="Ver conversa"
                     >

--- a/frontend/src/pages/whatsapp/WhatsappTicketsModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappTicketsModal.tsx
@@ -22,6 +22,7 @@ import { SelectComPesquisa } from '../../components/ui/SelectComPesquisa'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
+import { marcarTicketAtivo, TICKETS_PATH } from '../../lib/ticketAtivo'
 
 type Modo = 'vincular' | 'abrir'
 
@@ -160,9 +161,12 @@ export function WhatsappTicketsModal({ chat, open, onClose, onSuccess }: Props) 
               {chat.ticket_ids.map((tid) => (
                 <Link
                   key={tid}
-                  to={`/tickets/${tid}`}
+                  to={TICKETS_PATH}
                   className="inline-flex rounded-full border border-cyan-200 bg-cyan-50 px-2.5 py-0.5 text-xs font-medium text-cyan-800 dark:border-cyan-800 dark:bg-cyan-950/40 dark:text-cyan-300"
-                  onClick={onClose}
+                  onClick={() => {
+                    marcarTicketAtivo(tid)
+                    onClose()
+                  }}
                 >
                   Ticket #{tid}
                 </Link>


### PR DESCRIPTION
## Summary

URLs estáveis no painel interno e correção de scroll no cadastro de funcionários:

- Mesa de chat (#654): conversa activa só em estado/`sessionStorage`; barra fica em `/chat/atendendo`, `/chat/espera`, `/chat/interno`. Rotas antigas (`/chat/c/:id`, `/whatsapp/c/:id`) redireccionam.
- Tickets (#655): detalhe sem id na barra (`/tickets`); lista preserva filtros ao voltar. `/tickets/:id` redirecciona.
- Funcionários (#685): formulário de criar/editar volta a mostrar o topo e a rolar até ao fim.

Closes #654, #655, #685

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest` — 551 passed, 1 skipped
- [x] `npm run build`
- [ ] Manual: abrir conversas A → B na mesa; URL permanece `/chat/...` sem id; F5 restaura o último da sessão; Esc/Voltar da UI fecha o painel sem sair do módulo
- [ ] Manual: abrir ticket na lista; URL `/tickets`; voltar mantém filtros; favorito `/tickets/123` abre o mesmo ticket
- [ ] Manual: `/funcionarios-rede/:id/editar` — título visível, scroll até Cancelar/Salvar, sem faixa vazia em baixo

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Fora de escopo → issues: #697 (hrefs de notificação/e-mail), #698 (helpers sem gravar sessão no render), #699 (Voltar nativo do browser), #700 (portal `/portal/tickets`)
- [x] Não há stubs/nullable pendentes neste lote
- [x] Follow-ups listados neste PR
