### PR TITLE
fix(whatsapp): inatividade após demanda e checkbox no dark mode (#712 #713)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Correções
 
+- WhatsApp (#712): após **registar demanda** com o chat ainda aberto, o encerramento por inatividade volta a fechar sozinho (o marco da demanda já não zera o relógio nem trava o worker)
+- Encerrar chat (#713): em modo escuro, o texto «Confirmo concluir sem classificar» volta a ser legível
 - Login (#677): em subdomínio do cliente, **Voltar ao site** abre a landing DeskRudder (apex) em vez de voltar ao próprio login
 - Funcionários da rede (#685): ao editar/criar, o formulário volta a mostrar o topo e a rolar até ao fim — sem espaço vazio abaixo dos botões nem conteúdo preso fora do ecrã
 - Links antigos (#654 / #655): endereços com número (chat da fila, conversa do WhatsApp, detalhe de ticket) continuam a funcionar e abrem o item certo no novo formato

--- a/backend/app/services/whatsapp_inactivity_worker.py
+++ b/backend/app/services/whatsapp_inactivity_worker.py
@@ -16,6 +16,13 @@ from app.services.whatsapp_auto_messages import (
 
 logger = logging.getLogger(__name__)
 
+# Marcos internos: não são silêncio do cliente nem actividade que reinicia o prazo.
+_EVENTOS_NAO_ATIVIDADE = (
+    "comentario_interno",
+    "demanda_registrada",
+    "demanda_escalada",
+)
+
 
 def _evolution_configurada(st: WhatsappSettings | None) -> bool:
     return bool(
@@ -37,7 +44,7 @@ def _mensagens_relevantes_q(db: Session, chat_id: int):
         WhatsappMensagem.chat_id == chat_id,
         or_(
             WhatsappMensagem.evento_sistema.is_(None),
-            WhatsappMensagem.evento_sistema != "comentario_interno",
+            WhatsappMensagem.evento_sistema.notin_(_EVENTOS_NAO_ATIVIDADE),
         ),
     )
 
@@ -72,7 +79,7 @@ def _referencia_inatividade_cliente(db: Session, chat: WhatsappChat) -> datetime
     humana do atendente), desde que já exista pelo menos uma outbound humana
     (não dispara na fila / só com auto_assumido/BOT).
 
-    Comentários internos e eventos de sistema não contam como atividade.
+    Comentários internos e marcos de demanda não contam como atividade.
     """
     last_out = _ultima_outbound_humana(db, chat.id)
     if not last_out or last_out.created_at is None:
@@ -178,7 +185,16 @@ def _encerrar_por_inatividade(db: Session, chat: WhatsappChat, st: WhatsappSetti
     from app.services.whatsapp_avaliacao import finalizar_atendimento_whatsapp
 
     finalizar_atendimento_whatsapp(db, chat, st, evento_encerrado="auto_encerrado_inatividade")
-    chat.classificacao_demanda_pendente = True
+    ja_classificado = (
+        db.query(WhatsappMensagem.id)
+        .filter(
+            WhatsappMensagem.chat_id == chat.id,
+            WhatsappMensagem.evento_sistema.in_(("demanda_registrada", "demanda_escalada")),
+        )
+        .limit(1)
+        .first()
+    )
+    chat.classificacao_demanda_pendente = not bool(ja_classificado)
     # Com avaliação ativa o evento_encerrado não é gravado — marco interno para o painel pedir demanda.
     ja_tem = (
         db.query(WhatsappMensagem.id)

--- a/backend/tests/test_whatsapp_inatividade_encerramento.py
+++ b/backend/tests/test_whatsapp_inatividade_encerramento.py
@@ -136,6 +136,59 @@ def test_worker_encerra_apos_aviso(client, seed_base, auth_headers, db_session, 
     assert marco is not None
 
 
+def test_worker_encerra_apos_aviso_mesmo_com_marco_demanda(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    """#712: demanda registada depois do aviso não anula o encerramento automático."""
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session, wa_id="5511999001122")
+    agora = datetime.now(timezone.utc)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Aguardando",
+            tipo_midia="texto",
+            atendente_id=1,
+            created_at=agora - timedelta(minutes=20),
+        )
+    )
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso de encerramento",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=agora - timedelta(minutes=8),
+        )
+    )
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="Demanda registada: Dúvida — Resolvido na sessão",
+            tipo_midia="texto",
+            evento_sistema="demanda_registrada",
+            created_at=agora - timedelta(minutes=1),
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-dem-inativ"),
+    )
+
+    n = process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+
+    assert n == 1
+    assert chat.estado == "encerrado"
+    assert chat.classificacao_demanda_pendente is False
+
+
 def test_pode_registrar_demanda_apos_encerramento_inatividade(
     client, seed_base, auth_headers, db_session, monkeypatch
 ):

--- a/frontend/src/components/ui/CheckboxField.tsx
+++ b/frontend/src/components/ui/CheckboxField.tsx
@@ -25,12 +25,12 @@ export function CheckboxField({
 
   const chipClasses =
     variant === 'chip'
-      ? `inline-flex cursor-pointer select-none items-center gap-2.5 rounded-lg border px-3 py-2 text-sm transition-all duration-150 focus-within:ring-2 focus-within:ring-slate-500 focus-within:ring-offset-2 ${
+      ? `inline-flex cursor-pointer select-none items-center gap-2.5 rounded-lg border px-3 py-2 text-sm transition-all duration-150 focus-within:ring-2 focus-within:ring-slate-500 focus-within:ring-offset-2 dark:focus-within:ring-offset-slate-900 ${
           checked
-            ? 'border-slate-800 bg-white shadow-sm ring-1 ring-slate-800/12'
-            : 'border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50/90'
+            ? 'border-slate-800 bg-white shadow-sm ring-1 ring-slate-800/12 dark:border-cyan-500/50 dark:bg-slate-800 dark:ring-cyan-400/20'
+            : 'border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50/90 dark:border-slate-600 dark:bg-slate-800/80 dark:hover:border-slate-500 dark:hover:bg-slate-800'
         }`
-      : `inline-flex cursor-pointer select-none items-center gap-2.5 rounded-md text-sm focus-within:ring-2 focus-within:ring-slate-500 focus-within:ring-offset-1`
+      : `inline-flex cursor-pointer select-none items-center gap-2.5 rounded-md text-sm focus-within:ring-2 focus-within:ring-slate-500 focus-within:ring-offset-1 dark:focus-within:ring-offset-slate-900`
 
   return (
     <label
@@ -40,7 +40,9 @@ export function CheckboxField({
       <span
         aria-hidden
         className={`flex size-4 shrink-0 items-center justify-center rounded border-2 transition-colors duration-150 ${
-          checked ? 'border-slate-800 bg-slate-800' : 'border-slate-300 bg-white'
+          checked
+            ? 'border-slate-800 bg-slate-800 dark:border-cyan-400 dark:bg-cyan-500'
+            : 'border-slate-300 bg-white dark:border-slate-400 dark:bg-slate-800'
         }`}
       >
         {checked && (
@@ -55,7 +57,15 @@ export function CheckboxField({
           </svg>
         )}
       </span>
-      <span className={`font-medium ${checked ? 'text-slate-900' : 'text-slate-700'}`}>{children}</span>
+      <span
+        className={`font-medium ${
+          checked
+            ? 'text-slate-900 dark:text-slate-100'
+            : 'text-slate-700 dark:text-slate-200'
+        }`}
+      >
+        {children}
+      </span>
     </label>
   )
 }

--- a/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
@@ -55,8 +55,9 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
     void tick
     if (!ativa || chat.estado !== 'em_atendimento') return null
 
-    const semComentario = msgs.filter((m) => m.evento_sistema !== 'comentario_interno')
-    const lastAny = semComentario[semComentario.length - 1]
+    const IGNORAR_ATIVIDADE = new Set(['comentario_interno', 'demanda_registrada', 'demanda_escalada'])
+    const semMarcoInterno = msgs.filter((m) => !IGNORAR_ATIVIDADE.has(m.evento_sistema ?? ''))
+    const lastAny = semMarcoInterno[semMarcoInterno.length - 1]
     const posAvisoAtivo = lastAny?.evento_sistema === 'auto_inativ_aviso'
 
     if (chat.inatividade_pausada) {


### PR DESCRIPTION
## Summary

- **#712:** o marco de demanda já não trava o encerramento automático por inatividade (worker + relógio no header).
- **#713:** texto e caixa do `CheckboxField` ficam legíveis no dark mode ao confirmar «concluir sem classificar».

Closes #712
Closes #713

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

> PR **`main → staging`**: o `[Unreleased]` vira a release publicada no deploy.  
> Guia: [docs/RELEASES.md](../docs/RELEASES.md)

## Test plan

- [ ] Chat em atendimento com inatividade ligada: aviso enviado → **registar demanda** (chat continua aberto) → prazo pós-aviso esgota → chat encerra sozinho (não fica em 00:00)
- [ ] Relógio no header continua na fase «após aviso» mesmo com marco de demanda
- [ ] Encerrar pelo botão da UI e Esc continuam a funcionar
- [ ] Comentário interno e Pausar inatividade (#577) inalterados
- [ ] Dark mode: modal encerrar → «Concluir sem registar demanda» → texto de confirmação e ✓ visíveis
- [ ] Light mode: o mesmo checkbox continua legível
- [ ] Local: `docker compose run --rm --no-deps backend pytest -q tests/test_whatsapp_inatividade_encerramento.py` (15 passed)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — portal (mesmo padrão de inatividade) ficou fora do #712; radios nativos dos modais fora do #713
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável — N/A
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados — nenhum follow-up novo; próximos na fila: #699 / #700

> Guia: [docs/ISSUE_CLOSURE.md](../docs/ISSUE_CLOSURE.md)
