### PR TITLE
feat(config): reorganizar menu Equipe, Tickets e PDV (#865)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Configurações (#865): menu reorganizado — **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; Catálogos PDV em **PDV**; Empresa só com dados da instalação; URLs antigas redirecionam
 - Chat interno (#916): cada setor activo passa a ter canal próprio (criação ao cadastrar/activar + backfill); canais vazios aparecem em Interno → Setores; o vínculo do atendente ao setor basta para ver o canal; admin vê todos
 - UI (#870): responsividade — coluna principal do painel ocupa sempre a largura disponível (grid + `w-full`/`min-w-0` no Layout); contentores internos alinhados; abas e header legíveis em qualquer largura
 - UI (#866): botão **Cancelar** com gradiente vermelho preenchido (mesmo molde do Salvar), distinto de Excluir; ConfirmDialog, portal e formulários alinhados

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -629,7 +629,7 @@ function AppRoutes() {
             </AdminRoute>
           }
         />
-        <Route path="setores" element={<Navigate to="/configuracoes/equipa/setores" replace />} />
+        <Route path="setores" element={<Navigate to="/configuracoes/equipe/setores" replace />} />
         <Route
           path="atendentes/novo"
           element={
@@ -654,7 +654,7 @@ function AppRoutes() {
             </AdminRoute>
           }
         />
-        <Route path="atendentes" element={<Navigate to="/configuracoes/equipa/atendentes" replace />} />
+        <Route path="atendentes" element={<Navigate to="/configuracoes/equipe/atendentes" replace />} />
         <Route
           path="funcionarios-rede/:id"
           element={
@@ -711,7 +711,7 @@ function AppRoutes() {
             </AdminRoute>
           }
         />
-        <Route path="respostas-prontas" element={<Navigate to="/configuracoes/equipa/respostas-prontas" replace />} />
+        <Route path="respostas-prontas" element={<Navigate to="/configuracoes/tickets/respostas-prontas" replace />} />
         <Route
           path="base-conhecimento/novo"
           element={<Navigate to="/ajuda/artigos/novo" replace />}
@@ -745,7 +745,7 @@ function AppRoutes() {
             </AdminRoute>
           }
         />
-        <Route path="status-ticket" element={<Navigate to="/configuracoes/equipa/status-ticket" replace />} />
+        <Route path="status-ticket" element={<Navigate to="/configuracoes/tickets/status-ticket" replace />} />
         <Route path="auditoria" element={<Navigate to="/configuracoes/administracao/auditoria" replace />} />
         <Route
           path="tipos-negocio/novo"
@@ -771,7 +771,7 @@ function AppRoutes() {
             </AdminRoute>
           }
         />
-        <Route path="tipos-negocio" element={<Navigate to="/configuracoes/empresa-catalogos/tipos-negocio" replace />} />
+        <Route path="tipos-negocio" element={<Navigate to="/configuracoes/comercial/tipos-negocio" replace />} />
         <Route
           path="configuracoes"
           element={
@@ -817,6 +817,8 @@ function AppRoutes() {
         <Route path="configuracoes/atendimento/*" element={<ConfigLegacyRedirect />} />
         <Route path="configuracoes/cadastros/*" element={<ConfigLegacyRedirect />} />
         <Route path="configuracoes/sistema/*" element={<ConfigLegacyRedirect />} />
+        <Route path="configuracoes/equipa/*" element={<ConfigLegacyRedirect />} />
+        <Route path="configuracoes/empresa-catalogos/*" element={<ConfigLegacyRedirect />} />
         <Route path="configuracoes/whatsapp" element={<ConfigLegacyRedirect />} />
         <Route path="configuracoes/empresa-email" element={<ConfigLegacyRedirect />} />
         <Route path="configuracoes/pdv-catalogos" element={<ConfigLegacyRedirect />} />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -132,6 +132,16 @@ const icons: Record<string, React.ReactNode> = {
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
     </svg>
   ),
+  pdv: (
+    <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+      />
+    </svg>
+  ),
   setores: (
     <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z" />
@@ -387,10 +397,12 @@ const navStructure: NavItem[] = [
     ],
     children: [
       { to: '/configuracoes', label: 'Visão geral', icon: 'configuracoes' },
-      { to: '/configuracoes/equipa', label: 'Equipa e tickets', icon: 'setores' },
+      { to: '/configuracoes/equipe', label: 'Equipe', icon: 'setores' },
+      { to: '/configuracoes/tickets', label: 'Tickets', icon: 'tickets' },
       { to: '/configuracoes/canais', label: 'Canais', icon: 'chat' },
       { to: '/configuracoes/comercial', label: 'Comercial / CRM', icon: 'tiposNegocio' },
-      { to: '/configuracoes/empresa-catalogos', label: 'Empresa e catálogos', icon: 'empresas' },
+      { to: '/configuracoes/empresa', label: 'Empresa', icon: 'empresas' },
+      { to: '/configuracoes/postos-pdv', label: 'PDV', icon: 'pdv' },
       { to: '/configuracoes/administracao', label: 'Administração', icon: 'configuracoes' },
       { to: '/solicitacoes-melhoria', label: 'Sugestões', icon: 'ajudaConsultar', adminOnly: true },
     ],

--- a/frontend/src/pages/KbPortalSettings.tsx
+++ b/frontend/src/pages/KbPortalSettings.tsx
@@ -145,7 +145,7 @@ export function KbPortalSettingsPage({ embedded = false }: { embedded?: boolean 
       denied={
         <SemPermissao
           title="Você não tem permissão para personalizar o portal público."
-          voltarPara="/configuracoes/empresa-catalogos/empresa"
+          voltarPara="/configuracoes/empresa/empresa"
           voltarLabel="Voltar para Sistema"
         />
       }

--- a/frontend/src/pages/SlaCalendarios.tsx
+++ b/frontend/src/pages/SlaCalendarios.tsx
@@ -186,7 +186,7 @@ export function SlaCalendariosPage({ embedded = false }: { embedded?: boolean })
     >
       <p className="text-sm text-slate-600 dark:text-slate-400 mb-4">
         Vincule calendários em{' '}
-        <Link to="/configuracoes/equipa/sla/politicas" className="text-sky-600 hover:underline dark:text-sky-400">
+        <Link to="/configuracoes/tickets/sla/politicas" className="text-sky-600 hover:underline dark:text-sky-400">
           Políticas SLA
         </Link>
         . Calendários inativos não aparecem em novos vínculos.

--- a/frontend/src/pages/SlaConfigLayout.tsx
+++ b/frontend/src/pages/SlaConfigLayout.tsx
@@ -1,8 +1,8 @@
 import { NavLink, Outlet } from 'react-router-dom'
 
 const SUB_TABS = [
-  { to: '/configuracoes/equipa/sla/politicas', label: 'Políticas' },
-  { to: '/configuracoes/equipa/sla/calendarios', label: 'Calendários' },
+  { to: '/configuracoes/tickets/sla/politicas', label: 'Políticas' },
+  { to: '/configuracoes/tickets/sla/calendarios', label: 'Calendários' },
 ] as const
 
 export function SlaConfigLayout() {

--- a/frontend/src/pages/SlaPoliticas.tsx
+++ b/frontend/src/pages/SlaPoliticas.tsx
@@ -406,7 +406,7 @@ export function SlaPoliticasPage({ embedded = false }: { embedded?: boolean }) {
               </select>
               <span className="mt-1 block text-xs text-slate-500 dark:text-slate-400">
                 Gerencie calendários em{' '}
-                <Link to="/configuracoes/equipa/sla/calendarios" className="text-sky-600 hover:underline dark:text-sky-400">
+                <Link to="/configuracoes/tickets/sla/calendarios" className="text-sky-600 hover:underline dark:text-sky-400">
                   SLA → Calendários
                 </Link>
                 . Apenas calendários ativos podem ser vinculados em novas políticas.

--- a/frontend/src/pages/TicketNaturezaMotivo.tsx
+++ b/frontend/src/pages/TicketNaturezaMotivo.tsx
@@ -189,7 +189,7 @@ export function TicketNaturezaMotivoPage({ embedded = false }: { embedded?: bool
   const denied = (
     <SemPermissao
       title="Apenas administradores podem gerir naturezas e motivos."
-      voltarPara="/configuracoes/equipa/natureza-motivo"
+      voltarPara="/configuracoes/tickets/natureza-motivo"
       voltarLabel="Voltar"
     />
   )

--- a/frontend/src/pages/config/ConfigLegacyRedirect.tsx
+++ b/frontend/src/pages/config/ConfigLegacyRedirect.tsx
@@ -1,25 +1,41 @@
 import { Navigate, useLocation } from 'react-router-dom'
 import { CONFIG_LEGACY_REDIRECTS } from './configNav'
 
-/** Mantém bookmarks e links antigos a funcionar (#833). */
+/** Mantém bookmarks e links antigos a funcionar (#833, #865). */
 export function ConfigLegacyRedirect() {
   const { pathname } = useLocation()
   const exact = CONFIG_LEGACY_REDIRECTS.find((r) => r.from === pathname)
   if (exact) return <Navigate to={exact.to} replace />
 
   const prefixRules: Array<[string, string]> = [
-    ['/configuracoes/atendimento', '/configuracoes/equipa'],
     ['/configuracoes/sistema/email', '/configuracoes/canais/email'],
     ['/configuracoes/sistema/whatsapp', '/configuracoes/canais/whatsapp'],
     ['/configuracoes/sistema/base-conhecimento', '/configuracoes/canais/base-conhecimento'],
     ['/configuracoes/sistema/auditoria', '/configuracoes/administracao/auditoria'],
-    ['/configuracoes/sistema', '/configuracoes/empresa-catalogos'],
+    ['/configuracoes/sistema', '/configuracoes/empresa'],
     ['/configuracoes/cadastros/custos', '/configuracoes/comercial/custos'],
     ['/configuracoes/cadastros/funil-crm', '/configuracoes/comercial/funil-crm'],
     ['/configuracoes/cadastros/propostas', '/configuracoes/comercial/propostas'],
     ['/configuracoes/cadastros/contratos', '/configuracoes/comercial/contratos'],
     ['/configuracoes/cadastros/implantacao', '/configuracoes/comercial/implantacao'],
-    ['/configuracoes/cadastros', '/configuracoes/empresa-catalogos'],
+    ['/configuracoes/cadastros/tipos-negocio', '/configuracoes/comercial/tipos-negocio'],
+    ['/configuracoes/cadastros/pdv', '/configuracoes/postos-pdv/pdv'],
+    ['/configuracoes/cadastros', '/configuracoes'],
+    ['/configuracoes/empresa-catalogos/tipos-negocio', '/configuracoes/comercial/tipos-negocio'],
+    ['/configuracoes/empresa-catalogos/pdv', '/configuracoes/postos-pdv/pdv'],
+    ['/configuracoes/empresa-catalogos', '/configuracoes/empresa'],
+    ['/configuracoes/equipa/status-ticket', '/configuracoes/tickets/status-ticket'],
+    ['/configuracoes/equipa/natureza-motivo', '/configuracoes/tickets/natureza-motivo'],
+    ['/configuracoes/equipa/respostas-prontas', '/configuracoes/tickets/respostas-prontas'],
+    ['/configuracoes/equipa/roteamento', '/configuracoes/tickets/roteamento'],
+    ['/configuracoes/equipa/sla', '/configuracoes/tickets/sla'],
+    ['/configuracoes/equipa', '/configuracoes/equipe'],
+    ['/configuracoes/atendimento/status-ticket', '/configuracoes/tickets/status-ticket'],
+    ['/configuracoes/atendimento/natureza-motivo', '/configuracoes/tickets/natureza-motivo'],
+    ['/configuracoes/atendimento/respostas-prontas', '/configuracoes/tickets/respostas-prontas'],
+    ['/configuracoes/atendimento/roteamento', '/configuracoes/tickets/roteamento'],
+    ['/configuracoes/atendimento/sla', '/configuracoes/tickets/sla'],
+    ['/configuracoes/atendimento', '/configuracoes/equipe'],
   ]
   for (const [from, to] of prefixRules) {
     if (pathname === from || pathname.startsWith(`${from}/`)) {

--- a/frontend/src/pages/config/configNav.ts
+++ b/frontend/src/pages/config/configNav.ts
@@ -1,4 +1,4 @@
-/** Navegação de Configurações — hub + sidebar + abas (#833). */
+/** Navegação de Configurações — hub + sidebar + abas (#833, #865). */
 
 export type ConfigNavItem = {
   /** Segmento de URL (último path). */
@@ -21,10 +21,10 @@ export type ConfigNavGroup = {
 
 export const CONFIG_GROUPS: ConfigNavGroup[] = [
   {
-    id: 'equipa',
-    pathPrefix: 'equipa',
-    label: 'Equipa e tickets',
-    description: 'Setores, atendentes, fluxo de tickets, roteamento e SLA.',
+    id: 'equipe',
+    pathPrefix: 'equipe',
+    label: 'Equipe',
+    description: 'Setores e atendentes que operam o painel.',
     icon: 'setores',
     items: [
       {
@@ -39,6 +39,15 @@ export const CONFIG_GROUPS: ConfigNavGroup[] = [
         hint: 'Usuários internos que operam tickets e o chat.',
         keywords: ['utilizador', 'usuário', 'login', 'perfil'],
       },
+    ],
+  },
+  {
+    id: 'tickets',
+    pathPrefix: 'tickets',
+    label: 'Tickets',
+    description: 'Fluxo de chamados, roteamento e SLA.',
+    icon: 'tickets',
+    items: [
       {
         slug: 'status-ticket',
         label: 'Status de ticket',
@@ -102,9 +111,15 @@ export const CONFIG_GROUPS: ConfigNavGroup[] = [
     id: 'comercial',
     pathPrefix: 'comercial',
     label: 'Comercial / CRM',
-    description: 'Funil, propostas, contratos, custos e checklist de implantação.',
+    description: 'Tipos de negócio, funil, propostas, contratos, custos e checklist de implantação.',
     icon: 'tiposNegocio',
     items: [
+      {
+        slug: 'tipos-negocio',
+        label: 'Tipos de negócio',
+        hint: 'Classificação das empresas atendidas (posto, conveniência, restaurante…).',
+        keywords: ['posto', 'classificação', 'tipo'],
+      },
       {
         slug: 'funil-crm',
         label: 'Funil CRM',
@@ -139,28 +154,31 @@ export const CONFIG_GROUPS: ConfigNavGroup[] = [
   },
   {
     id: 'empresa',
-    pathPrefix: 'empresa-catalogos',
-    label: 'Empresa e catálogos',
-    description: 'Dados da instalação, tipos de negócio e catálogos de PDV.',
+    pathPrefix: 'empresa',
+    label: 'Empresa',
+    description: 'Dados institucionais da instalação DeskRudder (CNPJ, logo e endereço).',
     icon: 'empresas',
     items: [
       {
         slug: 'empresa',
-        label: 'Empresa',
-        hint: 'Dados institucionais da instalação — CNPJ, logo e endereço.',
-        keywords: ['cnpj', 'logo', 'institucional'],
+        label: 'Dados da instalação',
+        hint: 'CNPJ, logo e endereço da empresa que usa o sistema.',
+        keywords: ['cnpj', 'logo', 'institucional', 'instalação'],
       },
-      {
-        slug: 'tipos-negocio',
-        label: 'Tipos de negócio',
-        hint: 'Classificação das empresas (posto, conveniência, restaurante…).',
-        keywords: ['posto', 'classificação', 'tipo'],
-      },
+    ],
+  },
+  {
+    id: 'postos-pdv',
+    pathPrefix: 'postos-pdv',
+    label: 'PDV',
+    description: 'Catálogos usados no cadastro de PDVs das empresas atendidas.',
+    icon: 'pdv',
+    items: [
       {
         slug: 'pdv',
         label: 'Catálogos PDV',
         hint: 'Rótulos de dispositivo e tipos de acesso remoto usados no cadastro de PDVs por empresa.',
-        keywords: ['pdv', 'remoto', 'dispositivo'],
+        keywords: ['pdv', 'remoto', 'dispositivo', 'posto', 'catálogo'],
       },
     ],
   },
@@ -199,35 +217,49 @@ export function findConfigGroupByPrefix(pathPrefix: string): ConfigNavGroup | un
   return CONFIG_GROUPS.find((g) => g.pathPrefix === pathPrefix)
 }
 
-/** Redirects 1:1 de URLs antigas (#833). */
+/** Destinos finais após #833 e #865 (bookmarks e links antigos). */
 export const CONFIG_LEGACY_REDIRECTS: Array<{ from: string; to: string }> = [
-  { from: '/configuracoes/atendimento', to: '/configuracoes/equipa' },
-  { from: '/configuracoes/atendimento/setores', to: '/configuracoes/equipa/setores' },
-  { from: '/configuracoes/atendimento/atendentes', to: '/configuracoes/equipa/atendentes' },
-  { from: '/configuracoes/atendimento/status-ticket', to: '/configuracoes/equipa/status-ticket' },
-  { from: '/configuracoes/atendimento/natureza-motivo', to: '/configuracoes/equipa/natureza-motivo' },
-  { from: '/configuracoes/atendimento/respostas-prontas', to: '/configuracoes/equipa/respostas-prontas' },
-  { from: '/configuracoes/atendimento/roteamento', to: '/configuracoes/equipa/roteamento' },
-  { from: '/configuracoes/atendimento/sla', to: '/configuracoes/equipa/sla' },
-  { from: '/configuracoes/atendimento/sla/politicas', to: '/configuracoes/equipa/sla/politicas' },
-  { from: '/configuracoes/atendimento/sla/calendarios', to: '/configuracoes/equipa/sla/calendarios' },
+  { from: '/configuracoes/atendimento', to: '/configuracoes/equipe' },
+  { from: '/configuracoes/atendimento/setores', to: '/configuracoes/equipe/setores' },
+  { from: '/configuracoes/atendimento/atendentes', to: '/configuracoes/equipe/atendentes' },
+  { from: '/configuracoes/atendimento/status-ticket', to: '/configuracoes/tickets/status-ticket' },
+  { from: '/configuracoes/atendimento/natureza-motivo', to: '/configuracoes/tickets/natureza-motivo' },
+  { from: '/configuracoes/atendimento/respostas-prontas', to: '/configuracoes/tickets/respostas-prontas' },
+  { from: '/configuracoes/atendimento/roteamento', to: '/configuracoes/tickets/roteamento' },
+  { from: '/configuracoes/atendimento/sla', to: '/configuracoes/tickets/sla' },
+  { from: '/configuracoes/atendimento/sla/politicas', to: '/configuracoes/tickets/sla/politicas' },
+  { from: '/configuracoes/atendimento/sla/calendarios', to: '/configuracoes/tickets/sla/calendarios' },
   { from: '/configuracoes/atendimento/base-conhecimento', to: '/ajuda/artigos' },
-  { from: '/configuracoes/sistema', to: '/configuracoes/empresa-catalogos' },
-  { from: '/configuracoes/sistema/empresa', to: '/configuracoes/empresa-catalogos/empresa' },
+  { from: '/configuracoes/equipa', to: '/configuracoes/equipe' },
+  { from: '/configuracoes/equipa/setores', to: '/configuracoes/equipe/setores' },
+  { from: '/configuracoes/equipa/atendentes', to: '/configuracoes/equipe/atendentes' },
+  { from: '/configuracoes/equipa/status-ticket', to: '/configuracoes/tickets/status-ticket' },
+  { from: '/configuracoes/equipa/natureza-motivo', to: '/configuracoes/tickets/natureza-motivo' },
+  { from: '/configuracoes/equipa/respostas-prontas', to: '/configuracoes/tickets/respostas-prontas' },
+  { from: '/configuracoes/equipa/roteamento', to: '/configuracoes/tickets/roteamento' },
+  { from: '/configuracoes/equipa/sla', to: '/configuracoes/tickets/sla' },
+  { from: '/configuracoes/equipa/sla/politicas', to: '/configuracoes/tickets/sla/politicas' },
+  { from: '/configuracoes/equipa/sla/calendarios', to: '/configuracoes/tickets/sla/calendarios' },
+  { from: '/configuracoes/sistema', to: '/configuracoes/empresa' },
+  { from: '/configuracoes/sistema/empresa', to: '/configuracoes/empresa/empresa' },
   { from: '/configuracoes/sistema/email', to: '/configuracoes/canais/email' },
   { from: '/configuracoes/sistema/whatsapp', to: '/configuracoes/canais/whatsapp' },
   { from: '/configuracoes/sistema/base-conhecimento', to: '/configuracoes/canais/base-conhecimento' },
   { from: '/configuracoes/sistema/auditoria', to: '/configuracoes/administracao/auditoria' },
-  { from: '/configuracoes/sistema/empresa-email', to: '/configuracoes/empresa-catalogos/empresa' },
-  { from: '/configuracoes/cadastros', to: '/configuracoes/empresa-catalogos' },
-  { from: '/configuracoes/cadastros/tipos-negocio', to: '/configuracoes/empresa-catalogos/tipos-negocio' },
-  { from: '/configuracoes/cadastros/pdv', to: '/configuracoes/empresa-catalogos/pdv' },
+  { from: '/configuracoes/sistema/empresa-email', to: '/configuracoes/empresa/empresa' },
+  { from: '/configuracoes/cadastros', to: '/configuracoes' },
+  { from: '/configuracoes/cadastros/tipos-negocio', to: '/configuracoes/comercial/tipos-negocio' },
+  { from: '/configuracoes/cadastros/pdv', to: '/configuracoes/postos-pdv/pdv' },
   { from: '/configuracoes/cadastros/custos', to: '/configuracoes/comercial/custos' },
   { from: '/configuracoes/cadastros/funil-crm', to: '/configuracoes/comercial/funil-crm' },
   { from: '/configuracoes/cadastros/propostas', to: '/configuracoes/comercial/propostas' },
   { from: '/configuracoes/cadastros/contratos', to: '/configuracoes/comercial/contratos' },
   { from: '/configuracoes/cadastros/implantacao', to: '/configuracoes/comercial/implantacao' },
   { from: '/configuracoes/whatsapp', to: '/configuracoes/canais/whatsapp' },
-  { from: '/configuracoes/empresa-email', to: '/configuracoes/empresa-catalogos/empresa' },
-  { from: '/configuracoes/pdv-catalogos', to: '/configuracoes/empresa-catalogos/pdv' },
+  { from: '/configuracoes/empresa-email', to: '/configuracoes/empresa/empresa' },
+  { from: '/configuracoes/pdv-catalogos', to: '/configuracoes/postos-pdv/pdv' },
+  { from: '/configuracoes/empresa-catalogos', to: '/configuracoes/empresa' },
+  { from: '/configuracoes/empresa-catalogos/empresa', to: '/configuracoes/empresa/empresa' },
+  { from: '/configuracoes/empresa-catalogos/tipos-negocio', to: '/configuracoes/comercial/tipos-negocio' },
+  { from: '/configuracoes/empresa-catalogos/pdv', to: '/configuracoes/postos-pdv/pdv' },
 ]


### PR DESCRIPTION
## Summary

- Configurações reorganizadas: **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; catálogos em **PDV**; Empresa só com dados da instalação
- Sidebar e hub alinhados; redirects para URLs antigas (`equipa`, `empresa-catalogos`, `atendimento`, `cadastros`, …)

Closes #865

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] Smoke local anterior: hub, Equipe, Tickets, Empresa, PDV, Comercial; redirects `equipa` e `empresa-catalogos`
- [ ] Abrir `/configuracoes` e confirmar grupos Equipe / Tickets / PDV / Comercial / Empresa
- [ ] Sidebar: labels Equipe, Tickets, Empresa, PDV
- [ ] Bookmark antigo `/configuracoes/equipa/setores` → `/equipe/setores`

## Follow-ups / backlog

- [x] Fora de escopo documentado na #865 (sem redesign extra)
- [x] Sem stubs nullable novos
