### PR TITLE
docs(mobile): listing Play Store e privacidade (#739) — fecho L6 Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Mobile (#739): runbook de publicação na Play Store (textos de listing, checklist AAB, versão Android) e página pública de **privacidade** em `/privacidade` (URL para a Console)
 - Controle de ponto (#761–#765 / #770–#772): entrada e saída pelo próprio utilizador; histórico com totais; admin vê a equipe e a visão do dia; no cadastro do atendente há flag **Usa escala** e ciclo personalizável (horas trabalhadas × horas de folga, ex. 12×36) com data de início
 - Ponto (#766–#768): pausas (almoço) sem fechar o dia; ajustes manuais do admin com motivo e auditoria; exportação CSV da equipe
 - Ponto (#769 / #773 / #774): banner de lembretes (online sem ponto / jornada longa / dia de escala sem entrada); indicador «Online sem ponto» na visão do dia; justificativas do utilizador com aprovação do admin

--- a/docs/MOBILE_APP_BRIEF.md
+++ b/docs/MOBILE_APP_BRIEF.md
@@ -188,7 +188,7 @@ Estados do chat: `aguardando_atendente` | `em_atendimento` | `encerrado`
 - Relatórios/dashboards avançados
 - Portal do cliente / funcionários de posto
 - Chat interno (há suporte parcial no APK; fora do MVP PWA inicial)
-- Capacitor iOS / listing nas lojas (#738 / #739)
+- Capacitor iOS (#738); listing Play documentado em `MOBILE_STORE_RELEASE.md` (#739)
 
 **Capacitor Android** (L6.1–L6.3): feito — ver `docs/MOBILE_CAPACITOR.md`.
 
@@ -380,10 +380,10 @@ O projecto web já é **React + TypeScript**. Ordem fechada no épico #689:
 | Fase | Abordagem |
 |------|-----------|
 | **PWA no SPA actual** | Reutiliza o painel; instalável em `https://{slug}.…`; API `/v1` na mesma instância |
-| **Capacitor (lojas)** | Android na `main` (Conta → `api-{slug}` + push UnifiedPush); iOS/listing → #738 / #739 |
+| **Capacitor (lojas)** | Android na `main` (Conta → `api-{slug}` + push UnifiedPush); listing Play → #739 / `MOBILE_STORE_RELEASE.md`; iOS → #738 |
 | React Native / Flutter | **Fora da v1** |
 
-Como construir o APK, validar e gerar AAB: **`docs/MOBILE_CAPACITOR.md`** (#696 / #735–#737 / #784).
+Como construir o APK, validar e gerar AAB: **`docs/MOBILE_CAPACITOR.md`**. Listing e privacidade da loja: **`docs/MOBILE_STORE_RELEASE.md`** (#739).
 
 ### Tempo real: SSE (já existe)
 

--- a/docs/MOBILE_CAPACITOR.md
+++ b/docs/MOBILE_CAPACITOR.md
@@ -2,7 +2,7 @@
 
 O APK é um WebView Capacitor com um **SPA mais leve**: login, **tickets** e **chat** (mesa WhatsApp / hub). Não leva landing, SaaS, CRM, cadastros nem dashboards.
 
-**Estado (Android):** L6.1 shell + L6.2 Conta + L6.3 push (VAPID + UnifiedPush) + hotfix Conta/teclado (#784) estão na `main`. **iOS** → #738. **Listing nas lojas** → #739.
+**Estado (Android):** L6.1–L6.3 + hotfix Conta/teclado na `main`. **Listing / release lojas** → [`docs/MOBILE_STORE_RELEASE.md`](MOBILE_STORE_RELEASE.md) (#739). **iOS** → #738.
 
 **Não há base de dados no telemóvel.** Os dados são os da **instância da empresa** (mesmo Postgres da API). Um binário serve várias empresas via campo **Conta**.
 
@@ -105,12 +105,11 @@ Cada instância precisa de `VAPID_*` no `client.env` e `https://localhost` em `C
 4. Assinar com o keystore DeskRudder (fora do git — guardar no cofre da equipa)
 5. Versão: `versionCode` / `versionName` em `frontend/android/app/build.gradle` (bump por release de loja)
 
-Publicação na Play Store (listing, privacy, track interna) = issue **#739** (conta Google Play do Luis).
+Listing, textos Play Console, privacidade e checklist de upload: **[`docs/MOBILE_STORE_RELEASE.md`](MOBILE_STORE_RELEASE.md)** (#739). Conta Google Play = Luis.
 
-## Fora deste documento (issues abertas)
+## Fora deste documento
 
 - iOS + APNs — **#738** (precisa Mac + Apple Developer)
-- Listing Play / App Store — **#739**
 
 ## Alertas com a app fechada (UnifiedPush / VAPID) — #737
 
@@ -120,6 +119,6 @@ O worker `web-push-outbox` já existente envia para PWA **e** APK. Mute da fila 
 
 O distribuidor embutido usa os servidores de push da Google só como transporte nos telemóveis com Play Services. Sem Play Services, o alerta com a app fechada não chega (a PWA no Chrome continua a funcionar).
 
-Ícones/splash oficiais: usar os PNG em `frontend/public/deskrudder-pwa-*.png` num lote posterior (`@capacitor/assets`) — pode ir junto de #739.
+Ícones de loja: `frontend/public/deskrudder-pwa-512.png` (e outline) — ver `MOBILE_STORE_RELEASE.md`. Opcional: regenerar splash nativo com `@capacitor/assets`.
 
 No Windows, se a pasta do clone tiver acentos (ex. `Repositórios`), o Gradle precisa de `android.overridePathCheck=true` em `frontend/android/gradle.properties` (já no repo).

--- a/docs/MOBILE_STORE_RELEASE.md
+++ b/docs/MOBILE_STORE_RELEASE.md
@@ -1,0 +1,118 @@
+# Publicação nas lojas — DeskRudder (#739)
+
+Runbook para **listing mínimo** e release do app Capacitor. O binário Android já está na `main` (L6.1–L6.3). Este documento fecha o aceite de código/docs do **#739**; o upload na Console depende das contas developer (Luis).
+
+**Não** exige PWA global `app.` — um APK/AAB + campo Conta → `api-{slug}`.
+
+| Canal | Estado |
+|-------|--------|
+| Play Store (Android) | Pronto para listing + AAB em teste interno (conta Google Play) |
+| App Store (iOS) | Bloqueado por **#738** (Mac + Apple Developer) — secção stub abaixo |
+
+Build técnico do APK/AAB: [`docs/MOBILE_CAPACITOR.md`](MOBILE_CAPACITOR.md).
+
+---
+
+## Identidade do app
+
+| Campo | Valor |
+|-------|--------|
+| Nome | DeskRudder |
+| Nome curto (≤12) | DeskRudder |
+| `applicationId` / package | `br.com.deskrudder.app` |
+| Categoria Play | Produtividade / Empresas |
+| Contacto | `contato@deskrudder.com.br` |
+| Política de privacidade (URL pública) | `https://deskrudder.com.br/privacidade` |
+| Ícone loja | `frontend/public/deskrudder-pwa-512.png` (fundo Deck) + outline `deskrudder-pwa-512-outline.png` |
+| Feature graphic (1024×500) | Gerar a partir do mark + wordmark (`BRAND.md`); não versionar binário grande no git até existir arte final |
+
+Tagline: **O leme da sua operação de atendimento**.
+
+---
+
+## Textos Play Console (copiar/colar)
+
+### Descrição curta (≤80 caracteres)
+
+```text
+Atendimento WhatsApp e tickets no telemóvel — conta da sua empresa.
+```
+
+### Descrição completa
+
+```text
+O DeskRudder no telemóvel para atendentes: fila WhatsApp, chats em curso e tickets da sua empresa — com os mesmos dados do painel web.
+
+• Conta da empresa: no primeiro login indica o identificador (ex. duplexsoft); nas seguintes o app já aponta para a API certa.
+• Operação: assumir fila, responder (texto e mídia), transferir, encerrar e abrir tickets.
+• Alertas com a app fechada: fila e mensagens dos atendimentos já teus (quando a instância tiver Web Push/VAPID configurado).
+• Um único app para várias empresas clientes DeskRudder — sem base de dados local no telemóvel.
+
+Requer ligação à internet e uma conta DeskRudder activa na instância da sua empresa.
+```
+
+### O que há de novo (modelo por release)
+
+```text
+Melhorias de estabilidade e alinhamento com o painel web. Actualize para manter alertas e login por conta da empresa.
+```
+
+(Preencher com bullets reais do `CHANGELOG.md` → `[Unreleased]` / CalVer no dia do upload.)
+
+### Classificação de conteúdo / dados
+
+- Público-alvo: **atendentes internos** (não consumidores finais do posto).
+- Dados: autenticação, chats/tickets da **instância** do cliente; sem anúncios; sem venda de dados.
+- Permissões típicas Android: Internet; notificações; microfone/câmara/ficheiros só para anexos WhatsApp (conforme uso).
+
+---
+
+## Checklist — Play (teste interno / fechado)
+
+1. [ ] Conta Google Play Console activa (Luis).
+2. [ ] Criar app `DeskRudder` / package `br.com.deskrudder.app`.
+3. [ ] Preencher listing (nome, descrições acima, ícone 512, feature graphic).
+4. [ ] URL de privacidade: `https://deskrudder.com.br/privacidade` (página no repo; deploy na apex).
+5. [ ] Gerar **AAB** assinado — ver `MOBILE_CAPACITOR.md` → «Gerar APK / AAB».
+6. [ ] Bump `versionCode` / `versionName` em `frontend/android/app/build.gradle` **antes** de cada upload.
+7. [ ] Upload na track **Internal testing** (ou Closed); adicionar e-mails dos testers.
+8. [ ] Smoke no dispositivo: checklist 11 itens em `MOBILE_CAPACITOR.md`.
+9. [ ] Confirmar push (VAPID na instância + UnifiedPush) com app fechada.
+
+Keystore e `google-services.json` (se algum dia necessário) **fora do git**.
+
+---
+
+## Versão Android (convenção)
+
+| Campo | Onde | Regra |
+|-------|------|--------|
+| `versionCode` | `app/build.gradle` | Inteiro monotónico (+1 por upload Play) |
+| `versionName` | idem | Semântico curto alinhado ao produto (ex. `1.0.0`, `1.0.1`) — independente do CalVer do painel web |
+
+Nunca publicar com `VITE_API_URL` definido no build de loja.
+
+---
+
+## App Store / TestFlight (#738)
+
+Quando existir Mac + Apple Developer:
+
+1. `npx cap add ios` / `cap sync ios` (issue #738).
+2. Bundle ID alinhado a `br.com.deskrudder.app` (ou variante registada na Apple).
+3. Listing: reutilizar textos PT-BR desta página; screenshots iPhone.
+4. Privacidade: mesma URL `https://deskrudder.com.br/privacidade`.
+5. TestFlight interno antes de App Review.
+
+Até lá, o épico Mobile (#689 / #696) considera **Android + docs de loja** como L6 entregue no código; iOS permanece follow-up explícito.
+
+---
+
+## Relação com o épico
+
+| Issue | Entrega |
+|-------|---------|
+| #735 / #736 | Shell Android + Conta |
+| #737 | Push UnifiedPush/VAPID |
+| #739 | Este doc + URL de privacidade + textos listing |
+| #738 | iOS + APNs (fora deste lote) |

--- a/frontend/android/app/build.gradle
+++ b/frontend/android/app/build.gradle
@@ -15,8 +15,9 @@ android {
         applicationId "br.com.deskrudder.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
+        // Bump versionCode (+1) e versionName a cada upload Play — ver docs/MOBILE_STORE_RELEASE.md (#739)
         versionCode 1
-        versionName "1.0"
+        versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { EsqueciSenha } from './pages/EsqueciSenha'
 import { RedefinirSenha } from './pages/RedefinirSenha'
 import { AvaliarTicket } from './pages/AvaliarTicket'
 import { LandingPage } from './pages/marketing/LandingPage'
+import { PrivacidadePage } from './pages/marketing/PrivacidadePage'
 import { TrialPage } from './pages/marketing/TrialPage'
 import { Dashboard } from './pages/Dashboard'
 import { DashboardTickets } from './pages/DashboardTickets'
@@ -251,6 +252,7 @@ function AppRoutes() {
       <Route path="/login/admin" element={<Login />} />
       <Route path="/auth/sessao" element={<AuthSessao />} />
       <Route path="/trial" element={<TrialPage />} />
+      <Route path="/privacidade" element={<PrivacidadePage />} />
       <Route path="/esqueci-senha" element={<EsqueciSenha />} />
       <Route path="/redefinir-senha" element={<RedefinirSenha />} />
       <Route path="/avaliar-ticket" element={<AvaliarTicket />} />

--- a/frontend/src/pages/marketing/LandingPage.tsx
+++ b/frontend/src/pages/marketing/LandingPage.tsx
@@ -497,6 +497,9 @@ export function LandingPage() {
             <Link to="/login/admin" className="font-medium text-sky-300 hover:text-sky-200">
               {landingFooter.loginLabel}
             </Link>
+            <Link to="/privacidade" className="text-slate-400 hover:text-slate-200">
+              Política de privacidade
+            </Link>
             <a href={`mailto:${landingContactEmail}`} className="text-slate-400 hover:text-slate-200">
               {landingFooter.contactLabel}: {landingContactEmail}
             </a>

--- a/frontend/src/pages/marketing/PrivacidadePage.tsx
+++ b/frontend/src/pages/marketing/PrivacidadePage.tsx
@@ -1,0 +1,121 @@
+import { Link } from 'react-router-dom'
+import { BrandLogo } from '../../brand'
+import { APP_NAME } from '../../brand/tokens'
+import { landingContactEmail } from '../../content/landing'
+import { MarketingLayout } from './MarketingLayout'
+
+/** Política de privacidade pública — URL exigida pela Play Console (#739). */
+export function PrivacidadePage() {
+  return (
+    <MarketingLayout>
+      <div className="mx-auto max-w-3xl px-5 py-12 sm:px-8 lg:px-10">
+        <Link to="/" className="inline-flex items-center gap-2 text-sm font-medium text-sky-300 hover:text-sky-200">
+          ← Voltar
+        </Link>
+        <div className="mt-8">
+          <BrandLogo variant="wordmark" size="md" markVariant="onDark" />
+        </div>
+        <h1 className="mt-6 text-3xl font-bold tracking-tight text-white sm:text-4xl">
+          Política de privacidade
+        </h1>
+        <p className="mt-2 text-sm text-slate-500">Última actualização: agosto de 2026 · App e painel {APP_NAME}</p>
+
+        <div className="prose prose-invert mt-10 max-w-none space-y-8 text-slate-300 prose-headings:text-white prose-a:text-sky-300">
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold text-white">1. Quem somos</h2>
+            <p>
+              O {APP_NAME} é um sistema de atendimento (helpdesk) operado por instância dedicada para cada
+              empresa cliente. Esta política descreve o tratamento de dados no <strong>painel web</strong>,
+              na <strong>PWA</strong> e no <strong>aplicativo Android</strong> (package{' '}
+              <code className="text-sky-200">br.com.deskrudder.app</code>).
+            </p>
+            <p>
+              Contacto: <a href={`mailto:${landingContactEmail}`}>{landingContactEmail}</a>.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold text-white">2. Dados que tratamos</h2>
+            <ul className="list-disc space-y-2 pl-5">
+              <li>
+                <strong>Conta e autenticação:</strong> e-mail, nome, credenciais (hash), tokens de sessão e,
+                no app, o identificador da empresa (slug) escolhido no login.
+              </li>
+              <li>
+                <strong>Operação de atendimento:</strong> tickets, mensagens WhatsApp/portal, anexos,
+                metadados de fila e preferências de notificação — sempre na base da <em>instância</em> da
+                empresa cliente.
+              </li>
+              <li>
+                <strong>Notificações:</strong> endpoints Web Push / UnifiedPush associados ao utilizador na
+                instância, para alertas de fila e mensagens.
+              </li>
+              <li>
+                <strong>Dados técnicos:</strong> logs de aplicação, endereço IP e user-agent para segurança e
+                diagnóstico.
+              </li>
+            </ul>
+            <p>
+              O aplicativo móvel <strong>não</strong> guarda uma cópia local da base de dados: os dados são
+              os da API da empresa indicada na Conta.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold text-white">3. Finalidades</h2>
+            <p>
+              Prestação do serviço de atendimento, autenticação, notificações operacionais, suporte técnico e
+              melhoria de estabilidade. Não vendemos dados pessoais. Não usamos os dados do atendimento para
+              publicidade de terceiros.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold text-white">4. Partilha e subprocessadores</h2>
+            <p>
+              Os dados da operação permanecem na infraestrutura da instância do cliente (ou do operador
+              SaaS, conforme o contrato). Transportes de push (ex. serviços Google Play no Android) podem
+              ser usados só para entregar a notificação, sem acesso ao conteúdo do painel.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold text-white">5. Conservação e direitos</h2>
+            <p>
+              Os prazos seguem o contrato com a empresa cliente e a legislação aplicável (incluindo LGPD).
+              Pedidos de acesso, correcção ou eliminação devem ser feitos ao administrador da instância ou
+              a <a href={`mailto:${landingContactEmail}`}>{landingContactEmail}</a>.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold text-white">6. Segurança</h2>
+            <p>
+              Comunicação HTTPS, isolamento por instância (single-tenant em produção) e controlos de acesso
+              por perfil (RBAC). Credenciais e keystores de publicação de loja não fazem parte do código
+              público.
+            </p>
+          </section>
+
+          <section className="space-y-3">
+            <h2 className="text-xl font-semibold text-white">7. Alterações</h2>
+            <p>
+              Podemos actualizar esta página; a data no topo reflecte a versão vigente. Uso continuado do
+              serviço após a alteração constitui ciência da nova versão, salvo obrigação legal em contrário.
+            </p>
+          </section>
+        </div>
+
+        <p className="mt-12 text-sm text-slate-500">
+          <Link to="/" className="text-sky-300 hover:text-sky-200">
+            {APP_NAME}
+          </Link>
+          {' · '}
+          <a href={`mailto:${landingContactEmail}`} className="hover:text-slate-300">
+            {landingContactEmail}
+          </a>
+        </p>
+      </div>
+    </MarketingLayout>
+  )
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Runbook `docs/MOBILE_STORE_RELEASE.md`: textos de listing Play, checklist AAB/teste interno, versão Android, stub App Store (#738).
- Página pública `/privacidade` (URL para a Play Console) + link no rodapé da landing.
- Brief / `MOBILE_CAPACITOR` alinhados; `versionName` 1.0.0 com nota de bump.

Closes #739

## CHANGELOG

- [x] `CHANGELOG.md` → `[Unreleased]` (Melhorias)

## Test plan

- [ ] Abrir `https://deskrudder.com.br/privacidade` (após deploy staging) ou localhost na apex/marketing host
- [ ] Revisar textos em `docs/MOBILE_STORE_RELEASE.md` antes de colar na Play Console
- [ ] `npm run build` frontend (CI)

## Follow-ups

- [x] #738 Capacitor iOS + APNs (Mac + Apple Developer) — não fecha neste PR
- [ ] Conta Google Play: upload AAB na track interna (ops / Luis)
- [ ] Fechar #696 / #689 no GitHub se ainda abertas (L6 Android + docs; iOS adiado)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d42c332-c341-4c3b-942d-9da04c1d6e07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d42c332-c341-4c3b-942d-9da04c1d6e07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

