### PR TITLE
feat(implantacao): ticket e checklist após assinatura do contrato (#325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Implantação (#325 / #358–#361): ao marcar o contrato como assinado, abre um ticket no setor configurado (Implantação ou Suporte) com checklist (documentos, WebPosto, PDVs, treino). O modelo é editável em Cadastros; o ticket só fecha com os itens obrigatórios feitos; o admin tem atalho para cadastrar PDVs da empresa
 - Atendimentos (#825): no telemóvel, Estado/datas/Atendente ficam num acordeão **Filtros** (recolhido por defeito) para a lista aparecer logo; a busca continua visível; badge indica filtros activos
 - Mobile: o APK passa a usar o **mesmo painel** do browser no telemóvel (menu e rotas completos conforme RBAC); mantém Conta/slug, HTTP nativo e push
 - Mobile: ícone do APK Android alinhado ao da PWA/computador (mark DeskRudder no fundo Deck)

--- a/backend/alembic/versions/103_implantacao_checklist.py
+++ b/backend/alembic/versions/103_implantacao_checklist.py
@@ -1,0 +1,113 @@
+"""Implantação: checklist no ticket e ticket automático pós-assinatura (#325).
+
+Revision ID: 103_implantacao_checklist
+Revises: 102_ponto_rh_avancado
+Create Date: 2026-08-20
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "103_implantacao_checklist"
+down_revision = "102_ponto_rh_avancado"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if not insp.has_table("implantacao_checklist_templates"):
+        op.create_table(
+            "implantacao_checklist_templates",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("nome", sa.String(120), nullable=False),
+            sa.Column("versao", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("setor_id", sa.Integer(), sa.ForeignKey("setores.id", ondelete="SET NULL"), nullable=True),
+            sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.create_index("ix_implantacao_checklist_templates_setor_id", "implantacao_checklist_templates", ["setor_id"])
+        op.create_index("ix_implantacao_checklist_templates_ativo", "implantacao_checklist_templates", ["ativo"])
+
+    if not insp.has_table("implantacao_checklist_template_itens"):
+        op.create_table(
+            "implantacao_checklist_template_itens",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column(
+                "template_id",
+                sa.Integer(),
+                sa.ForeignKey("implantacao_checklist_templates.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("titulo", sa.String(200), nullable=False),
+            sa.Column("descricao", sa.Text(), nullable=True),
+            sa.Column("ordem", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("obrigatorio", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("chave", sa.String(64), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.UniqueConstraint("template_id", "ordem", name="uq_implantacao_template_item_ordem"),
+        )
+        op.create_index(
+            "ix_implantacao_checklist_template_itens_template_id",
+            "implantacao_checklist_template_itens",
+            ["template_id"],
+        )
+        op.create_index("ix_implantacao_checklist_template_itens_chave", "implantacao_checklist_template_itens", ["chave"])
+
+    cols = {c["name"] for c in insp.get_columns("tickets")} if insp.has_table("tickets") else set()
+    if "contrato_id" not in cols:
+        op.add_column(
+            "tickets",
+            sa.Column(
+                "contrato_id",
+                sa.Integer(),
+                sa.ForeignKey("comercial_contratos.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+        )
+        op.create_index("ix_tickets_contrato_id", "tickets", ["contrato_id"], unique=True)
+
+    if not insp.has_table("ticket_checklist_itens"):
+        op.create_table(
+            "ticket_checklist_itens",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("ticket_id", sa.Integer(), sa.ForeignKey("tickets.id", ondelete="CASCADE"), nullable=False),
+            sa.Column(
+                "template_item_id",
+                sa.Integer(),
+                sa.ForeignKey("implantacao_checklist_template_itens.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("titulo", sa.String(200), nullable=False),
+            sa.Column("descricao", sa.Text(), nullable=True),
+            sa.Column("ordem", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column("obrigatorio", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("chave", sa.String(64), nullable=True),
+            sa.Column("concluido", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+            sa.Column("concluido_por_id", sa.Integer(), sa.ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True),
+            sa.Column("concluido_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("observacao", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+            sa.UniqueConstraint("ticket_id", "ordem", name="uq_ticket_checklist_item_ordem"),
+        )
+        op.create_index("ix_ticket_checklist_itens_ticket_id", "ticket_checklist_itens", ["ticket_id"])
+        op.create_index("ix_ticket_checklist_itens_chave", "ticket_checklist_itens", ["chave"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ticket_checklist_itens"):
+        op.drop_table("ticket_checklist_itens")
+    cols = {c["name"] for c in insp.get_columns("tickets")} if insp.has_table("tickets") else set()
+    if "contrato_id" in cols:
+        op.drop_index("ix_tickets_contrato_id", table_name="tickets")
+        op.drop_column("tickets", "contrato_id")
+    if insp.has_table("implantacao_checklist_template_itens"):
+        op.drop_table("implantacao_checklist_template_itens")
+    if insp.has_table("implantacao_checklist_templates"):
+        op.drop_table("implantacao_checklist_templates")

--- a/backend/app/api/comercial_contrato.py
+++ b/backend/app/api/comercial_contrato.py
@@ -272,8 +272,27 @@ def marcar_assinado(
         atendente.id,
         payload={"status": row.status, "avancar_funil": data.avancar_funil},
     )
+    from app.services.implantacao import ticket_por_contrato
+    from app.services.ticket_distribuicao import pos_criar_ticket_na_fila
+
+    ticket_impl = ticket_por_contrato(db, row.id)
+    if ticket_impl:
+        registrar_audit(
+            db,
+            "ticket",
+            ticket_impl.id,
+            "create",
+            atendente.id,
+            payload={"origem": "implantacao_contrato", "contrato_id": row.id},
+        )
     db.commit()
     db.refresh(row)
+    if ticket_impl:
+        from app.models.ticket import Ticket
+
+        ticket_impl = db.query(Ticket).filter(Ticket.id == ticket_impl.id).first()
+        if ticket_impl:
+            pos_criar_ticket_na_fila(db, ticket_impl)
     return svc.contrato_para_read(svc.obter_contrato(db, row.id, atendente=atendente), incluir_html=True)
 
 

--- a/backend/app/api/implantacao.py
+++ b/backend/app/api/implantacao.py
@@ -1,0 +1,58 @@
+"""Implantação — templates de checklist (#325 / #358)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.core.auth import exigir_admin, exigir_comercial_ou_admin
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.schemas.implantacao import (
+    ImplantacaoTemplateCreate,
+    ImplantacaoTemplateRead,
+    ImplantacaoTemplateUpdate,
+)
+from app.services import implantacao as svc
+
+router = APIRouter(prefix="/comercial", tags=["comercial-implantacao"])
+
+
+@router.get("/implantacao-templates", response_model=list[ImplantacaoTemplateRead])
+def listar_templates(
+    incluir_inativos: bool = Query(False),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_comercial_ou_admin),
+):
+    if incluir_inativos and atendente.role != "admin":
+        incluir_inativos = False
+    rows = svc.listar_templates(db, incluir_inativos=incluir_inativos, tenant_id=atendente.tenant_id)
+    db.commit()
+    return [svc.template_para_read(r) for r in rows]
+
+
+@router.post("/implantacao-templates", response_model=ImplantacaoTemplateRead, status_code=201)
+def criar_template(
+    data: ImplantacaoTemplateCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = svc.criar_template(db, data, atendente.tenant_id)
+    registrar_audit(db, "implantacao_checklist_template", row.id, "create", atendente.id)
+    db.commit()
+    return svc.template_para_read(row)
+
+
+@router.patch("/implantacao-templates/{template_id}", response_model=ImplantacaoTemplateRead)
+def atualizar_template(
+    template_id: int,
+    data: ImplantacaoTemplateUpdate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_admin),
+):
+    row = svc.obter_template(db, template_id, apenas_ativos=False)
+    row = svc.atualizar_template(db, row, data, atendente.tenant_id)
+    registrar_audit(db, "implantacao_checklist_template", row.id, "update", atendente.id)
+    db.commit()
+    return svc.template_para_read(row)

--- a/backend/app/api/tickets.py
+++ b/backend/app/api/tickets.py
@@ -13,6 +13,7 @@ from app.models.funcionario_rede import FuncionarioRede
 from app.models.ticket_anexo import TicketAnexo
 from app.models.ticket_vinculo import TIPO_DUPLICADO_DE, TicketVinculo
 from app.models.ticket_classificacao import TicketMotivo
+from app.schemas.implantacao import TicketChecklistItemPatch, TicketChecklistRead
 from app.schemas.ticket import (
     EmpresaVinculoSugerida,
     TicketChildBrief,
@@ -404,7 +405,24 @@ def _ticket_para_read(t: Ticket, db: Session | None = None, *, sla_estado: str |
         sla_primeira_resposta_em=t.sla_primeira_resposta_em,
         sla_violado=bool(t.sla_violado),
         sla_estado=sla_estado,
+        contrato_id=t.contrato_id,
+        negociacao_id=_negociacao_id_do_ticket(db, t),
     )
+
+
+def _negociacao_id_do_ticket(db: Session | None, t: Ticket) -> int | None:
+    if db is None or not t.contrato_id:
+        return None
+    from app.models.comercial_contrato import Contrato
+    from app.models.crm import CrmNegociacaoCnpjLinha
+
+    contrato = db.query(Contrato).filter(Contrato.id == t.contrato_id).first()
+    if not contrato:
+        return None
+    linha = contrato.linha or db.query(CrmNegociacaoCnpjLinha).filter(
+        CrmNegociacaoCnpjLinha.id == contrato.negociacao_linha_cnpj_id
+    ).first()
+    return linha.negociacao_id if linha else None
 
 
 def _pode_ver_ticket(db: Session, atendente: Atendente, ticket: Ticket) -> bool:
@@ -903,6 +921,51 @@ def obter(
         minutos_pausados=minutos_pausa_sla(db, ticket, ate=now, calendar=calendar),
     )
     return _ticket_para_read(ticket, db, sla_estado=estado)
+
+
+@router.get("/{ticket_id}/checklist", response_model=TicketChecklistRead)
+def obter_checklist(
+    ticket_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if not _pode_ver_ticket(db, atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+    from app.services import implantacao as implantacao_svc
+
+    return implantacao_svc.checklist_do_ticket(db, ticket)
+
+
+@router.patch("/{ticket_id}/checklist/itens/{item_id}", response_model=TicketChecklistRead)
+def atualizar_item_checklist(
+    ticket_id: int,
+    item_id: int,
+    data: TicketChecklistItemPatch,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ticket = db.query(Ticket).filter(Ticket.id == ticket_id).first()
+    if not ticket:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Ticket não encontrado")
+    if not _pode_ver_ticket(db, atendente, ticket):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este ticket")
+    from app.core.audit import registrar_audit
+    from app.services import implantacao as implantacao_svc
+
+    implantacao_svc.atualizar_item_checklist(db, ticket, item_id, data, atendente)
+    registrar_audit(
+        db,
+        "ticket_checklist_item",
+        item_id,
+        "update",
+        atendente.id,
+        payload={"ticket_id": ticket_id},
+    )
+    db.commit()
+    return implantacao_svc.checklist_do_ticket(db, ticket)
 
 
 @router.get("/{ticket_id}/sla", response_model=TicketSlaRead)
@@ -1740,6 +1803,9 @@ def atualizar(
                     status_code=status.HTTP_400_BAD_REQUEST,
                     detail="Não é possível fechar este ticket enquanto existir ticket filho direto ainda em aberto.",
                 )
+            from app.services.implantacao import assert_pode_fechar_ticket
+
+            assert_pode_fechar_ticket(db, ticket)
 
     fechando = False
     if "status_id" in update:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -43,6 +43,7 @@ from app.api import (
     comercial_custos,
     comercial_proposta,
     comercial_contrato,
+    implantacao,
     crm,
     system_settings,
     tenant,
@@ -570,6 +571,7 @@ app.include_router(ticket_catalogos.router, prefix=API_V1_PREFIX)
 app.include_router(comercial_custos.router, prefix=API_V1_PREFIX)
 app.include_router(comercial_proposta.router, prefix=API_V1_PREFIX)
 app.include_router(comercial_contrato.router, prefix=API_V1_PREFIX)
+app.include_router(implantacao.router, prefix=API_V1_PREFIX)
 app.include_router(crm.router, prefix=API_V1_PREFIX)
 app.include_router(empresa_pdvs.router, prefix=API_V1_PREFIX)
 app.include_router(system_settings.router, prefix=API_V1_PREFIX)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -66,6 +66,11 @@ from app.models.crm import (
 )
 from app.models.comercial_proposta import Proposta, PropostaTemplate
 from app.models.comercial_contrato import Contrato, ContratoPdf, ContratoPolitica, ContratoTemplate
+from app.models.implantacao_checklist import (
+    ImplantacaoChecklistTemplate,
+    ImplantacaoChecklistTemplateItem,
+    TicketChecklistItem,
+)
 from app.models.cliente_saas import ClienteSaaS
 from app.models.saas_alerta_emitido import SaasAlertaEmitido
 from app.models.lead_comercial import LeadComercial
@@ -156,6 +161,9 @@ __all__ = [
     "Contrato",
     "ContratoPdf",
     "ContratoPolitica",
+    "ImplantacaoChecklistTemplate",
+    "ImplantacaoChecklistTemplateItem",
+    "TicketChecklistItem",
     "ClienteSaaS",
     "SaasAlertaEmitido",
     "LeadComercial",

--- a/backend/app/models/implantacao_checklist.py
+++ b/backend/app/models/implantacao_checklist.py
@@ -1,0 +1,90 @@
+"""Checklist de implantação copiado para o ticket após contrato assinado (#325 / #358)."""
+
+from __future__ import annotations
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+CHAVE_CADASTRAR_PDVS = "cadastrar_pdvs"
+
+ITENS_PADRAO: tuple[tuple[str, str | None, bool, str | None], ...] = (
+    ("Coleta de documentos", "Contrato assinado, dados fiscais e acessos necessários.", True, None),
+    ("Cadastro na base WebPosto", "Criar ou confirmar a base e os logins operacionais.", True, None),
+    ("Cadastrar PDVs", "Cadastrar os PDVs da empresa (cadastro operacional).", True, CHAVE_CADASTRAR_PDVS),
+    ("Treinamento da equipe", "Treinamento de operação (caixa, retaguarda, helpdesk).", True, None),
+    ("Validação operacional", "Conferir operação no dia a dia antes de encerrar a implantação.", False, None),
+)
+
+
+class ImplantacaoChecklistTemplate(Base):
+    __tablename__ = "implantacao_checklist_templates"
+
+    id = Column(Integer, primary_key=True, index=True)
+    nome = Column(String(120), nullable=False)
+    versao = Column(Integer, nullable=False, default=1)
+    setor_id = Column(Integer, ForeignKey("setores.id", ondelete="SET NULL"), nullable=True, index=True)
+    ativo = Column(Boolean, nullable=False, default=True, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    setor = relationship("Setor")
+    itens = relationship(
+        "ImplantacaoChecklistTemplateItem",
+        back_populates="template",
+        cascade="all, delete-orphan",
+        order_by="ImplantacaoChecklistTemplateItem.ordem",
+    )
+
+
+class ImplantacaoChecklistTemplateItem(Base):
+    __tablename__ = "implantacao_checklist_template_itens"
+    __table_args__ = (UniqueConstraint("template_id", "ordem", name="uq_implantacao_template_item_ordem"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    template_id = Column(
+        Integer,
+        ForeignKey("implantacao_checklist_templates.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    titulo = Column(String(200), nullable=False)
+    descricao = Column(Text, nullable=True)
+    ordem = Column(Integer, nullable=False, default=1)
+    obrigatorio = Column(Boolean, nullable=False, default=True)
+    chave = Column(String(64), nullable=True, index=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    template = relationship("ImplantacaoChecklistTemplate", back_populates="itens")
+
+
+class TicketChecklistItem(Base):
+    """Snapshot dos itens do template no ticket de implantação."""
+
+    __tablename__ = "ticket_checklist_itens"
+    __table_args__ = (UniqueConstraint("ticket_id", "ordem", name="uq_ticket_checklist_item_ordem"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    ticket_id = Column(Integer, ForeignKey("tickets.id", ondelete="CASCADE"), nullable=False, index=True)
+    template_item_id = Column(
+        Integer,
+        ForeignKey("implantacao_checklist_template_itens.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    titulo = Column(String(200), nullable=False)
+    descricao = Column(Text, nullable=True)
+    ordem = Column(Integer, nullable=False, default=1)
+    obrigatorio = Column(Boolean, nullable=False, default=True)
+    chave = Column(String(64), nullable=True, index=True)
+    concluido = Column(Boolean, nullable=False, default=False)
+    concluido_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    concluido_em = Column(DateTime(timezone=True), nullable=True)
+    observacao = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    ticket = relationship("Ticket", back_populates="checklist_itens")
+    concluido_por = relationship("Atendente")

--- a/backend/app/models/ticket.py
+++ b/backend/app/models/ticket.py
@@ -18,6 +18,13 @@ class Ticket(Base):
     status_id = Column(Integer, ForeignKey("status_ticket.id"), nullable=False)
     atendente_id = Column(Integer, ForeignKey("atendentes.id"), nullable=True)  # responsável
     aberto_por_id = Column(Integer, ForeignKey("funcionarios_rede.id"), nullable=True)  # quem abriu (portal futuro)
+    contrato_id = Column(
+        Integer,
+        ForeignKey("comercial_contratos.id", ondelete="SET NULL"),
+        nullable=True,
+        unique=True,
+        index=True,
+    )
     parent_ticket_id = Column(Integer, ForeignKey("tickets.id", ondelete="SET NULL"), nullable=True)
     prioridade = Column(
         SAEnum(PrioridadeTicket, name="ticket_prioridade", native_enum=False, values_callable=lambda x: [e.value for e in x]),
@@ -73,6 +80,11 @@ class Ticket(Base):
         "TicketMensagem",
         back_populates="ticket",
         order_by="TicketMensagem.created_at",
+    )
+    checklist_itens = relationship(
+        "TicketChecklistItem",
+        back_populates="ticket",
+        order_by="TicketChecklistItem.ordem",
     )
 
 

--- a/backend/app/schemas/comercial_contrato.py
+++ b/backend/app/schemas/comercial_contrato.py
@@ -157,5 +157,7 @@ class ContratoRead(BaseModel):
     dias_restantes_fidelidade: int | None = None
     multa_rescisao: MultaRescisaoEstimativa | None = None
     interno: ContratoInternoRead | None = None
+    implantacao_ticket_id: int | None = None
+    implantacao_ticket_protocolo: str | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/implantacao.py
+++ b/backend/app/schemas/implantacao.py
@@ -1,0 +1,76 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ImplantacaoTemplateItemIn(BaseModel):
+    titulo: str = Field(..., min_length=1, max_length=200)
+    descricao: str | None = Field(None, max_length=2000)
+    ordem: int = Field(1, ge=1)
+    obrigatorio: bool = True
+    chave: str | None = Field(None, max_length=64)
+
+
+class ImplantacaoTemplateItemRead(ImplantacaoTemplateItemIn):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ImplantacaoTemplateCreate(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=120)
+    setor_id: int | None = None
+    ativo: bool = True
+    itens: list[ImplantacaoTemplateItemIn] = Field(default_factory=list)
+
+
+class ImplantacaoTemplateUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=120)
+    setor_id: int | None = None
+    ativo: bool | None = None
+    itens: list[ImplantacaoTemplateItemIn] | None = None
+
+
+class ImplantacaoTemplateRead(BaseModel):
+    id: int
+    nome: str
+    versao: int
+    setor_id: int | None = None
+    setor_nome: str | None = None
+    ativo: bool
+    itens: list[ImplantacaoTemplateItemRead] = Field(default_factory=list)
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TicketChecklistItemPatch(BaseModel):
+    concluido: bool | None = None
+    observacao: str | None = Field(None, max_length=2000)
+
+
+class TicketChecklistItemRead(BaseModel):
+    id: int
+    titulo: str
+    descricao: str | None = None
+    ordem: int
+    obrigatorio: bool
+    chave: str | None = None
+    concluido: bool
+    concluido_por_id: int | None = None
+    concluido_por_nome: str | None = None
+    concluido_em: datetime | None = None
+    observacao: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TicketChecklistRead(BaseModel):
+    aplicavel: bool
+    ticket_id: int
+    contrato_id: int | None = None
+    negociacao_id: int | None = None
+    empresa_id: int | None = None
+    progresso_pct: int = 0
+    itens_obrigatorios_pendentes: int = 0
+    pdvs_ativos: int | None = None
+    itens: list[TicketChecklistItemRead] = Field(default_factory=list)

--- a/backend/app/schemas/ticket.py
+++ b/backend/app/schemas/ticket.py
@@ -197,6 +197,8 @@ class TicketRead(BaseModel):
         default=None,
         description="Pior estado SLA resumido: dentro, em_risco, violado ou cumprido.",
     )
+    contrato_id: int | None = None
+    negociacao_id: int | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/comercial_contrato.py
+++ b/backend/app/services/comercial_contrato.py
@@ -952,6 +952,9 @@ def marcar_assinado(db: Session, row: Contrato, data: ContratoMarcarAssinadoIn, 
     row.assinado_em = data.assinado_em or datetime.now(timezone.utc)
     linha = row.linha or obter_linha(db, row.negociacao_linha_cnpj_id)
     converter_pos_assinatura(db, row, linha, ator)
+    from app.services.implantacao import criar_ticket_implantacao
+
+    criar_ticket_implantacao(db, row, ator)
     db.add(
         CrmNegociacaoAtividade(
             negociacao_id=linha.negociacao_id,
@@ -1106,6 +1109,12 @@ def contrato_para_read(row: Contrato, *, incluir_html: bool = False) -> dict[str
             emp = sess.query(Empresa).filter(Empresa.id == row.empresa_id).first()
             if emp is not None:
                 rede_id = emp.rede_id
+    ticket_impl = None
+    sess = object_session(row)
+    if sess is not None:
+        from app.models.ticket import Ticket
+
+        ticket_impl = sess.query(Ticket).filter(Ticket.contrato_id == row.id).first()
     return {
         "id": row.id,
         "negociacao_linha_cnpj_id": row.negociacao_linha_cnpj_id,
@@ -1156,6 +1165,8 @@ def contrato_para_read(row: Contrato, *, incluir_html: bool = False) -> dict[str
         "dias_restantes_fidelidade": dias,
         "multa_rescisao": estimar_multa_rescisao(row),
         "interno": _interno_read(row, linha),
+        "implantacao_ticket_id": ticket_impl.id if ticket_impl else None,
+        "implantacao_ticket_protocolo": ticket_impl.protocolo if ticket_impl else None,
     }
 
 

--- a/backend/app/services/implantacao.py
+++ b/backend/app/services/implantacao.py
@@ -1,0 +1,459 @@
+"""Checklist de implantação: template admin + cópia no ticket (#325 / #358–#361)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from fastapi import HTTPException, status
+from sqlalchemy import func
+from sqlalchemy.orm import Session, joinedload
+
+from app.models import EmpresaPdv, Setor, StatusTicket, Ticket, TicketHistorico, TicketMensagem
+from app.models.comercial_contrato import Contrato
+from app.models.crm import CrmNegociacaoCnpjLinha
+from app.models.empresa import Empresa
+from app.models.implantacao_checklist import (
+    CHAVE_CADASTRAR_PDVS,
+    ITENS_PADRAO,
+    ImplantacaoChecklistTemplate,
+    ImplantacaoChecklistTemplateItem,
+    TicketChecklistItem,
+)
+from app.models.atendente import Atendente
+from app.schemas.implantacao import (
+    ImplantacaoTemplateCreate,
+    ImplantacaoTemplateItemIn,
+    ImplantacaoTemplateUpdate,
+    TicketChecklistItemPatch,
+)
+from app.services.protocolo_mensal import gerar_protocolo_ticket
+from app.services.ticket_escopo import rede_id_de_empresa
+
+CHAVE_PDVS = CHAVE_CADASTRAR_PDVS
+
+
+def _setor_implantacao(db: Session, tenant_id: int, preferido_id: int | None) -> Setor | None:
+    if preferido_id:
+        row = (
+            db.query(Setor)
+            .filter(Setor.id == preferido_id, Setor.tenant_id == tenant_id, Setor.ativo.is_(True))
+            .first()
+        )
+        if row:
+            return row
+    for slug in ("implantacao", "suporte"):
+        row = (
+            db.query(Setor)
+            .filter(Setor.tenant_id == tenant_id, Setor.slug == slug, Setor.ativo.is_(True))
+            .first()
+        )
+        if row:
+            return row
+    return (
+        db.query(Setor)
+        .filter(Setor.tenant_id == tenant_id, Setor.ativo.is_(True))
+        .order_by(Setor.id.asc())
+        .first()
+    )
+
+
+def _itens_read(row: ImplantacaoChecklistTemplate) -> list[dict]:
+    itens = sorted(row.itens or [], key=lambda i: (i.ordem, i.id))
+    return [
+        {
+            "id": i.id,
+            "titulo": i.titulo,
+            "descricao": i.descricao,
+            "ordem": i.ordem,
+            "obrigatorio": bool(i.obrigatorio),
+            "chave": i.chave,
+        }
+        for i in itens
+    ]
+
+
+def template_para_read(row: ImplantacaoChecklistTemplate) -> dict:
+    return {
+        "id": row.id,
+        "nome": row.nome,
+        "versao": row.versao,
+        "setor_id": row.setor_id,
+        "setor_nome": row.setor.nome if row.setor else None,
+        "ativo": bool(row.ativo),
+        "itens": _itens_read(row),
+    }
+
+
+def _substituir_itens(
+    db: Session,
+    row: ImplantacaoChecklistTemplate,
+    itens: list[ImplantacaoTemplateItemIn],
+) -> None:
+    row.itens.clear()
+    db.flush()
+    for i, item in enumerate(itens, start=1):
+        chave = (item.chave or "").strip() or None
+        db.add(
+            ImplantacaoChecklistTemplateItem(
+                template_id=row.id,
+                titulo=item.titulo.strip(),
+                descricao=(item.descricao or "").strip() or None,
+                ordem=i,
+                obrigatorio=item.obrigatorio,
+                chave=chave,
+            )
+        )
+    db.flush()
+
+
+def garantir_template_padrao(db: Session, tenant_id: int) -> ImplantacaoChecklistTemplate:
+    row = (
+        db.query(ImplantacaoChecklistTemplate)
+        .options(joinedload(ImplantacaoChecklistTemplate.itens), joinedload(ImplantacaoChecklistTemplate.setor))
+        .order_by(ImplantacaoChecklistTemplate.id.asc())
+        .first()
+    )
+    if row:
+        return row
+    setor = _setor_implantacao(db, tenant_id, None)
+    row = ImplantacaoChecklistTemplate(
+        nome="Implantação padrão",
+        versao=1,
+        setor_id=setor.id if setor else None,
+        ativo=True,
+    )
+    db.add(row)
+    db.flush()
+    for i, (titulo, desc, obrig, chave) in enumerate(ITENS_PADRAO, start=1):
+        db.add(
+            ImplantacaoChecklistTemplateItem(
+                template_id=row.id,
+                titulo=titulo,
+                descricao=desc,
+                ordem=i,
+                obrigatorio=obrig,
+                chave=chave,
+            )
+        )
+    db.flush()
+    return (
+        db.query(ImplantacaoChecklistTemplate)
+        .options(joinedload(ImplantacaoChecklistTemplate.itens), joinedload(ImplantacaoChecklistTemplate.setor))
+        .filter(ImplantacaoChecklistTemplate.id == row.id)
+        .first()
+    )
+
+
+def listar_templates(db: Session, *, incluir_inativos: bool, tenant_id: int) -> list[ImplantacaoChecklistTemplate]:
+    garantir_template_padrao(db, tenant_id)
+    q = db.query(ImplantacaoChecklistTemplate).options(
+        joinedload(ImplantacaoChecklistTemplate.itens),
+        joinedload(ImplantacaoChecklistTemplate.setor),
+    )
+    if not incluir_inativos:
+        q = q.filter(ImplantacaoChecklistTemplate.ativo.is_(True))
+    return q.order_by(ImplantacaoChecklistTemplate.id.asc()).all()
+
+
+def obter_template(db: Session, template_id: int, *, apenas_ativos: bool = True) -> ImplantacaoChecklistTemplate:
+    q = db.query(ImplantacaoChecklistTemplate).options(
+        joinedload(ImplantacaoChecklistTemplate.itens),
+        joinedload(ImplantacaoChecklistTemplate.setor),
+    ).filter(ImplantacaoChecklistTemplate.id == template_id)
+    if apenas_ativos:
+        q = q.filter(ImplantacaoChecklistTemplate.ativo.is_(True))
+    row = q.first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Modelo de checklist não encontrado.")
+    return row
+
+
+def criar_template(db: Session, data: ImplantacaoTemplateCreate, tenant_id: int) -> ImplantacaoChecklistTemplate:
+    if data.setor_id is not None:
+        setor = _setor_implantacao(db, tenant_id, data.setor_id)
+        if setor is None or setor.id != data.setor_id:
+            raise HTTPException(status_code=400, detail="Setor inválido ou inativo.")
+    row = ImplantacaoChecklistTemplate(
+        nome=data.nome.strip(),
+        versao=1,
+        setor_id=data.setor_id,
+        ativo=data.ativo,
+    )
+    db.add(row)
+    db.flush()
+    itens = data.itens or [
+        ImplantacaoTemplateItemIn(titulo=t, descricao=d, ordem=i, obrigatorio=o, chave=c)
+        for i, (t, d, o, c) in enumerate(ITENS_PADRAO, start=1)
+    ]
+    _substituir_itens(db, row, itens)
+    return obter_template(db, row.id, apenas_ativos=False)
+
+
+def atualizar_template(
+    db: Session, row: ImplantacaoChecklistTemplate, data: ImplantacaoTemplateUpdate, tenant_id: int
+) -> ImplantacaoChecklistTemplate:
+    payload = data.model_dump(exclude_unset=True)
+    if "nome" in payload and data.nome:
+        row.nome = data.nome.strip()
+    if "ativo" in payload and data.ativo is not None:
+        row.ativo = data.ativo
+    if "setor_id" in payload:
+        if data.setor_id is None:
+            row.setor_id = None
+        else:
+            setor = _setor_implantacao(db, tenant_id, data.setor_id)
+            if setor is None or setor.id != data.setor_id:
+                raise HTTPException(status_code=400, detail="Setor inválido ou inativo.")
+            row.setor_id = data.setor_id
+    if data.itens is not None:
+        _substituir_itens(db, row, data.itens)
+        row.versao = int(row.versao or 1) + 1
+    db.flush()
+    return obter_template(db, row.id, apenas_ativos=False)
+
+
+def obter_template_ativo(db: Session, tenant_id: int) -> ImplantacaoChecklistTemplate:
+    garantir_template_padrao(db, tenant_id)
+    row = (
+        db.query(ImplantacaoChecklistTemplate)
+        .options(joinedload(ImplantacaoChecklistTemplate.itens), joinedload(ImplantacaoChecklistTemplate.setor))
+        .filter(ImplantacaoChecklistTemplate.ativo.is_(True))
+        .order_by(ImplantacaoChecklistTemplate.id.asc())
+        .first()
+    )
+    if not row:
+        raise HTTPException(
+            status_code=400,
+            detail="Não há checklist de implantação ativo. Configure em Cadastros.",
+        )
+    if not row.itens:
+        raise HTTPException(
+            status_code=400,
+            detail="O checklist de implantação ativo não tem itens.",
+        )
+    return row
+
+
+def copiar_checklist_para_ticket(db: Session, ticket: Ticket, template: ImplantacaoChecklistTemplate) -> None:
+    if db.query(TicketChecklistItem.id).filter(TicketChecklistItem.ticket_id == ticket.id).first():
+        return
+    for i, item in enumerate(sorted(template.itens, key=lambda x: (x.ordem, x.id)), start=1):
+        db.add(
+            TicketChecklistItem(
+                ticket_id=ticket.id,
+                template_item_id=item.id,
+                titulo=item.titulo,
+                descricao=item.descricao,
+                ordem=item.ordem or i,
+                obrigatorio=bool(item.obrigatorio),
+                chave=item.chave,
+            )
+        )
+    db.flush()
+
+
+def progresso_pct(itens: list[TicketChecklistItem]) -> int:
+    if not itens:
+        return 0
+    feitos = sum(1 for i in itens if i.concluido)
+    return int(round(100 * feitos / len(itens)))
+
+
+def itens_obrigatorios_pendentes(db: Session, ticket_id: int) -> list[TicketChecklistItem]:
+    return (
+        db.query(TicketChecklistItem)
+        .filter(
+            TicketChecklistItem.ticket_id == ticket_id,
+            TicketChecklistItem.obrigatorio.is_(True),
+            TicketChecklistItem.concluido.is_(False),
+        )
+        .order_by(TicketChecklistItem.ordem.asc())
+        .all()
+    )
+
+
+def assert_pode_fechar_ticket(db: Session, ticket: Ticket) -> None:
+    if not ticket.contrato_id:
+        return
+    pendentes = itens_obrigatorios_pendentes(db, ticket.id)
+    if pendentes:
+        nomes = ", ".join(p.titulo for p in pendentes[:4])
+        extra = "…" if len(pendentes) > 4 else ""
+        raise HTTPException(
+            status_code=400,
+            detail=f"Conclua os itens obrigatórios da implantação antes de fechar o ticket: {nomes}{extra}",
+        )
+
+
+def _pdvs_ativos(db: Session, empresa_id: int | None) -> int | None:
+    if not empresa_id:
+        return None
+    return (
+        db.query(func.count(EmpresaPdv.id))
+        .filter(EmpresaPdv.empresa_id == empresa_id, EmpresaPdv.ativo.is_(True))
+        .scalar()
+        or 0
+    )
+
+
+def checklist_do_ticket(db: Session, ticket: Ticket) -> dict:
+    itens = (
+        db.query(TicketChecklistItem)
+        .options(joinedload(TicketChecklistItem.concluido_por))
+        .filter(TicketChecklistItem.ticket_id == ticket.id)
+        .order_by(TicketChecklistItem.ordem.asc(), TicketChecklistItem.id.asc())
+        .all()
+    )
+    if not ticket.contrato_id and not itens:
+        return {
+            "aplicavel": False,
+            "ticket_id": ticket.id,
+            "contrato_id": None,
+            "negociacao_id": None,
+            "empresa_id": ticket.empresa_id,
+            "progresso_pct": 0,
+            "itens_obrigatorios_pendentes": 0,
+            "pdvs_ativos": None,
+            "itens": [],
+        }
+    negociacao_id = None
+    if ticket.contrato_id:
+        contrato = db.query(Contrato).filter(Contrato.id == ticket.contrato_id).first()
+        if contrato:
+            linha = contrato.linha or db.query(CrmNegociacaoCnpjLinha).filter(
+                CrmNegociacaoCnpjLinha.id == contrato.negociacao_linha_cnpj_id
+            ).first()
+            if linha:
+                negociacao_id = linha.negociacao_id
+    pend = sum(1 for i in itens if i.obrigatorio and not i.concluido)
+    return {
+        "aplicavel": True,
+        "ticket_id": ticket.id,
+        "contrato_id": ticket.contrato_id,
+        "negociacao_id": negociacao_id,
+        "empresa_id": ticket.empresa_id,
+        "progresso_pct": progresso_pct(itens),
+        "itens_obrigatorios_pendentes": pend,
+        "pdvs_ativos": _pdvs_ativos(db, ticket.empresa_id),
+        "itens": [
+            {
+                "id": i.id,
+                "titulo": i.titulo,
+                "descricao": i.descricao,
+                "ordem": i.ordem,
+                "obrigatorio": bool(i.obrigatorio),
+                "chave": i.chave,
+                "concluido": bool(i.concluido),
+                "concluido_por_id": i.concluido_por_id,
+                "concluido_por_nome": i.concluido_por.nome if i.concluido_por else None,
+                "concluido_em": i.concluido_em,
+                "observacao": i.observacao,
+            }
+            for i in itens
+        ],
+    }
+
+
+def atualizar_item_checklist(
+    db: Session,
+    ticket: Ticket,
+    item_id: int,
+    data: TicketChecklistItemPatch,
+    ator: Atendente,
+) -> TicketChecklistItem:
+    if ticket.fechado_em is not None and ator.role != "admin":
+        raise HTTPException(status_code=403, detail="Ticket fechado. Apenas administradores podem alterar o checklist.")
+    item = (
+        db.query(TicketChecklistItem)
+        .filter(TicketChecklistItem.id == item_id, TicketChecklistItem.ticket_id == ticket.id)
+        .first()
+    )
+    if not item:
+        raise HTTPException(status_code=404, detail="Item do checklist não encontrado.")
+    payload = data.model_dump(exclude_unset=True)
+    if "observacao" in payload:
+        item.observacao = (data.observacao or "").strip() or None
+    if "concluido" in payload and data.concluido is not None:
+        antes = bool(item.concluido)
+        item.concluido = data.concluido
+        if data.concluido:
+            item.concluido_por_id = ator.id
+            item.concluido_em = datetime.now(timezone.utc)
+        else:
+            item.concluido_por_id = None
+            item.concluido_em = None
+        if antes != bool(data.concluido):
+            db.add(
+                TicketHistorico(
+                    ticket_id=ticket.id,
+                    atendente_id=ator.id,
+                    campo="checklist",
+                    valor_antigo="concluído" if antes else "pendente",
+                    valor_novo=f"{item.titulo}: {'concluído' if data.concluido else 'pendente'}",
+                )
+            )
+    db.flush()
+    return item
+
+
+def ticket_por_contrato(db: Session, contrato_id: int) -> Ticket | None:
+    return db.query(Ticket).filter(Ticket.contrato_id == contrato_id).first()
+
+
+def criar_ticket_implantacao(db: Session, contrato: Contrato, ator: Atendente) -> Ticket | None:
+    """Idempotente: um ticket por contrato. Devolve o existente se já houver."""
+    existente = ticket_por_contrato(db, contrato.id)
+    if existente:
+        return existente
+    if not contrato.empresa_id:
+        return None
+    empresa = db.query(Empresa).filter(Empresa.id == contrato.empresa_id).first()
+    if not empresa:
+        return None
+    template = obter_template_ativo(db, ator.tenant_id)
+    setor = _setor_implantacao(db, ator.tenant_id, template.setor_id)
+    if not setor:
+        raise HTTPException(
+            status_code=400,
+            detail="Defina o setor do checklist de implantação em Cadastros (Implantação ou Suporte).",
+        )
+    status_inicial = db.query(StatusTicket).filter(StatusTicket.ativo.is_(True)).order_by(StatusTicket.ordem).first()
+    if not status_inicial:
+        raise HTTPException(status_code=400, detail="Cadastre ao menos um status de ticket.")
+    linha = contrato.linha or db.query(CrmNegociacaoCnpjLinha).filter(
+        CrmNegociacaoCnpjLinha.id == contrato.negociacao_linha_cnpj_id
+    ).first()
+    razao = (linha.razao_social if linha else None) or empresa.nome
+    assunto = f"Implantação — {razao}"[:500]
+    descricao = (
+        f"Ticket automático após assinatura do contrato #{contrato.id}.\n"
+        f"Empresa: {empresa.nome}."
+    )
+    ticket = Ticket(
+        tenant_id=ator.tenant_id,
+        protocolo=gerar_protocolo_ticket(db),
+        empresa_id=empresa.id,
+        rede_id=rede_id_de_empresa(db, empresa.id, tenant_id=ator.tenant_id) or empresa.rede_id,
+        setor_id=setor.id,
+        status_id=status_inicial.id,
+        contrato_id=contrato.id,
+        assunto=assunto,
+        descricao=descricao,
+        aberto_por_id=None,
+    )
+    db.add(ticket)
+    db.flush()
+    from app.services.sla_policy import aplicar_sla_snapshot_ao_ticket
+
+    aplicar_sla_snapshot_ao_ticket(db, ticket)
+    db.add(
+        TicketMensagem(
+            ticket_id=ticket.id,
+            atendente_id=ator.id,
+            tipo="abertura",
+            corpo=descricao,
+        )
+    )
+    copiar_checklist_para_ticket(db, ticket, template)
+    db.flush()
+    return ticket

--- a/backend/tests/test_implantacao.py
+++ b/backend/tests/test_implantacao.py
@@ -1,0 +1,184 @@
+"""Implantação via ticket e checklist (#325 / #358–#361)."""
+
+from __future__ import annotations
+
+from app.models import StatusTicket
+from app.models.ticket_classificacao import TicketMotivo, TicketNatureza
+from tests.test_comercial_contrato import _anexar_pdf_assinado, _negociacao_com_linha
+
+
+def _assinar_contrato(client, h):
+    _, linha = _negociacao_com_linha(client, h)
+    c = client.post("/v1/comercial/contratos", headers=h, json={"linha_id": linha["id"]})
+    assert c.status_code == 201, c.text
+    cid = c.json()["id"]
+    _anexar_pdf_assinado(client, h, cid)
+    ass = client.post(f"/v1/comercial/contratos/{cid}/marcar-assinado", headers=h, json={})
+    assert ass.status_code == 200, ass.text
+    return ass.json()
+
+
+def test_comercial_le_template_admin_escreve(client, auth_headers):
+    h_admin = auth_headers["admin"]
+    h_com = auth_headers["comercial"]
+    h_at = auth_headers["a1"]
+
+    lst = client.get("/v1/comercial/implantacao-templates", headers=h_com)
+    assert lst.status_code == 200, lst.text
+    assert len(lst.json()) >= 1
+    chaves = {i.get("chave") for t in lst.json() for i in t["itens"]}
+    assert "cadastrar_pdvs" in chaves
+
+    assert client.post(
+        "/v1/comercial/implantacao-templates",
+        headers=h_com,
+        json={"nome": "X", "itens": [{"titulo": "A", "ordem": 1, "obrigatorio": True}]},
+    ).status_code == 403
+    assert client.post(
+        "/v1/comercial/implantacao-templates",
+        headers=h_at,
+        json={"nome": "X", "itens": [{"titulo": "A", "ordem": 1, "obrigatorio": True}]},
+    ).status_code == 403
+
+    tid = lst.json()[0]["id"]
+    patch = client.patch(
+        f"/v1/comercial/implantacao-templates/{tid}",
+        headers=h_admin,
+        json={
+            "nome": "Implantação padrão",
+            "itens": [
+                {"titulo": "Docs", "ordem": 1, "obrigatorio": True},
+                {"titulo": "PDVs", "ordem": 2, "obrigatorio": True, "chave": "cadastrar_pdvs"},
+            ],
+        },
+    )
+    assert patch.status_code == 200, patch.text
+    assert len(patch.json()["itens"]) == 2
+    assert patch.json()["versao"] >= 2
+
+    created = client.post(
+        "/v1/comercial/implantacao-templates",
+        headers=h_admin,
+        json={
+            "nome": "Checklist extra",
+            "itens": [{"titulo": "Kickoff", "ordem": 1, "obrigatorio": True}],
+        },
+    )
+    assert created.status_code == 201, created.text
+    assert created.json()["nome"] == "Checklist extra"
+
+
+def test_marcar_assinado_abre_ticket_idempotente(client, auth_headers):
+    h = auth_headers["comercial"]
+    h_admin = auth_headers["admin"]
+    body = _assinar_contrato(client, h)
+    assert body["status"] == "assinado"
+    tid = body["implantacao_ticket_id"]
+    assert tid
+    assert body["implantacao_ticket_protocolo"]
+
+    t = client.get(f"/v1/tickets/{tid}", headers=h_admin)
+    assert t.status_code == 200, t.text
+    assert t.json()["contrato_id"] == body["id"]
+    assert t.json()["assunto"].startswith("Implantação")
+
+    chk = client.get(f"/v1/tickets/{tid}/checklist", headers=h_admin)
+    assert chk.status_code == 200, chk.text
+    data = chk.json()
+    assert data["aplicavel"] is True
+    assert data["contrato_id"] == body["id"]
+    assert len(data["itens"]) >= 1
+    assert data["progresso_pct"] == 0
+
+    # reprocessar assinatura não duplica
+    again = client.post(f"/v1/comercial/contratos/{body['id']}/marcar-assinado", headers=h, json={})
+    assert again.status_code == 400
+    body2 = client.get(f"/v1/comercial/contratos/{body['id']}", headers=h).json()
+    assert body2["implantacao_ticket_id"] == tid
+
+
+def test_checklist_rbac_e_fechar_bloqueado(client, auth_headers, seed_base, db_session):
+    h_com = auth_headers["comercial"]
+    h_a1 = auth_headers["a1"]
+    h_a2 = auth_headers["a2"]
+    h_admin = auth_headers["admin"]
+    body = _assinar_contrato(client, h_com)
+    tid = body["implantacao_ticket_id"]
+
+    assert client.get(f"/v1/tickets/{tid}/checklist", headers=h_a2).status_code == 403
+    assert client.get(f"/v1/tickets/{tid}/checklist", headers=h_com).status_code == 403
+
+    chk = client.get(f"/v1/tickets/{tid}/checklist", headers=h_a1)
+    assert chk.status_code == 200, chk.text
+    item = chk.json()["itens"][0]
+    patched = client.patch(
+        f"/v1/tickets/{tid}/checklist/itens/{item['id']}",
+        headers=h_a1,
+        json={"concluido": True, "observacao": "ok"},
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["itens"][0]["concluido"] is True
+    assert patched.json()["progresso_pct"] > 0
+
+    fechado = db_session.query(StatusTicket).filter(StatusTicket.slug == "fechado").first()
+    if not fechado:
+        fechado = StatusTicket(nome="Fechado", slug="fechado", ordem=99, ativo=True)
+        db_session.add(fechado)
+        db_session.commit()
+        db_session.refresh(fechado)
+
+    close = client.patch(
+        f"/v1/tickets/{tid}",
+        headers=h_admin,
+        json={"status_id": fechado.id},
+    )
+    assert close.status_code == 400, close.text
+    assert "obrigatório" in close.json()["detail"].lower() or "implantação" in close.json()["detail"].lower()
+
+    for it in patched.json()["itens"]:
+        if it["obrigatorio"] and not it["concluido"]:
+            r = client.patch(
+                f"/v1/tickets/{tid}/checklist/itens/{it['id']}",
+                headers=h_admin,
+                json={"concluido": True},
+            )
+            assert r.status_code == 200, r.text
+
+    chk2 = client.get(f"/v1/tickets/{tid}/checklist", headers=h_admin).json()
+    assert chk2["itens_obrigatorios_pendentes"] == 0
+    assert "cadastrar_pdvs" in {i.get("chave") for i in chk2["itens"]}
+    assert chk2["pdvs_ativos"] == 0
+
+    nat = TicketNatureza(nome="Implantação", slug="implantacao_test", ordem=80, ativo=True)
+    db_session.add(nat)
+    db_session.flush()
+    motivo = TicketMotivo(natureza_id=nat.id, nome="Go-live", slug="go_live", ordem=1, ativo=True)
+    db_session.add(motivo)
+    db_session.commit()
+    db_session.refresh(motivo)
+
+    ok_close = client.patch(
+        f"/v1/tickets/{tid}",
+        headers=h_admin,
+        json={"status_id": fechado.id, "motivo_id": motivo.id},
+    )
+    assert ok_close.status_code == 200, ok_close.text
+    assert ok_close.json()["fechado_em"]
+
+    item_id = chk2["itens"][0]["id"]
+    assert (
+        client.patch(
+            f"/v1/tickets/{tid}/checklist/itens/{item_id}",
+            headers=h_a1,
+            json={"observacao": "depois de fechar"},
+        ).status_code
+        == 403
+    )
+    admin_patch = client.patch(
+        f"/v1/tickets/{tid}/checklist/itens/{item_id}",
+        headers=h_admin,
+        json={"observacao": "ajuste admin"},
+    )
+    assert admin_patch.status_code == 200, admin_patch.text
+    marcado = next(i for i in admin_patch.json()["itens"] if i["id"] == item_id)
+    assert marcado["observacao"] == "ajuste admin"

--- a/docs/BACKEND_RBAC.md
+++ b/docs/BACKEND_RBAC.md
@@ -36,6 +36,7 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 | Funil CRM (mutação) | `POST/PATCH /v1/crm/funil-estagios` — UI em Configurações → Cadastros → Funil CRM |
 | Modelos de proposta (CRUD) | `POST/PATCH /v1/comercial/proposta-templates`, `POST /v1/comercial/proposta-templates/preview` — UI em Cadastros → Modelos de proposta |
 | Modelos de contrato (CRUD) | `POST/PATCH /v1/comercial/contrato-templates`, `POST /v1/comercial/contrato-templates/preview`, `GET /v1/comercial/contrato-templates/chaves` |
+| Checklist de implantação (CRUD) | `POST/PATCH /v1/comercial/implantacao-templates` — UI em Cadastros → Checklist de implantação |
 | Política de reajuste do contrato | `PATCH /v1/comercial/contrato-politica` (percentual e rótulo padrão da instância) |
 
 ## Comercial ou administrador (`exigir_comercial_ou_admin`)
@@ -47,13 +48,14 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 | **Simular custos** | `POST /v1/comercial/custos/simular` |
 | **Listar itens catálogo** | `GET /v1/comercial/custos/itens` (mutações continuam só admin) |
 | **Proposta comercial** | `GET /v1/comercial/proposta-templates` (ativos), `POST/GET /v1/comercial/propostas*`, `GET .../pdf`, `POST .../marcar-enviada` |
-| **Contrato comercial** | `GET /v1/comercial/contrato-templates` (ativos), `GET /v1/comercial/contrato-templates/chaves`, `GET /v1/comercial/contrato-politica`, `POST/GET /v1/comercial/contratos*`, `GET .../pdf`, `POST/GET .../pdf-assinado`, `POST .../marcar-enviado`, `POST .../marcar-assinado`, `POST .../cancelar` (também rescinde assinado com estimativa de multa no payload/atividade). Lista e detalhe (incl. PDF e `multa_rescisao`): comercial só as próprias negociações; admin todos (filtros `so_minhas` e `responsavel_id`). Marcar assinado cria/vincula Rede e Empresa internamente — comercial **não** ganha CRUD de Rede/Empresa. |
+| **Contrato comercial** | `GET /v1/comercial/contrato-templates` (ativos), `GET /v1/comercial/contrato-templates/chaves`, `GET /v1/comercial/contrato-politica`, `POST/GET /v1/comercial/contratos*`, `GET .../pdf`, `POST/GET .../pdf-assinado`, `POST .../marcar-enviado`, `POST .../marcar-assinado`, `POST .../cancelar` (também rescinde assinado com estimativa de multa no payload/atividade). Lista e detalhe (incl. PDF e `multa_rescisao`): comercial só as próprias negociações; admin todos (filtros `so_minhas` e `responsavel_id`). Marcar assinado cria/vincula Rede e Empresa internamente — comercial **não** ganha CRUD de Rede/Empresa. Também abre ticket de implantação (checklist) no setor configurado. |
+| **Checklist de implantação (leitura)** | `GET /v1/comercial/implantacao-templates` (comercial/admin; `incluir_inativos` só admin) |
 
 ## Autenticado com escopo de setor (`obter_atendente_atual`)
 
 | Recurso | Comportamento |
 |---------|----------------|
-| **Tickets** | Listagem e operações respeitam setores visíveis; regras extra em `tickets.py` (responsável, fila, fechado, reabrir só admin). |
+| **Tickets** | Listagem e operações respeitam setores visíveis; regras extra em `tickets.py` (responsável, fila, fechado, reabrir só admin). Checklist de implantação: `GET/PATCH /v1/tickets/{id}/checklist*` no mesmo escopo; fechar bloqueado se itens obrigatórios pendentes. |
 | **Dashboard** | Agregações filtradas por setor para não admin. |
 | **Notificações** | Contagens e itens filtrados por setor / responsável. |
 | **GET /v1/setores** | Lista apenas setores aos quais o atendente está vinculado (e homônimos). |
@@ -78,3 +80,4 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 - **CRM UI** (#341–#344): menu **CRM** e rotas `/crm/leads`, `/crm/negociacoes/:id` para `admin` e `comercial`.
 - **Proposta** (#345–#348): card na negociação para comercial/admin; CRUD de templates só admin.
 - **Contrato** (#349–#357): card na negociação, lista `/crm/contratos` (comercial: próprias; admin: todas); CRUD de templates e política de reajuste em Cadastros (só admin).
+- **Implantação** (#358–#361): CRUD do checklist em Cadastros (admin); ticket automático ao assinar; checklist no detalhe do ticket para quem já vê o ticket.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import { Tickets } from './pages/Tickets'
 import { TicketNovo } from './pages/TicketNovo'
 import { ConfigPropostaTemplates } from './pages/ConfigPropostaTemplates'
 import { ConfigContratoTemplates } from './pages/ConfigContratoTemplates'
+import { ConfigImplantacaoChecklist } from './pages/ConfigImplantacaoChecklist'
 import { CrmLeads } from './pages/CrmLeads'
 import { CrmNegociacaoDetalhe } from './pages/CrmNegociacaoDetalhe'
 import { CrmContratos } from './pages/CrmContratos'
@@ -744,6 +745,7 @@ function AppRoutes() {
           <Route path="funil-crm" element={<ConfigCrmFunil embedded />} />
           <Route path="propostas" element={<ConfigPropostaTemplates embedded />} />
           <Route path="contratos" element={<ConfigContratoTemplates embedded />} />
+          <Route path="implantacao" element={<ConfigImplantacaoChecklist embedded />} />
         </Route>
         <Route
           path="configuracoes/sistema"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1518,6 +1518,12 @@ export const tickets = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
+  getChecklist: (id: number) => api<Tickets.Checklist>(`/tickets/${id}/checklist`),
+  patchChecklistItem: (ticketId: number, itemId: number, data: Tickets.ChecklistItemPatch) =>
+    api<Tickets.Checklist>(`/tickets/${ticketId}/checklist/itens/${itemId}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
   anexosList: (id: number) => api<Tickets.Anexo[]>(`/tickets/${id}/anexos`),
   uploadAnexo: (id: number, file: File, mensagemId?: number | null) => {
     const fd = new FormData()
@@ -3315,6 +3321,8 @@ export namespace ComercialContrato {
     dias_restantes_fidelidade?: number | null;
     multa_rescisao?: MultaRescisao | null;
     interno?: Interno | null;
+    implantacao_ticket_id?: number | null;
+    implantacao_ticket_protocolo?: string | null;
   }
   export interface GerarRequest {
     linha_id: number;
@@ -3343,6 +3351,48 @@ export namespace ComercialContrato {
     reajuste_percentual: string | number;
     reajuste_rotulo: string;
   }
+}
+
+export const comercialImplantacaoTemplates = {
+  list: (params?: { incluir_inativos?: boolean }) =>
+    api<ImplantacaoChecklist.Template[]>(withParams('/comercial/implantacao-templates', params)),
+  create: (data: ImplantacaoChecklist.TemplateCreate) =>
+    api<ImplantacaoChecklist.Template>('/comercial/implantacao-templates', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  update: (id: number, data: ImplantacaoChecklist.TemplateUpdate) =>
+    api<ImplantacaoChecklist.Template>(`/comercial/implantacao-templates/${id}`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+};
+
+export namespace ImplantacaoChecklist {
+  export interface TemplateItem {
+    id?: number;
+    titulo: string;
+    descricao?: string | null;
+    ordem: number;
+    obrigatorio: boolean;
+    chave?: string | null;
+  }
+  export interface Template {
+    id: number;
+    nome: string;
+    versao: number;
+    setor_id?: number | null;
+    setor_nome?: string | null;
+    ativo: boolean;
+    itens: TemplateItem[];
+  }
+  export interface TemplateCreate {
+    nome: string;
+    setor_id?: number | null;
+    ativo?: boolean;
+    itens?: TemplateItem[];
+  }
+  export type TemplateUpdate = Partial<TemplateCreate>;
 }
 
 export const comercialContratoTemplates = {
@@ -4083,6 +4133,36 @@ export namespace Tickets {
     sla_policy_id?: number | null;
     sla_violado?: boolean;
     sla_estado?: 'dentro' | 'em_risco' | 'violado' | 'cumprido' | null;
+    contrato_id?: number | null;
+    negociacao_id?: number | null;
+  }
+  export interface ChecklistItem {
+    id: number;
+    titulo: string;
+    descricao?: string | null;
+    ordem: number;
+    obrigatorio: boolean;
+    chave?: string | null;
+    concluido: boolean;
+    concluido_por_id?: number | null;
+    concluido_por_nome?: string | null;
+    concluido_em?: string | null;
+    observacao?: string | null;
+  }
+  export interface Checklist {
+    aplicavel: boolean;
+    ticket_id: number;
+    contrato_id?: number | null;
+    negociacao_id?: number | null;
+    empresa_id?: number | null;
+    progresso_pct: number;
+    itens_obrigatorios_pendentes: number;
+    pdvs_ativos?: number | null;
+    itens: ChecklistItem[];
+  }
+  export interface ChecklistItemPatch {
+    concluido?: boolean;
+    observacao?: string | null;
   }
   export interface SlaMetaDetalhe {
     meta_minutos: number | null;

--- a/frontend/src/components/crm/CrmContratoCard.tsx
+++ b/frontend/src/components/crm/CrmContratoCard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import {
   comercialContratoPolitica,
   comercialContratoTemplates,
@@ -18,6 +18,8 @@ import { useToast } from '../ui/Toast'
 import { maskCnpjCpf } from '../../utils/maskCnpjCpf'
 import { CrmDadosFiscaisFields } from './CrmDadosFiscaisFields'
 import { emptyFiscal, fiscaisDaLinha, fiscalPayload, formatPercentualPt, parsePercentualPt } from './crmFiscais'
+import { marcarTicketAtivo, TICKETS_PATH } from '../../lib/ticketAtivo'
+import { exibirProtocolo } from '../../lib/exibirProtocolo'
 
 const STATUS_LABEL: Record<string, string> = {
   rascunho: 'Rascunho',
@@ -673,6 +675,18 @@ export function CrmContratoCard({ negociacao, lead = null, onChanged, embedded =
                 </Button>
               ) : null}
             </div>
+            {preview.status === 'assinado' && preview.implantacao_ticket_id ? (
+              <p className="text-sm text-slate-600 dark:text-slate-300">
+                Ticket de implantação:{' '}
+                <Link
+                  to={TICKETS_PATH}
+                  onClick={() => marcarTicketAtivo(preview.implantacao_ticket_id as number)}
+                  className="font-medium text-cyan-700 underline dark:text-cyan-400"
+                >
+                  {exibirProtocolo(preview.implantacao_ticket_protocolo || String(preview.implantacao_ticket_id))}
+                </Link>
+              </p>
+            ) : null}
           </div>
           <iframe
             title={`Preview do contrato ${preview.id}`}

--- a/frontend/src/components/tickets/TicketImplantacaoChecklist.tsx
+++ b/frontend/src/components/tickets/TicketImplantacaoChecklist.tsx
@@ -1,0 +1,151 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ApiError, tickets, type Tickets } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useAuth } from '../../contexts/AuthContext'
+import { useToast } from '../ui/Toast'
+import { CheckboxField } from '../ui/CheckboxField'
+import { Input } from '../ui/Input'
+
+const CHAVE_PDVS = 'cadastrar_pdvs'
+
+export function TicketImplantacaoChecklist({
+  ticketId,
+  empresaId,
+  fechado,
+}: {
+  ticketId: number
+  empresaId: number | null
+  fechado: boolean
+}) {
+  const toast = useToast()
+  const { isAdmin } = useAuth()
+  const [data, setData] = useState<Tickets.Checklist | null>(null)
+  const [savingId, setSavingId] = useState<number | null>(null)
+  const [obsDraft, setObsDraft] = useState<Record<number, string>>({})
+
+  const load = useCallback(() => {
+    tickets
+      .getChecklist(ticketId)
+      .then((c) => {
+        setData(c)
+        const next: Record<number, string> = {}
+        for (const it of c.itens) next[it.id] = it.observacao || ''
+        setObsDraft(next)
+      })
+      .catch((err: unknown) => {
+        if (err instanceof ApiError && err.status === 403) return
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar o checklist.'))
+      })
+  }, [ticketId, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  if (!data?.aplicavel) return null
+
+  const soLeitura = fechado && !isAdmin
+
+  const patch = async (itemId: number, body: Tickets.ChecklistItemPatch) => {
+    setSavingId(itemId)
+    try {
+      const next = await tickets.patchChecklistItem(ticketId, itemId, body)
+      setData(next)
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível atualizar o item.'))
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-3 sm:p-4 dark:border-slate-800 dark:bg-slate-900/40">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-100">Checklist de implantação</h2>
+          <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">
+            {data.progresso_pct}% concluído
+            {data.itens_obrigatorios_pendentes > 0
+              ? ` · ${data.itens_obrigatorios_pendentes} obrigatório(s) pendente(s)`
+              : ' · itens obrigatórios concluídos'}
+          </p>
+        </div>
+        <div
+          className="h-2 w-32 overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800"
+          role="progressbar"
+          aria-valuenow={data.progresso_pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div className="h-full bg-cyan-600 dark:bg-cyan-500" style={{ width: `${data.progresso_pct}%` }} />
+        </div>
+      </div>
+      <ul className="mt-3 space-y-3">
+        {data.itens.map((item) => (
+          <li
+            key={item.id}
+            className="rounded-lg border border-slate-100 p-2.5 dark:border-slate-800"
+          >
+            <CheckboxField
+              checked={item.concluido}
+              disabled={soLeitura || savingId === item.id}
+              onChange={(e) => void patch(item.id, { concluido: e.target.checked })}
+            >
+              {item.titulo}
+              {item.obrigatorio ? (
+                <span className="ml-1 text-[10px] font-semibold uppercase text-amber-700 dark:text-amber-400">
+                  obrigatório
+                </span>
+              ) : null}
+            </CheckboxField>
+            {item.descricao ? (
+              <p className="mt-1 pl-7 text-xs text-slate-500 dark:text-slate-400">{item.descricao}</p>
+            ) : null}
+            {item.chave === CHAVE_PDVS ? (
+              <p className="mt-1 pl-7 text-xs text-slate-600 dark:text-slate-300">
+                PDVs ativos: {data.pdvs_ativos ?? 0}
+                {isAdmin && empresaId ? (
+                  <>
+                    {' · '}
+                    <Link
+                      to={`/empresas/${empresaId}?aba=pdvs`}
+                      className="font-medium text-cyan-700 underline dark:text-cyan-400"
+                    >
+                      Abrir cadastro de PDVs
+                    </Link>
+                  </>
+                ) : (
+                  <span className="text-slate-500"> · o admin cadastra os PDVs na empresa</span>
+                )}
+              </p>
+            ) : null}
+            {item.concluido && item.concluido_por_nome ? (
+              <p className="mt-1 pl-7 text-[11px] text-slate-400">Marcado por {item.concluido_por_nome}</p>
+            ) : null}
+            <div className="mt-2 pl-7">
+              <Input
+                label="Observação"
+                value={obsDraft[item.id] ?? ''}
+                disabled={soLeitura}
+                onChange={(e) => setObsDraft((p) => ({ ...p, [item.id]: e.target.value }))}
+                onBlur={() => {
+                  const val = (obsDraft[item.id] ?? '').trim()
+                  if (val === (item.observacao || '')) return
+                  void patch(item.id, { observacao: val || null })
+                }}
+              />
+            </div>
+          </li>
+        ))}
+      </ul>
+      {fechado && !isAdmin ? (
+        <p className="mt-2 text-xs text-slate-500">Ticket fechado — só um admin altera o checklist.</p>
+      ) : fechado && isAdmin ? (
+        <p className="mt-2 text-xs text-slate-500">Ticket fechado — como admin ainda podes ajustar o checklist.</p>
+      ) : data.itens_obrigatorios_pendentes > 0 ? (
+        <p className="mt-2 text-xs text-slate-500">O ticket só pode ser fechado quando os itens obrigatórios estiverem concluídos.</p>
+      ) : null}
+    </section>
+  )
+}

--- a/frontend/src/pages/ConfigImplantacaoChecklist.tsx
+++ b/frontend/src/pages/ConfigImplantacaoChecklist.tsx
@@ -1,0 +1,268 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ApiError,
+  comercialImplantacaoTemplates,
+  setores,
+  type ImplantacaoChecklist,
+  type Setores,
+} from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Button } from '../components/ui/Button'
+import { Card } from '../components/ui/Card'
+import { CheckboxField } from '../components/ui/CheckboxField'
+import { Input, TEXTAREA_FIELD_CLASS } from '../components/ui/Input'
+import { Select } from '../components/ui/Select'
+import { Switch } from '../components/ui/Switch'
+import { useToast } from '../components/ui/Toast'
+import { ConfigListPageShell } from '../components/config/ConfigListPageShell'
+import { SemPermissao } from './SemPermissao'
+
+type ItemForm = {
+  titulo: string
+  descricao: string
+  obrigatorio: boolean
+  chave: string
+}
+
+const CHAVE_PDVS = 'cadastrar_pdvs'
+
+const itensPadrao = (): ItemForm[] => [
+  {
+    titulo: 'Coleta de documentos',
+    descricao: 'Contrato assinado, dados fiscais e acessos necessários.',
+    obrigatorio: true,
+    chave: '',
+  },
+  {
+    titulo: 'Cadastro na base WebPosto',
+    descricao: 'Criar ou confirmar a base e os logins operacionais.',
+    obrigatorio: true,
+    chave: '',
+  },
+  {
+    titulo: 'Cadastrar PDVs',
+    descricao: 'Cadastrar os PDVs da empresa (cadastro operacional).',
+    obrigatorio: true,
+    chave: CHAVE_PDVS,
+  },
+  {
+    titulo: 'Treinamento da equipe',
+    descricao: 'Treinamento de operação (caixa, retaguarda, helpdesk).',
+    obrigatorio: true,
+    chave: '',
+  },
+  {
+    titulo: 'Validação operacional',
+    descricao: 'Conferir operação no dia a dia antes de encerrar a implantação.',
+    obrigatorio: false,
+    chave: '',
+  },
+]
+
+const emptyItem = (): ItemForm => ({ titulo: '', descricao: '', obrigatorio: true, chave: '' })
+
+export function ConfigImplantacaoChecklist({ embedded = false }: { embedded?: boolean }) {
+  const toast = useToast()
+  const [list, setList] = useState<ImplantacaoChecklist.Template[]>([])
+  const [setorOpts, setSetorOpts] = useState<Setores.Setor[]>([])
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [editing, setEditing] = useState<ImplantacaoChecklist.Template | 'create' | null>(null)
+  const [nome, setNome] = useState('')
+  const [setorId, setSetorId] = useState<number | ''>('')
+  const [ativo, setAtivo] = useState(true)
+  const [itens, setItens] = useState<ItemForm[]>([])
+  const [saving, setSaving] = useState(false)
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    Promise.all([
+      comercialImplantacaoTemplates.list({ incluir_inativos: true }),
+      setores.list().catch(() => ({ items: [] as Setores.Setor[], total: 0 })),
+    ])
+      .then(([templates, sts]) => {
+        setList(templates)
+        setSetorOpts(sts.items || [])
+      })
+      .catch((err: unknown) => {
+        if (err instanceof ApiError && err.status === 403) setForbidden(true)
+        else toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar o checklist.'))
+      })
+      .finally(() => setLoading(false))
+  }, [toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  const openCreate = () => {
+    setEditing('create')
+    setNome('Implantação')
+    setSetorId('')
+    setAtivo(true)
+    setItens(itensPadrao())
+  }
+
+  const openEdit = (row: ImplantacaoChecklist.Template) => {
+    setEditing(row)
+    setNome(row.nome)
+    setSetorId(row.setor_id ?? '')
+    setAtivo(row.ativo)
+    setItens(
+      row.itens.map((i) => ({
+        titulo: i.titulo,
+        descricao: i.descricao || '',
+        obrigatorio: i.obrigatorio,
+        chave: i.chave || '',
+      })),
+    )
+  }
+
+  const save = async () => {
+    if (!editing) return
+    setSaving(true)
+    const payload = {
+      nome,
+      setor_id: setorId === '' ? null : Number(setorId),
+      ativo,
+      itens: itens
+        .filter((i) => i.titulo.trim())
+        .map((i, idx) => ({
+          titulo: i.titulo.trim(),
+          descricao: i.descricao.trim() || null,
+          ordem: idx + 1,
+          obrigatorio: i.obrigatorio,
+          chave: i.chave.trim() || null,
+        })),
+    }
+    try {
+      if (editing === 'create') {
+        await comercialImplantacaoTemplates.create(payload)
+        toast.showSuccess('Checklist criado.')
+      } else {
+        await comercialImplantacaoTemplates.update(editing.id, payload)
+        toast.showSuccess('Checklist guardado.')
+      }
+      setEditing(null)
+      load()
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível guardar.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <ConfigListPageShell
+      embedded={embedded}
+      forbidden={forbidden}
+      denied={<SemPermissao title="Só administradores editam o checklist de implantação." />}
+      title="Checklist de implantação"
+      subtitle="Itens copiados para o ticket automático quando o contrato é marcado como assinado. Se houver vários modelos ativos, usa-se o mais antigo."
+      actions={<Button onClick={openCreate}>Novo modelo</Button>}
+    >
+      {loading ? <p className="text-sm text-slate-500">A carregar…</p> : null}
+      <div className="space-y-3">
+        {list.map((row) => (
+          <Card key={row.id} className="p-4">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="font-medium text-slate-800 dark:text-slate-100">{row.nome}</p>
+                <p className="text-xs text-slate-500">
+                  Setor: {row.setor_nome || '— (Suporte / Implantação se existir)'} · {row.itens.length} itens
+                  {row.ativo ? '' : ' · inativo'}
+                </p>
+              </div>
+              <Button variant="secondary" onClick={() => openEdit(row)}>
+                Editar
+              </Button>
+            </div>
+          </Card>
+        ))}
+      </div>
+      {editing ? (
+        <div className="mt-4 space-y-3 rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+          <p className="text-sm font-medium text-slate-800 dark:text-slate-100">
+            {editing === 'create' ? 'Novo modelo' : 'Editar modelo'}
+          </p>
+          <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} />
+          <Select
+            label="Setor do ticket automático"
+            value={setorId}
+            onChange={(v) => setSetorId(v === '' ? '' : Number(v))}
+            includeEmpty
+            emptyLabel="Detetar Implantação ou Suporte"
+            options={setorOpts.map((s) => ({ value: s.id, label: s.nome }))}
+          />
+          <Switch
+            checked={ativo}
+            onCheckedChange={setAtivo}
+            label="Modelo ativo"
+            showStatusPill
+          />
+          <div className="space-y-3">
+            <p className="text-xs text-slate-500 dark:text-slate-400">
+              No item de PDVs, a chave deve ser{' '}
+              <code className="font-mono text-[11px]">cadastrar_pdvs</code> para aparecer o atalho no ticket.
+              Outras chaves não têm efeito nesta versão.
+            </p>
+            {itens.map((item, idx) => (
+              <div key={idx} className="space-y-2 rounded-lg border border-slate-100 p-3 dark:border-slate-800">
+                <Input
+                  label={`Item ${idx + 1}`}
+                  value={item.titulo}
+                  onChange={(e) =>
+                    setItens((p) => p.map((it, i) => (i === idx ? { ...it, titulo: e.target.value } : it)))
+                  }
+                />
+                <textarea
+                  className={TEXTAREA_FIELD_CLASS}
+                  rows={2}
+                  placeholder="Descrição (opcional)"
+                  value={item.descricao}
+                  onChange={(e) =>
+                    setItens((p) => p.map((it, i) => (i === idx ? { ...it, descricao: e.target.value } : it)))
+                  }
+                />
+                <CheckboxField
+                  checked={item.obrigatorio}
+                  onChange={(e) =>
+                    setItens((p) => p.map((it, i) => (i === idx ? { ...it, obrigatorio: e.target.checked } : it)))
+                  }
+                >
+                  Obrigatório para fechar o ticket
+                </CheckboxField>
+                <Input
+                  label="Chave (opcional)"
+                  value={item.chave}
+                  placeholder="cadastrar_pdvs"
+                  onChange={(e) =>
+                    setItens((p) => p.map((it, i) => (i === idx ? { ...it, chave: e.target.value } : it)))
+                  }
+                />
+                <Button
+                  variant="ghost"
+                  onClick={() => setItens((p) => p.filter((_, i) => i !== idx))}
+                >
+                  Remover item
+                </Button>
+              </div>
+            ))}
+            <Button variant="secondary" onClick={() => setItens((p) => [...p, emptyItem()])}>
+              Adicionar item
+            </Button>
+          </div>
+          <div className="flex gap-2">
+            <Button onClick={() => void save()} disabled={saving}>
+              Guardar
+            </Button>
+            <Button variant="ghost" onClick={() => setEditing(null)}>
+              Cancelar
+            </Button>
+          </div>
+        </div>
+      ) : null}
+    </ConfigListPageShell>
+  )
+}

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import {
   ApiError,
   empresas as apiEmpresas,
@@ -41,6 +41,7 @@ export function EmpresaDetalhe() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const location = useLocation()
+  const [searchParams] = useSearchParams()
   const voltarParaRede = (location.state as { voltarPara?: string } | null)?.voltarPara
   const voltarHistorico = useVoltarAnterior(voltarParaRede ?? '/empresas')
   const voltar = useCallback(() => {
@@ -60,6 +61,13 @@ export function EmpresaDetalhe() {
   const [loadFailure, setLoadFailure] = useState<{ titulo: string; detalhe?: string } | null>(null)
   const [forbidden, setForbidden] = useState(false)
   const [aba, setAba] = useState<Aba>('geral')
+
+  useEffect(() => {
+    const q = searchParams.get('aba')
+    if (q === 'pdvs' || q === 'tickets' || q === 'chats' || q === 'funcionarios' || q === 'analises' || q === 'geral') {
+      setAba(q)
+    }
+  }, [searchParams])
 
   const [pageT, setPageT] = useState(1)
   const [buscaT, setBuscaT] = useState('')

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -49,6 +49,7 @@ import { TicketFilhosMassaPanel } from '../components/tickets/TicketFilhosMassaP
 import { TicketMetaChip } from '../components/tickets/TicketMetaChip'
 import { TicketDetalheSkeleton } from '../components/tickets/TicketDetalheSkeleton'
 import { TicketSlaCard } from '../components/tickets/TicketSlaCard'
+import { TicketImplantacaoChecklist } from '../components/tickets/TicketImplantacaoChecklist'
 import {
   TicketClassificacaoFields,
   classificacaoFromTicket,
@@ -1660,6 +1661,11 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
         <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
           <div className="mx-auto max-w-6xl space-y-4 px-3 pb-8 pt-3 sm:space-y-6 sm:px-5 sm:pb-10 sm:pt-4 md:px-6">
         {!ticket.fechado_em ? <TicketSlaCard ticketId={ticket.id} fechado={false} /> : null}
+        <TicketImplantacaoChecklist
+          ticketId={ticket.id}
+          empresaId={ticket.empresa_id}
+          fechado={Boolean(ticket.fechado_em)}
+        />
         {temVinculosHierarquia && (
           <div className="rounded-xl border border-slate-200/90 bg-slate-50/50 px-3 py-2.5 text-sm dark:border-slate-800/80 dark:bg-slate-900/35">
             <div className="flex flex-wrap items-start justify-between gap-3">

--- a/frontend/src/pages/config/ConfigCadastrosLayout.tsx
+++ b/frontend/src/pages/config/ConfigCadastrosLayout.tsx
@@ -9,6 +9,7 @@ const TABS = [
   { to: '/configuracoes/cadastros/funil-crm', label: 'Funil CRM' },
   { to: '/configuracoes/cadastros/propostas', label: 'Modelos de proposta' },
   { to: '/configuracoes/cadastros/contratos', label: 'Modelos de contrato' },
+  { to: '/configuracoes/cadastros/implantacao', label: 'Checklist de implantação' },
 ] as const
 
 const TAB_HINTS: Record<string, string> = {
@@ -18,6 +19,7 @@ const TAB_HINTS: Record<string, string> = {
   'funil-crm': 'Estágios do funil comercial (Lead, Em negociação…). Usados na lista e no Kanban do CRM.',
   propostas: 'HTML dos modelos da proposta comercial. Placeholders são preenchidos na negociação.',
   contratos: 'HTML dos modelos do contrato comercial. Placeholders (fidelidade, setup, cláusulas) são preenchidos na negociação.',
+  implantacao: 'Itens copiados para o ticket automático quando o contrato é marcado como assinado. Defina o setor (Implantação ou Suporte).',
 }
 
 function abaAtiva(pathname: string): string {
@@ -31,7 +33,7 @@ export function ConfigCadastrosLayout() {
 
   return (
     <PageContainer>
-      <PageHeader title="Cadastros" subtitle="Tipos de negócio, catálogos de PDV, custos, funil CRM e modelos de proposta e contrato." />
+      <PageHeader title="Cadastros" subtitle="Tipos de negócio, catálogos de PDV, custos, funil CRM, modelos comerciais e checklist de implantação." />
       <ConfigSectionTabs tabs={[...TABS]} ariaLabel="Seções de cadastros" />
       {hint ? <p className="text-sm text-slate-600 dark:text-slate-400">{hint}</p> : null}
       <Outlet />


### PR DESCRIPTION
## Summary

- Fecha o épico de implantação (#325 / #358–#361): ao marcar o contrato como assinado, abre um ticket no setor configurado (Implantação ou Suporte) com checklist copiado do modelo
- O modelo é editável em Cadastros (admin); o ticket só fecha com os itens obrigatórios concluídos; o admin tem atalho para cadastrar PDVs da empresa
- Comercial não opera o checklist só por ser comercial; quem já vê o ticket (setor + admin) marca os itens

Closes #358
Closes #359
Closes #360
Closes #361
Closes #325

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] Cadastros → Checklist de implantação: editar itens, setor, chave `cadastrar_pdvs`; criar **Novo modelo**
- [ ] Marcar contrato como assinado → abre um ticket (protocolo no cartão); repetir não duplica
- [ ] Detalhe do ticket: checklist, progresso, observação; fechar bloqueado com obrigatório pendente
- [ ] Atendente de outro setor / comercial: 403 no checklist
- [ ] Admin: atalho «Abrir cadastro de PDVs»; após fechar o ticket, admin ainda altera o checklist e o atendente não
- [ ] `pytest -q` e `npm run build` (já corridos localmente)

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Fora de escopo já com issue ou wontfix neste lote: ClickSign API, boleto/NFS-e (#326 / #362), IGPM (#745), janela 3 meses / go-live
- [x] Stubs/campos nullable — N/A (snapshot do checklist no ticket; template não reescreve tickets em curso)
- [x] Follow-ups existentes: #745 (reajuste IGPM), #326 (faturamento, começa pelo spike #362)
