### PR TITLE
docs(saas): cutover admin-center (#877/#878)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Infra (#876 / #877 / #878): painel admin em `api.deskrudder.com.br` + SPA em `deskrudder.com.br`; fila e contas ops migradas para o Postgres comercial; DuplexSoft passa a só **ingerir** sugestões (control-plane desligado nessa instância)
 - Infra (#876): stack `admin-center` sobe com Postgres TLS (self-signed) e `DATABASE_URL` com `sslmode=require`, exigido em produção
 - Fila de sugestões no Cursor: cada ops gera o **próprio token** em Conta / Cursor (`/saas/conta`) e cola no Cursor. Recusar ou comentar fica ligado a essa conta, não a um segredo partilhado da VPS
 - Painel SaaS: cadastro da **equipa** (`/saas/usuarios`) — contas do `/login/admin`. Senha temporária uma vez; cada pessoa gera o token Cursor na própria conta

--- a/deploy/admin-center/README.md
+++ b/deploy/admin-center/README.md
@@ -26,16 +26,31 @@ Health esperado: `"saas_control_plane": true`.
 
 DNS: `api.deskrudder.com.br` → IP da VPS. Nginx: copie `nginx.site.conf.example` e peça TLS (Certbot).
 
-SPA comercial (dist **separado** do cliente):
+SPA comercial (dist **separado** do cliente — não sobrescreve o `frontend/dist` da DuplexSoft):
 
 ```bash
-cp deploy/admin-center/frontend.env.production.example frontend/.env.production
-cd frontend && npm ci && npm run build
+cd /opt/dx-connect/frontend
+export VITE_API_URL=https://api.deskrudder.com.br
+export VITE_SAAS_CONTROL_PLANE=true
+export VITE_MARKETING_SITE_URL=https://deskrudder.com.br
+export VITE_CLIENT_APP_HOST=deskrudder.com.br
+export VITE_DEFAULT_TENANT_ID=1
+npm ci
+npx vite build --outDir /tmp/admin-center-spa-dist --emptyOutDir
 sudo mkdir -p /var/www/dx-connect/admin-center/dist
-sudo rsync -a dist/ /var/www/dx-connect/admin-center/dist/
+sudo rsync -a --delete /tmp/admin-center-spa-dist/ /var/www/dx-connect/admin-center/dist/
 ```
 
-Até o cutover (#878), a DuplexSoft pode continuar com `SAAS_CONTROL_PLANE=true` no compose legado. Não desligue essa flag antes de migrar a fila.
+Nginx da landing (`deskrudder.com.br`): `root /var/www/dx-connect/admin-center/dist;`  
+Painel DuplexSoft continua em `/opt/dx-connect/frontend/dist` (API `api-duplexsoft`).
+
+## Cutover (#878) — feito em produção
+
+1. Migrar tabelas SaaS + mídia `solicitacao_media` + `protocol_sequences` (`kind=S`) + contas `saas_ops` para o Postgres do `admin-center`
+2. Criar licença `clientes_saas` slug `duplexsoft` e token de ingest
+3. Na DuplexSoft (`backend/.env`): `SAAS_CONTROL_PLANE=false`, `SAAS_INSTANCE_SLUG=duplexsoft`, `SAAS_CONTROL_PLANE_INGEST_URL` + `SAAS_INSTANCE_INGEST_TOKEN`
+4. Desactivar contas `saas_ops` na BD DuplexSoft (ficam só na comercial)
+5. Health esperado: `api.deskrudder.com.br` → `saas_control_plane: true`; `api-duplexsoft…` → `false`
 
 ## O que este diretório versiona
 

--- a/docs/SAAS_CONTROL_PLANE.md
+++ b/docs/SAAS_CONTROL_PLANE.md
@@ -6,6 +6,8 @@ Instância comercial (`deskrudder.com.br`): registo de licenças, trial, provisi
 
 A instância comercial **não** partilha Postgres nem container com o cliente DuplexSoft. Runbook: [`deploy/admin-center/README.md`](../deploy/admin-center/README.md) (épico #875).
 
+Em produção (após #877 / #878): API comercial em `https://api.deskrudder.com.br` (`saas_control_plane: true`); landing/`/saas` em `https://deskrudder.com.br`; DuplexSoft em `api-duplexsoft…` com `saas_control_plane: false` + ingest.
+
 ## Ativar
 
 ```bash


### PR DESCRIPTION
## Summary
- Documenta o cutover feito na VPS: SPA em `deskrudder.com.br` → `api.deskrudder.com.br`, fila/ops migrados, DuplexSoft com ingest e `saas_control_plane: false`
- Atualiza `deploy/admin-center/README.md`, `docs/SAAS_CONTROL_PLANE.md` e CHANGELOG

## Test plan
- [x] `api.deskrudder.com.br/health` → saas true
- [x] `api-duplexsoft…/health` → saas false
- [x] 6 protocolos `#S202608-0001`…`0006` na BD comercial
- [ ] Login ops em https://deskrudder.com.br/login/admin
- [ ] MCP apontando a `api.deskrudder.com.br` lista a fila

Closes #877
Closes #878