### PR TITLE
feat(mobile): push nativo Android com VAPID + UnifiedPush (#737)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 #### Melhorias
 
 - Mobile chat (#747–#759): lista a 100% da largura; teclado sem vão/corte no campo; composer estilo WhatsApp; reagir pelo menu da seta; demanda e modais em folha inferior; header da app oculto na conversa; Encerrar/empresa/setor no telemóvel; empty states úteis; ícones PWA legíveis (fundo claro + contorno branco no desktop)
+- Mobile (#737): no **app Android**, os alertas com a app fechada usam o mesmo canal da instância (sem Firebase); o clique abre a mesa certa
+- Mobile (#735 / #736): app Android (instalação pelo APK) focado em **tickets e chat**; na primeira vez escolhes a **conta da empresa** (ex. duplexsoft) e nas seguintes o login já usa essa base
 - Contratos comerciais (#324 / #349–#357): gerar PDF por CNPJ (fidelidade, setup, cláusulas, dados fiscais e nome da base WebPosto); reajuste padrão da instância ou override no contrato; anexar PDF assinado (ClickSign ou outro) com referência opcional; ao marcar assinado, cria ou vincula Rede e Empresa pelo CNPJ (sem PDVs), copia e-mail/telefone e cria contacto na rede para o chat; rascunho → enviado → assinado; lista com filtro por responsável; painel interno com custo, lucro e margem %; modelos em Cadastros. Na negociação, os dados fiscais ficam no gerar contrato; depois de assinado, a linha e o nome da Rede não se editam
 - Proposta comercial (#323 / #345–#348): modelos HTML versionados, geração a partir da negociação (CNPJs à escolha), preview, PDF e marcar como enviada (com opção de avançar o funil) — sem custo/margem no documento do cliente
 - CRM (#322 / #336–#344): perfil comercial, funil, leads e negociações multi-CNPJ (API + UI — lista/Kanban, detalhe com custos/margem e timeline); configuração dos estágios em Cadastros; simulação e leitura do catálogo de custos para comercial (CRUD do catálogo continua só admin)
@@ -25,7 +27,6 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Chat e tickets (#699): o Voltar do navegador fecha o painel da conversa ou do chamado e permanece na mesa (`/chat/…`, `/tickets`), sem o número na barra
 - Portal (#700): chamados e atendimentos WhatsApp ficam em `/portal/tickets` e `/portal/chats`, sem o número na barra; links antigos com id continuam a abrir o item certo
 - Mobile (#690 / #691): o painel no endereço do cliente pode ser **adicionado à tela inicial** (PWA); o brief mobile descreve PWA primeiro, depois lojas
-- Mobile (#735 / #736): app Android (instalação pelo APK) focado em **tickets e chat**; na primeira vez escolhes a **conta da empresa** (ex. duplexsoft) e nas seguintes o login já usa essa base
 - Mobile (#692): no telemóvel, WhatsApp e tickets dão para operar por completo — assumir, responder (texto/mídia), transferir, encerrar, abrir ticket; fila e detalhe do chamado com botões grandes e teclado que não cobre o campo de mensagem
 - WhatsApp (#723): quem abre um chat em atendimento (colega ou admin) também vê o cronômetro de inatividade; Pausar/Retomar continua só com o responsável
 - Notificações (#693 / #694): no telemóvel podes receber alertas mesmo com a app fechada — fila de espera e mensagens nos chats/tickets já teus. Activa em Notificações; o silêncio da fila na mesa também vale com a app fechada

--- a/backend/tests/test_web_push.py
+++ b/backend/tests/test_web_push.py
@@ -56,6 +56,25 @@ def test_registrar_listar_apagar_subscription(client, seed_base, auth_headers, d
     assert db_session.query(PushSubscription).count() == 0
 
 
+def test_registra_subscription_formato_unifiedpush(client, auth_headers, monkeypatch):
+    """APK Android (#737): endpoint Web Push + chaves base64url, sem Firebase."""
+    monkeypatch.setattr("app.config.settings.WEB_PUSH_VAPID_PUBLIC_KEY", "BNpublic")
+    monkeypatch.setattr("app.config.settings.WEB_PUSH_VAPID_PRIVATE_KEY", "priv")
+    payload = {
+        "endpoint": "https://fcm.googleapis.com/wp/eid-abc",
+        "p256dh": "BNabcdefghijklmnopqrstuvwxyz0123456789-_xx",
+        "auth": "dGVzdGF1dGg",
+        "user_agent": "DeskRudder-Android-UnifiedPush",
+    }
+    r = client.post("/v1/web-push/subscriptions", headers=auth_headers["a1"], json=payload)
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["endpoint"] == payload["endpoint"]
+    r = client.post("/v1/web-push/subscriptions", headers=auth_headers["a1"], json=payload)
+    assert r.status_code == 201
+    assert r.json()["id"] == body["id"]
+
+
 def test_nao_registra_endpoint_de_outro_utilizador(client, seed_base, auth_headers, db_session):
     a1 = seed_base["a1"]
     db_session.add(

--- a/docs/MOBILE_APP_BRIEF.md
+++ b/docs/MOBILE_APP_BRIEF.md
@@ -138,7 +138,7 @@ Sistema de **helpdesk** para **redes de postos/empresas**:
 |------|--------|
 | Agora | **PWA** no frontend React actual (mesmo `/v1`, mesma origem do painel) |
 | Em curso | **Capacitor** Android: 1 APK + campo Conta → `api-{slug}` (tickets e chat) |
-| Depois | Play Store / App Store + FCM/APNs |
+| Depois | Play Store / App Store + UnifiedPush (VAPID) no Android / APNs no iOS |
 | Não na v1 | React Native / Flutter |
 
 **Install (híbrido C):** PWA por `{slug}` agora; nas lojas será **1 app** + campo Conta → `api-{slug}`.  
@@ -380,7 +380,7 @@ O projecto web já é **React + TypeScript**. Ordem fechada no épico #689:
 | **PWA no SPA actual** | Reutiliza o painel; instalável em `https://{slug}.…`; API `/v1` na mesma instância |
 | **Capacitor (lojas)** | Empacota o mesmo frontend; campo Conta resolve `api-{slug}` |
 
-Como construir o APK debug: **`docs/MOBILE_CAPACITOR.md`** (issue #735).
+Como construir o APK debug e o push nativo (VAPID + UnifiedPush, sem Firebase): **`docs/MOBILE_CAPACITOR.md`** (#735 / #737).
 | React Native / Flutter | **Fora da v1** |
 
 ### Tempo real: SSE (já existe)

--- a/docs/MOBILE_CAPACITOR.md
+++ b/docs/MOBILE_CAPACITOR.md
@@ -1,4 +1,4 @@
-# App Android (Capacitor) — L6.1 / L6.2 (#735 / #736)
+# App Android (Capacitor) — L6.1 / L6.2 / L6.3 (#735 / #736 / #737)
 
 O APK é um WebView Capacitor com um **SPA mais leve**: login, **tickets** e **chat** (mesa WhatsApp / hub). Não leva landing, SaaS, CRM, cadastros nem dashboards.
 
@@ -73,9 +73,16 @@ O `Host` da API no telemóvel, no modo local, é o IP do PC; o WebView continua 
 
 ## Fora deste lote
 
-- FCM (#737)
 - iOS (#738)
 - Listing nas lojas (#739)
+
+## Alertas com a app fechada (UnifiedPush / VAPID) — #737
+
+Não há projecto Firebase nem `google-services.json`. O APK pede um endpoint **Web Push** (UnifiedPush) e grava-o na API da instância (`POST /v1/web-push/subscriptions`), com as mesmas chaves VAPID do `client.env`.
+
+O worker `web-push-outbox` já existente envia para PWA **e** APK. Mute da fila e deep link são os da PWA.
+
+O distribuidor embutido usa os servidores de push da Google só como transporte nos telemóveis com Play Services. Sem Play Services, o alerta com a app fechada não chega (a PWA no Chrome continua a funcionar).
 
 Ícones/splash oficiais: usar os PNG em `frontend/public/deskrudder-pwa-*.png` num lote posterior (`@capacitor/assets`).
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -107,6 +107,8 @@ O subscribe corre no browser em `https://{slug}.…`. `CORS_ORIGINS` tem de incl
 
 App Capacitor Android (#735 / #736): origem do WebView `https://localhost`. Cada instância (`api-{slug}`) precisa desse valor em `CORS_ORIGINS` do **`client.env` no VPS** (não basta o default do `config.py` se o env já define CORS). Recriar o contentor da API depois de gravar.
 
+O APK Android (#737) **não usa Firebase**. Os alertas com a app fechada reutilizam o mesmo par VAPID e o worker `web-push-outbox`. Não há variável FCM extra no `client.env`.
+
 Exemplo Duplex:
 
 ```bash
@@ -125,7 +127,7 @@ Web Push no iPhone/iPad exige **iOS 16.4+** e a PWA **instalada** (Partilhar →
 
 1. Release na `staging` / stack do cliente com migration `095_web_push`
 2. Gerar VAPID e preencher o `client.env`; CORS = origem HTTPS do SPA
-3. Atendente no Android/Chrome: Notificações → activar alertas; fechar a app; pôr um chat na fila
+3. Atendente no Android/Chrome **ou** no APK DeskRudder: Notificações → activar alertas; fechar a app; pôr um chat na fila
 4. Tocar no alerta e confirmar que abre a mesa certa
 5. Silenciar a fila na mesa e confirmar que **não** chega push de fila
 

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -1,8 +1,16 @@
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 
 android {
     namespace = "br.com.deskrudder.app"
     compileSdk = rootProject.ext.compileSdkVersion
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
+    }
+    kotlinOptions {
+        jvmTarget = '21'
+    }
     defaultConfig {
         applicationId "br.com.deskrudder.app"
         minSdkVersion rootProject.ext.minSdkVersion
@@ -36,6 +44,8 @@ dependencies {
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
     implementation project(':capacitor-android')
+    implementation 'org.unifiedpush.android:connector:3.3.3'
+    implementation 'org.unifiedpush.android:embedded-fcm-distributor:3.1.0'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -33,9 +33,18 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths"></meta-data>
         </provider>
+
+        <service
+            android:name=".DeskRudderPushService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="org.unifiedpush.android.connector.PUSH_EVENT" />
+            </intent-filter>
+        </service>
     </application>
 
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 </manifest>

--- a/frontend/android/app/src/main/java/br/com/deskrudder/app/DeskRudderPushService.kt
+++ b/frontend/android/app/src/main/java/br/com/deskrudder/app/DeskRudderPushService.kt
@@ -1,0 +1,108 @@
+package br.com.deskrudder.app
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat
+import org.unifiedpush.android.connector.FailedReason
+import org.unifiedpush.android.connector.PushService
+import org.unifiedpush.android.connector.data.PushEndpoint
+import org.unifiedpush.android.connector.data.PushMessage
+
+/**
+ * Recebe eventos UnifiedPush com a app em segundo plano ou fechada (#737).
+ * O payload é o JSON Web Push já usado pela PWA (`tipo`, `id`, `titulo`, `url_path`, `corpo`).
+ */
+class DeskRudderPushService : PushService() {
+    override fun onNewEndpoint(endpoint: PushEndpoint, instance: String) {
+        val keys = endpoint.pubKeySet ?: return
+        UnifiedPushStore.saveEndpoint(this, endpoint.url, keys.pubKey, keys.auth)
+        UnifiedPushPlugin.emitEndpoint(endpoint.url, keys.pubKey, keys.auth)
+    }
+
+    override fun onMessage(message: PushMessage, instance: String) {
+        val raw = try {
+            String(message.content, Charsets.UTF_8)
+        } catch (_: Exception) {
+            "{}"
+        }
+        // Só mostra o alerta. A mesa só abre no toque (PendingIntent → handleOnNewIntent),
+        // como a PWA (notificationclick). Não gravar pending nem emitir "open" aqui:
+        // senão a app em primeiro plano saltava sozinha, e o próximo arranque
+        // reabria o último push mesmo sem clique.
+        showNotification(raw)
+    }
+
+    override fun onRegistrationFailed(reason: FailedReason, instance: String) {
+        UnifiedPushPlugin.emitRegistrationError(reason.name)
+    }
+
+    override fun onUnregistered(instance: String) {
+        UnifiedPushStore.clearEndpoint(this)
+        UnifiedPushPlugin.emitUnregistered()
+    }
+
+    private fun showNotification(raw: String) {
+        if (Build.VERSION.SDK_INT >= 33 &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            return
+        }
+        ensureChannel()
+        val data = UnifiedPushStore.payloadToJson(raw)
+        val titulo = data.optString("titulo").ifBlank { "DeskRudder" }
+        val corpo = data.optString("corpo").ifBlank { "Nova actividade no atendimento" }
+        val tipo = data.optString("tipo")
+        val id = data.optLong("id", 0L)
+        val tag = "${tipo.ifBlank { "push" }}:$id"
+
+        val tap = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP
+            putExtra(UnifiedPushStore.EXTRA_PAYLOAD, raw)
+        }
+        val pending = PendingIntent.getActivity(
+            this,
+            tag.hashCode(),
+            tap,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_stat_notify)
+            .setContentTitle(titulo)
+            .setContentText(corpo)
+            .setAutoCancel(true)
+            .setContentIntent(pending)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setDefaults(NotificationCompat.DEFAULT_ALL)
+            .build()
+        NotificationManagerCompat.from(this).notify(tag.hashCode(), notification)
+    }
+
+    private fun ensureChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = getSystemService(NotificationManager::class.java) ?: return
+        if (manager.getNotificationChannel(CHANNEL_ID) != null) return
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                "Alertas de atendimento",
+                NotificationManager.IMPORTANCE_HIGH,
+            ).apply {
+                description = "Fila e mensagens nos teus chats e tickets"
+            },
+        )
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "deskrudder_push"
+    }
+}

--- a/frontend/android/app/src/main/java/br/com/deskrudder/app/MainActivity.java
+++ b/frontend/android/app/src/main/java/br/com/deskrudder/app/MainActivity.java
@@ -1,5 +1,12 @@
 package br.com.deskrudder.app;
 
+import android.os.Bundle;
 import com.getcapacitor.BridgeActivity;
 
-public class MainActivity extends BridgeActivity {}
+public class MainActivity extends BridgeActivity {
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        registerPlugin(UnifiedPushPlugin.class);
+        super.onCreate(savedInstanceState);
+    }
+}

--- a/frontend/android/app/src/main/java/br/com/deskrudder/app/UnifiedPushPlugin.kt
+++ b/frontend/android/app/src/main/java/br/com/deskrudder/app/UnifiedPushPlugin.kt
@@ -1,0 +1,190 @@
+package br.com.deskrudder.app
+
+import android.Manifest
+import android.content.Intent
+import android.os.Build
+import com.getcapacitor.JSObject
+import com.getcapacitor.PermissionState
+import com.getcapacitor.Plugin
+import com.getcapacitor.PluginCall
+import com.getcapacitor.PluginMethod
+import com.getcapacitor.annotation.CapacitorPlugin
+import com.getcapacitor.annotation.Permission
+import com.getcapacitor.annotation.PermissionCallback
+import org.json.JSONObject
+import org.unifiedpush.android.connector.UnifiedPush
+import java.lang.ref.WeakReference
+
+@CapacitorPlugin(
+    name = "DeskRudderUnifiedPush",
+    permissions = [
+        Permission(
+            alias = "notifications",
+            strings = [Manifest.permission.POST_NOTIFICATIONS],
+        ),
+    ],
+)
+class UnifiedPushPlugin : Plugin() {
+    @PluginMethod
+    fun registerPush(call: PluginCall) {
+        val vapid = call.getString("vapidPublicKey")?.trim().orEmpty()
+        if (vapid.isEmpty()) {
+            call.reject("sem_vapid")
+            return
+        }
+        if (needsNotificationPermission() && getPermissionState("notifications") != PermissionState.GRANTED) {
+            requestPermissionForAlias("notifications", call, "onNotificationsPermission")
+            return
+        }
+        startRegistration(call, vapid)
+    }
+
+    @PermissionCallback
+    fun onNotificationsPermission(call: PluginCall) {
+        if (getPermissionState("notifications") != PermissionState.GRANTED) {
+            call.reject("negado")
+            return
+        }
+        val vapid = call.getString("vapidPublicKey")?.trim().orEmpty()
+        if (vapid.isEmpty()) {
+            call.reject("sem_vapid")
+            return
+        }
+        startRegistration(call, vapid)
+    }
+
+    @PluginMethod
+    fun unregisterPush(call: PluginCall) {
+        try {
+            UnifiedPush.unregister(context)
+        } catch (_: Exception) {
+            /* logout continua */
+        }
+        UnifiedPushStore.clearEndpoint(context)
+        call.resolve()
+    }
+
+    @PluginMethod
+    fun consumePendingOpen(call: PluginCall) {
+        val fromIntent = activity?.intent?.getStringExtra(UnifiedPushStore.EXTRA_PAYLOAD)
+        if (!fromIntent.isNullOrBlank()) {
+            activity?.intent?.removeExtra(UnifiedPushStore.EXTRA_PAYLOAD)
+            call.resolve(jsonToJs(UnifiedPushStore.payloadToJson(fromIntent)))
+            return
+        }
+        val pending = UnifiedPushStore.consumePendingOpen(context)
+        if (pending.isNullOrBlank()) {
+            call.resolve(JSObject())
+            return
+        }
+        call.resolve(jsonToJs(UnifiedPushStore.payloadToJson(pending)))
+    }
+
+    override fun load() {
+        instance = WeakReference(this)
+    }
+
+    override fun handleOnNewIntent(intent: Intent?) {
+        super.handleOnNewIntent(intent)
+        val raw = intent?.getStringExtra(UnifiedPushStore.EXTRA_PAYLOAD) ?: return
+        emitOpen(raw)
+    }
+
+    private fun startRegistration(call: PluginCall, vapid: String) {
+        val act = activity
+        if (act == null) {
+            call.reject("indisponivel")
+            return
+        }
+        pendingRegister = call
+        try {
+            UnifiedPush.tryUseCurrentOrDefaultDistributor(act) { success ->
+                if (!success) {
+                    completeRegisterError("indisponivel")
+                    return@tryUseCurrentOrDefaultDistributor
+                }
+                try {
+                    UnifiedPush.register(
+                        context,
+                        "default",
+                        "DeskRudder",
+                        vapid,
+                    )
+                } catch (_: UnifiedPush.VapidNotValidException) {
+                    completeRegisterError("sem_vapid")
+                } catch (_: Exception) {
+                    completeRegisterError("indisponivel")
+                }
+            }
+        } catch (_: Exception) {
+            completeRegisterError("indisponivel")
+        }
+    }
+
+    private fun completeRegisterError(code: String) {
+        val call = pendingRegister ?: return
+        pendingRegister = null
+        call.reject(code)
+    }
+
+    private fun deliverEndpoint(url: String, p256dh: String, auth: String) {
+        val data = JSObject()
+            .put("endpoint", url)
+            .put("p256dh", p256dh)
+            .put("auth", auth)
+        notifyListeners("endpoint", data, true)
+        val call = pendingRegister
+        if (call != null) {
+            pendingRegister = null
+            call.resolve(data)
+        }
+    }
+
+    private fun deliverOpen(raw: String) {
+        notifyListeners("open", jsonToJs(UnifiedPushStore.payloadToJson(raw)), true)
+    }
+
+    private fun deliverRegistrationError(reason: String) {
+        val data = JSObject().put("reason", reason)
+        notifyListeners("registrationError", data, true)
+        completeRegisterError(if (reason.contains("NETWORK", ignoreCase = true)) "indisponivel" else "indisponivel")
+    }
+
+    private fun needsNotificationPermission(): Boolean = Build.VERSION.SDK_INT >= 33
+
+    companion object {
+        private var instance: WeakReference<UnifiedPushPlugin>? = null
+        @Volatile
+        private var pendingRegister: PluginCall? = null
+
+        fun emitEndpoint(url: String, p256dh: String, auth: String) {
+            instance?.get()?.deliverEndpoint(url, p256dh, auth)
+        }
+
+        fun emitOpen(raw: String) {
+            instance?.get()?.deliverOpen(raw)
+        }
+
+        fun emitRegistrationError(reason: String) {
+            instance?.get()?.deliverRegistrationError(reason)
+        }
+
+        fun emitUnregistered() {
+            instance?.get()?.notifyListeners("unregistered", JSObject(), false)
+        }
+
+        private fun jsonToJs(obj: JSONObject): JSObject {
+            val out = JSObject()
+            val tipo = obj.optString("tipo")
+            if (tipo.isNotBlank()) out.put("tipo", tipo)
+            if (obj.has("id") && !obj.isNull("id")) out.put("id", obj.optLong("id"))
+            val urlPath = obj.optString("url_path")
+            if (urlPath.isNotBlank()) out.put("url_path", urlPath)
+            val titulo = obj.optString("titulo")
+            if (titulo.isNotBlank()) out.put("titulo", titulo)
+            val corpo = obj.optString("corpo")
+            if (corpo.isNotBlank()) out.put("corpo", corpo)
+            return out
+        }
+    }
+}

--- a/frontend/android/app/src/main/java/br/com/deskrudder/app/UnifiedPushStore.kt
+++ b/frontend/android/app/src/main/java/br/com/deskrudder/app/UnifiedPushStore.kt
@@ -1,0 +1,66 @@
+package br.com.deskrudder.app
+
+import android.content.Context
+import org.json.JSONObject
+
+/** Persistência local do endpoint UnifiedPush e do clique da notificação (#737). */
+internal object UnifiedPushStore {
+    private const val PREFS = "deskrudder_push"
+    private const val KEY_ENDPOINT = "endpoint"
+    private const val KEY_P256DH = "p256dh"
+    private const val KEY_AUTH = "auth"
+    private const val KEY_PENDING = "pending_open"
+    const val EXTRA_PAYLOAD = "deskrudder_push_payload"
+
+    data class Endpoint(val url: String, val p256dh: String, val auth: String)
+
+    private fun prefs(context: Context) =
+        context.applicationContext.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    fun saveEndpoint(context: Context, url: String, p256dh: String, auth: String) {
+        prefs(context).edit()
+            .putString(KEY_ENDPOINT, url)
+            .putString(KEY_P256DH, p256dh)
+            .putString(KEY_AUTH, auth)
+            .apply()
+    }
+
+    fun loadEndpoint(context: Context): Endpoint? {
+        val p = prefs(context)
+        val url = p.getString(KEY_ENDPOINT, null)?.trim().orEmpty()
+        val p256dh = p.getString(KEY_P256DH, null)?.trim().orEmpty()
+        val auth = p.getString(KEY_AUTH, null)?.trim().orEmpty()
+        if (url.isEmpty() || p256dh.isEmpty() || auth.isEmpty()) return null
+        return Endpoint(url, p256dh, auth)
+    }
+
+    fun clearEndpoint(context: Context) {
+        prefs(context).edit()
+            .remove(KEY_ENDPOINT)
+            .remove(KEY_P256DH)
+            .remove(KEY_AUTH)
+            .apply()
+    }
+
+    fun savePendingOpen(context: Context, payloadJson: String) {
+        prefs(context).edit().putString(KEY_PENDING, payloadJson).apply()
+    }
+
+    fun consumePendingOpen(context: Context): String? {
+        val p = prefs(context)
+        val raw = p.getString(KEY_PENDING, null)
+        if (!raw.isNullOrBlank()) {
+            p.edit().remove(KEY_PENDING).apply()
+            return raw
+        }
+        return null
+    }
+
+    fun payloadToJson(raw: String): JSONObject {
+        return try {
+            JSONObject(raw)
+        } catch (_: Exception) {
+            JSONObject().put("titulo", "DeskRudder").put("corpo", raw.take(200))
+        }
+    }
+}

--- a/frontend/android/app/src/main/res/drawable/ic_stat_notify.xml
+++ b/frontend/android/app/src/main/res/drawable/ic_stat_notify.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4c0,1.1 0.89,2 2,2zM18,16v-5c0,-3.07 -1.64,-5.64 -4.5,-6.32V4c0,-0.83 -0.67,-1.5 -1.5,-1.5S10.5,3.17 10.5,4v0.68C7.63,5.36 6,7.92 6,11v5l-2,2v1h16v-1l-2,-2z" />
+</vector>

--- a/frontend/android/build.gradle
+++ b/frontend/android/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.0'
         classpath 'com.google.gms:google-services:4.4.4'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:2.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -158,9 +158,7 @@ function LayoutInner() {
         {notificacoesEnabled && !isCapacitorNative() && !ocultarHeaderMobile ? (
           <AlertaDesktopPermissaoBanner enabled />
         ) : null}
-        {notificacoesEnabled && !isCapacitorNative() && !ocultarHeaderMobile ? (
-          <WebPushOptInBanner enabled />
-        ) : null}
+        {notificacoesEnabled && !ocultarHeaderMobile ? <WebPushOptInBanner enabled /> : null}
 
         <main className="min-h-0 flex-1 overflow-hidden">
           <div

--- a/frontend/src/components/WebPushOptInBanner.tsx
+++ b/frontend/src/components/WebPushOptInBanner.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { notificacoes, webPush } from '../api/client'
 import { Button } from './ui/Button'
 import { syncWebPushSubscription } from '../hooks/useWebPush'
+import { isCapacitorNative } from '../lib/capacitorNative'
 import { webPushRequerPwaIos } from '../lib/pwaDisplay'
 
 const LS_DISMISS = 'deskrudder-web-push-optin-dismissed'
@@ -24,7 +25,7 @@ function writeDismissed() {
 
 type Props = { enabled: boolean }
 
-/** Convite para alertas com a PWA fechada (#694). */
+/** Convite para alertas com a app fechada (PWA #694 / APK #737). */
 export function WebPushOptInBanner({ enabled }: Props) {
   const [visible, setVisible] = useState(false)
   const [busy, setBusy] = useState(false)
@@ -39,12 +40,12 @@ export function WebPushOptInBanner({ enabled }: Props) {
       setVisible(false)
       return
     }
-    if (webPushRequerPwaIos()) {
+    if (!isCapacitorNative() && webPushRequerPwaIos()) {
       setVisible(true)
       setFeedback('ios_pwa')
       return
     }
-    if (!('Notification' in window) || !('PushManager' in window)) {
+    if (!isCapacitorNative() && (!('Notification' in window) || !('PushManager' in window))) {
       setVisible(false)
       return
     }
@@ -54,7 +55,11 @@ export function WebPushOptInBanner({ enabled }: Props) {
         setVisible(false)
         return
       }
-      if (Notification.permission === 'denied') {
+      if (
+        !isCapacitorNative() &&
+        'Notification' in window &&
+        Notification.permission === 'denied'
+      ) {
         setVisible(false)
         return
       }
@@ -117,7 +122,7 @@ export function WebPushOptInBanner({ enabled }: Props) {
         className="flex shrink-0 flex-wrap items-center justify-between gap-2 border-b border-amber-200 bg-amber-50 px-4 py-2.5 text-sm text-amber-950 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-100"
       >
         <p className="min-w-0 flex-1">
-          Notificações bloqueadas neste browser. Permite-as nas definições do site para alertas com a app fechada.
+          Notificações bloqueadas neste dispositivo. Permite-as nas definições para alertas com a app fechada.
         </p>
         <Button type="button" variant="ghost" className="h-8 shrink-0 px-2 text-xs" onClick={() => setFeedback(null)}>
           Fechar

--- a/frontend/src/hooks/useWebPush.ts
+++ b/frontend/src/hooks/useWebPush.ts
@@ -1,15 +1,100 @@
 import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { notificacoes, webPush } from '../api/client'
-import { isFilaAguardandoMuted } from './useAlertaFilaSemResponsavel'
-import { aplicarAberturaWebPush } from '../lib/webPushDeepLink'
+import { isCapacitorNative } from '../lib/capacitorNative'
+import { aplicarAberturaWebPush, type WebPushOpenPayload } from '../lib/webPushDeepLink'
 import { urlBase64ToUint8Array } from '../lib/webPushKeys'
 import { webPushRequerPwaIos } from '../lib/pwaDisplay'
+import { DeskRudderUnifiedPush, type UnifiedPushOpen } from '../plugins/unifiedPush'
+import { isFilaAguardandoMuted } from './useAlertaFilaSemResponsavel'
+
+const LS_UNIFIED_ENDPOINT = 'deskrudder-unifiedpush-endpoint'
+const NATIVE_UA = 'DeskRudder-Android-UnifiedPush'
+
+function pluginErrorCode(err: unknown): string {
+  if (!err || typeof err !== 'object') return String(err)
+  const rec = err as { message?: string; errorMessage?: string }
+  return (rec.errorMessage || rec.message || '').toLowerCase()
+}
+
+function temAbertura(data: UnifiedPushOpen | WebPushOpenPayload | null | undefined): boolean {
+  if (!data) return false
+  if (data.tipo) return true
+  if (data.url_path) return true
+  return Number.isFinite(Number(data.id)) && Number(data.id) > 0
+}
+
+async function syncUnifiedPushSubscription(
+  opts?: { ativar?: boolean },
+): Promise<'ok' | 'sem_vapid' | 'negado' | 'indisponivel' | 'ios_pwa'> {
+  const vapid = await webPush.vapid()
+  if (!vapid.configurado || !vapid.public_key) return 'sem_vapid'
+
+  if (opts?.ativar === false) {
+    const endpoint = (() => {
+      try {
+        return localStorage.getItem(LS_UNIFIED_ENDPOINT)
+      } catch {
+        return null
+      }
+    })()
+    if (endpoint) {
+      try {
+        await webPush.apagarEndpoint(endpoint)
+      } catch {
+        /* sessão já a expirar */
+      }
+      try {
+        localStorage.removeItem(LS_UNIFIED_ENDPOINT)
+      } catch {
+        /* ignore */
+      }
+    }
+    try {
+      await DeskRudderUnifiedPush.unregisterPush()
+    } catch {
+      /* ignore */
+    }
+    await notificacoes.preferenciasUpdate({ push_habilitado: false })
+    return 'ok'
+  }
+
+  try {
+    const sub = await DeskRudderUnifiedPush.registerPush({ vapidPublicKey: vapid.public_key })
+    if (!sub.endpoint || !sub.p256dh || !sub.auth) return 'indisponivel'
+    await webPush.registrar({
+      endpoint: sub.endpoint,
+      p256dh: sub.p256dh,
+      auth: sub.auth,
+      user_agent: NATIVE_UA,
+    })
+    try {
+      localStorage.setItem(LS_UNIFIED_ENDPOINT, sub.endpoint)
+    } catch {
+      /* ignore */
+    }
+    if (opts?.ativar === true) {
+      await notificacoes.preferenciasUpdate({
+        push_habilitado: true,
+        push_fila: !isFilaAguardandoMuted(),
+      })
+    }
+    return 'ok'
+  } catch (err) {
+    const code = pluginErrorCode(err)
+    if (code.includes('negado')) return 'negado'
+    if (code.includes('sem_vapid')) return 'sem_vapid'
+    return 'indisponivel'
+  }
+}
 
 export async function syncWebPushSubscription(
   opts?: { ativar?: boolean },
 ): Promise<'ok' | 'sem_vapid' | 'negado' | 'indisponivel' | 'ios_pwa'> {
   if (typeof window === 'undefined') return 'indisponivel'
+  if (isCapacitorNative()) {
+    return syncUnifiedPushSubscription(opts)
+  }
   if (opts?.ativar !== false && webPushRequerPwaIos()) {
     return 'ios_pwa'
   }
@@ -68,7 +153,7 @@ export async function syncWebPushSubscription(
   return 'ok'
 }
 
-/** Reinscreve se já estava activo, aplica deep link e escuta o Service Worker (#694). */
+/** Reinscreve se já estava activo, aplica deep link e escuta o Service Worker / UnifiedPush. */
 export function useWebPushSession(enabled: boolean) {
   const navigate = useNavigate()
 
@@ -76,6 +161,63 @@ export function useWebPushSession(enabled: boolean) {
     if (!enabled) return
     aplicarPushQueryNaUrl()
     let cancelled = false
+
+    if (isCapacitorNative()) {
+      let removeEndpoint: (() => void) | undefined
+      let removeOpen: (() => void) | undefined
+      void (async () => {
+        try {
+          const endpointHandle = await DeskRudderUnifiedPush.addListener('endpoint', (data) => {
+            void webPush
+              .registrar({
+                endpoint: data.endpoint,
+                p256dh: data.p256dh,
+                auth: data.auth,
+                user_agent: NATIVE_UA,
+              })
+              .then(() => {
+                try {
+                  localStorage.setItem(LS_UNIFIED_ENDPOINT, data.endpoint)
+                } catch {
+                  /* ignore */
+                }
+              })
+              .catch(() => undefined)
+          })
+          const openHandle = await DeskRudderUnifiedPush.addListener('open', (data) => {
+            if (!temAbertura(data)) return
+            navigate(aplicarAberturaWebPush(data))
+          })
+          removeEndpoint = () => {
+            void endpointHandle.remove()
+          }
+          removeOpen = () => {
+            void openHandle.remove()
+          }
+          const pending = await DeskRudderUnifiedPush.consumePendingOpen()
+          if (!cancelled && temAbertura(pending)) {
+            navigate(aplicarAberturaWebPush(pending))
+          }
+          const prefs = await notificacoes.preferenciasGet()
+          if (cancelled) return
+          const muted = isFilaAguardandoMuted()
+          if (muted && prefs.push_fila) {
+            await notificacoes.preferenciasUpdate({ push_fila: false })
+          }
+          if (prefs.push_habilitado) {
+            await syncWebPushSubscription()
+          }
+        } catch {
+          /* sessão a carregar ou vapid desligado */
+        }
+      })()
+      return () => {
+        cancelled = true
+        removeEndpoint?.()
+        removeOpen?.()
+      }
+    }
+
     void (async () => {
       try {
         const prefs = await notificacoes.preferenciasGet()
@@ -107,7 +249,33 @@ export function useWebPushSession(enabled: boolean) {
 }
 
 export async function revogarWebPushNoLogout(): Promise<void> {
-  if (typeof window === 'undefined' || !('serviceWorker' in navigator) || !('PushManager' in window)) return
+  if (typeof window === 'undefined') return
+  if (isCapacitorNative()) {
+    const endpoint = (() => {
+      try {
+        return localStorage.getItem(LS_UNIFIED_ENDPOINT)
+      } catch {
+        return null
+      }
+    })()
+    try {
+      if (endpoint) await webPush.apagarEndpoint(endpoint)
+    } catch {
+      /* logout continua */
+    }
+    try {
+      localStorage.removeItem(LS_UNIFIED_ENDPOINT)
+    } catch {
+      /* ignore */
+    }
+    try {
+      await DeskRudderUnifiedPush.unregisterPush()
+    } catch {
+      /* logout continua */
+    }
+    return
+  }
+  if (!('serviceWorker' in navigator) || !('PushManager' in window)) return
   try {
     const registration = await navigator.serviceWorker.getRegistration()
     if (!registration) return

--- a/frontend/src/pages/NotificacoesPreferencias.tsx
+++ b/frontend/src/pages/NotificacoesPreferencias.tsx
@@ -116,12 +116,12 @@ export function NotificacoesPreferencias() {
                   if (v && r !== 'ok') {
                     const msg =
                       r === 'negado'
-                        ? 'Permita notificações neste browser para activar os alertas.'
+                        ? 'Permita notificações neste dispositivo para activar os alertas.'
                         : r === 'sem_vapid'
                           ? 'Alertas no telemóvel ainda não estão configurados nesta instância.'
                           : r === 'ios_pwa'
                             ? 'No iPhone, adiciona o DeskRudder ao ecrã inicial e activa os alertas a partir desse atalho.'
-                            : 'Este browser não suporta alertas com a app fechada.'
+                            : 'Este dispositivo não suporta alertas com a app fechada.'
                     toast.showError(msg)
                     return
                   }
@@ -132,7 +132,7 @@ export function NotificacoesPreferencias() {
               })()
             }}
             label="Alertas no telemóvel"
-            description="Fila e mensagens nos teus chats e tickets, mesmo com a app fechada. No iPhone só no atalho da tela inicial."
+            description="Fila e mensagens nos teus chats e tickets, mesmo com a app fechada. No app Android usa o mesmo canal da instância; no iPhone, o atalho da tela inicial (Safari 16.4+)."
             showStatusPill
             statusOnText="Ativo"
             statusOffText="Inativo"

--- a/frontend/src/plugins/unifiedPush.ts
+++ b/frontend/src/plugins/unifiedPush.ts
@@ -1,0 +1,59 @@
+import { WebPlugin, registerPlugin, type PluginListenerHandle } from '@capacitor/core'
+
+export type UnifiedPushEndpoint = {
+  endpoint: string
+  p256dh: string
+  auth: string
+}
+
+export type UnifiedPushOpen = {
+  tipo?: string
+  id?: number
+  url_path?: string
+  titulo?: string
+  corpo?: string
+}
+
+export type UnifiedPushRegistrationError = {
+  reason: string
+}
+
+interface DeskRudderUnifiedPushPlugin {
+  registerPush(options: { vapidPublicKey: string }): Promise<UnifiedPushEndpoint>
+  unregisterPush(): Promise<void>
+  consumePendingOpen(): Promise<UnifiedPushOpen>
+  addListener(
+    eventName: 'endpoint',
+    listenerFunc: (data: UnifiedPushEndpoint) => void,
+  ): Promise<PluginListenerHandle>
+  addListener(
+    eventName: 'open',
+    listenerFunc: (data: UnifiedPushOpen) => void,
+  ): Promise<PluginListenerHandle>
+  addListener(
+    eventName: 'registrationError',
+    listenerFunc: (data: UnifiedPushRegistrationError) => void,
+  ): Promise<PluginListenerHandle>
+  addListener(eventName: 'unregistered', listenerFunc: () => void): Promise<PluginListenerHandle>
+}
+
+class DeskRudderUnifiedPushWeb extends WebPlugin {
+  async registerPush(): Promise<UnifiedPushEndpoint> {
+    throw this.unavailable('UnifiedPush só está disponível no app Android.')
+  }
+
+  async unregisterPush(): Promise<void> {
+    /* no-op no browser */
+  }
+
+  async consumePendingOpen(): Promise<UnifiedPushOpen> {
+    return {}
+  }
+}
+
+export const DeskRudderUnifiedPush = registerPlugin<DeskRudderUnifiedPushPlugin>(
+  'DeskRudderUnifiedPush',
+  {
+    web: () => new DeskRudderUnifiedPushWeb(),
+  },
+)


### PR DESCRIPTION
## Summary

- Push nativo no APK Android (#737) **sem Firebase**: UnifiedPush + VAPID da instância.
- O endpoint Web Push regista-se em `POST /v1/web-push/subscriptions` (mesmo canal/worker da PWA).
- Banner e preferências de Notificações no app nativo; clique na notificação abre a mesa certa.
- Docs (`MOBILE_CAPACITOR`, `OPERATIONS`, brief) alinhados ao canal VAPID/UnifiedPush.

Closes #737

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest` backend (suite completa) — verde
- [x] `npm run build` frontend — verde
- [ ] APK: login com Conta → activar alertas → fechar app → mensagem na fila → notificação → toque abre a mesa
- [ ] Silenciar fila na mesa → não chega alerta de fila
- [ ] Logout revoga o endpoint do aparelho

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Fora de escopo deste lote: iOS/APNs (#738), listing Play/App Store (#739)
- [x] Sem stubs nullable novos
