### PR TITLE
feat(ponto): geofence, offline/sync e relatorios mensais (#844)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Ponto (#841): ao bater **saída** com pausa aberta, a pausa é encerrada automaticamente (origem sistema) e o dia fecha — sem exigir duas correções; toast na UI
 - Ponto (#842): calendário mensal em **Meu ponto** e **Ponto da equipe** (por atendente), com cores por meta de jornada (vermelho / verde / azul HE / laranja feriado); setting **jornada diária (minutos)** (padrão 480)
 - Ponto (UX): **Meu ponto** redesenhado — relógio ao vivo, botão principal contextual (entrada / retomar / saída), cards de métricas, períodos de hoje e calendário mais legível (inspirado no DX Ponto)
-- Ponto: batida pode incluir **geolocalização opcional** (lat/lon/precisão) — web e APK; se a permissão falhar, o ponto regista na mesma (geo obrigatória / geofence ficam para follow-up)
+- Ponto (#844): **geofence** — admin cadastra locais (lat/lon + raio), política de geo (opcional / recomendada / obrigatória); batidas fora da área ficam marcadas; link para mapa (OSM) no histórico admin
+- Ponto: batida com **geolocalização** (lat/lon/precisão) — web e APK via `@capacitor/geolocation`; política da instância controla obrigatoriedade
+- Ponto: **offline + sync** — batidas guardadas localmente quando sem rede e enviadas ao voltar online
+- Ponto: **Ponto da equipe** alinhado visualmente a Meu ponto (digest em cards); relatório **PDF** e **Excel** mensal no filtro do histórico
 - Faturamento (#326 / #363 / #364): faturas internas mensais para o financeiro conferir e **aprovar** (ou rejeitar com motivo). Geração automática no início do mês, ou avulsa na tela Faturamento; o botão do mês também reabre rejeitadas. Vencimento no **dia 10 do mês seguinte**. Na empresa, a flag **Emite NFS-e** (ligada por defeito) fica registada na fatura; boleto e nota fiscal só no lote seguinte, e só se a fatura estiver aprovada. O seed cria o setor **Financeiro** se ainda não existir.
 - Sugestões (#799 / #800–#807): a partir de **Sobre** (Release Notes), enviar sugestão ou problema; acompanhar em **Minhas solicitações**; admin faz triagem, responde (público/interno) e pode criar/sincronizar issue no GitHub (só interno)
 - WhatsApp (#837): **Exportar PDF** da conversa (header / menu ⋮) — relatório com protocolo, contacto e mensagens; mídia como rótulo; comentários internos excluídos; mesma permissão de ver o chat

--- a/backend/alembic/versions/109_ponto_geofence.py
+++ b/backend/alembic/versions/109_ponto_geofence.py
@@ -1,0 +1,86 @@
+"""Geofence: locais da empresa + política de geo (#844).
+
+Revision ID: 109_ponto_geofence
+Revises: 108_ponto_geolocalizacao
+Create Date: 2026-08-22
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "109_ponto_geofence"
+down_revision = "108_ponto_geolocalizacao"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "politica_geolocalizacao" not in cols:
+            op.add_column(
+                "ponto_settings",
+                sa.Column(
+                    "politica_geolocalizacao",
+                    sa.String(20),
+                    nullable=False,
+                    server_default="opcional",
+                ),
+            )
+
+    if not insp.has_table("ponto_locais"):
+        op.create_table(
+            "ponto_locais",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column(
+                "tenant_id",
+                sa.Integer(),
+                sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column("nome", sa.String(255), nullable=False),
+            sa.Column("latitude", sa.Float(), nullable=False),
+            sa.Column("longitude", sa.Float(), nullable=False),
+            sa.Column("raio_metros", sa.Integer(), nullable=False, server_default="200"),
+            sa.Column("ativo", sa.Boolean(), nullable=False, server_default="true"),
+        )
+
+    if insp.has_table("ponto_batidas"):
+        cols = {c["name"] for c in insp.get_columns("ponto_batidas")}
+        if "fora_area" not in cols:
+            op.add_column(
+                "ponto_batidas",
+                sa.Column("fora_area", sa.Boolean(), nullable=False, server_default="false"),
+            )
+        if "distancia_metros" not in cols:
+            op.add_column("ponto_batidas", sa.Column("distancia_metros", sa.Float(), nullable=True))
+        if "local_id" not in cols:
+            op.add_column(
+                "ponto_batidas",
+                sa.Column(
+                    "local_id",
+                    sa.Integer(),
+                    sa.ForeignKey("ponto_locais.id", ondelete="SET NULL"),
+                    nullable=True,
+                ),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_batidas"):
+        cols = {c["name"] for c in insp.get_columns("ponto_batidas")}
+        for name in ("local_id", "distancia_metros", "fora_area"):
+            if name in cols:
+                op.drop_column("ponto_batidas", name)
+    if insp.has_table("ponto_locais"):
+        op.drop_table("ponto_locais")
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "politica_geolocalizacao" in cols:
+            op.drop_column("ponto_settings", "politica_geolocalizacao")

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -30,11 +30,15 @@ from app.schemas.ponto import (
     PontoJustificativaCreate,
     PontoJustificativaDecisao,
     PontoJustificativaRead,
+    PontoLocalCreate,
+    PontoLocalRead,
+    PontoSettingsPublicRead,
     PontoSettingsRead,
     PontoSettingsUpdate,
 )
 from app.services import ponto as ponto_svc
 from app.services import ponto_justificativa as just_svc
+from app.services import ponto_relatorio as ponto_relatorio_svc
 from app.services import ponto_settings as ponto_settings_svc
 
 router = APIRouter(prefix="/ponto", tags=["ponto"])
@@ -110,6 +114,17 @@ def meu_calendario(
     return ponto_svc.calendario(db, atendente, ano, mes)
 
 
+@router.get("/me/settings", response_model=PontoSettingsPublicRead)
+def minhas_settings_ponto(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ponto_svc.exigir_acesso_ponto(atendente)
+    out = ponto_settings_svc.settings_public_read(db, atendente.tenant_id)
+    db.commit()
+    return out
+
+
 @router.get("/batidas/export.csv")
 def exportar_csv(
     atendente_id: int | None = Query(None),
@@ -125,6 +140,42 @@ def exportar_csv(
         content=conteudo.encode("utf-8"),
         media_type="text/csv; charset=utf-8",
         headers={"Content-Disposition": 'attachment; filename="ponto_batidas.csv"'},
+    )
+
+
+@router.get("/batidas/export.pdf")
+def exportar_pdf(
+    atendente_id: int | None = Query(None),
+    desde: date | None = Query(None),
+    ate: date | None = Query(None),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    pdf = ponto_relatorio_svc.export_pdf_mensal(
+        db, admin, atendente_id=atendente_id, desde=desde, ate=ate
+    )
+    return Response(
+        content=pdf,
+        media_type="application/pdf",
+        headers={"Content-Disposition": 'attachment; filename="ponto_relatorio.pdf"'},
+    )
+
+
+@router.get("/batidas/export.xlsx")
+def exportar_xlsx(
+    atendente_id: int | None = Query(None),
+    desde: date | None = Query(None),
+    ate: date | None = Query(None),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    xlsx = ponto_relatorio_svc.export_xlsx_mensal(
+        db, admin, atendente_id=atendente_id, desde=desde, ate=ate
+    )
+    return Response(
+        content=xlsx,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers={"Content-Disposition": 'attachment; filename="ponto_relatorio.xlsx"'},
     )
 
 
@@ -303,6 +354,33 @@ def remover_feriado(
     admin: Atendente = Depends(exigir_admin),
 ):
     ponto_settings_svc.remover_feriado(db, admin, feriado_id)
+    return Response(status_code=204)
+
+
+@router.get("/locais", response_model=list[PontoLocalRead])
+def listar_locais(
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return ponto_settings_svc.listar_locais(db, admin.tenant_id)
+
+
+@router.post("/locais", response_model=PontoLocalRead, status_code=201)
+def criar_local(
+    data: PontoLocalCreate,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return ponto_settings_svc.criar_local(db, admin, data)
+
+
+@router.delete("/locais/{local_id}", status_code=204)
+def remover_local(
+    local_id: int,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    ponto_settings_svc.remover_local(db, admin, local_id)
     return Response(status_code=204)
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,7 +4,7 @@ from app.models.tipo_negocio import TipoNegocio
 from app.models.atendente import Atendente, AtendenteSetor
 from app.models.ponto_batida import PontoBatida
 from app.models.ponto_justificativa import PontoJustificativa
-from app.models.ponto_settings import PontoFeriado, PontoSettings
+from app.models.ponto_settings import PontoFeriado, PontoLocal, PontoSettings
 from app.models.setor import Setor
 from app.models.setor_distribuicao_round_robin import SetorDistribuicaoRoundRobin
 from app.models.funcionario_rede import FuncionarioRede, FuncionarioRedeEmpresa
@@ -93,6 +93,7 @@ __all__ = [
     "PontoBatida",
     "PontoJustificativa",
     "PontoSettings",
+    "PontoLocal",
     "PontoFeriado",
     "FuncionarioRede",
     "FuncionarioRedeEmpresa",

--- a/backend/app/models/ponto_batida.py
+++ b/backend/app/models/ponto_batida.py
@@ -22,6 +22,9 @@ class PontoBatida(Base):
     latitude = Column(Float, nullable=True)
     longitude = Column(Float, nullable=True)
     accuracy_metros = Column(Float, nullable=True)
+    fora_area = Column(Boolean, nullable=False, default=False, server_default="false")
+    distancia_metros = Column(Float, nullable=True)
+    local_id = Column(Integer, ForeignKey("ponto_locais.id", ondelete="SET NULL"), nullable=True)
     anulada = Column(Boolean, nullable=False, default=False, server_default="false")
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 

--- a/backend/app/models/ponto_settings.py
+++ b/backend/app/models/ponto_settings.py
@@ -1,6 +1,6 @@
 """Settings e feriados custom do ponto (#779 / #782)."""
 
-from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, String, UniqueConstraint
+from sqlalchemy import Boolean, Column, Date, DateTime, Float, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.sql import func
 
 from app.database import Base
@@ -14,9 +14,22 @@ class PontoSettings(Base):
     usar_feriados_nacionais = Column(Boolean, nullable=False, default=True, server_default="true")
     fecho_automatico_ativo = Column(Boolean, nullable=False, default=False, server_default="false")
     fecho_apos_horas = Column(Integer, nullable=False, default=14, server_default="14")
-    # Meta de horas do dia para cores do calendário (#842); default 8h.
     jornada_diaria_minutos = Column(Integer, nullable=False, default=480, server_default="480")
+    # opcional | recomendada | obrigatoria (#844)
+    politica_geolocalizacao = Column(String(20), nullable=False, default="opcional", server_default="opcional")
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+
+class PontoLocal(Base):
+    __tablename__ = "ponto_locais"
+
+    id = Column(Integer, primary_key=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    nome = Column(String(255), nullable=False)
+    latitude = Column(Float, nullable=False)
+    longitude = Column(Float, nullable=False)
+    raio_metros = Column(Integer, nullable=False, default=200, server_default="200")
+    ativo = Column(Boolean, nullable=False, default=True, server_default="true")
 
 
 class PontoFeriado(Base):

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -27,7 +27,37 @@ class PontoBatidaRead(BaseModel):
     latitude: float | None = None
     longitude: float | None = None
     accuracy_metros: float | None = None
+    fora_area: bool = False
+    distancia_metros: float | None = None
+    local_id: int | None = None
     anulada: bool = False
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+PoliticaGeolocalizacao = Literal["opcional", "recomendada", "obrigatoria"]
+
+
+class PontoSettingsPublicRead(BaseModel):
+    politica_geolocalizacao: PoliticaGeolocalizacao = "opcional"
+    tem_locais_ativos: bool = False
+
+
+class PontoLocalCreate(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=255)
+    latitude: float = Field(..., ge=-90, le=90)
+    longitude: float = Field(..., ge=-180, le=180)
+    raio_metros: int = Field(default=200, ge=20, le=50_000)
+    ativo: bool | None = True
+
+
+class PontoLocalRead(BaseModel):
+    id: int
+    nome: str
+    latitude: float
+    longitude: float
+    raio_metros: int
+    ativo: bool = True
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -68,6 +98,9 @@ class PontoBatidaAdminItem(BaseModel):
     latitude: float | None = None
     longitude: float | None = None
     accuracy_metros: float | None = None
+    fora_area: bool = False
+    distancia_metros: float | None = None
+    local_id: int | None = None
     anulada: bool = False
 
 
@@ -153,6 +186,7 @@ class PontoSettingsRead(BaseModel):
     fecho_automatico_ativo: bool = False
     fecho_apos_horas: int = 14
     jornada_diaria_minutos: int = 480
+    politica_geolocalizacao: PoliticaGeolocalizacao = "opcional"
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -162,6 +196,7 @@ class PontoSettingsUpdate(BaseModel):
     fecho_automatico_ativo: bool | None = None
     fecho_apos_horas: int | None = Field(default=None, ge=4, le=48)
     jornada_diaria_minutos: int | None = Field(default=None, ge=60, le=1440)
+    politica_geolocalizacao: PoliticaGeolocalizacao | None = None
 
 
 class PontoFeriadoCreate(BaseModel):

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -162,6 +162,15 @@ def bater(
     if has_lat and (latitude < -90 or latitude > 90 or longitude < -180 or longitude > 180):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Coordenadas inválidas.")
 
+    from app.services import ponto_geofence as geo_svc
+
+    geo_res = geo_svc.validar_batida_geolocalizacao(
+        db,
+        atendente.tenant_id,
+        latitude=float(latitude) if has_lat else None,
+        longitude=float(longitude) if has_lon else None,
+    )
+
     ultima = ultima_batida(db, atendente.id)
     em_jornada = bool(ultima and ultima.tipo in TIPOS_EM_JORNADA)
     em_pausa = bool(ultima and ultima.tipo == "pausa_inicio")
@@ -224,6 +233,9 @@ def bater(
         latitude=float(latitude) if has_lat else None,
         longitude=float(longitude) if has_lon else None,
         accuracy_metros=float(accuracy_metros) if accuracy_metros is not None and has_lat else None,
+        fora_area=bool(geo_res.fora_area),
+        distancia_metros=geo_res.distancia_metros,
+        local_id=geo_res.local_id,
         anulada=False,
     )
     db.add(batida)
@@ -369,6 +381,9 @@ def listar_batidas_admin(
             latitude=getattr(b, "latitude", None),
             longitude=getattr(b, "longitude", None),
             accuracy_metros=getattr(b, "accuracy_metros", None),
+            fora_area=bool(getattr(b, "fora_area", False)),
+            distancia_metros=getattr(b, "distancia_metros", None),
+            local_id=getattr(b, "local_id", None),
             anulada=bool(b.anulada),
         )
         for b, a in rows

--- a/backend/app/services/ponto_geofence.py
+++ b/backend/app/services/ponto_geofence.py
@@ -1,0 +1,120 @@
+"""Geofence e política de geolocalização (#844)."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.models.ponto_settings import PontoLocal, PontoSettings
+
+POLITICAS_VALIDAS = frozenset({"opcional", "recomendada", "obrigatoria"})
+
+
+@dataclass
+class ResultadoGeofence:
+    fora_area: bool = False
+    distancia_metros: float | None = None
+    local_id: int | None = None
+    local_nome: str | None = None
+
+
+def distancia_metros(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Haversine — distância em metros."""
+    r = 6371000.0
+    p1, p2 = math.radians(lat1), math.radians(lat2)
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = math.sin(dlat / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dlon / 2) ** 2
+    return 2 * r * math.asin(math.sqrt(a))
+
+
+def locais_ativos(db: Session, tenant_id: int) -> list[PontoLocal]:
+    return (
+        db.query(PontoLocal)
+        .filter(PontoLocal.tenant_id == tenant_id, PontoLocal.ativo.is_(True))
+        .order_by(PontoLocal.nome.asc())
+        .all()
+    )
+
+
+def avaliar_coordenadas(
+    db: Session,
+    tenant_id: int,
+    latitude: float,
+    longitude: float,
+) -> ResultadoGeofence:
+    """Encontra o local mais próximo e se está dentro do raio."""
+    locais = locais_ativos(db, tenant_id)
+    if not locais:
+        return ResultadoGeofence()
+    melhor: PontoLocal | None = None
+    melhor_dist = float("inf")
+    dentro_de: PontoLocal | None = None
+    dist_dentro = float("inf")
+    for loc in locais:
+        d = distancia_metros(latitude, longitude, float(loc.latitude), float(loc.longitude))
+        if d < melhor_dist:
+            melhor_dist = d
+            melhor = loc
+        if d <= int(loc.raio_metros or 200) and d < dist_dentro:
+            dist_dentro = d
+            dentro_de = loc
+    if dentro_de is not None:
+        return ResultadoGeofence(
+            fora_area=False,
+            distancia_metros=round(dist_dentro, 1),
+            local_id=dentro_de.id,
+            local_nome=dentro_de.nome,
+        )
+    return ResultadoGeofence(
+        fora_area=True,
+        distancia_metros=round(melhor_dist, 1) if melhor is not None else None,
+        local_id=melhor.id if melhor is not None else None,
+        local_nome=melhor.nome if melhor is not None else None,
+    )
+
+
+def validar_batida_geolocalizacao(
+    db: Session,
+    tenant_id: int,
+    *,
+    latitude: float | None,
+    longitude: float | None,
+) -> ResultadoGeofence:
+    """Aplica política da instância; levanta 400 se obrigatória e inválida."""
+    from app.services.ponto_settings import get_or_create_settings
+
+    settings = get_or_create_settings(db, tenant_id)
+    politica = (getattr(settings, "politica_geolocalizacao", None) or "opcional").strip().lower()
+    if politica not in POLITICAS_VALIDAS:
+        politica = "opcional"
+    locais = locais_ativos(db, tenant_id)
+    has_coords = latitude is not None and longitude is not None
+
+    if politica == "obrigatoria" and locais:
+        if not has_coords:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Geolocalização obrigatória para bater o ponto nesta instância.",
+            )
+        res = avaliar_coordenadas(db, tenant_id, float(latitude), float(longitude))
+        if res.fora_area:
+            nome = res.local_nome or "área permitida"
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Você está fora da área permitida ({nome}). Aproxime-se do local de trabalho.",
+            )
+        return res
+
+    if not has_coords or not locais:
+        return ResultadoGeofence()
+
+    res = avaliar_coordenadas(db, tenant_id, float(latitude), float(longitude))
+    if politica == "recomendada" and res.fora_area:
+        return res
+    if politica == "opcional":
+        return res
+    return res

--- a/backend/app/services/ponto_relatorio.py
+++ b/backend/app/services/ponto_relatorio.py
@@ -1,0 +1,185 @@
+"""Relatório mensal de ponto — PDF e Excel (#844)."""
+
+from __future__ import annotations
+
+import io
+from datetime import date, datetime, timezone
+from html import escape
+
+from sqlalchemy.orm import Session
+
+from app.models.atendente import Atendente
+from app.models.ponto_batida import PontoBatida
+from app.services.comercial_proposta import html_para_pdf
+from app.services.ponto import PONTO_TZ, _as_utc, _bounds_periodo, _intervalos_de_batidas, _q_ativas
+
+MESES_PT = (
+    "",
+    "Janeiro",
+    "Fevereiro",
+    "Março",
+    "Abril",
+    "Maio",
+    "Junho",
+    "Julho",
+    "Agosto",
+    "Setembro",
+    "Outubro",
+    "Novembro",
+    "Dezembro",
+)
+
+
+def _coletar_intervalos(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int | None,
+    desde: date | None,
+    ate: date | None,
+) -> list[tuple[str, object]]:
+    q = _q_ativas(db).filter(PontoBatida.tenant_id == admin.tenant_id)
+    if atendente_id is not None:
+        q = q.filter(PontoBatida.atendente_id == atendente_id)
+    inicio, fim = _bounds_periodo(desde, ate)
+    if inicio is not None:
+        q = q.filter(PontoBatida.registrado_em >= inicio)
+    if fim is not None:
+        q = q.filter(PontoBatida.registrado_em < fim)
+    batidas = q.order_by(PontoBatida.atendente_id.asc(), PontoBatida.registrado_em.asc()).all()
+    nomes = {
+        a.id: a.nome
+        for a in db.query(Atendente).filter(Atendente.tenant_id == admin.tenant_id).all()
+    }
+    por_atendente: dict[int, list[PontoBatida]] = {}
+    for b in batidas:
+        por_atendente.setdefault(b.atendente_id, []).append(b)
+    linhas: list[tuple[str, object]] = []
+    for aid in sorted(por_atendente.keys(), key=lambda x: (nomes.get(x, "").lower(), x)):
+        for it in _intervalos_de_batidas(por_atendente[aid]):
+            linhas.append((nomes.get(aid, str(aid)), it))
+    return linhas
+
+
+def _titulo_periodo(desde: date | None, ate: date | None) -> str:
+    if desde and ate and desde.year == ate.year and desde.month == ate.month and desde.day == 1:
+        ultimo = (date(desde.year, desde.month % 12 + 1, 1) if desde.month < 12 else date(desde.year + 1, 1, 1))
+        from datetime import timedelta
+
+        fim_mes = ultimo - timedelta(days=1)
+        if ate >= fim_mes:
+            return f"{MESES_PT[desde.month]} / {desde.year}"
+    d1 = desde.isoformat() if desde else "—"
+    d2 = ate.isoformat() if ate else "—"
+    return f"{d1} a {d2}"
+
+
+def export_pdf_mensal(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int | None,
+    desde: date | None,
+    ate: date | None,
+) -> bytes:
+    linhas = _coletar_intervalos(db, admin, atendente_id=atendente_id, desde=desde, ate=ate)
+    titulo = _titulo_periodo(desde, ate)
+    gerado = datetime.now(timezone.utc).astimezone(PONTO_TZ).strftime("%d/%m/%Y %H:%M")
+
+    rows_html = ""
+    total_min = 0.0
+    for nome, it in linhas:
+        trab = (it.duracao_segundos or 0) / 60 if it.duracao_segundos is not None else 0
+        if not it.aberto:
+            total_min += trab
+        entrada = _as_utc(it.entrada_em).astimezone(PONTO_TZ).strftime("%d/%m/%Y %H:%M")
+        saida = (
+            _as_utc(it.saida_em).astimezone(PONTO_TZ).strftime("%d/%m/%Y %H:%M") if it.saida_em else "—"
+        )
+        rows_html += (
+            "<tr>"
+            f"<td>{escape(nome)}</td>"
+            f"<td>{it.data.strftime('%d/%m/%Y')}</td>"
+            f"<td>{entrada}</td>"
+            f"<td>{saida}</td>"
+            f"<td>{round((it.segundos_pausa or 0) / 60, 1)}</td>"
+            f"<td>{round(trab, 1) if not it.aberto else '—'}</td>"
+            f"<td>{'sim' if it.aberto else 'não'}</td>"
+            "</tr>"
+        )
+
+    html = f"""<!DOCTYPE html>
+<html lang="pt-BR">
+<head><meta charset="utf-8"><title>Relatório de ponto</title>
+<style>
+  body {{ font-family: sans-serif; font-size: 11px; color: #111; }}
+  h1 {{ font-size: 18px; margin-bottom: 4px; }}
+  .meta {{ color: #555; margin-bottom: 16px; }}
+  table {{ width: 100%; border-collapse: collapse; }}
+  th, td {{ border: 1px solid #ccc; padding: 4px 6px; text-align: left; }}
+  th {{ background: #f0f0f0; }}
+  .total {{ margin-top: 12px; font-weight: bold; }}
+</style>
+</head>
+<body>
+  <h1>Relatório de ponto — {escape(titulo)}</h1>
+  <p class="meta">Gerado em {gerado} · DeskRudder</p>
+  <table>
+    <thead><tr>
+      <th>Atendente</th><th>Data</th><th>Entrada</th><th>Saída</th>
+      <th>Pausas (min)</th><th>Trabalhado (min)</th><th>Aberto</th>
+    </tr></thead>
+    <tbody>{rows_html or '<tr><td colspan="7">Sem registos no período.</td></tr>'}</tbody>
+  </table>
+  <p class="total">Total trabalhado (fechado): {round(total_min / 60, 2)} h ({round(total_min, 0)} min)</p>
+</body>
+</html>"""
+    return html_para_pdf(html)
+
+
+def export_xlsx_mensal(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int | None,
+    desde: date | None,
+    ate: date | None,
+) -> bytes:
+    try:
+        from openpyxl import Workbook
+    except ImportError as exc:  # pragma: no cover
+        from fastapi import HTTPException
+
+        raise HTTPException(
+            status_code=503,
+            detail="Exportação Excel indisponível (openpyxl não instalado).",
+        ) from exc
+
+    linhas = _coletar_intervalos(db, admin, atendente_id=atendente_id, desde=desde, ate=ate)
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Ponto"
+    ws.append(
+        ["Atendente", "Data", "Entrada", "Saída", "Pausas (min)", "Trabalhado (min)", "Aberto"]
+    )
+    total_min = 0.0
+    for nome, it in linhas:
+        trab = (it.duracao_segundos or 0) / 60 if it.duracao_segundos is not None else None
+        if trab is not None and not it.aberto:
+            total_min += trab
+        ws.append(
+            [
+                nome,
+                it.data.isoformat(),
+                _as_utc(it.entrada_em).astimezone(PONTO_TZ).strftime("%Y-%m-%d %H:%M"),
+                _as_utc(it.saida_em).astimezone(PONTO_TZ).strftime("%Y-%m-%d %H:%M") if it.saida_em else "",
+                round((it.segundos_pausa or 0) / 60, 2),
+                round(trab, 2) if trab is not None and not it.aberto else "",
+                "sim" if it.aberto else "não",
+            ]
+        )
+    ws.append([])
+    ws.append(["Total trabalhado (h)", round(total_min / 60, 2)])
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()

--- a/backend/app/services/ponto_settings.py
+++ b/backend/app/services/ponto_settings.py
@@ -10,13 +10,17 @@ from sqlalchemy.orm import Session
 from app.core.audit import registrar_audit
 from app.core.business_calendar import is_feriado_nacional_br
 from app.models.atendente import Atendente
-from app.models.ponto_settings import PontoFeriado, PontoSettings
+from app.models.ponto_settings import PontoFeriado, PontoLocal, PontoSettings
 from app.schemas.ponto import (
     PontoFeriadoCreate,
     PontoFeriadoRead,
+    PontoLocalCreate,
+    PontoLocalRead,
+    PontoSettingsPublicRead,
     PontoSettingsRead,
     PontoSettingsUpdate,
 )
+from app.services.ponto_geofence import POLITICAS_VALIDAS, locais_ativos
 
 
 def get_or_create_settings(db: Session, tenant_id: int) -> PontoSettings:
@@ -57,6 +61,14 @@ def settings_update(db: Session, admin: Atendente, data: PontoSettingsUpdate) ->
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="jornada_diaria_minutos deve estar entre 60 e 1440.",
             )
+    if "politica_geolocalizacao" in payload:
+        p = (payload["politica_geolocalizacao"] or "").strip().lower()
+        if p not in POLITICAS_VALIDAS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="politica_geolocalizacao deve ser opcional, recomendada ou obrigatoria.",
+            )
+        payload["politica_geolocalizacao"] = p
     for k, v in payload.items():
         setattr(row, k, v)
     registrar_audit(
@@ -70,6 +82,72 @@ def settings_update(db: Session, admin: Atendente, data: PontoSettingsUpdate) ->
     db.commit()
     db.refresh(row)
     return PontoSettingsRead.model_validate(row)
+
+
+def settings_public_read(db: Session, tenant_id: int) -> PontoSettingsPublicRead:
+    row = get_or_create_settings(db, tenant_id)
+    politica = (getattr(row, "politica_geolocalizacao", None) or "opcional").strip().lower()
+    if politica not in POLITICAS_VALIDAS:
+        politica = "opcional"
+    tem = len(locais_ativos(db, tenant_id)) > 0
+    return PontoSettingsPublicRead(politica_geolocalizacao=politica, tem_locais_ativos=tem)
+
+
+def listar_locais(db: Session, tenant_id: int) -> list[PontoLocalRead]:
+    rows = (
+        db.query(PontoLocal)
+        .filter(PontoLocal.tenant_id == tenant_id)
+        .order_by(PontoLocal.nome.asc(), PontoLocal.id.asc())
+        .all()
+    )
+    return [PontoLocalRead.model_validate(r) for r in rows]
+
+
+def criar_local(db: Session, admin: Atendente, data: PontoLocalCreate) -> PontoLocalRead:
+    nome = (data.nome or "").strip()
+    if not nome:
+        raise HTTPException(status_code=400, detail="Informe o nome do local.")
+    row = PontoLocal(
+        tenant_id=admin.tenant_id,
+        nome=nome[:255],
+        latitude=float(data.latitude),
+        longitude=float(data.longitude),
+        raio_metros=int(data.raio_metros or 200),
+        ativo=True if data.ativo is None else bool(data.ativo),
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(
+        db,
+        "ponto_local",
+        row.id,
+        "create",
+        admin.id,
+        payload={"nome": nome, "latitude": data.latitude, "longitude": data.longitude},
+    )
+    db.commit()
+    db.refresh(row)
+    return PontoLocalRead.model_validate(row)
+
+
+def remover_local(db: Session, admin: Atendente, local_id: int) -> None:
+    row = (
+        db.query(PontoLocal)
+        .filter(PontoLocal.id == local_id, PontoLocal.tenant_id == admin.tenant_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Local não encontrado")
+    registrar_audit(
+        db,
+        "ponto_local",
+        row.id,
+        "delete",
+        admin.id,
+        payload={"nome": row.nome},
+    )
+    db.delete(row)
+    db.commit()
 
 
 def eh_feriado(db: Session, tenant_id: int, dia: date) -> bool:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,3 +15,4 @@ bcrypt>=5.0.0,<6
 svix>=1.99.1
 pywebpush==2.0.3
 weasyprint==69.0
+openpyxl==3.1.5

--- a/backend/tests/test_ponto_geofence.py
+++ b/backend/tests/test_ponto_geofence.py
@@ -1,0 +1,122 @@
+"""Testes de geofence e política de geo (#844)."""
+
+import pytest
+
+
+def _criar_local(client, headers, *, lat=-23.55052, lon=-46.633308, raio=500):
+    return client.post(
+        "/v1/ponto/locais",
+        headers=headers,
+        json={
+            "nome": "Matriz",
+            "latitude": lat,
+            "longitude": lon,
+            "raio_metros": raio,
+        },
+    )
+
+
+def _set_politica(client, headers, politica: str):
+    return client.patch(
+        "/v1/ponto/settings",
+        headers=headers,
+        json={"politica_geolocalizacao": politica},
+    )
+
+
+def test_ponto_geofence_obrigatoria_dentro(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    assert _criar_local(client, admin).status_code == 201
+    assert _set_politica(client, admin, "obrigatoria").status_code == 200
+
+    r = client.post(
+        "/v1/ponto/bater",
+        headers=user,
+        json={
+            "tipo": "entrada",
+            "latitude": -23.55052,
+            "longitude": -46.633308,
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["fora_area"] is False
+
+
+def test_ponto_geofence_obrigatoria_sem_geo(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    assert _criar_local(client, admin).status_code == 201
+    assert _set_politica(client, admin, "obrigatoria").status_code == 200
+
+    r = client.post("/v1/ponto/bater", headers=user, json={"tipo": "entrada"})
+    assert r.status_code == 400
+    assert "obrigat" in r.json()["detail"].lower()
+
+
+def test_ponto_geofence_obrigatoria_fora(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    assert _criar_local(client, admin, lat=-23.55, lon=-46.63, raio=100).status_code == 201
+    assert _set_politica(client, admin, "obrigatoria").status_code == 200
+
+    r = client.post(
+        "/v1/ponto/bater",
+        headers=user,
+        json={"tipo": "entrada", "latitude": -23.60, "longitude": -46.70},
+    )
+    assert r.status_code == 400
+    assert "fora" in r.json()["detail"].lower()
+
+
+def test_ponto_geofence_recomendada_fora_regista(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    assert _criar_local(client, admin, lat=-23.55, lon=-46.63, raio=100).status_code == 201
+    assert _set_politica(client, admin, "recomendada").status_code == 200
+
+    r = client.post(
+        "/v1/ponto/bater",
+        headers=user,
+        json={"tipo": "entrada", "latitude": -23.60, "longitude": -46.70},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["fora_area"] is True
+
+
+def test_ponto_locais_crud(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    r = _criar_local(client, admin)
+    assert r.status_code == 201
+    local_id = r.json()["id"]
+    lst = client.get("/v1/ponto/locais", headers=admin)
+    assert lst.status_code == 200
+    assert any(x["id"] == local_id for x in lst.json())
+    assert client.delete(f"/v1/ponto/locais/{local_id}", headers=admin).status_code == 204
+
+
+def test_ponto_me_settings(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    _set_politica(client, admin, "recomendada")
+    r = client.get("/v1/ponto/me/settings", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    body = r.json()
+    assert body["politica_geolocalizacao"] == "recomendada"
+    assert body["tem_locais_ativos"] is False
+
+
+def test_ponto_export_pdf_xlsx(client, seed_base, auth_headers, monkeypatch):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    client.post("/v1/ponto/bater", headers=user, json={"tipo": "entrada"})
+    client.post("/v1/ponto/bater", headers=user, json={"tipo": "saida"})
+
+    monkeypatch.setattr("app.services.ponto_relatorio.html_para_pdf", lambda _html: b"%PDF-fake")
+
+    r_pdf = client.get("/v1/ponto/batidas/export.pdf", headers=admin)
+    assert r_pdf.status_code == 200
+    assert r_pdf.headers["content-type"].startswith("application/pdf")
+
+    r_xlsx = client.get("/v1/ponto/batidas/export.xlsx", headers=admin)
+    assert r_xlsx.status_code == 200
+    assert "spreadsheetml" in r_xlsx.headers["content-type"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@capacitor/android": "^8.5.0",
         "@capacitor/app": "^8.1.1",
         "@capacitor/core": "^8.5.0",
+        "@capacitor/geolocation": "^8.2.2",
         "qrcode.react": "^4.2.0",
         "react": "19.2.8",
         "react-dom": "19.2.8",
@@ -1683,6 +1684,24 @@
       "dependencies": {
         "tslib": "^2.1.0"
       }
+    },
+    "node_modules/@capacitor/geolocation": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/geolocation/-/geolocation-8.2.2.tgz",
+      "integrity": "sha512-X8ryw6CfL4LspJnnfVL4++DUKKZVfdUIA9JljWVRljEDIQxZQZtz6xf7qstht+ymc+le6oa5EaUChVA6KsCYlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/synapse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
+      "license": "ISC"
     },
     "node_modules/@emnapi/core": {
       "version": "1.11.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@capacitor/android": "^8.5.0",
     "@capacitor/app": "^8.1.1",
     "@capacitor/core": "^8.5.0",
+    "@capacitor/geolocation": "^8.2.2",
     "qrcode.react": "^4.2.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -772,6 +772,49 @@ export const ponto = {
     }
     return res.blob()
   },
+  exportPdf: async (params?: { atendente_id?: number; desde?: string; ate?: string }) => {
+    const token = getAuthToken()
+    const headers: Record<string, string> = {}
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+    }
+    if (token) headers.Authorization = `Bearer ${token}`
+    const url = `${apiOrigin()}${API_VERSION_PREFIX}${withParams('/ponto/batidas/export.pdf', params)}`
+    const res = await fetch(url, { headers })
+    if (res.status === 401) {
+      invalidateSessionAndRedirectToLogin()
+      throw new ApiError('Sessão expirada ou inválida.', 401, {})
+    }
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}))
+      throw new ApiError(mensagemErroApi(errBody, res.status), res.status, errBody)
+    }
+    return res.blob()
+  },
+  exportXlsx: async (params?: { atendente_id?: number; desde?: string; ate?: string }) => {
+    const token = getAuthToken()
+    const headers: Record<string, string> = {}
+    if (isMultiTenantMode()) {
+      headers['X-Dx-Tenant-Id'] = String(resolveTenantIdFromHostname())
+    }
+    if (token) headers.Authorization = `Bearer ${token}`
+    const url = `${apiOrigin()}${API_VERSION_PREFIX}${withParams('/ponto/batidas/export.xlsx', params)}`
+    const res = await fetch(url, { headers })
+    if (res.status === 401) {
+      invalidateSessionAndRedirectToLogin()
+      throw new ApiError('Sessão expirada ou inválida.', 401, {})
+    }
+    if (!res.ok) {
+      const errBody = await res.json().catch(() => ({}))
+      throw new ApiError(mensagemErroApi(errBody, res.status), res.status, errBody)
+    }
+    return res.blob()
+  },
+  meSettings: () => api<Ponto.SettingsPublic>('/ponto/me/settings'),
+  locais: () => api<Ponto.Local[]>('/ponto/locais'),
+  criarLocal: (data: Ponto.LocalCreate) =>
+    api<Ponto.Local>('/ponto/locais', { method: 'POST', body: JSON.stringify(data) }),
+  removerLocal: (id: number) => api<void>(`/ponto/locais/${id}`, { method: 'DELETE' }),
 };
 
 export namespace WhatsappSettings {
@@ -4652,6 +4695,7 @@ export namespace Presenca {
 export namespace Ponto {
   export type Tipo = 'entrada' | 'saida' | 'pausa_inicio' | 'pausa_fim'
   export type Origem = 'web' | 'mobile' | 'admin' | 'sistema'
+  export type PoliticaGeolocalizacao = 'opcional' | 'recomendada' | 'obrigatoria'
   export type StatusDia =
     | 'ok'
     | 'falta'
@@ -4677,6 +4721,9 @@ export namespace Ponto {
     latitude?: number | null
     longitude?: number | null
     accuracy_metros?: number | null
+    fora_area?: boolean
+    distancia_metros?: number | null
+    local_id?: number | null
     anulada?: boolean
   }
   export interface BatidaAdmin {
@@ -4689,6 +4736,9 @@ export namespace Ponto {
     latitude?: number | null
     longitude?: number | null
     accuracy_metros?: number | null
+    fora_area?: boolean
+    distancia_metros?: number | null
+    local_id?: number | null
     anulada?: boolean
   }
   export interface Intervalo {
@@ -4778,12 +4828,33 @@ export namespace Ponto {
     fecho_automatico_ativo: boolean
     fecho_apos_horas: number
     jornada_diaria_minutos: number
+    politica_geolocalizacao: PoliticaGeolocalizacao
+  }
+  export interface SettingsPublic {
+    politica_geolocalizacao: PoliticaGeolocalizacao
+    tem_locais_ativos: boolean
   }
   export interface SettingsUpdate {
     usar_feriados_nacionais?: boolean
     fecho_automatico_ativo?: boolean
     fecho_apos_horas?: number
     jornada_diaria_minutos?: number
+    politica_geolocalizacao?: PoliticaGeolocalizacao
+  }
+  export interface Local {
+    id: number
+    nome: string
+    latitude: number
+    longitude: number
+    raio_metros: number
+    ativo: boolean
+  }
+  export interface LocalCreate {
+    nome: string
+    latitude: number
+    longitude: number
+    raio_metros?: number
+    ativo?: boolean
   }
   export interface Feriado {
     id: number

--- a/frontend/src/components/PontoMetricCard.tsx
+++ b/frontend/src/components/PontoMetricCard.tsx
@@ -1,0 +1,27 @@
+export function PontoMetricCard({
+  label,
+  value,
+  hint,
+  tone = 'neutral',
+}: {
+  label: string
+  value: string
+  hint?: string
+  tone?: 'neutral' | 'good' | 'warn' | 'info'
+}) {
+  const toneCls =
+    tone === 'good'
+      ? 'border-emerald-200/80 bg-emerald-50/80 dark:border-emerald-900/60 dark:bg-emerald-950/30'
+      : tone === 'warn'
+        ? 'border-amber-200/80 bg-amber-50/80 dark:border-amber-900/60 dark:bg-amber-950/30'
+        : tone === 'info'
+          ? 'border-sky-200/80 bg-sky-50/80 dark:border-sky-900/60 dark:bg-sky-950/30'
+          : 'border-slate-200 bg-slate-50/80 dark:border-slate-800 dark:bg-slate-900/40'
+  return (
+    <div className={`rounded-xl border px-4 py-3 ${toneCls}`}>
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</p>
+      <p className="mt-1 text-lg font-semibold tabular-nums text-slate-900 dark:text-slate-100">{value}</p>
+      {hint ? <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">{hint}</p> : null}
+    </div>
+  )
+}

--- a/frontend/src/lib/geolocation.ts
+++ b/frontend/src/lib/geolocation.ts
@@ -1,4 +1,7 @@
-/** Geolocalização para batidas de ponto (web + WebView Capacitor). */
+/** Geolocalização para batidas de ponto (web + Capacitor APK). */
+
+import { Geolocation } from '@capacitor/geolocation'
+import { isCapacitorNative } from './capacitorNative'
 
 export type GeoPosition = {
   latitude: number
@@ -11,19 +14,40 @@ export type GeoError = {
   message: string
 }
 
-const OPTIONS: PositionOptions = {
+const WEB_OPTIONS: PositionOptions = {
   enableHighAccuracy: true,
   timeout: 12_000,
   maximumAge: 60_000,
 }
 
 export function geolocationSupported(): boolean {
+  if (isCapacitorNative()) return true
   return typeof navigator !== 'undefined' && !!navigator.geolocation
 }
 
-export function getCurrentPosition(): Promise<GeoPosition> {
+async function getCurrentPositionNative(): Promise<GeoPosition> {
+  let perm = await Geolocation.checkPermissions()
+  if (perm.location === 'denied' || perm.coarseLocation === 'denied') {
+    perm = await Geolocation.requestPermissions()
+  }
+  if (perm.location === 'denied' && perm.coarseLocation === 'denied') {
+    throw { code: 1, message: 'Permissão de localização negada.' } satisfies GeoError
+  }
+  const pos = await Geolocation.getCurrentPosition({
+    enableHighAccuracy: true,
+    timeout: 12_000,
+    maximumAge: 60_000,
+  })
+  return {
+    latitude: pos.coords.latitude,
+    longitude: pos.coords.longitude,
+    accuracy: pos.coords.accuracy,
+  }
+}
+
+function getCurrentPositionWeb(): Promise<GeoPosition> {
   return new Promise((resolve, reject) => {
-    if (!geolocationSupported()) {
+    if (!navigator.geolocation) {
       reject({ code: 0, message: 'Geolocalização não é suportada neste dispositivo.' } satisfies GeoError)
       return
     }
@@ -46,7 +70,14 @@ export function getCurrentPosition(): Promise<GeoPosition> {
         }
         reject({ code: err.code, message } satisfies GeoError)
       },
-      OPTIONS,
+      WEB_OPTIONS,
     )
   })
+}
+
+export async function getCurrentPosition(): Promise<GeoPosition> {
+  if (isCapacitorNative()) {
+    return getCurrentPositionNative()
+  }
+  return getCurrentPositionWeb()
 }

--- a/frontend/src/lib/pontoFormat.ts
+++ b/frontend/src/lib/pontoFormat.ts
@@ -1,0 +1,60 @@
+/** Formatação compartilhada entre Meu ponto e Ponto da equipe. */
+
+export function formatarHora(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return iso
+  }
+}
+
+export function formatarHoraCurta(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
+  } catch {
+    return iso
+  }
+}
+
+export function formatarDuracao(segundos: number | null | undefined): string {
+  if (segundos == null || segundos < 0) return '—'
+  const h = Math.floor(segundos / 3600)
+  const m = Math.floor((segundos % 3600) / 60)
+  if (h <= 0) return `${m} min`
+  return `${h} h ${String(m).padStart(2, '0')} min`
+}
+
+export function inicioMesIso(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`
+}
+
+export function hojeIso(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+export function linkMapaOsm(lat: number, lon: number): string {
+  return `https://www.openstreetmap.org/?mlat=${lat}&mlon=${lon}#map=17/${lat}/${lon}`
+}
+
+export function rotuloPoliticaGeo(p: PontoPoliticaGeo): string {
+  switch (p) {
+    case 'obrigatoria':
+      return 'Obrigatória'
+    case 'recomendada':
+      return 'Recomendada'
+    default:
+      return 'Opcional'
+  }
+}
+
+export type PontoPoliticaGeo = 'opcional' | 'recomendada' | 'obrigatoria'

--- a/frontend/src/lib/pontoOfflineQueue.ts
+++ b/frontend/src/lib/pontoOfflineQueue.ts
@@ -1,0 +1,88 @@
+/** Fila offline de batidas de ponto — localStorage + sync ao voltar online. */
+
+import type { Ponto } from '../api/client'
+
+const STORAGE_KEY = 'dx-ponto-offline-queue-v1'
+
+export type PendingPontoBatida = {
+  id: string
+  tipo: Ponto.Tipo
+  created_at: string
+  latitude?: number
+  longitude?: number
+  accuracy_metros?: number
+}
+
+function readAll(): PendingPontoBatida[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as PendingPontoBatida[]
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+function writeAll(items: PendingPontoBatida[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(items))
+}
+
+export function listPendingPontoBatidas(): PendingPontoBatida[] {
+  return readAll()
+}
+
+export function countPendingPontoBatidas(): number {
+  return readAll().length
+}
+
+export function enqueuePontoBatida(
+  item: Omit<PendingPontoBatida, 'id' | 'created_at'> & { created_at?: string },
+): PendingPontoBatida {
+  const entry: PendingPontoBatida = {
+    id: crypto.randomUUID(),
+    created_at: item.created_at ?? new Date().toISOString(),
+    tipo: item.tipo,
+    latitude: item.latitude,
+    longitude: item.longitude,
+    accuracy_metros: item.accuracy_metros,
+  }
+  writeAll([...readAll(), entry])
+  return entry
+}
+
+export function removePendingPontoBatida(id: string) {
+  writeAll(readAll().filter((x) => x.id !== id))
+}
+
+export function isLikelyOfflineError(err: unknown): boolean {
+  if (typeof navigator !== 'undefined' && !navigator.onLine) return true
+  if (err instanceof TypeError) return true
+  return false
+}
+
+export async function syncPendingPontoBatidas(
+  bater: (data: Ponto.Bater) => Promise<Ponto.Batida>,
+  origem: Ponto.Origem,
+): Promise<number> {
+  if (typeof navigator !== 'undefined' && !navigator.onLine) return 0
+  const pending = readAll()
+  if (pending.length === 0) return 0
+  let synced = 0
+  for (const item of pending) {
+    try {
+      await bater({
+        tipo: item.tipo,
+        origem,
+        latitude: item.latitude,
+        longitude: item.longitude,
+        accuracy_metros: item.accuracy_metros,
+      })
+      removePendingPontoBatida(item.id)
+      synced += 1
+    } catch {
+      break
+    }
+  }
+  return synced
+}

--- a/frontend/src/pages/MeuPonto.tsx
+++ b/frontend/src/pages/MeuPonto.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { ponto, type Ponto } from '../api/client'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { PontoCalendarioMes } from '../components/PontoCalendarioMes'
+import { PontoMetricCard } from '../components/PontoMetricCard'
 import { Button } from '../components/ui/Button'
 import { Card } from '../components/ui/Card'
 import { Input } from '../components/ui/Input'
@@ -10,54 +11,20 @@ import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
 import { isCapacitorNative } from '../lib/capacitorNative'
 import { geolocationSupported, getCurrentPosition, type GeoError } from '../lib/geolocation'
-
-function formatarHora(iso: string | null | undefined): string {
-  if (!iso) return '—'
-  try {
-    return new Date(iso).toLocaleString('pt-BR', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-  } catch {
-    return iso
-  }
-}
-
-function formatarHoraCurta(iso: string | null | undefined): string {
-  if (!iso) return '—'
-  try {
-    return new Date(iso).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
-  } catch {
-    return iso
-  }
-}
-
-function formatarDuracao(segundos: number | null | undefined): string {
-  if (segundos == null || segundos < 0) return '—'
-  const h = Math.floor(segundos / 3600)
-  const m = Math.floor((segundos % 3600) / 60)
-  if (h <= 0) return `${m} min`
-  return `${h} h ${String(m).padStart(2, '0')} min`
-}
-
-function inicioMesIso(): string {
-  const d = new Date()
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`
-}
-
-function hojeIso(): string {
-  const d = new Date()
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-}
-
-type AcaoPrincipal = {
-  tipo: Ponto.Tipo
-  rotulo: string
-  dica: string
-}
+import {
+  countPendingPontoBatidas,
+  enqueuePontoBatida,
+  isLikelyOfflineError,
+  syncPendingPontoBatidas,
+} from '../lib/pontoOfflineQueue'
+import {
+  formatarDuracao,
+  formatarHora,
+  formatarHoraCurta,
+  hojeIso,
+  inicioMesIso,
+  rotuloPoliticaGeo,
+} from '../lib/pontoFormat'
 
 function acaoPrincipal(emJornada: boolean, emPausa: boolean): AcaoPrincipal {
   if (!emJornada) {
@@ -69,32 +36,10 @@ function acaoPrincipal(emJornada: boolean, emPausa: boolean): AcaoPrincipal {
   return { tipo: 'saida', rotulo: 'Registrar saída', dica: 'Com pausa aberta, a pausa fecha automaticamente' }
 }
 
-function MetricCard({
-  label,
-  value,
-  hint,
-  tone = 'neutral',
-}: {
-  label: string
-  value: string
-  hint?: string
-  tone?: 'neutral' | 'good' | 'warn' | 'info'
-}) {
-  const toneCls =
-    tone === 'good'
-      ? 'border-emerald-200/80 bg-emerald-50/80 dark:border-emerald-900/60 dark:bg-emerald-950/30'
-      : tone === 'warn'
-        ? 'border-amber-200/80 bg-amber-50/80 dark:border-amber-900/60 dark:bg-amber-950/30'
-        : tone === 'info'
-          ? 'border-sky-200/80 bg-sky-50/80 dark:border-sky-900/60 dark:bg-sky-950/30'
-          : 'border-slate-200 bg-slate-50/80 dark:border-slate-800 dark:bg-slate-900/40'
-  return (
-    <div className={`rounded-xl border px-4 py-3 ${toneCls}`}>
-      <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">{label}</p>
-      <p className="mt-1 text-lg font-semibold tabular-nums text-slate-900 dark:text-slate-100">{value}</p>
-      {hint ? <p className="mt-0.5 text-xs text-slate-500 dark:text-slate-400">{hint}</p> : null}
-    </div>
-  )
+type AcaoPrincipal = {
+  tipo: Ponto.Tipo
+  rotulo: string
+  dica: string
 }
 
 export function MeuPonto() {
@@ -122,21 +67,33 @@ export function MeuPonto() {
   const [incluirLocalizacao, setIncluirLocalizacao] = useState(
     () => isCapacitorNative() || geolocationSupported(),
   )
+  const [geoSettings, setGeoSettings] = useState<Ponto.SettingsPublic | null>(null)
+  const [pendentesOffline, setPendentesOffline] = useState(countPendingPontoBatidas())
   const [obtendoLocalizacao, setObtendoLocalizacao] = useState(false)
+
+  const politicaGeo = geoSettings?.politica_geolocalizacao ?? 'opcional'
+  const geoObrigatoria = politicaGeo === 'obrigatoria' && !!geoSettings?.tem_locais_ativos
+  const geoRecomendada = politicaGeo === 'recomendada' && !!geoSettings?.tem_locais_ativos
+  const deveIncluirGeo = geoObrigatoria || (geoRecomendada ? true : incluirLocalizacao)
 
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [me, hist, js, bh] = await Promise.all([
+        const [me, hist, js, bh, gs] = await Promise.all([
           ponto.me(),
           ponto.minhasBatidas({ desde, ate, limit: 100 }),
           ponto.minhasJustificativas(),
           ponto.meuBancoHoras(desde, ate),
+          ponto.meSettings(),
         ])
         setEstado(me)
         setHistorico(hist)
         setJustifs(js)
         setBanco(bh)
+        setGeoSettings(gs)
+        if (gs.politica_geolocalizacao === 'obrigatoria' && gs.tem_locais_ativos) {
+          setIncluirLocalizacao(true)
+        }
       } catch (err) {
         if (!silencioso) {
           toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar o ponto.'))
@@ -187,14 +144,31 @@ export function MeuPonto() {
     return () => window.clearInterval(t)
   }, [])
 
+  useEffect(() => {
+    const origem = isCapacitorNative() ? 'mobile' : 'web'
+    const sync = async () => {
+      const n = await syncPendingPontoBatidas((data) => ponto.bater(data), origem)
+      setPendentesOffline(countPendingPontoBatidas())
+      if (n > 0) {
+        toast.showSuccess(`${n} batida(s) offline sincronizada(s).`)
+        await Promise.all([carregar(true), carregarCalendario(true)])
+      }
+    }
+    void sync()
+    const onOnline = () => void sync()
+    window.addEventListener('online', onOnline)
+    return () => window.removeEventListener('online', onOnline)
+  }, [carregar, carregarCalendario, toast])
+
   async function bater(tipo: Ponto.Tipo) {
     setBatendo(true)
     const fechouPausaAuto = tipo === 'saida' && !!estado?.em_pausa
+    const origem = isCapacitorNative() ? 'mobile' : 'web'
     let geo:
       | { latitude: number; longitude: number; accuracy_metros: number }
       | undefined
     try {
-      if (incluirLocalizacao && geolocationSupported()) {
+      if (deveIncluirGeo && geolocationSupported()) {
         setObtendoLocalizacao(true)
         try {
           const pos = await getCurrentPosition()
@@ -205,16 +179,31 @@ export function MeuPonto() {
           }
         } catch (geoErr) {
           const msg = (geoErr as GeoError)?.message || 'Localização indisponível'
+          if (geoObrigatoria) {
+            toast.showError(`${msg} A geolocalização é obrigatória nesta instância.`)
+            return
+          }
           toast.showWarning(`${msg} O ponto será registado sem localização.`)
         } finally {
           setObtendoLocalizacao(false)
         }
       }
-      await ponto.bater({
+
+      if (!navigator.onLine) {
+        enqueuePontoBatida({ tipo, ...geo })
+        setPendentesOffline(countPendingPontoBatidas())
+        toast.showWarning('Sem ligação — batida guardada offline. Será enviada ao voltar online.')
+        return
+      }
+
+      const batida = await ponto.bater({
         tipo,
-        origem: isCapacitorNative() ? 'mobile' : 'web',
+        origem,
         ...(geo ?? {}),
       })
+      if (batida.fora_area) {
+        toast.showWarning('Batida registada fora da área permitida.')
+      }
       if (fechouPausaAuto) {
         toast.showSuccess(
           geo
@@ -232,6 +221,12 @@ export function MeuPonto() {
       }
       await Promise.all([carregar(true), carregarCalendario(true)])
     } catch (err) {
+      if (isLikelyOfflineError(err)) {
+        enqueuePontoBatida({ tipo, ...geo })
+        setPendentesOffline(countPendingPontoBatidas())
+        toast.showWarning('Falha de rede — batida guardada offline.')
+        return
+      }
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível bater o ponto.'))
     } finally {
       setObtendoLocalizacao(false)
@@ -338,21 +333,38 @@ export function MeuPonto() {
               </div>
               <div>
                 <p className="mb-2 text-sm text-slate-600 dark:text-slate-300">{principal.dica}</p>
-                {geolocationSupported() ? (
+                {geolocationSupported() && !geoObrigatoria ? (
                   <label className="mb-3 flex items-start gap-2 text-sm text-slate-600 dark:text-slate-300">
                     <input
                       type="checkbox"
                       className="mt-0.5"
-                      checked={incluirLocalizacao}
+                      checked={deveIncluirGeo}
+                      disabled={geoRecomendada}
                       onChange={(e) => setIncluirLocalizacao(e.target.checked)}
                     />
                     <span>
                       Incluir localização na batida
-                      <span className="mt-0.5 block text-xs text-slate-500">
-                        Opcional — útil no telemóvel/APK. Se falhar, o ponto regista na mesma.
-                      </span>
+                      {geoRecomendada ? (
+                        <span className="mt-0.5 block text-xs text-amber-700 dark:text-amber-300">
+                          Política recomendada — fora da área gera aviso, mas regista.
+                        </span>
+                      ) : (
+                        <span className="mt-0.5 block text-xs text-slate-500">
+                          Opcional — útil no telemóvel/APK. Se falhar, o ponto regista na mesma.
+                        </span>
+                      )}
                     </span>
                   </label>
+                ) : null}
+                {geoObrigatoria ? (
+                  <p className="mb-3 text-sm text-amber-800 dark:text-amber-200">
+                    Geolocalização <strong>obrigatória</strong> ({rotuloPoliticaGeo(politicaGeo)}).
+                  </p>
+                ) : null}
+                {pendentesOffline > 0 ? (
+                  <p className="mb-3 text-sm text-amber-800 dark:text-amber-200">
+                    {pendentesOffline} batida(s) aguardando sync offline.
+                  </p>
                 ) : null}
                 <Button
                   type="button"
@@ -435,19 +447,19 @@ export function MeuPonto() {
 
       {/* Métricas — estilo cards do dx-ponto */}
       <div className="mt-4 grid gap-3 sm:grid-cols-3">
-        <MetricCard
+        <PontoMetricCard
           label="Trabalhado no período"
           value={formatarDuracao(historico?.total_segundos_fechados)}
           hint={`${desde} → ${ate}`}
           tone="info"
         />
-        <MetricCard
+        <PontoMetricCard
           label="Pausas"
           value={formatarDuracao(historico?.total_segundos_pausa ?? 0)}
           hint="Não conta como trabalhado"
           tone="neutral"
         />
-        <MetricCard
+        <PontoMetricCard
           label="Banco de horas"
           value={
             banco

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -3,6 +3,7 @@ import { ApiError, atendentes, ponto, type Atendentes, type Ponto } from '../api
 import { coletarTodasPaginas } from '../api/collectPages'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { PontoCalendarioMes } from '../components/PontoCalendarioMes'
+import { PontoMetricCard } from '../components/PontoMetricCard'
 import { Button } from '../components/ui/Button'
 import { Card } from '../components/ui/Card'
 import { Input } from '../components/ui/Input'
@@ -10,31 +11,15 @@ import { PageContainer, PageHeader } from '../components/ui/PageContainer'
 import { Select } from '../components/ui/Select'
 import { useToast } from '../components/ui/Toast'
 import { useAuth } from '../contexts/AuthContext'
+import {
+  formatarDuracao,
+  formatarHora,
+  hojeIso,
+  inicioMesIso,
+  linkMapaOsm,
+  rotuloPoliticaGeo,
+} from '../lib/pontoFormat'
 import { SemPermissao } from './SemPermissao'
-
-function formatarHora(iso: string | null | undefined): string {
-  if (!iso) return '—'
-  try {
-    return new Date(iso).toLocaleString('pt-BR', {
-      day: '2-digit',
-      month: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-  } catch {
-    return iso
-  }
-}
-
-function inicioMesIso(): string {
-  const d = new Date()
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`
-}
-
-function hojeIso(): string {
-  const d = new Date()
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-}
 
 function rotuloStatus(s: Ponto.HojeItem['status']): string {
   switch (s) {
@@ -55,14 +40,6 @@ function rotuloStatus(s: Ponto.HojeItem['status']): string {
     default:
       return 'Livre'
   }
-}
-
-function formatarDuracao(segundos: number | null | undefined): string {
-  if (segundos == null || segundos < 0) return '—'
-  const h = Math.floor(segundos / 3600)
-  const m = Math.floor((segundos % 3600) / 60)
-  if (h <= 0) return `${m} min`
-  return `${h} h ${String(m).padStart(2, '0')} min`
 }
 
 function toDatetimeLocalValue(d = new Date()): string {
@@ -95,6 +72,11 @@ export function PontoEquipe() {
   const [feriadoData, setFeriadoData] = useState('')
   const [feriadoNome, setFeriadoNome] = useState('')
   const [salvandoSettings, setSalvandoSettings] = useState(false)
+  const [locais, setLocais] = useState<Ponto.Local[]>([])
+  const [localNome, setLocalNome] = useState('')
+  const [localLat, setLocalLat] = useState('')
+  const [localLon, setLocalLon] = useState('')
+  const [localRaio, setLocalRaio] = useState('200')
   const agoraCal = new Date()
   const [calAno, setCalAno] = useState(agoraCal.getFullYear())
   const [calMes, setCalMes] = useState(agoraCal.getMonth() + 1)
@@ -105,7 +87,7 @@ export function PontoEquipe() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [hist, dia, js, dig, st, fer] = await Promise.all([
+        const [hist, dia, js, dig, st, fer, locs] = await Promise.all([
           ponto.batidasAdmin({
             atendente_id: atendenteId ? Number(atendenteId) : undefined,
             desde,
@@ -117,6 +99,7 @@ export function PontoEquipe() {
           ponto.digest(),
           ponto.settings(),
           ponto.feriados(new Date().getFullYear()),
+          ponto.locais(),
         ])
         setItems(hist.items)
         setTotal(hist.total)
@@ -125,6 +108,7 @@ export function PontoEquipe() {
         setDigest(dig)
         setSettings(st)
         setFeriados(fer)
+        setLocais(locs)
         setSemPermissao(false)
         if (atendenteId) {
           const bh = await ponto.bancoHorasAdmin(Number(atendenteId), desde, ate)
@@ -200,6 +184,28 @@ export function PontoEquipe() {
     }
   }
 
+  async function exportarRelatorio(ext: 'pdf' | 'xlsx') {
+    try {
+      const params = {
+        atendente_id: atendenteId ? Number(atendenteId) : undefined,
+        desde,
+        ate,
+      }
+      const blob =
+        ext === 'pdf' ? await ponto.exportPdf(params) : await ponto.exportXlsx(params)
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = ext === 'pdf' ? 'ponto_relatorio.pdf' : 'ponto_relatorio.xlsx'
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      toast.showError(
+        mensagemFalhaParaToast(err, `Não foi possível exportar o ${ext.toUpperCase()}.`),
+      )
+    }
+  }
+
   async function salvarAjuste() {
     if (!ajusteAtendente || !ajusteMotivo.trim()) {
       toast.showWarning('Informe atendente e motivo do ajuste.')
@@ -257,6 +263,7 @@ export function PontoEquipe() {
         fecho_automatico_ativo: settings.fecho_automatico_ativo,
         fecho_apos_horas: settings.fecho_apos_horas,
         jornada_diaria_minutos: settings.jornada_diaria_minutos,
+        politica_geolocalizacao: settings.politica_geolocalizacao,
       })
       setSettings(st)
       toast.showSuccess('Configurações de ponto salvas.')
@@ -264,6 +271,36 @@ export function PontoEquipe() {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar as configurações.'))
     } finally {
       setSalvandoSettings(false)
+    }
+  }
+
+  async function adicionarLocal() {
+    if (!localNome.trim() || !localLat || !localLon) {
+      toast.showWarning('Informe nome, latitude e longitude do local.')
+      return
+    }
+    try {
+      await ponto.criarLocal({
+        nome: localNome.trim(),
+        latitude: Number(localLat),
+        longitude: Number(localLon),
+        raio_metros: Number(localRaio) || 200,
+      })
+      toast.showSuccess('Local cadastrado.')
+      setLocalNome('')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível cadastrar o local.'))
+    }
+  }
+
+  async function apagarLocal(id: number) {
+    try {
+      await ponto.removerLocal(id)
+      toast.showSuccess('Local removido.')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível remover o local.'))
     }
   }
 
@@ -306,34 +343,41 @@ export function PontoEquipe() {
     <PageContainer>
       <PageHeader
         title="Ponto da equipe"
-        subtitle="Batidas, visão do dia, ajustes auditados e exportação CSV."
+        subtitle="Visão do dia, batidas, geofence, ajustes auditados e relatórios mensais."
       />
 
-      <div className="space-y-4">
-        <Card title="Digest do dia">
-          {digest ? (
-            <div className="flex flex-wrap gap-4 text-sm">
-              <span>
-                Faltas: <strong>{digest.faltas}</strong>
-              </span>
-              <span>
-                Atrasos: <strong>{digest.atrasos}</strong>
-              </span>
-              <span>
-                Jornadas abertas: <strong>{digest.jornadas_abertas}</strong>
-              </span>
-              <span>
-                Online sem ponto: <strong>{digest.online_sem_ponto}</strong>
-              </span>
-              <span>
-                Justificativas pendentes: <strong>{digest.justificativas_pendentes}</strong>
-              </span>
+      <Card className="overflow-hidden border-cyan-200/60 bg-gradient-to-br from-slate-50 via-white to-cyan-50/40 dark:border-cyan-900/40 dark:from-slate-950 dark:via-slate-900 dark:to-cyan-950/20">
+        {loading && !digest ? (
+          <div className="h-28 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+        ) : (
+          <div className="space-y-4">
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500 dark:text-slate-400">
+              Digest de hoje
+            </p>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+              <PontoMetricCard label="Faltas" value={String(digest?.faltas ?? 0)} tone="warn" />
+              <PontoMetricCard label="Atrasos" value={String(digest?.atrasos ?? 0)} tone="warn" />
+              <PontoMetricCard
+                label="Jornadas abertas"
+                value={String(digest?.jornadas_abertas ?? 0)}
+                tone="info"
+              />
+              <PontoMetricCard
+                label="Online sem ponto"
+                value={String(digest?.online_sem_ponto ?? 0)}
+                tone="warn"
+              />
+              <PontoMetricCard
+                label="Justificativas"
+                value={String(digest?.justificativas_pendentes ?? 0)}
+                hint="pendentes"
+              />
             </div>
-          ) : (
-            <p className="text-sm text-slate-500">Carregando…</p>
-          )}
-        </Card>
+          </div>
+        )}
+      </Card>
 
+      <div className="space-y-4">
         <Card title="Hoje">
           {loading && !hoje ? (
             <div className="h-24 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
@@ -473,6 +517,12 @@ export function PontoEquipe() {
             <Button type="button" variant="secondary" onClick={() => void exportarCsv()}>
               Exportar CSV
             </Button>
+            <Button type="button" variant="secondary" onClick={() => void exportarRelatorio('pdf')}>
+              PDF mensal
+            </Button>
+            <Button type="button" variant="secondary" onClick={() => void exportarRelatorio('xlsx')}>
+              Excel mensal
+            </Button>
           </div>
           <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
             {total} batida{total === 1 ? '' : 's'} no filtro
@@ -514,14 +564,27 @@ export function PontoEquipe() {
                       <td className="py-2 pr-3">
                         {b.origem ?? '—'}
                         {b.latitude != null && b.longitude != null ? (
-                          <span
-                            className="ml-1 text-xs text-cyan-700 dark:text-cyan-300"
-                            title={`${b.latitude.toFixed(5)}, ${b.longitude.toFixed(5)}${
-                              b.accuracy_metros != null ? ` (±${Math.round(b.accuracy_metros)} m)` : ''
-                            }`}
-                          >
-                            · GPS
-                          </span>
+                          <>
+                            <span
+                              className="ml-1 text-xs text-cyan-700 dark:text-cyan-300"
+                              title={`${b.latitude.toFixed(5)}, ${b.longitude.toFixed(5)}${
+                                b.accuracy_metros != null ? ` (±${Math.round(b.accuracy_metros)} m)` : ''
+                              }`}
+                            >
+                              · GPS
+                            </span>
+                            {b.fora_area ? (
+                              <span className="ml-1 text-xs text-amber-700 dark:text-amber-300">· fora</span>
+                            ) : null}
+                            <a
+                              className="ml-1 text-xs text-cyan-700 underline dark:text-cyan-300"
+                              href={linkMapaOsm(b.latitude, b.longitude)}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              mapa
+                            </a>
+                          </>
                         ) : null}
                       </td>
                       <td className="py-2">
@@ -610,6 +673,25 @@ export function PontoEquipe() {
                   })
                 }
               />
+              <Select
+                label="Política de geolocalização"
+                value={settings.politica_geolocalizacao ?? 'opcional'}
+                onChange={(v) =>
+                  setSettings({
+                    ...settings,
+                    politica_geolocalizacao: String(v) as Ponto.PoliticaGeolocalizacao,
+                  })
+                }
+                options={[
+                  { value: 'opcional', label: rotuloPoliticaGeo('opcional') },
+                  { value: 'recomendada', label: rotuloPoliticaGeo('recomendada') },
+                  { value: 'obrigatoria', label: rotuloPoliticaGeo('obrigatoria') },
+                ]}
+              />
+              <p className="text-xs text-slate-500">
+                Com locais cadastrados: opcional regista geo; recomendada avisa fora da área; obrigatória
+                bloqueia sem GPS ou fora do raio.
+              </p>
               <Button type="button" disabled={salvandoSettings} onClick={() => void salvarSettings()}>
                 Salvar configurações
               </Button>
@@ -617,6 +699,67 @@ export function PontoEquipe() {
           ) : (
             <p className="text-sm text-slate-500">Carregando…</p>
           )}
+        </Card>
+
+        <Card title="Locais (geofence)">
+          <div className="mb-4 flex flex-wrap items-end gap-3">
+            <Input label="Nome" value={localNome} onChange={(e) => setLocalNome(e.target.value)} />
+            <Input
+              label="Latitude"
+              type="number"
+              step="any"
+              value={localLat}
+              onChange={(e) => setLocalLat(e.target.value)}
+            />
+            <Input
+              label="Longitude"
+              type="number"
+              step="any"
+              value={localLon}
+              onChange={(e) => setLocalLon(e.target.value)}
+            />
+            <Input
+              label="Raio (m)"
+              type="number"
+              min={20}
+              value={localRaio}
+              onChange={(e) => setLocalRaio(e.target.value)}
+            />
+            <Button type="button" onClick={() => void adicionarLocal()}>
+              Adicionar local
+            </Button>
+          </div>
+          <ul className="space-y-2 text-sm">
+            {locais.length === 0 ? (
+              <li className="text-slate-500">Nenhum local cadastrado — geofence inactivo.</li>
+            ) : (
+              locais.map((loc) => (
+                <li
+                  key={loc.id}
+                  className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                >
+                  <span>
+                    <strong>{loc.nome}</strong> · {loc.latitude.toFixed(5)}, {loc.longitude.toFixed(5)} · raio{' '}
+                    {loc.raio_metros} m
+                    {!loc.ativo ? ' (inactivo)' : ''}
+                  </span>
+                  <div className="flex gap-2">
+                    <a
+                      className="text-xs text-cyan-700 underline dark:text-cyan-300"
+                      href={linkMapaOsm(loc.latitude, loc.longitude)}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Ver mapa
+                    </a>
+                    <Button type="button" variant="ghost" onClick={() => void apagarLocal(loc.id)}>
+                      Remover
+                    </Button>
+                  </div>
+                </li>
+              ))
+            )}
+          </ul>
         </Card>
 
         <Card title="Feriados da instância">


### PR DESCRIPTION
## Summary
- Geofence (#844): CRUD de locais, politica opcional/recomendada/obrigatoria, campos fora_area na batida
- Meu ponto: respeita politica de geo, fila offline + sync ao voltar online
- APK: @capacitor/geolocation nativo
- Ponto da equipe: digest em cards (mesmo nivel visual), link mapa OSM, PDF/Excel mensal

Closes #844

## Test plan
- [x] docker compose run --rm --no-deps backend pytest tests/test_ponto_geofence.py tests/test_ponto.py -q -o addopts= (23 passed)
- [x] npx tsc -b (frontend)
- [ ] Migration 109 em ambiente local
- [ ] npm run cap:sync + batida com GPS no APK
- [ ] Admin: cadastrar local, export PDF/Excel no filtro mensal

Made with [Cursor](https://cursor.com)