### PR TITLE
feat(sidebar): Atendimentos com Chat, Tickets e Histórico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
-- Menu: o grupo do chat no menu lateral passa a chamar-se **Atendimentos**, com **Chat** e **Histórico**
+- Menu: grupo **Atendimentos** no menu lateral com **Chat**, **Tickets** e **Histórico** (toda a operação de atendimento junta)
 - Menu (#793): **Ponto** (Meu ponto / Equipe online / Ponto da equipe) e **Chat** (Chat / Atendimentos) passam a ser grupos expansíveis no menu lateral, no mesmo padrão de Configurações
 - WhatsApp (#788): gravação de áudio deixa de ficar presa em «A preparar microfone…» (o compositor reiniciava o MediaRecorder a cada render) e rejeita blobs vazios/truncados antes do envio; MIME preferido ogg/webm opus
 - Mobile (#739): runbook de publicação na Play Store (textos de listing, checklist AAB, versão Android) e página pública de **privacidade** em `/privacidade` (URL para a Console)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Menu: o grupo do chat no menu lateral passa a chamar-se **Atendimentos**, com **Chat** e **Histórico**
 - Menu (#793): **Ponto** (Meu ponto / Equipe online / Ponto da equipe) e **Chat** (Chat / Atendimentos) passam a ser grupos expansíveis no menu lateral, no mesmo padrão de Configurações
 - WhatsApp (#788): gravação de áudio deixa de ficar presa em «A preparar microfone…» (o compositor reiniciava o MediaRecorder a cada render) e rejeita blobs vazios/truncados antes do envio; MIME preferido ogg/webm opus
 - Mobile (#739): runbook de publicação na Play Store (textos de listing, checklist AAB, versão Android) e página pública de **privacidade** em `/privacidade` (URL para a Console)

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -318,8 +318,8 @@ const navStructure: NavItem[] = [
   },
   {
     type: 'group',
-    id: 'chat',
-    label: 'Chat',
+    id: 'atendimentos',
+    label: 'Atendimentos',
     icon: 'chat',
     /** Hub `/chat/*`, histórico/avaliações e rotas legadas `/whatsapp/c/:id` */
     extraActivePrefixes: ['/chat/', '/whatsapp/'],
@@ -332,7 +332,7 @@ const navStructure: NavItem[] = [
       },
       {
         to: '/whatsapp/historico',
-        label: 'Atendimentos',
+        label: 'Histórico',
         icon: 'chatHistory',
         activePrefix: '/whatsapp/',
       },

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -290,7 +290,34 @@ const navStructure: NavItem[] = [
       },
     ],
   },
-  { type: 'link', to: '/tickets', label: 'Tickets', icon: 'tickets' },
+  {
+    type: 'group',
+    id: 'atendimentos',
+    label: 'Atendimentos',
+    icon: 'chat',
+    /** Hub `/chat/*`, tickets, histórico/avaliações e rotas legadas `/whatsapp/c/:id` */
+    extraActivePrefixes: ['/chat/', '/whatsapp/', '/tickets'],
+    children: [
+      {
+        to: '/chat/atendendo',
+        label: 'Chat',
+        icon: 'chat',
+        activePrefix: '/chat/',
+      },
+      {
+        to: '/tickets',
+        label: 'Tickets',
+        icon: 'tickets',
+        activePrefix: '/tickets',
+      },
+      {
+        to: '/whatsapp/historico',
+        label: 'Histórico',
+        icon: 'chatHistory',
+        activePrefix: '/whatsapp/',
+      },
+    ],
+  },
   {
     type: 'group',
     id: 'comercial',
@@ -313,28 +340,6 @@ const navStructure: NavItem[] = [
         icon: 'tiposNegocio',
         comercialOuAdmin: true,
         activePrefix: '/crm/contratos',
-      },
-    ],
-  },
-  {
-    type: 'group',
-    id: 'atendimentos',
-    label: 'Atendimentos',
-    icon: 'chat',
-    /** Hub `/chat/*`, histórico/avaliações e rotas legadas `/whatsapp/c/:id` */
-    extraActivePrefixes: ['/chat/', '/whatsapp/'],
-    children: [
-      {
-        to: '/chat/atendendo',
-        label: 'Chat',
-        icon: 'chat',
-        activePrefix: '/chat/',
-      },
-      {
-        to: '/whatsapp/historico',
-        label: 'Histórico',
-        icon: 'chatHistory',
-        activePrefix: '/whatsapp/',
       },
     ],
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumo

Ajuste do menu lateral (#793 + follow-up):

**Atendimentos** ▾
- Chat (`/chat/atendendo`)
- Tickets (`/tickets`)
- Histórico (`/whatsapp/historico`)

Tickets deixa de ser link solto no 1.º nível. O bloco **Atendimentos** sobe para logo após **Ponto** (antes de Comercial), mantendo a operação de atendimento junta.

Rotas e RBAC inalterados; `activePrefix` / `extraActivePrefixes` incluem `/tickets`.

## Test plan
- [ ] 1.º nível: **Atendimentos** (sem Tickets solto)
- [ ] Filhos: Chat · Tickets · Histórico
- [ ] Em `/tickets`, grupo aberto e item Tickets activo
- [ ] Chat e Histórico continuam a destacar correctamente
- [ ] App nativo: Tickets e Chat/Histórico disponíveis no grupo

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d42c332-c341-4c3b-942d-9da04c1d6e07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d42c332-c341-4c3b-942d-9da04c1d6e07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

