### PR TITLE
docs(mobile): alinhar brief ao épico #689 / L6 concluído

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Interno
 
+- Mobile: brief (`MOBILE_APP_BRIEF.md`) alinhado ao estado real do épico #689 / L6 Android (PWA + Capacitor + listing docs; iOS = #738)
 - Deploy (#734): ligação SSH ao VPS em IPv4, diagnóstico do IP do runner e segunda tentativa noutro runner só em timeout de rede
 - Mobile (#735): `CORS_ORIGINS` das instâncias passa a incluir `https://localhost` (origem do WebView Android)
 - Mobile (#735): projecto Capacitor Android no `frontend/` (`npm run build:android`); `stack-client.sh` documentado como `<comando> <slug>`

--- a/docs/MOBILE_APP_BRIEF.md
+++ b/docs/MOBILE_APP_BRIEF.md
@@ -136,15 +136,16 @@ Sistema de **helpdesk** para **redes de postos/empresas**:
 
 | Fase | Stack |
 |------|--------|
-| Agora | **PWA** no frontend React actual (mesmo `/v1`, mesma origem do painel) |
-| Em curso | **Capacitor** Android: 1 APK + campo Conta → `api-{slug}` (tickets e chat) |
-| Depois | Play Store / App Store + UnifiedPush (VAPID) no Android / APNs no iOS |
+| Feito | **PWA** no frontend React (mesmo `/v1`, mesma origem do painel) — L0–L5 |
+| Feito | **Capacitor Android**: 1 APK + Conta → `api-{slug}` (tickets/chat) + UnifiedPush/VAPID — L6.1–L6.3 |
+| Feito (docs) | Listing Play + privacidade — `docs/MOBILE_STORE_RELEASE.md` (#739); upload AAB = conta Google (ops) |
+| Follow-up | **iOS** Capacitor + APNs — #738 (Mac + Apple Developer) |
 | Não na v1 | React Native / Flutter |
 
-**Install (híbrido C):** PWA por `{slug}` agora; nas lojas será **1 app** + campo Conta → `api-{slug}`.  
-**Infra:** 1 VPS; **novo container/stack por cliente** (não há PWA global `app.` nesta fase).
+**Install (híbrido C):** PWA por `{slug}`; nas lojas **1 app** Android + campo Conta → `api-{slug}` (sem PWA global `app.`).  
+**Infra:** 1 VPS; **novo container/stack por cliente**.
 
-**Push v1 (L3/L4, hardening L5):** fila **e** mensagens em chats/tickets **já meus**, com a PWA fechada. **Android/Chrome** é o piloto. **iOS Safari:** só com a app na tela inicial (iOS 16.4+); na aba do Safari o push não é fiável.
+**Push:** fila **e** mensagens em chats/tickets **já meus**, com a app/PWA fechada — Web Push VAPID (PWA) e o mesmo canal no APK (UnifiedPush). **iOS Safari:** só com a app na tela inicial (iOS 16.4+).
 
 ### Fase 1 — Core (login + tempo real)
 
@@ -450,10 +451,10 @@ Somente ambiente local (nunca produção):
 
 > **Projeto:** DeskRudder (DX Connect) — helpdesk para redes de postos.  
 > **Backend:** FastAPI + JWT em `/v1` (não Django).  
-> **Mobile v1:** PWA no SPA actual para **atendentes** (WhatsApp + tickets). Não RN na v1.  
-> **Install:** PWA por `https://{slug}.deskrudder.com.br`; lojas depois (Capacitor + campo Conta).  
+> **Mobile v1:** PWA + APK Capacitor Android para **atendentes** (WhatsApp + tickets). Não RN na v1.  
+> **Install:** PWA por `https://{slug}.deskrudder.com.br`; lojas = 1 app + campo Conta → `api-{slug}` (listing: `MOBILE_STORE_RELEASE.md`).  
 > **Infra:** 1 VPS, um container/stack por cliente.  
-> **Tempo real:** SSE `GET /v1/events/stream` (já no web). Push com app fechada = Web Push VAPID (Android/Chrome; iOS só PWA no ecrã inicial, 16.4+).  
+> **Tempo real:** SSE `GET /v1/events/stream`. Push com app fechada = Web Push VAPID (PWA + UnifiedPush no Android). iOS nativo = #738.  
 > **Começar por:** Login → Fila WhatsApp → Conversa (assumir/enviar/encerrar) e lista/detalhe de tickets.  
 > **Auth:** `POST /v1/auth/login` → Bearer token → `GET /v1/atendentes/me`.  
 > **APIs:** `/notificacoes/resumo`, `/whatsapp/chats/fila`, `/whatsapp/chats/meus`, `/whatsapp/chats/{id}/mensagens`, `/tickets?situacao=abertos`.  


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Alinha `docs/MOBILE_APP_BRIEF.md` ao estado real do épico Mobile (#689) e L6 Android (#696): PWA, Capacitor + Conta + UnifiedPush e listing docs (#739) como **feitos**; iOS nativo permanece #738.
- Não há feature em falta nestas issues — só documentação desactualizada («Em curso» / «lojas depois»).

## CHANGELOG

- [x] Interno em `[Unreleased]`

## Test plan

- [x] Revisão do brief §5 e §12 vs `MOBILE_CAPACITOR.md` / `MOBILE_STORE_RELEASE.md`

## Follow-ups

- [x] #738 iOS (já no backlog)
- [ ] Upload AAB Play = ops (Luis)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d42c332-c341-4c3b-942d-9da04c1d6e07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d42c332-c341-4c3b-942d-9da04c1d6e07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

