### PR TITLE
feat(faturamento): faturas internas com aprovação e copyright reservado

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Faturamento (#326 / #363 / #364): faturas internas mensais para o financeiro conferir e **aprovar** (ou rejeitar com motivo). Geração automática no início do mês, ou avulsa na tela Faturamento; o botão do mês também reabre rejeitadas. Vencimento no **dia 10 do mês seguinte**. Na empresa, a flag **Emite NFS-e** (ligada por defeito) fica registada na fatura; boleto e nota fiscal só no lote seguinte, e só se a fatura estiver aprovada. O seed cria o setor **Financeiro** se ainda não existir.
 - Sugestões (#799 / #800–#807): a partir de **Sobre** (Release Notes), enviar sugestão ou problema; acompanhar em **Minhas solicitações**; admin faz triagem, responde (público/interno) e pode criar/sincronizar issue no GitHub (só interno)
 - WhatsApp (#837): **Exportar PDF** da conversa (header / menu ⋮) — relatório com protocolo, contacto e mensagens; mídia como rótulo; comentários internos excluídos; mesma permissão de ver o chat
 - Configurações (#833): hub com **pesquisa** e cartões por domínio; menu reorganizado (Equipa e tickets, Canais, Comercial/CRM, Empresa e catálogos, Administração); URLs antigas redireccionam
@@ -63,6 +64,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Interno
 
+- Licença: o repositório deixa a MIT e passa a **copyright reservado** (Luis Gustavo da S. Sousa); copiar, modificar ou usar sem autorização por escrito é proibido — ver `LICENSE`
 - Mobile: brief (`MOBILE_APP_BRIEF.md`) alinhado ao estado real do épico #689 / L6 Android (PWA + Capacitor + listing docs; iOS = #738)
 - Deploy (#734): ligação SSH ao VPS em IPv4, diagnóstico do IP do runner e segunda tentativa noutro runner só em timeout de rede
 - Mobile (#735): `CORS_ORIGINS` das instâncias passa a incluir `https://localhost` (origem do WebView Android)

--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,31 @@
-MIT License
+Copyright (c) 2026 Luis Gustavo da S. Sousa
+Todos os direitos reservados.
 
-Copyright (c) 2026
+O software DX Connect (incluindo código-fonte, documentação, assets e demais
+arquivos deste repositório) é propriedade exclusiva do titular do copyright.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Nenhuma licença é concedida.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+É expressamente proibido, sem autorização prévia e por escrito do titular:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  - copiar, reproduzir ou clonar o software para uso próprio ou de terceiros;
+  - modificar, adaptar ou criar obras derivadas;
+  - distribuir, sublicenciar, publicar, disponibilizar ou vender o software,
+    no todo ou em parte;
+  - usar o software, ou qualquer parte dele, em produto, serviço ou ambiente
+    de produção, comercial ou interno, fora do que o titular autorizar.
 
+A mera disponibilização deste repositório (por exemplo, no GitHub) não
+constitui oferta de licença, cessão de direitos nem autorização de uso.
+
+Componentes de terceiros incluídos neste projeto (bibliotecas, frameworks e
+demais dependências) permanecem sob as respectivas licenças originais.
+Esta reserva de direitos aplica-se apenas ao código e aos materiais de
+autoria do titular.
+
+O software é fornecido "no estado em que se encontra", sem garantias de
+qualquer espécie, expressas ou implícitas, incluindo comercialização e
+adequação a um fim específico.
+
+Para autorização de uso, licenciamento comercial ou qualquer outra permissão:
+gustaavojaco@gmail.com

--- a/README.md
+++ b/README.md
@@ -131,7 +131,10 @@ npm run build
 
 ### Licença
 
-Este projeto está licenciado sob os termos da licença **MIT**. Veja o arquivo `LICENSE` para mais detalhes.
+Copyright (c) 2026 Luis Gustavo da S. Sousa. Todos os direitos reservados.
+O código deste repositório não é software livre: copiar, modificar,
+redistribuir ou usar sem autorização por escrito é proibido.
+Para autorização: gustaavojaco@gmail.com. Veja o arquivo `LICENSE`.
 
 # DX Connect
 

--- a/backend/alembic/versions/106_faturamento_fatura.py
+++ b/backend/alembic/versions/106_faturamento_fatura.py
@@ -1,0 +1,77 @@
+"""Fatura interna e flag emite_nfse na empresa (#326 / #363 / #364).
+
+Revision ID: 106_faturamento_fatura
+Revises: 105_solicitacoes_melhoria
+Create Date: 2026-08-21
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "106_faturamento_fatura"
+down_revision = "105_solicitacoes_melhoria"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("empresas"):
+        cols = {c["name"] for c in insp.get_columns("empresas")}
+        if "emite_nfse" not in cols:
+            op.add_column(
+                "empresas",
+                sa.Column("emite_nfse", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            )
+
+    if not insp.has_table("faturamento_faturas"):
+        op.create_table(
+            "faturamento_faturas",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column(
+                "contrato_id",
+                sa.Integer(),
+                sa.ForeignKey("comercial_contratos.id", ondelete="RESTRICT"),
+                nullable=False,
+            ),
+            sa.Column(
+                "empresa_id",
+                sa.Integer(),
+                sa.ForeignKey("empresas.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("competencia", sa.String(7), nullable=False),
+            sa.Column("valor", sa.Numeric(14, 2), nullable=False),
+            sa.Column("vencimento", sa.Date(), nullable=False),
+            sa.Column("emite_nfse", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("status", sa.String(32), nullable=False, server_default="aguardando_aprovacao"),
+            sa.Column("rejeicao_motivo", sa.Text(), nullable=True),
+            sa.Column("gerada_em", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column(
+                "aprovada_por_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+                nullable=True,
+            ),
+            sa.Column("aprovada_em", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+            sa.UniqueConstraint("contrato_id", "competencia", name="uq_faturamento_fatura_contrato_competencia"),
+        )
+        op.create_index("ix_faturamento_faturas_contrato_id", "faturamento_faturas", ["contrato_id"])
+        op.create_index("ix_faturamento_faturas_empresa_id", "faturamento_faturas", ["empresa_id"])
+        op.create_index("ix_faturamento_faturas_competencia", "faturamento_faturas", ["competencia"])
+        op.create_index("ix_faturamento_faturas_status", "faturamento_faturas", ["status"])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("faturamento_faturas"):
+        op.drop_table("faturamento_faturas")
+    if insp.has_table("empresas"):
+        cols = {c["name"] for c in insp.get_columns("empresas")}
+        if "emite_nfse" in cols:
+            op.drop_column("empresas", "emite_nfse")

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -13,7 +13,7 @@ from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import exigir_admin, obter_atendente_atual, validar_role
 from app.services.atendente_avaliacoes import calcular_avaliacoes_atendente
 from app.services.escala import validar_campos_escala, validar_horario_previsto
-from app.core.setor_scope import ids_setores_mesmo_nome, ids_setores_visiveis_atendente
+from app.core.setor_scope import atendente_e_financeiro, ids_setores_mesmo_nome, ids_setores_visiveis_atendente
 from app.core.security import hash_senha, verificar_senha
 from app.core.audit import registrar_audit
 
@@ -30,7 +30,7 @@ class OrdenarAtendentesPor(str, Enum):
     ativo = "ativo"
 
 
-def _atendente_para_read(atendente: Atendente) -> AtendenteRead:
+def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) -> AtendenteRead:
     return AtendenteRead(
         id=atendente.id,
         email=atendente.email,
@@ -40,6 +40,7 @@ def _atendente_para_read(atendente: Atendente) -> AtendenteRead:
         created_at=atendente.created_at,
         updated_at=atendente.updated_at,
         setor_ids=[s.id for s in atendente.setores],
+        e_financeiro=e_financeiro,
         must_change_password=bool(getattr(atendente, "must_change_password", False)),
         usa_escala=bool(getattr(atendente, "usa_escala", False)),
         escala_horas_trabalho=getattr(atendente, "escala_horas_trabalho", None),
@@ -139,8 +140,11 @@ def criar_atendente(
 
 
 @router.get("/me", response_model=AtendenteRead)
-def me(atendente: Atendente = Depends(obter_atendente_atual)):
-    return _atendente_para_read(atendente)
+def me(
+    atendente: Atendente = Depends(obter_atendente_atual),
+    db: Session = Depends(get_db),
+):
+    return _atendente_para_read(atendente, e_financeiro=atendente_e_financeiro(db, atendente))
 
 
 @router.post("/me/trocar-senha", response_model=AtendenteRead)

--- a/backend/app/api/faturamento.py
+++ b/backend/app/api/faturamento.py
@@ -1,0 +1,123 @@
+"""Faturamento — faturas internas e aprovação (#326)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query, Response
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.core.auth import exigir_financeiro_ou_admin
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.schemas.faturamento import (
+    ContratoElegivelRead,
+    FaturaGerarCompetenciaIn,
+    FaturaGerarCompetenciaOut,
+    FaturaGerarIn,
+    FaturaRead,
+    FaturaRejeitarIn,
+)
+from app.services import faturamento as svc
+
+router = APIRouter(prefix="/faturamento", tags=["faturamento"])
+
+
+@router.get("/faturas", response_model=list[FaturaRead])
+def listar_faturas(
+    competencia: str | None = Query(None),
+    status: str | None = Query(None),
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_financeiro_ou_admin),
+):
+    rows = svc.listar_faturas(db, competencia=competencia, status_filtro=status)
+    return [svc.fatura_para_read(db, r) for r in rows]
+
+
+@router.get("/contratos-elegiveis", response_model=list[ContratoElegivelRead])
+def listar_contratos_elegiveis(
+    db: Session = Depends(get_db),
+    _: Atendente = Depends(exigir_financeiro_ou_admin),
+):
+    return svc.listar_contratos_elegiveis(db)
+
+
+@router.post("/faturas", response_model=FaturaRead)
+def gerar_fatura(
+    data: FaturaGerarIn,
+    response: Response,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_financeiro_ou_admin),
+):
+    row, created = svc.gerar_fatura_contrato(db, data.contrato_id, data.competencia)
+    registrar_audit(
+        db,
+        "faturamento_fatura",
+        row.id,
+        "create" if created else "update",
+        atendente.id,
+        payload={"contrato_id": row.contrato_id, "competencia": row.competencia},
+    )
+    db.commit()
+    response.status_code = 201 if created else 200
+    return svc.fatura_para_read(db, svc.obter_fatura(db, row.id))
+
+
+@router.post("/faturas/gerar-competencia", response_model=FaturaGerarCompetenciaOut)
+def gerar_competencia(
+    data: FaturaGerarCompetenciaIn,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_financeiro_ou_admin),
+):
+    competencia, criadas, existentes, reabertas, audit_id = svc.gerar_competencia(
+        db, data.competencia, reabrir_rejeitadas=True
+    )
+    if audit_id is not None:
+        registrar_audit(
+            db,
+            "faturamento_fatura",
+            audit_id,
+            "create" if criadas else "update",
+            atendente.id,
+            payload={"competencia": competencia, "criadas": criadas, "reabertas": reabertas},
+        )
+    db.commit()
+    return {
+        "competencia": competencia,
+        "criadas": criadas,
+        "existentes": existentes,
+        "reabertas": reabertas,
+    }
+
+
+@router.post("/faturas/{fatura_id}/aprovar", response_model=FaturaRead)
+def aprovar_fatura(
+    fatura_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_financeiro_ou_admin),
+):
+    row = svc.obter_fatura(db, fatura_id)
+    row = svc.aprovar_fatura(db, row, atendente)
+    registrar_audit(db, "faturamento_fatura", row.id, "update", atendente.id, payload={"status": row.status})
+    db.commit()
+    return svc.fatura_para_read(db, svc.obter_fatura(db, row.id))
+
+
+@router.post("/faturas/{fatura_id}/rejeitar", response_model=FaturaRead)
+def rejeitar_fatura(
+    fatura_id: int,
+    data: FaturaRejeitarIn,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(exigir_financeiro_ou_admin),
+):
+    row = svc.obter_fatura(db, fatura_id)
+    row = svc.rejeitar_fatura(db, row, data.motivo)
+    registrar_audit(
+        db,
+        "faturamento_fatura",
+        row.id,
+        "update",
+        atendente.id,
+        payload={"status": row.status},
+    )
+    db.commit()
+    return svc.fatura_para_read(db, svc.obter_fatura(db, row.id))

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -1,9 +1,10 @@
 from fastapi import Depends, HTTPException, Query, Request, status
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, subqueryload
 
 from app.database import get_db
 from app.models.atendente import Atendente
+from app.core.setor_scope import atendente_e_financeiro
 from app.core.security import decodificar_token
 from app.core.tenant_context import (
     assert_token_tenant_matches_request,
@@ -42,6 +43,7 @@ def _carregar_atendente_por_token(
         tenant_id = effective_tenant_id()
     atendente = (
         db.query(Atendente)
+        .options(subqueryload(Atendente.setores))
         .filter(
             Atendente.tenant_id == tenant_id,
             Atendente.email == email,
@@ -120,6 +122,19 @@ def exigir_comercial_ou_admin(atendente: Atendente = Depends(obter_atendente_atu
             detail="Acesso restrito a perfil comercial ou administrador",
         )
     return atendente
+
+
+def exigir_financeiro_ou_admin(
+    atendente: Atendente = Depends(obter_atendente_atual),
+    db: Session = Depends(get_db),
+) -> Atendente:
+    """Faturamento interno (#326): admin ou atendente do setor Financeiro."""
+    if atendente_e_financeiro(db, atendente):
+        return atendente
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Acesso restrito ao setor Financeiro ou administrador",
+    )
 
 
 def exigir_saas_ops(atendente: Atendente = Depends(obter_atendente_atual)) -> Atendente:

--- a/backend/app/core/setor_scope.py
+++ b/backend/app/core/setor_scope.py
@@ -34,6 +34,27 @@ def ids_setores_mesmo_nome(db: Session, setor_id: int) -> set[int]:
     return out if out else {setor_id}
 
 
+def ids_setores_financeiro(db: Session) -> set[int]:
+    """Setores Financeiro (slug ou nome) e homônimos — aprovação de faturas (#326)."""
+    rows = db.query(Setor).filter(Setor.ativo.is_(True)).all()
+    ids: set[int] = set()
+    for s in rows:
+        slug = (s.slug or "").strip().lower()
+        nome = (s.nome or "").strip().lower()
+        if slug == "financeiro" or nome == "financeiro":
+            ids.add(s.id)
+            ids |= ids_setores_mesmo_nome(db, s.id)
+    return ids
+
+
+def atendente_e_financeiro(db: Session, atendente: Atendente) -> bool:
+    """Admin ou vínculo ao setor Financeiro (inclui homônimos)."""
+    if atendente.role == "admin":
+        return True
+    vis = ids_setores_visiveis_atendente(db, atendente)
+    return bool(vis & ids_setores_financeiro(db))
+
+
 def ids_setores_visiveis_atendente(db: Session, atendente: Atendente) -> set[int]:
     """IDs de setor que o atendente enxerga (inclui duplicatas de nome dos vínculos dele)."""
     out: set[int] = set()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -44,6 +44,7 @@ from app.api import (
     comercial_proposta,
     comercial_contrato,
     implantacao,
+    faturamento,
     crm,
     system_settings,
     tenant,
@@ -390,6 +391,32 @@ async def lifespan(app: FastAPI):
         name="ponto-fecho-automatico",
     ).start()
 
+    def faturamento_mensal_loop() -> None:
+        from app.database import SessionLocal
+        from app.services.faturamento import processar_faturamento_mensal
+
+        interval = 300
+        while True:
+            db = SessionLocal()
+            try:
+                n = processar_faturamento_mensal(db)
+                if n:
+                    db.commit()
+                else:
+                    db.rollback()
+            except Exception as e:
+                logger.warning("Worker faturamento mensal: %s", e)
+                db.rollback()
+            finally:
+                db.close()
+            time.sleep(interval)
+
+    threading.Thread(
+        target=faturamento_mensal_loop,
+        daemon=True,
+        name="faturamento-mensal",
+    ).start()
+
     if settings.SAAS_CONTROL_PLANE:
 
         def saas_provision_loop() -> None:
@@ -573,6 +600,7 @@ app.include_router(comercial_custos.router, prefix=API_V1_PREFIX)
 app.include_router(comercial_proposta.router, prefix=API_V1_PREFIX)
 app.include_router(comercial_contrato.router, prefix=API_V1_PREFIX)
 app.include_router(implantacao.router, prefix=API_V1_PREFIX)
+app.include_router(faturamento.router, prefix=API_V1_PREFIX)
 app.include_router(crm.router, prefix=API_V1_PREFIX)
 app.include_router(empresa_pdvs.router, prefix=API_V1_PREFIX)
 app.include_router(system_settings.router, prefix=API_V1_PREFIX)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -66,6 +66,7 @@ from app.models.crm import (
 )
 from app.models.comercial_proposta import Proposta, PropostaTemplate
 from app.models.comercial_contrato import Contrato, ContratoPdf, ContratoPolitica, ContratoTemplate
+from app.models.faturamento import Fatura
 from app.models.implantacao_checklist import (
     ImplantacaoChecklistTemplate,
     ImplantacaoChecklistTemplateItem,
@@ -164,6 +165,7 @@ __all__ = [
     "Proposta",
     "ContratoTemplate",
     "Contrato",
+    "Fatura",
     "ContratoPdf",
     "ContratoPolitica",
     "ImplantacaoChecklistTemplate",

--- a/backend/app/models/empresa.py
+++ b/backend/app/models/empresa.py
@@ -44,6 +44,8 @@ class Empresa(Base):
     resp_legal_estado = Column(String(2), nullable=True)
     resp_legal_cep = Column(String(10), nullable=True)
     ativo = Column(Boolean, default=True)
+    # NFS-e na emissão (lote 3); fatura copia o snapshot (#364)
+    emite_nfse = Column(Boolean, nullable=False, default=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/app/models/faturamento.py
+++ b/backend/app/models/faturamento.py
@@ -1,0 +1,41 @@
+"""Fatura interna mensal — conferência do financeiro antes de boleto/NFS-e (#326)."""
+
+from __future__ import annotations
+
+from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, Numeric, String, Text, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+FATURA_AGUARDANDO = "aguardando_aprovacao"
+FATURA_APROVADA = "aprovada"
+FATURA_REJEITADA = "rejeitada"
+FATURA_CANCELADA = "cancelada"
+FATURA_STATUSES = frozenset({FATURA_AGUARDANDO, FATURA_APROVADA, FATURA_REJEITADA, FATURA_CANCELADA})
+
+VENCIMENTO_DIA_PADRAO = 10
+
+
+class Fatura(Base):
+    __tablename__ = "faturamento_faturas"
+    __table_args__ = (UniqueConstraint("contrato_id", "competencia", name="uq_faturamento_fatura_contrato_competencia"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    contrato_id = Column(Integer, ForeignKey("comercial_contratos.id", ondelete="RESTRICT"), nullable=False, index=True)
+    empresa_id = Column(Integer, ForeignKey("empresas.id", ondelete="SET NULL"), nullable=True, index=True)
+    competencia = Column(String(7), nullable=False, index=True)  # YYYY-MM
+    valor = Column(Numeric(14, 2), nullable=False)
+    vencimento = Column(Date, nullable=False)
+    emite_nfse = Column(Boolean, nullable=False, default=True)
+    status = Column(String(32), nullable=False, default=FATURA_AGUARDANDO, index=True)
+    rejeicao_motivo = Column(Text, nullable=True)
+    gerada_em = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    aprovada_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    aprovada_em = Column(DateTime(timezone=True), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    contrato = relationship("Contrato")
+    empresa = relationship("Empresa")
+    aprovada_por = relationship("Atendente", foreign_keys=[aprovada_por_id])

--- a/backend/app/schemas/atendente.py
+++ b/backend/app/schemas/atendente.py
@@ -45,6 +45,7 @@ class AtendenteRead(AtendenteBase):
     created_at: datetime | None = None
     updated_at: datetime | None = None
     setor_ids: list[int] = []
+    e_financeiro: bool = False
     must_change_password: bool = False
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/empresa.py
+++ b/backend/app/schemas/empresa.py
@@ -36,6 +36,7 @@ class EmpresaBase(BaseModel):
     resp_legal_estado: str | None = None
     resp_legal_cep: str | None = None
     ativo: bool = True
+    emite_nfse: bool = True
 
 
 class EmpresaCreate(EmpresaBase):
@@ -76,6 +77,7 @@ class EmpresaUpdate(BaseModel):
     resp_legal_estado: str | None = None
     resp_legal_cep: str | None = None
     ativo: bool | None = None
+    emite_nfse: bool | None = None
 
 
 class EmpresaRead(EmpresaBase):

--- a/backend/app/schemas/faturamento.py
+++ b/backend/app/schemas/faturamento.py
@@ -1,0 +1,54 @@
+from datetime import date, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class FaturaRead(BaseModel):
+    id: int
+    contrato_id: int
+    empresa_id: int | None = None
+    empresa_nome: str | None = None
+    cnpj: str | None = None
+    razao_social: str | None = None
+    competencia: str
+    valor: Decimal
+    vencimento: date
+    emite_nfse: bool
+    status: str
+    rejeicao_motivo: str | None = None
+    gerada_em: datetime | None = None
+    aprovada_por_id: int | None = None
+    aprovada_por_nome: str | None = None
+    aprovada_em: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class FaturaGerarIn(BaseModel):
+    contrato_id: int
+    competencia: str | None = Field(None, description="YYYY-MM; omite = mês atual (America/Sao_Paulo)")
+
+
+class FaturaGerarCompetenciaIn(BaseModel):
+    competencia: str | None = None
+
+
+class FaturaRejeitarIn(BaseModel):
+    motivo: str = Field(..., min_length=3, max_length=2000)
+
+
+class FaturaGerarCompetenciaOut(BaseModel):
+    competencia: str
+    criadas: int
+    existentes: int
+    reabertas: int = 0
+
+
+class ContratoElegivelRead(BaseModel):
+    id: int
+    empresa_id: int | None = None
+    empresa_nome: str | None = None
+    cnpj: str | None = None
+    razao_social: str | None = None
+    valor_mensalidade: Decimal

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -5,7 +5,7 @@ import bcrypt
 
 from app.config import settings
 from app.database import SessionLocal
-from app.models import StatusTicket, Atendente, Tenant
+from app.models import StatusTicket, Atendente, Tenant, Setor
 
 
 def _hash_senha(senha: str) -> str:
@@ -30,6 +30,18 @@ def _ensure_status_aguardando_atendimento(db):
     print("Status «Aguardando atendimento» adicionado (fila do setor).")
 
 
+def _ensure_setor_financeiro(db):
+    """Setor usado na aprovação de faturas (#326) — slug financeiro."""
+    if db.query(Setor).filter(func.lower(Setor.slug) == "financeiro").first():
+        return
+    tenant = db.query(Tenant).order_by(Tenant.id.asc()).first()
+    if not tenant:
+        return
+    db.add(Setor(tenant_id=tenant.id, nome="Financeiro", slug="financeiro", ativo=True))
+    db.commit()
+    print("Setor Financeiro criado (faturamento).")
+
+
 def _ensure_default_tenant(db):
     if not db.query(Tenant).filter(Tenant.id == 1).first():
         db.add(Tenant(id=1, nome="Padrão", ativo=True))
@@ -40,6 +52,7 @@ def run_seed():
     db = SessionLocal()
     try:
         _ensure_default_tenant(db)
+        _ensure_setor_financeiro(db)
         if db.query(StatusTicket).count() == 0:
             for ordem, (nome, slug) in enumerate(
                 [

--- a/backend/app/services/faturamento.py
+++ b/backend/app/services/faturamento.py
@@ -1,0 +1,274 @@
+"""Fatura interna: geração mensal e aprovação do financeiro (#326)."""
+
+from __future__ import annotations
+
+import calendar
+import re
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session, joinedload
+
+from app.models.atendente import Atendente
+from app.models.comercial_contrato import CONTRATO_ASSINADO, Contrato
+from app.models.crm import CrmNegociacaoCnpjLinha
+from app.models.empresa import Empresa
+from app.models.faturamento import (
+    FATURA_AGUARDANDO,
+    FATURA_APROVADA,
+    FATURA_CANCELADA,
+    FATURA_REJEITADA,
+    VENCIMENTO_DIA_PADRAO,
+    Fatura,
+)
+
+TZ_SP = ZoneInfo("America/Sao_Paulo")
+_COMPETENCIA_RE = re.compile(r"^(\d{4})-(\d{2})$")
+
+
+def competencia_atual(hoje: date | None = None) -> str:
+    d = hoje or datetime.now(TZ_SP).date()
+    return f"{d.year:04d}-{d.month:02d}"
+
+
+def validar_competencia(valor: str | None) -> str:
+    raw = (valor or competencia_atual()).strip()
+    m = _COMPETENCIA_RE.match(raw)
+    if not m:
+        raise HTTPException(status_code=400, detail="Competência inválida. Use YYYY-MM.")
+    ano, mes = int(m.group(1)), int(m.group(2))
+    if mes < 1 or mes > 12:
+        raise HTTPException(status_code=400, detail="Competência inválida. Use YYYY-MM.")
+    return f"{ano:04d}-{mes:02d}"
+
+
+def vencimento_da_competencia(competencia: str) -> date:
+    """Dia 10 do mês seguinte à competência (fatura de agosto vence em 10/09)."""
+    ano, mes = (int(p) for p in competencia.split("-"))
+    if mes == 12:
+        ano, mes = ano + 1, 1
+    else:
+        mes += 1
+    ultimo = calendar.monthrange(ano, mes)[1]
+    dia = min(VENCIMENTO_DIA_PADRAO, ultimo)
+    return date(ano, mes, dia)
+
+
+def _linha_contrato(db: Session, contrato: Contrato) -> CrmNegociacaoCnpjLinha | None:
+    if contrato.linha:
+        return contrato.linha
+    return db.query(CrmNegociacaoCnpjLinha).filter(CrmNegociacaoCnpjLinha.id == contrato.negociacao_linha_cnpj_id).first()
+
+
+def fatura_para_read(db: Session, row: Fatura) -> dict:
+    contrato = row.contrato or db.query(Contrato).filter(Contrato.id == row.contrato_id).first()
+    empresa = row.empresa
+    if empresa is None and row.empresa_id:
+        empresa = db.query(Empresa).filter(Empresa.id == row.empresa_id).first()
+    linha = _linha_contrato(db, contrato) if contrato else None
+    return {
+        "id": row.id,
+        "contrato_id": row.contrato_id,
+        "empresa_id": row.empresa_id,
+        "empresa_nome": empresa.nome if empresa else None,
+        "cnpj": linha.cnpj if linha else (empresa.cnpj_cpf if empresa else None),
+        "razao_social": (linha.razao_social if linha else None) or (empresa.razao_social if empresa else None),
+        "competencia": row.competencia,
+        "valor": row.valor,
+        "vencimento": row.vencimento,
+        "emite_nfse": bool(row.emite_nfse),
+        "status": row.status,
+        "rejeicao_motivo": row.rejeicao_motivo,
+        "gerada_em": row.gerada_em,
+        "aprovada_por_id": row.aprovada_por_id,
+        "aprovada_por_nome": row.aprovada_por.nome if row.aprovada_por else None,
+        "aprovada_em": row.aprovada_em,
+    }
+
+
+def _contratos_faturaveis(db: Session) -> list[Contrato]:
+    return (
+        db.query(Contrato)
+        .options(joinedload(Contrato.linha))
+        .filter(Contrato.status == CONTRATO_ASSINADO, Contrato.empresa_id.isnot(None))
+        .order_by(Contrato.id.asc())
+        .all()
+    )
+
+
+def _emite_nfse_empresa(db: Session, empresa_id: int | None) -> bool:
+    if not empresa_id:
+        return True
+    emp = db.query(Empresa).filter(Empresa.id == empresa_id).first()
+    if emp is None:
+        return True
+    return bool(getattr(emp, "emite_nfse", True))
+
+
+def _competencia_antes_inicio(contrato: Contrato, competencia: str) -> bool:
+    inicio = contrato.data_inicio
+    if inicio is None:
+        return False
+    return competencia < f"{inicio.year:04d}-{inicio.month:02d}"
+
+
+def _preencher_fatura(db: Session, row: Fatura, contrato: Contrato, competencia: str) -> None:
+    row.contrato_id = contrato.id
+    row.empresa_id = contrato.empresa_id
+    row.competencia = competencia
+    row.valor = Decimal(str(contrato.valor_mensalidade or 0))
+    row.vencimento = vencimento_da_competencia(competencia)
+    row.emite_nfse = _emite_nfse_empresa(db, contrato.empresa_id)
+    row.status = FATURA_AGUARDANDO
+    row.rejeicao_motivo = None
+    row.aprovada_por_id = None
+    row.aprovada_em = None
+    row.gerada_em = datetime.now(timezone.utc)
+
+
+def obter_fatura(db: Session, fatura_id: int) -> Fatura:
+    row = (
+        db.query(Fatura)
+        .options(
+            joinedload(Fatura.contrato).joinedload(Contrato.linha),
+            joinedload(Fatura.empresa),
+            joinedload(Fatura.aprovada_por),
+        )
+        .filter(Fatura.id == fatura_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Fatura não encontrada.")
+    return row
+
+
+def listar_faturas(db: Session, *, competencia: str | None, status_filtro: str | None) -> list[Fatura]:
+    q = db.query(Fatura).options(
+        joinedload(Fatura.contrato).joinedload(Contrato.linha),
+        joinedload(Fatura.empresa),
+        joinedload(Fatura.aprovada_por),
+    )
+    if competencia:
+        q = q.filter(Fatura.competencia == validar_competencia(competencia))
+    if status_filtro:
+        q = q.filter(Fatura.status == status_filtro.strip())
+    return q.order_by(Fatura.competencia.desc(), Fatura.id.desc()).all()
+
+
+def listar_contratos_elegiveis(db: Session) -> list[dict]:
+    out: list[dict] = []
+    for c in _contratos_faturaveis(db):
+        emp = db.query(Empresa).filter(Empresa.id == c.empresa_id).first() if c.empresa_id else None
+        linha = _linha_contrato(db, c)
+        out.append(
+            {
+                "id": c.id,
+                "empresa_id": c.empresa_id,
+                "empresa_nome": emp.nome if emp else None,
+                "cnpj": linha.cnpj if linha else (emp.cnpj_cpf if emp else None),
+                "razao_social": (linha.razao_social if linha else None) or (emp.razao_social if emp else None),
+                "valor_mensalidade": c.valor_mensalidade,
+            }
+        )
+    return out
+
+
+def gerar_fatura_contrato(db: Session, contrato_id: int, competencia: str | None) -> tuple[Fatura, bool]:
+    comp = validar_competencia(competencia)
+    contrato = (
+        db.query(Contrato)
+        .options(joinedload(Contrato.linha))
+        .filter(Contrato.id == contrato_id)
+        .first()
+    )
+    if not contrato:
+        raise HTTPException(status_code=404, detail="Contrato não encontrado.")
+    if contrato.status != CONTRATO_ASSINADO or not contrato.empresa_id:
+        raise HTTPException(status_code=400, detail="Só contratos assinados com empresa vinculada geram fatura.")
+    if _competencia_antes_inicio(contrato, comp):
+        raise HTTPException(status_code=400, detail="Competência anterior ao início do contrato.")
+    existente = db.query(Fatura).filter(Fatura.contrato_id == contrato.id, Fatura.competencia == comp).first()
+    if existente:
+        if existente.status == FATURA_APROVADA:
+            raise HTTPException(status_code=400, detail="Já existe fatura aprovada desta competência.")
+        if existente.status == FATURA_CANCELADA:
+            raise HTTPException(status_code=400, detail="Fatura desta competência está cancelada.")
+        if existente.status == FATURA_AGUARDANDO:
+            return existente, False
+        _preencher_fatura(db, existente, contrato, comp)
+        db.flush()
+        return existente, False
+    row = Fatura()
+    _preencher_fatura(db, row, contrato, comp)
+    db.add(row)
+    db.flush()
+    return row, True
+
+
+def gerar_competencia(
+    db: Session,
+    competencia: str | None,
+    *,
+    reabrir_rejeitadas: bool = False,
+) -> tuple[str, int, int, int, int | None]:
+    """Gera faturas da competência. O job não reabre rejeitadas; a acção manual sim."""
+    comp = validar_competencia(competencia)
+    criadas = 0
+    existentes = 0
+    reabertas = 0
+    audit_id: int | None = None
+    for contrato in _contratos_faturaveis(db):
+        if _competencia_antes_inicio(contrato, comp):
+            continue
+        existente = db.query(Fatura).filter(Fatura.contrato_id == contrato.id, Fatura.competencia == comp).first()
+        if existente:
+            if reabrir_rejeitadas and existente.status == FATURA_REJEITADA:
+                _preencher_fatura(db, existente, contrato, comp)
+                reabertas += 1
+                if audit_id is None:
+                    audit_id = existente.id
+            else:
+                existentes += 1
+            continue
+        row = Fatura()
+        _preencher_fatura(db, row, contrato, comp)
+        db.add(row)
+        db.flush()
+        criadas += 1
+        if audit_id is None:
+            audit_id = row.id
+    db.flush()
+    return comp, criadas, existentes, reabertas, audit_id
+
+
+def processar_faturamento_mensal(db: Session) -> int:
+    """Job: gera faturas novas da competência atual (idempotente; não reabre rejeitadas)."""
+    _, criadas, _, _, _ = gerar_competencia(db, None, reabrir_rejeitadas=False)
+    return criadas
+
+
+def aprovar_fatura(db: Session, row: Fatura, ator: Atendente) -> Fatura:
+    if row.status != FATURA_AGUARDANDO:
+        raise HTTPException(status_code=400, detail="Só faturas aguardando aprovação podem ser aprovadas.")
+    row.status = FATURA_APROVADA
+    row.aprovada_por_id = ator.id
+    row.aprovada_em = datetime.now(timezone.utc)
+    row.rejeicao_motivo = None
+    db.flush()
+    return row
+
+
+def rejeitar_fatura(db: Session, row: Fatura, motivo: str) -> Fatura:
+    if row.status != FATURA_AGUARDANDO:
+        raise HTTPException(status_code=400, detail="Só faturas aguardando aprovação podem ser rejeitadas.")
+    texto = (motivo or "").strip()
+    if len(texto) < 3:
+        raise HTTPException(status_code=400, detail="Informe o motivo da rejeição.")
+    row.status = FATURA_REJEITADA
+    row.rejeicao_motivo = texto
+    row.aprovada_por_id = None
+    row.aprovada_em = None
+    db.flush()
+    return row

--- a/backend/tests/test_faturamento.py
+++ b/backend/tests/test_faturamento.py
@@ -1,0 +1,167 @@
+"""Fatura interna e aprovação do financeiro (#326 / #363 / #364)."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from app.database import SessionLocal
+from app.services.faturamento import processar_faturamento_mensal, vencimento_da_competencia
+from tests.test_implantacao import _assinar_contrato
+
+
+def test_vencimento_dia_10_mes_seguinte():
+    assert vencimento_da_competencia("2026-08") == date(2026, 9, 10)
+    assert vencimento_da_competencia("2026-12") == date(2027, 1, 10)
+
+
+def test_rbac_faturamento(client, auth_headers):
+    h_com = auth_headers["comercial"]
+    h_a1 = auth_headers["a1"]
+    h_a2 = auth_headers["a2"]
+    h_admin = auth_headers["admin"]
+    assert client.get("/v1/faturamento/faturas", headers=h_com).status_code == 403
+    assert client.get("/v1/faturamento/faturas", headers=h_a1).status_code == 403
+    assert client.get("/v1/faturamento/faturas", headers=h_a2).status_code == 200
+    assert client.get("/v1/faturamento/faturas", headers=h_admin).status_code == 200
+    me_a2 = client.get("/v1/atendentes/me", headers=h_a2)
+    assert me_a2.status_code == 200
+    assert me_a2.json()["e_financeiro"] is True
+    me_a1 = client.get("/v1/atendentes/me", headers=h_a1)
+    assert me_a1.json()["e_financeiro"] is False
+    me_admin = client.get("/v1/atendentes/me", headers=h_admin)
+    assert me_admin.json()["e_financeiro"] is True
+
+    assert client.post(
+        "/v1/faturamento/faturas/99999/aprovar",
+        headers=h_a1,
+    ).status_code == 403
+    assert client.post(
+        "/v1/faturamento/faturas/99999/aprovar",
+        headers=h_a2,
+    ).status_code == 404
+    assert client.post(
+        "/v1/faturamento/faturas",
+        headers=h_a2,
+        json={"contrato_id": 99999, "competencia": "2026-08"},
+    ).status_code == 404
+
+
+def test_gerar_aprovar_rejeitar_e_job_idempotente(client, auth_headers):
+    h_com = auth_headers["comercial"]
+    h_fin = auth_headers["a2"]
+    h_admin = auth_headers["admin"]
+    contrato = _assinar_contrato(client, h_com)
+    cid = contrato["id"]
+    empresa_id = contrato["empresa_id"]
+    assert empresa_id
+
+    patch_nf = client.patch(
+        f"/v1/empresas/{empresa_id}",
+        headers=h_admin,
+        json={"emite_nfse": False},
+    )
+    assert patch_nf.status_code == 200, patch_nf.text
+    assert patch_nf.json()["emite_nfse"] is False
+
+    g = client.post(
+        "/v1/faturamento/faturas",
+        headers=h_fin,
+        json={"contrato_id": cid, "competencia": "2026-08"},
+    )
+    assert g.status_code == 201, g.text
+    fatura = g.json()
+    assert fatura["status"] == "aguardando_aprovacao"
+    assert fatura["competencia"] == "2026-08"
+    assert fatura["emite_nfse"] is False
+    assert float(fatura["valor"]) == 900.0
+    assert fatura["vencimento"] == "2026-09-10"
+    fid = fatura["id"]
+
+    dup = client.post(
+        "/v1/faturamento/faturas",
+        headers=h_fin,
+        json={"contrato_id": cid, "competencia": "2026-08"},
+    )
+    assert dup.status_code == 200
+    assert dup.json()["id"] == fid
+
+    curto = client.post(
+        f"/v1/faturamento/faturas/{fid}/rejeitar",
+        headers=h_fin,
+        json={"motivo": "ab"},
+    )
+    assert curto.status_code == 422
+
+    rejeita = client.post(
+        f"/v1/faturamento/faturas/{fid}/rejeitar",
+        headers=h_fin,
+        json={"motivo": "Valor conferido no contrato está desatualizado"},
+    )
+    assert rejeita.status_code == 200, rejeita.text
+    assert rejeita.json()["status"] == "rejeitada"
+
+    db = SessionLocal()
+    try:
+        processar_faturamento_mensal(db)
+        db.commit()
+    finally:
+        db.close()
+    ainda = client.get("/v1/faturamento/faturas", headers=h_fin, params={"competencia": "2026-08"})
+    assert any(x["id"] == fid and x["status"] == "rejeitada" for x in ainda.json())
+
+    lote = client.post(
+        "/v1/faturamento/faturas/gerar-competencia",
+        headers=h_admin,
+        json={"competencia": "2026-08"},
+    )
+    assert lote.status_code == 200, lote.text
+    assert lote.json()["reabertas"] >= 1
+    reaberta = client.get("/v1/faturamento/faturas", headers=h_fin, params={"competencia": "2026-08"})
+    assert any(x["id"] == fid and x["status"] == "aguardando_aprovacao" for x in reaberta.json())
+
+    regen = client.post(
+        "/v1/faturamento/faturas",
+        headers=h_fin,
+        json={"contrato_id": cid, "competencia": "2026-08"},
+    )
+    assert regen.status_code == 200
+    assert regen.json()["id"] == fid
+    assert regen.json()["status"] == "aguardando_aprovacao"
+    assert regen.json()["rejeicao_motivo"] is None
+
+    aprova = client.post(f"/v1/faturamento/faturas/{fid}/aprovar", headers=h_fin)
+    assert aprova.status_code == 200, aprova.text
+    assert aprova.json()["status"] == "aprovada"
+    assert aprova.json()["aprovada_por_id"]
+
+    recusa_aprovada = client.post(
+        "/v1/faturamento/faturas",
+        headers=h_fin,
+        json={"contrato_id": cid, "competencia": "2026-08"},
+    )
+    assert recusa_aprovada.status_code == 400
+
+    job = client.post(
+        "/v1/faturamento/faturas/gerar-competencia",
+        headers=h_admin,
+        json={"competencia": "2026-08"},
+    )
+    assert job.status_code == 200, job.text
+    assert job.json()["criadas"] == 0
+    assert job.json()["existentes"] >= 1
+
+    db = SessionLocal()
+    try:
+        n = processar_faturamento_mensal(db)
+        db.commit()
+        assert n >= 0
+    finally:
+        db.close()
+
+    lst = client.get("/v1/faturamento/faturas", headers=h_fin, params={"status": "aprovada"})
+    assert lst.status_code == 200
+    assert any(x["id"] == fid for x in lst.json())
+
+    elig = client.get("/v1/faturamento/contratos-elegiveis", headers=h_fin)
+    assert elig.status_code == 200
+    assert any(x["id"] == cid for x in elig.json())

--- a/docs/BACKEND_RBAC.md
+++ b/docs/BACKEND_RBAC.md
@@ -38,6 +38,7 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 | Modelos de contrato (CRUD) | `POST/PATCH /v1/comercial/contrato-templates`, `POST /v1/comercial/contrato-templates/preview`, `GET /v1/comercial/contrato-templates/chaves` |
 | Checklist de implantação (CRUD) | `POST/PATCH /v1/comercial/implantacao-templates` — UI em Cadastros → Checklist de implantação |
 | Política de reajuste do contrato | `PATCH /v1/comercial/contrato-politica` (percentual e rótulo padrão da instância) |
+| Empresa (flag NFS-e) | `PATCH /v1/empresas/{id}` campo `emite_nfse` (default true) — snapshot copiado para a fatura |
 
 ## Comercial ou administrador (`exigir_comercial_ou_admin`)
 
@@ -50,6 +51,17 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 | **Proposta comercial** | `GET /v1/comercial/proposta-templates` (ativos), `POST/GET /v1/comercial/propostas*`, `GET .../pdf`, `POST .../marcar-enviada` |
 | **Contrato comercial** | `GET /v1/comercial/contrato-templates` (ativos), `GET /v1/comercial/contrato-templates/chaves`, `GET /v1/comercial/contrato-politica`, `POST/GET /v1/comercial/contratos*`, `GET .../pdf`, `POST/GET .../pdf-assinado`, `POST .../marcar-enviado`, `POST .../marcar-assinado`, `POST .../cancelar` (também rescinde assinado com estimativa de multa no payload/atividade). Lista e detalhe (incl. PDF e `multa_rescisao`): comercial só as próprias negociações; admin todos (filtros `so_minhas` e `responsavel_id`). Marcar assinado cria/vincula Rede e Empresa internamente — comercial **não** ganha CRUD de Rede/Empresa. Também abre ticket de implantação (checklist) no setor configurado. |
 | **Checklist de implantação (leitura)** | `GET /v1/comercial/implantacao-templates` (comercial/admin; `incluir_inativos` só admin) |
+
+## Financeiro ou administrador (`exigir_financeiro_ou_admin`)
+
+Admin **ou** atendente vinculado ao setor com slug/nome `financeiro` (homônimos inclusos). **Não** há role `financeiro`. Comercial **não** acessa.
+
+| Recurso | Rotas |
+|---------|--------|
+| Faturas internas | `GET/POST /v1/faturamento/faturas`, `POST /v1/faturamento/faturas/gerar-competencia`, `POST .../aprovar`, `POST .../rejeitar` (motivo obrigatório) |
+| Contratos faturáveis | `GET /v1/faturamento/contratos-elegiveis` (assinados com empresa) |
+
+UI: menu **Faturamento**. Job `faturamento-mensal` gera a competência atual (idempotente; **não** reabre rejeitadas). A acção manual «Gerar faturas do mês» reabre rejeitadas. Boleto/NFS-e ficam para lote posterior e só após fatura **aprovada**. O seed cria o setor `financeiro` se faltar.
 
 ## Autenticado com escopo de setor (`obter_atendente_atual`)
 
@@ -67,13 +79,13 @@ Dependência: `exigir_comercial_ou_admin` em `app.core.auth`.
 
 ## Referência de código
 
-- `app.core.auth`: `obter_atendente_atual`, `exigir_admin`, `exigir_comercial_ou_admin`, `validar_role`.
-- `app.core.setor_scope`: `ids_setores_visiveis_atendente`, `ids_setores_mesmo_nome`, `responsavel_elegivel_para_setor_do_ticket`, `select_rede_ids_com_ticket_nos_setores`.
-- Testes: `backend/tests/test_rbac_tickets.py`, `test_rbac_catalogos.py`, `test_rbac_admin_only.py`, `test_crm.py`.
+- `app.core.auth`: `obter_atendente_atual`, `exigir_admin`, `exigir_comercial_ou_admin`, `exigir_financeiro_ou_admin`, `validar_role`.
+- `app.core.setor_scope`: `ids_setores_visiveis_atendente`, `ids_setores_mesmo_nome`, `ids_setores_financeiro`, `atendente_e_financeiro`, `responsavel_elegivel_para_setor_do_ticket`, `select_rede_ids_com_ticket_nos_setores`.
+- Testes: `backend/tests/test_rbac_tickets.py`, `test_rbac_catalogos.py`, `test_rbac_admin_only.py`, `test_crm.py`, `test_faturamento.py`.
 
 ## Frontend (alinhamento)
 
-- **Menu**: grupos «Clientes» e «Configurações» só aparecem para `role === 'admin'` (`Sidebar.tsx`).
+- **Menu**: grupos «Clientes» e «Configurações» só aparecem para `role === 'admin'` (`Sidebar.tsx`). **Faturamento** aparece para admin ou `e_financeiro` em `/me` (setor Financeiro).
 - **Rotas**: páginas de cadastro usam `AdminRoute` em `App.tsx` — atendente vê `AcessoNegado` se aceder por URL.
 - **Tickets / novo ticket**: listas de **setores** e **empresas** seguem o filtro da API; não se recorta setor no cliente por `setor_ids` do `/me` (homônimos). Quando o atendente ainda não tem empresas no escopo, o UI explica o critério da rede com ticket nos setores dele.
 - **403**: mensagens vêm do corpo da API (`api/client` + `errorMessage.ts`).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { ConfigImplantacaoChecklist } from './pages/ConfigImplantacaoChecklist'
 import { CrmLeads } from './pages/CrmLeads'
 import { CrmNegociacaoDetalhe } from './pages/CrmNegociacaoDetalhe'
 import { CrmContratos } from './pages/CrmContratos'
+import { Faturamento } from './pages/Faturamento'
 import { ConfigCrmFunil } from './pages/ConfigCrmFunil'
 import { Redes } from './pages/Redes'
 import { RedeDetalhe } from './pages/RedeDetalhe'
@@ -181,6 +182,25 @@ function ComercialOuAdminRoute({ children }: { children: React.ReactNode }) {
       <AcessoNegado
         title="Área exclusiva para comercial ou administradores"
         detail="Você está autenticado, mas esta página só pode ser acessada por usuários com perfil comercial ou administrador."
+      />
+    )
+  }
+  return <>{children}</>
+}
+
+function FinanceiroOuAdminRoute({ children }: { children: React.ReactNode }) {
+  const { user, loading, isFinanceiroOuAdmin } = useAuth()
+  if (loading) {
+    return <PageLoading fullscreen label="Carregando sessão…" />
+  }
+  if (!user) {
+    return <Navigate to="/login" replace />
+  }
+  if (!isFinanceiroOuAdmin) {
+    return (
+      <AcessoNegado
+        title="Área exclusiva para o financeiro ou administradores"
+        detail="Você está autenticado, mas esta página só pode ser acessada por quem atende o setor Financeiro ou por administradores."
       />
     )
   }
@@ -415,6 +435,14 @@ function AppRoutes() {
             <ComercialOuAdminRoute>
               <CrmContratos />
             </ComercialOuAdminRoute>
+          }
+        />
+        <Route
+          path="faturamento"
+          element={
+            <FinanceiroOuAdminRoute>
+              <Faturamento />
+            </FinanceiroOuAdminRoute>
           }
         />
         <Route path="chat" element={<ChatHubShell />}>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2243,6 +2243,7 @@ export namespace Empresas {
     resp_legal_estado: string | null;
     resp_legal_cep: string | null;
     ativo: boolean;
+    emite_nfse?: boolean;
     created_at?: string | null;
     updated_at?: string | null;
   }
@@ -2298,6 +2299,7 @@ export namespace Empresas {
     resp_legal_estado?: string | null;
     resp_legal_cep?: string | null;
     ativo?: boolean;
+    emite_nfse?: boolean;
   }
   export interface Update {
     rede_id?: number;
@@ -2333,6 +2335,7 @@ export namespace Empresas {
     resp_legal_estado?: string | null;
     resp_legal_cep?: string | null;
     ativo?: boolean;
+    emite_nfse?: boolean;
   }
 }
 
@@ -2396,6 +2399,7 @@ export namespace Atendentes {
     role: string;
     ativo: boolean;
     setor_ids: number[];
+    e_financeiro?: boolean;
     must_change_password?: boolean;
     usa_escala?: boolean;
     escala_horas_trabalho?: number | null;
@@ -3390,6 +3394,61 @@ export const comercialImplantacaoTemplates = {
     api<ImplantacaoChecklist.Template>(`/comercial/implantacao-templates/${id}`, {
       method: 'PATCH',
       body: JSON.stringify(data),
+    }),
+};
+
+export namespace Faturamento {
+  export interface Fatura {
+    id: number;
+    contrato_id: number;
+    empresa_id: number | null;
+    empresa_nome: string | null;
+    cnpj: string | null;
+    razao_social: string | null;
+    competencia: string;
+    valor: string | number;
+    vencimento: string;
+    emite_nfse: boolean;
+    status: string;
+    rejeicao_motivo: string | null;
+    gerada_em?: string | null;
+    aprovada_por_id: number | null;
+    aprovada_por_nome: string | null;
+    aprovada_em: string | null;
+  }
+  export interface ContratoElegivel {
+    id: number;
+    empresa_id: number | null;
+    empresa_nome: string | null;
+    cnpj: string | null;
+    razao_social: string | null;
+    valor_mensalidade: string | number;
+  }
+  export interface GerarCompetenciaOut {
+    competencia: string;
+    criadas: number;
+    existentes: number;
+    reabertas: number;
+  }
+}
+
+export const faturamento = {
+  listFaturas: (params?: { competencia?: string; status?: string }) =>
+    api<Faturamento.Fatura[]>(withParams('/faturamento/faturas', params)),
+  listContratosElegiveis: () => api<Faturamento.ContratoElegivel[]>('/faturamento/contratos-elegiveis'),
+  gerarFatura: (data: { contrato_id: number; competencia?: string | null }) =>
+    api<Faturamento.Fatura>('/faturamento/faturas', { method: 'POST', body: JSON.stringify(data) }),
+  gerarCompetencia: (data?: { competencia?: string | null }) =>
+    api<Faturamento.GerarCompetenciaOut>('/faturamento/faturas/gerar-competencia', {
+      method: 'POST',
+      body: JSON.stringify(data ?? {}),
+    }),
+  aprovar: (id: number) =>
+    api<Faturamento.Fatura>(`/faturamento/faturas/${id}/aprovar`, { method: 'POST' }),
+  rejeitar: (id: number, motivo: string) =>
+    api<Faturamento.Fatura>(`/faturamento/faturas/${id}/rejeitar`, {
+      method: 'POST',
+      body: JSON.stringify({ motivo }),
     }),
 };
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -33,7 +33,7 @@ const menuIcon = (
 )
 
 function LayoutInner() {
-  const { user, logout, isAdmin, isComercialOuAdmin } = useAuth()
+  const { user, logout, isAdmin, isComercialOuAdmin, isFinanceiroOuAdmin } = useAuth()
   const { subscribe } = useEventStream()
   const location = useLocation()
   useVisualViewportCss()
@@ -116,6 +116,7 @@ function LayoutInner() {
         onMobileClose={() => setSidebarMobileOpen(false)}
         isAdmin={isAdmin ?? false}
         isComercialOuAdmin={isComercialOuAdmin ?? false}
+        isFinanceiroOuAdmin={isFinanceiroOuAdmin ?? false}
         userNome={user?.nome ?? ''}
         userRole={perfilExibicao(user?.role)}
         onLogout={logout}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -226,6 +226,8 @@ interface NavLink {
   adminOnly?: boolean
   /** Visível para admin ou comercial (CRM). */
   comercialOuAdmin?: boolean
+  /** Visível para admin ou setor Financeiro (faturamento). */
+  financeiroOuAdmin?: boolean
   /** Mantém o item ativo em rotas filhas (ex.: `/crm/negociacoes/:id`) */
   activePrefix?: string
   /** Só na instância comercial (control-plane SaaS). */
@@ -239,6 +241,7 @@ interface NavGroup {
   icon: string
   adminOnly?: boolean
   comercialOuAdmin?: boolean
+  financeiroOuAdmin?: boolean
   saasOnly?: boolean
   /** Ex.: conversa aberta `/whatsapp/c/:id` mantém o grupo Chat ativo */
   extraActivePrefixes?: string[]
@@ -254,6 +257,7 @@ interface NavItemLink {
   activePrefix?: string
   adminOnly?: boolean
   comercialOuAdmin?: boolean
+  financeiroOuAdmin?: boolean
   saasOnly?: boolean
 }
 
@@ -336,6 +340,13 @@ const navStructure: NavItem[] = [
     ],
   },
   {
+    type: 'link',
+    to: '/faturamento',
+    label: 'Faturamento',
+    icon: 'auditoria',
+    financeiroOuAdmin: true,
+  },
+  {
     type: 'group',
     id: 'clientes',
     label: 'Clientes',
@@ -403,13 +414,15 @@ function navGroupMatchesPath(pathname: string, group: NavGroup): boolean {
 }
 
 function navItemVisivel(
-  item: { adminOnly?: boolean; comercialOuAdmin?: boolean; saasOnly?: boolean },
+  item: { adminOnly?: boolean; comercialOuAdmin?: boolean; financeiroOuAdmin?: boolean; saasOnly?: boolean },
   isAdmin: boolean,
   isComercialOuAdmin: boolean,
+  isFinanceiroOuAdmin: boolean,
   saasEnabled: boolean,
 ): boolean {
   if (item.adminOnly && !isAdmin) return false
   if (item.comercialOuAdmin && !isComercialOuAdmin) return false
+  if (item.financeiroOuAdmin && !isFinanceiroOuAdmin) return false
   if (item.saasOnly && !saasEnabled) return false
   return true
 }
@@ -418,9 +431,12 @@ function navChildrenVisible(
   children: NavLink[],
   isAdmin: boolean,
   isComercialOuAdmin: boolean,
+  isFinanceiroOuAdmin: boolean,
   saasEnabled: boolean,
 ): NavLink[] {
-  return children.filter((child) => navItemVisivel(child, isAdmin, isComercialOuAdmin, saasEnabled))
+  return children.filter((child) =>
+    navItemVisivel(child, isAdmin, isComercialOuAdmin, isFinanceiroOuAdmin, saasEnabled),
+  )
 }
 
 interface SidebarProps {
@@ -429,6 +445,7 @@ interface SidebarProps {
   onMobileClose: () => void
   isAdmin: boolean
   isComercialOuAdmin: boolean
+  isFinanceiroOuAdmin: boolean
   userNome: string
   userRole: string
   onLogout: () => void
@@ -440,6 +457,7 @@ export function Sidebar({
   onMobileClose,
   isAdmin,
   isComercialOuAdmin,
+  isFinanceiroOuAdmin,
   userNome,
   userRole,
   onLogout,
@@ -493,14 +511,14 @@ export function Sidebar({
   )
 
   const items = navStructure.filter((item) =>
-    navItemVisivel(item, isAdmin, isComercialOuAdmin, saasEnabled),
+    navItemVisivel(item, isAdmin, isComercialOuAdmin, isFinanceiroOuAdmin, saasEnabled),
   ) as NavItem[]
 
   // Abrir grupo automaticamente quando a rota pertence a ele
   useEffect(() => {
     for (const item of navStructure) {
       if (item.type === 'group') {
-        if (navItemVisivel(item, isAdmin, isComercialOuAdmin, saasEnabled)) {
+        if (navItemVisivel(item, isAdmin, isComercialOuAdmin, isFinanceiroOuAdmin, saasEnabled)) {
           if (navGroupMatchesPath(location.pathname, item)) {
             setOpenGroup(item.id)
             return
@@ -508,7 +526,7 @@ export function Sidebar({
         }
       }
     }
-  }, [location.pathname, isAdmin, isComercialOuAdmin, saasEnabled])
+  }, [location.pathname, isAdmin, isComercialOuAdmin, isFinanceiroOuAdmin, saasEnabled])
 
   // No drawer mobile usamos acordeão (não flyout); evita estado do flyout “preso”
   useEffect(() => {
@@ -571,6 +589,7 @@ export function Sidebar({
                 openFlyoutGroup.children,
                 isAdmin,
                 isComercialOuAdmin,
+                isFinanceiroOuAdmin,
                 saasEnabled,
               ).map((child) => (
                 <li key={child.to} role="none">
@@ -682,7 +701,13 @@ export function Sidebar({
                       }`}
                       role="group"
                     >
-                      {navChildrenVisible(group.children, isAdmin, isComercialOuAdmin, saasEnabled).map(
+                      {navChildrenVisible(
+                        group.children,
+                        isAdmin,
+                        isComercialOuAdmin,
+                        isFinanceiroOuAdmin,
+                        saasEnabled,
+                      ).map(
                         (child) => (
                         <li key={child.to} className="min-w-0 border-l border-slate-200 pl-3 ml-4 dark:border-slate-700">
                           <Link

--- a/frontend/src/components/empresa/empresaFormCopy.ts
+++ b/frontend/src/components/empresa/empresaFormCopy.ts
@@ -4,6 +4,8 @@ export const EMPRESA_SECAO_DOCUMENTO_NOMES =
   'Preencha razão social e nome fantasia conforme o CNPJ. O nome exibido em listas e telas do sistema usa automaticamente o nome fantasia; se estiver vazio, usamos a razão social.'
 
 export const EMPRESA_HINT_ATIVA = 'Empresas inativas somem dos filtros padrão, mas o histórico permanece.'
+export const EMPRESA_HINT_EMITE_NFSE =
+  'Quando desligado, a fatura interna marca que este cliente não recebe NFS-e. Boleto e nota só são emitidos depois da aprovação do financeiro.'
 
 export const EMPRESA_SECAO_RESPONSAVEL_LEGAL =
   'Dados da pessoa que representa a empresa em contratos de prestação de serviço e documentos correlatos. Todos os campos são opcionais; preencha conforme o instrumento exigir.'

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -17,6 +17,8 @@ interface AuthContextValue {
   refreshUser: () => Promise<void>
   isAdmin: boolean
   isComercialOuAdmin: boolean
+  /** Admin ou atendente do setor Financeiro (faturamento interno). */
+  isFinanceiroOuAdmin: boolean
   /** Equipa comercial DeskRudder (control-plane SaaS). */
   isSaasOps: boolean
 }
@@ -104,6 +106,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     refreshUser,
     isAdmin: user?.role === 'admin',
     isComercialOuAdmin: user?.role === 'admin' || user?.role === 'comercial',
+    isFinanceiroOuAdmin: user?.role === 'admin' || Boolean(user?.e_financeiro),
     isSaasOps: user?.role === 'saas_ops',
   }
 

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -356,6 +356,10 @@ export function EmpresaDetalhe() {
                 </dd>
               </div>
               <DetailRow label="Tipo de negócio" value={tipoNegocioNome || undefined} />
+              <DetailRow
+                label="Emite NFS-e"
+                value={empresa.emite_nfse === false ? 'Não' : 'Sim'}
+              />
             </dl>
           </section>
 

--- a/frontend/src/pages/EmpresaForm.tsx
+++ b/frontend/src/pages/EmpresaForm.tsx
@@ -15,6 +15,7 @@ import { Input } from '../components/ui/Input'
 import { FormSection } from '../components/ui/FormSection'
 import {
   EMPRESA_HINT_ATIVA,
+  EMPRESA_HINT_EMITE_NFSE,
   EMPRESA_SECAO_DOCUMENTO_NOMES,
   EMPRESA_SECAO_RESPONSAVEL_LEGAL,
   nomeParaApiEmpresa,
@@ -69,6 +70,7 @@ function aplicarEmpresaNoFormulario(e: Empresas.Empresa, setters: {
   setRespLegalEstado: (v: string) => void
   setRespLegalCep: (v: string) => void
   setAtivo: (v: boolean) => void
+  setEmiteNfse: (v: boolean) => void
 }) {
   setters.setRedeId(e.rede_id)
   setters.setTipoNegocioId(e.tipo_negocio_id ?? '')
@@ -102,6 +104,7 @@ function aplicarEmpresaNoFormulario(e: Empresas.Empresa, setters: {
   setters.setRespLegalEstado((e.resp_legal_estado ?? '').toUpperCase().slice(0, 2))
   setters.setRespLegalCep(e.resp_legal_cep ? maskCep(e.resp_legal_cep.replace(/\D/g, '')) : '')
   setters.setAtivo(e.ativo)
+  setters.setEmiteNfse(e.emite_nfse !== false)
 }
 
 export function EmpresaForm() {
@@ -147,6 +150,7 @@ export function EmpresaForm() {
   const [respLegalEstado, setRespLegalEstado] = useState('')
   const [respLegalCep, setRespLegalCep] = useState('')
   const [ativo, setAtivo] = useState(true)
+  const [emiteNfse, setEmiteNfse] = useState(true)
   const [saving, setSaving] = useState(false)
   const [loadingCnpj, setLoadingCnpj] = useState(false)
   const [forbidden, setForbidden] = useState(false)
@@ -233,6 +237,7 @@ export function EmpresaForm() {
           setRespLegalEstado,
           setRespLegalCep,
           setAtivo,
+          setEmiteNfse,
         })
       })
       .catch((err) => {
@@ -335,6 +340,7 @@ export function EmpresaForm() {
         resp_legal_estado: respLegalEstado.trim() || null,
         resp_legal_cep: respLegalCep.replace(/\D/g, '') || null,
         ativo,
+        emite_nfse: emiteNfse,
       }
       if (isEdit && !Number.isNaN(empresaId)) {
         await apiEmpresas.update(empresaId, payload)
@@ -614,6 +620,14 @@ export function EmpresaForm() {
                   onCheckedChange={setAtivo}
                   label="Empresa ativa"
                   description={EMPRESA_HINT_ATIVA}
+                />
+                <Switch
+                  bare
+                  showStatusPill
+                  checked={emiteNfse}
+                  onCheckedChange={setEmiteNfse}
+                  label="Emite NFS-e"
+                  description={EMPRESA_HINT_EMITE_NFSE}
                 />
               </FormSection>
 

--- a/frontend/src/pages/Faturamento.tsx
+++ b/frontend/src/pages/Faturamento.tsx
@@ -1,0 +1,353 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  ApiError,
+  faturamento,
+  type Faturamento,
+} from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { Button } from '../components/ui/Button'
+import { Card } from '../components/ui/Card'
+import { Input, TEXTAREA_FIELD_CLASS } from '../components/ui/Input'
+import { PageContainer, PageHeader } from '../components/ui/PageContainer'
+import { Select } from '../components/ui/Select'
+import { useToast } from '../components/ui/Toast'
+import { SemPermissao } from './SemPermissao'
+
+const STATUS_LABEL: Record<string, string> = {
+  aguardando_aprovacao: 'Aguardando aprovação',
+  aprovada: 'Aprovada',
+  rejeitada: 'Rejeitada',
+  cancelada: 'Cancelada',
+}
+
+const STATUS_FILTROS = ['', 'aguardando_aprovacao', 'aprovada', 'rejeitada'] as const
+
+function competenciaAtual(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+}
+
+function formatMoney(v: string | number): string {
+  const n = typeof v === 'number' ? v : Number(v)
+  if (Number.isNaN(n)) return String(v)
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })
+}
+
+function formatDate(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  const d = new Date(iso.includes('T') ? iso : `${iso}T00:00:00`)
+  if (Number.isNaN(d.getTime())) return '—'
+  return d.toLocaleDateString('pt-BR')
+}
+
+function classeStatus(status: string): string {
+  if (status === 'aprovada') return 'bg-emerald-50 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300'
+  if (status === 'rejeitada') return 'bg-red-50 text-red-800 dark:bg-red-950/40 dark:text-red-300'
+  if (status === 'aguardando_aprovacao')
+    return 'bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-200'
+  return 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300'
+}
+
+export function Faturamento() {
+  const toast = useToast()
+  const [list, setList] = useState<Faturamento.Fatura[]>([])
+  const [contratos, setContratos] = useState<Faturamento.ContratoElegivel[]>([])
+  const [loading, setLoading] = useState(true)
+  const [forbidden, setForbidden] = useState(false)
+  const [status, setStatus] = useState('')
+  const [competencia, setCompetencia] = useState(competenciaAtual)
+  const [gerando, setGerando] = useState(false)
+  const [contratoId, setContratoId] = useState<number | ''>('')
+  const [rejeitarId, setRejeitarId] = useState<number | null>(null)
+  const [motivo, setMotivo] = useState('')
+  const [savingId, setSavingId] = useState<number | null>(null)
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    faturamento
+      .listFaturas({
+        competencia: competencia || undefined,
+        status: status || undefined,
+      })
+      .then(setList)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          setList([])
+          return
+        }
+        toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível carregar as faturas.'))
+        setList([])
+      })
+      .finally(() => setLoading(false))
+  }, [competencia, status, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  useEffect(() => {
+    faturamento
+      .listContratosElegiveis()
+      .then(setContratos)
+      .catch(() => setContratos([]))
+  }, [])
+
+  const contratoOptions = useMemo(
+    () =>
+      contratos.map((c) => ({
+        value: c.id,
+        label: `${c.razao_social || c.empresa_nome || `Contrato #${c.id}`} — ${formatMoney(c.valor_mensalidade)}`,
+      })),
+    [contratos],
+  )
+
+  async function gerarMes() {
+    setGerando(true)
+    try {
+      const r = await faturamento.gerarCompetencia({ competencia: competencia || undefined })
+      const novas = r.criadas
+      const reabertas = r.reabertas ?? 0
+      if (novas || reabertas) {
+        const partes = [
+          novas ? `${novas} nova(s)` : null,
+          reabertas ? `${reabertas} rejeitada(s) reaberta(s)` : null,
+        ].filter(Boolean)
+        toast.showSuccess(`${partes.join(', ')} em ${r.competencia}.`)
+      } else {
+        toast.showSuccess(`Nenhuma fatura nova — ${r.existentes} já existiam em ${r.competencia}.`)
+      }
+      load()
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível gerar as faturas do mês.'))
+    } finally {
+      setGerando(false)
+    }
+  }
+
+  async function gerarAvulsa() {
+    if (contratoId === '') {
+      toast.showWarning('Escolha o contrato.')
+      return
+    }
+    setGerando(true)
+    try {
+      await faturamento.gerarFatura({
+        contrato_id: Number(contratoId),
+        competencia: competencia || undefined,
+      })
+      toast.showSuccess('Fatura gerada para conferência.')
+      load()
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível gerar a fatura.'))
+    } finally {
+      setGerando(false)
+    }
+  }
+
+  async function aprovar(id: number) {
+    setSavingId(id)
+    try {
+      await faturamento.aprovar(id)
+      toast.showSuccess('Fatura aprovada. Boleto e NFS-e ficam para o próximo lote.')
+      load()
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível aprovar.'))
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  async function confirmarRejeicao() {
+    if (rejeitarId == null) return
+    if (motivo.trim().length < 3) {
+      toast.showWarning('Informe o motivo da rejeição.')
+      return
+    }
+    setSavingId(rejeitarId)
+    try {
+      await faturamento.rejeitar(rejeitarId, motivo.trim())
+      toast.showSuccess('Fatura rejeitada. Gere de novo depois de corrigir o contrato.')
+      setRejeitarId(null)
+      setMotivo('')
+      load()
+    } catch (err) {
+      toast.showWarning(mensagemFalhaParaToast(err, 'Não foi possível rejeitar.'))
+    } finally {
+      setSavingId(null)
+    }
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Você não tem permissão para ver o faturamento."
+        detail="A conferência de faturas é só para o setor Financeiro e administradores."
+        voltarPara="/"
+        voltarLabel="Voltar para o Dashboard"
+      />
+    )
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title="Faturamento"
+        subtitle="Faturas internas do mês para o financeiro conferir e aprovar. Boleto e nota fiscal só depois da aprovação."
+      />
+
+      <Card>
+        <div className="space-y-4">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="w-40">
+            <Input
+              label="Competência"
+              type="month"
+              value={competencia}
+              onChange={(e) => setCompetencia(e.target.value)}
+            />
+          </div>
+          <div className="min-w-[220px] flex-1">
+            <Select
+              label="Contrato (gerar avulsa)"
+              value={contratoId}
+              onChange={(v) => setContratoId(v === '' ? '' : Number(v))}
+              options={contratoOptions}
+              includeEmpty
+              emptyLabel="Escolher contrato…"
+            />
+          </div>
+          <Button variant="secondary" onClick={gerarAvulsa} disabled={gerando || contratoId === ''}>
+            Gerar fatura
+          </Button>
+          <Button onClick={gerarMes} disabled={gerando} loading={gerando}>
+            Gerar faturas do mês
+          </Button>
+        </div>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          O job automático cria faturas novas da competência (não reabre rejeitadas). «Gerar faturas do mês»
+          também reabre as rejeitadas desta competência. Vencimento: dia 10 do mês seguinte.
+        </p>
+        </div>
+      </Card>
+
+      <div className="flex flex-wrap gap-2">
+        {STATUS_FILTROS.map((s) => (
+          <button
+            key={s || 'todos'}
+            type="button"
+            onClick={() => setStatus(s)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium transition ${
+              status === s
+                ? 'bg-slate-900 text-white dark:bg-slate-100 dark:text-slate-900'
+                : 'bg-slate-100 text-slate-700 hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200'
+            }`}
+          >
+            {s ? STATUS_LABEL[s] : 'Todas'}
+          </button>
+        ))}
+      </div>
+
+      {rejeitarId != null ? (
+        <Card className="space-y-3">
+          <p className="text-sm font-medium text-slate-800 dark:text-slate-100">Motivo da rejeição</p>
+          <textarea
+            className={TEXTAREA_FIELD_CLASS}
+            rows={3}
+            value={motivo}
+            onChange={(e) => setMotivo(e.target.value)}
+            placeholder="Explique o que precisa ser corrigido antes de gerar de novo."
+          />
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={confirmarRejeicao} variant="danger" disabled={savingId === rejeitarId}>
+              Confirmar rejeição
+            </Button>
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setRejeitarId(null)
+                setMotivo('')
+              }}
+            >
+              Cancelar
+            </Button>
+          </div>
+        </Card>
+      ) : null}
+
+      <Card>
+        {loading ? (
+          <p className="text-sm text-slate-500">Carregando faturas…</p>
+        ) : list.length === 0 ? (
+          <p className="text-sm text-slate-500">Nenhuma fatura nesta competência.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 text-xs uppercase tracking-wide text-slate-500 dark:border-slate-700">
+                  <th className="px-4 py-3 font-medium">Cliente</th>
+                  <th className="px-4 py-3 font-medium">Competência</th>
+                  <th className="px-4 py-3 font-medium">Valor</th>
+                  <th className="px-4 py-3 font-medium">Vencimento</th>
+                  <th className="px-4 py-3 font-medium">NFS-e</th>
+                  <th className="px-4 py-3 font-medium">Estado</th>
+                  <th className="px-4 py-3 font-medium">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {list.map((f) => (
+                  <tr key={f.id} className="border-b border-slate-100 last:border-0 dark:border-slate-800">
+                    <td className="px-4 py-3">
+                      <div className="font-medium text-slate-800 dark:text-slate-100">
+                        {f.razao_social || f.empresa_nome || `Contrato #${f.contrato_id}`}
+                      </div>
+                      <div className="font-mono text-xs text-slate-500">{f.cnpj || '—'}</div>
+                    </td>
+                    <td className="px-4 py-3 tabular-nums">{f.competencia}</td>
+                    <td className="px-4 py-3 tabular-nums">{formatMoney(f.valor)}</td>
+                    <td className="px-4 py-3">{formatDate(f.vencimento)}</td>
+                    <td className="px-4 py-3">{f.emite_nfse ? 'Sim' : 'Não'}</td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${classeStatus(f.status)}`}>
+                        {STATUS_LABEL[f.status] || f.status}
+                      </span>
+                      {f.rejeicao_motivo ? (
+                        <p className="mt-1 max-w-xs text-xs text-slate-500">{f.rejeicao_motivo}</p>
+                      ) : null}
+                    </td>
+                    <td className="px-4 py-3">
+                      {f.status === 'aguardando_aprovacao' ? (
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            variant="secondary"
+                            disabled={savingId === f.id}
+                            onClick={() => aprovar(f.id)}
+                          >
+                            Aprovar
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            disabled={savingId === f.id}
+                            onClick={() => {
+                              setRejeitarId(f.id)
+                              setMotivo('')
+                            }}
+                          >
+                            Rejeitar
+                          </Button>
+                        </div>
+                      ) : (
+                        <span className="text-xs text-slate-400">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </PageContainer>
+  )
+}


### PR DESCRIPTION
## Summary

- Lote 1 de faturamento interno (#326 / #363): gera fatura por contrato+competência (`YYYY-MM`), unique no banco, vencimento no **dia 10 do mês seguinte**. Job no início do mês; botão na tela reabre rejeitadas. Admin ou atendente do setor **Financeiro** aprova/rejeita (motivo ≥ 3 caracteres). Comercial não vê a tela.
- Flag **Emite NFS-e** na empresa (default ligado), snapshot na fatura. Boleto e NFS-e ficam para o lote seguinte e só depois de aprovada.
- Licença: sai a MIT; `LICENSE`/`README` passam a copyright reservado (Luis Gustavo da S. Sousa).

Closes #363

Relacionado (não fecha o épico): #326, #364 (flag; boleto/relatório depois), #367 (job; sem disparo de boleto/NF), #368 (UI de conferência/aprovação; sem 2ª via).

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] Migration `106_faturamento_fatura` sobe (`alembic upgrade head`); um único head
- [ ] Seed cria o setor **Financeiro** se não existir
- [ ] Admin e atendente do setor Financeiro: menu **Faturamento**, listar, gerar do mês, gerar avulsa, aprovar, rejeitar com motivo
- [ ] Comercial / atendente de outro setor: 403 / rota bloqueada; `/me` com `e_financeiro` só no próprio perfil
- [ ] Gerar competência já `aguardando` devolve 200 (não duplica); `rejeitada` regenera snapshot; `aprovada`/`cancelada` → 400
- [ ] Job mensal **não** reabre rejeitadas; o botão do mês **sim**
- [ ] Empresa: toggle Emite NFS-e visível e persistido
- [ ] `LICENSE` deixa de ser MIT; README aponta para copyright reservado

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Fora deste lote (já no GitHub): spike boleto/NFS-e #362, emissão #365/#366, envio ao cliente #327, contas a receber #328; UI 2ª via #368; relatório com/sem NF de #364
- [x] Épico #326 permanece aberto até boleto/NFS-e
- [ ] Comentário na issue fechada ou no PR lista links dos follow-ups criados
