### PR TITLE
fix(whatsapp): inatividade após demanda, dark mode e Sobre SaaS (#712 #713)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Correções
 
+- WhatsApp (#712): após registar demanda no chat aberto, o encerramento por inatividade continua a contar e o worker fecha o atendimento quando o prazo esgota (marco de demanda já não “prende” o relógio em 00:00)
+- Dark mode (#713): texto e caixa de confirmação ao concluir sem demanda ficam legíveis no tema escuro
+- Sobre (#672): notas antigas que começam com «SaaS» deixam de aparecer em `/sobre` mesmo se o histórico foi publicado antes da separação por produto
 - Login (#677): em subdomínio do cliente, **Voltar ao site** abre a landing DeskRudder (apex) em vez de voltar ao próprio login
 - Funcionários da rede (#685): ao editar/criar, o formulário volta a mostrar o topo e a rolar até ao fim — sem espaço vazio abaixo dos botões nem conteúdo preso fora do ecrã
 - Links antigos (#654 / #655): endereços com número (chat da fila, conversa do WhatsApp, detalhe de ticket) continuam a funcionar e abrem o item certo no novo formato

--- a/backend/app/services/system_release.py
+++ b/backend/app/services/system_release.py
@@ -18,6 +18,10 @@ PRODUCT_DESKRUDDER = "deskrudder"
 PRODUCT_SAAS = "saas"
 VALID_PRODUCTS = frozenset({PRODUCT_DESKRUDDER, PRODUCT_SAAS})
 
+# Histórico publicado antes da separação por produto (#672/#676): bullets SaaS
+# sem tag (ou tagueados como DeskRudder) ainda apareciam em /sobre.
+_SAAS_BULLET_RE = re.compile(r"(?i)^\s*saas\b")
+
 _LEGACY_BRAND_RE = re.compile(r"DX/Duplexsoft|Duplexsoft|DX Connect|DX-Connect", re.IGNORECASE)
 
 
@@ -90,7 +94,16 @@ def reload_release_notes_cache() -> None:
     _load_release_notes_raw.cache_clear()
 
 
+def looks_like_saas_bullet(text: str) -> bool:
+    """Heurística alinhada a scripts/migrate_release_notes_product.py."""
+    return bool(_SAAS_BULLET_RE.match((text or "").strip()))
+
+
 def _change_product(ch: dict[str, Any]) -> str:
+    text = str(ch.get("text") or "")
+    # Prefixo «SaaS» manda no histórico — corrige JSON antigo em produção.
+    if looks_like_saas_bullet(text):
+        return PRODUCT_SAAS
     raw = ch.get("product")
     if isinstance(raw, str) and raw.strip().lower() in VALID_PRODUCTS:
         return raw.strip().lower()

--- a/backend/app/services/whatsapp_inactivity_worker.py
+++ b/backend/app/services/whatsapp_inactivity_worker.py
@@ -42,14 +42,6 @@ def _mensagens_relevantes_q(db: Session, chat_id: int):
     )
 
 
-def _ultima_mensagem_relevante(db: Session, chat_id: int) -> WhatsappMensagem | None:
-    return (
-        _mensagens_relevantes_q(db, chat_id)
-        .order_by(desc(WhatsappMensagem.created_at), desc(WhatsappMensagem.id))
-        .first()
-    )
-
-
 def _ultima_outbound_humana(db: Session, chat_id: int) -> WhatsappMensagem | None:
     """Mensagem enviada pelo atendente (não BOT / auto_assumido / avisos de sistema)."""
     return (
@@ -110,19 +102,18 @@ def _normalizar_utc(dt: datetime) -> datetime:
     return dt
 
 
-def _aviso_ja_enviado_no_ciclo(db: Session, chat_id: int, referencia: datetime) -> bool:
-    """Evita reenvio do aviso quando vários workers processam o mesmo chat em paralelo."""
+def _ultimo_aviso_no_ciclo(db: Session, chat_id: int, referencia: datetime) -> WhatsappMensagem | None:
+    """Último auto_inativ_aviso do ciclo actual (após a referência de silêncio humano)."""
     ref = _normalizar_utc(referencia)
     return (
-        db.query(WhatsappMensagem.id)
+        db.query(WhatsappMensagem)
         .filter(
             WhatsappMensagem.chat_id == chat_id,
             WhatsappMensagem.evento_sistema == "auto_inativ_aviso",
             WhatsappMensagem.created_at >= ref,
         )
-        .limit(1)
+        .order_by(desc(WhatsappMensagem.created_at), desc(WhatsappMensagem.id))
         .first()
-        is not None
     )
 
 
@@ -224,21 +215,20 @@ def _processar_chat_inatividade(
     if aviso_min < 1 or pos_aviso_min < 1:
         return False
 
-    last = _ultima_mensagem_relevante(db, chat.id)
-    if last and last.evento_sistema == "auto_inativ_aviso":
-        if _minutos_desde(last.created_at, now) >= pos_aviso_min:
-            _encerrar_por_inatividade(db, chat, st)
-            return True
-        return False
-
+    # Relógio e fase pós-aviso usam só actividade humana (cliente/atendente).
+    # Marcos de sistema (ex.: demanda_registrada) NÃO substituem o auto_inativ_aviso (#712).
     referencia = _referencia_inatividade_cliente(db, chat)
     if referencia is None:
         return False
 
-    if _minutos_desde(referencia, now) < aviso_min:
+    aviso = _ultimo_aviso_no_ciclo(db, chat.id, referencia)
+    if aviso is not None:
+        if _minutos_desde(aviso.created_at, now) >= pos_aviso_min:
+            _encerrar_por_inatividade(db, chat, st)
+            return True
         return False
 
-    if _aviso_ja_enviado_no_ciclo(db, chat.id, referencia):
+    if _minutos_desde(referencia, now) < aviso_min:
         return False
 
     if not bool(getattr(st, "auto_msg_inativ_aviso_ativa", True)):

--- a/backend/tests/test_migrate_release_notes_product.py
+++ b/backend/tests/test_migrate_release_notes_product.py
@@ -42,3 +42,24 @@ def test_migrate_manifest_idempotent():
     again, stats2 = migrate_manifest(migrated)
     assert again == migrated
     assert stats2["kept"] == 3
+
+
+def test_migrate_reclassify_saas_overrides_wrong_tag():
+    data = {
+        "releases": [
+            {
+                "version": "26.08.006",
+                "changes": [
+                    {"product": "deskrudder", "category": "melhorias", "text": "SaaS: planos"},
+                    {"product": "deskrudder", "category": "correcoes", "text": "Chat (#651)"},
+                ],
+            }
+        ]
+    }
+    migrated, stats = migrate_manifest(data, reclassify_saas=True)
+    changes = migrated["releases"][0]["changes"]
+    assert changes[0]["product"] == "saas"
+    assert changes[1]["product"] == "deskrudder"
+    assert stats["reclassified_to_saas"] == 1
+    assert stats["saas"] == 1
+    assert stats["deskrudder"] == 1

--- a/backend/tests/test_system_release.py
+++ b/backend/tests/test_system_release.py
@@ -213,6 +213,41 @@ def test_system_release_notes_filters_by_product(client, auth_headers, monkeypat
     assert all(c.get("product") == "deskrudder" for c in body["current"]["changes"])
 
 
+def test_system_release_notes_hides_saas_prefix_even_if_wrongly_tagged(
+    client, auth_headers, monkeypatch, tmp_path
+):
+    """Histórico em produção: bullet «SaaS:…» sem tag ou com product=deskrudder."""
+    data_path = tmp_path / "release_notes.json"
+    payload = {
+        "current_version": "26.08.006",
+        "releases": [
+            {
+                "version": "26.08.006",
+                "version_display": "v26.08.006",
+                "date": "2026-08-13",
+                "status": "published",
+                "changes": [
+                    {"category": "melhorias", "text": "WhatsApp: fila"},
+                    {"product": "deskrudder", "category": "melhorias", "text": "SaaS: licenças"},
+                    {"category": "melhorias", "text": "SaaS DeskRudder (#519): painel"},
+                ],
+            }
+        ],
+        "upcoming": [],
+    }
+    data_path.write_text(json.dumps(payload), encoding="utf-8")
+
+    import app.services.system_release as sr
+
+    monkeypatch.setattr(sr, "_DATA_DIR", tmp_path)
+    reload_release_notes_cache()
+    monkeypatch.setenv("DX_CONNECT_VERSION", "26.08.006")
+
+    body = client.get("/v1/system/release-notes", headers=auth_headers["admin"]).json()
+    texts = [c["text"] for c in body["current"]["changes"]]
+    assert texts == ["WhatsApp: fila"]
+
+
 def test_saas_release_notes_rbac_and_filter(client, auth_headers, monkeypatch, tmp_path):
     from app.config import settings
 

--- a/backend/tests/test_whatsapp_inatividade_encerramento.py
+++ b/backend/tests/test_whatsapp_inatividade_encerramento.py
@@ -35,6 +35,38 @@ def _chat_em_atendimento(db_session, *, wa_id: str = "5511999887766", atendente_
     return chat
 
 
+def _seed_aviso_apos_humano(
+    db_session,
+    chat: WhatsappChat,
+    *,
+    minutos_aviso: int = 8,
+    minutos_humano: int = 20,
+    atendente_id: int = 1,
+) -> None:
+    """Outbound humana + aviso BOT — referência do ciclo (#712)."""
+    agora = datetime.now(timezone.utc)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ Atendente ]: Alguma dúvida?",
+            tipo_midia="texto",
+            atendente_id=atendente_id,
+            created_at=agora - timedelta(minutes=minutos_humano),
+        )
+    )
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="[ BOT ]: Aviso de encerramento",
+            tipo_midia="texto",
+            evento_sistema="auto_inativ_aviso",
+            created_at=agora - timedelta(minutes=minutos_aviso),
+        )
+    )
+
+
 def test_settings_exige_minutos_quando_inatividade_ativa(client, seed_base, auth_headers):
     r = client.patch(
         "/v1/settings/whatsapp",
@@ -99,17 +131,7 @@ def test_worker_envia_aviso_apos_inatividade(client, seed_base, auth_headers, db
 def test_worker_encerra_apos_aviso(client, seed_base, auth_headers, db_session, monkeypatch):
     _configurar_evolution(db_session)
     chat = _chat_em_atendimento(db_session, wa_id="5511999776655")
-    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
-    db_session.add(
-        WhatsappMensagem(
-            chat_id=chat.id,
-            direcao="outbound",
-            corpo="[ BOT ]: Aviso de encerramento",
-            tipo_midia="texto",
-            evento_sistema="auto_inativ_aviso",
-            created_at=antiga_aviso,
-        )
-    )
+    _seed_aviso_apos_humano(db_session, chat)
     db_session.commit()
 
     monkeypatch.setattr(
@@ -136,6 +158,39 @@ def test_worker_encerra_apos_aviso(client, seed_base, auth_headers, db_session, 
     assert marco is not None
 
 
+def test_worker_encerra_apos_aviso_mesmo_com_marco_demanda_depois(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    """#712: demanda_registrada após o aviso não impede o encerramento automático."""
+    _configurar_evolution(db_session)
+    chat = _chat_em_atendimento(db_session, wa_id="5511999001122")
+    _seed_aviso_apos_humano(db_session, chat, minutos_aviso=8, minutos_humano=25)
+    db_session.add(
+        WhatsappMensagem(
+            chat_id=chat.id,
+            direcao="outbound",
+            corpo="Demanda registada na sessão",
+            tipo_midia="texto",
+            evento_sistema="demanda_registrada",
+            created_at=datetime.now(timezone.utc) - timedelta(minutes=3),
+        )
+    )
+    db_session.commit()
+
+    monkeypatch.setattr(
+        "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
+        lambda *_a, **_k: (True, None, "wa-out-dem-ciclo"),
+    )
+
+    n = process_whatsapp_inactivity_closures(db_session)
+    db_session.commit()
+    db_session.refresh(chat)
+
+    assert n == 1
+    assert chat.estado == "encerrado"
+    assert chat.classificacao_demanda_pendente is True
+
+
 def test_pode_registrar_demanda_apos_encerramento_inatividade(
     client, seed_base, auth_headers, db_session, monkeypatch
 ):
@@ -144,17 +199,7 @@ def test_pode_registrar_demanda_apos_encerramento_inatividade(
     _configurar_evolution(db_session)
     a1_id = seed_base["a1"].id
     chat = _chat_em_atendimento(db_session, wa_id="5511999112233", atendente_id=a1_id)
-    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
-    db_session.add(
-        WhatsappMensagem(
-            chat_id=chat.id,
-            direcao="outbound",
-            corpo="[ BOT ]: Aviso",
-            tipo_midia="texto",
-            evento_sistema="auto_inativ_aviso",
-            created_at=antiga_aviso,
-        )
-    )
+    _seed_aviso_apos_humano(db_session, chat, atendente_id=a1_id)
     nat = TicketNatureza(nome="Nat Inativ", slug="nat-inativ-test", ordem=1, ativo=True)
     db_session.add(nat)
     db_session.flush()
@@ -186,17 +231,7 @@ def test_concluir_classificacao_sem_demanda(client, seed_base, auth_headers, db_
     _configurar_evolution(db_session)
     a1_id = seed_base["a1"].id
     chat = _chat_em_atendimento(db_session, wa_id="5511999223344", atendente_id=a1_id)
-    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
-    db_session.add(
-        WhatsappMensagem(
-            chat_id=chat.id,
-            direcao="outbound",
-            corpo="[ BOT ]: Aviso",
-            tipo_midia="texto",
-            evento_sistema="auto_inativ_aviso",
-            created_at=antiga_aviso,
-        )
-    )
+    _seed_aviso_apos_humano(db_session, chat, atendente_id=a1_id)
     db_session.commit()
     monkeypatch.setattr(
         "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
@@ -230,17 +265,7 @@ def test_inbound_abre_chat_novo_quando_pendente_classificacao(
     a1_id = seed_base["a1"].id
     wa = "5511888001122"
     chat = _chat_em_atendimento(db_session, wa_id=wa, atendente_id=a1_id)
-    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
-    db_session.add(
-        WhatsappMensagem(
-            chat_id=chat.id,
-            direcao="outbound",
-            corpo="[ BOT ]: Aviso",
-            tipo_midia="texto",
-            evento_sistema="auto_inativ_aviso",
-            created_at=antiga_aviso,
-        )
-    )
+    _seed_aviso_apos_humano(db_session, chat, atendente_id=a1_id)
     db_session.commit()
     monkeypatch.setattr(
         "app.services.whatsapp_inactivity_worker.evolution_api.evolution_send_text",
@@ -562,17 +587,7 @@ def test_concluir_classificacao_com_demandas_existentes(
     _configurar_evolution(db_session)
     a1_id = seed_base["a1"].id
     chat = _chat_em_atendimento(db_session, wa_id="5511999554433", atendente_id=a1_id)
-    antiga_aviso = datetime.now(timezone.utc) - timedelta(minutes=8)
-    db_session.add(
-        WhatsappMensagem(
-            chat_id=chat.id,
-            direcao="outbound",
-            corpo="[ BOT ]: Aviso",
-            tipo_midia="texto",
-            evento_sistema="auto_inativ_aviso",
-            created_at=antiga_aviso,
-        )
-    )
+    _seed_aviso_apos_humano(db_session, chat, atendente_id=a1_id)
     nat = TicketNatureza(nome="Nat Manter", slug="nat-manter-inativ", ordem=1, ativo=True)
     db_session.add(nat)
     db_session.flush()

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -94,7 +94,9 @@ Mesma CalVer; só bullets `product=saas` (licenças, planos, provisionamento, le
 | `VERSION` | Versão publicada (sem `v`) |
 | `docs/releases/manifest.json` | Histórico estruturado (`product` por bullet) |
 | `backend/app/data/release_notes.json` | Payload da API (gerado no deploy) |
-| `scripts/migrate_release_notes_product.py` | One-off / idempotente para taguear histórico (#676) |
+| `scripts/migrate_release_notes_product.py` | One-off / idempotente para taguear histórico (#676); `--reclassify-saas` corrige bullets «SaaS…» tagueados como DeskRudder |
+
+A API `/v1/system/release-notes` também **reclassifica em runtime** bullets cujo texto começa com «SaaS» (histórico em produção anterior à migração).
 
 Após cada deploy, o workflow commita `VERSION`, `CHANGELOG.md`, `manifest.json` e JSONs em `staging` (mensagem com `[skip ci]` para não redeployar).
 

--- a/frontend/src/components/ui/CheckboxField.tsx
+++ b/frontend/src/components/ui/CheckboxField.tsx
@@ -25,12 +25,12 @@ export function CheckboxField({
 
   const chipClasses =
     variant === 'chip'
-      ? `inline-flex cursor-pointer select-none items-center gap-2.5 rounded-lg border px-3 py-2 text-sm transition-all duration-150 focus-within:ring-2 focus-within:ring-slate-500 focus-within:ring-offset-2 ${
+      ? `inline-flex cursor-pointer select-none items-center gap-2.5 rounded-lg border px-3 py-2 text-sm transition-all duration-150 focus-within:ring-2 focus-within:ring-slate-500 focus-within:ring-offset-2 dark:focus-within:ring-offset-slate-900 ${
           checked
-            ? 'border-slate-800 bg-white shadow-sm ring-1 ring-slate-800/12'
-            : 'border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50/90'
+            ? 'border-slate-800 bg-white shadow-sm ring-1 ring-slate-800/12 dark:border-slate-400 dark:bg-slate-900 dark:ring-slate-400/20'
+            : 'border-slate-200 bg-white hover:border-slate-300 hover:bg-slate-50/90 dark:border-slate-600 dark:bg-slate-900 dark:hover:border-slate-500 dark:hover:bg-slate-800/80'
         }`
-      : `inline-flex cursor-pointer select-none items-center gap-2.5 rounded-md text-sm focus-within:ring-2 focus-within:ring-slate-500 focus-within:ring-offset-1`
+      : `inline-flex cursor-pointer select-none items-center gap-2.5 rounded-md text-sm focus-within:ring-2 focus-within:ring-slate-500 focus-within:ring-offset-1 dark:focus-within:ring-offset-slate-900`
 
   return (
     <label
@@ -40,11 +40,18 @@ export function CheckboxField({
       <span
         aria-hidden
         className={`flex size-4 shrink-0 items-center justify-center rounded border-2 transition-colors duration-150 ${
-          checked ? 'border-slate-800 bg-slate-800' : 'border-slate-300 bg-white'
+          checked
+            ? 'border-slate-800 bg-slate-800 dark:border-slate-200 dark:bg-slate-200'
+            : 'border-slate-300 bg-white dark:border-slate-500 dark:bg-slate-800'
         }`}
       >
         {checked && (
-          <svg className="size-2.5 text-white" viewBox="0 0 12 12" fill="none" aria-hidden>
+          <svg
+            className="size-2.5 text-white dark:text-slate-900"
+            viewBox="0 0 12 12"
+            fill="none"
+            aria-hidden
+          >
             <path
               d="M2.5 6l2.5 2.5 5-5.5"
               stroke="currentColor"
@@ -55,7 +62,13 @@ export function CheckboxField({
           </svg>
         )}
       </span>
-      <span className={`font-medium ${checked ? 'text-slate-900' : 'text-slate-700'}`}>{children}</span>
+      <span
+        className={`font-medium ${
+          checked ? 'text-slate-900 dark:text-slate-100' : 'text-slate-700 dark:text-slate-300'
+        }`}
+      >
+        {children}
+      </span>
     </label>
   )
 }

--- a/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
@@ -55,10 +55,6 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
     void tick
     if (!ativa || chat.estado !== 'em_atendimento') return null
 
-    const semComentario = msgs.filter((m) => m.evento_sistema !== 'comentario_interno')
-    const lastAny = semComentario[semComentario.length - 1]
-    const posAvisoAtivo = lastAny?.evento_sistema === 'auto_inativ_aviso'
-
     if (chat.inatividade_pausada) {
       return {
         restanteSec: avisoMin * 60,
@@ -68,8 +64,25 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
       }
     }
 
-    if (posAvisoAtivo && lastAny?.created_at) {
-      const elapsed = (Date.now() - new Date(lastAny.created_at).getTime()) / 1000
+    // Só actividade humana reinicia o ciclo — marcos de demanda/sistema não (#712).
+    const relevant = msgs.filter(
+      (m) =>
+        m.evento_sistema !== 'comentario_interno' &&
+        (m.direcao === 'inbound' || (m.direcao === 'outbound' && !m.evento_sistema)),
+    )
+    const lastHuman = relevant[relevant.length - 1]
+    const candidatos: number[] = []
+    if (lastHuman?.created_at) candidatos.push(new Date(lastHuman.created_at).getTime())
+    if (chat.inatividade_retomada_em) candidatos.push(new Date(chat.inatividade_retomada_em).getTime())
+    const refMs = candidatos.length > 0 ? Math.max(...candidatos) : 0
+
+    const avisos = msgs.filter((m) => m.evento_sistema === 'auto_inativ_aviso' && m.created_at)
+    const lastAviso = avisos[avisos.length - 1]
+    const avisoMs = lastAviso?.created_at ? new Date(lastAviso.created_at).getTime() : 0
+    const posAvisoAtivo = Boolean(lastAviso?.created_at && avisoMs >= refMs)
+
+    if (posAvisoAtivo && lastAviso?.created_at) {
+      const elapsed = (Date.now() - avisoMs) / 1000
       return {
         restanteSec: Math.max(0, posAvisoMin * 60 - elapsed),
         label: 'Tempo até encerrar por inatividade (após aviso)',
@@ -78,15 +91,6 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
       }
     }
 
-    const relevant = msgs.filter(
-      (m) =>
-        m.evento_sistema !== 'comentario_interno' &&
-        (m.direcao === 'inbound' || (m.direcao === 'outbound' && !m.evento_sistema)),
-    )
-    const last = relevant[relevant.length - 1]
-    const candidatos: number[] = []
-    if (last?.created_at) candidatos.push(new Date(last.created_at).getTime())
-    if (chat.inatividade_retomada_em) candidatos.push(new Date(chat.inatividade_retomada_em).getTime())
     if (candidatos.length === 0) {
       return {
         restanteSec: avisoMin * 60,
@@ -96,7 +100,6 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
       }
     }
 
-    const refMs = Math.max(...candidatos)
     const elapsed = (Date.now() - refMs) / 1000
     return {
       restanteSec: Math.max(0, avisoMin * 60 - elapsed),

--- a/scripts/migrate_release_notes_product.py
+++ b/scripts/migrate_release_notes_product.py
@@ -42,8 +42,21 @@ def classify_product(text: str) -> str:
     return PRODUCT_DESKRUDDER
 
 
-def migrate_manifest(data: dict) -> tuple[dict, dict[str, int]]:
-    stats = {"saas": 0, "deskrudder": 0, "kept": 0, "total": 0}
+def migrate_manifest(data: dict, *, reclassify_saas: bool = False) -> tuple[dict, dict[str, int]]:
+    """
+    Tagua bullets com product.
+
+    - Default: preserva product já válido; só classifica os sem tag.
+    - reclassify_saas=True: texto com prefixo «SaaS» → saas mesmo se estava deskrudder
+      (corrige histórico publicado antes da separação por produto).
+    """
+    stats = {
+        "saas": 0,
+        "deskrudder": 0,
+        "kept": 0,
+        "total": 0,
+        "reclassified_to_saas": 0,
+    }
     releases = []
     for rel in data.get("releases") or []:
         entry = dict(rel)
@@ -55,13 +68,18 @@ def migrate_manifest(data: dict) -> tuple[dict, dict[str, int]]:
             item = dict(ch)
             stats["total"] += 1
             existing = item.get("product")
-            if existing in (PRODUCT_DESKRUDDER, PRODUCT_SAAS):
+            inferred = classify_product(str(item.get("text") or ""))
+
+            if reclassify_saas and inferred == PRODUCT_SAAS and existing != PRODUCT_SAAS:
+                item["product"] = PRODUCT_SAAS
+                stats["reclassified_to_saas"] += 1
+                stats["saas"] += 1
+            elif existing in (PRODUCT_DESKRUDDER, PRODUCT_SAAS):
                 stats["kept"] += 1
                 stats[existing] += 1
             else:
-                product = classify_product(str(item.get("text") or ""))
-                item["product"] = product
-                stats[product] += 1
+                item["product"] = inferred
+                stats[inferred] += 1
             changes.append(item)
         entry["changes"] = changes
         releases.append(entry)
@@ -72,6 +90,11 @@ def main() -> int:
     ap = argparse.ArgumentParser(description="Classifica bullets do manifest com product (#676)")
     ap.add_argument("--dry-run", action="store_true", help="Só imprime estatísticas")
     ap.add_argument("--no-write-json", action="store_true", help="Não regenera release_notes.json")
+    ap.add_argument(
+        "--reclassify-saas",
+        action="store_true",
+        help="Força product=saas em bullets com prefixo «SaaS» (mesmo se tagueados DeskRudder)",
+    )
     args = ap.parse_args()
 
     if not MANIFEST_FILE.is_file():
@@ -79,10 +102,11 @@ def main() -> int:
         return 1
 
     raw = json.loads(MANIFEST_FILE.read_text(encoding="utf-8"))
-    migrated, stats = migrate_manifest(raw)
+    migrated, stats = migrate_manifest(raw, reclassify_saas=args.reclassify_saas)
     print(
         f"Bullets: total={stats['total']} deskrudder={stats['deskrudder']} "
-        f"saas={stats['saas']} (já tinham product={stats['kept']})"
+        f"saas={stats['saas']} (ja tinham product={stats['kept']}, "
+        f"reclassificados->saas={stats['reclassified_to_saas']})"
     )
 
     if args.dry_run:


### PR DESCRIPTION
## Summary

- **#712** — Encerramento por inatividade WhatsApp volta a funcionar depois de registar demanda (worker + countdown ignoram marcos de sistema).
- **#713** — Confirmar «concluir sem demanda» fica legível em dark mode (`CheckboxField`).
- **Sobre** — bullets históricos que começam com «SaaS» deixam de aparecer em `/sobre` mesmo se o JSON antigo estiver mal tagueado (#672).

Closes #712
Closes #713

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest` `tests/test_whatsapp_inatividade_encerramento.py` (inclui regressão demanda após aviso)
- [x] `pytest` `tests/test_system_release.py` + `tests/test_migrate_release_notes_product.py`
- [x] `npm run build`
- [ ] Manual: dark mode → modal encerrar por inatividade → «Concluir sem registar demanda» → texto legível
- [ ] Manual: inatividade ligada → registar demanda → relógio não fica preso em 00:00; worker encerra
- [ ] Manual: `/sobre` sem bullets «SaaS: …» da release antiga

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Fora de escopo documentado nas issues (#712 / #713)
- [x] N/A stubs
- [ ] Após merge: `/release-staging` para a correção do `/sobre` chegar às instâncias em produção
