### PR TITLE
chore(ci): acelerar pytest e pular jobs no lado inalterado

### DIFF
--- a/.cursor/commands/criar-pr.md
+++ b/.cursor/commands/criar-pr.md
@@ -76,7 +76,11 @@ Capture: `PR_NUMBER`, `PR_URL`.
 
 ## Passo 5 — Acompanhar CI (obrigatório)
 
-Workflow esperado: **`CI`** (jobs: `changelog`, `backend`, `frontend`).
+Workflow esperado: **`CI`** (jobs: `changes`, `changelog`, `backend`, `frontend`).
+
+Os jobs `backend` e `frontend` **sempre** aparecem (branch protection). Se o diff não toca nesse lado, o job conclui em segundos com “omitido” — isso é **sucesso**, não falha. Não trate skip rápido como CI quebrada.
+
+Pushes seguidos no mesmo PR **cancelam** a CI anterior (`concurrency`). `gh pr checks --watch` deve seguir o run mais recente.
 
 ### Monitorar até concluir
 

--- a/.cursor/commands/implementar-issue.md
+++ b/.cursor/commands/implementar-issue.md
@@ -38,7 +38,11 @@ Antes de editar código:
 - [ ] Teste em `backend/tests/`
 - [ ] Evento SSE pós-commit, se feature for tempo real
 
-Rodar: `docker compose run --rm --no-deps backend pytest -q`
+Rodar pytest **só se o lote tocou backend/scripts/CI** (mesma regra do `/revisar-e-testar`):
+
+```bash
+docker compose run --rm --no-deps backend pytest -q
+```
 
 ## Fase 3 — Frontend (se aplicável)
 

--- a/.cursor/commands/revisar-e-testar.md
+++ b/.cursor/commands/revisar-e-testar.md
@@ -30,14 +30,35 @@ Confirme que a branch **não** é `main`/`staging`. Se for, avise para usar `/in
 - [ ] Eventos publicados após commit DB
 - [ ] Payload compatível com consumidores existentes
 
-## Executar testes
+## Executar testes (só o que o diff toca)
+
+Mesma regra do GitHub Actions (`scripts/ci_detect_changes.py`): pytest do backend **não** corre em PR só de frontend, e `npm run build` **não** corre em PR só de backend.
 
 ```bash
+git fetch origin
+python scripts/ci_detect_changes.py --base origin/main --include-working-tree
+```
+
+Interprete `backend=true` / `frontend=true` e execute **apenas** o que aplicar:
+
+```bash
+# se backend=true
 docker compose run --rm --no-deps backend pytest -q
+
+# se frontend=true
 cd frontend && npm run build
 ```
 
-Se algum teste falhar, corrija antes de concluir a revisão.
+- `backend=false` → **não** rode pytest; no relatório: `pytest: omitido (diff sem backend/scripts/CI)`
+- `frontend=false` → **não** rode `npm run build`; no relatório: `npm run build: omitido (diff sem frontend/CI)`
+- Os dois `true` → rode os dois
+- Os dois `false` (só docs/Cursor) → não rode testes pesados; diga isso no relatório
+
+Se o script falhar (sem `origin/main`), assuma os dois `true`.
+
+Se algum teste **executado** falhar, corrija antes de concluir a revisão.
+
+Após mudar `backend/requirements-dev.txt`, faça `docker compose build backend` antes do pytest (a imagem precisa de `pytest-xdist`).
 
 ## Formato do relatório
 
@@ -55,8 +76,8 @@ Se algum teste falhar, corrija antes de concluir a revisão.
 - ...
 
 ## Testes executados
-- pytest: [passou/falhou]
-- npm run build: [passou/falhou]
+- pytest: [passou / falhou / omitido — motivo]
+- npm run build: [passou / falhou / omitido — motivo]
 ```
 
 Se revisão OK, sugira:

--- a/.cursor/rules/backend-fastapi.mdc
+++ b/.cursor/rules/backend-fastapi.mdc
@@ -34,7 +34,7 @@ Registrar rota em `app/main.py` se for módulo novo.
 
 - Novo endpoint ou regra de negócio → teste em `backend/tests/test_<area>.py`
 - Usar fixtures de `conftest.py` (`DX_CONNECT_TESTING=1`, SQLite in-memory)
-- Rodar: `docker compose run --rm --no-deps backend pytest -q`
+- Rodar (quando o diff toca backend): `docker compose run --rm --no-deps backend pytest -q` (`pytest.ini` já usa `-n auto`)
 
 ## SSE (se aplicável)
 

--- a/.cursor/rules/git-workflow.mdc
+++ b/.cursor/rules/git-workflow.mdc
@@ -76,7 +76,7 @@ Exceção: hotfix urgente na mesma linha só se o PR ainda **não** tiver sido m
 
 - Base: **`main`**
 - Corpo: resumo, test plan, link da issue
-- Aguardar CI (pytest + build frontend)
+- Aguardar CI (`backend` / `frontend` podem concluir em segundos se o diff não toca esse lado — isso é verde)
 - `/criar-pr` faz merge automático quando CI passa (main = testes)
 
 ## Release → staging (produção)

--- a/.cursor/rules/project-core.mdc
+++ b/.cursor/rules/project-core.mdc
@@ -30,6 +30,8 @@ docker compose run --rm --no-deps backend pytest -q
 docker compose up -d --build   # só se Dockerfile ou requirements mudaram
 ```
 
+**Não rode pytest do backend** se o diff vs `origin/main` (e working tree) não toca `backend/`, `scripts/` ou `.github/workflows/ci.yml`. **Não rode `npm run build`** se não toca `frontend/` nem o workflow de CI. Use `python scripts/ci_detect_changes.py --base origin/main --include-working-tree` (igual ao GitHub Actions e ao `/revisar-e-testar`).
+
 Frontend em dev: `npm run dev` na pasta `frontend/` (proxy `/api` → `:8000`). Use `/subir-local` para subir tudo.
 
 ## Arquitetura de deploy
@@ -41,7 +43,7 @@ Frontend em dev: `npm run dev` na pasta `frontend/` (proxy `/api` → `:8000`). 
 
 - [ ] Critérios de aceite da issue atendidos
 - [ ] RBAC e escopo por setor respeitados (admin vs atendente, homônimos)
-- [ ] Testes backend passando (`pytest -q`)
+- [ ] Testes backend passando (`pytest -q`) — ou omitidos de propósito se o diff não toca backend/scripts/CI
 - [ ] Se houve migration: `alembic heads` com um único head
 - [ ] Se afeta tempo real: evento SSE **após commit** no banco
 - [ ] Frontend builda (`npm run build`) se tocou em `frontend/`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 # CI: lint básico, auditoria de dependências e build do frontend.
 # Não substitui revisão humana nem SAST completo; complementa Dependabot.
+#
+# Jobs backend/frontend sempre reportam check (branch protection).
+# Passos pesados só correm se o diff tocar nesse lado — ver scripts/ci_detect_changes.py.
 
 name: CI
 
@@ -10,10 +13,32 @@ on:
     branches: [main, master, staging]
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.detect.outputs.backend }}
+      frontend: ${{ steps.detect.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Classificar diff (backend / frontend)
+        id: detect
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE: ${{ github.event.before }}
+        run: python3 scripts/ci_detect_changes.py --github-output
+
   changelog:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
@@ -33,57 +58,79 @@ jobs:
             --head "${{ github.event.pull_request.head.sha }}"
 
   backend:
+    needs: changes
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: backend
     steps:
       - uses: actions/checkout@v7
+        if: needs.changes.outputs.backend == 'true'
 
       - uses: actions/setup-python@v7
+        if: needs.changes.outputs.backend == 'true'
         with:
           python-version: "3.12"
           cache: pip
-          cache-dependency-path: backend/requirements.txt
-
-      - name: Instalar dependências do sistema (psycopg2)
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libpq-dev gcc
+          cache-dependency-path: |
+            backend/requirements.txt
+            backend/requirements-dev.txt
 
       - name: Instalar requirements e pip-audit
+        if: needs.changes.outputs.backend == 'true'
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt -r requirements-dev.txt pip-audit
 
       - name: Auditoria de vulnerabilidades (PyPI)
+        if: needs.changes.outputs.backend == 'true'
         run: pip-audit -r requirements.txt
 
       - name: Pytest
+        if: needs.changes.outputs.backend == 'true'
         run: pytest -q
 
       - name: Verificar sintaxe Python
+        if: needs.changes.outputs.backend == 'true'
         run: python -m compileall -q app
 
+      - name: Backend omitido (diff sem backend/scripts/CI)
+        if: needs.changes.outputs.backend != 'true'
+        working-directory: .
+        run: echo "Sem alterações de backend — pytest e pip-audit omitidos."
+
   frontend:
+    needs: changes
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: frontend
     steps:
       - uses: actions/checkout@v7
+        if: needs.changes.outputs.frontend == 'true'
 
       - uses: actions/setup-node@v7
+        if: needs.changes.outputs.frontend == 'true'
         with:
           node-version: "20"
           cache: npm
           cache-dependency-path: frontend/package-lock.json
 
       - name: Instalar dependências
+        if: needs.changes.outputs.frontend == 'true'
         run: npm ci
 
       - name: npm audit
+        if: needs.changes.outputs.frontend == 'true'
         run: npm audit --audit-level=high
 
       - name: Build de produção
+        if: needs.changes.outputs.frontend == 'true'
         env:
           VITE_API_URL: https://ci.invalid.example
         run: npm run build
+
+      - name: Frontend omitido (diff sem frontend/CI)
+        if: needs.changes.outputs.frontend != 'true'
+        working-directory: .
+        run: echo "Sem alterações de frontend — npm ci/build omitidos."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Portal (#700): chamados e atendimentos WhatsApp ficam em `/portal/tickets` e `/portal/chats`, sem o número na barra; links antigos com id continuam a abrir o item certo
 - Mobile (#690 / #691): o painel no endereço do cliente pode ser **adicionado à tela inicial** (PWA); o brief mobile descreve PWA primeiro, depois lojas
 - Menu (#716): a barra de rolagem da sidebar (painel e portal) fica fina e alinhada ao tema, sem o visual nativo do Windows
+- CI: testes do backend deixam de repetir bcrypt lento em cada caso; PRs só de interface já não esperam o pytest, e o contrário também (job do lado inalterado conclui em segundos)
 
 #### Correções
 

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 testpaths = tests
 pythonpath = .
+addopts = -n auto --maxprocesses=4

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,4 +1,5 @@
 # Dependências apenas para desenvolvimento / CI (pytest).
 -r requirements.txt
 pytest==9.1.1
+pytest-xdist==3.8.0
 httpx==0.28.1

--- a/backend/tests/README.md
+++ b/backend/tests/README.md
@@ -4,7 +4,7 @@ O `conftest.py` define `DX_CONNECT_TESTING=1`, `DATABASE_URL` em **SQLite em mem
 
 ## Com Docker (recomendado no projeto)
 
-O `docker-compose.yml` compila o backend com **`INSTALL_DEV=1`**, instalando `requirements-dev.txt` (pytest, httpx) na imagem, e monta **`./backend` em `/app`**, para que alterações em `tests/` e em `app/` entrem no container **sem rebuild**.
+O `docker-compose.yml` compila o backend com **`INSTALL_DEV=1`**, instalando `requirements-dev.txt` (pytest, pytest-xdist, httpx) na imagem, e monta **`./backend` em `/app`**, para que alterações em `tests/` e em `app/` entrem no container **sem rebuild**.
 
 ```bash
 # Na raiz do repositório (onde está docker-compose.yml)
@@ -12,7 +12,7 @@ docker compose build backend   # primeira vez ou após mudar requirements / Dock
 docker compose run --rm --no-deps backend pytest -q
 ```
 
-- `pytest` substitui o comando padrão (`uvicorn`) só nesta execução.
+- `pytest` substitui o comando padrão (`uvicorn`) só nesta execução. O `pytest.ini` usa `-n auto` (paralelo).
 - **`--no-deps`**: não sobe o Postgres; o `conftest.py` força SQLite em memória para os testes.
 - **Rebuild** só é necessário quando mudam `requirements*.txt`, `Dockerfile` ou outras dependências da imagem — não por cada alteração em `.py` de testes ou da app.
 
@@ -26,7 +26,7 @@ pytest
 
 ## PR e CI
 
-O merge do PR deve passar no job **Pytest** do GitHub Actions. Se quiser **só mergear depois de ver verde**, rode o comando Docker acima antes de aprovar.
+O merge do PR deve passar no job **backend** do GitHub Actions. PRs **só de frontend** não esperam o pytest (o job conclui em segundos). Se quiser **só mergear depois de ver verde**, rode o comando Docker acima antes de aprovar.
 
 ## Documentação de RBAC
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,6 +6,7 @@ Infra de testes (#46): variáveis de ambiente antes de importar `app`.
 from __future__ import annotations
 
 import os
+from functools import lru_cache
 
 # Sobrescreve .env local: SQLite em memória e modo de teste.
 os.environ["DX_CONNECT_TESTING"] = "1"
@@ -14,6 +15,19 @@ os.environ["SECRET_KEY"] = "01234567890123456789012345678901"
 os.environ["ENVIRONMENT"] = "development"
 os.environ["DEFAULT_TENANT_ID"] = "1"
 os.environ["INBOUND_EMAIL_DOMAIN"] = "inbound.dx.test"
+
+from app.core import security as _security
+
+_hash_senha_real = _security.hash_senha
+
+
+@lru_cache(maxsize=64)
+def hash_senha_teste(senha: str) -> str:
+    """bcrypt real, mas uma vez por senha distinta (gensalt é ~1s e o seed corre em quase todo teste)."""
+    return _hash_senha_real(senha)
+
+
+_security.hash_senha = hash_senha_teste
 
 import pytest
 from starlette.testclient import TestClient

--- a/backend/tests/test_ci_detect_changes.py
+++ b/backend/tests/test_ci_detect_changes.py
@@ -1,0 +1,59 @@
+"""Detecção de paths para pular pytest/build no CI e no /revisar-e-testar."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = ROOT / "scripts"
+if not (SCRIPTS / "ci_detect_changes.py").is_file():
+    SCRIPTS = Path("/scripts")
+sys.path.insert(0, str(SCRIPTS))
+
+from ci_detect_changes import classify, format_result, path_matches  # noqa: E402
+
+
+def test_frontend_only_nao_dispara_backend():
+    result = classify(
+        [
+            "frontend/src/components/Sidebar.tsx",
+            "frontend/src/index.css",
+        ]
+    )
+    assert result == {"backend": False, "frontend": True}
+
+
+def test_backend_only_nao_dispara_frontend():
+    result = classify(["backend/app/api/tickets.py", "backend/tests/test_health.py"])
+    assert result == {"backend": True, "frontend": False}
+
+
+def test_ci_yml_dispara_os_dois():
+    result = classify([".github/workflows/ci.yml"])
+    assert result == {"backend": True, "frontend": True}
+
+
+def test_scripts_dispara_backend():
+    result = classify(["scripts/ci_detect_changes.py"])
+    assert result == {"backend": True, "frontend": False}
+
+
+def test_docs_e_cursor_nao_disparam_jobs_pesados():
+    result = classify(
+        [
+            "docs/RELEASES.md",
+            ".cursor/commands/revisar-e-testar.md",
+            "CHANGELOG.md",
+        ]
+    )
+    assert result == {"backend": False, "frontend": False}
+
+
+def test_format_result():
+    assert format_result({"backend": True, "frontend": False}) == "backend=true\nfrontend=false"
+
+
+def test_path_matches_normaliza_barra():
+    assert path_matches("frontend\\src\\App.tsx", ("frontend/",)) is True
+    assert path_matches(".github/workflows/ci.yml", (".github/workflows/ci.yml",)) is True

--- a/backend/tests/test_ticket_mensagem_email_grace_timing.py
+++ b/backend/tests/test_ticket_mensagem_email_grace_timing.py
@@ -1,15 +1,12 @@
 """
-Teste de integração com tempo real (#140): janela de graça, edição e reagendamento.
+Teste de integração da janela de graça (#140): edição reagenda o envio.
 
-Requer grace curto via monkeypatch (8s). Demora ~20–25s no total.
+Relógio controlado via monkeypatch de `_utcnow` — sem `time.sleep`.
 """
 
 from __future__ import annotations
 
-import time
-from datetime import datetime, timezone
-
-import pytest
+from datetime import datetime, timedelta, timezone
 
 from app.models.ticket import TicketMensagem
 from app.services.ticket_mensagem_email_outbox import (
@@ -19,6 +16,17 @@ from app.services.ticket_mensagem_email_outbox import (
     process_pending_ticket_mensagem_emails,
 )
 from app.services.system_email_config import TransactionalEmailConfig
+
+
+class _Clock:
+    def __init__(self, now: datetime):
+        self.now = now
+
+    def utcnow(self) -> datetime:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now = self.now + timedelta(seconds=seconds)
 
 
 def _rfc822(mid: str = "<grace-timing@dx.local>") -> str:
@@ -52,11 +60,13 @@ def _mock_resend(monkeypatch):
 def test_janela_edicao_reinicia_contagem_e_envia_depois(client, seed_base, auth_headers, monkeypatch, db_session):
     """
     1) Agenda envio em +8s
-    2) Após 3s ainda pendente (dá tempo de editar)
+    2) Aos +3s ainda pendente (dá tempo de editar)
     3) Editar reinicia scheduled_at (~+8s a partir da edição)
     4) Só envia após o novo scheduled_at
     """
     grace = 8
+    clock = _Clock(datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc))
+    monkeypatch.setattr("app.services.ticket_mensagem_email_outbox._utcnow", clock.utcnow)
     monkeypatch.setattr("app.config.settings.TICKET_MENSAGEM_EMAIL_GRACE_SECONDS", grace)
     monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_WEBHOOK_SECRET", "gracet")
     monkeypatch.setattr("app.config.settings.EMAIL_INBOUND_DEFAULT_EMPRESA_ID", seed_base["empresa"].id)
@@ -71,7 +81,6 @@ def test_janela_edicao_reinicia_contagem_e_envia_depois(client, seed_base, auth_
     assert r0.status_code == 200
     tid = r0.json()["ticket_id"]
 
-    t0 = time.perf_counter()
     r1 = client.post(
         f"/v1/tickets/{tid}/mensagens",
         headers=auth_headers["admin"],
@@ -85,8 +94,10 @@ def test_janela_edicao_reinicia_contagem_e_envia_depois(client, seed_base, auth_
     mid = r1.json()["id"]
     sched1 = _as_utc(datetime.fromisoformat(r1.json()["scheduled_at"].replace("Z", "+00:00")))
     assert r1.json()["status"] == EMAIL_STATUS_PENDENTE
+    assert sched1 is not None
+    assert abs((sched1 - clock.now).total_seconds() - grace) < 1
 
-    time.sleep(3)
+    clock.advance(3)
     process_pending_ticket_mensagem_emails(db_session, limit=10)
     db_session.commit()
     m = db_session.query(TicketMensagem).filter(TicketMensagem.id == mid).first()
@@ -99,7 +110,6 @@ def test_janela_edicao_reinicia_contagem_e_envia_depois(client, seed_base, auth_
     )
     assert r_edit.status_code == 200
     token = r_edit.json()["edit_lock_token"]
-    t_antes_patch = time.perf_counter()
     r_patch = client.patch(
         f"/v1/tickets/{tid}/mensagens/{mid}",
         headers=auth_headers["admin"],
@@ -111,22 +121,15 @@ def test_janela_edicao_reinicia_contagem_e_envia_depois(client, seed_base, auth_
     assert m is not None and m.scheduled_at is not None
     sched2 = _as_utc(m.scheduled_at)
     assert sched2 and sched1 and sched2 > sched1, "Edição deve reagendar para depois do horário original"
-    seg_ate_envio = (sched2 - datetime.now(timezone.utc)).total_seconds()
-    assert seg_ate_envio >= grace - 2, "Novo envio ~grace segundos após salvar edição"
+    assert abs((sched2 - clock.now).total_seconds() - grace) < 1
 
-    # Antes do novo prazo: ainda pendente
-    wait_until = seg_ate_envio - 1.5
-    if wait_until > 0:
-        time.sleep(wait_until)
+    clock.advance(grace - 1.5)
     process_pending_ticket_mensagem_emails(db_session, limit=10)
     db_session.commit()
     db_session.refresh(m)
     assert m.email_status == EMAIL_STATUS_PENDENTE, "Ainda não deve enviar antes do scheduled_at reagendado"
 
-    # Após o prazo reagendado: envia
-    restante = (sched2 - datetime.now(timezone.utc)).total_seconds() + 0.5
-    if restante > 0:
-        time.sleep(restante)
+    clock.advance(2)
     n = process_pending_ticket_mensagem_emails(db_session, limit=10)
     db_session.commit()
     db_session.refresh(m)
@@ -134,12 +137,3 @@ def test_janela_edicao_reinicia_contagem_e_envia_depois(client, seed_base, auth_
     assert m.email_status == EMAIL_STATUS_ENVIADA
     assert m.corpo == "Versão 2 — texto corrigido"
     assert m.sent_at is not None
-
-    elapsed = time.perf_counter() - t0
-    elapsed_edit = time.perf_counter() - t_antes_patch
-    print(
-        f"\n[grace-timing] total={elapsed:.1f}s | "
-        f"editou aos ~{t_antes_patch - t0:.1f}s | "
-        f"enviou após reagendamento (grace={grace}s)\n"
-    )
-    assert elapsed >= grace + 3, "Tempo total cobre grace inicial + reagendamento após edição"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,8 @@ services:
     volumes:
       # Código + tests + pytest.ini do host (evita rebuild só por alteração em tests/).
       - ./backend:/app
+      # scripts/ na raiz (check_changelog, ci_detect_changes) — pytest no Docker importa daqui.
+      - ./scripts:/scripts:ro
 
 volumes:
   postgres_data:

--- a/scripts/ci_detect_changes.py
+++ b/scripts/ci_detect_changes.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Classifica o diff: pytest backend e/ou build frontend (CI e /revisar-e-testar)."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Alterar o workflow de CI reexecuta os dois jobs (o YAML é a definição deles).
+BACKEND_MARKERS = (
+    "backend/",
+    "scripts/",
+    ".github/workflows/ci.yml",
+)
+FRONTEND_MARKERS = (
+    "frontend/",
+    ".github/workflows/ci.yml",
+)
+
+
+def normalize(path: str) -> str:
+    p = path.replace("\\", "/").strip()
+    while p.startswith("./"):
+        p = p[2:]
+    return p
+
+
+def path_matches(path: str, markers: tuple[str, ...]) -> bool:
+    p = normalize(path)
+    for marker in markers:
+        if marker.endswith("/"):
+            if p.startswith(marker):
+                return True
+        elif p == marker:
+            return True
+    return False
+
+
+def classify(paths: list[str]) -> dict[str, bool]:
+    normalized = [normalize(p) for p in paths if p and p.strip()]
+    return {
+        "backend": any(path_matches(p, BACKEND_MARKERS) for p in normalized),
+        "frontend": any(path_matches(p, FRONTEND_MARKERS) for p in normalized),
+    }
+
+
+def _git(*args: str) -> list[str]:
+    r = subprocess.run(["git", *args], capture_output=True, text=True, check=False, cwd=ROOT)
+    if r.returncode != 0:
+        return []
+    return [ln.strip() for ln in r.stdout.splitlines() if ln.strip()]
+
+
+def git_changed_files(*, base: str, head: str, two_dot: bool, include_working_tree: bool) -> list[str]:
+    spec = f"{base} {head}" if two_dot else f"{base}...{head}"
+    files = set(_git("diff", "--name-only", *spec.split()))
+    if include_working_tree:
+        files.update(_git("diff", "--name-only"))
+        files.update(_git("diff", "--cached", "--name-only"))
+        files.update(_git("ls-files", "--others", "--exclude-standard"))
+    return sorted(files)
+
+
+def format_result(result: dict[str, bool]) -> str:
+    return "\n".join(
+        f"{key}={'true' if result[key] else 'false'}" for key in ("backend", "frontend")
+    )
+
+
+def write_github_output(result: dict[str, bool]) -> None:
+    out = os.environ.get("GITHUB_OUTPUT")
+    if not out:
+        raise SystemExit("GITHUB_OUTPUT não definido (use sem --github-output localmente)")
+    with open(out, "a", encoding="utf-8") as f:
+        f.write(format_result(result) + "\n")
+
+
+def _is_zero_sha(value: str | None) -> bool:
+    if not value:
+        return True
+    return set(value) <= {"0"}
+
+
+def classify_from_github_env() -> dict[str, bool]:
+    event = os.environ.get("GITHUB_EVENT_NAME", "")
+    if event == "workflow_dispatch":
+        return {"backend": True, "frontend": True}
+
+    if event == "pull_request":
+        base = os.environ.get("PR_BASE_SHA") or ""
+        head = os.environ.get("GITHUB_SHA") or "HEAD"
+        if _is_zero_sha(base):
+            return {"backend": True, "frontend": True}
+        return classify(git_changed_files(base=base, head=head, two_dot=False, include_working_tree=False))
+
+    if event == "push":
+        before = os.environ.get("BEFORE") or ""
+        head = os.environ.get("GITHUB_SHA") or "HEAD"
+        if _is_zero_sha(before):
+            return {"backend": True, "frontend": True}
+        return classify(git_changed_files(base=before, head=head, two_dot=True, include_working_tree=False))
+
+    raise SystemExit(f"Evento GitHub não suportado: {event!r}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Diz se o diff exige pytest backend e/ou build frontend")
+    ap.add_argument("--base", default="origin/main", help="Ref base (uso local / três pontos)")
+    ap.add_argument("--head", default="HEAD")
+    ap.add_argument("--include-working-tree", action="store_true", help="Inclui staged, unstaged e untracked")
+    ap.add_argument("--github-output", action="store_true", help="Escreve GITHUB_OUTPUT (Actions)")
+    ap.add_argument("--all", action="store_true", help="Força backend e frontend")
+    args = ap.parse_args(argv)
+
+    if args.all:
+        result = {"backend": True, "frontend": True}
+    elif args.github_output:
+        result = classify_from_github_env()
+    else:
+        files = git_changed_files(
+            base=args.base,
+            head=args.head,
+            two_dot=False,
+            include_working_tree=args.include_working_tree,
+        )
+        result = classify(files)
+
+    text = format_result(result)
+    if args.github_output:
+        write_github_output(result)
+    print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- O job **backend** do CI deixava ~12,5 min só no pytest porque `seed_base` gerava hashes bcrypt (~1 s) em quase cada um dos 550+ testes. Os hashes passam a ser calculados uma vez por senha (bcrypt real, só em cache).
- Pytest corre em paralelo (`pytest-xdist`, até 4 workers). O teste da janela de e-mail deixou de usar `time.sleep`.
- Jobs `backend`/`frontend` **sempre** reportam check (branch protection), mas os passos pesados só correm se o diff toca esse lado (`scripts/ci_detect_changes.py`). Pushes no mesmo PR cancelam a CI anterior.
- `/revisar-e-testar` e as rules do Cursor usam a mesma regra de paths.

Suíte local após a mudança: **561 passed em ~1 min 42 s** (antes ~13 min no Actions).

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `docker compose run --rm --no-deps backend pytest -q` — 561 passed, 1 skipped
- [x] `python scripts/ci_detect_changes.py --base origin/main --include-working-tree` classifica este PR como `backend=true` / `frontend=false` (o CI.yml desta branch dispara os dois jobs, de propósito)
- [ ] CI no GitHub: pytest verde; num PR só de `frontend/src` o job backend deve concluir em segundos com «omitido»

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] N/A — tooling de CI/testes, sem issue de produto nem stubs
