### PR TITLE
feat(frontend): Voltar nativo fecha o painel e URL fixa no portal (#699 #700)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Chat (#654): a mesa de atendimento fica sempre no mesmo endereço (`/chat/atendendo`, `/chat/espera`, `/chat/interno`) — o número da conversa deixa de aparecer na barra do navegador e a conversa aberta continua no painel ao trocar de aba
 - Tickets (#655): abrir um chamado mantém o endereço `/tickets`, sem o número do ticket na barra do navegador; ao voltar, a lista preserva filtros e página
 - Notificações (#697): o sininho e o e-mail interno do painel já não põem o número do chamado ou da conversa no endereço; o clique abre o item certo na mesa ou em tickets
+- Chat e tickets (#699): o Voltar do navegador fecha o painel da conversa ou do chamado e permanece na mesa (`/chat/…`, `/tickets`), sem o número na barra
+- Portal (#700): chamados e atendimentos WhatsApp ficam em `/portal/tickets` e `/portal/chats`, sem o número na barra; links antigos com id continuam a abrir o item certo
 
 #### Correções
 
 - Login (#677): em subdomínio do cliente, **Voltar ao site** abre a landing DeskRudder (apex) em vez de voltar ao próprio login
 - Funcionários da rede (#685): ao editar/criar, o formulário volta a mostrar o topo e a rolar até ao fim — sem espaço vazio abaixo dos botões nem conteúdo preso fora do ecrã
-- Links antigos (#654 / #655): endereços com número (chat da fila, conversa do WhatsApp, detalhe de ticket) continuam a funcionar e abrem o item certo no novo formato
+- Links antigos (#654 / #655 / #700): endereços com número (chat da fila, conversa do WhatsApp, detalhe de ticket no painel ou no portal) continuam a funcionar e abrem o item certo no novo formato
 - Chat (#698): a mesa deixa de gravar a conversa aberta só por desenhar a lista — só o clique (ou o sininho) muda o painel
 - WhatsApp (#683): envio de mensagem/áudio/anexo já não mostra toast verde que cobria o botão de enviar (erros continuam)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -94,10 +94,8 @@ import { PortalLogin } from './pages/portal/PortalLogin'
 import { PortalTrocarSenha } from './pages/portal/PortalTrocarSenha'
 import { PortalTickets } from './pages/portal/PortalTickets'
 import { PortalTicketNovo } from './pages/portal/PortalTicketNovo'
-import { PortalTicketDetalhe } from './pages/portal/PortalTicketDetalhe'
 import { PortalAjudaHome, PortalAjudaArtigo } from './pages/portal/PortalAjuda'
 import { PortalChats } from './pages/portal/PortalChats'
-import { PortalChatDetalhe } from './pages/portal/PortalChatDetalhe'
 import { PortalEquipe } from './pages/portal/PortalEquipe'
 import { PortalEquipeForm } from './pages/portal/PortalEquipeForm'
 import { ToastProvider } from './components/ui/Toast'
@@ -107,6 +105,12 @@ import { isMarketingHost } from './lib/marketingHost'
 import { isSaasControlPlaneFrontend } from './lib/saasControlPlane'
 import { gravarChatAtivoSession, type ChatAtivoCanal } from './lib/chatAtivo'
 import { chatHubModoDePath, chatHubPathParaModo } from './lib/chatHubPaths'
+import {
+  gravarPortalChatAtivoSession,
+  gravarPortalTicketAtivoSession,
+  PORTAL_CHATS_PATH,
+  PORTAL_TICKETS_PATH,
+} from './lib/portalAtivo'
 import { gravarTicketAtivoSession } from './lib/ticketAtivo'
 
 /**
@@ -204,6 +208,28 @@ function RedirectTicketDetalhe() {
   return <Navigate to="/tickets" replace state={location.state} />
 }
 
+/** `/portal/tickets/:id` legado: sessão + URL fixa `#700`. */
+function RedirectPortalTicketDetalhe() {
+  const { id } = useParams<{ id: string }>()
+  const location = useLocation()
+  const ticketId = Number(id)
+  if (Number.isFinite(ticketId) && ticketId > 0) {
+    gravarPortalTicketAtivoSession(ticketId)
+  }
+  return <Navigate to={PORTAL_TICKETS_PATH} replace state={location.state} />
+}
+
+/** `/portal/chats/:id` legado: sessão + URL fixa `#700`. */
+function RedirectPortalChatDetalhe() {
+  const { id } = useParams<{ id: string }>()
+  const location = useLocation()
+  const chatId = Number(id)
+  if (Number.isFinite(chatId) && chatId > 0) {
+    gravarPortalChatAtivoSession(chatId)
+  }
+  return <Navigate to={PORTAL_CHATS_PATH} replace state={location.state} />
+}
+
 function RedirectLegacyChatInterno() {
   const location = useLocation()
   const path = location.pathname.replace(/^\/chat-interno/, '/chat/interno')
@@ -230,9 +256,9 @@ function AppRoutes() {
         <Route path="trocar-senha" element={<PortalTrocarSenha />} />
         <Route path="tickets" element={<PortalTickets />} />
         <Route path="tickets/novo" element={<PortalTicketNovo />} />
-        <Route path="tickets/:id" element={<PortalTicketDetalhe />} />
+        <Route path="tickets/:id" element={<RedirectPortalTicketDetalhe />} />
         <Route path="chats" element={<PortalChats />} />
-        <Route path="chats/:id" element={<PortalChatDetalhe />} />
+        <Route path="chats/:id" element={<RedirectPortalChatDetalhe />} />
         <Route path="equipe" element={<PortalEquipe />} />
         <Route path="equipe/novo" element={<PortalEquipeForm />} />
         <Route path="equipe/:id" element={<PortalEquipeForm />} />

--- a/frontend/src/contexts/ChatHubContext.tsx
+++ b/frontend/src/contexts/ChatHubContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { useLocation } from 'react-router-dom'
 import { portalChats, whatsappChats } from '../api/client'
+import { useMesaPanelHistory } from '../hooks/useMesaPanelHistory'
 import {
   CHAT_ATIVO_EVENT,
   gravarChatAtivoSession,
@@ -8,6 +9,7 @@ import {
   type ChatAtivo,
   type ChatAtivoCanal,
 } from '../lib/chatAtivo'
+import { popMesaPanelState } from '../lib/mesaHistory'
 import { useEventStream } from './EventStreamContext'
 
 type ChatHubContextValue = {
@@ -19,7 +21,8 @@ type ChatHubContextValue = {
   /** Conversa aberta no painel (sem id na URL) (#654). */
   chatAtivo: ChatAtivo | null
   abrirChat: (canal: ChatAtivoCanal, id: number) => void
-  fecharChat: () => void
+  /** Limpa o painel. Devolve true se consumiu o Voltar extra do histórico (#699). */
+  fecharChat: () => boolean
 }
 
 const ChatHubContext = createContext<ChatHubContextValue | null>(null)
@@ -39,10 +42,16 @@ export function ChatHubProvider({ children }: { children: ReactNode }) {
     setChatAtivo(next)
   }, [])
 
-  const fecharChat = useCallback(() => {
+  const fecharChat = useCallback((opts?: { fromPopstate?: boolean }) => {
     gravarChatAtivoSession(null)
     setChatAtivo(null)
+    if (opts?.fromPopstate) return true
+    return popMesaPanelState()
   }, [])
+
+  useMesaPanelHistory('chat', chatAtivo != null, () => {
+    void fecharChat({ fromPopstate: true })
+  })
 
   /** Sync após clique que grava sessão (sininho / helpers sem side-effect) (#654 / #697 / #698). */
   useEffect(() => {

--- a/frontend/src/hooks/useMesaPanelHistory.ts
+++ b/frontend/src/hooks/useMesaPanelHistory.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react'
+import { useLocation } from 'react-router-dom'
+import { pushMesaPanelState, type MesaHistoryKind } from '../lib/mesaHistory'
+
+/**
+ * Garante `history.state` enquanto o painel está aberto e fecha no Voltar do browser (#699).
+ * `onFecharPorBrowser` deve só limpar o item activo — sem `history.back()` (já ocorreu).
+ */
+export function useMesaPanelHistory(
+  kind: MesaHistoryKind,
+  aberto: boolean,
+  onFecharPorBrowser: () => void,
+): void {
+  const { pathname } = useLocation()
+  const onFecharRef = useRef(onFecharPorBrowser)
+  onFecharRef.current = onFecharPorBrowser
+  const abertoRef = useRef(aberto)
+  abertoRef.current = aberto
+
+  useEffect(() => {
+    if (aberto) pushMesaPanelState(kind)
+  }, [aberto, kind, pathname])
+
+  useEffect(() => {
+    const onPop = () => {
+      if (abertoRef.current) onFecharRef.current()
+    }
+    window.addEventListener('popstate', onPop)
+    return () => window.removeEventListener('popstate', onPop)
+  }, [])
+}

--- a/frontend/src/hooks/useWhatsappVoltarLista.ts
+++ b/frontend/src/hooks/useWhatsappVoltarLista.ts
@@ -38,7 +38,8 @@ export function useWhatsappVoltarLista(fallbackPath = WHATSAPP_LIST_PATHS.atende
   const fecharChat = hub?.fecharChat
 
   const sairParaListaSegura = useCallback(() => {
-    fecharChat?.()
+    const consumiuHistorico = fecharChat?.() === true
+    if (consumiuHistorico) return
     const destino = resolveWhatsappListFallback(location.state, searchParams.get('from'), fallbackPath)
     if (destino === location.pathname || (estaNaAbaDoHub(location.pathname) && destino.startsWith('/chat/'))) {
       return
@@ -47,7 +48,8 @@ export function useWhatsappVoltarLista(fallbackPath = WHATSAPP_LIST_PATHS.atende
   }, [fecharChat, navigate, location.state, location.pathname, searchParams, fallbackPath])
 
   const voltarLista = useCallback(() => {
-    fecharChat?.()
+    const consumiuHistorico = fecharChat?.() === true
+    if (consumiuHistorico) return
     const returnPath = (location.state as WhatsappListReturnState | null)?.whatsappListReturn?.trim()
     if (returnPath && returnPath !== location.pathname) {
       navigate(returnPath)

--- a/frontend/src/lib/mesaHistory.ts
+++ b/frontend/src/lib/mesaHistory.ts
@@ -1,0 +1,44 @@
+/**
+ * Voltar nativo fecha o painel sem pôr id na URL (#699).
+ * `pushState` no mesmo path; `popstate` limpa o item activo.
+ * Não grava o id no histórico — Forward não reabre conversa encerrada (#653).
+ */
+
+export const MESA_HISTORY_FLAG = 'deskrudderMesa'
+
+export type MesaHistoryKind = 'chat' | 'ticket' | 'portal-ticket' | 'portal-chat'
+
+type MesaHistoryState = {
+  [MESA_HISTORY_FLAG]: true
+  kind: MesaHistoryKind
+}
+
+function asRecord(state: unknown): Record<string, unknown> {
+  return state != null && typeof state === 'object' && !Array.isArray(state)
+    ? (state as Record<string, unknown>)
+    : {}
+}
+
+export function isMesaHistoryState(state: unknown): state is MesaHistoryState {
+  return asRecord(state)[MESA_HISTORY_FLAG] === true
+}
+
+/** Abre o painel: uma entrada extra (mesmo URL). Trocar A→B faz replace, não empilha. */
+export function pushMesaPanelState(kind: MesaHistoryKind): void {
+  if (typeof window === 'undefined') return
+  const current = asRecord(window.history.state)
+  const next = { ...current, [MESA_HISTORY_FLAG]: true, kind }
+  if (current[MESA_HISTORY_FLAG] === true) {
+    window.history.replaceState(next, '')
+  } else {
+    window.history.pushState(next, '')
+  }
+}
+
+/** Fecha via UI/Esc: consome a entrada extra. Devolve true se chamou `history.back()`. */
+export function popMesaPanelState(): boolean {
+  if (typeof window === 'undefined') return false
+  if (!isMesaHistoryState(window.history.state)) return false
+  window.history.back()
+  return true
+}

--- a/frontend/src/lib/portalAtivo.ts
+++ b/frontend/src/lib/portalAtivo.ts
@@ -1,0 +1,52 @@
+/** Chamado / chat aberto no portal — sem id na URL (#700). */
+
+export const PORTAL_TICKETS_PATH = '/portal/tickets'
+export const PORTAL_CHATS_PATH = '/portal/chats'
+
+export const PORTAL_TICKET_ATIVO_SESSION_KEY = 'deskrudder-portal-ticket-ativo'
+export const PORTAL_CHAT_ATIVO_SESSION_KEY = 'deskrudder-portal-chat-ativo'
+
+export const PORTAL_TICKET_ATIVO_EVENT = 'deskrudder-portal-ticket-ativo'
+export const PORTAL_CHAT_ATIVO_EVENT = 'deskrudder-portal-chat-ativo'
+
+function lerId(key: string): number | null {
+  try {
+    const raw = sessionStorage.getItem(key)
+    if (!raw) return null
+    const id = Number(raw)
+    return Number.isFinite(id) && id > 0 ? id : null
+  } catch {
+    return null
+  }
+}
+
+function gravarId(key: string, eventName: string, id: number | null): void {
+  try {
+    if (id == null || !Number.isFinite(id) || id <= 0) {
+      sessionStorage.removeItem(key)
+    } else {
+      sessionStorage.setItem(key, String(id))
+    }
+  } catch {
+    /* quota / modo privado */
+  }
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new Event(eventName))
+  }
+}
+
+export function lerPortalTicketAtivoSession(): number | null {
+  return lerId(PORTAL_TICKET_ATIVO_SESSION_KEY)
+}
+
+export function gravarPortalTicketAtivoSession(id: number | null): void {
+  gravarId(PORTAL_TICKET_ATIVO_SESSION_KEY, PORTAL_TICKET_ATIVO_EVENT, id)
+}
+
+export function lerPortalChatAtivoSession(): number | null {
+  return lerId(PORTAL_CHAT_ATIVO_SESSION_KEY)
+}
+
+export function gravarPortalChatAtivoSession(id: number | null): void {
+  gravarId(PORTAL_CHAT_ATIVO_SESSION_KEY, PORTAL_CHAT_ATIVO_EVENT, id)
+}

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -28,6 +28,8 @@ import { rotuloPrioridade, classeBadgePrioridade } from '../lib/ticketPrioridade
 import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { SlaBadge } from '../components/tickets/SlaBadge'
 import { TicketDetalhe } from './TicketDetalhe'
+import { useMesaPanelHistory } from '../hooks/useMesaPanelHistory'
+import { popMesaPanelState } from '../lib/mesaHistory'
 import { gravarTicketAtivoSession, lerTicketAtivoSession, TICKET_ATIVO_EVENT } from '../lib/ticketAtivo'
 
 type ColunaOrdenacao =
@@ -129,10 +131,16 @@ export function Tickets() {
     setTicketAtivoId(id)
   }, [])
 
-  const fecharTicket = useCallback(() => {
+  const fecharTicket = useCallback((opts?: { fromPopstate?: boolean }) => {
     gravarTicketAtivoSession(null)
     setTicketAtivoId(null)
+    if (opts?.fromPopstate) return
+    popMesaPanelState()
   }, [])
+
+  useMesaPanelHistory('ticket', ticketAtivoId != null, () => {
+    fecharTicket({ fromPopstate: true })
+  })
 
   const situacao = useMemo<'abertos' | 'fechados'>(() => {
     const s = searchParams.get('situacao')

--- a/frontend/src/pages/portal/PortalChatDetalhe.tsx
+++ b/frontend/src/pages/portal/PortalChatDetalhe.tsx
@@ -26,15 +26,27 @@ function estadoLabel(estado: string) {
   return estado || '—'
 }
 
-export function PortalChatDetalhe() {
+type PortalChatDetalheProps = {
+  chatIdProp?: number
+  onVoltar?: () => void
+}
+
+export function PortalChatDetalhe({ chatIdProp, onVoltar }: PortalChatDetalheProps = {}) {
   const { id } = useParams<{ id: string }>()
-  const chatId = Number(id)
+  const chatId = chatIdProp ?? Number(id)
   const [chat, setChat] = useState<PortalCliente.WhatsappChatDetail | null>(null)
   const [mensagens, setMensagens] = useState<PortalCliente.WhatsappMensagem[]>([])
   const [loading, setLoading] = useState(true)
   const bottomRef = useRef<HTMLDivElement | null>(null)
   const toast = useToast()
   const navigate = useNavigate()
+  const voltarLista = useCallback(() => {
+    if (onVoltar) {
+      onVoltar()
+      return
+    }
+    navigate('/portal/chats')
+  }, [onVoltar, navigate])
 
   const carregar = useCallback(async () => {
     if (!Number.isFinite(chatId)) return
@@ -53,7 +65,7 @@ export function PortalChatDetalhe() {
       .catch((err) => {
         if (!cancelled) {
           toast.showError(mensagemFalhaParaToast(err, 'Atendimento não encontrado.'))
-          navigate('/portal/chats', { replace: true })
+          voltarLista()
         }
       })
       .finally(() => {
@@ -62,7 +74,7 @@ export function PortalChatDetalhe() {
     return () => {
       cancelled = true
     }
-  }, [carregar, navigate, toast])
+  }, [carregar, voltarLista, toast])
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
@@ -102,7 +114,7 @@ export function PortalChatDetalhe() {
       <div>
         <button
           type="button"
-          onClick={() => navigate('/portal/chats')}
+          onClick={voltarLista}
           className="mb-2 text-sm font-medium text-slate-500 hover:text-slate-800"
         >
           ← Voltar

--- a/frontend/src/pages/portal/PortalChats.tsx
+++ b/frontend/src/pages/portal/PortalChats.tsx
@@ -1,8 +1,15 @@
-import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom'
+import { useCallback, useEffect, useState } from 'react'
 import { portalCliente, type PortalCliente } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { useToast } from '../../components/ui/Toast'
+import { useMesaPanelHistory } from '../../hooks/useMesaPanelHistory'
+import { popMesaPanelState } from '../../lib/mesaHistory'
+import {
+  gravarPortalChatAtivoSession,
+  lerPortalChatAtivoSession,
+  PORTAL_CHAT_ATIVO_EVENT,
+} from '../../lib/portalAtivo'
+import { PortalChatDetalhe } from './PortalChatDetalhe'
 import {
   PortalPageHeader,
   PortalSegmentedControl,
@@ -51,6 +58,29 @@ export function PortalChats() {
   const [loading, setLoading] = useState(true)
   const [erro, setErro] = useState<string | null>(null)
   const toast = useToast()
+  const [chatAtivoId, setChatAtivoId] = useState<number | null>(() => lerPortalChatAtivoSession())
+
+  const abrirChat = useCallback((id: number) => {
+    gravarPortalChatAtivoSession(id)
+    setChatAtivoId(id)
+  }, [])
+
+  const fecharChat = useCallback((opts?: { fromPopstate?: boolean }) => {
+    gravarPortalChatAtivoSession(null)
+    setChatAtivoId(null)
+    if (opts?.fromPopstate) return
+    popMesaPanelState()
+  }, [])
+
+  useMesaPanelHistory('portal-chat', chatAtivoId != null, () => {
+    fecharChat({ fromPopstate: true })
+  })
+
+  useEffect(() => {
+    const sync = () => setChatAtivoId(lerPortalChatAtivoSession())
+    window.addEventListener(PORTAL_CHAT_ATIVO_EVENT, sync)
+    return () => window.removeEventListener(PORTAL_CHAT_ATIVO_EVENT, sync)
+  }, [])
 
   useEffect(() => {
     const t = window.setTimeout(() => setBuscaDebounced(busca.trim()), 300)
@@ -82,6 +112,10 @@ export function PortalChats() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [situacao, buscaDebounced])
+
+  if (chatAtivoId != null) {
+    return <PortalChatDetalhe chatIdProp={chatAtivoId} onVoltar={fecharChat} />
+  }
 
   return (
     <div className="space-y-6">
@@ -126,7 +160,7 @@ export function PortalChats() {
         <ul className="space-y-3">
           {items.map((c) => (
             <li key={c.id}>
-              <Link to={`/portal/chats/${c.id}`} className={`block ${portalCardClass}`}>
+              <button type="button" onClick={() => abrirChat(c.id)} className={`block w-full text-left ${portalCardClass}`}>
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <p className="font-mono text-xs font-semibold tracking-wide text-[var(--portal-primary)]">
@@ -144,7 +178,7 @@ export function PortalChats() {
                   </span>
                 </div>
                 <p className="mt-3 text-xs text-slate-400">{formatData(c.ultima_mensagem_em || c.created_at)}</p>
-              </Link>
+              </button>
             </li>
           ))}
         </ul>

--- a/frontend/src/pages/portal/PortalSidebar.tsx
+++ b/frontend/src/pages/portal/PortalSidebar.tsx
@@ -49,7 +49,7 @@ const icons = {
 
 const NAV_ITEMS: NavItem[] = [
   { to: '/portal/tickets', label: 'Chamados', end: true, icon: icons.tickets },
-  { to: '/portal/chats', label: 'Atendimentos', icon: icons.chats },
+  { to: '/portal/chats', label: 'Atendimentos', end: true, icon: icons.chats },
   { to: '/portal/equipe', label: 'Usuários', icon: icons.users, socioOnly: true },
   { to: '/portal/ajuda', label: 'Ajuda', icon: icons.help },
 ]

--- a/frontend/src/pages/portal/PortalTicketDetalhe.tsx
+++ b/frontend/src/pages/portal/PortalTicketDetalhe.tsx
@@ -19,9 +19,14 @@ function formatData(iso?: string | null) {
   }
 }
 
-export function PortalTicketDetalhe() {
+type PortalTicketDetalheProps = {
+  ticketIdProp?: number
+  onVoltar?: () => void
+}
+
+export function PortalTicketDetalhe({ ticketIdProp, onVoltar }: PortalTicketDetalheProps = {}) {
   const { id } = useParams<{ id: string }>()
-  const ticketId = Number(id)
+  const ticketId = ticketIdProp ?? Number(id)
   const [ticket, setTicket] = useState<PortalCliente.TicketDetail | null>(null)
   const [mensagens, setMensagens] = useState<PortalCliente.Mensagem[]>([])
   const [loading, setLoading] = useState(true)
@@ -31,6 +36,14 @@ export function PortalTicketDetalhe() {
   const bottomRef = useRef<HTMLDivElement | null>(null)
   const toast = useToast()
   const navigate = useNavigate()
+
+  const voltarLista = useCallback(() => {
+    if (onVoltar) {
+      onVoltar()
+      return
+    }
+    navigate('/portal/tickets')
+  }, [onVoltar, navigate])
 
   const carregar = useCallback(async () => {
     if (!Number.isFinite(ticketId)) return
@@ -49,7 +62,7 @@ export function PortalTicketDetalhe() {
       .catch((err) => {
         if (!cancelled) {
           toast.showError(mensagemFalhaParaToast(err, 'Chamado não encontrado.'))
-          navigate('/portal/tickets', { replace: true })
+          voltarLista()
         }
       })
       .finally(() => {
@@ -58,7 +71,7 @@ export function PortalTicketDetalhe() {
     return () => {
       cancelled = true
     }
-  }, [carregar, navigate, toast])
+  }, [carregar, voltarLista, toast])
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' })
@@ -139,7 +152,7 @@ export function PortalTicketDetalhe() {
       <div>
         <button
           type="button"
-          onClick={() => navigate('/portal/tickets')}
+          onClick={voltarLista}
           className="mb-2 text-sm font-medium text-slate-500 hover:text-slate-800"
         >
           ← Voltar

--- a/frontend/src/pages/portal/PortalTicketNovo.tsx
+++ b/frontend/src/pages/portal/PortalTicketNovo.tsx
@@ -5,6 +5,7 @@ import { usePortalAuth } from '../../contexts/PortalAuthContext'
 import { Button } from '../../components/ui/Button'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { gravarPortalTicketAtivoSession, PORTAL_TICKETS_PATH } from '../../lib/portalAtivo'
 
 const fieldClass =
   'w-full rounded-xl border border-slate-200 bg-white px-3.5 py-2.5 text-sm text-slate-900 shadow-sm focus:border-teal-500 focus:outline-none focus:ring-2 focus:ring-teal-500/25'
@@ -93,7 +94,8 @@ export function PortalTicketNovo() {
         }
       }
       toast.showSuccess('Chamado aberto com sucesso.')
-      navigate(`/portal/tickets/${ticket.id}`, { replace: true })
+      gravarPortalTicketAtivoSession(ticket.id)
+      navigate(PORTAL_TICKETS_PATH, { replace: true })
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível abrir o chamado.'))
     } finally {

--- a/frontend/src/pages/portal/PortalTickets.tsx
+++ b/frontend/src/pages/portal/PortalTickets.tsx
@@ -1,8 +1,16 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { portalCliente, type PortalCliente } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { useToast } from '../../components/ui/Toast'
+import { useMesaPanelHistory } from '../../hooks/useMesaPanelHistory'
+import { popMesaPanelState } from '../../lib/mesaHistory'
+import {
+  gravarPortalTicketAtivoSession,
+  lerPortalTicketAtivoSession,
+  PORTAL_TICKET_ATIVO_EVENT,
+} from '../../lib/portalAtivo'
+import { PortalTicketDetalhe } from './PortalTicketDetalhe'
 import {
   PortalPageHeader,
   PortalSegmentedControl,
@@ -43,6 +51,29 @@ export function PortalTickets() {
   const [loading, setLoading] = useState(true)
   const [erro, setErro] = useState<string | null>(null)
   const toast = useToast()
+  const [ticketAtivoId, setTicketAtivoId] = useState<number | null>(() => lerPortalTicketAtivoSession())
+
+  const abrirTicket = useCallback((id: number) => {
+    gravarPortalTicketAtivoSession(id)
+    setTicketAtivoId(id)
+  }, [])
+
+  const fecharTicket = useCallback((opts?: { fromPopstate?: boolean }) => {
+    gravarPortalTicketAtivoSession(null)
+    setTicketAtivoId(null)
+    if (opts?.fromPopstate) return
+    popMesaPanelState()
+  }, [])
+
+  useMesaPanelHistory('portal-ticket', ticketAtivoId != null, () => {
+    fecharTicket({ fromPopstate: true })
+  })
+
+  useEffect(() => {
+    const sync = () => setTicketAtivoId(lerPortalTicketAtivoSession())
+    window.addEventListener(PORTAL_TICKET_ATIVO_EVENT, sync)
+    return () => window.removeEventListener(PORTAL_TICKET_ATIVO_EVENT, sync)
+  }, [])
 
   useEffect(() => {
     const t = window.setTimeout(() => setBuscaDebounced(busca.trim()), 300)
@@ -74,6 +105,10 @@ export function PortalTickets() {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [situacao, buscaDebounced])
+
+  if (ticketAtivoId != null) {
+    return <PortalTicketDetalhe ticketIdProp={ticketAtivoId} onVoltar={fecharTicket} />
+  }
 
   return (
     <div className="space-y-6">
@@ -131,7 +166,7 @@ export function PortalTickets() {
         <ul className="space-y-3">
           {items.map((t) => (
             <li key={t.id}>
-              <Link to={`/portal/tickets/${t.id}`} className={`block ${portalCardClass}`}>
+              <button type="button" onClick={() => abrirTicket(t.id)} className={`block w-full text-left ${portalCardClass}`}>
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0">
                     <p className="font-mono text-xs font-semibold tracking-wide text-[var(--portal-primary)]">
@@ -149,7 +184,7 @@ export function PortalTickets() {
                 <p className="mt-3 text-xs text-slate-400">
                   Atualizado {formatData(t.ultima_mensagem_em || t.updated_at || t.created_at)}
                 </p>
-              </Link>
+              </button>
             </li>
           ))}
         </ul>


### PR DESCRIPTION
## Summary

- **#699:** com o painel aberto, o Voltar do browser fecha a conversa/chamado e permanece em `/chat/…` ou `/tickets` (sem id na barra). Sem painel, o Voltar sai da mesa. Esc e o botão Voltar da UI consomem a entrada extra; Forward não reabre conversa fechada (#653).
- **#700:** portal com URL fixa em `/portal/tickets` e `/portal/chats`; `/portal/tickets/novo` mantém-se e, após criar, abre o chamado sem `/{id}`. Links antigos `/portal/tickets/:id` e `/portal/chats/:id` redireccionam e abrem o item certo. CSAT público fora deste lote.

Closes #699
Closes #700

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] Mesa chat: abrir conversa em `/chat/atendendo` → Voltar do Chrome fecha o painel e a URL continua `/chat/atendendo`
- [ ] Mesa chat: sem painel, Voltar sai da mesa (Dashboard, etc.)
- [ ] Mesa tickets: o mesmo em `/tickets`
- [ ] Esc / botão Voltar da UI fecham o painel; o próximo Voltar do browser sai da mesa (não “falha” uma vez)
- [ ] Trocar de conversa A→B: um Voltar fecha o painel (não volta para A)
- [ ] Portal: abrir chamado em `/portal/tickets` — barra sem id; Voltar fecha o detalhe
- [ ] Portal: `/portal/tickets/novo` → após criar, URL `/portal/tickets` com o chamado aberto
- [ ] Portal: abrir atendimento em `/portal/chats` — barra sem id
- [ ] Favorito/link antigo `/portal/tickets/123` (e chats) abre o item certo no path fixo
- [ ] URL visível nunca mostra id/protocolo nestes fluxos

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — cada um virou issue `#___` ou está documentado como wontfix
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados

Fora de escopo (já nas issues, sem follow-up novo):

- Voltar percorrer várias conversas na pilha (A→B→Voltar→A) — #699
- CSAT público (token opaco) — #700
