### PR TITLE
feat(comercial): catálogo de chaves e preview do modelo de contrato (#775)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Contratos (#775): nos modelos de contrato, catálogo de chaves copiáveis (`{{contratada.*}}`, `{{contratante.*}}`, `{{contrato.*}}`) para o sistema preencher o HTML do cliente; multa e fidelidade passam a ser só dados (a cláusula fica no texto do modelo); preview com dados de exemplo
 - Mobile chat (#747–#759): lista a 100% da largura; teclado sem vão/corte no campo; composer estilo WhatsApp; reagir pelo menu da seta; demanda e modais em folha inferior; header da app oculto na conversa; Encerrar/empresa/setor no telemóvel; empty states úteis; ícones PWA legíveis (fundo claro + contorno branco no desktop)
 - Contratos comerciais (#324 / #349–#357): gerar PDF por CNPJ (fidelidade, setup, cláusulas, dados fiscais e nome da base WebPosto); reajuste padrão da instância ou override no contrato; anexar PDF assinado (ClickSign ou outro) com referência opcional; ao marcar assinado, cria ou vincula Rede e Empresa pelo CNPJ (sem PDVs), copia e-mail/telefone e cria contacto na rede para o chat; rascunho → enviado → assinado; lista com filtro por responsável; painel interno com custo, lucro e margem %; modelos em Cadastros. Na negociação, os dados fiscais ficam no gerar contrato; depois de assinado, a linha e o nome da Rede não se editam
 - Proposta comercial (#323 / #345–#348): modelos HTML versionados, geração a partir da negociação (CNPJs à escolha), preview, PDF e marcar como enviada (com opção de avançar o funil) — sem custo/margem no documento do cliente

--- a/backend/app/api/comercial_contrato.py
+++ b/backend/app/api/comercial_contrato.py
@@ -11,6 +11,7 @@ from app.core.auth import exigir_admin, exigir_comercial_ou_admin
 from app.database import get_db
 from app.models.atendente import Atendente
 from app.schemas.comercial_contrato import (
+    ContratoChaveCatalogoItem,
     ContratoGerarIn,
     ContratoMarcarAssinadoIn,
     ContratoMarcarEnviadoIn,
@@ -26,6 +27,14 @@ from app.schemas.comercial_contrato import (
 from app.services import comercial_contrato as svc
 
 router = APIRouter(prefix="/comercial", tags=["comercial-contratos"])
+
+
+@router.get("/contrato-templates/chaves", response_model=list[ContratoChaveCatalogoItem])
+def listar_chaves_template(
+    _: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    """Catálogo de placeholders {{chave}} para o modelo HTML do contrato."""
+    return svc.catalogo_chaves_contrato()
 
 
 @router.get("/contrato-templates", response_model=list[ContratoTemplateRead])
@@ -58,9 +67,10 @@ def criar_template(
 @router.post("/contrato-templates/preview", response_model=ContratoTemplatePreviewOut)
 def preview_template(
     data: ContratoTemplatePreviewIn,
+    db: Session = Depends(get_db),
     _: Atendente = Depends(exigir_admin),
 ):
-    return ContratoTemplatePreviewOut(html=svc.sanitize_html(data.conteudo_html))
+    return ContratoTemplatePreviewOut(html=svc.preencher_template_preview(db, data.conteudo_html))
 
 
 @router.patch("/contrato-templates/{template_id}", response_model=ContratoTemplateRead)

--- a/backend/app/schemas/comercial_contrato.py
+++ b/backend/app/schemas/comercial_contrato.py
@@ -42,6 +42,12 @@ class ContratoTemplatePreviewOut(BaseModel):
     html: str
 
 
+class ContratoChaveCatalogoItem(BaseModel):
+    grupo: str
+    chave: str
+    descricao: str
+
+
 class ContratoGerarIn(BaseModel):
     linha_id: int
     template_id: int | None = None

--- a/backend/app/services/comercial_contrato.py
+++ b/backend/app/services/comercial_contrato.py
@@ -58,29 +58,89 @@ TEMPLATE_PADRAO_HTML = """<!DOCTYPE html>
   </style>
 </head>
 <body>
-  <div class="logo">{{logo}}</div>
-  <p class="muted">{{empresa_sistema}}</p>
+  <div class="logo">{{contratada.logo}}</div>
   <h1>Contrato de prestação de serviços</h1>
-  <p><strong>Contratante:</strong> {{razao_social}} &nbsp; <strong>CNPJ:</strong> {{cnpj}}</p>
-  <p>{{endereco_contratante}}</p>
-  <p>{{resp_legal}}</p>
-  <p class="muted">Base WebPosto: {{nome_base_webposto}}</p>
+  <h2>Contratada</h2>
+  <p><strong>{{contratada.razao_social}}</strong> &nbsp; CNPJ {{contratada.cnpj}}</p>
+  <p>{{contratada.endereco}}</p>
+  <h2>Contratante</h2>
+  <p><strong>{{contratante.razao_social}}</strong> &nbsp; CNPJ {{contratante.cnpj}}</p>
+  <p>{{contratante.endereco}}</p>
+  <p>Responsável legal: {{contratante.resp_legal}}</p>
+  <p class="muted">Base WebPosto: {{contratante.nome_base_webposto}}</p>
   <h2>Objeto e valores</h2>
-  {{itens}}
-  <p><strong>Mensalidade:</strong> {{valor_mensalidade}}</p>
-  {{setup_bloco}}
+  {{contrato.itens}}
+  <p><strong>Mensalidade:</strong> {{contrato.valor_mensalidade}}</p>
+  {{contrato.setup_bloco}}
   <h2>Vigência e fidelidade</h2>
-  <p>Início: {{data_inicio}} &nbsp; Fim da fidelidade: {{data_fim_fidelidade}} ({{fidelidade_meses}} meses).</p>
-  <div>{{fidelidade}}</div>
-  <div>{{multa}}</div>
-  <div>{{reajuste}}</div>
+  <p>Início: {{contrato.data_inicio}} &nbsp; Fim da fidelidade: {{contrato.data_fim_fidelidade}}
+    ({{contrato.fidelidade_meses}} meses).</p>
+  <p>Em caso de rescisão antecipada, multa de até {{contrato.multa_max_mensalidades}} mensalidade(s)
+    — ajuste este texto conforme o parecer do seu advogado.</p>
+  <p>Após a fidelidade, renovação automática: {{contrato.reajuste}}.</p>
   <h2>Implantação</h2>
-  {{clausula_deslocamento}}
-  {{clausula_alimentacao}}
-  {{clausula_hospedagem}}
+  {{contrato.clausula_deslocamento}}
+  {{contrato.clausula_alimentacao}}
+  {{contrato.clausula_hospedagem}}
 </body>
 </html>
 """
+
+# Catálogo documentado na UI / GET .../contrato-templates/chaves (fonte única).
+CATALOGO_CHAVES_CONTRATO: tuple[dict[str, str], ...] = (
+    {"grupo": "contratada", "chave": "contratada.logo", "descricao": "Logo da empresa nas configurações do DeskRudder"},
+    {"grupo": "contratada", "chave": "contratada.razao_social", "descricao": "Razão social da contratada (empresa do sistema)"},
+    {"grupo": "contratada", "chave": "contratada.nome_fantasia", "descricao": "Nome fantasia da contratada"},
+    {"grupo": "contratada", "chave": "contratada.cnpj", "descricao": "CNPJ da contratada"},
+    {"grupo": "contratada", "chave": "contratada.email", "descricao": "E-mail da contratada"},
+    {"grupo": "contratada", "chave": "contratada.telefone", "descricao": "Telefone da contratada"},
+    {"grupo": "contratada", "chave": "contratada.endereco", "descricao": "Endereço completo formatado da contratada"},
+    {"grupo": "contratada", "chave": "contratada.bloco", "descricao": "Bloco resumo (nome, CNPJ e endereço) da contratada"},
+    {"grupo": "contratante", "chave": "contratante.razao_social", "descricao": "Razão social da linha CNPJ / lead"},
+    {"grupo": "contratante", "chave": "contratante.cnpj", "descricao": "CNPJ do contratante"},
+    {"grupo": "contratante", "chave": "contratante.endereco", "descricao": "Endereço fiscal do contratante"},
+    {"grupo": "contratante", "chave": "contratante.email", "descricao": "E-mail (dados fiscais ou lead)"},
+    {"grupo": "contratante", "chave": "contratante.telefone", "descricao": "Telefone (dados fiscais ou lead)"},
+    {"grupo": "contratante", "chave": "contratante.resp_legal_nome", "descricao": "Nome do responsável legal"},
+    {"grupo": "contratante", "chave": "contratante.resp_legal_cpf", "descricao": "CPF do responsável legal"},
+    {"grupo": "contratante", "chave": "contratante.resp_legal", "descricao": "Responsável legal (nome · CPF)"},
+    {"grupo": "contratante", "chave": "contratante.nome_base_webposto", "descricao": "Nome da base WebPosto (Rede)"},
+    {"grupo": "contrato", "chave": "contrato.itens", "descricao": "Tabela HTML com itens e mensalidade"},
+    {"grupo": "contrato", "chave": "contrato.valor_mensalidade", "descricao": "Mensalidade formatada (R$)"},
+    {"grupo": "contrato", "chave": "contrato.data_inicio", "descricao": "Data de início (dd/mm/aaaa)"},
+    {"grupo": "contrato", "chave": "contrato.data_fim_fidelidade", "descricao": "Fim do período de fidelidade"},
+    {"grupo": "contrato", "chave": "contrato.fidelidade_meses", "descricao": "Meses de fidelidade (número)"},
+    {"grupo": "contrato", "chave": "contrato.multa_max_mensalidades", "descricao": "Teto de multa em mensalidades (número; use no texto do seu modelo)"},
+    {"grupo": "contrato", "chave": "contrato.reajuste_percentual", "descricao": "Percentual de reajuste (ex.: 5,50)"},
+    {"grupo": "contrato", "chave": "contrato.reajuste_rotulo", "descricao": "Rótulo do reajuste (ex.: IGPM)"},
+    {"grupo": "contrato", "chave": "contrato.reajuste", "descricao": "Resumo curto: «8,50% (IGPM)» ou «sem reajuste»"},
+    {"grupo": "contrato", "chave": "contrato.setup_valor", "descricao": "Valor do setup (ou — se isento/ausente)"},
+    {"grupo": "contrato", "chave": "contrato.setup_isento", "descricao": "«sim» ou «não»"},
+    {"grupo": "contrato", "chave": "contrato.setup_bloco", "descricao": "Parágrafo HTML pronto sobre setup/implantação"},
+    {"grupo": "contrato", "chave": "contrato.clausula_deslocamento", "descricao": "Linha HTML se deslocamento for do contratante"},
+    {"grupo": "contrato", "chave": "contrato.clausula_alimentacao", "descricao": "Linha HTML se alimentação for do contratante"},
+    {"grupo": "contrato", "chave": "contrato.clausula_hospedagem", "descricao": "Linha HTML se hospedagem for do contratante"},
+    {"grupo": "legado", "chave": "logo", "descricao": "Alias de contratada.logo"},
+    {"grupo": "legado", "chave": "empresa_sistema", "descricao": "Alias de contratada.bloco"},
+    {"grupo": "legado", "chave": "razao_social", "descricao": "Alias de contratante.razao_social"},
+    {"grupo": "legado", "chave": "cnpj", "descricao": "Alias de contratante.cnpj"},
+    {"grupo": "legado", "chave": "endereco_contratante", "descricao": "Alias de contratante.endereco"},
+    {"grupo": "legado", "chave": "resp_legal", "descricao": "Alias de contratante.resp_legal"},
+    {"grupo": "legado", "chave": "nome_base_webposto", "descricao": "Alias de contratante.nome_base_webposto"},
+    {"grupo": "legado", "chave": "itens", "descricao": "Alias de contrato.itens"},
+    {"grupo": "legado", "chave": "valor_mensalidade", "descricao": "Alias de contrato.valor_mensalidade"},
+    {"grupo": "legado", "chave": "data_inicio", "descricao": "Alias de contrato.data_inicio"},
+    {"grupo": "legado", "chave": "data_fim_fidelidade", "descricao": "Alias de contrato.data_fim_fidelidade"},
+    {"grupo": "legado", "chave": "fidelidade_meses", "descricao": "Alias de contrato.fidelidade_meses"},
+    {"grupo": "legado", "chave": "fidelidade", "descricao": "Alias numérico (meses); não gera cláusula jurídica"},
+    {"grupo": "legado", "chave": "multa", "descricao": "Alias de contrato.multa_max_mensalidades (só o número)"},
+    {"grupo": "legado", "chave": "igpm", "descricao": "Alias de contrato.reajuste"},
+    {"grupo": "legado", "chave": "reajuste", "descricao": "Alias de contrato.reajuste"},
+    {"grupo": "legado", "chave": "setup_bloco", "descricao": "Alias de contrato.setup_bloco"},
+    {"grupo": "legado", "chave": "clausula_deslocamento", "descricao": "Alias de contrato.clausula_deslocamento"},
+    {"grupo": "legado", "chave": "clausula_alimentacao", "descricao": "Alias de contrato.clausula_alimentacao"},
+    {"grupo": "legado", "chave": "clausula_hospedagem", "descricao": "Alias de contrato.clausula_hospedagem"},
+)
 
 
 CAMPOS_FISCAIS_OBRIGATORIOS = (
@@ -300,7 +360,9 @@ def atualizar_template(db: Session, row: ContratoTemplate, data: ContratoTemplat
 def obter_linha(db: Session, linha_id: int) -> CrmNegociacaoCnpjLinha:
     row = (
         db.query(CrmNegociacaoCnpjLinha)
-        .options(joinedload(CrmNegociacaoCnpjLinha.negociacao))
+        .options(
+            joinedload(CrmNegociacaoCnpjLinha.negociacao).joinedload(CrmNegociacao.lead),
+        )
         .filter(CrmNegociacaoCnpjLinha.id == linha_id)
         .first()
     )
@@ -412,17 +474,12 @@ def _setup_bloco(*, setup_isento: bool, setup_valor: Decimal | None) -> str:
     return _p("Setup de implantação: conforme negociação (fora da mensalidade).")
 
 
-def _clausula_reajuste(pct: Decimal, rotulo: str) -> str:
+def _reajuste_curto(pct: Decimal, rotulo: str) -> str:
+    """Valor curto para o modelo — a cláusula jurídica fica no HTML do cliente."""
     if pct <= 0:
-        return _p(
-            "Após o período de fidelidade, a renovação é automática, sem nova fidelidade e "
-            "sem reajuste de mensalidade neste contrato."
-        )
-    rot = html.escape(rotulo or "índice informado neste contrato")
-    return _p(
-        f"Após o período de fidelidade, a renovação é automática, sem nova fidelidade, "
-        f"com reajuste de {_fmt_pct(pct)}% ({rot})."
-    )
+        return "sem reajuste"
+    rot = (rotulo or "").strip() or "índice do contrato"
+    return f"{_fmt_pct(pct)}% ({html.escape(rot)})"
 
 
 def _clausula_custo_cliente(ativo: bool, titulo: str) -> str:
@@ -431,7 +488,19 @@ def _clausula_custo_cliente(ativo: bool, titulo: str) -> str:
     return _p(html.escape(f"{titulo} por conta do contratante."))
 
 
-def preencher_template(db: Session, template_html: str, contrato: Contrato, linha: CrmNegociacaoCnpjLinha) -> str:
+def _empresa_sistema_row(db: Session) -> EmpresaSistema | None:
+    return db.query(EmpresaSistema).order_by(EmpresaSistema.id.asc()).first()
+
+
+def _esc(valor: str | None, *, default: str = "—") -> str:
+    s = (valor or "").strip()
+    return html.escape(s) if s else default
+
+
+def montar_valores_template(
+    db: Session, contrato: Contrato, linha: CrmNegociacaoCnpjLinha
+) -> dict[str, str]:
+    """Mapa chave → valor para substituição {{chave}} (prefixos + aliases legados)."""
     nomes = proposta_svc._nomes_itens_cliente(db, linha)
     itens_txt = html.escape(", ".join(nomes) if nomes else "—")
     tabela = (
@@ -448,58 +517,246 @@ def preencher_template(db: Session, template_html: str, contrato: Contrato, linh
     fiscal = _fiscal_dict(linha)
     neg = linha.negociacao
     nome_base = (neg.nome_base_webposto if neg else "") or ""
-    reaj = _clausula_reajuste(
-        Decimal(str(contrato.reajuste_percentual or 0)),
-        contrato.reajuste_rotulo or "",
-    )
-    resp = fiscal.get("resp_legal_nome") or ""
-    cpf = fiscal.get("resp_legal_cpf") or ""
+    pct = Decimal(str(contrato.reajuste_percentual or 0))
+    reaj = _reajuste_curto(pct, contrato.reajuste_rotulo or "")
+    resp_nome = fiscal.get("resp_legal_nome") or ""
+    resp_cpf = fiscal.get("resp_legal_cpf") or ""
     resp_txt = "—"
-    if resp:
-        resp_txt = html.escape(resp)
-        if cpf:
-            resp_txt += html.escape(f" · CPF {cpf}")
-    valores = {
-        "logo": proposta_svc._logo_html(db),
-        "empresa_sistema": _bloco_empresa_sistema(db) or proposta_svc._empresa_sistema_texto(db),
-        "razao_social": html.escape(linha.razao_social or "—"),
-        "cnpj": html.escape(proposta_svc._formatar_cnpj(linha.cnpj)),
-        "endereco_contratante": _endereco_formatado(fiscal),
-        "resp_legal": resp_txt,
-        "nome_base_webposto": html.escape(nome_base.strip() or "—"),
-        "itens": tabela,
-        "valor_mensalidade": html.escape(proposta_svc._money_br(contrato.valor_mensalidade)),
-        "data_inicio": html.escape(contrato.data_inicio.strftime("%d/%m/%Y")),
-        "data_fim_fidelidade": html.escape(contrato.data_fim_fidelidade.strftime("%d/%m/%Y")),
-        "fidelidade_meses": html.escape(str(fid)),
-        "setup_bloco": _setup_bloco(setup_isento=bool(contrato.setup_isento), setup_valor=contrato.setup_valor),
-        "fidelidade": _p(
-            html.escape(
-                f"O contratante permanece vinculado por {fid} meses de fidelidade, "
-                "contados da data de início."
-            )
-        ),
-        "multa": _p(
-            html.escape(
-                f"Em caso de rescisão antecipada, a multa é de até {multa_n} mensalidade(s), "
-                "a validar juridicamente."
-            )
-        ),
-        "igpm": reaj,
-        "reajuste": reaj,
-        "clausula_deslocamento": _clausula_custo_cliente(bool(contrato.deslocamento_cliente), "Deslocamento"),
-        "clausula_alimentacao": _clausula_custo_cliente(bool(contrato.alimentacao_cliente), "Alimentação"),
-        "clausula_hospedagem": _clausula_custo_cliente(bool(contrato.hospedagem_cliente), "Hospedagem"),
+    if resp_nome:
+        resp_txt = html.escape(resp_nome)
+        if resp_cpf:
+            resp_txt += html.escape(f" · CPF {resp_cpf}")
+
+    emp = _empresa_sistema_row(db)
+    emp_fiscal = {
+        "endereco": (emp.endereco if emp else "") or "",
+        "numero": (emp.numero if emp else "") or "",
+        "complemento": (emp.complemento if emp else "") or "",
+        "bairro": (emp.bairro if emp else "") or "",
+        "cidade": (emp.cidade if emp else "") or "",
+        "estado": (emp.estado if emp else "") or "",
+        "cep": (emp.cep if emp else "") or "",
     }
+    logo = proposta_svc._logo_html(db)
+    bloco_emp = _bloco_empresa_sistema(db) or proposta_svc._empresa_sistema_texto(db)
+    endereco_contratante = _endereco_formatado(fiscal)
+    endereco_contratada = _endereco_formatado(emp_fiscal)
+    setup_bloco = _setup_bloco(setup_isento=bool(contrato.setup_isento), setup_valor=contrato.setup_valor)
+    setup_valor_txt = (
+        "—"
+        if contrato.setup_isento or contrato.setup_valor is None
+        else html.escape(proposta_svc._money_br(contrato.setup_valor))
+    )
+    email_ctr = fiscal.get("email") or (neg.lead.email if neg and neg.lead else "") or ""
+    tel_ctr = fiscal.get("telefone") or (neg.lead.telefone if neg and neg.lead else "") or ""
+
+    contratada = {
+        "contratada.logo": logo,
+        "contratada.razao_social": _esc(emp.razao_social if emp else None),
+        "contratada.nome_fantasia": _esc((emp.nome_fantasia or emp.nome) if emp else None),
+        "contratada.cnpj": (
+            html.escape(proposta_svc._formatar_cnpj(emp.cnpj)) if emp and emp.cnpj else "—"
+        ),
+        "contratada.email": _esc(emp.email if emp else None),
+        "contratada.telefone": _esc(emp.telefone if emp else None),
+        "contratada.endereco": endereco_contratada,
+        "contratada.bloco": bloco_emp or "—",
+    }
+    contratante = {
+        "contratante.razao_social": html.escape(linha.razao_social or "—"),
+        "contratante.cnpj": html.escape(proposta_svc._formatar_cnpj(linha.cnpj)),
+        "contratante.endereco": endereco_contratante,
+        "contratante.email": _esc(email_ctr),
+        "contratante.telefone": _esc(tel_ctr),
+        "contratante.resp_legal_nome": _esc(resp_nome),
+        "contratante.resp_legal_cpf": _esc(resp_cpf),
+        "contratante.resp_legal": resp_txt,
+        "contratante.nome_base_webposto": html.escape(nome_base.strip() or "—"),
+    }
+    contrato_vals = {
+        "contrato.itens": tabela,
+        "contrato.valor_mensalidade": html.escape(proposta_svc._money_br(contrato.valor_mensalidade)),
+        "contrato.data_inicio": html.escape(contrato.data_inicio.strftime("%d/%m/%Y")),
+        "contrato.data_fim_fidelidade": html.escape(contrato.data_fim_fidelidade.strftime("%d/%m/%Y")),
+        "contrato.fidelidade_meses": html.escape(str(fid)),
+        "contrato.multa_max_mensalidades": html.escape(str(multa_n)),
+        "contrato.reajuste_percentual": html.escape(_fmt_pct(pct)),
+        "contrato.reajuste_rotulo": html.escape((contrato.reajuste_rotulo or "").strip() or "—"),
+        "contrato.reajuste": reaj,
+        "contrato.setup_valor": setup_valor_txt,
+        "contrato.setup_isento": "sim" if contrato.setup_isento else "não",
+        "contrato.setup_bloco": setup_bloco,
+        "contrato.clausula_deslocamento": _clausula_custo_cliente(
+            bool(contrato.deslocamento_cliente), "Deslocamento"
+        ),
+        "contrato.clausula_alimentacao": _clausula_custo_cliente(
+            bool(contrato.alimentacao_cliente), "Alimentação"
+        ),
+        "contrato.clausula_hospedagem": _clausula_custo_cliente(
+            bool(contrato.hospedagem_cliente), "Hospedagem"
+        ),
+    }
+    legado = {
+        "logo": contratada["contratada.logo"],
+        "empresa_sistema": contratada["contratada.bloco"],
+        "razao_social": contratante["contratante.razao_social"],
+        "cnpj": contratante["contratante.cnpj"],
+        "endereco_contratante": contratante["contratante.endereco"],
+        "resp_legal": contratante["contratante.resp_legal"],
+        "nome_base_webposto": contratante["contratante.nome_base_webposto"],
+        "itens": contrato_vals["contrato.itens"],
+        "valor_mensalidade": contrato_vals["contrato.valor_mensalidade"],
+        "data_inicio": contrato_vals["contrato.data_inicio"],
+        "data_fim_fidelidade": contrato_vals["contrato.data_fim_fidelidade"],
+        "fidelidade_meses": contrato_vals["contrato.fidelidade_meses"],
+        "fidelidade": contrato_vals["contrato.fidelidade_meses"],
+        "multa": contrato_vals["contrato.multa_max_mensalidades"],
+        "igpm": contrato_vals["contrato.reajuste"],
+        "reajuste": contrato_vals["contrato.reajuste"],
+        "setup_bloco": contrato_vals["contrato.setup_bloco"],
+        "clausula_deslocamento": contrato_vals["contrato.clausula_deslocamento"],
+        "clausula_alimentacao": contrato_vals["contrato.clausula_alimentacao"],
+        "clausula_hospedagem": contrato_vals["contrato.clausula_hospedagem"],
+    }
+    return {**contratada, **contratante, **contrato_vals, **legado}
+
+
+def catalogo_chaves_contrato() -> list[dict[str, str]]:
+    return [dict(item) for item in CATALOGO_CHAVES_CONTRATO]
+
+
+def _aplicar_valores_no_html(template_html: str, valores: dict[str, str]) -> str:
     html_out = sanitize_html(template_html)
-    for chave, valor in valores.items():
-        html_out = html_out.replace("{{" + chave + "}}", valor)
+    for chave in sorted(valores.keys(), key=lambda k: (-k.count("."), -len(k), k)):
+        html_out = html_out.replace("{{" + chave + "}}", valores[chave])
     if proposta_svc._VAZAMENTO.search(html_out):
         raise HTTPException(
             status_code=500,
             detail="O contrato gerado continha dados internos e foi bloqueado. Contacte o suporte.",
         )
     return html_out
+
+
+def montar_valores_preview_exemplo(db: Session) -> dict[str, str]:
+    """Mesmas chaves da geração, com dados fictícios (contratada real da instância quando existir)."""
+    emp = _empresa_sistema_row(db)
+    emp_fiscal = {
+        "endereco": (emp.endereco if emp else "") or "Av. Exemplo",
+        "numero": (emp.numero if emp else "") or "100",
+        "complemento": (emp.complemento if emp else "") or "",
+        "bairro": (emp.bairro if emp else "") or "Centro",
+        "cidade": (emp.cidade if emp else "") or "São Paulo",
+        "estado": (emp.estado if emp else "") or "SP",
+        "cep": (emp.cep if emp else "") or "01000-000",
+    }
+    logo = proposta_svc._logo_html(db)
+    bloco_emp = _bloco_empresa_sistema(db) or proposta_svc._empresa_sistema_texto(db)
+    if not bloco_emp:
+        bloco_emp = html.escape("Empresa Exemplo LTDA · CNPJ 00.000.000/0001-91")
+
+    razao_ctr = "Posto Exemplo LTDA"
+    cnpj_ctr = "12.345.678/0001-95"
+    itens_txt = "Licença mensal, Suporte"
+    tabela = (
+        "<table><thead><tr><th>Razão social</th><th>CNPJ</th><th>Itens</th><th>Mensalidade</th></tr></thead>"
+        "<tbody><tr>"
+        f"<td>{html.escape(razao_ctr)}</td>"
+        f"<td>{html.escape(cnpj_ctr)}</td>"
+        f"<td>{html.escape(itens_txt)}</td>"
+        f"<td>{html.escape('R$ 1.200,00')}</td>"
+        "</tr></tbody></table>"
+    )
+    setup_bloco = _setup_bloco(setup_isento=False, setup_valor=Decimal("1500.00"))
+    reaj = _reajuste_curto(Decimal("5.5"), "IGPM")
+    endereco_contratante = _endereco_formatado(
+        {
+            "endereco": "Rua do Cliente",
+            "numero": "50",
+            "complemento": "Sala 2",
+            "bairro": "Industrial",
+            "cidade": "Campinas",
+            "estado": "SP",
+            "cep": "13000-000",
+        }
+    )
+    resp_txt = html.escape("Maria Silva · CPF 123.456.789-00")
+
+    contratada = {
+        "contratada.logo": logo,
+        "contratada.razao_social": _esc(emp.razao_social if emp else None, default=html.escape("Empresa Exemplo LTDA")),
+        "contratada.nome_fantasia": _esc(
+            (emp.nome_fantasia or emp.nome) if emp else None,
+            default=html.escape("Empresa Exemplo"),
+        ),
+        "contratada.cnpj": (
+            html.escape(proposta_svc._formatar_cnpj(emp.cnpj))
+            if emp and emp.cnpj
+            else html.escape("00.000.000/0001-91")
+        ),
+        "contratada.email": _esc(emp.email if emp else None, default=html.escape("contato@exemplo.com")),
+        "contratada.telefone": _esc(emp.telefone if emp else None, default=html.escape("(11) 3000-0000")),
+        "contratada.endereco": _endereco_formatado(emp_fiscal),
+        "contratada.bloco": bloco_emp or "—",
+    }
+    contratante = {
+        "contratante.razao_social": html.escape(razao_ctr),
+        "contratante.cnpj": html.escape(cnpj_ctr),
+        "contratante.endereco": endereco_contratante,
+        "contratante.email": html.escape("cliente@exemplo.com"),
+        "contratante.telefone": html.escape("(19) 98888-0000"),
+        "contratante.resp_legal_nome": html.escape("Maria Silva"),
+        "contratante.resp_legal_cpf": html.escape("123.456.789-00"),
+        "contratante.resp_legal": resp_txt,
+        "contratante.nome_base_webposto": html.escape("base_exemplo"),
+    }
+    contrato_vals = {
+        "contrato.itens": tabela,
+        "contrato.valor_mensalidade": html.escape("R$ 1.200,00"),
+        "contrato.data_inicio": html.escape("01/01/2026"),
+        "contrato.data_fim_fidelidade": html.escape("01/01/2027"),
+        "contrato.fidelidade_meses": html.escape("12"),
+        "contrato.multa_max_mensalidades": html.escape("3"),
+        "contrato.reajuste_percentual": html.escape("5,50"),
+        "contrato.reajuste_rotulo": html.escape("IGPM"),
+        "contrato.reajuste": reaj,
+        "contrato.setup_valor": html.escape("R$ 1.500,00"),
+        "contrato.setup_isento": "não",
+        "contrato.setup_bloco": setup_bloco,
+        "contrato.clausula_deslocamento": _clausula_custo_cliente(True, "Deslocamento"),
+        "contrato.clausula_alimentacao": _clausula_custo_cliente(True, "Alimentação"),
+        "contrato.clausula_hospedagem": _clausula_custo_cliente(True, "Hospedagem"),
+    }
+    legado = {
+        "logo": contratada["contratada.logo"],
+        "empresa_sistema": contratada["contratada.bloco"],
+        "razao_social": contratante["contratante.razao_social"],
+        "cnpj": contratante["contratante.cnpj"],
+        "endereco_contratante": contratante["contratante.endereco"],
+        "resp_legal": contratante["contratante.resp_legal"],
+        "nome_base_webposto": contratante["contratante.nome_base_webposto"],
+        "itens": contrato_vals["contrato.itens"],
+        "valor_mensalidade": contrato_vals["contrato.valor_mensalidade"],
+        "data_inicio": contrato_vals["contrato.data_inicio"],
+        "data_fim_fidelidade": contrato_vals["contrato.data_fim_fidelidade"],
+        "fidelidade_meses": contrato_vals["contrato.fidelidade_meses"],
+        "fidelidade": contrato_vals["contrato.fidelidade_meses"],
+        "multa": contrato_vals["contrato.multa_max_mensalidades"],
+        "igpm": contrato_vals["contrato.reajuste"],
+        "reajuste": contrato_vals["contrato.reajuste"],
+        "setup_bloco": contrato_vals["contrato.setup_bloco"],
+        "clausula_deslocamento": contrato_vals["contrato.clausula_deslocamento"],
+        "clausula_alimentacao": contrato_vals["contrato.clausula_alimentacao"],
+        "clausula_hospedagem": contrato_vals["contrato.clausula_hospedagem"],
+    }
+    return {**contratada, **contratante, **contrato_vals, **legado}
+
+
+def preencher_template_preview(db: Session, template_html: str) -> str:
+    return _aplicar_valores_no_html(template_html, montar_valores_preview_exemplo(db))
+
+
+def preencher_template(db: Session, template_html: str, contrato: Contrato, linha: CrmNegociacaoCnpjLinha) -> str:
+    return _aplicar_valores_no_html(template_html, montar_valores_template(db, contrato, linha))
 
 
 def _montar_snapshots(

--- a/backend/tests/test_comercial_contrato.py
+++ b/backend/tests/test_comercial_contrato.py
@@ -132,12 +132,14 @@ def test_admin_crud_contrato_template_e_preview(client, auth_headers):
     prev = client.post(
         "/v1/comercial/contrato-templates/preview",
         headers=h,
-        json={"conteudo_html": '<p onclick="x()">Oi</p><iframe src="x"></iframe>'},
+        json={"conteudo_html": '<p onclick="x()">Oi {{contratante.cnpj}}</p><iframe src="x"></iframe>'},
     )
     assert prev.status_code == 200
     html = prev.json()["html"]
     assert "onclick" not in html.lower()
     assert "iframe" not in html.lower()
+    assert "{{" not in html
+    assert "12.345.678/0001-95" in html
 
     patched = client.patch(
         f"/v1/comercial/contrato-templates/{body['id']}",
@@ -155,6 +157,90 @@ def test_admin_crud_contrato_template_e_preview(client, auth_headers):
     )
     assert mesmo_html.status_code == 200
     assert mesmo_html.json()["versao"] == 2
+
+
+def test_catalogo_chaves_contrato(client, auth_headers):
+    h = auth_headers["admin"]
+    r = client.get("/v1/comercial/contrato-templates/chaves", headers=h)
+    assert r.status_code == 200, r.text
+    chaves = {item["chave"] for item in r.json()}
+    assert "contratada.cnpj" in chaves
+    assert "contratante.razao_social" in chaves
+    assert "contrato.multa_max_mensalidades" in chaves
+    assert "cnpj" in chaves  # alias legado
+    assert client.get("/v1/comercial/contrato-templates/chaves", headers=auth_headers["a1"]).status_code == 403
+
+
+def test_preview_preenche_chaves_exemplo(client, auth_headers):
+    h = auth_headers["admin"]
+    r = client.post(
+        "/v1/comercial/contrato-templates/preview",
+        headers=h,
+        json={
+            "conteudo_html": (
+                "<p>{{contratada.razao_social}}</p>"
+                "<p>{{contratante.razao_social}}</p>"
+                "<p>{{contrato.valor_mensalidade}}</p>"
+                "<p>{{contrato.reajuste}}</p>"
+                "<p>{{cnpj}}</p>"
+            ),
+        },
+    )
+    assert r.status_code == 200, r.text
+    html = r.json()["html"]
+    assert "{{" not in html
+    assert "Posto Exemplo LTDA" in html
+    assert "1.200" in html
+    assert "5,50%" in html or "IGPM" in html
+    assert "12.345.678/0001-95" in html
+    assert client.post(
+        "/v1/comercial/contrato-templates/preview",
+        headers=auth_headers["comercial"],
+        json={"conteudo_html": "<p>{{cnpj}}</p>"},
+    ).status_code == 403
+
+
+def test_chaves_prefixadas_e_aliases_no_html(client, auth_headers, seed_base):
+    h_admin = auth_headers["admin"]
+    h = auth_headers["comercial"]
+    tmpl = client.post(
+        "/v1/comercial/contrato-templates",
+        headers=h_admin,
+        json={
+            "nome": "Chaves prefixadas",
+            "conteudo_html": (
+                "<p>CTR={{contratante.cnpj}}</p>"
+                "<p>LEG={{cnpj}}</p>"
+                "<p>FID={{contrato.fidelidade_meses}}</p>"
+                "<p>MUL={{contrato.multa_max_mensalidades}}</p>"
+                "<p>OLD_MUL={{multa}}</p>"
+                "<p>REA={{contrato.reajuste}}</p>"
+            ),
+        },
+    )
+    assert tmpl.status_code == 201, tmpl.text
+    _, linha = _negociacao_com_linha(client, h)
+    gerada = client.post(
+        "/v1/comercial/contratos",
+        headers=h,
+        json={
+            "linha_id": linha["id"],
+            "template_id": tmpl.json()["id"],
+            "fidelidade_meses": 12,
+            "multa_max_mensalidades": 3,
+            "sem_reajuste": True,
+        },
+    )
+    assert gerada.status_code == 201, gerada.text
+    html = gerada.json()["conteudo_html_snapshot"] or ""
+    assert "CTR=" in html and "{{" not in html
+    assert "LEG=" in html
+    assert "FID=12" in html
+    assert "MUL=3" in html
+    assert "OLD_MUL=3" in html
+    assert "REA=sem reajuste" in html
+    assert "a validar juridicamente" not in html.lower()
+    assert "permanece vinculado" not in html.lower()
 
 
 def test_comercial_gera_contrato_sem_custo_e_pdf(client, auth_headers, seed_base):

--- a/docs/BACKEND_RBAC.md
+++ b/docs/BACKEND_RBAC.md
@@ -35,7 +35,7 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 | Catálogo comercial (leitura itens) | `GET /v1/comercial/custos/itens` — também comercial (montar pacote na negociação) |
 | Funil CRM (mutação) | `POST/PATCH /v1/crm/funil-estagios` — UI em Configurações → Cadastros → Funil CRM |
 | Modelos de proposta (CRUD) | `POST/PATCH /v1/comercial/proposta-templates`, `POST /v1/comercial/proposta-templates/preview` — UI em Cadastros → Modelos de proposta |
-| Modelos de contrato (CRUD) | `POST/PATCH /v1/comercial/contrato-templates`, `POST /v1/comercial/contrato-templates/preview` |
+| Modelos de contrato (CRUD) | `POST/PATCH /v1/comercial/contrato-templates`, `POST /v1/comercial/contrato-templates/preview`, `GET /v1/comercial/contrato-templates/chaves` |
 | Política de reajuste do contrato | `PATCH /v1/comercial/contrato-politica` (percentual e rótulo padrão da instância) |
 
 ## Comercial ou administrador (`exigir_comercial_ou_admin`)
@@ -47,7 +47,7 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 | **Simular custos** | `POST /v1/comercial/custos/simular` |
 | **Listar itens catálogo** | `GET /v1/comercial/custos/itens` (mutações continuam só admin) |
 | **Proposta comercial** | `GET /v1/comercial/proposta-templates` (ativos), `POST/GET /v1/comercial/propostas*`, `GET .../pdf`, `POST .../marcar-enviada` |
-| **Contrato comercial** | `GET /v1/comercial/contrato-templates` (ativos), `GET /v1/comercial/contrato-politica`, `POST/GET /v1/comercial/contratos*`, `GET .../pdf`, `POST/GET .../pdf-assinado`, `POST .../marcar-enviado`, `POST .../marcar-assinado`, `POST .../cancelar`. Lista e detalhe (incl. PDF): comercial só as próprias negociações; admin todos (filtros `so_minhas` e `responsavel_id`). Marcar assinado cria/vincula Rede e Empresa internamente — comercial **não** ganha CRUD de Rede/Empresa. |
+| **Contrato comercial** | `GET /v1/comercial/contrato-templates` (ativos), `GET /v1/comercial/contrato-templates/chaves`, `GET /v1/comercial/contrato-politica`, `POST/GET /v1/comercial/contratos*`, `GET .../pdf`, `POST/GET .../pdf-assinado`, `POST .../marcar-enviado`, `POST .../marcar-assinado`, `POST .../cancelar`. Lista e detalhe (incl. PDF): comercial só as próprias negociações; admin todos (filtros `so_minhas` e `responsavel_id`). Marcar assinado cria/vincula Rede e Empresa internamente — comercial **não** ganha CRUD de Rede/Empresa. |
 
 ## Autenticado com escopo de setor (`obter_atendente_atual`)
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -3144,6 +3144,11 @@ export namespace ComercialContrato {
     vigencia_inicio?: string | null;
     ativo?: boolean;
   }
+  export interface ChaveCatalogo {
+    grupo: string;
+    chave: string;
+    descricao: string;
+  }
   export interface Interno {
     total_custo?: string | number | null;
     margem_calculada?: string | number | null;
@@ -3230,6 +3235,7 @@ export namespace ComercialContrato {
 export const comercialContratoTemplates = {
   list: (params?: { incluir_inativos?: boolean }) =>
     api<ComercialContrato.Template[]>(withParams('/comercial/contrato-templates', params)),
+  chaves: () => api<ComercialContrato.ChaveCatalogo[]>('/comercial/contrato-templates/chaves'),
   create: (data: ComercialContrato.TemplateCreate) =>
     api<ComercialContrato.Template>('/comercial/contrato-templates', {
       method: 'POST',

--- a/frontend/src/pages/ConfigContratoTemplates.tsx
+++ b/frontend/src/pages/ConfigContratoTemplates.tsx
@@ -1,5 +1,10 @@
-import { useCallback, useEffect, useState } from 'react'
-import { ApiError, comercialContratoPolitica, comercialContratoTemplates, type ComercialContrato } from '../api/client'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  ApiError,
+  comercialContratoPolitica,
+  comercialContratoTemplates,
+  type ComercialContrato,
+} from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { Button } from '../components/ui/Button'
 import { Card } from '../components/ui/Card'
@@ -12,28 +17,12 @@ import { ConfigListPageShell } from '../components/config/ConfigListPageShell'
 import { formatPercentualPt, parsePercentualPt } from '../components/crm/crmFiscais'
 import { SemPermissao } from './SemPermissao'
 
-const PLACEHOLDERS = [
-  '{{razao_social}}',
-  '{{cnpj}}',
-  '{{itens}}',
-  '{{valor_mensalidade}}',
-  '{{setup_bloco}}',
-  '{{data_inicio}}',
-  '{{data_fim_fidelidade}}',
-  '{{fidelidade_meses}}',
-  '{{fidelidade}}',
-  '{{multa}}',
-  '{{igpm}}',
-  '{{reajuste}}',
-  '{{endereco_contratante}}',
-  '{{resp_legal}}',
-  '{{nome_base_webposto}}',
-  '{{clausula_deslocamento}}',
-  '{{clausula_alimentacao}}',
-  '{{clausula_hospedagem}}',
-  '{{logo}}',
-  '{{empresa_sistema}}',
-] as const
+const GRUPO_LABEL: Record<string, string> = {
+  contratada: 'Contratada (empresa nas configurações)',
+  contratante: 'Contratante (lead / linha CNPJ)',
+  contrato: 'Contrato (valores da geração)',
+  legado: 'Aliases antigos (ainda funcionam)',
+}
 
 type FormState = {
   nome: string
@@ -50,6 +39,7 @@ const emptyForm = (): FormState => ({
 export function ConfigContratoTemplates({ embedded = false }: { embedded?: boolean }) {
   const toast = useToast()
   const [list, setList] = useState<ComercialContrato.Template[]>([])
+  const [chaves, setChaves] = useState<ComercialContrato.ChaveCatalogo[]>([])
   const [loading, setLoading] = useState(true)
   const [forbidden, setForbidden] = useState(false)
   const [incluirInativos, setIncluirInativos] = useState(false)
@@ -61,12 +51,33 @@ export function ConfigContratoTemplates({ embedded = false }: { embedded?: boole
   const [politicaRotulo, setPoliticaRotulo] = useState('')
   const [savingPolitica, setSavingPolitica] = useState(false)
 
+  const chavesPorGrupo = useMemo(() => {
+    const ord = ['contratada', 'contratante', 'contrato', 'legado']
+    const map = new Map<string, ComercialContrato.ChaveCatalogo[]>()
+    for (const item of chaves) {
+      const arr = map.get(item.grupo) || []
+      arr.push(item)
+      map.set(item.grupo, arr)
+    }
+    return ord.filter((g) => map.has(g)).map((g) => ({ grupo: g, itens: map.get(g)! }))
+  }, [chaves])
+
   const load = useCallback(() => {
     setLoading(true)
     setForbidden(false)
-    comercialContratoTemplates
-      .list({ incluir_inativos: incluirInativos })
-      .then(setList)
+    Promise.all([
+      comercialContratoTemplates.list({ incluir_inativos: incluirInativos }),
+      comercialContratoTemplates.chaves().catch(() => [] as ComercialContrato.ChaveCatalogo[]),
+      comercialContratoPolitica.get().catch(() => null),
+    ])
+      .then(([templates, catalogo, pol]) => {
+        setList(templates)
+        setChaves(catalogo)
+        if (pol) {
+          setPoliticaPct(formatPercentualPt(pol.reajuste_percentual ?? '0'))
+          setPoliticaRotulo(pol.reajuste_rotulo || '')
+        }
+      })
       .catch((err) => {
         if (err instanceof ApiError && err.status === 403) {
           setForbidden(true)
@@ -82,19 +93,6 @@ export function ConfigContratoTemplates({ embedded = false }: { embedded?: boole
   useEffect(() => {
     load()
   }, [load])
-
-  useEffect(() => {
-    comercialContratoPolitica
-      .get()
-      .then((p) => {
-        setPoliticaPct(formatPercentualPt(p.reajuste_percentual ?? '0'))
-        setPoliticaRotulo(p.reajuste_rotulo || '')
-      })
-      .catch((err) => {
-        if (err instanceof ApiError && err.status === 403) return
-        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar o reajuste padrão.'))
-      })
-  }, [toast])
 
   function openCreate() {
     setForm(emptyForm())
@@ -113,10 +111,6 @@ export function ConfigContratoTemplates({ embedded = false }: { embedded?: boole
   }
 
   async function handlePreview() {
-    if (!form.conteudo_html.trim()) {
-      toast.showWarning('Informe o HTML do modelo.')
-      return
-    }
     try {
       const r = await comercialContratoTemplates.preview(form.conteudo_html)
       setPreviewHtml(r.html)
@@ -127,10 +121,6 @@ export function ConfigContratoTemplates({ embedded = false }: { embedded?: boole
 
   async function handleSave(e: React.FormEvent) {
     e.preventDefault()
-    if (!form.nome.trim() || !form.conteudo_html.trim()) {
-      toast.showWarning('Informe nome e HTML do modelo.')
-      return
-    }
     setSaving(true)
     try {
       if (modal === 'create') {
@@ -146,7 +136,7 @@ export function ConfigContratoTemplates({ embedded = false }: { embedded?: boole
           conteudo_html: form.conteudo_html,
           ativo: form.ativo,
         })
-        toast.showSuccess('Modelo atualizado. A versão sobe se o HTML mudar; contratos já gerados não mudam.')
+        toast.showSuccess('Modelo atualizado.')
       }
       setModal(null)
       load()
@@ -180,6 +170,16 @@ export function ConfigContratoTemplates({ embedded = false }: { embedded?: boole
     }
   }
 
+  async function copiarChave(chave: string) {
+    const token = `{{${chave}}}`
+    try {
+      await navigator.clipboard.writeText(token)
+      toast.showSuccess(`Copiado: ${token}`)
+    } catch {
+      toast.showWarning(`Não foi possível copiar. Use: ${token}`)
+    }
+  }
+
   const denied = (
     <SemPermissao
       title="Você não tem permissão para configurar modelos de contrato."
@@ -198,13 +198,15 @@ export function ConfigContratoTemplates({ embedded = false }: { embedded?: boole
       actions={<Button onClick={openCreate}>Novo modelo</Button>}
     >
       <p className="mb-3 text-sm text-slate-500 dark:text-slate-400">
-        HTML usado ao gerar o contrato na negociação. Não inclua custo ou margem — esses dados são internos.
-        Editar o HTML sobe a versão do modelo; o PDF já gerado permanece na versão gravada no contrato.
+        Cole o HTML do contrato aprovado pelo advogado do cliente. Use as chaves abaixo para o
+        DeskRudder preencher contratada (empresa nas configurações), contratante (lead/CNPJ) e
+        valores do contrato. Não inclua custo ou margem — esses dados são internos. Editar o HTML
+        sobe a versão do modelo; o PDF já gerado permanece na versão gravada no contrato.
       </p>
       <Card title="Reajuste anual padrão" className="mb-3">
         <p className="mb-3 text-sm text-slate-500">
-          Usado ao gerar contratos, salvo override ou «sem reajuste» na negociação. Não consulta índice (IGPM)
-          automaticamente. O recálculo anual na data de aniversário entra numa versão seguinte.
+          Usado ao gerar contratos, salvo override ou «sem reajuste» na negociação. Não consulta índice
+          (IGPM) automaticamente. O recálculo anual na data de aniversário entra numa versão seguinte.
         </p>
         <form onSubmit={(e) => void handleSavePolitica(e)} className="flex flex-col gap-3 sm:flex-row sm:items-end">
           <div className="sm:w-40">
@@ -229,19 +231,43 @@ export function ConfigContratoTemplates({ embedded = false }: { embedded?: boole
           </Button>
         </form>
       </Card>
-      <details className="mb-3 rounded-lg border border-slate-200 px-3 py-2 text-sm dark:border-slate-700">
+      <details className="mb-3 rounded-lg border border-slate-200 px-3 py-2 text-sm dark:border-slate-700" open>
         <summary className="cursor-pointer font-medium text-slate-700 dark:text-slate-200">
-          Placeholders disponíveis
+          Chaves do modelo (clique para copiar)
         </summary>
-        <ul className="mt-2 flex flex-wrap gap-1.5">
-          {PLACEHOLDERS.map((p) => (
-            <li key={p}>
-              <code className="rounded bg-slate-100 px-1.5 py-0.5 text-xs text-slate-800 dark:bg-slate-800 dark:text-slate-200">
-                {p}
-              </code>
-            </li>
-          ))}
-        </ul>
+        <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+          Exemplo: <code className="rounded bg-slate-100 px-1 dark:bg-slate-800">{'{{contratante.cnpj}}'}</code> vira
+          o CNPJ do lead. A cláusula de multa/fidelidade deve estar no seu HTML; as chaves só
+          substituem números e dados.
+        </p>
+        {chavesPorGrupo.length === 0 ? (
+          <p className="mt-2 text-slate-500">Catálogo indisponível.</p>
+        ) : (
+          <div className="mt-3 space-y-4">
+            {chavesPorGrupo.map(({ grupo, itens }) => (
+              <div key={grupo}>
+                <p className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  {GRUPO_LABEL[grupo] || grupo}
+                </p>
+                <ul className="flex flex-col gap-1.5">
+                  {itens.map((item) => (
+                    <li key={item.chave} className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                      <button
+                        type="button"
+                        onClick={() => void copiarChave(item.chave)}
+                        className="rounded bg-slate-100 px-1.5 py-0.5 font-mono text-xs text-cyan-800 hover:bg-cyan-50 dark:bg-slate-800 dark:text-cyan-300 dark:hover:bg-slate-700"
+                        title="Copiar"
+                      >
+                        {`{{${item.chave}}}`}
+                      </button>
+                      <span className="text-xs text-slate-500 dark:text-slate-400">{item.descricao}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
       </details>
       <Card>
         <div className="mb-3">
@@ -322,7 +348,8 @@ export function ConfigContratoTemplates({ embedded = false }: { embedded?: boole
               {previewHtml ? (
                 <div>
                   <p className="mb-1 text-xs text-slate-500">
-                    Sanitiza o HTML. Placeholders só são preenchidos ao gerar o contrato na negociação.
+                    Preview com dados de exemplo (contratada da instância quando existir). Sanitiza o HTML
+                    e preenche as chaves como na geração do contrato.
                   </p>
                   <iframe
                     title="Preview do modelo"


### PR DESCRIPTION
## Summary

Fecha **#775**: modelos de contrato como mail-merge com catálogo de chaves documentado e preview preenchido.

- Prefixos `{{contratada.*}}` (empresa do sistema), `{{contratante.*}}` (lead/linha CNPJ), `{{contrato.*}}` (valores da geração)
- Aliases legados (`{{cnpj}}`, `{{multa}}`, …) continuam a funcionar
- `{{multa}}` / `{{fidelidade}}` passam a ser só números — a cláusula fica no HTML do cliente
- Cadastros: lista de chaves copiável por grupo; preview com dados de exemplo (contratada real quando existir)
- Endpoint `GET /v1/comercial/contrato-templates/chaves`

Closes #775

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `docker compose run --rm --no-deps backend pytest -q tests/test_comercial_contrato.py` (20 passed)
- [ ] Cadastros → Modelos de contrato: abrir catálogo, copiar uma chave, colar no HTML
- [ ] Preview: vê dados de exemplo (não fica `{{…}}` literal); HTML perigoso continua sanitizado
- [ ] Gerar contrato na negociação com modelo novo (prefixos) e com aliases antigos
- [ ] Comercial 403 no CRUD/preview de templates; admin OK

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — cada um virou issue ou está documentado
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados

- Estimativa de multa na rescisão de contrato assinado: **#355**
- Job/fonte IGPM anual: **#745**
- Termos de uso da plataforma: adiado (advogado)
