### PR TITLE
feat(whatsapp): pesquisa de empresa, drop de ficheiros e respostas prontas (#728 #729 #730)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Notificações (#693 / #694): no telemóvel podes receber alertas mesmo com a app fechada — fila de espera e mensagens nos chats/tickets já teus. Activa em Notificações; o silêncio da fila na mesa também vale com a app fechada
 - Mobile (#695): no iPhone, o painel explica que os alertas com a app fechada só funcionam depois de adicionar o DeskRudder à tela inicial (Safari 16.4+)
 - Menu (#716): a barra de rolagem da sidebar (painel e portal) fica fina e alinhada ao tema, sem o visual nativo do Windows
+- WhatsApp (#728): no modal da empresa do atendimento dá para **pesquisar pelo nome do posto**, em vez de só rolar a lista
+- WhatsApp (#729): arrastar um ficheiro para a conversa abre a pré-visualização (como colar com Ctrl+V)
+- WhatsApp (#730): no compositor há um atalho para **respostas prontas** do setor (insere o texto; o envio continua a ser teu)
 - CI: testes do backend deixam de repetir bcrypt lento em cada caso; PRs só de interface já não esperam o pytest, e o contrário também (job do lado inalterado conclui em segundos)
 
 #### Correções

--- a/frontend/src/components/RespostasProntasPicker.tsx
+++ b/frontend/src/components/RespostasProntasPicker.tsx
@@ -9,9 +9,11 @@ type Props = {
   setorId: number
   disabled?: boolean
   onInserir: (texto: string) => void
+  /** Ícone compacto para a barra do compositor WhatsApp. */
+  modoComposer?: boolean
 }
 
-export function RespostasProntasPicker({ setorId, disabled, onInserir }: Props) {
+export function RespostasProntasPicker({ setorId, disabled, onInserir, modoComposer = false }: Props) {
   const toast = useToast()
   const [aberto, setAberto] = useState(false)
   const [busca, setBusca] = useState('')
@@ -59,20 +61,38 @@ export function RespostasProntasPicker({ setorId, disabled, onInserir }: Props) 
     setBusca('')
   }
 
+  const icone = (
+    <svg className="size-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+    </svg>
+  )
+
   return (
     <div className="relative" ref={painelRef}>
-      <Button
-        type="button"
-        variant="secondary"
-        disabled={disabled}
-        onClick={() => setAberto((v) => !v)}
-        className="inline-flex items-center gap-2 text-xs sm:text-sm"
-      >
-        <svg className="size-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-        </svg>
-        Respostas prontas
-      </Button>
+      {modoComposer ? (
+        <button
+          type="button"
+          disabled={disabled}
+          title="Respostas prontas"
+          aria-label="Respostas prontas"
+          aria-expanded={aberto}
+          onClick={() => setAberto((v) => !v)}
+          className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-slate-600 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-40 dark:text-slate-300 dark:hover:bg-slate-800"
+        >
+          {icone}
+        </button>
+      ) : (
+        <Button
+          type="button"
+          variant="secondary"
+          disabled={disabled}
+          onClick={() => setAberto((v) => !v)}
+          className="inline-flex items-center gap-2 text-xs sm:text-sm"
+        >
+          {icone}
+          Respostas prontas
+        </Button>
+      )}
       {aberto ? (
         <div className="absolute bottom-full left-0 z-30 mb-2 w-[min(100vw-2rem,22rem)] rounded-xl border border-slate-200 bg-white p-3 shadow-xl dark:border-slate-800 dark:bg-slate-900">
           <Input
@@ -82,7 +102,7 @@ export function RespostasProntasPicker({ setorId, disabled, onInserir }: Props) 
             className="mb-2 text-sm"
             autoFocus
           />
-          <div className="max-h-56 overflow-y-auto">
+          <div className="dx-scrollbar max-h-56 overflow-y-auto">
             {loading ? (
               <p className="py-4 text-center text-xs text-slate-500 dark:text-slate-400">Carregando…</p>
             ) : itens.length === 0 ? (

--- a/frontend/src/components/chat/ChatIniciarConversaModal.tsx
+++ b/frontend/src/components/chat/ChatIniciarConversaModal.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { whatsappChats, type WhatsappChats } from '../../api/client'
 import { Button } from '../../components/ui/Button'
 import { Input, TEXTAREA_FIELD_CLASS } from '../../components/ui/Input'
-import { Select } from '../../components/ui/Select'
+import { SelectComPesquisa } from '../../components/ui/SelectComPesquisa'
 import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { chatWhatsappLink } from '../../lib/chatHubPaths'
@@ -118,14 +118,13 @@ export function ChatIniciarConversaModal({
           />
           {multiEmpresa && (
             <div className="space-y-1">
-              <Select
+              <SelectComPesquisa
                 label="Empresa do atendimento (opcional)"
                 value={empresaId}
-                onChange={(value) => setEmpresaId(value === '' ? '' : Number(value))}
-                options={empresasLista.map((e) => ({ value: e.id, label: e.nome }))}
+                onChange={(id) => setEmpresaId(id)}
+                items={empresasLista.map((e) => ({ id: e.id, label: e.nome }))}
                 placeholder="Definir depois na conversa"
-                includeEmpty
-                emptyLabel="Definir depois na conversa"
+                hint="Digite parte do nome do posto"
               />
               <p className="text-[11px] text-slate-500">
                 Se ainda não souber, pergunte ao cliente na conversa e vincule a empresa a qualquer

--- a/frontend/src/components/ui/SelectComPesquisa.tsx
+++ b/frontend/src/components/ui/SelectComPesquisa.tsx
@@ -113,7 +113,7 @@ export function SelectComPesquisa({
             aria-label={`Buscar em ${label}`}
           />
           <p className="px-3 py-1.5 text-xs text-slate-400 dark:text-slate-500">{hint}</p>
-          <ul className="max-h-52 overflow-y-auto py-1">
+          <ul className="dx-scrollbar max-h-52 overflow-y-auto py-1">
             {displayed.length === 0 ? (
               <li className="px-3 py-2 text-sm text-slate-500 dark:text-slate-400">Nenhum resultado.</li>
             ) : (

--- a/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappComposerBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, type ClipboardEvent } from 'react'
 import { Button } from '../../components/ui/Button'
 import { KbConsultaButton } from '../../components/KbConsultaModal'
+import { RespostasProntasPicker } from '../../components/RespostasProntasPicker'
 import type { TipoAnexoPicker } from './WhatsappBarraAnexos'
 import { WhatsappGravadorAudioInline } from './WhatsappGravadorAudioInline'
 import { WhatsappEmojiFigurinhaPanel } from './WhatsappEmojiFigurinhaPanel'
@@ -16,6 +17,8 @@ type Props = {
   onEnviarFigurinha: (file: File) => void
   /** Ctrl+V / colar ficheiro do clipboard (imagem, etc.) */
   onColarArquivo?: (file: File) => void
+  /** Setor do chat para respostas prontas; omitir esconde o botão. */
+  setorId?: number | null
   enviando: boolean
   encerrado: boolean
   podeEnviar: boolean
@@ -47,6 +50,7 @@ export function WhatsappComposerBar({
   onInserirEmoji,
   onEnviarFigurinha,
   onColarArquivo,
+  setorId,
   enviando,
   encerrado,
   podeEnviar,
@@ -182,6 +186,17 @@ export function WhatsappComposerBar({
             />
           )}
         </div>
+
+        {setorId != null && (
+          <div className="relative shrink-0">
+            <RespostasProntasPicker
+              setorId={setorId}
+              modoComposer
+              disabled={acoesBloqueadas || modoInterno || !podeEnviar}
+              onInserir={inserirEmojiNoCursor}
+            />
+          </div>
+        )}
 
         {onInserirReferenciaKb && (
           <KbConsultaButton

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, useRef, type MouseEvent } from 'react'
+import { useCallback, useEffect, useMemo, useState, useRef, type DragEvent, type MouseEvent } from 'react'
 
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 
@@ -42,6 +42,7 @@ import { TEXTAREA_FIELD_CLASS } from '../../components/ui/Input'
 import { Button } from '../../components/ui/Button'
 
 import { Select } from '../../components/ui/Select'
+import { SelectComPesquisa } from '../../components/ui/SelectComPesquisa'
 
 import { useToast } from '../../components/ui/Toast'
 
@@ -569,6 +570,8 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
 
   const [pickerAnexo, setPickerAnexo] = useState<TipoAnexoPicker>('imagem')
   const [arquivoPendente, setArquivoPendente] = useState<File | null>(null)
+  const [dragAtivo, setDragAtivo] = useState(false)
+  const dragDepthRef = useRef(0)
   const [legendaMidia, setLegendaMidia] = useState('')
 
 
@@ -1456,6 +1459,52 @@ useEffect(() => {
 
   const modoHub = chatIdProp != null || location.pathname.startsWith('/chat/')
 
+  const podeAceitarDrop = Boolean(podeEnviar && !encerrado && !modoInterno && !enviando)
+
+  function resetDrag() {
+    dragDepthRef.current = 0
+    setDragAtivo(false)
+  }
+
+  function handleDragEnter(e: DragEvent<HTMLElement>) {
+    e.preventDefault()
+    e.stopPropagation()
+    if (![...e.dataTransfer.types].includes('Files')) return
+    dragDepthRef.current += 1
+    if (podeAceitarDrop) setDragAtivo(true)
+  }
+
+  function handleDragOver(e: DragEvent<HTMLElement>) {
+    e.preventDefault()
+    e.stopPropagation()
+    if (![...e.dataTransfer.types].includes('Files')) return
+    e.dataTransfer.dropEffect = podeAceitarDrop ? 'copy' : 'none'
+  }
+
+  function handleDragLeave(e: DragEvent<HTMLElement>) {
+    e.preventDefault()
+    e.stopPropagation()
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1)
+    if (dragDepthRef.current === 0) setDragAtivo(false)
+  }
+
+  function handleDrop(e: DragEvent<HTMLElement>) {
+    e.preventDefault()
+    e.stopPropagation()
+    resetDrag()
+    const files = Array.from(e.dataTransfer.files || [])
+    if (files.length === 0) return
+    if (!podeAceitarDrop) {
+      toast.showWarning(motivoAnexoDesabilitado || 'Não é possível anexar neste chat.')
+      return
+    }
+    setArquivoPendente(files[0])
+    setLegendaMidia('')
+    if (files.length > 1) {
+      toast.showWarning('Só é possível anexar um ficheiro de cada vez. Foi usado o primeiro.')
+    }
+  }
+
   return (
 
     <div
@@ -1575,7 +1624,23 @@ useEffect(() => {
 
       {/* ÁREA DE CONVERSA */}
 
-      <main className="flex flex-1 flex-col min-w-0 bg-white dark:bg-slate-950">
+      <main
+        className="relative flex min-w-0 flex-1 flex-col bg-white dark:bg-slate-950"
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
+      >
+        {dragAtivo && podeAceitarDrop && (
+          <div
+            className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center border-2 border-dashed border-cyan-500 bg-cyan-950/40"
+            aria-hidden
+          >
+            <p className="rounded-xl bg-white/95 px-4 py-2 text-sm font-semibold text-cyan-800 shadow-sm dark:bg-slate-900/95 dark:text-cyan-200">
+              Solte o ficheiro para anexar
+            </p>
+          </div>
+        )}
 
        
 
@@ -2250,6 +2315,7 @@ useEffect(() => {
                 setArquivoPendente(file)
                 setLegendaMidia('')
               }}
+              setorId={chat?.setor_id}
               onInserirReferenciaKb={inserirReferenciaKb}
               focoPedidoEm={focoComposerEm}
               placeholder={composerPlaceholder}
@@ -2359,14 +2425,14 @@ useEffect(() => {
                 encerrado.
               </p>
               <div className="mt-4">
-                <Select
+                <SelectComPesquisa
                   label="Empresa"
                   value={empresaContextoId}
-                  onChange={(value) => setEmpresaContextoId(value === '' ? '' : Number(value))}
-                  options={(chat.empresas_opcoes || []).map((e) => ({ value: e.id, label: e.nome }))}
+                  onChange={(id) => setEmpresaContextoId(id)}
+                  items={(chat.empresas_opcoes || []).map((e) => ({ id: e.id, label: e.nome }))}
                   placeholder="Selecione a empresa"
-                  includeEmpty
-                  emptyLabel="Selecione a empresa"
+                  hint="Digite parte do nome do posto"
+                  required
                 />
               </div>
               <div className="mt-5 flex justify-end gap-2">


### PR DESCRIPTION
## Summary

Lote de UX operacional no WhatsApp da mesa:

- **#728** — o modal «Empresa do atendimento» passa a `SelectComPesquisa` (filtro por nome do posto). O mesmo no iniciar conversa.
- **#729** — arrastar um ficheiro para a área da conversa abre a pré-visualização (como Ctrl+V); não envia sozinho. Overlay «Solte o ficheiro para anexar». Sidebar não recebe o drop.
- **#730** — ícone de respostas prontas no compositor (setor do chat + globais); insere o texto no cursor. O picker do ticket mantém-se.

Closes #728
Closes #729
Closes #730

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] Modal empresa: digitar «ABADIA» filtra a lista; confirmar vincula a empresa no chat
- [x] Arrastar PNG para a conversa → «Anexo selecionado» + «Enviar anexo»; cancelar não envia
- [x] Compositor: ícone respostas prontas; busca por título; escolher insere o texto (não envia)
- [ ] Desktop Chrome/Edge com ficheiro do explorador (smoke extra)
- [ ] No telemóvel, arrastar da app de ficheiros pode não existir (limitação de plataforma)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Drag-and-drop no chat interno / portal — já marcado como opcional em #729 (fora deste lote)
- [x] Auto-envio ao escolher resposta pronta — fora de escopo em #730
- [x] Sem stubs/campos nullable neste lote
