### PR TITLE
feat(mobile): hardening PWA/push no iOS e checklist VAPID (#695)

### DIFF
--- a/.cursor/skills/deploy-cliente/SKILL.md
+++ b/.cursor/skills/deploy-cliente/SKILL.md
@@ -28,7 +28,7 @@ Gera `deploy/clients/NOME_CLIENTE/` (não commitar secrets).
 
 ### Checklist pós-provision
 
-1. Editar `client.env`: CORS, ALLOWED_HOSTS, RESEND, SEED_ADMIN
+1. Editar `client.env`: CORS (origem HTTPS da PWA), ALLOWED_HOSTS, RESEND, SEED_ADMIN, **VAPID** (`WEB_PUSH_VAPID_*`)
 2. `bash deploy/scripts/stack-client.sh NOME_CLIENTE migrate`
 3. `bash deploy/scripts/stack-client.sh NOME_CLIENTE up`
 4. `bash deploy/scripts/stack-client.sh NOME_CLIENTE seed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Mobile (#692): no telemóvel, WhatsApp e tickets dão para operar por completo — assumir, responder (texto/mídia), transferir, encerrar, abrir ticket; fila e detalhe do chamado com botões grandes e teclado que não cobre o campo de mensagem
 - WhatsApp (#723): quem abre um chat em atendimento (colega ou admin) também vê o cronômetro de inatividade; Pausar/Retomar continua só com o responsável
 - Notificações (#693 / #694): no telemóvel podes receber alertas mesmo com a app fechada — fila de espera e mensagens nos chats/tickets já teus. Activa em Notificações; o silêncio da fila na mesa também vale com a app fechada
+- Mobile (#695): no iPhone, o painel explica que os alertas com a app fechada só funcionam depois de adicionar o DeskRudder à tela inicial (Safari 16.4+)
 - Menu (#716): a barra de rolagem da sidebar (painel e portal) fica fina e alinhada ao tema, sem o visual nativo do Windows
 - CI: testes do backend deixam de repetir bcrypt lento em cada caso; PRs só de interface já não esperam o pytest, e o contrário também (job do lado inalterado conclui em segundos)
 

--- a/backend/app/services/health_checks.py
+++ b/backend/app/services/health_checks.py
@@ -40,6 +40,7 @@ def integrations_status() -> dict[str, Any]:
         "email_inbound": email_inbound,
         "evolution_whatsapp": "configured" if evolution else "missing",
         "ticket_closed_webhook": "configured" if bool((settings.TICKET_CLOSED_WEBHOOK_URL or "").strip()) else "missing",
+        "web_push": "configured" if bool((settings.WEB_PUSH_VAPID_PUBLIC_KEY or "").strip() and (settings.WEB_PUSH_VAPID_PRIVATE_KEY or "").strip()) else "missing",
     }
 
 

--- a/backend/tests/test_observabilidade.py
+++ b/backend/tests/test_observabilidade.py
@@ -23,6 +23,7 @@ def test_health_liveness(client):
     assert body.get("status") == "ok"
     assert "capabilities" in body
     assert "integrations" in body
+    assert "web_push" in body["integrations"]
     assert "environment" in body
 
 

--- a/deploy/clients/README.md
+++ b/deploy/clients/README.md
@@ -40,7 +40,8 @@ Isto cria `deploy/clients/duplexsoft/` com `client.env` (senhas geradas), `docke
 
 Edite `deploy/clients/duplexsoft/client.env`:
 
-- `CORS_ORIGINS` / `ALLOWED_HOSTS` alinhados aos domínios reais
+- `CORS_ORIGINS` / `ALLOWED_HOSTS` alinhados aos domínios reais (`CORS_ORIGINS` = origem HTTPS da PWA)
+- Par **VAPID** (`WEB_PUSH_VAPID_*`) desta stack — gerar uma vez; vazio = push desligado (`docs/OPERATIONS.md`)
 - `DX_CONNECT_MULTI_TENANT=false` (padrão) e `CLIENT_APP_HOST={slug}.connect...`
 - `RESEND_API_KEY`, e-mail transaccional, webhooks
 - `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD` para o primeiro admin

--- a/deploy/clients/_template/client.env.example
+++ b/deploy/clients/_template/client.env.example
@@ -16,7 +16,7 @@ SECRET_KEY=ALTERE_SECRET_KEY_MIN_32_CHARS_ALEATORIO
 ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 
-# Origem do SPA (HTTPS em produção)
+# Origem do SPA / PWA (HTTPS em produção) — obrigatório para Web Push
 CORS_ORIGINS=https://exemplo.deskrudder.com.br
 
 # Hostnames que a API aceita (TrustedHostMiddleware)

--- a/docs/MOBILE_APP_BRIEF.md
+++ b/docs/MOBILE_APP_BRIEF.md
@@ -143,7 +143,7 @@ Sistema de **helpdesk** para **redes de postos/empresas**:
 **Install (híbrido C):** PWA por `{slug}` agora; nas lojas será **1 app** + campo Conta → `api-{slug}`.  
 **Infra:** 1 VPS; **novo container/stack por cliente** (não há PWA global `app.` nesta fase).
 
-**Push v1 (L3/L4):** fila **e** mensagens em chats/tickets **já meus**, com a PWA fechada (Android/Chrome primeiro).
+**Push v1 (L3/L4, hardening L5):** fila **e** mensagens em chats/tickets **já meus**, com a PWA fechada. **Android/Chrome** é o piloto. **iOS Safari:** só com a app na tela inicial (iOS 16.4+); na aba do Safari o push não é fiável.
 
 ### Fase 1 — Core (login + tempo real)
 
@@ -394,6 +394,8 @@ Documentação: `docs/REALTIME_SSE.md`.
 
 Web Push com a app fechada está em **L3/L4** (`/v1/web-push`, worker `push_outbox`) — não substitui o SSE com a PWA aberta.
 
+**iOS Safari:** Web Push exige iOS 16.4+ e PWA adicionada ao ecrã inicial. Sem isso, o iPhone não entrega o alerta com a app fechada. Ver `docs/OPERATIONS.md` (checklist piloto).
+
 ### Cliente HTTP (pseudocódigo)
 
 ```typescript
@@ -446,7 +448,7 @@ Somente ambiente local (nunca produção):
 > **Mobile v1:** PWA no SPA actual para **atendentes** (WhatsApp + tickets). Não RN na v1.  
 > **Install:** PWA por `https://{slug}.deskrudder.com.br`; lojas depois (Capacitor + campo Conta).  
 > **Infra:** 1 VPS, um container/stack por cliente.  
-> **Tempo real:** SSE `GET /v1/events/stream` (já no web). Push com app fechado = lote seguinte.  
+> **Tempo real:** SSE `GET /v1/events/stream` (já no web). Push com app fechada = Web Push VAPID (Android/Chrome; iOS só PWA no ecrã inicial, 16.4+).  
 > **Começar por:** Login → Fila WhatsApp → Conversa (assumir/enviar/encerrar) e lista/detalhe de tickets.  
 > **Auth:** `POST /v1/auth/login` → Bearer token → `GET /v1/atendentes/me`.  
 > **APIs:** `/notificacoes/resumo`, `/whatsapp/chats/fila`, `/whatsapp/chats/meus`, `/whatsapp/chats/{id}/mensagens`, `/tickets?situacao=abertos`.  

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -34,7 +34,7 @@ Guia para quem opera o DX Connect em staging/produção: healthchecks, filas de 
 
 1. Uptime em `GET /health` (intervalo 1–5 min).
 2. Alerta se `GET /health/ready` retorna **503** por > 2 min.
-3. Logs com `"event": "notificacao_email_send_failed_permanent"`, `"ticket_email_send_failed_permanent"` ou `"webhook_outbox_send_failed_permanent"`.
+3. Logs com `"event": "notificacao_email_send_failed_permanent"`, `"ticket_email_send_failed_permanent"`, `"webhook_outbox_send_failed_permanent"` ou `"web_push_outbox_send_failed_permanent"`.
 
 ## Workers em background
 
@@ -81,6 +81,42 @@ Variáveis **por stack** do cliente (não globais na VPS):
 
 Fila: tabela `push_outbox`. Subscriptions em `push_subscription` (só do JWT; revogadas no logout do dispositivo e ao forçar saída).
 
+`GET /health` → `integrations.web_push`: `configured` se o par VAPID estiver no env desta stack; `missing` = push desligado.
+
+Falhas do worker: eventos `web_push_outbox_send_retry`, `web_push_outbox_send_failed_permanent`, `web_push_subscription_expired` (410/404). Contagem na BD:
+
+```sql
+SELECT status, count(*) FROM push_outbox GROUP BY status;
+```
+
+### Gerar par VAPID (uma vez por cliente)
+
+Na máquina com o backend (ou no container):
+
+```bash
+docker compose run --rm --no-deps backend python -c "from py_vapid import Vapid; v=Vapid(); v.generate_keys(); print(v.public_key); print(v.private_key)"
+```
+
+Copiar as duas linhas para `WEB_PUSH_VAPID_PUBLIC_KEY` / `WEB_PUSH_VAPID_PRIVATE_KEY` no `client.env` **daquele** slug. Não reutilizar o mesmo par em outro cliente.
+
+Reiniciar o stack (`stack-client.sh SLUG up`) depois de gravar o env.
+
+### CORS / origem da PWA
+
+O subscribe corre no browser em `https://{slug}.…`. `CORS_ORIGINS` tem de incluir **exactamente** essa origem (com `https://`, sem barra final). `ALLOWED_HOSTS` é o hostname da **API** (`api-{slug}.…`).
+
+### iOS Safari (#695)
+
+Web Push no iPhone/iPad exige **iOS 16.4+** e a PWA **instalada** (Partilhar → Adicionar ao Ecrã Início). Na aba Safari o sistema não entrega push. Android/Chrome (instalado ou não, com permissão) é o caminho do piloto.
+
+### Checklist piloto (um slug)
+
+1. Release na `staging` / stack do cliente com migration `095_web_push`
+2. Gerar VAPID e preencher o `client.env`; CORS = origem HTTPS do SPA
+3. Atendente no Android/Chrome: Notificações → activar alertas; fechar a app; pôr um chat na fila
+4. Tocar no alerta e confirmar que abre a mesa certa
+5. Silenciar a fila na mesa e confirmar que **não** chega push de fila
+
 ## Retry Evolution API (WhatsApp)
 
 Envio de texto/mídia via Evolution usa retry **síncrono** em falhas transitórias (rede, HTTP 429/502/503/504):
@@ -116,6 +152,10 @@ Eventos relevantes (JSON em uma linha):
 | `webhook_outbox_send_ok` | Webhook entregue |
 | `webhook_outbox_send_retry` | Retry do webhook |
 | `webhook_outbox_send_failed_permanent` | Webhook esgotou tentativas |
+| `web_push_outbox_send_ok` | Push entregue |
+| `web_push_outbox_send_retry` | Retry do Web Push |
+| `web_push_outbox_send_failed_permanent` | Push esgotou tentativas |
+| `web_push_subscription_expired` | Endpoint 410/404 — subscription apagada |
 | `evolution_http_retry` | Retry HTTP Evolution |
 | `evolution_http_failed_permanent` | Evolution falhou após tentativas |
 

--- a/docs/PRE_DEPLOY_CHECKLIST.md
+++ b/docs/PRE_DEPLOY_CHECKLIST.md
@@ -49,7 +49,8 @@ Legenda: **OK** atendido no repositório | **Você** validação manual no servi
 | Item | Status |
 |------|--------|
 | Frontend fala com API fora do localhost | **Você** — definir `VITE_API_URL` pública e publicar o `dist/`. |
-| CORS correto | **Você** — `CORS_ORIGINS` com a origem HTTPS exata do site (com/sem `www`). |
+| CORS correto | **Você** — `CORS_ORIGINS` com a origem HTTPS exata do site (com/sem `www`). Para Web Push, tem de ser a origem da PWA (`https://{slug}.…`). |
+| Web Push (VAPID) por stack | **Você** — gerar par VAPID e pôr em `client.env`; vazio = push desligado. Ver `docs/OPERATIONS.md`. |
 | Login + fluxo principal | **Você** — testar em HTTPS após deploy. |
 
 ## Segurança mínima

--- a/frontend/src/components/PwaInstallBanner.tsx
+++ b/frontend/src/components/PwaInstallBanner.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { isMarketingHost } from '../lib/marketingHost'
 import { isSaasControlPlaneFrontend } from '../lib/saasControlPlane'
+import { isIosSafari, isStandaloneDisplay } from '../lib/pwaDisplay'
 import { Button } from './ui/Button'
 
 const LS_DISMISS = 'deskrudder-pwa-install-dismissed'
@@ -24,22 +25,6 @@ function writeDismissed() {
   } catch {
     /* ignore */
   }
-}
-
-function isStandaloneDisplay(): boolean {
-  if (typeof window === 'undefined') return false
-  if (window.matchMedia('(display-mode: standalone)').matches) return true
-  const nav = window.navigator as Navigator & { standalone?: boolean }
-  return nav.standalone === true
-}
-
-function isIosSafari(): boolean {
-  if (typeof navigator === 'undefined') return false
-  const ua = navigator.userAgent
-  const iOS =
-    /iPad|iPhone|iPod/.test(ua) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
-  if (!iOS) return false
-  return /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS/.test(ua)
 }
 
 type Props = {

--- a/frontend/src/components/WebPushOptInBanner.tsx
+++ b/frontend/src/components/WebPushOptInBanner.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { notificacoes, webPush } from '../api/client'
 import { Button } from './ui/Button'
 import { syncWebPushSubscription } from '../hooks/useWebPush'
+import { webPushRequerPwaIos } from '../lib/pwaDisplay'
 
 const LS_DISMISS = 'deskrudder-web-push-optin-dismissed'
 
@@ -27,14 +28,23 @@ type Props = { enabled: boolean }
 export function WebPushOptInBanner({ enabled }: Props) {
   const [visible, setVisible] = useState(false)
   const [busy, setBusy] = useState(false)
-  const [feedback, setFeedback] = useState<'ok' | 'negado' | 'sem_vapid' | null>(null)
+  const [feedback, setFeedback] = useState<'ok' | 'negado' | 'sem_vapid' | 'ios_pwa' | null>(null)
 
   const reavaliar = useCallback(async () => {
-    if (!enabled || typeof window === 'undefined' || !('Notification' in window) || !('PushManager' in window)) {
+    if (!enabled || typeof window === 'undefined') {
       setVisible(false)
       return
     }
     if (readDismissed()) {
+      setVisible(false)
+      return
+    }
+    if (webPushRequerPwaIos()) {
+      setVisible(true)
+      setFeedback('ios_pwa')
+      return
+    }
+    if (!('Notification' in window) || !('PushManager' in window)) {
       setVisible(false)
       return
     }
@@ -72,7 +82,33 @@ export function WebPushOptInBanner({ enabled }: Props) {
     return null
   }
 
-  if (!visible && feedback !== 'negado' && feedback !== 'sem_vapid') return null
+  if (!visible && feedback !== 'negado' && feedback !== 'sem_vapid' && feedback !== 'ios_pwa') return null
+
+  if (feedback === 'ios_pwa') {
+    return (
+      <div
+        role="status"
+        className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-indigo-200 bg-indigo-50 px-4 py-2.5 text-sm text-slate-800 dark:border-indigo-900/40 dark:bg-indigo-950/30 dark:text-slate-100"
+      >
+        <p className="min-w-0 flex-1">
+          No iPhone/iPad, os alertas com a app fechada só funcionam depois de <strong>Adicionar ao Ecrã Início</strong>{' '}
+          (Safari 16.4 ou posterior). Abre o atalho e activa os alertas aí.
+        </p>
+        <Button
+          type="button"
+          variant="ghost"
+          className="h-8 shrink-0 px-2 text-xs"
+          onClick={() => {
+            writeDismissed()
+            setVisible(false)
+            setFeedback(null)
+          }}
+        >
+          Entendi
+        </Button>
+      </div>
+    )
+  }
 
   if (feedback === 'negado') {
     return (
@@ -135,6 +171,8 @@ export function WebPushOptInBanner({ enabled }: Props) {
                   window.setTimeout(() => setFeedback(null), 5000)
                 } else if (r === 'negado') {
                   setFeedback('negado')
+                } else if (r === 'ios_pwa') {
+                  setFeedback('ios_pwa')
                 } else {
                   setFeedback('sem_vapid')
                   setVisible(false)

--- a/frontend/src/hooks/useWebPush.ts
+++ b/frontend/src/hooks/useWebPush.ts
@@ -4,9 +4,16 @@ import { notificacoes, webPush } from '../api/client'
 import { isFilaAguardandoMuted } from './useAlertaFilaSemResponsavel'
 import { aplicarAberturaWebPush } from '../lib/webPushDeepLink'
 import { urlBase64ToUint8Array } from '../lib/webPushKeys'
+import { webPushRequerPwaIos } from '../lib/pwaDisplay'
 
-export async function syncWebPushSubscription(opts?: { ativar?: boolean }): Promise<'ok' | 'sem_vapid' | 'negado' | 'indisponivel'> {
-  if (typeof window === 'undefined' || !('serviceWorker' in navigator) || !('PushManager' in window)) {
+export async function syncWebPushSubscription(
+  opts?: { ativar?: boolean },
+): Promise<'ok' | 'sem_vapid' | 'negado' | 'indisponivel' | 'ios_pwa'> {
+  if (typeof window === 'undefined') return 'indisponivel'
+  if (opts?.ativar !== false && webPushRequerPwaIos()) {
+    return 'ios_pwa'
+  }
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) {
     return 'indisponivel'
   }
   const vapid = await webPush.vapid()

--- a/frontend/src/lib/pwaDisplay.ts
+++ b/frontend/src/lib/pwaDisplay.ts
@@ -1,0 +1,22 @@
+/** Detecção de PWA / iOS Safari (#691 / #695). */
+
+export function isStandaloneDisplay(): boolean {
+  if (typeof window === 'undefined') return false
+  if (window.matchMedia('(display-mode: standalone)').matches) return true
+  const nav = window.navigator as Navigator & { standalone?: boolean }
+  return nav.standalone === true
+}
+
+export function isIosSafari(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const ua = navigator.userAgent
+  const iOS =
+    /iPad|iPhone|iPod/.test(ua) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+  if (!iOS) return false
+  return /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS/.test(ua)
+}
+
+/** No iPhone/iPad, Web Push só funciona na PWA do ecrã inicial (Safari 16.4+). */
+export function webPushRequerPwaIos(): boolean {
+  return isIosSafari() && !isStandaloneDisplay()
+}

--- a/frontend/src/pages/NotificacoesPreferencias.tsx
+++ b/frontend/src/pages/NotificacoesPreferencias.tsx
@@ -99,7 +99,8 @@ export function NotificacoesPreferencias() {
             atinge 80% do prazo ou estoura a meta de primeira resposta ou resolução.
           </li>
           <li>
-            <strong>Telemóvel</strong> — com a app fechada, alertas de fila e de mensagens nos teus atendimentos (é preciso activar e permitir notificações no browser).
+            <strong>Telemóvel</strong> — com a app fechada, alertas de fila e de mensagens nos teus atendimentos. No
+            iPhone, primeiro adiciona o DeskRudder ao ecrã inicial (Safari 16.4+).
           </li>
         </ul>
       </div>
@@ -118,7 +119,9 @@ export function NotificacoesPreferencias() {
                         ? 'Permita notificações neste browser para activar os alertas.'
                         : r === 'sem_vapid'
                           ? 'Alertas no telemóvel ainda não estão configurados nesta instância.'
-                          : 'Este browser não suporta alertas com a app fechada.'
+                          : r === 'ios_pwa'
+                            ? 'No iPhone, adiciona o DeskRudder ao ecrã inicial e activa os alertas a partir desse atalho.'
+                            : 'Este browser não suporta alertas com a app fechada.'
                     toast.showError(msg)
                     return
                   }
@@ -129,7 +132,7 @@ export function NotificacoesPreferencias() {
               })()
             }}
             label="Alertas no telemóvel"
-            description="Fila e mensagens nos teus chats e tickets, mesmo com a app fechada."
+            description="Fila e mensagens nos teus chats e tickets, mesmo com a app fechada. No iPhone só no atalho da tela inicial."
             showStatusPill
             statusOnText="Ativo"
             statusOffText="Inativo"


### PR DESCRIPTION
## Summary

- Hardening do Web Push / PWA (#695): no iPhone o painel explica que os alertas com a app fechada só existem depois de **Adicionar ao Ecrã Início** (Safari 16.4+).
- Ops: `GET /health` → `integrations.web_push`; logs de falha; gerar VAPID e CORS da PWA documentados por stack.
- Checklist de piloto num slug (Android/Chrome) em `docs/OPERATIONS.md`.

Não fecha #695 — o piloto na VPS (VAPID no `client.env` + teste com a app fechada) continua nessa issue. Capacitor/lojas: #696.

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

> PR **`main → staging`**: o `[Unreleased]` vira a release publicada no deploy.  
> Guia: [docs/RELEASES.md](../docs/RELEASES.md)

## Test plan

- [x] `docker compose run --rm --no-deps backend pytest -q -o addopts= tests/test_observabilidade.py::test_health_liveness tests/test_web_push.py` (9 passed)
- [ ] iPhone: banner pede ecrã inicial; no atalho da PWA o opt-in de push continua disponível
- [ ] Android/Chrome: activar alertas em Notificações (sem regressão)
- [ ] Piloto produção: ver checklist em `docs/OPERATIONS.md` (issue #695)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — piloto VPS permanece em #695; lojas em #696
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável — N/A
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados
