### PR TITLE
fix(frontend): scrollbar da sidebar alinhada ao tema (#716)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Chat e tickets (#699): o Voltar do navegador fecha o painel da conversa ou do chamado e permanece na mesa (`/chat/…`, `/tickets`), sem o número na barra
 - Portal (#700): chamados e atendimentos WhatsApp ficam em `/portal/tickets` e `/portal/chats`, sem o número na barra; links antigos com id continuam a abrir o item certo
 - Mobile (#690 / #691): o painel no endereço do cliente pode ser **adicionado à tela inicial** (PWA); o brief mobile descreve PWA primeiro, depois lojas
+- Menu (#716): a barra de rolagem da sidebar (painel e portal) fica fina e alinhada ao tema, sem o visual nativo do Windows
 
 #### Correções
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -135,7 +135,7 @@ function LayoutInner() {
                   ? isChatHub
                     ? 'flex h-full min-h-0 flex-col overflow-hidden'
                     : 'flex h-full min-h-0 flex-col overflow-hidden px-4 pt-4 md:px-6 md:pt-6'
-                  : 'h-full min-h-0 overflow-x-hidden overflow-y-auto p-4 md:p-6'
+                  : 'dx-scrollbar h-full min-h-0 overflow-x-hidden overflow-y-auto p-4 md:p-6'
               }
             >
               <Outlet />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -543,7 +543,7 @@ export function Sidebar({
       </div>
 
       <nav
-        className={`min-w-0 flex-1 overflow-x-hidden overflow-y-auto py-3 px-2 ${!expanded ? 'md:px-2' : ''}`}
+        className={`dx-scrollbar min-w-0 flex-1 overflow-x-hidden overflow-y-auto py-3 px-2 ${!expanded ? 'md:px-2' : ''}`}
         aria-label="Menu principal"
       >
         <ul className={`min-w-0 space-y-0.5 px-2 ${!expanded ? 'md:px-0' : ''}`}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -161,14 +161,14 @@
   @apply border-slate-200;
 }
 
-/* Scrollbar discreta (Kanban CRM e listas horizontais) — evita a barra nativa do Windows */
+/* Scrollbar discreta (sidebar, Kanban CRM) — evita a barra nativa do Windows */
 .dx-scrollbar {
   scrollbar-width: thin;
   scrollbar-color: rgb(148 163 184 / 0.55) transparent;
 }
 
 .dark .dx-scrollbar {
-  scrollbar-color: rgb(100 116 139 / 0.7) transparent;
+  scrollbar-color: rgb(148 163 184 / 0.45) transparent;
 }
 
 .dx-scrollbar::-webkit-scrollbar {
@@ -191,11 +191,11 @@
 }
 
 .dark .dx-scrollbar::-webkit-scrollbar-thumb {
-  background: rgb(100 116 139 / 0.7);
+  background: rgb(148 163 184 / 0.45);
 }
 
 .dark .dx-scrollbar::-webkit-scrollbar-thumb:hover {
-  background: rgb(148 163 184 / 0.55);
+  background: rgb(203 213 225 / 0.6);
 }
 
 .dx-scrollbar::-webkit-scrollbar-button {

--- a/frontend/src/pages/portal/PortalSidebar.tsx
+++ b/frontend/src/pages/portal/PortalSidebar.tsx
@@ -138,7 +138,7 @@ export function PortalSidebar({
       </div>
 
       <nav
-        className={`min-w-0 flex-1 overflow-x-hidden overflow-y-auto py-3 px-2 ${!expanded ? 'md:px-2' : ''}`}
+        className={`dx-scrollbar min-w-0 flex-1 overflow-x-hidden overflow-y-auto py-3 px-2 ${!expanded ? 'md:px-2' : ''}`}
         aria-label="Menu do portal"
       >
         <ul className={`min-w-0 space-y-0.5 px-2 ${!expanded ? 'md:px-0' : ''}`}>


### PR DESCRIPTION
## Summary

- Sidebar do painel e do portal passam a usar a scrollbar discreta já usada no CRM (`dx-scrollbar`).
- Thumb um pouco mais claro no tema escuro para contrastar com o fundo navy.
- Conteúdo principal (`Layout` `<main>`) alinhado ao mesmo visual.

Closes #716

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**
- [x] Cada entrega do lote tem pelo menos um bullet

## Test plan

- [x] Windows: menu longo (Chat + Clientes + Ajuda) — barra fina, sem setas, visível no dark
- [x] Light mode: thumb ainda visível
- [x] Rolar até ao fundo: perfil / Sair acessíveis
- [x] Portal do cliente: mesmo padrão no menu lateral
- [x] CHANGELOG `[Unreleased]`

## Follow-ups / backlog

- [x] Fora de escopo da #716 (esconder scrollbar, lib de scroll) — não aplicável
- [x] N/A stubs
