### PR TITLE
feat(web-push): alertas com a PWA fechada (#693 #694)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Mobile (#690 / #691): o painel no endereço do cliente pode ser **adicionado à tela inicial** (PWA); o brief mobile descreve PWA primeiro, depois lojas
 - Mobile (#692): no telemóvel, WhatsApp e tickets dão para operar por completo — assumir, responder (texto/mídia), transferir, encerrar, abrir ticket; fila e detalhe do chamado com botões grandes e teclado que não cobre o campo de mensagem
 - WhatsApp (#723): quem abre um chat em atendimento (colega ou admin) também vê o cronômetro de inatividade; Pausar/Retomar continua só com o responsável
+- Notificações (#693 / #694): no telemóvel podes receber alertas mesmo com a app fechada — fila de espera e mensagens nos chats/tickets já teus. Activa em Notificações; o silêncio da fila na mesa também vale com a app fechada
 - Menu (#716): a barra de rolagem da sidebar (painel e portal) fica fina e alinhada ao tema, sem o visual nativo do Windows
 - CI: testes do backend deixam de repetir bcrypt lento em cada caso; PRs só de interface já não esperam o pytest, e o contrário também (job do lado inalterado conclui em segundos)
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -68,6 +68,13 @@ LOG_LEVEL=INFO
 # TICKET_CLOSED_WEBHOOK_URL=https://integracao.exemplo.com/dx/ticket-closed
 # TICKET_CLOSED_WEBHOOK_SECRET=segredo-compartilhado-para-hmac
 # WEBHOOK_OUTBOX_WORKER_INTERVAL_SECONDS=15
+#
+# --- Web Push (VAPID) por instância / stack (#693) ---
+# Gerar: python -c "from py_vapid import Vapid01; v=Vapid01(); v.generate_keys(); print(v.public_key.decode() if hasattr(v.public_key,'decode') else v.public_key)"
+# WEB_PUSH_VAPID_PUBLIC_KEY=
+# WEB_PUSH_VAPID_PRIVATE_KEY=
+# WEB_PUSH_VAPID_SUBJECT=mailto:ops@deskrudder.com.br
+# WEB_PUSH_WORKER_INTERVAL_SECONDS=5
 
 # Cache IBGE (municípios): intervalo entre syncs em segundos e idade máxima (horas) antes de re-sync.
 # IBGE_MUNICIPIOS_SYNC_INTERVAL_SECONDS=86400

--- a/backend/alembic/versions/095_web_push.py
+++ b/backend/alembic/versions/095_web_push.py
@@ -1,0 +1,83 @@
+"""Web Push: subscriptions, outbox e preferências (#693 / #694).
+
+Revision ID: 095_web_push
+Revises: 094_wpp_midia_nome_original
+Create Date: 2026-08-18
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "095_web_push"
+down_revision = "094_wpp_midia_nome_original"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    tables = set(insp.get_table_names())
+
+    if "push_subscription" not in tables:
+        op.create_table(
+            "push_subscription",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("atendente_id", sa.Integer(), sa.ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("endpoint", sa.String(length=2048), nullable=False),
+            sa.Column("p256dh", sa.String(length=255), nullable=False),
+            sa.Column("auth", sa.String(length=255), nullable=False),
+            sa.Column("user_agent", sa.String(length=512), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+            sa.UniqueConstraint("endpoint", name="uq_push_subscription_endpoint"),
+        )
+        op.create_index("ix_push_subscription_atendente_id", "push_subscription", ["atendente_id"])
+
+    if "push_outbox" not in tables:
+        op.create_table(
+            "push_outbox",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("atendente_id", sa.Integer(), sa.ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("event_type", sa.String(length=64), nullable=False),
+            sa.Column("dedup_key", sa.String(length=255), nullable=False),
+            sa.Column("payload_json", sa.Text(), nullable=False),
+            sa.Column("status", sa.String(length=32), nullable=False, server_default="pendente"),
+            sa.Column("tentativas", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("last_error", sa.Text(), nullable=True),
+            sa.Column("scheduled_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+            sa.UniqueConstraint("dedup_key", name="uq_push_outbox_dedup_key"),
+        )
+        op.create_index("ix_push_outbox_atendente_id", "push_outbox", ["atendente_id"])
+        op.create_index("ix_push_outbox_event_type", "push_outbox", ["event_type"])
+        op.create_index("ix_push_outbox_status", "push_outbox", ["status"])
+        op.create_index("ix_push_outbox_scheduled_at", "push_outbox", ["scheduled_at"])
+
+    prefs_cols = {c["name"] for c in insp.get_columns("atendente_notificacao_preferencias")}
+    if "push_habilitado" not in prefs_cols:
+        op.add_column(
+            "atendente_notificacao_preferencias",
+            sa.Column("push_habilitado", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        )
+    if "push_fila" not in prefs_cols:
+        op.add_column(
+            "atendente_notificacao_preferencias",
+            sa.Column("push_fila", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    prefs_cols = {c["name"] for c in insp.get_columns("atendente_notificacao_preferencias")}
+    if "push_fila" in prefs_cols:
+        op.drop_column("atendente_notificacao_preferencias", "push_fila")
+    if "push_habilitado" in prefs_cols:
+        op.drop_column("atendente_notificacao_preferencias", "push_habilitado")
+    tables = set(insp.get_table_names())
+    if "push_outbox" in tables:
+        op.drop_table("push_outbox")
+    if "push_subscription" in tables:
+        op.drop_table("push_subscription")

--- a/backend/app/api/web_push.py
+++ b/backend/app/api/web_push.py
@@ -1,0 +1,62 @@
+from fastapi import APIRouter, Depends, Query, status
+from sqlalchemy.orm import Session
+
+from app.core.auth import obter_atendente_atual
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.schemas.web_push import PushSubscriptionCreate, PushSubscriptionRead, PushVapidPublic
+from app.services import web_push as svc
+
+router = APIRouter(prefix="/web-push", tags=["web-push"])
+
+
+@router.get("/vapid", response_model=PushVapidPublic)
+def obter_vapid_publico(atendente: Atendente = Depends(obter_atendente_atual)):
+    del atendente
+    key = svc.vapid_public_key()
+    return PushVapidPublic(configurado=bool(key), public_key=key)
+
+
+@router.get("/subscriptions", response_model=list[PushSubscriptionRead])
+def listar_subscriptions(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return svc.listar_minhas(db, atendente.id)
+
+
+@router.post("/subscriptions", response_model=PushSubscriptionRead, status_code=status.HTTP_201_CREATED)
+def registrar_subscription(
+    body: PushSubscriptionCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return svc.registrar(
+        db,
+        atendente.id,
+        endpoint=body.endpoint,
+        p256dh=body.p256dh,
+        auth=body.auth,
+        user_agent=body.user_agent,
+    )
+
+
+@router.delete("/subscriptions/{subscription_id}", status_code=status.HTTP_204_NO_CONTENT)
+def apagar_subscription(
+    subscription_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    svc.remover(db, atendente.id, subscription_id)
+    return None
+
+
+@router.delete("/subscriptions", status_code=status.HTTP_204_NO_CONTENT)
+def apagar_por_endpoint(
+    endpoint: str = Query(..., min_length=8),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Revoga o dispositivo actual no logout."""
+    svc.remover_por_endpoint(db, atendente.id, endpoint)
+    return None

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -67,6 +67,11 @@ class Settings(BaseSettings):
     # Webhook de saída ao fechar ticket (#119). URL vazia = desligado.
     TICKET_CLOSED_WEBHOOK_URL: str | None = None
     TICKET_CLOSED_WEBHOOK_SECRET: str | None = None
+    # Web Push (VAPID) — um par por stack/cliente (#693). Vazio = push desligado.
+    WEB_PUSH_VAPID_PUBLIC_KEY: str | None = None
+    WEB_PUSH_VAPID_PRIVATE_KEY: str | None = None
+    WEB_PUSH_VAPID_SUBJECT: str = "mailto:ops@deskrudder.com.br"
+    WEB_PUSH_WORKER_INTERVAL_SECONDS: int = 5
     # Tentativas HTTP para Evolution API (falhas transitórias).
     EVOLUTION_HTTP_MAX_ATTEMPTS: int = 3
     WHATSAPP_INACTIVITY_WORKER_INTERVAL_SECONDS: int = 60

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -54,6 +54,7 @@ from app.api import (
     saas,
     saas_public,
     saas_leads,
+    web_push,
 )
 from app.config import settings
 from app.core.audit import clear_audit_request_context, set_audit_request_context
@@ -257,6 +258,29 @@ async def lifespan(app: FastAPI):
         target=webhook_outbox_loop,
         daemon=True,
         name="webhook-outbox",
+    ).start()
+
+    def web_push_outbox_loop() -> None:
+        from app.database import SessionLocal
+        from app.services.web_push_outbox import process_pending_web_push
+
+        interval = max(3, settings.WEB_PUSH_WORKER_INTERVAL_SECONDS)
+        while True:
+            db = SessionLocal()
+            try:
+                process_pending_web_push(db, limit=40)
+                db.commit()
+            except Exception as e:
+                logger.warning("Worker Web Push outbox: %s", e)
+                db.rollback()
+            finally:
+                db.close()
+            time.sleep(interval)
+
+    threading.Thread(
+        target=web_push_outbox_loop,
+        daemon=True,
+        name="web-push-outbox",
     ).start()
 
     def whatsapp_inactivity_loop() -> None:
@@ -504,6 +528,7 @@ app.include_router(cadastro_aux.router, prefix=API_V1_PREFIX)
 app.include_router(notificacoes.router, prefix=API_V1_PREFIX)
 app.include_router(events.router, prefix=API_V1_PREFIX)
 app.include_router(presenca.router, prefix=API_V1_PREFIX)
+app.include_router(web_push.router, prefix=API_V1_PREFIX)
 app.include_router(whatsapp_settings.router, prefix=API_V1_PREFIX)
 app.include_router(whatsapp_chats.router, prefix=API_V1_PREFIX)
 app.include_router(whatsapp_webhook.router, prefix=API_V1_PREFIX)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -37,6 +37,7 @@ from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
 from app.models.ticket_avaliacao import TicketAvaliacao, TicketCsatInvite
 from app.models.atendente_notificacao import AtendenteNotificacaoPreferencias, NotificacaoEmailOutbox
 from app.models.webhook_outbox import WebhookOutbox
+from app.models.web_push import PushOutbox, PushSubscription
 from app.models.routing_rule import RoutingRule
 from app.models.business_calendar import BusinessCalendar
 from app.models.sla_policy import SlaPolicy
@@ -111,6 +112,8 @@ __all__ = [
     "AtendenteNotificacaoPreferencias",
     "NotificacaoEmailOutbox",
     "WebhookOutbox",
+    "PushSubscription",
+    "PushOutbox",
     "RoutingRule",
     "BusinessCalendar",
     "SlaPolicy",

--- a/backend/app/models/atendente_notificacao.py
+++ b/backend/app/models/atendente_notificacao.py
@@ -14,6 +14,8 @@ class AtendenteNotificacaoPreferencias(Base):
     email_nova_mensagem = Column(Boolean, nullable=False, default=True)
     email_sla_em_risco = Column(Boolean, nullable=False, default=True)
     email_sla_violado = Column(Boolean, nullable=False, default=True)
+    push_habilitado = Column(Boolean, nullable=False, default=False)
+    push_fila = Column(Boolean, nullable=False, default=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
 

--- a/backend/app/models/web_push.py
+++ b/backend/app/models/web_push.py
@@ -1,0 +1,43 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class PushSubscription(Base):
+    """Subscription Web Push do atendente (por dispositivo / browser) (#693)."""
+
+    __tablename__ = "push_subscription"
+    __table_args__ = (UniqueConstraint("endpoint", name="uq_push_subscription_endpoint"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    endpoint = Column(String(2048), nullable=False)
+    p256dh = Column(String(255), nullable=False)
+    auth = Column(String(255), nullable=False)
+    user_agent = Column(String(512), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now(), nullable=True)
+
+    atendente = relationship("Atendente", backref="push_subscriptions")
+
+
+class PushOutbox(Base):
+    """Fila de envio Web Push — worker após commit (#693)."""
+
+    __tablename__ = "push_outbox"
+
+    id = Column(Integer, primary_key=True, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    event_type = Column(String(64), nullable=False, index=True)
+    dedup_key = Column(String(255), nullable=False, unique=True, index=True)
+    payload_json = Column(Text, nullable=False)
+    status = Column(String(32), nullable=False, default="pendente", index=True)
+    tentativas = Column(Integer, nullable=False, default=0, server_default="0")
+    last_error = Column(Text, nullable=True)
+    scheduled_at = Column(DateTime(timezone=True), nullable=False, index=True)
+    sent_at = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    atendente = relationship("Atendente", backref="push_outbox")

--- a/backend/app/schemas/atendente_notificacao.py
+++ b/backend/app/schemas/atendente_notificacao.py
@@ -7,6 +7,8 @@ class NotificacaoPreferenciasRead(BaseModel):
     email_nova_mensagem: bool = True
     email_sla_em_risco: bool = True
     email_sla_violado: bool = True
+    push_habilitado: bool = False
+    push_fila: bool = True
 
 
 class NotificacaoPreferenciasUpdate(BaseModel):
@@ -15,3 +17,5 @@ class NotificacaoPreferenciasUpdate(BaseModel):
     email_nova_mensagem: bool | None = None
     email_sla_em_risco: bool | None = None
     email_sla_violado: bool | None = None
+    push_habilitado: bool | None = None
+    push_fila: bool | None = None

--- a/backend/app/schemas/web_push.py
+++ b/backend/app/schemas/web_push.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, Field
+
+
+class PushSubscriptionCreate(BaseModel):
+    endpoint: str = Field(min_length=8, max_length=2048)
+    p256dh: str = Field(min_length=8, max_length=255)
+    auth: str = Field(min_length=8, max_length=255)
+    user_agent: str | None = Field(default=None, max_length=512)
+
+
+class PushSubscriptionRead(BaseModel):
+    id: int
+    endpoint: str
+    user_agent: str | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class PushVapidPublic(BaseModel):
+    configurado: bool
+    public_key: str | None = None

--- a/backend/app/services/notificacao_atendente_email.py
+++ b/backend/app/services/notificacao_atendente_email.py
@@ -64,6 +64,8 @@ def preferencias_para_dict(p: AtendenteNotificacaoPreferencias) -> dict:
         "email_nova_mensagem": bool(p.email_nova_mensagem),
         "email_sla_em_risco": bool(getattr(p, "email_sla_em_risco", True)),
         "email_sla_violado": bool(getattr(p, "email_sla_violado", True)),
+        "push_habilitado": bool(getattr(p, "push_habilitado", False)),
+        "push_fila": bool(getattr(p, "push_fila", True)),
     }
 
 

--- a/backend/app/services/presenca.py
+++ b/backend/app/services/presenca.py
@@ -103,6 +103,9 @@ async def forcar_saida(db: Session, *, admin: Atendente, alvo_id: int) -> None:
     alvo.presenca_online_desde = None
     alvo.presenca_heartbeat_em = None
     db.add(alvo)
+    from app.services.web_push import revogar_todas
+
+    revogar_todas(db, alvo.id)
     db.commit()
 
     try:

--- a/backend/app/services/realtime_emit.py
+++ b/backend/app/services/realtime_emit.py
@@ -210,6 +210,15 @@ def emit_notificacao_after_counter_change(db: Session) -> None:
     _emit_notificacao_after_counter_change(db)
 
 
+def _enfileirar_web_push(**kwargs) -> None:
+    try:
+        from app.services.web_push_outbox import enfileirar_para_atendentes
+
+        enfileirar_para_atendentes(**kwargs)
+    except Exception:
+        logger.exception("Web Push: falha ao enfileirar")
+
+
 def emit_chat_mensagem(
     db: Session,
     chat: WhatsappChat,
@@ -223,6 +232,19 @@ def emit_chat_mensagem(
     payload = {"chat_id": chat.id, "mensagem": mensagem_payload}
     _publish_to_atendentes(recipients, "chat.mensagem", payload)
     _emit_notificacao_after_counter_change(db)
+    if chat.atendente_id and chat.estado == "em_atendimento":
+        direcao = (mensagem_payload or {}).get("direcao")
+        if direcao == "inbound":
+            nome = chat.cliente_nome or "WhatsApp"
+            _enfileirar_web_push(
+                atendente_ids={chat.atendente_id},
+                event_type="chat.mensagem",
+                entity_id=int((mensagem_payload or {}).get("id") or chat.id),
+                titulo=f"WhatsApp · {nome}",
+                url_path="/chat/atendendo",
+                corpo=str((mensagem_payload or {}).get("corpo") or "Nova mensagem")[:180],
+                exclude_atendente_id=exclude_atendente_id,
+            )
 
 
 def emit_chat_fila(
@@ -244,6 +266,16 @@ def emit_chat_fila(
         payload["chat"] = chat_payload
     _publish_to_atendentes(recipients, "chat.fila", payload)
     _emit_notificacao_after_counter_change(db)
+    if chat.estado == "aguardando_atendente":
+        nome = (chat_payload or {}).get("cliente_nome") or chat.cliente_nome or "cliente"
+        _enfileirar_web_push(
+            atendente_ids=recipients,
+            event_type="chat.fila",
+            entity_id=chat.id,
+            titulo="Cliente na fila WhatsApp",
+            url_path="/chat/espera",
+            corpo=str(nome)[:180],
+        )
 
 
 def emit_ticket_mensagem(
@@ -261,6 +293,16 @@ def emit_ticket_mensagem(
     _publish_to_atendentes(recipients, "ticket.mensagem", payload)
     if emit_notificacao:
         _emit_notificacao_after_counter_change(db)
+    if ticket.atendente_id:
+        _enfileirar_web_push(
+            atendente_ids={ticket.atendente_id},
+            event_type="ticket.mensagem",
+            entity_id=int((mensagem_payload or {}).get("id") or ticket.id),
+            titulo=f"Ticket {ticket.protocolo}",
+            url_path="/tickets",
+            corpo=str((mensagem_payload or {}).get("corpo") or ticket.assunto or "Nova mensagem")[:180],
+            exclude_atendente_id=exclude_atendente_id,
+        )
 
 
 def emit_ticket_fila(db: Session, ticket: Ticket) -> None:
@@ -274,6 +316,14 @@ def emit_ticket_fila(db: Session, ticket: Ticket) -> None:
     }
     _publish_to_atendentes(recipients, "ticket.fila", payload)
     _emit_notificacao_after_counter_change(db)
+    _enfileirar_web_push(
+        atendente_ids=recipients,
+        event_type="ticket.fila",
+        entity_id=ticket.id,
+        titulo="Chamado na fila",
+        url_path="/tickets",
+        corpo=str(ticket.protocolo or ticket.assunto or "")[:180],
+    )
 
 
 def emit_chat_mensagem_from_models(
@@ -327,6 +377,18 @@ def emit_portal_chat_mensagem(
     payload = {"chat_id": chat.id, "mensagem": mensagem_payload}
     _publish_to_atendentes(recipients, "portal.chat.mensagem", payload)
     _emit_notificacao_after_counter_change(db)
+    if chat.atendente_id and chat.estado == "em_atendimento":
+        direcao = (mensagem_payload or {}).get("direcao")
+        if direcao == "inbound":
+            _enfileirar_web_push(
+                atendente_ids={chat.atendente_id},
+                event_type="portal.chat.mensagem",
+                entity_id=int((mensagem_payload or {}).get("id") or chat.id),
+                titulo="Portal · nova mensagem",
+                url_path="/chat/atendendo",
+                corpo=str((mensagem_payload or {}).get("corpo") or "Nova mensagem")[:180],
+                exclude_atendente_id=exclude_atendente_id,
+            )
 
 
 def emit_portal_chat_fila(
@@ -348,6 +410,15 @@ def emit_portal_chat_fila(
         payload["chat"] = chat_payload
     _publish_to_atendentes(recipients, "portal.chat.fila", payload)
     _emit_notificacao_after_counter_change(db)
+    if chat.estado == "aguardando_atendente":
+        _enfileirar_web_push(
+            atendente_ids=recipients,
+            event_type="portal.chat.fila",
+            entity_id=chat.id,
+            titulo="Cliente na fila do portal",
+            url_path="/chat/espera",
+            corpo="Novo atendimento no portal",
+        )
 
 
 def emit_portal_chat_mensagem_from_models(

--- a/backend/app/services/web_push.py
+++ b/backend/app/services/web_push.py
@@ -1,0 +1,87 @@
+"""CRUD de subscriptions Web Push e chave VAPID pública (#693)."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.web_push import PushSubscription
+
+
+def vapid_configurado() -> bool:
+    pub = (settings.WEB_PUSH_VAPID_PUBLIC_KEY or "").strip()
+    priv = (settings.WEB_PUSH_VAPID_PRIVATE_KEY or "").strip()
+    return bool(pub and priv)
+
+
+def vapid_public_key() -> str | None:
+    if not vapid_configurado():
+        return None
+    return (settings.WEB_PUSH_VAPID_PUBLIC_KEY or "").strip()
+
+
+def listar_minhas(db: Session, atendente_id: int) -> list[PushSubscription]:
+    return (
+        db.query(PushSubscription)
+        .filter(PushSubscription.atendente_id == atendente_id)
+        .order_by(PushSubscription.id.desc())
+        .all()
+    )
+
+
+def registrar(db: Session, atendente_id: int, *, endpoint: str, p256dh: str, auth: str, user_agent: str | None) -> PushSubscription:
+    endpoint = endpoint.strip()
+    existente = db.query(PushSubscription).filter(PushSubscription.endpoint == endpoint).first()
+    if existente:
+        if existente.atendente_id != atendente_id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Esta subscription pertence a outro utilizador.",
+            )
+        existente.p256dh = p256dh.strip()
+        existente.auth = auth.strip()
+        existente.user_agent = (user_agent or "").strip() or None
+        db.add(existente)
+        db.commit()
+        db.refresh(existente)
+        return existente
+    row = PushSubscription(
+        atendente_id=atendente_id,
+        endpoint=endpoint,
+        p256dh=p256dh.strip(),
+        auth=auth.strip(),
+        user_agent=(user_agent or "").strip() or None,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def remover(db: Session, atendente_id: int, subscription_id: int) -> None:
+    row = db.query(PushSubscription).filter(PushSubscription.id == subscription_id).first()
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Subscription não encontrada")
+    if row.atendente_id != atendente_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Não pode remover a subscription de outro utilizador.")
+    db.delete(row)
+    db.commit()
+
+
+def remover_por_endpoint(db: Session, atendente_id: int, endpoint: str) -> None:
+    row = (
+        db.query(PushSubscription)
+        .filter(PushSubscription.atendente_id == atendente_id, PushSubscription.endpoint == endpoint.strip())
+        .first()
+    )
+    if row is None:
+        return
+    db.delete(row)
+    db.commit()
+
+
+def revogar_todas(db: Session, atendente_id: int) -> int:
+    n = db.query(PushSubscription).filter(PushSubscription.atendente_id == atendente_id).delete()
+    db.flush()
+    return int(n or 0)

--- a/backend/app/services/web_push_outbox.py
+++ b/backend/app/services/web_push_outbox.py
@@ -1,0 +1,208 @@
+"""Outbox Web Push — enfileirar após o evento de negócio e enviar no worker (#693)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.core.structured_log import log_event
+from app.database import SessionLocal
+from app.models.atendente_notificacao import AtendenteNotificacaoPreferencias
+from app.models.web_push import PushOutbox, PushSubscription
+from app.services.email_outbox_policy import MAX_EMAIL_SEND_ATTEMPTS, retry_delay_seconds
+from app.services.notificacao_atendente_email import obter_ou_criar_preferencias
+from app.services.web_push import vapid_configurado
+
+logger = logging.getLogger(__name__)
+
+STATUS_PENDENTE = "pendente"
+STATUS_ENVIADA = "enviada"
+STATUS_FALHA = "falha"
+
+TIPOS_FILA = frozenset({"chat.fila", "ticket.fila", "portal.chat.fila"})
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _prefs_permitem(prefs: AtendenteNotificacaoPreferencias, event_type: str) -> bool:
+    if not bool(getattr(prefs, "push_habilitado", False)):
+        return False
+    if event_type in TIPOS_FILA and not bool(getattr(prefs, "push_fila", True)):
+        return False
+    return True
+
+
+def _dedup_ja_processado(db: Session, dedup_key: str) -> bool:
+    row = db.query(PushOutbox.id).filter(PushOutbox.dedup_key == dedup_key).first()
+    return row is not None
+
+
+def enfileirar_para_atendentes(
+    *,
+    atendente_ids: Iterable[int],
+    event_type: str,
+    entity_id: int,
+    titulo: str,
+    url_path: str,
+    corpo: str | None = None,
+    exclude_atendente_id: int | None = None,
+) -> None:
+    """Abre sessão própria para não interferir no commit do chamador (emit pós-commit)."""
+    if not vapid_configurado():
+        return
+    ids = {int(i) for i in atendente_ids if i is not None}
+    if exclude_atendente_id is not None:
+        ids.discard(int(exclude_atendente_id))
+    if not ids:
+        return
+
+    payload_base = {
+        "tipo": event_type,
+        "id": int(entity_id),
+        "titulo": titulo,
+        "url_path": url_path,
+        "corpo": (corpo or "").strip() or None,
+    }
+    now = _utcnow()
+    db = SessionLocal()
+    try:
+        for aid in ids:
+            prefs = obter_ou_criar_preferencias(db, aid)
+            if not _prefs_permitem(prefs, event_type):
+                continue
+            tem_sub = (
+                db.query(PushSubscription.id).filter(PushSubscription.atendente_id == aid).limit(1).first()
+            )
+            if tem_sub is None:
+                continue
+            if event_type in TIPOS_FILA:
+                dedup_key = f"{event_type}:{entity_id}:{aid}:{int(now.timestamp() // 60)}"
+            else:
+                dedup_key = f"{event_type}:{entity_id}:{aid}"
+            if _dedup_ja_processado(db, dedup_key):
+                continue
+            db.add(
+                PushOutbox(
+                    atendente_id=aid,
+                    event_type=event_type,
+                    dedup_key=dedup_key,
+                    payload_json=json.dumps(payload_base, ensure_ascii=False),
+                    status=STATUS_PENDENTE,
+                    scheduled_at=now,
+                )
+            )
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+    except Exception:
+        db.rollback()
+        logger.exception("Falha ao enfileirar Web Push (%s:%s)", event_type, entity_id)
+    finally:
+        db.close()
+
+
+def _enviar_uma(sub: PushSubscription, payload: dict[str, Any]) -> tuple[int, str | None]:
+    from pywebpush import WebPushException, webpush
+
+    info = {
+        "endpoint": sub.endpoint,
+        "keys": {"p256dh": sub.p256dh, "auth": sub.auth},
+    }
+    claims = {"sub": (settings.WEB_PUSH_VAPID_SUBJECT or "mailto:ops@deskrudder.com.br").strip()}
+    try:
+        webpush(
+            subscription_info=info,
+            data=json.dumps(payload, ensure_ascii=False),
+            vapid_private_key=(settings.WEB_PUSH_VAPID_PRIVATE_KEY or "").strip(),
+            vapid_claims=claims,
+        )
+        return 201, None
+    except WebPushException as e:
+        code = 0
+        resp = getattr(e, "response", None)
+        if resp is not None:
+            code = int(getattr(resp, "status_code", 0) or 0)
+        return code, str(e)[:2000]
+    except Exception as e:
+        return 0, str(e)[:2000]
+
+
+def process_pending_web_push(db: Session, *, limit: int = 40) -> int:
+    if not vapid_configurado():
+        return 0
+    now = _utcnow()
+    rows = (
+        db.query(PushOutbox)
+        .filter(PushOutbox.status == STATUS_PENDENTE, PushOutbox.scheduled_at <= now)
+        .order_by(PushOutbox.scheduled_at.asc())
+        .limit(limit)
+        .all()
+    )
+    sent = 0
+    for row in rows:
+        subs = db.query(PushSubscription).filter(PushSubscription.atendente_id == row.atendente_id).all()
+        if not subs:
+            row.status = STATUS_ENVIADA
+            row.sent_at = now
+            row.last_error = "sem subscription"
+            continue
+        payload = json.loads(row.payload_json)
+        row.tentativas = int(row.tentativas or 0) + 1
+        algum_ok = False
+        ultimo_erro = None
+        for sub in subs:
+            code, err = _enviar_uma(sub, payload)
+            if 200 <= code < 300 or code == 201:
+                algum_ok = True
+                continue
+            if code in (404, 410):
+                db.delete(sub)
+                log_event(logger, "web_push_subscription_expired", subscription_id=sub.id, http_status=code)
+                continue
+            ultimo_erro = err or f"HTTP {code}"
+        if algum_ok:
+            row.status = STATUS_ENVIADA
+            row.sent_at = now
+            row.last_error = None
+            sent += 1
+            log_event(logger, "web_push_outbox_send_ok", outbox_id=row.id, event_type=row.event_type)
+            continue
+        ainda_subs = (
+            db.query(PushSubscription.id).filter(PushSubscription.atendente_id == row.atendente_id).first()
+        )
+        if ainda_subs is None:
+            row.status = STATUS_ENVIADA
+            row.sent_at = now
+            row.last_error = "subscription expirada"
+            continue
+        row.last_error = ultimo_erro or "falha no envio"
+        if row.tentativas >= MAX_EMAIL_SEND_ATTEMPTS:
+            row.status = STATUS_FALHA
+            log_event(
+                logger,
+                "web_push_outbox_send_failed_permanent",
+                level=logging.ERROR,
+                outbox_id=row.id,
+                tentativas=row.tentativas,
+                error=row.last_error[:500],
+            )
+        else:
+            delay = retry_delay_seconds(row.tentativas)
+            row.scheduled_at = now + timedelta(seconds=delay)
+            log_event(
+                logger,
+                "web_push_outbox_send_retry",
+                level=logging.WARNING,
+                outbox_id=row.id,
+                tentativas=row.tentativas,
+                retry_in_seconds=delay,
+            )
+    return sent

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,3 +13,4 @@ PyJWT[crypto]==2.13.0
 cryptography>=50.0.0
 bcrypt>=5.0.0,<6
 svix>=1.99.1
+pywebpush==2.0.3

--- a/backend/tests/test_notificacoes_atendente.py
+++ b/backend/tests/test_notificacoes_atendente.py
@@ -26,6 +26,8 @@ def test_preferencias_padrao_e_atualizacao(client, seed_base, auth_headers):
     assert body["email_nova_mensagem"] is True
     assert body["email_sla_em_risco"] is True
     assert body["email_sla_violado"] is True
+    assert body["push_habilitado"] is False
+    assert body["push_fila"] is True
 
     r2 = client.patch(
         "/v1/notificacoes/preferencias",

--- a/backend/tests/test_web_push.py
+++ b/backend/tests/test_web_push.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.models.web_push import PushOutbox, PushSubscription
+from app.services.notificacao_atendente_email import obter_ou_criar_preferencias
+from app.services.web_push_outbox import STATUS_PENDENTE, enfileirar_para_atendentes, process_pending_web_push
+
+
+def test_vapid_desligado_sem_chaves(client, auth_headers):
+    r = client.get("/v1/web-push/vapid", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["configurado"] is False
+    assert body["public_key"] is None
+
+
+def test_vapid_exige_jwt(client):
+    r = client.get("/v1/web-push/vapid")
+    assert r.status_code in (401, 403)
+
+
+def test_registrar_listar_apagar_subscription(client, seed_base, auth_headers, db_session, monkeypatch):
+    monkeypatch.setattr("app.config.settings.WEB_PUSH_VAPID_PUBLIC_KEY", "BNpublic")
+    monkeypatch.setattr("app.config.settings.WEB_PUSH_VAPID_PRIVATE_KEY", "priv")
+
+    r = client.get("/v1/web-push/vapid", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    assert r.json()["configurado"] is True
+    assert r.json()["public_key"] == "BNpublic"
+
+    payload = {
+        "endpoint": "https://push.example.com/a1",
+        "p256dh": "p256dh-key-value",
+        "auth": "auth-key-value",
+        "user_agent": "TestAgent",
+    }
+    r = client.post("/v1/web-push/subscriptions", headers=auth_headers["a1"], json=payload)
+    assert r.status_code == 201, r.text
+    sub_id = r.json()["id"]
+
+    r = client.get("/v1/web-push/subscriptions", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    assert len(r.json()) == 1
+    assert r.json()[0]["endpoint"] == payload["endpoint"]
+
+    r = client.get("/v1/web-push/subscriptions", headers=auth_headers["a2"])
+    assert r.status_code == 200
+    assert r.json() == []
+
+    r = client.delete(f"/v1/web-push/subscriptions/{sub_id}", headers=auth_headers["a2"])
+    assert r.status_code == 403
+
+    r = client.delete(f"/v1/web-push/subscriptions/{sub_id}", headers=auth_headers["a1"])
+    assert r.status_code == 204
+    assert db_session.query(PushSubscription).count() == 0
+
+
+def test_nao_registra_endpoint_de_outro_utilizador(client, seed_base, auth_headers, db_session):
+    a1 = seed_base["a1"]
+    db_session.add(
+        PushSubscription(
+            atendente_id=a1.id,
+            endpoint="https://push.example.com/owned-by-a1",
+            p256dh="p256dh-key-value",
+            auth="auth-key-value",
+        )
+    )
+    db_session.commit()
+    r = client.post(
+        "/v1/web-push/subscriptions",
+        headers=auth_headers["a2"],
+        json={
+            "endpoint": "https://push.example.com/owned-by-a1",
+            "p256dh": "p256dh-key-value",
+            "auth": "auth-key-value",
+        },
+    )
+    assert r.status_code == 403
+    assert db_session.query(PushSubscription).count() == 1
+
+
+def test_nao_apaga_subscription_alheia_por_endpoint(client, seed_base, auth_headers, db_session):
+    a1 = seed_base["a1"]
+    db_session.add(
+        PushSubscription(
+            atendente_id=a1.id,
+            endpoint="https://push.example.com/a1-only",
+            p256dh="p256dh-key-value",
+            auth="auth-key-value",
+        )
+    )
+    db_session.commit()
+    r = client.delete(
+        "/v1/web-push/subscriptions",
+        headers=auth_headers["a2"],
+        params={"endpoint": "https://push.example.com/a1-only"},
+    )
+    assert r.status_code == 204
+    assert db_session.query(PushSubscription).count() == 1
+
+
+def test_enfileira_so_com_pref_e_subscription(seed_base, db_session, monkeypatch):
+    monkeypatch.setattr("app.services.web_push_outbox.vapid_configurado", lambda: True)
+    a1 = seed_base["a1"]
+    prefs = obter_ou_criar_preferencias(db_session, a1.id)
+    prefs.push_habilitado = True
+    prefs.push_fila = True
+    db_session.add(
+        PushSubscription(
+            atendente_id=a1.id,
+            endpoint="https://push.example.com/fila",
+            p256dh="p256dh-key-value",
+            auth="auth-key-value",
+        )
+    )
+    db_session.commit()
+
+    enfileirar_para_atendentes(
+        atendente_ids={a1.id, seed_base["a2"].id},
+        event_type="chat.fila",
+        entity_id=99,
+        titulo="Cliente na fila WhatsApp",
+        url_path="/chat/espera",
+        corpo="João",
+    )
+    rows = db_session.query(PushOutbox).all()
+    assert len(rows) == 1
+    assert rows[0].atendente_id == a1.id
+    assert rows[0].status == STATUS_PENDENTE
+
+
+def test_nao_enfileira_fila_quando_mute(seed_base, db_session, monkeypatch):
+    monkeypatch.setattr("app.services.web_push_outbox.vapid_configurado", lambda: True)
+    a1 = seed_base["a1"]
+    prefs = obter_ou_criar_preferencias(db_session, a1.id)
+    prefs.push_habilitado = True
+    prefs.push_fila = False
+    db_session.add(
+        PushSubscription(
+            atendente_id=a1.id,
+            endpoint="https://push.example.com/mute",
+            p256dh="p256dh-key-value",
+            auth="auth-key-value",
+        )
+    )
+    db_session.commit()
+    enfileirar_para_atendentes(
+        atendente_ids={a1.id},
+        event_type="chat.fila",
+        entity_id=7,
+        titulo="Cliente na fila WhatsApp",
+        url_path="/chat/espera",
+    )
+    assert db_session.query(PushOutbox).count() == 0
+
+
+def test_worker_envia_e_respeita_410(seed_base, db_session, monkeypatch):
+    monkeypatch.setattr("app.config.settings.WEB_PUSH_VAPID_PUBLIC_KEY", "pub")
+    monkeypatch.setattr("app.config.settings.WEB_PUSH_VAPID_PRIVATE_KEY", "priv")
+    monkeypatch.setattr("app.services.web_push_outbox.vapid_configurado", lambda: True)
+    a1 = seed_base["a1"]
+    prefs = obter_ou_criar_preferencias(db_session, a1.id)
+    prefs.push_habilitado = True
+    sub = PushSubscription(
+        atendente_id=a1.id,
+        endpoint="https://push.example.com/gone",
+        p256dh="p256dh-key-value",
+        auth="auth-key-value",
+    )
+    db_session.add(sub)
+    db_session.commit()
+    db_session.add(
+        PushOutbox(
+            atendente_id=a1.id,
+            event_type="ticket.fila",
+            dedup_key="ticket.fila:1:x",
+            payload_json='{"tipo":"ticket.fila","id":1,"titulo":"Fila","url_path":"/tickets"}',
+            status=STATUS_PENDENTE,
+            scheduled_at=datetime.now(timezone.utc),
+        )
+    )
+    db_session.commit()
+
+    def fake_enviar(sub_row, payload):
+        return 410, "Gone"
+
+    monkeypatch.setattr("app.services.web_push_outbox._enviar_uma", fake_enviar)
+    process_pending_web_push(db_session, limit=10)
+    db_session.commit()
+    assert db_session.query(PushSubscription).count() == 0

--- a/deploy/clients/_template/client.env.example
+++ b/deploy/clients/_template/client.env.example
@@ -38,6 +38,11 @@ INBOUND_EMAIL_DOMAIN=notify.deskrudder.com.br
 # SUPPORT_REPLY_TO_EMAIL=suporte@suaempresa.com.br
 # RESEND_WEBHOOK_SECRET=whsec_...
 # DX_CONNECT_WEBHOOK_BASE_URL=https://api-exemplo.deskrudder.com.br
+#
+# Web Push — par VAPID desta stack (não partilhar entre clientes)
+# WEB_PUSH_VAPID_PUBLIC_KEY=
+# WEB_PUSH_VAPID_PRIVATE_KEY=
+# WEB_PUSH_VAPID_SUBJECT=mailto:ops@deskrudder.com.br
 
 # Seed inicial (produção) — após primeiro up: docker compose ... exec backend python -m app.seed
 SEED_ADMIN_EMAIL=admin@email.com

--- a/docs/MOBILE_APP_BRIEF.md
+++ b/docs/MOBILE_APP_BRIEF.md
@@ -392,7 +392,7 @@ O painel **já usa SSE**, não só polling.
 
 Documentação: `docs/REALTIME_SSE.md`.
 
-Web Push (app fechado) é **lote posterior** (L3/L4) — não substitui o SSE com a PWA aberta.
+Web Push com a app fechada está em **L3/L4** (`/v1/web-push`, worker `push_outbox`) — não substitui o SSE com a PWA aberta.
 
 ### Cliente HTTP (pseudocódigo)
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -43,6 +43,7 @@ Guia para quem opera o DX Connect em staging/produção: healthchecks, filas de 
 | `notificacao-email-outbox` | `NOTIFICACAO_EMAIL_WORKER_INTERVAL_SECONDS` (10s) | E-mails de notificação a atendentes |
 | `ticket-mensagem-email-outbox` | `TICKET_MENSAGEM_EMAIL_WORKER_INTERVAL_SECONDS` (5s) | Respostas públicas ao cliente por e-mail |
 | `webhook-outbox` | `WEBHOOK_OUTBOX_WORKER_INTERVAL_SECONDS` (15s) | POST HTTP ao fechar ticket (#119) |
+| `web-push-outbox` | `WEB_PUSH_WORKER_INTERVAL_SECONDS` (5s) | Web Push (fila e mensagens meus) (#693) |
 
 Todos fazem **commit** após cada ciclo (mesmo com 0 envios), para persistir tentativas e retries.
 
@@ -69,6 +70,16 @@ Payload mínimo:
 ```
 
 Fila: tabela `webhook_outbox` (mesma política de 5 tentativas que e-mail).
+
+## Web Push (VAPID) — #693
+
+Variáveis **por stack** do cliente (não globais na VPS):
+
+- `WEB_PUSH_VAPID_PUBLIC_KEY` / `WEB_PUSH_VAPID_PRIVATE_KEY` — par VAPID; vazio = push desligado
+- `WEB_PUSH_VAPID_SUBJECT` — `mailto:` de contacto (claim VAPID)
+- `WEB_PUSH_WORKER_INTERVAL_SECONDS` — intervalo do worker (padrão 5s)
+
+Fila: tabela `push_outbox`. Subscriptions em `push_subscription` (só do JWT; revogadas no logout do dispositivo e ao forçar saída).
 
 ## Retry Evolution API (WhatsApp)
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,7 +33,10 @@
         "typescript": "~6.0.3",
         "typescript-eslint": "^8.65.0",
         "vite": "^8.2.0",
-        "vite-plugin-pwa": "^1.3.0"
+        "vite-plugin-pwa": "^1.3.0",
+        "workbox-core": "^7.3.0",
+        "workbox-precaching": "^7.3.0",
+        "workbox-routing": "^7.3.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,10 @@
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.65.0",
     "vite": "^8.2.0",
-    "vite-plugin-pwa": "^1.3.0"
+    "vite-plugin-pwa": "^1.3.0",
+    "workbox-core": "^7.3.0",
+    "workbox-precaching": "^7.3.0",
+    "workbox-routing": "^7.3.0"
   },
   "overrides": {
     "react-router": "8.3.0"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1570,6 +1570,8 @@ export namespace Notificacoes {
     email_nova_mensagem: boolean;
     email_sla_em_risco: boolean;
     email_sla_violado: boolean;
+    push_habilitado: boolean;
+    push_fila: boolean;
   }
 }
 
@@ -1585,6 +1587,38 @@ export const notificacoes = {
       method: 'PATCH',
       body: JSON.stringify(data),
     }),
+};
+
+export namespace WebPush {
+  export interface Vapid {
+    configurado: boolean
+    public_key: string | null
+  }
+  export interface Subscription {
+    id: number
+    endpoint: string
+    user_agent: string | null
+  }
+  export interface RegistrarBody {
+    endpoint: string
+    p256dh: string
+    auth: string
+    user_agent?: string | null
+  }
+}
+
+export const webPush = {
+  vapid: () => api<WebPush.Vapid>('/web-push/vapid'),
+  listar: () => api<WebPush.Subscription[]>('/web-push/subscriptions'),
+  registrar: (body: WebPush.RegistrarBody) =>
+    api<WebPush.Subscription>('/web-push/subscriptions', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  apagar: (id: number) =>
+    api<void>(`/web-push/subscriptions/${id}`, { method: 'DELETE' }),
+  apagarEndpoint: (endpoint: string) =>
+    api<void>(`/web-push/subscriptions?endpoint=${encodeURIComponent(endpoint)}`, { method: 'DELETE' }),
 };
 
 export namespace ChatInterno {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -10,7 +10,9 @@ import { BrandLogo } from '../brand'
 import { useTheme } from '../contexts/ThemeContext'
 import { AlertaDesktopPermissaoBanner } from './AlertaDesktopPermissaoBanner'
 import { PwaInstallBanner } from './PwaInstallBanner'
+import { WebPushOptInBanner } from './WebPushOptInBanner'
 import { useVisualViewportCss } from '../hooks/useVisualViewportCss'
+import { useWebPushSession } from '../hooks/useWebPush'
 import { lerTicketAtivoSession, TICKET_ATIVO_EVENT } from '../lib/ticketAtivo'
 
 function perfilExibicao(role: string | undefined): string {
@@ -39,6 +41,7 @@ function LayoutInner() {
 
   const notificacoesEnabled = Boolean(user && !user.must_change_password)
   useAlertaFilaSemResponsavel(notificacoesEnabled)
+  useWebPushSession(notificacoesEnabled)
 
   useEffect(() => {
     setChatInternoAlertUserId(user?.id ?? null)
@@ -129,6 +132,7 @@ function LayoutInner() {
 
           {notificacoesEnabled ? <PwaInstallBanner enabled /> : null}
           {notificacoesEnabled ? <AlertaDesktopPermissaoBanner enabled /> : null}
+          {notificacoesEnabled ? <WebPushOptInBanner enabled /> : null}
 
           <main className="min-h-0 flex-1 overflow-hidden">
             <div

--- a/frontend/src/components/NavbarNotificacoes.tsx
+++ b/frontend/src/components/NavbarNotificacoes.tsx
@@ -260,7 +260,7 @@ export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
                 className="text-xs font-medium text-cyan-700 hover:underline dark:text-cyan-400"
                 onClick={() => setAberto(false)}
               >
-                Preferências de e-mail
+                Preferências de notificações
               </Link>
             </div>
           </div>,
@@ -293,7 +293,7 @@ export function NavbarNotificacoes({ enabled }: { enabled: boolean }) {
               className="text-xs font-medium text-cyan-700 hover:underline dark:text-cyan-400"
               onClick={() => setAberto(false)}
             >
-              Preferências de e-mail
+              Preferências de notificações
             </Link>
           </div>
         </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -669,7 +669,7 @@ export function Sidebar({
         <Link
           to="/notificacoes/preferencias"
           onClick={onMobileClose}
-          title="Notificações por e-mail"
+          title="Notificações"
           className={`mt-2 flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium text-slate-600 hover:bg-slate-100 active:bg-slate-200 touch-manipulation min-h-[44px] dark:text-slate-400 dark:hover:bg-slate-800 dark:active:bg-slate-700 ${
             expanded ? '' : 'md:justify-center md:px-2'
           }`}

--- a/frontend/src/components/WebPushOptInBanner.tsx
+++ b/frontend/src/components/WebPushOptInBanner.tsx
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useState } from 'react'
+import { notificacoes, webPush } from '../api/client'
+import { Button } from './ui/Button'
+import { syncWebPushSubscription } from '../hooks/useWebPush'
+
+const LS_DISMISS = 'deskrudder-web-push-optin-dismissed'
+
+function readDismissed(): boolean {
+  try {
+    return localStorage.getItem(LS_DISMISS) === '1'
+  } catch {
+    return false
+  }
+}
+
+function writeDismissed() {
+  try {
+    localStorage.setItem(LS_DISMISS, '1')
+  } catch {
+    /* ignore */
+  }
+}
+
+type Props = { enabled: boolean }
+
+/** Convite para alertas com a PWA fechada (#694). */
+export function WebPushOptInBanner({ enabled }: Props) {
+  const [visible, setVisible] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [feedback, setFeedback] = useState<'ok' | 'negado' | 'sem_vapid' | null>(null)
+
+  const reavaliar = useCallback(async () => {
+    if (!enabled || typeof window === 'undefined' || !('Notification' in window) || !('PushManager' in window)) {
+      setVisible(false)
+      return
+    }
+    if (readDismissed()) {
+      setVisible(false)
+      return
+    }
+    try {
+      const [vapid, prefs] = await Promise.all([webPush.vapid(), notificacoes.preferenciasGet()])
+      if (!vapid.configurado || prefs.push_habilitado) {
+        setVisible(false)
+        return
+      }
+      if (Notification.permission === 'denied') {
+        setVisible(false)
+        return
+      }
+      setVisible(true)
+    } catch {
+      setVisible(false)
+    }
+  }, [enabled])
+
+  useEffect(() => {
+    void reavaliar()
+  }, [reavaliar])
+
+  if (!enabled || feedback === 'ok') {
+    if (feedback === 'ok') {
+      return (
+        <div
+          role="status"
+          className="shrink-0 border-b border-emerald-200 bg-emerald-50 px-4 py-2.5 text-sm text-emerald-900 dark:border-emerald-900/50 dark:bg-emerald-950/40 dark:text-emerald-100"
+        >
+          Alertas no telemóvel activos — vais ser avisado mesmo com a app fechada.
+        </div>
+      )
+    }
+    return null
+  }
+
+  if (!visible && feedback !== 'negado' && feedback !== 'sem_vapid') return null
+
+  if (feedback === 'negado') {
+    return (
+      <div
+        role="status"
+        className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-amber-200 bg-amber-50 px-4 py-2.5 text-sm text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100"
+      >
+        <p className="min-w-0 flex-1">
+          Notificações bloqueadas neste browser. Permite-as nas definições do site para alertas com a app fechada.
+        </p>
+        <Button type="button" variant="ghost" className="h-8 shrink-0 px-2 text-xs" onClick={() => setFeedback(null)}>
+          Fechar
+        </Button>
+      </div>
+    )
+  }
+
+  if (feedback === 'sem_vapid') return null
+
+  return (
+    <div
+      role="region"
+      aria-label="Ativar alertas no telemóvel"
+      className="flex shrink-0 flex-col gap-2 border-b border-indigo-200 bg-indigo-50 px-4 py-3 text-sm text-slate-800 dark:border-indigo-900/40 dark:bg-indigo-950/30 dark:text-slate-100 sm:flex-row sm:items-center sm:justify-between"
+    >
+      <div className="min-w-0 space-y-0.5">
+        <p className="font-semibold text-slate-900 dark:text-white">Alertas com a app fechada?</p>
+        <p className="text-xs text-slate-600 dark:text-slate-300 sm:text-sm">
+          Recebe avisos da fila e de mensagens nos teus atendimentos mesmo fora do painel. Podes desligar em
+          Notificações.
+        </p>
+      </div>
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-9 px-3"
+          disabled={busy}
+          onClick={() => {
+            writeDismissed()
+            setVisible(false)
+          }}
+        >
+          Agora não
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          className="h-9 px-4"
+          loading={busy}
+          onClick={() => {
+            void (async () => {
+              setBusy(true)
+              try {
+                const r = await syncWebPushSubscription({ ativar: true })
+                if (r === 'ok') {
+                  writeDismissed()
+                  setVisible(false)
+                  setFeedback('ok')
+                  window.setTimeout(() => setFeedback(null), 5000)
+                } else if (r === 'negado') {
+                  setFeedback('negado')
+                } else {
+                  setFeedback('sem_vapid')
+                  setVisible(false)
+                }
+              } finally {
+                setBusy(false)
+              }
+            })()
+          }}
+        >
+          Ativar
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/ChatFilaSomToggle.tsx
+++ b/frontend/src/components/chat/ChatFilaSomToggle.tsx
@@ -1,3 +1,4 @@
+import { notificacoes } from '../../api/client'
 import {
   setFilaAguardandoMuted,
   useFilaAguardandoMuted,
@@ -27,7 +28,9 @@ export function ChatFilaSomToggle({ className = '', size = 'sm' }: Props) {
       onClick={(e) => {
         e.preventDefault()
         e.stopPropagation()
-        setFilaAguardandoMuted(!muted)
+        const nextMuted = !muted
+        setFilaAguardandoMuted(nextMuted)
+        void notificacoes.preferenciasUpdate({ push_fila: !nextMuted }).catch(() => undefined)
       }}
       className={`inline-flex ${dim} shrink-0 items-center justify-center rounded-lg text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-slate-800 dark:hover:text-slate-100 ${
         muted ? 'text-amber-600 dark:text-amber-400' : ''

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from 'react'
 import { atendentes, clearAuthToken, getAuthToken, ApiError, type Atendentes } from '../api/client'
+import { revogarWebPushNoLogout } from '../hooks/useWebPush'
 
 interface AuthContextValue {
   user: Atendentes.Atendente | null
@@ -65,8 +66,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [refreshUser])
 
   const logout = useCallback(() => {
-    clearAuthToken()
-    setUser(null)
+    let finished = false
+    const done = () => {
+      if (finished) return
+      finished = true
+      clearAuthToken()
+      setUser(null)
+    }
+    const timer = window.setTimeout(done, 2500)
+    void revogarWebPushNoLogout()
+      .catch(() => undefined)
+      .finally(() => {
+        window.clearTimeout(timer)
+        done()
+      })
   }, [])
 
   const value: AuthContextValue = {

--- a/frontend/src/hooks/useWebPush.ts
+++ b/frontend/src/hooks/useWebPush.ts
@@ -1,0 +1,129 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { notificacoes, webPush } from '../api/client'
+import { isFilaAguardandoMuted } from './useAlertaFilaSemResponsavel'
+import { aplicarAberturaWebPush } from '../lib/webPushDeepLink'
+import { urlBase64ToUint8Array } from '../lib/webPushKeys'
+
+export async function syncWebPushSubscription(opts?: { ativar?: boolean }): Promise<'ok' | 'sem_vapid' | 'negado' | 'indisponivel'> {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator) || !('PushManager' in window)) {
+    return 'indisponivel'
+  }
+  const vapid = await webPush.vapid()
+  if (!vapid.configurado || !vapid.public_key) return 'sem_vapid'
+
+  const ativar = opts?.ativar
+  const registration = await navigator.serviceWorker.ready
+
+  if (ativar === false) {
+    const existente = await registration.pushManager.getSubscription()
+    if (existente) {
+      try {
+        await webPush.apagarEndpoint(existente.endpoint)
+      } catch {
+        /* sessão já a expirar */
+      }
+      await existente.unsubscribe()
+    }
+    await notificacoes.preferenciasUpdate({ push_habilitado: false })
+    return 'ok'
+  }
+
+  if (Notification.permission === 'denied') return 'negado'
+  if (Notification.permission === 'default') {
+    const perm = await Notification.requestPermission()
+    if (perm !== 'granted') return 'negado'
+  }
+
+  let sub = await registration.pushManager.getSubscription()
+  if (!sub) {
+    sub = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(vapid.public_key) as BufferSource,
+    })
+  }
+  const json = sub.toJSON()
+  const p256dh = json.keys?.p256dh
+  const auth = json.keys?.auth
+  if (!json.endpoint || !p256dh || !auth) return 'indisponivel'
+  await webPush.registrar({
+    endpoint: json.endpoint,
+    p256dh,
+    auth,
+    user_agent: navigator.userAgent.slice(0, 512),
+  })
+  if (ativar === true) {
+    await notificacoes.preferenciasUpdate({
+      push_habilitado: true,
+      push_fila: !isFilaAguardandoMuted(),
+    })
+  }
+  return 'ok'
+}
+
+/** Reinscreve se já estava activo, aplica deep link e escuta o Service Worker (#694). */
+export function useWebPushSession(enabled: boolean) {
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    if (!enabled) return
+    aplicarPushQueryNaUrl()
+    let cancelled = false
+    void (async () => {
+      try {
+        const prefs = await notificacoes.preferenciasGet()
+        if (cancelled) return
+        const muted = isFilaAguardandoMuted()
+        if (muted && prefs.push_fila) {
+          await notificacoes.preferenciasUpdate({ push_fila: false })
+        }
+        if (prefs.push_habilitado && Notification.permission === 'granted') {
+          await syncWebPushSubscription()
+        }
+      } catch {
+        /* sessão a carregar ou vapid desligado */
+      }
+    })()
+
+    const onMsg = (ev: MessageEvent) => {
+      const data = ev.data as { type?: string; tipo?: string; id?: number; url_path?: string } | null
+      if (!data || data.type !== 'web-push-open') return
+      const path = aplicarAberturaWebPush(data)
+      navigate(path)
+    }
+    navigator.serviceWorker?.addEventListener('message', onMsg)
+    return () => {
+      cancelled = true
+      navigator.serviceWorker?.removeEventListener('message', onMsg)
+    }
+  }, [enabled, navigate])
+}
+
+export async function revogarWebPushNoLogout(): Promise<void> {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator) || !('PushManager' in window)) return
+  try {
+    const registration = await navigator.serviceWorker.getRegistration()
+    if (!registration) return
+    const sub = await registration.pushManager.getSubscription()
+    if (!sub) return
+    await webPush.apagarEndpoint(sub.endpoint)
+    await sub.unsubscribe()
+  } catch {
+    /* logout continua mesmo se o push falhar */
+  }
+}
+
+export function aplicarPushQueryNaUrl(): void {
+  if (typeof window === 'undefined') return
+  const params = new URLSearchParams(window.location.search)
+  const tipo = params.get('push_tipo')
+  const idRaw = params.get('push_id')
+  if (!tipo || !idRaw) return
+  const id = Number(idRaw)
+  if (!Number.isFinite(id)) return
+  aplicarAberturaWebPush({ tipo, id })
+  params.delete('push_tipo')
+  params.delete('push_id')
+  const next = `${window.location.pathname}${params.toString() ? `?${params}` : ''}${window.location.hash}`
+  window.history.replaceState({}, '', next)
+}

--- a/frontend/src/lib/webPushDeepLink.ts
+++ b/frontend/src/lib/webPushDeepLink.ts
@@ -1,0 +1,27 @@
+import { marcarTicketAtivo } from './ticketAtivo'
+import { gravarChatAtivoSession } from './chatAtivo'
+
+export type WebPushOpenPayload = {
+  tipo?: string
+  id?: number
+  url_path?: string
+}
+
+/** Abre o chat/ticket certo a partir do clique na notificação (#694). */
+export function aplicarAberturaWebPush(data: WebPushOpenPayload): string {
+  const tipo = data.tipo || ''
+  const id = Number(data.id)
+  if (tipo.startsWith('chat.') && Number.isFinite(id) && id > 0) {
+    gravarChatAtivoSession({ canal: 'whatsapp', id })
+    return data.url_path || (tipo === 'chat.fila' ? '/chat/espera' : '/chat/atendendo')
+  }
+  if (tipo.startsWith('portal.chat.') && Number.isFinite(id) && id > 0) {
+    gravarChatAtivoSession({ canal: 'portal', id })
+    return data.url_path || '/chat/espera'
+  }
+  if (tipo.startsWith('ticket.') && Number.isFinite(id) && id > 0) {
+    marcarTicketAtivo(id)
+    return data.url_path || '/tickets'
+  }
+  return data.url_path || '/'
+}

--- a/frontend/src/lib/webPushKeys.ts
+++ b/frontend/src/lib/webPushKeys.ts
@@ -1,0 +1,10 @@
+export function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
+  const raw = atob(base64)
+  const output = new Uint8Array(raw.length)
+  for (let i = 0; i < raw.length; i += 1) {
+    output[i] = raw.charCodeAt(i)
+  }
+  return output
+}

--- a/frontend/src/pages/NotificacoesPreferencias.tsx
+++ b/frontend/src/pages/NotificacoesPreferencias.tsx
@@ -6,6 +6,7 @@ import { Card } from '../components/ui/Card'
 import { Button } from '../components/ui/Button'
 import { Switch } from '../components/ui/Switch'
 import { useToast } from '../components/ui/Toast'
+import { syncWebPushSubscription } from '../hooks/useWebPush'
 
 export function NotificacoesPreferencias() {
   const toast = useToast()
@@ -17,6 +18,8 @@ export function NotificacoesPreferencias() {
     email_nova_mensagem: true,
     email_sla_em_risco: true,
     email_sla_violado: true,
+    push_habilitado: false,
+    push_fila: true,
   })
 
   useEffect(() => {
@@ -72,11 +75,11 @@ export function NotificacoesPreferencias() {
           <span aria-hidden>←</span> Voltar
         </Link>
         <h1 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">
-          Notificações por e-mail
+          Notificações
         </h1>
         <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
-          Escolha quando deseja receber e-mails sobre atividade nos seus chamados. Os alertas in-app (sino no topo)
-          continuam independentes — fila, mensagens não lidas e WhatsApp.
+          Escolha quando deseja receber e-mails e alertas no telemóvel. Os avisos in-app (sino no topo) continuam
+          independentes — fila, mensagens não lidas e WhatsApp.
         </p>
       </div>
 
@@ -96,12 +99,60 @@ export function NotificacoesPreferencias() {
             atinge 80% do prazo ou estoura a meta de primeira resposta ou resolução.
           </li>
           <li>
-            Em desenvolvimento, sem SMTP configurado, o sistema simula o envio e registra no log do backend.
+            <strong>Telemóvel</strong> — com a app fechada, alertas de fila e de mensagens nos teus atendimentos (é preciso activar e permitir notificações no browser).
           </li>
         </ul>
       </div>
 
-      <Card title="Preferências">
+      <Card title="Telemóvel (app fechada)">
+        <div className="space-y-4">
+          <Switch
+            checked={prefs.push_habilitado}
+            onCheckedChange={(v) => {
+              void (async () => {
+                try {
+                  const r = await syncWebPushSubscription({ ativar: v })
+                  if (v && r !== 'ok') {
+                    const msg =
+                      r === 'negado'
+                        ? 'Permita notificações neste browser para activar os alertas.'
+                        : r === 'sem_vapid'
+                          ? 'Alertas no telemóvel ainda não estão configurados nesta instância.'
+                          : 'Este browser não suporta alertas com a app fechada.'
+                    toast.showError(msg)
+                    return
+                  }
+                  setPrefs((p) => ({ ...p, push_habilitado: v }))
+                } catch (err) {
+                  toast.showError(mensagemFalhaParaToast(err, 'Não foi possível actualizar o push.'))
+                }
+              })()
+            }}
+            label="Alertas no telemóvel"
+            description="Fila e mensagens nos teus chats e tickets, mesmo com a app fechada."
+            showStatusPill
+            statusOnText="Ativo"
+            statusOffText="Inativo"
+          />
+          <Switch
+            checked={prefs.push_fila}
+            onCheckedChange={(v) => {
+              setPrefs((p) => ({ ...p, push_fila: v }))
+              void notificacoes.preferenciasUpdate({ push_fila: v }).catch((err) => {
+                toast.showError(mensagemFalhaParaToast(err, 'Não foi possível actualizar o alerta da fila.'))
+              })
+            }}
+            label="Avisar fila de espera"
+            description="O mesmo silêncio do botão de som na mesa também vale com a app fechada."
+            disabled={!prefs.push_habilitado}
+            showStatusPill
+            statusOnText="Sim"
+            statusOffText="Não"
+          />
+        </div>
+      </Card>
+
+      <Card title="E-mail">
         <form onSubmit={handleSave} className="space-y-5">
           <Switch
             checked={prefs.email_habilitado}

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -1,0 +1,76 @@
+/// <reference lib="webworker" />
+import { clientsClaim } from 'workbox-core'
+import {
+  cleanupOutdatedCaches,
+  createHandlerBoundToURL,
+  precacheAndRoute,
+} from 'workbox-precaching'
+import { NavigationRoute, registerRoute } from 'workbox-routing'
+
+declare const self: ServiceWorkerGlobalScope & { __WB_MANIFEST: Array<{ url: string; revision: string | null }> }
+
+self.skipWaiting()
+clientsClaim()
+precacheAndRoute(self.__WB_MANIFEST)
+cleanupOutdatedCaches()
+
+try {
+  registerRoute(
+    new NavigationRoute(createHandlerBoundToURL('index.html'), {
+      denylist: [/^\/api/, /^\/v1/, /^\/docs/, /^\/health/, /^\/openapi/],
+    }),
+  )
+} catch {
+  /* em dev o index.html pode ainda não estar no precache */
+}
+
+type PushPayload = {
+  tipo?: string
+  id?: number
+  titulo?: string
+  url_path?: string
+  corpo?: string | null
+}
+
+self.addEventListener('push', (event: PushEvent) => {
+  let data: PushPayload = {}
+  try {
+    if (event.data) data = event.data.json() as PushPayload
+  } catch {
+    data = { titulo: event.data?.text() || 'DeskRudder' }
+  }
+  const title = data.titulo || 'DeskRudder'
+  const body = data.corpo || 'Nova actividade no atendimento'
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body,
+      icon: '/deskrudder-pwa-192.png',
+      badge: '/deskrudder-pwa-192.png',
+      data,
+      tag: `${data.tipo || 'push'}:${data.id || ''}`,
+      renotify: true,
+    }),
+  )
+})
+
+self.addEventListener('notificationclick', (event: NotificationEvent) => {
+  event.notification.close()
+  const data = (event.notification.data || {}) as PushPayload
+  const path = data.url_path || '/'
+  event.waitUntil(
+    (async () => {
+      const all = await self.clients.matchAll({ type: 'window', includeUncontrolled: true })
+      for (const client of all) {
+        if ('focus' in client) {
+          client.postMessage({ type: 'web-push-open', ...data })
+          await client.focus()
+          return
+        }
+      }
+      const url = new URL(path, self.location.origin)
+      if (data.tipo) url.searchParams.set('push_tipo', String(data.tipo))
+      if (data.id != null) url.searchParams.set('push_id', String(data.id))
+      await self.clients.openWindow(url.toString())
+    })(),
+  )
+})

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/sw.ts"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -21,6 +21,9 @@ export default defineConfig(({ mode }) => {
       react(),
       tailwindcss(),
       VitePWA({
+        strategies: 'injectManifest',
+        srcDir: 'src',
+        filename: 'sw.ts',
         registerType: 'autoUpdate',
         injectRegister: 'auto',
         includeAssets: ['favicon.ico', 'deskrudder-pwa-180.png', 'deskrudder-pwa-192.png', 'deskrudder-pwa-512.png'],
@@ -41,12 +44,10 @@ export default defineConfig(({ mode }) => {
             { src: '/deskrudder-pwa-512.png', sizes: '512x512', type: 'image/png', purpose: 'maskable' },
           ],
         },
-        workbox: {
+        injectManifest: {
           globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2,webmanifest}'],
-          navigateFallback: '/index.html',
-          navigateFallbackDenylist: [/^\/api/, /^\/v1/, /^\/docs/, /^\/health/, /^\/openapi/],
         },
-        devOptions: { enabled: false },
+        devOptions: { enabled: true, type: 'module' },
       }),
     ],
     resolve: {


### PR DESCRIPTION
## Summary

- Backend Web Push por instância: subscriptions (`push_subscription`), outbox + worker após commit, chave VAPID pública, 403 se o endpoint for de outro, revogação no logout e ao forçar saída (#693).
- Frontend: opt-in (banner + Notificações), Service Worker (`push` / `notificationclick`) e deep link para a mesa/ticket certo (#694).
- Gatilhos v1: fila WhatsApp/portal/tickets e mensagens só nos atendimentos já meus; mute da fila na mesa também vale com a app fechada.

Closes #693
Closes #694

Fora deste PR (já no épico): piloto produção #695, Capacitor/lojas #696.

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

> PR **`main → staging`**: o `[Unreleased]` vira a release publicada no deploy.  
> Guia: [docs/RELEASES.md](../docs/RELEASES.md)

## Test plan

- [x] `docker compose run --rm --no-deps backend pytest -q -o addopts= tests/test_web_push.py tests/test_notificacoes_atendente.py::test_preferencias_padrao_e_atualizacao` (9 passed)
- [x] `docker compose run --rm --no-deps backend alembic heads` → único head `095_web_push`
- [x] `npx tsc -b` e `vite build` (injectManifest → `dist/sw.js`)
- [ ] Com `WEB_PUSH_VAPID_*` no `.env` da instância: activar alertas em Notificações, fechar a PWA, gerar fila/mensagem e tocar no alerta (validação em dispositivo fica no #695)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — cada um virou issue `#695` / `#696` (já existentes no épico #689)
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável — N/A
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados

Follow-ups: #695 (piloto Android/Chrome + iOS Safari), #696 (Capacitor / lojas).
