### PR TITLE
fix(whatsapp): gravação de áudio presa / vazia (#788)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- WhatsApp (#788): gravação de áudio deixa de ficar presa em «A preparar microfone…» (o compositor reiniciava o MediaRecorder a cada render) e rejeita blobs vazios/truncados antes do envio; MIME preferido ogg/webm opus
 - Mobile (#739): runbook de publicação na Play Store (textos de listing, checklist AAB, versão Android) e página pública de **privacidade** em `/privacidade` (URL para a Console)
 - Controle de ponto (#761–#765 / #770–#772): entrada e saída pelo próprio utilizador; histórico com totais; admin vê a equipe e a visão do dia; no cadastro do atendente há flag **Usa escala** e ciclo personalizável (horas trabalhadas × horas de folga, ex. 12×36) com data de início
 - Ponto (#766–#768): pausas (almoço) sem fechar o dia; ajustes manuais do admin com motivo e auditoria; exportação CSV da equipe

--- a/frontend/src/lib/gravacaoAudio.ts
+++ b/frontend/src/lib/gravacaoAudio.ts
@@ -1,0 +1,39 @@
+/** Preferências de MIME para nota de voz (WhatsApp / Evolution PTT). */
+const MIME_CANDIDATOS = [
+  'audio/ogg;codecs=opus',
+  'audio/webm;codecs=opus',
+  'audio/webm',
+  'audio/mp4',
+] as const
+
+/** Blobs só com cabeçalho (sem samples) costumam ficar abaixo disto. */
+export const TAMANHO_MIN_AUDIO_BYTES = 512
+
+export function escolherMimeGravacao(): string {
+  if (typeof MediaRecorder === 'undefined' || typeof MediaRecorder.isTypeSupported !== 'function') {
+    return ''
+  }
+  for (const mime of MIME_CANDIDATOS) {
+    if (MediaRecorder.isTypeSupported(mime)) return mime
+  }
+  return ''
+}
+
+export function extensaoAudioMime(mime: string): string {
+  const m = (mime || '').toLowerCase()
+  if (m.includes('ogg')) return 'ogg'
+  if (m.includes('mp4') || m.includes('mpeg') || m.includes('m4a') || m.includes('aac')) return 'm4a'
+  if (m.includes('wav')) return 'wav'
+  return 'webm'
+}
+
+export function criarMediaRecorder(stream: MediaStream): MediaRecorder {
+  const mime = escolherMimeGravacao()
+  return mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream)
+}
+
+export function ficheiroDeBlobGravacao(blob: Blob): File {
+  const type = blob.type || 'audio/webm'
+  const ext = extensaoAudioMime(type)
+  return new File([blob], `audio-${Date.now()}.${ext}`, { type })
+}

--- a/frontend/src/pages/whatsapp/WhatsappGravadorAudio.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappGravadorAudio.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { Button } from '../../components/ui/Button'
+import {
+  TAMANHO_MIN_AUDIO_BYTES,
+  criarMediaRecorder,
+  ficheiroDeBlobGravacao,
+} from '../../lib/gravacaoAudio'
 
 type Props = {
   disabled?: boolean
@@ -16,8 +21,12 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
   const streamRef = useRef<MediaStream | null>(null)
   const chunksRef = useRef<Blob[]>([])
   const timerRef = useRef<number | null>(null)
-
   const canceladoRef = useRef(false)
+  const onConcluidoRef = useRef(onConcluido)
+
+  useEffect(() => {
+    onConcluidoRef.current = onConcluido
+  }, [onConcluido])
 
   const pararStream = useCallback(() => {
     streamRef.current?.getTracks().forEach((t) => t.stop())
@@ -28,48 +37,90 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
     }
   }, [])
 
-  useEffect(() => () => pararStream(), [pararStream])
+  const pararRecorder = useCallback(() => {
+    const rec = recorderRef.current
+    if (!rec || rec.state === 'inactive') return
+    try {
+      if (rec.state === 'recording') rec.requestData()
+    } catch {
+      /* ignore */
+    }
+    try {
+      rec.stop()
+    } catch {
+      /* ignore */
+    }
+  }, [])
+
+  useEffect(() => () => {
+    canceladoRef.current = true
+    const rec = recorderRef.current
+    if (rec && rec.state !== 'inactive') {
+      pararRecorder()
+    } else {
+      pararStream()
+    }
+  }, [pararRecorder, pararStream])
 
   async function iniciar() {
     if (disabled || gravando) return
     setErro(null)
     canceladoRef.current = false
     chunksRef.current = []
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setErro('Microfone não suportado neste browser (use HTTPS).')
+      return
+    }
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          channelCount: 1,
+        },
+      })
       streamRef.current = stream
-      const mime =
-        MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
-          ? 'audio/webm;codecs=opus'
-          : MediaRecorder.isTypeSupported('audio/webm')
-            ? 'audio/webm'
-            : ''
-      const recorder = mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream)
+      let recorder: MediaRecorder
+      try {
+        recorder = criarMediaRecorder(stream)
+      } catch {
+        stream.getTracks().forEach((t) => t.stop())
+        streamRef.current = null
+        setErro('Gravação de áudio não suportada neste browser.')
+        return
+      }
       recorderRef.current = recorder
       recorder.ondataavailable = (ev) => {
         if (canceladoRef.current) return
-        if (ev.data.size > 0) chunksRef.current.push(ev.data)
+        if (ev.data && ev.data.size > 0) chunksRef.current.push(ev.data)
+      }
+      recorder.onerror = () => {
+        setErro('Falha na gravação. Tente novamente.')
+        setGravando(false)
+        setSegundos(0)
+        pararStream()
       }
       recorder.onstop = () => {
         pararStream()
+        recorderRef.current = null
         if (canceladoRef.current) {
           chunksRef.current = []
           setGravando(false)
           setSegundos(0)
           return
         }
-        const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' })
-        if (blob.size === 0) {
-          setErro('Gravação vazia. Tente novamente.')
+        const mime = recorder.mimeType || chunksRef.current[0]?.type || 'audio/webm'
+        const blob = new Blob(chunksRef.current, { type: mime })
+        chunksRef.current = []
+        if (blob.size < TAMANHO_MIN_AUDIO_BYTES) {
+          setErro('Gravação vazia ou demasiado curta. Tente novamente.')
           setGravando(false)
           setSegundos(0)
           return
         }
-        const ext = blob.type.includes('ogg') ? 'ogg' : 'webm'
-        const file = new File([blob], `audio-${Date.now()}.${ext}`, { type: blob.type || 'audio/webm' })
         setGravando(false)
         setSegundos(0)
-        onConcluido(file)
+        onConcluidoRef.current(ficheiroDeBlobGravacao(blob))
       }
       recorder.start(250)
       setGravando(true)
@@ -83,19 +134,20 @@ export function WhatsappGravadorAudio({ disabled, onConcluido, onCancelar }: Pro
 
   function parar() {
     canceladoRef.current = false
-    const rec = recorderRef.current
-    if (rec && rec.state !== 'inactive') rec.stop()
-    recorderRef.current = null
+    pararRecorder()
   }
 
   function cancelar() {
     canceladoRef.current = true
     if (gravando) {
       const rec = recorderRef.current
-      if (rec && rec.state !== 'inactive') rec.stop()
-      recorderRef.current = null
+      if (rec && rec.state !== 'inactive') {
+        pararRecorder()
+      } else {
+        pararStream()
+        recorderRef.current = null
+      }
       chunksRef.current = []
-      pararStream()
       setGravando(false)
       setSegundos(0)
     }

--- a/frontend/src/pages/whatsapp/WhatsappGravadorAudioInline.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappGravadorAudioInline.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '../../components/ui/Button'
+import {
+  TAMANHO_MIN_AUDIO_BYTES,
+  criarMediaRecorder,
+  ficheiroDeBlobGravacao,
+} from '../../lib/gravacaoAudio'
 
 type Props = {
   disabled?: boolean
@@ -16,8 +21,17 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
   const streamRef = useRef<MediaStream | null>(null)
   const chunksRef = useRef<Blob[]>([])
   const timerRef = useRef<number | null>(null)
-  const iniciouRef = useRef(false)
   const canceladoRef = useRef(false)
+  const onConcluidoRef = useRef(onConcluido)
+  const onCancelarRef = useRef(onCancelar)
+
+  useEffect(() => {
+    onConcluidoRef.current = onConcluido
+  }, [onConcluido])
+
+  useEffect(() => {
+    onCancelarRef.current = onCancelar
+  }, [onCancelar])
 
   const pararStream = useCallback(() => {
     streamRef.current?.getTracks().forEach((t) => t.stop())
@@ -28,78 +42,140 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
     }
   }, [])
 
+  const pararRecorder = useCallback(() => {
+    const rec = recorderRef.current
+    if (!rec || rec.state === 'inactive') return
+    try {
+      if (rec.state === 'recording') rec.requestData()
+    } catch {
+      /* alguns browsers não implementam requestData */
+    }
+    try {
+      rec.stop()
+    } catch {
+      /* already stopped */
+    }
+  }, [])
+
   useEffect(() => {
-    if (disabled || iniciouRef.current) return
-    iniciouRef.current = true
+    if (disabled) return
+
+    let alive = true
     canceladoRef.current = false
+    chunksRef.current = []
+    setErro(null)
+    setSegundos(0)
+    setGravando(false)
+
     void (async () => {
-      setErro(null)
-      chunksRef.current = []
+      if (!navigator.mediaDevices?.getUserMedia) {
+        if (alive) setErro('Microfone não suportado neste browser (use HTTPS).')
+        return
+      }
       try {
-        const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
-        streamRef.current = stream
-        const mime = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
-          ? 'audio/webm;codecs=opus'
-          : MediaRecorder.isTypeSupported('audio/webm')
-            ? 'audio/webm'
-            : ''
-        const recorder = mime ? new MediaRecorder(stream, { mimeType: mime }) : new MediaRecorder(stream)
-        recorderRef.current = recorder
-        recorder.ondataavailable = (ev) => {
-          if (canceladoRef.current) return
-          if (ev.data.size > 0) chunksRef.current.push(ev.data)
+        const stream = await navigator.mediaDevices.getUserMedia({
+          audio: {
+            echoCancellation: true,
+            noiseSuppression: true,
+            channelCount: 1,
+          },
+        })
+        if (!alive) {
+          stream.getTracks().forEach((t) => t.stop())
+          return
         }
+        streamRef.current = stream
+
+        let recorder: MediaRecorder
+        try {
+          recorder = criarMediaRecorder(stream)
+        } catch {
+          stream.getTracks().forEach((t) => t.stop())
+          streamRef.current = null
+          if (alive) setErro('Gravação de áudio não suportada neste browser.')
+          return
+        }
+        recorderRef.current = recorder
+
+        recorder.ondataavailable = (ev) => {
+          if (canceladoRef.current || !alive) return
+          if (ev.data && ev.data.size > 0) chunksRef.current.push(ev.data)
+        }
+
+        recorder.onerror = () => {
+          if (!alive) return
+          setErro('Falha na gravação. Tente novamente.')
+          setGravando(false)
+          pararStream()
+        }
+
         recorder.onstop = () => {
           pararStream()
-          if (canceladoRef.current) {
+          recorderRef.current = null
+          if (!alive || canceladoRef.current) {
             chunksRef.current = []
             setGravando(false)
             return
           }
-          const blob = new Blob(chunksRef.current, { type: recorder.mimeType || 'audio/webm' })
-          if (blob.size === 0) {
-            setErro('Gravação vazia.')
+          const mime = recorder.mimeType || chunksRef.current[0]?.type || 'audio/webm'
+          const blob = new Blob(chunksRef.current, { type: mime })
+          chunksRef.current = []
+          if (blob.size < TAMANHO_MIN_AUDIO_BYTES) {
+            setErro('Gravação vazia ou demasiado curta. Segure um pouco e tente de novo.')
             setGravando(false)
             return
           }
-          const ext = blob.type.includes('ogg') ? 'ogg' : 'webm'
-          onConcluido(new File([blob], `audio-${Date.now()}.${ext}`, { type: blob.type || 'audio/webm' }))
+          setGravando(false)
+          onConcluidoRef.current(ficheiroDeBlobGravacao(blob))
         }
+
         recorder.start(250)
+        if (!alive) {
+          pararRecorder()
+          return
+        }
         setGravando(true)
         timerRef.current = window.setInterval(() => setSegundos((s) => s + 1), 1000)
       } catch {
         pararStream()
-        setErro('Microfone indisponível.')
+        if (alive) setErro('Microfone indisponível. Verifique as permissões do browser.')
       }
     })()
+
     return () => {
+      alive = false
       canceladoRef.current = true
-      pararStream()
+      // Parar o MediaRecorder primeiro; as tracks saem no onstop (evita blob truncado).
       const rec = recorderRef.current
-      if (rec && rec.state !== 'inactive') rec.stop()
+      if (rec && rec.state !== 'inactive') {
+        pararRecorder()
+      } else {
+        pararStream()
+      }
     }
-  }, [disabled, onConcluido, pararStream])
+  }, [disabled, pararRecorder, pararStream])
 
   const mm = String(Math.floor(segundos / 60)).padStart(2, '0')
   const ss = String(segundos % 60).padStart(2, '0')
 
   function parar() {
+    if (!gravando) return
     canceladoRef.current = false
-    const rec = recorderRef.current
-    if (rec && rec.state !== 'inactive') rec.stop()
-    recorderRef.current = null
+    pararRecorder()
   }
 
   function cancelar() {
     canceladoRef.current = true
     chunksRef.current = []
-    pararStream()
     const rec = recorderRef.current
-    if (rec && rec.state !== 'inactive') rec.stop()
-    recorderRef.current = null
+    if (rec && rec.state !== 'inactive') {
+      pararRecorder()
+    } else {
+      pararStream()
+      recorderRef.current = null
+    }
     setGravando(false)
-    onCancelar()
+    onCancelarRef.current()
   }
 
   return (
@@ -107,7 +183,7 @@ export function WhatsappGravadorAudioInline({ disabled, onConcluido, onCancelar 
       <div className="flex items-center gap-2 text-xs">
         {gravando && <span className="h-2 w-2 animate-pulse rounded-full bg-rose-500" />}
         <span className="font-medium text-rose-800 dark:text-rose-200">
-          {gravando ? `A gravar ${mm}:${ss}` : 'A preparar microfone…'}
+          {gravando ? `A gravar ${mm}:${ss}` : erro ? 'Gravação interrompida' : 'A preparar microfone…'}
         </span>
       </div>
       <div className="flex gap-2">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumo

Corrige a gravação de nota de voz no composer WhatsApp (e chat interno, que reutiliza o mesmo componente).

**Causa (microfone «A preparar…»):** o `useEffect` do `WhatsappGravadorAudioInline` dependia de `onConcluido`. O composer passava um callback inline novo a cada render → cleanup cancelava o `MediaRecorder` e o `iniciouRef` impedia reinício → UI presa em «A preparar microfone…».

**Áudio enviado vazio / truncado:** no cleanup as tracks do microfone eram paradas *antes* de `recorder.stop()`, o que em alguns browsers gera blob só com cabeçalho (size > 0 mas sem samples úteis). Evolution aceita e o WhatsApp mostra nota vazia.

### Alterações
- Callbacks via refs — o efeito já não reinicia a gravação a cada render
- Parar `MediaRecorder` antes de cortar as tracks; `requestData()` antes do `stop`
- MIME preferido: `ogg/opus` → `webm/opus` → fallbacks
- Rejeitar blobs &lt; 512 bytes com mensagem clara
- Helper partilhado `frontend/src/lib/gravacaoAudio.ts`

Closes #788

## Test plan
- [ ] No WhatsApp, tocar no microfone: deve passar a «A gravar mm:ss» em poucos segundos (não ficar preso em preparar)
- [ ] Gravar ≥2 s e enviar: o contacto recebe áudio audível
- [ ] Cancelar a meio: não envia; microfone libertado
- [ ] Gravação muito curta: mensagem de erro, sem envio
- [ ] Mesmo fluxo no chat interno (composer com mic)
- [ ] Repetir com a conversa a receber SSE / mensagens enquanto grava (re-renders) — deve continuar a gravar

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d42c332-c341-4c3b-942d-9da04c1d6e07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d42c332-c341-4c3b-942d-9da04c1d6e07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

