### PR TITLE
fix(deploy): SSH IPv4 e retry noutro runner (#734)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,9 @@
 #
 # Opcional: crie um Environment "production" com estes secrets e descomente "environment: production" abaixo.
 #
-# SSH intermitente: git pull e rsync usam retry inline (5 tentativas, 15s entre elas).
-# Se ainda falhar com "Connection timed out", re-run do job no GitHub Actions - ver deploy/github-actions.md.
+# SSH (#734): IPv4 obrigatorio; keyscan sem || true; IP do runner no log.
+# Timeout TCP: o job deploy-retry corre noutro ubuntu-latest (IP novo) e reutiliza o artefacto do frontend.
+# Ver deploy/github-actions.md.
 
 name: Deploy
 
@@ -37,32 +38,27 @@ on:
       - "CHANGELOG.md"
       - "scripts/**"
       - "docs/releases/**"
+      - "deploy/scripts/**"
 
 concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+env:
+  EVENT_REF: ${{ github.ref_name }}
+  SKIP_MIGRATIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_migrations == true || false }}
+
 jobs:
-  deploy:
+  prepare:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]'))
     permissions:
-      contents: write
-    # environment: production
-
+      contents: read
     env:
-      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
-      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
-      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
-      DEPLOY_FRONTEND_DIST: ${{ secrets.DEPLOY_FRONTEND_DIST }}
       VITE_API_URL: ${{ secrets.VITE_API_URL }}
-      SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT }}
       DEPLOY_GIT_REF: ${{ secrets.DEPLOY_GIT_REF }}
-      EVENT_REF: ${{ github.ref_name }}
-      DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
-      # workflow_dispatch: checkbox; push: primeiro termo e false (short-circuit, nao avalia inputs)
-      SKIP_MIGRATIONS: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_migrations == true || false }}
-
+    outputs:
+      expected_deploy_sha: ${{ steps.sha.outputs.sha }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -70,10 +66,12 @@ jobs:
           fetch-depth: 0
 
       - name: Resolver SHA esperado no ref deployado
+        id: sha
         run: |
           REF="${EVENT_REF:-${DEPLOY_GIT_REF:-staging}}"
           git fetch origin "${REF}"
           SHA="$(git rev-parse --short "origin/${REF}")"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
           echo "EXPECTED_DEPLOY_SHA=${SHA}" >> "$GITHUB_ENV"
           echo "SHA esperado em producao (origin/${REF}): ${SHA}"
 
@@ -94,248 +92,113 @@ jobs:
           npm ci
           npm run build
 
-      - name: Validar secrets de deploy
+      - name: Empacotar artefacto de deploy
         run: |
-          if [ -z "${DEPLOY_HOST:-}" ] || [ -z "${DEPLOY_USER:-}" ] || [ -z "${DEPLOY_PATH:-}" ] || [ -z "${DEPLOY_FRONTEND_DIST:-}" ]; then
-            echo "::error::Defina DEPLOY_HOST, DEPLOY_USER, DEPLOY_PATH e DEPLOY_FRONTEND_DIST."
-            exit 1
-          fi
-          if [ -z "${DEPLOY_SSH_KEY:-}" ]; then
-            echo "::error::Defina DEPLOY_SSH_KEY."
-            exit 1
-          fi
+          {
+            echo "EXPECTED_DEPLOY_SHA=${EXPECTED_DEPLOY_SHA}"
+            echo "DX_CONNECT_VERSION=${DX_CONNECT_VERSION}"
+          } > deploy-meta.env
+          echo "deploy-meta.env:" && cat deploy-meta.env
 
-      - name: SSH - known_hosts e chave
+      - name: Upload artefacto
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-payload
+          retention-days: 2
+          path: |
+            frontend/dist
+            VERSION
+            CHANGELOG.md
+            docs/releases/manifest.json
+            backend/app/data/release_notes.json
+            frontend/public/release-notes.json
+            deploy-meta.env
+
+  deploy:
+    name: Deploy VPS
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+      DEPLOY_FRONTEND_DIST: ${{ secrets.DEPLOY_FRONTEND_DIST }}
+      VITE_API_URL: ${{ secrets.VITE_API_URL }}
+      SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT }}
+      DEPLOY_GIT_REF: ${{ secrets.DEPLOY_GIT_REF }}
+      DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+    outputs:
+      network_timeout: ${{ steps.vps.outputs.network_timeout }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Download artefacto
+        uses: actions/download-artifact@v4
+        with:
+          name: deploy-payload
+          path: .
+
+      - name: Deploy no VPS (SSH IPv4)
+        id: vps
         run: |
-          mkdir -p ~/.ssh
-          echo "$DEPLOY_SSH_KEY" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          P="${SSH_PORT:-22}"
-          ssh-keyscan -p "$P" -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
-          echo "SSH_PORT=${P}" >> "$GITHUB_ENV"
-          echo "DEPLOY_KEY_PATH=${HOME}/.ssh/deploy_key" >> "$GITHUB_ENV"
-          echo "SSH_MUX_PATH=${HOME}/.ssh/cm-%r@%h:%p" >> "$GITHUB_ENV"
-
-      - name: Git pull no VPS
-        run: |
-          REF="${EVENT_REF:-${DEPLOY_GIT_REF:-staging}}"
-          echo "Deploy ref no VPS: ${REF}"
-
-          ssh_base() {
-            ssh -i "$DEPLOY_KEY_PATH" \
-              -o StrictHostKeyChecking=accept-new \
-              -o ConnectTimeout=20 \
-              -o ServerAliveInterval=15 \
-              -o ServerAliveCountMax=3 \
-              -o ControlMaster=auto \
-              -o "ControlPath=${SSH_MUX_PATH}" \
-              -o ControlPersist=120 \
-              -p "${SSH_PORT}" \
-              "${DEPLOY_USER}@${DEPLOY_HOST}" "$@"
-          }
-
-          retry() {
-            local attempt=1 max=5 delay=15
-            while true; do
-              if "$@"; then return 0; fi
-              if [ "$attempt" -ge "$max" ]; then
-                echo "::error::Comando falhou apos ${max} tentativas."
-                return 1
-              fi
-              echo "Tentativa ${attempt}/${max} falhou; nova em ${delay}s (runner GitHub -> VPS)..."
-              sleep "$delay"
-              attempt=$((attempt + 1))
-              delay=$((delay + 15))
-            done
-          }
-
-          retry ssh_base \
-            "REF='${REF}' DEPLOY_PATH='${DEPLOY_PATH}' bash -s" << 'REMOTE_SCRIPT'
-          set -ex
-          cd "$DEPLOY_PATH"
-          echo "==> Deploy branch/ref: $REF"
-          git fetch origin
-          git checkout "$REF"
-          git reset --hard "origin/$REF"
-          REMOTE_SCRIPT
-
-      - name: Rsync - artefatos de release para VPS
-        run: |
-          ssh_rsync_release() {
-            rsync -avz \
-              -e "ssh -i ${DEPLOY_KEY_PATH} -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20 -o ControlMaster=auto -o ControlPath=${SSH_MUX_PATH} -o ControlPersist=120 -p ${SSH_PORT}" \
-              "$1" "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_PATH}/$2"
-          }
-
-          retry() {
-            local attempt=1 max=5 delay=15
-            while true; do
-              if "$@"; then return 0; fi
-              if [ "$attempt" -ge "$max" ]; then
-                echo "::error::Rsync release falhou apos ${max} tentativas."
-                return 1
-              fi
-              echo "Tentativa ${attempt}/${max} falhou; nova em ${delay}s..."
-              sleep "$delay"
-              attempt=$((attempt + 1))
-              delay=$((delay + 15))
-            done
-          }
-
-          retry ssh_rsync_release "VERSION" ""
-          retry ssh_rsync_release "CHANGELOG.md" ""
-          retry ssh_rsync_release "docs/releases/manifest.json" "docs/releases/"
-          retry ssh_rsync_release "backend/app/data/release_notes.json" "backend/app/data/"
-          retry ssh_rsync_release "frontend/public/release-notes.json" "frontend/public/"
-
-      - name: Alembic + Docker Compose no VPS
-        run: |
-          REF="${EVENT_REF:-${DEPLOY_GIT_REF:-staging}}"
-
-          ssh_base() {
-            ssh -i "$DEPLOY_KEY_PATH" \
-              -o StrictHostKeyChecking=accept-new \
-              -o ConnectTimeout=20 \
-              -o ServerAliveInterval=15 \
-              -o ServerAliveCountMax=3 \
-              -o ControlMaster=auto \
-              -o "ControlPath=${SSH_MUX_PATH}" \
-              -o ControlPersist=120 \
-              -p "${SSH_PORT}" \
-              "${DEPLOY_USER}@${DEPLOY_HOST}" "$@"
-          }
-
-          retry() {
-            local attempt=1 max=5 delay=15
-            while true; do
-              if "$@"; then return 0; fi
-              if [ "$attempt" -ge "$max" ]; then
-                echo "::error::Comando falhou apos ${max} tentativas."
-                return 1
-              fi
-              echo "Tentativa ${attempt}/${max} falhou; nova em ${delay}s (runner GitHub -> VPS)..."
-              sleep "$delay"
-              attempt=$((attempt + 1))
-              delay=$((delay + 15))
-            done
-          }
-
-          retry ssh_base \
-            "REF='${REF}' DEPLOY_PATH='${DEPLOY_PATH}' SKIP_MIGRATIONS='${SKIP_MIGRATIONS}' WEBHOOK_BASE_URL='${VITE_API_URL}' DX_CONNECT_VERSION='${DX_CONNECT_VERSION:-}' bash -s" << 'REMOTE_SCRIPT'
-          set -ex
-          cd "$DEPLOY_PATH"
-          export DX_CONNECT_GIT_SHA="$(git rev-parse --short HEAD)"
-          echo "==> Commit: $DX_CONNECT_GIT_SHA"
-          if [ -z "${DX_CONNECT_VERSION:-}" ] && [ -f VERSION ]; then
-            export DX_CONNECT_VERSION="$(tr -d '\n\r' < VERSION)"
-          fi
-          echo "==> Versão: ${DX_CONNECT_VERSION:-n/a}"
-          WEBHOOK_BASE_URL="${WEBHOOK_BASE_URL:-}" bash deploy/scripts/ensure-evolution-env.sh backend/.env
-          COMPOSE="docker compose --env-file backend/.env -f docker-compose.prod.yml"
-          if [ "$SKIP_MIGRATIONS" != "true" ]; then
-            $COMPOSE build --no-cache backend
-            # -T + /dev/null: evita que `compose run` consuma o restante do script (heredoc via bash -s)
-            $COMPOSE run --rm -T backend alembic upgrade head < /dev/null
+          set +e
+          bash deploy/scripts/gha_deploy_vps.sh
+          rc=$?
+          if [ "$rc" -eq 75 ]; then
+            echo "network_timeout=true" >> "$GITHUB_OUTPUT"
           else
-            $COMPOSE build --no-cache backend
+            echo "network_timeout=false" >> "$GITHUB_OUTPUT"
           fi
-          WEBHOOK_BASE_URL="${WEBHOOK_BASE_URL:-}" bash deploy/scripts/restart-backend-prod.sh "$DEPLOY_PATH"
-          PUBLIC_HEALTH="$(curl -sf "${WEBHOOK_BASE_URL%/}/health")"
-          echo "Health publico (mesmo host): ${PUBLIC_HEALTH}"
-          echo "${PUBLIC_HEALTH}" | DX_CONNECT_GIT_SHA="${DX_CONNECT_GIT_SHA}" python3 -c "
-          import json, os, sys
-          body = json.load(sys.stdin)
-          caps = body.get('capabilities') or {}
-          missing = [k for k in ('pdv_catalogos', 'empresa_pdvs') if not caps.get(k)]
-          if missing:
-              print(f'::error::URL publica sem rotas PDV: faltam {missing}', file=sys.stderr)
-              sys.exit(1)
-          expected = os.environ.get('DX_CONNECT_GIT_SHA', '')
-          actual = (body.get('git_sha') or '') or ''
-          if expected and actual and actual != expected:
-              print(f'::error::git_sha publico {actual!r} != commit {expected!r}', file=sys.stderr)
-              sys.exit(1)
-          print('OK: health publico no VPS', actual, caps)
-          "
-          for i in 1 2 3 4 5 6; do
-            curl -sf "http://127.0.0.1:8080" >/dev/null && { echo "Evolution API: OK (8080)"; break; }
-            sleep 5
-          done
-          curl -sf "http://127.0.0.1:8080" >/dev/null || echo "Evolution API: aguardar ou conferir logs (docker logs dx-connect-evolution-api)"
-          REMOTE_SCRIPT
-
-      - name: Rsync - frontend dist para VPS
-        run: |
-          ssh_rsync() {
-            rsync -avz --delete \
-              -e "ssh -i ${DEPLOY_KEY_PATH} -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20 -o ControlMaster=auto -o ControlPath=${SSH_MUX_PATH} -o ControlPersist=120 -p ${SSH_PORT}" \
-              frontend/dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_FRONTEND_DIST}/"
-          }
-
-          retry() {
-            local attempt=1 max=5 delay=15
-            while true; do
-              if "$@"; then return 0; fi
-              if [ "$attempt" -ge "$max" ]; then
-                echo "::error::Rsync falhou apos ${max} tentativas."
-                return 1
-              fi
-              echo "Tentativa ${attempt}/${max} falhou; nova em ${delay}s..."
-              sleep "$delay"
-              attempt=$((attempt + 1))
-              delay=$((delay + 15))
-            done
-          }
-
-          retry ssh_rsync
-
-      - name: Verificar rotas da API (health)
-        run: |
-          API_BASE="${VITE_API_URL%/}"
-          echo "GET ${API_BASE}/health"
-          export HEALTH_JSON="$(curl -sf "${API_BASE}/health")"
-          echo "$HEALTH_JSON"
-          python3 <<'PY'
-          import json, os, sys
-          body = json.loads(os.environ["HEALTH_JSON"])
-          caps = body.get("capabilities") or {}
-          need = (
-              "settings_empresa_sistema",
-              "tenant_atual",
-              "settings_email",
-              "pdv_catalogos",
-              "empresa_pdvs",
-          )
-          missing = [k for k in need if not caps.get(k)]
-          if missing:
-              print(
-                  f"::error::API sem rotas esperadas (backend antigo?): faltam {missing}. git_sha={body.get('git_sha')!r}",
-                  file=sys.stderr,
-              )
-              sys.exit(1)
-          expected_sha = os.environ.get("EXPECTED_DEPLOY_SHA", "") or os.environ.get("GITHUB_SHA", "")[:7]
-          actual_sha = (body.get("git_sha") or "") or ""
-          if expected_sha and actual_sha and actual_sha != expected_sha:
-              print(
-                  f"::error::git_sha em producao ({actual_sha!r}) difere do commit deployado ({expected_sha!r}). "
-                  "Processo antigo pode ainda estar na porta 8000.",
-                  file=sys.stderr,
-              )
-              sys.exit(1)
-          print("OK: capabilities", caps, "git_sha", body.get("git_sha"), "expected", expected_sha)
-          PY
+          exit "$rc"
 
       - name: Persistir manifest e CHANGELOG em staging
         if: github.ref == 'refs/heads/staging'
+        run: bash deploy/scripts/gha_persist_release.sh
+
+  deploy-retry:
+    name: Deploy VPS (retry noutro runner)
+    needs: [prepare, deploy]
+    if: failure() && needs.deploy.result == 'failure' && needs.deploy.outputs.network_timeout == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+      DEPLOY_FRONTEND_DIST: ${{ secrets.DEPLOY_FRONTEND_DIST }}
+      VITE_API_URL: ${{ secrets.VITE_API_URL }}
+      SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT }}
+      DEPLOY_GIT_REF: ${{ secrets.DEPLOY_GIT_REF }}
+      DEPLOY_SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Download artefacto (sem rebuild do frontend)
+        uses: actions/download-artifact@v4
+        with:
+          name: deploy-payload
+          path: .
+
+      - name: Deploy no VPS (SSH IPv4, IP novo)
+        id: vps
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add VERSION CHANGELOG.md docs/releases/manifest.json \
-            backend/app/data/release_notes.json frontend/public/release-notes.json
-          if git diff --staged --quiet; then
-            echo "Nenhum artefato de release para commitar."
-            exit 0
+          set +e
+          bash deploy/scripts/gha_deploy_vps.sh
+          rc=$?
+          if [ "$rc" -eq 75 ]; then
+            echo "::error::Retry noutro runner tambem deu Connection timed out. Re-run all jobs ou confira firewall Hostinger (IP deste runner no log). Nao altere secrets."
           fi
-          VER="$(tr -d '\n\r' < VERSION)"
-          git commit -m "chore(release): publica v${VER} [skip ci]"
-          git push origin HEAD:staging
+          exit "$rc"
+
+      - name: Persistir manifest e CHANGELOG em staging
+        if: github.ref == 'refs/heads/staging'
+        run: bash deploy/scripts/gha_persist_release.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### DeskRudder
 
+#### Interno / Infra
+
+- Deploy CI (#734): SSH para o VPS força IPv4, o log mostra o IP do runner e, se der timeout, o GitHub tenta sozinho noutro job (sem clicar em Re-run)
+
 #### Melhorias
 
 - Proposta comercial (#323 / #345–#348): modelos HTML versionados, geração a partir da negociação (CNPJs à escolha), preview, PDF e marcar como enviada (com opção de avançar o funil) — sem custo/margem no documento do cliente

--- a/deploy/github-actions.md
+++ b/deploy/github-actions.md
@@ -2,9 +2,9 @@
 
 O workflow [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml) faz:
 
-1. **Build do frontend** no runner (usa `VITE_API_URL` dos secrets).
-2. **`rsync`** da pasta `frontend/dist/` para o caminho no VPS (`DEPLOY_FRONTEND_DIST`).
-3. **SSH** no servidor: `git pull`, `alembic upgrade head`, `docker compose -f docker-compose.prod.yml up -d --build`.
+1. Job **prepare**: build do frontend no runner (`VITE_API_URL`) + CalVer; envia artefacto.
+2. Job **Deploy VPS**: SSH **IPv4** — `git pull`, `rsync` de `frontend/dist/` para `DEPLOY_FRONTEND_DIST`, Alembic, compose.
+3. Se o SSH der `Connection timed out`, job **Deploy VPS (retry noutro runner)** — mesmo artefacto, IP novo. Ver troubleshooting abaixo.
 
 Disparo automático em **push** para **`staging`** quando mudam `backend/`, `frontend/`, `docker-compose.prod.yml` ou o próprio workflow. A branch **`main`** não dispara deploy (último estágio de testes/integração); após validar em `main`, abra PR **`main → staging`**, merge e o deploy roda no VPS. Também pode rodar manualmente em **Actions → Deploy → Run workflow**.
 
@@ -101,17 +101,26 @@ Em cada deploy o workflow executa `alembic upgrade head` antes do `up --build`. 
 ssh: connect to host *** port 22: Connection timed out
 ```
 
-Costuma aparecer nas etapas **Rsync - frontend dist para VPS** ou **Git pull + Alembic + Docker Compose**. O build do frontend no runner pode ter passado normalmente.
+Costuma aparecer no job **Deploy VPS** (git pull / rsync / Alembic). O job **prepare** (build do frontend) pode ter passado. O log inclui o **IP público IPv4 do runner** (ex. via `api.ipify.org`) para cruzar com o firewall da Hostinger.
 
-**Causa provável:** falha de rede **transitória** entre o runner do GitHub Actions e o VPS. Não indica, por si só, chave SSH errada ou VPS fora do ar — o mesmo deploy costuma funcionar na segunda tentativa.
+**Causa:** o TCP SYN para a porta 22 **não teve resposta** — o `sshd` nem chegou a autenticar. Não é chave SSH errada (`Permission denied (publickey)`). Hipóteses: firewall/proteção a **alguns** IPs do pool Azure do GitHub Actions; IPv6 partido (`DEPLOY_HOST` com AAAA e o runner insiste nesse caminho); rota transitória.
 
-**O que fazer (em ordem):**
+O retry **dentro do mesmo job** (5 tentativas, 15 s) usa o **mesmo** runner/IP e costuma falhar as 5 vezes seguidas. **Re-run all jobs** (ou o job `deploy-retry`) muda de máquina no pool `ubuntu-latest` e costuma ligar à primeira. O passo `ssh-keyscan` **não** engole falha: se não houver host key, o job falha com timeout vs DNS vs recusa.
 
-1. **Aguarde o retry automático** — `rsync` e `ssh` usam [`deploy/scripts/retry.sh`](../deploy/scripts/retry.sh) com até **5 tentativas** e **15 s** entre elas (opções `ConnectTimeout=30`, keepalive SSH).
-2. **Se o job ainda falhar:** no GitHub, abra **Actions → Deploy → run com falha → Re-run failed jobs** (ou **Re-run all jobs**). Historicamente isso resolve na segunda execução.
-3. **Se persistir em vários re-runs:** confira firewall do VPS (porta SSH acessível), serviço `sshd` ativo, `DEPLOY_HOST` / `DEPLOY_SSH_PORT` corretos e se o IP do servidor não mudou.
+**O que o workflow faz sozinho (#734):**
 
-**Disparo manual alternativo:** **Actions → Deploy → Run workflow** na branch `staging` (equivalente a um novo deploy completo).
+1. SSH e rsync forçam **IPv4** (`ssh -4` / `AddressFamily inet`).
+2. Retry no mesmo job: [`deploy/scripts/retry.sh`](../deploy/scripts/retry.sh) (5×, 15 s, `ConnectTimeout=20`).
+3. Se ainda for `Connection timed out` (exit 75), o job **Deploy VPS (retry noutro runner)** corre noutro `ubuntu-latest`, **sem** rebuild do frontend (reutiliza o artefacto).
+4. Esse segundo job **não** corre em falhas que não são de rede (`Permission denied`, git/alembic/compose, health).
+
+**Se o retry automático também falhar:**
+
+1. **Re-run all jobs** no run falhado (não altere secrets).
+2. Confira firewall do VPS, `sshd`, `DEPLOY_HOST` / `DEPLOY_SSH_PORT` e se o IP do servidor mudou. O IP do runner está no log.
+3. **Actions → Deploy → Run workflow** na branch `staging` (deploy completo novo).
+
+Fora de escopo: whitelist permanente de todos os ranges GitHub (mudam com frequência); self-hosted runner; mudar porta SSH ou credenciais.
 
 ### Outros erros comuns
 

--- a/deploy/scripts/gha_deploy_vps.sh
+++ b/deploy/scripts/gha_deploy_vps.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# Deploy SSH no VPS a partir do GitHub Actions (#734).
+# Força IPv4, diagnostica keyscan/IP do runner e classifica timeout (exit 75)
+# vs falha de credencial/comando (exit 1).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+RETRY_SH="${ROOT}/deploy/scripts/retry.sh"
+LOG="${DEPLOY_SSH_LOG:-${RUNNER_TEMP:-/tmp}/deploy-ssh.log}"
+mkdir -p "$(dirname "$LOG")"
+: >"$LOG"
+
+EXIT_TIMEOUT=75
+
+die_timeout() {
+  echo "::error::$*" | tee -a "$LOG"
+  exit "$EXIT_TIMEOUT"
+}
+
+die_other() {
+  echo "::error::$*" | tee -a "$LOG"
+  exit 1
+}
+
+classify_and_exit() {
+  local rc="${1:-1}"
+  if grep -qiE 'permission denied \(publickey\)|permission denied \(keyboard-interactive,publickey\)' "$LOG"; then
+    die_other "SSH: Permission denied (publickey) — não é timeout de rede. Sem retry noutro runner. Confira DEPLOY_SSH_KEY / authorized_keys."
+  fi
+  if grep -qiE 'connection timed out|connect timed out|operation timed out' "$LOG"; then
+    die_timeout "SSH: Connection timed out neste runner (IPv4 ${RUNNER_PUBLIC_IPV4:-desconhecido}). O workflow pode repetir noutro job."
+  fi
+  die_other "Deploy SSH falhou (exit ${rc}) — não classificado como timeout de rede. Ver log."
+}
+
+retry() {
+  bash "$RETRY_SH" "$@"
+}
+
+run_logged() {
+  local rc=0
+  set +e
+  set -o pipefail
+  "$@" 2>&1 | tee -a "$LOG"
+  rc=${PIPESTATUS[0]}
+  set +o pipefail
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    classify_and_exit "$rc"
+  fi
+}
+
+if [ -z "${DEPLOY_HOST:-}" ] || [ -z "${DEPLOY_USER:-}" ] || [ -z "${DEPLOY_PATH:-}" ] || [ -z "${DEPLOY_FRONTEND_DIST:-}" ]; then
+  die_other "Defina DEPLOY_HOST, DEPLOY_USER, DEPLOY_PATH e DEPLOY_FRONTEND_DIST."
+fi
+if [ -z "${DEPLOY_SSH_KEY:-}" ]; then
+  die_other "Defina DEPLOY_SSH_KEY."
+fi
+if [ ! -f "$RETRY_SH" ]; then
+  die_other "Script de retry em falta: ${RETRY_SH}"
+fi
+
+if [ -f "${ROOT}/deploy-meta.env" ]; then
+  # shellcheck disable=SC1091
+  set -a
+  # Valores gerados no job prepare (SHA / CalVer); não contém secrets.
+  source "${ROOT}/deploy-meta.env"
+  set +a
+fi
+
+P="${SSH_PORT:-22}"
+DEPLOY_KEY_PATH="${DEPLOY_KEY_PATH:-${HOME}/.ssh/deploy_key}"
+SSH_MUX_PATH="${SSH_MUX_PATH:-${HOME}/.ssh/cm-%r@%h:%p}"
+SSH_CONFIG="${HOME}/.ssh/deploy_config"
+REF="${EVENT_REF:-${DEPLOY_GIT_REF:-staging}}"
+SKIP_MIGRATIONS="${SKIP_MIGRATIONS:-false}"
+API_BASE="${VITE_API_URL:-}"
+API_BASE="${API_BASE%/}"
+
+echo "Deploy ref no VPS: ${REF}" | tee -a "$LOG"
+
+# --- IP público IPv4 do runner (cruzar com firewall Hostinger)
+RUNNER_PUBLIC_IPV4="$(curl -4 -fsS --max-time 10 https://api.ipify.org || true)"
+if [ -z "$RUNNER_PUBLIC_IPV4" ]; then
+  RUNNER_PUBLIC_IPV4="$(curl -4 -fsS --max-time 10 https://ipv4.icanhazip.com | tr -d '\n\r' || true)"
+fi
+RUNNER_PUBLIC_IPV4="${RUNNER_PUBLIC_IPV4:-desconhecido}"
+echo "IP público IPv4 do runner: ${RUNNER_PUBLIC_IPV4}" | tee -a "$LOG"
+echo "DEPLOY_HOST=${DEPLOY_HOST} SSH_PORT=${P} AddressFamily=inet (ssh -4)" | tee -a "$LOG"
+
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+printf '%s\n' "$DEPLOY_SSH_KEY" >"$DEPLOY_KEY_PATH"
+chmod 600 "$DEPLOY_KEY_PATH"
+
+cat >"$SSH_CONFIG" <<EOF
+Host deploy-vps
+  HostName ${DEPLOY_HOST}
+  User ${DEPLOY_USER}
+  Port ${P}
+  IdentityFile ${DEPLOY_KEY_PATH}
+  IdentitiesOnly yes
+  AddressFamily inet
+  ConnectTimeout 20
+  ServerAliveInterval 15
+  ServerAliveCountMax 3
+  StrictHostKeyChecking accept-new
+  ControlMaster auto
+  ControlPath ${SSH_MUX_PATH}
+  ControlPersist 120
+EOF
+chmod 600 "$SSH_CONFIG"
+
+# --- ssh-keyscan IPv4: falha explícita (sem || true)
+KEYSCAN_OUT="$(mktemp)"
+KEYSCAN_ERR="$(mktemp)"
+set +e
+ssh-keyscan -4 -p "$P" -T 20 -H "$DEPLOY_HOST" >"$KEYSCAN_OUT" 2>"$KEYSCAN_ERR"
+KS_RC=$?
+set -e
+tee -a "$LOG" <"$KEYSCAN_ERR"
+if [ ! -s "$KEYSCAN_OUT" ]; then
+  echo "::error::ssh-keyscan não obteve host key de ${DEPLOY_HOST} (porta ${P}, IPv4, timeout 20s). exit=${KS_RC}" | tee -a "$LOG"
+  if grep -qiE 'timed out|timeout' "$KEYSCAN_ERR"; then
+    die_timeout "Causa: timeout TCP no keyscan (rede/firewall/IPv6). IP do runner: ${RUNNER_PUBLIC_IPV4}."
+  fi
+  if grep -qiE 'name or service not known|could not resolve|temporary failure in name resolution|no address associated' "$KEYSCAN_ERR"; then
+    die_other "Causa: DNS não resolveu ${DEPLOY_HOST}."
+  fi
+  if grep -qiE 'connection refused' "$KEYSCAN_ERR"; then
+    die_other "Causa: conexão recusada (sshd ou porta ${P})."
+  fi
+  die_other "Causa: keyscan sem host key (ver stderr). IP do runner: ${RUNNER_PUBLIC_IPV4}."
+fi
+cat "$KEYSCAN_OUT" >>~/.ssh/known_hosts
+echo "ssh-keyscan OK (IPv4): $(wc -l <"$KEYSCAN_OUT") chave(s)" | tee -a "$LOG"
+rm -f "$KEYSCAN_OUT" "$KEYSCAN_ERR"
+
+ssh_base() {
+  ssh -4 -F "$SSH_CONFIG" deploy-vps "$@"
+}
+
+ssh_rsync() {
+  local src="$1" dest="$2"
+  rsync -avz \
+    -e "ssh -4 -F ${SSH_CONFIG} -o AddressFamily=inet" \
+    "$src" "deploy-vps:${dest}"
+}
+
+export SSH_CONFIG
+export -f ssh_base ssh_rsync
+
+# --- Git pull
+run_logged retry ssh_base \
+  "REF='${REF}' DEPLOY_PATH='${DEPLOY_PATH}' bash -s" <<'REMOTE_SCRIPT'
+set -ex
+cd "$DEPLOY_PATH"
+echo "==> Deploy branch/ref: $REF"
+git fetch origin
+git checkout "$REF"
+git reset --hard "origin/$REF"
+REMOTE_SCRIPT
+
+# --- Artefatos de release
+run_logged retry ssh_rsync "${ROOT}/VERSION" "${DEPLOY_PATH}/"
+run_logged retry ssh_rsync "${ROOT}/CHANGELOG.md" "${DEPLOY_PATH}/"
+run_logged retry ssh_rsync "${ROOT}/docs/releases/manifest.json" "${DEPLOY_PATH}/docs/releases/"
+run_logged retry ssh_rsync "${ROOT}/backend/app/data/release_notes.json" "${DEPLOY_PATH}/backend/app/data/"
+run_logged retry ssh_rsync "${ROOT}/frontend/public/release-notes.json" "${DEPLOY_PATH}/frontend/public/"
+
+# --- Alembic + compose
+run_logged retry ssh_base \
+  "REF='${REF}' DEPLOY_PATH='${DEPLOY_PATH}' SKIP_MIGRATIONS='${SKIP_MIGRATIONS}' WEBHOOK_BASE_URL='${API_BASE}' DX_CONNECT_VERSION='${DX_CONNECT_VERSION:-}' bash -s" <<'REMOTE_SCRIPT'
+set -ex
+cd "$DEPLOY_PATH"
+export DX_CONNECT_GIT_SHA="$(git rev-parse --short HEAD)"
+echo "==> Commit: $DX_CONNECT_GIT_SHA"
+if [ -z "${DX_CONNECT_VERSION:-}" ] && [ -f VERSION ]; then
+  export DX_CONNECT_VERSION="$(tr -d '\n\r' < VERSION)"
+fi
+echo "==> Versão: ${DX_CONNECT_VERSION:-n/a}"
+WEBHOOK_BASE_URL="${WEBHOOK_BASE_URL:-}" bash deploy/scripts/ensure-evolution-env.sh backend/.env
+COMPOSE="docker compose --env-file backend/.env -f docker-compose.prod.yml"
+if [ "$SKIP_MIGRATIONS" != "true" ]; then
+  $COMPOSE build --no-cache backend
+  $COMPOSE run --rm -T backend alembic upgrade head < /dev/null
+else
+  $COMPOSE build --no-cache backend
+fi
+WEBHOOK_BASE_URL="${WEBHOOK_BASE_URL:-}" bash deploy/scripts/restart-backend-prod.sh "$DEPLOY_PATH"
+PUBLIC_HEALTH="$(curl -sf "${WEBHOOK_BASE_URL%/}/health")"
+echo "Health publico (mesmo host): ${PUBLIC_HEALTH}"
+echo "${PUBLIC_HEALTH}" | DX_CONNECT_GIT_SHA="${DX_CONNECT_GIT_SHA}" python3 -c "
+import json, os, sys
+body = json.load(sys.stdin)
+caps = body.get('capabilities') or {}
+missing = [k for k in ('pdv_catalogos', 'empresa_pdvs') if not caps.get(k)]
+if missing:
+    print(f'::error::URL publica sem rotas PDV: faltam {missing}', file=sys.stderr)
+    sys.exit(1)
+expected = os.environ.get('DX_CONNECT_GIT_SHA', '')
+actual = (body.get('git_sha') or '') or ''
+if expected and actual and actual != expected:
+    print(f'::error::git_sha publico {actual!r} != commit {expected!r}', file=sys.stderr)
+    sys.exit(1)
+print('OK: health publico no VPS', actual, caps)
+"
+for i in 1 2 3 4 5 6; do
+  curl -sf "http://127.0.0.1:8080" >/dev/null && { echo "Evolution API: OK (8080)"; break; }
+  sleep 5
+done
+curl -sf "http://127.0.0.1:8080" >/dev/null || echo "Evolution API: aguardar ou conferir logs (docker logs dx-connect-evolution-api)"
+REMOTE_SCRIPT
+
+# --- Frontend dist
+if [ ! -d "${ROOT}/frontend/dist" ]; then
+  die_other "frontend/dist em falta no runner — o job prepare tem de enviar o artefacto."
+fi
+run_logged retry rsync -avz --delete \
+  -e "ssh -4 -F ${SSH_CONFIG} -o AddressFamily=inet" \
+  "${ROOT}/frontend/dist/" "deploy-vps:${DEPLOY_FRONTEND_DIST}/"
+
+# --- Health público
+if [ -z "$API_BASE" ]; then
+  die_other "VITE_API_URL vazio — não dá para verificar /health."
+fi
+echo "GET ${API_BASE}/health" | tee -a "$LOG"
+HEALTH_JSON="$(curl -sf "${API_BASE}/health")"
+echo "$HEALTH_JSON" | tee -a "$LOG"
+EXPECTED_DEPLOY_SHA="${EXPECTED_DEPLOY_SHA:-}"
+export HEALTH_JSON EXPECTED_DEPLOY_SHA
+python3 <<'PY'
+import json, os, sys
+body = json.loads(os.environ["HEALTH_JSON"])
+caps = body.get("capabilities") or {}
+need = (
+    "settings_empresa_sistema",
+    "tenant_atual",
+    "settings_email",
+    "pdv_catalogos",
+    "empresa_pdvs",
+)
+missing = [k for k in need if not caps.get(k)]
+if missing:
+    print(
+        f"::error::API sem rotas esperadas (backend antigo?): faltam {missing}. git_sha={body.get('git_sha')!r}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+expected_sha = os.environ.get("EXPECTED_DEPLOY_SHA", "") or os.environ.get("GITHUB_SHA", "")[:7]
+actual_sha = (body.get("git_sha") or "") or ""
+if expected_sha and actual_sha and actual_sha != expected_sha:
+    print(
+        f"::error::git_sha em producao ({actual_sha!r}) difere do commit deployado ({expected_sha!r}). "
+        "Processo antigo pode ainda estar na porta 8000.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+print("OK: capabilities", caps, "git_sha", body.get("git_sha"), "expected", expected_sha)
+PY
+
+echo "Deploy VPS concluído (runner IPv4 ${RUNNER_PUBLIC_IPV4})."

--- a/deploy/scripts/gha_persist_release.sh
+++ b/deploy/scripts/gha_persist_release.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Commit dos artefactos CalVer na branch staging (job Deploy).
+set -euo pipefail
+
+if [ "${GITHUB_REF:-}" != "refs/heads/staging" ]; then
+  echo "Skip persist (ref ${GITHUB_REF:-} != refs/heads/staging)."
+  exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git add VERSION CHANGELOG.md docs/releases/manifest.json \
+  backend/app/data/release_notes.json frontend/public/release-notes.json
+if git diff --staged --quiet; then
+  echo "Nenhum artefato de release para commitar."
+  exit 0
+fi
+VER="$(tr -d '\n\r' < VERSION)"
+git commit -m "chore(release): publica v${VER} [skip ci]"
+git push origin HEAD:staging


### PR DESCRIPTION
## Summary

- Endurece o deploy CI (#734): SSH/rsync forçam IPv4, `ssh-keyscan` deixa de engolir falha, e o log mostra o IP público do runner.
- Se a falha for `Connection timed out`, um segundo job corre noutro `ubuntu-latest` e reutiliza o artefacto do frontend (sem rebuild). Não dispara em `Permission denied` nem em falhas de git/alembic/health.
- Sem alteração de secrets; este PR **não** mergeia em `staging`.

Closes #734

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] CI verde neste PR (jobs backend/frontend omitidos — diff só de deploy/docs)
- [ ] No próximo release `main → staging`, o job **prepare** faz upload do artefacto e **Deploy VPS** mostra `IP público IPv4 do runner`
- [ ] Se o SSH der timeout, o job **Deploy VPS (retry noutro runner)** arranca sozinho
- [ ] Falha `Permission denied` **não** dispara o retry

## Follow-ups / backlog

- [x] Fora de escopo (whitelist Hostinger, self-hosted runner, mudar porta/credenciais) permanece na issue
- [x] Próximo lote de produto: Contratos #324 (após este merge; branch nova)
- [x] Comentário na #734 e #324 com a ordem acordada
