### PR TITLE
feat(comercial): proposta PDF a partir da negociacao (#323 #345-348)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,10 @@ jobs:
       - name: Instalar requirements e pip-audit
         if: needs.changes.outputs.backend == 'true'
         run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0 \
+            libcairo2 libgdk-pixbuf-2.0-0 libharfbuzz0b fonts-dejavu-core shared-mime-info
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt -r requirements-dev.txt pip-audit
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Proposta comercial (#323 / #345–#348): modelos HTML versionados, geração a partir da negociação (CNPJs à escolha), preview, PDF e marcar como enviada (com opção de avançar o funil) — sem custo/margem no documento do cliente
 - CRM (#322 / #336–#344): perfil comercial, funil, leads e negociações multi-CNPJ (API + UI — lista/Kanban, detalhe com custos/margem e timeline); configuração dos estágios em Cadastros; simulação e leitura do catálogo de custos para comercial (CRUD do catálogo continua só admin)
 - Sobre: as notas de atualização passam a mostrar só o que mudou no helpdesk nesta instância; melhorias do painel SaaS deixam de aparecer misturadas (#672 / #674)
 - WhatsApp (#684): número do contacto visível no header da conversa (com copiar)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -11,6 +11,15 @@ ENV DX_CONNECT_VERSION=${DX_CONNECT_VERSION}
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
     libpq-dev \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libpangoft2-1.0-0 \
+    libcairo2 \
+    libgdk-pixbuf-2.0-0 \
+    libharfbuzz0b \
+    libffi8 \
+    fonts-dejavu-core \
+    shared-mime-info \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/backend/alembic/versions/096_comercial_propostas.py
+++ b/backend/alembic/versions/096_comercial_propostas.py
@@ -1,0 +1,122 @@
+"""Proposta comercial: templates versionados e documentos gerados (#323 / #345–#347).
+
+Revision ID: 096_comercial_propostas
+Revises: 095_web_push
+Create Date: 2026-08-18
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "096_comercial_propostas"
+down_revision = "095_web_push"
+branch_labels = None
+depends_on = None
+
+# Sem as palavras «custo»/«margem» — o HTML do cliente não deve carregá-las.
+_TEMPLATE_PADRAO_HTML = """<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8"/>
+  <style>
+    body { font-family: DejaVu Sans, Arial, sans-serif; color: #1e293b; margin: 24px; font-size: 13px; }
+    h1 { font-size: 20px; margin: 0 0 8px; }
+    h2 { font-size: 14px; margin: 20px 0 8px; }
+    table { width: 100%; border-collapse: collapse; margin: 8px 0 16px; }
+    th, td { border: 1px solid #cbd5e1; padding: 8px; text-align: left; }
+    th { background: #f1f5f9; }
+    .muted { color: #64748b; font-size: 12px; }
+    .logo img { max-height: 72px; }
+  </style>
+</head>
+<body>
+  <div class="logo">{{logo}}</div>
+  <p class="muted">{{empresa_sistema}}</p>
+  <h1>Proposta comercial</h1>
+  <p><strong>Cliente:</strong> {{razao_social}} &nbsp; <strong>CNPJ:</strong> {{cnpj}}</p>
+  <h2>Itens</h2>
+  {{itens}}
+  <p><strong>Valor mensal:</strong> {{valor_mensalidade}}</p>
+  <h2>Condições</h2>
+  <div>{{condicoes}}</div>
+</body>
+</html>
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if not insp.has_table("comercial_proposta_templates"):
+        op.create_table(
+            "comercial_proposta_templates",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("nome", sa.String(120), nullable=False),
+            sa.Column("versao", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("conteudo_html", sa.Text(), nullable=False),
+            sa.Column("vigencia_inicio", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+            sa.UniqueConstraint("nome", "versao", name="uq_comercial_proposta_template_nome_versao"),
+        )
+        op.create_index("ix_comercial_proposta_templates_nome", "comercial_proposta_templates", ["nome"])
+        op.create_index("ix_comercial_proposta_templates_ativo", "comercial_proposta_templates", ["ativo"])
+
+    if not insp.has_table("comercial_propostas"):
+        op.create_table(
+            "comercial_propostas",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "negociacao_id",
+                sa.Integer(),
+                sa.ForeignKey("crm_negociacoes.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "template_id",
+                sa.Integer(),
+                sa.ForeignKey("comercial_proposta_templates.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column(
+                "gerado_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column("status", sa.String(20), nullable=False, server_default="rascunho"),
+            sa.Column("conteudo_html_snapshot", sa.Text(), nullable=False),
+            sa.Column("conteudo_hash", sa.String(64), nullable=False),
+            sa.Column("linha_ids", sa.JSON(), nullable=False),
+            sa.Column("pdf_storage_key", sa.String(255), nullable=True),
+            sa.Column("canal", sa.String(20), nullable=True),
+            sa.Column("enviado_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.create_index("ix_comercial_propostas_negociacao_id", "comercial_propostas", ["negociacao_id"])
+        op.create_index("ix_comercial_propostas_template_id", "comercial_propostas", ["template_id"])
+        op.create_index("ix_comercial_propostas_status", "comercial_propostas", ["status"])
+        op.create_index("ix_comercial_propostas_created_at", "comercial_propostas", ["created_at"])
+
+    bind.execute(
+        sa.text(
+            """
+            INSERT INTO comercial_proposta_templates (nome, versao, conteudo_html, vigencia_inicio, ativo)
+            SELECT :nome, 1, :html, CURRENT_TIMESTAMP, true
+            WHERE NOT EXISTS (SELECT 1 FROM comercial_proposta_templates LIMIT 1)
+            """
+        ),
+        {"nome": "Padrão", "html": _TEMPLATE_PADRAO_HTML},
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("comercial_propostas"):
+        op.drop_table("comercial_propostas")
+    if insp.has_table("comercial_proposta_templates"):
+        op.drop_table("comercial_proposta_templates")

--- a/backend/app/api/comercial_proposta.py
+++ b/backend/app/api/comercial_proposta.py
@@ -1,0 +1,151 @@
+"""API de proposta comercial (#323 / #345–#347)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import Response
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.core.auth import exigir_admin, exigir_comercial_ou_admin
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.schemas.comercial_proposta import (
+    PropostaGerarIn,
+    PropostaMarcarEnviadaIn,
+    PropostaRead,
+    PropostaTemplateCreate,
+    PropostaTemplatePreviewIn,
+    PropostaTemplatePreviewOut,
+    PropostaTemplateRead,
+    PropostaTemplateUpdate,
+)
+from app.services import comercial_proposta as svc
+
+router = APIRouter(prefix="/comercial", tags=["comercial-propostas"])
+
+
+@router.get("/proposta-templates", response_model=list[PropostaTemplateRead])
+def listar_templates(
+    incluir_inativos: bool = Query(False),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    if incluir_inativos and atendente.role != "admin":
+        incluir_inativos = False
+    svc.garantir_template_padrao(db)
+    rows = svc.listar_templates(db, incluir_inativos=incluir_inativos)
+    db.commit()
+    return rows
+
+
+@router.post("/proposta-templates", response_model=PropostaTemplateRead, status_code=201)
+def criar_template(
+    data: PropostaTemplateCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = svc.criar_template(db, data)
+    registrar_audit(db, "comercial_proposta_template", row.id, "create", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.post("/proposta-templates/preview", response_model=PropostaTemplatePreviewOut)
+def preview_template(
+    data: PropostaTemplatePreviewIn,
+    _: Atendente = Depends(exigir_admin),
+):
+    return PropostaTemplatePreviewOut(html=svc.sanitize_html(data.conteudo_html))
+
+
+@router.patch("/proposta-templates/{template_id}", response_model=PropostaTemplateRead)
+def atualizar_template(
+    template_id: int,
+    data: PropostaTemplateUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = svc.obter_template(db, template_id, apenas_ativos=False)
+    row = svc.atualizar_template(db, row, data)
+    registrar_audit(db, "comercial_proposta_template", row.id, "update", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.get("/propostas", response_model=list[PropostaRead])
+def listar_propostas(
+    negociacao_id: int = Query(...),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    return [svc.proposta_para_read(r) for r in svc.listar_propostas(db, negociacao_id)]
+
+
+@router.post("/propostas", response_model=PropostaRead, status_code=201)
+def gerar_proposta(
+    data: PropostaGerarIn,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    row = svc.gerar_proposta(db, data, atendente)
+    registrar_audit(
+        db,
+        "comercial_proposta",
+        row.id,
+        "create",
+        atendente.id,
+        payload={"negociacao_id": row.negociacao_id, "status": row.status},
+    )
+    db.commit()
+    db.refresh(row)
+    return svc.proposta_para_read(row)
+
+
+@router.get("/propostas/{proposta_id}", response_model=PropostaRead)
+def obter_proposta(
+    proposta_id: int,
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    return svc.proposta_para_read(svc.obter_proposta(db, proposta_id))
+
+
+@router.get("/propostas/{proposta_id}/pdf")
+def baixar_pdf(
+    proposta_id: int,
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    row = svc.obter_proposta(db, proposta_id)
+    pdf = svc.garantir_pdf(db, row)
+    db.commit()
+    return Response(
+        content=pdf,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="proposta-{row.id}.pdf"'},
+    )
+
+
+@router.post("/propostas/{proposta_id}/marcar-enviada", response_model=PropostaRead)
+def marcar_enviada(
+    proposta_id: int,
+    data: PropostaMarcarEnviadaIn,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    row = svc.obter_proposta(db, proposta_id)
+    row = svc.marcar_enviada(db, row, data, atendente)
+    registrar_audit(
+        db,
+        "comercial_proposta",
+        row.id,
+        "update",
+        atendente.id,
+        payload={"status": row.status, "canal": row.canal, "avancar_funil": data.avancar_funil},
+    )
+    db.commit()
+    db.refresh(row)
+    return svc.proposta_para_read(row)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,6 +40,7 @@ from app.api import (
     ticket_catalogos,
     empresa_pdvs,
     comercial_custos,
+    comercial_proposta,
     crm,
     system_settings,
     tenant,
@@ -538,6 +539,7 @@ app.include_router(respostas_prontas.router, prefix=API_V1_PREFIX)
 app.include_router(pdv_catalogos.router, prefix=API_V1_PREFIX)
 app.include_router(ticket_catalogos.router, prefix=API_V1_PREFIX)
 app.include_router(comercial_custos.router, prefix=API_V1_PREFIX)
+app.include_router(comercial_proposta.router, prefix=API_V1_PREFIX)
 app.include_router(crm.router, prefix=API_V1_PREFIX)
 app.include_router(empresa_pdvs.router, prefix=API_V1_PREFIX)
 app.include_router(system_settings.router, prefix=API_V1_PREFIX)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -61,6 +61,7 @@ from app.models.crm import (
     CrmNegociacaoCnpjLinha,
     FunilEstagio,
 )
+from app.models.comercial_proposta import Proposta, PropostaTemplate
 from app.models.cliente_saas import ClienteSaaS
 from app.models.saas_alerta_emitido import SaasAlertaEmitido
 from app.models.lead_comercial import LeadComercial
@@ -141,6 +142,8 @@ __all__ = [
     "CrmNegociacao",
     "CrmNegociacaoCnpjLinha",
     "CrmNegociacaoAtividade",
+    "PropostaTemplate",
+    "Proposta",
     "ClienteSaaS",
     "SaasAlertaEmitido",
     "LeadComercial",

--- a/backend/app/models/comercial_proposta.py
+++ b/backend/app/models/comercial_proposta.py
@@ -1,0 +1,71 @@
+"""Proposta comercial versionada a partir da negociação CRM (#323 / #345–#347)."""
+
+from __future__ import annotations
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from sqlalchemy.types import JSON
+
+from app.database import Base
+
+PROPOSTA_RASCUNHO = "rascunho"
+PROPOSTA_ENVIADA = "enviada"
+PROPOSTA_SUBSTITUIDA = "substituida"
+PROPOSTA_STATUSES = frozenset({PROPOSTA_RASCUNHO, PROPOSTA_ENVIADA, PROPOSTA_SUBSTITUIDA})
+
+CANAL_EMAIL = "email"
+CANAL_IMPRESSO = "impresso"
+CANAL_OUTRO = "outro"
+PROPOSTA_CANAIS = frozenset({CANAL_EMAIL, CANAL_IMPRESSO, CANAL_OUTRO})
+
+
+class PropostaTemplate(Base):
+    __tablename__ = "comercial_proposta_templates"
+    __table_args__ = (UniqueConstraint("nome", "versao", name="uq_comercial_proposta_template_nome_versao"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    nome = Column(String(120), nullable=False, index=True)
+    versao = Column(Integer, nullable=False, default=1)
+    conteudo_html = Column(Text, nullable=False)
+    vigencia_inicio = Column(DateTime(timezone=True), nullable=True)
+    ativo = Column(Boolean, nullable=False, default=True, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    propostas = relationship("Proposta", back_populates="template")
+
+
+class Proposta(Base):
+    __tablename__ = "comercial_propostas"
+
+    id = Column(Integer, primary_key=True, index=True)
+    negociacao_id = Column(
+        Integer, ForeignKey("crm_negociacoes.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    template_id = Column(
+        Integer, ForeignKey("comercial_proposta_templates.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    gerado_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="RESTRICT"), nullable=False)
+    status = Column(String(20), nullable=False, default=PROPOSTA_RASCUNHO, index=True)
+    conteudo_html_snapshot = Column(Text, nullable=False)
+    conteudo_hash = Column(String(64), nullable=False)
+    linha_ids = Column(JSON, nullable=False, default=lambda: [])
+    pdf_storage_key = Column(String(255), nullable=True)
+    canal = Column(String(20), nullable=True)
+    enviado_em = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    template = relationship("PropostaTemplate", back_populates="propostas")
+    negociacao = relationship("CrmNegociacao")
+    gerado_por = relationship("Atendente", foreign_keys=[gerado_por_id])

--- a/backend/app/schemas/comercial_proposta.py
+++ b/backend/app/schemas/comercial_proposta.py
@@ -1,0 +1,80 @@
+"""Schemas da proposta comercial (#323 / #345–#347)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class PropostaTemplateCreate(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=120)
+    conteudo_html: str = Field(..., min_length=1)
+    vigencia_inicio: datetime | None = None
+    ativo: bool = True
+
+
+class PropostaTemplateUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=120)
+    conteudo_html: str | None = Field(None, min_length=1)
+    vigencia_inicio: datetime | None = None
+    ativo: bool | None = None
+
+
+class PropostaTemplateRead(BaseModel):
+    id: int
+    nome: str
+    versao: int
+    conteudo_html: str
+    vigencia_inicio: datetime | None = None
+    ativo: bool
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PropostaTemplatePreviewIn(BaseModel):
+    conteudo_html: str = Field(..., min_length=1)
+
+
+class PropostaTemplatePreviewOut(BaseModel):
+    html: str
+
+
+class PropostaGerarIn(BaseModel):
+    negociacao_id: int
+    template_id: int | None = None
+    linha_ids: list[int] | None = None
+    condicoes: str | None = Field(None, max_length=8000)
+
+
+class PropostaMarcarEnviadaIn(BaseModel):
+    canal: str
+    enviado_em: datetime | None = None
+    avancar_funil: bool = False
+
+    @field_validator("canal")
+    @classmethod
+    def _canal(cls, v: str) -> str:
+        s = (v or "").strip().lower()
+        if s not in {"email", "impresso", "outro"}:
+            raise ValueError("Canal deve ser email, impresso ou outro.")
+        return s
+
+
+class PropostaRead(BaseModel):
+    id: int
+    negociacao_id: int
+    template_id: int
+    template_nome: str | None = None
+    template_versao: int | None = None
+    gerado_por_id: int
+    status: str
+    conteudo_html_snapshot: str
+    conteudo_hash: str
+    linha_ids: list[int]
+    canal: str | None = None
+    enviado_em: datetime | None = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/comercial_proposta.py
+++ b/backend/app/services/comercial_proposta.py
@@ -1,0 +1,436 @@
+"""Proposta comercial: templates, montagem sem custo/margem e PDF (#323 / #345–#347)."""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import logging
+import re
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import func
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.atendente import Atendente
+from app.models.comercial_custo import CustoCatalogoItem
+from app.models.comercial_proposta import (
+    PROPOSTA_ENVIADA,
+    PROPOSTA_RASCUNHO,
+    PROPOSTA_SUBSTITUIDA,
+    Proposta,
+    PropostaTemplate,
+)
+from app.models.crm import ATIVIDADE_DOCUMENTO, CrmNegociacaoAtividade, CrmNegociacaoCnpjLinha
+from app.models.empresa_sistema import EmpresaSistema
+from app.schemas.comercial_proposta import (
+    PropostaGerarIn,
+    PropostaMarcarEnviadaIn,
+    PropostaTemplateCreate,
+    PropostaTemplateUpdate,
+)
+from app.services import crm as crm_svc
+from app.services.system_logo_storage import caminho_absoluto_logo
+from app.services.ticket_anexo_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
+
+logger = logging.getLogger(__name__)
+
+_TAGS_PERIGOSAS = re.compile(
+    r"</?(?:script|iframe|object|embed|link|meta|form)(?:\s[^>]*)?>",
+    re.IGNORECASE,
+)
+_ATTR_EVENTO = re.compile(r"\s+on\w+\s*=\s*(['\"]).*?\1", re.IGNORECASE | re.DOTALL)
+_ATTR_JS = re.compile(r"\s+(href|src)\s*=\s*(['\"])\s*javascript:[^'\"]*\2", re.IGNORECASE)
+
+# Termos internos que nunca podem ir ao documento do cliente.
+_VAZAMENTO = re.compile(
+    r"total_custo|valor_custo|margem_calculada|snapshot_custo|override_custo|lucro\s*bruto|tef_override",
+    re.IGNORECASE,
+)
+
+TEMPLATE_PADRAO_HTML = """<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8"/>
+  <style>
+    body { font-family: DejaVu Sans, Arial, sans-serif; color: #1e293b; margin: 24px; font-size: 13px; }
+    h1 { font-size: 20px; margin: 0 0 8px; }
+    h2 { font-size: 14px; margin: 20px 0 8px; }
+    table { width: 100%; border-collapse: collapse; margin: 8px 0 16px; }
+    th, td { border: 1px solid #cbd5e1; padding: 8px; text-align: left; }
+    th { background: #f1f5f9; }
+    .muted { color: #64748b; font-size: 12px; }
+    .logo img { max-height: 72px; }
+  </style>
+</head>
+<body>
+  <div class="logo">{{logo}}</div>
+  <p class="muted">{{empresa_sistema}}</p>
+  <h1>Proposta comercial</h1>
+  <p><strong>Cliente:</strong> {{razao_social}} &nbsp; <strong>CNPJ:</strong> {{cnpj}}</p>
+  <h2>Itens</h2>
+  {{itens}}
+  <p><strong>Valor mensal:</strong> {{valor_mensalidade}}</p>
+  <h2>Condições</h2>
+  <div>{{condicoes}}</div>
+</body>
+</html>
+"""
+
+
+def sanitize_html(fragment: str) -> str:
+    s = _TAGS_PERIGOSAS.sub("", fragment or "")
+    s = _ATTR_EVENTO.sub("", s)
+    s = _ATTR_JS.sub("", s)
+    return s
+
+
+def _money_br(valor: Decimal | int | float | str | None) -> str:
+    try:
+        n = Decimal(str(valor if valor is not None else 0))
+    except Exception:
+        n = Decimal("0")
+    q = f"{n.quantize(Decimal('0.01')):,.2f}"
+    return "R$ " + q.replace(",", "X").replace(".", ",").replace("X", ".")
+
+
+def _formatar_cnpj(digits: str | None) -> str:
+    d = "".join(c for c in (digits or "") if c.isdigit())
+    if len(d) != 14:
+        return digits or "—"
+    return f"{d[:2]}.{d[2:5]}.{d[5:8]}/{d[8:12]}-{d[12:]}"
+
+
+def _hash_html(conteudo: str) -> str:
+    return hashlib.sha256(conteudo.encode("utf-8")).hexdigest()
+
+
+def garantir_template_padrao(db: Session) -> PropostaTemplate:
+    row = (
+        db.query(PropostaTemplate)
+        .filter(PropostaTemplate.ativo.is_(True))
+        .order_by(PropostaTemplate.id.asc())
+        .first()
+    )
+    if row:
+        return row
+    row = PropostaTemplate(
+        nome="Padrão",
+        versao=1,
+        conteudo_html=TEMPLATE_PADRAO_HTML,
+        vigencia_inicio=datetime.now(timezone.utc),
+        ativo=True,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def listar_templates(db: Session, *, incluir_inativos: bool = False) -> list[PropostaTemplate]:
+    garantir_template_padrao(db)
+    q = db.query(PropostaTemplate)
+    if not incluir_inativos:
+        q = q.filter(PropostaTemplate.ativo.is_(True))
+    return q.order_by(PropostaTemplate.nome.asc(), PropostaTemplate.versao.desc()).all()
+
+
+def obter_template(db: Session, template_id: int, *, apenas_ativos: bool = False) -> PropostaTemplate:
+    q = db.query(PropostaTemplate).filter(PropostaTemplate.id == template_id)
+    if apenas_ativos:
+        q = q.filter(PropostaTemplate.ativo.is_(True))
+    row = q.first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Modelo de proposta não encontrado.")
+    return row
+
+
+def _proxima_versao(db: Session, nome: str) -> int:
+    atual = db.query(func.max(PropostaTemplate.versao)).filter(PropostaTemplate.nome == nome).scalar()
+    return int(atual or 0) + 1
+
+
+def criar_template(db: Session, data: PropostaTemplateCreate) -> PropostaTemplate:
+    nome = data.nome.strip()
+    row = PropostaTemplate(
+        nome=nome,
+        versao=_proxima_versao(db, nome),
+        conteudo_html=sanitize_html(data.conteudo_html),
+        vigencia_inicio=data.vigencia_inicio or datetime.now(timezone.utc),
+        ativo=data.ativo,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def atualizar_template(db: Session, row: PropostaTemplate, data: PropostaTemplateUpdate) -> PropostaTemplate:
+    payload = data.model_dump(exclude_unset=True)
+    if "conteudo_html" in payload and payload["conteudo_html"] is not None:
+        row.conteudo_html = sanitize_html(payload["conteudo_html"])
+    if "nome" in payload and payload["nome"] is not None:
+        row.nome = payload["nome"].strip()
+    if "vigencia_inicio" in payload:
+        row.vigencia_inicio = payload["vigencia_inicio"]
+    if "ativo" in payload and payload["ativo"] is not None:
+        row.ativo = payload["ativo"]
+    db.flush()
+    return row
+
+
+def _logo_html(db: Session) -> str:
+    emp = db.query(EmpresaSistema).order_by(EmpresaSistema.id.asc()).first()
+    if not emp or not emp.logo_filename:
+        return ""
+    path = caminho_absoluto_logo(emp.logo_filename)
+    if not path:
+        return ""
+    import base64
+
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return ""
+    mime = (emp.logo_mimetype or "image/png").split(";")[0].strip()
+    b64 = base64.b64encode(raw).decode("ascii")
+    return f'<img src="data:{mime};base64,{b64}" alt=""/>'
+
+
+def _empresa_sistema_texto(db: Session) -> str:
+    emp = db.query(EmpresaSistema).order_by(EmpresaSistema.id.asc()).first()
+    if not emp:
+        return ""
+    partes = [p for p in (emp.nome_fantasia or emp.nome, emp.razao_social) if p]
+    return html.escape(" · ".join(dict.fromkeys(partes)))
+
+
+def _nomes_itens_cliente(db: Session, linha: CrmNegociacaoCnpjLinha) -> list[str]:
+    """Só nomes visíveis ao cliente — nunca custo/margem do snapshot interno."""
+    nomes: list[str] = []
+    snap = linha.snapshot_custo if isinstance(linha.snapshot_custo, dict) else {}
+    for item in snap.get("itens") or []:
+        if not isinstance(item, dict):
+            continue
+        nome = str(item.get("nome") or "").strip()
+        if nome:
+            nomes.append(nome)
+    if nomes:
+        return nomes
+    ids = [int(i) for i in (linha.item_ids or []) if i is not None]
+    if not ids:
+        return []
+    rows = db.query(CustoCatalogoItem).filter(CustoCatalogoItem.id.in_(ids)).all()
+    by_id = {int(r.id): str(r.nome) for r in rows}
+    return [by_id[i] for i in ids if i in by_id]
+
+
+def _tabela_itens(db: Session, linhas: list[CrmNegociacaoCnpjLinha]) -> str:
+    rows: list[str] = []
+    for ln in linhas:
+        nomes = _nomes_itens_cliente(db, ln)
+        itens = html.escape(", ".join(nomes) if nomes else "—")
+        razao = html.escape(ln.razao_social or "—")
+        cnpj = html.escape(_formatar_cnpj(ln.cnpj))
+        valor = html.escape(_money_br(ln.valor_negociado))
+        rows.append(
+            f"<tr><td>{razao}</td><td>{cnpj}</td><td>{itens}</td><td>{valor}</td></tr>"
+        )
+    corpo = "".join(rows) or "<tr><td colspan='4'>—</td></tr>"
+    return (
+        "<table><thead><tr>"
+        "<th>Razão social</th><th>CNPJ</th><th>Itens</th><th>Valor mensal</th>"
+        "</tr></thead><tbody>"
+        f"{corpo}</tbody></table>"
+    )
+
+
+def _condicoes_html(raw: str | None) -> str:
+    s = (raw or "").strip()
+    if not s:
+        return "<p>—</p>"
+    if "<" in s:
+        return sanitize_html(s) or "<p>—</p>"
+    return "<p>" + html.escape(s).replace("\n", "<br/>") + "</p>"
+
+
+def preencher_template(
+    db: Session,
+    template_html: str,
+    linhas: list[CrmNegociacaoCnpjLinha],
+    *,
+    condicoes: str | None,
+) -> str:
+    if not linhas:
+        raise HTTPException(status_code=400, detail="Selecione pelo menos uma linha CNPJ.")
+    razoes = [ln.razao_social for ln in linhas if (ln.razao_social or "").strip()]
+    cnpjs = [_formatar_cnpj(ln.cnpj) for ln in linhas]
+    total = sum((Decimal(str(ln.valor_negociado or 0)) for ln in linhas), Decimal("0"))
+    valores = {
+        "razao_social": html.escape(" / ".join(razoes) if razoes else "—"),
+        "cnpj": html.escape(" / ".join(cnpjs) if cnpjs else "—"),
+        "itens": _tabela_itens(db, linhas),
+        "valor_mensalidade": html.escape(_money_br(total)),
+        "condicoes": _condicoes_html(condicoes),
+        "logo": _logo_html(db),
+        "empresa_sistema": _empresa_sistema_texto(db),
+    }
+    html_out = sanitize_html(template_html)
+    for chave, valor in valores.items():
+        html_out = html_out.replace("{{" + chave + "}}", valor)
+    if _VAZAMENTO.search(html_out):
+        raise HTTPException(
+            status_code=500,
+            detail="A proposta gerada continha dados internos e foi bloqueada. Contacte o suporte.",
+        )
+    return html_out
+
+
+def html_para_pdf(html_doc: str) -> bytes:
+    """Converte o snapshot HTML em PDF. WeasyPrint no Docker/produção; testes podem substituir."""
+    try:
+        from weasyprint import HTML  # type: ignore
+    except Exception as exc:  # pragma: no cover - ambiente sem libs nativas
+        logger.warning("WeasyPrint indisponível: %s", exc)
+        raise HTTPException(
+            status_code=503,
+            detail="Geração de PDF indisponível neste ambiente. Use o preview HTML ou instale as bibliotecas do WeasyPrint.",
+        ) from exc
+    try:
+        pdf = HTML(string=html_doc, encoding="utf-8").write_pdf()
+    except Exception as exc:
+        logger.exception("Falha ao gerar PDF da proposta")
+        raise HTTPException(status_code=500, detail="Não foi possível gerar o PDF.") from exc
+    if not pdf:
+        raise HTTPException(status_code=500, detail="Não foi possível gerar o PDF.")
+    return pdf
+
+
+def listar_propostas(db: Session, negociacao_id: int) -> list[Proposta]:
+    crm_svc.obter_negociacao(db, negociacao_id)
+    return (
+        db.query(Proposta)
+        .options(joinedload(Proposta.template))
+        .filter(Proposta.negociacao_id == negociacao_id)
+        .order_by(Proposta.created_at.desc())
+        .all()
+    )
+
+
+def obter_proposta(db: Session, proposta_id: int) -> Proposta:
+    row = (
+        db.query(Proposta)
+        .options(joinedload(Proposta.template))
+        .filter(Proposta.id == proposta_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Proposta não encontrada.")
+    return row
+
+
+def gerar_proposta(db: Session, data: PropostaGerarIn, ator: Atendente) -> Proposta:
+    neg = crm_svc.obter_negociacao(db, data.negociacao_id)
+    linhas_all: list[CrmNegociacaoCnpjLinha] = list(neg.linhas or [])
+    if not linhas_all:
+        raise HTTPException(status_code=400, detail="A negociação não tem linhas CNPJ.")
+    if data.linha_ids:
+        wanted = set(data.linha_ids)
+        linhas = [ln for ln in linhas_all if ln.id in wanted]
+        if len(linhas) != len(wanted):
+            raise HTTPException(status_code=400, detail="Uma ou mais linhas não pertencem a esta negociação.")
+    else:
+        linhas = sorted(linhas_all, key=lambda ln: (ln.ordem or 0, ln.id))
+    if data.template_id:
+        tmpl = obter_template(db, data.template_id, apenas_ativos=True)
+    else:
+        tmpl = garantir_template_padrao(db)
+
+    snapshot = preencher_template(db, tmpl.conteudo_html, linhas, condicoes=data.condicoes)
+
+    anteriores = (
+        db.query(Proposta)
+        .filter(Proposta.negociacao_id == neg.id, Proposta.status == PROPOSTA_RASCUNHO)
+        .all()
+    )
+    for ant in anteriores:
+        ant.status = PROPOSTA_SUBSTITUIDA
+
+    row = Proposta(
+        negociacao_id=neg.id,
+        template_id=tmpl.id,
+        gerado_por_id=ator.id,
+        status=PROPOSTA_RASCUNHO,
+        conteudo_html_snapshot=snapshot,
+        conteudo_hash=_hash_html(snapshot),
+        linha_ids=[ln.id for ln in linhas],
+    )
+    db.add(row)
+    db.flush()
+    db.add(
+        CrmNegociacaoAtividade(
+            negociacao_id=neg.id,
+            autor_id=ator.id,
+            tipo=ATIVIDADE_DOCUMENTO,
+            texto=f"Proposta #{row.id} gerada (rascunho).",
+        )
+    )
+    db.flush()
+    return row
+
+
+def garantir_pdf(db: Session, row: Proposta) -> bytes:
+    if row.pdf_storage_key:
+        path = caminho_absoluto_arquivo(row.pdf_storage_key)
+        if path:
+            return path.read_bytes()
+    pdf = html_para_pdf(row.conteudo_html_snapshot)
+    try:
+        key = gravar_bytes_em_disco(pdf, mimetype="application/pdf", nome_original=f"proposta-{row.id}.pdf")
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail="Não foi possível guardar o PDF.") from exc
+    row.pdf_storage_key = key
+    db.flush()
+    return pdf
+
+
+def marcar_enviada(db: Session, row: Proposta, data: PropostaMarcarEnviadaIn, ator: Atendente) -> Proposta:
+    if row.status == PROPOSTA_SUBSTITUIDA:
+        raise HTTPException(status_code=400, detail="Esta proposta foi substituída por uma versão mais recente.")
+    row.status = PROPOSTA_ENVIADA
+    row.canal = data.canal
+    row.enviado_em = data.enviado_em or datetime.now(timezone.utc)
+    db.add(
+        CrmNegociacaoAtividade(
+            negociacao_id=row.negociacao_id,
+            autor_id=ator.id,
+            tipo=ATIVIDADE_DOCUMENTO,
+            texto=f"Proposta #{row.id} marcada como enviada ({row.canal}).",
+        )
+    )
+    if data.avancar_funil:
+        neg = crm_svc.obter_negociacao(db, row.negociacao_id)
+        atual = crm_svc.obter_estagio(db, estagio_id=neg.estagio_id)
+        if atual.slug != "proposta_enviada":
+            crm_svc.mover_estagio(db, neg, ator=ator, estagio_slug="proposta_enviada", nota="Proposta enviada ao cliente.")
+    db.flush()
+    return row
+
+
+def proposta_para_read(row: Proposta) -> dict[str, Any]:
+    tmpl = row.template
+    return {
+        "id": row.id,
+        "negociacao_id": row.negociacao_id,
+        "template_id": row.template_id,
+        "template_nome": tmpl.nome if tmpl else None,
+        "template_versao": tmpl.versao if tmpl else None,
+        "gerado_por_id": row.gerado_por_id,
+        "status": row.status,
+        "conteudo_html_snapshot": row.conteudo_html_snapshot,
+        "conteudo_hash": row.conteudo_hash,
+        "linha_ids": list(row.linha_ids or []),
+        "canal": row.canal,
+        "enviado_em": row.enviado_em,
+        "created_at": row.created_at,
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,4 +14,4 @@ cryptography>=50.0.0
 bcrypt>=5.0.0,<6
 svix>=1.99.1
 pywebpush==2.0.3
-weasyprint==66.0
+weasyprint==69.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,4 @@ cryptography>=50.0.0
 bcrypt>=5.0.0,<6
 svix>=1.99.1
 pywebpush==2.0.3
+weasyprint==66.0

--- a/backend/tests/test_comercial_proposta.py
+++ b/backend/tests/test_comercial_proposta.py
@@ -1,0 +1,233 @@
+"""Proposta comercial — templates, montagem e PDF (#323 / #345–#347)."""
+
+from __future__ import annotations
+
+import pytest
+
+TERMOS_INTERNOS = (
+    "total_custo",
+    "margem_calculada",
+    "snapshot_custo",
+    "valor_custo",
+    "override_custo",
+    "tef_override",
+    "lucro bruto",
+)
+
+
+@pytest.fixture(autouse=True)
+def _pdf_fake(monkeypatch):
+    def _fake(html: str) -> bytes:
+        return b"%PDF-1.4\n" + html.encode("utf-8")
+
+    monkeypatch.setattr("app.services.comercial_proposta.html_para_pdf", _fake)
+
+
+def _criar_item_catalogo(client, h_admin) -> int:
+    client.post(
+        "/v1/comercial/salario-minimo",
+        headers=h_admin,
+        json={"valor": "1518.00", "vigencia_inicio": "2025-01-01", "vigencia_fim": None},
+    )
+    item = client.post(
+        "/v1/comercial/custos/itens",
+        headers=h_admin,
+        json={
+            "nome": "Licença mensal",
+            "slug": "licenca-proposta-test",
+            "tipo": "percentual_sm",
+            "percentual_sm": "10",
+            "aplica_tier_posto": False,
+            "ordem": 1,
+            "ativo": True,
+        },
+    )
+    assert item.status_code == 201, item.text
+    return item.json()["id"]
+
+
+def _negociacao_com_linha(client, h, *, item_id: int | None = None):
+    lead = client.post("/v1/crm/leads", headers=h, json={"nome": "Posto Proposta"}).json()
+    neg_id = lead["negociacao_ativa_id"]
+    payload = {
+        "razao_social": "Posto Proposta LTDA",
+        "cnpj": "12.345.678/0001-95",
+        "valor_negociado": "800.00",
+        "item_ids": [item_id] if item_id else [],
+    }
+    ln = client.post(f"/v1/crm/negociacoes/{neg_id}/linhas", headers=h, json=payload)
+    assert ln.status_code == 201, ln.text
+    return neg_id, ln.json()
+
+
+def _assert_sem_internos(texto: str | bytes) -> None:
+    blob = texto.decode("utf-8", errors="ignore") if isinstance(texto, (bytes, bytearray)) else texto
+    low = blob.lower()
+    for termo in TERMOS_INTERNOS:
+        assert termo not in low, f"vazamento de «{termo}» no documento do cliente"
+
+
+def test_atendente_403_proposta(client, auth_headers, seed_base):
+    h = auth_headers["a1"]
+    assert client.get("/v1/comercial/proposta-templates", headers=h).status_code == 403
+    assert client.get("/v1/comercial/propostas", headers=h, params={"negociacao_id": 1}).status_code == 403
+    assert client.post(
+        "/v1/comercial/propostas",
+        headers=h,
+        json={"negociacao_id": 1},
+    ).status_code == 403
+
+
+def test_comercial_403_crud_templates(client, auth_headers):
+    h = auth_headers["comercial"]
+    r = client.post(
+        "/v1/comercial/proposta-templates",
+        headers=h,
+        json={"nome": "X", "conteudo_html": "<p>{{razao_social}}</p>"},
+    )
+    assert r.status_code == 403
+
+
+def test_admin_crud_template_e_preview_sanitiza(client, auth_headers):
+    h = auth_headers["admin"]
+    created = client.post(
+        "/v1/comercial/proposta-templates",
+        headers=h,
+        json={
+            "nome": "Institucional",
+            "conteudo_html": "<h1>{{razao_social}}</h1><script>alert(1)</script>",
+        },
+    )
+    assert created.status_code == 201, created.text
+    body = created.json()
+    assert body["versao"] == 1
+    assert "<script" not in body["conteudo_html"].lower()
+
+    prev = client.post(
+        "/v1/comercial/proposta-templates/preview",
+        headers=h,
+        json={"conteudo_html": '<p onclick="x()">Oi</p><iframe src="x"></iframe>'},
+    )
+    assert prev.status_code == 200
+    html = prev.json()["html"]
+    assert "onclick" not in html.lower()
+    assert "iframe" not in html.lower()
+
+    patched = client.patch(
+        f"/v1/comercial/proposta-templates/{body['id']}",
+        headers=h,
+        json={"conteudo_html": "<p>Olá {{cnpj}}</p>"},
+    )
+    assert patched.status_code == 200
+    assert "Olá" in patched.json()["conteudo_html"]
+
+    lista = client.get("/v1/comercial/proposta-templates", headers=h)
+    assert lista.status_code == 200
+    assert any(t["id"] == body["id"] for t in lista.json())
+
+
+def test_comercial_gera_proposta_sem_custo_e_pdf(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    item_id = _criar_item_catalogo(client, auth_headers["admin"])
+    neg_id, linha = _negociacao_com_linha(client, h, item_id=item_id)
+
+    gerada = client.post(
+        "/v1/comercial/propostas",
+        headers=h,
+        json={
+            "negociacao_id": neg_id,
+            "linha_ids": [linha["id"]],
+            "condicoes": "Pagamento até o dia 10.",
+        },
+    )
+    assert gerada.status_code == 201, gerada.text
+    prop = gerada.json()
+    assert prop["status"] == "rascunho"
+    html = prop["conteudo_html_snapshot"]
+    assert "Posto Proposta LTDA" in html
+    assert "800" in html
+    assert "Licença mensal" in html
+    assert "Pagamento até o dia 10" in html
+    _assert_sem_internos(html)
+    assert "margem" not in html.lower()
+    assert "custo" not in html.lower()
+
+    pdf = client.get(f"/v1/comercial/propostas/{prop['id']}/pdf", headers=h)
+    assert pdf.status_code == 200
+    assert pdf.headers["content-type"].startswith("application/pdf")
+    _assert_sem_internos(pdf.content)
+    assert b"custo" not in pdf.content.lower()
+    assert b"margem" not in pdf.content.lower()
+
+    lst = client.get("/v1/comercial/propostas", headers=h, params={"negociacao_id": neg_id})
+    assert lst.status_code == 200
+    assert len(lst.json()) == 1
+
+
+def test_regeneracao_invalida_rascunho_e_preserva_snapshot(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    h_adm = auth_headers["admin"]
+    neg_id, _ = _negociacao_com_linha(client, h)
+
+    t1 = client.get("/v1/comercial/proposta-templates", headers=h)
+    assert t1.status_code == 200, t1.text
+    tmpl_id = t1.json()[0]["id"]
+
+    p1 = client.post(
+        "/v1/comercial/propostas",
+        headers=h,
+        json={"negociacao_id": neg_id, "template_id": tmpl_id, "condicoes": "v1"},
+    )
+    assert p1.status_code == 201, p1.text
+    html_v1 = p1.json()["conteudo_html_snapshot"]
+    assert "v1" in html_v1
+
+    client.patch(
+        f"/v1/comercial/proposta-templates/{tmpl_id}",
+        headers=h_adm,
+        json={"conteudo_html": "<p>NOVO {{razao_social}}</p><div>{{condicoes}}</div>"},
+    )
+
+    p2 = client.post(
+        "/v1/comercial/propostas",
+        headers=h,
+        json={"negociacao_id": neg_id, "template_id": tmpl_id, "condicoes": "v2"},
+    )
+    assert p2.status_code == 201, p2.text
+    assert p2.json()["id"] != p1.json()["id"]
+
+    antiga = client.get(f"/v1/comercial/propostas/{p1.json()['id']}", headers=h)
+    assert antiga.status_code == 200
+    assert antiga.json()["status"] == "substituida"
+    assert antiga.json()["conteudo_html_snapshot"] == html_v1
+    assert "NOVO" not in antiga.json()["conteudo_html_snapshot"]
+
+    nova = client.get(f"/v1/comercial/propostas/{p2.json()['id']}", headers=h)
+    assert nova.json()["status"] == "rascunho"
+    assert "v2" in nova.json()["conteudo_html_snapshot"]
+    assert "NOVO" in nova.json()["conteudo_html_snapshot"]
+
+
+def test_marcar_enviada_avanca_funil(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    neg_id, _ = _negociacao_com_linha(client, h)
+    p = client.post("/v1/comercial/propostas", headers=h, json={"negociacao_id": neg_id})
+    assert p.status_code == 201, p.text
+
+    env = client.post(
+        f"/v1/comercial/propostas/{p.json()['id']}/marcar-enviada",
+        headers=h,
+        json={"canal": "email", "avancar_funil": True},
+    )
+    assert env.status_code == 200, env.text
+    assert env.json()["status"] == "enviada"
+    assert env.json()["canal"] == "email"
+    assert env.json()["enviado_em"]
+
+    neg = client.get(f"/v1/crm/negociacoes/{neg_id}", headers=h)
+    assert neg.status_code == 200
+    assert neg.json()["estagio_slug"] == "proposta_enviada"
+
+    acts = client.get(f"/v1/crm/negociacoes/{neg_id}/atividades", headers=h)
+    textos = " ".join(a["texto"] for a in acts.json()["items"])
+    assert "enviada" in textos.lower()

--- a/docs/BACKEND_RBAC.md
+++ b/docs/BACKEND_RBAC.md
@@ -34,6 +34,7 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 | Catálogo comercial (CRUD) | `POST/PATCH/DELETE /v1/comercial/salario-minimo*`, `POST/PATCH/DELETE /v1/comercial/custos/itens*` |
 | Catálogo comercial (leitura itens) | `GET /v1/comercial/custos/itens` — também comercial (montar pacote na negociação) |
 | Funil CRM (mutação) | `POST/PATCH /v1/crm/funil-estagios` — UI em Configurações → Cadastros → Funil CRM |
+| Modelos de proposta (CRUD) | `POST/PATCH /v1/comercial/proposta-templates`, `POST /v1/comercial/proposta-templates/preview` — UI em Cadastros → Modelos de proposta |
 
 ## Comercial ou administrador (`exigir_comercial_ou_admin`)
 
@@ -43,6 +44,7 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 | **Funil (leitura)** | `GET /v1/crm/funil-estagios` |
 | **Simular custos** | `POST /v1/comercial/custos/simular` |
 | **Listar itens catálogo** | `GET /v1/comercial/custos/itens` (mutações continuam só admin) |
+| **Proposta comercial** | `GET /v1/comercial/proposta-templates` (ativos), `POST/GET /v1/comercial/propostas*`, `GET .../pdf`, `POST .../marcar-enviada` |
 
 ## Autenticado com escopo de setor (`obter_atendente_atual`)
 
@@ -71,3 +73,4 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 - **Tickets / novo ticket**: listas de **setores** e **empresas** seguem o filtro da API; não se recorta setor no cliente por `setor_ids` do `/me` (homônimos). Quando o atendente ainda não tem empresas no escopo, o UI explica o critério da rede com ticket nos setores dele.
 - **403**: mensagens vêm do corpo da API (`api/client` + `errorMessage.ts`).
 - **CRM UI** (#341–#344): menu **CRM** e rotas `/crm/leads`, `/crm/negociacoes/:id` para `admin` e `comercial`.
+- **Proposta** (#345–#348): card na negociação para comercial/admin; CRUD de templates só admin.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { TicketNovo } from './pages/TicketNovo'
 import { CrmLeads } from './pages/CrmLeads'
 import { CrmNegociacaoDetalhe } from './pages/CrmNegociacaoDetalhe'
 import { ConfigCrmFunil } from './pages/ConfigCrmFunil'
+import { ConfigPropostaTemplates } from './pages/ConfigPropostaTemplates'
 import { Redes } from './pages/Redes'
 import { RedeDetalhe } from './pages/RedeDetalhe'
 import { RedeForm } from './pages/RedeForm'
@@ -715,6 +716,7 @@ function AppRoutes() {
           <Route path="pdv" element={<ConfigPdvCatalogos embedded />} />
           <Route path="custos" element={<ConfigComercialCustos embedded />} />
           <Route path="funil-crm" element={<ConfigCrmFunil embedded />} />
+          <Route path="propostas" element={<ConfigPropostaTemplates embedded />} />
         </Route>
         <Route
           path="configuracoes/sistema"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2979,6 +2979,111 @@ export namespace ComercialCustos {
   }
 }
 
+export namespace ComercialProposta {
+  export interface Template {
+    id: number;
+    nome: string;
+    versao: number;
+    conteudo_html: string;
+    vigencia_inicio?: string | null;
+    ativo: boolean;
+    created_at: string;
+  }
+  export interface TemplateCreate {
+    nome: string;
+    conteudo_html: string;
+    vigencia_inicio?: string | null;
+    ativo?: boolean;
+  }
+  export interface TemplateUpdate {
+    nome?: string;
+    conteudo_html?: string;
+    vigencia_inicio?: string | null;
+    ativo?: boolean;
+  }
+  export interface Proposta {
+    id: number;
+    negociacao_id: number;
+    template_id: number;
+    template_nome?: string | null;
+    template_versao?: number | null;
+    gerado_por_id: number;
+    status: 'rascunho' | 'enviada' | 'substituida' | string;
+    conteudo_html_snapshot: string;
+    conteudo_hash: string;
+    linha_ids: number[];
+    canal?: string | null;
+    enviado_em?: string | null;
+    created_at: string;
+  }
+  export interface GerarRequest {
+    negociacao_id: number;
+    template_id?: number | null;
+    linha_ids?: number[] | null;
+    condicoes?: string | null;
+  }
+  export interface MarcarEnviadaRequest {
+    canal: 'email' | 'impresso' | 'outro';
+    enviado_em?: string | null;
+    avancar_funil?: boolean;
+  }
+}
+
+export const comercialPropostaTemplates = {
+  list: (params?: { incluir_inativos?: boolean }) =>
+    api<ComercialProposta.Template[]>(withParams('/comercial/proposta-templates', params)),
+  create: (data: ComercialProposta.TemplateCreate) =>
+    api<ComercialProposta.Template>('/comercial/proposta-templates', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  update: (id: number, data: ComercialProposta.TemplateUpdate) =>
+    api<ComercialProposta.Template>(`/comercial/proposta-templates/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+  preview: (conteudo_html: string) =>
+    api<{ html: string }>('/comercial/proposta-templates/preview', {
+      method: 'POST',
+      body: JSON.stringify({ conteudo_html }),
+    }),
+};
+
+export const comercialPropostas = {
+  list: (negociacao_id: number) =>
+    api<ComercialProposta.Proposta[]>(withParams('/comercial/propostas', { negociacao_id })),
+  get: (id: number) => api<ComercialProposta.Proposta>(`/comercial/propostas/${id}`),
+  gerar: (data: ComercialProposta.GerarRequest) =>
+    api<ComercialProposta.Proposta>('/comercial/propostas', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  marcarEnviada: (id: number, data: ComercialProposta.MarcarEnviadaRequest) =>
+    api<ComercialProposta.Proposta>(`/comercial/propostas/${id}/marcar-enviada`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  downloadPdf: async (id: number) => {
+    const token = getAuthToken();
+    const headers: Record<string, string> = {};
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname());
+    }
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const url = `${BASE}${API_VERSION_PREFIX}/comercial/propostas/${id}/pdf`;
+    const res = await fetch(url, { headers });
+    if (res.status === 401) {
+      invalidateSessionAndRedirectToLogin();
+      throw new ApiError('Sessão expirada ou inválida.', 401, {});
+    }
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}));
+      throw new ApiError(mensagemErroApi(errBody, res.status), res.status, errBody);
+    }
+    return res.blob();
+  },
+};
+
 export const crmFunil = {
   list: (params?: { incluir_inativos?: boolean }) =>
     api<Crm.FunilEstagio[]>(withParams('/crm/funil-estagios', params)),

--- a/frontend/src/components/crm/CrmPropostaCard.tsx
+++ b/frontend/src/components/crm/CrmPropostaCard.tsx
@@ -1,0 +1,331 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  comercialPropostaTemplates,
+  comercialPropostas,
+  type ComercialProposta,
+  type Crm,
+} from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { Button } from '../ui/Button'
+import { Card } from '../ui/Card'
+import { Input, TEXTAREA_FIELD_CLASS } from '../ui/Input'
+import { Select } from '../ui/Select'
+import { useToast } from '../ui/Toast'
+
+const STATUS_LABEL: Record<string, string> = {
+  rascunho: 'Rascunho',
+  enviada: 'Enviada',
+  substituida: 'Substituída',
+}
+
+const CANAL_OPTIONS = [
+  { value: 'email', label: 'E-mail' },
+  { value: 'impresso', label: 'Impresso' },
+  { value: 'outro', label: 'Outro' },
+]
+
+function formatDateTime(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+type Props = {
+  negociacao: Crm.Negociacao
+  onChanged: () => void
+}
+
+export function CrmPropostaCard({ negociacao, onChanged }: Props) {
+  const toast = useToast()
+  const linhas = negociacao.linhas || []
+
+  const [templates, setTemplates] = useState<ComercialProposta.Template[]>([])
+  const [propostas, setPropostas] = useState<ComercialProposta.Proposta[]>([])
+  const [templateId, setTemplateId] = useState<number | ''>('')
+  const [linhaIds, setLinhaIds] = useState<number[]>([])
+  const [condicoes, setCondicoes] = useState('')
+  const [gerando, setGerando] = useState(false)
+  const [preview, setPreview] = useState<ComercialProposta.Proposta | null>(null)
+
+  const [enviarId, setEnviarId] = useState<number | null>(null)
+  const [canal, setCanal] = useState<'email' | 'impresso' | 'outro'>('email')
+  const [enviadoEm, setEnviadoEm] = useState('')
+  const [avancarFunil, setAvancarFunil] = useState(true)
+  const [marcando, setMarcando] = useState(false)
+  const [baixandoId, setBaixandoId] = useState<number | null>(null)
+
+  const load = useCallback(async () => {
+    const [tmpls, props] = await Promise.all([
+      comercialPropostaTemplates.list(),
+      comercialPropostas.list(negociacao.id),
+    ])
+    setTemplates(tmpls)
+    setPropostas(props)
+    setTemplateId((prev) => {
+      if (prev !== '' && tmpls.some((t) => t.id === prev)) return prev
+      return tmpls[0]?.id ?? ''
+    })
+    const rascunho = props.find((p) => p.status === 'rascunho')
+    setPreview((atual) => {
+      if (atual && props.some((p) => p.id === atual.id)) {
+        return props.find((p) => p.id === atual.id) || rascunho || props[0] || null
+      }
+      return rascunho || props[0] || null
+    })
+  }, [negociacao.id])
+
+  useEffect(() => {
+    void load().catch((err) => {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar as propostas.'))
+    })
+  }, [load, toast])
+
+  useEffect(() => {
+    setLinhaIds((negociacao.linhas || []).map((ln) => ln.id))
+  }, [negociacao])
+
+  const templateOptions = useMemo(
+    () => templates.map((t) => ({ value: String(t.id), label: `${t.nome} (v${t.versao})` })),
+    [templates],
+  )
+
+  function toggleLinha(id: number) {
+    setLinhaIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+  }
+
+  async function handleGerar() {
+    if (linhas.length === 0) {
+      toast.showWarning('Adicione pelo menos uma linha CNPJ antes de gerar a proposta.')
+      return
+    }
+    if (linhaIds.length === 0) {
+      toast.showWarning('Selecione pelo menos um CNPJ.')
+      return
+    }
+    setGerando(true)
+    try {
+      const row = await comercialPropostas.gerar({
+        negociacao_id: negociacao.id,
+        template_id: templateId === '' ? null : templateId,
+        linha_ids: linhaIds,
+        condicoes: condicoes.trim() || null,
+      })
+      setPreview(row)
+      toast.showSuccess('Proposta gerada. Revise o preview antes de enviar.')
+      await load()
+      onChanged()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível gerar a proposta.'))
+    } finally {
+      setGerando(false)
+    }
+  }
+
+  async function handlePdf(id: number) {
+    setBaixandoId(id)
+    try {
+      const blob = await comercialPropostas.downloadPdf(id)
+      downloadBlob(blob, `proposta-${id}.pdf`)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível baixar o PDF.'))
+    } finally {
+      setBaixandoId(null)
+    }
+  }
+
+  async function handleMarcarEnviada() {
+    if (enviarId == null) return
+    setMarcando(true)
+    try {
+      await comercialPropostas.marcarEnviada(enviarId, {
+        canal,
+        enviado_em: enviadoEm ? new Date(enviadoEm).toISOString() : null,
+        avancar_funil: avancarFunil,
+      })
+      toast.showSuccess(
+        avancarFunil ? 'Proposta marcada como enviada e funil atualizado.' : 'Proposta marcada como enviada.',
+      )
+      setEnviarId(null)
+      await load()
+      onChanged()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível marcar a proposta como enviada.'))
+    } finally {
+      setMarcando(false)
+    }
+  }
+
+  return (
+    <Card title="Proposta comercial">
+      <p className="mb-3 text-sm text-slate-500">
+        O documento enviado ao cliente mostra só itens e valores negociados — custo e margem ficam só nesta tela.
+      </p>
+
+      {linhas.length === 0 ? (
+        <p className="text-sm text-slate-500">Cadastre linhas CNPJ para gerar a proposta.</p>
+      ) : (
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-slate-700 dark:text-slate-300">CNPJs incluídos</p>
+            {linhas.map((ln) => (
+              <label key={ln.id} className="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+                <input
+                  type="checkbox"
+                  checked={linhaIds.includes(ln.id)}
+                  onChange={() => toggleLinha(ln.id)}
+                  className="size-4 rounded border-slate-300"
+                />
+                <span>
+                  {ln.razao_social || 'Sem razão social'} · {ln.cnpj || 'sem CNPJ'}
+                </span>
+              </label>
+            ))}
+          </div>
+          {templateOptions.length > 0 ? (
+            <Select
+              label="Modelo"
+              value={templateId === '' ? '' : String(templateId)}
+              onChange={(v) => setTemplateId(v ? Number(v) : '')}
+              options={templateOptions}
+            />
+          ) : (
+            <p className="text-xs text-slate-500">Nenhum modelo ativo. O sistema usa o padrão na primeira geração.</p>
+          )}
+          <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+            Condições (opcional)
+            <textarea
+              value={condicoes}
+              onChange={(e) => setCondicoes(e.target.value)}
+              rows={3}
+              className={`mt-1 ${TEXTAREA_FIELD_CLASS}`}
+              placeholder="Prazo, forma de pagamento, observações visíveis ao cliente…"
+            />
+          </label>
+          <Button onClick={() => void handleGerar()} disabled={gerando}>
+            {gerando ? 'Gerando…' : 'Gerar proposta'}
+          </Button>
+        </div>
+      )}
+
+      {preview ? (
+        <div className="mt-4">
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <p className="text-sm font-medium text-slate-700 dark:text-slate-300">
+              Preview — proposta #{preview.id} ({STATUS_LABEL[preview.status] || preview.status})
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant="secondary"
+                onClick={() => void handlePdf(preview.id)}
+                disabled={baixandoId === preview.id}
+              >
+                {baixandoId === preview.id ? 'Baixando…' : 'Baixar PDF'}
+              </Button>
+              {preview.status === 'rascunho' ? (
+                <Button variant="secondary" onClick={() => setEnviarId(preview.id)}>
+                  Marcar enviada
+                </Button>
+              ) : null}
+            </div>
+          </div>
+          <iframe
+            title={`Preview da proposta ${preview.id}`}
+            sandbox=""
+            srcDoc={preview.conteudo_html_snapshot}
+            className="h-80 w-full rounded-lg border border-slate-200 bg-white dark:border-slate-700"
+          />
+        </div>
+      ) : null}
+
+      {propostas.length > 0 ? (
+        <div className="mt-4">
+          <p className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-300">Propostas anteriores</p>
+          <ul className="space-y-2 text-sm">
+            {propostas.map((p) => (
+              <li
+                key={p.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-700"
+              >
+                <div>
+                  <span className="font-medium text-slate-900 dark:text-slate-100">#{p.id}</span>
+                  {' · '}
+                  {STATUS_LABEL[p.status] || p.status}
+                  {p.template_nome ? ` · ${p.template_nome} v${p.template_versao}` : ''}
+                  <div className="text-xs text-slate-500">
+                    {formatDateTime(p.created_at)}
+                    {p.enviado_em
+                      ? ` · enviada ${formatDateTime(p.enviado_em)} (${CANAL_OPTIONS.find((c) => c.value === p.canal)?.label || p.canal})`
+                      : ''}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <Button variant="ghost" onClick={() => setPreview(p)}>
+                    Ver
+                  </Button>
+                  <Button variant="ghost" onClick={() => void handlePdf(p.id)} disabled={baixandoId === p.id}>
+                    PDF
+                  </Button>
+                  {p.status !== 'substituida' && p.status !== 'enviada' ? (
+                    <Button variant="ghost" onClick={() => setEnviarId(p.id)}>
+                      Enviada
+                    </Button>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {enviarId != null ? (
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-0 sm:items-center sm:p-4">
+          <div className="w-full rounded-t-2xl bg-white p-5 shadow-xl dark:bg-slate-900 sm:max-w-md sm:rounded-2xl">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Marcar proposta como enviada</h2>
+            <p className="mt-1 text-sm text-slate-500">Não envia e-mail automático — só registra o canal e a data.</p>
+            <div className="mt-4 space-y-3">
+              <Select
+                label="Canal"
+                value={canal}
+                onChange={(v) => setCanal(String(v) as 'email' | 'impresso' | 'outro')}
+                options={CANAL_OPTIONS}
+              />
+              <Input
+                label="Data de envio (opcional)"
+                type="datetime-local"
+                value={enviadoEm}
+                onChange={(e) => setEnviadoEm(e.target.value)}
+              />
+              <label className="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+                <input
+                  type="checkbox"
+                  checked={avancarFunil}
+                  onChange={(e) => setAvancarFunil(e.target.checked)}
+                  className="size-4 rounded border-slate-300"
+                />
+                Avançar funil para «Proposta enviada»
+              </label>
+              <div className="flex justify-end gap-2 pt-2">
+                <Button type="button" variant="secondary" onClick={() => setEnviarId(null)} disabled={marcando}>
+                  Cancelar
+                </Button>
+                <Button onClick={() => void handleMarcarEnviada()} disabled={marcando}>
+                  {marcando ? 'Salvando…' : 'Confirmar'}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </Card>
+  )
+}

--- a/frontend/src/pages/ConfigPropostaTemplates.tsx
+++ b/frontend/src/pages/ConfigPropostaTemplates.tsx
@@ -1,0 +1,250 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ApiError, comercialPropostaTemplates, type ComercialProposta } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Button } from '../components/ui/Button'
+import { Card } from '../components/ui/Card'
+import { Input, TEXTAREA_FIELD_CLASS } from '../components/ui/Input'
+import { Switch } from '../components/ui/Switch'
+import { FiltroInativos } from '../components/ui/FiltroInativos'
+import { IconPencil } from '../components/ui/IconPencil'
+import { useToast } from '../components/ui/Toast'
+import { ConfigListPageShell } from '../components/config/ConfigListPageShell'
+import { SemPermissao } from './SemPermissao'
+
+const PLACEHOLDERS =
+  '{{razao_social}}, {{cnpj}}, {{itens}}, {{valor_mensalidade}}, {{condicoes}}, {{logo}}, {{empresa_sistema}}'
+
+type FormState = {
+  nome: string
+  conteudo_html: string
+  ativo: boolean
+}
+
+const emptyForm = (): FormState => ({
+  nome: '',
+  conteudo_html: '',
+  ativo: true,
+})
+
+export function ConfigPropostaTemplates({ embedded = false }: { embedded?: boolean }) {
+  const toast = useToast()
+  const [list, setList] = useState<ComercialProposta.Template[]>([])
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [incluirInativos, setIncluirInativos] = useState(false)
+  const [modal, setModal] = useState<'create' | ComercialProposta.Template | null>(null)
+  const [form, setForm] = useState<FormState>(emptyForm())
+  const [saving, setSaving] = useState(false)
+  const [previewHtml, setPreviewHtml] = useState<string | null>(null)
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    comercialPropostaTemplates
+      .list({ incluir_inativos: incluirInativos })
+      .then(setList)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar os modelos.'))
+        setList([])
+      })
+      .finally(() => setLoading(false))
+  }, [incluirInativos, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  function openCreate() {
+    setForm(emptyForm())
+    setPreviewHtml(null)
+    setModal('create')
+  }
+
+  function openEdit(row: ComercialProposta.Template) {
+    setForm({
+      nome: row.nome,
+      conteudo_html: row.conteudo_html,
+      ativo: row.ativo,
+    })
+    setPreviewHtml(null)
+    setModal(row)
+  }
+
+  async function handlePreview() {
+    if (!form.conteudo_html.trim()) {
+      toast.showWarning('Informe o HTML do modelo.')
+      return
+    }
+    try {
+      const r = await comercialPropostaTemplates.preview(form.conteudo_html)
+      setPreviewHtml(r.html)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível gerar o preview.'))
+    }
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    if (!form.nome.trim() || !form.conteudo_html.trim()) {
+      toast.showWarning('Informe nome e HTML do modelo.')
+      return
+    }
+    setSaving(true)
+    try {
+      if (modal === 'create') {
+        await comercialPropostaTemplates.create({
+          nome: form.nome.trim(),
+          conteudo_html: form.conteudo_html,
+          ativo: form.ativo,
+        })
+        toast.showSuccess('Modelo criado.')
+      } else if (modal && typeof modal === 'object') {
+        await comercialPropostaTemplates.update(modal.id, {
+          nome: form.nome.trim(),
+          conteudo_html: form.conteudo_html,
+          ativo: form.ativo,
+        })
+        toast.showSuccess('Modelo atualizado. Propostas já geradas não mudam.')
+      }
+      setModal(null)
+      load()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o modelo.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const denied = (
+    <SemPermissao
+      title="Você não tem permissão para configurar modelos de proposta."
+      detail="Apenas administradores gerem os templates da proposta comercial."
+      voltarPara="/"
+      voltarLabel="Voltar para o Dashboard"
+    />
+  )
+
+  return (
+    <ConfigListPageShell
+      embedded={embedded}
+      forbidden={forbidden}
+      denied={denied}
+      title="Modelos de proposta"
+      actions={<Button onClick={openCreate}>Novo modelo</Button>}
+    >
+      <p className="mb-3 text-sm text-slate-500 dark:text-slate-400">
+        HTML usado ao gerar a proposta na negociação. Placeholders: {PLACEHOLDERS}. Não inclua custo ou margem —
+        esses dados são internos.
+      </p>
+      <Card>
+        <div className="mb-3">
+          <FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />
+        </div>
+        {loading ? (
+          <p className="text-slate-500">Carregando…</p>
+        ) : list.length === 0 ? (
+          <p className="text-slate-500">Nenhum modelo encontrado.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[560px] text-left text-sm">
+              <thead>
+                <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Nome</th>
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Versão</th>
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Ativo</th>
+                  <th className="px-3 py-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {list.map((row) => (
+                  <tr key={row.id} className="border-b border-slate-100 dark:border-slate-800/80">
+                    <td className="px-3 py-2.5 font-medium text-slate-900 dark:text-slate-100">{row.nome}</td>
+                    <td className="px-3 py-2.5 text-slate-600">v{row.versao}</td>
+                    <td className="px-3 py-2.5">{row.ativo ? 'Sim' : 'Não'}</td>
+                    <td className="px-3 py-2.5 text-right">
+                      <button
+                        type="button"
+                        onClick={() => openEdit(row)}
+                        className="inline-flex size-8 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
+                        aria-label={`Editar ${row.nome}`}
+                      >
+                        <IconPencil />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+
+      {modal ? (
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-0 sm:items-center sm:p-4">
+          <div className="max-h-[92vh] w-full overflow-y-auto rounded-t-2xl bg-white p-5 shadow-xl dark:bg-slate-900 sm:max-w-2xl sm:rounded-2xl">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              {modal === 'create' ? 'Novo modelo' : 'Editar modelo'}
+            </h2>
+            <form onSubmit={handleSave} className="mt-4 space-y-3">
+              <Input
+                label="Nome"
+                value={form.nome}
+                onChange={(e) => setForm((p) => ({ ...p, nome: e.target.value }))}
+                required
+              />
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+                HTML
+                <textarea
+                  value={form.conteudo_html}
+                  onChange={(e) => setForm((p) => ({ ...p, conteudo_html: e.target.value }))}
+                  rows={12}
+                  required
+                  className={`mt-1 font-mono text-xs ${TEXTAREA_FIELD_CLASS}`}
+                />
+              </label>
+              <Switch
+                bare
+                checked={form.ativo}
+                onCheckedChange={(ativo) => setForm((p) => ({ ...p, ativo }))}
+                label="Modelo ativo"
+                description="Inativos não aparecem na geração da proposta."
+                showStatusPill
+                statusOnText="Ativo"
+                statusOffText="Inativo"
+              />
+              {previewHtml ? (
+                <div>
+                  <p className="mb-1 text-xs text-slate-500">
+                    Sanitiza o HTML. Placeholders só são preenchidos ao gerar a proposta na negociação.
+                  </p>
+                  <iframe
+                    title="Preview do modelo"
+                    sandbox=""
+                    srcDoc={previewHtml}
+                    className="h-64 w-full rounded-lg border border-slate-200 bg-white dark:border-slate-700"
+                  />
+                </div>
+              ) : null}
+              <div className="flex flex-wrap justify-end gap-2 pt-2">
+                <Button type="button" variant="secondary" onClick={() => setModal(null)} disabled={saving}>
+                  Cancelar
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => void handlePreview()} disabled={saving}>
+                  Preview
+                </Button>
+                <Button type="submit" disabled={saving}>
+                  {saving ? 'Salvando…' : 'Salvar'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </ConfigListPageShell>
+  )
+}

--- a/frontend/src/pages/CrmNegociacaoDetalhe.tsx
+++ b/frontend/src/pages/CrmNegociacaoDetalhe.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import {
   ApiError,
@@ -20,6 +20,7 @@ import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { SemPermissao } from './SemPermissao'
+import { CrmPropostaCard } from '../components/crm/CrmPropostaCard'
 
 const TIPO_ATIVIDADE_LABEL: Record<string, string> = {
   nota: 'Nota',
@@ -107,6 +108,7 @@ export function CrmNegociacaoDetalhe() {
 
   const [notaTexto, setNotaTexto] = useState('')
   const [savingNota, setSavingNota] = useState(false)
+  const loadedOnceRef = useRef(false)
 
   const load = useCallback(async () => {
     if (!id || Number.isNaN(negociacaoId)) {
@@ -114,7 +116,7 @@ export function CrmNegociacaoDetalhe() {
       setLoading(false)
       return
     }
-    setLoading(true)
+    if (!loadedOnceRef.current) setLoading(true)
     setForbidden(false)
     setFalha(null)
     try {
@@ -129,6 +131,7 @@ export function CrmNegociacaoDetalhe() {
       setLead(l)
       setEstagios(funil)
       setAtividades(acts.items)
+      loadedOnceRef.current = true
     } catch (err) {
       if (err instanceof ApiError && err.status === 403) {
         setForbidden(true)
@@ -449,6 +452,8 @@ export function CrmNegociacaoDetalhe() {
           </div>
         )}
       </Card>
+
+      <CrmPropostaCard negociacao={neg} onChanged={() => void load()} />
 
       <Card title="Histórico">
         <form onSubmit={handleAddNota} className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end">

--- a/frontend/src/pages/config/ConfigCadastrosLayout.tsx
+++ b/frontend/src/pages/config/ConfigCadastrosLayout.tsx
@@ -7,6 +7,7 @@ const TABS = [
   { to: '/configuracoes/cadastros/pdv', label: 'Catálogos PDV' },
   { to: '/configuracoes/cadastros/custos', label: 'Catálogo de custos' },
   { to: '/configuracoes/cadastros/funil-crm', label: 'Funil CRM' },
+  { to: '/configuracoes/cadastros/propostas', label: 'Modelos de proposta' },
 ] as const
 
 const TAB_HINTS: Record<string, string> = {
@@ -14,6 +15,7 @@ const TAB_HINTS: Record<string, string> = {
   pdv: 'Rótulos de dispositivo e tipos de acesso remoto usados no cadastro de PDVs por empresa.',
   custos: 'Salário mínimo com vigência, perfis/módulos de custo e simulador estimado para negociação.',
   'funil-crm': 'Estágios do funil comercial (Lead, Em negociação…). Usados na lista e no Kanban do CRM.',
+  propostas: 'HTML dos modelos da proposta comercial. Placeholders são preenchidos na negociação.',
 }
 
 function abaAtiva(pathname: string): string {
@@ -27,7 +29,7 @@ export function ConfigCadastrosLayout() {
 
   return (
     <PageContainer>
-      <PageHeader title="Cadastros" subtitle="Tipos de negócio, catálogos de PDV, custos comerciais e funil CRM." />
+      <PageHeader title="Cadastros" subtitle="Tipos de negócio, catálogos de PDV, custos, funil CRM e modelos de proposta." />
       <ConfigSectionTabs tabs={[...TABS]} ariaLabel="Seções de cadastros" />
       {hint ? <p className="text-sm text-slate-600 dark:text-slate-400">{hint}</p> : null}
       <Outlet />


### PR DESCRIPTION
## Summary

Lote da proposta comercial (#323 / #345–#348): o comercial gera um PDF a partir da negociação, com modelo HTML versionado, sem custo/margem no documento do cliente.

- **#345** — templates CRUD (admin), preview sanitizado, snapshot imutável na geração
- **#346** — montagem 1/N CNPJs; re-gerar invalida só o rascunho (enviada permanece)
- **#347** — PDF WeasyPrint, marcar enviada (canal + data, sem e-mail automático), audit
- **#348** — UI na negociação (gerar, preview, PDF, lista, funil opcional) + aba em Cadastros

Closes #323
Closes #345
Closes #346
Closes #347
Closes #348

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] Admin: Cadastros → Modelos de proposta (listar Padrão, criar, preview, salvar)
- [x] Comercial/admin: na negociação, adicionar linha CNPJ, gerar proposta, preview sem custo/margem
- [x] Baixar PDF (WeasyPrint) e marcar enviada com avanço de funil para «Proposta enviada»
- [x] Re-gerar: rascunho anterior vira Substituída; enviada permanece
- [x] Comercial: gera proposta; 403 em Cadastros/modelos
- [x] Atendente: sem CRM no menu; 403 em negociação e em modelos
- [x] `pytest` local (lote) e `npm run build`

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] ClickSign / contratos / envio de e-mail automático — já no épico seguinte (#324+)
- [x] SSE fora de escopo v1 (não há evento em tempo real nesta entrega)
- [ ] Polish opcional (não bloqueia): preview do modelo com dados de exemplo; máscara de CNPJ no checkbox da negociação
