### PR TITLE
feat(chat-interno): canal automatico por setor (#916)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Chat interno (#916): cada setor activo passa a ter canal próprio (criação ao cadastrar/activar + backfill); canais vazios aparecem em Interno → Setores; o vínculo do atendente ao setor basta para ver o canal; admin vê todos
 - UI (#870): responsividade — coluna principal do painel ocupa sempre a largura disponível (grid + `w-full`/`min-w-0` no Layout); contentores internos alinhados; abas e header legíveis em qualquer largura
 - UI (#866): botão **Cancelar** com gradiente vermelho preenchido (mesmo molde do Salvar), distinto de Excluir; ConfirmDialog, portal e formulários alinhados
 - UI (#867): controlo **Voltar** com estilo de botão (fundo/padding) em cadastros, detalhes, portal, WhatsApp e ecrãs de erro de carregamento

--- a/backend/alembic/versions/119_chat_interno_canal_setor_backfill.py
+++ b/backend/alembic/versions/119_chat_interno_canal_setor_backfill.py
@@ -1,0 +1,43 @@
+"""Backfill canais internos por setor activo (#916).
+
+Revision ID: 119_chat_interno_canal_setor_backfill
+Revises: 118_saas_ops_mcp_token
+Create Date: 2026-08-24
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "119_chat_interno_canal_setor_backfill"
+down_revision = "118_saas_ops_mcp_token"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("setores") or not insp.has_table("conversas_internas"):
+        return
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO conversas_internas (tenant_id, tipo, titulo, setor_id)
+            SELECT s.tenant_id, 'setor', s.nome, s.id
+            FROM setores s
+            WHERE s.ativo IS TRUE
+              AND NOT EXISTS (
+                SELECT 1
+                FROM conversas_internas c
+                WHERE c.tenant_id = s.tenant_id
+                  AND c.tipo = 'setor'
+                  AND c.setor_id = s.id
+              )
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # Não remove canais criados pelo backfill — podem ter mensagens.
+    pass

--- a/backend/app/api/setores.py
+++ b/backend/app/api/setores.py
@@ -13,6 +13,7 @@ from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import obter_atendente_atual, exigir_admin
 from app.core.audit import registrar_audit
 from app.core.setor_scope import ids_setores_visiveis_atendente
+from app.services.chat_interno import obter_ou_criar_canal_setor
 from app.services.ticket_distribuicao import setor_para_distribuicao_read, validar_atendentes_elegiveis
 
 router = APIRouter(prefix="/setores", tags=["setores"])
@@ -80,6 +81,8 @@ def criar_setor(
     setor = Setor(**data.model_dump(), tenant_id=atendente.tenant_id)
     db.add(setor)
     db.flush()
+    if setor.ativo:
+        obter_ou_criar_canal_setor(db, atendente.tenant_id, setor.id)
     registrar_audit(db, "setor", setor.id, "create", atendente.id)
     db.commit()
     db.refresh(setor)
@@ -110,6 +113,9 @@ def atualizar_setor(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Setor não encontrado")
     for k, v in data.model_dump(exclude_unset=True).items():
         setattr(setor, k, v)
+    db.flush()
+    if setor.ativo:
+        obter_ou_criar_canal_setor(db, atendente.tenant_id, setor.id)
     registrar_audit(db, "setor", setor_id, "update", atendente.id)
     db.commit()
     db.refresh(setor)

--- a/backend/app/services/chat_interno.py
+++ b/backend/app/services/chat_interno.py
@@ -482,6 +482,7 @@ def obter_ou_criar_canal_setor(db: Session, tenant_id: int, setor_id: int) -> Co
         tenant_id=tenant_id,
         tipo=TIPO_CONVERSA_SETOR,
         setor_id=setor_id,
+        titulo=setor.nome,
     )
     db.add(conversa)
     db.flush()
@@ -684,7 +685,12 @@ def listar_conversas_inbox(db: Session, atendente: Atendente) -> list[ConversaIn
     for conversa in conversas:
         nao_lidas = contar_nao_lidas(db, conversa, atendente.id)
         ultima = obter_ultima_mensagem_visivel(db, conversa.id, atendente.id)
-        if ultima is None and nao_lidas == 0 and conversa.tipo != TIPO_CONVERSA_GRUPO:
+        # Grupos e canais de setor aparecem mesmo vazios (comunicados / primeiro aviso).
+        if (
+            ultima is None
+            and nao_lidas == 0
+            and conversa.tipo not in (TIPO_CONVERSA_GRUPO, TIPO_CONVERSA_SETOR)
+        ):
             continue
         resumos.append(
             ConversaInboxResumo(

--- a/backend/tests/test_chat_interno_api.py
+++ b/backend/tests/test_chat_interno_api.py
@@ -169,3 +169,133 @@ def test_responder_mensagem_interna(client, seed_base, auth_headers):
         headers=auth_headers["a1"],
     )
     assert r404.status_code == 400
+
+
+def test_criar_setor_cria_canal_interno(client, seed_base, auth_headers, db_session):
+    """#916 — criar setor activo cria conversa tipo setor."""
+    from app.models.chat_interno import ConversaInterna, TIPO_CONVERSA_SETOR
+
+    r = client.post(
+        "/v1/setores",
+        json={"nome": "Financeiro IC", "slug": "financeiro-ic", "ativo": True},
+        headers=auth_headers["admin"],
+    )
+    assert r.status_code == 201, r.text
+    setor_id = r.json()["id"]
+
+    canal = (
+        db_session.query(ConversaInterna)
+        .filter(
+            ConversaInterna.tipo == TIPO_CONVERSA_SETOR,
+            ConversaInterna.setor_id == setor_id,
+        )
+        .one()
+    )
+    assert canal.titulo == "Financeiro IC"
+
+
+def test_activar_setor_cria_canal_interno(client, seed_base, auth_headers, db_session):
+    """#916 — activar setor inactivo garante o canal."""
+    from app.models.chat_interno import ConversaInterna, TIPO_CONVERSA_SETOR
+
+    r = client.post(
+        "/v1/setores",
+        json={"nome": "Inactivo IC", "slug": "inactivo-ic", "ativo": False},
+        headers=auth_headers["admin"],
+    )
+    assert r.status_code == 201, r.text
+    setor_id = r.json()["id"]
+    assert (
+        db_session.query(ConversaInterna)
+        .filter(ConversaInterna.setor_id == setor_id, ConversaInterna.tipo == TIPO_CONVERSA_SETOR)
+        .count()
+        == 0
+    )
+
+    r_act = client.patch(
+        f"/v1/setores/{setor_id}",
+        json={"ativo": True},
+        headers=auth_headers["admin"],
+    )
+    assert r_act.status_code == 200, r_act.text
+    assert (
+        db_session.query(ConversaInterna)
+        .filter(ConversaInterna.setor_id == setor_id, ConversaInterna.tipo == TIPO_CONVERSA_SETOR)
+        .count()
+        == 1
+    )
+
+
+def test_inbox_lista_canal_setor_vazio(client, seed_base, auth_headers):
+    """#916 — canal de setor sem mensagens aparece em Interno → Setores."""
+    setor1 = seed_base["setor1"].id
+    r_canal = client.get(f"/v1/chat-interno/setores/{setor1}/canal", headers=auth_headers["a1"])
+    assert r_canal.status_code == 200
+    canal_id = r_canal.json()["id"]
+
+    r = client.get("/v1/chat-interno/conversas", headers=auth_headers["a1"])
+    assert r.status_code == 200
+    setores = [c for c in r.json() if c["tipo"] == "setor"]
+    assert any(c["id"] == canal_id for c in setores)
+    assert any(c["id"] == canal_id and c.get("ultima_mensagem_corpo") is None for c in setores)
+
+
+def test_inbox_setor_respeita_vinculo_e_admin_ve_todos(client, seed_base, auth_headers):
+    """#916 — membro vê o seu; outro setor 403; admin vê todos os canais."""
+    setor1 = seed_base["setor1"].id
+    setor2 = seed_base["setor2"].id
+    c1 = client.get(f"/v1/chat-interno/setores/{setor1}/canal", headers=auth_headers["a1"]).json()
+    c2 = client.get(f"/v1/chat-interno/setores/{setor2}/canal", headers=auth_headers["a2"]).json()
+
+    inbox_a1 = client.get("/v1/chat-interno/conversas", headers=auth_headers["a1"]).json()
+    ids_a1 = {c["id"] for c in inbox_a1 if c["tipo"] == "setor"}
+    assert c1["id"] in ids_a1
+    assert c2["id"] not in ids_a1
+
+    assert (
+        client.get(f"/v1/chat-interno/setores/{setor2}/canal", headers=auth_headers["a1"]).status_code
+        == 403
+    )
+
+    inbox_admin = client.get("/v1/chat-interno/conversas", headers=auth_headers["admin"]).json()
+    ids_admin = {c["id"] for c in inbox_admin if c["tipo"] == "setor"}
+    assert c1["id"] in ids_admin
+    assert c2["id"] in ids_admin
+
+
+def test_vincular_setor_mostra_canal_na_inbox(client, seed_base, auth_headers, db_session):
+    """#916 — novo vínculo setor_ids passa a listar o canal sem passo manual."""
+    from app.models.chat_interno import ConversaInterna, TIPO_CONVERSA_SETOR
+
+    r_setor = client.post(
+        "/v1/setores",
+        json={"nome": "Novo Setor IC", "slug": "novo-setor-ic", "ativo": True},
+        headers=auth_headers["admin"],
+    )
+    assert r_setor.status_code == 201, r_setor.text
+    setor_id = r_setor.json()["id"]
+    canal = (
+        db_session.query(ConversaInterna)
+        .filter(ConversaInterna.setor_id == setor_id, ConversaInterna.tipo == TIPO_CONVERSA_SETOR)
+        .one()
+    )
+
+    a1_id = seed_base["a1"].id
+    r_patch = client.patch(
+        f"/v1/atendentes/{a1_id}",
+        json={"setor_ids": [seed_base["setor1"].id, setor_id]},
+        headers=auth_headers["admin"],
+    )
+    assert r_patch.status_code == 200, r_patch.text
+
+    inbox = client.get("/v1/chat-interno/conversas", headers=auth_headers["a1"]).json()
+    assert any(c["id"] == canal.id for c in inbox if c["tipo"] == "setor")
+
+    r_un = client.patch(
+        f"/v1/atendentes/{a1_id}",
+        json={"setor_ids": [seed_base["setor1"].id]},
+        headers=auth_headers["admin"],
+    )
+    assert r_un.status_code == 200, r_un.text
+    inbox2 = client.get("/v1/chat-interno/conversas", headers=auth_headers["a1"]).json()
+    assert not any(c["id"] == canal.id for c in inbox2 if c["tipo"] == "setor")

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -630,7 +630,9 @@ export function ChatInternoThread({ conversaIdProp }: ChatInternoThreadProps = {
           <p className="text-center text-base text-rose-600">Erro ao carregar mensagens.</p>
         ) : mensagens.length === 0 ? (
           <p className="text-center text-base text-slate-400">
-            {isSetor ? 'Nenhum comunicado ainda. Publique o primeiro aviso.' : 'Nenhuma mensagem. Diga olá!'}
+            {isSetor
+              ? 'Ainda sem mensagens — escreva o primeiro comunicado'
+              : 'Nenhuma mensagem. Diga olá!'}
           </p>
         ) : (
           mensagens.map((m, idx) => {


### PR DESCRIPTION
## Summary

- Cada setor activo passa a ter canal interno próprio: criação ao cadastrar/activar + backfill Alembic (`119`)
- Canais **vazios** aparecem em Chat interno → Interno → Setores (como os grupos)
- Vínculo `setor_ids` basta para o atendente ver o canal; admin continua a ver todos
- Empty state na thread: «Ainda sem mensagens — escreva o primeiro comunicado»

Closes #916

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest` `tests/test_chat_interno_api.py` + `test_chat_interno_modelo.py` (20 passed)
- [x] `alembic heads` → único head `119_chat_interno_canal_setor_backfill`
- [ ] Migrar local e abrir Chat interno → Interno → Setores (canais visíveis mesmo vazios)
- [ ] Criar setor novo → canal aparece sem passo manual
- [ ] Atendente sem vínculo não vê o canal; acesso por URL → 403
- [ ] Admin vê canais de todos os setores

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — redesign do chat, SSE de conversa criada e canais multi-setor ficam de fora (documentado na #916)
- [x] Sem stubs nullable novos
- [x] Decisões comentadas na #916
