### PR TITLE
fix(whatsapp): modal de setor centralizado no mobile ao atender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- WhatsApp (mobile): ao **Atender**, o modal de setor fica **centralizado** com lista tocável (sem dropdown cortado no rodapé); o Select genérico também abre para cima quando não há espaço abaixo
 - WhatsApp: selecção de **Empresa do atendimento** no modal — lista deixa de ficar cortada/desproporcional (menu no fluxo do formulário; modal um pouco mais estreito)
 - Configurações (#865): menu reorganizado — **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; Catálogos PDV em **PDV**; Empresa só com dados da instalação; URLs antigas redirecionam
 - Chat interno (#916): cada setor activo passa a ter canal próprio (criação ao cadastrar/activar + backfill); canais vazios aparecem em Interno → Setores; o vínculo do atendente ao setor basta para ver o canal; admin vê todos

--- a/frontend/src/components/chat/AssumirWhatsappSetorModal.tsx
+++ b/frontend/src/components/chat/AssumirWhatsappSetorModal.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from 'react'
 import { setores, type Setores } from '../../api/client'
 import { coletarTodasPaginas } from '../../api/collectPages'
 import { Button } from '../ui/Button'
-import { Select } from '../ui/Select'
 
 type Props = {
   open: boolean
@@ -64,47 +63,68 @@ export function AssumirWhatsappSetorModal({
 
   return (
     <div
-      className="fixed inset-0 z-[180] flex items-end justify-center bg-black/50 p-0 backdrop-blur-sm md:items-center md:p-4"
+      className="fixed inset-0 z-[180] flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
       role="dialog"
       aria-modal
       aria-labelledby="assumir-setor-titulo"
       onClick={onClose}
     >
       <div
-        className="w-full max-w-md rounded-t-2xl bg-white p-5 shadow-xl md:rounded-2xl dark:bg-slate-900"
+        className="flex max-h-[min(85dvh,var(--vv-height,85dvh))] w-full max-w-md flex-col overflow-hidden rounded-2xl bg-white shadow-xl dark:bg-slate-900"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 id="assumir-setor-titulo" className="text-lg font-bold text-slate-900 dark:text-white">
-          Escolher setor
-        </h2>
-        <p className="mt-1 text-sm text-slate-500">
-          Você atende em mais de um setor. Selecione o setor deste atendimento — ele aparece no
-          prefixo das mensagens no WhatsApp do cliente.
-        </p>
-        <div className="mt-4">
-          <Select
-            label="Setor"
-            value={setorId}
-            onChange={(v) => setSetorId(v === '' ? '' : Number(v))}
-            options={opcoes}
-            placeholder={carregando ? 'Carregando…' : 'Selecione o setor'}
-            includeEmpty
-            emptyLabel="Selecione…"
-            disabled={carregando || loading || opcoes.length === 0}
-          />
-          {!carregando && erroCarga && (
-            <p className="mt-2 text-sm text-red-600 dark:text-red-400">
+        <div className="shrink-0 px-5 pt-5">
+          <h2 id="assumir-setor-titulo" className="text-lg font-bold text-slate-900 dark:text-white">
+            Escolher setor
+          </h2>
+          <p className="mt-1 text-sm text-slate-500">
+            Você atende em mais de um setor. Selecione o setor deste atendimento — ele aparece no
+            prefixo das mensagens no WhatsApp do cliente.
+          </p>
+        </div>
+        <div className="dx-scrollbar mt-4 min-h-0 flex-1 overflow-y-auto px-5">
+          <p className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-300">Setor</p>
+          {carregando ? (
+            <p className="py-3 text-sm text-slate-500">Carregando…</p>
+          ) : erroCarga ? (
+            <p className="py-2 text-sm text-red-600 dark:text-red-400">
               Não foi possível carregar os setores. Feche e tente de novo.
             </p>
-          )}
-          {!carregando && !erroCarga && opcoes.length === 0 && (
-            <p className="mt-2 text-sm text-amber-700 dark:text-amber-300">
+          ) : opcoes.length === 0 ? (
+            <p className="py-2 text-sm text-amber-700 dark:text-amber-300">
               Nenhum setor ativo encontrado no seu vínculo. Peça a um admin para rever os setores do
               seu usuário.
             </p>
+          ) : (
+            <div
+              role="radiogroup"
+              aria-label="Setor do atendimento"
+              className="flex flex-col gap-2 pb-1"
+            >
+              {opcoes.map((o) => {
+                const selected = setorId === o.value
+                return (
+                  <button
+                    key={o.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    disabled={loading}
+                    onClick={() => setSetorId(o.value)}
+                    className={`flex min-h-11 w-full items-center rounded-xl px-3 py-2.5 text-left text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/40 disabled:opacity-50 ${
+                      selected
+                        ? 'bg-slate-900 font-medium text-white dark:bg-cyan-600 dark:text-white'
+                        : 'bg-slate-50 text-slate-800 ring-1 ring-slate-200/90 hover:bg-slate-100 dark:bg-slate-800/60 dark:text-slate-100 dark:ring-slate-700 dark:hover:bg-slate-800'
+                    }`}
+                  >
+                    <span className="min-w-0 flex-1 break-words">{o.label}</span>
+                  </button>
+                )
+              })}
+            </div>
           )}
         </div>
-        <div className="mt-5 flex justify-end gap-2">
+        <div className="flex shrink-0 justify-end gap-2 border-t border-slate-100 px-5 py-4 dark:border-slate-800">
           <Button type="button" variant="cancel" onClick={onClose} disabled={loading}>
             Cancelar
           </Button>

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -75,10 +75,15 @@ export function Select({
     if (!el) return
     const r = el.getBoundingClientRect()
     const gap = 6
-    const below = r.bottom + gap
-    const maxH = Math.min(280, Math.max(120, window.innerHeight - below - 12))
+    const margin = 12
+    const vh = window.visualViewport?.height ?? window.innerHeight
+    const spaceBelow = vh - r.bottom - gap - margin
+    const spaceAbove = r.top - gap - margin
+    // Em bottom sheets no mobile quase não há espaço abaixo — abre para cima.
+    const openBelow = spaceBelow >= 140 || spaceBelow >= spaceAbove
+    const maxH = Math.min(280, Math.max(96, openBelow ? spaceBelow : spaceAbove))
     setMenuPos({
-      top: below,
+      top: openBelow ? r.bottom + gap : Math.max(margin, r.top - gap - maxH),
       left: r.left,
       width: r.width,
       maxH,


### PR DESCRIPTION
## Summary
- Modal **Escolher setor** ao atender WhatsApp: lista tocável centralizada (sem dropdown cortado no bottom sheet)
- `Select` genérico abre o menu para cima quando não há espaço abaixo

## Test plan
- [ ] Em viewport mobile (~390px), atendente multi-setor: Atender chat sem setor → modal centralizado
- [ ] Selecionar setor e confirmar Atender
- [ ] Cancelar fecha o modal
- [ ] Desktop: modal continua utilizável