### PR TITLE
feat(config): hub e reorganização das Configurações (#833)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Configurações (#833): hub com **pesquisa** e cartões por domínio; menu reorganizado (Equipa e tickets, Canais, Comercial/CRM, Empresa e catálogos, Administração); URLs antigas redireccionam
 - WhatsApp (#831): clicar no **número** do contacto (lista Em atendimento, Aguardando, histórico e header) copia automaticamente, com «Copiado!» discreto
 - Alertas (#823): com a app/aba em **segundo plano**, a fila continua a chamar via notificação do sistema (re-alerta periódico + vibração no push); silenciar na mesa alinha com «Avisar fila» nas preferências
 - WhatsApp (#827): mensagens **encaminhadas** pelo cliente mostram o rótulo «Encaminhada» (ou «Encaminhada muitas vezes») no balão do chat, como no WhatsApp

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -67,9 +67,9 @@ import { ConfigWhatsapp } from './pages/ConfigWhatsapp'
 import { ConfigPdvCatalogos } from './pages/ConfigPdvCatalogos'
 import { ConfigComercialCustos } from './pages/ConfigComercialCustos'
 import { ConfigEmpresaEmail } from './pages/ConfigEmpresaEmail'
-import { ConfigAtendimentoLayout } from './pages/config/ConfigAtendimentoLayout'
-import { ConfigCadastrosLayout } from './pages/config/ConfigCadastrosLayout'
-import { ConfigSistemaLayout } from './pages/config/ConfigSistemaLayout'
+import { ConfigHubPage } from './pages/config/ConfigHubPage'
+import { ConfigDomainIndexRedirect, ConfigDomainLayout } from './pages/config/ConfigDomainLayout'
+import { ConfigLegacyRedirect } from './pages/config/ConfigLegacyRedirect'
 import { WhatsappLayout } from './pages/whatsapp/WhatsappLayout'
 import { WhatsappHistorico } from './pages/whatsapp/WhatsappHistorico'
 import { WhatsappAvaliacoes } from './pages/whatsapp/WhatsappAvaliacoes'
@@ -351,7 +351,7 @@ function AppRoutes() {
             }
           />
         </Route>
-        <Route path="ajuda/portal" element={<Navigate to="/configuracoes/sistema/base-conhecimento" replace />} />
+        <Route path="ajuda/portal" element={<Navigate to="/configuracoes/canais/base-conhecimento" replace />} />
         <Route
           path="ajuda/artigos/novo"
           element={
@@ -565,7 +565,7 @@ function AppRoutes() {
             </AdminRoute>
           }
         />
-        <Route path="setores" element={<Navigate to="/configuracoes/atendimento/setores" replace />} />
+        <Route path="setores" element={<Navigate to="/configuracoes/equipa/setores" replace />} />
         <Route
           path="atendentes/novo"
           element={
@@ -590,7 +590,7 @@ function AppRoutes() {
             </AdminRoute>
           }
         />
-        <Route path="atendentes" element={<Navigate to="/configuracoes/atendimento/atendentes" replace />} />
+        <Route path="atendentes" element={<Navigate to="/configuracoes/equipa/atendentes" replace />} />
         <Route
           path="funcionarios-rede/:id"
           element={
@@ -647,7 +647,7 @@ function AppRoutes() {
             </AdminRoute>
           }
         />
-        <Route path="respostas-prontas" element={<Navigate to="/configuracoes/atendimento/respostas-prontas" replace />} />
+        <Route path="respostas-prontas" element={<Navigate to="/configuracoes/equipa/respostas-prontas" replace />} />
         <Route
           path="base-conhecimento/novo"
           element={<Navigate to="/ajuda/artigos/novo" replace />}
@@ -681,8 +681,8 @@ function AppRoutes() {
             </AdminRoute>
           }
         />
-        <Route path="status-ticket" element={<Navigate to="/configuracoes/atendimento/status-ticket" replace />} />
-        <Route path="auditoria" element={<Navigate to="/configuracoes/sistema/auditoria" replace />} />
+        <Route path="status-ticket" element={<Navigate to="/configuracoes/equipa/status-ticket" replace />} />
+        <Route path="auditoria" element={<Navigate to="/configuracoes/administracao/auditoria" replace />} />
         <Route
           path="tipos-negocio/novo"
           element={
@@ -707,74 +707,54 @@ function AppRoutes() {
             </AdminRoute>
           }
         />
-        <Route path="tipos-negocio" element={<Navigate to="/configuracoes/cadastros/tipos-negocio" replace />} />
+        <Route path="tipos-negocio" element={<Navigate to="/configuracoes/empresa-catalogos/tipos-negocio" replace />} />
         <Route
-          path="configuracoes/atendimento"
+          path="configuracoes"
           element={
             <AdminRoute>
-              <ConfigAtendimentoLayout />
+              <ConfigHubPage />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="configuracoes/:domain"
+          element={
+            <AdminRoute>
+              <ConfigDomainLayout />
             </AdminRoute>
           }
         >
-          <Route index element={<Navigate to="setores" replace />} />
+          <Route index element={<ConfigDomainIndexRedirect />} />
           <Route path="setores" element={<Setores embedded />} />
           <Route path="atendentes" element={<Atendentes embedded />} />
           <Route path="status-ticket" element={<StatusTicketPage embedded />} />
           <Route path="natureza-motivo" element={<TicketNaturezaMotivoPage embedded />} />
           <Route path="respostas-prontas" element={<RespostasProntasPage embedded />} />
-          <Route path="base-conhecimento" element={<Navigate to="/ajuda/artigos" replace />} />
           <Route path="roteamento" element={<RoteamentoRegrasPage embedded />} />
           <Route path="sla" element={<SlaConfigLayout />}>
             <Route index element={<Navigate to="politicas" replace />} />
             <Route path="politicas" element={<SlaPoliticasPage embedded />} />
             <Route path="calendarios" element={<SlaCalendariosPage embedded />} />
           </Route>
-        </Route>
-        <Route
-          path="configuracoes/cadastros"
-          element={
-            <AdminRoute>
-              <ConfigCadastrosLayout />
-            </AdminRoute>
-          }
-        >
-          <Route index element={<Navigate to="tipos-negocio" replace />} />
-          <Route path="tipos-negocio" element={<TiposNegocio embedded />} />
-          <Route path="pdv" element={<ConfigPdvCatalogos embedded />} />
-          <Route path="custos" element={<ConfigComercialCustos embedded />} />
+          <Route path="whatsapp" element={<ConfigWhatsapp embedded />} />
+          <Route path="email" element={<ConfigEmpresaEmail embedded section="email" />} />
+          <Route path="base-conhecimento" element={<KbPortalSettingsPage embedded />} />
           <Route path="funil-crm" element={<ConfigCrmFunil embedded />} />
           <Route path="propostas" element={<ConfigPropostaTemplates embedded />} />
           <Route path="contratos" element={<ConfigContratoTemplates embedded />} />
+          <Route path="custos" element={<ConfigComercialCustos embedded />} />
           <Route path="implantacao" element={<ConfigImplantacaoChecklist embedded />} />
-        </Route>
-        <Route
-          path="configuracoes/sistema"
-          element={
-            <AdminRoute>
-              <ConfigSistemaLayout />
-            </AdminRoute>
-          }
-        >
-          <Route index element={<Navigate to="empresa" replace />} />
           <Route path="empresa" element={<ConfigEmpresaEmail embedded section="empresa" />} />
-          <Route path="email" element={<ConfigEmpresaEmail embedded section="email" />} />
-          <Route path="empresa-email" element={<Navigate to="empresa" replace />} />
-          <Route path="whatsapp" element={<ConfigWhatsapp embedded />} />
-          <Route path="base-conhecimento" element={<KbPortalSettingsPage embedded />} />
+          <Route path="tipos-negocio" element={<TiposNegocio embedded />} />
+          <Route path="pdv" element={<ConfigPdvCatalogos embedded />} />
           <Route path="auditoria" element={<Auditoria embedded />} />
         </Route>
-        <Route
-          path="configuracoes/whatsapp"
-          element={<Navigate to="/configuracoes/sistema/whatsapp" replace />}
-        />
-        <Route
-          path="configuracoes/empresa-email"
-          element={<Navigate to="/configuracoes/sistema/empresa" replace />}
-        />
-        <Route
-          path="configuracoes/pdv-catalogos"
-          element={<Navigate to="/configuracoes/cadastros/pdv" replace />}
-        />
+        <Route path="configuracoes/atendimento/*" element={<ConfigLegacyRedirect />} />
+        <Route path="configuracoes/cadastros/*" element={<ConfigLegacyRedirect />} />
+        <Route path="configuracoes/sistema/*" element={<ConfigLegacyRedirect />} />
+        <Route path="configuracoes/whatsapp" element={<ConfigLegacyRedirect />} />
+        <Route path="configuracoes/empresa-email" element={<ConfigLegacyRedirect />} />
+        <Route path="configuracoes/pdv-catalogos" element={<ConfigLegacyRedirect />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -375,9 +375,12 @@ const navStructure: NavItem[] = [
       '/auditoria',
     ],
     children: [
-      { to: '/configuracoes/atendimento', label: 'Atendimento', icon: 'setores' },
-      { to: '/configuracoes/cadastros', label: 'Cadastros', icon: 'tiposNegocio' },
-      { to: '/configuracoes/sistema', label: 'Sistema', icon: 'configuracoes' },
+      { to: '/configuracoes', label: 'Visão geral', icon: 'configuracoes' },
+      { to: '/configuracoes/equipa', label: 'Equipa e tickets', icon: 'setores' },
+      { to: '/configuracoes/canais', label: 'Canais', icon: 'chat' },
+      { to: '/configuracoes/comercial', label: 'Comercial / CRM', icon: 'tiposNegocio' },
+      { to: '/configuracoes/empresa-catalogos', label: 'Empresa e catálogos', icon: 'empresas' },
+      { to: '/configuracoes/administracao', label: 'Administração', icon: 'configuracoes' },
     ],
   },
 ]
@@ -524,6 +527,8 @@ export function Sidebar({
 
   const isLinkActive = (to: string, activePrefix?: string) => {
     if (location.pathname === to) return true
+    // Hub de Configurações — só activo na página índice (#833)
+    if (to === '/configuracoes') return false
     if (to === '/crm/leads' && location.pathname.startsWith('/crm/negociacoes')) return true
     if (activePrefix && location.pathname.startsWith(activePrefix)) return true
     if (to !== '/' && location.pathname.startsWith(`${to}/`)) return true

--- a/frontend/src/pages/CrmLeads.tsx
+++ b/frontend/src/pages/CrmLeads.tsx
@@ -430,7 +430,7 @@ export function CrmLeads() {
               <>
                 {' '}
                 <Link
-                  to="/configuracoes/cadastros/funil-crm"
+                  to="/configuracoes/comercial/funil-crm"
                   className="font-medium text-cyan-700 hover:underline dark:text-cyan-400"
                 >
                   Configurar funil

--- a/frontend/src/pages/KbPortalSettings.tsx
+++ b/frontend/src/pages/KbPortalSettings.tsx
@@ -145,7 +145,7 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
       denied={
         <SemPermissao
           title="Você não tem permissão para personalizar o portal público."
-          voltarPara="/configuracoes/sistema/empresa"
+          voltarPara="/configuracoes/empresa-catalogos/empresa"
           voltarLabel="Voltar para Sistema"
         />
       }

--- a/frontend/src/pages/SlaCalendarios.tsx
+++ b/frontend/src/pages/SlaCalendarios.tsx
@@ -186,7 +186,7 @@ export function SlaCalendariosPage({ embedded = false }: { embedded?: boolean })
     >
       <p className="text-sm text-slate-600 dark:text-slate-400 mb-4">
         Vincule calendários em{' '}
-        <Link to="/configuracoes/atendimento/sla/politicas" className="text-sky-600 hover:underline dark:text-sky-400">
+        <Link to="/configuracoes/equipa/sla/politicas" className="text-sky-600 hover:underline dark:text-sky-400">
           Políticas SLA
         </Link>
         . Calendários inativos não aparecem em novos vínculos.

--- a/frontend/src/pages/SlaConfigLayout.tsx
+++ b/frontend/src/pages/SlaConfigLayout.tsx
@@ -1,8 +1,8 @@
 import { NavLink, Outlet } from 'react-router-dom'
 
 const SUB_TABS = [
-  { to: '/configuracoes/atendimento/sla/politicas', label: 'Políticas' },
-  { to: '/configuracoes/atendimento/sla/calendarios', label: 'Calendários' },
+  { to: '/configuracoes/equipa/sla/politicas', label: 'Políticas' },
+  { to: '/configuracoes/equipa/sla/calendarios', label: 'Calendários' },
 ] as const
 
 export function SlaConfigLayout() {

--- a/frontend/src/pages/SlaPoliticas.tsx
+++ b/frontend/src/pages/SlaPoliticas.tsx
@@ -406,7 +406,7 @@ export function SlaPoliticasPage({ embedded = false }: { embedded?: boolean }) {
               </select>
               <span className="mt-1 block text-xs text-slate-500 dark:text-slate-400">
                 Gerencie calendários em{' '}
-                <Link to="/configuracoes/atendimento/sla/calendarios" className="text-sky-600 hover:underline dark:text-sky-400">
+                <Link to="/configuracoes/equipa/sla/calendarios" className="text-sky-600 hover:underline dark:text-sky-400">
                   SLA → Calendários
                 </Link>
                 . Apenas calendários ativos podem ser vinculados em novas políticas.

--- a/frontend/src/pages/TicketNaturezaMotivo.tsx
+++ b/frontend/src/pages/TicketNaturezaMotivo.tsx
@@ -189,7 +189,7 @@ export function TicketNaturezaMotivoPage({ embedded = false }: { embedded?: bool
   const denied = (
     <SemPermissao
       title="Apenas administradores podem gerir naturezas e motivos."
-      voltarPara="/configuracoes/atendimento/natureza-motivo"
+      voltarPara="/configuracoes/equipa/natureza-motivo"
       voltarLabel="Voltar"
     />
   )

--- a/frontend/src/pages/config/ConfigDomainLayout.tsx
+++ b/frontend/src/pages/config/ConfigDomainLayout.tsx
@@ -1,0 +1,44 @@
+import { Navigate, Outlet, useLocation, useParams } from 'react-router-dom'
+import { PageContainer, PageHeader } from '../../components/ui/PageContainer'
+import { ConfigSectionTabs } from '../../components/config/ConfigSectionTabs'
+import { ConfigLegacyRedirect } from './ConfigLegacyRedirect'
+import { configItemPath, findConfigGroupByPrefix } from './configNav'
+
+/** Index do domínio → primeira aba. */
+export function ConfigDomainIndexRedirect() {
+  const { domain } = useParams<{ domain: string }>()
+  const group = findConfigGroupByPrefix(domain || '')
+  const first = group?.items[0]
+  if (!group || !first) return <ConfigLegacyRedirect />
+  return <Navigate to={configItemPath(group, first)} replace />
+}
+
+/** Layout de domínio de Configurações (abas + hint) — #833. */
+export function ConfigDomainLayout() {
+  const { pathname } = useLocation()
+  const { domain } = useParams<{ domain: string }>()
+  const group = findConfigGroupByPrefix(domain || '')
+
+  if (!group) {
+    return <ConfigLegacyRedirect />
+  }
+
+  const tabs = group.items.map((item) => ({
+    to: configItemPath(group, item),
+    label: item.label,
+  }))
+
+  const escaped = group.pathPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const slug =
+    pathname.match(new RegExp(`/configuracoes/${escaped}/([^/]+)`))?.[1] ?? group.items[0]?.slug
+  const hint = group.items.find((i) => i.slug === slug)?.hint ?? ''
+
+  return (
+    <PageContainer>
+      <PageHeader title={group.label} subtitle={group.description} />
+      <ConfigSectionTabs tabs={tabs} ariaLabel={`Seções: ${group.label}`} />
+      {hint ? <p className="text-sm text-slate-600 dark:text-slate-400">{hint}</p> : null}
+      <Outlet />
+    </PageContainer>
+  )
+}

--- a/frontend/src/pages/config/ConfigHubPage.tsx
+++ b/frontend/src/pages/config/ConfigHubPage.tsx
@@ -1,0 +1,93 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { PageContainer, PageHeader } from '../../components/ui/PageContainer'
+import { Input } from '../../components/ui/Input'
+import { CONFIG_GROUPS, configGroupIndexPath, configItemPath } from './configNav'
+
+function normalize(s: string): string {
+  return s
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '')
+    .toLowerCase()
+}
+
+/** Hub de Configurações com busca e cartões por domínio (#833). */
+export function ConfigHubPage() {
+  const [q, setQ] = useState('')
+  const query = normalize(q.trim())
+
+  const groups = useMemo(() => {
+    if (!query) return CONFIG_GROUPS
+    return CONFIG_GROUPS.map((g) => {
+      const items = g.items.filter((item) => {
+        const hay = normalize(
+          [item.label, item.hint, ...item.keywords, g.label, g.description].join(' '),
+        )
+        return hay.includes(query)
+      })
+      return { ...g, items }
+    }).filter((g) => g.items.length > 0)
+  }, [query])
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Configurações"
+        subtitle="Encontre qualquer ajuste por domínio — ou pesquise por palavra."
+      />
+
+      <div className="relative max-w-xl">
+        <Input
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Pesquisar (ex.: WhatsApp, SLA, proposta…)"
+          className="pl-10"
+          aria-label="Pesquisar configurações"
+        />
+        <span className="pointer-events-none absolute left-3 top-2.5 text-slate-400" aria-hidden>
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <circle cx="11" cy="11" r="8" />
+            <path d="m21 21-4.3-4.3" />
+          </svg>
+        </span>
+      </div>
+
+      {groups.length === 0 ? (
+        <p className="text-sm text-slate-500">Nenhum resultado para «{q.trim()}».</p>
+      ) : (
+        <div className="space-y-10">
+          {groups.map((group) => (
+            <section key={group.id} className="space-y-4">
+              <div className="flex flex-wrap items-end justify-between gap-2 border-b border-slate-200 pb-2 dark:border-slate-800">
+                <div>
+                  <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{group.label}</h2>
+                  <p className="text-sm text-slate-500">{group.description}</p>
+                </div>
+                <Link
+                  to={configGroupIndexPath(group)}
+                  className="text-xs font-semibold text-cyan-700 hover:underline dark:text-cyan-400"
+                >
+                  Abrir secção →
+                </Link>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                {group.items.map((item) => (
+                  <Link
+                    key={item.slug}
+                    to={configItemPath(group, item)}
+                    className="group rounded-xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-cyan-400/60 hover:ring-1 hover:ring-cyan-500/30 dark:border-slate-800 dark:bg-slate-900/80"
+                  >
+                    <h3 className="font-semibold text-slate-900 group-hover:text-cyan-700 dark:text-slate-100 dark:group-hover:text-cyan-300">
+                      {item.label}
+                    </h3>
+                    <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">{item.hint}</p>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </PageContainer>
+  )
+}

--- a/frontend/src/pages/config/ConfigLegacyRedirect.tsx
+++ b/frontend/src/pages/config/ConfigLegacyRedirect.tsx
@@ -1,0 +1,30 @@
+import { Navigate, useLocation } from 'react-router-dom'
+import { CONFIG_LEGACY_REDIRECTS } from './configNav'
+
+/** Mantém bookmarks e links antigos a funcionar (#833). */
+export function ConfigLegacyRedirect() {
+  const { pathname } = useLocation()
+  const exact = CONFIG_LEGACY_REDIRECTS.find((r) => r.from === pathname)
+  if (exact) return <Navigate to={exact.to} replace />
+
+  const prefixRules: Array<[string, string]> = [
+    ['/configuracoes/atendimento', '/configuracoes/equipa'],
+    ['/configuracoes/sistema/email', '/configuracoes/canais/email'],
+    ['/configuracoes/sistema/whatsapp', '/configuracoes/canais/whatsapp'],
+    ['/configuracoes/sistema/base-conhecimento', '/configuracoes/canais/base-conhecimento'],
+    ['/configuracoes/sistema/auditoria', '/configuracoes/administracao/auditoria'],
+    ['/configuracoes/sistema', '/configuracoes/empresa-catalogos'],
+    ['/configuracoes/cadastros/custos', '/configuracoes/comercial/custos'],
+    ['/configuracoes/cadastros/funil-crm', '/configuracoes/comercial/funil-crm'],
+    ['/configuracoes/cadastros/propostas', '/configuracoes/comercial/propostas'],
+    ['/configuracoes/cadastros/contratos', '/configuracoes/comercial/contratos'],
+    ['/configuracoes/cadastros/implantacao', '/configuracoes/comercial/implantacao'],
+    ['/configuracoes/cadastros', '/configuracoes/empresa-catalogos'],
+  ]
+  for (const [from, to] of prefixRules) {
+    if (pathname === from || pathname.startsWith(`${from}/`)) {
+      return <Navigate to={pathname.replace(from, to)} replace />
+    }
+  }
+  return <Navigate to="/configuracoes" replace />
+}

--- a/frontend/src/pages/config/configNav.ts
+++ b/frontend/src/pages/config/configNav.ts
@@ -1,0 +1,227 @@
+/** Navegação de Configurações — hub + sidebar + abas (#833). */
+
+export type ConfigNavItem = {
+  /** Segmento de URL (último path). */
+  slug: string
+  label: string
+  hint: string
+  keywords: string[]
+}
+
+export type ConfigNavGroup = {
+  id: string
+  /** Prefixo de rota: /configuracoes/{pathPrefix}/… */
+  pathPrefix: string
+  label: string
+  description: string
+  /** Ícone do Sidebar (chave em ICONS). */
+  icon: string
+  items: ConfigNavItem[]
+}
+
+export const CONFIG_GROUPS: ConfigNavGroup[] = [
+  {
+    id: 'equipa',
+    pathPrefix: 'equipa',
+    label: 'Equipa e tickets',
+    description: 'Setores, atendentes, fluxo de tickets, roteamento e SLA.',
+    icon: 'setores',
+    items: [
+      {
+        slug: 'setores',
+        label: 'Setores',
+        hint: 'Áreas de atuação dos atendentes (suporte, financeiro, comercial…).',
+        keywords: ['setor', 'área', 'equipe'],
+      },
+      {
+        slug: 'atendentes',
+        label: 'Atendentes',
+        hint: 'Usuários internos que operam tickets e o chat.',
+        keywords: ['utilizador', 'usuário', 'login', 'perfil'],
+      },
+      {
+        slug: 'status-ticket',
+        label: 'Status de ticket',
+        hint: 'Etapas do fluxo de chamados (aberto, em atendimento, encerrado…).',
+        keywords: ['estado', 'pipeline', 'status'],
+      },
+      {
+        slug: 'natureza-motivo',
+        label: 'Natureza e motivo',
+        hint: 'Categorias (natureza) e itens específicos (motivo) usados ao encerrar tickets.',
+        keywords: ['classificação', 'categoria', 'encerrar'],
+      },
+      {
+        slug: 'respostas-prontas',
+        label: 'Respostas prontas',
+        hint: 'Macros reutilizáveis ao responder tickets — globais ou por setor.',
+        keywords: ['macro', 'template', 'resposta'],
+      },
+      {
+        slug: 'roteamento',
+        label: 'Roteamento',
+        hint: 'Regras automáticas de setor e prioridade na criação de tickets (e-mail e manual).',
+        keywords: ['regra', 'automação', 'distribuição'],
+      },
+      {
+        slug: 'sla',
+        label: 'SLA',
+        hint: 'Metas de SLA por setor/prioridade e calendários comerciais (horário útil).',
+        keywords: ['prazo', 'meta', 'calendário'],
+      },
+    ],
+  },
+  {
+    id: 'canais',
+    pathPrefix: 'canais',
+    label: 'Canais',
+    description: 'WhatsApp, e-mail e portal da base de conhecimento.',
+    icon: 'chat',
+    items: [
+      {
+        slug: 'whatsapp',
+        label: 'WhatsApp',
+        hint: 'Conexão, mensagens automáticas, inatividade, avaliação e horários de atendimento.',
+        keywords: ['wpp', 'evolution', 'fila', 'inatividade'],
+      },
+      {
+        slug: 'email',
+        label: 'E-mail',
+        hint: 'Encaminhamento por setor e envio de respostas aos clientes.',
+        keywords: ['smtp', 'mail', 'inbox'],
+      },
+      {
+        slug: 'base-conhecimento',
+        label: 'Base de conhecimento',
+        hint: 'Personalização do portal público /kb — cores, textos e aparência.',
+        keywords: ['kb', 'portal', 'ajuda', 'artigos'],
+      },
+    ],
+  },
+  {
+    id: 'comercial',
+    pathPrefix: 'comercial',
+    label: 'Comercial / CRM',
+    description: 'Funil, propostas, contratos, custos e checklist de implantação.',
+    icon: 'tiposNegocio',
+    items: [
+      {
+        slug: 'funil-crm',
+        label: 'Funil CRM',
+        hint: 'Estágios do funil comercial (Lead, Em negociação…). Usados na lista e no Kanban do CRM.',
+        keywords: ['crm', 'lead', 'kanban', 'estágio'],
+      },
+      {
+        slug: 'propostas',
+        label: 'Modelos de proposta',
+        hint: 'HTML dos modelos da proposta comercial. Placeholders são preenchidos na negociação.',
+        keywords: ['proposta', 'comercial', 'html'],
+      },
+      {
+        slug: 'contratos',
+        label: 'Modelos de contrato',
+        hint: 'HTML dos modelos do contrato comercial. Placeholders (fidelidade, setup, cláusulas) são preenchidos na negociação.',
+        keywords: ['contrato', 'assinatura', 'fidelidade'],
+      },
+      {
+        slug: 'custos',
+        label: 'Catálogo de custos',
+        hint: 'Salário mínimo com vigência, perfis/módulos de custo e simulador estimado para negociação.',
+        keywords: ['custo', 'preço', 'simulador'],
+      },
+      {
+        slug: 'implantacao',
+        label: 'Checklist de implantação',
+        hint: 'Itens copiados para o ticket automático quando o contrato é marcado como assinado.',
+        keywords: ['implantação', 'checklist', 'onboarding'],
+      },
+    ],
+  },
+  {
+    id: 'empresa',
+    pathPrefix: 'empresa-catalogos',
+    label: 'Empresa e catálogos',
+    description: 'Dados da instalação, tipos de negócio e catálogos de PDV.',
+    icon: 'empresas',
+    items: [
+      {
+        slug: 'empresa',
+        label: 'Empresa',
+        hint: 'Dados institucionais da instalação — CNPJ, logo e endereço.',
+        keywords: ['cnpj', 'logo', 'institucional'],
+      },
+      {
+        slug: 'tipos-negocio',
+        label: 'Tipos de negócio',
+        hint: 'Classificação das empresas (posto, conveniência, restaurante…).',
+        keywords: ['posto', 'classificação', 'tipo'],
+      },
+      {
+        slug: 'pdv',
+        label: 'Catálogos PDV',
+        hint: 'Rótulos de dispositivo e tipos de acesso remoto usados no cadastro de PDVs por empresa.',
+        keywords: ['pdv', 'remoto', 'dispositivo'],
+      },
+    ],
+  },
+  {
+    id: 'admin',
+    pathPrefix: 'administracao',
+    label: 'Administração',
+    description: 'Auditoria e ferramentas administrativas.',
+    icon: 'configuracoes',
+    items: [
+      {
+        slug: 'auditoria',
+        label: 'Auditoria',
+        hint: 'Histórico de alterações em cadastros e configurações.',
+        keywords: ['log', 'histórico', 'alterações'],
+      },
+    ],
+  },
+]
+
+export function configItemPath(group: ConfigNavGroup, item: ConfigNavItem): string {
+  return `/configuracoes/${group.pathPrefix}/${item.slug}`
+}
+
+export function configGroupIndexPath(group: ConfigNavGroup): string {
+  return `/configuracoes/${group.pathPrefix}`
+}
+
+export function findConfigGroupByPrefix(pathPrefix: string): ConfigNavGroup | undefined {
+  return CONFIG_GROUPS.find((g) => g.pathPrefix === pathPrefix)
+}
+
+/** Redirects 1:1 de URLs antigas (#833). */
+export const CONFIG_LEGACY_REDIRECTS: Array<{ from: string; to: string }> = [
+  { from: '/configuracoes/atendimento', to: '/configuracoes/equipa' },
+  { from: '/configuracoes/atendimento/setores', to: '/configuracoes/equipa/setores' },
+  { from: '/configuracoes/atendimento/atendentes', to: '/configuracoes/equipa/atendentes' },
+  { from: '/configuracoes/atendimento/status-ticket', to: '/configuracoes/equipa/status-ticket' },
+  { from: '/configuracoes/atendimento/natureza-motivo', to: '/configuracoes/equipa/natureza-motivo' },
+  { from: '/configuracoes/atendimento/respostas-prontas', to: '/configuracoes/equipa/respostas-prontas' },
+  { from: '/configuracoes/atendimento/roteamento', to: '/configuracoes/equipa/roteamento' },
+  { from: '/configuracoes/atendimento/sla', to: '/configuracoes/equipa/sla' },
+  { from: '/configuracoes/atendimento/sla/politicas', to: '/configuracoes/equipa/sla/politicas' },
+  { from: '/configuracoes/atendimento/sla/calendarios', to: '/configuracoes/equipa/sla/calendarios' },
+  { from: '/configuracoes/atendimento/base-conhecimento', to: '/ajuda/artigos' },
+  { from: '/configuracoes/sistema', to: '/configuracoes/empresa-catalogos' },
+  { from: '/configuracoes/sistema/empresa', to: '/configuracoes/empresa-catalogos/empresa' },
+  { from: '/configuracoes/sistema/email', to: '/configuracoes/canais/email' },
+  { from: '/configuracoes/sistema/whatsapp', to: '/configuracoes/canais/whatsapp' },
+  { from: '/configuracoes/sistema/base-conhecimento', to: '/configuracoes/canais/base-conhecimento' },
+  { from: '/configuracoes/sistema/auditoria', to: '/configuracoes/administracao/auditoria' },
+  { from: '/configuracoes/sistema/empresa-email', to: '/configuracoes/empresa-catalogos/empresa' },
+  { from: '/configuracoes/cadastros', to: '/configuracoes/empresa-catalogos' },
+  { from: '/configuracoes/cadastros/tipos-negocio', to: '/configuracoes/empresa-catalogos/tipos-negocio' },
+  { from: '/configuracoes/cadastros/pdv', to: '/configuracoes/empresa-catalogos/pdv' },
+  { from: '/configuracoes/cadastros/custos', to: '/configuracoes/comercial/custos' },
+  { from: '/configuracoes/cadastros/funil-crm', to: '/configuracoes/comercial/funil-crm' },
+  { from: '/configuracoes/cadastros/propostas', to: '/configuracoes/comercial/propostas' },
+  { from: '/configuracoes/cadastros/contratos', to: '/configuracoes/comercial/contratos' },
+  { from: '/configuracoes/cadastros/implantacao', to: '/configuracoes/comercial/implantacao' },
+  { from: '/configuracoes/whatsapp', to: '/configuracoes/canais/whatsapp' },
+  { from: '/configuracoes/empresa-email', to: '/configuracoes/empresa-catalogos/empresa' },
+  { from: '/configuracoes/pdv-catalogos', to: '/configuracoes/empresa-catalogos/pdv' },
+]


### PR DESCRIPTION
﻿## Summary

- Closes #833 — hub `/configuracoes` com pesquisa + cartões por domínio
- Sidebar: Visão geral, Equipa e tickets, Canais, Comercial/CRM, Empresa e catálogos, Administração
- Novos prefixos de URL; redirects das rotas antigas (`atendimento` / `cadastros` / `sistema`)
- RBAC admin inalterado

## CHANGELOG

- [x] `CHANGELOG.md` → `[Unreleased]`

## Test plan

- [ ] Admin: `/configuracoes` — pesquisa «WhatsApp» / «SLA» / «proposta» encontra cartões
- [ ] Menu: cada grupo abre abas correctas; WhatsApp em Canais (não Sistema)
- [ ] Bookmark antigo `/configuracoes/sistema/whatsapp` → canais/whatsapp
- [ ] `/configuracoes/atendimento/sla/politicas` → equipa/sla/politicas
- [ ] Mobile: menu escaneável; hub utilizável
- [ ] Não-admin: Configurações continua oculto

## Follow-ups

- [x] #738 iOS — fim do projecto
- [x] Layouts antigos `Config*Layout` (atendimento/cadastros/sistema) ficam sem uso — chore de limpeza opcional
