### PR TITLE
fix(release): restaura CHANGELOG [Unreleased] para o Deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ## [Unreleased]
 
-## [26.08.011] - 2026-08-22
-
 ### SaaS Control Plane
 
 #### Melhorias
@@ -21,6 +19,20 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 - UI (#870): responsividade — coluna principal do painel ocupa sempre a largura disponível (grid + `w-full`/`min-w-0` no Layout); contentores internos alinhados; abas e header legíveis em qualquer largura
 - UI (#866): botão **Cancelar** com gradiente vermelho preenchido (mesmo molde do Salvar), distinto de Excluir; ConfirmDialog, portal e formulários alinhados
+
+## [26.08.011] - 2026-08-22
+
+### SaaS Control Plane
+
+#### Melhorias
+
+- Fila de sugestões no Cursor (MCP): o ops liga-se à API comercial (`api.deskrudder.com.br`); o token fica só na VPS e no Cursor de cada pessoa, não no git
+
+### DeskRudder
+
+#### Melhorias
+
+- UI (#866): botão **Cancelar** padronizado em vermelho (`variant=cancel`, bordo forte), distinto de Excluir; ConfirmDialog e formulários/modais alinhados
 - UI (#867): controlo **Voltar** com estilo de botão (fundo/padding) em cadastros, detalhes, portal, WhatsApp e ecrãs de erro de carregamento
 - Sugestões: cada pedido ganha um **protocolo único** (`#S202608-0001`) no painel DeskRudder, visível depois em Minhas solicitações, para amarrar a issue no GitHub
 - Sugestões: no painel SaaS dá para **ligar pedidos iguais** de vários clientes (peso da demanda). O cliente não vê este grupo; na issue GitHub entram todos os protocolos


### PR DESCRIPTION
## Summary

O Deploy em `staging` falhou: o merge do [#918](https://github.com/lgustavoss/dx-connect/pull/918) esvaziou `CHANGELOG.md` `[Unreleased]` (as notas do lote foram parar à versão já publicada `26.08.011`). O job recusa publicar só «Atualização do sistema».

Este hotfix:
- Volta as notas do lote (token Cursor, equipa ops, login, UI #870/#866) para `[Unreleased]`
- Restaura o texto original de `26.08.011`

Código do #918 já está em `staging`. Só falta o CHANGELOG para o Deploy voltar a correr.

## CHANGELOG

- [x] `[Unreleased]` com o lote a publicar (hotfix de release notes)

## Test plan

- [ ] Após merge: o workflow **Deploy** em `staging` passa no passo «Preparar release (CalVer + release notes)»
- [ ] Sobre / SaaS Sobre mostram a nova CalVer com os bullets deste lote

## Merge

**Merge apenas após aprovação no GitHub (`staging` = produção).** O agente não mergeia.
