### PR TITLE
fix(alembic): revision 119 ≤32 chars (hotfix deploy)

### DIFF
--- a/.cursor/rules/alembic-migrations.mdc
+++ b/.cursor/rules/alembic-migrations.mdc
@@ -20,6 +20,7 @@ Referência: `docs/ALEMBIC_MIGRATIONS.md`
 2. `down_revision` = `revision` real da migration anterior (não o nome do arquivo)
 3. **Nunca** alterar `revision` de migration já aplicada em algum ambiente
 4. DDL idempotente quando possível; downgrade coerente se o projeto exigir
+5. `revision` (string) ≤ **32** caracteres — coluna `alembic_version.version_num` é `varchar(32)`
 
 ## Múltiplos heads
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,13 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### DeskRudder
 
+#### Correções
+
+- Deploy: migration do chat interno (#916) usava um ID Alembic maior que 32 caracteres e quebrava o `upgrade` em produção; ID encurtado para caber em `alembic_version`
+
 #### Melhorias
 
-- WhatsApp: selecção de **Empresa do atendimento** no modal — lista deixa de ficar cortada/desproporcional (menu no fluxo do formulário; modal um pouco mais estreito)
+- WhatsApp: seleção de **Empresa do atendimento** no modal — lista deixa de ficar cortada/desproporcional (menu no fluxo do formulário; modal um pouco mais estreito)
 - Configurações (#865): menu reorganizado — **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; Catálogos PDV em **PDV**; Empresa só com dados da instalação; URLs antigas redirecionam
 - Chat interno (#916): cada setor activo passa a ter canal próprio (criação ao cadastrar/activar + backfill); canais vazios aparecem em Interno → Setores; o vínculo do atendente ao setor basta para ver o canal; admin vê todos
 - UI (#870): responsividade — coluna principal do painel ocupa sempre a largura disponível (grid + `w-full`/`min-w-0` no Layout); contentores internos alinhados; abas e header legíveis em qualquer largura

--- a/backend/alembic/versions/119_chat_canal_setor_backfill.py
+++ b/backend/alembic/versions/119_chat_canal_setor_backfill.py
@@ -1,6 +1,6 @@
-"""Backfill canais internos por setor activo (#916).
+"""Backfill canais internos por setor ativo (#916).
 
-Revision ID: 119_chat_interno_canal_setor_backfill
+Revision ID: 119_chat_canal_setor_backfill
 Revises: 118_saas_ops_mcp_token
 Create Date: 2026-08-24
 """
@@ -8,7 +8,7 @@ Create Date: 2026-08-24
 import sqlalchemy as sa
 from alembic import op
 
-revision = "119_chat_interno_canal_setor_backfill"
+revision = "119_chat_canal_setor_backfill"
 down_revision = "118_saas_ops_mcp_token"
 branch_labels = None
 depends_on = None

--- a/docs/ALEMBIC_MIGRATIONS.md
+++ b/docs/ALEMBIC_MIGRATIONS.md
@@ -5,6 +5,7 @@
 - O encadeamento das migrations é definido pelos IDs **internos** `revision` e `down_revision`.
 - O `down_revision` deve apontar para um **`revision` que existe** (em algum arquivo dentro de `backend/alembic/versions/`).
 - **Nome do arquivo não é referência**. Se o arquivo chama `004_atendente_must_change_password.py`, isso **não** significa que o `revision` seja `"004_atendente_must_change_password"`.
+- O valor de `revision` deve ter no máximo **32** caracteres (`alembic_version.version_num` é `varchar(32)`).
 
 Quando esse encadeamento fica inconsistente, o comando `alembic upgrade head` falha antes mesmo de consultar o banco, com erros do tipo `KeyError`/`Revision ... is not present`.
 


### PR DESCRIPTION
## Summary
- Hotfix: deploy em `staging` falhou em `alembic upgrade` porque `119_chat_interno_canal_setor_backfill` (37 chars) não cabe em `alembic_version.version_num` (`varchar(32)`)
- ID encurtado para `119_chat_canal_setor_backfill` (29 chars); migration ainda não tinha sido stamped (rollback transacional)
- Docs/rule: lembrar limite de 32 caracteres

## Test plan
- [ ] CI verde
- [ ] Após merge em main: PR `main → staging` e novo Deploy
- [ ] Confirmar `alembic upgrade head` na VPS (sem `StringDataRightTruncation`)