### PR TITLE
release: main → staging

### DIFF
--- a/.cursor/mcp.json.example
+++ b/.cursor/mcp.json.example
@@ -5,7 +5,7 @@
       "args": ["backend/scripts/mcp_deskrudder_saas.py"],
       "env": {
         "DESKRUDDER_API_URL": "https://api.deskrudder.com.br",
-        "DESKRUDDER_MCP_TOKEN": "COLE_AQUI_O_MESMO_SAAS_MCP_TOKEN_DA_INSTANCIA_COMERCIAL"
+        "DESKRUDDER_MCP_TOKEN": "COLE_O_TOKEN_GERADO_EM_/saas/conta"
       }
     }
   }

--- a/.github/ISSUE_TEMPLATE/01-feature.md
+++ b/.github/ISSUE_TEMPLATE/01-feature.md
@@ -1,0 +1,36 @@
+---
+name: "Feature de produto"
+about: "Solicitar uma nova funcionalidade de produto"
+title: "feat(area): "
+labels: ["enhancement", "product"]
+assignees: []
+---
+
+## Objetivo
+Descreva em 1-2 frases o resultado esperado para o usuário.
+
+## Contexto
+Explique o problema atual e por que esta funcionalidade é necessária.
+
+## Escopo
+- [ ] Item 1
+- [ ] Item 2
+- [ ] Item 3
+
+## Critérios de aceite
+- [ ] Cenário principal funciona de ponta a ponta.
+- [ ] RBAC/permissões aplicadas corretamente (quando aplicável).
+- [ ] Mensagens e textos em português.
+- [ ] Testes adicionados/atualizados para o comportamento novo.
+
+## Fora de escopo
+- Item explicitamente adiado para follow-up.
+
+## Origem
+Ex.: Solicitação comercial, feedback de usuário, issue #NNN, épico #NNN.
+
+## Labels sugeridas (ajustar na criação)
+- `backend` se tocar API/regras de negócio.
+- `frontend` se tocar UI/fluxo.
+- `ux` se alterar experiência/telas.
+- `security` se envolver acesso, senha, autenticação ou permissões.

--- a/.github/ISSUE_TEMPLATE/02-bug.md
+++ b/.github/ISSUE_TEMPLATE/02-bug.md
@@ -1,0 +1,45 @@
+---
+name: "Bug"
+about: "Reportar comportamento incorreto"
+title: "fix(area): "
+labels: ["bug"]
+assignees: []
+---
+
+## Objetivo
+Corrigir o comportamento incorreto sem regressões.
+
+## Contexto
+Descreva onde o bug acontece e o impacto para o usuário/negócio.
+
+## Comportamento atual
+Explique o que acontece hoje.
+
+## Comportamento esperado
+Explique o que deveria acontecer.
+
+## Passos para reproduzir
+1. ...
+2. ...
+3. ...
+
+## Escopo
+- [ ] Corrigir causa raiz.
+- [ ] Garantir cobertura de teste do caso.
+- [ ] Validar que não houve regressão nas áreas adjacentes.
+
+## Critérios de aceite
+- [ ] Bug não reproduz mais com os mesmos passos.
+- [ ] Cenários relacionados continuam funcionando.
+- [ ] Mensagens/feedback para usuário em português.
+
+## Fora de escopo
+- Refatorações amplas não necessárias para a correção.
+
+## Origem
+Ex.: incidente, reporte interno, issue #NNN, PR #NNN.
+
+## Labels sugeridas (ajustar na criação)
+- `backend` e/ou `frontend` conforme área afetada.
+- `ux` se houver impacto de usabilidade/interface.
+- `security` se houver risco de acesso indevido ou exposição de dados.

--- a/.github/ISSUE_TEMPLATE/03-discovery.md
+++ b/.github/ISSUE_TEMPLATE/03-discovery.md
@@ -1,0 +1,43 @@
+---
+name: "Discovery"
+about: "Investigar problema, hipótese ou oportunidade"
+title: "discovery(area): "
+labels: ["discovery", "product"]
+assignees: []
+---
+
+## Objetivo
+Responder perguntas em aberto para suportar decisão de produto/técnica.
+
+## Contexto
+Descreva o cenário e por que a investigação é necessária agora.
+
+## Hipóteses / perguntas
+- [ ] Pergunta 1
+- [ ] Pergunta 2
+- [ ] Pergunta 3
+
+## Escopo da investigação
+- [ ] Levantar alternativas e trade-offs.
+- [ ] Validar restrições técnicas e de RBAC.
+- [ ] Propor recomendação com próximos passos.
+
+## Critérios de aceite
+- [ ] Perguntas-chave respondidas com evidências.
+- [ ] Decisão recomendada registrada.
+- [ ] Follow-ups gerados como issues separadas, se necessário.
+
+## Fora de escopo
+- Implementação completa da solução.
+
+## Entregáveis
+- Resumo da investigação.
+- Opções avaliadas.
+- Recomendação final.
+
+## Origem
+Ex.: dúvida em issue #NNN, descoberta em PR #NNN, demanda comercial.
+
+## Labels sugeridas (ajustar na criação)
+- `backend` e/ou `frontend` se já houver área provável.
+- `security` se a investigação envolver autenticação/permissões.

--- a/.github/ISSUE_TEMPLATE/04-epic.md
+++ b/.github/ISSUE_TEMPLATE/04-epic.md
@@ -1,0 +1,41 @@
+---
+name: "Épico"
+about: "Rastrear um lote de trabalho multi-issue"
+title: "epic(area): "
+labels: ["epic", "product"]
+assignees: []
+---
+
+## Objetivo
+Descreva o resultado de negócio/produto esperado ao concluir o épico.
+
+## Contexto
+Explique o problema maior e a motivação do lote.
+
+## Escopo do épico
+- Dentro:
+  - ...
+- Fora:
+  - ...
+
+## Checklist de issues filhas
+- [ ] #000 - título da issue filha
+- [ ] #000 - título da issue filha
+- [ ] #000 - título da issue filha
+
+## Critérios de aceite do épico
+- [ ] Todas as issues filhas obrigatórias concluídas.
+- [ ] Critérios de produto validados com o time.
+- [ ] Documentação operacional atualizada (se aplicável).
+
+## Riscos / dependências
+- Dependência 1
+- Dependência 2
+
+## Origem
+Ex.: iniciativa trimestral, demanda comercial, issue mãe #NNN.
+
+## Labels sugeridas (ajustar na criação)
+- Label de domínio quando aplicável (ex.: `chat-interno`, `email`).
+- `backend` e/ou `frontend` conforme abrangência.
+- `security` se houver impacto de acesso/permissões.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
-- UI (#866): botão **Cancelar** padronizado em vermelho (`variant=cancel`, bordo forte), distinto de Excluir; ConfirmDialog e formulários/modais alinhados
+- UI (#870): responsividade — coluna principal do painel ocupa sempre a largura disponível (grid + `w-full`/`min-w-0` no Layout); contentores internos alinhados; abas e header legíveis em qualquer largura
+- UI (#866): botão **Cancelar** com gradiente vermelho preenchido (mesmo molde do Salvar), distinto de Excluir; ConfirmDialog, portal e formulários alinhados
 - UI (#867): controlo **Voltar** com estilo de botão (fundo/padding) em cadastros, detalhes, portal, WhatsApp e ecrãs de erro de carregamento
 - Sugestões: cada pedido ganha um **protocolo único** (`#S202608-0001`) no painel DeskRudder, visível depois em Minhas solicitações, para amarrar a issue no GitHub
 - Sugestões: no painel SaaS dá para **ligar pedidos iguais** de vários clientes (peso da demanda). O cliente não vê este grupo; na issue GitHub entram todos os protocolos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
-- Fila de sugestões no Cursor (MCP): o ops liga-se à API comercial (`api.deskrudder.com.br`); o token fica só na VPS e no Cursor de cada pessoa, não no git
+- Fila de sugestões no Cursor: cada ops gera o **próprio token** em Conta / Cursor (`/saas/conta`) e cola no Cursor. Recusar ou comentar fica ligado a essa conta, não a um segredo partilhado da VPS
+- Painel SaaS: cadastro da **equipa** (`/saas/usuarios`) — contas do `/login/admin`. Senha temporária uma vez; cada pessoa gera o token Cursor na própria conta
+- Login ops: no primeiro acesso (trocar senha) o painel SaaS já não mostra «não disponível nesta instância»; redirecciona para definir senha nova
 
 ### DeskRudder
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,8 +36,7 @@ LOG_LEVEL=INFO
 # SAAS_CONTROL_PLANE_INGEST_URL=https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes
 # SAAS_INSTANCE_INGEST_TOKEN=
 # SAAS_TRIAGEM_PULL_INTERVAL_SECONDS=60
-# Token do MCP Cursor — só na instância comercial (VPS). Gerar uma vez (ex.: openssl rand -base64 32).
-# O mesmo valor vai em DESKRUDDER_MCP_TOKEN no .cursor/mcp.json de cada ops (ficheiro gitignored).
+# Token MCP legado (instância comercial). Preferir token pessoal gerado em /saas/conta.
 # SAAS_MCP_TOKEN=
 #
 # --- Multi-tenant legado (só se DX_CONNECT_MULTI_TENANT=true) ---

--- a/backend/alembic/versions/118_saas_ops_mcp_token.py
+++ b/backend/alembic/versions/118_saas_ops_mcp_token.py
@@ -1,0 +1,46 @@
+"""Token Cursor MCP pessoal por saas_ops (#915).
+
+Revision ID: 118_saas_ops_mcp_token
+Revises: 117_saas_solicitacao_grupo
+Create Date: 2026-08-24
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "118_saas_ops_mcp_token"
+down_revision = "117_saas_solicitacao_grupo"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("atendentes"):
+        return
+    cols = {c["name"] for c in insp.get_columns("atendentes")}
+    if "mcp_token_hash" not in cols:
+        op.add_column(
+            "atendentes",
+            sa.Column("mcp_token_hash", sa.String(length=64), nullable=True),
+        )
+        op.create_index("ix_atendentes_mcp_token_hash", "atendentes", ["mcp_token_hash"], unique=True)
+    if "mcp_token_gerado_em" not in cols:
+        op.add_column(
+            "atendentes",
+            sa.Column("mcp_token_gerado_em", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("atendentes"):
+        return
+    cols = {c["name"] for c in insp.get_columns("atendentes")}
+    if "mcp_token_gerado_em" in cols:
+        op.drop_column("atendentes", "mcp_token_gerado_em")
+    if "mcp_token_hash" in cols:
+        op.drop_index("ix_atendentes_mcp_token_hash", table_name="atendentes")
+        op.drop_column("atendentes", "mcp_token_hash")

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -63,7 +63,10 @@ def listar_atendentes(
     db: Session = Depends(get_db),
     atendente_logado: Atendente = Depends(exigir_admin),
 ):
-    q = db.query(Atendente).filter(Atendente.tenant_id == atendente_logado.tenant_id)
+    q = db.query(Atendente).filter(
+        Atendente.tenant_id == atendente_logado.tenant_id,
+        Atendente.role != "saas_ops",
+    )
     if not incluir_inativos:
         q = q.filter(Atendente.ativo.is_(True))
     if busca and busca.strip():
@@ -230,7 +233,7 @@ def obter_atendente(
     _: Atendente = Depends(exigir_admin),
 ):
     atendente = db.query(Atendente).filter(Atendente.id == atendente_id).first()
-    if not atendente:
+    if not atendente or atendente.role == "saas_ops":
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Atendente não encontrado")
     return _atendente_para_read(atendente)
 
@@ -243,7 +246,7 @@ def atualizar_atendente(
     atendente_logado: Atendente = Depends(exigir_admin),
 ):
     atendente = db.query(Atendente).filter(Atendente.id == atendente_id).first()
-    if not atendente:
+    if not atendente or atendente.role == "saas_ops":
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Atendente não encontrado")
     update = data.model_dump(exclude_unset=True)
     if "senha" in update and update["senha"]:
@@ -302,7 +305,7 @@ def excluir_atendente(
     _: Atendente = Depends(exigir_admin),
 ):
     atendente = db.query(Atendente).filter(Atendente.id == atendente_id).first()
-    if not atendente:
+    if not atendente or atendente.role == "saas_ops":
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Atendente não encontrado")
     db.delete(atendente)
     db.commit()

--- a/backend/app/api/saas_ops_conta.py
+++ b/backend/app/api/saas_ops_conta.py
@@ -1,0 +1,57 @@
+"""Conta do ops no control-plane — token Cursor (#915)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.core.auth import exigir_saas_ops
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.schemas.saas_mcp_token import SaasMcpTokenEstado, SaasMcpTokenGerado
+from app.services import saas_mcp_token as mcp_token
+
+router = APIRouter(prefix="/saas/me", tags=["saas-ops-conta"])
+
+
+def _exigir_control_plane() -> None:
+    if not settings.SAAS_CONTROL_PLANE:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Painel SaaS não disponível nesta instância",
+        )
+
+
+@router.get("/mcp-token", response_model=SaasMcpTokenEstado)
+def obter_estado_mcp_token(
+    _: None = Depends(_exigir_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+):
+    """Estado do token Cursor desta conta. Nunca devolve o segredo."""
+    return SaasMcpTokenEstado.model_validate(mcp_token.estado(ops))
+
+
+@router.post("/mcp-token", response_model=SaasMcpTokenGerado)
+def gerar_mcp_token(
+    db: Session = Depends(get_db),
+    _: None = Depends(_exigir_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+):
+    """Gera ou regenera o token. O plaintext só sai nesta resposta."""
+    token = mcp_token.gerar(db, ops)
+    db.commit()
+    db.refresh(ops)
+    return SaasMcpTokenGerado(token=token, **mcp_token.estado(ops))
+
+
+@router.delete("/mcp-token", response_model=SaasMcpTokenEstado)
+def revogar_mcp_token(
+    db: Session = Depends(get_db),
+    _: None = Depends(_exigir_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+):
+    mcp_token.revogar(db, ops)
+    db.commit()
+    db.refresh(ops)
+    return SaasMcpTokenEstado.model_validate(mcp_token.estado(ops))

--- a/backend/app/api/saas_ops_usuarios.py
+++ b/backend/app/api/saas_ops_usuarios.py
@@ -1,0 +1,92 @@
+"""Equipa do control-plane — contas saas_ops (#883)."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.api.saas import exigir_saas_control_plane
+from app.core.auth import exigir_saas_ops
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.schemas.lista_paginada import ListaPaginada
+from app.schemas.saas_ops_usuario import (
+    SaasOpsUsuarioCreate,
+    SaasOpsUsuarioCriado,
+    SaasOpsUsuarioRead,
+    SaasOpsUsuarioSenha,
+    SaasOpsUsuarioUpdate,
+)
+from app.services import saas_ops_usuarios as svc
+
+router = APIRouter(prefix="/saas/usuarios", tags=["saas-ops-usuarios"])
+
+_MAX_PAGE = 100
+_DEFAULT_PAGE = 20
+
+
+@router.get("", response_model=ListaPaginada[SaasOpsUsuarioRead])
+def listar_usuarios(
+    incluir_inativos: bool = Query(False),
+    busca: str | None = Query(None),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+    db: Session = Depends(get_db),
+):
+    rows, total = svc.listar(
+        db, ops, incluir_inativos=incluir_inativos, busca=busca, offset=offset, limit=limit
+    )
+    return ListaPaginada(items=[SaasOpsUsuarioRead.model_validate(svc.para_dict(r)) for r in rows], total=total)
+
+
+@router.post("", response_model=SaasOpsUsuarioCriado, status_code=201)
+def criar_usuario(
+    data: SaasOpsUsuarioCreate,
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+    db: Session = Depends(get_db),
+):
+    row, senha = svc.criar(db, ops, data)
+    db.commit()
+    db.refresh(row)
+    return SaasOpsUsuarioCriado(senha_temporaria=senha, **svc.para_dict(row))
+
+
+@router.get("/{usuario_id}", response_model=SaasOpsUsuarioRead)
+def obter_usuario(
+    usuario_id: int,
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+    db: Session = Depends(get_db),
+):
+    row = svc.obter(db, ops, usuario_id)
+    return SaasOpsUsuarioRead.model_validate(svc.para_dict(row))
+
+
+@router.patch("/{usuario_id}", response_model=SaasOpsUsuarioRead)
+def actualizar_usuario(
+    usuario_id: int,
+    data: SaasOpsUsuarioUpdate,
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+    db: Session = Depends(get_db),
+):
+    row = svc.actualizar(db, ops, usuario_id, data)
+    db.commit()
+    db.refresh(row)
+    return SaasOpsUsuarioRead.model_validate(svc.para_dict(row))
+
+
+@router.post("/{usuario_id}/senha-temporaria", response_model=SaasOpsUsuarioSenha)
+def redefinir_senha(
+    usuario_id: int,
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+    db: Session = Depends(get_db),
+):
+    row, senha = svc.redefinir_senha(db, ops, usuario_id)
+    db.commit()
+    db.refresh(row)
+    return SaasOpsUsuarioSenha(senha_temporaria=senha)

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -7,6 +7,7 @@ from app.database import get_db
 from app.models.atendente import Atendente
 from app.core.setor_scope import atendente_e_financeiro
 from app.core.security import decodificar_token
+from app.services.saas_mcp_token import resolver_ops_mcp_token
 from app.core.tenant_context import (
     assert_token_tenant_matches_request,
     effective_tenant_id,
@@ -68,8 +69,12 @@ def _carregar_atendente_por_token(
     method = request.method.upper()
     if getattr(atendente, "must_change_password", False):
         # Rotas são montadas com prefixo (ex.: /v1/atendentes/me).
-        pode = (path.endswith("/atendentes/me") and method == "GET") or (
-            path.endswith("/atendentes/me/trocar-senha") and method == "POST"
+        # /system/info é usado pelo shell SaaS para saber se o control-plane está
+        # ligado; bloquear aqui gerava 403 falso «painel não disponível».
+        pode = (
+            (path.endswith("/atendentes/me") and method == "GET")
+            or (path.endswith("/atendentes/me/trocar-senha") and method == "POST")
+            or (path.endswith("/system/info") and method == "GET")
         )
         if not pode:
             raise HTTPException(
@@ -169,7 +174,7 @@ def exigir_fila_saas(
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
     x_saas_mcp_token: str | None = Header(None, alias="X-Saas-Mcp-Token"),
 ) -> Atendente:
-    """JWT saas_ops ou token longo SAAS_MCP_TOKEN (Cursor MCP)."""
+    """JWT saas_ops, token pessoal do painel (#915) ou SAAS_MCP_TOKEN legado."""
     import secrets
 
     expected = (settings.SAAS_MCP_TOKEN or "").strip()
@@ -178,6 +183,12 @@ def exigir_fila_saas(
         bearer = (credentials.credentials or "").strip()
     else:
         bearer = ""
+    for raw in (presented, bearer):
+        if not raw:
+            continue
+        pessoal = resolver_ops_mcp_token(db, raw)
+        if pessoal is not None:
+            return pessoal
     if expected and presented and secrets.compare_digest(presented, expected):
         return _actor_mcp(db)
     if expected and bearer and secrets.compare_digest(bearer, expected):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -60,6 +60,8 @@ from app.api import (
     saas_public,
     saas_leads,
     saas_solicitacoes,
+    saas_ops_conta,
+    saas_ops_usuarios,
     web_push,
     solicitacoes_melhoria,
 )
@@ -643,6 +645,8 @@ app.include_router(saas.router, prefix=API_V1_PREFIX)
 app.include_router(saas_public.router, prefix=API_V1_PREFIX)
 app.include_router(saas_leads.router, prefix=API_V1_PREFIX)
 app.include_router(saas_solicitacoes.router, prefix=API_V1_PREFIX)
+app.include_router(saas_ops_conta.router, prefix=API_V1_PREFIX)
+app.include_router(saas_ops_usuarios.router, prefix=API_V1_PREFIX)
 app.include_router(solicitacoes_melhoria.router, prefix=API_V1_PREFIX)
 
 

--- a/backend/app/models/atendente.py
+++ b/backend/app/models/atendente.py
@@ -32,6 +32,9 @@ class Atendente(Base):
     presenca_heartbeat_em = Column(DateTime(timezone=True), nullable=True, index=True)
     # Incrementado ao forçar saída — invalida access/refresh tokens com claim "ver" antigo.
     token_version = Column(Integer, nullable=False, default=0, server_default="0")
+    # Token Cursor MCP pessoal (#915): plaintext só na geração; Bearer resolve este ops.
+    mcp_token_hash = Column(String(64), nullable=True, unique=True, index=True)
+    mcp_token_gerado_em = Column(DateTime(timezone=True), nullable=True)
     # Controle de ponto / escala (#761+): flag + ciclo horas trabalhadas × horas de folga.
     usa_escala = Column(Boolean, nullable=False, default=False, server_default="false")
     escala_horas_trabalho = Column(Integer, nullable=True)

--- a/backend/app/schemas/saas_mcp_token.py
+++ b/backend/app/schemas/saas_mcp_token.py
@@ -1,0 +1,18 @@
+"""Token Cursor MCP pessoal do saas_ops (#915)."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SaasMcpTokenEstado(BaseModel):
+    configurado: bool
+    gerado_em: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SaasMcpTokenGerado(SaasMcpTokenEstado):
+    """Plaintext só nesta resposta."""
+
+    token: str

--- a/backend/app/schemas/saas_ops_usuario.py
+++ b/backend/app/schemas/saas_ops_usuario.py
@@ -1,0 +1,38 @@
+"""Utilizadores do painel SaaS (role saas_ops) — #883."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SaasOpsUsuarioRead(BaseModel):
+    id: int
+    nome: str
+    email: str
+    ativo: bool
+    must_change_password: bool
+    mcp_token_configurado: bool
+    mcp_token_gerado_em: datetime | None = None
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SaasOpsUsuarioCreate(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=255)
+    email: str = Field(..., min_length=3, max_length=255)
+
+
+class SaasOpsUsuarioCriado(SaasOpsUsuarioRead):
+    """Senha temporária só nesta resposta."""
+
+    senha_temporaria: str
+
+
+class SaasOpsUsuarioUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=255)
+    ativo: bool | None = None
+
+
+class SaasOpsUsuarioSenha(BaseModel):
+    senha_temporaria: str

--- a/backend/app/services/saas_mcp_token.py
+++ b/backend/app/services/saas_mcp_token.py
@@ -1,0 +1,66 @@
+"""Token Cursor por conta saas_ops (#915)."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import datetime, timezone
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.models.atendente import Atendente
+
+TOKEN_PREFIX = "drmcp_"
+
+
+def _agora() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def hash_mcp_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def gerar_token_plaintext() -> str:
+    return f"{TOKEN_PREFIX}{secrets.token_urlsafe(32)}"
+
+
+def estado(ops: Atendente) -> dict:
+    return {
+        "configurado": bool((ops.mcp_token_hash or "").strip()),
+        "gerado_em": ops.mcp_token_gerado_em,
+    }
+
+
+def gerar(db: Session, ops: Atendente) -> str:
+    token = gerar_token_plaintext()
+    ops.mcp_token_hash = hash_mcp_token(token)
+    ops.mcp_token_gerado_em = _agora()
+    db.add(ops)
+    registrar_audit(db, "atendente", ops.id, "gerar_mcp_token", ops.id)
+    db.flush()
+    return token
+
+
+def revogar(db: Session, ops: Atendente) -> None:
+    ops.mcp_token_hash = None
+    ops.mcp_token_gerado_em = None
+    db.add(ops)
+    registrar_audit(db, "atendente", ops.id, "revogar_mcp_token", ops.id)
+    db.flush()
+
+
+def resolver_ops_mcp_token(db: Session, raw: str) -> Atendente | None:
+    """Devolve o saas_ops dono do token, ou None se o Bearer não for um token pessoal."""
+    token = (raw or "").strip()
+    if not token:
+        return None
+    digest = hash_mcp_token(token)
+    row = db.query(Atendente).filter(Atendente.mcp_token_hash == digest).first()
+    if row is None:
+        return None
+    if row.role != "saas_ops" or not row.ativo:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Não autorizado")
+    return row

--- a/backend/app/services/saas_ops_usuarios.py
+++ b/backend/app/services/saas_ops_usuarios.py
@@ -1,0 +1,155 @@
+"""Cadastro da equipa saas_ops no control-plane (#883)."""
+
+from __future__ import annotations
+
+import secrets
+
+from fastapi import HTTPException, status
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.core.security import hash_senha
+from app.models.atendente import Atendente
+from app.schemas.saas_ops_usuario import SaasOpsUsuarioCreate, SaasOpsUsuarioUpdate
+
+
+def _agora_senha() -> str:
+    return secrets.token_urlsafe(12)
+
+
+def _normalizar_email(email: str) -> str:
+    return (email or "").strip().lower()
+
+
+def _validar_email(email: str) -> str:
+    valor = _normalizar_email(email)
+    if "@" not in valor or valor.startswith("@") or valor.endswith("@"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe um e-mail válido.")
+    return valor
+
+
+def para_dict(row: Atendente) -> dict:
+    return {
+        "id": row.id,
+        "nome": row.nome,
+        "email": row.email,
+        "ativo": bool(row.ativo),
+        "must_change_password": bool(row.must_change_password),
+        "mcp_token_configurado": bool((row.mcp_token_hash or "").strip()),
+        "mcp_token_gerado_em": row.mcp_token_gerado_em,
+        "created_at": row.created_at,
+    }
+
+
+def _query_ops(db: Session, tenant_id: int):
+    return db.query(Atendente).filter(Atendente.tenant_id == tenant_id, Atendente.role == "saas_ops")
+
+
+def _obter_ops(db: Session, tenant_id: int, usuario_id: int) -> Atendente:
+    row = _query_ops(db, tenant_id).filter(Atendente.id == usuario_id).first()
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Utilizador não encontrado")
+    return row
+
+
+def _contar_ops_activos(db: Session, tenant_id: int, excluir_id: int | None = None) -> int:
+    q = _query_ops(db, tenant_id).filter(Atendente.ativo.is_(True))
+    if excluir_id is not None:
+        q = q.filter(Atendente.id != excluir_id)
+    return q.count()
+
+
+def listar(
+    db: Session,
+    actor: Atendente,
+    *,
+    incluir_inativos: bool,
+    busca: str | None,
+    offset: int,
+    limit: int,
+) -> tuple[list[Atendente], int]:
+    q = _query_ops(db, actor.tenant_id)
+    if not incluir_inativos:
+        q = q.filter(Atendente.ativo.is_(True))
+    if busca and busca.strip():
+        term = f"%{busca.strip()}%"
+        q = q.filter((Atendente.nome.ilike(term)) | (Atendente.email.ilike(term)))
+    total = q.count()
+    rows = q.order_by(Atendente.nome.asc(), Atendente.id.asc()).offset(offset).limit(limit).all()
+    return rows, total
+
+
+def obter(db: Session, actor: Atendente, usuario_id: int) -> Atendente:
+    return _obter_ops(db, actor.tenant_id, usuario_id)
+
+
+def criar(db: Session, actor: Atendente, data: SaasOpsUsuarioCreate) -> tuple[Atendente, str]:
+    email = _validar_email(data.email)
+    nome = (data.nome or "").strip()
+    if not nome:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe o nome.")
+    existe = (
+        db.query(Atendente)
+        .filter(Atendente.tenant_id == actor.tenant_id, func.lower(Atendente.email) == email)
+        .first()
+    )
+    if existe:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="E-mail já cadastrado")
+    senha = _agora_senha()
+    row = Atendente(
+        tenant_id=actor.tenant_id,
+        email=email,
+        nome=nome,
+        senha_hash=hash_senha(senha),
+        role="saas_ops",
+        ativo=True,
+        must_change_password=True,
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(db, "atendente", row.id, "create_saas_ops", actor.id)
+    return row, senha
+
+
+def actualizar(db: Session, actor: Atendente, usuario_id: int, data: SaasOpsUsuarioUpdate) -> Atendente:
+    row = _obter_ops(db, actor.tenant_id, usuario_id)
+    update = data.model_dump(exclude_unset=True)
+    if "nome" in update and update["nome"] is not None:
+        nome = update["nome"].strip()
+        if not nome:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe o nome.")
+        row.nome = nome
+    if "ativo" in update and update["ativo"] is not None:
+        activo = bool(update["ativo"])
+        if not activo:
+            if row.id == actor.id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Não podes desactivar a tua própria conta.",
+                )
+            if row.ativo and _contar_ops_activos(db, actor.tenant_id, excluir_id=row.id) < 1:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Não é possível desactivar o último utilizador activo da equipa.",
+                )
+        row.ativo = activo
+    registrar_audit(db, "atendente", row.id, "update_saas_ops", actor.id)
+    db.flush()
+    return row
+
+
+def redefinir_senha(db: Session, actor: Atendente, usuario_id: int) -> tuple[Atendente, str]:
+    row = _obter_ops(db, actor.tenant_id, usuario_id)
+    if not row.ativo:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Active a conta antes de gerar uma senha nova.",
+        )
+    senha = _agora_senha()
+    row.senha_hash = hash_senha(senha)
+    row.must_change_password = True
+    row.token_version = int(row.token_version or 0) + 1
+    registrar_audit(db, "atendente", row.id, "reset_senha_saas_ops", actor.id)
+    db.flush()
+    return row, senha

--- a/backend/scripts/mcp_deskrudder_saas.py
+++ b/backend/scripts/mcp_deskrudder_saas.py
@@ -4,9 +4,10 @@ O processo corre no PC do ops (Cursor). A API é a do control-plane em produçã
 
 Env:
   DESKRUDDER_API_URL   (omissão: https://api.deskrudder.com.br)
-  DESKRUDDER_MCP_TOKEN (igual a SAAS_MCP_TOKEN na instância comercial da VPS)
+  DESKRUDDER_MCP_TOKEN (token gerado em /saas/conta; legado: SAAS_MCP_TOKEN da VPS)
 
-Em local, no .cursor/mcp.json usa http://127.0.0.1:8000; o token pode vir do backend/.env.
+Em local, no .cursor/mcp.json usa http://127.0.0.1:8000 e o token de /saas/conta
+(legado: SAAS_MCP_TOKEN no backend/.env).
 """
 
 from __future__ import annotations
@@ -186,8 +187,8 @@ def _api(method: str, path: str, body: dict | None = None) -> tuple[int, object]
     if not token:
         raise RuntimeError(
             "Define DESKRUDDER_MCP_TOKEN no .cursor/mcp.json "
-            "(o mesmo SAAS_MCP_TOKEN da instância comercial). "
-            "Em local (127.0.0.1) também podes pôr SAAS_MCP_TOKEN no backend/.env."
+            "(token gerado em /saas/conta). "
+            "Em local (127.0.0.1) também podes pôr SAAS_MCP_TOKEN no backend/.env (legado)."
         )
     url = f"{API}{path}"
     data = None if body is None else json.dumps(body, ensure_ascii=False).encode("utf-8")

--- a/backend/tests/test_saas_clientes.py
+++ b/backend/tests/test_saas_clientes.py
@@ -194,3 +194,21 @@ def test_system_info_expõe_saas_flag(client, auth_headers, monkeypatch):
     r = client.get("/v1/system/info", headers=auth_headers["ops"])
     assert r.status_code == 200
     assert r.json()["saas_control_plane"] is True
+
+
+def test_system_info_com_must_change_password(client, seed_base, auth_headers, db_session, monkeypatch):
+    """Ops no primeiro login ainda precisa de /system/info para o shell SaaS não mostrar 403 falso."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    ops = seed_base["ops"]
+    ops.must_change_password = True
+    db_session.commit()
+
+    info = client.get("/v1/system/info", headers=auth_headers["ops"])
+    assert info.status_code == 200
+    assert info.json()["saas_control_plane"] is True
+
+    bloqueado = client.get("/v1/saas/clientes", headers=auth_headers["ops"])
+    assert bloqueado.status_code == 403
+    assert "Altere sua senha" in (bloqueado.json().get("detail") or "")

--- a/backend/tests/test_saas_mcp_token.py
+++ b/backend/tests/test_saas_mcp_token.py
@@ -1,0 +1,129 @@
+"""Token Cursor MCP pessoal (#915)."""
+
+from __future__ import annotations
+
+from app.core.security import criar_access_token, hash_senha
+from app.models.atendente import Atendente
+
+
+def _headers_ops(email: str) -> dict[str, str]:
+    tok = criar_access_token({"sub": email, "tid": 1})
+    return {"Authorization": f"Bearer {tok}", "X-Dx-Tenant-Id": "1"}
+
+
+def _criar_ops2(db_session, seed_base) -> Atendente:
+    row = Atendente(
+        tenant_id=seed_base["tenant"].id,
+        email="ops2@test.local",
+        nome="Ops Dois",
+        senha_hash=hash_senha("ops123456"),
+        role="saas_ops",
+        ativo=True,
+        must_change_password=False,
+    )
+    db_session.add(row)
+    db_session.commit()
+    db_session.refresh(row)
+    return row
+
+
+def test_mcp_token_painel_404_sem_control_plane(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", False)
+    r = client.get("/v1/saas/me/mcp-token", headers=auth_headers["ops"])
+    assert r.status_code == 404
+
+
+def test_mcp_token_gerar_lista_e_nao_e_o_primeiro_ops(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
+    ops2 = _criar_ops2(db_session, seed_base)
+    h2 = _headers_ops(ops2.email)
+
+    estado = client.get("/v1/saas/me/mcp-token", headers=h2)
+    assert estado.status_code == 200, estado.text
+    assert estado.json()["configurado"] is False
+
+    gerado = client.post("/v1/saas/me/mcp-token", headers=h2)
+    assert gerado.status_code == 200, gerado.text
+    token = gerado.json()["token"]
+    assert token.startswith("drmcp_")
+    assert gerado.json()["configurado"] is True
+
+    sid = client.post(
+        "/v1/solicitacoes-melhoria",
+        headers=auth_headers["a1"],
+        json={
+            "tipo": "sugestao",
+            "titulo": "Token pessoal",
+            "descricao": "Quem recusou tem de ser o ops dois.",
+        },
+    ).json()["id"]
+    lista_ops = client.get("/v1/saas/solicitacoes", headers=auth_headers["ops"])
+    saas_id = next(i["id"] for i in lista_ops.json()["items"] if i["origem_solicitacao_id"] == sid)
+
+    mcp = {"Authorization": f"Bearer {token}"}
+    listed = client.get("/v1/saas/solicitacoes", headers=mcp)
+    assert listed.status_code == 200, listed.text
+
+    comentario = client.post(
+        f"/v1/saas/solicitacoes/{saas_id}/comentarios",
+        headers=mcp,
+        json={"corpo": "nota interna do ops dois", "publico_cliente": False},
+    )
+    assert comentario.status_code == 200, comentario.text
+    ultimo = comentario.json()["comentarios"][-1]
+    assert ultimo["autor_nome"] == "Ops Dois"
+
+
+def test_mcp_token_regenerar_invalida_o_anterior(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    primeiro = client.post("/v1/saas/me/mcp-token", headers=auth_headers["ops"]).json()["token"]
+    segundo = client.post("/v1/saas/me/mcp-token", headers=auth_headers["ops"]).json()["token"]
+    assert primeiro != segundo
+    antigo = client.get("/v1/saas/solicitacoes", headers={"Authorization": f"Bearer {primeiro}"})
+    assert antigo.status_code == 401
+    novo = client.get("/v1/saas/solicitacoes", headers={"Authorization": f"Bearer {segundo}"})
+    assert novo.status_code == 200, novo.text
+
+
+def test_mcp_token_revogar_e_conta_inactiva(client, seed_base, auth_headers, db_session, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    token = client.post("/v1/saas/me/mcp-token", headers=auth_headers["ops"]).json()["token"]
+    rev = client.delete("/v1/saas/me/mcp-token", headers=auth_headers["ops"])
+    assert rev.status_code == 200
+    assert rev.json()["configurado"] is False
+    assert client.get("/v1/saas/solicitacoes", headers={"Authorization": f"Bearer {token}"}).status_code == 401
+
+    token2 = client.post("/v1/saas/me/mcp-token", headers=auth_headers["ops"]).json()["token"]
+    seed_base["ops"].ativo = False
+    db_session.commit()
+    assert client.get("/v1/saas/solicitacoes", headers={"Authorization": f"Bearer {token2}"}).status_code == 401
+
+
+def test_mcp_token_so_o_proprio_ops_jwt(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    assert client.get("/v1/saas/me/mcp-token", headers=auth_headers["admin"]).status_code == 403
+    pessoal = client.post("/v1/saas/me/mcp-token", headers=auth_headers["ops"]).json()["token"]
+    with_mcp = client.post("/v1/saas/me/mcp-token", headers={"Authorization": f"Bearer {pessoal}"})
+    assert with_mcp.status_code == 401
+
+
+def test_mcp_token_legado_env_ainda_lista(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_MCP_TOKEN", "mcp-legado-vps")
+    listed = client.get("/v1/saas/solicitacoes", headers={"Authorization": "Bearer mcp-legado-vps"})
+    assert listed.status_code == 200, listed.text

--- a/backend/tests/test_saas_ops_usuarios.py
+++ b/backend/tests/test_saas_ops_usuarios.py
@@ -1,0 +1,144 @@
+"""Cadastro da equipa saas_ops no painel (#883)."""
+
+from __future__ import annotations
+
+from app.core.security import criar_access_token, hash_senha
+from app.models.atendente import Atendente
+
+
+def _headers_ops(email: str) -> dict[str, str]:
+    tok = criar_access_token({"sub": email, "tid": 1})
+    return {"Authorization": f"Bearer {tok}", "X-Dx-Tenant-Id": "1"}
+
+
+def test_saas_usuarios_404_sem_control_plane(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", False)
+    r = client.get("/v1/saas/usuarios", headers=auth_headers["ops"])
+    assert r.status_code == 404
+
+
+def test_saas_usuarios_admin_helpdesk_403(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    assert client.get("/v1/saas/usuarios", headers=auth_headers["admin"]).status_code == 403
+
+
+def test_saas_usuarios_criar_login_e_token_cursor(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
+    criado = client.post(
+        "/v1/saas/usuarios",
+        headers=auth_headers["ops"],
+        json={"nome": "Dev Cursor", "email": "dev.cursor@test.local"},
+    )
+    assert criado.status_code == 201, criado.text
+    body = criado.json()
+    senha = body["senha_temporaria"]
+    assert len(senha) >= 8
+    assert body["must_change_password"] is True
+    assert body["mcp_token_configurado"] is False
+    assert "mcp_token_hash" not in body
+
+    login = client.post("/v1/auth/login", json={"email": body["email"], "senha": senha})
+    assert login.status_code == 200, login.text
+    assert login.json()["must_change_password"] is True
+
+    h_dev = _headers_ops(body["email"])
+    troca = client.post(
+        "/v1/atendentes/me/trocar-senha",
+        headers=h_dev,
+        json={"senha_atual": senha, "senha_nova": "novaSenhaSegura1"},
+    )
+    assert troca.status_code == 200, troca.text
+    token = client.post("/v1/saas/me/mcp-token", headers=h_dev)
+    assert token.status_code == 200, token.text
+    listed = client.get("/v1/saas/solicitacoes", headers={"Authorization": f"Bearer {token.json()['token']}"})
+    assert listed.status_code == 200, listed.text
+
+    lista = client.get("/v1/saas/usuarios", headers=auth_headers["ops"])
+    assert lista.status_code == 200
+    row = next(i for i in lista.json()["items"] if i["email"] == body["email"])
+    assert row["mcp_token_configurado"] is True
+
+
+def test_saas_usuarios_nao_desactiva_ultimo_nem_a_si(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    ops_id = seed_base["ops"].id
+    self_off = client.patch(
+        f"/v1/saas/usuarios/{ops_id}",
+        headers=auth_headers["ops"],
+        json={"ativo": False},
+    )
+    assert self_off.status_code == 400
+
+    outro = client.post(
+        "/v1/saas/usuarios",
+        headers=auth_headers["ops"],
+        json={"nome": "Ops Extra", "email": "ops.extra@test.local"},
+    ).json()
+    extra_off = client.patch(
+        f"/v1/saas/usuarios/{outro['id']}",
+        headers=auth_headers["ops"],
+        json={"ativo": False},
+    )
+    assert extra_off.status_code == 200
+    ultimo = client.patch(
+        f"/v1/saas/usuarios/{ops_id}",
+        headers=auth_headers["ops"],
+        json={"ativo": False},
+    )
+    assert ultimo.status_code == 400
+
+
+def test_saas_usuarios_helpdesk_nao_ve_ops(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    lista = client.get("/v1/atendentes", headers=auth_headers["admin"])
+    assert lista.status_code == 200
+    emails = {i["email"] for i in lista.json()["items"]}
+    assert seed_base["ops"].email not in emails
+    assert client.get(f"/v1/atendentes/{seed_base['ops'].id}", headers=auth_headers["admin"]).status_code == 404
+
+
+def test_saas_usuarios_email_duplicado_e_reset_senha(
+    client, seed_base, auth_headers, db_session, monkeypatch
+):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    dup = client.post(
+        "/v1/saas/usuarios",
+        headers=auth_headers["ops"],
+        json={"nome": "Cópia", "email": seed_base["ops"].email},
+    )
+    assert dup.status_code == 400
+
+    extra = Atendente(
+        tenant_id=seed_base["tenant"].id,
+        email="ops.reset@test.local",
+        nome="Reset Me",
+        senha_hash=hash_senha("antiga123"),
+        role="saas_ops",
+        ativo=True,
+        must_change_password=False,
+    )
+    db_session.add(extra)
+    db_session.commit()
+    db_session.refresh(extra)
+
+    reset = client.post(f"/v1/saas/usuarios/{extra.id}/senha-temporaria", headers=auth_headers["ops"])
+    assert reset.status_code == 200, reset.text
+    senha = reset.json()["senha_temporaria"]
+    login_old = client.post("/v1/auth/login", json={"email": extra.email, "senha": "antiga123"})
+    assert login_old.status_code == 401
+    login_new = client.post("/v1/auth/login", json={"email": extra.email, "senha": senha})
+    assert login_new.status_code == 200
+    assert login_new.json()["must_change_password"] is True

--- a/docs/SAAS_CONTROL_PLANE.md
+++ b/docs/SAAS_CONTROL_PLANE.md
@@ -117,10 +117,12 @@ No control-plane (`SAAS_CONTROL_PLANE=true`), a abertura grava directo na tabela
 - `POST /v1/saas/ingest/solicitacoes` — Bearer ou `X-Saas-Instance-Token`; o token é conferido (SHA-256) com `clientes_saas.ingest_token_hash` do slug do body.
 - `POST /v1/saas/ingest/solicitacoes/{origem_id}/media` — o mesmo token; `file` + `storage_key` (UUID da instância) + `papel`. A chave é reutilizada para o markdown `![…](/v1/solicitacoes-melhoria/media/…)` resolver no painel SaaS. 404 se o JSON ainda não chegou (a outbox reenvia).
 - `GET /v1/saas/ingest/solicitacoes/sync` — mesmo token; devolve status + comentários públicos daquele slug (`?since=` opcional).
-- `GET /v1/saas/solicitacoes` e `GET /v1/saas/solicitacoes/{id}` — `saas_ops` (JWT) ou token `SAAS_MCP_TOKEN` (MCP Cursor).
+- `GET /v1/saas/solicitacoes` e `GET /v1/saas/solicitacoes/{id}` — `saas_ops` (JWT) ou token Cursor pessoal (`/saas/conta`) / `SAAS_MCP_TOKEN` legado.
 - `PATCH …/solicitacoes/{id}/github` — liga a issue criada no GitHub ao pedido (e ao grupo, se houver). Só ops / MCP; o cliente não vê.
 - `POST …/solicitacoes/{id}/vinculos` e `DELETE …/vinculos/{membro_id}` — grupo de pedidos iguais (peso). Só ops / MCP.
 - `PATCH /v1/saas/solicitacoes/{id}/status` e `POST /v1/saas/solicitacoes/{id}/comentarios` — triagem.
+- `POST /v1/saas/me/mcp-token` — gera o token Cursor desta conta (plaintext uma vez). `GET` estado; `DELETE` revoga.
+- `GET/POST /v1/saas/usuarios` e `PATCH /v1/saas/usuarios/{id}` — equipa `saas_ops` (nome, e-mail, activo). `POST …/senha-temporaria` devolve senha uma vez. Não são atendentes da instância do cliente.
 - `POST /v1/saas/clientes/{id}/gerar-token-ingest` — devolve o plaintext **uma vez** e escreve no `client.env` se a pasta do cliente já existir.
 - `SAAS_INGEST_PUBLIC_URL` (opcional) — URL escrita no env das instâncias; por omissão `https://api.{SAAS_PROVISION_BASE_DOMAIN}/v1/saas/ingest/solicitacoes`.
 
@@ -130,20 +132,9 @@ Handoff Cursor é #857: o Cursor **puxa** a fila (MCP `deskrudder-saas`) contra 
 
 O script corre no PC do ops. A fila é a da instância comercial (`SAAS_CONTROL_PLANE=true`).
 
-1. **No `client.env` da stack comercial** (não nas instâncias de cliente), gerar um token longo e **não** reutilizar o de desenvolvimento:
-
-   ```bash
-   openssl rand -base64 32
-   ```
-
-   ```
-   SAAS_CONTROL_PLANE=true
-   SAAS_MCP_TOKEN=<valor gerado>
-   ```
-
-   Reiniciar o container da instância comercial depois do release `staging`.
-
-2. **Em cada Cursor** (PC, notebook, outro dev): copiar `.cursor/mcp.json.example` para `.cursor/mcp.json` (gitignored), colar o **mesmo** token em `DESKRUDDER_MCP_TOKEN`, e manter:
+1. Entre no painel admin (`/login/admin`) com a **tua** conta `saas_ops`.
+2. Abra **Conta / Cursor** (`/saas/conta`) e gere o token. O valor aparece **uma vez** — copie para o Cursor. Regenerar invalida o token anterior.
+3. Em cada Cursor: copiar `.cursor/mcp.json.example` para `.cursor/mcp.json` (gitignored), colar **o teu** token em `DESKRUDDER_MCP_TOKEN`, e manter:
 
    ```
    DESKRUDDER_API_URL=https://api.deskrudder.com.br
@@ -151,7 +142,9 @@ O script corre no PC do ops. A fila é a da instância comercial (`SAAS_CONTROL_
 
    Cursor → Settings → MCP → habilitar `deskrudder-saas`.
 
-3. **Teste local** (Docker neste repo): no `.cursor/mcp.json` usa `http://127.0.0.1:8000`. O token pode ser o `SAAS_MCP_TOKEN` do `backend/.env` (não misturar com o da VPS).
+4. **Teste local** (Docker neste repo): no `.cursor/mcp.json` usa `http://127.0.0.1:8000` e um token gerado no painel local (não o da VPS).
+
+O `SAAS_MCP_TOKEN` no `.env` da VPS ainda é aceite como **legado** (não identifica a pessoa). Prefira o token do painel.
 
 Ferramentas: listar, obter, alterar status, comentar, vincular pedidos iguais, ligar issue GitHub (aceitam `id` ou protocolo). Sem OpenAI e sem `CURSOR_API_KEY` no DeskRudder. O GitHub MCP (criar issues) é à parte e também é por instalação do Cursor.
 
@@ -163,7 +156,7 @@ Ferramentas: listar, obter, alterar status, comentar, vincular pedidos iguais, l
 
 1. Flags dual: `SAAS_CONTROL_PLANE=true` + `VITE_SAAS_CONTROL_PLANE=true` só na instância comercial.
 2. Migrations `084`–`092` aplicadas (`alembic upgrade head`).
-3. Login ops via `/login/admin` (`ops@deskrudder.local`) → shell SaaS (Licenças / Planos / Leads / Sugestões), sem menu de tickets.
+3. Login ops via `/login/admin` → shell SaaS (Licenças / Planos / Leads / Sugestões / Equipa / Conta / Cursor). Sem menu de tickets.
 4. Login atendimento via `/login` (`admin@email.com` ou `atendente@email.com`) → painel de tickets/chat (sem menu SaaS).
 5. Lead → **Converter em licença** (escolher plano) ou prefill manual; trial em `/trial`; contacto na LP.
 6. Provisionar com `SAAS_PROVISION_EXEC_ENABLED=false` → `aguardando_ops` → copiar comandos → **Confirmar provisionamento** após health (dispara e-mail de entrega ao contacto se Resend estiver ok).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -98,6 +98,9 @@ import { SaasSolicitacoes } from './pages/saas/SaasSolicitacoes'
 import { SaasSolicitacaoDetalhe } from './pages/saas/SaasSolicitacaoDetalhe'
 import { SaasLayout } from './pages/saas/SaasLayout'
 import { SaasSobre } from './pages/saas/SaasSobre'
+import { SaasConta } from './pages/saas/SaasConta'
+import { SaasUsuarios } from './pages/saas/SaasUsuarios'
+import { SaasUsuarioForm } from './pages/saas/SaasUsuarioForm'
 import { KbPublicLayout } from './pages/kb-public/KbPublicLayout'
 import { KbPublicHome } from './pages/kb-public/KbPublicHome'
 import { KbPublicArtigo } from './pages/kb-public/KbPublicArtigo'
@@ -153,6 +156,9 @@ function LayoutOrLanding() {
     return <Navigate to="/login" replace state={{ from: location }} />
   }
   if (user.role === 'saas_ops') {
+    if (user.must_change_password || location.pathname === '/alterar-senha') {
+      return <Layout />
+    }
     return <Navigate to="/saas/licencas" replace />
   }
   return <Layout />
@@ -315,6 +321,10 @@ function AppRoutes() {
         <Route path="leads" element={<SaasLeads />} />
         <Route path="solicitacoes/:id" element={<SaasSolicitacaoDetalhe />} />
         <Route path="solicitacoes" element={<SaasSolicitacoes />} />
+        <Route path="usuarios/novo" element={<SaasUsuarioForm />} />
+        <Route path="usuarios/:id" element={<SaasUsuarioForm />} />
+        <Route path="usuarios" element={<SaasUsuarios />} />
+        <Route path="conta" element={<SaasConta />} />
         <Route path="sobre" element={<SaasSobre />} />
       </Route>
       <Route

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5274,6 +5274,59 @@ export const saasSolicitacoes = {
     }),
 };
 
+export namespace SaasOpsConta {
+  export interface McpEstado {
+    configurado: boolean
+    gerado_em: string | null
+  }
+  export interface McpGerado extends McpEstado {
+    token: string
+  }
+}
+
+export const saasOpsConta = {
+  mcpToken: () => api<SaasOpsConta.McpEstado>('/saas/me/mcp-token'),
+  gerarMcpToken: () =>
+    api<SaasOpsConta.McpGerado>('/saas/me/mcp-token', { method: 'POST', body: JSON.stringify({}) }),
+  revogarMcpToken: () =>
+    api<SaasOpsConta.McpEstado>('/saas/me/mcp-token', { method: 'DELETE' }),
+};
+
+export namespace SaasOpsUsuarios {
+  export interface Usuario {
+    id: number
+    nome: string
+    email: string
+    ativo: boolean
+    must_change_password: boolean
+    mcp_token_configurado: boolean
+    mcp_token_gerado_em: string | null
+    created_at: string | null
+  }
+  export interface Criado extends Usuario {
+    senha_temporaria: string
+  }
+}
+
+export const saasOpsUsuarios = {
+  list: (params?: {
+    incluir_inativos?: boolean
+    busca?: string
+    offset?: number
+    limit?: number
+  }) => listPaginated<SaasOpsUsuarios.Usuario>('/saas/usuarios', params),
+  get: (id: number) => api<SaasOpsUsuarios.Usuario>(`/saas/usuarios/${id}`),
+  create: (data: { nome: string; email: string }) =>
+    api<SaasOpsUsuarios.Criado>('/saas/usuarios', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id: number, data: { nome?: string; ativo?: boolean }) =>
+    api<SaasOpsUsuarios.Usuario>(`/saas/usuarios/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  senhaTemporaria: (id: number) =>
+    api<{ senha_temporaria: string }>(`/saas/usuarios/${id}/senha-temporaria`, {
+      method: 'POST',
+      body: JSON.stringify({}),
+    }),
+};
+
 export namespace SaasSolicitacoesProduto {
   export interface ListaItem {
     id: number;

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -102,7 +102,7 @@ function LayoutInner() {
 
   return (
     <div
-      className="flex h-[var(--vv-height,100dvh)] max-h-[var(--vv-height,100dvh)] min-h-0 overflow-hidden bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95 md:grid md:grid-cols-[var(--sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
+      className="grid h-[var(--vv-height,100dvh)] max-h-[var(--vv-height,100dvh)] min-h-0 w-full min-w-0 grid-cols-1 overflow-hidden bg-gradient-to-b from-slate-50 to-slate-100/90 dark:from-slate-950 dark:to-slate-900/95 md:grid-cols-[var(--sidebar-w)_minmax(0,1fr)] md:transition-[grid-template-columns] md:duration-200 md:ease-out"
       style={
         {
           ['--sidebar-w' as never]: sidebarW,
@@ -123,10 +123,10 @@ function LayoutInner() {
         onLogout={logout}
       />
 
-      <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden md:col-start-2 md:row-start-1">
+      <div className="flex h-full min-h-0 min-w-0 w-full flex-col overflow-hidden md:col-start-2 md:row-start-1">
         <header
-          className={`z-30 h-16 min-h-[64px] shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-800 dark:bg-slate-950 md:flex md:gap-3 md:px-6 ${
-            ocultarHeaderMobile ? 'hidden' : 'flex'
+          className={`z-30 flex h-16 min-h-[64px] w-full min-w-0 shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-800 dark:bg-slate-950 md:gap-3 md:px-6 ${
+            ocultarHeaderMobile ? 'hidden' : ''
           }`}
         >
           <button
@@ -152,7 +152,7 @@ function LayoutInner() {
           <div className="min-w-0 flex-1" />
           <NavbarNotificacoes enabled={notificacoesEnabled} />
           <ThemeToggle />
-          <div className="hidden min-w-0 text-right sm:block">
+          <div className="hidden min-w-0 max-w-[7rem] shrink text-right sm:block md:max-w-[10rem] lg:max-w-none">
             <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{user?.nome}</p>
             <p className="truncate text-xs text-slate-500 dark:text-slate-400">{perfilExibicao(user?.role)}</p>
           </div>
@@ -165,14 +165,14 @@ function LayoutInner() {
         {notificacoesEnabled && !ocultarHeaderMobile ? <WebPushOptInBanner enabled /> : null}
         <PontoAlertasBanner />
 
-        <main className="min-h-0 flex-1 overflow-hidden">
+        <main className="min-h-0 min-w-0 w-full flex-1 overflow-hidden">
           <div
             className={
               scrollInternoNaPagina
                 ? isChatHub
-                  ? 'flex h-full min-h-0 flex-col overflow-hidden'
-                  : 'flex h-full min-h-0 flex-col overflow-hidden px-4 pt-4 md:px-6 md:pt-6'
-                : 'dx-scrollbar h-full min-h-0 overflow-x-hidden overflow-y-auto p-4 md:p-6'
+                  ? 'flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden'
+                  : 'flex h-full min-h-0 w-full min-w-0 flex-col overflow-hidden px-4 pt-4 md:px-6 md:pt-6'
+                : 'dx-scrollbar h-full min-h-0 w-full min-w-0 overflow-x-hidden overflow-y-auto p-4 md:p-6'
             }
           >
             <Outlet />

--- a/frontend/src/components/config/ConfigSectionTabs.tsx
+++ b/frontend/src/components/config/ConfigSectionTabs.tsx
@@ -18,8 +18,8 @@ type Props = {
 
 export function ConfigSectionTabs({ tabs, ariaLabel }: Props) {
   return (
-    <div className="border-b border-slate-200 dark:border-slate-800">
-      <nav className="-mb-px flex flex-wrap gap-1" aria-label={ariaLabel}>
+    <div className="w-full min-w-0 border-b border-slate-200 dark:border-slate-800">
+      <nav className="-mb-px flex w-full min-w-0 flex-wrap gap-1" aria-label={ariaLabel}>
         {tabs.map((tab) => (
           <NavLink key={tab.to} to={tab.to} end={tab.end} className={tabClass}>
             {tab.label}

--- a/frontend/src/components/tickets/TicketDetalheSkeleton.tsx
+++ b/frontend/src/components/tickets/TicketDetalheSkeleton.tsx
@@ -12,7 +12,7 @@ export function TicketDetalheSkeleton() {
       aria-label="Carregando ticket"
     >
       <div className="shrink-0 border-b border-slate-200/70 bg-white dark:border-slate-800/70 dark:bg-slate-950 sm:rounded-b-2xl sm:border sm:border-t-0">
-        <div className="mx-auto max-w-6xl space-y-3 px-3 py-2.5 sm:px-5 sm:py-4 lg:py-5">
+        <div className="mx-auto w-full min-w-0 max-w-6xl space-y-3 px-3 py-2.5 sm:px-5 sm:py-4 lg:py-5">
           <Pulse className="h-4 w-16" />
           <div className="flex items-start justify-between gap-3">
             <Pulse className="h-6 w-32 lg:h-8 lg:w-40" />
@@ -39,7 +39,7 @@ export function TicketDetalheSkeleton() {
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-6xl space-y-4 px-3 py-3 sm:space-y-6 sm:px-5 sm:py-4 md:px-6">
+        <div className="mx-auto w-full min-w-0 max-w-6xl space-y-4 px-3 py-3 sm:space-y-6 sm:px-5 sm:py-4 md:px-6">
           <div className="rounded-xl border border-slate-200/90 bg-white p-4 dark:border-slate-800/80 dark:bg-slate-950/40">
             <Pulse className="mb-3 h-4 w-28" />
             <div className="space-y-3">

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -13,9 +13,9 @@ const variants: Record<Variant, string> = {
   secondary:
     'bg-slate-100 text-slate-800 hover:bg-slate-200 focus:ring-slate-400 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700',
   danger: 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500',
-  /** Descartar / sair — vermelho claro no light; no dark bem visível (≠ Excluir sólido). */
+  /** Descartar / sair — gradiente vermelho no mesmo molde do primary (≠ Excluir sólido). */
   cancel:
-    'border-2 border-red-500 bg-red-50 text-red-800 hover:bg-red-100 focus:ring-red-500 dark:border-red-400 dark:bg-red-950/70 dark:text-red-100 dark:hover:bg-red-900/80',
+    'bg-gradient-to-r from-red-500 to-red-600 text-white shadow-md shadow-red-500/20 hover:from-red-400 hover:to-red-500 focus:ring-red-400 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-slate-950',
   ghost:
     'bg-transparent text-slate-700 hover:bg-slate-100 focus:ring-slate-400 dark:text-slate-300 dark:hover:bg-slate-800',
 }

--- a/frontend/src/components/ui/PageContainer.tsx
+++ b/frontend/src/components/ui/PageContainer.tsx
@@ -16,7 +16,12 @@ const SPACING_CLASS = {
 export type PageContainerMaxWidth = keyof typeof MAX_WIDTH_CLASS
 export type PageContainerSpacing = keyof typeof SPACING_CLASS
 
-export const PAGE_CONTAINER_CLASS = `mx-auto w-full ${MAX_WIDTH_CLASS['6xl']} ${SPACING_CLASS.normal} pb-10`
+export const PAGE_CONTAINER_CLASS = `mx-auto w-full min-w-0 ${MAX_WIDTH_CLASS['6xl']} ${SPACING_CLASS.normal} pb-10`
+
+/** Largura útil em wrappers legados (forms/detalhes fora do PageContainer). */
+export function contentWidthClass(maxWidth: PageContainerMaxWidth = '6xl') {
+  return `mx-auto w-full min-w-0 ${MAX_WIDTH_CLASS[maxWidth]}`
+}
 
 type PageContainerProps = {
   children: ReactNode
@@ -34,7 +39,7 @@ export function PageContainer({
 }: PageContainerProps) {
   return (
     <div
-      className={`mx-auto w-full ${MAX_WIDTH_CLASS[maxWidth]} ${SPACING_CLASS[spacing]} ${spacing === 'none' ? '' : 'pb-10'} ${className}`.trim()}
+      className={`mx-auto w-full min-w-0 ${MAX_WIDTH_CLASS[maxWidth]} ${SPACING_CLASS[spacing]} ${spacing === 'none' ? '' : 'pb-10'} ${className}`.trim()}
     >
       {children}
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -26,6 +26,7 @@
   }
 
   #root {
+    width: 100%;
     height: 100%;
     max-height: 100dvh;
     overflow: hidden;

--- a/frontend/src/pages/AcessoNegado.tsx
+++ b/frontend/src/pages/AcessoNegado.tsx
@@ -8,7 +8,7 @@ export function AcessoNegado({
   detail?: string
 } = {}) {
   return (
-    <div className="mx-auto max-w-lg rounded-2xl border border-amber-200/80 bg-amber-50/90 p-6 text-amber-950 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
+    <div className="mx-auto w-full min-w-0 max-w-lg rounded-2xl border border-amber-200/80 bg-amber-50/90 p-6 text-amber-950 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
       <p className="text-sm font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-300">403 — Acesso restrito</p>
       <h1 className="mt-2 text-lg font-semibold text-slate-900 dark:text-slate-100">{title}</h1>
       <p className="mt-3 text-sm leading-relaxed text-slate-700 dark:text-slate-300">{detail}</p>

--- a/frontend/src/pages/AlterarSenha.tsx
+++ b/frontend/src/pages/AlterarSenha.tsx
@@ -6,6 +6,7 @@ import { Button } from '../components/ui/Button'
 import { useToast } from '../components/ui/Toast'
 import { IconEye, IconEyeOff } from '../components/ui/IconEye'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
+import { SAAS_LICENCAS_PATH } from '../lib/saasControlPlane'
 
 const fieldClass =
   'w-full rounded-xl border border-slate-200 bg-white px-3.5 py-3 text-[0.9375rem] text-slate-900 shadow-inner placeholder:text-slate-400 focus:border-cyan-500/50 focus:outline-none focus:ring-2 focus:ring-cyan-400/25 dark:border-white/10 dark:bg-white/[0.06] dark:text-slate-100 dark:placeholder:text-slate-500'
@@ -18,7 +19,7 @@ export function AlterarSenha() {
   const [mostrarNova, setMostrarNova] = useState(false)
   const [mostrarConf, setMostrarConf] = useState(false)
   const [loading, setLoading] = useState(false)
-  const { refreshUser } = useAuth()
+  const { refreshUser, user } = useAuth()
   const navigate = useNavigate()
   const toast = useToast()
 
@@ -37,7 +38,7 @@ export function AlterarSenha() {
       await atendentes.trocarSenha(senhaAtual, senhaNova)
       await refreshUser()
       toast.showSuccess('Senha alterada com sucesso.')
-      navigate('/', { replace: true })
+      navigate(user?.role === 'saas_ops' ? SAAS_LICENCAS_PATH : '/', { replace: true })
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar a senha.'))
     } finally {

--- a/frontend/src/pages/AlterarSenha.tsx
+++ b/frontend/src/pages/AlterarSenha.tsx
@@ -46,7 +46,7 @@ export function AlterarSenha() {
   }
 
   return (
-    <div className="mx-auto max-w-lg">
+    <div className="mx-auto w-full min-w-0 max-w-lg">
       <h1 className="mb-2 text-xl font-semibold text-slate-900 dark:text-slate-100">Definir nova senha</h1>
       <p className="mb-6 text-sm text-slate-600 dark:text-slate-400">
         Por segurança, altere a senha temporária antes de continuar usando o sistema.

--- a/frontend/src/pages/AtendenteDetalhe.tsx
+++ b/frontend/src/pages/AtendenteDetalhe.tsx
@@ -82,7 +82,7 @@ export function AtendenteDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -105,7 +105,7 @@ export function AtendenteDetalhe() {
   if (!atendente) return null
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -209,7 +209,7 @@ export function AtendenteForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Atendente não encontrado."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/ConfigWhatsapp.tsx
+++ b/frontend/src/pages/ConfigWhatsapp.tsx
@@ -99,14 +99,14 @@ function renderQrPayload(data: Record<string, unknown> | null | undefined) {
   const raw = data.base64 ?? data.qrcode
   if (typeof raw === 'string') {
     if (raw.startsWith('data:image')) {
-      return <img src={raw} alt="QR Code WhatsApp" className="mx-auto max-w-[280px] rounded-lg" />
+      return <img src={raw} alt="QR Code WhatsApp" className="mx-auto w-full min-w-0 max-w-[280px] rounded-lg" />
     }
     if (raw.length > 80) {
       return (
         <img
           src={`data:image/png;base64,${raw}`}
           alt="QR Code WhatsApp"
-          className="mx-auto max-w-[280px] rounded-lg"
+          className="mx-auto w-full min-w-0 max-w-[280px] rounded-lg"
         />
       )
     }

--- a/frontend/src/pages/CrmContratos.tsx
+++ b/frontend/src/pages/CrmContratos.tsx
@@ -106,7 +106,7 @@ export function CrmContratos() {
   }
 
   return (
-    <div className="mx-auto max-w-6xl space-y-4 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-4 pb-10">
       <div>
         <h1 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Contratos</h1>
         <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">

--- a/frontend/src/pages/CrmNegociacaoDetalhe.tsx
+++ b/frontend/src/pages/CrmNegociacaoDetalhe.tsx
@@ -367,7 +367,7 @@ export function CrmNegociacaoDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-5xl pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-5xl pb-10">
         <div className="h-72 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -386,7 +386,7 @@ export function CrmNegociacaoDetalhe() {
   if (falha || !neg) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo={falha?.titulo || 'Negociação não encontrada.'}
         detalhe={falha?.detalhe}
         onVoltar={voltar}
@@ -395,7 +395,7 @@ export function CrmNegociacaoDetalhe() {
   }
 
   return (
-    <div className="mx-auto max-w-5xl space-y-4 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <VoltarButton onClick={voltar} />
         <Button variant="secondary" onClick={() => navigate('/crm/leads')}>

--- a/frontend/src/pages/EmpresaDetalhe.tsx
+++ b/frontend/src/pages/EmpresaDetalhe.tsx
@@ -216,7 +216,7 @@ export function EmpresaDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-4 w-24 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
         <div className="h-9 w-2/3 max-w-md animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
@@ -226,7 +226,7 @@ export function EmpresaDetalhe() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para acessar esta empresa."
           detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
@@ -277,7 +277,7 @@ export function EmpresaDetalhe() {
   )
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-8 pb-10">
       <div>
         <VoltarButton onClick={voltar} />
       </div>

--- a/frontend/src/pages/EmpresaForm.tsx
+++ b/frontend/src/pages/EmpresaForm.tsx
@@ -388,7 +388,7 @@ export function EmpresaForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-6xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-6xl space-y-4 pb-10"
         titulo="Empresa não encontrada."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/FuncionarioRedeDetalhe.tsx
+++ b/frontend/src/pages/FuncionarioRedeDetalhe.tsx
@@ -174,7 +174,7 @@ export function FuncionarioRedeDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-4 w-40 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
         <div className="h-9 w-2/3 max-w-md animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-48 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
@@ -184,7 +184,7 @@ export function FuncionarioRedeDetalhe() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para acessar este funcionário."
           detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
@@ -212,7 +212,7 @@ export function FuncionarioRedeDetalhe() {
       : null
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-8 pb-10">
       <div>
         <VoltarButton onClick={voltarAnterior} />
       </div>

--- a/frontend/src/pages/FuncionarioRedeForm.tsx
+++ b/frontend/src/pages/FuncionarioRedeForm.tsx
@@ -240,7 +240,7 @@ export function FuncionarioRedeForm() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-3xl space-y-6">
+      <div className="mx-auto w-full min-w-0 max-w-3xl space-y-6">
         <div className="h-9 w-56 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-72 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
@@ -249,7 +249,7 @@ export function FuncionarioRedeForm() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-5xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-5xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para editar este funcionário."
           detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
@@ -263,7 +263,7 @@ export function FuncionarioRedeForm() {
   if (funcionarioInexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Funcionário não encontrado."
         detalhe={funcionarioInexistente.detalhe}
         onVoltar={voltarAnterior}
@@ -272,7 +272,7 @@ export function FuncionarioRedeForm() {
   }
 
   return (
-    <div ref={topoRef} className="mx-auto max-w-5xl space-y-6 pb-10">
+    <div ref={topoRef} className="mx-auto w-full min-w-0 max-w-5xl space-y-6 pb-10">
       <div className="flex items-center justify-between gap-3">
         <VoltarButton onClick={voltarAnterior} />
       </div>

--- a/frontend/src/pages/KbArtigoForm.tsx
+++ b/frontend/src/pages/KbArtigoForm.tsx
@@ -286,7 +286,7 @@ export function KbArtigoForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Artigo não encontrado."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -476,7 +476,8 @@ function LoginCredenciais({ variant = 'tenant' }: { variant?: 'tenant' | 'ops' }
   const location = useLocation()
   const [searchParams] = useSearchParams()
 
-  function destinoAposLogin(role: string): string {
+  function destinoAposLogin(role: string, mustChangePassword?: boolean): string {
+    if (mustChangePassword) return '/alterar-senha'
     if (role === 'saas_ops') return SAAS_LICENCAS_PATH
     const next = (searchParams.get('next') || '').trim()
     if (next.startsWith('/') && !next.startsWith('//') && !next.startsWith('/saas')) return next
@@ -513,6 +514,11 @@ function LoginCredenciais({ variant = 'tenant' }: { variant?: 'tenant' | 'ops' }
         return
       }
       if (!isOps && me.role === 'saas_ops') {
+        if (me.must_change_password) {
+          showSuccess('Login ops realizado. Defina uma senha nova…')
+          navigate('/alterar-senha', { replace: true })
+          return
+        }
         showSuccess('Login ops realizado. Abrindo o painel SaaS…')
         navigate(SAAS_LICENCAS_PATH, { replace: true })
         return
@@ -528,7 +534,7 @@ function LoginCredenciais({ variant = 'tenant' }: { variant?: 'tenant' | 'ops' }
         /* storage indisponível */
       }
       showSuccess('Login realizado com sucesso. Redirecionando...')
-      navigate(destinoAposLogin(me.role), { replace: true })
+      navigate(destinoAposLogin(me.role, me.must_change_password), { replace: true })
     } catch (err) {
       showError(mensagemFalhaParaToast(err, 'Falha no login. Verifique suas credenciais e tente novamente.'))
     } finally {

--- a/frontend/src/pages/NotificacoesPreferencias.tsx
+++ b/frontend/src/pages/NotificacoesPreferencias.tsx
@@ -67,14 +67,14 @@ export function NotificacoesPreferencias() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-2xl">
+      <div className="mx-auto w-full min-w-0 max-w-2xl">
         <div className="h-48 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
   }
 
   return (
-    <div className="mx-auto max-w-2xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-2xl space-y-6 pb-10">
       <div>
         <VoltarButton onClick={() => navigate('/')} />
         <h1 className="mt-3 text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">

--- a/frontend/src/pages/RedeDetalhe.tsx
+++ b/frontend/src/pages/RedeDetalhe.tsx
@@ -789,7 +789,7 @@ export function RedeDetalhe() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para acessar esta rede."
           detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
@@ -802,7 +802,7 @@ export function RedeDetalhe() {
 
   if (loading && !rede && !loadFailure) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-4 w-24 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
         <div className="h-9 w-2/3 max-w-md animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
@@ -836,7 +836,7 @@ export function RedeDetalhe() {
     tipoNegocioIdEmpresa === '' ? '' : tiposNegocioList.find((t) => t.id === Number(tipoNegocioIdEmpresa))?.nome ?? ''
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <div className="flex flex-wrap items-center gap-3">
         <nav aria-label="breadcrumb" className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
           {linkRedes}

--- a/frontend/src/pages/RedeForm.tsx
+++ b/frontend/src/pages/RedeForm.tsx
@@ -100,7 +100,7 @@ export function RedeForm() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-2xl space-y-6">
+      <div className="mx-auto w-full min-w-0 max-w-2xl space-y-6">
         <div className="h-9 w-56 animate-pulse rounded-lg bg-slate-200 dark:bg-slate-700" />
         <div className="h-64 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
@@ -109,7 +109,7 @@ export function RedeForm() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-5xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-5xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para editar esta rede."
           detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
@@ -123,7 +123,7 @@ export function RedeForm() {
   if (redeInexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Rede não encontrada."
         detalhe={redeInexistente.detalhe}
         onVoltar={voltarAnterior}
@@ -132,7 +132,7 @@ export function RedeForm() {
   }
 
   return (
-    <div className="mx-auto max-w-5xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-5xl space-y-6 pb-10">
       <div className="flex items-center justify-between gap-3">
         <VoltarButton onClick={voltarAnterior} />
       </div>

--- a/frontend/src/pages/RespostaProntaDetalhe.tsx
+++ b/frontend/src/pages/RespostaProntaDetalhe.tsx
@@ -55,7 +55,7 @@ export function RespostaProntaDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-56 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -80,7 +80,7 @@ export function RespostaProntaDetalhe() {
   const escopo = item.setor_nome ?? (item.setor_id != null ? `Setor #${item.setor_id}` : 'Global (todos os setores)')
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/RespostaProntaForm.tsx
+++ b/frontend/src/pages/RespostaProntaForm.tsx
@@ -141,7 +141,7 @@ export function RespostaProntaForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Resposta pronta não encontrada."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/SemPermissao.tsx
+++ b/frontend/src/pages/SemPermissao.tsx
@@ -17,7 +17,7 @@ export function SemPermissao({
   const classeVoltar =
     'inline-flex rounded-lg border border-slate-300 bg-white px-4 py-2.5 text-sm font-medium text-slate-800 transition hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-900 dark:text-slate-100 dark:hover:bg-slate-800'
   return (
-    <div className="mx-auto max-w-lg rounded-2xl border border-amber-200/80 bg-amber-50/90 p-6 text-amber-950 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
+    <div className="mx-auto w-full min-w-0 max-w-lg rounded-2xl border border-amber-200/80 bg-amber-50/90 p-6 text-amber-950 shadow-sm dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-100">
       <p className="text-sm font-semibold uppercase tracking-wide text-amber-800 dark:text-amber-300">403 — Sem permissão</p>
       <h1 className="mt-2 text-lg font-semibold text-slate-900 dark:text-slate-100">{title}</h1>
       <p className="mt-3 text-sm leading-relaxed text-slate-700 dark:text-slate-300">{detail}</p>

--- a/frontend/src/pages/SetorDetalhe.tsx
+++ b/frontend/src/pages/SetorDetalhe.tsx
@@ -236,7 +236,7 @@ export function SetorDetalhe() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para acessar este setor."
           detail="Se isso estiver incorreto, peça ao administrador para ajustar seu perfil."
@@ -258,7 +258,7 @@ export function SetorDetalhe() {
   }
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
         <VoltarButton onClick={voltarAnterior} />
         <span aria-hidden className="text-slate-300 dark:text-slate-600">

--- a/frontend/src/pages/SetorForm.tsx
+++ b/frontend/src/pages/SetorForm.tsx
@@ -113,7 +113,7 @@ export function SetorForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Setor não encontrado."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/StatusTicketDetalhe.tsx
+++ b/frontend/src/pages/StatusTicketDetalhe.tsx
@@ -55,7 +55,7 @@ export function StatusTicketDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-48 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -78,7 +78,7 @@ export function StatusTicketDetalhe() {
   if (!item) return null
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/StatusTicketForm.tsx
+++ b/frontend/src/pages/StatusTicketForm.tsx
@@ -132,7 +132,7 @@ export function StatusTicketForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Status não encontrado."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/TicketDetalhe.tsx
+++ b/frontend/src/pages/TicketDetalhe.tsx
@@ -1260,7 +1260,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <SemPermissao
           title="Você não tem permissão para acessar este ticket."
           detail="Este chamado pertence a um setor fora do seu escopo. Se precisar, peça ao administrador para ajustar seus vínculos de setor."
@@ -1383,7 +1383,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
     <>
       <div className="-m-4 flex h-full min-h-0 flex-col overflow-hidden md:-m-6">
         <div className="relative z-20 shrink-0 border-b border-slate-200/70 bg-white shadow-sm dark:border-slate-800/70 dark:bg-slate-950 sm:rounded-b-2xl sm:border sm:border-t-0">
-          <div className="mx-auto max-w-6xl px-3 py-2.5 sm:px-5 sm:py-4 lg:py-5">
+          <div className="mx-auto w-full min-w-0 max-w-6xl px-3 py-2.5 sm:px-5 sm:py-4 lg:py-5">
             {linkVoltar}
 
             <div className="flex items-start justify-between gap-3 lg:items-center">
@@ -1648,7 +1648,7 @@ export function TicketDetalhe({ ticketIdProp, onVoltar }: TicketDetalheProps = {
         </div>
 
         <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto">
-          <div className="mx-auto max-w-6xl space-y-4 px-3 pb-8 pt-3 sm:space-y-6 sm:px-5 sm:pb-10 sm:pt-4 md:px-6">
+          <div className="mx-auto w-full min-w-0 max-w-6xl space-y-4 px-3 pb-8 pt-3 sm:space-y-6 sm:px-5 sm:pb-10 sm:pt-4 md:px-6">
         {!ticket.fechado_em ? <TicketSlaCard ticketId={ticket.id} fechado={false} /> : null}
         <TicketImplantacaoChecklist
           ticketId={ticket.id}

--- a/frontend/src/pages/TicketNovo.tsx
+++ b/frontend/src/pages/TicketNovo.tsx
@@ -239,7 +239,7 @@ export function TicketNovo() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-3xl space-y-6">
+      <div className="mx-auto w-full min-w-0 max-w-3xl space-y-6">
         <SemPermissao
           title="Você não tem permissão para abrir tickets."
           detail="Seu usuário não conseguiu carregar setores/empresas necessários para criar um chamado. Peça ao administrador para ajustar seu perfil e vínculos de setor."
@@ -257,7 +257,7 @@ export function TicketNovo() {
       noValidate
     >
       <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
-        <div className="mx-auto max-w-3xl space-y-6 pb-4">
+        <div className="mx-auto w-full min-w-0 max-w-3xl space-y-6 pb-4">
       <nav aria-label="breadcrumb" className="flex flex-wrap items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
         <VoltarButton onClick={voltarAnterior} />
         <span aria-hidden className="text-slate-300 dark:text-slate-600">

--- a/frontend/src/pages/TipoNegocioDetalhe.tsx
+++ b/frontend/src/pages/TipoNegocioDetalhe.tsx
@@ -55,7 +55,7 @@ export function TipoNegocioDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-40 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -78,7 +78,7 @@ export function TipoNegocioDetalhe() {
   if (!item) return null
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/TipoNegocioForm.tsx
+++ b/frontend/src/pages/TipoNegocioForm.tsx
@@ -109,7 +109,7 @@ export function TipoNegocioForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Tipo de negócio não encontrado."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/chat-interno/ChatInternoSetorCanal.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoSetorCanal.tsx
@@ -40,7 +40,7 @@ export function ChatInternoSetorCanal() {
 
   if (forbidden) {
     return (
-      <div className="mx-auto max-w-3xl p-4">
+      <div className="mx-auto w-full min-w-0 max-w-3xl p-4">
         <SemPermissao
           title="Sem permissão para este canal"
           detail="Você não está vinculado a este setor."

--- a/frontend/src/pages/config/ConfigHubPage.tsx
+++ b/frontend/src/pages/config/ConfigHubPage.tsx
@@ -36,7 +36,7 @@ export function ConfigHubPage() {
         subtitle="Encontre qualquer ajuste por domínio — ou pesquise por palavra."
       />
 
-      <div className="relative max-w-xl">
+      <div className="relative w-full min-w-0 max-w-xl">
         <Input
           value={q}
           onChange={(e) => setQ(e.target.value)}

--- a/frontend/src/pages/marketing/LandingPage.tsx
+++ b/frontend/src/pages/marketing/LandingPage.tsx
@@ -44,7 +44,7 @@ function SectionHeading({
   align?: 'left' | 'center'
 }) {
   return (
-    <div className={align === 'center' ? 'mx-auto max-w-3xl text-center' : 'max-w-3xl'}>
+    <div className={align === 'center' ? 'mx-auto w-full min-w-0 max-w-3xl text-center' : 'max-w-3xl'}>
       {eyebrow ? (
         <p className="mb-3 text-xs font-semibold uppercase tracking-[0.25em] text-sky-400">{eyebrow}</p>
       ) : null}
@@ -261,7 +261,7 @@ export function LandingPage() {
           </div>
         </section>
 
-        <section className="mx-auto max-w-7xl px-5 pb-8 sm:px-8 lg:px-10">
+        <section className="mx-auto w-full min-w-0 max-w-7xl px-5 pb-8 sm:px-8 lg:px-10">
           <div className="rounded-[1.5rem] border border-white/10 bg-gradient-to-r from-white/[0.06] via-white/[0.03] to-white/[0.05] px-6 py-5 shadow-[0_20px_60px_rgba(2,8,23,0.18)] backdrop-blur-sm sm:px-8">
             <div className="flex flex-wrap items-center justify-between gap-3">
               <p className="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">Por que empresas escolhem o DeskRudder</p>
@@ -273,7 +273,7 @@ export function LandingPage() {
           </div>
         </section>
 
-        <section className="mx-auto max-w-7xl px-5 pb-8 sm:px-8 lg:px-10">
+        <section className="mx-auto w-full min-w-0 max-w-7xl px-5 pb-8 sm:px-8 lg:px-10">
           <div className="rounded-[1.75rem] border border-sky-400/20 bg-gradient-to-br from-sky-500/10 via-white/[0.03] to-slate-950/80 p-6 shadow-[0_25px_70px_rgba(2,8,23,0.22)] backdrop-blur-md sm:p-8">
             <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
               <div className="max-w-2xl">
@@ -296,7 +296,7 @@ export function LandingPage() {
         </section>
 
         <section id="valor" className="py-14 sm:py-16">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading
               eyebrow="O que muda na operação"
               title="Uma operação mais limpa, mais rápida e mais previsível"
@@ -317,7 +317,7 @@ export function LandingPage() {
         </section>
 
         <section className="pb-8 sm:pb-10">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <div className="grid gap-6 lg:grid-cols-3">
               {experienceHighlights.map((item) => (
                 <div key={item.title} className="relative overflow-hidden rounded-[1.5rem] border border-white/10 bg-gradient-to-br from-white/[0.04] to-white/[0.02] p-6 shadow-[0_15px_45px_rgba(2,8,23,0.12)] before:absolute before:left-0 before:top-0 before:h-px before:w-full before:bg-gradient-to-r before:from-transparent before:via-sky-400/60 before:to-transparent">
@@ -330,7 +330,7 @@ export function LandingPage() {
         </section>
 
         <section className="border-t border-white/10 bg-[#071826]/70 py-16 sm:py-20">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingPain.title} />
             <ul className="mt-10 grid gap-6 md:grid-cols-3">
               {landingPain.items.map((item, index) => (
@@ -349,7 +349,7 @@ export function LandingPage() {
         </section>
 
         <section className="py-16 sm:py-20">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <div className="grid gap-6 lg:grid-cols-2">
               <div className="rounded-[1.75rem] border border-rose-400/20 bg-rose-500/10 p-8 shadow-[0_20px_60px_rgba(2,8,23,0.16)]">
                 <p className="text-sm font-semibold uppercase tracking-[0.2em] text-rose-300">Antes</p>
@@ -374,7 +374,7 @@ export function LandingPage() {
         </section>
 
         <section id="produto" className="scroll-mt-24 py-16 sm:py-20">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading
               eyebrow="O que você encontra"
               title="Tudo o que sua equipe precisa para atender melhor"
@@ -419,7 +419,7 @@ export function LandingPage() {
         </section>
 
         <section className="border-y border-sky-500/20 bg-gradient-to-r from-sky-700/20 via-[#0B2D4A]/85 to-sky-500/20 py-14 sm:py-16">
-          <div className="mx-auto max-w-3xl px-5 text-center sm:px-8">
+          <div className="mx-auto w-full min-w-0 max-w-3xl px-5 text-center sm:px-8">
             <h2 className="text-2xl font-bold text-white sm:text-3xl">{landingMidCta.title}</h2>
             <p className="mt-3 text-slate-200">{landingMidCta.body}</p>
             <div className="mt-8 flex justify-center">
@@ -429,7 +429,7 @@ export function LandingPage() {
         </section>
 
         <section id="resultados" className="scroll-mt-24 py-16 sm:py-20">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingOutcomes.title} />
             <ul className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
               {landingOutcomes.items.map((item) => (
@@ -443,7 +443,7 @@ export function LandingPage() {
         </section>
 
         <section className="border-t border-white/10 bg-[#0A1628]/70 py-16 sm:py-20">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingHowItWorks.title} />
             <ol className="mt-12 grid gap-10 md:grid-cols-3">
               {landingHowItWorks.steps.map((s) => (
@@ -458,7 +458,7 @@ export function LandingPage() {
         </section>
 
         <section className="py-16 sm:py-20">
-          <div className="mx-auto max-w-7xl px-5 sm:px-8 lg:px-10">
+          <div className="mx-auto w-full min-w-0 max-w-7xl px-5 sm:px-8 lg:px-10">
             <SectionHeading title={landingAudience.title} body={landingAudience.body} />
             <ul className="mt-10 grid gap-6 md:grid-cols-3">
               {landingAudience.segments.map((seg) => (
@@ -472,7 +472,7 @@ export function LandingPage() {
         </section>
 
         <section id="contato" className="scroll-mt-24 border-t border-white/10 py-16 sm:py-24">
-          <div className="mx-auto max-w-3xl px-5 text-center sm:px-8">
+          <div className="mx-auto w-full min-w-0 max-w-3xl px-5 text-center sm:px-8">
             <div className="mx-auto inline-flex items-center gap-2 rounded-full border border-sky-400/25 bg-sky-400/10 px-3.5 py-2 text-sm text-sky-200">
               <span className="size-2 rounded-full bg-sky-400" />
               {APP_NAME}

--- a/frontend/src/pages/marketing/PrivacidadePage.tsx
+++ b/frontend/src/pages/marketing/PrivacidadePage.tsx
@@ -10,7 +10,7 @@ export function PrivacidadePage() {
   const navigate = useNavigate()
   return (
     <MarketingLayout>
-      <div className="mx-auto max-w-3xl px-5 py-12 sm:px-8 lg:px-10">
+      <div className="mx-auto w-full min-w-0 max-w-3xl px-5 py-12 sm:px-8 lg:px-10">
         <VoltarButton onClick={() => navigate('/')} />
         <div className="mt-8">
           <BrandLogo variant="wordmark" size="md" markVariant="onDark" />

--- a/frontend/src/pages/portal/PortalTrocarSenha.tsx
+++ b/frontend/src/pages/portal/PortalTrocarSenha.tsx
@@ -47,7 +47,7 @@ export function PortalTrocarSenha() {
   }
 
   return (
-    <div className="mx-auto max-w-md space-y-5">
+    <div className="mx-auto w-full min-w-0 max-w-md space-y-5">
       <div>
         <h1 className="text-xl font-semibold text-slate-900">Definir nova senha</h1>
         <p className="mt-1 text-sm text-slate-600">

--- a/frontend/src/pages/portal/portalUi.tsx
+++ b/frontend/src/pages/portal/portalUi.tsx
@@ -10,9 +10,9 @@ export const portalPrimaryBtnClass =
 export const portalSecondaryBtnClass =
   'inline-flex items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50'
 
-/** Descartar / Cancelar — alinhado ao Button variant=cancel do painel interno (#866). */
+/** Descartar / Cancelar — gradiente vermelho, alinhado ao Button variant=cancel (#866). */
 export const portalCancelBtnClass =
-  'inline-flex items-center justify-center gap-2 rounded-lg border-2 border-red-500 bg-red-50 px-4 py-2 text-sm font-medium text-red-800 shadow-sm transition hover:bg-red-100'
+  'inline-flex items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-red-500 to-red-600 px-4 py-2 text-sm font-medium text-white shadow-md shadow-red-500/20 transition hover:from-red-400 hover:to-red-500 focus:outline-none focus:ring-2 focus:ring-red-400 focus:ring-offset-2 disabled:opacity-50'
 
 export const portalCardClass =
   'rounded-xl border border-slate-200/90 bg-white p-4 shadow-sm transition hover:border-slate-300 hover:shadow-md'

--- a/frontend/src/pages/saas/SaasConta.tsx
+++ b/frontend/src/pages/saas/SaasConta.tsx
@@ -1,0 +1,224 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { saasOpsConta, ApiError, type SaasOpsConta } from '../../api/client'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/errorMessage'
+import { Button } from '../../components/ui/Button'
+import { Card } from '../../components/ui/Card'
+import { CarregamentoFalhou } from '../../components/ui/CarregamentoFalhou'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import { useToast } from '../../components/ui/Toast'
+import { VoltarButton } from '../../components/ui/VoltarButton'
+import { useVoltarAnterior } from '../../hooks/useVoltarAnterior'
+import { SemPermissao } from '../SemPermissao'
+import { SAAS_LICENCAS_PATH } from '../../lib/saasControlPlane'
+
+function formatWhen(iso: string | null | undefined): string {
+  if (!iso) return '—'
+  try {
+    return new Date(iso).toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' })
+  } catch {
+    return iso
+  }
+}
+
+export function SaasConta() {
+  const toast = useToast()
+  const voltarAnterior = useVoltarAnterior(SAAS_LICENCAS_PATH)
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [indisponivel, setIndisponivel] = useState(false)
+  const [falha, setFalha] = useState<{ titulo: string; detalhe?: string } | null>(null)
+  const [estado, setEstado] = useState<SaasOpsConta.McpEstado | null>(null)
+  const [plaintext, setPlaintext] = useState<string | null>(null)
+  const [confirmarGerar, setConfirmarGerar] = useState(false)
+  const [confirmarRevogar, setConfirmarRevogar] = useState(false)
+
+  const carregar = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    setIndisponivel(false)
+    setFalha(null)
+    saasOpsConta
+      .mcpToken()
+      .then(setEstado)
+      .catch((err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setIndisponivel(true)
+          return
+        }
+        setFalha(interpretarFalhaCarregamento(err, 'Não foi possível carregar a conta.'))
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  useEffect(() => {
+    carregar()
+  }, [carregar])
+
+  async function gerar() {
+    setBusy(true)
+    try {
+      const row = await saasOpsConta.gerarMcpToken()
+      setEstado({ configurado: row.configurado, gerado_em: row.gerado_em })
+      setPlaintext(row.token)
+      toast.showSuccess(
+        estado?.configurado
+          ? 'Token regenerado. O anterior deixa de funcionar no Cursor.'
+          : 'Token gerado. Copie agora — não voltamos a mostrá-lo.',
+      )
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível gerar o token.'))
+    } finally {
+      setBusy(false)
+      setConfirmarGerar(false)
+    }
+  }
+
+  async function revogar() {
+    setBusy(true)
+    try {
+      const row = await saasOpsConta.revogarMcpToken()
+      setEstado(row)
+      setPlaintext(null)
+      toast.showSuccess('Token Cursor revogado.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível revogar o token.'))
+    } finally {
+      setBusy(false)
+      setConfirmarRevogar(false)
+    }
+  }
+
+  async function copiar() {
+    if (!plaintext) return
+    try {
+      await navigator.clipboard.writeText(plaintext)
+      toast.showSuccess('Token copiado.')
+    } catch {
+      toast.showError('Não foi possível copiar. Seleccione o token e copie manualmente.')
+    }
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Conta exclusiva da equipa SaaS."
+        detail="Entre com a conta ops em /login/admin."
+        voltarPara="/login/admin"
+        voltarLabel="Voltar ao login admin"
+      />
+    )
+  }
+  if (indisponivel) {
+    return (
+      <SemPermissao
+        title="Painel SaaS não disponível nesta instância."
+        detail="O token Cursor só existe no control-plane DeskRudder."
+        voltarPara="/login/admin"
+        voltarLabel="Voltar ao login admin"
+      />
+    )
+  }
+  if (falha) {
+    return (
+      <CarregamentoFalhou
+        titulo={falha.titulo}
+        detalhe={falha.detalhe}
+        onVoltar={carregar}
+        voltarLabel="Tentar novamente"
+      />
+    )
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-4">
+      <VoltarButton onClick={voltarAnterior} />
+      <Card
+        title="Integração Cursor"
+        description="O token identifica a tua conta ops nas sugestões (recusar, comentar, ligar issue). Cada pessoa gera o seu. Novas contas criam-se em Equipa."
+      >
+        {loading || !estado ? (
+          <p className="text-sm text-slate-500">A carregar…</p>
+        ) : (
+          <div className="space-y-4">
+            <p className="text-sm text-slate-600 dark:text-slate-400">
+              {estado.configurado
+                ? `Token activo. Gerado em ${formatWhen(estado.gerado_em)}.`
+                : 'Ainda não há token nesta conta.'}{' '}
+              <Link to="/saas/usuarios" className="font-medium text-sky-700 underline dark:text-sky-300">
+                Gerir equipa
+              </Link>
+            </p>
+            {plaintext ? (
+              <div className="space-y-2">
+                <label htmlFor="mcp-token-plain" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
+                  Copie agora — não voltamos a mostrar o valor completo
+                </label>
+                <textarea
+                  id="mcp-token-plain"
+                  readOnly
+                  value={plaintext}
+                  rows={3}
+                  className="w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 font-mono text-xs text-slate-800 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+                />
+                <Button type="button" variant="secondary" onClick={() => void copiar()}>
+                  Copiar token
+                </Button>
+                <p className="text-xs text-slate-500">
+                  No Cursor: <code className="rounded bg-slate-100 px-1 dark:bg-slate-800">.cursor/mcp.json</code> →{' '}
+                  <code className="rounded bg-slate-100 px-1 dark:bg-slate-800">DESKRUDDER_MCP_TOKEN</code>. Depois
+                  Settings → MCP → habilitar deskrudder-saas.
+                </p>
+              </div>
+            ) : null}
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                loading={busy}
+                onClick={() => {
+                  if (estado.configurado) {
+                    setConfirmarGerar(true)
+                    return
+                  }
+                  void gerar()
+                }}
+              >
+                {estado.configurado ? 'Regenerar token' : 'Gerar token'}
+              </Button>
+              {estado.configurado ? (
+                <Button type="button" variant="danger" loading={busy} onClick={() => setConfirmarRevogar(true)}>
+                  Revogar
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        )}
+      </Card>
+      <ConfirmDialog
+        open={confirmarGerar}
+        title="Regenerar token Cursor?"
+        message="O token que está no Cursor deixa de funcionar. Terá de colar o novo valor no mcp.json."
+        confirmLabel="Regenerar"
+        variant="danger"
+        loading={busy}
+        onConfirm={() => void gerar()}
+        onCancel={() => setConfirmarGerar(false)}
+      />
+      <ConfirmDialog
+        open={confirmarRevogar}
+        title="Revogar token Cursor?"
+        message="O Cursor deixa de autenticar nesta conta até gerar um token novo."
+        confirmLabel="Revogar"
+        variant="danger"
+        loading={busy}
+        onConfirm={() => void revogar()}
+        onCancel={() => setConfirmarRevogar(false)}
+      />
+    </div>
+  )
+}

--- a/frontend/src/pages/saas/SaasLayout.tsx
+++ b/frontend/src/pages/saas/SaasLayout.tsx
@@ -38,6 +38,11 @@ export function SaasLayout() {
 
   useEffect(() => {
     let cancelled = false
+    if (loading || user?.must_change_password) {
+      return () => {
+        cancelled = true
+      }
+    }
     if (isSaasControlPlaneFrontend()) {
       setPlaneOk(true)
       return () => {
@@ -55,13 +60,16 @@ export function SaasLayout() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [loading, user?.must_change_password])
 
-  if (loading || planeOk === null) {
+  if (loading) {
     return <PageLoading fullscreen label="Carregando painel SaaS…" />
   }
   if (!user) {
     return <Navigate to="/login/admin" replace state={{ from: location }} />
+  }
+  if (user.must_change_password) {
+    return <Navigate to="/alterar-senha" replace />
   }
   if (!isSaasOps) {
     return (
@@ -74,6 +82,9 @@ export function SaasLayout() {
         />
       </div>
     )
+  }
+  if (planeOk === null) {
+    return <PageLoading fullscreen label="Carregando painel SaaS…" />
   }
   if (!planeOk) {
     return (
@@ -148,6 +159,12 @@ export function SaasLayout() {
           </NavLink>
           <NavLink to="/saas/solicitacoes" className={navLinkClass}>
             <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Sugestões' : 'Sug'}</span>
+          </NavLink>
+          <NavLink to="/saas/usuarios" className={navLinkClass}>
+            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Equipa' : 'Eq'}</span>
+          </NavLink>
+          <NavLink to="/saas/conta" className={navLinkClass}>
+            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Conta / Cursor' : 'Conta'}</span>
           </NavLink>
           <NavLink to="/saas/sobre" className={navLinkClass}>
             <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Sobre' : 'Info'}</span>

--- a/frontend/src/pages/saas/SaasLeadDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasLeadDetalhe.tsx
@@ -125,7 +125,7 @@ export function SaasLeadDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-40 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -154,7 +154,7 @@ export function SaasLeadDetalhe() {
   if (!item) return null
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/saas/SaasLicencaDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasLicencaDetalhe.tsx
@@ -143,7 +143,7 @@ export function SaasLicencaDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-40 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -185,7 +185,7 @@ export function SaasLicencaDetalhe() {
   })
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/saas/SaasLicencaForm.tsx
+++ b/frontend/src/pages/saas/SaasLicencaForm.tsx
@@ -238,7 +238,7 @@ export function SaasLicencaForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Licença não encontrada."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/saas/SaasPlanoForm.tsx
+++ b/frontend/src/pages/saas/SaasPlanoForm.tsx
@@ -195,7 +195,7 @@ export function SaasPlanoForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        className="mx-auto max-w-5xl space-y-4 pb-10"
+        className="mx-auto w-full min-w-0 max-w-5xl space-y-4 pb-10"
         titulo="Plano não encontrado."
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}

--- a/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
@@ -202,7 +202,7 @@ export function SaasSolicitacaoDetalhe() {
 
   if (loading) {
     return (
-      <div className="mx-auto max-w-6xl space-y-6 pb-10">
+      <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
         <div className="h-40 animate-pulse rounded-2xl bg-slate-100 dark:bg-slate-800/50" />
       </div>
     )
@@ -231,7 +231,7 @@ export function SaasSolicitacaoDetalhe() {
   if (!item) return null
 
   return (
-    <div className="mx-auto max-w-6xl space-y-6 pb-10">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">

--- a/frontend/src/pages/saas/SaasUsuarioForm.tsx
+++ b/frontend/src/pages/saas/SaasUsuarioForm.tsx
@@ -1,0 +1,254 @@
+import { useEffect, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { ApiError, saasOpsUsuarios } from '../../api/client'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/errorMessage'
+import { Button } from '../../components/ui/Button'
+import { CadastroFormPageShell } from '../../components/ui/CadastroFormPageShell'
+import { CarregamentoFalhou } from '../../components/ui/CarregamentoFalhou'
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import { FormSection } from '../../components/ui/FormSection'
+import { InlineCadastroFooter } from '../../components/ui/InlineCadastroPanel'
+import { Input } from '../../components/ui/Input'
+import { Switch } from '../../components/ui/Switch'
+import { useToast } from '../../components/ui/Toast'
+import { useAuth } from '../../contexts/AuthContext'
+import { useVoltarAnterior } from '../../hooks/useVoltarAnterior'
+import { SemPermissao } from '../SemPermissao'
+
+export function SaasUsuarioForm() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const { user } = useAuth()
+  const voltarAnterior = useVoltarAnterior('/saas/usuarios')
+
+  const usuarioId = id ? parseInt(id, 10) : NaN
+  const isEdit = id != null
+  const isSelf = isEdit && user?.id === usuarioId
+
+  const [loading, setLoading] = useState(isEdit)
+  const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [indisponivel, setIndisponivel] = useState(false)
+  const [inexistente, setInexistente] = useState<{ detalhe?: string } | null>(null)
+  const [nome, setNome] = useState('')
+  const [email, setEmail] = useState('')
+  const [ativo, setAtivo] = useState(true)
+  const [tokenConfigurado, setTokenConfigurado] = useState(false)
+  const [senhaTemporaria, setSenhaTemporaria] = useState<string | null>(null)
+  const [confirmarReset, setConfirmarReset] = useState(false)
+
+  useEffect(() => {
+    if (!isEdit) return
+    if (!id || Number.isNaN(usuarioId)) {
+      setInexistente({ detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setIndisponivel(false)
+    setInexistente(null)
+    saasOpsUsuarios
+      .get(usuarioId)
+      .then((row) => {
+        if (cancelled) return
+        setNome(row.nome)
+        setEmail(row.email)
+        setAtivo(row.ativo)
+        setTokenConfigurado(row.mcp_token_configurado)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setIndisponivel(true)
+          return
+        }
+        setInexistente(interpretarFalhaCarregamento(err, 'Utilizador não encontrado.'))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, isEdit, usuarioId])
+
+  async function copiarSenha() {
+    if (!senhaTemporaria) return
+    try {
+      await navigator.clipboard.writeText(senhaTemporaria)
+      toast.showSuccess('Senha copiada.')
+    } catch {
+      toast.showError('Não foi possível copiar. Seleccione a senha e copie manualmente.')
+    }
+  }
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!nome.trim() || (!isEdit && !email.trim())) {
+      toast.showError('Informe nome e e-mail.')
+      return
+    }
+    setSaving(true)
+    try {
+      if (isEdit) {
+        const row = await saasOpsUsuarios.update(usuarioId, { nome: nome.trim(), ativo })
+        setAtivo(row.ativo)
+        toast.showSuccess('Utilizador actualizado.')
+        navigate('/saas/usuarios')
+        return
+      }
+      const row = await saasOpsUsuarios.create({ nome: nome.trim(), email: email.trim() })
+      setSenhaTemporaria(row.senha_temporaria)
+      setEmail(row.email)
+      toast.showSuccess('Utilizador criado. Copie a senha temporária agora.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível guardar o utilizador.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function resetSenha() {
+    setSaving(true)
+    try {
+      const row = await saasOpsUsuarios.senhaTemporaria(usuarioId)
+      setSenhaTemporaria(row.senha_temporaria)
+      toast.showSuccess('Senha temporária gerada. Copie agora.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível gerar a senha.'))
+    } finally {
+      setSaving(false)
+      setConfirmarReset(false)
+    }
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Conta exclusiva da equipa SaaS."
+        detail="Entre com a conta ops em /login/admin."
+        voltarPara="/login/admin"
+        voltarLabel="Voltar ao login admin"
+      />
+    )
+  }
+  if (indisponivel) {
+    return (
+      <SemPermissao
+        title="Painel SaaS não disponível nesta instância."
+        voltarPara="/login/admin"
+        voltarLabel="Voltar ao login admin"
+      />
+    )
+  }
+  if (inexistente) {
+    return (
+      <CarregamentoFalhou
+        titulo={inexistente.detalhe ? 'Utilizador não encontrado.' : 'Não foi possível carregar.'}
+        detalhe={inexistente.detalhe}
+        onVoltar={voltarAnterior}
+      />
+    )
+  }
+
+  return (
+    <CadastroFormPageShell onVoltar={voltarAnterior}>
+      <form onSubmit={(ev) => void onSubmit(ev)} className="space-y-4">
+        <FormSection
+          title={isEdit ? 'Editar utilizador' : 'Novo utilizador'}
+          description="Esta conta entra no painel DeskRudder (/login/admin). Não é um atendente da instância do cliente."
+        >
+          {loading ? (
+            <p className="text-sm text-slate-500">A carregar…</p>
+          ) : (
+            <div className="space-y-4">
+              <Input label="Nome" value={nome} onChange={(ev) => setNome(ev.target.value)} required />
+              <Input
+                label="E-mail"
+                type="email"
+                value={email}
+                onChange={(ev) => setEmail(ev.target.value)}
+                required
+                disabled={isEdit}
+              />
+              {isEdit ? (
+                <Switch
+                  checked={ativo}
+                  onCheckedChange={setAtivo}
+                  label="Conta activa"
+                  showStatusPill
+                  disabled={isSelf}
+                  description={isSelf ? 'Não podes desactivar a tua própria conta.' : undefined}
+                />
+              ) : null}
+              {isEdit ? (
+                <p className="text-sm text-slate-600 dark:text-slate-400">
+                  Token Cursor: {tokenConfigurado ? 'configurado' : 'ainda não gerado'}.
+                  {isSelf ? (
+                    <>
+                      {' '}
+                      <Link to="/saas/conta" className="font-medium text-sky-700 underline dark:text-sky-300">
+                        Gerar o teu token
+                      </Link>
+                    </>
+                  ) : (
+                    ' Cada pessoa gera o token depois de entrar na própria conta.'
+                  )}
+                </p>
+              ) : null}
+              {senhaTemporaria ? (
+                <div className="space-y-2">
+                  <Input label="Senha temporária (copie agora)" readOnly value={senhaTemporaria} />
+                  <Button type="button" variant="secondary" onClick={() => void copiarSenha()}>
+                    Copiar senha
+                  </Button>
+                  <p className="text-xs text-slate-500">
+                    Login em /login/admin. No primeiro acesso a pessoa define senha nova e, em Conta / Cursor, gera
+                    o token.
+                  </p>
+                </div>
+              ) : null}
+            </div>
+          )}
+        </FormSection>
+        {senhaTemporaria && !isEdit ? (
+          <div className="flex justify-end">
+            <Button type="button" onClick={() => navigate('/saas/usuarios')}>
+              Ir para a lista
+            </Button>
+          </div>
+        ) : (
+          <InlineCadastroFooter
+            onCancel={voltarAnterior}
+            saving={saving}
+            submitLabel={isEdit ? 'Guardar' : 'Criar'}
+          />
+        )}
+      </form>
+      {isEdit && !loading ? (
+        <div className="mt-4">
+          <Button type="button" variant="secondary" loading={saving} onClick={() => setConfirmarReset(true)}>
+            Gerar senha temporária
+          </Button>
+        </div>
+      ) : null}
+      <ConfirmDialog
+        open={confirmarReset}
+        title="Gerar senha temporária?"
+        message="A sessão actual desta pessoa no painel deixa de valer. Copie a senha nova e envie-lhe."
+        confirmLabel="Gerar senha"
+        variant="danger"
+        loading={saving}
+        onConfirm={() => void resetSenha()}
+        onCancel={() => setConfirmarReset(false)}
+      />
+    </CadastroFormPageShell>
+  )
+}

--- a/frontend/src/pages/saas/SaasUsuarios.tsx
+++ b/frontend/src/pages/saas/SaasUsuarios.tsx
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ApiError, saasOpsUsuarios, type SaasOpsUsuarios } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { ConfigListPageShell } from '../../components/config/ConfigListPageShell'
+import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../../components/ui/BarraBuscaPaginacao'
+import { Button } from '../../components/ui/Button'
+import { Card } from '../../components/ui/Card'
+import { FiltroInativos } from '../../components/ui/FiltroInativos'
+import { useToast } from '../../components/ui/Toast'
+import { SemPermissao } from '../SemPermissao'
+
+export function SaasUsuarios() {
+  const navigate = useNavigate()
+  const toast = useToast()
+  const [list, setList] = useState<SaasOpsUsuarios.Usuario[]>([])
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const [busca, setBusca] = useState('')
+  const [debouncedBusca, setDebouncedBusca] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [incluirInativos, setIncluirInativos] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [indisponivel, setIndisponivel] = useState(false)
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
+    return () => clearTimeout(t)
+  }, [busca])
+
+  useEffect(() => {
+    setPage(1)
+  }, [debouncedBusca, incluirInativos])
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    setIndisponivel(false)
+    saasOpsUsuarios
+      .list({
+        incluir_inativos: incluirInativos,
+        busca: debouncedBusca || undefined,
+        offset: (page - 1) * PAGE_SIZE_PADRAO,
+        limit: PAGE_SIZE_PADRAO,
+      })
+      .then(({ items, total: t }) => {
+        setList(items)
+        setTotal(t)
+      })
+      .catch((err) => {
+        setList([])
+        setTotal(0)
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setIndisponivel(true)
+          return
+        }
+        toast.showError(mensagemFalhaParaToast(err, 'Não encontramos a equipa.'))
+      })
+      .finally(() => setLoading(false))
+  }, [debouncedBusca, incluirInativos, page, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  if (indisponivel) {
+    return (
+      <SemPermissao
+        title="Painel SaaS não disponível nesta instância."
+        detail="A equipa DeskRudder só existe no control-plane."
+        voltarPara="/login/admin"
+        voltarLabel="Voltar ao login admin"
+      />
+    )
+  }
+
+  return (
+    <ConfigListPageShell
+      forbidden={forbidden}
+      denied={
+        <SemPermissao
+          title="Você não tem permissão para gerir a equipa."
+          voltarPara="/login/admin"
+          voltarLabel="Voltar ao login admin"
+        />
+      }
+      title="Equipa DeskRudder"
+      actions={<Button onClick={() => navigate('/saas/usuarios/novo')}>Novo utilizador</Button>}
+    >
+      <Card
+        title="Utilizadores"
+        description="Contas do painel /login/admin. Cada pessoa gera o próprio token Cursor em Conta / Cursor."
+      >
+        <BarraBuscaPaginacao
+          busca={busca}
+          onBuscaChange={setBusca}
+          placeholder="Buscar por nome ou e-mail"
+          page={page}
+          total={total}
+          onPageChange={setPage}
+          disabled={loading}
+          extra={<FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />}
+        />
+        {loading ? (
+          <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
+        ) : list.length === 0 ? (
+          <p className="text-slate-500 dark:text-slate-400">Nenhum utilizador encontrado.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px] text-left text-sm">
+              <thead>
+                <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
+                    Nome
+                  </th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
+                    E-mail
+                  </th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
+                    Token Cursor
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                {list.map((u) => (
+                  <tr
+                    key={u.id}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => navigate(`/saas/usuarios/${u.id}`)}
+                    onKeyDown={(ev) => {
+                      if (ev.key === 'Enter' || ev.key === ' ') {
+                        ev.preventDefault()
+                        navigate(`/saas/usuarios/${u.id}`)
+                      }
+                    }}
+                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
+                  >
+                    <td className="px-4 py-3.5 sm:px-6">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className={`font-medium ${u.ativo ? 'text-slate-800 dark:text-slate-100' : 'text-slate-400'}`}>
+                          {u.nome}
+                        </span>
+                        {!u.ativo ? (
+                          <span className="shrink-0 rounded bg-slate-200 px-1.5 py-0.5 text-xs text-slate-600 dark:text-slate-400">
+                            Inactivo
+                          </span>
+                        ) : null}
+                        {u.must_change_password ? (
+                          <span className="shrink-0 rounded bg-amber-100 px-1.5 py-0.5 text-xs text-amber-800 dark:bg-amber-500/20 dark:text-amber-200">
+                            Trocar senha
+                          </span>
+                        ) : null}
+                      </div>
+                    </td>
+                    <td className="max-w-[16rem] truncate px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400" title={u.email}>
+                      {u.email}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400">
+                      {u.mcp_token_configurado ? 'Configurado' : 'Ainda não'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </ConfigListPageShell>
+  )
+}

--- a/frontend/src/pages/whatsapp/WhatsappLayout.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappLayout.tsx
@@ -25,7 +25,7 @@ export function WhatsappLayout() {
     }`
 
   return (
-    <div className="mx-auto max-w-6xl space-y-8 pb-10 pt-4 animate-in fade-in slide-in-from-top-1 duration-500">
+    <div className="mx-auto w-full min-w-0 max-w-6xl space-y-8 pb-10 pt-4 animate-in fade-in slide-in-from-top-1 duration-500">
       <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
         <div>
           <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary

Release `main` → `staging` (produção).

Lote neste PR (commits em `origin/staging..origin/main`):

**SaaS Control Plane**
- Token Cursor pessoal: cada ops gera o próprio token em Conta / Cursor (`/saas/conta`); recusar/comentar fica ligado a essa conta
- Cadastro da equipa no painel (`/saas/usuarios`) — contas do `/login/admin`
- Primeiro login ops (trocar senha) deixa de mostrar «painel não disponível»

**DeskRudder**
- UI (#870): responsividade do painel; botão Cancelar com gradiente vermelho preenchido

**Interno**
- Templates padronizados de issue no GitHub

O `[Unreleased]` em `CHANGELOG.md` descreve o lote que o deploy de `staging` publica (CalVer).

## Test plan

- [ ] Login ops `/login/admin` → Equipa + Conta / Cursor
- [ ] Gerar token, colar no Cursor, comentar na fila com o nome dessa conta
- [ ] Primeiro acesso ops (senha temporária) redirecciona para alterar senha
- [ ] Painel no telemóvel: coluna principal ocupa a largura; Cancelar visível como botão vermelho preenchido
- [ ] Após merge: Sobre / SaaS Sobre reflectem a nova CalVer

## Merge

**Merge apenas após aprovação manual no GitHub (`staging` = produção).** O agente não mergeia este PR.
