### PR TITLE
feat(sugestoes): Release Notes → triagem → GitHub (#799)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Sugestões (#799 / #800–#807): a partir de **Sobre** (Release Notes), enviar sugestão ou problema; acompanhar em **Minhas solicitações**; admin faz triagem, responde (público/interno) e pode criar/sincronizar issue no GitHub (só interno)
 - WhatsApp (#837): **Exportar PDF** da conversa (header / menu ⋮) — relatório com protocolo, contacto e mensagens; mídia como rótulo; comentários internos excluídos; mesma permissão de ver o chat
 - Configurações (#833): hub com **pesquisa** e cartões por domínio; menu reorganizado (Equipa e tickets, Canais, Comercial/CRM, Empresa e catálogos, Administração); URLs antigas redireccionam
 - WhatsApp (#831): clicar no **número** do contacto (lista Em atendimento, Aguardando, histórico e header) copia automaticamente, com «Copiado!» discreto

--- a/backend/alembic/versions/105_solicitacoes_melhoria.py
+++ b/backend/alembic/versions/105_solicitacoes_melhoria.py
@@ -1,0 +1,107 @@
+"""Solicitações de melhoria / problema a partir dos Release Notes (#799 / #800–#807).
+
+Revision ID: 105_solicitacoes_melhoria
+Revises: 104_wpp_mensagem_encaminhada
+Create Date: 2026-08-21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "105_solicitacoes_melhoria"
+down_revision = "104_wpp_mensagem_encaminhada"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if not insp.has_table("solicitacoes_melhoria"):
+        op.create_table(
+            "solicitacoes_melhoria",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("organizacao_id", sa.Integer(), nullable=False, index=True),
+            sa.Column(
+                "autor_atendente_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+                index=True,
+            ),
+            sa.Column("autor_nome", sa.String(255), nullable=True),
+            sa.Column("tipo", sa.String(32), nullable=False, index=True),
+            sa.Column("titulo", sa.String(200), nullable=False),
+            sa.Column("descricao", sa.Text(), nullable=False),
+            sa.Column("status", sa.String(40), nullable=False, server_default="aberta", index=True),
+            sa.Column("motivo_nao_desenvolvimento", sa.Text(), nullable=True),
+            sa.Column("versao_contexto", sa.String(64), nullable=True),
+            sa.Column("github_repo", sa.String(200), nullable=True),
+            sa.Column("github_issue_number", sa.Integer(), nullable=True),
+            sa.Column("github_issue_url", sa.String(500), nullable=True),
+            sa.Column("github_last_sync_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("github_last_error", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+
+    if not insp.has_table("solicitacoes_melhoria_historico"):
+        op.create_table(
+            "solicitacoes_melhoria_historico",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column(
+                "solicitacao_id",
+                sa.Integer(),
+                sa.ForeignKey("solicitacoes_melhoria.id", ondelete="CASCADE"),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column("status_anterior", sa.String(40), nullable=True),
+            sa.Column("status_novo", sa.String(40), nullable=False),
+            sa.Column("motivo", sa.Text(), nullable=True),
+            sa.Column(
+                "atendente_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("mensagem_publica", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        )
+
+    if not insp.has_table("solicitacoes_melhoria_comentarios"):
+        op.create_table(
+            "solicitacoes_melhoria_comentarios",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column(
+                "solicitacao_id",
+                sa.Integer(),
+                sa.ForeignKey("solicitacoes_melhoria.id", ondelete="CASCADE"),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column("corpo", sa.Text(), nullable=False),
+            sa.Column("publico_cliente", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("origem", sa.String(32), nullable=False, server_default="manual"),
+            sa.Column(
+                "autor_atendente_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("autor_nome", sa.String(255), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    for table in (
+        "solicitacoes_melhoria_comentarios",
+        "solicitacoes_melhoria_historico",
+        "solicitacoes_melhoria",
+    ):
+        if insp.has_table(table):
+            op.drop_table(table)

--- a/backend/app/api/solicitacoes_melhoria.py
+++ b/backend/app/api/solicitacoes_melhoria.py
@@ -1,0 +1,114 @@
+"""API de solicitações de melhoria (#799 / #800–#807)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.core.auth import exigir_admin, obter_atendente_atual
+from app.models.atendente import Atendente
+from app.schemas.solicitacao_melhoria import (
+    SolicitacaoComentarioCreate,
+    SolicitacaoMelhoriaCreate,
+    SolicitacaoMelhoriaListaItem,
+    SolicitacaoMelhoriaRead,
+    SolicitacaoMelhoriaStatusUpdate,
+)
+from app.services import solicitacao_melhoria as svc
+from app.services import solicitacao_melhoria_github as gh_svc
+
+router = APIRouter(prefix="/solicitacoes-melhoria", tags=["solicitacoes-melhoria"])
+
+
+@router.post("", response_model=SolicitacaoMelhoriaRead)
+def criar_solicitacao(
+    data: SolicitacaoMelhoriaCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    row = svc.criar(db, atendente, data)
+    return svc.serializar(row, incluir_github=False, incluir_internos=False)
+
+
+@router.get("/minhas", response_model=list[SolicitacaoMelhoriaListaItem])
+def listar_minhas(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    rows = svc.listar_minhas(db, atendente)
+    return [svc.item_lista(r, incluir_github=False) for r in rows]
+
+
+@router.get("/admin", response_model=list[SolicitacaoMelhoriaListaItem])
+def listar_admin(
+    status: str | None = Query(None),
+    tipo: str | None = Query(None),
+    organizacao_id: int | None = Query(None),
+    desde: datetime | None = Query(None),
+    ate: datetime | None = Query(None),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_admin),
+):
+    rows = svc.listar_admin(
+        db, status_filtro=status, tipo=tipo, organizacao_id=organizacao_id, desde=desde, ate=ate
+    )
+    return [svc.item_lista(r, incluir_github=True) for r in rows]
+
+
+@router.get("/{solicitacao_id}", response_model=SolicitacaoMelhoriaRead)
+def obter(
+    solicitacao_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    row = svc.obter_para_leitura(db, solicitacao_id, atendente)
+    admin = atendente.role == "admin"
+    return svc.serializar(row, incluir_github=admin, incluir_internos=admin)
+
+
+@router.patch("/{solicitacao_id}/status", response_model=SolicitacaoMelhoriaRead)
+def alterar_status(
+    solicitacao_id: int,
+    data: SolicitacaoMelhoriaStatusUpdate,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    row = svc.alterar_status(db, solicitacao_id, admin, data)
+    return svc.serializar(row, incluir_github=True, incluir_internos=True)
+
+
+@router.post("/{solicitacao_id}/comentarios", response_model=SolicitacaoMelhoriaRead)
+def comentar(
+    solicitacao_id: int,
+    data: SolicitacaoComentarioCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    row = svc.adicionar_comentario(db, solicitacao_id, atendente, data)
+    admin = atendente.role == "admin"
+    return svc.serializar(row, incluir_github=admin, incluir_internos=admin)
+
+
+@router.post("/{solicitacao_id}/github", response_model=SolicitacaoMelhoriaRead)
+def criar_github(
+    solicitacao_id: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    row = svc.obter_para_leitura(db, solicitacao_id, admin)
+    row = gh_svc.criar_issue(db, row, admin)
+    return svc.serializar(row, incluir_github=True, incluir_internos=True)
+
+
+@router.post("/{solicitacao_id}/github/sincronizar", response_model=SolicitacaoMelhoriaRead)
+def sync_github(
+    solicitacao_id: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    row = svc.obter_para_leitura(db, solicitacao_id, admin)
+    row = gh_svc.sincronizar_issue(db, row, admin)
+    return svc.serializar(row, incluir_github=True, incluir_internos=True)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -139,6 +139,11 @@ class Settings(BaseSettings):
     KB_MEDIA_DIR: str = "data/kb_media"
     KB_MEDIA_MAX_BYTES: int = 2 * 1024 * 1024
 
+    # Sugestões Release Notes → GitHub (#805 / #806). Vazio = integração desligada.
+    GITHUB_TOKEN: str | None = None
+    # Ex.: lgustavoss/dx-connect
+    GITHUB_REPO_SUGESTOES: str | None = None
+
     @property
     def evolution_embutida_disponivel(self) -> bool:
         return bool(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -59,6 +59,7 @@ from app.api import (
     saas_public,
     saas_leads,
     web_push,
+    solicitacoes_melhoria,
 )
 from app.config import settings
 from app.core.audit import clear_audit_request_context, set_audit_request_context
@@ -587,6 +588,7 @@ app.include_router(portal.router, prefix=API_V1_PREFIX)
 app.include_router(saas.router, prefix=API_V1_PREFIX)
 app.include_router(saas_public.router, prefix=API_V1_PREFIX)
 app.include_router(saas_leads.router, prefix=API_V1_PREFIX)
+app.include_router(solicitacoes_melhoria.router, prefix=API_V1_PREFIX)
 
 
 def _app_route_paths() -> set[str]:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -75,6 +75,11 @@ from app.models.cliente_saas import ClienteSaaS
 from app.models.saas_alerta_emitido import SaasAlertaEmitido
 from app.models.lead_comercial import LeadComercial
 from app.models.saas_plano import SaasModulo, SaasPlano, SaasPlanoModulo
+from app.models.solicitacao_melhoria import (
+    SolicitacaoMelhoria,
+    SolicitacaoMelhoriaComentario,
+    SolicitacaoMelhoriaHistorico,
+)
 
 __all__ = [
     "Rede",

--- a/backend/app/models/solicitacao_melhoria.py
+++ b/backend/app/models/solicitacao_melhoria.py
@@ -1,0 +1,80 @@
+"""Solicitações de melhoria / problema (#799)."""
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class SolicitacaoMelhoria(Base):
+    __tablename__ = "solicitacoes_melhoria"
+
+    id = Column(Integer, primary_key=True, index=True)
+    # Instância / tenant — isolamento “organização” (#800 / #801).
+    organizacao_id = Column(Integer, nullable=False, index=True)
+    autor_atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True, index=True)
+    autor_nome = Column(String(255), nullable=True)
+    tipo = Column(String(32), nullable=False, index=True)  # sugestao | problema
+    titulo = Column(String(200), nullable=False)
+    descricao = Column(Text, nullable=False)
+    status = Column(String(40), nullable=False, default="aberta", server_default="aberta", index=True)
+    motivo_nao_desenvolvimento = Column(Text, nullable=True)
+    versao_contexto = Column(String(64), nullable=True)
+    github_repo = Column(String(200), nullable=True)
+    github_issue_number = Column(Integer, nullable=True)
+    github_issue_url = Column(String(500), nullable=True)
+    github_last_sync_at = Column(DateTime(timezone=True), nullable=True)
+    github_last_error = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    autor = relationship("Atendente", foreign_keys=[autor_atendente_id])
+    historico = relationship(
+        "SolicitacaoMelhoriaHistorico",
+        back_populates="solicitacao",
+        order_by="SolicitacaoMelhoriaHistorico.created_at",
+        cascade="all, delete-orphan",
+    )
+    comentarios = relationship(
+        "SolicitacaoMelhoriaComentario",
+        back_populates="solicitacao",
+        order_by="SolicitacaoMelhoriaComentario.created_at",
+        cascade="all, delete-orphan",
+    )
+
+
+class SolicitacaoMelhoriaHistorico(Base):
+    __tablename__ = "solicitacoes_melhoria_historico"
+
+    id = Column(Integer, primary_key=True, index=True)
+    solicitacao_id = Column(
+        Integer, ForeignKey("solicitacoes_melhoria.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    status_anterior = Column(String(40), nullable=True)
+    status_novo = Column(String(40), nullable=False)
+    motivo = Column(Text, nullable=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    mensagem_publica = Column(Text, nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    solicitacao = relationship("SolicitacaoMelhoria", back_populates="historico")
+    atendente = relationship("Atendente")
+
+
+class SolicitacaoMelhoriaComentario(Base):
+    __tablename__ = "solicitacoes_melhoria_comentarios"
+
+    id = Column(Integer, primary_key=True, index=True)
+    solicitacao_id = Column(
+        Integer, ForeignKey("solicitacoes_melhoria.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    corpo = Column(Text, nullable=False)
+    publico_cliente = Column(Boolean, nullable=False, default=True, server_default="true")
+    origem = Column(String(32), nullable=False, default="manual", server_default="manual")
+    autor_atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    autor_nome = Column(String(255), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    solicitacao = relationship("SolicitacaoMelhoria", back_populates="comentarios")
+    autor = relationship("Atendente", foreign_keys=[autor_atendente_id])

--- a/backend/app/schemas/solicitacao_melhoria.py
+++ b/backend/app/schemas/solicitacao_melhoria.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+TipoSolicitacao = Literal["sugestao", "problema"]
+StatusSolicitacao = Literal[
+    "aberta",
+    "em_analise",
+    "planejada",
+    "em_desenvolvimento",
+    "concluida",
+    "nao_sera_desenvolvida",
+]
+
+
+class SolicitacaoMelhoriaCreate(BaseModel):
+    tipo: TipoSolicitacao
+    titulo: str = Field(..., min_length=3, max_length=200)
+    descricao: str = Field(..., min_length=10, max_length=8000)
+    versao_contexto: str | None = Field(None, max_length=64)
+
+
+class SolicitacaoMelhoriaStatusUpdate(BaseModel):
+    status: StatusSolicitacao
+    motivo_nao_desenvolvimento: str | None = Field(None, max_length=4000)
+
+
+class SolicitacaoComentarioCreate(BaseModel):
+    corpo: str = Field(..., min_length=1, max_length=8000)
+    publico_cliente: bool = True
+
+
+class SolicitacaoHistoricoRead(BaseModel):
+    id: int
+    status_anterior: str | None
+    status_novo: str
+    status_novo_rotulo: str
+    motivo: str | None
+    mensagem_publica: str | None
+    atendente_nome: str | None = None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class SolicitacaoComentarioRead(BaseModel):
+    id: int
+    corpo: str
+    publico_cliente: bool
+    origem: str
+    autor_nome: str | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class SolicitacaoMelhoriaRead(BaseModel):
+    id: int
+    organizacao_id: int
+    autor_atendente_id: int | None
+    autor_nome: str | None
+    tipo: str
+    titulo: str
+    descricao: str
+    status: str
+    status_rotulo: str
+    motivo_nao_desenvolvimento: str | None
+    versao_contexto: str | None
+    mensagem_status: str
+    created_at: datetime
+    updated_at: datetime | None
+    # Campos GitHub só em respostas admin (preenchidos no serializer interno)
+    github_repo: str | None = None
+    github_issue_number: int | None = None
+    github_issue_url: str | None = None
+    github_last_error: str | None = None
+    historico: list[SolicitacaoHistoricoRead] = []
+    comentarios: list[SolicitacaoComentarioRead] = []
+
+    model_config = {"from_attributes": True}
+
+
+class SolicitacaoMelhoriaListaItem(BaseModel):
+    id: int
+    tipo: str
+    titulo: str
+    status: str
+    status_rotulo: str
+    autor_nome: str | None
+    organizacao_id: int
+    created_at: datetime
+    updated_at: datetime | None
+    github_issue_number: int | None = None
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/solicitacao_melhoria.py
+++ b/backend/app/services/solicitacao_melhoria.py
@@ -1,0 +1,292 @@
+"""Regras de negócio — solicitações de melhoria (#800–#804)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.audit import registrar_audit
+from app.models.atendente import Atendente
+from app.models.solicitacao_melhoria import (
+    SolicitacaoMelhoria,
+    SolicitacaoMelhoriaComentario,
+    SolicitacaoMelhoriaHistorico,
+)
+from app.schemas.solicitacao_melhoria import (
+    SolicitacaoComentarioCreate,
+    SolicitacaoComentarioRead,
+    SolicitacaoHistoricoRead,
+    SolicitacaoMelhoriaCreate,
+    SolicitacaoMelhoriaListaItem,
+    SolicitacaoMelhoriaRead,
+    SolicitacaoMelhoriaStatusUpdate,
+)
+from app.services.solicitacao_melhoria_copy import (
+    STATUS_FINAIS,
+    STATUS_VALIDOS,
+    TIPOS_VALIDOS,
+    mensagem_publica_status,
+    rotulo_status,
+)
+
+
+def organizacao_id_de(atendente: Atendente) -> int:
+    return int(getattr(atendente, "tenant_id", None) or 1)
+
+
+def _is_admin(atendente: Atendente) -> bool:
+    return atendente.role == "admin"
+
+
+def _carregar(db: Session, solicitacao_id: int) -> SolicitacaoMelhoria:
+    row = (
+        db.query(SolicitacaoMelhoria)
+        .options(
+            joinedload(SolicitacaoMelhoria.historico).joinedload(SolicitacaoMelhoriaHistorico.atendente),
+            joinedload(SolicitacaoMelhoria.comentarios),
+        )
+        .filter(SolicitacaoMelhoria.id == solicitacao_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Solicitação não encontrada")
+    return row
+
+
+def _garantir_mesma_org(row: SolicitacaoMelhoria, atendente: Atendente) -> None:
+    if _is_admin(atendente):
+        return
+    if row.organizacao_id != organizacao_id_de(atendente):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Sem permissão para esta solicitação")
+
+
+def _historico_read(h: SolicitacaoMelhoriaHistorico) -> SolicitacaoHistoricoRead:
+    nome = None
+    if h.atendente is not None:
+        nome = h.atendente.nome
+    return SolicitacaoHistoricoRead(
+        id=h.id,
+        status_anterior=h.status_anterior,
+        status_novo=h.status_novo,
+        status_novo_rotulo=rotulo_status(h.status_novo),
+        motivo=h.motivo,
+        mensagem_publica=h.mensagem_publica,
+        atendente_nome=nome,
+        created_at=h.created_at,
+    )
+
+
+def serializar(row: SolicitacaoMelhoria, *, incluir_github: bool, incluir_internos: bool) -> SolicitacaoMelhoriaRead:
+    comentarios = [
+        SolicitacaoComentarioRead(
+            id=c.id,
+            corpo=c.corpo,
+            publico_cliente=c.publico_cliente,
+            origem=c.origem,
+            autor_nome=c.autor_nome,
+            created_at=c.created_at,
+        )
+        for c in (row.comentarios or [])
+        if incluir_internos or c.publico_cliente
+    ]
+    return SolicitacaoMelhoriaRead(
+        id=row.id,
+        organizacao_id=row.organizacao_id,
+        autor_atendente_id=row.autor_atendente_id,
+        autor_nome=row.autor_nome,
+        tipo=row.tipo,
+        titulo=row.titulo,
+        descricao=row.descricao,
+        status=row.status,
+        status_rotulo=rotulo_status(row.status),
+        motivo_nao_desenvolvimento=row.motivo_nao_desenvolvimento,
+        versao_contexto=row.versao_contexto,
+        mensagem_status=mensagem_publica_status(row.status, motivo=row.motivo_nao_desenvolvimento),
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        github_repo=row.github_repo if incluir_github else None,
+        github_issue_number=row.github_issue_number if incluir_github else None,
+        github_issue_url=row.github_issue_url if incluir_github else None,
+        github_last_error=row.github_last_error if incluir_github else None,
+        historico=[_historico_read(h) for h in (row.historico or [])],
+        comentarios=comentarios,
+    )
+
+
+def criar(db: Session, atendente: Atendente, data: SolicitacaoMelhoriaCreate) -> SolicitacaoMelhoria:
+    if data.tipo not in TIPOS_VALIDOS:
+        raise HTTPException(status_code=400, detail="Tipo inválido")
+    row = SolicitacaoMelhoria(
+        organizacao_id=organizacao_id_de(atendente),
+        autor_atendente_id=atendente.id,
+        autor_nome=atendente.nome,
+        tipo=data.tipo,
+        titulo=data.titulo.strip(),
+        descricao=data.descricao.strip(),
+        status="aberta",
+        versao_contexto=(data.versao_contexto or "").strip() or None,
+    )
+    db.add(row)
+    db.flush()
+    msg = mensagem_publica_status("aberta")
+    db.add(
+        SolicitacaoMelhoriaHistorico(
+            solicitacao_id=row.id,
+            status_anterior=None,
+            status_novo="aberta",
+            atendente_id=atendente.id,
+            mensagem_publica=msg,
+        )
+    )
+    db.commit()
+    return _carregar(db, row.id)
+
+
+def listar_minhas(db: Session, atendente: Atendente) -> list[SolicitacaoMelhoria]:
+    org = organizacao_id_de(atendente)
+    q = db.query(SolicitacaoMelhoria).filter(SolicitacaoMelhoria.organizacao_id == org)
+    if not _is_admin(atendente):
+        # Utilizador “cliente”: vê as da organização (instância), foco nas próprias no UI.
+        pass
+    return q.order_by(SolicitacaoMelhoria.created_at.desc()).limit(200).all()
+
+
+def listar_admin(
+    db: Session,
+    *,
+    status_filtro: str | None = None,
+    tipo: str | None = None,
+    organizacao_id: int | None = None,
+    desde: datetime | None = None,
+    ate: datetime | None = None,
+) -> list[SolicitacaoMelhoria]:
+    q = db.query(SolicitacaoMelhoria)
+    if status_filtro:
+        q = q.filter(SolicitacaoMelhoria.status == status_filtro)
+    if tipo:
+        q = q.filter(SolicitacaoMelhoria.tipo == tipo)
+    if organizacao_id is not None:
+        q = q.filter(SolicitacaoMelhoria.organizacao_id == organizacao_id)
+    if desde is not None:
+        q = q.filter(SolicitacaoMelhoria.created_at >= desde)
+    if ate is not None:
+        q = q.filter(SolicitacaoMelhoria.created_at <= ate)
+    return q.order_by(SolicitacaoMelhoria.created_at.desc()).limit(500).all()
+
+
+def obter_para_leitura(db: Session, solicitacao_id: int, atendente: Atendente) -> SolicitacaoMelhoria:
+    row = _carregar(db, solicitacao_id)
+    _garantir_mesma_org(row, atendente)
+    return row
+
+
+def alterar_status(
+    db: Session,
+    solicitacao_id: int,
+    admin: Atendente,
+    data: SolicitacaoMelhoriaStatusUpdate,
+) -> SolicitacaoMelhoria:
+    if not _is_admin(admin):
+        raise HTTPException(status_code=403, detail="Apenas admin pode alterar o status")
+    if data.status not in STATUS_VALIDOS:
+        raise HTTPException(status_code=400, detail="Status inválido")
+    row = _carregar(db, solicitacao_id)
+    if data.status == "nao_sera_desenvolvida" and not (data.motivo_nao_desenvolvimento or "").strip():
+        raise HTTPException(
+            status_code=400,
+            detail="Informe o motivo quando marcar como não será desenvolvida",
+        )
+    anterior = row.status
+    if anterior == data.status:
+        return row
+    row.status = data.status
+    if data.status == "nao_sera_desenvolvida":
+        row.motivo_nao_desenvolvimento = (data.motivo_nao_desenvolvimento or "").strip()
+    elif data.motivo_nao_desenvolvimento is not None and data.status != "nao_sera_desenvolvida":
+        # não limpa obrigatoriamente — mantém histórico se reabrir
+        pass
+    msg = mensagem_publica_status(data.status, motivo=row.motivo_nao_desenvolvimento)
+    db.add(
+        SolicitacaoMelhoriaHistorico(
+            solicitacao_id=row.id,
+            status_anterior=anterior,
+            status_novo=data.status,
+            motivo=row.motivo_nao_desenvolvimento if data.status == "nao_sera_desenvolvida" else None,
+            atendente_id=admin.id,
+            mensagem_publica=msg,
+        )
+    )
+    registrar_audit(
+        db,
+        "solicitacao_melhoria",
+        row.id,
+        "status_change",
+        admin.id,
+        payload={
+            "de": anterior,
+            "para": data.status,
+            "motivo": row.motivo_nao_desenvolvimento if data.status == "nao_sera_desenvolvida" else None,
+        },
+    )
+    db.add(row)
+    db.commit()
+    return _carregar(db, row.id)
+
+
+def adicionar_comentario(
+    db: Session,
+    solicitacao_id: int,
+    atendente: Atendente,
+    data: SolicitacaoComentarioCreate,
+) -> SolicitacaoMelhoria:
+    row = _carregar(db, solicitacao_id)
+    _garantir_mesma_org(row, atendente)
+    is_admin = _is_admin(atendente)
+
+    if not is_admin:
+        # Cliente: só comentários públicos nas solicitações da org; bloqueado se status final.
+        if not data.publico_cliente:
+            raise HTTPException(status_code=403, detail="Não é possível criar notas internas")
+        if row.status in STATUS_FINAIS:
+            raise HTTPException(
+                status_code=400,
+                detail="Esta solicitação está encerrada e já não aceita respostas",
+            )
+        # Só o autor responde (critério #801 “seus próprios”)
+        if row.autor_atendente_id != atendente.id:
+            raise HTTPException(status_code=403, detail="Só o autor pode responder nesta solicitação")
+
+    if is_admin and data.publico_cliente is False:
+        publico = False
+    else:
+        publico = True if not is_admin else bool(data.publico_cliente)
+
+    db.add(
+        SolicitacaoMelhoriaComentario(
+            solicitacao_id=row.id,
+            corpo=data.corpo.strip(),
+            publico_cliente=publico,
+            origem="manual",
+            autor_atendente_id=atendente.id,
+            autor_nome=atendente.nome,
+        )
+    )
+    db.commit()
+    return _carregar(db, row.id)
+
+
+def item_lista(row: SolicitacaoMelhoria, *, incluir_github: bool) -> SolicitacaoMelhoriaListaItem:
+    return SolicitacaoMelhoriaListaItem(
+        id=row.id,
+        tipo=row.tipo,
+        titulo=row.titulo,
+        status=row.status,
+        status_rotulo=rotulo_status(row.status),
+        autor_nome=row.autor_nome,
+        organizacao_id=row.organizacao_id,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        github_issue_number=row.github_issue_number if incluir_github else None,
+    )

--- a/backend/app/services/solicitacao_melhoria_copy.py
+++ b/backend/app/services/solicitacao_melhoria_copy.py
@@ -1,0 +1,40 @@
+"""Microcopy pública de status das solicitações (#807)."""
+
+from __future__ import annotations
+
+STATUS_LABELS: dict[str, str] = {
+    "aberta": "Recebida",
+    "em_analise": "Em análise",
+    "planejada": "Planejada",
+    "em_desenvolvimento": "Em desenvolvimento",
+    "concluida": "Concluída",
+    "nao_sera_desenvolvida": "Não será desenvolvida",
+}
+
+STATUS_MENSAGENS: dict[str, str] = {
+    "aberta": "Recebemos o seu pedido. A equipa vai analisar em breve.",
+    "em_analise": "Estamos a analisar o seu pedido com atenção.",
+    "planejada": "O seu pedido foi incluído no planeamento de melhorias.",
+    "em_desenvolvimento": "Já estamos a trabalhar nesta melhoria.",
+    "concluida": "Esta melhoria ficou disponível. Obrigado pelo contributo!",
+    "nao_sera_desenvolvida": (
+        "Neste momento não vamos avançar com este pedido. "
+        "Apreciamos o feedback — se fizer sentido no futuro, voltamos a avaliar."
+    ),
+}
+
+STATUS_FINAIS = frozenset({"concluida", "nao_sera_desenvolvida"})
+
+STATUS_VALIDOS = frozenset(STATUS_LABELS.keys())
+TIPOS_VALIDOS = frozenset({"sugestao", "problema"})
+
+
+def mensagem_publica_status(status: str, *, motivo: str | None = None) -> str:
+    base = STATUS_MENSAGENS.get(status, "O estado do seu pedido foi atualizado.")
+    if status == "nao_sera_desenvolvida" and (motivo or "").strip():
+        return f"{base}\n\nMotivo: {motivo.strip()}"
+    return base
+
+
+def rotulo_status(status: str) -> str:
+    return STATUS_LABELS.get(status, status.replace("_", " "))

--- a/backend/app/services/solicitacao_melhoria_github.py
+++ b/backend/app/services/solicitacao_melhoria_github.py
@@ -1,0 +1,163 @@
+"""GitHub Issues para solicitações de melhoria (#805 / #806)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+import httpx
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.atendente import Atendente
+from app.models.solicitacao_melhoria import SolicitacaoMelhoria, SolicitacaoMelhoriaComentario
+
+logger = logging.getLogger(__name__)
+
+
+def github_configurado() -> bool:
+    token = (settings.GITHUB_TOKEN or "").strip()
+    repo = (settings.GITHUB_REPO_SUGESTOES or "").strip()
+    return bool(token and repo and "/" in repo)
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {settings.GITHUB_TOKEN.strip()}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def montar_corpo_issue(row: SolicitacaoMelhoria) -> str:
+    return (
+        f"## Solicitação DeskRudder #{row.id}\n\n"
+        f"**Tipo:** {row.tipo}\n"
+        f"**Autor:** {row.autor_nome or '—'}\n"
+        f"**Organização (tenant):** {row.organizacao_id}\n"
+        f"**Versão no envio:** {row.versao_contexto or '—'}\n"
+        f"**Status interno:** {row.status}\n\n"
+        f"### Título\n{row.titulo}\n\n"
+        f"### Descrição\n{row.descricao}\n"
+    )
+
+
+def criar_issue(db: Session, row: SolicitacaoMelhoria, admin: Atendente) -> SolicitacaoMelhoria:
+    if not github_configurado():
+        raise HTTPException(
+            status_code=503,
+            detail="Integração GitHub não configurada (GITHUB_TOKEN / GITHUB_REPO_SUGESTOES).",
+        )
+    if row.github_issue_number:
+        raise HTTPException(status_code=400, detail="Esta solicitação já tem issue no GitHub.")
+
+    repo = settings.GITHUB_REPO_SUGESTOES.strip()
+    url = f"https://api.github.com/repos/{repo}/issues"
+    payload = {
+        "title": f"[DeskRudder #{row.id}] {row.titulo}"[:240],
+        "body": montar_corpo_issue(row),
+        "labels": ["deskrudder-sugestao", row.tipo],
+    }
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            res = client.post(url, headers=_headers(), json=payload)
+    except httpx.HTTPError as exc:
+        logger.warning("GitHub create issue falhou: %s", exc)
+        row.github_last_error = str(exc)
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        raise HTTPException(status_code=502, detail="Falha ao contactar o GitHub. Tente novamente.") from exc
+
+    if res.status_code >= 400:
+        row.github_last_error = (res.text or "")[:2000]
+        db.add(row)
+        db.commit()
+        db.refresh(row)
+        raise HTTPException(status_code=502, detail="GitHub rejeitou a criação da issue. Pode tentar de novo.")
+
+    data = res.json()
+    row.github_repo = repo
+    row.github_issue_number = int(data["number"])
+    row.github_issue_url = data.get("html_url")
+    row.github_last_error = None
+    row.github_last_sync_at = datetime.now(timezone.utc)
+    db.add(row)
+    db.add(
+        SolicitacaoMelhoriaComentario(
+            solicitacao_id=row.id,
+            corpo=f"Issue GitHub criada: #{row.github_issue_number}",
+            publico_cliente=False,
+            origem="github",
+            autor_atendente_id=admin.id,
+            autor_nome=admin.nome,
+        )
+    )
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def sincronizar_issue(db: Session, row: SolicitacaoMelhoria, admin: Atendente) -> SolicitacaoMelhoria:
+    """Lê o estado da issue e regista comentário interno (#806) — nunca publica ao cliente."""
+    if not github_configurado():
+        raise HTTPException(
+            status_code=503,
+            detail="Integração GitHub não configurada (GITHUB_TOKEN / GITHUB_REPO_SUGESTOES).",
+        )
+    if not row.github_issue_number or not row.github_repo:
+        raise HTTPException(status_code=400, detail="Solicitação sem issue GitHub vinculada.")
+
+    url = f"https://api.github.com/repos/{row.github_repo}/issues/{row.github_issue_number}"
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            res = client.get(url, headers=_headers())
+    except httpx.HTTPError as exc:
+        row.github_last_error = str(exc)
+        db.add(row)
+        db.commit()
+        raise HTTPException(status_code=502, detail="Falha ao sincronizar com o GitHub.") from exc
+
+    if res.status_code >= 400:
+        row.github_last_error = (res.text or "")[:2000]
+        db.add(row)
+        db.commit()
+        raise HTTPException(status_code=502, detail="GitHub rejeitou a sincronização.")
+
+    data = res.json()
+    state = data.get("state", "unknown")
+    labels = [lb.get("name") for lb in (data.get("labels") or []) if isinstance(lb, dict)]
+    label_txt = ", ".join(labels) if labels else "—"
+    corpo = (
+        f"Sync GitHub #{row.github_issue_number}: estado={state}; labels={label_txt}. "
+        f"(Conteúdo interno — não visível ao cliente.)"
+    )
+    db.add(
+        SolicitacaoMelhoriaComentario(
+            solicitacao_id=row.id,
+            corpo=corpo,
+            publico_cliente=False,
+            origem="github",
+            autor_atendente_id=admin.id,
+            autor_nome=admin.nome,
+        )
+    )
+    row.github_last_sync_at = datetime.now(timezone.utc)
+    row.github_last_error = None
+    # Sugestão opcional de status (#806) — só regista nota, não muda sozinho.
+    if state == "closed" and row.status not in ("concluida", "nao_sera_desenvolvida"):
+        db.add(
+            SolicitacaoMelhoriaComentario(
+                solicitacao_id=row.id,
+                corpo="Sugestão: issue GitHub fechada — considere marcar a solicitação como concluída.",
+                publico_cliente=False,
+                origem="github",
+                autor_atendente_id=admin.id,
+                autor_nome=admin.nome,
+            )
+        )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row

--- a/backend/tests/test_solicitacoes_melhoria.py
+++ b/backend/tests/test_solicitacoes_melhoria.py
@@ -1,0 +1,139 @@
+"""Solicitações de melhoria — Release Notes (#799 / #800–#807)."""
+
+from __future__ import annotations
+
+
+def _criar(client, headers, **kw):
+    body = {
+        "tipo": "sugestao",
+        "titulo": "Melhorar filtros do histórico",
+        "descricao": "Gostaria de filtrar por período e setor na lista de atendimentos.",
+        "versao_contexto": "2026.08.21",
+    }
+    body.update(kw)
+    return client.post("/v1/solicitacoes-melhoria", headers=headers, json=body)
+
+
+def test_criar_e_listar_minhas(client, seed_base, auth_headers):
+    r = _criar(client, auth_headers["a1"])
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["status"] == "aberta"
+    assert data["status_rotulo"] == "Recebida"
+    assert data["github_issue_url"] is None
+    assert "mensagem_status" in data
+
+    lista = client.get("/v1/solicitacoes-melhoria/minhas", headers=auth_headers["a1"])
+    assert lista.status_code == 200
+    assert any(i["id"] == data["id"] for i in lista.json())
+
+
+def test_status_so_admin_e_motivo_obrigatorio(client, seed_base, auth_headers):
+    sid = _criar(client, auth_headers["a1"]).json()["id"]
+
+    denied = client.patch(
+        f"/v1/solicitacoes-melhoria/{sid}/status",
+        headers=auth_headers["a1"],
+        json={"status": "em_analise"},
+    )
+    assert denied.status_code == 403
+
+    bad = client.patch(
+        f"/v1/solicitacoes-melhoria/{sid}/status",
+        headers=auth_headers["admin"],
+        json={"status": "nao_sera_desenvolvida"},
+    )
+    assert bad.status_code == 400
+
+    ok = client.patch(
+        f"/v1/solicitacoes-melhoria/{sid}/status",
+        headers=auth_headers["admin"],
+        json={
+            "status": "nao_sera_desenvolvida",
+            "motivo_nao_desenvolvimento": "Fora do roadmap deste trimestre.",
+        },
+    )
+    assert ok.status_code == 200
+    body = ok.json()
+    assert body["status"] == "nao_sera_desenvolvida"
+    assert "Fora do roadmap" in (body["motivo_nao_desenvolvimento"] or "")
+    assert any(h["status_novo"] == "nao_sera_desenvolvida" for h in body["historico"])
+
+
+def test_comentarios_publico_vs_interno(client, seed_base, auth_headers):
+    sid = _criar(client, auth_headers["a1"]).json()["id"]
+
+    # Cliente não cria nota interna
+    r403 = client.post(
+        f"/v1/solicitacoes-melhoria/{sid}/comentarios",
+        headers=auth_headers["a1"],
+        json={"corpo": "segredo", "publico_cliente": False},
+    )
+    assert r403.status_code == 403
+
+    pub = client.post(
+        f"/v1/solicitacoes-melhoria/{sid}/comentarios",
+        headers=auth_headers["a1"],
+        json={"corpo": "Posso dar mais detalhes se precisarem.", "publico_cliente": True},
+    )
+    assert pub.status_code == 200
+
+    admin_c = client.post(
+        f"/v1/solicitacoes-melhoria/{sid}/comentarios",
+        headers=auth_headers["admin"],
+        json={"corpo": "Nota interna de triagem", "publico_cliente": False},
+    )
+    assert admin_c.status_code == 200
+
+    cliente_view = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["a1"]).json()
+    corpos = [c["corpo"] for c in cliente_view["comentarios"]]
+    assert "Posso dar mais detalhes" in "".join(corpos)
+    assert "Nota interna" not in "".join(corpos)
+
+    admin_view = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["admin"]).json()
+    assert any("Nota interna" in c["corpo"] for c in admin_view["comentarios"])
+
+
+def test_a2_nao_comenta_solicitacao_de_a1(client, seed_base, auth_headers):
+    sid = _criar(client, auth_headers["a1"]).json()["id"]
+    # Mesma org (tenant) — pode ler, mas só autor responde
+    r = client.post(
+        f"/v1/solicitacoes-melhoria/{sid}/comentarios",
+        headers=auth_headers["a2"],
+        json={"corpo": "Eu também quero isto", "publico_cliente": True},
+    )
+    assert r.status_code == 403
+
+
+def test_status_final_bloqueia_resposta_cliente(client, seed_base, auth_headers):
+    sid = _criar(client, auth_headers["a1"]).json()["id"]
+    client.patch(
+        f"/v1/solicitacoes-melhoria/{sid}/status",
+        headers=auth_headers["admin"],
+        json={"status": "concluida"},
+    )
+    r = client.post(
+        f"/v1/solicitacoes-melhoria/{sid}/comentarios",
+        headers=auth_headers["a1"],
+        json={"corpo": "Obrigado!", "publico_cliente": True},
+    )
+    assert r.status_code == 400
+
+
+def test_github_sem_config_503(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "GITHUB_TOKEN", None)
+    monkeypatch.setattr(settings, "GITHUB_REPO_SUGESTOES", None)
+    sid = _criar(client, auth_headers["a1"]).json()["id"]
+    r = client.post(f"/v1/solicitacoes-melhoria/{sid}/github", headers=auth_headers["admin"])
+    assert r.status_code == 503
+
+
+def test_admin_lista_filtra(client, seed_base, auth_headers):
+    _criar(client, auth_headers["a1"], tipo="problema", titulo="Bug no PDF export")
+    r = client.get("/v1/solicitacoes-melhoria/admin?tipo=problema", headers=auth_headers["admin"])
+    assert r.status_code == 200
+    assert all(i["tipo"] == "problema" for i in r.json())
+    denied = client.get("/v1/solicitacoes-melhoria/admin", headers=auth_headers["a1"])
+    assert denied.status_code == 403

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -81,6 +81,8 @@ import { ChatHubPlaceholder } from './pages/chat/ChatHubPlaceholder'
 import { AlterarSenha } from './pages/AlterarSenha'
 import { NotificacoesPreferencias } from './pages/NotificacoesPreferencias'
 import { Sobre } from './pages/Sobre'
+import { MinhasSolicitacoesPage } from './pages/MinhasSolicitacoes'
+import { SolicitacoesMelhoriaAdminPage } from './pages/SolicitacoesMelhoriaAdmin'
 import { AcessoNegado } from './pages/AcessoNegado'
 import { SaasLicencas } from './pages/saas/SaasLicencas'
 import { SaasLicencaForm } from './pages/saas/SaasLicencaForm'
@@ -370,6 +372,24 @@ function AppRoutes() {
         />
         <Route path="notificacoes/preferencias" element={<NotificacoesPreferencias />} />
         <Route path="sobre" element={<Sobre />} />
+        <Route path="minhas-solicitacoes" element={<MinhasSolicitacoesPage />} />
+        <Route path="minhas-solicitacoes/:id" element={<MinhasSolicitacoesPage />} />
+        <Route
+          path="solicitacoes-melhoria"
+          element={
+            <AdminRoute>
+              <SolicitacoesMelhoriaAdminPage />
+            </AdminRoute>
+          }
+        />
+        <Route
+          path="solicitacoes-melhoria/:id"
+          element={
+            <AdminRoute>
+              <SolicitacoesMelhoriaAdminPage />
+            </AdminRoute>
+          }
+        />
         <Route path="tickets" element={<Tickets />} />
         <Route path="tickets/novo" element={<TicketNovo />} />
         <Route path="tickets/:id" element={<RedirectTicketDetalhe />} />
@@ -748,6 +768,7 @@ function AppRoutes() {
           <Route path="tipos-negocio" element={<TiposNegocio embedded />} />
           <Route path="pdv" element={<ConfigPdvCatalogos embedded />} />
           <Route path="auditoria" element={<Auditoria embedded />} />
+          <Route path="sugestoes" element={<Navigate to="/solicitacoes-melhoria" replace />} />
         </Route>
         <Route path="configuracoes/atendimento/*" element={<ConfigLegacyRedirect />} />
         <Route path="configuracoes/cadastros/*" element={<ConfigLegacyRedirect />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -4798,6 +4798,119 @@ export const system = {
   releaseNotes: () => api<System.ReleaseNotes>('/system/release-notes'),
 };
 
+export namespace SolicitacoesMelhoria {
+  export type Tipo = 'sugestao' | 'problema'
+  export type Status =
+    | 'aberta'
+    | 'em_analise'
+    | 'planejada'
+    | 'em_desenvolvimento'
+    | 'concluida'
+    | 'nao_sera_desenvolvida'
+
+  export interface ListaItem {
+    id: number
+    tipo: Tipo | string
+    titulo: string
+    status: Status | string
+    status_rotulo: string
+    autor_nome?: string | null
+    organizacao_id: number
+    created_at: string
+    updated_at?: string | null
+    github_issue_number?: number | null
+  }
+
+  export interface Historico {
+    id: number
+    status_anterior?: string | null
+    status_novo: string
+    status_novo_rotulo: string
+    motivo?: string | null
+    mensagem_publica?: string | null
+    atendente_nome?: string | null
+    created_at: string
+  }
+
+  export interface Comentario {
+    id: number
+    corpo: string
+    publico_cliente: boolean
+    origem: string
+    autor_nome?: string | null
+    created_at: string
+  }
+
+  export interface Detalhe {
+    id: number
+    organizacao_id: number
+    autor_atendente_id?: number | null
+    autor_nome?: string | null
+    tipo: Tipo | string
+    titulo: string
+    descricao: string
+    status: Status | string
+    status_rotulo: string
+    motivo_nao_desenvolvimento?: string | null
+    versao_contexto?: string | null
+    mensagem_status: string
+    created_at: string
+    updated_at?: string | null
+    github_repo?: string | null
+    github_issue_number?: number | null
+    github_issue_url?: string | null
+    github_last_error?: string | null
+    historico: Historico[]
+    comentarios: Comentario[]
+  }
+
+  export interface Create {
+    tipo: Tipo
+    titulo: string
+    descricao: string
+    versao_contexto?: string | null
+  }
+}
+
+export const solicitacoesMelhoria = {
+  criar: (data: SolicitacoesMelhoria.Create) =>
+    api<SolicitacoesMelhoria.Detalhe>('/solicitacoes-melhoria', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  minhas: () => api<SolicitacoesMelhoria.ListaItem[]>('/solicitacoes-melhoria/minhas'),
+  adminLista: (params?: {
+    status?: string
+    tipo?: string
+    organizacao_id?: number
+    desde?: string
+    ate?: string
+  }) =>
+    api<SolicitacoesMelhoria.ListaItem[]>(
+      withParams('/solicitacoes-melhoria/admin', params as Record<string, string | number | undefined>),
+    ),
+  get: (id: number) => api<SolicitacoesMelhoria.Detalhe>(`/solicitacoes-melhoria/${id}`),
+  alterarStatus: (
+    id: number,
+    data: { status: SolicitacoesMelhoria.Status; motivo_nao_desenvolvimento?: string | null },
+  ) =>
+    api<SolicitacoesMelhoria.Detalhe>(`/solicitacoes-melhoria/${id}/status`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
+  comentar: (id: number, data: { corpo: string; publico_cliente?: boolean }) =>
+    api<SolicitacoesMelhoria.Detalhe>(`/solicitacoes-melhoria/${id}/comentarios`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
+  criarGithub: (id: number) =>
+    api<SolicitacoesMelhoria.Detalhe>(`/solicitacoes-melhoria/${id}/github`, { method: 'POST' }),
+  syncGithub: (id: number) =>
+    api<SolicitacoesMelhoria.Detalhe>(`/solicitacoes-melhoria/${id}/github/sincronizar`, {
+      method: 'POST',
+    }),
+};
+
 /** Release notes do control-plane (RBAC saas_ops). */
 export const saasReleaseNotes = {
   get: () => api<System.ReleaseNotes>('/saas/release-notes'),

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -381,6 +381,7 @@ const navStructure: NavItem[] = [
       { to: '/configuracoes/comercial', label: 'Comercial / CRM', icon: 'tiposNegocio' },
       { to: '/configuracoes/empresa-catalogos', label: 'Empresa e catálogos', icon: 'empresas' },
       { to: '/configuracoes/administracao', label: 'Administração', icon: 'configuracoes' },
+      { to: '/solicitacoes-melhoria', label: 'Sugestões', icon: 'ajudaConsultar', adminOnly: true },
     ],
   },
 ]

--- a/frontend/src/components/release/ReleaseNotesView.tsx
+++ b/frontend/src/components/release/ReleaseNotesView.tsx
@@ -1,7 +1,10 @@
 import { Link } from 'react-router-dom'
+import { useState } from 'react'
 import type { System } from '../../api/client'
 import { Card } from '../../components/ui/Card'
+import { Button } from '../../components/ui/Button'
 import { BrandLogo } from '../../brand'
+import { SolicitacaoMelhoriaModal } from './SolicitacaoMelhoriaModal'
 
 const CATEGORY_LABEL: Record<string, string> = {
   melhorias: 'Melhorias',
@@ -70,6 +73,8 @@ export type ReleaseNotesViewProps = {
   notes: System.ReleaseNotes | null
   loading?: boolean
   showBrandLogo?: boolean
+  /** CTA sugestões (#802) — desligar no SaaS Sobre se não fizer sentido. */
+  showSugestoesCta?: boolean
 }
 
 /** Lista partilhada de versão + histórico filtrado por produto (#674 / #675). */
@@ -83,7 +88,9 @@ export function ReleaseNotesView({
   notes,
   loading = false,
   showBrandLogo = true,
+  showSugestoesCta = true,
 }: ReleaseNotesViewProps) {
+  const [modalAberto, setModalAberto] = useState(false)
   const pastReleases = (notes?.releases ?? []).filter((r) => r.version !== notes?.current?.version)
 
   if (loading) {
@@ -123,7 +130,26 @@ export function ReleaseNotesView({
         <p className="text-xs text-slate-500 dark:text-slate-400">
           CalVer do último deploy (mesma versão nos painéis DeskRudder e SaaS).
         </p>
+        {showSugestoesCta ? (
+          <div className="flex flex-wrap items-center gap-3 pt-2">
+            <Button type="button" variant="primary" className="text-sm" onClick={() => setModalAberto(true)}>
+              Enviar sugestão / relatar problema
+            </Button>
+            <Link
+              to="/minhas-solicitacoes"
+              className="text-sm font-medium text-cyan-700 hover:underline dark:text-cyan-400"
+            >
+              Minhas solicitações →
+            </Link>
+          </div>
+        ) : null}
       </Card>
+
+      <SolicitacaoMelhoriaModal
+        open={modalAberto}
+        versaoContexto={versionLabel}
+        onClose={() => setModalAberto(false)}
+      />
 
       {notes?.current ? (
         <section className="space-y-3">

--- a/frontend/src/components/release/SolicitacaoMelhoriaModal.tsx
+++ b/frontend/src/components/release/SolicitacaoMelhoriaModal.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState } from 'react'
+import { solicitacoesMelhoria, type SolicitacoesMelhoria } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { Button } from '../ui/Button'
+import { Input, TEXTAREA_FIELD_CLASS } from '../ui/Input'
+import { Select } from '../ui/Select'
+import { useToast } from '../ui/Toast'
+
+type Props = {
+  open: boolean
+  versaoContexto?: string | null
+  onClose: () => void
+  onCriado?: (id: number) => void
+}
+
+/** Formulário para enviar sugestão / relatar problema a partir dos Release Notes (#802). */
+export function SolicitacaoMelhoriaModal({ open, versaoContexto, onClose, onCriado }: Props) {
+  const toast = useToast()
+  const [tipo, setTipo] = useState<SolicitacoesMelhoria.Tipo>('sugestao')
+  const [titulo, setTitulo] = useState('')
+  const [descricao, setDescricao] = useState('')
+  const [enviando, setEnviando] = useState(false)
+  const [erro, setErro] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setTipo('sugestao')
+    setTitulo('')
+    setDescricao('')
+    setErro(null)
+  }, [open])
+
+  if (!open) return null
+
+  async function enviar() {
+    setErro(null)
+    const t = titulo.trim()
+    const d = descricao.trim()
+    if (t.length < 3) {
+      setErro('Indique um título com pelo menos 3 caracteres.')
+      return
+    }
+    if (d.length < 10) {
+      setErro('Descreva o pedido com pelo menos 10 caracteres.')
+      return
+    }
+    setEnviando(true)
+    try {
+      const row = await solicitacoesMelhoria.criar({
+        tipo,
+        titulo: t,
+        descricao: d,
+        versao_contexto: versaoContexto || null,
+      })
+      toast.showSuccess('Pedido enviado. Pode acompanhar em Minhas solicitações.')
+      onCriado?.(row.id)
+      onClose()
+    } catch (err) {
+      const msg = mensagemFalhaParaToast(err, 'Não foi possível enviar o pedido.')
+      setErro(msg)
+      toast.showError(msg)
+    } finally {
+      setEnviando(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 p-4 sm:items-center" role="dialog" aria-modal>
+      <div className="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-2xl bg-white p-5 shadow-xl dark:bg-slate-900">
+        <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">Enviar sugestão ou relatar problema</h2>
+        <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
+          Conte-nos o que gostaria de ver melhorado. A equipa analisa e responde pelo acompanhamento do pedido.
+        </p>
+
+        <div className="mt-4 space-y-3">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-600 dark:text-slate-300">Tipo</label>
+            <Select
+              value={tipo}
+              onChange={(v) => setTipo(String(v) as SolicitacoesMelhoria.Tipo)}
+              options={[
+                { value: 'sugestao', label: 'Sugestão de melhoria' },
+                { value: 'problema', label: 'Relatar problema' },
+              ]}
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-600 dark:text-slate-300">Título</label>
+            <Input value={titulo} onChange={(e) => setTitulo(e.target.value)} placeholder="Resumo em poucas palavras" maxLength={200} />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-slate-600 dark:text-slate-300">Descrição</label>
+            <textarea
+              className={TEXTAREA_FIELD_CLASS}
+              rows={5}
+              value={descricao}
+              onChange={(e) => setDescricao(e.target.value)}
+              placeholder="Explique o contexto, o que esperava e o impacto no dia a dia."
+              maxLength={8000}
+            />
+          </div>
+          {erro ? <p className="text-sm text-rose-600 dark:text-rose-400">{erro}</p> : null}
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={onClose} disabled={enviando}>
+            Cancelar
+          </Button>
+          <Button type="button" variant="primary" loading={enviando} onClick={() => void enviar()}>
+            Enviar
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/MinhasSolicitacoes.tsx
+++ b/frontend/src/pages/MinhasSolicitacoes.tsx
@@ -1,0 +1,197 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { solicitacoesMelhoria, type SolicitacoesMelhoria } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { PageContainer, PageHeader } from '../components/ui/PageContainer'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { TEXTAREA_FIELD_CLASS } from '../components/ui/Input'
+import { useToast } from '../components/ui/Toast'
+import { useAuth } from '../contexts/AuthContext'
+
+const STATUS_FINAIS = new Set(['concluida', 'nao_sera_desenvolvida'])
+
+function fmt(dt: string): string {
+  try {
+    return new Date(dt).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
+  } catch {
+    return dt
+  }
+}
+
+/** Lista + detalhe das solicitações do utilizador (#803). */
+export function MinhasSolicitacoesPage() {
+  const { id } = useParams()
+  const toast = useToast()
+  const { user } = useAuth()
+  const [lista, setLista] = useState<SolicitacoesMelhoria.ListaItem[]>([])
+  const [detalhe, setDetalhe] = useState<SolicitacoesMelhoria.Detalhe | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [resposta, setResposta] = useState('')
+  const [enviando, setEnviando] = useState(false)
+
+  const carregarLista = useCallback(() => {
+    return solicitacoesMelhoria
+      .minhas()
+      .then(setLista)
+      .catch((err) => toast.showError(mensagemFalhaParaToast(err, 'Falha ao carregar solicitações')))
+  }, [toast])
+
+  useEffect(() => {
+    let cancel = false
+    setLoading(true)
+    void carregarLista().finally(() => {
+      if (!cancel) setLoading(false)
+    })
+    return () => {
+      cancel = true
+    }
+  }, [carregarLista])
+
+  useEffect(() => {
+    if (!id) {
+      setDetalhe(null)
+      return
+    }
+    let cancel = false
+    void solicitacoesMelhoria
+      .get(Number(id))
+      .then((d) => {
+        if (!cancel) setDetalhe(d)
+      })
+      .catch((err) => toast.showError(mensagemFalhaParaToast(err, 'Falha ao abrir solicitação')))
+    return () => {
+      cancel = true
+    }
+  }, [id, toast])
+
+  async function enviarResposta() {
+    if (!detalhe || !resposta.trim()) return
+    setEnviando(true)
+    try {
+      const atualizado = await solicitacoesMelhoria.comentar(detalhe.id, {
+        corpo: resposta.trim(),
+        publico_cliente: true,
+      })
+      setDetalhe(atualizado)
+      setResposta('')
+      toast.showSuccess('Resposta enviada')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível enviar'))
+    } finally {
+      setEnviando(false)
+    }
+  }
+
+  const podeResponder =
+    detalhe &&
+    !STATUS_FINAIS.has(detalhe.status) &&
+    detalhe.autor_atendente_id === user?.id
+
+  if (id && detalhe) {
+    return (
+      <PageContainer>
+        <PageHeader
+          title={detalhe.titulo}
+          subtitle={`${detalhe.tipo === 'problema' ? 'Problema' : 'Sugestão'} · ${detalhe.status_rotulo}`}
+        />
+        <Link to="/minhas-solicitacoes" className="text-sm text-cyan-700 hover:underline dark:text-cyan-400">
+          ← Voltar à lista
+        </Link>
+
+        <Card className="space-y-3 p-5">
+          <p className="text-sm text-slate-700 dark:text-slate-200 whitespace-pre-wrap">{detalhe.descricao}</p>
+          <p className="rounded-lg bg-slate-50 p-3 text-sm text-slate-600 dark:bg-slate-800/60 dark:text-slate-300">
+            {detalhe.mensagem_status}
+          </p>
+          {detalhe.status === 'nao_sera_desenvolvida' && detalhe.motivo_nao_desenvolvimento ? (
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              <span className="font-medium">Motivo: </span>
+              {detalhe.motivo_nao_desenvolvimento}
+            </p>
+          ) : null}
+        </Card>
+
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Acompanhamento</h2>
+          <div className="space-y-2">
+            {detalhe.historico.map((h) => (
+              <Card key={`h-${h.id}`} className="p-3 text-sm">
+                <p className="font-medium text-slate-800 dark:text-slate-100">{h.status_novo_rotulo}</p>
+                {h.mensagem_publica ? (
+                  <p className="mt-1 whitespace-pre-wrap text-slate-600 dark:text-slate-300">{h.mensagem_publica}</p>
+                ) : null}
+                <p className="mt-1 text-xs text-slate-400">{fmt(h.created_at)}</p>
+              </Card>
+            ))}
+            {detalhe.comentarios.map((c) => (
+              <Card key={`c-${c.id}`} className="p-3 text-sm">
+                <p className="text-xs font-medium text-slate-500">{c.autor_nome || 'Equipa'} · {fmt(c.created_at)}</p>
+                <p className="mt-1 whitespace-pre-wrap text-slate-700 dark:text-slate-200">{c.corpo}</p>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        {podeResponder ? (
+          <Card className="space-y-3 p-5">
+            <label className="text-sm font-medium text-slate-700 dark:text-slate-200">Responder</label>
+            <textarea
+              className={TEXTAREA_FIELD_CLASS}
+              rows={3}
+              value={resposta}
+              onChange={(e) => setResposta(e.target.value)}
+              placeholder="Escreva uma mensagem para a equipa…"
+            />
+            <Button type="button" variant="primary" loading={enviando} onClick={() => void enviarResposta()}>
+              Enviar resposta
+            </Button>
+          </Card>
+        ) : STATUS_FINAIS.has(detalhe.status) ? (
+          <p className="text-sm text-slate-500">Este pedido está encerrado e já não aceita respostas.</p>
+        ) : null}
+      </PageContainer>
+    )
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Minhas solicitações"
+        subtitle="Acompanhe sugestões e problemas enviados a partir das notas de versão."
+      />
+      <div className="flex flex-wrap gap-3 text-sm">
+        <Link to="/sobre" className="text-cyan-700 hover:underline dark:text-cyan-400">
+          ← Sobre / Release Notes
+        </Link>
+      </div>
+      {loading ? (
+        <p className="text-sm text-slate-500">A carregar…</p>
+      ) : lista.length === 0 ? (
+        <Card className="p-8 text-center text-sm text-slate-500">
+          Ainda não tem pedidos. Envie uma sugestão em{' '}
+          <Link to="/sobre" className="text-cyan-700 underline dark:text-cyan-400">
+            Sobre
+          </Link>
+          .
+        </Card>
+      ) : (
+        <div className="space-y-2">
+          {lista.map((item) => (
+            <Link key={item.id} to={`/minhas-solicitacoes/${item.id}`} className="block">
+              <Card className="p-4 transition hover:ring-1 hover:ring-cyan-400/50">
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <h3 className="font-semibold text-slate-900 dark:text-slate-50">{item.titulo}</h3>
+                  <span className="text-xs font-medium text-slate-500">{item.status_rotulo}</span>
+                </div>
+                <p className="mt-1 text-xs text-slate-400">
+                  {item.tipo === 'problema' ? 'Problema' : 'Sugestão'} · {fmt(item.created_at)}
+                </p>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </PageContainer>
+  )
+}

--- a/frontend/src/pages/SolicitacoesMelhoriaAdmin.tsx
+++ b/frontend/src/pages/SolicitacoesMelhoriaAdmin.tsx
@@ -1,0 +1,308 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { solicitacoesMelhoria, type SolicitacoesMelhoria } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { PageContainer, PageHeader } from '../components/ui/PageContainer'
+import { Card } from '../components/ui/Card'
+import { Button } from '../components/ui/Button'
+import { Input, TEXTAREA_FIELD_CLASS } from '../components/ui/Input'
+import { Select } from '../components/ui/Select'
+import { useToast } from '../components/ui/Toast'
+
+const STATUS_OPTS = [
+  { value: '', label: 'Todos os status' },
+  { value: 'aberta', label: 'Recebida' },
+  { value: 'em_analise', label: 'Em análise' },
+  { value: 'planejada', label: 'Planejada' },
+  { value: 'em_desenvolvimento', label: 'Em desenvolvimento' },
+  { value: 'concluida', label: 'Concluída' },
+  { value: 'nao_sera_desenvolvida', label: 'Não será desenvolvida' },
+]
+
+function fmt(dt: string): string {
+  try {
+    return new Date(dt).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
+  } catch {
+    return dt
+  }
+}
+
+/** Painel admin de triagem (#804) + GitHub (#805/#806). */
+export function SolicitacoesMelhoriaAdminPage() {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const [lista, setLista] = useState<SolicitacoesMelhoria.ListaItem[]>([])
+  const [detalhe, setDetalhe] = useState<SolicitacoesMelhoria.Detalhe | null>(null)
+  const [filtroStatus, setFiltroStatus] = useState('')
+  const [filtroTipo, setFiltroTipo] = useState('')
+  const [filtroOrg, setFiltroOrg] = useState('')
+  const [desde, setDesde] = useState('')
+  const [ate, setAte] = useState('')
+  const [novoStatus, setNovoStatus] = useState<SolicitacoesMelhoria.Status>('em_analise')
+  const [motivo, setMotivo] = useState('')
+  const [comentario, setComentario] = useState('')
+  const [publico, setPublico] = useState(true)
+  const [busy, setBusy] = useState(false)
+
+  const carregarLista = useCallback(() => {
+    return solicitacoesMelhoria
+      .adminLista({
+        status: filtroStatus || undefined,
+        tipo: filtroTipo || undefined,
+        organizacao_id: filtroOrg ? Number(filtroOrg) : undefined,
+        desde: desde || undefined,
+        ate: ate || undefined,
+      })
+      .then(setLista)
+      .catch((err) => toast.showError(mensagemFalhaParaToast(err, 'Falha ao listar')))
+  }, [filtroStatus, filtroTipo, filtroOrg, desde, ate, toast])
+
+  useEffect(() => {
+    void carregarLista()
+  }, [carregarLista])
+
+  useEffect(() => {
+    if (!id) {
+      setDetalhe(null)
+      return
+    }
+    void solicitacoesMelhoria
+      .get(Number(id))
+      .then((d) => {
+        setDetalhe(d)
+        setNovoStatus(d.status as SolicitacoesMelhoria.Status)
+        setMotivo(d.motivo_nao_desenvolvimento || '')
+      })
+      .catch((err) => toast.showError(mensagemFalhaParaToast(err, 'Falha ao abrir')))
+  }, [id, toast])
+
+  async function salvarStatus() {
+    if (!detalhe) return
+    setBusy(true)
+    try {
+      const atualizado = await solicitacoesMelhoria.alterarStatus(detalhe.id, {
+        status: novoStatus,
+        motivo_nao_desenvolvimento:
+          novoStatus === 'nao_sera_desenvolvida' ? motivo.trim() || null : undefined,
+      })
+      setDetalhe(atualizado)
+      toast.showSuccess('Status atualizado')
+      void carregarLista()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar o status'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function enviarComentario() {
+    if (!detalhe || !comentario.trim()) return
+    setBusy(true)
+    try {
+      const atualizado = await solicitacoesMelhoria.comentar(detalhe.id, {
+        corpo: comentario.trim(),
+        publico_cliente: publico,
+      })
+      setDetalhe(atualizado)
+      setComentario('')
+      toast.showSuccess(publico ? 'Resposta pública enviada' : 'Nota interna registada')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao comentar'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function criarGithub() {
+    if (!detalhe) return
+    setBusy(true)
+    try {
+      const atualizado = await solicitacoesMelhoria.criarGithub(detalhe.id)
+      setDetalhe(atualizado)
+      toast.showSuccess('Issue criada no GitHub')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao criar issue (pode tentar de novo)'))
+      const refreshed = await solicitacoesMelhoria.get(detalhe.id).catch(() => null)
+      if (refreshed) setDetalhe(refreshed)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function syncGithub() {
+    if (!detalhe) return
+    setBusy(true)
+    try {
+      const atualizado = await solicitacoesMelhoria.syncGithub(detalhe.id)
+      setDetalhe(atualizado)
+      toast.showSuccess('Sincronização GitHub concluída (nota interna)')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Falha ao sincronizar'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (id && detalhe) {
+    return (
+      <PageContainer>
+        <PageHeader title={`#${detalhe.id} · ${detalhe.titulo}`} subtitle="Triagem interna" />
+        <button
+          type="button"
+          className="text-sm text-cyan-700 hover:underline dark:text-cyan-400"
+          onClick={() => navigate('/solicitacoes-melhoria')}
+        >
+          ← Voltar à lista
+        </button>
+
+        <Card className="space-y-2 p-5 text-sm">
+          <p>
+            <span className="text-slate-500">Autor:</span> {detalhe.autor_nome || '—'} · org {detalhe.organizacao_id}
+          </p>
+          <p>
+            <span className="text-slate-500">Tipo:</span> {detalhe.tipo} ·{' '}
+            <span className="text-slate-500">Status:</span> {detalhe.status_rotulo}
+          </p>
+          <p className="whitespace-pre-wrap text-slate-800 dark:text-slate-100">{detalhe.descricao}</p>
+          {detalhe.github_issue_url ? (
+            <p>
+              GitHub:{' '}
+              <a href={detalhe.github_issue_url} className="text-cyan-700 underline" target="_blank" rel="noreferrer">
+                #{detalhe.github_issue_number}
+              </a>
+            </p>
+          ) : null}
+          {detalhe.github_last_error ? (
+            <p className="text-rose-600 dark:text-rose-400">Último erro GitHub: {detalhe.github_last_error}</p>
+          ) : null}
+        </Card>
+
+        <Card className="space-y-3 p-5">
+          <h2 className="font-semibold">Alterar status</h2>
+          <Select
+            value={novoStatus}
+            onChange={(v) => setNovoStatus(String(v) as SolicitacoesMelhoria.Status)}
+            options={STATUS_OPTS.filter((o) => o.value !== '') as { value: string; label: string }[]}
+          />
+          {novoStatus === 'nao_sera_desenvolvida' ? (
+            <textarea
+              className={TEXTAREA_FIELD_CLASS}
+              rows={3}
+              value={motivo}
+              onChange={(e) => setMotivo(e.target.value)}
+              placeholder="Motivo amigável para o cliente (obrigatório)"
+            />
+          ) : null}
+          <Button type="button" variant="primary" loading={busy} onClick={() => void salvarStatus()}>
+            Guardar status
+          </Button>
+        </Card>
+
+        <Card className="space-y-3 p-5">
+          <h2 className="font-semibold">Resposta / nota</h2>
+          <textarea
+            className={TEXTAREA_FIELD_CLASS}
+            rows={3}
+            value={comentario}
+            onChange={(e) => setComentario(e.target.value)}
+            placeholder="Mensagem…"
+          />
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={publico} onChange={(e) => setPublico(e.target.checked)} />
+            Visível para o cliente
+          </label>
+          <Button type="button" variant="primary" loading={busy} onClick={() => void enviarComentario()}>
+            Enviar
+          </Button>
+        </Card>
+
+        <Card className="flex flex-wrap gap-2 p-5">
+          <Button type="button" variant="ghost" loading={busy} onClick={() => void criarGithub()} disabled={!!detalhe.github_issue_number}>
+            Criar issue no GitHub
+          </Button>
+          <Button type="button" variant="ghost" loading={busy} onClick={() => void syncGithub()} disabled={!detalhe.github_issue_number}>
+            Sincronizar GitHub
+          </Button>
+        </Card>
+
+        <section className="space-y-2">
+          <h2 className="text-sm font-semibold text-slate-500">Timeline</h2>
+          {detalhe.historico.map((h) => (
+            <Card key={`h-${h.id}`} className="p-3 text-sm">
+              <p className="font-medium">
+                {h.status_novo_rotulo}
+                {h.atendente_nome ? ` · ${h.atendente_nome}` : ''}
+              </p>
+              {h.mensagem_publica ? <p className="mt-1 whitespace-pre-wrap">{h.mensagem_publica}</p> : null}
+              <p className="text-xs text-slate-400">{fmt(h.created_at)}</p>
+            </Card>
+          ))}
+          {detalhe.comentarios.map((c) => (
+            <Card key={`c-${c.id}`} className="p-3 text-sm">
+              <p className="text-xs text-slate-500">
+                {c.publico_cliente ? 'Público' : 'Interno'} · {c.autor_nome || '—'} · {fmt(c.created_at)}
+                {c.origem === 'github' ? ' · GitHub' : ''}
+              </p>
+              <p className="mt-1 whitespace-pre-wrap">{c.corpo}</p>
+            </Card>
+          ))}
+        </section>
+      </PageContainer>
+    )
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader title="Sugestões de clientes" subtitle="Triagem de pedidos vindos das notas de versão." />
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        <Select
+          value={filtroStatus}
+          onChange={(v) => setFiltroStatus(String(v))}
+          options={[
+            { value: 'aberta', label: 'Recebida' },
+            { value: 'em_analise', label: 'Em análise' },
+            { value: 'planejada', label: 'Planejada' },
+            { value: 'em_desenvolvimento', label: 'Em desenvolvimento' },
+            { value: 'concluida', label: 'Concluída' },
+            { value: 'nao_sera_desenvolvida', label: 'Não será desenvolvida' },
+          ]}
+          includeEmpty
+          emptyLabel="Todos os status"
+        />
+        <Select
+          value={filtroTipo}
+          onChange={(v) => setFiltroTipo(String(v))}
+          options={[
+            { value: 'sugestao', label: 'Sugestão' },
+            { value: 'problema', label: 'Problema' },
+          ]}
+          includeEmpty
+          emptyLabel="Todos os tipos"
+        />
+        <Input value={filtroOrg} onChange={(e) => setFiltroOrg(e.target.value)} placeholder="Org / tenant id" />
+        <Input type="date" value={desde} onChange={(e) => setDesde(e.target.value)} aria-label="Desde" />
+        <Input type="date" value={ate} onChange={(e) => setAte(e.target.value)} aria-label="Até" />
+      </div>
+      <div className="space-y-2">
+        {lista.map((item) => (
+          <Link key={item.id} to={`/solicitacoes-melhoria/${item.id}`} className="block">
+            <Card className="p-4 hover:ring-1 hover:ring-cyan-400/40">
+              <div className="flex flex-wrap justify-between gap-2">
+                <h3 className="font-semibold">
+                  #{item.id} {item.titulo}
+                </h3>
+                <span className="text-xs">{item.status_rotulo}</span>
+              </div>
+              <p className="text-xs text-slate-500">
+                {item.autor_nome} · org {item.organizacao_id} · {fmt(item.created_at)}
+                {item.github_issue_number ? ` · GH #${item.github_issue_number}` : ''}
+              </p>
+            </Card>
+          </Link>
+        ))}
+        {lista.length === 0 ? <p className="text-sm text-slate-500">Nenhuma solicitação com estes filtros.</p> : null}
+      </div>
+    </PageContainer>
+  )
+}

--- a/frontend/src/pages/config/configNav.ts
+++ b/frontend/src/pages/config/configNav.ts
@@ -177,6 +177,12 @@ export const CONFIG_GROUPS: ConfigNavGroup[] = [
         hint: 'Histórico de alterações em cadastros e configurações.',
         keywords: ['log', 'histórico', 'alterações'],
       },
+      {
+        slug: 'sugestoes',
+        label: 'Sugestões de clientes',
+        hint: 'Triagem de pedidos enviados a partir das notas de versão.',
+        keywords: ['sugestão', 'feedback', 'release', 'github'],
+      },
     ],
   },
 ]


### PR DESCRIPTION
﻿## Summary

- Closes #799, #800, #801, #802, #803, #804, #805, #806, #807
- Backend: entidade solicitação + histórico + comentários (público/interno) + migration `105`
- Sobre / Release Notes: CTA «Enviar sugestão / relatar problema»
- `/minhas-solicitacoes` — lista, timeline, respostas (bloqueadas em status final)
- Admin `/solicitacoes-melhoria` — filtros, status (motivo obrigatório), resposta pública/nota interna, criar/sync GitHub
- Env opcional: `GITHUB_TOKEN`, `GITHUB_REPO_SUGESTOES`

## CHANGELOG

- [x] `CHANGELOG.md` → `[Unreleased]`

## Test plan

- [ ] `/sobre` → enviar sugestão → sucesso e link Minhas solicitações
- [ ] Autor vê timeline e responde; status «Concluída» bloqueia resposta
- [ ] Admin altera para «Não será desenvolvida» sem motivo → erro; com motivo → OK
- [ ] Nota interna não aparece na vista do autor
- [ ] Sem GitHub configurado: «Criar issue» → 503 amigável; com token → cria e sync gera nota interna
- [ ] Não-admin não acede `/solicitacoes-melhoria`

## Follow-ups

- [ ] Portal cliente (`/portal`) com Release Notes — se quiserem o mesmo fluxo fora do painel interno
- [x] #738 iOS — fim do projecto
