### PR TITLE
fix(ui): responsividade geral do painel e Cancelar gradiente (#870)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
-- UI (#866): botão **Cancelar** padronizado em vermelho (`variant=cancel`, bordo forte), distinto de Excluir; ConfirmDialog e formulários/modais alinhados
+- UI (#870): responsividade — coluna principal do painel ocupa sempre a largura disponível (grid + `w-full`/`min-w-0` no Layout); contentores internos alinhados; abas e header legíveis em qualquer largura
+- UI (#866): botão **Cancelar** com gradiente vermelho preenchido (mesmo molde do Salvar), distinto de Excluir; ConfirmDialog, portal e formulários alinhados
 - UI (#867): controlo **Voltar** com estilo de botão (fundo/padding) em cadastros, detalhes, portal, WhatsApp e ecrãs de erro de carregamento
 - Sugestões: cada pedido ganha um **protocolo único** (`#S202608-0001`) no painel DeskRudder, visível depois em Minhas solicitações, para amarrar a issue no GitHub
 - Sugestões: no painel SaaS dá para **ligar pedidos iguais** de vários clientes (peso da demanda). O cliente não vê este grupo; na issue GitHub entram todos os protocolos

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -102,7 +102,7 @@ function LayoutInner() {
 
   return (
     <div
-      className="flex h-[var(--vv-height,100dvh)] max-h-[var(--vv-height,100dvh)] min-h-0 overflow-hidden bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95 md:grid md:grid-cols-[var(--sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
+      className="grid h-[var(--vv-height,100dvh)] max-h-[var(--vv-height,100dvh)] min-h-0 w-full min-w-0 grid-cols-1 overflow-hidden bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95 md:grid-cols-[var(--sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
       style={
         {
           ['--sidebar-w' as never]: sidebarW,
@@ -123,10 +123,10 @@ function LayoutInner() {
         onLogout={logout}
       />
 
-      <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden md:col-start-2 md:row-start-1">
+      <div className="flex h-full min-h-0 min-w-0 w-full flex-col overflow-hidden md:col-start-2 md:row-start-1">
         <header
-          className={`z-30 h-16 min-h-[64px] shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-800 dark:bg-slate-950 md:flex md:gap-3 md:px-6 ${
-            ocultarHeaderMobile ? 'hidden' : 'flex'
+          className={`z-30 flex h-16 min-h-[64px] w-full min-w-0 shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-800 dark:bg-slate-950 md:gap-3 md:px-6 ${
+            ocultarHeaderMobile ? 'hidden' : ''
           }`}
         >
           <button
@@ -152,7 +152,7 @@ function LayoutInner() {
           <div className="min-w-0 flex-1" />
           <NavbarNotificacoes enabled={notificacoesEnabled} />
           <ThemeToggle />
-          <div className="hidden min-w-0 text-right sm:block">
+          <div className="hidden min-w-0 max-w-[7rem] shrink text-right sm:block md:max-w-[10rem] lg:max-w-none">
             <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{user?.nome}</p>
             <p className="truncate text-xs text-slate-500 dark:text-slate-400">{perfilExibicao(user?.role)}</p>
           </div>
@@ -165,14 +165,14 @@ function LayoutInner() {
         {notificacoesEnabled && !ocultarHeaderMobile ? <WebPushOptInBanner enabled /> : null}
         <PontoAlertasBanner />
 
-        <main className="min-h-0 flex-1 overflow-hidden">
+        <main className="min-h-0 min-w-0 w-full flex-1 overflow-hidden">
           <div
             className={
               scrollInternoNaPagina
                 ? isChatHub
-                  ? 'flex h-full min-h-0 flex-col overflow-hidden'
-                  : 'flex h-full min-h-0 flex-col overflow-hidden px-4 pt-4 md:px-6 md:pt-6'
-                : 'dx-scrollbar h-full min-h-0 overflow-x-hidden overflow-y-auto p-4 md:p-6'
+                  ? 'flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden'
+                  : 'flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden px-4 pt-4 md:px-6 md:pt-6'
+                : 'dx-scrollbar h-full min-h-0 w-full min-w-0 overflow-x-hidden overflow-y-auto p-4 md:p-6'
             }
           >
             <Outlet />

--- a/frontend/src/components/config/ConfigSectionTabs.tsx
+++ b/frontend/src/components/config/ConfigSectionTabs.tsx
@@ -18,8 +18,8 @@ type Props = {
 
 export function ConfigSectionTabs({ tabs, ariaLabel }: Props) {
   return (
-    <div className="border-b border-slate-200 dark:border-slate-800">
-      <nav className="-mb-px flex flex-wrap gap-1" aria-label={ariaLabel}>
+    <div className="w-full min-w-0 border-b border-slate-200 dark:border-slate-800">
+      <nav className="-mb-px flex w-full min-w-0 flex-wrap gap-1" aria-label={ariaLabel}>
         {tabs.map((tab) => (
           <NavLink key={tab.to} to={tab.to} end={tab.end} className={tabClass}>
             {tab.label}

--- a/frontend/src/components/tickets/TicketDetalheSkeleton.tsx
+++ b/frontend/src/components/tickets/TicketDetalheSkeleton.tsx
@@ -12,7 +12,7 @@ export function TicketDetalheSkeleton() {
       aria-label="Carregando ticket"
     >
       <div className="shrink-0 border-b border-slate-200/70 bg-white dark:border-slate-800/70 dark:bg-slate-950 sm:rounded-b-2xl sm:border sm:border-t-0">
-        <div className="mx-auto max-w-6xl space-y-3 px-3 py-2.5 sm:px-5 sm:py-4 lg:py-5">
+        <div className="mx-auto w-full min-w-0 max-w-6xl space-y-3 px-3 py-2.5 sm:px-5 sm:py-4 lg:py-5">
           <Pulse className="h-4 w-16" />
           <div className="flex items-start justify-between gap-3">
             <Pulse className="h-6 w-32 lg:h-8 lg:w-40" />
@@ -39,7 +39,7 @@ export function TicketDetalheSkeleton() {
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-6xl space-y-4 px-3 py-3 sm:space-y-6 sm:px-5 sm:py-4 md:px-6">
+        <div className="mx-auto w-full min-w-0 max-w-6xl space-y-4 px-3 py-3 sm:space-y-6 sm:px-5 sm:py-4 md:px-6">
           <div className="rounded-xl border border-slate-200/90 bg-white p-4 dark:border-slate-800/80 dark:bg-slate-950/40">
             <Pulse className="mb-3 h-4 w-28" />
             <div className="space-y-3">

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -13,9 +13,9 @@ const variants: Record<Variant, string> = {
   secondary:
     'bg-slate-100 text-slate-800 hover:bg-slate-200 focus:ring-slate-400 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700',
   danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
-  /** Descartar / sair — vermelho claro no light; no dark bem visível (≠ Excluir sólido). */
+  /** Descartar / sair — gradiente vermelho no mesmo molde do primary (≠ Excluir sólido). */
   cancel:
-    'border-2 border-red-500 bg-red-50 text-red-800 hover:bg-red-100 focus:ring-red-500 dark:border-red-400 dark:bg-red-950/70 dark:text-red-100 dark:hover:bg-red-900/80',
+    'bg-gradient-to-r from-red-500 to-red-600 text-white shadow-md shadow-red-500/20 hover:from-red-400 hover:to-red-500 focus:ring-red-400 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-slate-950',
   ghost:
     'bg-transparent text-slate-700 hover:bg-slate-100 focus:ring-slate-400 dark:text-slate-300 dark:hover:bg-slate-800',
 }

--- a/frontend/src/components/ui/PageContainer.tsx
+++ b/frontend/src/components/ui/PageContainer.tsx
@@ -16,7 +16,12 @@ const SPACING_CLASS = {
 export type PageContainerMaxWidth = keyof typeof MAX_WIDTH_CLASS
 export type PageContainerSpacing = keyof typeof SPACING_CLASS
 
-export const PAGE_CONTAINER_CLASS = `mx-auto w-full ${MAX_WIDTH_CLASS['6xl']} ${SPACING_CLASS.normal} pb-10`
+export const PAGE_CONTAINER_CLASS = `mx-auto w-full min-w-0 ${MAX_WIDTH_CLASS['6xl']} ${SPACING_CLASS.normal} pb-10`
+
+/** Largura útil em wrappers legados (forms/detalhes fora do PageContainer). */
+export function contentWidthClass(maxWidth: PageContainerMaxWidth = '6xl') {
+  return `mx-auto w-full min-w-0 ${MAX_WIDTH_CLASS[maxWidth]}`
+}
 
 type PageContainerProps = {
   children: ReactNode
@@ -34,7 +39,7 @@ export function PageContainer({
 }: PageContainerProps) {
   return (
     <div
-      className={`mx-auto w-full ${MAX_WIDTH_CLASS[maxWidth]} ${SPACING_CLASS[spacing]} ${spacing === 'none' ? '' : 'pb-10'} ${className}`.trim()}
+      className={`mx-auto w-full min-w-0 ${MAX_WIDTH_CLASS[maxWidth]} ${SPACING_CLASS[spacing]} ${spacing === 'none' ? '' : 'pb-10'} ${className}`.trim()}
     >
       {children}
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,6 +26,7 @@
   }
 
   #root {
+    width: 100%;
     height: 100%;
     max-height: 100dvh;
     overflow: hidden;

--- a/frontend/src/pages/AcessoNegado.tsx
+++ b/frontend/src/pages/AcessoNegado.tsx
@@ -8,7 +8,7 @@ export function AcessoNegado({
   detail?: string
 } = {}) {
   return (
-    <div className="mx-auto max-w-lg rounded-2xl border border-amber-200/80 bg-amber-50/90 p-6 text-amber-950 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
+    <div className="mx-auto w-full min-w-0 max-w-lg rounded-2xl border border-amber-200/80 bg-amber-50/90 p-6 text-amber-950 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
       <p className="text-sm font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-300">403 — Acesso restrito</p>
       <h1 className="mt-2 text-lg font-semibold text-slate-900 dark:text-slate-100">{title}</h1>
       <p className="mt-3 text-sm leading-relaxed text-slate-700 dark:text-slate-300">{detail}</p>

--- a/frontend/src/pages/AlterarSenha.tsx
+++ b/frontend/src/pages/AlterarSenha.tsx
@@ -46,7 +46,7 @@ export function AlterarSenha() {
   }
 
   return (
-    <div className="mx-auto max-w-lg">
+    <div className="mx-auto w-full min-w-0 max-w-lg">
       <h1 className="mb-2 text-xl font-semibold text-slate-900 dark:text-slate-100">Definir nova senha</h1>
       <p className="mb-6 text-sm text-slate-600 dark:text-slate-400">
         Por segurança, altere a senha temporária antes de continuar usando o sistema.

--- a/frontend/src/pages/AtendenteDetalhe.tsx
+++ b/frontend/src/pages/AtendenteDetalhe.tsx
@@ -82,7 +82,7 @@ export function AtendenteDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -105,7 +105,7 @@ export function AtendenteDetalhe() {
   if (!atendente) return null
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -209,7 +209,7 @@ export function AtendenteForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Atendente não encontrado."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -99,14 +99,14 @@ function renderQrPayload(data: Record<string, unknown> | null | undefined) {
   const raw = data.base64 ?? data.qrcode
   if (typeof raw === 'string') {
     if (raw.startsWith('data:image')) {
-      return <img src={raw} alt="QR Code WhatsApp" className="mx-auto max-w-[280px] rounded-lg" />
+      return <img src={raw} alt="QR Code WhatsApp" className="mx-auto w-full min-w-0 max-w-[280px] rounded-lg" />
     }
     if (raw.length > 80) {
       return (
         <img
           src={`data:image/png;base64,${raw}`}
           alt="QR Code WhatsApp"
-          className="mx-auto max-w-[280px] rounded-lg"
+          className="mx-auto w-full min-w-0 max-w-[280px] rounded-lg"
         />
       )
     }

--- a/frontend/src/pages/CrmContratos.tsx
+++ b/frontend/src/pages/CrmContratos.tsx
@@ -106,7 +106,7 @@ export function CrmContratos() {
   }
 
   return (
-    <div className="mx-auto max-w-6xl space-y-4 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-4 pb-10">
       <div>
         <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Contratos</h1>
         <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">

--- a/frontend/src/pages/CrmNegociacaoDetalhe.tsx
+++ b/frontend/src/pages/CrmNegociacaoDetalhe.tsx
@@ -367,7 +367,7 @@ export function CrmNegociacaoDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-5xl pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-5xl pb-10">
         <div className="h-72 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -386,7 +386,7 @@ export function CrmNegociacaoDetalhe() {
   if (falha || !neg) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo={falha?.titulo || 'Negociação não encontrada.'}
         detalhe={falha?.detalhe}
         onVoltar={voltar}
@@ -395,7 +395,7 @@ export function CrmNegociacaoDetalhe() {
   }
 
   return (
-    <div className="mx-auto max-w-5xl space-y-4 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <VoltarButton onClick={voltar} />
         <Button variant="secondary" onClick={() => navigate('/crm/leads')}>

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -216,7 +216,7 @@ export function EmpresaDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-4 w-24 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
         <div className="h-9 w-2/3 max-w-md animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
@@ -226,7 +226,7 @@ export function EmpresaDetalhe() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para acessar esta empresa."
           detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
@@ -277,7 +277,7 @@ export function EmpresaDetalhe() {
   )
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-8 pb-10">
       <div>
         <VoltarButton onClick={voltar} />
       </div>

--- a/frontend/src/pages/EmpresaForm.tsx
+++ b/frontend/src/pages/EmpresaForm.tsx
@@ -388,7 +388,7 @@ export function EmpresaForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-6xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-6xl space-y-4 pb-10"
         titulo="Empresa não encontrada."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/FuncionarioRedeDetalhe.tsx
+++ b/frontend/src/pages/FuncionarioRedeDetalhe.tsx
@@ -174,7 +174,7 @@ export function FuncionarioRedeDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-4 w-40 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
         <div className="h-9 w-2/3 max-w-md animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-48 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
@@ -184,7 +184,7 @@ export function FuncionarioRedeDetalhe() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para acessar este funcionário."
           detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
@@ -212,7 +212,7 @@ export function FuncionarioRedeDetalhe() {
       : null
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-8 pb-10">
       <div>
         <VoltarButton onClick={voltarAnterior} />
       </div>

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -240,7 +240,7 @@ export function FuncionarioRedeForm() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-3xl space-y-6">
+      <div className="mx-auto w-full min-w-0 max-w-3xl space-y-6">
         <div className="h-9 w-56 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-72 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
@@ -249,7 +249,7 @@ export function FuncionarioRedeForm() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-5xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-5xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para editar este funcionário."
           detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
@@ -263,7 +263,7 @@ export function FuncionarioRedeForm() {
   if (funcionarioInexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Funcionário não encontrado."
         detalhe={funcionarioInexistente.detalhe}
         onVoltar={voltarAnterior}
@@ -272,7 +272,7 @@ export function FuncionarioRedeForm() {
   }
 
   return (
-    <div ref={topoRef} className="mx-auto max-w-5xl space-y-6 pb-10">
+    <div ref={topoRef} className="mx-auto w-full min-w-0 max-w-5xl space-y-6 pb-10">
       <div className="flex items-center justify-between gap-3">
         <VoltarButton onClick={voltarAnterior} />
       </div>

--- a/frontend/src/pages/KbArtigoForm.tsx
+++ b/frontend/src/pages/KbArtigoForm.tsx
@@ -286,7 +286,7 @@ export function KbArtigoForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Artigo não encontrado."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/NotificacoesPreferencias.tsx
+++ b/frontend/src/pages/NotificacoesPreferencias.tsx
@@ -67,14 +67,14 @@ export function NotificacoesPreferencias() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-2xl">
+      <div className="mx-auto w-full min-w-0 max-w-2xl">
         <div className="h-48 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
   }
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-2xl space-y-6 pb-10">
       <div>
         <VoltarButton onClick={() => navigate('/')} />
         <h1 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">

--- a/frontend/src/pages/RedeDetalhe.tsx
+++ b/frontend/src/pages/RedeDetalhe.tsx
@@ -789,7 +789,7 @@ export function RedeDetalhe() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para acessar esta rede."
           detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
@@ -802,7 +802,7 @@ export function RedeDetalhe() {
 
   if (loading && !rede && !loadFailure) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-4 w-24 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
         <div className="h-9 w-2/3 max-w-md animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
@@ -836,7 +836,7 @@ export function RedeDetalhe() {
     tipoNegocioIdEmpresa === '' ? '' : tiposNegocioList.find((t) => t.id === Number(tipoNegocioIdEmpresa))?.nome ?? ''
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <div className="flex flex-wrap items-center gap-3">
         <nav aria-label="breadcrumb" className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
           {linkRedes}

--- a/frontend/src/pages/RedeForm.tsx
+++ b/frontend/src/pages/RedeForm.tsx
@@ -100,7 +100,7 @@ export function RedeForm() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-2xl space-y-6">
+      <div className="mx-auto w-full min-w-0 max-w-2xl space-y-6">
         <div className="h-9 w-56 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
@@ -109,7 +109,7 @@ export function RedeForm() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-5xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-5xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para editar esta rede."
           detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
@@ -123,7 +123,7 @@ export function RedeForm() {
   if (redeInexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Rede não encontrada."
         detalhe={redeInexistente.detalhe}
         onVoltar={voltarAnterior}
@@ -132,7 +132,7 @@ export function RedeForm() {
   }
 
   return (
-    <div className="mx-auto max-w-5xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-5xl space-y-6 pb-10">
       <div className="flex items-center justify-between gap-3">
         <VoltarButton onClick={voltarAnterior} />
       </div>

--- a/frontend/src/pages/RespostaProntaDetalhe.tsx
+++ b/frontend/src/pages/RespostaProntaDetalhe.tsx
@@ -55,7 +55,7 @@ export function RespostaProntaDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-56 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -80,7 +80,7 @@ export function RespostaProntaDetalhe() {
   const escopo = item.setor_nome ?? (item.setor_id != null ? `Setor #${item.setor_id}` : 'Global (todos os setores)')
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/RespostaProntaForm.tsx
+++ b/frontend/src/pages/RespostaProntaForm.tsx
@@ -141,7 +141,7 @@ export function RespostaProntaForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Resposta pronta não encontrada."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/SemPermissao.tsx
+++ b/frontend/src/pages/SemPermissao.tsx
@@ -17,7 +17,7 @@ export function SemPermissao({
   const classeVoltar =
     'inline-flex rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800'
   return (
-    <div className="mx-auto max-w-lg rounded-2xl border border-amber-200/80 bg-amber-50/90 p-6 text-amber-950 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
+    <div className="mx-auto w-full min-w-0 max-w-lg rounded-2xl border border-amber-200/80 bg-amber-50/90 p-6 text-amber-950 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
       <p className="text-sm font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-300">403 — Sem permissão</p>
       <h1 className="mt-2 text-lg font-semibold text-slate-900 dark:text-slate-100">{title}</h1>
       <p className="mt-3 text-sm leading-relaxed text-slate-700 dark:text-slate-300">{detail}</p>

--- a/frontend/src/pages/SetorDetalhe.tsx
+++ b/frontend/src/pages/SetorDetalhe.tsx
@@ -236,7 +236,7 @@ export function SetorDetalhe() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para acessar este setor."
           detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
@@ -258,7 +258,7 @@ export function SetorDetalhe() {
   }
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
         <VoltarButton onClick={voltarAnterior} />
         <span aria-hidden className="text-slate-300 dark:text-slate-600">

--- a/frontend/src/pages/SetorForm.tsx
+++ b/frontend/src/pages/SetorForm.tsx
@@ -113,7 +113,7 @@ export function SetorForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Setor não encontrado."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/StatusTicketDetalhe.tsx
+++ b/frontend/src/pages/StatusTicketDetalhe.tsx
@@ -55,7 +55,7 @@ export function StatusTicketDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-48 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -78,7 +78,7 @@ export function StatusTicketDetalhe() {
   if (!item) return null
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/StatusTicketForm.tsx
+++ b/frontend/src/pages/StatusTicketForm.tsx
@@ -132,7 +132,7 @@ export function StatusTicketForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Status não encontrado."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -1260,7 +1260,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para acessar este ticket."
           detail="Este chamado pertence a um setor fora do seu escopo. Se precisar, peça ao administrador para ajustar seus vínculos de setor."
@@ -1383,7 +1383,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
     <>
       <div className="-m-4 flex h-full min-h-0 flex-col overflow-hidden md:-m-6">
         <div className="relative z-20 shrink-0 border-b border-slate-200/70 bg-white shadow-sm dark:border-slate-800/70 dark:bg-slate-950 sm:rounded-b-2xl sm:border sm:border-t-0">
-          <div className="mx-auto max-w-6xl px-3 py-2.5 sm:px-5 sm:py-4 lg:py-5">
+          <div className="mx-auto w-full min-w-0 max-w-6xl px-3 py-2.5 sm:px-5 sm:py-4 lg:py-5">
             {linkVoltar}
 
             <div className="flex items-start justify-between gap-3 lg:items-center">
@@ -1648,7 +1648,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
         </div>
 
         <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
-          <div className="mx-auto max-w-6xl space-y-4 px-3 pb-8 pt-3 sm:space-y-6 sm:px-5 sm:pb-10 sm:pt-4 md:px-6">
+          <div className="mx-auto w-full min-w-0 max-w-6xl space-y-4 px-3 pb-8 pt-3 sm:space-y-6 sm:px-5 sm:pb-10 sm:pt-4 md:px-6">
         {!ticket.fechado_em ? <TicketSlaCard ticketId={ticket.id} fechado={false} /> : null}
         <TicketImplantacaoChecklist
           ticketId={ticket.id}

--- a/frontend/src/pages/TicketNovo.tsx
+++ b/frontend/src/pages/TicketNovo.tsx
@@ -239,7 +239,7 @@ export function TicketNovo() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-3xl space-y-6">
+      <div className="mx-auto w-full min-w-0 max-w-3xl space-y-6">
         <SemPermissao
           title="Você não tem permissão para abrir tickets."
           detail="Seu usuário não conseguiu carregar setores/empresas necessários para criar um chamado. Peça ao administrador para ajustar seu perfil e vínculos de setor."
@@ -257,7 +257,7 @@ export function TicketNovo() {
       noValidate
     >
       <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
-        <div className="mx-auto max-w-3xl space-y-6 pb-4">
+        <div className="mx-auto w-full min-w-0 max-w-3xl space-y-6 pb-4">
       <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
         <VoltarButton onClick={voltarAnterior} />
         <span aria-hidden className="text-slate-300 dark:text-slate-600">

--- a/frontend/src/pages/TipoNegocioDetalhe.tsx
+++ b/frontend/src/pages/TipoNegocioDetalhe.tsx
@@ -55,7 +55,7 @@ export function TipoNegocioDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-40 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -78,7 +78,7 @@ export function TipoNegocioDetalhe() {
   if (!item) return null
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/TipoNegocioForm.tsx
+++ b/frontend/src/pages/TipoNegocioForm.tsx
@@ -109,7 +109,7 @@ export function TipoNegocioForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Tipo de negócio não encontrado."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/chat-interno/ChatInternoSetorCanal.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoSetorCanal.tsx
@@ -40,7 +40,7 @@ export function ChatInternoSetorCanal() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-3xl p-4">
+      <div className="mx-auto w-full min-w-0 max-w-3xl p-4">
         <SemPermissao
           title="Sem permissão para este canal"
           detail="Você não está vinculado a este setor."

--- a/frontend/src/pages/config/ConfigHubPage.tsx
+++ b/frontend/src/pages/config/ConfigHubPage.tsx
@@ -36,7 +36,7 @@ export function ConfigHubPage() {
         subtitle="Encontre qualquer ajuste por domínio — ou pesquise por palavra."
       />
 
-      <div className="relative max-w-xl">
+      <div className="relative w-full min-w-0 max-w-xl">
         <Input
           value={q}
           onChange={(e) => setQ(e.target.value)}

--- a/frontend/src/pages/marketing/LandingPage.tsx
+++ b/frontend/src/pages/marketing/LandingPage.tsx
@@ -44,7 +44,7 @@ function SectionHeading({
   align?: 'left' | 'center'
 }) {
   return (
-    <div className={align === 'center' ? 'mx-auto max-w-3xl text-center' : 'max-w-3xl'}>
+    <div className={align === 'center' ? 'mx-auto w-full min-w-0 max-w-3xl text-center' : 'max-w-3xl'}>
       {eyebrow ? (
         <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-sky-400">{eyebrow}</p>
       ) : null}
@@ -261,7 +261,7 @@ export function LandingPage() {
           </div>
         </section>
 
-        <section className="mx-auto max-w-7xl px-5 pb-8 sm:px-8 lg:px-10">
+        <section className="mx-auto w-full min-w-0 max-w-7xl px-5 pb-8 sm:px-8 lg:px-10">
           <div className="rounded-[1.5rem] border border-white/10 bg-gradient-to-r from-white/[0.06] via-white/[0.03] to-white/[0.05] px-6 py-5 shadow-[0_20px_60px_rgba(2,8,23,0.18)] backdrop-blur-sm sm:px-8">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">Por que empresas escolhem o DeskRudder</p>
@@ -273,7 +273,7 @@ export function LandingPage() {
           </div>
         </section>
 
-        <section className="mx-auto max-w-7xl px-5 pb-8 sm:px-8 lg:px-10">
+        <section className="mx-auto w-full min-w-0 max-w-7xl px-5 pb-8 sm:px-8 lg:px-10">
           <div className="rounded-[1.75rem] border border-sky-400/20 bg-gradient-to-br from-sky-500/10 via-white/[0.03] to-slate-950/80 p-6 shadow-[0_25px_70px_rgba(2,8,23,0.22)] backdrop-blur-md sm:p-8">
             <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
               <div className="max-w-2xl">
@@ -296,7 +296,7 @@ export function LandingPage() {
         </section>
 
         <section id="valor" className="py-14 sm:py-16">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading
               eyebrow="O que muda na operação"
               title="Uma operação mais limpa, mais rápida e mais previsível"
@@ -317,7 +317,7 @@ export function LandingPage() {
         </section>
 
         <section className="pb-8 sm:pb-10">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <div className="grid gap-6 lg:grid-cols-3">
               {experienceHighlights.map((item) => (
                 <div key={item.title} className="relative overflow-hidden rounded-[1.5rem] border border-white/10 bg-gradient-to-br from-white/[0.04] to-white/[0.02] p-6 shadow-[0_15px_45px_rgba(2,8,23,0.12)] before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/60 before:to-transparent">
@@ -330,7 +330,7 @@ export function LandingPage() {
         </section>
 
         <section className="border-t border-white/10 bg-[#071826]/70 py-16 sm:py-20">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingPain.title} />
             <ul className="mt-10 grid gap-6 md:grid-cols-3">
               {landingPain.items.map((item, index) => (
@@ -349,7 +349,7 @@ export function LandingPage() {
         </section>
 
         <section className="py-16 sm:py-20">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <div className="grid gap-6 lg:grid-cols-2">
               <div className="rounded-[1.75rem] border border-rose-400/20 bg-rose-500/10 p-8 shadow-[0_20px_60px_rgba(2,8,23,0.16)]">
                 <p className="text-sm font-semibold uppercase tracking-[0.2em] text-rose-300">Antes</p>
@@ -374,7 +374,7 @@ export function LandingPage() {
         </section>
 
         <section id="produto" className="scroll-mt-24 py-16 sm:py-20">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading
               eyebrow="O que você encontra"
               title="Tudo o que sua equipe precisa para atender melhor"
@@ -419,7 +419,7 @@ export function LandingPage() {
         </section>
 
         <section className="border-y border-sky-500/20 bg-gradient-to-r from-sky-700/20 via-[#0B2D4A]/85 to-sky-500/20 py-14 sm:py-16">
-          <div className="mx-auto max-w-3xl px-5 text-center sm:px-8">
+          <div className="mx-auto w-full min-w-0 max-w-3xl px-5 text-center sm:px-8">
             <h2 className="text-2xl font-bold text-white sm:text-3xl">{landingMidCta.title}</h2>
             <p className="mt-3 text-slate-200">{landingMidCta.body}</p>
             <div className="mt-8 flex justify-center">
@@ -429,7 +429,7 @@ export function LandingPage() {
         </section>
 
         <section id="resultados" className="scroll-mt-24 py-16 sm:py-20">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingOutcomes.title} />
             <ul className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
               {landingOutcomes.items.map((item) => (
@@ -443,7 +443,7 @@ export function LandingPage() {
         </section>
 
         <section className="border-t border-white/10 bg-[#0A1628]/70 py-16 sm:py-20">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingHowItWorks.title} />
             <ol className="mt-12 grid gap-10 md:grid-cols-3">
               {landingHowItWorks.steps.map((s) => (
@@ -458,7 +458,7 @@ export function LandingPage() {
         </section>
 
         <section className="py-16 sm:py-20">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingAudience.title} body={landingAudience.body} />
             <ul className="mt-10 grid gap-6 md:grid-cols-3">
               {landingAudience.segments.map((seg) => (
@@ -472,7 +472,7 @@ export function LandingPage() {
         </section>
 
         <section id="contato" className="scroll-mt-24 border-t border-white/10 py-16 sm:py-24">
-          <div className="mx-auto max-w-3xl px-5 text-center sm:px-8">
+          <div className="mx-auto w-full min-w-0 max-w-3xl px-5 text-center sm:px-8">
             <div className="mx-auto inline-flex items-center gap-2 rounded-full border border-sky-400/25 bg-sky-400/10 px-3.5 py-2 text-sm text-sky-200">
               <span className="size-2 rounded-full bg-sky-400" />
               {APP_NAME}

--- a/frontend/src/pages/marketing/PrivacidadePage.tsx
+++ b/frontend/src/pages/marketing/PrivacidadePage.tsx
@@ -10,7 +10,7 @@ export function PrivacidadePage() {
   const navigate = useNavigate()
   return (
     <MarketingLayout>
-      <div className="mx-auto max-w-3xl px-5 py-12 sm:px-8 lg:px-10">
+      <div className="mx-auto w-full min-w-0 max-w-3xl px-5 py-12 sm:px-8 lg:px-10">
         <VoltarButton onClick={() => navigate('/')} />
         <div className="mt-8">
           <BrandLogo variant="wordmark" size="md" markVariant="onDark" />

--- a/frontend/src/pages/portal/PortalTrocarSenha.tsx
+++ b/frontend/src/pages/portal/PortalTrocarSenha.tsx
@@ -47,7 +47,7 @@ export function PortalTrocarSenha() {
   }
 
   return (
-    <div className="mx-auto max-w-md space-y-5">
+    <div className="mx-auto w-full min-w-0 max-w-md space-y-5">
       <div>
         <h1 className="text-xl font-semibold text-slate-900">Definir nova senha</h1>
         <p className="mt-1 text-sm text-slate-600">

--- a/frontend/src/pages/portal/portalUi.tsx
+++ b/frontend/src/pages/portal/portalUi.tsx
@@ -10,9 +10,9 @@ export const portalPrimaryBtnClass =
 export const portalSecondaryBtnClass =
   'inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50'
 
-/** Descartar / Cancelar — alinhado ao Button variant=cancel do painel interno (#866). */
+/** Descartar / Cancelar — gradiente vermelho, alinhado ao Button variant=cancel (#866). */
 export const portalCancelBtnClass =
-  'inline-flex items-center justify-center gap-2 rounded-lg border-2 border-red-500 bg-red-50 px-4 py-2 text-sm font-medium text-red-800 shadow-sm transition hover:bg-red-100'
+  'inline-flex items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-red-500 to-red-600 px-4 py-2 text-sm font-medium text-white shadow-md shadow-red-500/20 transition hover:from-red-400 hover:to-red-500 focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 disabled:opacity-50'
 
 export const portalCardClass =
   'rounded-xl border border-slate-200/90 bg-white p-4 shadow-sm transition hover:border-slate-300 hover:shadow-md'

--- a/frontend/src/pages/saas/SaasLeadDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasLeadDetalhe.tsx
@@ -125,7 +125,7 @@ export function SaasLeadDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-40 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -154,7 +154,7 @@ export function SaasLeadDetalhe() {
   if (!item) return null
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/saas/SaasLicencaDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasLicencaDetalhe.tsx
@@ -143,7 +143,7 @@ export function SaasLicencaDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-40 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -185,7 +185,7 @@ export function SaasLicencaDetalhe() {
   })
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/saas/SaasLicencaForm.tsx
+++ b/frontend/src/pages/saas/SaasLicencaForm.tsx
@@ -238,7 +238,7 @@ export function SaasLicencaForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Licença não encontrada."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/saas/SaasPlanoForm.tsx
+++ b/frontend/src/pages/saas/SaasPlanoForm.tsx
@@ -195,7 +195,7 @@ export function SaasPlanoForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Plano não encontrado."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
@@ -202,7 +202,7 @@ export function SaasSolicitacaoDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-40 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -231,7 +231,7 @@ export function SaasSolicitacaoDetalhe() {
   if (!item) return null
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/whatsapp/WhatsappLayout.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappLayout.tsx
@@ -25,7 +25,7 @@ export function WhatsappLayout() {
     }`
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 pb-10 pt-4 animate-in fade-in slide-in-from-top-1 duration-500">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-8 pb-10 pt-4 animate-in fade-in slide-in-from-top-1 duration-500">
       <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- **#870**: coluna principal do painel ocupa sempre a largura disponível (Layout em grid, w-full/min-w-0 na casca e nos contentores internos)
- Abas de Configurações e header legíveis em qualquer largura (inclui painel estreito do IDE e janelas <768px)
- **Cancelar**: gradiente vermelho preenchido, mesmo molde do botão primary/Salvar (portal alinhado)

## Test plan
- [x] 
px tsc -b frontend OK
- [x] Smoke visual: Empresa e catálogos, Equipa/setores, Novo ticket — larguras 390px, 700px, 1280px
- [x] Cancelar + Criar ticket / Salvar lado a lado (Novo ticket, Novo atendente)

Closes #870