### PR TITLE
feat(sidebar): agrupar Ponto e Chat em blocos expansíveis (#793)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Menu (#793): **Ponto** (Meu ponto / Equipe online / Ponto da equipe) e **Chat** (Chat / Atendimentos) passam a ser grupos expansíveis no menu lateral, no mesmo padrão de Configurações
 - WhatsApp (#788): gravação de áudio deixa de ficar presa em «A preparar microfone…» (o compositor reiniciava o MediaRecorder a cada render) e rejeita blobs vazios/truncados antes do envio; MIME preferido ogg/webm opus
 - Mobile (#739): runbook de publicação na Play Store (textos de listing, checklist AAB, versão Android) e página pública de **privacidade** em `/privacidade` (URL para a Console)
 - Controle de ponto (#761–#765 / #770–#772): entrada e saída pelo próprio utilizador; histórico com totais; admin vê a equipe e a visão do dia; no cadastro do atendente há flag **Usa escala** e ciclo personalizável (horas trabalhadas × horas de folga, ex. 12×36) com data de início

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -267,26 +267,28 @@ type NavItem = NavItemLink | NavGroup
 const navStructure: NavItem[] = [
   { type: 'link', to: '/', label: 'Dashboard', icon: 'dashboard', hideOnNative: true },
   {
-    type: 'link',
-    to: '/ponto',
-    label: 'Meu ponto',
+    type: 'group',
+    id: 'ponto',
+    label: 'Ponto',
     icon: 'ponto',
-  },
-  {
-    type: 'link',
-    to: '/equipe/online',
-    label: 'Equipe online',
-    icon: 'equipeOnline',
-    adminOnly: true,
-    hideOnNative: true,
-  },
-  {
-    type: 'link',
-    to: '/equipe/ponto',
-    label: 'Ponto da equipe',
-    icon: 'equipeOnline',
-    adminOnly: true,
-    hideOnNative: true,
+    extraActivePrefixes: ['/ponto', '/equipe/online', '/equipe/ponto'],
+    children: [
+      { to: '/ponto', label: 'Meu ponto', icon: 'ponto' },
+      {
+        to: '/equipe/online',
+        label: 'Equipe online',
+        icon: 'equipeOnline',
+        adminOnly: true,
+        hideOnNative: true,
+      },
+      {
+        to: '/equipe/ponto',
+        label: 'Ponto da equipe',
+        icon: 'equipeOnline',
+        adminOnly: true,
+        hideOnNative: true,
+      },
+    ],
   },
   { type: 'link', to: '/tickets', label: 'Tickets', icon: 'tickets' },
   {
@@ -314,8 +316,28 @@ const navStructure: NavItem[] = [
       },
     ],
   },
-  { type: 'link', to: '/chat/atendendo', label: 'Chat', icon: 'chat', activePrefix: '/chat/' },
-  { type: 'link', to: '/whatsapp/historico', label: 'Atendimentos', icon: 'chatHistory' },
+  {
+    type: 'group',
+    id: 'chat',
+    label: 'Chat',
+    icon: 'chat',
+    /** Hub `/chat/*`, histórico/avaliações e rotas legadas `/whatsapp/c/:id` */
+    extraActivePrefixes: ['/chat/', '/whatsapp/'],
+    children: [
+      {
+        to: '/chat/atendendo',
+        label: 'Chat',
+        icon: 'chat',
+        activePrefix: '/chat/',
+      },
+      {
+        to: '/whatsapp/historico',
+        label: 'Atendimentos',
+        icon: 'chatHistory',
+        activePrefix: '/whatsapp/',
+      },
+    ],
+  },
   {
     type: 'group',
     id: 'clientes',
@@ -368,7 +390,14 @@ const navStructure: NavItem[] = [
 
 function navGroupMatchesPath(pathname: string, group: NavGroup): boolean {
   if (
-    group.children.some((c) => pathname === c.to || (c.to !== '/' && pathname.startsWith(c.to)))
+    group.children.some(
+      (c) =>
+        pathname === c.to ||
+        (c.activePrefix != null &&
+          c.activePrefix !== '' &&
+          pathname.startsWith(c.activePrefix)) ||
+        (c.to !== '/' && pathname.startsWith(c.to)),
+    )
   ) {
     return true
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumo

O menu lateral tinha vários links soltos no 1.º nível (ponto/equipe e chat/atendimentos). Passam a grupos expansíveis no mesmo padrão de Configurações / Comercial / Clientes / Ajuda.

| Grupo | Filhos |
|-------|--------|
| **Ponto** | Meu ponto · Equipe online · Ponto da equipe |
| **Chat** | Chat (`/chat/atendendo`) · Atendimentos (`/whatsapp/historico`) |

### Detalhes
- RBAC intacto: Equipe online / Ponto da equipe continuam `adminOnly`
- Capacitor: `hideOnNative` mantido nos filhos admin; Meu ponto e Chat/Atendimentos continuam no app nativo
- Rota ativa abre o grupo e destaca o filho (`activePrefix` + `extraActivePrefixes`, incl. hub `/chat/*` e `/whatsapp/*`)
- `navGroupMatchesPath` passa a respeitar `activePrefix` dos filhos

Closes #793

## Test plan
- [ ] Menu 1.º nível mais curto: blocos **Ponto** e **Chat** em vez de 5 links soltos
- [ ] Expandir/recolher igual a Configurações
- [ ] Atendente: em Ponto só vê «Meu ponto»; não vê Equipe online / Ponto da equipe
- [ ] Admin: vê os 3 filhos de Ponto
- [ ] Em `/chat/espera` ou `/chat/interno`, grupo Chat aberto e item Chat ativo
- [ ] Em `/whatsapp/historico` (e avaliações), grupo Chat aberto e Atendimentos ativo
- [ ] App nativo: sem Equipe online / Ponto da equipe; Chat e Meu ponto disponíveis

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d42c332-c341-4c3b-942d-9da04c1d6e07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d42c332-c341-4c3b-942d-9da04c1d6e07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

