### PR TITLE
feat(comercial): contratos PDF por CNPJ da negociacao (#324 #349-356)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,15 @@ backend/data/
 # Frontend
 frontend/node_modules
 frontend/dist
+frontend/dev-dist
 frontend/.env.production
 frontend/.env.production.local
 frontend/.playwright-browsers
 frontend/public/_crop-*.png
 frontend/public/_debug-*.png
+
+# Python
+**/__pycache__/
 
 # IDE / OS
 .idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Contratos comerciais (#324 / #349–#356): gerar PDF por CNPJ da negociação (fidelidade, setup e cláusulas de implantação), sem custo/margem no documento; rascunho → enviado → assinado; lista com filtro por responsável; painel interno com custo, lucro e margem %; modelos em Cadastros (versão sobe ao editar o HTML)
 - Proposta comercial (#323 / #345–#348): modelos HTML versionados, geração a partir da negociação (CNPJs à escolha), preview, PDF e marcar como enviada (com opção de avançar o funil) — sem custo/margem no documento do cliente
 - CRM (#322 / #336–#344): perfil comercial, funil, leads e negociações multi-CNPJ (API + UI — lista/Kanban, detalhe com custos/margem e timeline); configuração dos estágios em Cadastros; simulação e leitura do catálogo de custos para comercial (CRUD do catálogo continua só admin)
 - Sobre: as notas de atualização passam a mostrar só o que mudou no helpdesk nesta instância; melhorias do painel SaaS deixam de aparecer misturadas (#672 / #674)

--- a/backend/alembic/versions/097_comercial_contratos.py
+++ b/backend/alembic/versions/097_comercial_contratos.py
@@ -1,0 +1,171 @@
+"""Contrato comercial: templates, documento por CNPJ e versões de PDF (#324 / #349–#352).
+
+Revision ID: 097_comercial_contratos
+Revises: 096_comercial_propostas
+Create Date: 2026-08-19
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "097_comercial_contratos"
+down_revision = "096_comercial_propostas"
+branch_labels = None
+depends_on = None
+
+_TEMPLATE_PADRAO_HTML = """<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8"/>
+  <style>
+    body { font-family: DejaVu Sans, Arial, sans-serif; color: #1e293b; margin: 24px; font-size: 13px; }
+    h1 { font-size: 20px; margin: 0 0 8px; }
+    h2 { font-size: 14px; margin: 20px 0 8px; }
+    table { width: 100%; border-collapse: collapse; margin: 8px 0 16px; }
+    th, td { border: 1px solid #cbd5e1; padding: 8px; text-align: left; }
+    th { background: #f1f5f9; }
+    .muted { color: #64748b; font-size: 12px; }
+    .logo img { max-height: 72px; }
+  </style>
+</head>
+<body>
+  <div class="logo">{{logo}}</div>
+  <p class="muted">{{empresa_sistema}}</p>
+  <h1>Contrato de prestação de serviços</h1>
+  <p><strong>Contratante:</strong> {{razao_social}} &nbsp; <strong>CNPJ:</strong> {{cnpj}}</p>
+  <h2>Objeto e valores</h2>
+  {{itens}}
+  <p><strong>Mensalidade:</strong> {{valor_mensalidade}}</p>
+  {{setup_bloco}}
+  <h2>Vigência e fidelidade</h2>
+  <p>Início: {{data_inicio}} &nbsp; Fim da fidelidade: {{data_fim_fidelidade}} ({{fidelidade_meses}} meses).</p>
+  <div>{{fidelidade}}</div>
+  <div>{{multa}}</div>
+  <div>{{igpm}}</div>
+  <h2>Implantação</h2>
+  {{clausula_deslocamento}}
+  {{clausula_alimentacao}}
+  {{clausula_hospedagem}}
+</body>
+</html>
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if not insp.has_table("comercial_contrato_templates"):
+        op.create_table(
+            "comercial_contrato_templates",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("nome", sa.String(120), nullable=False),
+            sa.Column("versao", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("conteudo_html", sa.Text(), nullable=False),
+            sa.Column("vigencia_inicio", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+            sa.UniqueConstraint("nome", "versao", name="uq_comercial_contrato_template_nome_versao"),
+        )
+        op.create_index("ix_comercial_contrato_templates_nome", "comercial_contrato_templates", ["nome"])
+        op.create_index("ix_comercial_contrato_templates_ativo", "comercial_contrato_templates", ["ativo"])
+
+    if not insp.has_table("comercial_contratos"):
+        op.create_table(
+            "comercial_contratos",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "negociacao_linha_cnpj_id",
+                sa.Integer(),
+                sa.ForeignKey("crm_negociacao_cnpj_linhas.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column(
+                "empresa_id",
+                sa.Integer(),
+                sa.ForeignKey("empresas.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column(
+                "template_id",
+                sa.Integer(),
+                sa.ForeignKey("comercial_contrato_templates.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column(
+                "gerado_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column("status", sa.String(20), nullable=False, server_default="rascunho"),
+            sa.Column("valor_mensalidade", sa.Numeric(14, 2), nullable=False),
+            sa.Column("snapshot_custo", sa.JSON(), nullable=True),
+            sa.Column("snapshot_itens", sa.JSON(), nullable=False),
+            sa.Column("snapshot_comercial", sa.JSON(), nullable=False),
+            sa.Column("data_inicio", sa.Date(), nullable=False),
+            sa.Column("data_fim_fidelidade", sa.Date(), nullable=False),
+            sa.Column("fidelidade_meses", sa.Integer(), nullable=False, server_default="12"),
+            sa.Column("setup_valor", sa.Numeric(14, 2), nullable=True),
+            sa.Column("setup_isento", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+            sa.Column("deslocamento_cliente", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("alimentacao_cliente", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("hospedagem_cliente", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("multa_max_mensalidades", sa.Integer(), nullable=False, server_default="3"),
+            sa.Column("enviado_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("assinado_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.create_index("ix_comercial_contratos_linha", "comercial_contratos", ["negociacao_linha_cnpj_id"])
+        op.create_index("ix_comercial_contratos_empresa_id", "comercial_contratos", ["empresa_id"])
+        op.create_index("ix_comercial_contratos_template_id", "comercial_contratos", ["template_id"])
+        op.create_index("ix_comercial_contratos_status", "comercial_contratos", ["status"])
+        op.create_index("ix_comercial_contratos_created_at", "comercial_contratos", ["created_at"])
+
+    if not insp.has_table("comercial_contrato_pdfs"):
+        op.create_table(
+            "comercial_contrato_pdfs",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column(
+                "contrato_id",
+                sa.Integer(),
+                sa.ForeignKey("comercial_contratos.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "gerado_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column("conteudo_html_snapshot", sa.Text(), nullable=False),
+            sa.Column("conteudo_hash", sa.String(64), nullable=False),
+            sa.Column("pdf_storage_key", sa.String(255), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        )
+        op.create_index("ix_comercial_contrato_pdfs_contrato_id", "comercial_contrato_pdfs", ["contrato_id"])
+        op.create_index("ix_comercial_contrato_pdfs_created_at", "comercial_contrato_pdfs", ["created_at"])
+
+    bind.execute(
+        sa.text(
+            """
+            INSERT INTO comercial_contrato_templates (nome, versao, conteudo_html, vigencia_inicio, ativo)
+            SELECT :nome, 1, :html, CURRENT_TIMESTAMP, true
+            WHERE NOT EXISTS (SELECT 1 FROM comercial_contrato_templates LIMIT 1)
+            """
+        ),
+        {"nome": "Padrão", "html": _TEMPLATE_PADRAO_HTML},
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("comercial_contrato_pdfs"):
+        op.drop_table("comercial_contrato_pdfs")
+    if insp.has_table("comercial_contratos"):
+        op.drop_table("comercial_contratos")
+    if insp.has_table("comercial_contrato_templates"):
+        op.drop_table("comercial_contrato_templates")

--- a/backend/app/api/comercial_contrato.py
+++ b/backend/app/api/comercial_contrato.py
@@ -1,0 +1,217 @@
+"""API de contrato comercial (#324 / #349–#352)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import Response
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.core.auth import exigir_admin, exigir_comercial_ou_admin
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.schemas.comercial_contrato import (
+    ContratoGerarIn,
+    ContratoMarcarAssinadoIn,
+    ContratoMarcarEnviadoIn,
+    ContratoRead,
+    ContratoTemplateCreate,
+    ContratoTemplatePreviewIn,
+    ContratoTemplatePreviewOut,
+    ContratoTemplateRead,
+    ContratoTemplateUpdate,
+)
+from app.services import comercial_contrato as svc
+
+router = APIRouter(prefix="/comercial", tags=["comercial-contratos"])
+
+
+@router.get("/contrato-templates", response_model=list[ContratoTemplateRead])
+def listar_templates(
+    incluir_inativos: bool = Query(False),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    if incluir_inativos and atendente.role != "admin":
+        incluir_inativos = False
+    svc.garantir_template_padrao(db)
+    rows = svc.listar_templates(db, incluir_inativos=incluir_inativos)
+    db.commit()
+    return rows
+
+
+@router.post("/contrato-templates", response_model=ContratoTemplateRead, status_code=201)
+def criar_template(
+    data: ContratoTemplateCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = svc.criar_template(db, data)
+    registrar_audit(db, "comercial_contrato_template", row.id, "create", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.post("/contrato-templates/preview", response_model=ContratoTemplatePreviewOut)
+def preview_template(
+    data: ContratoTemplatePreviewIn,
+    _: Atendente = Depends(exigir_admin),
+):
+    return ContratoTemplatePreviewOut(html=svc.sanitize_html(data.conteudo_html))
+
+
+@router.patch("/contrato-templates/{template_id}", response_model=ContratoTemplateRead)
+def atualizar_template(
+    template_id: int,
+    data: ContratoTemplateUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = svc.obter_template(db, template_id, apenas_ativos=False)
+    row = svc.atualizar_template(db, row, data)
+    registrar_audit(db, "comercial_contrato_template", row.id, "update", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.get("/contratos", response_model=list[ContratoRead])
+def listar_contratos(
+    negociacao_id: int | None = Query(None),
+    status: str | None = Query(None),
+    cnpj: str | None = Query(None),
+    so_minhas: bool | None = Query(None),
+    responsavel_id: int | None = Query(None),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    filtrar_minhas = so_minhas
+    if negociacao_id is None and atendente.role != "admin":
+        filtrar_minhas = True
+    elif filtrar_minhas is None:
+        filtrar_minhas = False
+    incluir_html = negociacao_id is not None
+    return [
+        svc.contrato_para_read(r, incluir_html=incluir_html)
+        for r in svc.listar_contratos(
+            db,
+            negociacao_id=negociacao_id,
+            status=status,
+            cnpj=cnpj,
+            responsavel_id=responsavel_id,
+            so_minhas=bool(filtrar_minhas),
+            atendente=atendente,
+        )
+    ]
+
+
+@router.post("/contratos", response_model=ContratoRead, status_code=201)
+def gerar_contrato(
+    data: ContratoGerarIn,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    row = svc.gerar_contrato(db, data, atendente)
+    registrar_audit(
+        db,
+        "comercial_contrato",
+        row.id,
+        "create",
+        atendente.id,
+        payload={"linha_id": row.negociacao_linha_cnpj_id, "status": row.status},
+    )
+    db.commit()
+    db.refresh(row)
+    return svc.contrato_para_read(svc.obter_contrato(db, row.id), incluir_html=True)
+
+
+@router.get("/contratos/{contrato_id}", response_model=ContratoRead)
+def obter_contrato(
+    contrato_id: int,
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    return svc.contrato_para_read(svc.obter_contrato(db, contrato_id), incluir_html=True)
+
+
+@router.get("/contratos/{contrato_id}/pdf")
+def baixar_pdf(
+    contrato_id: int,
+    pdf_id: int | None = Query(None),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    row = svc.obter_contrato(db, contrato_id)
+    pdf_row, pdf = svc.garantir_pdf(db, row, pdf_id=pdf_id)
+    db.commit()
+    return Response(
+        content=pdf,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="contrato-{row.id}-{pdf_row.id}.pdf"'},
+    )
+
+
+@router.post("/contratos/{contrato_id}/marcar-enviado", response_model=ContratoRead)
+def marcar_enviado(
+    contrato_id: int,
+    data: ContratoMarcarEnviadoIn,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    row = svc.obter_contrato(db, contrato_id)
+    row = svc.marcar_enviado(db, row, data, atendente)
+    registrar_audit(
+        db,
+        "comercial_contrato",
+        row.id,
+        "update",
+        atendente.id,
+        payload={"status": row.status},
+    )
+    db.commit()
+    db.refresh(row)
+    return svc.contrato_para_read(svc.obter_contrato(db, row.id), incluir_html=True)
+
+
+@router.post("/contratos/{contrato_id}/marcar-assinado", response_model=ContratoRead)
+def marcar_assinado(
+    contrato_id: int,
+    data: ContratoMarcarAssinadoIn,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    row = svc.obter_contrato(db, contrato_id)
+    row = svc.marcar_assinado(db, row, data, atendente)
+    registrar_audit(
+        db,
+        "comercial_contrato",
+        row.id,
+        "update",
+        atendente.id,
+        payload={"status": row.status, "avancar_funil": data.avancar_funil},
+    )
+    db.commit()
+    db.refresh(row)
+    return svc.contrato_para_read(svc.obter_contrato(db, row.id), incluir_html=True)
+
+
+@router.post("/contratos/{contrato_id}/cancelar", response_model=ContratoRead)
+def cancelar_contrato(
+    contrato_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    row = svc.obter_contrato(db, contrato_id)
+    row = svc.cancelar_contrato(db, row, atendente)
+    registrar_audit(
+        db,
+        "comercial_contrato",
+        row.id,
+        "update",
+        atendente.id,
+        payload={"status": row.status},
+    )
+    db.commit()
+    db.refresh(row)
+    return svc.contrato_para_read(svc.obter_contrato(db, row.id), incluir_html=True)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,6 +41,7 @@ from app.api import (
     empresa_pdvs,
     comercial_custos,
     comercial_proposta,
+    comercial_contrato,
     crm,
     system_settings,
     tenant,
@@ -540,6 +541,7 @@ app.include_router(pdv_catalogos.router, prefix=API_V1_PREFIX)
 app.include_router(ticket_catalogos.router, prefix=API_V1_PREFIX)
 app.include_router(comercial_custos.router, prefix=API_V1_PREFIX)
 app.include_router(comercial_proposta.router, prefix=API_V1_PREFIX)
+app.include_router(comercial_contrato.router, prefix=API_V1_PREFIX)
 app.include_router(crm.router, prefix=API_V1_PREFIX)
 app.include_router(empresa_pdvs.router, prefix=API_V1_PREFIX)
 app.include_router(system_settings.router, prefix=API_V1_PREFIX)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -62,6 +62,7 @@ from app.models.crm import (
     FunilEstagio,
 )
 from app.models.comercial_proposta import Proposta, PropostaTemplate
+from app.models.comercial_contrato import Contrato, ContratoPdf, ContratoTemplate
 from app.models.cliente_saas import ClienteSaaS
 from app.models.saas_alerta_emitido import SaasAlertaEmitido
 from app.models.lead_comercial import LeadComercial
@@ -144,6 +145,9 @@ __all__ = [
     "CrmNegociacaoAtividade",
     "PropostaTemplate",
     "Proposta",
+    "ContratoTemplate",
+    "Contrato",
+    "ContratoPdf",
     "ClienteSaaS",
     "SaasAlertaEmitido",
     "LeadComercial",

--- a/backend/app/models/comercial_contrato.py
+++ b/backend/app/models/comercial_contrato.py
@@ -1,0 +1,120 @@
+"""Contrato comercial por CNPJ da negociação (#324 / #349–#352)."""
+
+from __future__ import annotations
+
+from sqlalchemy import (
+    Boolean,
+    Column,
+    Date,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+from sqlalchemy.types import JSON
+
+from app.database import Base
+
+CONTRATO_RASCUNHO = "rascunho"
+CONTRATO_ENVIADO = "enviado"
+CONTRATO_ASSINADO = "assinado"
+CONTRATO_CANCELADO = "cancelado"
+CONTRATO_RENOVADO = "renovado"
+CONTRATO_STATUSES = frozenset(
+    {
+        CONTRATO_RASCUNHO,
+        CONTRATO_ENVIADO,
+        CONTRATO_ASSINADO,
+        CONTRATO_CANCELADO,
+        CONTRATO_RENOVADO,
+    }
+)
+CONTRATO_STATUS_ATIVOS = frozenset({CONTRATO_RASCUNHO, CONTRATO_ENVIADO, CONTRATO_ASSINADO})
+
+FIDELIDADE_MESES_PADRAO = 12
+MULTA_MAX_MENSALIDADES_PADRAO = 3
+
+
+class ContratoTemplate(Base):
+    __tablename__ = "comercial_contrato_templates"
+    __table_args__ = (UniqueConstraint("nome", "versao", name="uq_comercial_contrato_template_nome_versao"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    nome = Column(String(120), nullable=False, index=True)
+    versao = Column(Integer, nullable=False, default=1)
+    conteudo_html = Column(Text, nullable=False)
+    vigencia_inicio = Column(DateTime(timezone=True), nullable=True)
+    ativo = Column(Boolean, nullable=False, default=True, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    contratos = relationship("Contrato", back_populates="template")
+
+
+class Contrato(Base):
+    __tablename__ = "comercial_contratos"
+
+    id = Column(Integer, primary_key=True, index=True)
+    negociacao_linha_cnpj_id = Column(
+        Integer,
+        ForeignKey("crm_negociacao_cnpj_linhas.id", ondelete="RESTRICT"),
+        nullable=False,
+        index=True,
+    )
+    empresa_id = Column(Integer, ForeignKey("empresas.id", ondelete="SET NULL"), nullable=True, index=True)
+    template_id = Column(
+        Integer, ForeignKey("comercial_contrato_templates.id", ondelete="RESTRICT"), nullable=False, index=True
+    )
+    gerado_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="RESTRICT"), nullable=False)
+    status = Column(String(20), nullable=False, default=CONTRATO_RASCUNHO, index=True)
+    valor_mensalidade = Column(Numeric(14, 2), nullable=False)
+    snapshot_custo = Column(JSON, nullable=True)
+    snapshot_itens = Column(JSON, nullable=False, default=lambda: [])
+    snapshot_comercial = Column(JSON, nullable=False, default=lambda: {})
+    data_inicio = Column(Date, nullable=False)
+    data_fim_fidelidade = Column(Date, nullable=False)
+    fidelidade_meses = Column(Integer, nullable=False, default=FIDELIDADE_MESES_PADRAO)
+    setup_valor = Column(Numeric(14, 2), nullable=True)
+    setup_isento = Column(Boolean, nullable=False, default=False)
+    deslocamento_cliente = Column(Boolean, nullable=False, default=True)
+    alimentacao_cliente = Column(Boolean, nullable=False, default=True)
+    hospedagem_cliente = Column(Boolean, nullable=False, default=True)
+    multa_max_mensalidades = Column(Integer, nullable=False, default=MULTA_MAX_MENSALIDADES_PADRAO)
+    enviado_em = Column(DateTime(timezone=True), nullable=True)
+    assinado_em = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    template = relationship("ContratoTemplate", back_populates="contratos")
+    linha = relationship("CrmNegociacaoCnpjLinha")
+    gerado_por = relationship("Atendente", foreign_keys=[gerado_por_id])
+    pdfs = relationship(
+        "ContratoPdf",
+        back_populates="contrato",
+        cascade="all, delete-orphan",
+        order_by="ContratoPdf.id",
+    )
+
+
+class ContratoPdf(Base):
+    """Versão de PDF gerada a partir do snapshot HTML (#352)."""
+
+    __tablename__ = "comercial_contrato_pdfs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    contrato_id = Column(
+        Integer, ForeignKey("comercial_contratos.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    gerado_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="RESTRICT"), nullable=False)
+    conteudo_html_snapshot = Column(Text, nullable=False)
+    conteudo_hash = Column(String(64), nullable=False)
+    pdf_storage_key = Column(String(255), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)
+
+    contrato = relationship("Contrato", back_populates="pdfs")
+    gerado_por = relationship("Atendente", foreign_keys=[gerado_por_id])

--- a/backend/app/schemas/comercial_contrato.py
+++ b/backend/app/schemas/comercial_contrato.py
@@ -1,0 +1,119 @@
+"""Schemas de contrato comercial (#324 / #349–#352)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ContratoTemplateCreate(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=120)
+    conteudo_html: str = Field(..., min_length=1)
+    vigencia_inicio: datetime | None = None
+    ativo: bool = True
+
+
+class ContratoTemplateUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=120)
+    conteudo_html: str | None = Field(None, min_length=1)
+    vigencia_inicio: datetime | None = None
+    ativo: bool | None = None
+
+
+class ContratoTemplateRead(BaseModel):
+    id: int
+    nome: str
+    versao: int
+    conteudo_html: str
+    vigencia_inicio: datetime | None = None
+    ativo: bool
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ContratoTemplatePreviewIn(BaseModel):
+    conteudo_html: str = Field(..., min_length=1)
+
+
+class ContratoTemplatePreviewOut(BaseModel):
+    html: str
+
+
+class ContratoGerarIn(BaseModel):
+    linha_id: int
+    template_id: int | None = None
+    data_inicio: date | None = None
+    fidelidade_meses: int = Field(12, ge=1, le=60)
+    setup_valor: Decimal | None = None
+    setup_isento: bool = False
+    deslocamento_cliente: bool = True
+    alimentacao_cliente: bool = True
+    hospedagem_cliente: bool = True
+    multa_max_mensalidades: int = Field(3, ge=0, le=12)
+
+
+class ContratoMarcarEnviadoIn(BaseModel):
+    enviado_em: datetime | None = None
+
+
+class ContratoMarcarAssinadoIn(BaseModel):
+    assinado_em: datetime | None = None
+    avancar_funil: bool = False
+
+
+class ContratoPdfRead(BaseModel):
+    id: int
+    contrato_id: int
+    gerado_por_id: int
+    conteudo_hash: str
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ContratoInternoRead(BaseModel):
+    total_custo: Decimal | None = None
+    margem_calculada: Decimal | None = None
+    margem_percentual: Decimal | None = None
+    lucro_bruto: Decimal | None = None
+
+
+class ContratoRead(BaseModel):
+    id: int
+    negociacao_linha_cnpj_id: int
+    negociacao_id: int | None = None
+    empresa_id: int | None = None
+    template_id: int
+    template_nome: str | None = None
+    template_versao: int | None = None
+    gerado_por_id: int
+    status: str
+    valor_mensalidade: Decimal
+    snapshot_itens: list
+    data_inicio: date
+    data_fim_fidelidade: date
+    fidelidade_meses: int
+    setup_valor: Decimal | None = None
+    setup_isento: bool
+    deslocamento_cliente: bool
+    alimentacao_cliente: bool
+    hospedagem_cliente: bool
+    multa_max_mensalidades: int
+    enviado_em: datetime | None = None
+    assinado_em: datetime | None = None
+    created_at: datetime
+    pdf_atual_id: int | None = None
+    pdfs: list[ContratoPdfRead] = []
+    cnpj: str | None = None
+    razao_social: str | None = None
+    responsavel_id: int | None = None
+    responsavel_nome: str | None = None
+    lead_nome: str | None = None
+    conteudo_html_snapshot: str | None = None
+    dias_restantes_fidelidade: int | None = None
+    interno: ContratoInternoRead | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/comercial_contrato.py
+++ b/backend/app/services/comercial_contrato.py
@@ -1,0 +1,608 @@
+"""Contrato comercial: templates, snapshot por CNPJ e PDF (#324 / #349–#352)."""
+
+from __future__ import annotations
+
+import calendar
+import hashlib
+import html
+from datetime import date, datetime, timezone
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any
+
+from fastapi import HTTPException
+from sqlalchemy import func
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.atendente import Atendente
+from app.models.comercial_contrato import (
+    CONTRATO_ASSINADO,
+    CONTRATO_CANCELADO,
+    CONTRATO_ENVIADO,
+    CONTRATO_RASCUNHO,
+    CONTRATO_STATUS_ATIVOS,
+    FIDELIDADE_MESES_PADRAO,
+    MULTA_MAX_MENSALIDADES_PADRAO,
+    Contrato,
+    ContratoPdf,
+    ContratoTemplate,
+)
+from app.models.crm import ATIVIDADE_DOCUMENTO, CrmNegociacao, CrmNegociacaoAtividade, CrmNegociacaoCnpjLinha
+from app.schemas.comercial_contrato import (
+    ContratoGerarIn,
+    ContratoMarcarAssinadoIn,
+    ContratoMarcarEnviadoIn,
+    ContratoTemplateCreate,
+    ContratoTemplateUpdate,
+)
+from app.services import comercial_proposta as proposta_svc
+from app.services import crm as crm_svc
+from app.services.ticket_anexo_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
+
+TEMPLATE_PADRAO_HTML = """<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8"/>
+  <style>
+    body { font-family: DejaVu Sans, Arial, sans-serif; color: #1e293b; margin: 24px; font-size: 13px; }
+    h1 { font-size: 20px; margin: 0 0 8px; }
+    h2 { font-size: 14px; margin: 20px 0 8px; }
+    table { width: 100%; border-collapse: collapse; margin: 8px 0 16px; }
+    th, td { border: 1px solid #cbd5e1; padding: 8px; text-align: left; }
+    th { background: #f1f5f9; }
+    .muted { color: #64748b; font-size: 12px; }
+    .logo img { max-height: 72px; }
+  </style>
+</head>
+<body>
+  <div class="logo">{{logo}}</div>
+  <p class="muted">{{empresa_sistema}}</p>
+  <h1>Contrato de prestação de serviços</h1>
+  <p><strong>Contratante:</strong> {{razao_social}} &nbsp; <strong>CNPJ:</strong> {{cnpj}}</p>
+  <h2>Objeto e valores</h2>
+  {{itens}}
+  <p><strong>Mensalidade:</strong> {{valor_mensalidade}}</p>
+  {{setup_bloco}}
+  <h2>Vigência e fidelidade</h2>
+  <p>Início: {{data_inicio}} &nbsp; Fim da fidelidade: {{data_fim_fidelidade}} ({{fidelidade_meses}} meses).</p>
+  <div>{{fidelidade}}</div>
+  <div>{{multa}}</div>
+  <div>{{igpm}}</div>
+  <h2>Implantação</h2>
+  {{clausula_deslocamento}}
+  {{clausula_alimentacao}}
+  {{clausula_hospedagem}}
+</body>
+</html>
+"""
+
+
+def sanitize_html(fragment: str) -> str:
+    return proposta_svc.sanitize_html(fragment)
+
+
+def _add_months(d: date, months: int) -> date:
+    month = d.month - 1 + months
+    year = d.year + month // 12
+    month = month % 12 + 1
+    day = min(d.day, calendar.monthrange(year, month)[1])
+    return date(year, month, day)
+
+
+def _hash_html(conteudo: str) -> str:
+    return hashlib.sha256(conteudo.encode("utf-8")).hexdigest()
+
+
+def garantir_template_padrao(db: Session) -> ContratoTemplate:
+    row = (
+        db.query(ContratoTemplate)
+        .filter(ContratoTemplate.ativo.is_(True))
+        .order_by(ContratoTemplate.id.asc())
+        .first()
+    )
+    if row:
+        return row
+    row = ContratoTemplate(
+        nome="Padrão",
+        versao=1,
+        conteudo_html=TEMPLATE_PADRAO_HTML,
+        vigencia_inicio=datetime.now(timezone.utc),
+        ativo=True,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def listar_templates(db: Session, *, incluir_inativos: bool = False) -> list[ContratoTemplate]:
+    garantir_template_padrao(db)
+    q = db.query(ContratoTemplate)
+    if not incluir_inativos:
+        q = q.filter(ContratoTemplate.ativo.is_(True))
+    return q.order_by(ContratoTemplate.nome.asc(), ContratoTemplate.versao.desc()).all()
+
+
+def obter_template(db: Session, template_id: int, *, apenas_ativos: bool = False) -> ContratoTemplate:
+    q = db.query(ContratoTemplate).filter(ContratoTemplate.id == template_id)
+    if apenas_ativos:
+        q = q.filter(ContratoTemplate.ativo.is_(True))
+    row = q.first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Modelo de contrato não encontrado.")
+    return row
+
+
+def _proxima_versao(db: Session, nome: str) -> int:
+    atual = db.query(func.max(ContratoTemplate.versao)).filter(ContratoTemplate.nome == nome).scalar()
+    return int(atual or 0) + 1
+
+
+def criar_template(db: Session, data: ContratoTemplateCreate) -> ContratoTemplate:
+    nome = data.nome.strip()
+    row = ContratoTemplate(
+        nome=nome,
+        versao=_proxima_versao(db, nome),
+        conteudo_html=sanitize_html(data.conteudo_html),
+        vigencia_inicio=data.vigencia_inicio or datetime.now(timezone.utc),
+        ativo=data.ativo,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def atualizar_template(db: Session, row: ContratoTemplate, data: ContratoTemplateUpdate) -> ContratoTemplate:
+    payload = data.model_dump(exclude_unset=True)
+    html_mudou = False
+    if "conteudo_html" in payload and payload["conteudo_html"] is not None:
+        novo_html = sanitize_html(payload["conteudo_html"])
+        html_mudou = novo_html != (row.conteudo_html or "")
+        row.conteudo_html = novo_html
+    if "nome" in payload and payload["nome"] is not None:
+        row.nome = payload["nome"].strip()
+    if html_mudou:
+        row.versao = _proxima_versao(db, row.nome)
+    if "vigencia_inicio" in payload:
+        row.vigencia_inicio = payload["vigencia_inicio"]
+    if "ativo" in payload and payload["ativo"] is not None:
+        row.ativo = payload["ativo"]
+    db.flush()
+    return row
+
+
+def obter_linha(db: Session, linha_id: int) -> CrmNegociacaoCnpjLinha:
+    row = db.query(CrmNegociacaoCnpjLinha).filter(CrmNegociacaoCnpjLinha.id == linha_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Linha CNPJ da negociação não encontrada.")
+    return row
+
+
+def _contrato_ativo_da_linha(db: Session, linha_id: int) -> Contrato | None:
+    return (
+        db.query(Contrato)
+        .options(joinedload(Contrato.template), joinedload(Contrato.pdfs), joinedload(Contrato.linha))
+        .filter(
+            Contrato.negociacao_linha_cnpj_id == linha_id,
+            Contrato.status.in_(tuple(CONTRATO_STATUS_ATIVOS)),
+        )
+        .order_by(Contrato.id.desc())
+        .first()
+    )
+
+
+def _opts_contrato():
+    return (
+        joinedload(Contrato.template),
+        joinedload(Contrato.pdfs),
+        joinedload(Contrato.linha)
+        .joinedload(CrmNegociacaoCnpjLinha.negociacao)
+        .joinedload(CrmNegociacao.responsavel),
+        joinedload(Contrato.linha)
+        .joinedload(CrmNegociacaoCnpjLinha.negociacao)
+        .joinedload(CrmNegociacao.lead),
+    )
+
+
+def obter_contrato(db: Session, contrato_id: int) -> Contrato:
+    row = (
+        db.query(Contrato)
+        .options(*_opts_contrato())
+        .filter(Contrato.id == contrato_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Contrato não encontrado.")
+    return row
+
+
+def listar_contratos(
+    db: Session,
+    *,
+    negociacao_id: int | None = None,
+    status: str | None = None,
+    cnpj: str | None = None,
+    responsavel_id: int | None = None,
+    so_minhas: bool = False,
+    atendente: Atendente | None = None,
+) -> list[Contrato]:
+    if negociacao_id is not None:
+        crm_svc.obter_negociacao(db, negociacao_id)
+    q = (
+        db.query(Contrato)
+        .options(*_opts_contrato())
+        .join(CrmNegociacaoCnpjLinha, Contrato.negociacao_linha_cnpj_id == CrmNegociacaoCnpjLinha.id)
+        .join(CrmNegociacao, CrmNegociacaoCnpjLinha.negociacao_id == CrmNegociacao.id)
+    )
+    if negociacao_id is not None:
+        q = q.filter(CrmNegociacaoCnpjLinha.negociacao_id == negociacao_id)
+    if status:
+        q = q.filter(Contrato.status == status.strip())
+    if cnpj and cnpj.strip():
+        term = f"%{cnpj.strip()}%"
+        q = q.filter(
+            (CrmNegociacaoCnpjLinha.cnpj.ilike(term)) | (CrmNegociacaoCnpjLinha.razao_social.ilike(term))
+        )
+    if so_minhas and atendente is not None:
+        q = q.filter(CrmNegociacao.responsavel_id == atendente.id)
+    elif responsavel_id is not None:
+        q = q.filter(CrmNegociacao.responsavel_id == responsavel_id)
+    return q.order_by(Contrato.created_at.desc()).all()
+
+
+def _p(texto: str) -> str:
+    return f"<p>{texto}</p>"
+
+
+def _setup_bloco(*, setup_isento: bool, setup_valor: Decimal | None) -> str:
+    if setup_isento:
+        return _p("Setup de implantação: <strong>isento</strong> (não há cobrança avulsa de implantação).")
+    if setup_valor is not None:
+        return _p(
+            "Setup de implantação (cobrança única, <strong>fora</strong> da mensalidade): "
+            + html.escape(proposta_svc._money_br(setup_valor))
+        )
+    return _p("Setup de implantação: conforme negociação (fora da mensalidade).")
+
+
+def _clausula_custo_cliente(ativo: bool, titulo: str) -> str:
+    if not ativo:
+        return ""
+    return _p(html.escape(f"{titulo} por conta do contratante."))
+
+
+def preencher_template(db: Session, template_html: str, contrato: Contrato, linha: CrmNegociacaoCnpjLinha) -> str:
+    nomes = proposta_svc._nomes_itens_cliente(db, linha)
+    itens_txt = html.escape(", ".join(nomes) if nomes else "—")
+    tabela = (
+        "<table><thead><tr><th>Razão social</th><th>CNPJ</th><th>Itens</th><th>Mensalidade</th></tr></thead>"
+        "<tbody><tr>"
+        f"<td>{html.escape(linha.razao_social or '—')}</td>"
+        f"<td>{html.escape(proposta_svc._formatar_cnpj(linha.cnpj))}</td>"
+        f"<td>{itens_txt}</td>"
+        f"<td>{html.escape(proposta_svc._money_br(contrato.valor_mensalidade))}</td>"
+        "</tr></tbody></table>"
+    )
+    fid = int(contrato.fidelidade_meses or FIDELIDADE_MESES_PADRAO)
+    multa_n = int(contrato.multa_max_mensalidades or MULTA_MAX_MENSALIDADES_PADRAO)
+    valores = {
+        "logo": proposta_svc._logo_html(db),
+        "empresa_sistema": proposta_svc._empresa_sistema_texto(db),
+        "razao_social": html.escape(linha.razao_social or "—"),
+        "cnpj": html.escape(proposta_svc._formatar_cnpj(linha.cnpj)),
+        "itens": tabela,
+        "valor_mensalidade": html.escape(proposta_svc._money_br(contrato.valor_mensalidade)),
+        "data_inicio": html.escape(contrato.data_inicio.strftime("%d/%m/%Y")),
+        "data_fim_fidelidade": html.escape(contrato.data_fim_fidelidade.strftime("%d/%m/%Y")),
+        "fidelidade_meses": html.escape(str(fid)),
+        "setup_bloco": _setup_bloco(setup_isento=bool(contrato.setup_isento), setup_valor=contrato.setup_valor),
+        "fidelidade": _p(
+            html.escape(
+                f"O contratante permanece vinculado por {fid} meses de fidelidade, "
+                "contados da data de início."
+            )
+        ),
+        "multa": _p(
+            html.escape(
+                f"Em caso de rescisão antecipada, a multa é de até {multa_n} mensalidade(s), "
+                "a validar juridicamente."
+            )
+        ),
+        "igpm": _p(
+            "Após o período de fidelidade, a renovação é automática, sem nova fidelidade, "
+            "com reajuste pelo IGPM acumulado em 12 meses."
+        ),
+        "clausula_deslocamento": _clausula_custo_cliente(bool(contrato.deslocamento_cliente), "Deslocamento"),
+        "clausula_alimentacao": _clausula_custo_cliente(bool(contrato.alimentacao_cliente), "Alimentação"),
+        "clausula_hospedagem": _clausula_custo_cliente(bool(contrato.hospedagem_cliente), "Hospedagem"),
+    }
+    html_out = sanitize_html(template_html)
+    for chave, valor in valores.items():
+        html_out = html_out.replace("{{" + chave + "}}", valor)
+    if proposta_svc._VAZAMENTO.search(html_out):
+        raise HTTPException(
+            status_code=500,
+            detail="O contrato gerado continha dados internos e foi bloqueado. Contacte o suporte.",
+        )
+    return html_out
+
+
+def _montar_snapshots(db: Session, linha: CrmNegociacaoCnpjLinha, data: ContratoGerarIn) -> dict[str, Any]:
+    nomes = proposta_svc._nomes_itens_cliente(db, linha)
+    snap_custo = linha.snapshot_custo if isinstance(linha.snapshot_custo, dict) else None
+    return {
+        "valor_mensalidade": Decimal(str(linha.valor_negociado or 0)),
+        "snapshot_custo": snap_custo,
+        "snapshot_itens": [{"nome": n} for n in nomes],
+        "snapshot_comercial": {
+            "valor_mensalidade": str(Decimal(str(linha.valor_negociado or 0))),
+            "setup_valor": str(data.setup_valor) if data.setup_valor is not None else None,
+            "setup_isento": data.setup_isento,
+            "fidelidade_meses": data.fidelidade_meses,
+            "multa_max_mensalidades": data.multa_max_mensalidades,
+            "deslocamento_cliente": data.deslocamento_cliente,
+            "alimentacao_cliente": data.alimentacao_cliente,
+            "hospedagem_cliente": data.hospedagem_cliente,
+        },
+    }
+
+
+def _aplicar_campos_geracao(row: Contrato, data: ContratoGerarIn, snaps: dict[str, Any], tmpl: ContratoTemplate) -> None:
+    inicio = data.data_inicio or date.today()
+    meses = int(data.fidelidade_meses or FIDELIDADE_MESES_PADRAO)
+    row.template_id = tmpl.id
+    row.valor_mensalidade = snaps["valor_mensalidade"]
+    row.snapshot_custo = snaps["snapshot_custo"]
+    row.snapshot_itens = snaps["snapshot_itens"]
+    snap_com = dict(snaps["snapshot_comercial"] or {})
+    snap_com["template_id"] = tmpl.id
+    snap_com["template_versao"] = tmpl.versao
+    row.snapshot_comercial = snap_com
+    row.data_inicio = inicio
+    row.data_fim_fidelidade = _add_months(inicio, meses)
+    row.fidelidade_meses = meses
+    row.setup_valor = data.setup_valor
+    row.setup_isento = data.setup_isento
+    row.deslocamento_cliente = data.deslocamento_cliente
+    row.alimentacao_cliente = data.alimentacao_cliente
+    row.hospedagem_cliente = data.hospedagem_cliente
+    row.multa_max_mensalidades = data.multa_max_mensalidades
+
+
+def _gravar_pdf_versao(db: Session, contrato: Contrato, html_doc: str, ator: Atendente) -> ContratoPdf:
+    pdf_row = ContratoPdf(
+        contrato_id=contrato.id,
+        gerado_por_id=ator.id,
+        conteudo_html_snapshot=html_doc,
+        conteudo_hash=_hash_html(html_doc),
+    )
+    db.add(pdf_row)
+    db.flush()
+    return pdf_row
+
+
+def gerar_contrato(db: Session, data: ContratoGerarIn, ator: Atendente) -> Contrato:
+    linha = obter_linha(db, data.linha_id)
+    if not (linha.razao_social or "").strip() or not (linha.cnpj or "").strip():
+        raise HTTPException(status_code=400, detail="A linha precisa de razão social e CNPJ para gerar o contrato.")
+    if data.template_id:
+        tmpl = obter_template(db, data.template_id, apenas_ativos=True)
+    else:
+        tmpl = garantir_template_padrao(db)
+
+    existente = _contrato_ativo_da_linha(db, linha.id)
+    if existente and existente.status == CONTRATO_ASSINADO:
+        raise HTTPException(
+            status_code=400,
+            detail="Contrato já assinado: o snapshot não é editável (aditivo fica para uma issue futura).",
+        )
+    if existente and existente.status == CONTRATO_ENVIADO:
+        raise HTTPException(
+            status_code=400,
+            detail="Contrato já enviado. Não é possível regenerar; cancele ou marque como assinado.",
+        )
+
+    snaps = _montar_snapshots(db, linha, data)
+    if existente:
+        row = existente
+        _aplicar_campos_geracao(row, data, snaps, tmpl)
+        texto_ativ = f"Contrato #{row.id} regenerado (rascunho)."
+    else:
+        row = Contrato(
+            negociacao_linha_cnpj_id=linha.id,
+            empresa_id=linha.empresa_id,
+            gerado_por_id=ator.id,
+            status=CONTRATO_RASCUNHO,
+        )
+        _aplicar_campos_geracao(row, data, snaps, tmpl)
+        db.add(row)
+        db.flush()
+        texto_ativ = f"Contrato #{row.id} gerado (rascunho)."
+
+    snapshot_html = preencher_template(db, tmpl.conteudo_html, row, linha)
+    _gravar_pdf_versao(db, row, snapshot_html, ator)
+    db.add(
+        CrmNegociacaoAtividade(
+            negociacao_id=linha.negociacao_id,
+            autor_id=ator.id,
+            tipo=ATIVIDADE_DOCUMENTO,
+            texto=texto_ativ,
+        )
+    )
+    db.flush()
+    return obter_contrato(db, row.id)
+
+
+def _pdf_mais_recente(row: Contrato) -> ContratoPdf | None:
+    pdfs = list(row.pdfs or [])
+    if not pdfs:
+        return None
+    return max(pdfs, key=lambda p: p.id)
+
+
+def garantir_pdf(db: Session, row: Contrato, *, pdf_id: int | None = None) -> tuple[ContratoPdf, bytes]:
+    if pdf_id is not None:
+        pdf_row = next((p for p in (row.pdfs or []) if p.id == pdf_id), None)
+        if not pdf_row:
+            raise HTTPException(status_code=404, detail="Versão de PDF não encontrada.")
+    else:
+        pdf_row = _pdf_mais_recente(row)
+        if not pdf_row:
+            raise HTTPException(status_code=400, detail="Este contrato ainda não tem PDF gerado.")
+    if pdf_row.pdf_storage_key:
+        path = caminho_absoluto_arquivo(pdf_row.pdf_storage_key)
+        if path:
+            return pdf_row, path.read_bytes()
+    pdf = proposta_svc.html_para_pdf(pdf_row.conteudo_html_snapshot)
+    try:
+        key = gravar_bytes_em_disco(pdf, mimetype="application/pdf", nome_original=f"contrato-{row.id}-{pdf_row.id}.pdf")
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail="Não foi possível guardar o PDF.") from exc
+    pdf_row.pdf_storage_key = key
+    db.flush()
+    return pdf_row, pdf
+
+
+def marcar_enviado(db: Session, row: Contrato, data: ContratoMarcarEnviadoIn, ator: Atendente) -> Contrato:
+    if row.status != CONTRATO_RASCUNHO:
+        raise HTTPException(status_code=400, detail="Só o rascunho pode ser marcado como enviado.")
+    row.status = CONTRATO_ENVIADO
+    row.enviado_em = data.enviado_em or datetime.now(timezone.utc)
+    linha = row.linha or obter_linha(db, row.negociacao_linha_cnpj_id)
+    db.add(
+        CrmNegociacaoAtividade(
+            negociacao_id=linha.negociacao_id,
+            autor_id=ator.id,
+            tipo=ATIVIDADE_DOCUMENTO,
+            texto=f"Contrato #{row.id} marcado como enviado.",
+        )
+    )
+    db.flush()
+    return row
+
+
+def marcar_assinado(db: Session, row: Contrato, data: ContratoMarcarAssinadoIn, ator: Atendente) -> Contrato:
+    if row.status not in {CONTRATO_RASCUNHO, CONTRATO_ENVIADO}:
+        raise HTTPException(status_code=400, detail="Só rascunho ou enviado podem ser marcados como assinados.")
+    row.status = CONTRATO_ASSINADO
+    row.assinado_em = data.assinado_em or datetime.now(timezone.utc)
+    linha = row.linha or obter_linha(db, row.negociacao_linha_cnpj_id)
+    db.add(
+        CrmNegociacaoAtividade(
+            negociacao_id=linha.negociacao_id,
+            autor_id=ator.id,
+            tipo=ATIVIDADE_DOCUMENTO,
+            texto=f"Contrato #{row.id} marcado como assinado (registro manual).",
+        )
+    )
+    if data.avancar_funil:
+        neg = crm_svc.obter_negociacao(db, linha.negociacao_id)
+        atual = crm_svc.obter_estagio(db, estagio_id=neg.estagio_id)
+        if atual.slug != "contrato_assinado":
+            crm_svc.mover_estagio(
+                db,
+                neg,
+                ator=ator,
+                estagio_slug="contrato_assinado",
+                nota="Contrato assinado (registro manual).",
+            )
+    db.flush()
+    return row
+
+
+def cancelar_contrato(db: Session, row: Contrato, ator: Atendente) -> Contrato:
+    if row.status in {CONTRATO_CANCELADO, CONTRATO_ASSINADO}:
+        raise HTTPException(
+            status_code=400,
+            detail="Contrato assinado ou já cancelado não pode ser cancelado nesta tela.",
+        )
+    row.status = CONTRATO_CANCELADO
+    linha = row.linha or obter_linha(db, row.negociacao_linha_cnpj_id)
+    db.add(
+        CrmNegociacaoAtividade(
+            negociacao_id=linha.negociacao_id,
+            autor_id=ator.id,
+            tipo=ATIVIDADE_DOCUMENTO,
+            texto=f"Contrato #{row.id} cancelado.",
+        )
+    )
+    db.flush()
+    return row
+
+
+def _interno_read(row: Contrato, linha: CrmNegociacaoCnpjLinha | None) -> dict[str, Any] | None:
+    if linha is None:
+        return None
+    valor = Decimal(str(row.valor_mensalidade or 0))
+    custo = Decimal(str(linha.total_custo)) if linha.total_custo is not None else None
+    lucro = None
+    margem_pct = None
+    if custo is not None:
+        lucro = (valor - custo).quantize(Decimal("0.01"))
+        if valor != 0:
+            margem_pct = ((lucro / valor) * Decimal("100")).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    return {
+        "total_custo": linha.total_custo,
+        "margem_calculada": linha.margem_calculada,
+        "margem_percentual": margem_pct,
+        "lucro_bruto": lucro,
+    }
+
+
+def contrato_para_read(row: Contrato, *, incluir_html: bool = False) -> dict[str, Any]:
+    tmpl = row.template
+    linha = row.linha
+    neg = linha.negociacao if linha else None
+    pdfs = sorted(row.pdfs or [], key=lambda p: p.id)
+    atual = pdfs[-1] if pdfs else None
+    dias: int | None = None
+    if row.data_fim_fidelidade:
+        dias = (row.data_fim_fidelidade - date.today()).days
+    snap_com = row.snapshot_comercial if isinstance(row.snapshot_comercial, dict) else {}
+    versao_snapshot = snap_com.get("template_versao")
+    try:
+        template_versao = int(versao_snapshot) if versao_snapshot is not None else (tmpl.versao if tmpl else None)
+    except (TypeError, ValueError):
+        template_versao = tmpl.versao if tmpl else None
+    return {
+        "id": row.id,
+        "negociacao_linha_cnpj_id": row.negociacao_linha_cnpj_id,
+        "negociacao_id": linha.negociacao_id if linha else None,
+        "empresa_id": row.empresa_id,
+        "template_id": row.template_id,
+        "template_nome": tmpl.nome if tmpl else None,
+        "template_versao": template_versao,
+        "gerado_por_id": row.gerado_por_id,
+        "status": row.status,
+        "valor_mensalidade": row.valor_mensalidade,
+        "snapshot_itens": list(row.snapshot_itens or []),
+        "data_inicio": row.data_inicio,
+        "data_fim_fidelidade": row.data_fim_fidelidade,
+        "fidelidade_meses": row.fidelidade_meses,
+        "setup_valor": row.setup_valor,
+        "setup_isento": row.setup_isento,
+        "deslocamento_cliente": row.deslocamento_cliente,
+        "alimentacao_cliente": row.alimentacao_cliente,
+        "hospedagem_cliente": row.hospedagem_cliente,
+        "multa_max_mensalidades": row.multa_max_mensalidades,
+        "enviado_em": row.enviado_em,
+        "assinado_em": row.assinado_em,
+        "created_at": row.created_at,
+        "pdf_atual_id": atual.id if atual else None,
+        "pdfs": [
+            {
+                "id": p.id,
+                "contrato_id": p.contrato_id,
+                "gerado_por_id": p.gerado_por_id,
+                "conteudo_hash": p.conteudo_hash,
+                "created_at": p.created_at,
+            }
+            for p in pdfs
+        ],
+        "cnpj": linha.cnpj if linha else None,
+        "razao_social": linha.razao_social if linha else None,
+        "responsavel_id": neg.responsavel_id if neg else None,
+        "responsavel_nome": neg.responsavel.nome if neg and neg.responsavel else None,
+        "lead_nome": neg.lead.nome if neg and neg.lead else None,
+        "conteudo_html_snapshot": atual.conteudo_html_snapshot if incluir_html and atual else None,
+        "dias_restantes_fidelidade": dias,
+        "interno": _interno_read(row, linha),
+    }

--- a/backend/tests/test_comercial_contrato.py
+++ b/backend/tests/test_comercial_contrato.py
@@ -1,0 +1,376 @@
+"""Contrato comercial — templates, snapshot por CNPJ e PDF (#324 / #349–#352)."""
+
+from __future__ import annotations
+
+import pytest
+
+TERMOS_INTERNOS = (
+    "total_custo",
+    "margem_calculada",
+    "snapshot_custo",
+    "valor_custo",
+    "override_custo",
+    "tef_override",
+    "lucro bruto",
+)
+
+
+@pytest.fixture(autouse=True)
+def _pdf_fake(monkeypatch):
+    def _fake(html: str) -> bytes:
+        return b"%PDF-1.4\n" + html.encode("utf-8")
+
+    monkeypatch.setattr("app.services.comercial_proposta.html_para_pdf", _fake)
+
+
+def _criar_item_catalogo(client, h_admin) -> int:
+    client.post(
+        "/v1/comercial/salario-minimo",
+        headers=h_admin,
+        json={"valor": "1518.00", "vigencia_inicio": "2025-01-01", "vigencia_fim": None},
+    )
+    item = client.post(
+        "/v1/comercial/custos/itens",
+        headers=h_admin,
+        json={
+            "nome": "Licença mensal",
+            "slug": "licenca-contrato-test",
+            "tipo": "percentual_sm",
+            "percentual_sm": "10",
+            "aplica_tier_posto": False,
+            "ordem": 1,
+            "ativo": True,
+        },
+    )
+    assert item.status_code == 201, item.text
+    return item.json()["id"]
+
+
+def _negociacao_com_linha(client, h, *, item_id: int | None = None):
+    lead = client.post("/v1/crm/leads", headers=h, json={"nome": "Posto Contrato"}).json()
+    neg_id = lead["negociacao_ativa_id"]
+    payload = {
+        "razao_social": "Posto Contrato LTDA",
+        "cnpj": "12.345.678/0001-95",
+        "valor_negociado": "900.00",
+        "item_ids": [item_id] if item_id else [],
+    }
+    ln = client.post(f"/v1/crm/negociacoes/{neg_id}/linhas", headers=h, json=payload)
+    assert ln.status_code == 201, ln.text
+    return neg_id, ln.json()
+
+
+def _assert_sem_internos(texto: str | bytes) -> None:
+    blob = texto.decode("utf-8", errors="ignore") if isinstance(texto, (bytes, bytearray)) else texto
+    low = blob.lower()
+    for termo in TERMOS_INTERNOS:
+        assert termo not in low, f"vazamento de «{termo}» no documento do cliente"
+
+
+def test_atendente_403_contrato(client, auth_headers, seed_base):
+    h = auth_headers["a1"]
+    assert client.get("/v1/comercial/contrato-templates", headers=h).status_code == 403
+    assert client.get("/v1/comercial/contratos", headers=h, params={"negociacao_id": 1}).status_code == 403
+    assert client.post("/v1/comercial/contratos", headers=h, json={"linha_id": 1}).status_code == 403
+
+
+def test_comercial_403_crud_contrato_templates(client, auth_headers):
+    h = auth_headers["comercial"]
+    r = client.post(
+        "/v1/comercial/contrato-templates",
+        headers=h,
+        json={"nome": "X", "conteudo_html": "<p>{{razao_social}}</p>"},
+    )
+    assert r.status_code == 403
+
+
+def test_admin_crud_contrato_template_e_preview(client, auth_headers):
+    h = auth_headers["admin"]
+    created = client.post(
+        "/v1/comercial/contrato-templates",
+        headers=h,
+        json={
+            "nome": "Institucional",
+            "conteudo_html": "<h1>{{razao_social}}</h1><script>alert(1)</script>{{setup_bloco}}",
+        },
+    )
+    assert created.status_code == 201, created.text
+    body = created.json()
+    assert body["versao"] == 1
+    assert "<script" not in body["conteudo_html"].lower()
+
+    prev = client.post(
+        "/v1/comercial/contrato-templates/preview",
+        headers=h,
+        json={"conteudo_html": '<p onclick="x()">Oi</p><iframe src="x"></iframe>'},
+    )
+    assert prev.status_code == 200
+    html = prev.json()["html"]
+    assert "onclick" not in html.lower()
+    assert "iframe" not in html.lower()
+
+    patched = client.patch(
+        f"/v1/comercial/contrato-templates/{body['id']}",
+        headers=h,
+        json={"conteudo_html": "<p>Olá {{cnpj}}</p>"},
+    )
+    assert patched.status_code == 200
+    assert "Olá" in patched.json()["conteudo_html"]
+    assert patched.json()["versao"] == 2
+
+    mesmo_html = client.patch(
+        f"/v1/comercial/contrato-templates/{body['id']}",
+        headers=h,
+        json={"ativo": True},
+    )
+    assert mesmo_html.status_code == 200
+    assert mesmo_html.json()["versao"] == 2
+
+
+def test_comercial_gera_contrato_sem_custo_e_pdf(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    item_id = _criar_item_catalogo(client, auth_headers["admin"])
+    neg_id, linha = _negociacao_com_linha(client, h, item_id=item_id)
+
+    gerada = client.post(
+        "/v1/comercial/contratos",
+        headers=h,
+        json={
+            "linha_id": linha["id"],
+            "setup_valor": "1500.00",
+            "setup_isento": False,
+            "fidelidade_meses": 12,
+        },
+    )
+    assert gerada.status_code == 201, gerada.text
+    c = gerada.json()
+    assert c["status"] == "rascunho"
+    assert c["negociacao_id"] == neg_id
+    assert float(c["valor_mensalidade"]) == 900
+    assert c["setup_valor"] is not None
+    assert c["fidelidade_meses"] == 12
+    assert len(c["pdfs"]) == 1
+    html = client.get(f"/v1/comercial/contratos/{c['id']}", headers=h).json()
+    pdf = client.get(f"/v1/comercial/contratos/{c['id']}/pdf", headers=h)
+    assert pdf.status_code == 200
+    assert pdf.headers["content-type"].startswith("application/pdf")
+    blob = pdf.content.decode("utf-8", errors="ignore")
+    assert "Posto Contrato LTDA" in blob
+    assert "900" in blob
+    assert "Licença mensal" in blob
+    assert "fidelidade" in blob.lower()
+    assert "setup" in blob.lower()
+    assert "fora" in blob.lower()
+    assert "deslocamento" in blob.lower()
+    _assert_sem_internos(blob)
+    assert "margem" not in blob.lower()
+    assert "snapshot_custo" not in blob.lower()
+    # mensalidade não inclui o setup
+    assert "1.500" in blob or "1500" in blob
+    assert html["snapshot_itens"]
+
+    lst = client.get("/v1/comercial/contratos", headers=h, params={"negociacao_id": neg_id})
+    assert lst.status_code == 200
+    assert len(lst.json()) == 1
+
+
+def test_setup_isento_renderiza_bloco_e_nao_muda_mensalidade(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    neg_id, linha = _negociacao_com_linha(client, h)
+    r = client.post(
+        "/v1/comercial/contratos",
+        headers=h,
+        json={"linha_id": linha["id"], "setup_isento": True, "setup_valor": "2000.00"},
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["setup_isento"] is True
+    assert float(r.json()["valor_mensalidade"]) == 900
+    pdf = client.get(f"/v1/comercial/contratos/{r.json()['id']}/pdf", headers=h)
+    blob = pdf.content.decode("utf-8", errors="ignore").lower()
+    assert "isento" in blob
+    assert "900" in blob
+
+
+def test_um_contrato_ativo_por_linha_e_historico_pdf(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    _, linha = _negociacao_com_linha(client, h)
+    p1 = client.post(
+        "/v1/comercial/contratos",
+        headers=h,
+        json={"linha_id": linha["id"], "data_inicio": "2026-01-15"},
+    )
+    assert p1.status_code == 201, p1.text
+    cid = p1.json()["id"]
+    assert p1.json()["data_inicio"] == "2026-01-15"
+    assert p1.json()["data_fim_fidelidade"] == "2027-01-15"
+    hash1 = p1.json()["pdfs"][0]["conteudo_hash"]
+
+    p2 = client.post(
+        "/v1/comercial/contratos",
+        headers=h,
+        json={"linha_id": linha["id"], "data_inicio": "2026-02-01"},
+    )
+    assert p2.status_code == 201, p2.text
+    assert p2.json()["id"] == cid
+    assert p2.json()["data_inicio"] == "2026-02-01"
+    assert len(p2.json()["pdfs"]) == 2
+    assert p2.json()["pdfs"][0]["conteudo_hash"] == hash1
+    assert p2.json()["pdfs"][1]["conteudo_hash"] != hash1
+
+    pdf_v1 = client.get(
+        f"/v1/comercial/contratos/{cid}/pdf",
+        headers=h,
+        params={"pdf_id": p2.json()["pdfs"][0]["id"]},
+    )
+    assert pdf_v1.status_code == 200
+    assert b"15/01/2026" in pdf_v1.content
+
+
+def test_assinado_nao_edita_snapshot(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    _, linha = _negociacao_com_linha(client, h)
+    c = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": linha["id"]})
+    assert c.status_code == 201, c.text
+    cid = c.json()["id"]
+    env = client.post(f"/v1/comercial/contratos/{cid}/marcar-enviado", headers=h, json={})
+    assert env.status_code == 200
+    assert env.json()["status"] == "enviado"
+    regen = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": linha["id"]})
+    assert regen.status_code == 400
+
+    ass = client.post(
+        f"/v1/comercial/contratos/{cid}/marcar-assinado",
+        headers=h,
+        json={"avancar_funil": True},
+    )
+    assert ass.status_code == 200, ass.text
+    assert ass.json()["status"] == "assinado"
+    assert ass.json()["assinado_em"]
+    regen2 = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": linha["id"]})
+    assert regen2.status_code == 400
+
+    neg_id = c.json()["negociacao_id"]
+    neg = client.get(f"/v1/crm/negociacoes/{neg_id}", headers=h)
+    assert neg.json()["estagio_slug"] == "contrato_assinado"
+
+
+def test_segunda_linha_pode_ter_contrato_proprio(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    lead = client.post("/v1/crm/leads", headers=h, json={"nome": "Rede Dois CNPJ"}).json()
+    neg_id = lead["negociacao_ativa_id"]
+    l1 = client.post(
+        f"/v1/crm/negociacoes/{neg_id}/linhas",
+        headers=h,
+        json={"razao_social": "Posto A", "cnpj": "12.345.678/0001-95", "valor_negociado": "100"},
+    )
+    l2 = client.post(
+        f"/v1/crm/negociacoes/{neg_id}/linhas",
+        headers=h,
+        json={"razao_social": "Posto B", "cnpj": "98.765.432/0001-10", "valor_negociado": "200"},
+    )
+    assert l1.status_code == 201 and l2.status_code == 201
+    c1 = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": l1.json()["id"]})
+    c2 = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": l2.json()["id"]})
+    assert c1.status_code == 201 and c2.status_code == 201
+    assert c1.json()["id"] != c2.json()["id"]
+    lst = client.get("/v1/comercial/contratos", headers=h, params={"negociacao_id": neg_id})
+    assert len(lst.json()) == 2
+
+
+def test_lista_so_minhas_e_interno_nao_vai_no_pdf(client, auth_headers, seed_base):
+    h_com = auth_headers["comercial"]
+    h_admin = auth_headers["admin"]
+    _, linha_com = _negociacao_com_linha(client, h_com)
+    c_com = client.post("/v1/comercial/contratos", headers=h_com, json={"linha_id": linha_com["id"]})
+    assert c_com.status_code == 201, c_com.text
+
+    _, linha_adm = _negociacao_com_linha(client, h_admin)
+    c_adm = client.post("/v1/comercial/contratos", headers=h_admin, json={"linha_id": linha_adm["id"]})
+    assert c_adm.status_code == 201, c_adm.text
+
+    lst_com = client.get("/v1/comercial/contratos", headers=h_com)
+    assert lst_com.status_code == 200
+    ids_com = {r["id"] for r in lst_com.json()}
+    assert c_com.json()["id"] in ids_com
+    assert c_adm.json()["id"] not in ids_com
+    assert all(r.get("conteudo_html_snapshot") is None for r in lst_com.json())
+
+    lst_admin = client.get("/v1/comercial/contratos", headers=h_admin)
+    ids_admin = {r["id"] for r in lst_admin.json()}
+    assert c_com.json()["id"] in ids_admin
+    assert c_adm.json()["id"] in ids_admin
+
+    detalhe = client.get(f"/v1/comercial/contratos/{c_com.json()['id']}", headers=h_com).json()
+    assert detalhe["interno"] is not None
+    assert "total_custo" in detalhe["interno"]
+    assert detalhe["interno"]["lucro_bruto"] is not None
+    assert detalhe["interno"]["margem_percentual"] is not None
+    assert detalhe["responsavel_nome"]
+    assert detalhe["dias_restantes_fidelidade"] is not None
+
+    lst_resp = client.get(
+        "/v1/comercial/contratos",
+        headers=h_admin,
+        params={"responsavel_id": seed_base["comercial"].id},
+    )
+    ids_resp = {r["id"] for r in lst_resp.json()}
+    assert c_com.json()["id"] in ids_resp
+    assert c_adm.json()["id"] not in ids_resp
+    pdf = client.get(f"/v1/comercial/contratos/{c_com.json()['id']}/pdf", headers=h_com)
+    _assert_sem_internos(pdf.content)
+    assert "margem" not in pdf.content.decode("utf-8", errors="ignore").lower()
+
+
+def test_cancelar_rascunho_e_bloqueia_assinado(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    _, linha = _negociacao_com_linha(client, h)
+    c = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": linha["id"]})
+    cid = c.json()["id"]
+    cancelado = client.post(f"/v1/comercial/contratos/{cid}/cancelar", headers=h)
+    assert cancelado.status_code == 200, cancelado.text
+    assert cancelado.json()["status"] == "cancelado"
+    assert client.post(f"/v1/comercial/contratos/{cid}/cancelar", headers=h).status_code == 400
+
+    novo = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": linha["id"]})
+    assert novo.status_code == 201, novo.text
+    nid = novo.json()["id"]
+    assert nid != cid
+    ass = client.post(f"/v1/comercial/contratos/{nid}/marcar-assinado", headers=h, json={})
+    assert ass.status_code == 200
+    assert client.post(f"/v1/comercial/contratos/{nid}/cancelar", headers=h).status_code == 400
+
+
+def test_versao_do_modelo_fica_gravada_no_contrato(client, auth_headers, seed_base):
+    h_admin = auth_headers["admin"]
+    h = auth_headers["comercial"]
+    tmpl = client.post(
+        "/v1/comercial/contrato-templates",
+        headers=h_admin,
+        json={"nome": "Freeze", "conteudo_html": "<p>v1 {{razao_social}}</p>"},
+    ).json()
+    assert tmpl["versao"] == 1
+    _, linha = _negociacao_com_linha(client, h)
+    gerado = client.post(
+        "/v1/comercial/contratos",
+        headers=h,
+        json={"linha_id": linha["id"], "template_id": tmpl["id"]},
+    )
+    assert gerado.status_code == 201, gerado.text
+    assert gerado.json()["template_versao"] == 1
+
+    patched = client.patch(
+        f"/v1/comercial/contrato-templates/{tmpl['id']}",
+        headers=h_admin,
+        json={"conteudo_html": "<p>v2 {{cnpj}}</p>"},
+    )
+    assert patched.json()["versao"] == 2
+    frozen = client.get(f"/v1/comercial/contratos/{gerado.json()['id']}", headers=h).json()
+    assert frozen["template_versao"] == 1
+
+    regen = client.post(
+        "/v1/comercial/contratos",
+        headers=h,
+        json={"linha_id": linha["id"], "template_id": tmpl["id"]},
+    )
+    assert regen.status_code == 201, regen.text
+    assert regen.json()["template_versao"] == 2

--- a/docs/BACKEND_RBAC.md
+++ b/docs/BACKEND_RBAC.md
@@ -35,6 +35,7 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 | Catálogo comercial (leitura itens) | `GET /v1/comercial/custos/itens` — também comercial (montar pacote na negociação) |
 | Funil CRM (mutação) | `POST/PATCH /v1/crm/funil-estagios` — UI em Configurações → Cadastros → Funil CRM |
 | Modelos de proposta (CRUD) | `POST/PATCH /v1/comercial/proposta-templates`, `POST /v1/comercial/proposta-templates/preview` — UI em Cadastros → Modelos de proposta |
+| Modelos de contrato (CRUD) | `POST/PATCH /v1/comercial/contrato-templates`, `POST /v1/comercial/contrato-templates/preview` |
 
 ## Comercial ou administrador (`exigir_comercial_ou_admin`)
 
@@ -45,6 +46,7 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 | **Simular custos** | `POST /v1/comercial/custos/simular` |
 | **Listar itens catálogo** | `GET /v1/comercial/custos/itens` (mutações continuam só admin) |
 | **Proposta comercial** | `GET /v1/comercial/proposta-templates` (ativos), `POST/GET /v1/comercial/propostas*`, `GET .../pdf`, `POST .../marcar-enviada` |
+| **Contrato comercial** | `GET /v1/comercial/contrato-templates` (ativos), `POST/GET /v1/comercial/contratos*`, `GET .../pdf`, `POST .../marcar-enviado`, `POST .../marcar-assinado`, `POST .../cancelar`. Lista global: comercial só os das próprias negociações; admin todos (filtros `so_minhas` e `responsavel_id`) |
 
 ## Autenticado com escopo de setor (`obter_atendente_atual`)
 
@@ -74,3 +76,4 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 - **403**: mensagens vêm do corpo da API (`api/client` + `errorMessage.ts`).
 - **CRM UI** (#341–#344): menu **CRM** e rotas `/crm/leads`, `/crm/negociacoes/:id` para `admin` e `comercial`.
 - **Proposta** (#345–#348): card na negociação para comercial/admin; CRUD de templates só admin.
+- **Contrato** (#349–#356): card na negociação, lista `/crm/contratos` (comercial: próprias; admin: todas); CRUD de templates em Cadastros (só admin).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,10 +17,12 @@ import { RelatoriosChats } from './pages/RelatoriosChats'
 import { PresencaOnline } from './pages/PresencaOnline'
 import { Tickets } from './pages/Tickets'
 import { TicketNovo } from './pages/TicketNovo'
+import { ConfigPropostaTemplates } from './pages/ConfigPropostaTemplates'
+import { ConfigContratoTemplates } from './pages/ConfigContratoTemplates'
 import { CrmLeads } from './pages/CrmLeads'
 import { CrmNegociacaoDetalhe } from './pages/CrmNegociacaoDetalhe'
+import { CrmContratos } from './pages/CrmContratos'
 import { ConfigCrmFunil } from './pages/ConfigCrmFunil'
-import { ConfigPropostaTemplates } from './pages/ConfigPropostaTemplates'
 import { Redes } from './pages/Redes'
 import { RedeDetalhe } from './pages/RedeDetalhe'
 import { RedeForm } from './pages/RedeForm'
@@ -367,6 +369,14 @@ function AppRoutes() {
           element={
             <ComercialOuAdminRoute>
               <CrmNegociacaoDetalhe />
+            </ComercialOuAdminRoute>
+          }
+        />
+        <Route
+          path="crm/contratos"
+          element={
+            <ComercialOuAdminRoute>
+              <CrmContratos />
             </ComercialOuAdminRoute>
           }
         />
@@ -717,6 +727,7 @@ function AppRoutes() {
           <Route path="custos" element={<ConfigComercialCustos embedded />} />
           <Route path="funil-crm" element={<ConfigCrmFunil embedded />} />
           <Route path="propostas" element={<ConfigPropostaTemplates embedded />} />
+          <Route path="contratos" element={<ConfigContratoTemplates embedded />} />
         </Route>
         <Route
           path="configuracoes/sistema"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3084,6 +3084,167 @@ export const comercialPropostas = {
   },
 };
 
+export namespace ComercialContrato {
+  export interface Template {
+    id: number;
+    nome: string;
+    versao: number;
+    conteudo_html: string;
+    vigencia_inicio?: string | null;
+    ativo: boolean;
+    created_at: string;
+  }
+  export interface TemplateCreate {
+    nome: string;
+    conteudo_html: string;
+    vigencia_inicio?: string | null;
+    ativo?: boolean;
+  }
+  export interface TemplateUpdate {
+    nome?: string;
+    conteudo_html?: string;
+    vigencia_inicio?: string | null;
+    ativo?: boolean;
+  }
+  export interface Interno {
+    total_custo?: string | number | null;
+    margem_calculada?: string | number | null;
+    margem_percentual?: string | number | null;
+    lucro_bruto?: string | number | null;
+  }
+  export interface Pdf {
+    id: number;
+    contrato_id: number;
+    gerado_por_id: number;
+    conteudo_hash: string;
+    created_at: string;
+  }
+  export interface Contrato {
+    id: number;
+    negociacao_linha_cnpj_id: number;
+    negociacao_id?: number | null;
+    empresa_id?: number | null;
+    template_id: number;
+    template_nome?: string | null;
+    template_versao?: number | null;
+    gerado_por_id: number;
+    status: 'rascunho' | 'enviado' | 'assinado' | 'cancelado' | 'renovado' | string;
+    valor_mensalidade: string | number;
+    snapshot_itens: unknown[];
+    data_inicio: string;
+    data_fim_fidelidade: string;
+    fidelidade_meses: number;
+    setup_valor?: string | number | null;
+    setup_isento: boolean;
+    deslocamento_cliente: boolean;
+    alimentacao_cliente: boolean;
+    hospedagem_cliente: boolean;
+    multa_max_mensalidades: number;
+    enviado_em?: string | null;
+    assinado_em?: string | null;
+    created_at: string;
+    pdf_atual_id?: number | null;
+    pdfs: Pdf[];
+    cnpj?: string | null;
+    razao_social?: string | null;
+    responsavel_id?: number | null;
+    responsavel_nome?: string | null;
+    lead_nome?: string | null;
+    conteudo_html_snapshot?: string | null;
+    dias_restantes_fidelidade?: number | null;
+    interno?: Interno | null;
+  }
+  export interface GerarRequest {
+    linha_id: number;
+    template_id?: number | null;
+    data_inicio?: string | null;
+    fidelidade_meses?: number;
+    setup_valor?: string | null;
+    setup_isento?: boolean;
+    deslocamento_cliente?: boolean;
+    alimentacao_cliente?: boolean;
+    hospedagem_cliente?: boolean;
+    multa_max_mensalidades?: number;
+  }
+  export interface MarcarEnviadoRequest {
+    enviado_em?: string | null;
+  }
+  export interface MarcarAssinadoRequest {
+    assinado_em?: string | null;
+    avancar_funil?: boolean;
+  }
+}
+
+export const comercialContratoTemplates = {
+  list: (params?: { incluir_inativos?: boolean }) =>
+    api<ComercialContrato.Template[]>(withParams('/comercial/contrato-templates', params)),
+  create: (data: ComercialContrato.TemplateCreate) =>
+    api<ComercialContrato.Template>('/comercial/contrato-templates', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  update: (id: number, data: ComercialContrato.TemplateUpdate) =>
+    api<ComercialContrato.Template>(`/comercial/contrato-templates/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+  preview: (conteudo_html: string) =>
+    api<{ html: string }>('/comercial/contrato-templates/preview', {
+      method: 'POST',
+      body: JSON.stringify({ conteudo_html }),
+    }),
+};
+
+export const comercialContratos = {
+  list: (params?: {
+    negociacao_id?: number;
+    status?: string;
+    cnpj?: string;
+    so_minhas?: boolean;
+    responsavel_id?: number;
+  }) =>
+    api<ComercialContrato.Contrato[]>(withParams('/comercial/contratos', params)),
+  get: (id: number) => api<ComercialContrato.Contrato>(`/comercial/contratos/${id}`),
+  gerar: (data: ComercialContrato.GerarRequest) =>
+    api<ComercialContrato.Contrato>('/comercial/contratos', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  marcarEnviado: (id: number, data: ComercialContrato.MarcarEnviadoRequest = {}) =>
+    api<ComercialContrato.Contrato>(`/comercial/contratos/${id}/marcar-enviado`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  marcarAssinado: (id: number, data: ComercialContrato.MarcarAssinadoRequest = {}) =>
+    api<ComercialContrato.Contrato>(`/comercial/contratos/${id}/marcar-assinado`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  cancelar: (id: number) =>
+    api<ComercialContrato.Contrato>(`/comercial/contratos/${id}/cancelar`, { method: 'POST' }),
+  downloadPdf: async (id: number, pdfId?: number) => {
+    const token = getAuthToken();
+    const headers: Record<string, string> = {};
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname());
+    }
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const url = `${BASE}${API_VERSION_PREFIX}/comercial/contratos/${id}/pdf${
+      pdfId != null ? `?pdf_id=${pdfId}` : ''
+    }`;
+    const res = await fetch(url, { headers });
+    if (res.status === 401) {
+      invalidateSessionAndRedirectToLogin();
+      throw new ApiError('Sessão expirada ou inválida.', 401, {});
+    }
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}));
+      throw new ApiError(mensagemErroApi(errBody, res.status), res.status, errBody);
+    }
+    return res.blob();
+  },
+};
+
 export const crmFunil = {
   list: (params?: { incluir_inativos?: boolean }) =>
     api<Crm.FunilEstagio[]>(withParams('/crm/funil-estagios', params)),

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -272,7 +272,14 @@ const navStructure: NavItem[] = [
         label: 'CRM',
         icon: 'tiposNegocio',
         comercialOuAdmin: true,
-        activePrefix: '/crm/',
+        activePrefix: '/crm/leads',
+      },
+      {
+        to: '/crm/contratos',
+        label: 'Contratos',
+        icon: 'tiposNegocio',
+        comercialOuAdmin: true,
+        activePrefix: '/crm/contratos',
       },
     ],
   },
@@ -460,6 +467,7 @@ export function Sidebar({
 
   const isLinkActive = (to: string, activePrefix?: string) => {
     if (location.pathname === to) return true
+    if (to === '/crm/leads' && location.pathname.startsWith('/crm/negociacoes')) return true
     if (activePrefix && location.pathname.startsWith(activePrefix)) return true
     if (to !== '/' && location.pathname.startsWith(`${to}/`)) return true
     return false

--- a/frontend/src/components/crm/CrmContratoCard.tsx
+++ b/frontend/src/components/crm/CrmContratoCard.tsx
@@ -1,0 +1,545 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  comercialContratoTemplates,
+  comercialContratos,
+  type ComercialContrato,
+  type Crm,
+} from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { Button } from '../ui/Button'
+import { Card } from '../ui/Card'
+import { ConfirmDialog } from '../ui/ConfirmDialog'
+import { Input } from '../ui/Input'
+import { Select } from '../ui/Select'
+import { useToast } from '../ui/Toast'
+import { maskCnpjCpf } from '../../utils/maskCnpjCpf'
+
+const STATUS_LABEL: Record<string, string> = {
+  rascunho: 'Rascunho',
+  enviado: 'Enviado',
+  assinado: 'Assinado',
+  cancelado: 'Cancelado',
+  renovado: 'Renovado',
+}
+
+const ATIVOS = new Set(['rascunho', 'enviado', 'assinado'])
+
+function money(v: string | number | null | undefined): string {
+  if (v == null || v === '') return '—'
+  const n = typeof v === 'number' ? v : Number(v)
+  if (Number.isNaN(n)) return String(v)
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })
+}
+
+function percent(v: string | number | null | undefined): string {
+  if (v == null || v === '') return '—'
+  const n = typeof v === 'number' ? v : Number(v)
+  if (Number.isNaN(n)) return String(v)
+  return `${n.toLocaleString('pt-BR', { maximumFractionDigits: 1, minimumFractionDigits: 0 })}%`
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const d = new Date(iso.includes('T') ? iso : `${iso}T00:00:00`)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString('pt-BR')
+}
+
+function formatDateTime(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+export function textoDiasFidelidade(dias: number | null | undefined): string {
+  if (dias == null) return '—'
+  if (dias > 1) return `${dias} dias restantes`
+  if (dias === 1) return '1 dia restante'
+  if (dias === 0) return 'Encerra hoje'
+  const abs = Math.abs(dias)
+  return abs === 1 ? 'Fidelidade encerrada há 1 dia' : `Fidelidade encerrada há ${abs} dias`
+}
+
+type Props = {
+  negociacao: Crm.Negociacao
+  onChanged: () => void
+  /** Sem o Card externo — o título fica no acordeão da página. */
+  embedded?: boolean
+}
+
+export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Props) {
+  const toast = useToast()
+  const linhas = negociacao.linhas || []
+
+  const [templates, setTemplates] = useState<ComercialContrato.Template[]>([])
+  const [contratos, setContratos] = useState<ComercialContrato.Contrato[]>([])
+  const [linhaId, setLinhaId] = useState<number | ''>('')
+  const [templateId, setTemplateId] = useState<number | ''>('')
+  const [dataInicio, setDataInicio] = useState('')
+  const [fidelidadeMeses, setFidelidadeMeses] = useState('12')
+  const [setupValor, setSetupValor] = useState('')
+  const [setupIsento, setSetupIsento] = useState(false)
+  const [deslocamento, setDeslocamento] = useState(true)
+  const [alimentacao, setAlimentacao] = useState(true)
+  const [hospedagem, setHospedagem] = useState(true)
+  const [multaMax, setMultaMax] = useState('3')
+  const [gerando, setGerando] = useState(false)
+  const [preview, setPreview] = useState<ComercialContrato.Contrato | null>(null)
+  const [baixandoId, setBaixandoId] = useState<number | null>(null)
+  const [enviandoId, setEnviandoId] = useState<number | null>(null)
+  const [assinandoId, setAssinandoId] = useState<number | null>(null)
+  const [avancarFunil, setAvancarFunil] = useState(true)
+  const [cancelarId, setCancelarId] = useState<number | null>(null)
+  const [cancelando, setCancelando] = useState(false)
+
+  const load = useCallback(async () => {
+    const [tmpls, rows] = await Promise.all([
+      comercialContratoTemplates.list(),
+      comercialContratos.list({ negociacao_id: negociacao.id }),
+    ])
+    setTemplates(tmpls)
+    setContratos(rows)
+    setTemplateId((prev) => {
+      if (prev !== '' && tmpls.some((t) => t.id === prev)) return prev
+      return tmpls[0]?.id ?? ''
+    })
+    const ativo = rows.find((c) => ATIVOS.has(c.status))
+    setPreview((atual) => {
+      if (atual && rows.some((c) => c.id === atual.id)) {
+        return rows.find((c) => c.id === atual.id) || ativo || rows[0] || null
+      }
+      return ativo || rows[0] || null
+    })
+  }, [negociacao.id])
+
+  useEffect(() => {
+    void load().catch((err) => {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar os contratos.'))
+    })
+  }, [load, toast])
+
+  useEffect(() => {
+    setLinhaId((prev) => {
+      if (prev !== '' && linhas.some((ln) => ln.id === prev)) return prev
+      return linhas[0]?.id ?? ''
+    })
+  }, [linhas])
+
+  const templateOptions = useMemo(
+    () => templates.map((t) => ({ value: String(t.id), label: `${t.nome} (v${t.versao})` })),
+    [templates],
+  )
+
+  const linhaOptions = useMemo(
+    () =>
+      linhas.map((ln) => ({
+        value: String(ln.id),
+        label: `${ln.razao_social || 'Sem razão social'} · ${ln.cnpj ? maskCnpjCpf(ln.cnpj) : 'sem CNPJ'}`,
+      })),
+    [linhas],
+  )
+
+  const linhaSel = linhas.find((ln) => ln.id === linhaId)
+  const contratoDaLinha = contratos.find(
+    (c) => c.negociacao_linha_cnpj_id === linhaId && ATIVOS.has(c.status),
+  )
+  const podeGerar =
+    linhaId !== '' && (!contratoDaLinha || contratoDaLinha.status === 'rascunho')
+
+  useEffect(() => {
+    if (!preview?.conteudo_html_snapshot && preview?.id) {
+      void comercialContratos
+        .get(preview.id)
+        .then((full) => setPreview(full))
+        .catch(() => undefined)
+    }
+  }, [preview?.id, preview?.conteudo_html_snapshot])
+
+  async function handleGerar() {
+    if (linhaId === '') {
+      toast.showWarning('Selecione o CNPJ do contrato.')
+      return
+    }
+    const meses = Number(fidelidadeMeses)
+    if (!Number.isInteger(meses) || meses < 1 || meses > 60) {
+      toast.showWarning('Fidelidade deve ser entre 1 e 60 meses.')
+      return
+    }
+    const multa = Number(multaMax)
+    if (!Number.isInteger(multa) || multa < 0 || multa > 12) {
+      toast.showWarning('Multa deve ser entre 0 e 12 mensalidades.')
+      return
+    }
+    setGerando(true)
+    try {
+      const row = await comercialContratos.gerar({
+        linha_id: linhaId,
+        template_id: templateId === '' ? null : templateId,
+        data_inicio: dataInicio || null,
+        fidelidade_meses: meses,
+        setup_valor: setupIsento ? null : setupValor.trim() || null,
+        setup_isento: setupIsento,
+        deslocamento_cliente: deslocamento,
+        alimentacao_cliente: alimentacao,
+        hospedagem_cliente: hospedagem,
+        multa_max_mensalidades: multa,
+      })
+      setPreview(row)
+      toast.showSuccess(
+        contratoDaLinha ? 'Contrato atualizado. Revise o preview.' : 'Contrato gerado. Revise o preview.',
+      )
+      await load()
+      onChanged()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível gerar o contrato.'))
+    } finally {
+      setGerando(false)
+    }
+  }
+
+  async function handlePdf(id: number) {
+    setBaixandoId(id)
+    try {
+      const blob = await comercialContratos.downloadPdf(id)
+      downloadBlob(blob, `contrato-${id}.pdf`)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível baixar o PDF.'))
+    } finally {
+      setBaixandoId(null)
+    }
+  }
+
+  async function handleEnviado(id: number) {
+    setEnviandoId(id)
+    try {
+      const row = await comercialContratos.marcarEnviado(id)
+      setPreview(row)
+      toast.showSuccess('Contrato marcado como enviado (registro manual).')
+      await load()
+      onChanged()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível marcar como enviado.'))
+    } finally {
+      setEnviandoId(null)
+    }
+  }
+
+  async function handleAssinado(id: number) {
+    setAssinandoId(id)
+    try {
+      const row = await comercialContratos.marcarAssinado(id, { avancar_funil: avancarFunil })
+      setPreview(row)
+      toast.showSuccess(
+        avancarFunil ? 'Contrato assinado e funil atualizado.' : 'Contrato marcado como assinado.',
+      )
+      setAssinandoId(null)
+      await load()
+      onChanged()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível marcar como assinado.'))
+      setAssinandoId(null)
+    }
+  }
+
+  async function handleCancelar() {
+    if (cancelarId == null) return
+    setCancelando(true)
+    try {
+      await comercialContratos.cancelar(cancelarId)
+      toast.showSuccess('Contrato cancelado.')
+      setCancelarId(null)
+      await load()
+      onChanged()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível cancelar o contrato.'))
+    } finally {
+      setCancelando(false)
+    }
+  }
+
+  const interno = preview?.interno
+  const linhaInterno = linhaSel
+
+  const inner = (
+    <>
+      <p className="mb-3 text-sm text-slate-500">
+        Um contrato por CNPJ. O PDF do cliente não inclui custo nem margem — esses valores ficam só neste
+        painel.
+      </p>
+
+      {linhas.length === 0 ? (
+        <p className="text-sm text-slate-500">Cadastre linhas CNPJ para gerar o contrato.</p>
+      ) : (
+        <div className="space-y-3">
+          <Select
+            label="CNPJ"
+            value={linhaId === '' ? '' : String(linhaId)}
+            onChange={(v) => setLinhaId(v ? Number(v) : '')}
+            options={linhaOptions}
+          />
+          {contratoDaLinha && contratoDaLinha.status !== 'rascunho' ? (
+            <p className="text-xs text-amber-800 dark:text-amber-200">
+              Esta linha já tem contrato {STATUS_LABEL[contratoDaLinha.status] || contratoDaLinha.status}.
+              Para gerar outro, cancele o atual (não é possível após assinado).
+            </p>
+          ) : null}
+          {podeGerar ? (
+            <>
+          {templateOptions.length > 0 ? (
+            <Select
+              label="Modelo"
+              value={templateId === '' ? '' : String(templateId)}
+              onChange={(v) => setTemplateId(v ? Number(v) : '')}
+              options={templateOptions}
+            />
+          ) : (
+            <p className="text-xs text-slate-500">Nenhum modelo ativo. O sistema usa o padrão na primeira geração.</p>
+          )}
+          <div className="grid gap-3 sm:grid-cols-3">
+            <Input
+              label="Início da vigência"
+              type="date"
+              hint="Vazio = hoje"
+              value={dataInicio}
+              onChange={(e) => setDataInicio(e.target.value)}
+            />
+            <Input
+              label="Fidelidade (meses)"
+              type="number"
+              min={1}
+              max={60}
+              value={fidelidadeMeses}
+              onChange={(e) => setFidelidadeMeses(e.target.value)}
+            />
+            <Input
+              label="Multa (mensalidades)"
+              type="number"
+              min={0}
+              max={12}
+              value={multaMax}
+              onChange={(e) => setMultaMax(e.target.value)}
+            />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Input
+              label="Setup (fora da mensalidade)"
+              type="number"
+              step="0.01"
+              min={0}
+              value={setupValor}
+              onChange={(e) => setSetupValor(e.target.value)}
+              disabled={setupIsento}
+              placeholder="Valor único de implantação"
+            />
+            <label className="flex items-center gap-2 pt-6 text-sm text-slate-700 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={setupIsento}
+                onChange={(e) => setSetupIsento(e.target.checked)}
+                className="size-4 rounded border-slate-300"
+              />
+              Setup isento
+            </label>
+          </div>
+          <div className="flex flex-wrap gap-4 text-sm text-slate-700 dark:text-slate-300">
+            <label className="inline-flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={deslocamento}
+                onChange={(e) => setDeslocamento(e.target.checked)}
+                className="size-4 rounded border-slate-300"
+              />
+              Deslocamento por conta do cliente
+            </label>
+            <label className="inline-flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={alimentacao}
+                onChange={(e) => setAlimentacao(e.target.checked)}
+                className="size-4 rounded border-slate-300"
+              />
+              Alimentação por conta do cliente
+            </label>
+            <label className="inline-flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={hospedagem}
+                onChange={(e) => setHospedagem(e.target.checked)}
+                className="size-4 rounded border-slate-300"
+              />
+              Hospedagem por conta do cliente
+            </label>
+          </div>
+          <Button onClick={() => void handleGerar()} disabled={gerando}>
+            {gerando
+              ? 'Gerando…'
+              : contratoDaLinha?.status === 'rascunho'
+                ? 'Atualizar contrato'
+                : 'Gerar contrato'}
+          </Button>
+            </>
+          ) : null}
+        </div>
+      )}
+
+      {preview ? (
+        <div className="mt-4 space-y-3">
+          <div className="rounded-xl bg-slate-50 p-3 text-sm dark:bg-slate-800/50">
+            <p className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">
+              Painel interno (não vai no PDF)
+            </p>
+            <div className="grid gap-2 sm:grid-cols-3">
+              <div>
+                <div className="text-xs text-slate-500">Custo</div>
+                <div className="font-semibold">{money(interno?.total_custo ?? linhaInterno?.total_custo)}</div>
+              </div>
+              <div>
+                <div className="text-xs text-slate-500">Lucro bruto</div>
+                <div className="font-semibold">{money(interno?.lucro_bruto)}</div>
+              </div>
+              <div>
+                <div className="text-xs text-slate-500">Margem</div>
+                <div className="font-semibold">{percent(interno?.margem_percentual)}</div>
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                Preview — contrato #{preview.id} ({STATUS_LABEL[preview.status] || preview.status})
+              </p>
+              <p className="text-xs text-slate-500">
+                {preview.razao_social || '—'} · {preview.cnpj ? maskCnpjCpf(preview.cnpj) : 'sem CNPJ'} · mensalidade{' '}
+                {money(preview.valor_mensalidade)} · fidelidade {preview.fidelidade_meses} meses (
+                {textoDiasFidelidade(preview.dias_restantes_fidelidade)})
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                variant="secondary"
+                onClick={() => void handlePdf(preview.id)}
+                disabled={baixandoId === preview.id}
+              >
+                {baixandoId === preview.id ? 'Baixando…' : 'Baixar PDF'}
+              </Button>
+              {preview.status === 'rascunho' ? (
+                <Button
+                  variant="secondary"
+                  onClick={() => void handleEnviado(preview.id)}
+                  disabled={enviandoId === preview.id}
+                >
+                  {enviandoId === preview.id ? 'Salvando…' : 'Marcar enviado'}
+                </Button>
+              ) : null}
+              {preview.status === 'rascunho' || preview.status === 'enviado' ? (
+                <>
+                  <Button variant="secondary" onClick={() => setAssinandoId(preview.id)}>
+                    Marcar assinado
+                  </Button>
+                  <Button variant="ghost" onClick={() => setCancelarId(preview.id)}>
+                    Cancelar contrato
+                  </Button>
+                </>
+              ) : null}
+            </div>
+          </div>
+          <iframe
+            title={`Preview do contrato ${preview.id}`}
+            sandbox=""
+            srcDoc={preview.conteudo_html_snapshot || ''}
+            className="h-80 w-full rounded-lg border border-slate-200 bg-white dark:border-slate-700"
+          />
+        </div>
+      ) : null}
+
+      {contratos.length > 1 ? (
+        <div className="mt-4">
+          <p className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-300">Contratos desta negociação</p>
+          <ul className="space-y-2 text-sm">
+            {contratos.map((c) => (
+              <li
+                key={c.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-700"
+              >
+                <div>
+                  <span className="font-medium text-slate-900 dark:text-slate-100">#{c.id}</span>
+                  {' · '}
+                  {STATUS_LABEL[c.status] || c.status}
+                  {' · '}
+                  {c.razao_social || (c.cnpj ? maskCnpjCpf(c.cnpj) : `linha ${c.negociacao_linha_cnpj_id}`)}
+                  <div className="text-xs text-slate-500">
+                    {formatDateTime(c.created_at)}
+                    {c.enviado_em ? ` · enviado ${formatDateTime(c.enviado_em)}` : ''}
+                    {c.assinado_em ? ` · assinado ${formatDateTime(c.assinado_em)}` : ''}
+                    {' · '}
+                    {textoDiasFidelidade(c.dias_restantes_fidelidade)}
+                    {c.data_fim_fidelidade ? ` (até ${formatDate(c.data_fim_fidelidade)})` : ''}
+                  </div>
+                </div>
+                <div className="flex gap-2">
+                  <Button variant="ghost" onClick={() => setPreview(c)}>
+                    Ver
+                  </Button>
+                  <Button variant="ghost" onClick={() => void handlePdf(c.id)} disabled={baixandoId === c.id}>
+                    PDF
+                  </Button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {assinandoId != null ? (
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-0 sm:items-center sm:p-4">
+          <div className="w-full rounded-t-2xl bg-white p-5 shadow-xl dark:bg-slate-900 sm:max-w-md sm:rounded-2xl">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Marcar contrato como assinado</h2>
+            <p className="mt-1 text-sm text-slate-500">
+              Registro manual — a assinatura eletrónica (ClickSign) fica para um lote seguinte.
+            </p>
+            <label className="mt-4 inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={avancarFunil}
+                onChange={(e) => setAvancarFunil(e.target.checked)}
+                className="size-4 rounded border-slate-300"
+              />
+              Avançar funil para «Contrato assinado»
+            </label>
+            <div className="flex justify-end gap-2 pt-4">
+              <Button type="button" variant="secondary" onClick={() => setAssinandoId(null)}>
+                Voltar
+              </Button>
+              <Button onClick={() => void handleAssinado(assinandoId)}>Confirmar</Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <ConfirmDialog
+        open={cancelarId != null}
+        title="Cancelar contrato?"
+        message="O rascunho ou o enviado deixa de valer. Depois de assinado não dá para cancelar nesta tela."
+        confirmLabel="Cancelar contrato"
+        cancelLabel="Voltar"
+        variant="danger"
+        loading={cancelando}
+        onConfirm={() => void handleCancelar()}
+        onCancel={() => setCancelarId(null)}
+      />
+    </>
+  )
+
+  if (embedded) return inner
+  return <Card title="Contrato comercial">{inner}</Card>
+}

--- a/frontend/src/components/crm/CrmPropostaCard.tsx
+++ b/frontend/src/components/crm/CrmPropostaCard.tsx
@@ -11,6 +11,7 @@ import { Card } from '../ui/Card'
 import { Input, TEXTAREA_FIELD_CLASS } from '../ui/Input'
 import { Select } from '../ui/Select'
 import { useToast } from '../ui/Toast'
+import { maskCnpjCpf } from '../../utils/maskCnpjCpf'
 
 const STATUS_LABEL: Record<string, string> = {
   rascunho: 'Rascunho',
@@ -43,9 +44,11 @@ function downloadBlob(blob: Blob, filename: string) {
 type Props = {
   negociacao: Crm.Negociacao
   onChanged: () => void
+  /** Sem o Card externo — o título fica no acordeão da página. */
+  embedded?: boolean
 }
 
-export function CrmPropostaCard({ negociacao, onChanged }: Props) {
+export function CrmPropostaCard({ negociacao, onChanged, embedded = false }: Props) {
   const toast = useToast()
   const linhas = negociacao.linhas || []
 
@@ -165,8 +168,8 @@ export function CrmPropostaCard({ negociacao, onChanged }: Props) {
     }
   }
 
-  return (
-    <Card title="Proposta comercial">
+  const inner = (
+    <>
       <p className="mb-3 text-sm text-slate-500">
         O documento enviado ao cliente mostra só itens e valores negociados — custo e margem ficam só nesta tela.
       </p>
@@ -186,7 +189,7 @@ export function CrmPropostaCard({ negociacao, onChanged }: Props) {
                   className="size-4 rounded border-slate-300"
                 />
                 <span>
-                  {ln.razao_social || 'Sem razão social'} · {ln.cnpj || 'sem CNPJ'}
+                  {ln.razao_social || 'Sem razão social'} · {ln.cnpj ? maskCnpjCpf(ln.cnpj) : 'sem CNPJ'}
                 </span>
               </label>
             ))}
@@ -326,6 +329,9 @@ export function CrmPropostaCard({ negociacao, onChanged }: Props) {
           </div>
         </div>
       ) : null}
-    </Card>
+    </>
   )
+
+  if (embedded) return inner
+  return <Card title="Proposta comercial">{inner}</Card>
 }

--- a/frontend/src/components/ui/CollapsibleCard.tsx
+++ b/frontend/src/components/ui/CollapsibleCard.tsx
@@ -1,0 +1,39 @@
+import { type ReactNode } from 'react'
+
+type Props = {
+  title: string
+  badge?: string | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  children: ReactNode
+}
+
+/** Card com cabeçalho clicável para recolher o conteúdo (acordeão independente). */
+export function CollapsibleCard({ title, badge, open, onOpenChange, children }: Props) {
+  return (
+    <details
+      className="rounded-xl border border-slate-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900/95 dark:shadow-none dark:ring-1 dark:ring-white/5"
+      open={open}
+      onToggle={(e) => {
+        const next = e.currentTarget.open
+        if (next !== open) onOpenChange(next)
+      }}
+    >
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-6 py-4 marker:content-none [&::-webkit-details-marker]:hidden">
+        <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-100">
+          {title}
+          {badge ? (
+            <span className="ml-2 text-sm font-normal text-slate-500 dark:text-slate-400">{badge}</span>
+          ) : null}
+        </h2>
+        <span
+          className={`shrink-0 text-slate-400 transition-transform ${open ? 'rotate-180' : ''}`}
+          aria-hidden
+        >
+          ▾
+        </span>
+      </summary>
+      <div className="border-t border-slate-200 px-6 py-4 dark:border-slate-800">{children}</div>
+    </details>
+  )
+}

--- a/frontend/src/components/ui/IconTrash.tsx
+++ b/frontend/src/components/ui/IconTrash.tsx
@@ -15,14 +15,8 @@ export function IconTrash({ className = 'size-5', ariaHidden = true }: IconTrash
       <path
         strokeLinecap="round"
         strokeLinejoin="round"
-        strokeWidth={1.7}
-        d="M10 4h4m-7 4h10m-9 0v9a2 2 0 002 2h4a2 2 0 002-2V8"
-      />
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth={1.7}
-        d="M10 11v5m4-5v5"
+        strokeWidth={2}
+        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
       />
     </svg>
   )

--- a/frontend/src/pages/ConfigContratoTemplates.tsx
+++ b/frontend/src/pages/ConfigContratoTemplates.tsx
@@ -1,0 +1,280 @@
+import { useCallback, useEffect, useState } from 'react'
+import { ApiError, comercialContratoTemplates, type ComercialContrato } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Button } from '../components/ui/Button'
+import { Card } from '../components/ui/Card'
+import { Input, TEXTAREA_FIELD_CLASS } from '../components/ui/Input'
+import { Switch } from '../components/ui/Switch'
+import { FiltroInativos } from '../components/ui/FiltroInativos'
+import { IconPencil } from '../components/ui/IconPencil'
+import { useToast } from '../components/ui/Toast'
+import { ConfigListPageShell } from '../components/config/ConfigListPageShell'
+import { SemPermissao } from './SemPermissao'
+
+const PLACEHOLDERS = [
+  '{{razao_social}}',
+  '{{cnpj}}',
+  '{{itens}}',
+  '{{valor_mensalidade}}',
+  '{{setup_bloco}}',
+  '{{data_inicio}}',
+  '{{data_fim_fidelidade}}',
+  '{{fidelidade_meses}}',
+  '{{fidelidade}}',
+  '{{multa}}',
+  '{{igpm}}',
+  '{{clausula_deslocamento}}',
+  '{{clausula_alimentacao}}',
+  '{{clausula_hospedagem}}',
+  '{{logo}}',
+  '{{empresa_sistema}}',
+] as const
+
+type FormState = {
+  nome: string
+  conteudo_html: string
+  ativo: boolean
+}
+
+const emptyForm = (): FormState => ({
+  nome: '',
+  conteudo_html: '',
+  ativo: true,
+})
+
+export function ConfigContratoTemplates({ embedded = false }: { embedded?: boolean }) {
+  const toast = useToast()
+  const [list, setList] = useState<ComercialContrato.Template[]>([])
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [incluirInativos, setIncluirInativos] = useState(false)
+  const [modal, setModal] = useState<'create' | ComercialContrato.Template | null>(null)
+  const [form, setForm] = useState<FormState>(emptyForm())
+  const [saving, setSaving] = useState(false)
+  const [previewHtml, setPreviewHtml] = useState<string | null>(null)
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    comercialContratoTemplates
+      .list({ incluir_inativos: incluirInativos })
+      .then(setList)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar os modelos.'))
+        setList([])
+      })
+      .finally(() => setLoading(false))
+  }, [incluirInativos, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  function openCreate() {
+    setForm(emptyForm())
+    setPreviewHtml(null)
+    setModal('create')
+  }
+
+  function openEdit(row: ComercialContrato.Template) {
+    setForm({
+      nome: row.nome,
+      conteudo_html: row.conteudo_html,
+      ativo: row.ativo,
+    })
+    setPreviewHtml(null)
+    setModal(row)
+  }
+
+  async function handlePreview() {
+    if (!form.conteudo_html.trim()) {
+      toast.showWarning('Informe o HTML do modelo.')
+      return
+    }
+    try {
+      const r = await comercialContratoTemplates.preview(form.conteudo_html)
+      setPreviewHtml(r.html)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível gerar o preview.'))
+    }
+  }
+
+  async function handleSave(e: React.FormEvent) {
+    e.preventDefault()
+    if (!form.nome.trim() || !form.conteudo_html.trim()) {
+      toast.showWarning('Informe nome e HTML do modelo.')
+      return
+    }
+    setSaving(true)
+    try {
+      if (modal === 'create') {
+        await comercialContratoTemplates.create({
+          nome: form.nome.trim(),
+          conteudo_html: form.conteudo_html,
+          ativo: form.ativo,
+        })
+        toast.showSuccess('Modelo criado.')
+      } else if (modal && typeof modal === 'object') {
+        await comercialContratoTemplates.update(modal.id, {
+          nome: form.nome.trim(),
+          conteudo_html: form.conteudo_html,
+          ativo: form.ativo,
+        })
+        toast.showSuccess('Modelo atualizado. A versão sobe se o HTML mudar; contratos já gerados não mudam.')
+      }
+      setModal(null)
+      load()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o modelo.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const denied = (
+    <SemPermissao
+      title="Você não tem permissão para configurar modelos de contrato."
+      detail="Apenas administradores gerem os templates do contrato comercial."
+      voltarPara="/"
+      voltarLabel="Voltar para o Dashboard"
+    />
+  )
+
+  return (
+    <ConfigListPageShell
+      embedded={embedded}
+      forbidden={forbidden}
+      denied={denied}
+      title="Modelos de contrato"
+      actions={<Button onClick={openCreate}>Novo modelo</Button>}
+    >
+      <p className="mb-3 text-sm text-slate-500 dark:text-slate-400">
+        HTML usado ao gerar o contrato na negociação. Não inclua custo ou margem — esses dados são internos.
+        Editar o HTML sobe a versão do modelo; o PDF já gerado permanece na versão gravada no contrato.
+      </p>
+      <details className="mb-3 rounded-lg border border-slate-200 px-3 py-2 text-sm dark:border-slate-700">
+        <summary className="cursor-pointer font-medium text-slate-700 dark:text-slate-200">
+          Placeholders disponíveis
+        </summary>
+        <ul className="mt-2 flex flex-wrap gap-1.5">
+          {PLACEHOLDERS.map((p) => (
+            <li key={p}>
+              <code className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200">
+                {p}
+              </code>
+            </li>
+          ))}
+        </ul>
+      </details>
+      <Card>
+        <div className="mb-3">
+          <FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />
+        </div>
+        {loading ? (
+          <p className="text-slate-500">Carregando…</p>
+        ) : list.length === 0 ? (
+          <p className="text-slate-500">Nenhum modelo encontrado.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[560px] text-left text-sm">
+              <thead>
+                <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Nome</th>
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Versão</th>
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Ativo</th>
+                  <th className="px-3 py-2" />
+                </tr>
+              </thead>
+              <tbody>
+                {list.map((row) => (
+                  <tr key={row.id} className="border-b border-slate-100 dark:border-slate-800/80">
+                    <td className="px-3 py-2.5 font-medium text-slate-900 dark:text-slate-100">{row.nome}</td>
+                    <td className="px-3 py-2.5 text-slate-600">v{row.versao}</td>
+                    <td className="px-3 py-2.5">{row.ativo ? 'Sim' : 'Não'}</td>
+                    <td className="px-3 py-2.5 text-right">
+                      <button
+                        type="button"
+                        onClick={() => openEdit(row)}
+                        className="inline-flex size-8 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
+                        aria-label={`Editar ${row.nome}`}
+                      >
+                        <IconPencil />
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+
+      {modal ? (
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-0 sm:items-center sm:p-4">
+          <div className="max-h-[92vh] w-full overflow-y-auto rounded-t-2xl bg-white p-5 shadow-xl dark:bg-slate-900 sm:max-w-2xl sm:rounded-2xl">
+            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+              {modal === 'create' ? 'Novo modelo' : 'Editar modelo'}
+            </h2>
+            <form onSubmit={handleSave} className="mt-4 space-y-3">
+              <Input
+                label="Nome"
+                value={form.nome}
+                onChange={(e) => setForm((p) => ({ ...p, nome: e.target.value }))}
+                required
+              />
+              <label className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+                HTML
+                <textarea
+                  value={form.conteudo_html}
+                  onChange={(e) => setForm((p) => ({ ...p, conteudo_html: e.target.value }))}
+                  rows={12}
+                  required
+                  className={`mt-1 font-mono text-xs ${TEXTAREA_FIELD_CLASS}`}
+                />
+              </label>
+              <Switch
+                bare
+                checked={form.ativo}
+                onCheckedChange={(ativo) => setForm((p) => ({ ...p, ativo }))}
+                label="Modelo ativo"
+                description="Inativos não aparecem na geração do contrato."
+                showStatusPill
+                statusOnText="Ativo"
+                statusOffText="Inativo"
+              />
+              {previewHtml ? (
+                <div>
+                  <p className="mb-1 text-xs text-slate-500">
+                    Sanitiza o HTML. Placeholders só são preenchidos ao gerar o contrato na negociação.
+                  </p>
+                  <iframe
+                    title="Preview do modelo"
+                    sandbox=""
+                    srcDoc={previewHtml}
+                    className="h-64 w-full rounded-lg border border-slate-200 bg-white dark:border-slate-700"
+                  />
+                </div>
+              ) : null}
+              <div className="flex flex-wrap justify-end gap-2 pt-2">
+                <Button type="button" variant="secondary" onClick={() => setModal(null)} disabled={saving}>
+                  Cancelar
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => void handlePreview()} disabled={saving}>
+                  Preview
+                </Button>
+                <Button type="submit" disabled={saving}>
+                  {saving ? 'Salvando…' : 'Salvar'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+    </ConfigListPageShell>
+  )
+}

--- a/frontend/src/pages/CrmContratos.tsx
+++ b/frontend/src/pages/CrmContratos.tsx
@@ -1,0 +1,236 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  ApiError,
+  atendentes,
+  comercialContratos,
+  type Atendentes,
+  type ComercialContrato,
+} from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Card } from '../components/ui/Card'
+import { Input } from '../components/ui/Input'
+import { Select } from '../components/ui/Select'
+import { useToast } from '../components/ui/Toast'
+import { useAuth } from '../contexts/AuthContext'
+import { textoDiasFidelidade } from '../components/crm/CrmContratoCard'
+import { maskCnpjCpf } from '../utils/maskCnpjCpf'
+import { SemPermissao } from './SemPermissao'
+
+const STATUS_LABEL: Record<string, string> = {
+  rascunho: 'Rascunho',
+  enviado: 'Enviado',
+  assinado: 'Assinado',
+  cancelado: 'Cancelado',
+  renovado: 'Renovado',
+}
+
+const STATUS_FILTROS = ['', 'rascunho', 'enviado', 'assinado', 'cancelado'] as const
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const d = new Date(iso.includes('T') ? iso : `${iso}T00:00:00`)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString('pt-BR')
+}
+
+function classeDias(dias: number | null | undefined): string {
+  if (dias == null) return 'text-slate-500'
+  if (dias < 0) return 'text-red-700 dark:text-red-300'
+  if (dias <= 30) return 'text-amber-800 dark:text-amber-200'
+  return 'text-slate-700 dark:text-slate-300'
+}
+
+export function CrmContratos() {
+  const toast = useToast()
+  const { isAdmin } = useAuth()
+  const [list, setList] = useState<ComercialContrato.Contrato[]>([])
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [status, setStatus] = useState('')
+  const [busca, setBusca] = useState('')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+  const [responsavelId, setResponsavelId] = useState<number | ''>('')
+  const [responsaveis, setResponsaveis] = useState<Atendentes.Atendente[]>([])
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
+    return () => clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    if (!isAdmin) return
+    atendentes
+      .list({ limit: 100, offset: 0 })
+      .then(({ items }) => {
+        setResponsaveis(items.filter((a) => a.ativo && (a.role === 'comercial' || a.role === 'admin')))
+      })
+      .catch(() => setResponsaveis([]))
+  }, [isAdmin])
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    comercialContratos
+      .list({
+        status: status || undefined,
+        cnpj: debouncedBusca || undefined,
+        responsavel_id: isAdmin && responsavelId !== '' ? responsavelId : undefined,
+      })
+      .then(setList)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar os contratos.'))
+        setList([])
+      })
+      .finally(() => setLoading(false))
+  }, [status, debouncedBusca, responsavelId, isAdmin, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para ver contratos."
+        detail="A lista de contratos é só para o perfil comercial e administradores."
+        voltarPara="/"
+        voltarLabel="Voltar para o Dashboard"
+      />
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-4 pb-10">
+      <div>
+        <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Contratos</h1>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          {isAdmin
+            ? 'Todos os contratos da instância. Filtre por responsável ou abra a negociação para gerar, enviar ou assinar.'
+            : 'Contratos das suas negociações. Abra a negociação para gerar, enviar ou assinar.'}
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="flex flex-wrap gap-2">
+          {STATUS_FILTROS.map((s) => (
+            <button
+              key={s || 'todos'}
+              type="button"
+              onClick={() => setStatus(s)}
+              className={`rounded-lg px-3 py-1.5 text-xs font-medium transition ${
+                status === s
+                  ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900'
+                  : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200'
+              }`}
+            >
+              {s ? STATUS_LABEL[s] : 'Todos'}
+            </button>
+          ))}
+        </div>
+        <div className="min-w-[200px] flex-1">
+          <Input
+            label="CNPJ ou razão social"
+            value={busca}
+            onChange={(e) => setBusca(e.target.value)}
+            placeholder="Filtrar…"
+          />
+        </div>
+        {isAdmin ? (
+          <div className="min-w-[200px]">
+            <Select
+              label="Responsável"
+              value={responsavelId === '' ? '' : String(responsavelId)}
+              onChange={(v) => setResponsavelId(v === '' ? '' : Number(v))}
+              options={responsaveis.map((a) => ({ value: String(a.id), label: a.nome }))}
+              includeEmpty
+              emptyLabel="Todos"
+            />
+          </div>
+        ) : null}
+      </div>
+
+      <Card>
+        {loading ? (
+          <p className="text-slate-500">Carregando…</p>
+        ) : list.length === 0 ? (
+          <div className="space-y-2 text-sm text-slate-500">
+            {status || debouncedBusca || responsavelId !== '' ? (
+              <p>Nenhum contrato encontrado com esses filtros.</p>
+            ) : (
+              <>
+                <p>Ainda não há contratos. O documento é gerado na negociação do CRM, por CNPJ.</p>
+                <p>
+                  <Link
+                    to="/crm/leads"
+                    className="font-medium text-cyan-700 hover:underline dark:text-cyan-400"
+                  >
+                    Abrir o CRM
+                  </Link>
+                </p>
+              </>
+            )}
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[720px] text-left text-sm">
+              <thead>
+                <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Status</th>
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">CNPJ</th>
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Responsável</th>
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Fidelidade</th>
+                  <th className="px-3 py-2 font-medium text-slate-600 dark:text-slate-300">Negociação</th>
+                </tr>
+              </thead>
+              <tbody>
+                {list.map((row) => (
+                  <tr key={row.id} className="border-b border-slate-100 dark:border-slate-800/80">
+                    <td className="px-3 py-2.5">
+                      <span className="font-medium text-slate-900 dark:text-slate-100">
+                        {STATUS_LABEL[row.status] || row.status}
+                      </span>
+                      <div className="text-xs text-slate-500">#{row.id}</div>
+                    </td>
+                    <td className="px-3 py-2.5">
+                      <div className="font-medium text-slate-900 dark:text-slate-100">
+                        {row.razao_social || '—'}
+                      </div>
+                      <div className="text-xs text-slate-500">
+                        {row.cnpj ? maskCnpjCpf(row.cnpj) : 'sem CNPJ'}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2.5 text-slate-700 dark:text-slate-300">
+                      {row.responsavel_nome || '—'}
+                    </td>
+                    <td className={`px-3 py-2.5 ${classeDias(row.dias_restantes_fidelidade)}`}>
+                      {textoDiasFidelidade(row.dias_restantes_fidelidade)}
+                      <div className="text-xs text-slate-500">até {formatDate(row.data_fim_fidelidade)}</div>
+                    </td>
+                    <td className="px-3 py-2.5">
+                      {row.negociacao_id ? (
+                        <Link
+                          to={`/crm/negociacoes/${row.negociacao_id}`}
+                          className="font-medium text-cyan-700 hover:underline dark:text-cyan-400"
+                        >
+                          {row.lead_nome || `Negociação #${row.negociacao_id}`}
+                        </Link>
+                      ) : (
+                        '—'
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/CrmNegociacaoDetalhe.tsx
+++ b/frontend/src/pages/CrmNegociacaoDetalhe.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import {
   ApiError,
+  comercialContratos,
   comercialCustosItens,
+  comercialPropostas,
   crmFunil,
   crmLeads,
   crmNegociacoes,
@@ -14,13 +16,18 @@ import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/err
 import { Button } from '../components/ui/Button'
 import { Card } from '../components/ui/Card'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
+import { CollapsibleCard } from '../components/ui/CollapsibleCard'
 import { ConfirmDialog } from '../components/ui/ConfirmDialog'
+import { IconPencil } from '../components/ui/IconPencil'
+import { IconTrash } from '../components/ui/IconTrash'
 import { Input } from '../components/ui/Input'
 import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
 import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { SemPermissao } from './SemPermissao'
 import { CrmPropostaCard } from '../components/crm/CrmPropostaCard'
+import { CrmContratoCard } from '../components/crm/CrmContratoCard'
+import { maskCnpjCpf } from '../utils/maskCnpjCpf'
 
 const TIPO_ATIVIDADE_LABEL: Record<string, string> = {
   nota: 'Nota',
@@ -35,6 +42,22 @@ const TIPO_CUSTO_LABEL: Record<string, string> = {
   valor_fixo: 'Valor fixo',
   composto_tef: 'TEF (base + adicional)',
 }
+
+const PROPOSTA_STATUS_LABEL: Record<string, string> = {
+  rascunho: 'Rascunho',
+  enviada: 'Enviada',
+  substituida: 'Substituída',
+}
+
+const CONTRATO_STATUS_LABEL: Record<string, string> = {
+  rascunho: 'Rascunho',
+  enviado: 'Enviado',
+  assinado: 'Assinado',
+  cancelado: 'Cancelado',
+  renovado: 'Renovado',
+}
+
+const CONTRATO_ATIVO = new Set(['rascunho', 'enviado', 'assinado'])
 
 function rotuloItemCusto(item: ComercialCustos.Item): string {
   const tipo = TIPO_CUSTO_LABEL[item.tipo] || null
@@ -85,6 +108,7 @@ const emptyLinhaForm = (): LinhaForm => ({
 export function CrmNegociacaoDetalhe() {
   const { id } = useParams<{ id: string }>()
   const negociacaoId = id ? parseInt(id, 10) : NaN
+  const navigate = useNavigate()
   const voltar = useVoltarAnterior('/crm/leads')
   const toast = useToast()
 
@@ -109,6 +133,13 @@ export function CrmNegociacaoDetalhe() {
   const [notaTexto, setNotaTexto] = useState('')
   const [savingNota, setSavingNota] = useState(false)
   const loadedOnceRef = useRef(false)
+
+  const [propostaAberta, setPropostaAberta] = useState(false)
+  const [contratoAberto, setContratoAberto] = useState(true)
+  const [historicoAberto, setHistoricoAberto] = useState(false)
+  const docInitRef = useRef(false)
+  const [propostaBadge, setPropostaBadge] = useState<string | null>(null)
+  const [contratoBadge, setContratoBadge] = useState<string | null>(null)
 
   const load = useCallback(async () => {
     if (!id || Number.isNaN(negociacaoId)) {
@@ -147,6 +178,39 @@ export function CrmNegociacaoDetalhe() {
   useEffect(() => {
     void load()
   }, [load])
+
+  const refreshDocBadges = useCallback(async () => {
+    if (Number.isNaN(negociacaoId)) return
+    try {
+      const [ps, cs] = await Promise.all([
+        comercialPropostas.list(negociacaoId),
+        comercialContratos.list({ negociacao_id: negociacaoId }),
+      ])
+      const proposta =
+        ps.find((p) => p.status === 'rascunho') || ps.find((p) => p.status === 'enviada') || ps[0]
+      const contrato = cs.find((c) => CONTRATO_ATIVO.has(c.status)) || cs[0]
+      setPropostaBadge(proposta ? PROPOSTA_STATUS_LABEL[proposta.status] || proposta.status : null)
+      setContratoBadge(contrato ? CONTRATO_STATUS_LABEL[contrato.status] || contrato.status : null)
+      if (!docInitRef.current) {
+        docInitRef.current = true
+        setPropostaAberta(!contrato)
+        setContratoAberto(true)
+        setHistoricoAberto(false)
+      }
+    } catch {
+      setPropostaBadge(null)
+      setContratoBadge(null)
+    }
+  }, [negociacaoId])
+
+  useEffect(() => {
+    void refreshDocBadges()
+  }, [refreshDocBadges])
+
+  function handleDocsChanged() {
+    void load()
+    void refreshDocBadges()
+  }
 
   useEffect(() => {
     coletarTodasPaginas<ComercialCustos.Item>((offset, limit) =>
@@ -306,32 +370,25 @@ export function CrmNegociacaoDetalhe() {
 
   return (
     <div className="mx-auto max-w-5xl space-y-4 pb-10">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <button
-            type="button"
-            onClick={voltar}
-            className="text-sm text-slate-500 hover:text-slate-800 dark:hover:text-slate-200"
-          >
-            ← Voltar
-          </button>
-          <h1 className="mt-1 text-xl font-semibold text-slate-900 dark:text-slate-100">
-            {neg.titulo || `Negociação #${neg.id}`}
-          </h1>
-          <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-            Lead:{' '}
-            <span className="font-medium text-slate-700 dark:text-slate-200">{lead?.nome || `#${neg.lead_id}`}</span>
-            {' · '}
-            Estágio: <span className="font-medium">{neg.estagio_nome || '—'}</span>
-            {!neg.ativa ? ' · encerrada' : null}
-          </p>
-        </div>
-        <Link
-          to="/crm/leads"
-          className="text-sm font-medium text-cyan-700 hover:underline dark:text-cyan-400"
-        >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <Button variant="secondary" onClick={voltar}>
+          ← Voltar
+        </Button>
+        <Button variant="secondary" onClick={() => navigate('/crm/leads')}>
           Lista de leads
-        </Link>
+        </Button>
+      </div>
+      <div>
+        <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">
+          {neg.titulo || `Negociação #${neg.id}`}
+        </h1>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          Lead:{' '}
+          <span className="font-medium text-slate-700 dark:text-slate-200">{lead?.nome || `#${neg.lead_id}`}</span>
+          {' · '}
+          Estágio: <span className="font-medium">{neg.estagio_nome || '—'}</span>
+          {!neg.ativa ? ' · encerrada' : null}
+        </p>
       </div>
 
       <Card title="Avançar estágio">
@@ -368,7 +425,10 @@ export function CrmNegociacaoDetalhe() {
 
       <Card title="Linhas por CNPJ">
         <div className="mb-3 flex justify-end">
-          <Button variant="secondary" onClick={openCreateLinha}>
+          <Button onClick={openCreateLinha}>
+            <span aria-hidden className="text-lg leading-none">
+              +
+            </span>
             Adicionar linha
           </Button>
         </div>
@@ -414,7 +474,7 @@ export function CrmNegociacaoDetalhe() {
                       {ln.razao_social || 'Sem razão social'}
                     </div>
                     <div className="text-xs text-slate-500">
-                      CNPJ: {ln.cnpj || '— (opcional até Documentação)'} · PDVs: {ln.quantidade_pdvs}
+                      CNPJ: {ln.cnpj ? maskCnpjCpf(ln.cnpj) : '— (opcional até Documentação)'} · PDVs: {ln.quantidade_pdvs}
                       {ln.desconto_posto_100k ? ' · desconto posto <100k' : ''}
                     </div>
                     <div className="mt-1 text-xs text-slate-500">
@@ -427,10 +487,12 @@ export function CrmNegociacaoDetalhe() {
                     </div>
                   </div>
                   <div className="flex gap-2">
-                    <Button variant="ghost" onClick={() => openEditLinha(ln)}>
+                    <Button variant="secondary" onClick={() => openEditLinha(ln)}>
+                      <IconPencil className="size-4" />
                       Editar
                     </Button>
-                    <Button variant="ghost" onClick={() => setDeleteLinhaId(ln.id)}>
+                    <Button variant="danger" onClick={() => setDeleteLinhaId(ln.id)}>
+                      <IconTrash className="size-5" />
                       Remover
                     </Button>
                   </div>
@@ -453,9 +515,30 @@ export function CrmNegociacaoDetalhe() {
         )}
       </Card>
 
-      <CrmPropostaCard negociacao={neg} onChanged={() => void load()} />
+      <CollapsibleCard
+        title="Proposta comercial"
+        badge={propostaBadge}
+        open={propostaAberta}
+        onOpenChange={setPropostaAberta}
+      >
+        <CrmPropostaCard negociacao={neg} onChanged={handleDocsChanged} embedded />
+      </CollapsibleCard>
 
-      <Card title="Histórico">
+      <CollapsibleCard
+        title="Contrato comercial"
+        badge={contratoBadge}
+        open={contratoAberto}
+        onOpenChange={setContratoAberto}
+      >
+        <CrmContratoCard negociacao={neg} onChanged={handleDocsChanged} embedded />
+      </CollapsibleCard>
+
+      <CollapsibleCard
+        title="Histórico"
+        badge={atividades.length > 0 ? String(atividades.length) : null}
+        open={historicoAberto}
+        onOpenChange={setHistoricoAberto}
+      >
         <form onSubmit={handleAddNota} className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-end">
           <div className="flex-1">
             <Input
@@ -489,7 +572,7 @@ export function CrmNegociacaoDetalhe() {
             ))}
           </ul>
         )}
-      </Card>
+      </CollapsibleCard>
 
       {linhaModal ? (
         <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-0 sm:items-center sm:p-4">

--- a/frontend/src/pages/config/ConfigCadastrosLayout.tsx
+++ b/frontend/src/pages/config/ConfigCadastrosLayout.tsx
@@ -8,6 +8,7 @@ const TABS = [
   { to: '/configuracoes/cadastros/custos', label: 'Catálogo de custos' },
   { to: '/configuracoes/cadastros/funil-crm', label: 'Funil CRM' },
   { to: '/configuracoes/cadastros/propostas', label: 'Modelos de proposta' },
+  { to: '/configuracoes/cadastros/contratos', label: 'Modelos de contrato' },
 ] as const
 
 const TAB_HINTS: Record<string, string> = {
@@ -16,6 +17,7 @@ const TAB_HINTS: Record<string, string> = {
   custos: 'Salário mínimo com vigência, perfis/módulos de custo e simulador estimado para negociação.',
   'funil-crm': 'Estágios do funil comercial (Lead, Em negociação…). Usados na lista e no Kanban do CRM.',
   propostas: 'HTML dos modelos da proposta comercial. Placeholders são preenchidos na negociação.',
+  contratos: 'HTML dos modelos do contrato comercial. Placeholders (fidelidade, setup, cláusulas) são preenchidos na negociação.',
 }
 
 function abaAtiva(pathname: string): string {
@@ -29,7 +31,7 @@ export function ConfigCadastrosLayout() {
 
   return (
     <PageContainer>
-      <PageHeader title="Cadastros" subtitle="Tipos de negócio, catálogos de PDV, custos, funil CRM e modelos de proposta." />
+      <PageHeader title="Cadastros" subtitle="Tipos de negócio, catálogos de PDV, custos, funil CRM e modelos de proposta e contrato." />
       <ConfigSectionTabs tabs={[...TABS]} ariaLabel="Seções de cadastros" />
       {hint ? <p className="text-sm text-slate-600 dark:text-slate-400">{hint}</p> : null}
       <Outlet />


### PR DESCRIPTION
## Summary

- Contratos comerciais por CNPJ da negociação: modelo HTML versionado, geração de PDF (fidelidade, setup e cláusulas de implantação), fluxo rascunho → enviado → assinado, cancelar (exceto assinado) e lista `/crm/contratos`.
- O PDF do cliente não inclui custo, lucro nem margem; o painel interno mostra esses números. Comercial vê só os contratos das próprias negociações; admin vê todos (filtro por responsável).
- UI na negociação (acordeão proposta / contrato / histórico), Cadastros → Modelos de contrato (só admin) e menu Comercial → Contratos.

Closes #349
Closes #350
Closes #351
Closes #352
Closes #356

Épico #324 permanece aberto (#353 ClickSign, #354–#355 IGPM/multa jurídica, #357 conversão Rede/Empresa).

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] Cadastros → Modelos de contrato: criar/editar HTML (versão sobe), preview; comercial não vê esta aba
- [ ] Na negociação com linha CNPJ: gerar contrato, baixar PDF (sem custo/margem), marcar enviado, marcar assinado (com avançar funil)
- [ ] Cancelar rascunho/enviado e gerar de novo na mesma linha; assinado não cancela nem regenera
- [ ] Lista `/crm/contratos`: comercial só as próprias; admin filtra por responsável; empty-state com link ao CRM
- [ ] Atendente: 403 nas rotas `/v1/comercial/contratos*`

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Fora deste lote (já no épico #324): ClickSign #353, IGPM/multa jurídica #354–#355, conversão Rede/Empresa #357
- [x] Stubs/campos nullable: aditivo sobre contrato assinado fica para issue futura (mencionado na API)
- [ ] Comentário na issue fechada ou no PR lista links dos follow-ups criados
