### PR TITLE
chore(mobile): finalizar L6 Android — docs, validação e build seguro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Mobile: documentação do APK Android (checklist de validação + gerar AAB) e o build ignora o `VITE_API_URL` placeholder da CI
 - Mobile: correções no APK — Conta/login sem ficar na empresa errada após falha ou «Trocar»; toque no alerta abre a conversa uma só vez; teclado no Android e no composer de tickets; envio sem double-tap (figurinha, portal, interno); safe area e rotas desconhecidas no app nativo
 - Contratos (#775): nos modelos de contrato, catálogo de chaves copiáveis (`{{contratada.*}}`, `{{contratante.*}}`, `{{contrato.*}}`) para o sistema preencher o HTML do cliente; multa e fidelidade passam a ser só dados (a cláusula fica no texto do modelo); preview com dados de exemplo
 - Mobile chat (#747–#759): lista a 100% da largura; teclado sem vão/corte no campo; composer estilo WhatsApp; reagir pelo menu da seta; demanda e modais em folha inferior; header da app oculto na conversa; Encerrar/empresa/setor no telemóvel; empty states úteis; ícones PWA legíveis (fundo claro + contorno branco no desktop)

--- a/docs/MOBILE_APP_BRIEF.md
+++ b/docs/MOBILE_APP_BRIEF.md
@@ -187,8 +187,10 @@ Estados do chat: `aguardando_atendente` | `em_atendimento` | `encerrado`
 - Cadastros admin (redes, empresas, atendentes, config WhatsApp)
 - Relatórios/dashboards avançados
 - Portal do cliente / funcionários de posto
-- Chat interno
-- Capacitor / lojas (L6 do épico #689)
+- Chat interno (há suporte parcial no APK; fora do MVP PWA inicial)
+- Capacitor iOS / listing nas lojas (#738 / #739)
+
+**Capacitor Android** (L6.1–L6.3): feito — ver `docs/MOBILE_CAPACITOR.md`.
 
 ---
 
@@ -378,10 +380,10 @@ O projecto web já é **React + TypeScript**. Ordem fechada no épico #689:
 | Fase | Abordagem |
 |------|-----------|
 | **PWA no SPA actual** | Reutiliza o painel; instalável em `https://{slug}.…`; API `/v1` na mesma instância |
-| **Capacitor (lojas)** | Empacota o mesmo frontend; campo Conta resolve `api-{slug}` |
-
-Como construir o APK debug e o push nativo (VAPID + UnifiedPush, sem Firebase): **`docs/MOBILE_CAPACITOR.md`** (#735 / #737).
+| **Capacitor (lojas)** | Android na `main` (Conta → `api-{slug}` + push UnifiedPush); iOS/listing → #738 / #739 |
 | React Native / Flutter | **Fora da v1** |
+
+Como construir o APK, validar e gerar AAB: **`docs/MOBILE_CAPACITOR.md`** (#696 / #735–#737 / #784).
 
 ### Tempo real: SSE (já existe)
 

--- a/docs/MOBILE_CAPACITOR.md
+++ b/docs/MOBILE_CAPACITOR.md
@@ -1,6 +1,8 @@
-# App Android (Capacitor) — L6.1 / L6.2 / L6.3 (#735 / #736 / #737)
+# App Android (Capacitor) — L6 (#696 / #735–#737)
 
 O APK é um WebView Capacitor com um **SPA mais leve**: login, **tickets** e **chat** (mesa WhatsApp / hub). Não leva landing, SaaS, CRM, cadastros nem dashboards.
+
+**Estado (Android):** L6.1 shell + L6.2 Conta + L6.3 push (VAPID + UnifiedPush) + hotfix Conta/teclado (#784) estão na `main`. **iOS** → #738. **Listing nas lojas** → #739.
 
 **Não há base de dados no telemóvel.** Os dados são os da **instância da empresa** (mesmo Postgres da API). Um binário serve várias empresas via campo **Conta**.
 
@@ -29,7 +31,7 @@ O Android usa **Capacitor HTTP** (pedido nativo), para o login não depender do 
 | Android Studio (Ladybug+) | SDK, emulador ou cabo USB com depuração |
 | Variável `ANDROID_HOME` | Pasta do SDK (o Studio costuma definir) |
 
-Não é preciso conta Google Play neste lote.
+Não é preciso conta Google Play neste lote de código.
 
 ## O que está no repo
 
@@ -51,6 +53,8 @@ npm run cap:open
 
 Sem `VITE_API_URL`, o APK pede a conta no login (produção / várias empresas). **Builds de loja não devem definir `VITE_API_URL`** — senão o ecrã Conta é ignorado e todos os pedidos vão para essa URL fixa de debug.
 
+O script `build:android` **ignora** o placeholder `https://ci.invalid.example` (usado só no job CI do PWA), para não embutir essa URL no APK por acidente no ambiente local.
+
 API **local** (mesmo Postgres do `docker compose` / painel no browser), só em builds de desenvolvimento:
 
 ```bash
@@ -61,7 +65,7 @@ $env:VITE_API_URL = "http://192.168.x.x:8000"
 npm run build:android
 ```
 
-Com `VITE_API_URL` definido, essa base **tem prioridade** sobre o slug (útil no emulador). Sem essa variável, o slug escolhe `https://api-{slug}.…`.
+Com `VITE_API_URL` definido (e válido), essa base **tem prioridade** sobre o slug (útil no emulador). Sem essa variável, o slug escolhe `https://api-{slug}.…`.
 
 O `Host` da API no telemóvel, no modo local, é o IP do PC; o WebView continua origem `https://localhost`. Firewall do Windows tem de deixar TCP 8000 na LAN. HTTP claro no emulador: o manifesto debug do Capacitor já permite cleartext.
 
@@ -73,10 +77,40 @@ O `Host` da API no telemóvel, no modo local, é o IP do PC; o WebView continua 
 | `npm run cap:sync` | Só copia `dist` para o projecto nativo |
 | `npm run cap:open` | Abre o Android Studio |
 
-## Fora deste lote
+## Checklist de validação (APK)
 
-- iOS (#738)
-- Listing nas lojas (#739)
+Correr após `npm run build:android` + instalar no emulador/dispositivo (**sem** `VITE_API_URL` para simular loja):
+
+| # | Cenário | Esperado |
+|---|---------|----------|
+| 1 | Primeiro arranque | Ecrã Conta + e-mail + senha |
+| 2 | Conta inexistente / senha errada | Toast de erro; **não** grava slug novo (restaura o anterior se houver) |
+| 3 | Login OK numa empresa | Entra em `/chat/atendendo`; pedidos a `api-{slug}` |
+| 4 | **Trocar** empresa | Pede Conta de novo; sessão anterior limpa; sem pedidos a `https://localhost` |
+| 5 | Login noutra empresa | Dados da nova instância |
+| 6 | Notificações → activar push | Endpoint UnifiedPush registado na API da instância |
+| 7 | App em segundo plano / fechada + evento fila/mensagem | Notificação sistema |
+| 8 | Toque na notificação | Abre a mesa/conversa **uma** vez |
+| 9 | Ticket: teclado no composer | Campo visível; double-tap no enviar não duplica |
+| 10 | WhatsApp: texto + figurinha | Envio único; teclado sem cortar o campo |
+| 11 | Voltar Android | Volta na navegação; na raiz pode sair da app |
+
+Cada instância precisa de `VAPID_*` no `client.env` e `https://localhost` em `CORS_ORIGINS`.
+
+## Gerar APK / AAB (release)
+
+1. `cd frontend` → **sem** `VITE_API_URL` na shell → `npm run build:android`
+2. Android Studio → `Build` → `Generate Signed Bundle / APK`
+3. Preferir **AAB** para Play Console; APK só para distribuição directa / sideload
+4. Assinar com o keystore DeskRudder (fora do git — guardar no cofre da equipa)
+5. Versão: `versionCode` / `versionName` em `frontend/android/app/build.gradle` (bump por release de loja)
+
+Publicação na Play Store (listing, privacy, track interna) = issue **#739** (conta Google Play do Luis).
+
+## Fora deste documento (issues abertas)
+
+- iOS + APNs — **#738** (precisa Mac + Apple Developer)
+- Listing Play / App Store — **#739**
 
 ## Alertas com a app fechada (UnifiedPush / VAPID) — #737
 
@@ -86,6 +120,6 @@ O worker `web-push-outbox` já existente envia para PWA **e** APK. Mute da fila 
 
 O distribuidor embutido usa os servidores de push da Google só como transporte nos telemóveis com Play Services. Sem Play Services, o alerta com a app fechada não chega (a PWA no Chrome continua a funcionar).
 
-Ícones/splash oficiais: usar os PNG em `frontend/public/deskrudder-pwa-*.png` num lote posterior (`@capacitor/assets`).
+Ícones/splash oficiais: usar os PNG em `frontend/public/deskrudder-pwa-*.png` num lote posterior (`@capacitor/assets`) — pode ir junto de #739.
 
 No Windows, se a pasta do clone tiver acentos (ex. `Repositórios`), o Gradle precisa de `android.overridePathCheck=true` em `frontend/android/gradle.properties` (já no repo).

--- a/frontend/scripts/build-android.mjs
+++ b/frontend/scripts/build-android.mjs
@@ -14,7 +14,17 @@ import path from 'node:path'
 
 const frontendRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
-const api = (process.env.VITE_API_URL || '').trim()
+/** Placeholder do job frontend na CI — nunca embutir no APK. */
+const CI_PLACEHOLDER = /ci\.invalid\.example/i
+
+let api = (process.env.VITE_API_URL || '').trim()
+if (api && CI_PLACEHOLDER.test(api)) {
+  console.warn(
+    `Ignorando VITE_API_URL=${api} (placeholder da CI). O APK usará a conta (slug) no login.`,
+  )
+  delete process.env.VITE_API_URL
+  api = ''
+}
 if (api) {
   console.log(`VITE_API_URL=${api} (debug: esta URL prevalece sobre o slug)`)
 } else {


### PR DESCRIPTION
## Summary

- Fecha o **L6 Android** (#696): checklist de validação do APK, runbook de AAB/release e brief actualizado
- `build:android` ignora `VITE_API_URL=https://ci.invalid.example` (placeholder da CI) para não embutir URL inválida no APK
- iOS (#738) e listing nas lojas (#739) ficam como follow-ups (bloqueados por Mac / contas developer)

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`**
- [x] Bullet de documentação / build Android

## Test plan

- [x] `npm run build:android` conclui com sucesso (sem `VITE_API_URL` efectivo após ignorar placeholder CI)
- [ ] Smoke manual no dispositivo: checklist em `docs/MOBILE_CAPACITOR.md` (11 itens)
- [ ] Confirmar no GitHub: #696 fechada; #738/#739 abertas

## Follow-ups / backlog

- [x] #738 — Capacitor iOS + APNs
- [x] #739 — Listing Play/App Store
- [x] Comentário no épico #689
