### PR TITLE
fix(mobile): Conta/login, deep link push e teclado no APK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Mobile: correções no APK — Conta/login sem ficar na empresa errada após falha ou «Trocar»; toque no alerta abre a conversa uma só vez; teclado no Android e no composer de tickets; envio sem double-tap (figurinha, portal, interno); safe area e rotas desconhecidas no app nativo
 - Contratos (#775): nos modelos de contrato, catálogo de chaves copiáveis (`{{contratada.*}}`, `{{contratante.*}}`, `{{contrato.*}}`) para o sistema preencher o HTML do cliente; multa e fidelidade passam a ser só dados (a cláusula fica no texto do modelo); preview com dados de exemplo
 - Mobile chat (#747–#759): lista a 100% da largura; teclado sem vão/corte no campo; composer estilo WhatsApp; reagir pelo menu da seta; demanda e modais em folha inferior; header da app oculto na conversa; Encerrar/empresa/setor no telemóvel; empty states úteis; ícones PWA legíveis (fundo claro + contorno branco no desktop)
 - Mobile (#737): no **app Android**, os alertas com a app fechada usam o mesmo canal da instância (sem Firebase); o clique abre a mesa certa

--- a/docs/MOBILE_CAPACITOR.md
+++ b/docs/MOBILE_CAPACITOR.md
@@ -14,7 +14,9 @@ O app grava essa conta no aparelho e passa a chamar:
 https://api-{slug}.deskrudder.com.br
 ```
 
-Nas vezes seguintes o ecrã de login já mostra essa empresa (e-mail/senha apenas). **Trocar** limpa a conta gravada.
+Nas vezes seguintes o ecrã de login já mostra essa empresa (e-mail/senha apenas). **Trocar** limpa a conta gravada **e os tokens** da sessão anterior (evita pedidos à API sem alvo ou à instância errada).
+
+O login **só mantém** o slug no aparelho se a autenticação for bem-sucedida; se falhar (conta/senha errada), a conta anterior (se houver) é restaurada.
 
 O Android usa **Capacitor HTTP** (pedido nativo), para o login não depender do CORS do browser. Mesmo assim, cada instância deve incluir `https://localhost` em `CORS_ORIGINS` (SSE e ferramentas web).
 
@@ -47,9 +49,9 @@ npm run build:android
 npm run cap:open
 ```
 
-Sem `VITE_API_URL`, o APK pede a conta no login (produção / várias empresas).
+Sem `VITE_API_URL`, o APK pede a conta no login (produção / várias empresas). **Builds de loja não devem definir `VITE_API_URL`** — senão o ecrã Conta é ignorado e todos os pedidos vão para essa URL fixa de debug.
 
-API **local** (mesmo Postgres do `docker compose` / painel no browser), só enquanto ainda não houver conta gravada — ou depois de **Trocar** empresa:
+API **local** (mesmo Postgres do `docker compose` / painel no browser), só em builds de desenvolvimento:
 
 ```bash
 # Emulador
@@ -59,7 +61,7 @@ $env:VITE_API_URL = "http://192.168.x.x:8000"
 npm run build:android
 ```
 
-Se o utilizador informar um slug (ex. `duplexsoft`), os pedidos vão para `https://api-duplexsoft.…`, não para o Docker.
+Com `VITE_API_URL` definido, essa base **tem prioridade** sobre o slug (útil no emulador). Sem essa variável, o slug escolhe `https://api-{slug}.…`.
 
 O `Host` da API no telemóvel, no modo local, é o IP do PC; o WebView continua origem `https://localhost`. Firewall do Windows tem de deixar TCP 8000 na LAN. HTTP claro no emulador: o manifesto debug do Capacitor já permite cleartext.
 

--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -15,6 +15,7 @@
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBarLaunch"
             android:launchMode="singleTask"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true">
 
             <intent-filter>

--- a/frontend/android/app/src/main/java/br/com/deskrudder/app/UnifiedPushPlugin.kt
+++ b/frontend/android/app/src/main/java/br/com/deskrudder/app/UnifiedPushPlugin.kt
@@ -87,6 +87,9 @@ class UnifiedPushPlugin : Plugin() {
     override fun handleOnNewIntent(intent: Intent?) {
         super.handleOnNewIntent(intent)
         val raw = intent?.getStringExtra(UnifiedPushStore.EXTRA_PAYLOAD) ?: return
+        // Limpar EXTRA para o consumePendingOpen no JS não reabrir o mesmo deep link.
+        intent.removeExtra(UnifiedPushStore.EXTRA_PAYLOAD)
+        activity?.intent?.removeExtra(UnifiedPushStore.EXTRA_PAYLOAD)
         emitOpen(raw)
     }
 

--- a/frontend/src/AppNative.tsx
+++ b/frontend/src/AppNative.tsx
@@ -74,6 +74,18 @@ function RedirectLegacyChatInterno() {
   return <Navigate to={`${path}${location.search}${location.hash}`} replace />
 }
 
+function NativeUnknownRoute() {
+  const { user, loading } = useAuth()
+  if (loading) {
+    return <PageLoading fullscreen label="Carregando…" />
+  }
+  if (!user) {
+    return <Navigate to="/login" replace />
+  }
+  // App nativo só tem tickets/chat — rotas de admin/CRM/etc. caem na mesa.
+  return <Navigate to="/chat/atendendo" replace />
+}
+
 function NativeRoutes() {
   return (
     <Suspense fallback={<PageLoading fullscreen label="Carregando…" />}>
@@ -161,7 +173,7 @@ function NativeRoutes() {
           </Route>
           <Route path="chat-interno/*" element={<RedirectLegacyChatInterno />} />
         </Route>
-        <Route path="*" element={<Navigate to="/chat/atendendo" replace />} />
+        <Route path="*" element={<NativeUnknownRoute />} />
       </Routes>
     </Suspense>
   )

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -21,6 +21,7 @@ function apiBaseUrl(): string {
         /* slug inválido no storage */
       }
     }
+    // Vazio de propósito: api()/SSE recusam pedidos — evita fetch relativo a https://localhost.
     return ''
   }
   if (import.meta.env.DEV) return '/api'
@@ -29,6 +30,12 @@ function apiBaseUrl(): string {
     throw new Error('VITE_API_URL não definido — o build de produção deveria ter falhado no vite.config.')
   }
   return url.replace(/\/+$/, '')
+}
+
+/** Capacitor: há alvo de API (slug gravado ou VITE_API_URL de debug). */
+export function hasNativeApiTarget(): boolean {
+  if (!isCapacitorNative()) return true
+  return Boolean(apiBaseUrl())
 }
 
 function apiOrigin(): string {

--- a/frontend/src/api/eventStream.ts
+++ b/frontend/src/api/eventStream.ts
@@ -31,11 +31,13 @@ function setAccessToken(accessToken: string): void {
 async function refreshAccessTokenForStream(): Promise<string | null> {
   const refresh_token = getRefreshToken()
   if (!refresh_token) return null
+  const base = resolvedApiBaseUrl()
+  if (!base) return null
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (isMultiTenantMode()) {
     headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
   }
-  const res = await fetch(`${resolvedApiBaseUrl()}${API_VERSION_PREFIX}/auth/refresh`, {
+  const res = await fetch(`${base}${API_VERSION_PREFIX}/auth/refresh`, {
     method: 'POST',
     headers,
     body: JSON.stringify({ refresh_token }),
@@ -48,7 +50,11 @@ async function refreshAccessTokenForStream(): Promise<string | null> {
 }
 
 export function buildEventStreamUrl(): string {
-  return `${resolvedApiBaseUrl()}${API_VERSION_PREFIX}/events/stream`
+  const base = resolvedApiBaseUrl()
+  if (!base) {
+    throw new Error('Informe a conta da empresa para ligar ao painel.')
+  }
+  return `${base}${API_VERSION_PREFIX}/events/stream`
 }
 
 function authHeaders(token: string): Record<string, string> {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -105,6 +105,7 @@ function LayoutInner() {
         {
           ['--sidebar-w' as never]: sidebarW,
           marginTop: 'var(--vv-offset-top, 0px)',
+          paddingTop: isCapacitorNative() ? 'env(safe-area-inset-top, 0px)' : undefined,
         } as React.CSSProperties
       }
     >

--- a/frontend/src/components/chat-interno/ChatInternoComposerBar.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoComposerBar.tsx
@@ -362,7 +362,7 @@ export function ChatInternoComposerBar({
 
 
 
-      <div className="shrink-0 border-t border-slate-200 bg-white px-3 py-3 dark:border-slate-800 dark:bg-slate-900 md:px-5 lg:px-6">
+      <div className="shrink-0 border-t border-slate-200 bg-white px-3 py-3 dark:border-slate-800 dark:bg-slate-900 md:px-5 lg:px-6 [:is(html[data-vv-keyboard='0'])_&]:pb-[max(0.75rem,env(safe-area-inset-bottom))]">
 
         {gravando && (
 

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,5 +1,12 @@
 import { createContext, useContext, useState, useEffect, useCallback, useRef, type ReactNode } from 'react'
-import { atendentes, clearAuthToken, getAuthToken, ApiError, type Atendentes } from '../api/client'
+import {
+  atendentes,
+  clearAuthToken,
+  getAuthToken,
+  hasNativeApiTarget,
+  ApiError,
+  type Atendentes,
+} from '../api/client'
 import { revogarWebPushNoLogout } from '../hooks/useWebPush'
 
 interface AuthContextValue {
@@ -25,6 +32,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const seq = ++refreshSeq.current
     const token = getAuthToken()
     if (!token) {
+      setUser(null)
+      setLoading(false)
+      return
+    }
+    // APK sem conta (após Trocar): não chamar /me nem SSE em https://localhost.
+    if (!hasNativeApiTarget()) {
+      clearAuthToken()
       setUser(null)
       setLoading(false)
       return

--- a/frontend/src/hooks/useVisualViewportCss.ts
+++ b/frontend/src/hooks/useVisualViewportCss.ts
@@ -1,22 +1,27 @@
 import { useEffect } from 'react'
+import { isCapacitorNative } from '../lib/capacitorNative'
 
 /**
  * Expõe a altura e o offset do visualViewport (teclado virtual) em CSS:
  * `--vv-height`, `--vv-offset-top`, `--vv-keyboard` (1 se teclado aberto).
  * Usado pelo shell e pelo composer do chat (#692 / #751).
+ *
+ * No Capacitor Android com `adjustResize`, o offsetTop costuma duplicar o
+ * deslocamento — aí só publicamos altura (offset = 0).
  */
 export function useVisualViewportCss(): void {
   useEffect(() => {
     const vv = window.visualViewport
     if (!vv) return
+    const native = isCapacitorNative()
     const apply = () => {
       const root = document.documentElement
       const height = Math.round(vv.height)
-      const offsetTop = Math.round(vv.offsetTop)
+      const offsetTop = native ? 0 : Math.round(vv.offsetTop)
       root.style.setProperty('--vv-height', `${height}px`)
       root.style.setProperty('--vv-offset-top', `${offsetTop}px`)
       // Heurística: teclado quando a viewport encolhe face a innerHeight
-      const keyboardOpen = window.innerHeight - height > 80 || offsetTop > 0
+      const keyboardOpen = window.innerHeight - height > 80 || (!native && vv.offsetTop > 0)
       root.style.setProperty('--vv-keyboard', keyboardOpen ? '1' : '0')
       root.dataset.vvKeyboard = keyboardOpen ? '1' : '0'
     }

--- a/frontend/src/hooks/useWebPush.ts
+++ b/frontend/src/hooks/useWebPush.ts
@@ -184,9 +184,16 @@ export function useWebPushSession(enabled: boolean) {
               })
               .catch(() => undefined)
           })
-          const openHandle = await DeskRudderUnifiedPush.addListener('open', (data) => {
+          let lastOpenKey = ''
+          const abrir = (data: { tipo?: string; id?: number; url_path?: string }) => {
             if (!temAbertura(data)) return
+            const key = `${data.tipo ?? ''}:${data.id ?? ''}:${data.url_path ?? ''}`
+            if (key === lastOpenKey) return
+            lastOpenKey = key
             navigate(aplicarAberturaWebPush(data))
+          }
+          const openHandle = await DeskRudderUnifiedPush.addListener('open', (data) => {
+            abrir(data)
           })
           removeEndpoint = () => {
             void endpointHandle.remove()
@@ -195,9 +202,7 @@ export function useWebPushSession(enabled: boolean) {
             void openHandle.remove()
           }
           const pending = await DeskRudderUnifiedPush.consumePendingOpen()
-          if (!cancelled && temAbertura(pending)) {
-            navigate(aplicarAberturaWebPush(pending))
-          }
+          if (!cancelled) abrir(pending)
           const prefs = await notificacoes.preferenciasGet()
           if (cancelled) return
           const muted = isFilaAguardandoMuted()

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-do
 import { useAuth } from '../contexts/AuthContext'
 import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
+import { clearAuthToken } from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import {
   BrandLogo,
@@ -304,6 +305,7 @@ function LoginCapacitor() {
 
   function pedirOutraEmpresa() {
     clearRememberedAccount()
+    clearAuthToken()
     setConta('')
     setTrocarEmpresa(true)
   }
@@ -325,8 +327,10 @@ function LoginCapacitor() {
     }
 
     setLoading(true)
+    const slugAnterior = readRememberedAccount()
+    // Precisa do slug no storage para apiBaseUrl() apontar à instância; só fica se o login OK.
+    writeRememberedAccount(slug)
     try {
-      writeRememberedAccount(slug)
       await login(email.trim(), senha, lembrarMe)
       try {
         if (lembrarMe) {
@@ -341,6 +345,8 @@ function LoginCapacitor() {
       showSuccess('Login realizado com sucesso.')
       navigate('/chat/atendendo', { replace: true })
     } catch (err) {
+      if (slugAnterior) writeRememberedAccount(slugAnterior)
+      else clearRememberedAccount()
       showError(mensagemFalhaParaToast(err, 'Falha no login. Verifique conta, e-mail e senha.'))
     } finally {
       setLoading(false)

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -273,6 +273,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
   const [tipoNovaMensagem, setTipoNovaMensagem] = useState<'publico' | 'interno'>('publico')
   const [notificarClienteEmail, setNotificarClienteEmail] = useState(false)
   const [enviandoMensagem, setEnviandoMensagem] = useState(false)
+  const enviandoMensagemRef = useRef(false)
   const [anexosSelecionados, setAnexosSelecionados] = useState<File[]>([])
   const [enviandoAnexos, setEnviandoAnexos] = useState(false)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
@@ -1123,8 +1124,25 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
     if (tipoNovaMensagem === 'interno') setNotificarClienteEmail(false)
   }, [tipoNovaMensagem])
 
+  /** Teclado virtual: manter o composer visível (paridade com WhatsApp #751). */
+  useEffect(() => {
+    const vv = window.visualViewport
+    if (!vv) return
+    const onVv = () => {
+      requestAnimationFrame(() => {
+        textareaRef.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+      })
+    }
+    vv.addEventListener('resize', onVv)
+    vv.addEventListener('scroll', onVv)
+    return () => {
+      vv.removeEventListener('resize', onVv)
+      vv.removeEventListener('scroll', onVv)
+    }
+  }, [])
+
   async function handleEnviarMensagem() {
-    if (!ticket) return
+    if (!ticket || enviandoMensagem || enviandoMensagemRef.current) return
     if (ticket.fechado_em) {
       toast.showWarning('Ticket fechado. Apenas admin pode reabrir para enviar mensagens.')
       return
@@ -1135,6 +1153,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
       return
     }
     const tipo = podeMensagemPublica ? tipoNovaMensagem : 'interno'
+    enviandoMensagemRef.current = true
     setEnviandoMensagem(true)
     try {
       const payload: Tickets.MensagemCreate = { corpo: texto, tipo }
@@ -1174,6 +1193,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
     } catch (err) {
       toast.showWarning(err instanceof Error ? err.message : 'Erro ao enviar')
     } finally {
+      enviandoMensagemRef.current = false
       setEnviandoMensagem(false)
     }
   }
@@ -1826,7 +1846,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
             </ul>
           )}
 
-          <div className="sticky bottom-0 z-10 -mx-3 border-t border-slate-200 bg-white px-3 pt-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] dark:border-slate-800/90 dark:bg-slate-950 sm:static sm:mx-0 sm:bg-transparent sm:px-0 sm:pb-0 sm:pt-4 dark:sm:bg-transparent">
+          <div className="sticky bottom-0 z-10 -mx-3 border-t border-slate-200 bg-white px-3 pt-3 pb-3 dark:border-slate-800/90 dark:bg-slate-950 sm:static sm:mx-0 sm:bg-transparent sm:px-0 sm:pb-0 sm:pt-4 dark:sm:bg-transparent [:is(html[data-vv-keyboard='0'])_&]:pb-[max(0.75rem,env(safe-area-inset-bottom))]">
             <p className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-300">Nova mensagem</p>
             {ticket.fechado_em ? (
               <div className="rounded-xl border border-emerald-200 bg-emerald-50/70 px-4 py-3 text-sm text-emerald-900 dark:border-emerald-800/60 dark:bg-emerald-950/25 dark:text-emerald-100">

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -60,6 +60,7 @@ export function ChatInternoThread({ conversaIdProp }: ChatInternoThreadProps = {
   const [texto, setTexto] = useState('')
   const [loading, setLoading] = useState(true)
   const [enviando, setEnviando] = useState(false)
+  const enviandoRef = useRef(false)
   const [msgRespondida, setMsgRespondida] = useState<ChatInterno.Mensagem | null>(null)
   const [focoComposerEm, setFocoComposerEm] = useState(0)
   const [forbidden, setForbidden] = useState(false)
@@ -434,7 +435,8 @@ export function ChatInternoThread({ conversaIdProp }: ChatInternoThreadProps = {
   }
 
   async function enviarMidia(file: File, caption?: string) {
-    if (enviando) return
+    if (enviando || enviandoRef.current) return
+    enviandoRef.current = true
     setEnviando(true)
     try {
       const msg = await chatInterno.enviarMidia(conversaId, file, caption, msgRespondida?.id ?? null)
@@ -452,13 +454,15 @@ export function ChatInternoThread({ conversaIdProp }: ChatInternoThreadProps = {
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar o arquivo.'))
     } finally {
+      enviandoRef.current = false
       setEnviando(false)
     }
   }
 
   async function enviar() {
     const corpo = texto.trim()
-    if (!corpo || enviando) return
+    if (!corpo || enviando || enviandoRef.current) return
+    enviandoRef.current = true
     setEnviando(true)
     try {
       const mencoes = montarMencoesDoCorpo(corpo, mencionaveis)
@@ -482,6 +486,7 @@ export function ChatInternoThread({ conversaIdProp }: ChatInternoThreadProps = {
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar a mensagem.'))
     } finally {
+      enviandoRef.current = false
       setEnviando(false)
     }
   }

--- a/frontend/src/pages/chat/PortalConversa.tsx
+++ b/frontend/src/pages/chat/PortalConversa.tsx
@@ -82,6 +82,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
   const [texto, setTexto] = useState('')
   const [loading, setLoading] = useState(true)
   const [enviando, setEnviando] = useState(false)
+  const enviandoRef = useRef(false)
   const [assumindo, setAssumindo] = useState(false)
   const [modalEncerrar, setModalEncerrar] = useState(false)
   const [modalTransferir, setModalTransferir] = useState(false)
@@ -196,7 +197,8 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
 
   async function enviar() {
     const corpo = texto.trim()
-    if (!corpo || !Number.isFinite(chatId)) return
+    if (!corpo || !Number.isFinite(chatId) || enviando || enviandoRef.current) return
+    enviandoRef.current = true
     setEnviando(true)
     try {
       const msg = await portalChats.enviar(chatId, corpo)
@@ -210,6 +212,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar a mensagem.'))
     } finally {
+      enviandoRef.current = false
       setEnviando(false)
     }
   }
@@ -255,7 +258,8 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
 
   async function confirmarEnvioMidia() {
     const responsavel = chat?.estado === 'em_atendimento' && chat.atendente_id === user?.id
-    if (!arquivoPendente || !Number.isFinite(chatId) || !responsavel || enviando) return
+    if (!arquivoPendente || !Number.isFinite(chatId) || !responsavel || enviando || enviandoRef.current) return
+    enviandoRef.current = true
     setEnviando(true)
     try {
       const msg = await portalChats.enviarMidia(chatId, arquivoPendente, legendaMidia.trim())
@@ -271,6 +275,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha no envio do anexo'))
     } finally {
+      enviandoRef.current = false
       setEnviando(false)
     }
   }

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1317,7 +1317,8 @@ useEffect(() => {
   }
 
   async function enviarFigurinha(file: File) {
-    if (!chat || !podeEnviar) return
+    if (!chat || !podeEnviar || enviando || enviandoMidiaRef.current) return
+    enviandoMidiaRef.current = true
     setEnviando(true)
     try {
       await whatsappChats.enviarFigurinha(chat.id, file, msgRespondida?.wa_message_id || null)
@@ -1327,6 +1328,7 @@ useEffect(() => {
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha ao enviar figurinha'))
     } finally {
+      enviandoMidiaRef.current = false
       setEnviando(false)
     }
   }


### PR DESCRIPTION
## Summary

- Corrige Conta/login no APK: slug só permanece após login OK; **Trocar** limpa tokens e evita pedidos sem alvo (`localhost`)
- UnifiedPush: deep link do toque na notificação sem abrir a conversa duas vezes
- Teclado Android (`adjustResize` + sem offset duplicado), composer de tickets alinhado ao WhatsApp, guards de double-tap (figurinha/portal/interno) e safe-area no shell nativo
- Catch-all do app nativo manda não autenticados para `/login`; docs de `VITE_API_URL` (só debug)

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] APK: login com conta errada → slug anterior (ou vazio) restaurado; tokens não ficam apontando para API errada
- [ ] APK: **Trocar** empresa → pede conta de novo; sem pedidos a `https://localhost`
- [ ] Toque em notificação push → abre a mesa/conversa **uma** vez
- [ ] Tickets: teclado não cobre o composer; double-tap no enviar não duplica mensagem
- [ ] WhatsApp: double-tap em figurinha não duplica envio
- [ ] Rotas desconhecidas sem sessão → `/login`

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — melhorias (bottom nav, Keyboard plugin, iOS #738) ficam no canvas de auditoria / backlog L6, não neste PR
- [x] Stubs/campos nullable — N/A
- [x] Sem issue GitHub dedicada; lote de hotfix da auditoria mobile pós-#735–#737
