### PR TITLE
feat(saas): release notes únicas, detalhe de sugestões e pt-BR no Cursor

### DIFF
--- a/.cursor/commands/implementar-issue.md
+++ b/.cursor/commands/implementar-issue.md
@@ -50,7 +50,7 @@ docker compose run --rm --no-deps backend pytest -q
 - [ ] Página ou componente em `pages/` / `components/`
 - [ ] `AdminRoute` se for área admin
 - [ ] Integrar SSE via `EventStreamContext` se aplicável
-- [ ] Mensagens de erro em português
+- [ ] Mensagens de erro em português do Brasil
 
 Rodar: `cd frontend && npm run build`
 

--- a/.cursor/commands/listar-solicitacoes.md
+++ b/.cursor/commands/listar-solicitacoes.md
@@ -1,0 +1,64 @@
+# Listar solicitações
+
+Mostra no chat as solicitações **pendentes** da fila SaaS DeskRudder (o mesmo painel `/saas/solicitacoes`).
+
+Este arquivo está no git (`.cursor/commands/`). Depois de um `git pull`, se `/listar-solicitacoes` não aparecer, recarregue a janela do Cursor.
+
+## Pré-requisito — MCP no PC de cada pessoa
+
+A fila **não** está no clone local. Cada desenvolvedor liga o MCP **no próprio Cursor** (`.cursor/mcp.json` é gitignored, não compartilhe token):
+
+1. Copiar `.cursor/mcp.json.example` → `.cursor/mcp.json`
+2. Entrar no painel admin (`https://deskrudder.com.br/login/admin`) com a conta `saas_ops`
+3. Abrir **Minha conta** (`/saas/conta`) e gerar o token Cursor (aparece **uma vez**)
+4. Colar em `DESKRUDDER_MCP_TOKEN`. A URL do example é a **API comercial**:
+   `https://api.deskrudder.com.br`
+   (épico #875 — stack própria, não a da DuplexSoft). Enquanto o split não estiver no ar, esse host ainda não existe; não use a API do cliente como se fosse o control-plane.
+5. Cursor → Settings → MCP → habilitar `deskrudder-saas` (fica verde)
+6. No Windows, se o servidor não iniciar: trocar `"command": "python"` por `"command": "py"`
+
+Sem MCP ligado: **não inventar a fila**. Pedir para completar os passos acima. Não ler nem imprimir o token.
+
+## O que é «pendente»
+
+Por omissão: status `aberta` (Recebida) e `em_analise`.
+
+Se o usuário pedir «todas», «planejadas» ou um protocolo/`#S…`, use esse filtro em vez do padrão.
+
+## Como listar
+
+Chamar `listar_solicitacoes` **duas vezes** (ou HTTP `GET /v1/saas/solicitacoes?status=…&limit=50`):
+
+- `status=aberta`
+- `status=em_analise`
+
+Não misturar com notas internas, GitHub ou peso se o usuário só pediu um resumo — o peso (`peso_clientes`) pode ir numa coluna curta.
+
+## Apresentação (português do Brasil)
+
+Tabela ou lista compacta:
+
+| Campo | Origem |
+|-------|--------|
+| Protocolo | `#SYYYYMM-NNNN` |
+| Título | título |
+| Cliente | slug da instância |
+| Tipo | sugestão / problema |
+| Status | rótulo (Recebida / Em análise) |
+| Peso | `peso_clientes` se > 1 |
+
+No topo: total pendente. Se `total=0`, dizer que a fila está vazia (ainda não chegou pedido ao control-plane).
+
+Não despejar JSON cru. Não citar o `mcp.json`.
+
+## HTTP de fallback (sem a ferramenta MCP, com `mcp.json` já configurado)
+
+`GET {DESKRUDDER_API_URL}/v1/saas/solicitacoes?status=aberta&limit=50` com `Authorization: Bearer {DESKRUDDER_MCP_TOKEN}`.
+
+Não imprimir o token.
+
+## Depois da listagem
+
+Só se o usuário pedir: detalhe (`obter_solicitacao`), alterar status, comentar, vincular pedidos ou ligar issue GitHub. Não triar sozinho.
+
+Comentário ao cliente: **português do Brasil**, sem GitHub/`issue #`. Sem pedido explícito de falar com o cliente, use nota interna (`publico_cliente=false`).

--- a/.cursor/commands/revisar-e-testar.md
+++ b/.cursor/commands/revisar-e-testar.md
@@ -13,7 +13,7 @@ Confirme que a branch **não** é `main`/`staging`. Se for, avise para usar `/in
 ### Geral
 - [ ] Mudança mínima — sem refatoração não solicitada
 - [ ] Critérios de aceite da issue atendidos
-- [ ] Strings de UI/erro em português
+- [ ] Strings de UI/erro em português do Brasil
 
 ### Backend
 - [ ] Lógica na camada `services/`, rotas finas

--- a/.cursor/rules/project-core.mdc
+++ b/.cursor/rules/project-core.mdc
@@ -9,7 +9,7 @@ Sistema interno de helpdesk para redes de postos (tickets, WhatsApp, e-mail, SSE
 
 ## Idioma e escopo
 
-- UI, mensagens de erro e docs em **português**.
+- UI, mensagens de erro, docs e textos ao cliente em **português do Brasil** (pt-BR) — ver rule `pt-br`.
 - Mudanças **mínimas**: só o necessário para a tarefa; não refatorar código adjacente.
 - **Não commitar** nem sugerir commit/push sem pedido explícito do usuário.
 - Git: branch nova por feature, PR para `main` — ver rule `git-workflow`.

--- a/.cursor/rules/pt-br.mdc
+++ b/.cursor/rules/pt-br.mdc
@@ -1,0 +1,30 @@
+---
+description: Português do Brasil em UI, chat, MCP e mensagens ao cliente
+alwaysApply: true
+---
+
+# Português do Brasil (pt-BR)
+
+Toda copy do produto, chat do agente, issue GitHub, docs novas e **mensagem ao cliente** (painel ou MCP `comentar_solicitacao` com `publico_cliente=true`) usa **português do Brasil**. Não use português de Portugal.
+
+## Vocabulário — evitar → usar
+
+| Evitar (PT-PT) | Usar (PT-BR) |
+|----------------|--------------|
+| equipa | equipe |
+| rato (dispositivo) | mouse |
+| planeamento | planejamento |
+| ficheiro | arquivo |
+| ecrã | tela |
+| utilizador | usuário |
+| actual / actualizar | atual / atualizar |
+| contacto | contato |
+| telemóvel | celular |
+| aceite (adj.: pedido aceite) | aceito |
+| guardar (persistir) | salvar |
+
+## Mensagem que o cliente lê
+
+- Sem GitHub, `issue #N`, «acompanhamento interno» ou jargão de ops.
+- Isso vai em **nota interna** (`publico_cliente=false`).
+- MCP: se o ops não pediu falar com o cliente, comente **interno**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ Guia para desenvolvimento assistido por IA no Cursor (time 2–3 devs).
 | Rule | Quando |
 |------|--------|
 | `project-core` | Sempre |
+| `pt-br` | Sempre — português do Brasil (UI, chat, MCP, mensagem ao cliente) |
 | `planning-github-source` | Sempre — planos/decisões no GitHub, sem `.md` locais de rascunho |
 | `backend-fastapi` | Arquivos em `backend/**` |
 | `frontend-react` | Arquivos em `frontend/**` |
@@ -47,6 +48,7 @@ Config: `.cursor/hooks.json`
 | `/testar-ui` | Smoke test no navegador integrado (login, rotas, console) |
 | `/criar-pr` | PR → watch CI → approve → **merge automático em main** (nunca staging) |
 | `/release-staging` | Abre PR `main → staging`; **não mergeia** (aprovação humana) |
+| `/listar-solicitacoes` | Fila SaaS pendente no chat (MCP `deskrudder-saas`; cada dev configura o próprio `mcp.json`) |
 
 ## Subagents (Task tool)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Fila de sugestões no Cursor: cada ops gera o **próprio token** em Conta / Cursor (`/saas/conta`) e cola no Cursor. Recusar ou comentar fica ligado a essa conta, não a um segredo partilhado da VPS
 - Painel SaaS: cadastro da **equipa** (`/saas/usuarios`) — contas do `/login/admin`. Senha temporária uma vez; cada pessoa gera o token Cursor na própria conta
 - Login ops: no primeiro acesso (trocar senha) o painel SaaS já não mostra «não disponível nesta instância»; redirecciona para definir senha nova
+- Sobre (#920): o painel ops lista **todas** as notas da versão, com etiqueta **Produto** ou **DevOps**. O helpdesk nas instâncias continua a ver só as de produto
+- Login do painel admin: em produção deixa de aparecer a dica de desenvolvimento (e-mail local)
+- Sugestões (#923): detalhe com **linha do tempo** (pedido + mensagens ao cliente); notas internas em cartão âmbar; status em passos clicáveis, como nos tickets
+- Sugestões: textos de acompanhamento em português do Brasil; mensagem ao cliente **não pode citar** GitHub nem número de issue (isso fica na nota interna)
+- Painel ops: menu **Equipe** (Usuários + Minha conta); **Sobre** e **Sair** no rodapé, no mesmo padrão do painel de atendimento
+- Cursor: textos ao cliente e do MCP em **português do Brasil**; comentário sem flag explícita fica **interno**. O comando `/listar-solicitacoes` passa a ir no repositório; o MCP aponta para `api.deskrudder.com.br` (control-plane, #875), não para a API da DuplexSoft
 
 ### DeskRudder
 
@@ -19,6 +25,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 - UI (#870): responsividade — coluna principal do painel ocupa sempre a largura disponível (grid + `w-full`/`min-w-0` no Layout); contentores internos alinhados; abas e header legíveis em qualquer largura
 - UI (#866): botão **Cancelar** com gradiente vermelho preenchido (mesmo molde do Salvar), distinto de Excluir; ConfirmDialog, portal e formulários alinhados
+- Sobre (#920): esta página mostra só melhorias de **produto**; as de DevOps não entram na lista
 - UI (#867): controlo **Voltar** com estilo de botão (fundo/padding) em cadastros, detalhes, portal, WhatsApp e ecrãs de erro de carregamento
 - Sugestões: cada pedido ganha um **protocolo único** (`#S202608-0001`) no painel DeskRudder, visível depois em Minhas solicitações, para amarrar a issue no GitHub
 - Sugestões: no painel SaaS dá para **ligar pedidos iguais** de vários clientes (peso da demanda). O cliente não vê este grupo; na issue GitHub entram todos os protocolos

--- a/backend/app/api/saas.py
+++ b/backend/app/api/saas.py
@@ -43,7 +43,7 @@ from app.services import saas_catalogo
 from app.services import saas_clientes as svc
 from app.services import saas_renovacoes
 from app.services.saas_resumo import obter_resumo
-from app.services.system_release import PRODUCT_SAAS, release_notes_payload
+from app.services.system_release import release_notes_payload
 
 router = APIRouter(prefix="/saas", tags=["saas"])
 
@@ -71,8 +71,8 @@ def obter_saas_release_notes(
     _: None = Depends(exigir_saas_control_plane),
     __: Atendente = Depends(exigir_saas_ops),
 ):
-    """Notas do control-plane SaaS — só bullets product=saas (#675)."""
-    return ReleaseNotesRead(**release_notes_payload(product=PRODUCT_SAAS))
+    """Notas da versão — todos os bullets, com ``product`` para tags (#920)."""
+    return ReleaseNotesRead(**release_notes_payload(product=None))
 
 
 def _http_from_saas(exc: svc.SaasErro) -> HTTPException:

--- a/backend/app/api/saas_public.py
+++ b/backend/app/api/saas_public.py
@@ -44,9 +44,9 @@ def solicitar_trial(
         status=row.status,
         data_renovacao=row.data_renovacao,
         mensagem=(
-            "Pedido de trial recebido. A equipa DeskRudder analisa a solicitação; "
+            "Pedido de trial recebido. A equipe DeskRudder analisa a solicitação; "
             "após aprovação, a base e a instância são criadas. "
-            f"Contactá-lo-emos em {row.contato_email}."
+            f"Entraremos em contato pelo e-mail {row.contato_email}."
         ),
     )
 
@@ -66,7 +66,7 @@ def enviar_contato_comercial(
     return LeadComercialPublicRead(
         id=row.id,
         mensagem=(
-            "Mensagem recebida. A equipa comercial DeskRudder vai responder "
+            "Mensagem recebida. A equipe comercial DeskRudder vai responder "
             f"em {row.email}."
         ),
     )

--- a/backend/app/api/system.py
+++ b/backend/app/api/system.py
@@ -17,5 +17,5 @@ def obter_system_info(_: Atendente = Depends(obter_atendente_atual)):
 
 @router.get("/release-notes", response_model=ReleaseNotesRead)
 def obter_release_notes(_: Atendente = Depends(obter_atendente_atual)):
-    """Notas do DeskRudder (helpdesk na instância) — exclui bullets SaaS."""
+    """Notas de produto no painel da instância — exclui bullets DevOps (#920)."""
     return ReleaseNotesRead(**release_notes_payload(product="deskrudder"))

--- a/backend/app/services/saas_solicitacao_triagem.py
+++ b/backend/app/services/saas_solicitacao_triagem.py
@@ -81,17 +81,37 @@ def alterar_status(
     return ingest.detalhe(db, ingest.obter(db, row.id))
 
 
+_INTERNO_NO_CLIENTE_RE = re.compile(
+    r"(?i)(github\.com|/\s*issues/\d+|\bgithub\b|\bissues?\s*#\s*\d+)",
+)
+
+
+def corpo_publico_cita_trabalho_interno(corpo: str) -> bool:
+    """GitHub / issue #N não pode ir na mensagem que o cliente vê."""
+    return bool(_INTERNO_NO_CLIENTE_RE.search(corpo or ""))
+
+
 def adicionar_comentario(
     db: Session,
     solicitacao_id: int,
     ops: Atendente,
     data: SaasSolicitacaoComentarioCreate,
 ) -> SaasSolicitacaoDetalhe:
+    corpo = data.corpo.strip()
+    publico = bool(data.publico_cliente)
+    if publico and corpo_publico_cita_trabalho_interno(corpo):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Não envie links ou números de issue do GitHub na mensagem ao cliente. "
+                "Use comentário interno."
+            ),
+        )
     row = ingest.obter(db, solicitacao_id)
     comentario = SaasSolicitacaoProdutoComentario(
         solicitacao_id=row.id,
-        corpo=data.corpo.strip(),
-        publico_cliente=bool(data.publico_cliente),
+        corpo=corpo,
+        publico_cliente=publico,
         autor_atendente_id=ops.id,
         autor_nome=ops.nome,
     )

--- a/backend/app/services/solicitacao_melhoria_copy.py
+++ b/backend/app/services/solicitacao_melhoria_copy.py
@@ -12,14 +12,14 @@ STATUS_LABELS: dict[str, str] = {
 }
 
 STATUS_MENSAGENS: dict[str, str] = {
-    "aberta": "Recebemos o seu pedido. A equipa vai analisar em breve.",
-    "em_analise": "Estamos a analisar o seu pedido com atenção.",
-    "planejada": "O seu pedido foi incluído no planeamento de melhorias.",
-    "em_desenvolvimento": "Já estamos a trabalhar nesta melhoria.",
-    "concluida": "Esta melhoria ficou disponível. Obrigado pelo contributo!",
+    "aberta": "Recebemos o seu pedido. A equipe vai analisar em breve.",
+    "em_analise": "Estamos analisando o seu pedido com atenção.",
+    "planejada": "O seu pedido foi incluído no planejamento de melhorias.",
+    "em_desenvolvimento": "Já estamos trabalhando nesta melhoria.",
+    "concluida": "Esta melhoria ficou disponível. Obrigado pela contribuição!",
     "nao_sera_desenvolvida": (
-        "Neste momento não vamos avançar com este pedido. "
-        "Apreciamos o feedback — se fizer sentido no futuro, voltamos a avaliar."
+        "Neste momento não vamos seguir com este pedido. "
+        "Agradecemos o feedback — se fizer sentido no futuro, voltamos a avaliar."
     ),
 }
 

--- a/backend/app/services/system_release.py
+++ b/backend/app/services/system_release.py
@@ -115,15 +115,17 @@ def _change_product(ch: dict[str, Any]) -> str:
     return PRODUCT_DESKRUDDER
 
 
-def _filter_release_for_product(rel: dict[str, Any], product: str) -> dict[str, Any] | None:
+def _filter_release_for_product(rel: dict[str, Any], product: str | None) -> dict[str, Any] | None:
+    """Anota ``product`` em cada bullet. Se ``product`` não for None, filtra."""
     changes = []
     for ch in rel.get("changes") or []:
         if not isinstance(ch, dict):
             continue
-        if _change_product(ch) != product:
+        prod = _change_product(ch)
+        if product is not None and prod != product:
             continue
         item = dict(ch)
-        item["product"] = product
+        item["product"] = prod
         changes.append(item)
     if not changes:
         return None
@@ -135,11 +137,21 @@ def _filter_release_for_product(rel: dict[str, Any], product: str) -> dict[str, 
 def release_notes_payload(
     *,
     version_override: str | None = None,
-    product: str = PRODUCT_DESKRUDDER,
+    product: str | None = PRODUCT_DESKRUDDER,
 ) -> dict[str, Any]:
-    product_key = (product or PRODUCT_DESKRUDDER).strip().lower()
-    if product_key not in VALID_PRODUCTS:
-        product_key = PRODUCT_DESKRUDDER
+    """Monta o payload das notas (#920).
+
+    ``product``:
+    - ``deskrudder`` / ``saas`` — só bullets desse tag (painel da instância).
+    - ``None`` — todas as notas, cada bullet com ``product`` (painel ops).
+    """
+    product_key: str | None
+    if product is None:
+        product_key = None
+    else:
+        product_key = product.strip().lower() or PRODUCT_DESKRUDDER
+        if product_key not in VALID_PRODUCTS:
+            product_key = PRODUCT_DESKRUDDER
 
     raw = _load_release_notes_raw()
     version = version_override or resolve_app_version()

--- a/backend/scripts/mcp_deskrudder_saas.py
+++ b/backend/scripts/mcp_deskrudder_saas.py
@@ -3,7 +3,7 @@
 O processo corre no PC do ops (Cursor). A API é a do control-plane em produção.
 
 Env:
-  DESKRUDDER_API_URL   (omissão: https://api.deskrudder.com.br)
+  DESKRUDDER_API_URL   (omissão: https://api.deskrudder.com.br — control-plane, #875)
   DESKRUDDER_MCP_TOKEN (token gerado em /saas/conta; legado: SAAS_MCP_TOKEN da VPS)
 
 Em local, no .cursor/mcp.json usa http://127.0.0.1:8000 e o token de /saas/conta
@@ -22,6 +22,12 @@ from pathlib import Path
 
 API = (os.environ.get("DESKRUDDER_API_URL") or "https://api.deskrudder.com.br").rstrip("/")
 PROTOCOL = "2024-11-05"
+MCP_INSTRUCTIONS = (
+    "Fila SaaS DeskRudder. Escreva sempre em português do Brasil (pt-BR). "
+    "comentar_solicitacao sem publico_cliente é nota interna. "
+    "Mensagem ao cliente (publico_cliente=true): o cliente lê — sem GitHub, issue #, "
+    "nem vocabulário de Portugal (equipe não equipa; mouse não rato; planejamento não planeamento)."
+)
 
 
 def _api_e_loopback() -> bool:
@@ -50,8 +56,8 @@ TOOLS = [
         "description": (
             "Lista pedidos de melhoria/bug na fila SaaS DeskRudder. "
             "Cada item tem protocolo #SYYYYMM-NNNN, único no produto DeskRudder. "
-            "peso_clientes > 1 significa vários clientes a pedir o mesmo (grupo só visível no SaaS). "
-            "No título da issue usa o protocolo; no corpo cola texto_github_demanda (lista de protocolos)."
+            "peso_clientes > 1 significa vários clientes pedindo o mesmo (grupo só visível no SaaS). "
+            "No título da issue use o protocolo; no corpo cole texto_github_demanda (lista de protocolos)."
         ),
         "inputSchema": {
             "type": "object",
@@ -85,9 +91,9 @@ TOOLS = [
     {
         "name": "alterar_status",
         "description": (
-            "Actualiza a triagem. O cliente vê o status em Minhas solicitações. "
+            "Atualiza a triagem. O cliente vê o status em Minhas solicitações. "
             "Valores: aberta, em_analise, planejada, em_desenvolvimento, concluida, nao_sera_desenvolvida. "
-            "nao_sera_desenvolvida exige motivo visível ao cliente."
+            "nao_sera_desenvolvida exige motivo visível ao cliente, em português do Brasil."
         ),
         "inputSchema": {
             "type": "object",
@@ -104,7 +110,9 @@ TOOLS = [
     {
         "name": "comentar_solicitacao",
         "description": (
-            "Comentário no pedido. publico_cliente=true vai para o cliente; false é nota interna só no SaaS."
+            "Comentário no pedido, em português do Brasil. "
+            "Sem publico_cliente (ou false) = nota interna só no SaaS. "
+            "publico_cliente=true o cliente lê: sem GitHub, issue # nem jargão de ops."
         ),
         "inputSchema": {
             "type": "object",
@@ -113,7 +121,10 @@ TOOLS = [
                 "protocolo": {"type": "string"},
                 "slug": {"type": "string"},
                 "corpo": {"type": "string"},
-                "publico_cliente": {"type": "boolean"},
+                "publico_cliente": {
+                    "type": "boolean",
+                    "description": "true = o cliente lê (pt-BR, sem GitHub). Omissão = nota interna.",
+                },
             },
             "required": ["corpo"],
         },
@@ -121,8 +132,8 @@ TOOLS = [
     {
         "name": "ligar_issue_github",
         "description": (
-            "Depois de criares a issue com o MCP GitHub, grava o URL neste pedido. "
-            "Cola texto_github_demanda no corpo da issue (um ou mais protocolos = demanda). "
+            "Depois de criar a issue com o MCP GitHub, grave a URL neste pedido. "
+            "Cole texto_github_demanda no corpo da issue (um ou mais protocolos = demanda). "
             "A issue fica ligada a todos os pedidos do grupo. O cliente NÃO vê o GitHub."
         ),
         "inputSchema": {
@@ -141,7 +152,7 @@ TOOLS = [
         "description": (
             "Marca dois pedidos como o mesmo pedido de produto (clientes diferentes). "
             "Sobe o peso. Só no painel SaaS; o cliente não vê. "
-            "Indique o pedido actual (id ou protocolo) e o outro (outra_id ou outro_protocolo)."
+            "Indique o pedido atual (id ou protocolo) e o outro (outra_id ou outro_protocolo)."
         ),
         "inputSchema": {
             "type": "object",
@@ -186,9 +197,9 @@ def _api(method: str, path: str, body: dict | None = None) -> tuple[int, object]
     token = _ler_token()
     if not token:
         raise RuntimeError(
-            "Define DESKRUDDER_MCP_TOKEN no .cursor/mcp.json "
+            "Defina DESKRUDDER_MCP_TOKEN no .cursor/mcp.json "
             "(token gerado em /saas/conta). "
-            "Em local (127.0.0.1) também podes pôr SAAS_MCP_TOKEN no backend/.env (legado)."
+            "No ambiente local (127.0.0.1) também pode usar SAAS_MCP_TOKEN no backend/.env (legado)."
         )
     url = f"{API}{path}"
     data = None if body is None else json.dumps(body, ensure_ascii=False).encode("utf-8")
@@ -290,7 +301,7 @@ def call_tool(name: str, args: dict) -> object:
         sid = _id_fila(args)
         payload = {
             "corpo": args["corpo"],
-            "publico_cliente": bool(args.get("publico_cliente", True)),
+            "publico_cliente": bool(args["publico_cliente"]) if "publico_cliente" in args else False,
         }
         _, body = _api("POST", f"/v1/saas/solicitacoes/{sid}/comentarios", payload)
         return body
@@ -343,6 +354,7 @@ def handle(msg: dict) -> dict | None:
                 "protocolVersion": PROTOCOL,
                 "capabilities": {"tools": {"listChanged": False}},
                 "serverInfo": {"name": "deskrudder-saas", "version": "1.0.0"},
+                "instructions": MCP_INSTRUCTIONS,
             },
         )
     if method == "ping":

--- a/backend/tests/test_saas_solicitacoes.py
+++ b/backend/tests/test_saas_solicitacoes.py
@@ -436,6 +436,33 @@ def test_comentario_publico_volta_interno_nao(client, seed_base, auth_headers, m
     assert cliente_view.get("github_issue_url") in (None, "")
 
 
+def test_comentario_publico_rejeita_issue_github(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
+    sid = _criar_solicitacao(client, auth_headers["a1"]).json()["id"]
+    h = auth_headers["ops"]
+    lista = client.get("/v1/saas/solicitacoes", headers=h).json()["items"]
+    saas_id = next(i["id"] for i in lista if i["origem_solicitacao_id"] == sid)
+
+    bad = client.post(
+        f"/v1/saas/solicitacoes/{saas_id}/comentarios",
+        headers=h,
+        json={"corpo": "Pedido aceite. Acompanhamento interno: issue #921.", "publico_cliente": True},
+    )
+    assert bad.status_code == 400, bad.text
+
+    ok = client.post(
+        f"/v1/saas/solicitacoes/{saas_id}/comentarios",
+        headers=h,
+        json={"corpo": "Acompanhamento interno: issue #921.", "publico_cliente": False},
+    )
+    assert ok.status_code == 200, ok.text
+    cliente_view = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["a1"]).json()
+    assert not any("921" in (c["corpo"] or "") for c in cliente_view["comentarios"])
+
+
 def test_admin_instancia_nao_tria(client, seed_base, auth_headers, monkeypatch):
     from app.config import settings
 
@@ -605,9 +632,35 @@ def test_mcp_stdio_initialize_e_tools():
     spec.loader.exec_module(mod)
     init = mod.handle({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
     assert init["result"]["serverInfo"]["name"] == "deskrudder-saas"
+    assert "português do Brasil" in init["result"]["instructions"]
     listed = mod.handle({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
     names = {t["name"] for t in listed["result"]["tools"]}
     assert {"listar_solicitacoes", "obter_solicitacao", "alterar_status", "comentar_solicitacao", "ligar_issue_github", "vincular_solicitacao", "desvincular_solicitacao"} <= names
+    comentar = next(t for t in listed["result"]["tools"] if t["name"] == "comentar_solicitacao")
+    assert "português do Brasil" in comentar["description"]
+
+
+def test_mcp_comentar_sem_flag_fica_interno(monkeypatch):
+    import importlib.util
+    from pathlib import Path
+
+    path = Path(__file__).resolve().parents[1] / "scripts" / "mcp_deskrudder_saas.py"
+    spec = importlib.util.spec_from_file_location("mcp_deskrudder_saas", path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    captured: dict = {}
+
+    def fake_api(method, path, body=None):
+        captured["body"] = body
+        return 200, {"ok": True}
+
+    monkeypatch.setattr(mod, "_api", fake_api)
+    monkeypatch.setattr(mod, "_id_fila", lambda args: 7)
+    mod.call_tool("comentar_solicitacao", {"id": 7, "corpo": "nota do agente"})
+    assert captured["body"]["publico_cliente"] is False
+    mod.call_tool("comentar_solicitacao", {"id": 7, "corpo": "olá", "publico_cliente": True})
+    assert captured["body"]["publico_cliente"] is True
 
 
 def test_vincular_pedidos_iguais_peso_e_nao_vaza_ao_cliente(client, seed_base, auth_headers, monkeypatch):

--- a/backend/tests/test_system_release.py
+++ b/backend/tests/test_system_release.py
@@ -290,7 +290,7 @@ def test_system_release_notes_hides_saas_prefix_even_if_wrongly_tagged(
     assert texts == ["WhatsApp: fila"]
 
 
-def test_saas_release_notes_rbac_and_filter(client, auth_headers, monkeypatch, tmp_path):
+def test_saas_release_notes_rbac_and_all_products(client, auth_headers, monkeypatch, tmp_path):
     from app.config import settings
 
     data_path = tmp_path / "release_notes.json"
@@ -324,8 +324,11 @@ def test_saas_release_notes_rbac_and_filter(client, auth_headers, monkeypatch, t
 
     ok = client.get("/v1/saas/release-notes", headers=auth_headers["ops"])
     assert ok.status_code == 200, ok.text
-    texts = [c["text"] for c in ok.json()["current"]["changes"]]
-    assert texts == ["SaaS: licenças"]
+    changes = ok.json()["current"]["changes"]
+    assert [(c["text"], c["product"]) for c in changes] == [
+        ("Chat fila", "deskrudder"),
+        ("SaaS: licenças", "saas"),
+    ]
 
 
 def test_health_includes_version(client, monkeypatch):

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -11,25 +11,25 @@ Guia de versionamento, CHANGELOG e o que o usuário vê em **Sobre**.
 
 Bump automático no **deploy de `staging`** (fuso `America/Sao_Paulo`).
 
-## Dois produtos, um deploy
+## Uma CalVer, umas notas (#920)
 
-Uma CalVer por merge `main → staging`, mas **dois feeds** de notas:
+Uma versão por merge `main → staging`. **Um** CHANGELOG / manifest — as subsecções `### DeskRudder` e `### SaaS Control Plane` são **tags** (produto vs devops), não feeds separados.
 
-| Produto | Código no manifest | Onde o usuário vê | API |
-|---------|--------------------|-------------------|-----|
-| DeskRudder (helpdesk na instância) | `deskrudder` | `/sobre` | `GET /v1/system/release-notes` |
-| SaaS Control Plane | `saas` | `/saas/sobre` | `GET /v1/saas/release-notes` (RBAC `saas_ops`) |
+| Tag no manifest | Significado | Quem vê |
+|-----------------|-------------|---------|
+| `deskrudder` (**Produto**) | Helpdesk na instância (chat, tickets, ponto, comercial na rede…) | `/sobre` (só estas) e `/saas/sobre` (com etiqueta) |
+| `saas` (**DevOps**) | Control-plane (licenças, planos, provisionamento, leads, equipa ops) | só `/saas/sobre`, com etiqueta DevOps |
 
-- **Comercial** (CM/FN, simulador, custos) = DeskRudder (roda no cliente).
-- **Landing / trial / leads B2B / licenças / planos** = SaaS.
+- **Comercial** (CM/FN, simulador, custos) = Produto (roda no cliente).
+- **Landing / trial / leads B2B / licenças / planos** = DevOps.
 
 ## Fluxo do time
 
 ```
-feature → PR main (+ CHANGELOG por produto) → PR main → staging (aprovação humana) → deploy → /sobre e /saas/sobre
+feature → PR main (+ CHANGELOG com tags Produto/DevOps) → PR main → staging (aprovação humana) → deploy → /sobre e /saas/sobre
 ```
 
-1. **Cada PR para `main`** com mudança de produto: bullets em `CHANGELOG.md` → `## [Unreleased]` na **subseção do produto** certo
+1. **Cada PR para `main`** com mudança visível: bullets em `CHANGELOG.md` → `## [Unreleased]` na **subseção** certa (tag Produto ou DevOps)
 2. **PR `main → staging`**: o `[Unreleased]` descreve **todo o lote** que será publicado
 3. **Merge em `staging`**: **só após análise e aprovação humana no GitHub** (`staging` = produção). Agentes/CI **não** mergeiam este PR automaticamente — usar `/release-staging` para abrir o PR e parar.
 4. **Deploy em `staging`**: consome `[Unreleased]`, gera nova CalVer, append em `docs/releases/manifest.json` (cada bullet com `product`), zera `[Unreleased]`
@@ -74,17 +74,17 @@ Isento (sem exigir CHANGELOG): só docs internos, planning, artefatos de release
 
 ## O que o usuário vê
 
-### `/sobre` (DeskRudder)
+### `/sobre` (DeskRudder — produto)
 
 | Seção | Conteúdo |
 |-------|----------|
 | **Versão atual** | CalVer do deploy |
 | **O que há de novo** | Só bullets `product=deskrudder` da release atual |
-| **Histórico** | Releases anteriores **sem** cards que só tinham itens SaaS |
+| **Histórico** | Releases anteriores **sem** cards que só tinham itens DevOps |
 
-### `/saas/sobre` (ops)
+### `/saas/sobre` (ops — tudo, com tags)
 
-Mesma CalVer; só bullets `product=saas` (licenças, planos, provisionamento, leads).
+Mesma CalVer e as **mesmas** notas. Cada bullet mostra etiqueta **Produto** ou **DevOps**.
 
 ## Arquivos
 
@@ -103,8 +103,8 @@ Após cada deploy, o workflow commita `VERSION`, `CHANGELOG.md`, `manifest.json`
 ## API (autenticada)
 
 - `GET /v1/system/info` — versão em execução
-- `GET /v1/system/release-notes` — feed DeskRudder
-- `GET /v1/saas/release-notes` — feed SaaS (`saas_ops` + control plane ligado)
+- `GET /v1/system/release-notes` — só bullets de produto (painel da instância)
+- `GET /v1/saas/release-notes` — todas as notas, com `product` em cada bullet (`saas_ops` + control plane ligado)
 
 ## Checklist — PR para `main`
 

--- a/docs/SAAS_CONTROL_PLANE.md
+++ b/docs/SAAS_CONTROL_PLANE.md
@@ -51,6 +51,10 @@ Com `SAAS_CONTROL_PLANE=true`, o seed cria:
 
 Sem `VITE_SAAS_CONTROL_PLANE=true`, a apex continua só com login por conta.
 
+### Produção (`deskrudder.com.br/login/admin`)
+
+Não uses as contas de desenvolvimento. O primeiro ops do control-plane é **`ops@deskrudder.com.br`**. A senha **não** está no git (foi gerada na VPS). Se não a tiveres, redefine na API (`docker exec` no container) — não corras o seed de dev em produção.
+
 ## API
 
 | Método | Rota | Quem |
@@ -133,14 +137,18 @@ Handoff Cursor é #857: o Cursor **puxa** a fila (MCP `deskrudder-saas`) contra 
 O script corre no PC do ops. A fila é a da instância comercial (`SAAS_CONTROL_PLANE=true`).
 
 1. Entre no painel admin (`/login/admin`) com a **tua** conta `saas_ops`.
-2. Abra **Conta / Cursor** (`/saas/conta`) e gere o token. O valor aparece **uma vez** — copie para o Cursor. Regenerar invalida o token anterior.
-3. Em cada Cursor: copiar `.cursor/mcp.json.example` para `.cursor/mcp.json` (gitignored), colar **o teu** token em `DESKRUDDER_MCP_TOKEN`, e manter:
+2. Abra **Minha conta** (`/saas/conta`) e gere o token. O valor aparece **uma vez** — copie para o Cursor. Regenerar invalida o token anterior.
+3. Em cada Cursor: copiar `.cursor/mcp.json.example` para `.cursor/mcp.json` (gitignored), colar **o seu** token em `DESKRUDDER_MCP_TOKEN`, e manter:
 
    ```
    DESKRUDDER_API_URL=https://api.deskrudder.com.br
    ```
 
-   Cursor → Settings → MCP → habilitar `deskrudder-saas`.
+   Alvo do épico #875 (stack comercial própria). **Não** apontar o MCP para `api-duplexsoft` — essa é a API do cliente.
+
+   Cursor → Settings → MCP → habilitar `deskrudder-saas`. No Windows, se o servidor não iniciar, use `"command": "py"` em vez de `"python"`.
+
+   Comando no chat: `/listar-solicitacoes` (arquivo versionado em `.cursor/commands/`).
 
 4. **Teste local** (Docker neste repo): no `.cursor/mcp.json` usa `http://127.0.0.1:8000` e um token gerado no painel local (não o da VPS).
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5093,7 +5093,7 @@ export const solicitacoesMelhoria = {
     }),
 };
 
-/** Release notes do control-plane (RBAC saas_ops). */
+/** Release notes da versão (RBAC saas_ops) — todas as notas, com product (#920). */
 export const saasReleaseNotes = {
   get: () => api<System.ReleaseNotes>('/saas/release-notes'),
 };

--- a/frontend/src/components/release/ReleaseNotesView.tsx
+++ b/frontend/src/components/release/ReleaseNotesView.tsx
@@ -14,6 +14,11 @@ const CATEGORY_LABEL: Record<string, string> = {
   interno: 'Interno / Infra',
 }
 
+const PRODUCT_LABEL: Record<string, string> = {
+  deskrudder: 'Produto',
+  saas: 'DevOps',
+}
+
 function categoryClass(category: string): string {
   if (category === 'correcoes') {
     return 'bg-amber-50 text-amber-900 ring-amber-200/70 dark:bg-amber-950/40 dark:text-amber-100 dark:ring-amber-800/50'
@@ -24,6 +29,13 @@ function categoryClass(category: string): string {
   return 'bg-cyan-50 text-cyan-900 ring-cyan-200/70 dark:bg-cyan-950/40 dark:text-cyan-100 dark:ring-cyan-800/50'
 }
 
+function productClass(product: string): string {
+  if (product === 'saas') {
+    return 'bg-violet-50 text-violet-900 ring-violet-200/70 dark:bg-violet-950/40 dark:text-violet-100 dark:ring-violet-800/50'
+  }
+  return 'bg-sky-50 text-sky-900 ring-sky-200/70 dark:bg-sky-950/40 dark:text-sky-100 dark:ring-sky-800/50'
+}
+
 function formatDate(value: string): string {
   const d = value.slice(0, 10)
   const [y, m, day] = d.split('-')
@@ -31,27 +43,51 @@ function formatDate(value: string): string {
   return `${day}/${m}/${y}`
 }
 
-function ChangeList({ items }: { items: System.ReleaseChange[] }) {
+function ChangeList({
+  items,
+  showProductTags,
+}: {
+  items: System.ReleaseChange[]
+  showProductTags?: boolean
+}) {
   if (!items.length) {
     return <p className="text-sm text-slate-500 dark:text-slate-400">Nenhum item registrado.</p>
   }
   return (
     <ul className="space-y-3">
-      {items.map((item, idx) => (
-        <li key={`${item.category}-${idx}`} className="flex items-start gap-3 text-sm leading-relaxed">
-          <span
-            className={`inline-flex min-w-[5.5rem] shrink-0 items-center justify-center self-start rounded-md px-2.5 py-1 text-center text-xs font-medium leading-none ring-1 ring-inset ${categoryClass(item.category)}`}
-          >
-            {CATEGORY_LABEL[item.category] ?? item.category}
-          </span>
-          <span className="min-w-0 flex-1 text-slate-700 dark:text-slate-200">{item.text}</span>
-        </li>
-      ))}
+      {items.map((item, idx) => {
+        const productKey = (item.product ?? 'deskrudder').toLowerCase()
+        return (
+          <li key={`${item.category}-${idx}`} className="flex items-start gap-3 text-sm leading-relaxed">
+            <span className="flex shrink-0 flex-wrap items-center gap-1.5 self-start">
+              {showProductTags ? (
+                <span
+                  className={`inline-flex min-w-[4.75rem] items-center justify-center rounded-md px-2.5 py-1 text-center text-xs font-medium leading-none ring-1 ring-inset ${productClass(productKey)}`}
+                >
+                  {PRODUCT_LABEL[productKey] ?? item.product ?? 'Produto'}
+                </span>
+              ) : null}
+              <span
+                className={`inline-flex min-w-[5.5rem] items-center justify-center rounded-md px-2.5 py-1 text-center text-xs font-medium leading-none ring-1 ring-inset ${categoryClass(item.category)}`}
+              >
+                {CATEGORY_LABEL[item.category] ?? item.category}
+              </span>
+            </span>
+            <span className="min-w-0 flex-1 text-slate-700 dark:text-slate-200">{item.text}</span>
+          </li>
+        )
+      })}
     </ul>
   )
 }
 
-function ReleaseBlock({ release }: { release: System.Release }) {
+function ReleaseBlock({
+  release,
+  showProductTags,
+}: {
+  release: System.Release
+  showProductTags?: boolean
+}) {
   return (
     <Card className="space-y-4 p-5">
       <div className="flex flex-wrap items-baseline justify-between gap-2">
@@ -60,7 +96,7 @@ function ReleaseBlock({ release }: { release: System.Release }) {
           {formatDate(String(release.date))}
         </time>
       </div>
-      <ChangeList items={release.changes} />
+      <ChangeList items={release.changes} showProductTags={showProductTags} />
     </Card>
   )
 }
@@ -77,6 +113,8 @@ export type ReleaseNotesViewProps = {
   showBrandLogo?: boolean
   /** CTA sugestões (#802) — desligar no SaaS Sobre se não fizer sentido. */
   showSugestoesCta?: boolean
+  /** Painel ops (#920): etiqueta Produto / DevOps em cada bullet. */
+  showProductTags?: boolean
 }
 
 function formatWhen(iso: string): string {
@@ -87,7 +125,7 @@ function formatWhen(iso: string): string {
   }
 }
 
-/** Lista partilhada de versão + histórico filtrado por produto (#674 / #675). */
+/** Lista partilhada de versão + histórico (#674 / #920). */
 export function ReleaseNotesView({
   backTo,
   backLabel = 'Voltar',
@@ -99,6 +137,7 @@ export function ReleaseNotesView({
   loading = false,
   showBrandLogo = true,
   showSugestoesCta = true,
+  showProductTags = false,
 }: ReleaseNotesViewProps) {
   const navigate = useNavigate()
   const [minhas, setMinhas] = useState<SolicitacoesMelhoria.ListaItem[]>([])
@@ -202,7 +241,7 @@ export function ReleaseNotesView({
       {notes?.current ? (
         <section className="space-y-3">
           <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-50">O que há de novo nesta versão</h2>
-          <ReleaseBlock release={notes.current} />
+          <ReleaseBlock release={notes.current} showProductTags={showProductTags} />
         </section>
       ) : (
         <p className="text-sm text-slate-500 dark:text-slate-400">
@@ -221,7 +260,7 @@ export function ReleaseNotesView({
               .slice()
               .reverse()
               .map((release) => (
-                <ReleaseBlock key={release.version} release={release} />
+                <ReleaseBlock key={release.version} release={release} showProductTags={showProductTags} />
               ))}
           </div>
         </section>

--- a/frontend/src/lib/saasSolicitacoes.ts
+++ b/frontend/src/lib/saasSolicitacoes.ts
@@ -1,0 +1,45 @@
+/** Status da fila de sugestões / problemas no painel ops (#923). */
+
+export const SAAS_SOLICITACAO_STATUS = [
+  { value: 'aberta', label: 'Recebida' },
+  { value: 'em_analise', label: 'Em análise' },
+  { value: 'planejada', label: 'Planejada' },
+  { value: 'em_desenvolvimento', label: 'Em desenvolvimento' },
+  { value: 'concluida', label: 'Concluída' },
+  { value: 'nao_sera_desenvolvida', label: 'Não será desenvolvida' },
+] as const
+
+export type SaasSolicitacaoStatus = (typeof SAAS_SOLICITACAO_STATUS)[number]['value']
+
+const BADGE: Record<string, string> = {
+  aberta:
+    'bg-slate-100 text-slate-800 ring-slate-200/80 dark:bg-slate-800/70 dark:text-slate-100 dark:ring-slate-600/70',
+  em_analise:
+    'bg-sky-50 text-sky-900 ring-sky-200/80 dark:bg-sky-950/50 dark:text-sky-100 dark:ring-sky-800/50',
+  planejada:
+    'bg-violet-50 text-violet-900 ring-violet-200/80 dark:bg-violet-950/40 dark:text-violet-100 dark:ring-violet-800/50',
+  em_desenvolvimento:
+    'bg-cyan-50 text-cyan-900 ring-cyan-200/80 dark:bg-cyan-950/40 dark:text-cyan-100 dark:ring-cyan-800/50',
+  concluida:
+    'bg-emerald-50 text-emerald-900 ring-emerald-200/80 dark:bg-emerald-950/40 dark:text-emerald-100 dark:ring-emerald-800/50',
+  nao_sera_desenvolvida:
+    'bg-rose-50 text-rose-900 ring-rose-200/80 dark:bg-rose-950/40 dark:text-rose-100 dark:ring-rose-800/50',
+}
+
+export function rotuloStatusSolicitacao(value: string): string {
+  return SAAS_SOLICITACAO_STATUS.find((s) => s.value === value)?.label ?? value
+}
+
+export function classesBadgeStatusSolicitacao(value: string): string {
+  return (
+    BADGE[value] ??
+    'bg-slate-100 text-slate-800 ring-slate-200/80 dark:bg-slate-800/70 dark:text-slate-100 dark:ring-slate-600/70'
+  )
+}
+
+/** GitHub / issue #N não deve ir na mensagem visível ao cliente. */
+export function mencionaTrabalhoInterno(texto: string): boolean {
+  const t = texto.trim()
+  if (!t) return false
+  return /github\.com|\bgithub\b|\bissues?\s*#\s*\d+|\/issues\/\d+/i.test(t)
+}

--- a/frontend/src/pages/ConfigEmpresaEmail.tsx
+++ b/frontend/src/pages/ConfigEmpresaEmail.tsx
@@ -604,7 +604,7 @@ export function ConfigEmpresaEmail({ embedded = false, section }: ConfigEmpresaE
                 </div>
               ) : (
                 <p className="mt-1.5">
-                  Indisponível neste servidor. A equipa de operação deve definir{' '}
+                  Indisponível neste servidor. A equipe de operação deve definir{' '}
                   <span className="font-mono">RESEND_API_KEY</span> e{' '}
                   <span className="font-mono">TRANSACTIONAL_FROM_EMAIL</span> no ambiente (VPS). Enquanto isso, os
                   tickets por encaminhamento funcionam; respostas ao cliente pelo painel não saem por e-mail.

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -203,7 +203,7 @@ function LoginConta() {
           </div>
           {isSaasControlPlaneFrontend() ? (
             <p className="text-center text-xs text-slate-500">
-              Equipa DeskRudder?{' '}
+              Equipe DeskRudder?{' '}
               <Link to="/login/admin" className="font-medium text-sky-300 hover:text-sky-200">
                 Acesso ao painel admin
               </Link>
@@ -510,7 +510,7 @@ function LoginCredenciais({ variant = 'tenant' }: { variant?: 'tenant' | 'ops' }
       const me = await atendentes.me()
       if (isOps && me.role !== 'saas_ops') {
         logout()
-        showError('Esta conta não é da equipa SaaS. Use o login do atendimento (/login).')
+        showError('Esta conta não é da equipe SaaS. Use o login do atendimento (/login).')
         return
       }
       if (!isOps && me.role === 'saas_ops') {
@@ -548,7 +548,7 @@ function LoginCredenciais({ variant = 'tenant' }: { variant?: 'tenant' | 'ops' }
         <>
           <p className="text-center text-xs leading-relaxed text-slate-500">
             {isOps
-              ? 'Acesso da equipa DeskRudder — gestão de licenças, leads e instâncias SaaS.'
+              ? 'Acesso da equipe DeskRudder — gestão de licenças, leads e instâncias SaaS.'
               : 'Use o usuário cadastrado pelo administrador. Problemas para acessar? Contate o suporte interno.'}
           </p>
           <div className="flex flex-col gap-2.5">
@@ -571,9 +571,11 @@ function LoginCredenciais({ variant = 'tenant' }: { variant?: 'tenant' | 'ops' }
           <div className="space-y-1.5 text-center">
             <p className="text-xs font-semibold uppercase tracking-[0.14em] text-sky-300/90">Painel admin</p>
             <h1 className="text-xl font-semibold text-white sm:text-2xl">Gestão SaaS DeskRudder</h1>
-            <p className="text-sm text-slate-400">
-              Conta da equipa comercial (role saas_ops). Em local: ops@deskrudder.local
-            </p>
+            {import.meta.env.DEV ? (
+              <p className="text-sm text-slate-400">
+                Desenvolvimento: ops@deskrudder.local
+              </p>
+            ) : null}
           </div>
         ) : null}
         <div>

--- a/frontend/src/pages/MinhasSolicitacoes.tsx
+++ b/frontend/src/pages/MinhasSolicitacoes.tsx
@@ -127,7 +127,7 @@ export function MinhasSolicitacoesPage() {
             ))}
             {detalhe.comentarios.map((c) => (
               <Card key={`c-${c.id}`} className="p-3 text-sm">
-                <p className="text-xs font-medium text-slate-500">{c.autor_nome || 'Equipa'} · {fmt(c.created_at)}</p>
+                <p className="text-xs font-medium text-slate-500">{c.autor_nome || 'Equipe'} · {fmt(c.created_at)}</p>
                 <p className="mt-1 whitespace-pre-wrap text-slate-700 dark:text-slate-200">{c.corpo}</p>
               </Card>
             ))}
@@ -142,14 +142,14 @@ export function MinhasSolicitacoesPage() {
               rows={3}
               value={resposta}
               onChange={(e) => setResposta(e.target.value)}
-              placeholder="Escreva uma mensagem para a equipa…"
+              placeholder="Escreva uma mensagem para a equipe…"
             />
             <Button type="button" variant="primary" loading={enviando} onClick={() => void enviarResposta()}>
               Enviar resposta
             </Button>
           </Card>
         ) : STATUS_FINAIS.has(detalhe.status) ? (
-          <p className="text-sm text-slate-500">Este pedido está encerrado e já não aceita respostas.</p>
+          <p className="text-sm text-slate-500">Este pedido está encerrado e não aceita mais respostas.</p>
         ) : null}
       </PageContainer>
     )

--- a/frontend/src/pages/Sobre.tsx
+++ b/frontend/src/pages/Sobre.tsx
@@ -5,7 +5,7 @@ import { APP_DESCRIPTION, APP_NAME } from '../brand'
 import { ReleaseNotesView } from '../components/release/ReleaseNotesView'
 import { useToast } from '../components/ui/Toast'
 
-/** Página Sobre do DeskRudder — só notas product=deskrudder (#674). */
+/** Página Sobre do DeskRudder — só notas de produto (#674 / #920). */
 export function Sobre() {
   const toast = useToast()
   const [loading, setLoading] = useState(true)
@@ -47,7 +47,7 @@ export function Sobre() {
       backTo="/"
       title="Sobre"
       brandCaption={APP_DESCRIPTION}
-      description={`Consulte a versão em uso e o que mudou nas atualizações do ${APP_NAME} nesta instância (helpdesk). Melhorias do painel SaaS não aparecem aqui.`}
+      description={`Consulte a versão em uso e o que mudou nas atualizações do ${APP_NAME} nesta instância (helpdesk). Melhorias de DevOps não aparecem aqui.`}
       versionLabel={versionLabel}
       notes={notes}
       loading={loading}

--- a/frontend/src/pages/saas/SaasConta.tsx
+++ b/frontend/src/pages/saas/SaasConta.tsx
@@ -69,7 +69,7 @@ export function SaasConta() {
       toast.showSuccess(
         estado?.configurado
           ? 'Token regenerado. O anterior deixa de funcionar no Cursor.'
-          : 'Token gerado. Copie agora — não voltamos a mostrá-lo.',
+          : 'Token gerado. Copie agora — não vamos mostrar de novo.',
       )
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível gerar o token.'))
@@ -107,7 +107,7 @@ export function SaasConta() {
   if (forbidden) {
     return (
       <SemPermissao
-        title="Conta exclusiva da equipa SaaS."
+        title="Conta exclusiva da equipe SaaS."
         detail="Entre com a conta ops em /login/admin."
         voltarPara="/login/admin"
         voltarLabel="Voltar ao login admin"
@@ -140,24 +140,24 @@ export function SaasConta() {
       <VoltarButton onClick={voltarAnterior} />
       <Card
         title="Integração Cursor"
-        description="O token identifica a tua conta ops nas sugestões (recusar, comentar, ligar issue). Cada pessoa gera o seu. Novas contas criam-se em Equipa."
+        description="O token identifica a sua conta ops nas sugestões (recusar, comentar, ligar issue). Cada pessoa gera o próprio. Novas contas são criadas em Usuários."
       >
         {loading || !estado ? (
-          <p className="text-sm text-slate-500">A carregar…</p>
+          <p className="text-sm text-slate-500">Carregando…</p>
         ) : (
           <div className="space-y-4">
             <p className="text-sm text-slate-600 dark:text-slate-400">
               {estado.configurado
-                ? `Token activo. Gerado em ${formatWhen(estado.gerado_em)}.`
+                ? `Token ativo. Gerado em ${formatWhen(estado.gerado_em)}.`
                 : 'Ainda não há token nesta conta.'}{' '}
               <Link to="/saas/usuarios" className="font-medium text-sky-700 underline dark:text-sky-300">
-                Gerir equipa
+                Gerir equipe
               </Link>
             </p>
             {plaintext ? (
               <div className="space-y-2">
                 <label htmlFor="mcp-token-plain" className="block text-sm font-medium text-slate-700 dark:text-slate-300">
-                  Copie agora — não voltamos a mostrar o valor completo
+                  Copie agora — não vamos mostrar o valor completo de novo
                 </label>
                 <textarea
                   id="mcp-token-plain"

--- a/frontend/src/pages/saas/SaasLayout.tsx
+++ b/frontend/src/pages/saas/SaasLayout.tsx
@@ -9,6 +9,12 @@ import { SemPermissao } from '../SemPermissao'
 import { isSaasControlPlaneFrontend, SAAS_LICENCAS_PATH } from '../../lib/saasControlPlane'
 import { system } from '../../api/client'
 
+const logoutIcon = (
+  <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
+  </svg>
+)
+
 const menuIcon = (
   <svg className="size-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
@@ -34,6 +40,12 @@ export function SaasLayout() {
   const [sidebarExpanded, setSidebarExpanded] = useState(true)
   const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false)
   const [planeOk, setPlaneOk] = useState<boolean | null>(null)
+  const [versionLabel, setVersionLabel] = useState<string | null>(() => {
+    const fromEnv =
+      (import.meta.env.VITE_APP_VERSION_DISPLAY as string | undefined)?.trim() ||
+      (import.meta.env.VITE_APP_VERSION as string | undefined)?.trim()
+    return fromEnv ? (fromEnv.startsWith('v') ? fromEnv : `v${fromEnv}`) : null
+  })
   const logoOnDark = resolved === 'dark'
 
   useEffect(() => {
@@ -43,19 +55,15 @@ export function SaasLayout() {
         cancelled = true
       }
     }
-    if (isSaasControlPlaneFrontend()) {
-      setPlaneOk(true)
-      return () => {
-        cancelled = true
-      }
-    }
     system
       .info()
       .then((info) => {
-        if (!cancelled) setPlaneOk(Boolean(info.saas_control_plane))
+        if (cancelled) return
+        if (info.version_display) setVersionLabel(info.version_display)
+        setPlaneOk(isSaasControlPlaneFrontend() || Boolean(info.saas_control_plane))
       })
       .catch(() => {
-        if (!cancelled) setPlaneOk(false)
+        if (!cancelled) setPlaneOk(isSaasControlPlaneFrontend())
       })
     return () => {
       cancelled = true
@@ -75,7 +83,7 @@ export function SaasLayout() {
     return (
       <div className="flex min-h-dvh items-center justify-center bg-slate-50 p-6 dark:bg-slate-950">
         <SemPermissao
-          title="Este painel é exclusivo da equipa SaaS DeskRudder."
+          title="Este painel é exclusivo da equipe SaaS DeskRudder."
           detail="Use o login do atendimento (/login) para tickets e chat, ou entre com a conta ops em /login/admin."
           voltarPara="/login"
           voltarLabel="Ir para login do atendimento"
@@ -147,7 +155,7 @@ export function SaasLayout() {
             <p className="mt-1 text-xs text-slate-500 dark:text-slate-500">Licenças, planos, leads e sugestões</p>
           ) : null}
         </div>
-        <nav className="flex flex-1 flex-col gap-1 p-3" onClick={() => setSidebarMobileOpen(false)}>
+        <nav className="flex flex-1 flex-col gap-1 overflow-y-auto p-3" onClick={() => setSidebarMobileOpen(false)}>
           <NavLink to={SAAS_LICENCAS_PATH} className={navLinkClass} end={false}>
             <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Licenças' : 'Lic'}</span>
           </NavLink>
@@ -160,30 +168,71 @@ export function SaasLayout() {
           <NavLink to="/saas/solicitacoes" className={navLinkClass}>
             <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Sugestões' : 'Sug'}</span>
           </NavLink>
+          {sidebarExpanded || sidebarMobileOpen ? (
+            <p className="mt-3 px-3 pt-2 text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-slate-400 dark:text-slate-500">
+              Equipe
+            </p>
+          ) : (
+            <div className="my-2 hidden border-t border-slate-200 dark:border-slate-800 md:block" />
+          )}
           <NavLink to="/saas/usuarios" className={navLinkClass}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Equipa' : 'Eq'}</span>
+            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Usuários' : 'Usr'}</span>
           </NavLink>
           <NavLink to="/saas/conta" className={navLinkClass}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Conta / Cursor' : 'Conta'}</span>
-          </NavLink>
-          <NavLink to="/saas/sobre" className={navLinkClass}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Sobre' : 'Info'}</span>
+            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Minha conta' : 'Conta'}</span>
           </NavLink>
         </nav>
-        <div className="border-t border-slate-200 p-3 dark:border-slate-800">
-          {sidebarExpanded || sidebarMobileOpen ? (
-            <div className="mb-3 px-1">
-              <p className="truncate text-sm font-medium text-slate-900 dark:text-white">{user.nome}</p>
-              <p className="truncate text-xs text-slate-500">Ops SaaS</p>
+        <div className={`shrink-0 border-t border-slate-200 p-2 dark:border-slate-800 ${sidebarExpanded ? '' : 'md:px-2'}`}>
+          {(sidebarExpanded || sidebarMobileOpen) ? (
+            <div className="flex items-center gap-3 px-3 py-2 text-slate-600 dark:text-slate-400">
+              <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-cyan-500 to-blue-600 text-xs font-semibold text-white shadow-sm shadow-cyan-500/25">
+                {user.nome?.charAt(0)?.toUpperCase() ?? '?'}
+              </span>
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{user.nome}</p>
+                <p className="truncate text-xs text-slate-500 dark:text-slate-400">Ops SaaS</p>
+              </div>
             </div>
           ) : null}
           <button
             type="button"
             onClick={handleLogout}
-            className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-50 hover:text-slate-900 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-white/5 dark:hover:text-white"
+            title="Sair"
+            className={`mt-2 flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium text-slate-600 hover:bg-slate-100 active:bg-slate-200 touch-manipulation min-h-[44px] dark:text-slate-400 dark:hover:bg-slate-800 dark:active:bg-slate-700 ${
+              sidebarExpanded || sidebarMobileOpen ? '' : 'md:justify-center md:px-2'
+            }`}
           >
-            {sidebarExpanded || sidebarMobileOpen ? 'Sair' : '⎋'}
+            {logoutIcon}
+            <span
+              className={
+                sidebarExpanded || sidebarMobileOpen
+                  ? 'min-w-0 truncate'
+                  : 'min-w-0 truncate md:hidden'
+              }
+            >
+              Sair
+            </span>
           </button>
+          <NavLink
+            to="/saas/sobre"
+            title="Sobre / novidades"
+            onClick={() => setSidebarMobileOpen(false)}
+            className={({ isActive }) =>
+              [
+                'mt-2 flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs font-medium text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800/80 dark:hover:text-slate-200',
+                sidebarExpanded || sidebarMobileOpen ? '' : 'md:justify-center md:px-2',
+                isActive ? 'bg-slate-100 text-slate-800 dark:bg-slate-800/80 dark:text-slate-100' : '',
+              ].join(' ')
+            }
+          >
+            <span className={`truncate ${sidebarExpanded || sidebarMobileOpen ? '' : 'md:text-[10px]'}`}>
+              {sidebarExpanded || sidebarMobileOpen
+                ? versionLabel
+                  ? `Sobre · ${versionLabel}`
+                  : 'Sobre'
+                : versionLabel || 'Sobre'}
+            </span>
+          </NavLink>
         </div>
       </aside>
 

--- a/frontend/src/pages/saas/SaasSobre.tsx
+++ b/frontend/src/pages/saas/SaasSobre.tsx
@@ -5,7 +5,7 @@ import { ReleaseNotesView } from '../../components/release/ReleaseNotesView'
 import { useToast } from '../../components/ui/Toast'
 import { SAAS_LICENCAS_PATH } from '../../lib/saasControlPlane'
 
-/** Novidades do control-plane SaaS (#675). */
+/** Novidades do painel ops — todas as notas da versão, com tags (#920). */
 export function SaasSobre() {
   const toast = useToast()
   const [loading, setLoading] = useState(true)
@@ -24,7 +24,7 @@ export function SaasSobre() {
       })
       .catch((err) => {
         if (!cancelled) {
-          toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar as novidades do SaaS.'))
+          toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar as novidades.'))
         }
       })
       .finally(() => {
@@ -47,12 +47,13 @@ export function SaasSobre() {
       backTo={SAAS_LICENCAS_PATH}
       backLabel="Voltar às licenças"
       title="Sobre / Novidades"
-      brandCaption="Painel admin SaaS — licenças, planos e provisionamento."
-      description="Atualizações do control-plane DeskRudder (ops). Notas do helpdesk nas instâncias dos clientes ficam em Sobre no painel de atendimento."
+      brandCaption="Painel admin — licenças, planos e provisionamento."
+      description="As mesmas notas da versão, com etiqueta Produto (helpdesk nas instâncias) ou DevOps (este painel). No DeskRudder o cliente vê só as de produto."
       versionLabel={versionLabel}
       notes={notes}
       loading={loading}
       showBrandLogo
+      showProductTags
     />
   )
 }

--- a/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
@@ -5,23 +5,21 @@ import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/
 import { Button } from '../../components/ui/Button'
 import { Card } from '../../components/ui/Card'
 import { CarregamentoFalhou } from '../../components/ui/CarregamentoFalhou'
-import { DetailRow } from '../../components/ui/DetailRow'
 import { Input, TEXTAREA_FIELD_CLASS } from '../../components/ui/Input'
-import { Select } from '../../components/ui/Select'
 import { useToast } from '../../components/ui/Toast'
 import { VoltarButton } from '../../components/ui/VoltarButton'
 import { useVoltarAnterior } from '../../hooks/useVoltarAnterior'
 import { SolicitacaoDescricao } from '../../components/release/SolicitacaoDescricao'
+import {
+  classesBadgeStatusSolicitacao,
+  mencionaTrabalhoInterno,
+  rotuloStatusSolicitacao,
+  SAAS_SOLICITACAO_STATUS,
+} from '../../lib/saasSolicitacoes'
 import { SemPermissao } from '../SemPermissao'
 
-const STATUS_OPTS = [
-  { value: 'aberta', label: 'Recebida' },
-  { value: 'em_analise', label: 'Em análise' },
-  { value: 'planejada', label: 'Planejada' },
-  { value: 'em_desenvolvimento', label: 'Em desenvolvimento' },
-  { value: 'concluida', label: 'Concluída' },
-  { value: 'nao_sera_desenvolvida', label: 'Não será desenvolvida' },
-]
+const STATUS_FLUXO = SAAS_SOLICITACAO_STATUS.filter((s) => s.value !== 'nao_sera_desenvolvida')
+const STATUS_REJEITAR = SAAS_SOLICITACAO_STATUS.find((s) => s.value === 'nao_sera_desenvolvida')!
 
 function formatWhen(iso: string | null | undefined): string {
   if (!iso) return '—'
@@ -34,6 +32,16 @@ function formatWhen(iso: string | null | undefined): string {
 
 function rotuloTipo(tipo: string): string {
   return tipo === 'problema' ? 'Problema' : 'Sugestão'
+}
+
+function StatusBadge({ status, rotulo }: { status: string; rotulo?: string }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeStatusSolicitacao(status)}`}
+    >
+      {rotulo || rotuloStatusSolicitacao(status)}
+    </span>
+  )
 }
 
 export function SaasSolicitacaoDetalhe() {
@@ -52,7 +60,7 @@ export function SaasSolicitacaoDetalhe() {
   const [novoStatus, setNovoStatus] = useState('em_analise')
   const [motivo, setMotivo] = useState('')
   const [comentario, setComentario] = useState('')
-  const [publico, setPublico] = useState(true)
+  const [tipoMensagem, setTipoMensagem] = useState<'publico' | 'interno'>('publico')
   const [buscaIgual, setBuscaIgual] = useState('')
   const [candidatos, setCandidatos] = useState<SaasSolicitacoesProduto.ListaItem[]>([])
 
@@ -121,17 +129,17 @@ export function SaasSolicitacaoDetalhe() {
     return () => clearTimeout(t)
   }, [buscaIgual, item])
 
-  async function salvarStatus() {
+  async function persistirStatus(status: string, motivoTexto?: string) {
     if (!item) return
     setBusy(true)
     try {
       const atualizado = await saasSolicitacoes.alterarStatus(item.id, {
-        status: novoStatus,
+        status,
         motivo_nao_desenvolvimento:
-          novoStatus === 'nao_sera_desenvolvida' ? motivo.trim() || null : undefined,
+          status === 'nao_sera_desenvolvida' ? motivoTexto?.trim() || null : undefined,
       })
       aplicarDetalhe(atualizado)
-      toast.showSuccess('Status actualizado. O cliente vê o andamento em Minhas solicitações.')
+      toast.showSuccess('Status atualizado. O cliente vê o andamento em Minhas solicitações.')
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar o status'))
     } finally {
@@ -139,8 +147,30 @@ export function SaasSolicitacaoDetalhe() {
     }
   }
 
+  async function escolherStatus(status: string) {
+    setNovoStatus(status)
+    if (status === 'nao_sera_desenvolvida') return
+    if (item && status === item.status) return
+    await persistirStatus(status)
+  }
+
+  async function confirmarRejeicao() {
+    if (!motivo.trim()) {
+      toast.showError('Informe um motivo amigável para o cliente.')
+      return
+    }
+    await persistirStatus('nao_sera_desenvolvida', motivo)
+  }
+
   async function enviarComentario() {
     if (!item || !comentario.trim()) return
+    const publico = tipoMensagem === 'publico'
+    if (publico && mencionaTrabalhoInterno(comentario)) {
+      toast.showError(
+        'Não envie links ou números de issue do GitHub na mensagem ao cliente. Use comentário interno.',
+      )
+      return
+    }
     setBusy(true)
     try {
       const atualizado = await saasSolicitacoes.comentar(item.id, {
@@ -149,7 +179,7 @@ export function SaasSolicitacaoDetalhe() {
       })
       aplicarDetalhe(atualizado)
       setComentario('')
-      toast.showSuccess(publico ? 'Resposta pública enviada ao cliente' : 'Nota interna registada (só no SaaS)')
+      toast.showSuccess(publico ? 'Resposta pública enviada ao cliente' : 'Nota interna registada (só neste painel)')
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Falha ao comentar'))
     } finally {
@@ -230,18 +260,32 @@ export function SaasSolicitacaoDetalhe() {
   }
   if (!item) return null
 
+  const comentarios = [...(item.comentarios || [])].sort(
+    (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+  )
+  const rejeitarPendente = novoStatus === 'nao_sera_desenvolvida' && item.status !== 'nao_sera_desenvolvida'
+  const internoActivo = tipoMensagem === 'interno'
+
   return (
     <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
       <VoltarButton onClick={voltarAnterior} />
 
       <header className="flex flex-wrap items-start justify-between gap-4">
-        <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-            {item.protocolo || 'Sem protocolo'} · {rotuloTipo(item.tipo)}
-          </p>
+        <div className="min-w-0 space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="font-mono text-xs font-semibold tracking-wide text-slate-500 dark:text-slate-400">
+              {item.protocolo || 'Sem protocolo'}
+            </p>
+            <span className="text-slate-300 dark:text-slate-600">·</span>
+            <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">
+              {rotuloTipo(item.tipo)}
+            </span>
+            <StatusBadge status={item.status} rotulo={item.status_rotulo} />
+          </div>
           <h1 className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-slate-50">{item.titulo}</h1>
           <p className="text-sm text-slate-500">
             {item.cliente_nome || item.instance_slug}
+            {item.autor_nome ? ` · ${item.autor_nome}` : ''}
             {item.versao_contexto ? ` · v${item.versao_contexto}` : ''}
             {(item.peso_clientes || 1) > 1 ? ` · ${item.peso_clientes} clientes pediram o mesmo` : ''}
           </p>
@@ -253,175 +297,309 @@ export function SaasSolicitacaoDetalhe() {
         ) : null}
       </header>
 
-      <Card title="Pedido">
-        <SolicitacaoDescricao descricao={item.descricao} anexos={item.anexos} />
-        <dl className="mt-4">
-          <DetailRow label="Protocolo" value={item.protocolo || '—'} mono />
-          <DetailRow label="Cliente" value={item.cliente_nome || '—'} />
-          <DetailRow label="Slug" value={item.instance_slug} mono />
-          <DetailRow label="Autor" value={item.autor_nome || '—'} />
-          <DetailRow label="Status" value={item.status_rotulo} />
-          <DetailRow label="Versão" value={item.versao_contexto || '—'} />
-          <DetailRow label="Aberto em" value={formatWhen(item.created_at_origem)} />
-          <DetailRow label="Recebido no SaaS" value={formatWhen(item.ingested_at)} />
-          <DetailRow
-            label="Peso"
-            value={
-              (item.peso_clientes || 1) > 1
-                ? `${item.peso_clientes} clientes · ${item.pedidos_grupo} pedidos`
-                : '1 cliente'
-            }
-          />
-        </dl>
-      </Card>
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_21rem] xl:items-start">
+        <aside className="space-y-6 xl:col-start-2 xl:row-start-1">
+          <Card title="Status" description="O cliente vê este andamento em Minhas solicitações.">
+            <nav className="space-y-1.5" aria-label="Status da triagem">
+              {STATUS_FLUXO.map((s) => {
+                const activo = novoStatus === s.value
+                return (
+                  <button
+                    key={s.value}
+                    type="button"
+                    disabled={busy}
+                    onClick={() => void escolherStatus(s.value)}
+                    className={`flex w-full items-center gap-2.5 rounded-xl border px-3 py-2 text-left text-sm transition disabled:opacity-60 ${
+                      activo
+                        ? 'border-cyan-300 bg-cyan-50/90 ring-1 ring-cyan-400/25 dark:border-cyan-700/60 dark:bg-cyan-950/35 dark:ring-cyan-600/30'
+                        : 'border-slate-200 bg-white hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 dark:hover:bg-slate-800/50'
+                    }`}
+                  >
+                    <span
+                      className={`size-2 shrink-0 rounded-full ${activo ? 'bg-cyan-500' : 'bg-slate-300 dark:bg-slate-600'}`}
+                    />
+                    <span className={`min-w-0 flex-1 font-medium ${activo ? 'text-slate-900 dark:text-slate-50' : 'text-slate-700 dark:text-slate-200'}`}>
+                      {s.label}
+                    </span>
+                    {item.status === s.value ? (
+                      <span className="text-[10px] font-semibold uppercase tracking-wide text-cyan-700 dark:text-cyan-300">
+                        atual
+                      </span>
+                    ) : null}
+                  </button>
+                )
+              })}
+              <div className="my-2 border-t border-slate-100 dark:border-slate-800" />
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void escolherStatus(STATUS_REJEITAR.value)}
+                className={`flex w-full items-center gap-2.5 rounded-xl border px-3 py-2 text-left text-sm transition disabled:opacity-60 ${
+                  novoStatus === STATUS_REJEITAR.value
+                    ? 'border-rose-300 bg-rose-50/90 ring-1 ring-rose-400/25 dark:border-rose-800/60 dark:bg-rose-950/35 dark:ring-rose-700/30'
+                    : 'border-slate-200 bg-white hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 dark:hover:bg-slate-800/50'
+                }`}
+              >
+                <span
+                  className={`size-2 shrink-0 rounded-full ${novoStatus === STATUS_REJEITAR.value ? 'bg-rose-500' : 'bg-slate-300 dark:bg-slate-600'}`}
+                />
+                <span className="min-w-0 flex-1 font-medium text-slate-700 dark:text-slate-200">
+                  {STATUS_REJEITAR.label}
+                </span>
+                {item.status === STATUS_REJEITAR.value ? (
+                  <span className="text-[10px] font-semibold uppercase tracking-wide text-rose-700 dark:text-rose-300">
+                    atual
+                  </span>
+                ) : null}
+              </button>
+            </nav>
+            {novoStatus === 'nao_sera_desenvolvida' ? (
+              <div className="mt-3 space-y-2">
+                <textarea
+                  className={TEXTAREA_FIELD_CLASS}
+                  rows={3}
+                  value={motivo}
+                  onChange={(e) => setMotivo(e.target.value)}
+                  placeholder="Motivo amigável para o cliente (obrigatório)"
+                />
+                <Button type="button" variant="primary" loading={busy} onClick={() => void confirmarRejeicao()}>
+                  {rejeitarPendente ? 'Salvar e informar o cliente' : 'Atualizar motivo'}
+                </Button>
+              </div>
+            ) : null}
+            <p className="mt-3 text-xs text-slate-500 dark:text-slate-400">
+              Aberto {formatWhen(item.created_at_origem)} · no SaaS {formatWhen(item.ingested_at)}
+            </p>
+          </Card>
 
-      <Card title="Pedidos iguais">
-        <p className="text-sm text-slate-500">
-          Só neste painel. O cliente não vê quem mais pediu a mesma coisa. Na issue, cola o bloco de protocolos.
-        </p>
-        {(item.grupo || []).length > 1 ? (
-          <ul className="mt-3 space-y-2">
-            {(item.grupo || []).map((m) => (
-              <li key={m.id} className="flex flex-wrap items-center justify-between gap-2 text-sm">
+          {item.github_issue_url ? (
+            <Card title="Issue no GitHub" description="Só neste painel — o cliente não vê o link.">
+              <a
+                href={item.github_issue_url}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex text-sm font-medium text-cyan-700 hover:underline dark:text-cyan-400"
+              >
+                {item.github_issue_number ? `#${item.github_issue_number}` : item.github_issue_url}
+              </a>
+            </Card>
+          ) : null}
+
+          <Card title="Pedidos iguais" description="Só neste painel. O cliente não vê quem mais pediu o mesmo.">
+            {(item.grupo || []).length > 1 ? (
+              <ul className="space-y-2">
+                {(item.grupo || []).map((m) => (
+                  <li key={m.id} className="flex flex-wrap items-center justify-between gap-2 text-sm">
+                    <button
+                      type="button"
+                      className="text-left font-medium text-cyan-800 hover:underline dark:text-cyan-300"
+                      onClick={() => navigate(`/saas/solicitacoes/${m.id}`)}
+                    >
+                      <span className="font-mono">{m.protocolo || `#${m.id}`}</span>
+                      {' · '}
+                      {m.cliente_nome || m.instance_slug}
+                    </button>
+                    {m.id !== item.id ? (
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        disabled={busy}
+                        onClick={() => void desvincularPedido(m.id)}
+                      >
+                        Desvincular
+                      </Button>
+                    ) : (
+                      <span className="text-xs text-slate-400">este pedido</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-slate-500">Ainda não está ligado a outros pedidos.</p>
+            )}
+            {item.texto_github_demanda ? (
+              <div className="mt-3 space-y-2">
+                <pre className="whitespace-pre-wrap rounded-lg bg-slate-50 p-3 text-xs text-slate-700 dark:bg-slate-900/60 dark:text-slate-200">
+                  {item.texto_github_demanda}
+                </pre>
+                <Button type="button" variant="secondary" onClick={() => void copiarDemandaGithub()}>
+                  Copiar para a issue
+                </Button>
+              </div>
+            ) : null}
+            <div className="mt-4 space-y-2">
+              <Input
+                label="Vincular outro pedido"
+                placeholder="Protocolo, título ou cliente…"
+                value={buscaIgual}
+                onChange={(e) => setBuscaIgual(e.target.value)}
+              />
+              {candidatos.length > 0 ? (
+                <ul className="space-y-1">
+                  {candidatos.map((c) => (
+                    <li key={c.id} className="flex flex-wrap items-center justify-between gap-2 text-sm">
+                      <span>
+                        <span className="font-mono text-cyan-800 dark:text-cyan-300">{c.protocolo || `#${c.id}`}</span>
+                        {' · '}
+                        {c.cliente_nome || c.instance_slug} — {c.titulo}
+                      </span>
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        disabled={busy}
+                        onClick={() => void vincularPedido({ id: c.id, protocolo: c.protocolo })}
+                      >
+                        Vincular
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          </Card>
+        </aside>
+
+        <div className="space-y-4 xl:col-start-1 xl:row-start-1">
+          <Card
+            title="Linha do tempo"
+            description="O pedido e o que o cliente vê. Notas internas ficam só neste painel (cartão âmbar)."
+          >
+            <ol className="relative space-y-4 border-l border-slate-200 pl-5 dark:border-slate-700">
+              <li className="relative">
+                <span className="absolute -left-[1.45rem] mt-1.5 size-2.5 rounded-full bg-slate-400 ring-4 ring-white dark:bg-slate-500 dark:ring-slate-900" />
+                <div className="rounded-xl border border-slate-200 border-l-4 border-l-slate-500 bg-slate-50/90 px-4 py-3 text-sm dark:border-slate-600 dark:border-l-slate-400 dark:bg-slate-800/50">
+                  <div className="flex flex-wrap items-center justify-between gap-2 border-b border-slate-200/70 pb-2 text-xs dark:border-slate-600/80">
+                    <span className="font-semibold text-slate-800 dark:text-slate-100">Pedido do cliente</span>
+                    <span className="text-slate-500 dark:text-slate-400">{formatWhen(item.created_at_origem)}</span>
+                  </div>
+                  <div className="mt-3">
+                    <SolicitacaoDescricao descricao={item.descricao} anexos={item.anexos} />
+                  </div>
+                  <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                    {item.autor_nome || 'Cliente'}
+                    {item.instance_slug ? ` · ${item.instance_slug}` : ''}
+                  </p>
+                </div>
+              </li>
+
+              {comentarios.map((c) => {
+                const interno = !c.publico_cliente
+                return (
+                  <li key={c.id} className="relative">
+                    <span
+                      className={`absolute -left-[1.45rem] mt-1.5 size-2.5 rounded-full ring-4 ring-white dark:ring-slate-900 ${
+                        interno ? 'bg-amber-500' : 'bg-cyan-500'
+                      }`}
+                    />
+                    <div
+                      className={`rounded-xl border px-4 py-3 text-sm ${
+                        interno
+                          ? 'border-amber-200/90 bg-amber-50/60 dark:border-amber-800/50 dark:bg-amber-950/25'
+                          : 'border-slate-200/90 bg-white shadow-sm dark:border-slate-600 dark:bg-slate-800/45 dark:shadow-none'
+                      }`}
+                    >
+                      <div
+                        className={`flex flex-wrap items-center justify-between gap-2 border-b pb-2 text-xs ${
+                          interno
+                            ? 'border-amber-200/50 dark:border-amber-800/40'
+                            : 'border-slate-200/60 dark:border-slate-600/80'
+                        }`}
+                      >
+                        <span className="font-semibold text-slate-800 dark:text-slate-100">
+                          {interno ? 'Nota interna' : 'Mensagem ao cliente'}
+                        </span>
+                        {interno ? (
+                          <span className="rounded-md bg-amber-100/90 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-amber-900 dark:bg-amber-900/50 dark:text-amber-100">
+                            Só equipe
+                          </span>
+                        ) : (
+                          <span className="rounded-md bg-cyan-50 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-cyan-800 dark:bg-cyan-950/50 dark:text-cyan-100">
+                            Visível ao cliente
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-2 whitespace-pre-wrap text-slate-800 dark:text-slate-200">{c.corpo}</p>
+                      <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                        {c.autor_nome || '—'} · {formatWhen(c.created_at)}
+                      </p>
+                    </div>
+                  </li>
+                )
+              })}
+            </ol>
+
+            {comentarios.length === 0 ? (
+              <p className="mt-4 text-sm text-slate-500 dark:text-slate-400">
+                Ainda não há respostas. O que enviares como mensagem ao cliente aparece em Minhas solicitações.
+              </p>
+            ) : null}
+
+            <div className="mt-5 border-t border-slate-200 pt-4 dark:border-slate-800">
+              <p className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-300">Nova mensagem</p>
+              <div className="mb-3 inline-flex rounded-xl bg-slate-100 p-1 ring-1 ring-slate-200/80 dark:bg-slate-800/90 dark:ring-slate-600/80">
                 <button
                   type="button"
-                  className="text-left font-medium text-cyan-800 hover:underline dark:text-cyan-300"
-                  onClick={() => navigate(`/saas/solicitacoes/${m.id}`)}
+                  onClick={() => setTipoMensagem('publico')}
+                  className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+                    tipoMensagem === 'publico'
+                      ? 'bg-white text-slate-900 shadow-sm dark:bg-slate-700 dark:text-slate-100 dark:shadow-none dark:ring-1 dark:ring-slate-500/30'
+                      : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200'
+                  }`}
                 >
-                  <span className="font-mono">{m.protocolo || `#${m.id}`}</span>
-                  {' · '}
-                  {m.cliente_nome || m.instance_slug}
+                  Mensagem ao cliente
                 </button>
-                {m.id !== item.id ? (
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    disabled={busy}
-                    onClick={() => void desvincularPedido(m.id)}
-                  >
-                    Desvincular
-                  </Button>
-                ) : (
-                  <span className="text-xs text-slate-400">este pedido</span>
-                )}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="mt-2 text-sm text-slate-500">Ainda não está ligado a outros pedidos.</p>
-        )}
-        {item.texto_github_demanda ? (
-          <div className="mt-3 space-y-2">
-            <pre className="whitespace-pre-wrap rounded-lg bg-slate-50 p-3 text-xs text-slate-700 dark:bg-slate-900/60 dark:text-slate-200">
-              {item.texto_github_demanda}
-            </pre>
-            <Button type="button" variant="secondary" onClick={() => void copiarDemandaGithub()}>
-              Copiar para a issue
-            </Button>
-          </div>
-        ) : null}
-        <div className="mt-4 space-y-2">
-          <Input
-            label="Vincular outro pedido"
-            placeholder="Protocolo, título ou cliente…"
-            value={buscaIgual}
-            onChange={(e) => setBuscaIgual(e.target.value)}
-          />
-          {candidatos.length > 0 ? (
-            <ul className="space-y-1">
-              {candidatos.map((c) => (
-                <li key={c.id} className="flex flex-wrap items-center justify-between gap-2 text-sm">
-                  <span>
-                    <span className="font-mono text-cyan-800 dark:text-cyan-300">{c.protocolo || `#${c.id}`}</span>
-                    {' · '}
-                    {c.cliente_nome || c.instance_slug} — {c.titulo}
-                  </span>
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    disabled={busy}
-                    onClick={() => void vincularPedido({ id: c.id, protocolo: c.protocolo })}
-                  >
-                    Vincular
-                  </Button>
-                </li>
-              ))}
-            </ul>
-          ) : null}
-        </div>
-      </Card>
-
-      {item.github_issue_url ? (
-        <Card title="Issue no GitHub">
-          <p className="text-sm text-slate-600 dark:text-slate-300">
-            Ligada pelo Cursor. Cole os protocolos do grupo no corpo da issue. O cliente não vê este link.
-          </p>
-          <a
-            href={item.github_issue_url}
-            target="_blank"
-            rel="noreferrer"
-            className="mt-2 inline-flex text-sm font-medium text-cyan-700 hover:underline dark:text-cyan-400"
-          >
-            {item.github_issue_url}
-          </a>
-        </Card>
-      ) : null}
-
-      <Card title="Triagem">
-        <div className="space-y-3">
-          <Select
-            value={novoStatus}
-            onChange={(v) => setNovoStatus(String(v))}
-            options={STATUS_OPTS}
-          />
-          {novoStatus === 'nao_sera_desenvolvida' ? (
-            <textarea
-              className={TEXTAREA_FIELD_CLASS}
-              rows={3}
-              value={motivo}
-              onChange={(e) => setMotivo(e.target.value)}
-              placeholder="Motivo amigável para o cliente (obrigatório)"
-            />
-          ) : null}
-          <Button type="button" variant="primary" loading={busy} onClick={() => void salvarStatus()}>
-            Guardar status
-          </Button>
-        </div>
-      </Card>
-
-      <Card title="Resposta / nota">
-        <div className="space-y-3">
-          <textarea
-            className={TEXTAREA_FIELD_CLASS}
-            rows={3}
-            value={comentario}
-            onChange={(e) => setComentario(e.target.value)}
-            placeholder="Mensagem…"
-          />
-          <label className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
-            <input type="checkbox" checked={publico} onChange={(e) => setPublico(e.target.checked)} />
-            Visível para o cliente (desmarque para nota interna — não sai deste painel)
-          </label>
-          <Button type="button" variant="primary" loading={busy} disabled={!comentario.trim()} onClick={() => void enviarComentario()}>
-            Enviar
-          </Button>
-        </div>
-      </Card>
-
-      <section className="space-y-2">
-        <h2 className="text-sm font-semibold text-slate-500">Comentários</h2>
-        {(item.comentarios || []).map((c) => (
-          <Card key={c.id} className="p-3 text-sm">
-            <p className="text-xs text-slate-500">
-              {c.publico_cliente ? 'Público' : 'Interno'} · {c.autor_nome || '—'} · {formatWhen(c.created_at)}
-            </p>
-            <p className="mt-1 whitespace-pre-wrap">{c.corpo}</p>
+                <button
+                  type="button"
+                  onClick={() => setTipoMensagem('interno')}
+                  className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+                    internoActivo
+                      ? 'bg-white text-amber-950 shadow-sm dark:bg-amber-950/55 dark:text-amber-100 dark:shadow-none dark:ring-1 dark:ring-amber-700/40'
+                      : 'text-slate-600 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-200'
+                  }`}
+                >
+                  Comentário interno
+                </button>
+              </div>
+              <textarea
+                className={`${TEXTAREA_FIELD_CLASS} ${
+                  internoActivo
+                    ? 'bg-amber-50 ring-amber-200/90 focus:ring-amber-400/30 dark:bg-amber-950/25 dark:ring-amber-800/60'
+                    : ''
+                }`}
+                rows={4}
+                value={comentario}
+                onChange={(e) => setComentario(e.target.value)}
+                placeholder={
+                  internoActivo
+                    ? 'Anotação visível apenas para a equipe ops…'
+                    : 'Resposta que o cliente vê em Minhas solicitações…'
+                }
+              />
+              {!internoActivo ? (
+                <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                  O cliente lê isto. Não cite GitHub, número de issue nem acompanhamento interno.
+                </p>
+              ) : null}
+              {tipoMensagem === 'publico' && mencionaTrabalhoInterno(comentario) ? (
+                <p className="mt-2 text-sm text-rose-700 dark:text-rose-300">
+                  Esta mensagem cita trabalho interno. Mude para comentário interno ou tire a issue/GitHub.
+                </p>
+              ) : null}
+              <div className="mt-3 flex justify-end">
+                <Button
+                  type="button"
+                  variant="primary"
+                  loading={busy}
+                  disabled={!comentario.trim() || (tipoMensagem === 'publico' && mencionaTrabalhoInterno(comentario))}
+                  onClick={() => void enviarComentario()}
+                >
+                  Enviar
+                </Button>
+              </div>
+            </div>
           </Card>
-        ))}
-        {(item.comentarios || []).length === 0 ? (
-          <p className="text-sm text-slate-500">Ainda não há comentários nesta solicitação.</p>
-        ) : null}
-      </section>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/saas/SaasSolicitacoes.tsx
+++ b/frontend/src/pages/saas/SaasSolicitacoes.tsx
@@ -7,6 +7,11 @@ import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../../components/ui/Barra
 import { Card } from '../../components/ui/Card'
 import { Select } from '../../components/ui/Select'
 import { useToast } from '../../components/ui/Toast'
+import {
+  classesBadgeStatusSolicitacao,
+  rotuloStatusSolicitacao,
+  SAAS_SOLICITACAO_STATUS,
+} from '../../lib/saasSolicitacoes'
 import { SemPermissao } from '../SemPermissao'
 
 const TIPO_OPTS = [
@@ -14,14 +19,7 @@ const TIPO_OPTS = [
   { value: 'problema', label: 'Problema' },
 ]
 
-const STATUS_OPTS = [
-  { value: 'aberta', label: 'Recebida' },
-  { value: 'em_analise', label: 'Em análise' },
-  { value: 'planejada', label: 'Planejada' },
-  { value: 'em_desenvolvimento', label: 'Em desenvolvimento' },
-  { value: 'concluida', label: 'Concluída' },
-  { value: 'nao_sera_desenvolvida', label: 'Não será desenvolvida' },
-]
+const STATUS_OPTS = SAAS_SOLICITACAO_STATUS.map((s) => ({ value: s.value, label: s.label }))
 
 function formatWhen(iso: string | null | undefined): string {
   if (!iso) return '—'
@@ -215,7 +213,13 @@ export function SaasSolicitacoes() {
                         '1'
                       )}
                     </td>
-                    <td className="px-4 py-3 text-slate-600 dark:text-slate-300 sm:px-6">{item.status_rotulo}</td>
+                    <td className="px-4 py-3 sm:px-6">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeStatusSolicitacao(item.status)}`}
+                      >
+                        {item.status_rotulo || rotuloStatusSolicitacao(item.status)}
+                      </span>
+                    </td>
                     <td className="px-4 py-3 text-slate-500 sm:px-6">
                       {formatWhen(item.created_at_origem || item.ingested_at)}
                     </td>

--- a/frontend/src/pages/saas/SaasUsuarioForm.tsx
+++ b/frontend/src/pages/saas/SaasUsuarioForm.tsx
@@ -69,7 +69,7 @@ export function SaasUsuarioForm() {
           setIndisponivel(true)
           return
         }
-        setInexistente(interpretarFalhaCarregamento(err, 'Utilizador não encontrado.'))
+        setInexistente(interpretarFalhaCarregamento(err, 'Usuário não encontrado.'))
       })
       .finally(() => {
         if (!cancelled) setLoading(false)
@@ -100,14 +100,14 @@ export function SaasUsuarioForm() {
       if (isEdit) {
         const row = await saasOpsUsuarios.update(usuarioId, { nome: nome.trim(), ativo })
         setAtivo(row.ativo)
-        toast.showSuccess('Utilizador actualizado.')
+        toast.showSuccess('Usuário atualizado.')
         navigate('/saas/usuarios')
         return
       }
       const row = await saasOpsUsuarios.create({ nome: nome.trim(), email: email.trim() })
       setSenhaTemporaria(row.senha_temporaria)
       setEmail(row.email)
-      toast.showSuccess('Utilizador criado. Copie a senha temporária agora.')
+      toast.showSuccess('Usuário criado. Copie a senha temporária agora.')
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível guardar o utilizador.'))
     } finally {
@@ -132,7 +132,7 @@ export function SaasUsuarioForm() {
   if (forbidden) {
     return (
       <SemPermissao
-        title="Conta exclusiva da equipa SaaS."
+        title="Conta exclusiva da equipe SaaS."
         detail="Entre com a conta ops em /login/admin."
         voltarPara="/login/admin"
         voltarLabel="Voltar ao login admin"
@@ -151,7 +151,7 @@ export function SaasUsuarioForm() {
   if (inexistente) {
     return (
       <CarregamentoFalhou
-        titulo={inexistente.detalhe ? 'Utilizador não encontrado.' : 'Não foi possível carregar.'}
+        titulo={inexistente.detalhe ? 'Usuário não encontrado.' : 'Não foi possível carregar.'}
         detalhe={inexistente.detalhe}
         onVoltar={voltarAnterior}
       />
@@ -166,7 +166,7 @@ export function SaasUsuarioForm() {
           description="Esta conta entra no painel DeskRudder (/login/admin). Não é um atendente da instância do cliente."
         >
           {loading ? (
-            <p className="text-sm text-slate-500">A carregar…</p>
+            <p className="text-sm text-slate-500">Carregando…</p>
           ) : (
             <div className="space-y-4">
               <Input label="Nome" value={nome} onChange={(ev) => setNome(ev.target.value)} required />
@@ -182,10 +182,10 @@ export function SaasUsuarioForm() {
                 <Switch
                   checked={ativo}
                   onCheckedChange={setAtivo}
-                  label="Conta activa"
+                  label="Conta ativa"
                   showStatusPill
                   disabled={isSelf}
-                  description={isSelf ? 'Não podes desactivar a tua própria conta.' : undefined}
+                  description={isSelf ? 'Você não pode desativar a própria conta.' : undefined}
                 />
               ) : null}
               {isEdit ? (
@@ -195,7 +195,7 @@ export function SaasUsuarioForm() {
                     <>
                       {' '}
                       <Link to="/saas/conta" className="font-medium text-sky-700 underline dark:text-sky-300">
-                        Gerar o teu token
+                        Gerar seu token
                       </Link>
                     </>
                   ) : (
@@ -210,7 +210,7 @@ export function SaasUsuarioForm() {
                     Copiar senha
                   </Button>
                   <p className="text-xs text-slate-500">
-                    Login em /login/admin. No primeiro acesso a pessoa define senha nova e, em Conta / Cursor, gera
+                    Login em /login/admin. No primeiro acesso a pessoa define senha nova e, em Minha conta, gera
                     o token.
                   </p>
                 </div>
@@ -228,7 +228,7 @@ export function SaasUsuarioForm() {
           <InlineCadastroFooter
             onCancel={voltarAnterior}
             saving={saving}
-            submitLabel={isEdit ? 'Guardar' : 'Criar'}
+            submitLabel={isEdit ? 'Salvar' : 'Criar'}
           />
         )}
       </form>
@@ -242,7 +242,7 @@ export function SaasUsuarioForm() {
       <ConfirmDialog
         open={confirmarReset}
         title="Gerar senha temporária?"
-        message="A sessão actual desta pessoa no painel deixa de valer. Copie a senha nova e envie-lhe."
+        message="A sessão atual desta pessoa no painel deixa de valer. Copie a senha nova e envie-lhe."
         confirmLabel="Gerar senha"
         variant="danger"
         loading={saving}

--- a/frontend/src/pages/saas/SaasUsuarios.tsx
+++ b/frontend/src/pages/saas/SaasUsuarios.tsx
@@ -58,7 +58,7 @@ export function SaasUsuarios() {
           setIndisponivel(true)
           return
         }
-        toast.showError(mensagemFalhaParaToast(err, 'Não encontramos a equipa.'))
+        toast.showError(mensagemFalhaParaToast(err, 'Não encontramos a equipe.'))
       })
       .finally(() => setLoading(false))
   }, [debouncedBusca, incluirInativos, page, toast])
@@ -71,7 +71,7 @@ export function SaasUsuarios() {
     return (
       <SemPermissao
         title="Painel SaaS não disponível nesta instância."
-        detail="A equipa DeskRudder só existe no control-plane."
+        detail="A equipe DeskRudder só existe no control-plane."
         voltarPara="/login/admin"
         voltarLabel="Voltar ao login admin"
       />
@@ -83,17 +83,17 @@ export function SaasUsuarios() {
       forbidden={forbidden}
       denied={
         <SemPermissao
-          title="Você não tem permissão para gerir a equipa."
+          title="Você não tem permissão para gerir a equipe."
           voltarPara="/login/admin"
           voltarLabel="Voltar ao login admin"
         />
       }
-      title="Equipa DeskRudder"
-      actions={<Button onClick={() => navigate('/saas/usuarios/novo')}>Novo utilizador</Button>}
+      title="Equipe DeskRudder"
+      actions={<Button onClick={() => navigate('/saas/usuarios/novo')}>Novo usuário</Button>}
     >
       <Card
-        title="Utilizadores"
-        description="Contas do painel /login/admin. Cada pessoa gera o próprio token Cursor em Conta / Cursor."
+        title="Usuários"
+        description="Quem entra no /login/admin (desenvolvimento e comercial). Cada pessoa gera o próprio token Cursor em Minha conta."
       >
         <BarraBuscaPaginacao
           busca={busca}
@@ -108,7 +108,7 @@ export function SaasUsuarios() {
         {loading ? (
           <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
         ) : list.length === 0 ? (
-          <p className="text-slate-500 dark:text-slate-400">Nenhum utilizador encontrado.</p>
+          <p className="text-slate-500 dark:text-slate-400">Nenhum usuário encontrado.</p>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full min-w-[640px] text-left text-sm">
@@ -147,7 +147,7 @@ export function SaasUsuarios() {
                         </span>
                         {!u.ativo ? (
                           <span className="shrink-0 rounded bg-slate-200 px-1.5 py-0.5 text-xs text-slate-600 dark:text-slate-400">
-                            Inactivo
+                            Inativo
                           </span>
                         ) : null}
                         {u.must_change_password ? (


### PR DESCRIPTION
## Summary

- Sobre (#920): uma CalVer, um CHANGELOG; o helpdesk vê só produto e o painel ops vê tudo com etiqueta **Produto** / **DevOps**.
- Sugestões (#923): detalhe com linha do tempo, notas internas em cartão âmbar e status em passos clicáveis; copy ao cliente em português do Brasil e sem citar GitHub/`issue #`.
- Cursor: regra pt-BR sempre ativa; `/listar-solicitacoes` versionado; MCP aponta para `api.deskrudder.com.br` (control-plane, #875), não para a API da DuplexSoft. Login ops em produção deixa de mostrar a dica local.

Closes #920
Closes #923

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] `/sobre` na instância lista só bullets de produto
- [ ] `/saas/sobre` lista todos, com etiqueta Produto ou DevOps
- [ ] `/saas/solicitacoes/{id}`: linha do tempo, nota interna âmbar, mensagem ao cliente vs comentário interno
- [ ] Mensagem pública com `issue #` é recusada; nota interna com o mesmo texto passa
- [ ] Login `/login/admin` em build de produção **não** mostra `ops@deskrudder.local`
- [ ] `/listar-solicitacoes` aparece no Cursor após pull; MCP usa `api.deskrudder.com.br` no example

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Split do control-plane (API/Postgres próprios) já está no épico **#875** (#876–#880) — próximo lote, branch nova após este PR na `main`
- [ ] Stubs/campos nullable têm issue de conclusão, se aplicável
- [ ] Comentário na issue fechada ou no PR lista links dos follow-ups criados
