### PR TITLE
fix(whatsapp): proporcao do select Empresa do atendimento

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- WhatsApp: selecção de **Empresa do atendimento** no modal — lista deixa de ficar cortada/desproporcional (menu no fluxo do formulário; modal um pouco mais estreito)
 - Configurações (#865): menu reorganizado — **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; Catálogos PDV em **PDV**; Empresa só com dados da instalação; URLs antigas redirecionam
 - Chat interno (#916): cada setor activo passa a ter canal próprio (criação ao cadastrar/activar + backfill); canais vazios aparecem em Interno → Setores; o vínculo do atendente ao setor basta para ver o canal; admin vê todos
 - UI (#870): responsividade — coluna principal do painel ocupa sempre a largura disponível (grid + `w-full`/`min-w-0` no Layout); contentores internos alinhados; abas e header legíveis em qualquer largura

--- a/frontend/src/components/chat/ChatIniciarConversaModal.tsx
+++ b/frontend/src/components/chat/ChatIniciarConversaModal.tsx
@@ -125,6 +125,7 @@ export function ChatIniciarConversaModal({
                 items={empresasLista.map((e) => ({ id: e.id, label: e.nome }))}
                 placeholder="Definir depois na conversa"
                 hint="Digite parte do nome do posto"
+                menuPlacement="inline"
               />
               <p className="text-[11px] text-slate-500">
                 Se ainda não souber, pergunte ao cliente na conversa e vincule a empresa a qualquer

--- a/frontend/src/components/ui/SelectComPesquisa.tsx
+++ b/frontend/src/components/ui/SelectComPesquisa.tsx
@@ -28,6 +28,12 @@ interface SelectComPesquisaProps {
   recentCount?: number
   hint?: string
   id?: string
+  /**
+   * `absolute` (padrão): lista flutuante sob o botão.
+   * `inline`: lista no fluxo do formulário — use dentro de modais/sheets com overflow
+   * para a caixa não ficar cortada nem desproporcional.
+   */
+  menuPlacement?: 'absolute' | 'inline'
 }
 
 export function SelectComPesquisa({
@@ -41,6 +47,7 @@ export function SelectComPesquisa({
   recentCount = DEFAULT_RECENT,
   hint = 'Sem digitar: últimos cadastros. Digite para filtrar.',
   id: domId,
+  menuPlacement = 'absolute',
 }: SelectComPesquisaProps) {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
@@ -75,7 +82,7 @@ export function SelectComPesquisa({
   }, [open])
 
   return (
-    <div ref={rootRef} className="relative">
+    <div ref={rootRef} className="relative w-full min-w-0">
       <label htmlFor={domId} className="mb-1 block text-sm font-medium text-slate-700 dark:text-slate-300">
         {label}
         {required ? ' *' : ''}
@@ -88,18 +95,24 @@ export function SelectComPesquisa({
         aria-expanded={open}
         aria-controls={listId}
         onClick={() => !disabled && setOpen((o) => !o)}
-        className="flex w-full items-center justify-between rounded-xl border-0 bg-white px-3 py-2 text-left text-sm text-slate-800 shadow-sm ring-1 ring-slate-200/90 transition-[box-shadow,ring] hover:ring-slate-300/80 focus:outline-none focus:ring-2 focus:ring-slate-400/35 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-900/50 dark:text-slate-100 dark:ring-slate-600 dark:hover:ring-slate-500 dark:focus:ring-cyan-500/30"
+        className="flex w-full min-w-0 items-center justify-between gap-2 rounded-xl border-0 bg-white px-3 py-2.5 text-left text-sm text-slate-800 shadow-sm ring-1 ring-slate-200/90 transition-[box-shadow,ring] hover:ring-slate-300/80 focus:outline-none focus:ring-2 focus:ring-slate-400/35 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-slate-900/50 dark:text-slate-100 dark:ring-slate-600 dark:hover:ring-slate-500 dark:focus:ring-cyan-500/30"
       >
-        <span className={!selectedLabel ? 'text-slate-400 dark:text-slate-500' : ''}>
+        <span
+          className={`min-w-0 flex-1 truncate ${!selectedLabel ? 'text-slate-400 dark:text-slate-500' : ''}`}
+        >
           {selectedLabel || placeholder}
         </span>
-        <span className="text-slate-400 dark:text-slate-500" aria-hidden>
+        <span className="shrink-0 text-slate-400 dark:text-slate-500" aria-hidden>
           {open ? '▴' : '▾'}
         </span>
       </button>
       {open && (
         <div
-          className="absolute z-30 mt-1.5 w-full overflow-hidden rounded-xl border border-slate-200/95 bg-white py-1.5 shadow-xl shadow-slate-200/50 ring-1 ring-slate-900/[0.04] dark:border-slate-600 dark:bg-slate-900 dark:shadow-slate-950/50 dark:ring-white/5"
+          className={
+            menuPlacement === 'inline'
+              ? 'relative z-10 mt-1.5 w-full min-w-0 overflow-hidden rounded-xl border border-slate-200/95 bg-white py-1.5 shadow-md ring-1 ring-slate-900/[0.04] dark:border-slate-600 dark:bg-slate-900 dark:ring-white/5'
+              : 'absolute left-0 right-0 z-30 mt-1.5 w-full min-w-0 overflow-hidden rounded-xl border border-slate-200/95 bg-white py-1.5 shadow-xl shadow-slate-200/50 ring-1 ring-slate-900/[0.04] dark:border-slate-600 dark:bg-slate-900 dark:shadow-slate-950/50 dark:ring-white/5'
+          }
           role="listbox"
           id={listId}
         >
@@ -108,12 +121,12 @@ export function SelectComPesquisa({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder={placeholder}
-            className="w-full border-b border-slate-100 bg-transparent px-3 py-2 text-sm text-slate-900 outline-none focus:bg-slate-50/50 dark:border-slate-800 dark:text-slate-100 dark:focus:bg-slate-800/50"
+            className="w-full border-b border-slate-100 bg-transparent px-3 py-2.5 text-sm text-slate-900 outline-none focus:bg-slate-50/50 dark:border-slate-800 dark:text-slate-100 dark:focus:bg-slate-800/50"
             autoFocus
             aria-label={`Buscar em ${label}`}
           />
           <p className="px-3 py-1.5 text-xs text-slate-400 dark:text-slate-500">{hint}</p>
-          <ul className="dx-scrollbar max-h-52 overflow-y-auto py-1">
+          <ul className="dx-scrollbar max-h-56 overflow-y-auto py-1">
             {displayed.length === 0 ? (
               <li className="px-3 py-2 text-sm text-slate-500 dark:text-slate-400">Nenhum resultado.</li>
             ) : (
@@ -123,14 +136,14 @@ export function SelectComPesquisa({
                     type="button"
                     role="option"
                     aria-selected={value === it.id}
-                    className={`mx-1 w-[calc(100%-0.5rem)] rounded-lg px-3 py-2 text-left text-sm transition-colors hover:bg-slate-50/80 dark:hover:bg-slate-800/80 ${value === it.id ? 'bg-slate-100/90 font-medium text-slate-900 dark:bg-slate-800 dark:text-slate-100' : 'text-slate-700 dark:text-slate-300'}`}
+                    className={`mx-1 w-[calc(100%-0.5rem)] rounded-lg px-3 py-2.5 text-left text-sm transition-colors hover:bg-slate-50/80 dark:hover:bg-slate-800/80 ${value === it.id ? 'bg-slate-100/90 font-medium text-slate-900 dark:bg-slate-800 dark:text-slate-100' : 'text-slate-700 dark:text-slate-300'}`}
                     onClick={() => {
                       onChange(it.id)
                       setOpen(false)
                       setQuery('')
                     }}
                   >
-                    {it.label}
+                    <span className="line-clamp-2 break-words">{it.label}</span>
                   </button>
                 </li>
               ))

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -2530,6 +2530,7 @@ useEffect(() => {
               setEmpresaContextoId('')
             }}
             zClassName="z-[120]"
+            panelClassName="md:max-w-md"
           >
             <p className="mb-4 text-sm text-slate-500">
               Vincule a empresa que o cliente indicou. Pode alterar enquanto o chat não estiver
@@ -2543,6 +2544,7 @@ useEffect(() => {
               placeholder="Selecione a empresa"
               hint="Digite parte do nome do posto"
               required
+              menuPlacement="inline"
             />
             <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
               <Button

--- a/frontend/src/pages/whatsapp/WhatsappTicketsModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappTicketsModal.tsx
@@ -223,6 +223,7 @@ export function WhatsappTicketsModal({ chat, open, onClose, onSuccess }: Props) 
                 placeholder="Selecione a empresa"
                 disabled={salvando}
                 required
+                menuPlacement="inline"
               />
               <Select
                 label="Setor"

--- a/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappVincFuncionarioModal.tsx
@@ -458,6 +458,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                 value={empresaVinculoId}
                 onChange={(id) => setEmpresaVinculoId(id)}
                 placeholder="Selecione a empresa"
+                menuPlacement="inline"
               />
             )}
           </div>
@@ -567,6 +568,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                   items={(catalogo?.redes ?? []).map((r) => ({ id: r.id, label: r.nome }))}
                   placeholder="Selecione a rede"
                   required
+                  menuPlacement="inline"
                 />
                 <div className="space-y-2">
                   <p className="text-sm font-medium text-slate-700 dark:text-slate-200">Escopo de empresas</p>
@@ -601,6 +603,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                         items={empresasDaRede.map((e) => ({ id: e.id, label: e.nome }))}
                         placeholder="Selecione a empresa"
                         required
+                        menuPlacement="inline"
                       />
                     ) : empresasDaRede.length > 0 ? (
                       <div className="flex max-h-40 flex-wrap gap-2 overflow-auto rounded-xl border border-slate-200 bg-slate-50/40 p-3 dark:border-slate-800 dark:bg-slate-800/40">
@@ -627,6 +630,7 @@ export function WhatsappVincFuncionarioModal({ chat, open, onClose, onSuccess }:
                     items={empresasContextoOpcoes.map((e) => ({ id: e.id, label: e.nome }))}
                     placeholder="Selecione a empresa de contexto"
                     required
+                    menuPlacement="inline"
                   />
                 )}
               </>


### PR DESCRIPTION
﻿## Summary

- Select de **Empresa do atendimento** no WhatsApp: lista deixa de ficar cortada/desproporcional no modal (menuPlacement=inline)
- Modal um pouco mais estreito; nomes longos truncados no botão
- Mesmo padrão noutros selects de empresa em modais WhatsApp

## CHANGELOG

- [x] Atualizei CHANGELOG.md → [Unreleased]

## Test plan

- [ ] Tema claro/escuro: abrir «Empresa do atendimento» no chat WhatsApp e expandir o select
- [ ] Confirmar que a lista de empresas aparece completa e alinhada ao campo
- [ ] Validar também no modal de iniciar conversa / vincular funcionário (se multi-empresa)

## Follow-ups

- [x] Sem follow-ups novos
