### PR TITLE
feat(whatsapp): copiar número ao clicar (#831)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- WhatsApp (#831): clicar no **número** do contacto (lista Em atendimento, Aguardando, histórico e header) copia automaticamente, com «Copiado!» discreto
 - Alertas (#823): com a app/aba em **segundo plano**, a fila continua a chamar via notificação do sistema (re-alerta periódico + vibração no push); silenciar na mesa alinha com «Avisar fila» nas preferências
 - WhatsApp (#827): mensagens **encaminhadas** pelo cliente mostram o rótulo «Encaminhada» (ou «Encaminhada muitas vezes») no balão do chat, como no WhatsApp
 - Implantação (#325 / #358–#361): ao marcar o contrato como assinado, abre um ticket no setor configurado (Implantação ou Suporte) com checklist (documentos, WebPosto, PDVs, treino). O modelo é editável em Cadastros; o ticket só fecha com os itens obrigatórios feitos; o admin tem atalho para cadastrar PDVs da empresa

--- a/frontend/src/components/chat/CopiarWaIdButton.tsx
+++ b/frontend/src/components/chat/CopiarWaIdButton.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+import { formatWaIdExibicao } from '../../utils/masks'
+
+type Props = {
+  waId: string
+  className?: string
+  /** Se false, mostra o `wa_id` cru (útil em listas densas). Default: formatado (#684). */
+  formatado?: boolean
+}
+
+/**
+ * Número WhatsApp clicável — copia `wa_id` para a área de transferência (#831 / #684).
+ * Usar `stopPropagation` para não abrir o card/link pai.
+ */
+export function CopiarWaIdButton({ waId, className = '', formatado = true }: Props) {
+  const [copiado, setCopiado] = useState(false)
+  const raw = waId.trim()
+  if (!raw) return null
+
+  return (
+    <button
+      type="button"
+      className={`max-w-full truncate font-mono text-xs transition hover:text-cyan-700 dark:hover:text-cyan-300 ${className}`}
+      title={copiado ? 'Copiado' : 'Clique para copiar o número'}
+      aria-label={copiado ? 'Número copiado' : 'Copiar número do contacto'}
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        void navigator.clipboard?.writeText(raw).then(() => {
+          setCopiado(true)
+          window.setTimeout(() => setCopiado(false), 1500)
+        })
+      }}
+    >
+      {copiado ? 'Copiado!' : formatado ? formatWaIdExibicao(raw) : raw}
+    </button>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -14,6 +14,7 @@ import { useToast } from '../../components/ui/Toast'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import { rotuloResponsavelChat } from '../../lib/whatsappChatMeta'
+import { CopiarWaIdButton } from '../../components/chat/CopiarWaIdButton'
 
 function TempoEspera({ data }: { data?: string | null }) {
   const [minutos, setMinutos] = useState(0)
@@ -206,7 +207,7 @@ export function WhatsappAtendendo() {
                         <h3 className="truncate font-bold text-slate-900 dark:text-slate-100">
                           {c.cliente_nome || 'Cliente'}
                         </h3>
-                        <p className="font-mono text-xs text-slate-500">{c.wa_id}</p>
+                        <CopiarWaIdButton waId={c.wa_id} className="mt-0.5 text-slate-500 dark:text-slate-400" />
                         {c.empresa_nome && (
                           <p className="mt-1 truncate text-[10px] font-medium text-slate-500 dark:text-slate-400">
                             {c.empresa_nome}
@@ -275,7 +276,7 @@ export function WhatsappAtendendo() {
                           <h3 className="font-bold text-slate-900 transition-colors group-hover:text-amber-700 dark:text-slate-100">
                             {c.cliente_nome || 'Cliente'}
                           </h3>
-                          <p className="mt-1 font-mono text-xs text-slate-400">{c.wa_id}</p>
+                          <CopiarWaIdButton waId={c.wa_id} className="mt-1 text-slate-400" />
                           <p className="mt-2 text-[10px] font-medium text-amber-800/80 dark:text-amber-200/80">
                             Encerrado por inatividade — falta registar a demanda
                           </p>
@@ -334,7 +335,7 @@ export function WhatsappAtendendo() {
                               Sem vínculo
                             </span>
                           )}
-                          <p className="mt-1 font-mono text-xs text-slate-400">{c.wa_id}</p>
+                          <CopiarWaIdButton waId={c.wa_id} className="mt-1 text-slate-400" />
                           <p className="mt-2 text-[10px] font-medium text-slate-500 dark:text-slate-400">
                             {rotuloResponsavelChat(c)}
                             {c.setor_nome ? ` • ${c.setor_nome}` : ''}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -33,8 +33,8 @@ import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
 import { ImageLightboxViewer } from '../../components/chat/ImageLightboxViewer'
 import { WhatsappMensagemAcoes } from '../../components/chat/WhatsappMensagemAcoes'
 import { WhatsappReacoesBar } from '../../components/chat/WhatsappReacoesBar'
+import { CopiarWaIdButton } from '../../components/chat/CopiarWaIdButton'
 import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
-import { formatWaIdExibicao } from '../../utils/masks'
 
 import { Card } from '../../components/ui/Card'
 import { ChatBottomSheet } from '../../components/ui/ChatBottomSheet'
@@ -611,7 +611,6 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
   const [zoomMsgId, setZoomMsgId] = useState<number | null>(null)
   const [videoZoomMsgId, setVideoZoomMsgId] = useState<number | null>(null)
   const [fotoPerfilAberta, setFotoPerfilAberta] = useState(false)
-  const [numeroCopiado, setNumeroCopiado] = useState(false)
   const [detalhesMobileAbertos, setDetalhesMobileAbertos] = useState(() => {
     try {
       return sessionStorage.getItem(WA_DETALHES_SESSION_KEY) === '1'
@@ -1703,20 +1702,10 @@ useEffect(() => {
                 {chat?.cliente_nome || 'Atendimento'}
               </h1>
               {chat?.wa_id ? (
-                <button
-                  type="button"
-                  className="mt-0.5 max-w-full truncate font-mono text-[11px] text-slate-500 transition hover:text-cyan-700 dark:text-slate-400 dark:hover:text-cyan-300"
-                  title={numeroCopiado ? 'Copiado' : 'Clique para copiar o número'}
-                  onClick={() => {
-                    const raw = chat.wa_id
-                    void navigator.clipboard?.writeText(raw).then(() => {
-                      setNumeroCopiado(true)
-                      window.setTimeout(() => setNumeroCopiado(false), 1500)
-                    })
-                  }}
-                >
-                  {numeroCopiado ? 'Copiado!' : formatWaIdExibicao(chat.wa_id)}
-                </button>
+                <CopiarWaIdButton
+                  waId={chat.wa_id}
+                  className="mt-0.5 text-[11px] text-slate-500 dark:text-slate-400"
+                />
               ) : null}
             </div>
 

--- a/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappHistorico.tsx
@@ -19,6 +19,7 @@ import {
 import { useWhatsappListScrollRestore } from '../../hooks/useWhatsappListScrollRestore'
 import { ChatIniciarConversaModal } from '../../components/chat/ChatIniciarConversaModal'
 import { CollapsibleCard } from '../../components/ui/CollapsibleCard'
+import { CopiarWaIdButton } from '../../components/chat/CopiarWaIdButton'
 
 const PAGE_SIZE = 15
 
@@ -281,12 +282,10 @@ export function WhatsappHistorico() {
                           {rotuloEstadoChat(c.estado)}
                         </span>
                       </div>
-                      <p
-                        className="mt-0.5 truncate font-mono text-[10px] font-bold text-slate-400"
-                        title={c.wa_id}
-                      >
-                        {c.wa_id}
-                      </p>
+                      <CopiarWaIdButton
+                        waId={c.wa_id}
+                        className="mt-0.5 text-[10px] font-bold text-slate-400"
+                      />
                       <p
                         className="truncate font-mono text-xs font-bold text-cyan-600 dark:text-cyan-400"
                         title={exibirProtocolo(c.protocolo)}


### PR DESCRIPTION
﻿## Summary

- Closes #831 — clicar no número do contacto copia o `wa_id` (feedback «Copiado!»)
- Listas Em atendimento / Aguardando / a classificar + histórico + header da conversa
- Helper `CopiarWaIdButton` com `stopPropagation` (não abre o card)

## CHANGELOG

- [x] `CHANGELOG.md` → `[Unreleased]`

## Test plan

- [ ] Lista Em atendimento: clique no número → copia; chat **não** abre
- [ ] Header da conversa: clique → copia (igual #684)
- [ ] Histórico / Aguardando: idem
- [ ] Mobile: clipboard OK em HTTPS

## Follow-ups

- [x] #833 Configurações — próximo lote
- [x] #738 iOS — fim do projecto
