### PR TITLE
feat(alertas): toque em segundo plano APK/PWA/desktop (#823)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Alertas (#823): com a app/aba em **segundo plano**, a fila continua a chamar via notificação do sistema (re-alerta periódico + vibração no push); silenciar na mesa alinha com «Avisar fila» nas preferências
 - WhatsApp (#827): mensagens **encaminhadas** pelo cliente mostram o rótulo «Encaminhada» (ou «Encaminhada muitas vezes») no balão do chat, como no WhatsApp
 - Implantação (#325 / #358–#361): ao marcar o contrato como assinado, abre um ticket no setor configurado (Implantação ou Suporte) com checklist (documentos, WebPosto, PDVs, treino). O modelo é editável em Cadastros; o ticket só fecha com os itens obrigatórios feitos; o admin tem atalho para cadastrar PDVs da empresa
 - Empresas (#824): na listagem, o **nome** fica em cima e o **CNPJ/CPF** em baixo no telemóvel (menos truncagem); botão para **copiar** o documento (só dígitos) com toast

--- a/docs/MOBILE_CAPACITOR.md
+++ b/docs/MOBILE_CAPACITOR.md
@@ -120,6 +120,17 @@ O worker `web-push-outbox` já existente envia para PWA **e** APK. Mute da fila 
 
 O distribuidor embutido usa os servidores de push da Google só como transporte nos telemóveis com Play Services. Sem Play Services, o alerta com a app fechada não chega (a PWA no Chrome continua a funcionar).
 
+### Matriz aberto / 2.º plano / fechado (#823)
+
+| Estado | O que alerta |
+|--------|----------------|
+| **Aberto** (aba/app em foco) | SSE + loop de áudio da fila (`alerta.mp3`); preferência «silenciar» na mesa corta o loop |
+| **2.º plano** (minimizada / outra app / aba oculta; processo ainda vivo) | Notification do SO com `renotify` + re-alerta periódico enquanto a fila > 0; no APK também `App.appStateChange`. Push do servidor continua a chegar em eventos novos |
+| **Fechada / kill** | Só **Web Push** (PWA) ou **UnifiedPush** (APK), com permissão activa |
+| **iOS** | PWA no ecrã inicial (#695); sem SSE em background; push limitado pelo Safari |
+
+Silenciar na mesa (`ChatFilaSomToggle`) e «Avisar fila de espera» em Notificações ficam alinhados (`push_fila` ↔ mute local).
+
 Ícones de loja: `frontend/public/deskrudder-pwa-512.png` (e outline) — ver `MOBILE_STORE_RELEASE.md`. Os mipmaps Android (`ic_launcher*`) devem usar o mesmo mark PWA (fundo Deck `#F8FAFC`); regenerar a partir de `deskrudder-pwa-512.png` se o asset de marca mudar. Opcional: splash nativo com `@capacitor/assets`.
 
 No Windows, se a pasta do clone tiver acentos (ex. `Repositórios`), o Gradle precisa de `android.overridePathCheck=true` em `frontend/android/gradle.properties` (já no repo).

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -109,6 +109,8 @@ App Capacitor Android (#735 / #736): origem do WebView `https://localhost`. Cada
 
 O APK Android (#737) **não usa Firebase**. Os alertas com a app fechada reutilizam o mesmo par VAPID e o worker `web-push-outbox`. Não há variável FCM extra no `client.env`.
 
+Com a app **minimizada** mas ainda em memória (#823): o frontend também emite Notification local / re-alerta periódico da fila (além do push por evento). Matriz completo em `docs/MOBILE_CAPACITOR.md`.
+
 Exemplo Duplex:
 
 ```bash

--- a/frontend/android/app/src/main/java/br/com/deskrudder/app/DeskRudderPushService.kt
+++ b/frontend/android/app/src/main/java/br/com/deskrudder/app/DeskRudderPushService.kt
@@ -82,6 +82,8 @@ class DeskRudderPushService : PushService() {
             .setAutoCancel(true)
             .setContentIntent(pending)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_MESSAGE)
+            .setOnlyAlertOnce(false)
             .setDefaults(NotificationCompat.DEFAULT_ALL)
             .build()
         NotificationManagerCompat.from(this).notify(tag.hashCode(), notification)
@@ -98,6 +100,14 @@ class DeskRudderPushService : PushService() {
                 NotificationManager.IMPORTANCE_HIGH,
             ).apply {
                 description = "Fila e mensagens nos teus chats e tickets"
+                enableVibration(true)
+                setSound(
+                    android.media.RingtoneManager.getDefaultUri(
+                        android.media.RingtoneManager.TYPE_NOTIFICATION,
+                    ),
+                    null,
+                )
+                setShowBadge(true)
             },
         )
     }

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -19,6 +19,10 @@ const POLL_SSE_SAFETY_MS = 60_000
 const POLL_STALE_GUARD_MS = 3000
 /** Dedup de transição idêntica (SSE duplicado / múltiplos listeners). */
 const ALERT_DEDUP_MS = 2000
+/** Re-alerta periódico via Notification enquanto a fila > 0 e a app está em 2.º plano (#823). */
+const FILA_BG_NUDGE_MS = 12_000
+const FILA_NOTIFY_DEDUP_MS = 4000
+const FILA_NOTIFY_TAG = 'dx-connect-fila-aguardando'
 
 /** Tickets na fila sem responsável */
 const SOUND_TICKET_FILA = '/sons/notification.mp3'
@@ -90,6 +94,10 @@ let wppFilaLoopRetryTimer: number | null = null
 let audioUnlocked = false
 let audioUnlockInstalled = false
 let lastFilaDesktopNotifyAt = 0
+let filaBgNudgeTimer: number | null = null
+/** APK: false quando o OS põe a app em segundo plano (#823). Browser: permanece true. */
+let nativeAppActive = true
+let capacitorAppStateBound = false
 let pollTimerId: number | null = null
 let sseSlowPollMode = false
 let sseListenerCount = 0
@@ -132,9 +140,11 @@ export function setFilaAguardandoMuted(muted: boolean) {
     // Corta na hora: loop + pulse one-shot na fila de alertas (#651)
     stopWppFilaLoop()
     stopWppFilaOneShots()
+    clearFilaBackgroundNudge()
   } else {
     const filaCount = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
     syncWppFilaBeep(filaCount)
+    syncFilaBackgroundNudge()
   }
   for (const l of listenersFilaMuted) l(muted)
 }
@@ -496,6 +506,45 @@ function syncWppFilaBeep(wppFilaCount: number) {
   } else {
     stopWppFilaLoop()
   }
+  syncFilaBackgroundNudge()
+}
+
+/** App minimizada / aba oculta / janela sem foco / APK em 2.º plano (#823). */
+function isAppInBackground(): boolean {
+  if (!nativeAppActive) return true
+  if (typeof document === 'undefined') return false
+  if (document.visibilityState === 'hidden') return true
+  try {
+    if (typeof document.hasFocus === 'function' && !document.hasFocus()) return true
+  } catch {
+    // ignore
+  }
+  return false
+}
+
+function clearFilaBackgroundNudge() {
+  if (filaBgNudgeTimer != null) {
+    window.clearInterval(filaBgNudgeTimer)
+    filaBgNudgeTimer = null
+  }
+}
+
+function syncFilaBackgroundNudge() {
+  const fila = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
+  const need = fila > 0 && !filaAguardandoMuted && isAppInBackground()
+  if (!need) {
+    clearFilaBackgroundNudge()
+    return
+  }
+  if (filaBgNudgeTimer != null) return
+  filaBgNudgeTimer = window.setInterval(() => {
+    const c = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
+    if (c <= 0 || filaAguardandoMuted || !isAppInBackground()) {
+      clearFilaBackgroundNudge()
+      return
+    }
+    notifyFilaDesktop(c, { force: true })
+  }, FILA_BG_NUDGE_MS)
 }
 
 async function trySetAppBadge(count: number) {
@@ -795,16 +844,16 @@ function installAudioUnlockListeners() {
 }
 
 /**
- * Notificação do SO quando a aba está oculta — browsers bloqueiam audio.play() em background.
- * Respeita silenciar da fila. Dedup ~4s para não spammar.
+ * Notificação do SO quando a app está em segundo plano — browsers/OS bloqueiam audio.play().
+ * Respeita silenciar da fila. Dedup ~4s (exceto `force` do nudge periódico #823).
  */
-function notifyFilaDesktop(filaCount: number) {
+function notifyFilaDesktop(filaCount: number, opts?: { force?: boolean }) {
   if (filaAguardandoMuted || filaCount <= 0) return
-  if (typeof document === 'undefined' || document.visibilityState === 'visible') return
+  if (!isAppInBackground()) return
   if (typeof Notification === 'undefined') return
   if (Notification.permission !== 'granted') return
   const now = Date.now()
-  if (now - lastFilaDesktopNotifyAt < 4000) return
+  if (!opts?.force && now - lastFilaDesktopNotifyAt < FILA_NOTIFY_DEDUP_MS) return
   lastFilaDesktopNotifyAt = now
   try {
     const body =
@@ -813,12 +862,18 @@ function notifyFilaDesktop(filaCount: number) {
         : `Há ${filaCount} chats aguardando atendimento`
     const n = new Notification(APP_NAME, {
       body,
-      tag: 'dx-connect-fila-aguardando',
+      tag: FILA_NOTIFY_TAG,
       silent: false,
-    })
+      renotify: true,
+      requireInteraction: true,
+    } as NotificationOptions)
     n.onclick = () => {
       try {
         window.focus()
+        const path = '/chat/espera'
+        if (window.location.pathname !== path) {
+          window.location.assign(path)
+        }
       } catch {
         // ignore
       }
@@ -842,19 +897,47 @@ function ensureStarted() {
 
   preloadSounds()
   installAudioUnlockListeners()
+  if (!capacitorAppStateBound) {
+    capacitorAppStateBound = true
+    void import('../lib/capacitorNative').then(({ bindCapacitorAppState }) => {
+      bindCapacitorAppState((isActive) => {
+        nativeAppActive = isActive
+        const fila = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
+        if (isActive) {
+          syncWppFilaBeep(fila)
+          void poll()
+        } else {
+          syncFilaBackgroundNudge()
+          if (fila > 0 && !filaAguardandoMuted) notifyFilaDesktop(fila)
+        }
+      })
+    })
+  }
 
   void poll()
   restartPollTimer()
 
   const onFocusOrVisible = () => {
-    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') return
+    if (isAppInBackground()) {
+      syncFilaBackgroundNudge()
+      return
+    }
     // Retoma o loop imediatamente ao voltar à aba (#652), sem esperar o poll
     const fila = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
     syncWppFilaBeep(fila)
     void poll()
   }
+  const onBlurOrHidden = () => {
+    syncFilaBackgroundNudge()
+    const fila = currentResumo.wpp_fila_count + currentResumo.portal_fila_count
+    if (fila > 0 && !filaAguardandoMuted) notifyFilaDesktop(fila)
+  }
   window.addEventListener('focus', onFocusOrVisible)
-  document.addEventListener('visibilitychange', onFocusOrVisible)
+  window.addEventListener('blur', onBlurOrHidden)
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') onBlurOrHidden()
+    else onFocusOrVisible()
+  })
 }
 
 export function usePendenciasResumo(enabled: boolean): Notificacoes.Resumo {

--- a/frontend/src/lib/capacitorNative.ts
+++ b/frontend/src/lib/capacitorNative.ts
@@ -1,5 +1,6 @@
 import { App } from '@capacitor/app'
 import { Capacitor } from '@capacitor/core'
+import type { PluginListenerHandle } from '@capacitor/core'
 
 /** WebView nativo (Capacitor). O host é `localhost` — não é a landing comercial. */
 export function isCapacitorNative(): boolean {
@@ -16,4 +17,21 @@ export function bindCapacitorBackButton(): void {
     }
     void App.exitApp()
   })
+}
+
+/**
+ * Estado activo do app nativo (APK) — espelha minimizar / trocar de app (#823).
+ * No browser devolve unsubscribe no-op e nunca chama o callback.
+ */
+export function bindCapacitorAppState(onChange: (isActive: boolean) => void): () => void {
+  if (!Capacitor.isNativePlatform()) return () => {}
+  let handle: PluginListenerHandle | null = null
+  void App.addListener('appStateChange', ({ isActive }) => {
+    onChange(isActive)
+  }).then((h) => {
+    handle = h
+  })
+  return () => {
+    void handle?.remove()
+  }
 }

--- a/frontend/src/pages/NotificacoesPreferencias.tsx
+++ b/frontend/src/pages/NotificacoesPreferencias.tsx
@@ -7,6 +7,7 @@ import { Button } from '../components/ui/Button'
 import { Switch } from '../components/ui/Switch'
 import { useToast } from '../components/ui/Toast'
 import { syncWebPushSubscription } from '../hooks/useWebPush'
+import { setFilaAguardandoMuted } from '../hooks/useAlertaFilaSemResponsavel'
 
 export function NotificacoesPreferencias() {
   const toast = useToast()
@@ -28,7 +29,11 @@ export function NotificacoesPreferencias() {
     notificacoes
       .preferenciasGet()
       .then((p) => {
-        if (!cancelled) setPrefs(p)
+        if (!cancelled) {
+          setPrefs(p)
+          // Preferência do servidor alinha o som local da mesa (#823)
+          setFilaAguardandoMuted(!p.push_fila)
+        }
       })
       .catch((err) => {
         if (!cancelled) {
@@ -49,6 +54,7 @@ export function NotificacoesPreferencias() {
     try {
       const updated = await notificacoes.preferenciasUpdate(prefs)
       setPrefs(updated)
+      setFilaAguardandoMuted(!updated.push_fila)
       toast.showSuccess('Preferências salvas.')
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar.'))
@@ -141,6 +147,7 @@ export function NotificacoesPreferencias() {
             checked={prefs.push_fila}
             onCheckedChange={(v) => {
               setPrefs((p) => ({ ...p, push_fila: v }))
+              setFilaAguardandoMuted(!v)
               void notificacoes.preferenciasUpdate({ push_fila: v }).catch((err) => {
                 toast.showError(mensagemFalhaParaToast(err, 'Não foi possível actualizar o alerta da fila.'))
               })

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -41,6 +41,7 @@ self.addEventListener('push', (event: PushEvent) => {
   }
   const title = data.titulo || 'DeskRudder'
   const body = data.corpo || 'Nova actividade no atendimento'
+  const isFila = data.tipo === 'chat.fila' || data.tipo === 'fila'
   event.waitUntil(
     self.registration.showNotification(title, {
       body,
@@ -49,6 +50,8 @@ self.addEventListener('push', (event: PushEvent) => {
       data,
       tag: `${data.tipo || 'push'}:${data.id || ''}`,
       renotify: true,
+      requireInteraction: isFila,
+      vibrate: isFila ? [200, 100, 200, 100, 200] : [180, 80, 180],
     }),
   )
 })


### PR DESCRIPTION
﻿## Summary

- Closes #823 (lote 1 — sem Foreground Service)
- Com app/aba em **segundo plano**, a fila continua a chamar via Notification do SO (`renotify` + re-alerta ~12s)
- APK: `App.appStateChange` + canal Android com vibração/som
- PWA SW: vibração + `requireInteraction` em alertas de fila
- Silenciar na mesa ↔ «Avisar fila» nas preferências
- Docs: matriz aberto / 2.º plano / fechado em `MOBILE_CAPACITOR.md` + nota em `OPERATIONS.md`

## CHANGELOG

- [x] Atualizei `CHANGELOG.md` → `[Unreleased]`
- [x] Bullet para utilizador final

## Test plan

- [ ] Desktop: minimizar / outra aba com fila > 0 → notificação; reaparece enquanto fila pendente; silenciar corta
- [ ] PWA Android: push + vibração; deep link
- [ ] APK: minimizar com push activo → alerta; app fechada → UnifiedPush (regressão #737)
- [ ] Preferências «Avisar fila» alinha som da mesa
- [ ] Toque na notificação local → `/chat/espera`

## Follow-ups / backlog

- [x] Foreground Service nativo «chamada contínua» — adiado (só se QA provar gap com processo vivo)
- [x] Push periódico do servidor enquanto fila > 0 — fora de escopo (spam)
- [x] iOS nativo #738 — bloqueado Mac
