### PR TITLE
feat(whatsapp): indicação de mensagem encaminhada (#827)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- WhatsApp (#827): mensagens **encaminhadas** pelo cliente mostram o rótulo «Encaminhada» (ou «Encaminhada muitas vezes») no balão do chat, como no WhatsApp
 - Implantação (#325 / #358–#361): ao marcar o contrato como assinado, abre um ticket no setor configurado (Implantação ou Suporte) com checklist (documentos, WebPosto, PDVs, treino). O modelo é editável em Cadastros; o ticket só fecha com os itens obrigatórios feitos; o admin tem atalho para cadastrar PDVs da empresa
 - Empresas (#824): na listagem, o **nome** fica em cima e o **CNPJ/CPF** em baixo no telemóvel (menos truncagem); botão para **copiar** o documento (só dígitos) com toast
 - Atendimentos (#825): no telemóvel, Estado/datas/Atendente ficam num acordeão **Filtros** (recolhido por defeito) para a lista aparecer logo; a busca continua visível; badge indica filtros activos

--- a/backend/alembic/versions/104_wpp_mensagem_encaminhada.py
+++ b/backend/alembic/versions/104_wpp_mensagem_encaminhada.py
@@ -1,0 +1,44 @@
+"""WhatsApp: flag de mensagem encaminhada (#827).
+
+Revision ID: 104_wpp_mensagem_encaminhada
+Revises: 103_implantacao_checklist
+Create Date: 2026-08-21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "104_wpp_mensagem_encaminhada"
+down_revision = "103_implantacao_checklist"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_mensagens"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_mensagens")}
+    if "is_forwarded" not in cols:
+        op.add_column(
+            "whatsapp_mensagens",
+            sa.Column("is_forwarded", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        )
+    if "forwarding_score" not in cols:
+        op.add_column(
+            "whatsapp_mensagens",
+            sa.Column("forwarding_score", sa.Integer(), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("whatsapp_mensagens"):
+        return
+    cols = {c["name"] for c in insp.get_columns("whatsapp_mensagens")}
+    if "forwarding_score" in cols:
+        op.drop_column("whatsapp_mensagens", "forwarding_score")
+    if "is_forwarded" in cols:
+        op.drop_column("whatsapp_mensagens", "is_forwarded")

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -772,6 +772,8 @@ def _mensagem_read(
         wa_message_id=m.wa_message_id,
         quoted_wa_message_id=getattr(m, "quoted_wa_message_id", None),
         quoted_corpo_preview=getattr(m, "quoted_corpo_preview", None),
+        is_forwarded=bool(getattr(m, "is_forwarded", False)),
+        forwarding_score=getattr(m, "forwarding_score", None),
         atendente_id=m.atendente_id,
         atendente_nome=m.atendente.nome if m.atendente else None,
         status_entrega=status,

--- a/backend/app/api/whatsapp_webhook.py
+++ b/backend/app/api/whatsapp_webhook.py
@@ -620,6 +620,8 @@ def _processar_mensagem_inbound(
                     wa_message_id=wa_mid,
                     quoted_wa_message_id=item.get("quoted_wa_message_id"),
                     quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
+                    is_forwarded=bool(item.get("is_forwarded")),
+                    forwarding_score=item.get("forwarding_score"),
                     atendente_id=None,
                 )
                 db.add(msg)
@@ -697,6 +699,8 @@ def _processar_mensagem_inbound(
         wa_message_id=wa_mid,
         quoted_wa_message_id=item.get("quoted_wa_message_id"),
         quoted_corpo_preview=str(q_prev).strip()[:500] if q_prev else None,
+        is_forwarded=bool(item.get("is_forwarded")),
+        forwarding_score=item.get("forwarding_score"),
         atendente_id=None,
     )
     db.add(msg)

--- a/backend/app/models/whatsapp_chat.py
+++ b/backend/app/models/whatsapp_chat.py
@@ -117,6 +117,9 @@ class WhatsappMensagem(Base):
     # Mensagem citada (reply do WhatsApp): id da mensagem na origem + texto de pré-visualização
     quoted_wa_message_id = Column(String(128), nullable=True)
     quoted_corpo_preview = Column(String(500), nullable=True)
+    # Encaminhada (contextInfo.isForwarded / forwardingScore) — #827
+    is_forwarded = Column(Boolean, nullable=False, server_default="false", default=False)
+    forwarding_score = Column(Integer, nullable=True)
     atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
     # pendente | enviada | entregue | lida | erro — apenas outbound ao cliente
     status_entrega = Column(String(20), nullable=True)

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -32,6 +32,8 @@ class WhatsappMensagemRead(BaseModel):
     wa_message_id: str | None = None
     quoted_wa_message_id: str | None = None
     quoted_corpo_preview: str | None = None
+    is_forwarded: bool = False
+    forwarding_score: int | None = None
     atendente_id: int | None = None
     atendente_nome: str | None = None
     status_entrega: str | None = None

--- a/backend/app/services/evolution_inbound.py
+++ b/backend/app/services/evolution_inbound.py
@@ -123,6 +123,37 @@ def _quoted_from_context_info(ctx: dict[str, Any]) -> tuple[str | None, str | No
     return wid, preview
 
 
+def _forward_from_context_info(ctx: dict[str, Any]) -> tuple[bool, int | None]:
+    """Extrai isForwarded / forwardingScore do contextInfo (Baileys / Evolution)."""
+    score_raw = ctx.get("forwardingScore")
+    if score_raw is None:
+        score_raw = ctx.get("ForwardingScore")
+    score: int | None = None
+    if score_raw is not None:
+        try:
+            score = int(score_raw)
+        except (TypeError, ValueError):
+            score = None
+
+    forwarded = bool(ctx.get("isForwarded") or ctx.get("IsForwarded"))
+    if score is not None and score > 0:
+        forwarded = True
+    return forwarded, score
+
+
+def _iter_context_infos(envelope: dict[str, Any], inner: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    ctx = envelope.get("contextInfo") or envelope.get("ContextInfo")
+    if isinstance(ctx, dict):
+        yield ctx
+    for sub_key in _SUBCOM_KEYS:
+        sub = inner.get(sub_key)
+        if not isinstance(sub, dict):
+            continue
+        nested = sub.get("contextInfo") or sub.get("ContextInfo")
+        if isinstance(nested, dict):
+            yield nested
+
+
 def quoted_reply_from_envelope(envelope: dict[str, Any], inner: dict[str, Any]) -> tuple[str | None, str | None]:
     """
     Extrai citação do payload do webhook.
@@ -130,26 +161,25 @@ def quoted_reply_from_envelope(envelope: dict[str, Any], inner: dict[str, Any]) 
     A Evolution API (prepareMessage) coloca contextInfo no envelope da mensagem,
     não dentro de extendedTextMessage — formato diferente do Baileys bruto usado em testes.
     """
-    ctx = envelope.get("contextInfo") or envelope.get("ContextInfo")
-    if isinstance(ctx, dict):
+    for ctx in _iter_context_infos(envelope, inner):
         wid, prev = _quoted_from_context_info(ctx)
         if wid:
             return wid, prev
-    return quoted_reply_from_inner(inner)
+    return None, None
 
 
 def quoted_reply_from_inner(inner: dict[str, Any]) -> tuple[str | None, str | None]:
     """Extrai resposta citada: id da mensagem original (stanzaId) e texto de pré-visualização."""
-    for sub_key in _SUBCOM_KEYS:
-        sub = inner.get(sub_key)
-        if not isinstance(sub, dict):
-            continue
-        ctx = sub.get("contextInfo") or sub.get("ContextInfo")
-        if isinstance(ctx, dict):
-            wid, preview = _quoted_from_context_info(ctx)
-            if wid:
-                return wid, preview
-    return None, None
+    return quoted_reply_from_envelope({}, inner)
+
+
+def forward_info_from_envelope(envelope: dict[str, Any], inner: dict[str, Any]) -> tuple[bool, int | None]:
+    """Extrai flag de encaminhamento (isForwarded / forwardingScore) do webhook (#827)."""
+    for ctx in _iter_context_infos(envelope, inner):
+        forwarded, score = _forward_from_context_info(ctx)
+        if forwarded or score is not None:
+            return forwarded, score
+    return False, None
 
 
 def _mimetype_de_obj_midia(obj: dict[str, Any]) -> str | None:
@@ -273,6 +303,7 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
     - mimetype: opcional
     - raw_envelope: objeto completo da mensagem (para POST getBase64FromMediaMessage), só se tipo != texto
     - quoted_wa_message_id, quoted_corpo_preview: se o cliente responde citando outra mensagem
+    - is_forwarded, forwarding_score: se a mensagem foi encaminhada (#827)
     """
     event = webhook_body.get("event") or webhook_body.get("Event") or ""
     ev = str(event).lower()
@@ -300,6 +331,7 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
         q_wid, q_prev = quoted_reply_from_envelope(m, inner)
         if q_prev and len(q_prev) > 500:
             q_prev = q_prev[:500]
+        is_forwarded, forwarding_score = forward_info_from_envelope(m, inner)
 
         media = _detect_media(inner)
         if media:
@@ -319,6 +351,8 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
                 "raw_envelope": m,
                 "quoted_wa_message_id": q_wid,
                 "quoted_corpo_preview": q_prev,
+                "is_forwarded": is_forwarded,
+                "forwarding_score": forwarding_score,
             }
             continue
 
@@ -341,6 +375,8 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
                 "raw_envelope": None,
                 "quoted_wa_message_id": q_wid,
                 "quoted_corpo_preview": q_prev,
+                "is_forwarded": is_forwarded,
+                "forwarding_score": forwarding_score,
             }
             continue
 
@@ -357,8 +393,9 @@ def iter_inbound_whatsapp_messages(webhook_body: dict[str, Any]) -> Iterator[dic
             "raw_envelope": None,
             "quoted_wa_message_id": q_wid,
             "quoted_corpo_preview": q_prev,
+            "is_forwarded": is_forwarded,
+            "forwarding_score": forwarding_score,
         }
-
 
 def _ack_de_update_dict(update: dict[str, Any]) -> int | str | None:
     if not isinstance(update, dict):

--- a/backend/tests/test_evolution_inbound_forward.py
+++ b/backend/tests/test_evolution_inbound_forward.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from app.services.evolution_inbound import (
+    forward_info_from_envelope,
+    quoted_reply_from_envelope,
+)
+
+
+def test_forward_envelope_evolution():
+    envelope = {
+        "key": {"remoteJid": "5511999999999@s.whatsapp.net", "fromMe": False, "id": "f1"},
+        "message": {"conversation": "Olá"},
+        "contextInfo": {
+            "isForwarded": True,
+            "forwardingScore": 3,
+        },
+    }
+    fwd, score = forward_info_from_envelope(envelope, envelope["message"])
+    assert fwd is True
+    assert score == 3
+
+
+def test_forward_baileys_aninhado():
+    inner = {
+        "extendedTextMessage": {
+            "text": "Encaminhada",
+            "contextInfo": {
+                "isForwarded": True,
+                "forwardingScore": 127,
+            },
+        }
+    }
+    envelope = {"message": inner}
+    fwd, score = forward_info_from_envelope(envelope, inner)
+    assert fwd is True
+    assert score == 127
+
+
+def test_forward_score_sem_flag_ainda_marca():
+    envelope = {
+        "message": {"conversation": "x"},
+        "contextInfo": {"forwardingScore": 2},
+    }
+    fwd, score = forward_info_from_envelope(envelope, envelope["message"])
+    assert fwd is True
+    assert score == 2
+
+
+def test_forward_ausente():
+    envelope = {
+        "message": {"conversation": "normal"},
+    }
+    fwd, score = forward_info_from_envelope(envelope, envelope["message"])
+    assert fwd is False
+    assert score is None
+
+
+def test_forward_e_citacao_juntos():
+    envelope = {
+        "message": {"conversation": "Resposta"},
+        "contextInfo": {
+            "stanzaId": "orig-9",
+            "quotedMessage": {"conversation": "Original"},
+            "isForwarded": True,
+            "forwardingScore": 1,
+        },
+    }
+    wid, prev = quoted_reply_from_envelope(envelope, envelope["message"])
+    fwd, score = forward_info_from_envelope(envelope, envelope["message"])
+    assert wid == "orig-9"
+    assert prev == "Original"
+    assert fwd is True
+    assert score == 1

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1098,6 +1098,8 @@ export namespace WhatsappChats {
     wa_message_id?: string | null
     quoted_wa_message_id?: string | null
     quoted_corpo_preview?: string | null
+    is_forwarded?: boolean
+    forwarding_score?: number | null
     atendente_id?: number | null
     atendente_nome?: string | null
     status_entrega?: 'pendente' | 'enviada' | 'entregue' | 'lida' | 'erro' | null

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -2141,6 +2141,34 @@ useEffect(() => {
                       />
                     )}
 
+                    {m.is_forwarded && !m.apagada && (
+                      <p
+                        className={`mb-1 flex items-center gap-1 text-[11px] italic ${
+                          isInbound ? 'text-slate-400 dark:text-slate-500' : 'text-white/80'
+                        }`}
+                      >
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="12"
+                          height="12"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          aria-hidden
+                          className="shrink-0 opacity-80"
+                        >
+                          <path d="m15 17 5-5-5-5" />
+                          <path d="M4 18v-2a4 4 0 0 1 4-4h12" />
+                        </svg>
+                        {(m.forwarding_score ?? 0) >= 127
+                          ? 'Encaminhada muitas vezes'
+                          : 'Encaminhada'}
+                      </p>
+                    )}
+
                     {m.quoted_wa_message_id && !m.apagada && (
                       <div 
                         onClick={() => {


### PR DESCRIPTION
﻿## Summary

- Closes #827 — mensagens encaminhadas pelo cliente mostram «Encaminhada» / «Encaminhada muitas vezes» no balão
- Parse de `contextInfo.isForwarded` / `forwardingScore` no inbound Evolution (texto e mídia)
- Migration `104_wpp_mensagem_encaminhada`; campos na API/SSE; citação continua em paralelo

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`**
- [x] Bullet de Melhorias para o utilizador final

## Test plan

- [ ] Encaminhar mensagem no WhatsApp nativo para o número da instância → rótulo visível no chat DeskRudder
- [ ] Mensagem normal sem encaminhar → sem rótulo
- [ ] Encaminhada + citada: ambos os indicadores
- [ ] Score ≥ 127 → «Encaminhada muitas vezes»
- [ ] Histórico antigo (sem flag) ok
- [x] `pytest` parse forward + quotes

## Follow-ups / backlog

- [x] Acção «Encaminhar» a partir do painel — fora de escopo v1 (issue)
- [x] Próximo lote produto: #823 (alertas em segundo plano)
