### PR TITLE
feat(deploy): stack do painel admin em deploy/admin-center (#875)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Sugestões: textos de acompanhamento em português do Brasil; mensagem ao cliente **não pode citar** GitHub nem número de issue (isso fica na nota interna)
 - Painel ops: menu **Equipe** (Usuários + Minha conta); **Sobre** e **Sair** no rodapé, no mesmo padrão do painel de atendimento
 - Cursor: textos ao cliente e do MCP em **português do Brasil**; comentário sem flag explícita fica **interno**. O comando `/listar-solicitacoes` passa a ir no repositório; o MCP aponta para `api.deskrudder.com.br` (control-plane, #875), não para a API da DuplexSoft
+- Infra (#876 / #877): stack do **painel admin** em `deploy/admin-center/` (Postgres + API em `127.0.0.1:8001`). Hosts: `deskrudder.com.br` e `api.deskrudder.com.br`. O helpdesk DuplexSoft continua na API `api-duplexsoft`
 
 ### DeskRudder
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,10 +26,12 @@ LOG_LEVEL=INFO
 # SAAS_TRIAL_DAYS=14
 # SAAS_RENEWAL_ALERT_DAYS_BEFORE=14
 # SAAS_PROVISION_BASE_DOMAIN=deskrudder.com.br
-# SAAS_PROVISION_API_PORT_START=8001
+# SAAS_PROVISION_API_PORT_START=8002   # 8001 reservado à API comercial (#876)
 # SAAS_PROVISION_EXEC_ENABLED=false   # true só no host com Docker/scripts
 # SAAS_REPO_ROOT=/opt/dx-connect
 # SAAS_INGEST_PUBLIC_URL=https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes
+# SEED_SAAS_OPS_EMAIL=ops@deskrudder.com.br
+# SEED_SAAS_OPS_PASSWORD=
 #
 # Instância cliente (não o control-plane): cópia das sugestões para o SaaS
 # SAAS_INSTANCE_SLUG=cliente01

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -34,6 +34,9 @@ class Settings(BaseSettings):
     # Sem SEED_ADMIN_EMAIL, nenhum admin é criado automaticamente em produção.
     SEED_ADMIN_EMAIL: EmailStr | None = None
     SEED_ADMIN_PASSWORD: str | None = None
+    # Control-plane em produção: primeiro saas_ops (mín. 8 caracteres). Vazio = não cria.
+    SEED_SAAS_OPS_EMAIL: EmailStr | None = None
+    SEED_SAAS_OPS_PASSWORD: str | None = None
     # Hostnames permitidos no header Host (TrustedHostMiddleware). Em produção não use "*".
     # Ex.: api.seudominio.com,127.0.0.1
     ALLOWED_HOSTS: str = "*"
@@ -96,6 +99,7 @@ class Settings(BaseSettings):
     # Domínio base dos clientes (ex.: deskrudder.com.br → slug.deskrudder.com.br).
     SAAS_PROVISION_BASE_DOMAIN: str | None = None
     SAAS_PROVISION_API_PORT_START: int = 8001
+    # Na stack comercial use 8002+ (8001 é a API do control-plane, #876).
     # Caixa da equipe comercial DeskRudder (trial, provisionamento, renovação).
     SAAS_NOTIFY_EMAIL: str | None = None
     # Raiz do repositório no host (para provision-client.sh). Vazio = parents do pacote app.
@@ -166,7 +170,7 @@ class Settings(BaseSettings):
             and (self.EVOLUTION_GLOBAL_API_KEY or "").strip()
         )
 
-    @field_validator("SEED_ADMIN_EMAIL", mode="before")
+    @field_validator("SEED_ADMIN_EMAIL", "SEED_SAAS_OPS_EMAIL", mode="before")
     @classmethod
     def normalize_seed_admin_email(cls, v):
         if v is None or (isinstance(v, str) and not v.strip()):

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -48,6 +48,38 @@ def _ensure_default_tenant(db):
         db.commit()
 
 
+def _ensure_saas_ops_producao(db):
+    """Primeiro ops do control-plane em produção (#876). Não usa contas de desenvolvimento."""
+    if not settings.is_production or not settings.SAAS_CONTROL_PLANE:
+        return
+    email = (str(settings.SEED_SAAS_OPS_EMAIL) if settings.SEED_SAAS_OPS_EMAIL else "").strip().lower()
+    pwd = (settings.SEED_SAAS_OPS_PASSWORD or "").strip()
+    if not email:
+        print(
+            "Produção (control-plane): saas_ops inicial não criado. "
+            "Defina SEED_SAAS_OPS_EMAIL e SEED_SAAS_OPS_PASSWORD (mín. 8 caracteres)."
+        )
+        return
+    if len(pwd) < 8:
+        print("Produção (control-plane): SEED_SAAS_OPS_PASSWORD deve ter ao menos 8 caracteres.")
+        return
+    if db.query(Atendente).filter(func.lower(Atendente.email) == email).first():
+        return
+    db.add(
+        Atendente(
+            tenant_id=1,
+            email=email,
+            nome="Ops SaaS DeskRudder",
+            senha_hash=_hash_senha(pwd),
+            role="saas_ops",
+            ativo=True,
+            must_change_password=True,
+        )
+    )
+    db.commit()
+    print(f"Usuário saas_ops criado: {email} — troque a senha no primeiro acesso.")
+
+
 def run_seed():
     db = SessionLocal()
     try:
@@ -169,6 +201,7 @@ def run_seed():
 
             ensure_funil_padrao(db)
             db.commit()
+        _ensure_saas_ops_producao(db)
     finally:
         db.close()
 

--- a/backend/tests/test_control_plane_deploy.py
+++ b/backend/tests/test_control_plane_deploy.py
@@ -1,0 +1,58 @@
+"""Templates e seed do control-plane comercial (#875 / #876)."""
+
+from pathlib import Path
+
+from app.models import Atendente, Tenant
+from app.seed import _ensure_saas_ops_producao
+
+ROOT = Path(__file__).resolve().parents[2]
+CP = ROOT / "deploy" / "admin-center"
+
+
+def test_templates_api_comercial_nao_e_duplexsoft():
+    nginx = (CP / "nginx.site.conf.example").read_text(encoding="utf-8")
+    assert "server_name api.deskrudder.com.br" in nginx
+    assert "127.0.0.1:8001" in nginx
+    assert "server_name api-duplexsoft" not in nginx
+    front = (CP / "frontend.env.production.example").read_text(encoding="utf-8")
+    assert "VITE_API_URL=https://api.deskrudder.com.br" in front
+    assert "VITE_SAAS_CONTROL_PLANE=true" in front
+    env = (CP / "client.env.example").read_text(encoding="utf-8")
+    assert "CLIENT_SLUG=admin-center" in env
+    assert "SAAS_CONTROL_PLANE=true" in env
+    assert "SAAS_PROVISION_API_PORT_START=8002" in env
+    assert "SAAS_INGEST_PUBLIC_URL=https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes" in env
+    script = (ROOT / "deploy" / "scripts" / "provision-client.sh").read_text(encoding="utf-8")
+    assert "provision-control-plane.sh" in script
+    assert "deploy/admin-center" in script
+    compose = (CP / "docker-compose.stack.yml").read_text(encoding="utf-8")
+    assert "context: ../../backend" in compose
+
+
+def test_seed_saas_ops_producao_cria_conta(db_session, monkeypatch):
+    from app.config import settings
+
+    db_session.add(Tenant(id=1, nome="Padrão", ativo=True))
+    db_session.commit()
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SEED_SAAS_OPS_EMAIL", "ops@deskrudder.com.br")
+    monkeypatch.setattr(settings, "SEED_SAAS_OPS_PASSWORD", "temporaria8")
+    _ensure_saas_ops_producao(db_session)
+    row = db_session.query(Atendente).filter(Atendente.email == "ops@deskrudder.com.br").one()
+    assert row.role == "saas_ops"
+    assert row.must_change_password is True
+    _ensure_saas_ops_producao(db_session)
+    assert db_session.query(Atendente).filter(Atendente.role == "saas_ops").count() == 1
+
+
+def test_seed_saas_ops_nao_cria_em_dev(db_session, monkeypatch):
+    from app.config import settings
+
+    db_session.add(Tenant(id=1, nome="Padrão", ativo=True))
+    db_session.commit()
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SEED_SAAS_OPS_EMAIL", "ops@deskrudder.com.br")
+    monkeypatch.setattr(settings, "SEED_SAAS_OPS_PASSWORD", "temporaria8")
+    _ensure_saas_ops_producao(db_session)
+    assert db_session.query(Atendente).filter(Atendente.email == "ops@deskrudder.com.br").first() is None

--- a/deploy/admin-center/.gitignore
+++ b/deploy/admin-center/.gitignore
@@ -1,0 +1,3 @@
+# Gerados no VPS por provision-control-plane.sh — não commitar secrets
+client.env
+docker-compose.yml

--- a/deploy/admin-center/README.md
+++ b/deploy/admin-center/README.md
@@ -1,0 +1,49 @@
+# Control-plane DeskRudder — Postgres + API próprios (#875)
+
+A instância comercial **não** é a DuplexSoft. Clientes ficam em `deploy/clients/{slug}/`. O painel ops fica em **`deploy/admin-center/`**.
+
+| Peça | Host | Porta loopback |
+|------|------|----------------|
+| API comercial | `api.deskrudder.com.br` | `127.0.0.1:8001` |
+| Landing + `/saas` | `deskrudder.com.br` | SPA em `/var/www/dx-connect/admin-center/dist` |
+| Helpdesk DuplexSoft | `duplexsoft.deskrudder.com.br` / `api-duplexsoft…` | `127.0.0.1:8000` (compose legado) |
+
+## No VPS
+
+```bash
+cd /opt/dx-connect   # ou o clone de deploy
+git pull
+bash deploy/scripts/provision-control-plane.sh
+# Guarde a senha do ops impressa. Edite client.env (Resend, etc.).
+bash deploy/scripts/stack-client.sh migrate admin-center
+bash deploy/scripts/stack-client.sh up admin-center
+bash deploy/scripts/stack-client.sh seed admin-center
+bash deploy/scripts/stack-client.sh health admin-center
+```
+
+Health esperado: `"saas_control_plane": true`.
+
+DNS: `api.deskrudder.com.br` → IP da VPS. Nginx: copie `nginx.site.conf.example` e peça TLS (Certbot).
+
+SPA comercial (dist **separado** do cliente):
+
+```bash
+cp deploy/admin-center/frontend.env.production.example frontend/.env.production
+cd frontend && npm ci && npm run build
+sudo mkdir -p /var/www/dx-connect/admin-center/dist
+sudo rsync -a dist/ /var/www/dx-connect/admin-center/dist/
+```
+
+Até o cutover (#878), a DuplexSoft pode continuar com `SAAS_CONTROL_PLANE=true` no compose legado. Não desligue essa flag antes de migrar a fila.
+
+## O que este diretório versiona
+
+Exemplos e o compose-template. `client.env` e `docker-compose.yml` gerados **não** vão no git.
+
+## Issues
+
+- #876 Postgres + container API
+- #877 Nginx/TLS + SPA
+- #878 migrar dados e desligar a flag na DuplexSoft
+- #880 deploy GHA em dois stacks
+- #879 docs/MCP após o cutover

--- a/deploy/admin-center/client.env.example
+++ b/deploy/admin-center/client.env.example
@@ -1,0 +1,63 @@
+# Painel admin DeskRudder — stack comercial (#875 / #876 / #877)
+#
+# Hosts (não são o padrão api-{slug}.{domínio} dos clientes):
+#   Painel / landing: https://deskrudder.com.br  (/saas, /login/admin)
+#   API:              https://api.deskrudder.com.br
+# Pasta no servidor:  deploy/admin-center/  (não fica em deploy/clients/)
+# Porta loopback: 127.0.0.1:8001 (8000 fica com o compose legado da DuplexSoft)
+#
+# Uso (na raiz do repositório, no VPS):
+#   bash deploy/scripts/provision-control-plane.sh
+#   # edite deploy/admin-center/client.env (Resend, etc.)
+#   bash deploy/scripts/stack-client.sh migrate admin-center
+#   bash deploy/scripts/stack-client.sh up admin-center
+#   bash deploy/scripts/stack-client.sh seed admin-center
+#   bash deploy/scripts/stack-client.sh health admin-center
+#
+# client.env e docker-compose.yml gerados não vão no git.
+
+CLIENT_SLUG=admin-center
+CLIENT_API_PORT=8001
+
+POSTGRES_USER=dxconnect
+POSTGRES_PASSWORD=ALTERE_SENHA_FORTE
+POSTGRES_DB=dxconnect_admin_center
+
+ENVIRONMENT=production
+DEBUG=false
+SECRET_KEY=ALTERE_SECRET_KEY_MIN_32_CHARS_ALEATORIO
+ALGORITHM=HS256
+ACCESS_TOKEN_EXPIRE_MINUTES=30
+
+CORS_ORIGINS=https://deskrudder.com.br,https://localhost
+ALLOWED_HOSTS=api.deskrudder.com.br,127.0.0.1,localhost
+
+LOG_LEVEL=INFO
+
+DX_CONNECT_MULTI_TENANT=false
+DEFAULT_TENANT_ID=1
+CLIENT_APP_HOST=deskrudder.com.br
+CONNECT_APP_BASE_DOMAIN=deskrudder.com.br
+INBOUND_EMAIL_DOMAIN=notify.deskrudder.com.br
+
+# Control-plane — só nesta stack
+SAAS_CONTROL_PLANE=true
+SAAS_PROVISION_BASE_DOMAIN=deskrudder.com.br
+# Clientes novos começam em 8002; 8001 é desta API comercial
+SAAS_PROVISION_API_PORT_START=8002
+SAAS_INGEST_PUBLIC_URL=https://api.deskrudder.com.br/v1/saas/ingest/solicitacoes
+SAAS_NOTIFY_EMAIL=comercial@deskrudder.com.br
+SAAS_TRIAL_DAYS=14
+SAAS_RENEWAL_ALERT_DAYS_BEFORE=14
+# SAAS_PROVISION_EXEC_ENABLED=false
+# SAAS_REPO_ROOT=/opt/dx-connect
+# SAAS_MCP_TOKEN=
+
+# Primeiro ops (produção). Não crie admin de helpdesk nesta base.
+SEED_SAAS_OPS_EMAIL=ops@deskrudder.com.br
+SEED_SAAS_OPS_PASSWORD=ALTERE_SENHA_OPS_INICIAL
+
+# Esta stack não é instância de cliente — sem ingest para si mesma
+SAAS_INSTANCE_SLUG=
+SAAS_CONTROL_PLANE_INGEST_URL=
+SAAS_INSTANCE_INGEST_TOKEN=

--- a/deploy/admin-center/docker-compose.stack.yml
+++ b/deploy/admin-center/docker-compose.stack.yml
@@ -1,0 +1,47 @@
+# Stack Docker do painel admin DeskRudder (Postgres + API).
+# Gerado em deploy/admin-center/docker-compose.yml (não vai no git).
+#
+# Build context: dois níveis até a raiz (não o mesmo path de deploy/clients/<slug>/).
+
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: dx-connect-db-${CLIENT_SLUG}
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
+  backend:
+    build:
+      context: ../../backend
+      dockerfile: Dockerfile
+      args:
+        DX_CONNECT_GIT_SHA: ${DX_CONNECT_GIT_SHA:-unknown}
+    container_name: dx-connect-api-${CLIENT_SLUG}
+    env_file:
+      - client.env
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+    ports:
+      - "127.0.0.1:${CLIENT_API_PORT}:8000"
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - backend_data:/app/data
+    restart: unless-stopped
+
+volumes:
+  db_data:
+    name: dx-connect-pgdata-${CLIENT_SLUG}
+  backend_data:
+    name: dx-connect-data-${CLIENT_SLUG}

--- a/deploy/admin-center/frontend.env.production.example
+++ b/deploy/admin-center/frontend.env.production.example
@@ -1,0 +1,13 @@
+# Build do SPA comercial (landing + /saas). Distinto do painel DuplexSoft.
+#
+#   cp deploy/admin-center/frontend.env.production.example frontend/.env.production
+#   cd frontend && npm ci && npm run build
+#   sudo mkdir -p /var/www/dx-connect/admin-center/dist
+#   sudo rsync -a dist/ /var/www/dx-connect/admin-center/dist/
+
+VITE_API_URL=https://api.deskrudder.com.br
+VITE_SAAS_CONTROL_PLANE=true
+VITE_MARKETING_SITE_URL=https://deskrudder.com.br
+VITE_CLIENT_APP_HOST=deskrudder.com.br
+VITE_DEFAULT_TENANT_ID=1
+# VITE_MULTI_TENANT=false

--- a/deploy/admin-center/nginx.site.conf.example
+++ b/deploy/admin-center/nginx.site.conf.example
@@ -1,0 +1,57 @@
+# Nginx — painel admin DeskRudder (#877)
+# API comercial + SPA da apex (landing / /saas / /login/admin).
+#
+# Copiar para /etc/nginx/sites-available/dx-connect-admin-center
+# Depois TLS: certbot --nginx -d deskrudder.com.br -d api.deskrudder.com.br
+#
+# Pré-requisitos:
+#   - API em 127.0.0.1:8001 (stack deploy/admin-center)
+#   - SPA comercial em /var/www/dx-connect/admin-center/dist
+#     (build com VITE_API_URL=https://api.deskrudder.com.br e VITE_SAAS_CONTROL_PLANE=true)
+#   - Painel DuplexSoft continua noutro vhost (api-duplexsoft / duplexsoft)
+
+upstream dx_connect_api_admin_center {
+    server 127.0.0.1:8001;
+    keepalive 16;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name api.deskrudder.com.br;
+
+    client_max_body_size 25M;
+
+    location / {
+        proxy_pass http://dx_connect_api_admin_center;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 120s;
+        proxy_read_timeout 120s;
+    }
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name deskrudder.com.br www.deskrudder.com.br;
+
+    root /var/www/dx-connect/admin-center/dist;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml;
+}

--- a/deploy/clients/README.md
+++ b/deploy/clients/README.md
@@ -2,10 +2,12 @@
 
 Cada cliente pagante tem:
 
-- **Subdomínio** próprio (`{slug}.connect.{domínio}` + `api-{slug}.connect.{domínio}`)
+- **Subdomínio** próprio (`{slug}.deskrudder.com.br` + `api-{slug}.deskrudder.com.br`)
 - **PostgreSQL** dedicado (container no stack do cliente)
 - **Um container** da API (`dx-connect-api-{slug}`)
-- **Porta loopback** distinta (`127.0.0.1:8001`, `8002`, …) para o Nginx fazer proxy
+- **Porta loopback** distinta (`127.0.0.1:8002`, `8003`, …) para o Nginx fazer proxy
+
+O **painel admin** DeskRudder (`/saas`) **não** fica em `clients/`. Pasta: [`../admin-center/`](../admin-center/README.md) (`provision-control-plane.sh`). Hosts: `deskrudder.com.br` e `api.deskrudder.com.br`. Não rode `provision-client.sh --slug deskrudder` nem `--slug admin-center`.
 
 Direção de produto: [`docs/DEPLOYMENT_ARCHITECTURE.md`](../../docs/DEPLOYMENT_ARCHITECTURE.md) · Issue **#191** (Fase 1 + Fase 2 single-tenant no código).
 

--- a/deploy/scripts/provision-client.sh
+++ b/deploy/scripts/provision-client.sh
@@ -36,6 +36,11 @@ if [[ ! "$SLUG" =~ ^[a-z][a-z0-9-]*$ ]]; then
   exit 1
 fi
 
+if [[ "$SLUG" == "deskrudder" || "$SLUG" == "admin-center" ]]; then
+  echo "Erro: o painel ops fica em deploy/admin-center/. Use deploy/scripts/provision-control-plane.sh"
+  exit 1
+fi
+
 if [[ ! "$API_PORT" =~ ^[0-9]+$ ]] || [[ "$API_PORT" -lt 1024 ]] || [[ "$API_PORT" -gt 65535 ]]; then
   echo "Erro: --api-port deve ser um número entre 1024 e 65535."
   exit 1

--- a/deploy/scripts/provision-control-plane.sh
+++ b/deploy/scripts/provision-control-plane.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Gera secrets em deploy/admin-center/ — stack comercial (#876).
+# Hosts: deskrudder.com.br + api.deskrudder.com.br (não api-admin-center.…).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+DEST="$ROOT/deploy/admin-center"
+TEMPLATE_COMPOSE="$DEST/docker-compose.stack.yml"
+TEMPLATE_ENV="$DEST/client.env.example"
+
+SLUG="admin-center"
+API_PORT="8001"
+
+if [[ ! -f "$TEMPLATE_COMPOSE" || ! -f "$TEMPLATE_ENV" ]]; then
+  echo "Erro: templates em falta em $DEST"
+  exit 1
+fi
+
+if [[ -f "$DEST/client.env" ]]; then
+  echo "Erro: já existe $DEST/client.env — a stack já foi provisionada. Edite o arquivo ou remova-o para gerar de novo."
+  exit 1
+fi
+
+PG_PASS="$(openssl rand -hex 16)"
+SECRET_KEY="$(openssl rand -hex 32)"
+OPS_PASS="$(openssl rand -base64 18 | tr -d '/+=' | head -c 16)"
+
+export CLIENT_SLUG="$SLUG"
+export CLIENT_API_PORT="$API_PORT"
+export POSTGRES_USER="dxconnect"
+export POSTGRES_PASSWORD="$PG_PASS"
+export POSTGRES_DB="dxconnect_admin_center"
+export DX_CONNECT_GIT_SHA="unknown"
+
+substitute() {
+  local src="$1" dest="$2"
+  if command -v envsubst >/dev/null 2>&1; then
+    envsubst <"$src" >"$dest"
+  else
+    sed -e "s/\${CLIENT_SLUG}/$CLIENT_SLUG/g" \
+        -e "s/\${CLIENT_API_PORT}/$CLIENT_API_PORT/g" \
+        -e "s/CLIENT_SLUG/$CLIENT_SLUG/g" \
+        -e "s/CLIENT_API_PORT/$CLIENT_API_PORT/g" \
+        "$src" >"$dest"
+  fi
+}
+
+substitute "$TEMPLATE_COMPOSE" "$DEST/docker-compose.yml"
+
+sed -e "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$PG_PASS/" \
+    -e "s/^SECRET_KEY=.*/SECRET_KEY=$SECRET_KEY/" \
+    -e "s/^SEED_SAAS_OPS_PASSWORD=.*/SEED_SAAS_OPS_PASSWORD=$OPS_PASS/" \
+    "$TEMPLATE_ENV" >"$DEST/client.env"
+
+chmod 600 "$DEST/client.env" 2>/dev/null || true
+
+echo ""
+echo "Painel admin provisionado em: $DEST"
+echo ""
+echo "  Painel: https://deskrudder.com.br/login/admin"
+echo "  API:    https://api.deskrudder.com.br"
+echo "  Loopback: 127.0.0.1:$API_PORT"
+echo ""
+echo "  POSTGRES_DB=$POSTGRES_DB"
+echo "  SEED_SAAS_OPS_EMAIL=ops@deskrudder.com.br"
+echo "  SEED_SAAS_OPS_PASSWORD=$OPS_PASS  (troque no primeiro acesso; não commite)"
+echo ""
+echo "Próximos passos:"
+echo "  1. Edite $DEST/client.env (Resend, etc.)"
+echo "  2. bash deploy/scripts/stack-client.sh migrate admin-center"
+echo "  3. bash deploy/scripts/stack-client.sh up admin-center"
+echo "  4. bash deploy/scripts/stack-client.sh seed admin-center"
+echo "  5. Nginx + DNS + TLS (deploy/admin-center/README.md)"
+echo "  6. Build SPA comercial (frontend.env.production.example)"

--- a/deploy/scripts/stack-client.sh
+++ b/deploy/scripts/stack-client.sh
@@ -1,25 +1,34 @@
 #!/usr/bin/env bash
-# Operações no stack Docker de um cliente (deploy/clients/<slug>/).
+# Operações no stack Docker: cliente (deploy/clients/<slug>/) ou painel ops (deploy/admin-center/).
 set -euo pipefail
 
 CMD="${1:-}"
 SLUG="${2:-}"
 
 usage() {
-  echo "Uso: $0 <comando> <slug>"
+  echo "Uso: $0 <comando> <slug|admin-center>"
   echo "Comandos: migrate | up | down | logs | seed | health"
+  echo "Painel ops: $0 migrate admin-center"
   exit 1
 }
 
 [[ -n "$CMD" && -n "$SLUG" ]] || usage
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
-CLIENT_DIR="$ROOT/deploy/clients/$SLUG"
+if [[ "$SLUG" == "admin-center" ]]; then
+  CLIENT_DIR="$ROOT/deploy/admin-center"
+else
+  CLIENT_DIR="$ROOT/deploy/clients/$SLUG"
+fi
 COMPOSE_FILE="$CLIENT_DIR/docker-compose.yml"
 PROJECT="dx-connect-$SLUG"
 
 if [[ ! -f "$COMPOSE_FILE" ]]; then
-  echo "Erro: não encontrado $COMPOSE_FILE — rode provision-client.sh primeiro."
+  if [[ "$SLUG" == "admin-center" ]]; then
+    echo "Erro: não encontrado $COMPOSE_FILE — rode deploy/scripts/provision-control-plane.sh primeiro."
+  else
+    echo "Erro: não encontrado $COMPOSE_FILE — rode provision-client.sh primeiro."
+  fi
   exit 1
 fi
 

--- a/docs/DEPLOYMENT_ARCHITECTURE.md
+++ b/docs/DEPLOYMENT_ARCHITECTURE.md
@@ -74,4 +74,5 @@ Legado multi-tenant: definir `DX_CONNECT_MULTI_TENANT=true` (e no front `VITE_MU
 - Épico deploy: **#170**
 - Épico refatoração de código: **#191**
 - Épico operacional legado: **#16**
+- Control-plane vs cliente DuplexSoft: **#875** — stack em [`deploy/admin-center/`](../deploy/admin-center/README.md)
 - Checklist de servidor: [`PRE_DEPLOY_CHECKLIST.md`](PRE_DEPLOY_CHECKLIST.md)

--- a/docs/SAAS_CONTROL_PLANE.md
+++ b/docs/SAAS_CONTROL_PLANE.md
@@ -4,6 +4,8 @@ Instância comercial (`deskrudder.com.br`): registo de licenças, trial, provisi
 
 **Não** confundir com módulos do produto na instância do cliente (CM/FN, `/kb`, portal).
 
+A instância comercial **não** partilha Postgres nem container com o cliente DuplexSoft. Runbook: [`deploy/admin-center/README.md`](../deploy/admin-center/README.md) (épico #875).
+
 ## Ativar
 
 ```bash
@@ -13,7 +15,7 @@ SAAS_NOTIFY_EMAIL=comercial@deskrudder.com.br
 SAAS_TRIAL_DAYS=14
 SAAS_RENEWAL_ALERT_DAYS_BEFORE=14
 SAAS_PROVISION_BASE_DOMAIN=deskrudder.com.br
-SAAS_PROVISION_API_PORT_START=8001
+SAAS_PROVISION_API_PORT_START=8002
 # Só no host de deploy com Docker/scripts:
 # SAAS_PROVISION_EXEC_ENABLED=true
 # SAAS_REPO_ROOT=/caminho/do/repo
@@ -34,7 +36,7 @@ Em instâncias de clientes: deixar `SAAS_CONTROL_PLANE=false` (padrão).
 
 Na raiz comercial o `/login` padrão pede **conta da empresa** e entrega a sessão no subdomínio (`{slug}.deskrudder.com.br` / `api-{slug}.deskrudder.com.br`).
 
-Para a **equipa DeskRudder** (control-plane), use:
+Para a **equipe DeskRudder** (control-plane), use:
 
 - Atalho da landing «Acessar painel admin» → `/login/admin`
 - Conta com role **`saas_ops`** (não o admin do tenant cliente)


### PR DESCRIPTION
## Summary

- Stack do **painel admin** em `deploy/admin-center/` (Postgres + API na porta `8001`), com hosts `deskrudder.com.br` e `api.deskrudder.com.br` — não mistura com `deploy/clients/`.
- `provision-control-plane.sh` + `stack-client.sh … admin-center`; seed de produção cria o primeiro `saas_ops`.
- Docs e CHANGELOG alinhados ao épico #875 (#876 / #877). Cutover de dados (#878) e deploy GHA em dois stacks (#880) ficam para lotes seguintes.

Closes #876

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] `bash deploy/scripts/provision-control-plane.sh` gera `client.env` + compose em `deploy/admin-center/`
- [ ] `stack-client.sh migrate|up|seed|health admin-center` sobe a API em `127.0.0.1:8001` com `saas_control_plane: true`
- [ ] `provision-client.sh --slug deskrudder` e `--slug admin-center` são rejeitados
- [ ] DNS `api.deskrudder.com.br` + Nginx do example antes do cutover em produção

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] #877 Nginx/TLS + SPA comercial (DNS ainda não existe na VPS)
- [x] #878 migrar fila/licenças e desligar flag na DuplexSoft
- [x] #880 deploy GHA em dois stacks
- [x] #879 docs/MCP após cutover
