### PR TITLE
chore(cursor): PR de release sem aviso de merge

### DIFF
--- a/.cursor/commands/release-staging.md
+++ b/.cursor/commands/release-staging.md
@@ -37,16 +37,10 @@ Não manter dois PRs de release abertos sem explicar; preferir **um** PR mergeá
 gh pr create --base staging --head main --title "release: main → staging" --body-file .cursor/pr-body-temp.md
 ```
 
-Corpo: Summary do lote (`[Unreleased]`), test plan, nota **“Merge apenas após aprovação manual (staging = produção)”**.
+Corpo do PR: Summary do lote (`[Unreleased]`) + test plan. **Sem** avisos sobre quem aprova/mergeia (isso é óbvio e irrelevante no GitHub).
 
 ## Passo 4 — Entrega
 
-Reporte só:
+No chat: URL do PR (base `staging`). Sem sermão sobre “merge só no GitHub”.
 
-| Item | Valor |
-|------|-------|
-| URL do PR | ... |
-| Base | staging |
-| Merge pelo agente | ❌ proibido — aguarda aprovação no GitHub |
-
-**Não** executar: `gh pr merge`, `gh pr review --approve` seguido de merge, push para `staging`.
+**Não** executar: `gh pr merge`, push para `staging`.

--- a/.cursor/rules/staging-release-approval.mdc
+++ b/.cursor/rules/staging-release-approval.mdc
@@ -27,7 +27,11 @@ alwaysApply: true
 
 ## Se o utilizador pedir merge em staging
 
-Responder: o PR está pronto no URL; **merge só no GitHub por ti** (staging = produção). Não executar `gh pr merge`.
+Não executar `gh pr merge`. Entregar o URL do PR e parar — sem repetir no chat/PR que “merge é só no GitHub”.
+
+## Corpo do PR `→ staging`
+
+Só Summary + test plan. **Não** incluir frases do tipo “Merge só no GitHub por ti” / “staging = produção” / “aprovação humana”.
 
 ## Relação com `/criar-pr`
 


### PR DESCRIPTION
## Summary
- Remove do template `/release-staging` e da rule o texto pedindo “merge só no GitHub” no corpo do PR / chat
- Agente continua sem mergear `staging`; o PR de release leva só Summary + test plan

## Test plan
- [ ] Abrir próximo `/release-staging` e confirmar que o corpo do PR não traz esse aviso