### PR TITLE
fix(chat): fecha o painel ao encerrar e corrige cores de estado

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Correções
 
+- Chat: ao encerrar o atendimento na mesa, o painel fecha (como Voltar), em vez de ficar aberto com a lista vazia; se ainda falta classificar a demanda, o painel permanece
+- Chat: o estado «Aguardando avaliação» passa a âmbar; «Encerrado» usa vermelho mais legível no tema escuro
 - WhatsApp (#712): após registar demanda no chat aberto, o encerramento por inatividade continua a contar e o worker fecha o atendimento quando o prazo esgota (marco de demanda já não “prende” o relógio em 00:00)
 - Dark mode (#713): texto e caixa de confirmação ao concluir sem demanda ficam legíveis no tema escuro
 - Sobre (#672): notas antigas que começam com «SaaS» deixam de aparecer em `/sobre` mesmo se o histórico foi publicado antes da separação por produto

--- a/frontend/src/lib/whatsappChatMeta.ts
+++ b/frontend/src/lib/whatsappChatMeta.ts
@@ -13,6 +13,14 @@ export function rotuloEstadoChat(estado: string): string {
   return estado.replace(/_/g, ' ')
 }
 
+/** Cor do rótulo de estado no header da conversa (contraste no tema claro e escuro). */
+export function classeCorEstadoChat(estado: string): string {
+  if (estado === 'aguardando_avaliacao') return 'text-amber-600 dark:text-amber-400'
+  if (estado === 'encerrado') return 'text-red-700 dark:text-red-400'
+  if (estado === 'em_atendimento') return 'text-emerald-600 dark:text-emerald-400'
+  return 'text-slate-600 dark:text-slate-300'
+}
+
 export function rotuloResponsavelChat(chat: ChatResumo, usuarioId?: number | null): string {
   if (chat.estado === 'aguardando_atendente') {
     return chat.setor_nome ? `Fila • ${chat.setor_nome}` : 'Na fila'

--- a/frontend/src/pages/chat/PortalConversa.tsx
+++ b/frontend/src/pages/chat/PortalConversa.tsx
@@ -18,7 +18,12 @@ import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel
 import { portalDemandasApi, type ChatDemanda } from '../../lib/chatDemandasApi'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { CHAT_HUB_PATHS, chatPortalLink } from '../../lib/chatHubPaths'
-import { mensagemTransferenciaSucesso, rotuloEstadoChat, rotuloResponsavelChat } from '../../lib/whatsappChatMeta'
+import {
+  classeCorEstadoChat,
+  mensagemTransferenciaSucesso,
+  rotuloEstadoChat,
+  rotuloResponsavelChat,
+} from '../../lib/whatsappChatMeta'
 import { mergeTimelineChat, textoMarcoDemanda } from '../../lib/whatsappDemandaUtils'
 import { WhatsappDemandaTimelineMarco } from '../whatsapp/WhatsappDemandaTimelineMarco'
 import { ACCEPT_ANEXO, type TipoAnexoPicker } from '../whatsapp/WhatsappBarraAnexos'
@@ -315,16 +320,14 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
   }
 
   async function handleEncerrado(atualizado: PortalChats.Chat) {
-    setChat(atualizado)
     void refreshContagens()
     void refetchPendenciasResumo()
-    if (atualizado.estado === 'aguardando_avaliacao') {
-      toast.showSuccess('Atendimento encerrado. Aguardando avaliação do visitante.')
-      return
-    }
-    toast.showSuccess('Atendimento encerrado.')
+    toast.showSuccess(
+      atualizado.estado === 'aguardando_avaliacao'
+        ? 'Atendimento encerrado. Aguardando avaliação do visitante.'
+        : 'Atendimento encerrado.',
+    )
     fecharChat()
-    navigate(CHAT_HUB_PATHS.atendendo)
   }
 
   if (!Number.isFinite(chatId)) {
@@ -364,8 +367,8 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
             <ChatCanalBadge canal="portal" />
           </div>
           <p className="truncate text-xs text-cyan-600 dark:text-cyan-400">{exibirProtocolo(chat.protocolo)}</p>
-          <p className="truncate text-xs text-slate-500">
-            {rotuloEstadoChat(chat.estado)}
+          <p className="truncate text-xs text-slate-500 dark:text-slate-400">
+            <span className={classeCorEstadoChat(chat.estado)}>{rotuloEstadoChat(chat.estado)}</span>
             {chat.setor_nome ? ` · ${chat.setor_nome}` : ''}
             {' · '}
             {rotuloResponsavelChat(chat, user?.id)}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -54,6 +54,7 @@ import { useEventStream } from '../../contexts/EventStreamContext'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
 import { CustomAudioPlayer } from '../../components/CustomAudioPlayer'
 import {
+  classeCorEstadoChat,
   mensagemTransferenciaSucesso,
   rotuloEstadoChat,
   rotuloResponsavelChat,
@@ -721,15 +722,22 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
 
   const viuEmAtendimentoRef = useRef(false)
   const inatividadeToastFeitoRef = useRef(false)
+  const fechouPainelAposEncerrarRef = useRef(false)
 
   useEffect(() => {
-    if (chat?.estado === 'em_atendimento') {
+    viuEmAtendimentoRef.current = false
+    inatividadeToastFeitoRef.current = false
+    fechouPainelAposEncerrarRef.current = false
+  }, [id])
+
+  useEffect(() => {
+    if (chat?.id === id && chat.estado === 'em_atendimento') {
       viuEmAtendimentoRef.current = true
     }
-  }, [chat?.estado])
+  }, [chat?.id, chat?.estado, id])
 
   useEffect(() => {
-    if (!chat || inatividadeToastFeitoRef.current) return
+    if (!chat || chat.id !== id || inatividadeToastFeitoRef.current) return
     if (!viuEmAtendimentoRef.current) return
 
     const fechado = chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao'
@@ -744,7 +752,17 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
     toast.showSuccess(
       'Atendimento encerrado por inatividade. Pode reler a conversa e registar a demanda no aviso abaixo.',
     )
-  }, [chat, msgs, user?.id, user?.role, toast])
+  }, [chat, id, msgs, user?.id, user?.role, toast])
+
+  useEffect(() => {
+    if (!chat || chat.id !== id || fechouPainelAposEncerrarRef.current) return
+    const naMesa = chatIdProp != null || location.pathname.startsWith('/chat/')
+    if (!naMesa || !viuEmAtendimentoRef.current) return
+    const fechado = chat.estado === 'encerrado' || chat.estado === 'aguardando_avaliacao'
+    if (!fechado || chat.classificacao_demanda_pendente) return
+    fechouPainelAposEncerrarRef.current = true
+    voltarLista()
+  }, [chat, id, chatIdProp, location.pathname, voltarLista])
 
   const refrescarTimelineDemandas = useCallback(() => {
     setDemandasReloadKey((k) => k + 1)
@@ -1287,9 +1305,6 @@ useEffect(() => {
 
 
   async function handleEncerrado(atualizado: WhatsappChats.Chat) {
-    setChat(atualizado)
-    await Promise.all([carregar(), carregarSidebar()])
-    refrescarTimelineDemandas()
     toast.showSuccess(
       atualizado.estado === 'aguardando_avaliacao' && atualizado.classificacao_demanda_pendente
         ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
@@ -1299,6 +1314,18 @@ useEffect(() => {
             ? 'Atendimento encerrado. Aguardando avaliação do cliente.'
             : 'Atendimento encerrado.',
     )
+    void refreshContagens()
+    void refetchPendenciasResumo()
+    const naMesa = chatIdProp != null || location.pathname.startsWith('/chat/')
+    // Demanda pendente: o painel fica aberto para classificar. Caso contrário, fecha como Voltar.
+    if (naMesa && !atualizado.classificacao_demanda_pendente) {
+      fechouPainelAposEncerrarRef.current = true
+      voltarLista()
+      return
+    }
+    setChat(atualizado)
+    await Promise.all([carregar(), carregarSidebar()])
+    refrescarTimelineDemandas()
   }
 
   async function confirmarEmpresaContexto() {
@@ -1776,7 +1803,7 @@ useEffect(() => {
                 {exibirProtocolo(chat?.protocolo)}
               </span>
               <span className="text-slate-300">•</span>
-              <span className={`capitalize ${encerrado ? 'text-red-500' : 'text-emerald-500'}`}>
+              <span className={classeCorEstadoChat(chat?.estado ?? '')}>
                 {chat ? rotuloEstadoChat(chat.estado) : '—'}
               </span>
               {chat && (


### PR DESCRIPTION
## Summary

- Ao **encerrar** um atendimento na mesa (`/chat/atendendo`), o painel fecha como o Voltar, em vez de ficar aberto sobre a lista vazia. Se ainda faltar classificar a demanda (ex.: inatividade), o painel permanece.
- O estado **Aguardando avaliação** passa a âmbar; **Encerrado** usa vermelho mais legível no tema escuro.
- Vale para WhatsApp e chat do portal.

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] Login local (`admin@email.com`) e mesa em tema escuro
- [x] Encerrar chat do portal na mesa persiste `encerrado` no banco; Voltar fecha o painel (mesmo `fecharChat`)
- [x] Rótulo «Em atendimento» no header do portal usa `text-emerald-600 dark:text-emerald-400`
- [ ] Encerrar WhatsApp na mesa: painel some e a lista fica só com «Nenhum atendimento em curso» (ou o próximo chat); toast de encerrado aparece
- [ ] Chat em `aguardando_avaliacao`: estado âmbar no header
- [ ] Chat `encerrado` no tema escuro: vermelho legível (`text-red-400`)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Sem issue GitHub neste lote — polish de UX combinado no chat
- [x] Composer/emojis, labels duplicados e prefixo nas bolhas ficam de fora (não agora)
