### PR TITLE
feat(notificacoes): URLs fixas no sininho e e-mail interno (#697, #698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - WhatsApp (#679): documentos mostram e descarregam com o **nome original** do ficheiro (envio e recebimento)
 - Chat (#654): a mesa de atendimento fica sempre no mesmo endereço (`/chat/atendendo`, `/chat/espera`, `/chat/interno`) — o número da conversa deixa de aparecer na barra do navegador e a conversa aberta continua no painel ao trocar de aba
 - Tickets (#655): abrir um chamado mantém o endereço `/tickets`, sem o número do ticket na barra do navegador; ao voltar, a lista preserva filtros e página
+- Notificações (#697): o sininho e o e-mail interno do painel já não põem o número do chamado ou da conversa no endereço; o clique abre o item certo na mesa ou em tickets
 
 #### Correções
 
 - Login (#677): em subdomínio do cliente, **Voltar ao site** abre a landing DeskRudder (apex) em vez de voltar ao próprio login
 - Funcionários da rede (#685): ao editar/criar, o formulário volta a mostrar o topo e a rolar até ao fim — sem espaço vazio abaixo dos botões nem conteúdo preso fora do ecrã
-- Links antigos (#654 / #655): endereços com número (chat da fila, conversa do WhatsApp, notificações de ticket) continuam a funcionar e abrem o item certo no novo formato
+- Links antigos (#654 / #655): endereços com número (chat da fila, conversa do WhatsApp, detalhe de ticket) continuam a funcionar e abrem o item certo no novo formato
+- Chat (#698): a mesa deixa de gravar a conversa aberta só por desenhar a lista — só o clique (ou o sininho) muda o painel
 - WhatsApp (#683): envio de mensagem/áudio/anexo já não mostra toast verde que cobria o botão de enviar (erros continuam)
 
 ### SaaS Control Plane

--- a/backend/app/api/notificacoes.py
+++ b/backend/app/api/notificacoes.py
@@ -309,7 +309,7 @@ def build_notificacao_itens(
                 titulo="Chats na fila",
                 descricao="WhatsApp — aguardando atendimento",
                 count=wpp_fila,
-                href="/whatsapp/atendendo",
+                href="/chat/espera",
                 created_at=datetime.now(timezone.utc),
             )
         )
@@ -339,10 +339,11 @@ def build_notificacao_itens(
             NotificacaoItem(
                 tipo="wpp_chats_com_resposta",
                 ticket_id=None,
+                chat_id=c.id,
                 titulo=f"{c.protocolo} — {nome}",
                 descricao="WhatsApp — cliente respondeu",
                 count=uc,
-                href=f"/whatsapp/c/{c.id}",
+                href="/chat/atendendo",
                 created_at=datetime.now(timezone.utc),
             )
         )
@@ -377,7 +378,7 @@ def build_notificacao_itens(
                 titulo=f"{t.protocolo} — {assunto[:80]}{'…' if len(assunto) > 80 else ''}",
                 descricao=descricao,
                 count=uc,
-                href=f"/tickets/{t.id}",
+                href="/tickets",
                 created_at=t.updated_at or t.created_at,
             )
         )
@@ -396,7 +397,7 @@ def build_notificacao_itens(
                 titulo=resumo.titulo,
                 descricao=descricao,
                 count=resumo.nao_lidas_count,
-                href=f"/chat/interno/{resumo.conversa.id}",
+                href="/chat/interno",
                 created_at=resumo.ultima_mensagem_em or resumo.conversa.created_at,
             )
         )

--- a/backend/app/schemas/notificacoes.py
+++ b/backend/app/schemas/notificacoes.py
@@ -42,6 +42,7 @@ class NotificacaoItem(BaseModel):
         "chat_interno",
     ]
     ticket_id: int | None = None
+    chat_id: int | None = None
     conversa_id: int | None = None
     titulo: str
     descricao: str

--- a/backend/app/services/notificacao_atendente_email.py
+++ b/backend/app/services/notificacao_atendente_email.py
@@ -38,9 +38,9 @@ def _debounce_minutes() -> int:
     return max(1, int(settings.NOTIFICACAO_EMAIL_DEBOUNCE_MINUTES))
 
 
-def _ticket_link(ticket_id: int) -> str:
+def _ticket_link() -> str:
     origin = _public_app_origin().rstrip("/")
-    return f"{origin}/tickets/{ticket_id}"
+    return f"{origin}/tickets"
 
 
 def obter_ou_criar_preferencias(db: Session, atendente_id: int) -> AtendenteNotificacaoPreferencias:
@@ -178,7 +178,7 @@ def notificar_ticket_atribuido(
     if not atendente:
         return
     proto = ticket.protocolo or str(ticket.id)
-    link = _ticket_link(ticket.id)
+    link = _ticket_link()
     subject = f"Chamado atribuído a você — {proto}"
     body = (
         f"Olá {atendente.nome},\n\n"
@@ -225,7 +225,7 @@ def notificar_nova_mensagem_ticket(
         return
 
     proto = ticket.protocolo or str(ticket.id)
-    link = _ticket_link(ticket.id)
+    link = _ticket_link()
     preview = (mensagem.corpo or "").strip().replace("\n", " ")[:200]
     if len((mensagem.corpo or "").strip()) > 200:
         preview += "…"
@@ -272,7 +272,7 @@ def notificar_sla_alerta_email(
     if ticket.fechado_em is not None:
         return
     proto = ticket.protocolo or str(ticket.id)
-    link = _ticket_link(ticket.id)
+    link = _ticket_link()
     tipo = TIPO_SLA_EM_RISCO if evento == "em_risco" else TIPO_SLA_VIOLADO
     subject = f"SLA {evento_label} — {proto} ({meta_label})"
     body = (

--- a/backend/tests/test_notificacoes_atendente.py
+++ b/backend/tests/test_notificacoes_atendente.py
@@ -57,6 +57,9 @@ def test_atribuicao_enfileira_email(client, seed_base, auth_headers, db_session)
     assert row is not None
     assert row.atendente_id == seed_base["a1"].id
     assert row.status == "pendente"
+    assert "Acesse:" in row.body
+    assert f"/tickets/{t['id']}" not in row.body
+    assert row.body.rstrip().endswith("/tickets")
 
 
 def test_atribuicao_respeita_preferencias(client, seed_base, auth_headers, db_session):

--- a/backend/tests/test_notificacoes_chat_interno.py
+++ b/backend/tests/test_notificacoes_chat_interno.py
@@ -32,7 +32,7 @@ def test_itens_chat_interno_link_conversa(db_session, seed_base):
     assert len(chat_itens) >= 1
     item = chat_itens[0]
     assert item.conversa_id == conversa.id
-    assert item.href == f"/chat/interno/{conversa.id}"
+    assert item.href == "/chat/interno"
     assert item.count >= 1
 
 

--- a/backend/tests/test_notificacoes_itens.py
+++ b/backend/tests/test_notificacoes_itens.py
@@ -65,7 +65,7 @@ def test_admin_nao_conta_nao_lidas_de_outro_responsavel(client, seed_base, auth_
 
 
 def test_itens_link_directo_por_ticket(client, seed_base, auth_headers, db_session, monkeypatch):
-    """Cada pendência de não-lida aponta para /tickets/{id}, nunca listagem genérica (#452)."""
+    """Cada pendência de não-lida aponta para /tickets + ticket_id (URL fixa, #697)."""
     _criar_ticket_com_mensagem(db_session, seed_base, atendente_id=seed_base["a1"].id)
 
     def fake_unread(db, ticket, atendente_id):
@@ -81,7 +81,8 @@ def test_itens_link_directo_por_ticket(client, seed_base, auth_headers, db_sessi
     assert len(ticket_itens) >= 1
     for item in ticket_itens:
         assert item.ticket_id is not None
-        assert item.href == f"/tickets/{item.ticket_id}"
+        assert item.href == "/tickets"
+        assert f"/tickets/{item.ticket_id}" not in item.href
         assert "situacao=abertos" not in item.href
 
 
@@ -91,9 +92,11 @@ def test_varios_tickets_nao_lidos_links_individuais(client, seed_base, auth_head
 
     itens = build_notificacao_itens(db_session, seed_base["a1"], limit=15)
     ticket_itens = [i for i in itens if i.tipo == "mensagens_nao_lidas"]
-    hrefs = {i.href for i in ticket_itens}
-    assert f"/tickets/{t1.id}" in hrefs
-    assert f"/tickets/{t2.id}" in hrefs
+    ids = {i.ticket_id for i in ticket_itens}
+    assert t1.id in ids
+    assert t2.id in ids
+    for item in ticket_itens:
+        assert item.href == "/tickets"
 
 
 def test_mensagem_anterior_a_visto_nao_conta(db_session, seed_base):

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -177,7 +177,7 @@ function RedirectKbArtigoEditar() {
 }
 
 /**
- * Rotas legadas com id na URL (`/chat/c/:id`, `/whatsapp/c/:id`, notificações):
+ * Rotas legadas com id na URL (`/chat/c/:id`, `/whatsapp/c/:id`, e-mails antigos):
  * guardam a conversa como ativa e caem na aba fixa do hub (#654).
  */
 function RedirectChatConversa({ canal }: { canal: ChatAtivoCanal }) {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1553,6 +1553,7 @@ export namespace Notificacoes {
       | 'wpp_chats_com_resposta'
       | 'chat_interno';
     ticket_id: number | null;
+    chat_id?: number | null;
     conversa_id?: number | null;
     titulo: string;
     descricao: string;

--- a/frontend/src/components/NavbarNotificacoes.tsx
+++ b/frontend/src/components/NavbarNotificacoes.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { notificacoes, type Notificacoes } from '../api/client'
 import { usePendenciasResumo } from '../hooks/useAlertaFilaSemResponsavel'
 import { useEventStream } from '../contexts/EventStreamContext'
+import { aplicarAtivoDaNotificacao } from '../lib/notificacaoNavegacao'
 
 const POLL_ITENS_MS = 30_000
 const POLL_ITENS_SSE_MS = 60_000
@@ -81,12 +82,15 @@ function ListaPendencias({
   return (
     <ul className="space-y-2 sm:space-y-0.5">
       {itens.map((item, idx) => (
-        <li key={`${item.tipo}-${item.conversa_id ?? item.ticket_id ?? 'fila'}-${idx}`}>
+        <li key={`${item.tipo}-${item.conversa_id ?? item.chat_id ?? item.ticket_id ?? 'fila'}-${idx}`}>
           <Link
             role="menuitem"
             to={item.href}
             className="flex gap-3 rounded-2xl border border-slate-200/90 bg-white px-4 py-3 text-left text-sm shadow-sm transition-colors hover:bg-slate-50 dark:border-slate-800/80 dark:bg-slate-900/50 dark:hover:bg-slate-800/80 sm:gap-2 sm:rounded-lg sm:border-0 sm:bg-transparent sm:px-2 sm:py-2 sm:shadow-none sm:hover:bg-slate-50 dark:sm:hover:bg-slate-800/80"
-            onClick={onNavigate}
+            onClick={() => {
+              aplicarAtivoDaNotificacao(item)
+              onNavigate()
+            }}
           >
             <div className="min-w-0 flex-1">
               <p className="truncate font-medium text-slate-900 dark:text-slate-100">{item.titulo}</p>

--- a/frontend/src/components/chat-interno/ChatInternoNovaConversaModal.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoNovaConversaModal.tsx
@@ -4,6 +4,7 @@ import { atendentes, chatInterno } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { useAuth } from '../../contexts/AuthContext'
 import { useChatInterno } from '../../contexts/ChatInternoContext'
+import { useChatHub } from '../../contexts/ChatHubContext'
 import { Button } from '../ui/Button'
 import { INPUT_FIELD_CLASS } from '../ui/Input'
 import { useToast } from '../ui/Toast'
@@ -22,6 +23,7 @@ export function ChatInternoNovaConversaModal({ open, onClose }: Props) {
   const navigate = useNavigate()
   const { user } = useAuth()
   const { carregar } = useChatInterno()
+  const { abrirChat } = useChatHub()
   const [modo, setModo] = useState<Modo>('direta')
   const [busca, setBusca] = useState('')
   const [tituloGrupo, setTituloGrupo] = useState('')
@@ -68,7 +70,8 @@ export function ChatInternoNovaConversaModal({ open, onClose }: Props) {
       const conv = await chatInterno.criarDireta(atendenteId)
       onClose()
       await carregar(true)
-      navigate(chatInternoLink(conv.id))
+      abrirChat('interno', conv.id)
+      navigate(chatInternoLink())
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível iniciar a conversa.'))
     } finally {
@@ -84,7 +87,8 @@ export function ChatInternoNovaConversaModal({ open, onClose }: Props) {
       const conv = await chatInterno.criarGrupo(titulo, selecionados)
       onClose()
       await carregar(true)
-      navigate(chatInternoLink(conv.id))
+      abrirChat('interno', conv.id)
+      navigate(chatInternoLink())
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível criar o grupo.'))
     } finally {

--- a/frontend/src/components/chat/ChatFilaAguardandoSheet.tsx
+++ b/frontend/src/components/chat/ChatFilaAguardandoSheet.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useId, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ChatListaEspera } from '../../pages/chat/ChatListaEspera'
-import { chatPortalLink, chatWhatsappLink } from '../../lib/chatHubPaths'
+import { chatHubItemLink } from '../../lib/chatHubLista'
+import { useChatHub } from '../../contexts/ChatHubContext'
 import { ChatFilaSomToggle } from './ChatFilaSomToggle'
 
 type Props = {
@@ -11,6 +12,7 @@ type Props = {
 
 export function ChatFilaAguardandoSheet({ open, onClose }: Props) {
   const navigate = useNavigate()
+  const { abrirChat } = useChatHub()
   const titleId = useId()
   const panelRef = useRef<HTMLDivElement>(null)
 
@@ -66,11 +68,8 @@ export function ChatFilaAguardandoSheet({ open, onClose }: Props) {
           <ChatListaEspera
             ignorarBusca
             onChatAssumido={(canal, chatId) => {
-              navigate(
-                canal === 'portal'
-                  ? chatPortalLink(chatId, 'atendendo')
-                  : chatWhatsappLink(chatId, 'atendendo'),
-              )
+              abrirChat(canal, chatId)
+              navigate(chatHubItemLink('atendendo'))
               onClose()
             }}
             onVerChat={onClose}

--- a/frontend/src/components/chat/ChatIniciarConversaModal.tsx
+++ b/frontend/src/components/chat/ChatIniciarConversaModal.tsx
@@ -7,6 +7,8 @@ import { Select } from '../../components/ui/Select'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { chatWhatsappLink } from '../../lib/chatHubPaths'
+import { gravarChatAtivoSession } from '../../lib/chatAtivo'
+import { useChatHubOpcional } from '../../contexts/ChatHubContext'
 
 type Props = {
   open: boolean
@@ -31,6 +33,7 @@ export function ChatIniciarConversaModal({
 }: Props) {
   const toast = useToast()
   const navigate = useNavigate()
+  const hub = useChatHubOpcional()
   const [telefone, setTelefone] = useState('')
   const [mensagem, setMensagem] = useState('')
   const [empresaId, setEmpresaId] = useState<number | ''>('')
@@ -78,7 +81,9 @@ export function ChatIniciarConversaModal({
         empresa_id: empresaId === '' ? undefined : Number(empresaId),
       })
       onClose()
-      navigate(chatWhatsappLink(chat.id, 'contatos'))
+      if (hub) hub.abrirChat('whatsapp', chat.id)
+      else gravarChatAtivoSession({ canal: 'whatsapp', id: chat.id })
+      navigate(chatWhatsappLink('contatos'))
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível iniciar a conversa.'))
     } finally {

--- a/frontend/src/contexts/ChatHubContext.tsx
+++ b/frontend/src/contexts/ChatHubContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState, t
 import { useLocation } from 'react-router-dom'
 import { portalChats, whatsappChats } from '../api/client'
 import {
+  CHAT_ATIVO_EVENT,
   gravarChatAtivoSession,
   lerChatAtivoSession,
   type ChatAtivo,
@@ -43,11 +44,17 @@ export function ChatHubProvider({ children }: { children: ReactNode }) {
     setChatAtivo(null)
   }, [])
 
-  /** Sync após navigate com `chatWhatsappLink` (grava sessão antes do path) (#654). */
+  /** Sync após clique que grava sessão (sininho / helpers sem side-effect) (#654 / #697 / #698). */
   useEffect(() => {
     if (!location.pathname.startsWith('/chat')) return
     setChatAtivo(lerChatAtivoSession())
   }, [location.pathname, location.key])
+
+  useEffect(() => {
+    const sync = () => setChatAtivo(lerChatAtivoSession())
+    window.addEventListener(CHAT_ATIVO_EVENT, sync)
+    return () => window.removeEventListener(CHAT_ATIVO_EVENT, sync)
+  }, [])
 
   const refreshContagens = useCallback(async () => {
     try {

--- a/frontend/src/lib/chatAtivo.ts
+++ b/frontend/src/lib/chatAtivo.ts
@@ -9,6 +9,8 @@ export type ChatAtivo = {
 
 export const CHAT_ATIVO_SESSION_KEY = 'deskrudder-chat-ativo'
 
+export const CHAT_ATIVO_EVENT = 'deskrudder-chat-ativo'
+
 export function lerChatAtivoSession(): ChatAtivo | null {
   try {
     const raw = sessionStorage.getItem(CHAT_ATIVO_SESSION_KEY)
@@ -32,10 +34,13 @@ export function gravarChatAtivoSession(ativo: ChatAtivo | null): void {
   try {
     if (!ativo) {
       sessionStorage.removeItem(CHAT_ATIVO_SESSION_KEY)
-      return
+    } else {
+      sessionStorage.setItem(CHAT_ATIVO_SESSION_KEY, JSON.stringify(ativo))
     }
-    sessionStorage.setItem(CHAT_ATIVO_SESSION_KEY, JSON.stringify(ativo))
   } catch {
     /* ignore */
+  }
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(CHAT_ATIVO_EVENT))
   }
 }

--- a/frontend/src/lib/chatHubPaths.ts
+++ b/frontend/src/lib/chatHubPaths.ts
@@ -1,4 +1,4 @@
-import { gravarChatAtivoSession, type ChatAtivoCanal } from './chatAtivo'
+import type { ChatAtivoCanal } from './chatAtivo'
 
 export const CHAT_HUB_PATHS = {
   atendendo: '/chat/atendendo',
@@ -35,27 +35,32 @@ export function chatHubModoDePath(pathname: string, search?: string): ChatHubMod
 }
 
 /**
- * Abre WhatsApp no hub: grava id na sessão e devolve path estável (#654).
- * Chamar no click / navigate (não em render de lista).
+ * Só o path da aba WhatsApp no hub — sem gravar sessão (#698).
+ * No clique: `abrirChat('whatsapp', id)` (ou `gravarChatAtivoSession`) e depois `navigate`.
  */
-export function chatWhatsappLink(chatId: number, from?: ChatHubModo) {
-  gravarChatAtivoSession({ canal: 'whatsapp', id: chatId })
+export function chatWhatsappLink(from?: ChatHubModo) {
   return {
     pathname: chatHubPathParaModo(from),
     search: '',
   }
 }
 
-export function chatPortalLink(chatId: number, from?: ChatHubModo) {
-  gravarChatAtivoSession({ canal: 'portal', id: chatId })
+/**
+ * Só o path da aba portal no hub — sem gravar sessão (#698).
+ * No clique: `abrirChat('portal', id)` e depois `navigate`.
+ */
+export function chatPortalLink(from?: ChatHubModo) {
   return {
     pathname: chatHubPathParaModo(from === 'espera' ? 'espera' : 'atendendo'),
     search: '',
   }
 }
 
-export function chatInternoLink(conversaId: number) {
-  gravarChatAtivoSession({ canal: 'interno', id: conversaId })
+/**
+ * Só o path do inbox interno — sem gravar sessão (#698).
+ * No clique: `abrirChat('interno', id)` e depois `navigate`.
+ */
+export function chatInternoLink() {
   return CHAT_HUB_PATHS.interno
 }
 

--- a/frontend/src/lib/notificacaoNavegacao.ts
+++ b/frontend/src/lib/notificacaoNavegacao.ts
@@ -1,0 +1,19 @@
+import type { Notificacoes } from '../api/client'
+import { gravarChatAtivoSession } from './chatAtivo'
+import { marcarTicketAtivo } from './ticketAtivo'
+
+/**
+ * Grava ticket/chat ativo antes de seguir o `href` estável (#697).
+ * Chamar no `onClick` do sininho — nunca no render da lista.
+ */
+export function aplicarAtivoDaNotificacao(item: Notificacoes.Item): void {
+  if (item.ticket_id != null && item.ticket_id > 0) {
+    marcarTicketAtivo(item.ticket_id)
+  }
+  if (item.chat_id != null && item.chat_id > 0) {
+    gravarChatAtivoSession({ canal: 'whatsapp', id: item.chat_id })
+  }
+  if (item.conversa_id != null && item.conversa_id > 0) {
+    gravarChatAtivoSession({ canal: 'interno', id: item.conversa_id })
+  }
+}

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -28,7 +28,7 @@ import { rotuloPrioridade, classeBadgePrioridade } from '../lib/ticketPrioridade
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { SlaBadge } from '../components/tickets/SlaBadge'
 import { TicketDetalhe } from './TicketDetalhe'
-import { gravarTicketAtivoSession, lerTicketAtivoSession } from '../lib/ticketAtivo'
+import { gravarTicketAtivoSession, lerTicketAtivoSession, TICKET_ATIVO_EVENT } from '../lib/ticketAtivo'
 
 type ColunaOrdenacao =
   | 'protocolo'
@@ -118,7 +118,10 @@ export function Tickets() {
   const [ticketAtivoId, setTicketAtivoId] = useState<number | null>(() => lerTicketAtivoSession())
 
   useEffect(() => {
-    setTicketAtivoId(lerTicketAtivoSession())
+    const sync = () => setTicketAtivoId(lerTicketAtivoSession())
+    sync()
+    window.addEventListener(TICKET_ATIVO_EVENT, sync)
+    return () => window.removeEventListener(TICKET_ATIVO_EVENT, sync)
   }, [location.key])
 
   const abrirTicket = useCallback((id: number) => {

--- a/frontend/src/pages/chat-interno/ChatInternoSetorCanal.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoSetorCanal.tsx
@@ -2,12 +2,14 @@ import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ApiError, chatInterno } from '../../api/client'
 import { chatInternoLink } from '../../lib/chatHubPaths'
+import { useChatHub } from '../../contexts/ChatHubContext'
 import { SemPermissao } from '../SemPermissao'
 
 export function ChatInternoSetorCanal() {
   const { setorId: setorIdParam } = useParams()
   const setorId = Number(setorIdParam)
   const navigate = useNavigate()
+  const { abrirChat } = useChatHub()
   const [forbidden, setForbidden] = useState(false)
 
   useEffect(() => {
@@ -19,7 +21,10 @@ export function ChatInternoSetorCanal() {
     ;(async () => {
       try {
         const canal = await chatInterno.obterCanalSetor(setorId)
-        if (!cancelled) navigate(chatInternoLink(canal.id), { replace: true })
+        if (!cancelled) {
+          abrirChat('interno', canal.id)
+          navigate(chatInternoLink(), { replace: true })
+        }
       } catch (err) {
         if (!cancelled && err instanceof ApiError && err.status === 403) {
           setForbidden(true)
@@ -31,7 +36,7 @@ export function ChatInternoSetorCanal() {
     return () => {
       cancelled = true
     }
-  }, [setorId, navigate])
+  }, [setorId, navigate, abrirChat])
 
   if (forbidden) {
     return (

--- a/frontend/src/pages/chat/PortalConversa.tsx
+++ b/frontend/src/pages/chat/PortalConversa.tsx
@@ -70,7 +70,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
   const toast = useToast()
   const { user } = useAuth()
   const { subscribe, useFallback } = useEventStream()
-  const { refreshContagens, filaCount, fecharChat } = useChatHub()
+  const { refreshContagens, filaCount, fecharChat, abrirChat } = useChatHub()
   const [chat, setChat] = useState<PortalChats.Chat | null>(null)
   const [mensagens, setMensagens] = useState<PortalChats.Mensagem[]>([])
   const [demandasTimeline, setDemandasTimeline] = useState<ChatDemanda[]>([])
@@ -235,7 +235,8 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
       void refreshContagens()
       void refetchPendenciasResumo()
       toast.showSuccess('Chat assumido.')
-      navigate(chatPortalLink(chat.id), { replace: true })
+      abrirChat('portal', chat.id)
+      navigate(chatPortalLink(), { replace: true })
     } catch (err) {
       const msg =
         err instanceof ApiError && err.status === 400

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -641,7 +641,7 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
   const menuMobileRef = useRef<HTMLDivElement>(null)
   const [filaAguardandoAberta, setFilaAguardandoAberta] = useState(false)
   const [assumindo, setAssumindo] = useState(false)
-  const { filaCount, refreshContagens } = useChatHub()
+  const { filaCount, refreshContagens, abrirChat } = useChatHub()
   const navigate = useNavigate()
   const location = useLocation()
   const [searchParams] = useSearchParams()
@@ -1248,7 +1248,8 @@ useEffect(() => {
       void refreshContagens()
       void refetchPendenciasResumo()
       toast.showSuccess('Chat assumido.')
-      navigate(chatWhatsappLink(chat.id, 'atendendo'), { replace: true })
+      abrirChat('whatsapp', chat.id)
+      navigate(chatWhatsappLink('atendendo'), { replace: true })
     } catch (err) {
       const msg =
         err instanceof ApiError && err.status === 400


### PR DESCRIPTION
## Summary

- Closes #697 — o sininho e o e-mail interno do painel passam a apontar para URLs fixas (`/tickets`, `/chat/atendendo`, `/chat/espera`, `/chat/interno`), com o id no payload; o clique grava o item activo na sessão (sem flash `/tickets/123`).
- Closes #698 — `chatWhatsappLink` / `chatPortalLink` / `chatInternoLink` devolvem só o path; gravar a conversa activa fica no clique / `abrirChat`.
- Rotas legadas com id na URL continuam a funcionar para e-mails antigos.
- Fora deste lote: #699 (Voltar nativo), #700 (portal tickets).

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] Sininho: clicando numa não-lida de ticket, a barra fica em `/tickets` e o detalhe abre o chamado certo (sem aparecer `/tickets/{id}`)
- [ ] Sininho: WhatsApp com resposta abre `/chat/atendendo` na conversa certa; fila WhatsApp abre `/chat/espera`
- [ ] Sininho: chat interno abre `/chat/interno` na conversa certa
- [ ] Já estando em `/tickets` ou `/chat/atendendo`, clicar outra pendência troca o item sem mudar o formato da URL
- [ ] E-mail de atribuição/nova mensagem/SLA: link `…/tickets` sem `/{id}`; protocolo visível no corpo
- [ ] Abrir da lista da mesa, assumir da fila, iniciar conversa e canal de setor continuam a abrir o chat certo
- [ ] Link antigo `/tickets/123` ou `/whatsapp/c/123` ainda redirecciona e abre o item

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — cada um virou issue `#699` / `#700` (já existentes)
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados
