### PR TITLE
feat(whatsapp): exportar conversa em PDF (#837)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- WhatsApp (#837): **Exportar PDF** da conversa (header / menu ⋮) — relatório com protocolo, contacto e mensagens; mídia como rótulo; comentários internos excluídos; mesma permissão de ver o chat
 - Configurações (#833): hub com **pesquisa** e cartões por domínio; menu reorganizado (Equipa e tickets, Canais, Comercial/CRM, Empresa e catálogos, Administração); URLs antigas redireccionam
 - WhatsApp (#831): clicar no **número** do contacto (lista Em atendimento, Aguardando, histórico e header) copia automaticamente, com «Copiado!» discreto
 - Alertas (#823): com a app/aba em **segundo plano**, a fila continua a chamar via notificação do sistema (re-alerta periódico + vibração no push); silenciar na mesa alinha com «Avisar fila» nas preferências

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -4,7 +4,7 @@ import re
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, Response
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy import desc, func, or_
 
@@ -1370,6 +1370,33 @@ def obter(
         db.commit()
         db.refresh(c)
     return _chat_read(db, c)
+
+
+@router.get("/{chat_id}/pdf")
+def exportar_chat_pdf(
+    chat_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Exporta a conversa em PDF (mesma permissão de visualização do chat) — #837."""
+    from app.services import whatsapp_chat_pdf as chat_pdf_svc
+
+    c = (
+        db.query(WhatsappChat)
+        .options(*_CHAT_LOAD_OPTIONS)
+        .filter(WhatsappChat.id == chat_id)
+        .first()
+    )
+    if not c:
+        raise HTTPException(status_code=404, detail="Chat não encontrado")
+    if not _pode_ver_chat(db, atendente, c):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para este chat")
+    pdf, filename = chat_pdf_svc.gerar_pdf_chat(db, c)
+    return Response(
+        content=pdf,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
 
 
 @router.post("/{chat_id}/foto-perfil", response_model=WhatsappChatRead)

--- a/backend/app/services/whatsapp_chat_pdf.py
+++ b/backend/app/services/whatsapp_chat_pdf.py
@@ -1,0 +1,222 @@
+"""Exportação de conversa WhatsApp em PDF (#837)."""
+
+from __future__ import annotations
+
+import html
+import logging
+import re
+from datetime import datetime
+from typing import Sequence
+
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.empresa_sistema import EmpresaSistema
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
+from app.services.comercial_proposta import html_para_pdf
+from app.services.whatsapp_avaliacao import mensagem_oculta_na_conversa
+
+logger = logging.getLogger(__name__)
+
+# Chats muito longos: exporta as primeiras N mensagens visíveis (ordem cronológica).
+MAX_MENSAGENS_PDF = 3000
+
+_ESTADO_ROTULO = {
+    "em_atendimento": "Em atendimento",
+    "aguardando_atendente": "Aguardando atendimento",
+    "aguardando_avaliacao": "Aguardando avaliação",
+    "encerrado": "Encerrado",
+}
+
+_EVENTO_ROTULO = {
+    "auto_espera": "Aviso automático (espera)",
+    "auto_assumido": "Atendimento assumido",
+    "auto_encerrado": "Encerrado automaticamente",
+    "auto_fora_horario": "Fora do horário",
+    "auto_inativ_aviso": "Aviso de inatividade",
+    "auto_encerrado_inatividade": "Encerrado por inatividade",
+    "transferencia": "Chat transferido",
+    "demanda_registrada": "Demanda registada",
+    "demanda_escalada": "Demanda escalada",
+}
+
+_TIPO_MIDIA_ROTULO = {
+    "imagem": "[Imagem]",
+    "audio": "[Áudio]",
+    "video": "[Vídeo]",
+    "documento": "[Documento]",
+    "figurinha": "[Figurinha]",
+}
+
+
+def _esc(value: object | None) -> str:
+    if value is None:
+        return ""
+    return html.escape(str(value), quote=True)
+
+
+def _fmt_dt(value: datetime | None) -> str:
+    if value is None:
+        return "—"
+    if value.tzinfo is not None:
+        local = value.astimezone()
+    else:
+        local = value
+    return local.strftime("%d/%m/%Y %H:%M")
+
+
+def _rotulo_estado(estado: str | None) -> str:
+    if not estado:
+        return "—"
+    return _ESTADO_ROTULO.get(estado, estado.replace("_", " "))
+
+
+def _autor(m: WhatsappMensagem) -> str:
+    evento = getattr(m, "evento_sistema", None)
+    if evento:
+        return "Sistema"
+    if m.direcao == "inbound":
+        return "Cliente"
+    nome = (getattr(m.atendente, "nome", None) if m.atendente else None) or getattr(m, "atendente_nome", None)
+    if nome:
+        return f"Atendente ({nome})"
+    return "Atendente"
+
+
+def _corpo_export(m: WhatsappMensagem) -> str:
+    if getattr(m, "apagada", False) or getattr(m, "apagada_em", None):
+        return "Mensagem apagada"
+    evento = getattr(m, "evento_sistema", None)
+    if evento:
+        rotulo = _EVENTO_ROTULO.get(evento, evento.replace("_", " "))
+        corpo = (m.corpo or "").strip()
+        return f"{rotulo}" + (f" — {corpo}" if corpo else "")
+    tipo = (getattr(m, "tipo_midia", None) or "texto").lower()
+    if tipo in _TIPO_MIDIA_ROTULO:
+        nome = (getattr(m, "midia_nome_original", None) or "").strip()
+        base = _TIPO_MIDIA_ROTULO[tipo]
+        if tipo == "documento" and nome:
+            base = f"[Documento: {nome}]"
+        corpo = (m.corpo or "").strip()
+        return f"{base}" + (f"\n{corpo}" if corpo else "")
+    return (m.corpo or "").strip() or "—"
+
+
+def _nome_ficheiro(protocolo: str | None, chat_id: int) -> str:
+    raw = (protocolo or "").strip() or str(chat_id)
+    safe = re.sub(r"[^\w.\-]+", "-", raw, flags=re.UNICODE).strip("-") or str(chat_id)
+    return f"chat-{safe}.pdf"
+
+
+def _mensagens_para_export(db: Session, chat_id: int) -> tuple[list[WhatsappMensagem], int]:
+    rows = (
+        db.query(WhatsappMensagem)
+        .options(joinedload(WhatsappMensagem.atendente))
+        .filter(WhatsappMensagem.chat_id == chat_id)
+        .order_by(WhatsappMensagem.created_at.asc(), WhatsappMensagem.id.asc())
+        .all()
+    )
+    visiveis: list[WhatsappMensagem] = []
+    for m in rows:
+        evento = getattr(m, "evento_sistema", None)
+        if mensagem_oculta_na_conversa(evento):
+            continue
+        # Comentários internos não vão para o PDF (uso típico: enviar ao cliente).
+        if evento == "comentario_interno":
+            continue
+        visiveis.append(m)
+    total = len(visiveis)
+    return visiveis[:MAX_MENSAGENS_PDF], total
+
+
+def _empresa_sistema_nome(db: Session) -> str:
+    row = db.query(EmpresaSistema).order_by(EmpresaSistema.id.asc()).first()
+    if not row:
+        return "DeskRudder"
+    return (row.nome_fantasia or row.nome or row.razao_social or "DeskRudder").strip()
+
+
+def montar_html_chat_pdf(
+    db: Session,
+    chat: WhatsappChat,
+    mensagens: Sequence[WhatsappMensagem],
+    *,
+    total_visiveis: int,
+) -> str:
+    marca = _empresa_sistema_nome(db)
+    protocolo = chat.protocolo or str(chat.id)
+    contacto = chat.cliente_nome or "Contacto"
+    empresa_nome = getattr(chat.empresa, "nome", None) if chat.empresa else None
+    setor_nome = getattr(chat.setor, "nome", None) if chat.setor else None
+    atendente_nome = getattr(chat.atendente, "nome", None) if chat.atendente else None
+
+    linhas: list[str] = []
+    for m in mensagens:
+        autor = _esc(_autor(m))
+        quando = _esc(_fmt_dt(m.created_at))
+        corpo = _esc(_corpo_export(m)).replace("\n", "<br/>")
+        classe = "sistema" if getattr(m, "evento_sistema", None) else ("cliente" if m.direcao == "inbound" else "atendente")
+        linhas.append(
+            f'<tr class="{classe}"><td class="meta"><strong>{autor}</strong><br/><span class="hora">{quando}</span></td>'
+            f'<td class="corpo">{corpo}</td></tr>'
+        )
+
+    aviso_corte = ""
+    if total_visiveis > len(mensagens):
+        aviso_corte = (
+            f'<p class="aviso">Exportação truncada: mostram-se as primeiras {len(mensagens)} de '
+            f"{total_visiveis} mensagens (limite {MAX_MENSAGENS_PDF}).</p>"
+        )
+
+    return f"""<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8"/>
+  <title>Chat { _esc(protocolo) }</title>
+  <style>
+    body {{ font-family: DejaVu Sans, Arial, sans-serif; font-size: 11pt; color: #1e293b; margin: 24px; }}
+    h1 {{ font-size: 16pt; margin: 0 0 4px; }}
+    .marca {{ color: #64748b; font-size: 9pt; margin-bottom: 16px; }}
+    .meta-grid {{ width: 100%; border-collapse: collapse; margin-bottom: 18px; }}
+    .meta-grid th, .meta-grid td {{ text-align: left; padding: 4px 8px 4px 0; vertical-align: top; }}
+    .meta-grid th {{ color: #64748b; font-weight: 600; width: 9rem; }}
+    table.msgs {{ width: 100%; border-collapse: collapse; }}
+    table.msgs td {{ border-top: 1px solid #e2e8f0; padding: 8px 6px; vertical-align: top; }}
+    table.msgs td.meta {{ width: 28%; color: #475569; font-size: 9pt; }}
+    table.msgs td.corpo {{ white-space: pre-wrap; word-break: break-word; }}
+    table.msgs tr.sistema td.corpo {{ font-style: italic; color: #64748b; }}
+    .hora {{ color: #94a3b8; }}
+    .aviso {{ margin-top: 16px; padding: 8px 10px; background: #fff7ed; border: 1px solid #fed7aa; font-size: 9pt; }}
+    .rodape {{ margin-top: 24px; font-size: 8pt; color: #94a3b8; }}
+  </style>
+</head>
+<body>
+  <div class="marca">{_esc(marca)} · Exportação de conversa WhatsApp</div>
+  <h1>Protocolo { _esc(protocolo) }</h1>
+  <table class="meta-grid">
+    <tr><th>Contacto</th><td>{_esc(contacto)}</td></tr>
+    <tr><th>Telefone</th><td>{_esc(chat.wa_id)}</td></tr>
+    <tr><th>Empresa</th><td>{_esc(empresa_nome) or "—"}</td></tr>
+    <tr><th>Setor</th><td>{_esc(setor_nome) or "—"}</td></tr>
+    <tr><th>Atendente</th><td>{_esc(atendente_nome) or "—"}</td></tr>
+    <tr><th>Estado</th><td>{_esc(_rotulo_estado(chat.estado))}</td></tr>
+    <tr><th>Abertura</th><td>{_esc(_fmt_dt(chat.created_at))}</td></tr>
+    <tr><th>Início atendimento</th><td>{_esc(_fmt_dt(chat.atendimento_inicio_at))}</td></tr>
+    <tr><th>Encerramento</th><td>{_esc(_fmt_dt(chat.encerramento_at))}</td></tr>
+  </table>
+  <table class="msgs">
+    <tbody>
+      {"".join(linhas) if linhas else '<tr><td colspan="2">Sem mensagens para exportar.</td></tr>'}
+    </tbody>
+  </table>
+  {aviso_corte}
+  <p class="rodape">Gerado em {_esc(_fmt_dt(datetime.now().astimezone()))}. Comentários internos não são incluídos.</p>
+</body>
+</html>
+"""
+
+
+def gerar_pdf_chat(db: Session, chat: WhatsappChat) -> tuple[bytes, str]:
+    mensagens, total = _mensagens_para_export(db, chat.id)
+    html_doc = montar_html_chat_pdf(db, chat, mensagens, total_visiveis=total)
+    pdf = html_para_pdf(html_doc)
+    return pdf, _nome_ficheiro(chat.protocolo, chat.id)

--- a/backend/tests/test_whatsapp_chat_pdf.py
+++ b/backend/tests/test_whatsapp_chat_pdf.py
@@ -1,0 +1,89 @@
+"""Exportação PDF de conversa WhatsApp (#837)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app.models.whatsapp_chat import WhatsappChat, WhatsappMensagem
+
+
+def test_exportar_chat_pdf_ok_e_403(client, seed_base, auth_headers, monkeypatch, db_session):
+    captured: list[str] = []
+
+    def _fake(html: str) -> bytes:
+        captured.append(html)
+        return b"%PDF-1.4\nfake-chat-pdf"
+
+    monkeypatch.setattr("app.services.comercial_proposta.html_para_pdf", _fake)
+
+    chat = WhatsappChat(
+        protocolo="PDF-TEST-837",
+        wa_id="5511999008371",
+        cliente_nome="Cliente Export",
+        estado="em_atendimento",
+        setor_id=seed_base["setor1"].id,
+        atendente_id=seed_base["a1"].id,
+        atendimento_inicio_at=datetime.now(timezone.utc),
+    )
+    db_session.add(chat)
+    db_session.flush()
+    db_session.add_all(
+        [
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="inbound",
+                corpo="Preciso de ajuda com o PDV",
+                tipo_midia="texto",
+            ),
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="outbound",
+                corpo="Claro, vamos verificar.",
+                tipo_midia="texto",
+                atendente_id=seed_base["a1"].id,
+            ),
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="outbound",
+                corpo="",
+                tipo_midia="imagem",
+                midia_nome_original="foto.jpg",
+                atendente_id=seed_base["a1"].id,
+            ),
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="outbound",
+                corpo="Transferido para Financeiro",
+                evento_sistema="transferencia",
+            ),
+            WhatsappMensagem(
+                chat_id=chat.id,
+                direcao="outbound",
+                corpo="Nota interna secreta",
+                evento_sistema="comentario_interno",
+                atendente_id=seed_base["a1"].id,
+            ),
+        ]
+    )
+    db_session.commit()
+    db_session.refresh(chat)
+
+    ok = client.get(f"/v1/whatsapp/chats/{chat.id}/pdf", headers=auth_headers["a1"])
+    assert ok.status_code == 200
+    assert ok.headers.get("content-type", "").startswith("application/pdf")
+    cd = ok.headers.get("content-disposition") or ""
+    assert "attachment" in cd
+    assert "chat-PDF-TEST-837.pdf" in cd or "PDF-TEST-837" in cd
+    assert ok.content.startswith(b"%PDF")
+    assert captured
+    assert "Preciso de ajuda" in captured[0]
+    assert "Claro, vamos verificar" in captured[0]
+    assert "[Imagem]" in captured[0]
+    assert "transferido" in captured[0].lower() or "Transfer" in captured[0]
+    assert "Nota interna secreta" not in captured[0]
+
+    denied = client.get(f"/v1/whatsapp/chats/{chat.id}/pdf", headers=auth_headers["a2"])
+    assert denied.status_code == 403
+
+    admin_ok = client.get(f"/v1/whatsapp/chats/{chat.id}/pdf", headers=auth_headers["admin"])
+    assert admin_ok.status_code == 200

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1298,6 +1298,29 @@ export const whatsappChats = {
     listPaginated<WhatsappChats.Avaliacao>('/whatsapp/chats/avaliacoes', params),
   get: (id: number) => api<WhatsappChats.Chat>(`/whatsapp/chats/${id}`),
   mensagens: (id: number) => api<WhatsappChats.Mensagem[]>(`/whatsapp/chats/${id}/mensagens`),
+  downloadPdf: async (id: number) => {
+    const token = getAuthToken()
+    const headers: Record<string, string> = {}
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+    }
+    if (token) headers.Authorization = `Bearer ${token}`
+    const url = `${apiOrigin()}${API_VERSION_PREFIX}/whatsapp/chats/${id}/pdf`
+    const res = await fetch(url, { headers })
+    if (res.status === 401) {
+      invalidateSessionAndRedirectToLogin()
+      throw new ApiError('Sessão expirada ou inválida.', 401, {})
+    }
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}))
+      throw new ApiError(mensagemErroApi(errBody, res.status), res.status, errBody)
+    }
+    const cd = res.headers.get('Content-Disposition') || ''
+    const match = /filename="([^"]+)"/i.exec(cd)
+    const filename = match?.[1] || `chat-${id}.pdf`
+    const blob = await res.blob()
+    return { blob, filename }
+  },
   demandas: (id: number) => api<WhatsappChats.Demanda[]>(`/whatsapp/chats/${id}/demandas`),
   registrarDemanda: (id: number, data: WhatsappChats.DemandaCreate) =>
     api<WhatsappChats.Demanda>(`/whatsapp/chats/${id}/demandas`, {

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -644,6 +644,7 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
   const [modalEncerrar, setModalEncerrar] = useState(false)
   const [menuMobileAberto, setMenuMobileAberto] = useState(false)
   const menuMobileRef = useRef<HTMLDivElement>(null)
+  const [exportandoPdf, setExportandoPdf] = useState(false)
   const [filaAguardandoAberta, setFilaAguardandoAberta] = useState(false)
   const [assumindo, setAssumindo] = useState(false)
   const { filaCount, refreshContagens, abrirChat } = useChatHub()
@@ -1450,6 +1451,25 @@ useEffect(() => {
 
   const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && (isResponsavel || isAdmin)
 
+  async function exportarPdfChat() {
+    if (!chat || exportandoPdf) return
+    setExportandoPdf(true)
+    try {
+      const { blob, filename } = await whatsappChats.downloadPdf(chat.id)
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = filename
+      a.click()
+      URL.revokeObjectURL(url)
+      toast.showSuccess('PDF da conversa descarregado')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao exportar PDF'))
+    } finally {
+      setExportandoPdf(false)
+    }
+  }
+
   const podeDefinirEmpresa =
     !encerrado &&
     Boolean(chat?.funcionario_rede_id) &&
@@ -1745,6 +1765,18 @@ useEffect(() => {
                 </Button>
               )}
 
+              {chat && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  className="hidden h-8 text-xs md:inline-flex"
+                  loading={exportandoPdf}
+                  onClick={() => void exportarPdfChat()}
+                >
+                  Exportar PDF
+                </Button>
+              )}
+
               {!encerrado && (
                 <>
                   {chat && (
@@ -1792,6 +1824,17 @@ useEffect(() => {
                     </button>
                     {menuMobileAberto && (
                       <div className="absolute right-0 top-full z-30 mt-1 min-w-[12rem] rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900">
+                        <button
+                          type="button"
+                          className="block min-h-11 w-full px-4 py-3 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
+                          disabled={exportandoPdf}
+                          onClick={() => {
+                            setMenuMobileAberto(false)
+                            void exportarPdfChat()
+                          }}
+                        >
+                          {exportandoPdf ? 'A exportar…' : 'Exportar PDF'}
+                        </button>
                         {podeTransferir && (
                           <button
                             type="button"
@@ -1863,6 +1906,35 @@ useEffect(() => {
                     )}
                   </div>
                 </>
+              )}
+
+              {chat && encerrado && (
+                <div className="relative md:hidden" ref={menuMobileRef}>
+                  <button
+                    type="button"
+                    aria-label="Mais ações"
+                    aria-expanded={menuMobileAberto}
+                    onClick={() => setMenuMobileAberto((o) => !o)}
+                    className="flex h-11 w-11 items-center justify-center rounded-lg text-lg text-slate-600 transition hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800"
+                  >
+                    ⋮
+                  </button>
+                  {menuMobileAberto && (
+                    <div className="absolute right-0 top-full z-30 mt-1 min-w-[12rem] rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900">
+                      <button
+                        type="button"
+                        className="block min-h-11 w-full px-4 py-3 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
+                        disabled={exportandoPdf}
+                        onClick={() => {
+                          setMenuMobileAberto(false)
+                          void exportarPdfChat()
+                        }}
+                      >
+                        {exportandoPdf ? 'A exportar…' : 'Exportar PDF'}
+                      </button>
+                    </div>
+                  )}
+                </div>
               )}
 
             </div>


### PR DESCRIPTION
﻿## Summary

- Closes #837 — exportar conversa WhatsApp em PDF
- `GET /v1/whatsapp/chats/{id}/pdf` (WeasyPrint), ficheiro `chat-{protocolo}.pdf`
- Mesma permissão `_pode_ver_chat`; comentários internos excluídos; mídia como rótulo
- Limite: primeiras 3000 mensagens (aviso no PDF se truncar)
- UI: **Exportar PDF** no header (desktop) e menu ⋮ (mobile, inclusive encerrado)

## CHANGELOG

- [x] `CHANGELOG.md` → `[Unreleased]`

## Test plan

- [ ] Abrir chat em atendimento → Exportar PDF → descarrega e abre com protocolo + mensagens
- [ ] Chat encerrado / histórico → mesmo botão disponível
- [ ] Atendente sem acesso ao chat → 403
- [ ] Mensagem de imagem no PDF aparece como `[Imagem]`
- [ ] Comentário interno **não** aparece no PDF
- [ ] Mobile: menu ⋮ → Exportar PDF

## Follow-ups

- [x] #738 iOS — fim do projecto
