### PR TITLE
fix(deploy): TLS Postgres nas stacks admin-center/clientes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Infra (#876): stack `admin-center` sobe com Postgres TLS (self-signed) e `DATABASE_URL` com `sslmode=require`, exigido em produção
 - Fila de sugestões no Cursor: cada ops gera o **próprio token** em Conta / Cursor (`/saas/conta`) e cola no Cursor. Recusar ou comentar fica ligado a essa conta, não a um segredo partilhado da VPS
 - Painel SaaS: cadastro da **equipa** (`/saas/usuarios`) — contas do `/login/admin`. Senha temporária uma vez; cada pessoa gera o token Cursor na própria conta
 - Login ops: no primeiro acesso (trocar senha) o painel SaaS já não mostra «não disponível nesta instância»; redirecciona para definir senha nova

--- a/backend/tests/test_control_plane_deploy.py
+++ b/backend/tests/test_control_plane_deploy.py
@@ -27,6 +27,12 @@ def test_templates_api_comercial_nao_e_duplexsoft():
     assert "deploy/admin-center" in script
     compose = (CP / "docker-compose.stack.yml").read_text(encoding="utf-8")
     assert "context: ../../backend" in compose
+    assert "sslmode=require" in compose
+    assert "ssl=on" in compose
+    assert "./certs/server.crt" in compose
+    script_cp = (ROOT / "deploy" / "scripts" / "provision-control-plane.sh").read_text(encoding="utf-8")
+    assert "certs" in script_cp
+    assert "openssl req" in script_cp
 
 
 def test_seed_saas_ops_producao_cria_conta(db_session, monkeypatch):

--- a/deploy/admin-center/.gitignore
+++ b/deploy/admin-center/.gitignore
@@ -1,3 +1,4 @@
 # Gerados no VPS por provision-control-plane.sh — não commitar secrets
 client.env
 docker-compose.yml
+certs/

--- a/deploy/admin-center/README.md
+++ b/deploy/admin-center/README.md
@@ -14,6 +14,7 @@ A instância comercial **não** é a DuplexSoft. Clientes ficam em `deploy/clien
 cd /opt/dx-connect   # ou o clone de deploy
 git pull
 bash deploy/scripts/provision-control-plane.sh
+# Gera client.env, docker-compose.yml e certs/ (TLS self-signed do Postgres).
 # Guarde a senha do ops impressa. Edite client.env (Resend, etc.).
 bash deploy/scripts/stack-client.sh migrate admin-center
 bash deploy/scripts/stack-client.sh up admin-center

--- a/deploy/admin-center/docker-compose.stack.yml
+++ b/deploy/admin-center/docker-compose.stack.yml
@@ -2,6 +2,7 @@
 # Gerado em deploy/admin-center/docker-compose.yml (não vai no git).
 #
 # Build context: dois níveis até a raiz (não o mesmo path de deploy/clients/<slug>/).
+# Postgres com TLS local (self-signed) — Settings exige sslmode=require em production.
 
 services:
   db:
@@ -11,8 +12,20 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
+    command:
+      [
+        "postgres",
+        "-c",
+        "ssl=on",
+        "-c",
+        "ssl_cert_file=/etc/postgresql/server.crt",
+        "-c",
+        "ssl_key_file=/etc/postgresql/server.key",
+      ]
     volumes:
       - db_data:/var/lib/postgresql/data
+      - ./certs/server.crt:/etc/postgresql/server.crt:ro
+      - ./certs/server.key:/etc/postgresql/server.key:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
@@ -30,7 +43,7 @@ services:
     env_file:
       - client.env
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?sslmode=require
     ports:
       - "127.0.0.1:${CLIENT_API_PORT}:8000"
     depends_on:

--- a/deploy/clients/_template/docker-compose.stack.yml
+++ b/deploy/clients/_template/docker-compose.stack.yml
@@ -9,6 +9,8 @@
 # Migrações:
 #   docker compose -f deploy/clients/CLIENT_SLUG/docker-compose.yml \
 #     --project-name dx-connect-CLIENT_SLUG run --rm backend alembic upgrade head
+#
+# Postgres com TLS local (self-signed) — Settings exige sslmode=require em production.
 
 services:
   db:
@@ -18,8 +20,20 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
+    command:
+      [
+        "postgres",
+        "-c",
+        "ssl=on",
+        "-c",
+        "ssl_cert_file=/etc/postgresql/server.crt",
+        "-c",
+        "ssl_key_file=/etc/postgresql/server.key",
+      ]
     volumes:
       - db_data:/var/lib/postgresql/data
+      - ./certs/server.crt:/etc/postgresql/server.crt:ro
+      - ./certs/server.key:/etc/postgresql/server.key:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 5s
@@ -37,7 +51,7 @@ services:
     env_file:
       - client.env
     environment:
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}?sslmode=require
     ports:
       - "127.0.0.1:${CLIENT_API_PORT}:8000"
     depends_on:

--- a/deploy/scripts/provision-client.sh
+++ b/deploy/scripts/provision-client.sh
@@ -109,6 +109,17 @@ substitute "$TEMPLATE/frontend.env.production.example" "$DEST/frontend.env.produ
 
 chmod 600 "$DEST/client.env" 2>/dev/null || true
 
+CERT_DIR="$DEST/certs"
+mkdir -p "$CERT_DIR"
+if [[ ! -f "$CERT_DIR/server.crt" ]]; then
+  openssl req -new -x509 -days 3650 -nodes -text \
+    -out "$CERT_DIR/server.crt" -keyout "$CERT_DIR/server.key" \
+    -subj "/CN=db"
+fi
+chmod 600 "$CERT_DIR/server.key"
+chmod 644 "$CERT_DIR/server.crt"
+chown 70:70 "$CERT_DIR/server.key" "$CERT_DIR/server.crt" 2>/dev/null || true
+
 echo ""
 echo "Cliente provisionado em: $DEST"
 echo ""

--- a/deploy/scripts/provision-control-plane.sh
+++ b/deploy/scripts/provision-control-plane.sh
@@ -54,6 +54,19 @@ sed -e "s/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=$PG_PASS/" \
 
 chmod 600 "$DEST/client.env" 2>/dev/null || true
 
+# TLS self-signed para o Postgres do compose (Settings exige sslmode=require em production)
+CERT_DIR="$DEST/certs"
+mkdir -p "$CERT_DIR"
+if [[ ! -f "$CERT_DIR/server.crt" ]]; then
+  openssl req -new -x509 -days 3650 -nodes -text \
+    -out "$CERT_DIR/server.crt" -keyout "$CERT_DIR/server.key" \
+    -subj "/CN=db"
+fi
+chmod 600 "$CERT_DIR/server.key"
+chmod 644 "$CERT_DIR/server.crt"
+# UID do user postgres na imagem postgres:16-alpine
+chown 70:70 "$CERT_DIR/server.key" "$CERT_DIR/server.crt" 2>/dev/null || true
+
 echo ""
 echo "Painel admin provisionado em: $DEST"
 echo ""


### PR DESCRIPTION
## Summary
- Compose `admin-center` e template de clientes: Postgres com TLS self-signed + `DATABASE_URL?sslmode=require`
- `provision-control-plane.sh` / `provision-client.sh` geram `certs/`
- Corrige falha vista no provision do painel admin em produção

## Test plan
- [ ] CI verde (teste `test_control_plane_deploy`)
- [ ] Já validado na VPS: `https://api.deskrudder.com.br/health` com `saas_control_plane: true`