### PR TITLE
feat(comercial): assinatura, reajuste e conversão Rede/Empresa (#353 #354 #357)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
-- Contratos comerciais (#324 / #349–#356): gerar PDF por CNPJ da negociação (fidelidade, setup e cláusulas de implantação), sem custo/margem no documento; rascunho → enviado → assinado; lista com filtro por responsável; painel interno com custo, lucro e margem %; modelos em Cadastros (versão sobe ao editar o HTML)
+- Contratos comerciais (#324 / #349–#357): gerar PDF por CNPJ (fidelidade, setup, cláusulas, dados fiscais e nome da base WebPosto); reajuste padrão da instância ou override no contrato; anexar PDF assinado (ClickSign ou outro) com referência opcional; ao marcar assinado, cria ou vincula Rede e Empresa pelo CNPJ (sem PDVs), copia e-mail/telefone e cria contacto na rede para o chat; rascunho → enviado → assinado; lista com filtro por responsável; painel interno com custo, lucro e margem %; modelos em Cadastros. Na negociação, os dados fiscais ficam no gerar contrato; depois de assinado, a linha e o nome da Rede não se editam
 - Proposta comercial (#323 / #345–#348): modelos HTML versionados, geração a partir da negociação (CNPJs à escolha), preview, PDF e marcar como enviada (com opção de avançar o funil) — sem custo/margem no documento do cliente
 - CRM (#322 / #336–#344): perfil comercial, funil, leads e negociações multi-CNPJ (API + UI — lista/Kanban, detalhe com custos/margem e timeline); configuração dos estágios em Cadastros; simulação e leitura do catálogo de custos para comercial (CRUD do catálogo continua só admin)
 - Sobre: as notas de atualização passam a mostrar só o que mudou no helpdesk nesta instância; melhorias do painel SaaS deixam de aparecer misturadas (#672 / #674)

--- a/backend/alembic/versions/098_comercial_contratos_f2.py
+++ b/backend/alembic/versions/098_comercial_contratos_f2.py
@@ -1,0 +1,91 @@
+"""Contratos F2: dados fiscais, reajuste configurável, PDF assinado e conversão (#353 #354 #357).
+
+Revision ID: 098_comercial_contratos_f2
+Revises: 097_comercial_contratos
+Create Date: 2026-08-19
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "098_comercial_contratos_f2"
+down_revision = "097_comercial_contratos"
+branch_labels = None
+depends_on = None
+
+
+def _colunas(insp, tabela: str) -> set[str]:
+    if not insp.has_table(tabela):
+        return set()
+    return {c["name"] for c in insp.get_columns(tabela)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    neg_cols = _colunas(insp, "crm_negociacoes")
+    if "nome_base_webposto" not in neg_cols:
+        op.add_column("crm_negociacoes", sa.Column("nome_base_webposto", sa.String(255), nullable=True))
+
+    linha_cols = _colunas(insp, "crm_negociacao_cnpj_linhas")
+    if "dados_fiscais" not in linha_cols:
+        op.add_column("crm_negociacao_cnpj_linhas", sa.Column("dados_fiscais", sa.JSON(), nullable=True))
+
+    ctr_cols = _colunas(insp, "comercial_contratos")
+    if "reajuste_percentual" not in ctr_cols:
+        op.add_column(
+            "comercial_contratos",
+            sa.Column("reajuste_percentual", sa.Numeric(7, 4), nullable=False, server_default="0"),
+        )
+    if "reajuste_rotulo" not in ctr_cols:
+        op.add_column(
+            "comercial_contratos",
+            sa.Column("reajuste_rotulo", sa.String(80), nullable=False, server_default=""),
+        )
+    op.alter_column("comercial_contratos", "reajuste_percentual", server_default=None)
+    op.alter_column("comercial_contratos", "reajuste_rotulo", server_default=None)
+    if "pdf_assinado_storage_key" not in ctr_cols:
+        op.add_column("comercial_contratos", sa.Column("pdf_assinado_storage_key", sa.String(255), nullable=True))
+    if "pdf_assinado_nome_original" not in ctr_cols:
+        op.add_column("comercial_contratos", sa.Column("pdf_assinado_nome_original", sa.String(255), nullable=True))
+    if "referencia_externa" not in ctr_cols:
+        op.add_column("comercial_contratos", sa.Column("referencia_externa", sa.String(120), nullable=True))
+
+    if not insp.has_table("comercial_contrato_politica"):
+        op.create_table(
+            "comercial_contrato_politica",
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("reajuste_percentual", sa.Numeric(7, 4), nullable=False, server_default="0"),
+            sa.Column("reajuste_rotulo", sa.String(80), nullable=False, server_default=""),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        bind.execute(
+            sa.text(
+                "INSERT INTO comercial_contrato_politica (id, reajuste_percentual, reajuste_rotulo) "
+                "SELECT 1, 0, '' WHERE NOT EXISTS (SELECT 1 FROM comercial_contrato_politica LIMIT 1)"
+            )
+        )
+    op.alter_column("comercial_contrato_politica", "reajuste_percentual", server_default=None)
+    op.alter_column("comercial_contrato_politica", "reajuste_rotulo", server_default=None)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("comercial_contrato_politica"):
+        op.drop_table("comercial_contrato_politica")
+    ctr_cols = _colunas(insp, "comercial_contratos")
+    for col in (
+        "referencia_externa",
+        "pdf_assinado_nome_original",
+        "pdf_assinado_storage_key",
+        "reajuste_rotulo",
+        "reajuste_percentual",
+    ):
+        if col in ctr_cols:
+            op.drop_column("comercial_contratos", col)
+    if "dados_fiscais" in _colunas(insp, "crm_negociacao_cnpj_linhas"):
+        op.drop_column("crm_negociacao_cnpj_linhas", "dados_fiscais")
+    if "nome_base_webposto" in _colunas(insp, "crm_negociacoes"):
+        op.drop_column("crm_negociacoes", "nome_base_webposto")

--- a/backend/app/api/comercial_contrato.py
+++ b/backend/app/api/comercial_contrato.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, File, Form, Query, UploadFile
 from fastapi.responses import Response
 from sqlalchemy.orm import Session
 
@@ -14,6 +14,8 @@ from app.schemas.comercial_contrato import (
     ContratoGerarIn,
     ContratoMarcarAssinadoIn,
     ContratoMarcarEnviadoIn,
+    ContratoPoliticaRead,
+    ContratoPoliticaUpdate,
     ContratoRead,
     ContratoTemplateCreate,
     ContratoTemplatePreviewIn,
@@ -76,6 +78,29 @@ def atualizar_template(
     return row
 
 
+@router.get("/contrato-politica", response_model=ContratoPoliticaRead)
+def obter_politica(
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    row = svc.garantir_politica(db)
+    db.commit()
+    return row
+
+
+@router.patch("/contrato-politica", response_model=ContratoPoliticaRead)
+def atualizar_politica(
+    data: ContratoPoliticaUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = svc.atualizar_politica(db, data)
+    registrar_audit(db, "comercial_contrato_politica", row.id, "update", atendente.id)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
 @router.get("/contratos", response_model=list[ContratoRead])
 def listar_contratos(
     negociacao_id: int | None = Query(None),
@@ -87,7 +112,7 @@ def listar_contratos(
     atendente: Atendente = Depends(exigir_comercial_ou_admin),
 ):
     filtrar_minhas = so_minhas
-    if negociacao_id is None and atendente.role != "admin":
+    if atendente.role != "admin":
         filtrar_minhas = True
     elif filtrar_minhas is None:
         filtrar_minhas = False
@@ -123,16 +148,16 @@ def gerar_contrato(
     )
     db.commit()
     db.refresh(row)
-    return svc.contrato_para_read(svc.obter_contrato(db, row.id), incluir_html=True)
+    return svc.contrato_para_read(svc.obter_contrato(db, row.id, atendente=atendente), incluir_html=True)
 
 
 @router.get("/contratos/{contrato_id}", response_model=ContratoRead)
 def obter_contrato(
     contrato_id: int,
     db: Session = Depends(get_db),
-    _: Atendente = Depends(exigir_comercial_ou_admin),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
 ):
-    return svc.contrato_para_read(svc.obter_contrato(db, contrato_id), incluir_html=True)
+    return svc.contrato_para_read(svc.obter_contrato(db, contrato_id, atendente=atendente), incluir_html=True)
 
 
 @router.get("/contratos/{contrato_id}/pdf")
@@ -140,15 +165,61 @@ def baixar_pdf(
     contrato_id: int,
     pdf_id: int | None = Query(None),
     db: Session = Depends(get_db),
-    _: Atendente = Depends(exigir_comercial_ou_admin),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
 ):
-    row = svc.obter_contrato(db, contrato_id)
+    row = svc.obter_contrato(db, contrato_id, atendente=atendente)
     pdf_row, pdf = svc.garantir_pdf(db, row, pdf_id=pdf_id)
     db.commit()
     return Response(
         content=pdf,
         media_type="application/pdf",
         headers={"Content-Disposition": f'attachment; filename="contrato-{row.id}-{pdf_row.id}.pdf"'},
+    )
+
+
+@router.post("/contratos/{contrato_id}/pdf-assinado", response_model=ContratoRead)
+def anexar_pdf_assinado(
+    contrato_id: int,
+    arquivo: UploadFile = File(...),
+    referencia_externa: str | None = Form(None),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    row = svc.obter_contrato(db, contrato_id, atendente=atendente)
+    conteudo = arquivo.file.read()
+    row = svc.anexar_pdf_assinado(
+        db,
+        row,
+        conteudo=conteudo,
+        nome_original=arquivo.filename,
+        content_type=arquivo.content_type,
+        referencia_externa=referencia_externa,
+        ator=atendente,
+    )
+    registrar_audit(
+        db,
+        "comercial_contrato",
+        row.id,
+        "update",
+        atendente.id,
+        payload={"pdf_assinado": True},
+    )
+    db.commit()
+    return svc.contrato_para_read(svc.obter_contrato(db, row.id, atendente=atendente), incluir_html=True)
+
+
+@router.get("/contratos/{contrato_id}/pdf-assinado")
+def baixar_pdf_assinado(
+    contrato_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    row = svc.obter_contrato(db, contrato_id, atendente=atendente)
+    pdf, nome = svc.bytes_pdf_assinado(row)
+    return Response(
+        content=pdf,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{nome}"'},
     )
 
 
@@ -159,7 +230,7 @@ def marcar_enviado(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(exigir_comercial_ou_admin),
 ):
-    row = svc.obter_contrato(db, contrato_id)
+    row = svc.obter_contrato(db, contrato_id, atendente=atendente)
     row = svc.marcar_enviado(db, row, data, atendente)
     registrar_audit(
         db,
@@ -171,7 +242,7 @@ def marcar_enviado(
     )
     db.commit()
     db.refresh(row)
-    return svc.contrato_para_read(svc.obter_contrato(db, row.id), incluir_html=True)
+    return svc.contrato_para_read(svc.obter_contrato(db, row.id, atendente=atendente), incluir_html=True)
 
 
 @router.post("/contratos/{contrato_id}/marcar-assinado", response_model=ContratoRead)
@@ -181,7 +252,7 @@ def marcar_assinado(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(exigir_comercial_ou_admin),
 ):
-    row = svc.obter_contrato(db, contrato_id)
+    row = svc.obter_contrato(db, contrato_id, atendente=atendente)
     row = svc.marcar_assinado(db, row, data, atendente)
     registrar_audit(
         db,
@@ -193,7 +264,7 @@ def marcar_assinado(
     )
     db.commit()
     db.refresh(row)
-    return svc.contrato_para_read(svc.obter_contrato(db, row.id), incluir_html=True)
+    return svc.contrato_para_read(svc.obter_contrato(db, row.id, atendente=atendente), incluir_html=True)
 
 
 @router.post("/contratos/{contrato_id}/cancelar", response_model=ContratoRead)
@@ -202,7 +273,7 @@ def cancelar_contrato(
     db: Session = Depends(get_db),
     atendente: Atendente = Depends(exigir_comercial_ou_admin),
 ):
-    row = svc.obter_contrato(db, contrato_id)
+    row = svc.obter_contrato(db, contrato_id, atendente=atendente)
     row = svc.cancelar_contrato(db, row, atendente)
     registrar_audit(
         db,
@@ -214,4 +285,4 @@ def cancelar_contrato(
     )
     db.commit()
     db.refresh(row)
-    return svc.contrato_para_read(svc.obter_contrato(db, row.id), incluir_html=True)
+    return svc.contrato_para_read(svc.obter_contrato(db, row.id, atendente=atendente), incluir_html=True)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -62,7 +62,7 @@ from app.models.crm import (
     FunilEstagio,
 )
 from app.models.comercial_proposta import Proposta, PropostaTemplate
-from app.models.comercial_contrato import Contrato, ContratoPdf, ContratoTemplate
+from app.models.comercial_contrato import Contrato, ContratoPdf, ContratoPolitica, ContratoTemplate
 from app.models.cliente_saas import ClienteSaaS
 from app.models.saas_alerta_emitido import SaasAlertaEmitido
 from app.models.lead_comercial import LeadComercial
@@ -148,6 +148,7 @@ __all__ = [
     "ContratoTemplate",
     "Contrato",
     "ContratoPdf",
+    "ContratoPolitica",
     "ClienteSaaS",
     "SaasAlertaEmitido",
     "LeadComercial",

--- a/backend/app/models/comercial_contrato.py
+++ b/backend/app/models/comercial_contrato.py
@@ -85,6 +85,11 @@ class Contrato(Base):
     alimentacao_cliente = Column(Boolean, nullable=False, default=True)
     hospedagem_cliente = Column(Boolean, nullable=False, default=True)
     multa_max_mensalidades = Column(Integer, nullable=False, default=MULTA_MAX_MENSALIDADES_PADRAO)
+    reajuste_percentual = Column(Numeric(7, 4), nullable=False, default=0)
+    reajuste_rotulo = Column(String(80), nullable=False, default="")
+    pdf_assinado_storage_key = Column(String(255), nullable=True)
+    pdf_assinado_nome_original = Column(String(255), nullable=True)
+    referencia_externa = Column(String(120), nullable=True)
     enviado_em = Column(DateTime(timezone=True), nullable=True)
     assinado_em = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False, index=True)
@@ -118,3 +123,14 @@ class ContratoPdf(Base):
 
     contrato = relationship("Contrato", back_populates="pdfs")
     gerado_por = relationship("Atendente", foreign_keys=[gerado_por_id])
+
+
+class ContratoPolitica(Base):
+    """Singleton da instância: reajuste padrão dos contratos (#354)."""
+
+    __tablename__ = "comercial_contrato_politica"
+
+    id = Column(Integer, primary_key=True)
+    reajuste_percentual = Column(Numeric(7, 4), nullable=False, default=0)
+    reajuste_rotulo = Column(String(80), nullable=False, default="")
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/app/models/crm.py
+++ b/backend/app/models/crm.py
@@ -95,6 +95,7 @@ class CrmNegociacao(Base):
     # True = negociação ativa do lead (no máximo uma por lead)
     ativa = Column(Boolean, nullable=False, default=True, index=True)
     titulo = Column(String(255), nullable=True)
+    nome_base_webposto = Column(String(255), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
@@ -131,6 +132,7 @@ class CrmNegociacaoCnpjLinha(Base):
     snapshot_custo = Column(JSON, nullable=True)
     total_custo = Column(Numeric(14, 2), nullable=True)
     margem_calculada = Column(Numeric(14, 2), nullable=True)
+    dados_fiscais = Column(JSON, nullable=True)
     # Preenchido pós-contrato (#324)
     empresa_id = Column(Integer, ForeignKey("empresas.id", ondelete="SET NULL"), nullable=True)
     ordem = Column(Integer, nullable=False, default=0)

--- a/backend/app/schemas/comercial_contrato.py
+++ b/backend/app/schemas/comercial_contrato.py
@@ -53,6 +53,21 @@ class ContratoGerarIn(BaseModel):
     alimentacao_cliente: bool = True
     hospedagem_cliente: bool = True
     multa_max_mensalidades: int = Field(3, ge=0, le=12)
+    sem_reajuste: bool = False
+    reajuste_percentual: Decimal | None = Field(None, ge=0, le=100)
+    reajuste_rotulo: str | None = Field(None, max_length=80)
+
+
+class ContratoPoliticaRead(BaseModel):
+    reajuste_percentual: Decimal
+    reajuste_rotulo: str
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ContratoPoliticaUpdate(BaseModel):
+    reajuste_percentual: Decimal | None = Field(None, ge=0, le=100)
+    reajuste_rotulo: str | None = Field(None, max_length=80)
 
 
 class ContratoMarcarEnviadoIn(BaseModel):
@@ -62,6 +77,7 @@ class ContratoMarcarEnviadoIn(BaseModel):
 class ContratoMarcarAssinadoIn(BaseModel):
     assinado_em: datetime | None = None
     avancar_funil: bool = False
+    referencia_externa: str | None = Field(None, max_length=120)
 
 
 class ContratoPdfRead(BaseModel):
@@ -86,6 +102,7 @@ class ContratoRead(BaseModel):
     negociacao_linha_cnpj_id: int
     negociacao_id: int | None = None
     empresa_id: int | None = None
+    rede_id: int | None = None
     template_id: int
     template_nome: str | None = None
     template_versao: int | None = None
@@ -102,6 +119,11 @@ class ContratoRead(BaseModel):
     alimentacao_cliente: bool
     hospedagem_cliente: bool
     multa_max_mensalidades: int
+    reajuste_percentual: Decimal
+    reajuste_rotulo: str
+    pdf_assinado_nome_original: str | None = None
+    tem_pdf_assinado: bool = False
+    referencia_externa: str | None = None
     enviado_em: datetime | None = None
     assinado_em: datetime | None = None
     created_at: datetime

--- a/backend/app/schemas/crm.py
+++ b/backend/app/schemas/crm.py
@@ -92,9 +92,41 @@ class CrmLeadRead(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
+class DadosFiscaisLinha(BaseModel):
+    nome: str | None = Field(None, max_length=255)
+    nome_fantasia: str | None = Field(None, max_length=255)
+    inscricao_estadual: str | None = Field(None, max_length=20)
+    endereco: str | None = Field(None, max_length=255)
+    numero: str | None = Field(None, max_length=20)
+    complemento: str | None = Field(None, max_length=100)
+    bairro: str | None = Field(None, max_length=100)
+    cidade: str | None = Field(None, max_length=100)
+    estado: str | None = Field(None, max_length=2)
+    cep: str | None = Field(None, max_length=10)
+    email: str | None = Field(None, max_length=255)
+    telefone: str | None = Field(None, max_length=20)
+    resp_legal_nome: str | None = Field(None, max_length=255)
+    resp_legal_cpf: str | None = Field(None, max_length=14)
+    resp_legal_rg: str | None = Field(None, max_length=20)
+    resp_legal_orgao_emissor: str | None = Field(None, max_length=30)
+    resp_legal_nacionalidade: str | None = Field(None, max_length=50)
+    resp_legal_estado_civil: str | None = Field(None, max_length=30)
+    resp_legal_cargo: str | None = Field(None, max_length=100)
+    resp_legal_email: str | None = Field(None, max_length=255)
+    resp_legal_telefone: str | None = Field(None, max_length=20)
+    resp_legal_endereco: str | None = Field(None, max_length=255)
+    resp_legal_numero: str | None = Field(None, max_length=20)
+    resp_legal_complemento: str | None = Field(None, max_length=100)
+    resp_legal_bairro: str | None = Field(None, max_length=100)
+    resp_legal_cidade: str | None = Field(None, max_length=100)
+    resp_legal_estado: str | None = Field(None, max_length=2)
+    resp_legal_cep: str | None = Field(None, max_length=10)
+
+
 class CrmLinhaCreate(BaseModel):
     cnpj: str | None = None
     razao_social: str | None = Field(None, max_length=255)
+    dados_fiscais: DadosFiscaisLinha | None = None
     item_ids: list[int] = Field(default_factory=list)
     quantidade_pdvs: int = Field(1, ge=1, le=500)
     desconto_posto_100k: bool = False
@@ -111,6 +143,7 @@ class CrmLinhaCreate(BaseModel):
 class CrmLinhaUpdate(BaseModel):
     cnpj: str | None = None
     razao_social: str | None = Field(None, max_length=255)
+    dados_fiscais: DadosFiscaisLinha | None = None
     item_ids: list[int] | None = None
     quantidade_pdvs: int | None = Field(None, ge=1, le=500)
     desconto_posto_100k: bool | None = None
@@ -133,6 +166,7 @@ class CrmLinhaRead(BaseModel):
     negociacao_id: int
     cnpj: str | None = None
     razao_social: str | None = None
+    dados_fiscais: dict[str, Any] | None = None
     item_ids: list[int] = Field(default_factory=list)
     quantidade_pdvs: int
     desconto_posto_100k: bool
@@ -158,6 +192,7 @@ class CrmNegociacaoCreate(BaseModel):
 
 class CrmNegociacaoUpdate(BaseModel):
     titulo: str | None = Field(None, max_length=255)
+    nome_base_webposto: str | None = Field(None, max_length=255)
     responsavel_id: int | None = None
 
 
@@ -170,6 +205,7 @@ class CrmNegociacaoRead(BaseModel):
     estagio_nome: str | None = None
     ativa: bool
     titulo: str | None = None
+    nome_base_webposto: str | None = None
     linhas: list[CrmLinhaRead] = Field(default_factory=list)
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/backend/app/services/comercial_contrato.py
+++ b/backend/app/services/comercial_contrato.py
@@ -11,7 +11,7 @@ from typing import Any
 
 from fastapi import HTTPException
 from sqlalchemy import func
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, joinedload, object_session
 
 from app.models.atendente import Atendente
 from app.models.comercial_contrato import (
@@ -24,9 +24,13 @@ from app.models.comercial_contrato import (
     MULTA_MAX_MENSALIDADES_PADRAO,
     Contrato,
     ContratoPdf,
+    ContratoPolitica,
     ContratoTemplate,
 )
 from app.models.crm import ATIVIDADE_DOCUMENTO, CrmNegociacao, CrmNegociacaoAtividade, CrmNegociacaoCnpjLinha
+from app.models.empresa import Empresa
+from app.models.empresa_sistema import EmpresaSistema
+from app.models.rede import Rede
 from app.schemas.comercial_contrato import (
     ContratoGerarIn,
     ContratoMarcarAssinadoIn,
@@ -36,7 +40,7 @@ from app.schemas.comercial_contrato import (
 )
 from app.services import comercial_proposta as proposta_svc
 from app.services import crm as crm_svc
-from app.services.ticket_anexo_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco
+from app.services.ticket_anexo_storage import caminho_absoluto_arquivo, gravar_bytes_em_disco, validar_upload
 
 TEMPLATE_PADRAO_HTML = """<!DOCTYPE html>
 <html lang="pt-BR">
@@ -58,6 +62,9 @@ TEMPLATE_PADRAO_HTML = """<!DOCTYPE html>
   <p class="muted">{{empresa_sistema}}</p>
   <h1>Contrato de prestação de serviços</h1>
   <p><strong>Contratante:</strong> {{razao_social}} &nbsp; <strong>CNPJ:</strong> {{cnpj}}</p>
+  <p>{{endereco_contratante}}</p>
+  <p>{{resp_legal}}</p>
+  <p class="muted">Base WebPosto: {{nome_base_webposto}}</p>
   <h2>Objeto e valores</h2>
   {{itens}}
   <p><strong>Mensalidade:</strong> {{valor_mensalidade}}</p>
@@ -66,7 +73,7 @@ TEMPLATE_PADRAO_HTML = """<!DOCTYPE html>
   <p>Início: {{data_inicio}} &nbsp; Fim da fidelidade: {{data_fim_fidelidade}} ({{fidelidade_meses}} meses).</p>
   <div>{{fidelidade}}</div>
   <div>{{multa}}</div>
-  <div>{{igpm}}</div>
+  <div>{{reajuste}}</div>
   <h2>Implantação</h2>
   {{clausula_deslocamento}}
   {{clausula_alimentacao}}
@@ -74,6 +81,127 @@ TEMPLATE_PADRAO_HTML = """<!DOCTYPE html>
 </body>
 </html>
 """
+
+
+CAMPOS_FISCAIS_OBRIGATORIOS = (
+    "endereco",
+    "numero",
+    "bairro",
+    "cidade",
+    "estado",
+    "cep",
+    "resp_legal_nome",
+    "resp_legal_cpf",
+)
+
+
+def _digits(valor: str | None) -> str:
+    return "".join(c for c in str(valor or "") if c.isdigit())
+
+
+def _fiscal_dict(linha: CrmNegociacaoCnpjLinha) -> dict[str, str]:
+    raw = linha.dados_fiscais if isinstance(linha.dados_fiscais, dict) else {}
+    out: dict[str, str] = {}
+    for k, v in raw.items():
+        if v is None:
+            continue
+        s = str(v).strip()
+        if s:
+            out[str(k)] = s
+    return out
+
+
+def assert_pronto_para_contrato(db: Session, linha: CrmNegociacaoCnpjLinha) -> CrmNegociacao:
+    neg = linha.negociacao or crm_svc.obter_negociacao(db, linha.negociacao_id)
+    if not (neg.nome_base_webposto or "").strip():
+        raise HTTPException(
+            status_code=400,
+            detail="Informe o nome da base WebPosto na negociação antes de gerar o contrato.",
+        )
+    if not (linha.razao_social or "").strip() or not _digits(linha.cnpj):
+        raise HTTPException(
+            status_code=400,
+            detail="A linha precisa de razão social e CNPJ para gerar o contrato.",
+        )
+    fiscal = _fiscal_dict(linha)
+    if any(not fiscal.get(c) for c in CAMPOS_FISCAIS_OBRIGATORIOS):
+        raise HTTPException(
+            status_code=400,
+            detail="Preencha os dados fiscais da linha (endereço completo e responsável legal) antes de gerar o contrato.",
+        )
+    return neg
+
+
+def garantir_politica(db: Session) -> ContratoPolitica:
+    row = db.query(ContratoPolitica).order_by(ContratoPolitica.id.asc()).first()
+    if row:
+        return row
+    row = ContratoPolitica(id=1, reajuste_percentual=Decimal("0"), reajuste_rotulo="")
+    db.add(row)
+    db.flush()
+    return row
+
+
+def atualizar_politica(db: Session, data) -> ContratoPolitica:
+    row = garantir_politica(db)
+    payload = data.model_dump(exclude_unset=True)
+    if "reajuste_percentual" in payload and payload["reajuste_percentual"] is not None:
+        row.reajuste_percentual = payload["reajuste_percentual"]
+    if "reajuste_rotulo" in payload and payload["reajuste_rotulo"] is not None:
+        row.reajuste_rotulo = payload["reajuste_rotulo"].strip()
+    db.flush()
+    return row
+
+
+def _resolver_reajuste(db: Session, data: ContratoGerarIn) -> tuple[Decimal, str]:
+    pol = garantir_politica(db)
+    rotulo_pol = (pol.reajuste_rotulo or "").strip()
+    if data.sem_reajuste:
+        rotulo = (data.reajuste_rotulo or "").strip()
+        return Decimal("0"), rotulo
+    if data.reajuste_percentual is not None:
+        rotulo = data.reajuste_rotulo.strip() if data.reajuste_rotulo is not None else rotulo_pol
+        return Decimal(str(data.reajuste_percentual)), rotulo
+    rotulo = data.reajuste_rotulo.strip() if data.reajuste_rotulo is not None else rotulo_pol
+    return Decimal(str(pol.reajuste_percentual or 0)), rotulo
+
+
+def _fmt_pct(valor: Decimal) -> str:
+    q = valor.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    return f"{q}".replace(".", ",")
+
+
+def _endereco_formatado(fiscal: dict[str, str], *, prefixo: str = "") -> str:
+    def g(chave: str) -> str:
+        return fiscal.get(f"{prefixo}{chave}" if prefixo else chave, "") or fiscal.get(chave, "")
+
+    linha1 = " ".join(p for p in (g("endereco"), g("numero"), g("complemento")) if p)
+    cid = " / ".join(p for p in (g("cidade"), g("estado")) if p)
+    partes = [p for p in (linha1, g("bairro"), cid, g("cep")) if p]
+    return html.escape(" · ".join(partes) if partes else "—")
+
+
+def _bloco_empresa_sistema(db: Session) -> str:
+    emp = db.query(EmpresaSistema).order_by(EmpresaSistema.id.asc()).first()
+    if not emp:
+        return ""
+    nomes = [p for p in (emp.razao_social, emp.nome_fantasia or emp.nome) if p]
+    fiscal = {
+        "endereco": emp.endereco or "",
+        "numero": emp.numero or "",
+        "complemento": emp.complemento or "",
+        "bairro": emp.bairro or "",
+        "cidade": emp.cidade or "",
+        "estado": emp.estado or "",
+        "cep": emp.cep or "",
+    }
+    bits = [html.escape(" · ".join(dict.fromkeys(nomes)))]
+    if emp.cnpj:
+        bits.append(html.escape(f"CNPJ {proposta_svc._formatar_cnpj(emp.cnpj)}"))
+    end = _endereco_formatado(fiscal)
+    if end and end != "—":
+        bits.append(end)
+    return " — ".join(bits)
 
 
 def sanitize_html(fragment: str) -> str:
@@ -170,7 +298,12 @@ def atualizar_template(db: Session, row: ContratoTemplate, data: ContratoTemplat
 
 
 def obter_linha(db: Session, linha_id: int) -> CrmNegociacaoCnpjLinha:
-    row = db.query(CrmNegociacaoCnpjLinha).filter(CrmNegociacaoCnpjLinha.id == linha_id).first()
+    row = (
+        db.query(CrmNegociacaoCnpjLinha)
+        .options(joinedload(CrmNegociacaoCnpjLinha.negociacao))
+        .filter(CrmNegociacaoCnpjLinha.id == linha_id)
+        .first()
+    )
     if not row:
         raise HTTPException(status_code=404, detail="Linha CNPJ da negociação não encontrada.")
     return row
@@ -202,7 +335,7 @@ def _opts_contrato():
     )
 
 
-def obter_contrato(db: Session, contrato_id: int) -> Contrato:
+def obter_contrato(db: Session, contrato_id: int, *, atendente: Atendente | None = None) -> Contrato:
     row = (
         db.query(Contrato)
         .options(*_opts_contrato())
@@ -211,7 +344,23 @@ def obter_contrato(db: Session, contrato_id: int) -> Contrato:
     )
     if not row:
         raise HTTPException(status_code=404, detail="Contrato não encontrado.")
+    _assert_acesso_contrato(row, atendente)
     return row
+
+
+def _assert_acesso_negociacao(neg: CrmNegociacao | None, atendente: Atendente | None) -> None:
+    if atendente is None or atendente.role == "admin":
+        return
+    if neg is None or neg.responsavel_id != atendente.id:
+        raise HTTPException(status_code=403, detail="Você não tem permissão para este contrato.")
+
+
+def _assert_acesso_contrato(row: Contrato, atendente: Atendente | None) -> None:
+    if atendente is None or atendente.role == "admin":
+        return
+    linha = row.linha
+    neg = linha.negociacao if linha else None
+    _assert_acesso_negociacao(neg, atendente)
 
 
 def listar_contratos(
@@ -263,6 +412,19 @@ def _setup_bloco(*, setup_isento: bool, setup_valor: Decimal | None) -> str:
     return _p("Setup de implantação: conforme negociação (fora da mensalidade).")
 
 
+def _clausula_reajuste(pct: Decimal, rotulo: str) -> str:
+    if pct <= 0:
+        return _p(
+            "Após o período de fidelidade, a renovação é automática, sem nova fidelidade e "
+            "sem reajuste de mensalidade neste contrato."
+        )
+    rot = html.escape(rotulo or "índice informado neste contrato")
+    return _p(
+        f"Após o período de fidelidade, a renovação é automática, sem nova fidelidade, "
+        f"com reajuste de {_fmt_pct(pct)}% ({rot})."
+    )
+
+
 def _clausula_custo_cliente(ativo: bool, titulo: str) -> str:
     if not ativo:
         return ""
@@ -283,11 +445,28 @@ def preencher_template(db: Session, template_html: str, contrato: Contrato, linh
     )
     fid = int(contrato.fidelidade_meses or FIDELIDADE_MESES_PADRAO)
     multa_n = int(contrato.multa_max_mensalidades or MULTA_MAX_MENSALIDADES_PADRAO)
+    fiscal = _fiscal_dict(linha)
+    neg = linha.negociacao
+    nome_base = (neg.nome_base_webposto if neg else "") or ""
+    reaj = _clausula_reajuste(
+        Decimal(str(contrato.reajuste_percentual or 0)),
+        contrato.reajuste_rotulo or "",
+    )
+    resp = fiscal.get("resp_legal_nome") or ""
+    cpf = fiscal.get("resp_legal_cpf") or ""
+    resp_txt = "—"
+    if resp:
+        resp_txt = html.escape(resp)
+        if cpf:
+            resp_txt += html.escape(f" · CPF {cpf}")
     valores = {
         "logo": proposta_svc._logo_html(db),
-        "empresa_sistema": proposta_svc._empresa_sistema_texto(db),
+        "empresa_sistema": _bloco_empresa_sistema(db) or proposta_svc._empresa_sistema_texto(db),
         "razao_social": html.escape(linha.razao_social or "—"),
         "cnpj": html.escape(proposta_svc._formatar_cnpj(linha.cnpj)),
+        "endereco_contratante": _endereco_formatado(fiscal),
+        "resp_legal": resp_txt,
+        "nome_base_webposto": html.escape(nome_base.strip() or "—"),
         "itens": tabela,
         "valor_mensalidade": html.escape(proposta_svc._money_br(contrato.valor_mensalidade)),
         "data_inicio": html.escape(contrato.data_inicio.strftime("%d/%m/%Y")),
@@ -306,10 +485,8 @@ def preencher_template(db: Session, template_html: str, contrato: Contrato, linh
                 "a validar juridicamente."
             )
         ),
-        "igpm": _p(
-            "Após o período de fidelidade, a renovação é automática, sem nova fidelidade, "
-            "com reajuste pelo IGPM acumulado em 12 meses."
-        ),
+        "igpm": reaj,
+        "reajuste": reaj,
         "clausula_deslocamento": _clausula_custo_cliente(bool(contrato.deslocamento_cliente), "Deslocamento"),
         "clausula_alimentacao": _clausula_custo_cliente(bool(contrato.alimentacao_cliente), "Alimentação"),
         "clausula_hospedagem": _clausula_custo_cliente(bool(contrato.hospedagem_cliente), "Hospedagem"),
@@ -325,13 +502,24 @@ def preencher_template(db: Session, template_html: str, contrato: Contrato, linh
     return html_out
 
 
-def _montar_snapshots(db: Session, linha: CrmNegociacaoCnpjLinha, data: ContratoGerarIn) -> dict[str, Any]:
+def _montar_snapshots(
+    db: Session,
+    linha: CrmNegociacaoCnpjLinha,
+    data: ContratoGerarIn,
+    *,
+    reajuste_percentual: Decimal,
+    reajuste_rotulo: str,
+    nome_base: str,
+) -> dict[str, Any]:
     nomes = proposta_svc._nomes_itens_cliente(db, linha)
     snap_custo = linha.snapshot_custo if isinstance(linha.snapshot_custo, dict) else None
+    fiscal = _fiscal_dict(linha)
     return {
         "valor_mensalidade": Decimal(str(linha.valor_negociado or 0)),
         "snapshot_custo": snap_custo,
         "snapshot_itens": [{"nome": n} for n in nomes],
+        "reajuste_percentual": reajuste_percentual,
+        "reajuste_rotulo": reajuste_rotulo,
         "snapshot_comercial": {
             "valor_mensalidade": str(Decimal(str(linha.valor_negociado or 0))),
             "setup_valor": str(data.setup_valor) if data.setup_valor is not None else None,
@@ -341,6 +529,10 @@ def _montar_snapshots(db: Session, linha: CrmNegociacaoCnpjLinha, data: Contrato
             "deslocamento_cliente": data.deslocamento_cliente,
             "alimentacao_cliente": data.alimentacao_cliente,
             "hospedagem_cliente": data.hospedagem_cliente,
+            "reajuste_percentual": str(reajuste_percentual),
+            "reajuste_rotulo": reajuste_rotulo,
+            "nome_base_webposto": nome_base,
+            "dados_fiscais": fiscal,
         },
     }
 
@@ -365,6 +557,8 @@ def _aplicar_campos_geracao(row: Contrato, data: ContratoGerarIn, snaps: dict[st
     row.alimentacao_cliente = data.alimentacao_cliente
     row.hospedagem_cliente = data.hospedagem_cliente
     row.multa_max_mensalidades = data.multa_max_mensalidades
+    row.reajuste_percentual = snaps["reajuste_percentual"]
+    row.reajuste_rotulo = snaps["reajuste_rotulo"]
 
 
 def _gravar_pdf_versao(db: Session, contrato: Contrato, html_doc: str, ator: Atendente) -> ContratoPdf:
@@ -381,8 +575,8 @@ def _gravar_pdf_versao(db: Session, contrato: Contrato, html_doc: str, ator: Ate
 
 def gerar_contrato(db: Session, data: ContratoGerarIn, ator: Atendente) -> Contrato:
     linha = obter_linha(db, data.linha_id)
-    if not (linha.razao_social or "").strip() or not (linha.cnpj or "").strip():
-        raise HTTPException(status_code=400, detail="A linha precisa de razão social e CNPJ para gerar o contrato.")
+    neg = assert_pronto_para_contrato(db, linha)
+    _assert_acesso_negociacao(neg, ator)
     if data.template_id:
         tmpl = obter_template(db, data.template_id, apenas_ativos=True)
     else:
@@ -400,7 +594,15 @@ def gerar_contrato(db: Session, data: ContratoGerarIn, ator: Atendente) -> Contr
             detail="Contrato já enviado. Não é possível regenerar; cancele ou marque como assinado.",
         )
 
-    snaps = _montar_snapshots(db, linha, data)
+    pct, rotulo = _resolver_reajuste(db, data)
+    snaps = _montar_snapshots(
+        db,
+        linha,
+        data,
+        reajuste_percentual=pct,
+        reajuste_rotulo=rotulo,
+        nome_base=(neg.nome_base_webposto or "").strip(),
+    )
     if existente:
         row = existente
         _aplicar_campos_geracao(row, data, snaps, tmpl)
@@ -482,9 +684,17 @@ def marcar_enviado(db: Session, row: Contrato, data: ContratoMarcarEnviadoIn, at
 def marcar_assinado(db: Session, row: Contrato, data: ContratoMarcarAssinadoIn, ator: Atendente) -> Contrato:
     if row.status not in {CONTRATO_RASCUNHO, CONTRATO_ENVIADO}:
         raise HTTPException(status_code=400, detail="Só rascunho ou enviado podem ser marcados como assinados.")
+    if not (row.pdf_assinado_storage_key or "").strip():
+        raise HTTPException(
+            status_code=400,
+            detail="Anexe o PDF assinado antes de marcar o contrato como assinado.",
+        )
+    if data.referencia_externa is not None:
+        row.referencia_externa = data.referencia_externa.strip() or None
     row.status = CONTRATO_ASSINADO
     row.assinado_em = data.assinado_em or datetime.now(timezone.utc)
     linha = row.linha or obter_linha(db, row.negociacao_linha_cnpj_id)
+    converter_pos_assinatura(db, row, linha, ator)
     db.add(
         CrmNegociacaoAtividade(
             negociacao_id=linha.negociacao_id,
@@ -505,7 +715,7 @@ def marcar_assinado(db: Session, row: Contrato, data: ContratoMarcarAssinadoIn, 
                 nota="Contrato assinado (registro manual).",
             )
     db.flush()
-    return row
+    return obter_contrato(db, row.id)
 
 
 def cancelar_contrato(db: Session, row: Contrato, ator: Atendente) -> Contrato:
@@ -562,11 +772,19 @@ def contrato_para_read(row: Contrato, *, incluir_html: bool = False) -> dict[str
         template_versao = int(versao_snapshot) if versao_snapshot is not None else (tmpl.versao if tmpl else None)
     except (TypeError, ValueError):
         template_versao = tmpl.versao if tmpl else None
+    rede_id = None
+    if row.empresa_id:
+        sess = object_session(row)
+        if sess is not None:
+            emp = sess.query(Empresa).filter(Empresa.id == row.empresa_id).first()
+            if emp is not None:
+                rede_id = emp.rede_id
     return {
         "id": row.id,
         "negociacao_linha_cnpj_id": row.negociacao_linha_cnpj_id,
         "negociacao_id": linha.negociacao_id if linha else None,
         "empresa_id": row.empresa_id,
+        "rede_id": rede_id,
         "template_id": row.template_id,
         "template_nome": tmpl.nome if tmpl else None,
         "template_versao": template_versao,
@@ -583,6 +801,11 @@ def contrato_para_read(row: Contrato, *, incluir_html: bool = False) -> dict[str
         "alimentacao_cliente": row.alimentacao_cliente,
         "hospedagem_cliente": row.hospedagem_cliente,
         "multa_max_mensalidades": row.multa_max_mensalidades,
+        "reajuste_percentual": row.reajuste_percentual,
+        "reajuste_rotulo": row.reajuste_rotulo or "",
+        "pdf_assinado_nome_original": row.pdf_assinado_nome_original,
+        "tem_pdf_assinado": bool(row.pdf_assinado_storage_key),
+        "referencia_externa": row.referencia_externa,
         "enviado_em": row.enviado_em,
         "assinado_em": row.assinado_em,
         "created_at": row.created_at,
@@ -606,3 +829,226 @@ def contrato_para_read(row: Contrato, *, incluir_html: bool = False) -> dict[str
         "dias_restantes_fidelidade": dias,
         "interno": _interno_read(row, linha),
     }
+
+
+def anexar_pdf_assinado(
+    db: Session,
+    row: Contrato,
+    *,
+    conteudo: bytes,
+    nome_original: str | None,
+    content_type: str | None,
+    referencia_externa: str | None,
+    ator: Atendente,
+) -> Contrato:
+    if row.status not in {CONTRATO_RASCUNHO, CONTRATO_ENVIADO}:
+        raise HTTPException(
+            status_code=400,
+            detail="Só é possível anexar o PDF assinado em contrato rascunho ou enviado.",
+        )
+    try:
+        nome, mime = validar_upload(nome_original, content_type, len(conteudo))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if mime and mime != "application/pdf":
+        raise HTTPException(status_code=400, detail="O anexo assinado deve ser um PDF.")
+    if not (nome.lower().endswith(".pdf") or mime == "application/pdf"):
+        raise HTTPException(status_code=400, detail="O anexo assinado deve ser um PDF.")
+    try:
+        key = gravar_bytes_em_disco(conteudo, mimetype="application/pdf", nome_original=nome)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    row.pdf_assinado_storage_key = key
+    row.pdf_assinado_nome_original = nome
+    if referencia_externa is not None:
+        row.referencia_externa = referencia_externa.strip() or None
+    linha = row.linha or obter_linha(db, row.negociacao_linha_cnpj_id)
+    db.add(
+        CrmNegociacaoAtividade(
+            negociacao_id=linha.negociacao_id,
+            autor_id=ator.id,
+            tipo=ATIVIDADE_DOCUMENTO,
+            texto=f"PDF assinado anexado ao contrato #{row.id}.",
+        )
+    )
+    db.flush()
+    return obter_contrato(db, row.id)
+
+
+def bytes_pdf_assinado(row: Contrato) -> tuple[bytes, str]:
+    if not row.pdf_assinado_storage_key:
+        raise HTTPException(status_code=404, detail="Este contrato ainda não tem PDF assinado anexado.")
+    path = caminho_absoluto_arquivo(row.pdf_assinado_storage_key)
+    if not path:
+        raise HTTPException(status_code=404, detail="Ficheiro do PDF assinado não encontrado.")
+    nome = row.pdf_assinado_nome_original or f"contrato-{row.id}-assinado.pdf"
+    return path.read_bytes(), nome
+
+
+def _contato_conversao(fiscal: dict[str, str], lead: Any) -> tuple[str | None, str | None]:
+    email = (fiscal.get("email") or "").strip()
+    if not email and lead is not None:
+        email = (getattr(lead, "email", None) or "").strip()
+    email = email.lower() or None
+    tel = _digits(fiscal.get("telefone"))
+    if not tel and lead is not None:
+        tel = _digits(getattr(lead, "telefone", None))
+    tel = tel[:20] or None
+    return email, tel
+
+
+def _aplicar_contato_empresa(empresa: Empresa, email: str | None, telefone: str | None) -> None:
+    if email and not (empresa.email or "").strip():
+        empresa.email = email[:255]
+    if telefone and not _digits(empresa.telefone):
+        empresa.telefone = telefone[:20]
+
+
+def _vincular_contato_chat(db: Session, empresa: Empresa, rede: Rede, fiscal: dict[str, str], lead: Any) -> None:
+    """Cria ou reutiliza um colaborador com e-mail/telefone para o chat encontrar o posto."""
+    from app.models.funcionario_rede import FuncionarioRede
+    from app.services.funcionario_escopo import sincronizar_vinculos_empresas
+    from app.services.funcionario_rede_resolver import assert_email_unico_por_rede
+
+    email, telefone = _contato_conversao(fiscal, lead)
+    if not email and not telefone:
+        return
+    nome = (fiscal.get("resp_legal_nome") or "").strip()
+    if not nome and lead is not None:
+        nome = (getattr(lead, "nome", None) or "").strip()
+    if not nome:
+        nome = (empresa.nome or "").strip() or "Contacto comercial"
+    existente = None
+    if telefone:
+        for f in db.query(FuncionarioRede).filter(FuncionarioRede.ativo.is_(True), FuncionarioRede.rede_id == rede.id):
+            if _digits(f.telefone) == telefone:
+                existente = f
+                break
+    if existente is None and email:
+        existente = (
+            db.query(FuncionarioRede)
+            .filter(
+                FuncionarioRede.ativo.is_(True),
+                FuncionarioRede.rede_id == rede.id,
+                func.lower(FuncionarioRede.email) == email,
+            )
+            .first()
+        )
+    if existente:
+        if not _digits(existente.telefone) and telefone:
+            existente.telefone = telefone
+        if not (existente.email or "").strip() and email:
+            existente.email = email
+        return
+    email_func = email
+    if email_func:
+        try:
+            assert_email_unico_por_rede(db, email=email_func, rede_id=rede.id)
+        except ValueError:
+            email_func = None
+        if not email_func and not telefone:
+            return
+    f = FuncionarioRede(
+        nome=nome[:255],
+        email=email_func,
+        telefone=telefone,
+        tipo="colaborador",
+        escopo_empresas="selected",
+        ativo=True,
+        rede_id=rede.id,
+        empresa_id=empresa.id,
+    )
+    db.add(f)
+    db.flush()
+    sincronizar_vinculos_empresas(db, f, escopo="selected", rede_id=rede.id, empresa_ids=[empresa.id])
+
+
+def converter_pos_assinatura(db: Session, contrato: Contrato, linha: CrmNegociacaoCnpjLinha, ator: Atendente) -> None:
+    """Cria ou vincula Rede + Empresa a partir do snapshot da linha (#357). Sem PDVs."""
+    if contrato.empresa_id and linha.empresa_id:
+        return
+    neg = linha.negociacao or crm_svc.obter_negociacao(db, linha.negociacao_id)
+    nome_base = (neg.nome_base_webposto or "").strip()
+    if not nome_base:
+        raise HTTPException(
+            status_code=400,
+            detail="Informe o nome da base WebPosto na negociação para criar a Rede.",
+        )
+    cnpj_digits = _digits(linha.cnpj)
+    if not cnpj_digits:
+        raise HTTPException(status_code=400, detail="A linha precisa de CNPJ para criar a Empresa.")
+    tenant_id = ator.tenant_id
+    fiscal = _fiscal_dict(linha)
+    snap = contrato.snapshot_comercial if isinstance(contrato.snapshot_comercial, dict) else {}
+    if isinstance(snap.get("dados_fiscais"), dict):
+        fiscal = {**fiscal, **{k: str(v).strip() for k, v in snap["dados_fiscais"].items() if v}}
+    lead = neg.lead
+    email_contato, telefone_contato = _contato_conversao(fiscal, lead)
+
+    rede = (
+        db.query(Rede)
+        .filter(Rede.tenant_id == tenant_id, func.lower(Rede.nome) == nome_base.lower())
+        .order_by(Rede.id.asc())
+        .first()
+    )
+    if not rede:
+        rede = Rede(tenant_id=tenant_id, nome=nome_base, ativo=True)
+        db.add(rede)
+        db.flush()
+
+    existente = None
+    for emp in db.query(Empresa).filter(Empresa.tenant_id == tenant_id).all():
+        if _digits(emp.cnpj_cpf) == cnpj_digits:
+            existente = emp
+            break
+    if existente:
+        _aplicar_contato_empresa(existente, email_contato, telefone_contato)
+        contrato.empresa_id = existente.id
+        linha.empresa_id = existente.id
+        _vincular_contato_chat(db, existente, rede, fiscal, lead)
+        db.flush()
+        return
+
+    nome_emp = fiscal.get("nome") or fiscal.get("nome_fantasia") or (linha.razao_social or "").strip() or nome_base
+    empresa = Empresa(
+        tenant_id=tenant_id,
+        rede_id=rede.id,
+        nome=nome_emp[:255],
+        cnpj_cpf=proposta_svc._formatar_cnpj(cnpj_digits) if len(cnpj_digits) == 14 else cnpj_digits,
+        razao_social=(linha.razao_social or "").strip() or None,
+        nome_fantasia=fiscal.get("nome_fantasia") or None,
+        inscricao_estadual=fiscal.get("inscricao_estadual") or None,
+        endereco=fiscal.get("endereco") or None,
+        numero=fiscal.get("numero") or None,
+        complemento=fiscal.get("complemento") or None,
+        bairro=fiscal.get("bairro") or None,
+        cidade=fiscal.get("cidade") or None,
+        estado=(fiscal.get("estado") or "")[:2] or None,
+        cep=fiscal.get("cep") or None,
+        email=email_contato,
+        telefone=telefone_contato,
+        resp_legal_nome=fiscal.get("resp_legal_nome") or None,
+        resp_legal_cpf=fiscal.get("resp_legal_cpf") or None,
+        resp_legal_rg=fiscal.get("resp_legal_rg") or None,
+        resp_legal_orgao_emissor=fiscal.get("resp_legal_orgao_emissor") or None,
+        resp_legal_nacionalidade=fiscal.get("resp_legal_nacionalidade") or None,
+        resp_legal_estado_civil=fiscal.get("resp_legal_estado_civil") or None,
+        resp_legal_cargo=fiscal.get("resp_legal_cargo") or None,
+        resp_legal_email=fiscal.get("resp_legal_email") or None,
+        resp_legal_telefone=fiscal.get("resp_legal_telefone") or None,
+        resp_legal_endereco=fiscal.get("resp_legal_endereco") or None,
+        resp_legal_numero=fiscal.get("resp_legal_numero") or None,
+        resp_legal_complemento=fiscal.get("resp_legal_complemento") or None,
+        resp_legal_bairro=fiscal.get("resp_legal_bairro") or None,
+        resp_legal_cidade=fiscal.get("resp_legal_cidade") or None,
+        resp_legal_estado=(fiscal.get("resp_legal_estado") or "")[:2] or None,
+        resp_legal_cep=fiscal.get("resp_legal_cep") or None,
+        ativo=True,
+    )
+    db.add(empresa)
+    db.flush()
+    contrato.empresa_id = empresa.id
+    linha.empresa_id = empresa.id
+    _vincular_contato_chat(db, empresa, rede, fiscal, lead)
+    db.flush()
+

--- a/backend/app/services/crm.py
+++ b/backend/app/services/crm.py
@@ -246,6 +246,7 @@ def negociacao_to_read(neg: CrmNegociacao) -> dict:
         "estagio_nome": est.nome if est else None,
         "ativa": neg.ativa,
         "titulo": neg.titulo,
+        "nome_base_webposto": neg.nome_base_webposto,
         "linhas": linhas,
         "created_at": neg.created_at,
         "updated_at": neg.updated_at,
@@ -449,8 +450,43 @@ def criar_negociacao(db: Session, data: CrmNegociacaoCreate, ator: Atendente) ->
     return obter_negociacao(db, neg.id)
 
 
+def _linha_tem_contrato_assinado(db: Session, linha_id: int) -> bool:
+    from app.models.comercial_contrato import CONTRATO_ASSINADO, Contrato
+
+    return (
+        db.query(Contrato.id)
+        .filter(Contrato.negociacao_linha_cnpj_id == linha_id, Contrato.status == CONTRATO_ASSINADO)
+        .first()
+        is not None
+    )
+
+
+def _negociacao_tem_contrato_assinado(db: Session, negociacao_id: int) -> bool:
+    from app.models.comercial_contrato import CONTRATO_ASSINADO, Contrato
+
+    return (
+        db.query(Contrato.id)
+        .join(CrmNegociacaoCnpjLinha, Contrato.negociacao_linha_cnpj_id == CrmNegociacaoCnpjLinha.id)
+        .filter(
+            CrmNegociacaoCnpjLinha.negociacao_id == negociacao_id,
+            Contrato.status == CONTRATO_ASSINADO,
+        )
+        .first()
+        is not None
+    )
+
+
 def atualizar_negociacao(db: Session, neg: CrmNegociacao, data: CrmNegociacaoUpdate) -> CrmNegociacao:
     payload = data.model_dump(exclude_unset=True)
+    if "nome_base_webposto" in payload:
+        atual = (neg.nome_base_webposto or "").strip() or None
+        raw = payload.get("nome_base_webposto")
+        novo = str(raw).strip() or None if raw is not None else None
+        if novo != atual and _negociacao_tem_contrato_assinado(db, neg.id):
+            raise HTTPException(
+                status_code=400,
+                detail="O nome da Rede não pode ser alterado depois de um contrato assinado.",
+            )
     if "responsavel_id" in payload and payload["responsavel_id"] is not None:
         _assert_responsavel_comercial(db, payload["responsavel_id"])
     for k, v in payload.items():
@@ -467,6 +503,7 @@ def add_linha(db: Session, neg: CrmNegociacao, data: CrmLinhaCreate) -> CrmNegoc
         negociacao_id=neg.id,
         cnpj=data.cnpj,
         razao_social=data.razao_social,
+        dados_fiscais=(data.dados_fiscais.model_dump(exclude_none=True) if data.dados_fiscais else {}),
         item_ids=list(data.item_ids or []),
         quantidade_pdvs=data.quantidade_pdvs,
         desconto_posto_100k=data.desconto_posto_100k,
@@ -482,9 +519,20 @@ def add_linha(db: Session, neg: CrmNegociacao, data: CrmLinhaCreate) -> CrmNegoc
 
 
 def atualizar_linha(db: Session, linha: CrmNegociacaoCnpjLinha, data: CrmLinhaUpdate) -> CrmNegociacaoCnpjLinha:
+    if _linha_tem_contrato_assinado(db, linha.id):
+        raise HTTPException(
+            status_code=400,
+            detail="Esta linha tem contrato assinado. Pacote, valores e dados fiscais não podem ser alterados.",
+        )
     neg = obter_negociacao(db, linha.negociacao_id)
     est = obter_estagio(db, estagio_id=neg.estagio_id)
     payload = data.model_dump(exclude_unset=True, exclude={"limpar_tef_override", "tef_override"})
+    if "dados_fiscais" in payload and payload["dados_fiscais"] is not None:
+        payload["dados_fiscais"] = (
+            payload["dados_fiscais"]
+            if isinstance(payload["dados_fiscais"], dict)
+            else data.dados_fiscais.model_dump(exclude_none=True)
+        )
     if data.limpar_tef_override:
         linha.tef_override = None
     elif data.tef_override is not None:
@@ -499,6 +547,11 @@ def atualizar_linha(db: Session, linha: CrmNegociacaoCnpjLinha, data: CrmLinhaUp
 
 
 def excluir_linha(db: Session, linha: CrmNegociacaoCnpjLinha) -> None:
+    if _linha_tem_contrato_assinado(db, linha.id):
+        raise HTTPException(
+            status_code=400,
+            detail="Não é possível remover uma linha com contrato assinado.",
+        )
     neg = obter_negociacao(db, linha.negociacao_id)
     est = obter_estagio(db, estagio_id=neg.estagio_id)
     restantes = [

--- a/backend/tests/test_comercial_contrato.py
+++ b/backend/tests/test_comercial_contrato.py
@@ -46,18 +46,48 @@ def _criar_item_catalogo(client, h_admin) -> int:
     return item.json()["id"]
 
 
-def _negociacao_com_linha(client, h, *, item_id: int | None = None):
+DADOS_FISCAIS_OK = {
+    "endereco": "Rua das Palmeiras",
+    "numero": "100",
+    "bairro": "Centro",
+    "cidade": "São Paulo",
+    "estado": "SP",
+    "cep": "01001000",
+    "resp_legal_nome": "Maria Silva",
+    "resp_legal_cpf": "39053344705",
+}
+
+
+def _negociacao_com_linha(client, h, *, item_id: int | None = None, cnpj: str = "12.345.678/0001-95"):
     lead = client.post("/v1/crm/leads", headers=h, json={"nome": "Posto Contrato"}).json()
     neg_id = lead["negociacao_ativa_id"]
+    base = client.patch(
+        f"/v1/crm/negociacoes/{neg_id}",
+        headers=h,
+        json={"nome_base_webposto": "base_posto_contrato_qa"},
+    )
+    assert base.status_code == 200, base.text
     payload = {
         "razao_social": "Posto Contrato LTDA",
-        "cnpj": "12.345.678/0001-95",
+        "cnpj": cnpj,
         "valor_negociado": "900.00",
         "item_ids": [item_id] if item_id else [],
+        "dados_fiscais": DADOS_FISCAIS_OK,
     }
     ln = client.post(f"/v1/crm/negociacoes/{neg_id}/linhas", headers=h, json=payload)
     assert ln.status_code == 201, ln.text
     return neg_id, ln.json()
+
+
+def _anexar_pdf_assinado(client, h, contrato_id: int, *, referencia: str | None = "prot-1"):
+    r = client.post(
+        f"/v1/comercial/contratos/{contrato_id}/pdf-assinado",
+        headers=h,
+        files={"arquivo": ("assinado.pdf", b"%PDF-1.4 signed", "application/pdf")},
+        data={"referencia_externa": referencia} if referencia is not None else None,
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
 
 
 def _assert_sem_internos(texto: str | bytes) -> None:
@@ -238,6 +268,13 @@ def test_assinado_nao_edita_snapshot(client, auth_headers, seed_base):
     regen = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": linha["id"]})
     assert regen.status_code == 400
 
+    sem_pdf = client.post(
+        f"/v1/comercial/contratos/{cid}/marcar-assinado",
+        headers=h,
+        json={"avancar_funil": True},
+    )
+    assert sem_pdf.status_code == 400
+    _anexar_pdf_assinado(client, h, cid)
     ass = client.post(
         f"/v1/comercial/contratos/{cid}/marcar-assinado",
         headers=h,
@@ -246,6 +283,8 @@ def test_assinado_nao_edita_snapshot(client, auth_headers, seed_base):
     assert ass.status_code == 200, ass.text
     assert ass.json()["status"] == "assinado"
     assert ass.json()["assinado_em"]
+    assert ass.json()["empresa_id"]
+    assert ass.json()["tem_pdf_assinado"] is True
     regen2 = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": linha["id"]})
     assert regen2.status_code == 400
 
@@ -258,15 +297,30 @@ def test_segunda_linha_pode_ter_contrato_proprio(client, auth_headers, seed_base
     h = auth_headers["comercial"]
     lead = client.post("/v1/crm/leads", headers=h, json={"nome": "Rede Dois CNPJ"}).json()
     neg_id = lead["negociacao_ativa_id"]
+    client.patch(
+        f"/v1/crm/negociacoes/{neg_id}",
+        headers=h,
+        json={"nome_base_webposto": "base_dois_cnpj"},
+    )
     l1 = client.post(
         f"/v1/crm/negociacoes/{neg_id}/linhas",
         headers=h,
-        json={"razao_social": "Posto A", "cnpj": "12.345.678/0001-95", "valor_negociado": "100"},
+        json={
+            "razao_social": "Posto A",
+            "cnpj": "12.345.678/0001-95",
+            "valor_negociado": "100",
+            "dados_fiscais": DADOS_FISCAIS_OK,
+        },
     )
     l2 = client.post(
         f"/v1/crm/negociacoes/{neg_id}/linhas",
         headers=h,
-        json={"razao_social": "Posto B", "cnpj": "98.765.432/0001-10", "valor_negociado": "200"},
+        json={
+            "razao_social": "Posto B",
+            "cnpj": "98.765.432/0001-10",
+            "valor_negociado": "200",
+            "dados_fiscais": DADOS_FISCAIS_OK,
+        },
     )
     assert l1.status_code == 201 and l2.status_code == 201
     c1 = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": l1.json()["id"]})
@@ -320,6 +374,14 @@ def test_lista_so_minhas_e_interno_nao_vai_no_pdf(client, auth_headers, seed_bas
     _assert_sem_internos(pdf.content)
     assert "margem" not in pdf.content.decode("utf-8", errors="ignore").lower()
 
+    alheio = c_adm.json()["id"]
+    assert client.get(f"/v1/comercial/contratos/{alheio}", headers=h_com).status_code == 403
+    assert client.get(f"/v1/comercial/contratos/{alheio}/pdf", headers=h_com).status_code == 403
+    assert client.post(f"/v1/comercial/contratos/{alheio}/marcar-enviado", headers=h_com, json={}).status_code == 403
+    assert client.post(f"/v1/comercial/contratos/{alheio}/cancelar", headers=h_com).status_code == 403
+    assert client.post("/v1/comercial/contratos", headers=h_com, json={"linha_id": linha_adm["id"]}).status_code == 403
+    assert client.get(f"/v1/comercial/contratos/{alheio}", headers=h_admin).status_code == 200
+
 
 def test_cancelar_rascunho_e_bloqueia_assinado(client, auth_headers, seed_base):
     h = auth_headers["comercial"]
@@ -335,6 +397,7 @@ def test_cancelar_rascunho_e_bloqueia_assinado(client, auth_headers, seed_base):
     assert novo.status_code == 201, novo.text
     nid = novo.json()["id"]
     assert nid != cid
+    _anexar_pdf_assinado(client, h, nid)
     ass = client.post(f"/v1/comercial/contratos/{nid}/marcar-assinado", headers=h, json={})
     assert ass.status_code == 200
     assert client.post(f"/v1/comercial/contratos/{nid}/cancelar", headers=h).status_code == 400
@@ -374,3 +437,197 @@ def test_versao_do_modelo_fica_gravada_no_contrato(client, auth_headers, seed_ba
     )
     assert regen.status_code == 201, regen.text
     assert regen.json()["template_versao"] == 2
+
+
+def test_gerar_exige_fiscal_e_base_webposto(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    lead = client.post("/v1/crm/leads", headers=h, json={"nome": "Sem Fiscal"}).json()
+    neg_id = lead["negociacao_ativa_id"]
+    ln = client.post(
+        f"/v1/crm/negociacoes/{neg_id}/linhas",
+        headers=h,
+        json={"razao_social": "Posto X", "cnpj": "12.345.678/0001-95", "valor_negociado": "10"},
+    )
+    assert ln.status_code == 201
+    r = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": ln.json()["id"]})
+    assert r.status_code == 400
+    client.patch(f"/v1/crm/negociacoes/{neg_id}", headers=h, json={"nome_base_webposto": "base_x"})
+    r2 = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": ln.json()["id"]})
+    assert r2.status_code == 400
+    client.patch(
+        f"/v1/crm/negociacoes/{neg_id}/linhas/{ln.json()['id']}",
+        headers=h,
+        json={"dados_fiscais": DADOS_FISCAIS_OK},
+    )
+    ok = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": ln.json()["id"]})
+    assert ok.status_code == 201, ok.text
+    html = ok.json()["conteudo_html_snapshot"] or ""
+    assert "Maria Silva" in html
+    assert "base_x" in html
+
+
+def test_reajuste_politica_e_override(client, auth_headers, seed_base):
+    h_admin = auth_headers["admin"]
+    h = auth_headers["comercial"]
+    assert client.patch(
+        "/v1/comercial/contrato-politica",
+        headers=h,
+        json={"reajuste_percentual": "8.5", "reajuste_rotulo": "IGPM interno"},
+    ).status_code == 403
+    pol = client.patch(
+        "/v1/comercial/contrato-politica",
+        headers=h_admin,
+        json={"reajuste_percentual": "8.5", "reajuste_rotulo": "IGPM interno"},
+    )
+    assert pol.status_code == 200, pol.text
+    _, linha = _negociacao_com_linha(client, h)
+    herdado = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": linha["id"]})
+    assert herdado.status_code == 201, herdado.text
+    assert float(herdado.json()["reajuste_percentual"]) == 8.5
+    assert "8,50%" in (herdado.json()["conteudo_html_snapshot"] or "")
+    assert "IGPM interno" in (herdado.json()["conteudo_html_snapshot"] or "")
+    sem = client.post(
+        "/v1/comercial/contratos",
+        headers=h,
+        json={"linha_id": linha["id"], "sem_reajuste": True},
+    )
+    assert sem.status_code == 201
+    assert float(sem.json()["reajuste_percentual"]) == 0
+    assert "sem reajuste" in (sem.json()["conteudo_html_snapshot"] or "")
+
+
+def test_conversao_idempotente_mesma_rede_dois_cnpjs(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    lead = client.post("/v1/crm/leads", headers=h, json={"nome": "Rede Conv"}).json()
+    neg_id = lead["negociacao_ativa_id"]
+    client.patch(f"/v1/crm/negociacoes/{neg_id}", headers=h, json={"nome_base_webposto": "base_conv_unica"})
+    l1 = client.post(
+        f"/v1/crm/negociacoes/{neg_id}/linhas",
+        headers=h,
+        json={
+            "razao_social": "Posto A Ltda",
+            "cnpj": "12.345.678/0001-95",
+            "valor_negociado": "100",
+            "dados_fiscais": DADOS_FISCAIS_OK,
+        },
+    ).json()
+    l2 = client.post(
+        f"/v1/crm/negociacoes/{neg_id}/linhas",
+        headers=h,
+        json={
+            "razao_social": "Posto B Ltda",
+            "cnpj": "98.765.432/0001-10",
+            "valor_negociado": "200",
+            "dados_fiscais": DADOS_FISCAIS_OK,
+        },
+    ).json()
+    c1 = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": l1["id"]}).json()
+    c2 = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": l2["id"]}).json()
+    _anexar_pdf_assinado(client, h, c1["id"])
+    _anexar_pdf_assinado(client, h, c2["id"])
+    a1 = client.post(f"/v1/comercial/contratos/{c1['id']}/marcar-assinado", headers=h, json={}).json()
+    a2 = client.post(f"/v1/comercial/contratos/{c2['id']}/marcar-assinado", headers=h, json={}).json()
+    assert a1["empresa_id"] and a2["empresa_id"]
+    assert a1["empresa_id"] != a2["empresa_id"]
+    e1 = client.get(f"/v1/empresas/{a1['empresa_id']}", headers=auth_headers["admin"]).json()
+    e2 = client.get(f"/v1/empresas/{a2['empresa_id']}", headers=auth_headers["admin"]).json()
+    assert e1["rede_id"] == e2["rede_id"]
+    assert e1["cnpj_cpf"]
+    again = client.post(
+        f"/v1/comercial/contratos/{c1['id']}/pdf-assinado",
+        headers=h,
+        files={"arquivo": ("x.pdf", b"%PDF-1.4", "application/pdf")},
+    )
+    assert again.status_code == 400
+
+
+def test_conversao_copia_contato_e_cria_colaborador(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    h_admin = auth_headers["admin"]
+    lead = client.post(
+        "/v1/crm/leads",
+        headers=h,
+        json={"nome": "Posto Contato", "email": "lead@email.com", "telefone": "34988887777"},
+    ).json()
+    neg_id = lead["negociacao_ativa_id"]
+    client.patch(f"/v1/crm/negociacoes/{neg_id}", headers=h, json={"nome_base_webposto": "base_contato_qa"})
+    ln = client.post(
+        f"/v1/crm/negociacoes/{neg_id}/linhas",
+        headers=h,
+        json={
+            "razao_social": "Posto Contato Ltda",
+            "cnpj": "12.345.678/0001-95",
+            "valor_negociado": "100",
+            "dados_fiscais": {
+                **DADOS_FISCAIS_OK,
+                "email": "empresa@email.com",
+                "telefone": "3432221111",
+            },
+        },
+    ).json()
+    cid = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": ln["id"]}).json()["id"]
+    _anexar_pdf_assinado(client, h, cid)
+    ass = client.post(f"/v1/comercial/contratos/{cid}/marcar-assinado", headers=h, json={}).json()
+    assert ass["empresa_id"]
+    assert ass["rede_id"]
+    emp = client.get(f"/v1/empresas/{ass['empresa_id']}", headers=h_admin).json()
+    assert emp["email"] == "empresa@email.com"
+    assert "".join(c for c in (emp["telefone"] or "") if c.isdigit()).endswith("32221111")
+    funcs = client.get(f"/v1/redes/{emp['rede_id']}/funcionarios", headers=h_admin)
+    assert funcs.status_code == 200, funcs.text
+    items = funcs.json()["items"]
+    tels = {"".join(c for c in (f.get("telefone") or "") if c.isdigit()) for f in items}
+    emails = {(f.get("email") or "").lower() for f in items}
+    assert any(t.endswith("32221111") for t in tels)
+    assert "empresa@email.com" in emails
+
+
+def test_conversao_usa_contato_do_lead_se_linha_nao_tem(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    h_admin = auth_headers["admin"]
+    lead = client.post(
+        "/v1/crm/leads",
+        headers=h,
+        json={"nome": "Lead Fallback", "email": "lead-fallback@email.com", "telefone": "34911112222"},
+    ).json()
+    neg_id = lead["negociacao_ativa_id"]
+    client.patch(f"/v1/crm/negociacoes/{neg_id}", headers=h, json={"nome_base_webposto": "base_lead_fallback"})
+    ln = client.post(
+        f"/v1/crm/negociacoes/{neg_id}/linhas",
+        headers=h,
+        json={
+            "razao_social": "Posto Fallback Ltda",
+            "cnpj": "98.765.432/0001-10",
+            "valor_negociado": "100",
+            "dados_fiscais": DADOS_FISCAIS_OK,
+        },
+    ).json()
+    cid = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": ln["id"]}).json()["id"]
+    _anexar_pdf_assinado(client, h, cid)
+    ass = client.post(f"/v1/comercial/contratos/{cid}/marcar-assinado", headers=h, json={}).json()
+    emp = client.get(f"/v1/empresas/{ass['empresa_id']}", headers=h_admin).json()
+    assert emp["email"] == "lead-fallback@email.com"
+    assert "".join(c for c in (emp["telefone"] or "") if c.isdigit()).endswith("911112222")
+
+
+def test_bloqueia_edicao_apos_contrato_assinado(client, auth_headers, seed_base):
+    h = auth_headers["comercial"]
+    neg_id, linha = _negociacao_com_linha(client, h)
+    cid = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": linha["id"]}).json()["id"]
+    _anexar_pdf_assinado(client, h, cid)
+    assert client.post(f"/v1/comercial/contratos/{cid}/marcar-assinado", headers=h, json={}).status_code == 200
+    patch_ln = client.patch(
+        f"/v1/crm/negociacoes/{neg_id}/linhas/{linha['id']}",
+        headers=h,
+        json={"valor_negociado": "1"},
+    )
+    assert patch_ln.status_code == 400
+    patch_neg = client.patch(
+        f"/v1/crm/negociacoes/{neg_id}",
+        headers=h,
+        json={"nome_base_webposto": "nome_alterado_apos_assinatura"},
+    )
+    assert patch_neg.status_code == 400
+    deleted = client.delete(f"/v1/crm/negociacoes/{neg_id}/linhas/{linha['id']}", headers=h)
+    assert deleted.status_code == 400
+

--- a/docs/BACKEND_RBAC.md
+++ b/docs/BACKEND_RBAC.md
@@ -36,6 +36,7 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 | Funil CRM (mutação) | `POST/PATCH /v1/crm/funil-estagios` — UI em Configurações → Cadastros → Funil CRM |
 | Modelos de proposta (CRUD) | `POST/PATCH /v1/comercial/proposta-templates`, `POST /v1/comercial/proposta-templates/preview` — UI em Cadastros → Modelos de proposta |
 | Modelos de contrato (CRUD) | `POST/PATCH /v1/comercial/contrato-templates`, `POST /v1/comercial/contrato-templates/preview` |
+| Política de reajuste do contrato | `PATCH /v1/comercial/contrato-politica` (percentual e rótulo padrão da instância) |
 
 ## Comercial ou administrador (`exigir_comercial_ou_admin`)
 
@@ -46,7 +47,7 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 | **Simular custos** | `POST /v1/comercial/custos/simular` |
 | **Listar itens catálogo** | `GET /v1/comercial/custos/itens` (mutações continuam só admin) |
 | **Proposta comercial** | `GET /v1/comercial/proposta-templates` (ativos), `POST/GET /v1/comercial/propostas*`, `GET .../pdf`, `POST .../marcar-enviada` |
-| **Contrato comercial** | `GET /v1/comercial/contrato-templates` (ativos), `POST/GET /v1/comercial/contratos*`, `GET .../pdf`, `POST .../marcar-enviado`, `POST .../marcar-assinado`, `POST .../cancelar`. Lista global: comercial só os das próprias negociações; admin todos (filtros `so_minhas` e `responsavel_id`) |
+| **Contrato comercial** | `GET /v1/comercial/contrato-templates` (ativos), `GET /v1/comercial/contrato-politica`, `POST/GET /v1/comercial/contratos*`, `GET .../pdf`, `POST/GET .../pdf-assinado`, `POST .../marcar-enviado`, `POST .../marcar-assinado`, `POST .../cancelar`. Lista e detalhe (incl. PDF): comercial só as próprias negociações; admin todos (filtros `so_minhas` e `responsavel_id`). Marcar assinado cria/vincula Rede e Empresa internamente — comercial **não** ganha CRUD de Rede/Empresa. |
 
 ## Autenticado com escopo de setor (`obter_atendente_atual`)
 
@@ -76,4 +77,4 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 - **403**: mensagens vêm do corpo da API (`api/client` + `errorMessage.ts`).
 - **CRM UI** (#341–#344): menu **CRM** e rotas `/crm/leads`, `/crm/negociacoes/:id` para `admin` e `comercial`.
 - **Proposta** (#345–#348): card na negociação para comercial/admin; CRUD de templates só admin.
-- **Contrato** (#349–#356): card na negociação, lista `/crm/contratos` (comercial: próprias; admin: todas); CRUD de templates em Cadastros (só admin).
+- **Contrato** (#349–#357): card na negociação, lista `/crm/contratos` (comercial: próprias; admin: todas); CRUD de templates e política de reajuste em Cadastros (só admin).

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3162,6 +3162,7 @@ export namespace ComercialContrato {
     negociacao_linha_cnpj_id: number;
     negociacao_id?: number | null;
     empresa_id?: number | null;
+    rede_id?: number | null;
     template_id: number;
     template_nome?: string | null;
     template_versao?: number | null;
@@ -3178,6 +3179,11 @@ export namespace ComercialContrato {
     alimentacao_cliente: boolean;
     hospedagem_cliente: boolean;
     multa_max_mensalidades: number;
+    reajuste_percentual?: string | number;
+    reajuste_rotulo?: string;
+    pdf_assinado_nome_original?: string | null;
+    tem_pdf_assinado?: boolean;
+    referencia_externa?: string | null;
     enviado_em?: string | null;
     assinado_em?: string | null;
     created_at: string;
@@ -3203,6 +3209,9 @@ export namespace ComercialContrato {
     alimentacao_cliente?: boolean;
     hospedagem_cliente?: boolean;
     multa_max_mensalidades?: number;
+    sem_reajuste?: boolean;
+    reajuste_percentual?: string | number | null;
+    reajuste_rotulo?: string | null;
   }
   export interface MarcarEnviadoRequest {
     enviado_em?: string | null;
@@ -3210,6 +3219,11 @@ export namespace ComercialContrato {
   export interface MarcarAssinadoRequest {
     assinado_em?: string | null;
     avancar_funil?: boolean;
+    referencia_externa?: string | null;
+  }
+  export interface Politica {
+    reajuste_percentual: string | number;
+    reajuste_rotulo: string;
   }
 }
 
@@ -3260,6 +3274,15 @@ export const comercialContratos = {
     }),
   cancelar: (id: number) =>
     api<ComercialContrato.Contrato>(`/comercial/contratos/${id}/cancelar`, { method: 'POST' }),
+  anexarPdfAssinado: (id: number, file: File, referenciaExterna?: string) => {
+    const fd = new FormData()
+    fd.append('arquivo', file)
+    if (referenciaExterna?.trim()) fd.append('referencia_externa', referenciaExterna.trim())
+    return api<ComercialContrato.Contrato>(`/comercial/contratos/${id}/pdf-assinado`, {
+      method: 'POST',
+      body: fd,
+    })
+  },
   downloadPdf: async (id: number, pdfId?: number) => {
     const token = getAuthToken();
     const headers: Record<string, string> = {};
@@ -3281,6 +3304,34 @@ export const comercialContratos = {
     }
     return res.blob();
   },
+  downloadPdfAssinado: async (id: number) => {
+    const token = getAuthToken();
+    const headers: Record<string, string> = {};
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname());
+    }
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const url = `${apiOrigin()}${API_VERSION_PREFIX}/comercial/contratos/${id}/pdf-assinado`;
+    const res = await fetch(url, { headers });
+    if (res.status === 401) {
+      invalidateSessionAndRedirectToLogin();
+      throw new ApiError('Sessão expirada ou inválida.', 401, {});
+    }
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}));
+      throw new ApiError(mensagemErroApi(errBody, res.status), res.status, errBody);
+    }
+    return res.blob();
+  },
+};
+
+export const comercialContratoPolitica = {
+  get: () => api<ComercialContrato.Politica>('/comercial/contrato-politica'),
+  update: (data: Partial<ComercialContrato.Politica>) =>
+    api<ComercialContrato.Politica>('/comercial/contrato-politica', {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
 };
 
 export const crmFunil = {
@@ -3421,11 +3472,43 @@ export namespace Crm {
     ativo?: boolean;
   }
 
+  export interface DadosFiscais {
+    nome?: string | null;
+    nome_fantasia?: string | null;
+    inscricao_estadual?: string | null;
+    endereco?: string | null;
+    numero?: string | null;
+    complemento?: string | null;
+    bairro?: string | null;
+    cidade?: string | null;
+    estado?: string | null;
+    cep?: string | null;
+    email?: string | null;
+    telefone?: string | null;
+    resp_legal_nome?: string | null;
+    resp_legal_cpf?: string | null;
+    resp_legal_rg?: string | null;
+    resp_legal_orgao_emissor?: string | null;
+    resp_legal_nacionalidade?: string | null;
+    resp_legal_estado_civil?: string | null;
+    resp_legal_cargo?: string | null;
+    resp_legal_email?: string | null;
+    resp_legal_telefone?: string | null;
+    resp_legal_endereco?: string | null;
+    resp_legal_numero?: string | null;
+    resp_legal_complemento?: string | null;
+    resp_legal_bairro?: string | null;
+    resp_legal_cidade?: string | null;
+    resp_legal_estado?: string | null;
+    resp_legal_cep?: string | null;
+  }
+
   export interface Linha {
     id: number;
     negociacao_id: number;
     cnpj?: string | null;
     razao_social?: string | null;
+    dados_fiscais?: DadosFiscais | null;
     item_ids: number[];
     quantidade_pdvs: number;
     desconto_posto_100k: boolean;
@@ -3443,6 +3526,7 @@ export namespace Crm {
   export interface LinhaCreate {
     cnpj?: string | null;
     razao_social?: string | null;
+    dados_fiscais?: DadosFiscais | null;
     item_ids?: number[];
     quantidade_pdvs?: number;
     desconto_posto_100k?: boolean;
@@ -3454,6 +3538,7 @@ export namespace Crm {
   export interface LinhaUpdate {
     cnpj?: string | null;
     razao_social?: string | null;
+    dados_fiscais?: DadosFiscais | null;
     item_ids?: number[];
     quantidade_pdvs?: number;
     desconto_posto_100k?: boolean;
@@ -3472,6 +3557,7 @@ export namespace Crm {
     estagio_nome?: string | null;
     ativa: boolean;
     titulo?: string | null;
+    nome_base_webposto?: string | null;
     linhas: Linha[];
     created_at?: string | null;
     updated_at?: string | null;
@@ -3486,6 +3572,7 @@ export namespace Crm {
 
   export interface NegociacaoUpdate {
     titulo?: string | null;
+    nome_base_webposto?: string | null;
     responsavel_id?: number | null;
   }
 

--- a/frontend/src/components/crm/CrmContratoCard.tsx
+++ b/frontend/src/components/crm/CrmContratoCard.tsx
@@ -1,7 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import {
+  comercialContratoPolitica,
   comercialContratoTemplates,
   comercialContratos,
+  crmNegociacoes,
   type ComercialContrato,
   type Crm,
 } from '../../api/client'
@@ -13,6 +16,8 @@ import { Input } from '../ui/Input'
 import { Select } from '../ui/Select'
 import { useToast } from '../ui/Toast'
 import { maskCnpjCpf } from '../../utils/maskCnpjCpf'
+import { CrmDadosFiscaisFields } from './CrmDadosFiscaisFields'
+import { emptyFiscal, fiscaisDaLinha, fiscalPayload, formatPercentualPt, parsePercentualPt } from './crmFiscais'
 
 const STATUS_LABEL: Record<string, string> = {
   rascunho: 'Rascunho',
@@ -33,9 +38,9 @@ function money(v: string | number | null | undefined): string {
 
 function percent(v: string | number | null | undefined): string {
   if (v == null || v === '') return '—'
-  const n = typeof v === 'number' ? v : Number(v)
+  const n = typeof v === 'number' ? v : parsePercentualPt(String(v))
   if (Number.isNaN(n)) return String(v)
-  return `${n.toLocaleString('pt-BR', { maximumFractionDigits: 1, minimumFractionDigits: 0 })}%`
+  return `${formatPercentualPt(n)}%`
 }
 
 function formatDate(iso: string | null | undefined): string {
@@ -72,14 +77,17 @@ export function textoDiasFidelidade(dias: number | null | undefined): string {
 
 type Props = {
   negociacao: Crm.Negociacao
+  lead?: Crm.Lead | null
   onChanged: () => void
   /** Sem o Card externo — o título fica no acordeão da página. */
   embedded?: boolean
 }
 
-export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Props) {
+export function CrmContratoCard({ negociacao, lead = null, onChanged, embedded = false }: Props) {
   const toast = useToast()
+  const navigate = useNavigate()
   const linhas = negociacao.linhas || []
+  const pdfInputRef = useRef<HTMLInputElement>(null)
 
   const [templates, setTemplates] = useState<ComercialContrato.Template[]>([])
   const [contratos, setContratos] = useState<ComercialContrato.Contrato[]>([])
@@ -93,22 +101,34 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
   const [alimentacao, setAlimentacao] = useState(true)
   const [hospedagem, setHospedagem] = useState(true)
   const [multaMax, setMultaMax] = useState('3')
+  const [semReajuste, setSemReajuste] = useState(false)
+  const [reajustePct, setReajustePct] = useState('')
+  const [reajusteRotulo, setReajusteRotulo] = useState('')
+  const [politica, setPolitica] = useState<ComercialContrato.Politica | null>(null)
   const [gerando, setGerando] = useState(false)
   const [preview, setPreview] = useState<ComercialContrato.Contrato | null>(null)
   const [baixandoId, setBaixandoId] = useState<number | null>(null)
+  const [baixandoAssinadoId, setBaixandoAssinadoId] = useState<number | null>(null)
   const [enviandoId, setEnviandoId] = useState<number | null>(null)
   const [assinandoId, setAssinandoId] = useState<number | null>(null)
   const [avancarFunil, setAvancarFunil] = useState(true)
+  const [pdfFile, setPdfFile] = useState<File | null>(null)
+  const [referenciaAnexo, setReferenciaAnexo] = useState('')
+  const [anexandoPdf, setAnexandoPdf] = useState(false)
   const [cancelarId, setCancelarId] = useState<number | null>(null)
   const [cancelando, setCancelando] = useState(false)
+  const [fiscais, setFiscais] = useState<Crm.DadosFiscais>(emptyFiscal)
+  const [editarGeracao, setEditarGeracao] = useState(false)
 
   const load = useCallback(async () => {
-    const [tmpls, rows] = await Promise.all([
+    const [tmpls, rows, pol] = await Promise.all([
       comercialContratoTemplates.list(),
       comercialContratos.list({ negociacao_id: negociacao.id }),
+      comercialContratoPolitica.get(),
     ])
     setTemplates(tmpls)
     setContratos(rows)
+    setPolitica(pol)
     setTemplateId((prev) => {
       if (prev !== '' && tmpls.some((t) => t.id === prev)) return prev
       return tmpls[0]?.id ?? ''
@@ -155,6 +175,19 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
   )
   const podeGerar =
     linhaId !== '' && (!contratoDaLinha || contratoDaLinha.status === 'rascunho')
+  const mostrarFormularioGeracao = podeGerar && (!contratoDaLinha || editarGeracao)
+
+  useEffect(() => {
+    setEditarGeracao(false)
+  }, [linhaId])
+
+  useEffect(() => {
+    if (!linhaSel) {
+      setFiscais(emptyFiscal())
+      return
+    }
+    setFiscais(fiscaisDaLinha(linhaSel, lead))
+  }, [linhaId, lead?.email, lead?.telefone, JSON.stringify(linhaSel?.dados_fiscais)])
 
   useEffect(() => {
     if (!preview?.conteudo_html_snapshot && preview?.id) {
@@ -180,8 +213,18 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
       toast.showWarning('Multa deve ser entre 0 e 12 mensalidades.')
       return
     }
+    if (!semReajuste && reajustePct.trim()) {
+      const n = parsePercentualPt(reajustePct)
+      if (!Number.isFinite(n) || n < 0 || n > 100) {
+        toast.showWarning('O percentual de reajuste deve estar entre 0 e 100.')
+        return
+      }
+    }
     setGerando(true)
     try {
+      await crmNegociacoes.updateLinha(negociacao.id, linhaId, {
+        dados_fiscais: fiscalPayload(fiscais),
+      })
       const row = await comercialContratos.gerar({
         linha_id: linhaId,
         template_id: templateId === '' ? null : templateId,
@@ -193,8 +236,12 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
         alimentacao_cliente: alimentacao,
         hospedagem_cliente: hospedagem,
         multa_max_mensalidades: multa,
+        sem_reajuste: semReajuste,
+        reajuste_percentual: semReajuste || !reajustePct.trim() ? null : String(parsePercentualPt(reajustePct)),
+        reajuste_rotulo: reajusteRotulo.trim() || null,
       })
       setPreview(row)
+      setEditarGeracao(false)
       toast.showSuccess(
         contratoDaLinha ? 'Contrato atualizado. Revise o preview.' : 'Contrato gerado. Revise o preview.',
       )
@@ -219,6 +266,39 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
     }
   }
 
+  async function handlePdfAssinado(id: number, nome?: string | null) {
+    setBaixandoAssinadoId(id)
+    try {
+      const blob = await comercialContratos.downloadPdfAssinado(id)
+      downloadBlob(blob, nome || `contrato-${id}-assinado.pdf`)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível baixar o PDF assinado.'))
+    } finally {
+      setBaixandoAssinadoId(null)
+    }
+  }
+
+  async function handleAnexarPdf(id: number) {
+    if (!pdfFile) {
+      toast.showWarning('Escolha o PDF assinado para anexar.')
+      return
+    }
+    setAnexandoPdf(true)
+    try {
+      const row = await comercialContratos.anexarPdfAssinado(id, pdfFile, referenciaAnexo)
+      setPreview(row)
+      setPdfFile(null)
+      if (pdfInputRef.current) pdfInputRef.current.value = ''
+      toast.showSuccess('PDF assinado anexado. Já podes marcar o contrato como assinado.')
+      await load()
+      onChanged()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível anexar o PDF assinado.'))
+    } finally {
+      setAnexandoPdf(false)
+    }
+  }
+
   async function handleEnviado(id: number) {
     setEnviandoId(id)
     try {
@@ -235,12 +315,21 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
   }
 
   async function handleAssinado(id: number) {
+    const atual = contratos.find((c) => c.id === id) || preview
+    if (!atual?.tem_pdf_assinado) {
+      toast.showWarning('Anexe o PDF assinado antes de marcar o contrato como assinado.')
+      return
+    }
     setAssinandoId(id)
     try {
-      const row = await comercialContratos.marcarAssinado(id, { avancar_funil: avancarFunil })
+      const row = await comercialContratos.marcarAssinado(id, {
+        avancar_funil: avancarFunil,
+      })
       setPreview(row)
       toast.showSuccess(
-        avancarFunil ? 'Contrato assinado e funil atualizado.' : 'Contrato marcado como assinado.',
+        avancarFunil
+          ? 'Contrato assinado, Rede/Empresa vinculadas e funil atualizado.'
+          : 'Contrato marcado como assinado. Rede e Empresa foram criadas ou vinculadas.',
       )
       setAssinandoId(null)
       await load()
@@ -274,7 +363,7 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
     <>
       <p className="mb-3 text-sm text-slate-500">
         Um contrato por CNPJ. O PDF do cliente não inclui custo nem margem — esses valores ficam só neste
-        painel.
+        painel. O nome da Rede (acima) e os dados fiscais abaixo são obrigatórios para gerar.
       </p>
 
       {linhas.length === 0 ? (
@@ -293,7 +382,12 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
               Para gerar outro, cancele o atual (não é possível após assinado).
             </p>
           ) : null}
-          {podeGerar ? (
+          {podeGerar && contratoDaLinha?.status === 'rascunho' && !editarGeracao ? (
+            <Button variant="secondary" onClick={() => setEditarGeracao(true)}>
+              Alterar rascunho
+            </Button>
+          ) : null}
+          {mostrarFormularioGeracao ? (
             <>
           {templateOptions.length > 0 ? (
             <Select
@@ -351,6 +445,44 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
               Setup isento
             </label>
           </div>
+          <div className="space-y-3 rounded-xl border border-slate-200 p-3 dark:border-slate-700">
+            <p className="text-sm font-medium text-slate-700 dark:text-slate-300">Reajuste anual</p>
+            <p className="text-xs text-slate-500">
+              Padrão da instância:{' '}
+              {politica
+                ? Number(politica.reajuste_percentual) > 0
+                  ? `${percent(politica.reajuste_percentual)}${politica.reajuste_rotulo ? ` · ${politica.reajuste_rotulo}` : ''}`
+                  : politica.reajuste_rotulo || 'sem reajuste'
+                : '—'}
+              . O admin altera em Cadastros → Modelos de contrato. Sem consulta automática a índice.
+            </p>
+            <label className="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+              <input
+                type="checkbox"
+                checked={semReajuste}
+                onChange={(e) => setSemReajuste(e.target.checked)}
+                className="size-4 rounded border-slate-300"
+              />
+              Sem reajuste neste contrato
+            </label>
+            {semReajuste ? null : (
+              <div className="grid gap-3 sm:grid-cols-2">
+                <Input
+                  label="Percentual (override)"
+                  inputMode="decimal"
+                  value={reajustePct}
+                  onChange={(e) => setReajustePct(e.target.value.replace(/[^\d,.]/g, ''))}
+                  hint="Vazio = padrão da instância. Ex.: 5,5"
+                />
+                <Input
+                  label="Rótulo (override)"
+                  value={reajusteRotulo}
+                  onChange={(e) => setReajusteRotulo(e.target.value)}
+                  placeholder={politica?.reajuste_rotulo || 'Ex.: IGPM'}
+                />
+              </div>
+            )}
+          </div>
           <div className="flex flex-wrap gap-4 text-sm text-slate-700 dark:text-slate-300">
             <label className="inline-flex items-center gap-2">
               <input
@@ -380,6 +512,11 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
               Hospedagem por conta do cliente
             </label>
           </div>
+          <CrmDadosFiscaisFields
+            value={fiscais}
+            onChange={(patch) => setFiscais((p) => ({ ...p, ...patch }))}
+            disabled={gerando}
+          />
           <Button onClick={() => void handleGerar()} disabled={gerando}>
             {gerando
               ? 'Gerando…'
@@ -422,7 +559,27 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
                 {preview.razao_social || '—'} · {preview.cnpj ? maskCnpjCpf(preview.cnpj) : 'sem CNPJ'} · mensalidade{' '}
                 {money(preview.valor_mensalidade)} · fidelidade {preview.fidelidade_meses} meses (
                 {textoDiasFidelidade(preview.dias_restantes_fidelidade)})
+                {Number(preview.reajuste_percentual) > 0
+                  ? ` · reajuste ${percent(preview.reajuste_percentual)}${preview.reajuste_rotulo ? ` ${preview.reajuste_rotulo}` : ''}`
+                  : ' · sem reajuste'}
               </p>
+              {preview.empresa_id || preview.rede_id ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {preview.empresa_id ? (
+                    <Button
+                      variant="secondary"
+                      onClick={() => navigate(`/empresas/${preview.empresa_id}`)}
+                    >
+                      Abrir empresa
+                    </Button>
+                  ) : null}
+                  {preview.rede_id ? (
+                    <Button variant="secondary" onClick={() => navigate(`/redes/${preview.rede_id}`)}>
+                      Abrir rede
+                    </Button>
+                  ) : null}
+                </div>
+              ) : null}
             </div>
             <div className="flex flex-wrap gap-2">
               <Button
@@ -443,7 +600,11 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
               ) : null}
               {preview.status === 'rascunho' || preview.status === 'enviado' ? (
                 <>
-                  <Button variant="secondary" onClick={() => setAssinandoId(preview.id)}>
+                  <Button
+                    variant="secondary"
+                    onClick={() => setAssinandoId(preview.id)}
+                    disabled={!preview.tem_pdf_assinado}
+                  >
                     Marcar assinado
                   </Button>
                   <Button variant="ghost" onClick={() => setCancelarId(preview.id)}>
@@ -459,6 +620,67 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
             srcDoc={preview.conteudo_html_snapshot || ''}
             className="h-80 w-full rounded-lg border border-slate-200 bg-white dark:border-slate-700"
           />
+        </div>
+      ) : null}
+
+      {preview && (preview.status === 'rascunho' || preview.status === 'enviado' || preview.tem_pdf_assinado) ? (
+        <div className="mt-3 space-y-3 rounded-xl border border-slate-200 p-3 dark:border-slate-700">
+          <p className="text-sm font-medium text-slate-700 dark:text-slate-300">PDF assinado</p>
+          <p className="text-xs text-slate-500">
+            Exporte o PDF gerado, assine no ClickSign ou outro e anexe aqui. Referência/protocolo é opcional.
+            Marcar assinado só fica disponível depois do anexo — isso cria ou vincula Rede e Empresa (sem PDVs).
+          </p>
+          {preview.tem_pdf_assinado ? (
+            <p className="text-sm text-slate-700 dark:text-slate-300">
+              Anexado: {preview.pdf_assinado_nome_original || 'PDF'}
+              {preview.referencia_externa ? ` · ref. ${preview.referencia_externa}` : ''}
+            </p>
+          ) : null}
+          {preview.tem_pdf_assinado ? (
+            <Button
+              variant="secondary"
+              onClick={() => void handlePdfAssinado(preview.id, preview.pdf_assinado_nome_original)}
+              disabled={baixandoAssinadoId === preview.id}
+            >
+              {baixandoAssinadoId === preview.id ? 'Baixando…' : 'Baixar PDF assinado'}
+            </Button>
+          ) : null}
+          {preview.status === 'rascunho' || preview.status === 'enviado' ? (
+            <div className="space-y-3">
+              <input
+                ref={pdfInputRef}
+                id="contrato-pdf-assinado"
+                type="file"
+                accept="application/pdf,.pdf"
+                className="sr-only"
+                aria-label="Ficheiro PDF assinado"
+                onChange={(e) => setPdfFile(e.target.files?.[0] || null)}
+              />
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => pdfInputRef.current?.click()}
+                >
+                  {preview.tem_pdf_assinado ? 'Escolher outro PDF' : 'Anexar PDF assinado'}
+                </Button>
+                {pdfFile ? (
+                  <span className="text-sm text-slate-600 dark:text-slate-300">{pdfFile.name}</span>
+                ) : (
+                  <span className="text-xs text-slate-500">Só ficheiros PDF</span>
+                )}
+              </div>
+              <Input
+                label="Referência / protocolo (opcional)"
+                value={referenciaAnexo}
+                onChange={(e) => setReferenciaAnexo(e.target.value)}
+                placeholder="Ex.: envelope ClickSign"
+              />
+              <Button onClick={() => void handleAnexarPdf(preview.id)} disabled={anexandoPdf || !pdfFile}>
+                {anexandoPdf ? 'Anexando…' : preview.tem_pdf_assinado ? 'Substituir PDF assinado' : 'Enviar anexo'}
+              </Button>
+            </div>
+          ) : null}
         </div>
       ) : null}
 
@@ -505,17 +727,25 @@ export function CrmContratoCard({ negociacao, onChanged, embedded = false }: Pro
           <div className="w-full rounded-t-2xl bg-white p-5 shadow-xl dark:bg-slate-900 sm:max-w-md sm:rounded-2xl">
             <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">Marcar contrato como assinado</h2>
             <p className="mt-1 text-sm text-slate-500">
-              Registro manual — a assinatura eletrónica (ClickSign) fica para um lote seguinte.
+              Confirma o PDF anexado
+              {preview?.referencia_externa ? ` (ref. ${preview.referencia_externa})` : ''}. A Rede e a
+              Empresa do CNPJ são criadas ou vinculadas; PDVs ficam para a implantação.
             </p>
-            <label className="mt-4 inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
-              <input
-                type="checkbox"
-                checked={avancarFunil}
-                onChange={(e) => setAvancarFunil(e.target.checked)}
-                className="size-4 rounded border-slate-300"
-              />
-              Avançar funil para «Contrato assinado»
-            </label>
+            <div className="mt-4 space-y-1">
+              <label className="inline-flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+                <input
+                  type="checkbox"
+                  checked={avancarFunil}
+                  onChange={(e) => setAvancarFunil(e.target.checked)}
+                  className="size-4 rounded border-slate-300"
+                />
+                Avançar funil para «Contrato assinado»
+              </label>
+              <p className="pl-6 text-xs text-slate-500">
+                Pode pular proposta ou outros estágios — há cliente que manda a documentação e já fecha o
+                contrato. Desmarque só se quiser deixar o funil onde está.
+              </p>
+            </div>
             <div className="flex justify-end gap-2 pt-4">
               <Button type="button" variant="secondary" onClick={() => setAssinandoId(null)}>
                 Voltar

--- a/frontend/src/components/crm/CrmDadosFiscaisFields.tsx
+++ b/frontend/src/components/crm/CrmDadosFiscaisFields.tsx
@@ -1,0 +1,100 @@
+import type { Crm } from '../../api/client'
+import { Input } from '../ui/Input'
+import { maskCnpjCpf } from '../../utils/maskCnpjCpf'
+import { maskCep, maskTelefoneBr } from '../../utils/masks'
+
+type Props = {
+  value: Crm.DadosFiscais
+  onChange: (patch: Partial<Crm.DadosFiscais>) => void
+  disabled?: boolean
+}
+
+export function CrmDadosFiscaisFields({ value, onChange, disabled }: Props) {
+  return (
+    <fieldset className="space-y-3 rounded-xl border border-slate-200 p-3 dark:border-slate-700" disabled={disabled}>
+      <legend className="px-1 text-sm font-medium text-slate-700 dark:text-slate-300">
+        Dados fiscais do contratante
+      </legend>
+      <p className="text-xs text-slate-500">
+        Endereço e responsável legal entram no PDF. E-mail e telefone vão para a ficha da Empresa ao assinar, para
+        atendimento (chat) depois da conversão.
+      </p>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <div className="sm:col-span-2">
+          <Input
+            label="Endereço"
+            value={value.endereco || ''}
+            onChange={(e) => onChange({ endereco: e.target.value })}
+          />
+        </div>
+        <Input label="Número" value={value.numero || ''} onChange={(e) => onChange({ numero: e.target.value })} />
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Input
+          label="Complemento"
+          value={value.complemento || ''}
+          onChange={(e) => onChange({ complemento: e.target.value })}
+        />
+        <Input label="Bairro" value={value.bairro || ''} onChange={(e) => onChange({ bairro: e.target.value })} />
+      </div>
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Input label="Cidade" value={value.cidade || ''} onChange={(e) => onChange({ cidade: e.target.value })} />
+        <Input
+          label="UF"
+          value={value.estado || ''}
+          onChange={(e) => onChange({ estado: e.target.value.toUpperCase().slice(0, 2) })}
+          maxLength={2}
+        />
+        <Input
+          label="CEP"
+          value={value.cep || ''}
+          onChange={(e) => onChange({ cep: maskCep(e.target.value) })}
+        />
+      </div>
+      <Input
+        label="Inscrição estadual"
+        value={value.inscricao_estadual || ''}
+        onChange={(e) => onChange({ inscricao_estadual: e.target.value })}
+      />
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Input
+          label="E-mail da empresa"
+          type="email"
+          value={value.email || ''}
+          onChange={(e) => onChange({ email: e.target.value })}
+          hint="Se o lead já tiver e-mail, vem preenchido."
+        />
+        <Input
+          label="Telefone / WhatsApp"
+          value={value.telefone || ''}
+          onChange={(e) => onChange({ telefone: maskTelefoneBr(e.target.value) })}
+          hint="Usado para vincular um contacto na rede ao assinar."
+        />
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Input
+          label="Responsável legal"
+          value={value.resp_legal_nome || ''}
+          onChange={(e) => onChange({ resp_legal_nome: e.target.value })}
+        />
+        <Input
+          label="CPF do responsável"
+          value={value.resp_legal_cpf || ''}
+          onChange={(e) => onChange({ resp_legal_cpf: maskCnpjCpf(e.target.value) })}
+        />
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <Input
+          label="RG"
+          value={value.resp_legal_rg || ''}
+          onChange={(e) => onChange({ resp_legal_rg: e.target.value })}
+        />
+        <Input
+          label="Cargo"
+          value={value.resp_legal_cargo || ''}
+          onChange={(e) => onChange({ resp_legal_cargo: e.target.value })}
+        />
+      </div>
+    </fieldset>
+  )
+}

--- a/frontend/src/components/crm/crmFiscais.ts
+++ b/frontend/src/components/crm/crmFiscais.ts
@@ -1,0 +1,81 @@
+import type { Crm } from '../../api/client'
+import { maskCnpjCpf } from '../../utils/maskCnpjCpf'
+import { digitsOnly, maskCep, maskTelefoneBr } from '../../utils/masks'
+
+export const FISCAIS_OBRIGATORIOS = [
+  'endereco',
+  'numero',
+  'bairro',
+  'cidade',
+  'estado',
+  'cep',
+  'resp_legal_nome',
+  'resp_legal_cpf',
+] as const
+
+export const emptyFiscal = (): Crm.DadosFiscais => ({
+  endereco: '',
+  numero: '',
+  complemento: '',
+  bairro: '',
+  cidade: '',
+  estado: '',
+  cep: '',
+  inscricao_estadual: '',
+  email: '',
+  telefone: '',
+  resp_legal_nome: '',
+  resp_legal_cpf: '',
+  resp_legal_rg: '',
+  resp_legal_cargo: '',
+})
+
+export function fiscaisDaLinha(ln: Crm.Linha, lead?: Crm.Lead | null): Crm.DadosFiscais {
+  const d = ln.dados_fiscais || {}
+  const email = (d.email || lead?.email || '').trim()
+  const telefoneFonte = d.telefone || lead?.telefone || ''
+  return {
+    ...emptyFiscal(),
+    ...d,
+    cep: d.cep ? maskCep(String(d.cep)) : '',
+    resp_legal_cpf: d.resp_legal_cpf ? maskCnpjCpf(String(d.resp_legal_cpf)) : '',
+    email,
+    telefone: telefoneFonte ? maskTelefoneBr(String(telefoneFonte)) : '',
+  }
+}
+
+export function linhaProntaParaContrato(ln: Crm.Linha): boolean {
+  const d = ln.dados_fiscais || {}
+  return FISCAIS_OBRIGATORIOS.every((c) => String(d[c] || '').trim().length > 0)
+}
+
+export function fiscalPayload(d: Crm.DadosFiscais): Crm.DadosFiscais {
+  const trim = (v: string | null | undefined) => (v || '').trim() || null
+  return {
+    endereco: trim(d.endereco),
+    numero: trim(d.numero),
+    complemento: trim(d.complemento),
+    bairro: trim(d.bairro),
+    cidade: trim(d.cidade),
+    estado: (d.estado || '').trim().toUpperCase().slice(0, 2) || null,
+    cep: digitsOnly(d.cep || '') || null,
+    inscricao_estadual: trim(d.inscricao_estadual),
+    email: trim(d.email),
+    telefone: digitsOnly(d.telefone || '') || null,
+    resp_legal_nome: trim(d.resp_legal_nome),
+    resp_legal_cpf: digitsOnly(d.resp_legal_cpf || '') || null,
+    resp_legal_rg: trim(d.resp_legal_rg),
+    resp_legal_cargo: trim(d.resp_legal_cargo),
+  }
+}
+
+/** Ex.: 5.5 → "5,5"; 0.0000 → "0" */
+export function formatPercentualPt(value: string | number | null | undefined): string {
+  const n = Number(String(value ?? '0').replace(',', '.'))
+  if (!Number.isFinite(n)) return '0'
+  return n.toLocaleString('pt-BR', { maximumFractionDigits: 2, minimumFractionDigits: 0 })
+}
+
+export function parsePercentualPt(value: string): number {
+  return Number(String(value).replace(/\s/g, '').replace(',', '.'))
+}

--- a/frontend/src/pages/ConfigContratoTemplates.tsx
+++ b/frontend/src/pages/ConfigContratoTemplates.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { ApiError, comercialContratoTemplates, type ComercialContrato } from '../api/client'
+import { ApiError, comercialContratoPolitica, comercialContratoTemplates, type ComercialContrato } from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { Button } from '../components/ui/Button'
 import { Card } from '../components/ui/Card'
@@ -9,6 +9,7 @@ import { FiltroInativos } from '../components/ui/FiltroInativos'
 import { IconPencil } from '../components/ui/IconPencil'
 import { useToast } from '../components/ui/Toast'
 import { ConfigListPageShell } from '../components/config/ConfigListPageShell'
+import { formatPercentualPt, parsePercentualPt } from '../components/crm/crmFiscais'
 import { SemPermissao } from './SemPermissao'
 
 const PLACEHOLDERS = [
@@ -23,6 +24,10 @@ const PLACEHOLDERS = [
   '{{fidelidade}}',
   '{{multa}}',
   '{{igpm}}',
+  '{{reajuste}}',
+  '{{endereco_contratante}}',
+  '{{resp_legal}}',
+  '{{nome_base_webposto}}',
   '{{clausula_deslocamento}}',
   '{{clausula_alimentacao}}',
   '{{clausula_hospedagem}}',
@@ -52,6 +57,9 @@ export function ConfigContratoTemplates({ embedded = false }: { embedded?: boole
   const [form, setForm] = useState<FormState>(emptyForm())
   const [saving, setSaving] = useState(false)
   const [previewHtml, setPreviewHtml] = useState<string | null>(null)
+  const [politicaPct, setPoliticaPct] = useState('0')
+  const [politicaRotulo, setPoliticaRotulo] = useState('')
+  const [savingPolitica, setSavingPolitica] = useState(false)
 
   const load = useCallback(() => {
     setLoading(true)
@@ -74,6 +82,19 @@ export function ConfigContratoTemplates({ embedded = false }: { embedded?: boole
   useEffect(() => {
     load()
   }, [load])
+
+  useEffect(() => {
+    comercialContratoPolitica
+      .get()
+      .then((p) => {
+        setPoliticaPct(formatPercentualPt(p.reajuste_percentual ?? '0'))
+        setPoliticaRotulo(p.reajuste_rotulo || '')
+      })
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) return
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar o reajuste padrão.'))
+      })
+  }, [toast])
 
   function openCreate() {
     setForm(emptyForm())
@@ -136,6 +157,29 @@ export function ConfigContratoTemplates({ embedded = false }: { embedded?: boole
     }
   }
 
+  async function handleSavePolitica(e: React.FormEvent) {
+    e.preventDefault()
+    const pct = parsePercentualPt(politicaPct)
+    if (Number.isNaN(pct) || pct < 0 || pct > 100) {
+      toast.showWarning('O percentual de reajuste deve estar entre 0 e 100.')
+      return
+    }
+    setSavingPolitica(true)
+    try {
+      const p = await comercialContratoPolitica.update({
+        reajuste_percentual: pct,
+        reajuste_rotulo: politicaRotulo.trim(),
+      })
+      setPoliticaPct(formatPercentualPt(p.reajuste_percentual ?? '0'))
+      setPoliticaRotulo(p.reajuste_rotulo || '')
+      toast.showSuccess('Reajuste padrão salvo. Contratos já gerados não mudam.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o reajuste padrão.'))
+    } finally {
+      setSavingPolitica(false)
+    }
+  }
+
   const denied = (
     <SemPermissao
       title="Você não tem permissão para configurar modelos de contrato."
@@ -157,6 +201,34 @@ export function ConfigContratoTemplates({ embedded = false }: { embedded?: boole
         HTML usado ao gerar o contrato na negociação. Não inclua custo ou margem — esses dados são internos.
         Editar o HTML sobe a versão do modelo; o PDF já gerado permanece na versão gravada no contrato.
       </p>
+      <Card title="Reajuste anual padrão" className="mb-3">
+        <p className="mb-3 text-sm text-slate-500">
+          Usado ao gerar contratos, salvo override ou «sem reajuste» na negociação. Não consulta índice (IGPM)
+          automaticamente. O recálculo anual na data de aniversário entra numa versão seguinte.
+        </p>
+        <form onSubmit={(e) => void handleSavePolitica(e)} className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="sm:w-40">
+            <Input
+              label="Percentual"
+              inputMode="decimal"
+              value={politicaPct}
+              onChange={(e) => setPoliticaPct(e.target.value.replace(/[^\d,.]/g, ''))}
+              hint="Ex.: 0 ou 5,5"
+            />
+          </div>
+          <div className="flex-1">
+            <Input
+              label="Rótulo"
+              value={politicaRotulo}
+              onChange={(e) => setPoliticaRotulo(e.target.value)}
+              placeholder="Ex.: IGPM"
+            />
+          </div>
+          <Button type="submit" disabled={savingPolitica}>
+            {savingPolitica ? 'Salvando…' : 'Salvar'}
+          </Button>
+        </form>
+      </Card>
       <details className="mb-3 rounded-lg border border-slate-200 px-3 py-2 text-sm dark:border-slate-700">
         <summary className="cursor-pointer font-medium text-slate-700 dark:text-slate-200">
           Placeholders disponíveis

--- a/frontend/src/pages/CrmNegociacaoDetalhe.tsx
+++ b/frontend/src/pages/CrmNegociacaoDetalhe.tsx
@@ -28,6 +28,7 @@ import { SemPermissao } from './SemPermissao'
 import { CrmPropostaCard } from '../components/crm/CrmPropostaCard'
 import { CrmContratoCard } from '../components/crm/CrmContratoCard'
 import { maskCnpjCpf } from '../utils/maskCnpjCpf'
+import { linhaProntaParaContrato } from '../components/crm/crmFiscais'
 
 const TIPO_ATIVIDADE_LABEL: Record<string, string> = {
   nota: 'Nota',
@@ -140,6 +141,9 @@ export function CrmNegociacaoDetalhe() {
   const docInitRef = useRef(false)
   const [propostaBadge, setPropostaBadge] = useState<string | null>(null)
   const [contratoBadge, setContratoBadge] = useState<string | null>(null)
+  const [linhasAssinadas, setLinhasAssinadas] = useState<Set<number>>(() => new Set())
+  const [nomeBase, setNomeBase] = useState('')
+  const [savingNomeBase, setSavingNomeBase] = useState(false)
 
   const load = useCallback(async () => {
     if (!id || Number.isNaN(negociacaoId)) {
@@ -153,6 +157,7 @@ export function CrmNegociacaoDetalhe() {
     try {
       const n = await crmNegociacoes.get(negociacaoId)
       setNeg(n)
+      setNomeBase(n.nome_base_webposto || '')
       setDestinoEstagio('')
       const [l, funil, acts] = await Promise.all([
         crmLeads.get(n.lead_id),
@@ -191,6 +196,7 @@ export function CrmNegociacaoDetalhe() {
       const contrato = cs.find((c) => CONTRATO_ATIVO.has(c.status)) || cs[0]
       setPropostaBadge(proposta ? PROPOSTA_STATUS_LABEL[proposta.status] || proposta.status : null)
       setContratoBadge(contrato ? CONTRATO_STATUS_LABEL[contrato.status] || contrato.status : null)
+      setLinhasAssinadas(new Set(cs.filter((c) => c.status === 'assinado').map((c) => c.negociacao_linha_cnpj_id)))
       if (!docInitRef.current) {
         docInitRef.current = true
         setPropostaAberta(!contrato)
@@ -339,6 +345,25 @@ export function CrmNegociacaoDetalhe() {
     }
   }
 
+  async function saveNomeBase() {
+    if (!neg || linhasAssinadas.size > 0) return
+    const proximo = nomeBase.trim() || null
+    const atual = (neg.nome_base_webposto || '').trim() || null
+    if (proximo === atual) return
+    setSavingNomeBase(true)
+    try {
+      const n = await crmNegociacoes.update(neg.id, {
+        nome_base_webposto: proximo,
+      })
+      setNeg(n)
+      setNomeBase(n.nome_base_webposto || '')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o nome da Rede.'))
+    } finally {
+      setSavingNomeBase(false)
+    }
+  }
+
   if (loading) {
     return (
       <div className="mx-auto max-w-5xl pb-10">
@@ -389,6 +414,27 @@ export function CrmNegociacaoDetalhe() {
           Estágio: <span className="font-medium">{neg.estagio_nome || '—'}</span>
           {!neg.ativa ? ' · encerrada' : null}
         </p>
+        <div className="mt-3 max-w-lg">
+          <Input
+            label="Nome da Rede (base WebPosto)"
+            value={nomeBase}
+            onChange={(e) => setNomeBase(e.target.value)}
+            onBlur={() => void saveNomeBase()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                void saveNomeBase()
+              }
+            }}
+            placeholder="Ex.: Rede Postos Norte"
+            disabled={linhasAssinadas.size > 0 || savingNomeBase || !neg.ativa}
+            hint={
+              linhasAssinadas.size > 0
+                ? 'Bloqueado após o contrato assinado — este nome é o da Rede no cadastro.'
+                : 'Salvo ao sair do campo. Vários CNPJs desta venda partilham a mesma Rede.'
+            }
+          />
+        </div>
       </div>
 
       <Card title="Avançar estágio">
@@ -476,6 +522,11 @@ export function CrmNegociacaoDetalhe() {
                     <div className="text-xs text-slate-500">
                       CNPJ: {ln.cnpj ? maskCnpjCpf(ln.cnpj) : '— (opcional até Documentação)'} · PDVs: {ln.quantidade_pdvs}
                       {ln.desconto_posto_100k ? ' · desconto posto <100k' : ''}
+                      {linhasAssinadas.has(ln.id)
+                        ? ' · contrato assinado (edição bloqueada)'
+                        : linhaProntaParaContrato(ln)
+                          ? ' · dados fiscais ok'
+                          : ' · dados fiscais no gerar contrato'}
                     </div>
                     <div className="mt-1 text-xs text-slate-500">
                       Pacote:{' '}
@@ -487,14 +538,22 @@ export function CrmNegociacaoDetalhe() {
                     </div>
                   </div>
                   <div className="flex gap-2">
-                    <Button variant="secondary" onClick={() => openEditLinha(ln)}>
-                      <IconPencil className="size-4" />
-                      Editar
-                    </Button>
-                    <Button variant="danger" onClick={() => setDeleteLinhaId(ln.id)}>
-                      <IconTrash className="size-5" />
-                      Remover
-                    </Button>
+                    {linhasAssinadas.has(ln.id) ? (
+                      <p className="max-w-[14rem] text-right text-xs text-slate-500">
+                        Pacote e valores ficam só de leitura para coincidir com o contrato assinado.
+                      </p>
+                    ) : (
+                      <>
+                        <Button variant="secondary" onClick={() => openEditLinha(ln)}>
+                          <IconPencil className="size-4" />
+                          Editar
+                        </Button>
+                        <Button variant="danger" onClick={() => setDeleteLinhaId(ln.id)}>
+                          <IconTrash className="size-5" />
+                          Remover
+                        </Button>
+                      </>
+                    )}
                   </div>
                 </div>
                 <div className="mt-2 grid gap-2 text-sm sm:grid-cols-3">
@@ -530,7 +589,7 @@ export function CrmNegociacaoDetalhe() {
         open={contratoAberto}
         onOpenChange={setContratoAberto}
       >
-        <CrmContratoCard negociacao={neg} onChanged={handleDocsChanged} embedded />
+        <CrmContratoCard negociacao={neg} lead={lead} onChanged={handleDocsChanged} embedded />
       </CollapsibleCard>
 
       <CollapsibleCard
@@ -576,7 +635,7 @@ export function CrmNegociacaoDetalhe() {
 
       {linhaModal ? (
         <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-0 sm:items-center sm:p-4">
-          <div className="max-h-[92vh] w-full overflow-y-auto rounded-t-2xl bg-white p-5 shadow-xl dark:bg-slate-900 sm:max-w-lg sm:rounded-2xl">
+          <div className="max-h-[92vh] w-full overflow-y-auto rounded-t-2xl bg-white p-5 shadow-xl dark:bg-slate-900 sm:max-w-2xl sm:rounded-2xl">
             <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
               {linhaModal === 'create' ? 'Nova linha CNPJ' : 'Editar linha'}
             </h2>
@@ -592,6 +651,9 @@ export function CrmNegociacaoDetalhe() {
                 value={linhaForm.razao_social}
                 onChange={(e) => setLinhaForm((p) => ({ ...p, razao_social: e.target.value }))}
               />
+              <p className="text-xs text-slate-500">
+                Endereço, responsável legal e contacto da empresa são preenchidos ao gerar o contrato.
+              </p>
               <Input
                 label="Valor negociado (R$)"
                 value={linhaForm.valor_negociado}


### PR DESCRIPTION
## Summary

Fecha o lote F2 de contratos comerciais no CRM: assinatura com PDF anexo, reajuste configurável e conversão Rede/Empresa ao marcar assinado.

- **#353** — gerar PDF, assinar fora (ClickSign ou outro), anexar PDF; marcar assinado exige o anexo; linha e nome da Rede ficam bloqueados depois de assinado
- **#354** — política de reajuste da instância (admin); herança, override ou sem reajuste no contrato (sem API IGPM nem job anual neste lote)
- **#357** — ao assinar, cria ou vincula Rede (`nome_base_webposto`) e Empresa(s) por CNPJ (sem PDVs); copia e-mail/telefone e cria contacto na rede para o chat
- Comercial só acede a contratos das próprias negociações (lista, detalhe, PDF e mutações); admin vê todas
- Migration `098_comercial_contratos_f2`

Closes #353
Closes #354
Closes #357

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `docker compose run --rm --no-deps backend pytest -q tests/test_comercial_contrato.py` (17 passed)
- [ ] Gerar contrato na negociação (fiscais obrigatórios neste passo; nome da Rede no header)
- [ ] Anexar PDF assinado e marcar assinado → Rede + Empresa criadas/vinculadas, sem PDVs; links Abrir empresa/rede
- [ ] Comercial não abre/PDF/muta contrato de outra negociação (403); admin continua a ver todos
- [ ] Cadastros: política de reajuste da instância; percentual no formato 5,5
- [ ] Após assinado, linha CNPJ e nome da Rede não editáveis

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — cada um virou issue `#745` ou está documentado como wontfix
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados

- Job anual / fonte IGPM / histórico de aplicações: **#745** (escopo original da #354; v1 ficou política configurável)
- Integração ClickSign (API): continua **fora do v1** (#324)
- Multa de rescisão: **#355** (já no épico, não neste lote)
- Ticket/checklist de implantação: **#358** (não dispara neste PR)
