### PR TITLE
fix(mobile): Meu ponto abre no APK (rota /ponto)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Mobile: no APK, **Meu ponto** (`/ponto`) abre de facto — deixava de cair na mesa de chat por falta de rota nativa
 - Menu: grupo **Atendimentos** no menu lateral com **Chat**, **Tickets** e **Histórico** (toda a operação de atendimento junta)
 - Menu (#793): **Ponto** (Meu ponto / Equipe online / Ponto da equipe) e **Chat** (Chat / Atendimentos) passam a ser grupos expansíveis no menu lateral, no mesmo padrão de Configurações
 - WhatsApp (#788): gravação de áudio deixa de ficar presa em «A preparar microfone…» (o compositor reiniciava o MediaRecorder a cada render) e rejeita blobs vazios/truncados antes do envio; MIME preferido ogg/webm opus

--- a/docs/MOBILE_CAPACITOR.md
+++ b/docs/MOBILE_CAPACITOR.md
@@ -1,6 +1,6 @@
 # App Android (Capacitor) — L6 (#696 / #735–#737)
 
-O APK é um WebView Capacitor com um **SPA mais leve**: login, **tickets** e **chat** (mesa WhatsApp / hub). Não leva landing, SaaS, CRM, cadastros nem dashboards.
+O APK é um WebView Capacitor com um **SPA mais leve**: login, **tickets**, **chat** (mesa WhatsApp / hub) e **meu ponto**. Não leva landing, SaaS, CRM, cadastros nem dashboards.
 
 **Estado (Android):** L6.1–L6.3 + hotfix Conta/teclado na `main`. **Listing / release lojas** → [`docs/MOBILE_STORE_RELEASE.md`](MOBILE_STORE_RELEASE.md) (#739). **iOS** → #738.
 
@@ -93,7 +93,8 @@ Correr após `npm run build:android` + instalar no emulador/dispositivo (**sem**
 | 8 | Toque na notificação | Abre a mesa/conversa **uma** vez |
 | 9 | Ticket: teclado no composer | Campo visível; double-tap no enviar não duplica |
 | 10 | WhatsApp: texto + figurinha | Envio único; teclado sem cortar o campo |
-| 11 | Voltar Android | Volta na navegação; na raiz pode sair da app |
+| 11 | Menu → Meu ponto | Abre `/ponto` (bater ponto / histórico); não volta ao chat |
+| 12 | Voltar Android | Volta na navegação; na raiz pode sair da app |
 
 Cada instância precisa de `VAPID_*` no `client.env` e `https://localhost` em `CORS_ORIGINS`.
 

--- a/frontend/src/AppNative.tsx
+++ b/frontend/src/AppNative.tsx
@@ -32,6 +32,7 @@ const WhatsappLayout = lazy(() => import('./pages/whatsapp/WhatsappLayout').then
 const WhatsappHistorico = lazy(() =>
   import('./pages/whatsapp/WhatsappHistorico').then((m) => ({ default: m.WhatsappHistorico })),
 )
+const MeuPonto = lazy(() => import('./pages/MeuPonto').then((m) => ({ default: m.MeuPonto })))
 
 function LayoutNative() {
   const { user, loading } = useAuth()
@@ -82,7 +83,7 @@ function NativeUnknownRoute() {
   if (!user) {
     return <Navigate to="/login" replace />
   }
-  // App nativo só tem tickets/chat — rotas de admin/CRM/etc. caem na mesa.
+  // App nativo: tickets/chat/ponto — rotas de admin/CRM/etc. caem na mesa.
   return <Navigate to="/chat/atendendo" replace />
 }
 
@@ -100,6 +101,7 @@ function NativeRoutes() {
           <Route path="tickets" element={<Tickets />} />
           <Route path="tickets/novo" element={<TicketNovo />} />
           <Route path="tickets/:id" element={<RedirectTicketDetalhe />} />
+          <Route path="ponto" element={<MeuPonto />} />
           <Route path="chat" element={<ChatHubShell />}>
             <Route element={<ChatHubLayout />}>
               <Route index element={<Navigate to="atendendo" replace />} />
@@ -179,7 +181,7 @@ function NativeRoutes() {
   )
 }
 
-/** Shell Capacitor: tickets + chat, sem landing/SaaS/cadastros (#735 / #736). */
+/** Shell Capacitor: tickets + chat + meu ponto, sem landing/SaaS/cadastros (#735 / #736). */
 export default function AppNative() {
   return (
     <ErrorBoundary>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Resumo

No APK, o menu mostra **Meu ponto**, mas `AppNative` não tinha a rota `/ponto`. O catch-all `NativeUnknownRoute` redirecionava para `/chat/atendendo` — sintoma: «abre o ponto e volta para atendimento».

### Correção
- Rota `ponto` → `MeuPonto` no shell Capacitor
- Docs / CHANGELOG actualizados

## Test plan
- [ ] APK: login atendente → Ponto → Meu ponto abre a página (bater ponto / histórico)
- [ ] Não redirecciona para chat
- [ ] Tickets e Chat continuam a funcionar

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d42c332-c341-4c3b-942d-9da04c1d6e07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d42c332-c341-4c3b-942d-9da04c1d6e07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

