### PR TITLE
feat(frontend): ops mobile WhatsApp/tickets e cronômetro visível (#692 #723)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Portal (#700): chamados e atendimentos WhatsApp ficam em `/portal/tickets` e `/portal/chats`, sem o número na barra; links antigos com id continuam a abrir o item certo
 - Mobile (#690 / #691): o painel no endereço do cliente pode ser **adicionado à tela inicial** (PWA); o brief mobile descreve PWA primeiro, depois lojas
 - Mobile (#692): no telemóvel, WhatsApp e tickets dão para operar por completo — assumir, responder (texto/mídia), transferir, encerrar, abrir ticket; fila e detalhe do chamado com botões grandes e teclado que não cobre o campo de mensagem
+- WhatsApp (#723): quem abre um chat em atendimento (colega ou admin) também vê o cronômetro de inatividade; Pausar/Retomar continua só com o responsável
 
 #### Correções
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Chat e tickets (#699): o Voltar do navegador fecha o painel da conversa ou do chamado e permanece na mesa (`/chat/…`, `/tickets`), sem o número na barra
 - Portal (#700): chamados e atendimentos WhatsApp ficam em `/portal/tickets` e `/portal/chats`, sem o número na barra; links antigos com id continuam a abrir o item certo
 - Mobile (#690 / #691): o painel no endereço do cliente pode ser **adicionado à tela inicial** (PWA); o brief mobile descreve PWA primeiro, depois lojas
+- Mobile (#692): no telemóvel, WhatsApp e tickets dão para operar por completo — assumir, responder (texto/mídia), transferir, encerrar, abrir ticket; fila e detalhe do chamado com botões grandes e teclado que não cobre o campo de mensagem
 
 #### Correções
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -10,6 +10,7 @@ import { BrandLogo } from '../brand'
 import { useTheme } from '../contexts/ThemeContext'
 import { AlertaDesktopPermissaoBanner } from './AlertaDesktopPermissaoBanner'
 import { PwaInstallBanner } from './PwaInstallBanner'
+import { useVisualViewportCss } from '../hooks/useVisualViewportCss'
 import { lerTicketAtivoSession, TICKET_ATIVO_EVENT } from '../lib/ticketAtivo'
 
 function perfilExibicao(role: string | undefined): string {
@@ -30,6 +31,7 @@ function LayoutInner() {
   const { user, logout, isAdmin, isComercialOuAdmin } = useAuth()
   const { subscribe } = useEventStream()
   const location = useLocation()
+  useVisualViewportCss()
   const [sidebarExpanded, setSidebarExpanded] = useState(true)
   const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false)
   const { resolved } = useTheme()
@@ -76,7 +78,7 @@ function LayoutInner() {
 
   return (
     <div
-      className="flex h-dvh max-h-dvh min-h-0 overflow-hidden bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95 md:grid md:grid-cols-[var(--sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
+      className="flex h-[var(--vv-height,100dvh)] max-h-[var(--vv-height,100dvh)] min-h-0 overflow-hidden bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95 md:grid md:grid-cols-[var(--sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
       style={
         {
           ['--sidebar-w' as never]: sidebarW,

--- a/frontend/src/components/chat/ChatFilaAguardandoSheet.tsx
+++ b/frontend/src/components/chat/ChatFilaAguardandoSheet.tsx
@@ -57,7 +57,7 @@ export function ChatFilaAguardandoSheet({ open, onClose }: Props) {
           </div>
           <button
             type="button"
-            className="rounded-lg px-2 py-1 text-2xl leading-none text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-100"
+            className="flex h-11 w-11 items-center justify-center rounded-lg text-2xl leading-none text-slate-500 hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-100"
             onClick={onClose}
             aria-label="Fechar"
           >

--- a/frontend/src/components/chat/ChatFilaSomToggle.tsx
+++ b/frontend/src/components/chat/ChatFilaSomToggle.tsx
@@ -6,13 +6,13 @@ import {
 type Props = {
   className?: string
   /** Compacto para caber no header mobile / tabs */
-  size?: 'sm' | 'md'
+  size?: 'sm' | 'md' | 'lg'
 }
 
 export function ChatFilaSomToggle({ className = '', size = 'sm' }: Props) {
   const muted = useFilaAguardandoMuted()
-  const dim = size === 'md' ? 'h-8 w-8' : 'h-7 w-7'
-  const icon = size === 'md' ? 18 : 16
+  const dim = size === 'lg' ? 'h-11 w-11' : size === 'md' ? 'h-8 w-8' : 'h-7 w-7'
+  const icon = size === 'lg' ? 20 : size === 'md' ? 18 : 16
 
   return (
     <button

--- a/frontend/src/components/chat/ChatHubSearch.tsx
+++ b/frontend/src/components/chat/ChatHubSearch.tsx
@@ -1,11 +1,13 @@
 import { useChatHub } from '../../contexts/ChatHubContext'
+import { ChatFilaSomToggle } from './ChatFilaSomToggle'
 
 export function ChatHubSearch({ placeholder = 'Pesquise por conversas' }: { placeholder?: string }) {
   const { busca, setBusca } = useChatHub()
 
   return (
     <div className="shrink-0 border-b border-slate-200 p-3 dark:border-slate-800">
-      <div className="relative">
+      <div className="flex items-center gap-2">
+        <div className="relative min-w-0 flex-1">
         <svg
           className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-slate-400"
           xmlns="http://www.w3.org/2000/svg"
@@ -23,8 +25,10 @@ export function ChatHubSearch({ placeholder = 'Pesquise por conversas' }: { plac
           value={busca}
           onChange={(e) => setBusca(e.target.value)}
           placeholder={placeholder}
-          className="w-full rounded-lg border border-slate-200 bg-slate-50 py-2 pl-9 pr-3 text-sm text-slate-900 placeholder:text-slate-400 focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500/40 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
+          className="w-full rounded-lg border border-slate-200 bg-slate-50 py-2.5 pl-9 pr-3 text-base text-slate-900 placeholder:text-slate-400 focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500/40 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100"
         />
+        </div>
+        <ChatFilaSomToggle size="lg" />
       </div>
     </div>
   )

--- a/frontend/src/components/chat/ChatHubTabs.tsx
+++ b/frontend/src/components/chat/ChatHubTabs.tsx
@@ -2,7 +2,6 @@ import { Link, useLocation } from 'react-router-dom'
 import { useChatInterno } from '../../contexts/ChatInternoContext'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { CHAT_HUB_PATHS, chatHubModoDePath } from '../../lib/chatHubPaths'
-import { ChatFilaSomToggle } from './ChatFilaSomToggle'
 
 type TabDef = {
   id: keyof typeof CHAT_HUB_PATHS
@@ -74,30 +73,11 @@ export function ChatHubTabs() {
     <nav className="flex shrink-0 border-b border-slate-200 dark:border-slate-800" aria-label="Modos de chat">
       {tabs.map((tab) => {
         const ativo = modo === tab.id
-        const tabClass = `relative flex flex-1 flex-col items-center gap-1 border-b-2 px-0.5 py-2.5 text-[10px] font-semibold transition-colors ${
+        const tabClass = `relative flex min-h-11 flex-1 flex-col items-center gap-1 border-b-2 px-0.5 py-2.5 text-[10px] font-semibold transition-colors ${
           ativo
             ? 'border-cyan-500 text-cyan-600 dark:text-cyan-400'
             : 'border-transparent text-slate-400 hover:text-slate-600 dark:hover:text-slate-300'
         }`
-
-        if (tab.id === 'espera') {
-          return (
-            <div key={tab.id} className="relative flex flex-1 items-stretch">
-              <Link to={tab.to} title={tab.label} className={tabClass}>
-                <span className={ativo ? 'text-cyan-600 dark:text-cyan-400' : ''}>{tab.icon}</span>
-                <span className="hidden sm:inline">{tab.label}</span>
-                {tab.badge != null && tab.badge > 0 && (
-                  <span className="absolute right-5 top-1 min-w-[1rem] rounded-full bg-cyan-600 px-1 text-center text-[9px] font-bold leading-4 text-white sm:right-6">
-                    {tab.badge > 99 ? '99+' : tab.badge}
-                  </span>
-                )}
-              </Link>
-              <div className="absolute right-0 top-1/2 z-10 -translate-y-1/2 pr-0.5">
-                <ChatFilaSomToggle />
-              </div>
-            </div>
-          )
-        }
 
         return (
           <Link key={tab.id} to={tab.to} title={tab.label} className={tabClass}>

--- a/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
+++ b/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
@@ -62,10 +62,10 @@ export function WhatsappMensagemAcoes({ mensagem, onEditar, onApagar }: Props) {
           aria-expanded={menuAberto}
           aria-haspopup="menu"
           title="Ações"
-          className={`flex h-6 w-6 items-center justify-center rounded-full text-white transition-opacity ${
+          className={`flex h-8 w-8 items-center justify-center rounded-full text-white transition-opacity md:h-6 md:w-6 ${
             menuAberto
               ? 'bg-black/30 opacity-100'
-              : 'bg-black/15 opacity-0 group-hover/bubble:opacity-100 group-focus-within/bubble:opacity-100 hover:bg-black/25'
+              : 'bg-black/15 opacity-100 hover:bg-black/25 md:opacity-0 md:group-hover/bubble:opacity-100 md:group-focus-within/bubble:opacity-100'
           }`}
           onClick={() => setMenuAberto((o) => !o)}
         >

--- a/frontend/src/components/chat/WhatsappReacoesBar.tsx
+++ b/frontend/src/components/chat/WhatsappReacoesBar.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import type { WhatsappChats } from '../../api/client'
 import { EMOJIS_REACAO_CHAT_INTERNO } from '../../lib/chatInternoReacoes'
 
@@ -18,34 +19,68 @@ export function WhatsappReacoesBar({
 }: Props) {
   const temReacoes = reacoes.length > 0
   const alignEnd = alinhamento === 'end'
+  const [pickerAberto, setPickerAberto] = useState(false)
 
   return (
     <>
       {podeReagir && onReagir ? (
         <div
-          className={`pointer-events-none absolute top-full z-20 flex flex-col ${
-            alignEnd ? 'right-0 items-end' : 'left-0 items-start'
-          }`}
+          className={`z-20 flex flex-col ${
+            alignEnd ? 'items-end' : 'items-start'
+          } ${temReacoes ? 'relative mt-1' : 'absolute top-full'}`}
         >
+          <button
+            type="button"
+            className="flex h-9 min-w-9 items-center justify-center rounded-full border border-slate-200 bg-white px-2 text-sm shadow-sm md:hidden dark:border-slate-600 dark:bg-slate-800"
+            aria-label="Reagir"
+            aria-expanded={pickerAberto}
+            onClick={() => setPickerAberto((o) => !o)}
+          >
+            😊
+          </button>
           <div
-            className="h-2 w-full min-w-[10rem] group-hover:pointer-events-auto group-focus-within:pointer-events-auto"
-            aria-hidden
-          />
-          <div className="opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
-            <div className="flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
+            className={`pointer-events-none absolute top-full z-20 mt-1 hidden flex-col md:flex ${
+              alignEnd ? 'right-0 items-end' : 'left-0 items-start'
+            }`}
+          >
+            <div
+              className="h-2 w-full min-w-[10rem] group-hover:pointer-events-auto group-focus-within:pointer-events-auto"
+              aria-hidden
+            />
+            <div className="opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+              <div className="flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
+                {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
+                  <button
+                    key={emoji}
+                    type="button"
+                    onClick={() => onReagir(emoji)}
+                    className="rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
+                    aria-label={`Reagir com ${emoji}`}
+                  >
+                    {emoji}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+          {pickerAberto ? (
+            <div className="mt-1 flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md md:hidden dark:border-slate-600 dark:bg-slate-800">
               {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
                 <button
                   key={emoji}
                   type="button"
-                  onClick={() => onReagir(emoji)}
-                  className="rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
+                  onClick={() => {
+                    onReagir(emoji)
+                    setPickerAberto(false)
+                  }}
+                  className="min-h-9 min-w-9 rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
                   aria-label={`Reagir com ${emoji}`}
                 >
                   {emoji}
                 </button>
               ))}
             </div>
-          </div>
+          ) : null}
         </div>
       ) : null}
 

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -53,7 +53,7 @@ export function ConfirmDialog({
 
   return (
     <div
-      className="fixed inset-0 z-[110] flex items-center justify-center bg-slate-900/50 p-4 backdrop-blur-sm"
+      className="fixed inset-0 z-[110] flex items-end justify-center bg-slate-900/50 p-0 backdrop-blur-sm md:items-center md:p-4"
       role="presentation"
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onCancel()
@@ -62,12 +62,12 @@ export function ConfirmDialog({
       <div
         ref={dialogRef}
         tabIndex={-1}
-        className="w-full max-w-lg outline-none"
+        className="w-full max-w-lg outline-none md:max-h-[min(92dvh,var(--vv-height,92dvh))]"
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
       >
-        <Card className="animate-in zoom-in-95 border-none p-0 shadow-xl ring-1 ring-slate-200 dark:ring-slate-800">
+        <Card className="max-h-[min(92dvh,var(--vv-height,92dvh))] animate-in zoom-in-95 overflow-y-auto rounded-b-none border-none p-0 shadow-xl ring-1 ring-slate-200 md:rounded-2xl dark:ring-slate-800">
           <div className="p-6">
             <div className="flex items-start justify-between gap-3">
               <h3 id={titleId} className="text-lg font-bold text-slate-900 dark:text-white">

--- a/frontend/src/hooks/useVisualViewportCss.ts
+++ b/frontend/src/hooks/useVisualViewportCss.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react'
+
+/**
+ * Expõe a altura visível real (teclado virtual no iOS/Android) em `--vv-height`.
+ * Usado pelo shell `h-dvh` para o compositor não ficar atrás do teclado (#692).
+ */
+export function useVisualViewportCss(): void {
+  useEffect(() => {
+    const vv = window.visualViewport
+    if (!vv) return
+    const apply = () => {
+      document.documentElement.style.setProperty('--vv-height', `${Math.round(vv.height)}px`)
+    }
+    apply()
+    vv.addEventListener('resize', apply)
+    vv.addEventListener('scroll', apply)
+    return () => {
+      vv.removeEventListener('resize', apply)
+      vv.removeEventListener('scroll', apply)
+      document.documentElement.style.removeProperty('--vv-height')
+    }
+  }, [])
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -23,7 +23,7 @@ import {
 import { isSaasControlPlaneFrontend, SAAS_LICENCAS_PATH } from '../lib/saasControlPlane'
 
 const fieldClass =
-  'w-full rounded-xl border border-white/10 bg-white/[0.06] px-3.5 py-3 text-[0.9375rem] text-slate-100 placeholder:text-slate-500 shadow-inner shadow-black/20 backdrop-blur-sm transition-colors focus:border-cyan-400/50 focus:outline-none focus:ring-2 focus:ring-cyan-400/25'
+  'w-full rounded-xl border border-white/10 bg-white/[0.06] px-3.5 py-3 text-base text-slate-100 placeholder:text-slate-500 shadow-inner shadow-black/20 backdrop-blur-sm transition-colors focus:border-cyan-400/50 focus:outline-none focus:ring-2 focus:ring-cyan-400/25'
 
 const secondaryLinkClass =
   'inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-white/15 bg-white/[0.06] px-4 py-2.5 text-sm font-medium transition hover:border-sky-400/40 hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/40'

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -1274,7 +1274,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
     ? new Date(ticket.created_at).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: 'numeric' })
     : '—'
 
-  const classeBtnAcao = 'h-9 w-full px-3 text-xs lg:w-auto sm:h-auto sm:text-sm'
+  const classeBtnAcao = 'min-h-11 w-full px-3 text-sm lg:min-h-9 lg:w-auto'
 
   const linkVoltar = (
     <button
@@ -1342,7 +1342,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
       {!ticket.fechado_em && (
         <>
           <span
-            className="hidden h-7 w-px shrink-0 bg-slate-200 dark:bg-slate-700 sm:inline-block"
+            className="hidden h-7 w-px shrink-0 bg-slate-200 dark:bg-slate-700 lg:inline-block"
             aria-hidden
           />
           <Button
@@ -1468,7 +1468,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
             )}
 
             {podeAtribuirAMim && (
-              <p className="mt-1.5 hidden text-xs text-slate-500 sm:block dark:text-slate-400">
+              <p className="mt-1.5 text-xs text-slate-500 dark:text-slate-400">
                 Na fila sem responsável — atribua a você para dar andamento.
               </p>
             )}
@@ -1826,7 +1826,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
             </ul>
           )}
 
-          <div className="border-t border-slate-200 pt-4 dark:border-slate-800/90">
+          <div className="sticky bottom-0 z-10 -mx-3 border-t border-slate-200 bg-white px-3 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] dark:border-slate-800/90 dark:bg-slate-950 sm:static sm:mx-0 sm:bg-transparent sm:px-0 sm:pb-0 sm:pt-4 dark:sm:bg-transparent">
             <p className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-300">Nova mensagem</p>
             {ticket.fechado_em ? (
               <div className="rounded-xl border border-emerald-200 bg-emerald-50/70 px-4 py-3 text-sm text-emerald-900 dark:border-emerald-800/60 dark:bg-emerald-950/25 dark:text-emerald-100">
@@ -1881,7 +1881,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
                   ? 'Anotação visível apenas para atendentes…'
                   : 'Descreva o que foi feito, testado ou o que falta…'
               }
-              className={`w-full rounded-xl border-0 px-3 py-2 text-sm text-slate-900 shadow-inner ring-1 placeholder:text-slate-400 focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-60 dark:text-slate-100 dark:placeholder:text-slate-500 ${
+              className={`w-full rounded-xl border-0 px-3 py-2 text-base text-slate-900 shadow-inner ring-1 placeholder:text-slate-400 focus:outline-none focus:ring-2 disabled:cursor-not-allowed disabled:opacity-60 dark:text-slate-100 dark:placeholder:text-slate-500 sm:text-sm ${
                 tipoNovaMensagem === 'interno' || !podeMensagemPublica
                   ? 'bg-amber-50 ring-amber-200/90 focus:bg-amber-50 focus:ring-amber-400/30 dark:bg-amber-950/25 dark:ring-amber-800/60 dark:focus:bg-amber-950/25 dark:focus:ring-amber-700/35'
                   : 'bg-slate-50 ring-slate-200/90 focus:bg-white focus:ring-slate-400/35 dark:bg-slate-900/80 dark:ring-slate-600 dark:focus:bg-slate-900 dark:focus:ring-slate-500/50'
@@ -1950,6 +1950,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
                 onClick={handleEnviarMensagem}
                 loading={enviandoMensagem || enviandoAnexos}
                 disabled={Boolean(ticket.fechado_em)}
+                className="w-full sm:w-auto"
               >
                 Enviar
               </Button>

--- a/frontend/src/pages/Tickets.tsx
+++ b/frontend/src/pages/Tickets.tsx
@@ -456,7 +456,7 @@ export function Tickets() {
                         { replace: true },
                       )
                     }}
-                    className={`min-h-[2.25rem] flex-1 rounded-xl px-3 py-2 text-center text-xs font-medium transition-all duration-200 sm:flex-none sm:px-4 sm:text-sm ${
+                    className={`min-h-11 flex-1 rounded-xl px-3 py-2 text-center text-xs font-medium transition-all duration-200 sm:min-h-[2.25rem] sm:flex-none sm:px-4 sm:text-sm ${
                       ativo
                         ? 'bg-white text-slate-900 shadow-sm ring-1 ring-slate-200/80 dark:bg-slate-700 dark:text-slate-50 dark:ring-slate-600/50'
                         : 'text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200'
@@ -488,7 +488,7 @@ export function Tickets() {
                 }}
                 placeholder="Buscar por protocolo (ex.: #T202605-0001), assunto ou empresa…"
                 disabled={loading}
-                className="w-full rounded-xl border-0 bg-slate-50 py-2.5 pl-10 pr-4 text-sm text-slate-900 shadow-inner ring-1 ring-slate-200/80 transition-shadow placeholder:text-slate-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-slate-400/25 dark:bg-slate-900/60 dark:text-slate-100 dark:ring-slate-700 dark:placeholder:text-slate-500 dark:focus:bg-slate-900"
+                className="w-full rounded-xl border-0 bg-slate-50 py-2.5 pl-10 pr-4 text-base text-slate-900 shadow-inner ring-1 ring-slate-200/80 transition-shadow placeholder:text-slate-400 focus:bg-white focus:outline-none focus:ring-2 focus:ring-slate-400/25 dark:bg-slate-900/60 dark:text-slate-100 dark:ring-slate-700 dark:placeholder:text-slate-500 dark:focus:bg-slate-900 sm:text-sm"
                 aria-label="Buscar tickets"
               />
             </div>
@@ -558,7 +558,7 @@ export function Tickets() {
                       if (id !== '') setFiltroAtendente('')
                       resetarPagina()
                     }}
-                    className={`min-h-[2.25rem] flex-1 rounded-xl px-3 py-2 text-center text-xs font-medium transition-all duration-200 sm:flex-none sm:px-4 sm:text-sm ${
+                    className={`min-h-11 flex-1 rounded-xl px-3 py-2 text-center text-xs font-medium transition-all duration-200 sm:min-h-[2.25rem] sm:flex-none sm:px-4 sm:text-sm ${
                       ativo
                         ? 'bg-white text-slate-900 shadow-sm ring-1 ring-slate-200/80 dark:bg-slate-700 dark:text-slate-50 dark:ring-slate-600/50'
                         : 'text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200'
@@ -603,7 +603,7 @@ export function Tickets() {
                         setFiltroSla(id)
                         resetarPagina()
                       }}
-                      className={`min-h-[2.25rem] flex-1 rounded-xl px-3 py-2 text-center text-xs font-medium transition-all duration-200 sm:flex-none sm:px-4 sm:text-sm ${
+                      className={`min-h-11 flex-1 rounded-xl px-3 py-2 text-center text-xs font-medium transition-all duration-200 sm:min-h-[2.25rem] sm:flex-none sm:px-4 sm:text-sm ${
                         ativo
                           ? 'bg-white text-slate-900 shadow-sm ring-1 ring-slate-200/80 dark:bg-slate-700 dark:text-slate-50 dark:ring-slate-600/50'
                           : 'text-slate-500 hover:text-slate-800 dark:text-slate-400 dark:hover:text-slate-200'

--- a/frontend/src/pages/chat/ChatListaEspera.tsx
+++ b/frontend/src/pages/chat/ChatListaEspera.tsx
@@ -189,13 +189,13 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
                     abrirChat(c.canal, c.id)
                     onVerChat?.()
                   }}
-                  className="flex-1 rounded-lg border border-slate-200 py-1.5 text-center text-xs font-semibold text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+                  className="flex min-h-11 flex-1 items-center justify-center rounded-lg border border-slate-200 py-2.5 text-center text-sm font-semibold text-slate-600 hover:bg-slate-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
                 >
                   Ver
                 </Link>
                 <Button
                   type="button"
-                  className="flex-1 py-1.5 text-xs"
+                  className="min-h-11 flex-1 py-2.5 text-sm"
                   loading={assumindoKey === chatHubItemKey(c)}
                   onClick={() => void assumir(c)}
                 >

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -209,10 +209,11 @@ export function WhatsappComposerBar({
           disabled={campoBloqueado}
           className="max-h-32 min-h-[44px] min-w-0 flex-1 resize-none border-0 bg-transparent px-2 py-2.5 text-base outline-none ring-0 focus:border-0 focus:outline-none focus:ring-0 sm:text-sm dark:text-slate-100 placeholder:text-slate-400"
           onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault()
-              if (!acoesBloqueadas && temTexto) enviar()
-            }
+            if (e.key !== 'Enter' || e.shiftKey) return
+            const tecladoFisico = window.matchMedia('(min-width: 768px)').matches
+            if (!tecladoFisico) return
+            e.preventDefault()
+            if (!acoesBloqueadas && temTexto) enviar()
           }}
           onPaste={handlePaste}
         />

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1657,7 +1657,7 @@ useEffect(() => {
 
               {!encerrado && (
                 <>
-                  {isResponsavel && chat && (
+                  {chat && (
                     <div className="hidden md:flex">
                       <WhatsappInatividadeControle
                         chat={chat}
@@ -1748,15 +1748,14 @@ useEffect(() => {
                             {chat?.empresa_id ? 'Alterar empresa' : 'Definir empresa'}
                           </button>
                         )}
-                        {isResponsavel && chat && (
-                          <div className="border-t border-slate-100 px-3 py-2 dark:border-slate-800">
-                            <WhatsappInatividadeControle
-                              chat={chat}
-                              msgs={msgs}
-                              isResponsavel={isResponsavel}
-                              onChatUpdate={aplicarChatAtualizado}
-                            />
-                          </div>
+                        {chat && (
+                          <WhatsappInatividadeControle
+                            chat={chat}
+                            msgs={msgs}
+                            isResponsavel={isResponsavel}
+                            onChatUpdate={aplicarChatAtualizado}
+                            className="border-t border-slate-100 px-3 py-2 dark:border-slate-800"
+                          />
                         )}
                       </div>
                     )}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -75,7 +75,6 @@ import {
 } from '../../lib/whatsappListReturn'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { ChatFilaAguardandoSheet } from '../../components/chat/ChatFilaAguardandoSheet'
-import { ChatFilaSomToggle } from '../../components/chat/ChatFilaSomToggle'
 import { chatWhatsappLink } from '../../lib/chatHubPaths'
 import { marcarTicketAtivo, TICKETS_PATH } from '../../lib/ticketAtivo'
 import { WhatsappInatividadeControle } from './WhatsappInatividadeControle'
@@ -608,9 +607,9 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
   const [numeroCopiado, setNumeroCopiado] = useState(false)
   const [detalhesMobileAbertos, setDetalhesMobileAbertos] = useState(() => {
     try {
-      return sessionStorage.getItem(WA_DETALHES_SESSION_KEY) !== '0'
+      return sessionStorage.getItem(WA_DETALHES_SESSION_KEY) === '1'
     } catch {
-      return true
+      return false
     }
   })
   const [modoInterno, setModoInterno] = useState(false)
@@ -1562,7 +1561,7 @@ useEffect(() => {
             <Button
               type="button"
               variant="ghost"
-              className="h-9 shrink-0 px-2 text-xs font-medium"
+              className="h-11 shrink-0 px-2 text-xs font-medium md:h-9"
               onClick={voltarLista}
               aria-label="Voltar à lista"
             >
@@ -1603,7 +1602,7 @@ useEffect(() => {
 
             <button
               type="button"
-              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 md:hidden dark:hover:bg-slate-800 dark:hover:text-slate-100"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 md:hidden dark:hover:bg-slate-800 dark:hover:text-slate-100"
               aria-expanded={detalhesMobileAbertos}
               aria-label={detalhesMobileAbertos ? 'Ocultar detalhes' : 'Mostrar detalhes'}
               onClick={() => {
@@ -1623,25 +1622,24 @@ useEffect(() => {
               </span>
             </button>
 
-            <div className="flex shrink-0 items-center gap-1 sm:gap-2">
+            <div className="flex shrink-0 items-center gap-1 md:gap-2">
 
               {modoHub && (
                 <div className="flex items-center gap-0.5 md:hidden">
                   <Button
                     type="button"
                     variant="secondary"
-                    className="relative h-8 shrink-0 px-2.5 text-xs font-semibold"
+                    className="relative h-11 min-w-11 shrink-0 px-2.5 text-xs font-semibold"
                     onClick={() => setFilaAguardandoAberta(true)}
                     aria-label={filaCount > 0 ? `Aguardando, ${filaCount} na fila` : 'Aguardando'}
                   >
-                    Aguardando
+                    Fila
                     {filaCount > 0 && (
                       <span className="ml-1 inline-flex min-w-[1rem] justify-center rounded-full bg-amber-500 px-1 text-[10px] font-bold leading-4 text-white">
                         {filaCount > 99 ? '99+' : filaCount}
                       </span>
                     )}
                   </Button>
-                  <ChatFilaSomToggle />
                 </div>
               )}
 
@@ -1649,7 +1647,7 @@ useEffect(() => {
                 <Button
                   type="button"
                   variant="primary"
-                  className="h-8 shrink-0 px-3 text-xs font-semibold"
+                  className="h-11 shrink-0 px-3 text-xs font-semibold"
                   loading={assumindo}
                   onClick={() => void assumirChat()}
                 >
@@ -1660,7 +1658,7 @@ useEffect(() => {
               {!encerrado && (
                 <>
                   {isResponsavel && chat && (
-                    <div className="hidden sm:flex">
+                    <div className="hidden md:flex">
                       <WhatsappInatividadeControle
                         chat={chat}
                         msgs={msgs}
@@ -1672,7 +1670,7 @@ useEffect(() => {
                   {podeTransferir && (
                     <Button
                       variant="primary"
-                      className="hidden sm:inline-flex text-xs h-8"
+                      className="hidden md:inline-flex h-8 text-xs"
                       onClick={() => setModalTransferir(true)}
                     >
                       Transferir
@@ -1680,25 +1678,25 @@ useEffect(() => {
                   )}
                   <Button
                     variant="ghost"
-                    className="hidden sm:inline-flex text-xs h-8"
+                    className="hidden md:inline-flex h-8 text-xs"
                     onClick={() => setModalTickets(true)}
                   >
                     Tickets{ticketsVinculados.length > 0 ? ` (${ticketsVinculados.length})` : ''}
                   </Button>
 
                   {podeEncerrar && (
-                    <Button variant="danger" className="h-8 px-2.5 text-xs sm:px-3" onClick={() => setModalEncerrar(true)}>
+                    <Button variant="danger" className="hidden h-8 px-3 text-xs md:inline-flex" onClick={() => setModalEncerrar(true)}>
                       Encerrar
                     </Button>
                   )}
 
-                  <div className="relative sm:hidden" ref={menuMobileRef}>
+                  <div className="relative md:hidden" ref={menuMobileRef}>
                     <button
                       type="button"
                       aria-label="Mais ações"
                       aria-expanded={menuMobileAberto}
                       onClick={() => setMenuMobileAberto((o) => !o)}
-                      className="flex h-8 w-8 items-center justify-center rounded-lg text-lg text-slate-600 transition hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+                      className="flex h-11 w-11 items-center justify-center rounded-lg text-lg text-slate-600 transition hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
                     >
                       ⋮
                     </button>
@@ -1707,7 +1705,7 @@ useEffect(() => {
                         {podeTransferir && (
                           <button
                             type="button"
-                            className="block w-full px-4 py-2.5 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
+                            className="block min-h-11 w-full px-4 py-3 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
                             onClick={() => {
                               setMenuMobileAberto(false)
                               setModalTransferir(true)
@@ -1718,7 +1716,7 @@ useEffect(() => {
                         )}
                         <button
                           type="button"
-                          className="block w-full px-4 py-2.5 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
+                          className="block min-h-11 w-full px-4 py-3 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
                           onClick={() => {
                             setMenuMobileAberto(false)
                             setModalTickets(true)
@@ -1726,10 +1724,22 @@ useEffect(() => {
                         >
                           Tickets{ticketsVinculados.length > 0 ? ` (${ticketsVinculados.length})` : ''}
                         </button>
+                        {podeEncerrar && (
+                          <button
+                            type="button"
+                            className="block min-h-11 w-full px-4 py-3 text-left text-sm text-rose-600 hover:bg-rose-50 dark:text-rose-400 dark:hover:bg-rose-950/40"
+                            onClick={() => {
+                              setMenuMobileAberto(false)
+                              setModalEncerrar(true)
+                            }}
+                          >
+                            Encerrar
+                          </button>
+                        )}
                         {podeDefinirEmpresa && (
                           <button
                             type="button"
-                            className="block w-full px-4 py-2.5 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
+                            className="block min-h-11 w-full px-4 py-3 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
                             onClick={() => {
                               setMenuMobileAberto(false)
                               abrirModalEmpresaContexto()
@@ -1977,7 +1987,7 @@ useEffect(() => {
                 {!isInbound && !isSystem && !m.apagada && (
                   <button
                     onClick={() => iniciarResposta(m)}
-                    className="opacity-25 group-hover:opacity-100 md:opacity-0 transition-opacity p-1.5 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 cursor-pointer shrink-0"
+                    className="flex h-11 w-11 shrink-0 cursor-pointer items-center justify-center rounded-full p-1.5 text-slate-400 opacity-100 transition-opacity hover:bg-slate-200 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-200 md:h-auto md:w-auto md:opacity-0 md:group-hover:opacity-100"
                     title="Responder"
                   >
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 17 4 12 9 7"/><path d="M20 18v-2a4 4 0 0 0-4-4H4"/></svg>
@@ -2075,7 +2085,7 @@ useEffect(() => {
                 {isInbound && !isSystem && !m.apagada && (
                   <button
                     onClick={() => iniciarResposta(m)}
-                    className="opacity-25 group-hover:opacity-100 md:opacity-0 transition-opacity p-1.5 hover:bg-slate-200 dark:hover:bg-slate-800 rounded-full text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 cursor-pointer shrink-0"
+                    className="flex h-11 w-11 shrink-0 cursor-pointer items-center justify-center rounded-full p-1.5 text-slate-400 opacity-100 transition-opacity hover:bg-slate-200 hover:text-slate-600 dark:hover:bg-slate-800 dark:hover:text-slate-200 md:h-auto md:w-auto md:opacity-0 md:group-hover:opacity-100"
                     title="Responder"
                   >
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 17 4 12 9 7"/><path d="M20 18v-2a4 4 0 0 0-4-4H4"/></svg>
@@ -2167,11 +2177,11 @@ useEffect(() => {
                   value={legendaMidia}
                   onChange={(e) => setLegendaMidia(e.target.value)}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                      e.preventDefault()
-                      e.stopPropagation()
-                      if (!enviando && podeEnviar) void confirmarEnvioMidia()
-                    }
+                    if (e.key !== 'Enter' || e.shiftKey) return
+                    if (!window.matchMedia('(min-width: 768px)').matches) return
+                    e.preventDefault()
+                    e.stopPropagation()
+                    if (!enviando && podeEnviar) void confirmarEnvioMidia()
                   }}
                   placeholder="Legenda opcional (visível no WhatsApp)"
                   className={`mt-2 ${TEXTAREA_FIELD_CLASS}`}
@@ -2235,8 +2245,8 @@ useEffect(() => {
       {/* Modais (Vincular exemplo) */}
 
       {modalTransferir && (
-  <div className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-900/50 backdrop-blur-sm">
-    <Card className="w-full max-w-lg p-6">
+  <div className="fixed inset-0 z-[100] flex items-end justify-center bg-slate-900/50 p-0 backdrop-blur-sm md:items-center md:p-4">
+    <Card className="max-h-[min(92dvh,var(--vv-height,92dvh))] w-full max-w-lg overflow-y-auto rounded-b-none p-6 md:rounded-2xl">
       <h3 className="text-lg font-bold">Transferir Atendimento</h3>
       {chat && (
         <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">

--- a/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappInatividadeControle.tsx
@@ -9,6 +9,7 @@ type Props = {
   msgs: WhatsappChats.Mensagem[]
   isResponsavel: boolean
   onChatUpdate: (c: WhatsappChats.Chat) => void
+  className?: string
 }
 
 function formatMmSs(totalSec: number): string {
@@ -18,8 +19,14 @@ function formatMmSs(totalSec: number): string {
   return `${mm}:${ss}`
 }
 
-/** Controlo de inatividade: countdown + pausar/retomar (#577). */
-export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatUpdate }: Props) {
+/** Countdown de inatividade para quem vê o chat; pausar/retomar só o responsável (#577 / #723). */
+export function WhatsappInatividadeControle({
+  chat,
+  msgs,
+  isResponsavel,
+  onChatUpdate,
+  className = '',
+}: Props) {
   const toast = useToast()
   const [avisoMin, setAvisoMin] = useState(15)
   const [posAvisoMin, setPosAvisoMin] = useState(5)
@@ -109,7 +116,7 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
     }
   }, [ativa, chat, msgs, avisoMin, posAvisoMin, tick])
 
-  if (!ativa || chat.estado !== 'em_atendimento' || !isResponsavel || fase == null) {
+  if (!ativa || chat.estado !== 'em_atendimento' || fase == null) {
     return null
   }
 
@@ -128,7 +135,7 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
   }
 
   return (
-    <div className="flex items-center gap-1.5">
+    <div className={`flex items-center gap-1.5 ${className}`.trim()}>
       <span
         className={`tabular-nums text-xs font-semibold ${
           fase.pausada
@@ -141,7 +148,7 @@ export function WhatsappInatividadeControle({ chat, msgs, isResponsavel, onChatU
       >
         {formatMmSs(fase.restanteSec)}
       </span>
-      {!fase.posAviso && (
+      {isResponsavel && !fase.posAviso && (
         <Button
           type="button"
           variant="ghost"

--- a/frontend/src/pages/whatsapp/WhatsappTicketsModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappTicketsModal.tsx
@@ -136,8 +136,8 @@ export function WhatsappTicketsModal({ chat, open, onClose, onSuccess }: Props) 
   }
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-slate-900/50 p-4 backdrop-blur-sm">
-      <Card className="flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden p-0 animate-in zoom-in-95">
+    <div className="fixed inset-0 z-[100] flex items-end justify-center bg-slate-900/50 p-0 backdrop-blur-sm md:items-center md:p-4">
+      <Card className="flex max-h-[min(92dvh,var(--vv-height,92dvh))] w-full max-w-lg flex-col overflow-hidden rounded-b-none p-0 animate-in zoom-in-95 md:rounded-2xl">
         <div className="border-b border-slate-100 px-6 py-4 dark:border-slate-800">
           <div className="flex items-start justify-between gap-4">
             <div>


### PR DESCRIPTION
## Summary

- Mobile (#692): operação completa de WhatsApp e tickets no telemóvel nas telas atuais (header, teclado, alvos de toque, fila, composer).
- WhatsApp (#723): cronômetro de inatividade visível para quem abre o chat em atendimento; Pausar/Retomar continua só com o responsável.

Closes #692
Closes #723

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] Telemóvel (~360px): abrir conversa WhatsApp — Encerrar/Transferir/Tickets no menu ⋮; detalhes fechados por omissão; teclado não cobre o compositor; Enter faz nova linha
- [ ] Fila Aguardando: Ver/Atender com alvo grande; assumir chat
- [ ] Tickets: lista em cards, filtros da fila, detalhe com Assumir e compositor fixo
- [ ] Login: campos não disparam zoom do iOS
- [ ] Chat em atendimento: operador vê countdown + Pausar; colega/admin vê o mesmo tempo sem Pausar
- [ ] Inatividade desligada ou chat não «Em atendimento»: controlo oculto
- [ ] Desktop e menu ⋮ consistentes

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Fora de escopo #692: admin/cadastros, dashboards, chat interno, portal, Web Push (#693/#694), piloto (#695), Capacitor (#696)
- [x] Fora de escopo #723: portal do funcionário
- [x] Sem stubs novos
