### PR TITLE
ci(deploy): GHA em duas stacks (#880)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,19 @@
-# Deploy: build do frontend no GitHub + rsync para o VPS + git pull + Alembic + Docker Compose.
+# Deploy: dois builds frontend + rsync + git pull + Alembic + Docker Compose (#880).
 #
 # Secrets (Settings -> Secrets and variables -> Actions):
-#   DEPLOY_HOST           - hostname ou IP do VPS
-#   DEPLOY_USER           - usuario SSH
-#   DEPLOY_SSH_KEY        - chave privada OpenSSH completa
-#   DEPLOY_PATH           - clone do repositorio no servidor (ex.: /home/deploy/dx-connect)
-#   DEPLOY_FRONTEND_DIST  - pasta onde o Nginx aponta o root do SPA (conteudo de frontend/dist)
-#   VITE_API_URL          - URL HTTPS da API (sem barra final)
+#   DEPLOY_HOST                  - hostname ou IP do VPS
+#   DEPLOY_USER                  - usuario SSH
+#   DEPLOY_SSH_KEY               - chave privada OpenSSH completa
+#   DEPLOY_PATH                  - clone do repositorio no servidor
+#   DEPLOY_FRONTEND_DIST         - dist do painel DuplexSoft (Nginx duplexsoft.*)
+#   DEPLOY_FRONTEND_DIST_ADMIN   - dist landing/SaaS (ex.: /var/www/dx-connect/admin-center/dist)
+#   VITE_API_URL                 - HTTPS API DuplexSoft (sem barra final)
+#   VITE_API_URL_ADMIN           - HTTPS API comercial api.deskrudder.com.br
 # Opcional:
-#   DEPLOY_SSH_PORT       - porta SSH (padrao 22)
-#   DEPLOY_GIT_REF        - branch no VPS (padrao staging; so usado se o workflow nao tiver github.ref_name)
+#   DEPLOY_SSH_PORT              - porta SSH (padrao 22)
+#   DEPLOY_GIT_REF               - branch no VPS (padrao staging)
 #
-# SSH: IPv4 obrigatório; timeout no mesmo runner (5x) e, se persistir, segundo job noutro IP.
-# Ver deploy/github-actions.md (#734).
+# Ver deploy/github-actions.md (#734 / #880).
 
 name: Deploy
 
@@ -30,6 +31,7 @@ on:
       - "backend/**"
       - "frontend/**"
       - "docker-compose.prod.yml"
+      - "deploy/admin-center/**"
       - ".github/workflows/deploy.yml"
       - "deploy/scripts/**"
       - "VERSION"
@@ -46,7 +48,9 @@ env:
   DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
   DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
   DEPLOY_FRONTEND_DIST: ${{ secrets.DEPLOY_FRONTEND_DIST }}
+  DEPLOY_FRONTEND_DIST_ADMIN: ${{ secrets.DEPLOY_FRONTEND_DIST_ADMIN }}
   VITE_API_URL: ${{ secrets.VITE_API_URL }}
+  VITE_API_URL_ADMIN: ${{ secrets.VITE_API_URL_ADMIN }}
   SSH_PORT: ${{ secrets.DEPLOY_SSH_PORT }}
   DEPLOY_GIT_REF: ${{ secrets.DEPLOY_GIT_REF }}
   EVENT_REF: ${{ github.ref_name }}
@@ -83,36 +87,72 @@ jobs:
           python3 scripts/prepare_release.py --deploy --write-env >> "$GITHUB_ENV"
           echo "dx_version=$(tr -d '\n\r' < VERSION)" >> "$GITHUB_OUTPUT"
 
-      - name: Build do frontend
-        working-directory: frontend
-        env:
-          VITE_APP_VERSION: ${{ env.DX_CONNECT_VERSION }}
-          VITE_APP_VERSION_DISPLAY: ${{ env.VITE_APP_VERSION_DISPLAY }}
+      - name: Validar secrets de build/deploy
         run: |
           if [ -z "${VITE_API_URL:-}" ]; then
-            echo "::error::Defina o secret VITE_API_URL (URL HTTPS da API, sem barra no final)."
+            echo "::error::Defina VITE_API_URL (API DuplexSoft HTTPS, sem barra no final)."
             exit 1
           fi
-          npm ci
-          npm run build
-
-      - name: Validar secrets de deploy
-        run: |
-          if [ -z "${DEPLOY_HOST:-}" ] || [ -z "${DEPLOY_USER:-}" ] || [ -z "${DEPLOY_PATH:-}" ] || [ -z "${DEPLOY_FRONTEND_DIST:-}" ]; then
-            echo "::error::Defina DEPLOY_HOST, DEPLOY_USER, DEPLOY_PATH e DEPLOY_FRONTEND_DIST."
+          if [ -z "${VITE_API_URL_ADMIN:-}" ]; then
+            echo "::error::Defina VITE_API_URL_ADMIN (API comercial https://api.deskrudder.com.br)."
+            exit 1
+          fi
+          if [ -z "${DEPLOY_HOST:-}" ] || [ -z "${DEPLOY_USER:-}" ] || [ -z "${DEPLOY_PATH:-}" ]; then
+            echo "::error::Defina DEPLOY_HOST, DEPLOY_USER e DEPLOY_PATH."
+            exit 1
+          fi
+          if [ -z "${DEPLOY_FRONTEND_DIST:-}" ] || [ -z "${DEPLOY_FRONTEND_DIST_ADMIN:-}" ]; then
+            echo "::error::Defina DEPLOY_FRONTEND_DIST (DuplexSoft) e DEPLOY_FRONTEND_DIST_ADMIN (landing/SaaS)."
             exit 1
           fi
           if [ -z "${DEPLOY_SSH_KEY:-}" ]; then
             echo "::error::Defina DEPLOY_SSH_KEY."
             exit 1
           fi
+          case "${VITE_API_URL}" in
+            *api.deskrudder.com.br*)
+              echo "::error::VITE_API_URL não pode ser a API comercial — use VITE_API_URL_ADMIN para isso."
+              exit 1
+              ;;
+          esac
+          case "${VITE_API_URL_ADMIN}" in
+            *api-duplexsoft*)
+              echo "::error::VITE_API_URL_ADMIN não pode ser a API DuplexSoft."
+              exit 1
+              ;;
+          esac
+
+      - name: Build frontend DuplexSoft
+        working-directory: frontend
+        env:
+          VITE_APP_VERSION: ${{ env.DX_CONNECT_VERSION }}
+          VITE_APP_VERSION_DISPLAY: ${{ env.VITE_APP_VERSION_DISPLAY }}
+          VITE_API_URL: ${{ env.VITE_API_URL }}
+        run: |
+          npm ci
+          # Sem VITE_SAAS_CONTROL_PLANE — painel do cliente
+          npx vite build --outDir dist-duplexsoft --emptyOutDir
+
+      - name: Build frontend admin-center (landing /saas)
+        working-directory: frontend
+        env:
+          VITE_APP_VERSION: ${{ env.DX_CONNECT_VERSION }}
+          VITE_APP_VERSION_DISPLAY: ${{ env.VITE_APP_VERSION_DISPLAY }}
+          VITE_API_URL: ${{ env.VITE_API_URL_ADMIN }}
+          VITE_SAAS_CONTROL_PLANE: "true"
+          VITE_MARKETING_SITE_URL: https://deskrudder.com.br
+          VITE_CLIENT_APP_HOST: deskrudder.com.br
+          VITE_DEFAULT_TENANT_ID: "1"
+        run: |
+          npx vite build --outDir dist-admin-center --emptyOutDir
 
       - name: Empacotar artefactos
         uses: actions/upload-artifact@v4
         with:
           name: deploy-dist
           path: |
-            frontend/dist/
+            frontend/dist-duplexsoft/
+            frontend/dist-admin-center/
             VERSION
             CHANGELOG.md
             docs/releases/manifest.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Infra (#880): deploy GitHub Actions atualiza **duas** stacks — build/dist DuplexSoft e build/dist comercial; migrate em cada Postgres; health com flags SaaS distintas
 - Infra (#876): stack `admin-center` sobe com Postgres TLS (self-signed) e `DATABASE_URL` com `sslmode=require`, exigido em produção
 - Fila de sugestões no Cursor: cada ops gera o **próprio token** em Conta / Cursor (`/saas/conta`) e cola no Cursor. Recusar ou comentar fica ligado a essa conta, não a um segredo partilhado da VPS
 - Painel SaaS: cadastro da **equipa** (`/saas/usuarios`) — contas do `/login/admin`. Senha temporária uma vez; cada pessoa gera o token Cursor na própria conta

--- a/backend/tests/test_deploy_dual_stack.py
+++ b/backend/tests/test_deploy_dual_stack.py
@@ -1,0 +1,34 @@
+"""Deploy GHA em duas stacks (#880) — contrato de secrets e artefactos."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WF = (ROOT / ".github" / "workflows" / "deploy.yml").read_text(encoding="utf-8")
+SCRIPT = (ROOT / "deploy" / "scripts" / "gha-deploy-vps.sh").read_text(encoding="utf-8")
+DOCS = (ROOT / "deploy" / "github-actions.md").read_text(encoding="utf-8")
+
+
+def test_workflow_exige_dois_vite_e_dois_dist():
+    assert "VITE_API_URL_ADMIN" in WF
+    assert "DEPLOY_FRONTEND_DIST_ADMIN" in WF
+    assert "dist-duplexsoft" in WF
+    assert "dist-admin-center" in WF
+    assert "VITE_SAAS_CONTROL_PLANE" in WF
+    assert "deploy/admin-center/**" in WF
+
+
+def test_gha_script_atualiza_admin_center_e_bloqueia_saas_no_cliente():
+    assert "stack-client.sh migrate admin-center" in SCRIPT
+    assert "stack-client.sh up admin-center" in SCRIPT
+    assert "saas_control_plane=true" in SCRIPT
+    assert "SAAS_CONTROL_PLANE=true" in SCRIPT  # guarda no .env do cliente
+    assert "dist-admin-center" in SCRIPT
+    assert "dist-duplexsoft" in SCRIPT
+    assert "VITE_API_URL_ADMIN" in SCRIPT
+
+
+def test_docs_listam_secrets_novos():
+    assert "VITE_API_URL_ADMIN" in DOCS
+    assert "DEPLOY_FRONTEND_DIST_ADMIN" in DOCS
+    assert "api.deskrudder.com.br" in DOCS
+    assert "#880" in DOCS

--- a/deploy/github-actions.md
+++ b/deploy/github-actions.md
@@ -1,18 +1,23 @@
-# Deploy com GitHub Actions (SSH + Docker Compose)
+# Deploy com GitHub Actions (SSH + Docker Compose) — #734 / #880
 
 O workflow [`.github/workflows/deploy.yml`](../.github/workflows/deploy.yml) faz:
 
-1. **Build do frontend** no runner (usa `VITE_API_URL` dos secrets).
-2. **`rsync`** da pasta `frontend/dist/` para o caminho no VPS (`DEPLOY_FRONTEND_DIST`).
-3. **SSH** no servidor: `git pull`, `alembic upgrade head`, `docker compose -f docker-compose.prod.yml up -d --build`.
+1. **Dois builds** do frontend no runner:
+   - **DuplexSoft** → `VITE_API_URL` (API do cliente), **sem** `VITE_SAAS_CONTROL_PLANE`
+   - **admin-center** (landing / `/saas`) → `VITE_API_URL_ADMIN` + `VITE_SAAS_CONTROL_PLANE=true`
+2. **`rsync`** de cada `dist` para o caminho Nginx correspondente no VPS.
+3. **SSH**: `git pull` + `alembic upgrade` + rebuild:
+   - Stack **DuplexSoft**: `docker-compose.prod.yml` + `backend/.env` (exige `SAAS_CONTROL_PLANE=false`)
+   - Stack **comercial**: `deploy/scripts/stack-client.sh migrate|up admin-center`
+4. Health das **duas** APIs com flags distintas (`saas_control_plane` false / true).
 
-Disparo automático em **push** para **`staging`** quando mudam `backend/`, `frontend/`, `docker-compose.prod.yml` ou o próprio workflow. A branch **`main`** não dispara deploy (último estágio de testes/integração); após validar em `main`, abra PR **`main → staging`**, merge e o deploy roda no VPS. Também pode rodar manualmente em **Actions → Deploy → Run workflow**.
+Disparo automático em **push** para **`staging`**. A branch **`main`** não dispara deploy. Após validar em `main`, PR **`main → staging`**, merge e o deploy roda no VPS. Também: **Actions → Deploy → Run workflow**.
 
-**Importante:** não defina `DEPLOY_GIT_REF=main` nos secrets se o ambiente de produção segue a branch **`staging`** — isso fazia o frontend atualizar e o backend continuar na `main` (rotas novas como `/v1/settings/empresa-sistema` respondiam 404).
+**Importante:** não defina `DEPLOY_GIT_REF=main` nos secrets se a produção segue **`staging`**.
 
-### Banner “staging had recent pushes” na aba Pull requests
+### Banner “staging had recent pushes”
 
-Depois de mergear um release **`main → staging`**, o GitHub exibe um aviso amarelo sugerindo **Compare & pull request**. Isso é **comportamento nativo** (a branch `staging` acabou de receber push) e **não indica erro**. **Ignore o botão** — ele abriria PR na direção **`staging → main`**, oposta ao fluxo correto. Não há configuração no GitHub para desligar esse aviso enquanto o deploy continuar em push para `staging`.
+Aviso nativo do GitHub após merge `main → staging`. **Ignore** o botão Compare & pull request (`staging → main`).
 
 ## Secrets no GitHub
 
@@ -20,76 +25,45 @@ Em **Settings → Secrets and variables → Actions → New repository secret**:
 
 | Secret | Descrição |
 |--------|-----------|
-| `DEPLOY_HOST` | Hostname ou IP do VPS (ex.: `api.exemplo.com` ou IP) |
-| `DEPLOY_USER` | Usuário SSH com permissão de `git`, `docker` e escrita em `DEPLOY_FRONTEND_DIST` |
-| `DEPLOY_SSH_KEY` | Chave **privada** completa (PEM), linha `-----BEGIN ... KEY-----` até o fim |
-| `DEPLOY_PATH` | Diretório no servidor onde está o **clone** deste repositório (ex.: `/home/deploy/dx-connect`) |
-| `DEPLOY_FRONTEND_DIST` | Pasta servida pelo Nginx como root do SPA (ex.: `/var/www/dx-connect`). Deve existir e o usuário SSH precisa poder escrever (ex.: pertencer ao grupo `www-data` ou `chown` adequado). |
-| `VITE_API_URL` | URL pública **HTTPS** da API, **sem barra no final** (igual ao `frontend/.env.production`) |
+| `DEPLOY_HOST` | Hostname ou IP do VPS |
+| `DEPLOY_USER` | Usuário SSH (`git`, `docker`, escrita nos dists) |
+| `DEPLOY_SSH_KEY` | Chave **privada** completa (PEM) |
+| `DEPLOY_PATH` | Clone do repo no servidor (ex.: `/opt/dx-connect`) |
+| `DEPLOY_FRONTEND_DIST` | Dist do **painel DuplexSoft** (ex.: `/opt/dx-connect/frontend/dist`) |
+| `DEPLOY_FRONTEND_DIST_ADMIN` | Dist da **landing/SaaS** (ex.: `/var/www/dx-connect/admin-center/dist`) |
+| `VITE_API_URL` | HTTPS da API **DuplexSoft** sem barra final (ex.: `https://api-duplexsoft.deskrudder.com.br`) |
+| `VITE_API_URL_ADMIN` | HTTPS da API **comercial** (ex.: `https://api.deskrudder.com.br`) |
 
 Opcionais:
 
 | Secret | Descrição |
 |--------|-----------|
 | `DEPLOY_SSH_PORT` | Porta SSH se não for 22 |
-| `DEPLOY_GIT_REF` | Override opcional da branch no VPS (só usado se o workflow não tiver `github.ref_name`; em push para `staging` usa a branch do push) |
+| `DEPLOY_GIT_REF` | Override da branch no VPS (evitar em produção normal) |
+
+O workflow **recusa** trocar as URLs (comercial em `VITE_API_URL` ou DuplexSoft em `VITE_API_URL_ADMIN`).
 
 ### Environment `production` (opcional)
 
-Se quiser **aprovação manual** ou secrets separados, crie um **Environment** chamado `production` no GitHub e descomente no workflow a linha `environment: production`. Configure os secrets no environment em vez dos secrets do repositório.
+Environment com aprovação manual: descomente `environment: production` no workflow e coloque os secrets lá.
 
 ## Preparação única no VPS
 
-1. **Clone do repositório** (repositório público ou configure acesso Git: SSH deploy key ou `https` com token):
+1. Clone do repositório + `backend/.env` DuplexSoft (`SAAS_CONTROL_PLANE=false` + ingest após #878).
+2. Stack comercial: `bash deploy/scripts/provision-control-plane.sh` + migrate/up/seed (ver [`admin-center/README.md`](admin-center/README.md)).
+3. Pastas de dist:
 
    ```bash
-   sudo mkdir -p /home/deploy && sudo chown "$USER:$USER" /home/deploy
-   cd /home/deploy
-   git clone https://github.com/SEU_USUARIO/dx-connect.git
-   cd dx-connect
+   sudo mkdir -p /var/www/dx-connect/admin-center/dist
+   sudo chown deploy:www-data /var/www/dx-connect/admin-center/dist /opt/dx-connect/frontend/dist
    ```
 
-2. **`backend/.env` de produção** no servidor (não vai para o Git): copie de `backend/.env.example` e preencha. Veja também `docs/PRE_DEPLOY_CHECKLIST.md`.
-
-3. **Docker**: usuário do deploy no grupo `docker` (`sudo usermod -aG docker "$USER"`) ou use `sudo` no workflow (não recomendado).
-
-4. **Pasta do frontend** (exemplo):
-
-   ```bash
-   sudo mkdir -p /var/www/dx-connect
-   sudo chown deploy:www-data /var/www/dx-connect
-   ```
-
-   Ajuste o `root` do Nginx para esse diretório e use o mesmo caminho em `DEPLOY_FRONTEND_DIST`.
-
-5. **Primeira subida da API** (migrations e containers — inclui Evolution API):
-
-   ```bash
-   cd /home/deploy/dx-connect
-   # backend/.env: EVOLUTION_GLOBAL_API_KEY, EVOLUTION_POSTGRES_PASSWORD,
-   # EVOLUTION_INTERNAL_BASE_URL=http://127.0.0.1:8080, DX_CONNECT_WEBHOOK_BASE_URL=https://...
-   docker compose --env-file backend/.env -f docker-compose.prod.yml run --rm -T backend alembic upgrade head < /dev/null
-   docker compose --env-file backend/.env -f docker-compose.prod.yml up -d --build
-   ```
-
-6. **Chave SSH para o GitHub**: no seu PC ou no VPS, gere um par só para deploy:
-
-   ```bash
-   ssh-keygen -t ed25519 -f github-deploy -C "github-actions-dx-connect" -N ""
-   ```
-
-   Coloque o conteúdo de `github-deploy` (privada) no secret `DEPLOY_SSH_KEY`. No servidor, em `~/.ssh/authorized_keys` do `DEPLOY_USER`, adicione uma linha com o conteúdo de `github-deploy.pub`.
-
-## Repositório privado
-
-O servidor precisa conseguir `git pull`. Opções:
-
-- **Deploy key** (somente leitura): Settings → Deploy keys → adicionar a chave **pública** do servidor; ou
-- **PAT** em URL remota: `git remote set-url origin https://TOKEN@github.com/...` (menos ideal).
+4. Nginx: DuplexSoft → `DEPLOY_FRONTEND_DIST`; `deskrudder.com.br` → `DEPLOY_FRONTEND_DIST_ADMIN`; APIs em `api-duplexsoft…` (:8000) e `api.deskrudder.com.br` (:8001).
+5. Chave SSH do Actions em `authorized_keys` do `DEPLOY_USER`.
 
 ## Migrações
 
-Em cada deploy o workflow executa `alembic upgrade head` antes do `up --build`. No **Run workflow** manual pode marcar **skip migrations** só em situações excepcionais.
+Cada deploy corre `alembic upgrade head` na BD DuplexSoft **e** na BD `admin-center` (salvo skip manual).
 
 ## Troubleshooting
 
@@ -101,30 +75,15 @@ Em cada deploy o workflow executa `alembic upgrade head` antes do `up --build`. 
 ssh: connect to host *** port 22: Connection timed out
 ```
 
-O job **`build`** (frontend + CalVer) pode ter passado; a falha é só na ligação **runner → VPS**.
+O job **`build`** pode ter passado; a falha é só na ligação **runner → VPS**.
 
-**Causa provável:** IPv6/rota transitória entre um IP do GitHub Actions e o VPS (Hostinger). **Não** é, por si só, chave SSH errada — `Permission denied` é outro caso e **não** dispara retry.
-
-**O que o workflow faz sozinho (#734):**
-
-1. SSH/`rsync`/`ssh-keyscan` forçam **IPv4** (`ssh -4`, `AddressFamily=inet`).
-2. O log imprime o **IPv4 público do runner** (`api.ipify.org`) para cruzar com firewall.
-3. `ssh-keyscan` **sem** `|| true`: timeout → exit 42; recusa/DNS → falha clara sem segundo job.
-4. Até **5 tentativas** no mesmo runner (15 s, depois +15 s).
-5. Se o timeout persistir: job **`deploy-retry`** noutro `ubuntu-latest` (outro IP), **reutiliza o artefacto** do frontend — sem rebuild e **sem** segundo retry.
-
-**O que fazer se ainda falhar:**
-
-1. Confira no log se foi timeout (há retry) vs `Permission denied` / git / alembic (não há).
-2. Firewall Hostinger: permitir SSH dos IPs do runner (o IPv4 está no log).
-3. **Actions → Deploy → Run workflow** na branch `staging` (deploy completo).
-4. Confira `DEPLOY_HOST` / `DEPLOY_SSH_PORT` e `sshd` no VPS.
+**O que o workflow faz (#734):** IPv4 forçado; até 5 tentativas; job **`deploy-retry`** noutro runner reutiliza o artefacto.
 
 ### Outros erros comuns
 
-- **`Permission denied (publickey)`**: confira `DEPLOY_SSH_KEY`, usuário e `authorized_keys` no VPS.
-- **`rsync` falha**: permissões em `DEPLOY_FRONTEND_DIST` e caminho absoluto correto.
-- **`docker: permission denied`**: usuário no grupo `docker` ou reiniciar sessão SSH após `usermod`.
-- **Build do frontend errado**: `VITE_API_URL` nos secrets deve ser a URL **pública** que o browser usa para chamar a API.
-- **404 em `/v1/settings/*` ou `/v1/tenant/*` com frontend novo**: o SPA foi atualizado mas o **container da API** ainda está na `main` antiga. Remova o secret `DEPLOY_GIT_REF=main` (deixe o workflow usar a branch do push, ex. `staging`). No VPS: `bash deploy/scripts/redeploy-staging-backend.sh`. Confirme: `curl -s https://SUA-API/health` deve incluir `"capabilities":{"settings_empresa_sistema":true,...}`.
-- **Deploy SSH “passa” mas `/health` continua com `git_sha` antigo**: o `docker compose run` no script remoto (`bash -s` + heredoc) pode **consumir o stdin** e impedir o restart do backend. O workflow usa `run --rm -T ... < /dev/null` para evitar isso.
+- **`Permission denied (publickey)`**: confira `DEPLOY_SSH_KEY` e `authorized_keys`.
+- **`rsync` falha**: permissões nos dois caminhos de dist.
+- **`admin-center não provisionado`**: falta `deploy/admin-center/client.env` no VPS.
+- **`SAAS_CONTROL_PLANE=true` na DuplexSoft**: o deploy aborta de propósito — corrigir `backend/.env` (cutover #878).
+- **Landing fala com API DuplexSoft**: dist admin desatualizado ou `DEPLOY_FRONTEND_DIST_ADMIN` / secret `VITE_API_URL_ADMIN` errados.
+- **404 em rotas novas**: `DEPLOY_GIT_REF=main` desalinhado — remova o secret e redeploye a `staging`.

--- a/deploy/scripts/gha-deploy-vps.sh
+++ b/deploy/scripts/gha-deploy-vps.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Deploy remoto no VPS a partir do runner GitHub Actions (#734).
+# Deploy remoto no VPS a partir do runner GitHub Actions (#734 / #880).
+# Atualiza stack DuplexSoft (compose legado) + stack admin-center em separado.
 # Exit 42 = SSH Connection timed out (o workflow dispara um segundo job noutro runner).
 # Exit 1 = falha que NÃO deve repetir (credencial, git, alembic, health, etc.).
 set -euo pipefail
@@ -11,8 +12,10 @@ cd "$ROOT"
 : "${DEPLOY_USER:?}"
 : "${DEPLOY_PATH:?}"
 : "${DEPLOY_FRONTEND_DIST:?}"
+: "${DEPLOY_FRONTEND_DIST_ADMIN:?}"
 : "${DEPLOY_SSH_KEY:?}"
 : "${VITE_API_URL:?}"
+: "${VITE_API_URL_ADMIN:?}"
 
 SSH_PORT="${SSH_PORT:-22}"
 mkdir -p "${HOME}/.ssh"
@@ -115,6 +118,8 @@ retry_net() {
 }
 
 echo "Deploy ref no VPS: ${REF}"
+echo "API DuplexSoft (cliente): ${VITE_API_URL}"
+echo "API admin-center:         ${VITE_API_URL_ADMIN}"
 
 retry_net "${SSH_BASE[@]}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
   "REF='${REF}' DEPLOY_PATH='${DEPLOY_PATH}' bash -s" << 'REMOTE_SCRIPT'
@@ -136,6 +141,7 @@ ssh_rsync_release "docs/releases/manifest.json" "docs/releases/"
 ssh_rsync_release "backend/app/data/release_notes.json" "backend/app/data/"
 ssh_rsync_release "frontend/public/release-notes.json" "frontend/public/"
 
+# --- Stack DuplexSoft (compose legado + backend/.env; NÃO reativa control-plane) ---
 retry_net "${SSH_BASE[@]}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
   "REF='${REF}' DEPLOY_PATH='${DEPLOY_PATH}' SKIP_MIGRATIONS='${SKIP_MIGRATIONS}' WEBHOOK_BASE_URL='${VITE_API_URL}' DX_CONNECT_VERSION='${DX_CONNECT_VERSION:-}' bash -s" << 'REMOTE_SCRIPT'
 set -ex
@@ -146,6 +152,13 @@ if [ -z "${DX_CONNECT_VERSION:-}" ] && [ -f VERSION ]; then
   export DX_CONNECT_VERSION="$(tr -d '\n\r' < VERSION)"
 fi
 echo "==> Versão: ${DX_CONNECT_VERSION:-n/a}"
+
+# Guarda: não reativar control-plane no cliente
+if grep -Eq '^SAAS_CONTROL_PLANE=true' backend/.env 2>/dev/null; then
+  echo "::error::backend/.env da DuplexSoft tem SAAS_CONTROL_PLANE=true — cutover #878 exige false."
+  exit 1
+fi
+
 WEBHOOK_BASE_URL="${WEBHOOK_BASE_URL:-}" bash deploy/scripts/ensure-evolution-env.sh backend/.env
 COMPOSE="docker compose --env-file backend/.env -f docker-compose.prod.yml"
 if [ "$SKIP_MIGRATIONS" != "true" ]; then
@@ -155,22 +168,26 @@ else
   $COMPOSE build --no-cache backend
 fi
 WEBHOOK_BASE_URL="${WEBHOOK_BASE_URL:-}" bash deploy/scripts/restart-backend-prod.sh "$DEPLOY_PATH"
+
 PUBLIC_HEALTH="$(curl -sf "${WEBHOOK_BASE_URL%/}/health")"
-echo "Health publico (mesmo host): ${PUBLIC_HEALTH}"
+echo "Health DuplexSoft: ${PUBLIC_HEALTH}"
 echo "${PUBLIC_HEALTH}" | DX_CONNECT_GIT_SHA="${DX_CONNECT_GIT_SHA}" python3 -c "
 import json, os, sys
 body = json.load(sys.stdin)
 caps = body.get('capabilities') or {}
+if caps.get('saas_control_plane'):
+    print('::error::DuplexSoft respondeu saas_control_plane=true (não pode após #878).', file=sys.stderr)
+    sys.exit(1)
 missing = [k for k in ('pdv_catalogos', 'empresa_pdvs') if not caps.get(k)]
 if missing:
-    print(f'::error::URL publica sem rotas PDV: faltam {missing}', file=sys.stderr)
+    print(f'::error::URL DuplexSoft sem rotas PDV: faltam {missing}', file=sys.stderr)
     sys.exit(1)
 expected = os.environ.get('DX_CONNECT_GIT_SHA', '')
 actual = (body.get('git_sha') or '') or ''
 if expected and actual and actual != expected:
-    print(f'::error::git_sha publico {actual!r} != commit {expected!r}', file=sys.stderr)
+    print(f'::error::git_sha DuplexSoft {actual!r} != commit {expected!r}', file=sys.stderr)
     sys.exit(1)
-print('OK: health publico no VPS', actual, caps)
+print('OK: DuplexSoft', actual, 'saas_control_plane=false')
 "
 for i in 1 2 3 4 5 6; do
   curl -sf "http://127.0.0.1:8080" >/dev/null && { echo "Evolution API: OK (8080)"; break; }
@@ -179,18 +196,79 @@ done
 curl -sf "http://127.0.0.1:8080" >/dev/null || echo "Evolution API: aguardar ou conferir logs (docker logs dx-connect-evolution-api)"
 REMOTE_SCRIPT
 
-retry_net rsync -avz --delete -e "$RSYNC_E" \
-  frontend/dist/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_FRONTEND_DIST}/"
+# --- Stack admin-center (Postgres + API comerciais) ---
+retry_net "${SSH_BASE[@]}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
+  "REF='${REF}' DEPLOY_PATH='${DEPLOY_PATH}' SKIP_MIGRATIONS='${SKIP_MIGRATIONS}' ADMIN_API_URL='${VITE_API_URL_ADMIN}' DX_CONNECT_VERSION='${DX_CONNECT_VERSION:-}' bash -s" << 'REMOTE_SCRIPT'
+set -ex
+cd "$DEPLOY_PATH"
+export DX_CONNECT_GIT_SHA="$(git rev-parse --short HEAD)"
+if [ -z "${DX_CONNECT_VERSION:-}" ] && [ -f VERSION ]; then
+  export DX_CONNECT_VERSION="$(tr -d '\n\r' < VERSION)"
+fi
 
-API_BASE="${VITE_API_URL%/}"
-echo "GET ${API_BASE}/health"
-export HEALTH_JSON EXPECTED_DEPLOY_SHA
-HEALTH_JSON="$(curl -sf "${API_BASE}/health")"
-echo "$HEALTH_JSON"
-python3 <<'PY'
+if [ ! -f deploy/admin-center/client.env ] || [ ! -f deploy/admin-center/docker-compose.yml ]; then
+  echo "::error::deploy/admin-center não provisionado no VPS (falta client.env / docker-compose.yml)."
+  exit 1
+fi
+
+if [ "$SKIP_MIGRATIONS" != "true" ]; then
+  bash deploy/scripts/stack-client.sh migrate admin-center
+fi
+bash deploy/scripts/stack-client.sh up admin-center
+
+# Health loopback
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  if curl -sf http://127.0.0.1:8001/health >/tmp/admin_health.json; then
+    break
+  fi
+  sleep 3
+done
+test -s /tmp/admin_health.json
+
+PUBLIC_HEALTH="$(curl -sf "${ADMIN_API_URL%/}/health")"
+echo "Health admin-center: ${PUBLIC_HEALTH}"
+echo "${PUBLIC_HEALTH}" | DX_CONNECT_GIT_SHA="${DX_CONNECT_GIT_SHA}" python3 -c "
+import json, os, sys
+body = json.load(sys.stdin)
+caps = body.get('capabilities') or {}
+if not caps.get('saas_control_plane'):
+    print('::error::admin-center sem saas_control_plane=true.', file=sys.stderr)
+    sys.exit(1)
+expected = os.environ.get('DX_CONNECT_GIT_SHA', '')
+actual = (body.get('git_sha') or '') or ''
+if expected and actual and actual != expected:
+    print(f'::error::git_sha admin-center {actual!r} != commit {expected!r}', file=sys.stderr)
+    sys.exit(1)
+print('OK: admin-center', actual, 'saas_control_plane=true')
+"
+REMOTE_SCRIPT
+
+# --- Frontends (dois artefactos) ---
+retry_net rsync -avz --delete -e "$RSYNC_E" \
+  frontend/dist-duplexsoft/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_FRONTEND_DIST}/"
+
+retry_net rsync -avz --delete -e "$RSYNC_E" \
+  frontend/dist-admin-center/ "${DEPLOY_USER}@${DEPLOY_HOST}:${DEPLOY_FRONTEND_DIST_ADMIN}/"
+
+check_health() {
+  local label="$1" url="$2" expect_saas="$3"
+  local json
+  echo "GET ${url}/health (${label})"
+  json="$(curl -sf "${url%/}/health")"
+  echo "$json"
+  EXPECTED_DEPLOY_SHA="${EXPECTED_DEPLOY_SHA:-}" LABEL="$label" EXPECT_SAAS="$expect_saas" HEALTH_JSON="$json" python3 <<'PY'
 import json, os, sys
 body = json.loads(os.environ["HEALTH_JSON"])
 caps = body.get("capabilities") or {}
+label = os.environ["LABEL"]
+expect = os.environ["EXPECT_SAAS"].lower() == "true"
+got = bool(caps.get("saas_control_plane"))
+if got != expect:
+    print(
+        f"::error::{label}: saas_control_plane={got} (esperado {expect}).",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 need = (
     "settings_empresa_sistema",
     "tenant_atual",
@@ -201,7 +279,7 @@ need = (
 missing = [k for k in need if not caps.get(k)]
 if missing:
     print(
-        f"::error::API sem rotas esperadas (backend antigo?): faltam {missing}. git_sha={body.get('git_sha')!r}",
+        f"::error::{label}: faltam capabilities {missing}. git_sha={body.get('git_sha')!r}",
         file=sys.stderr,
     )
     sys.exit(1)
@@ -209,10 +287,13 @@ expected_sha = os.environ.get("EXPECTED_DEPLOY_SHA", "") or os.environ.get("GITH
 actual_sha = (body.get("git_sha") or "") or ""
 if expected_sha and actual_sha and actual_sha != expected_sha:
     print(
-        f"::error::git_sha em producao ({actual_sha!r}) difere do commit deployado ({expected_sha!r}). "
-        "Processo antigo pode ainda estar na porta 8000.",
+        f"::error::{label}: git_sha {actual_sha!r} != {expected_sha!r}.",
         file=sys.stderr,
     )
     sys.exit(1)
-print("OK: capabilities", caps, "git_sha", body.get("git_sha"), "expected", expected_sha)
+print(f"OK: {label} capabilities", caps.get("saas_control_plane"), "git_sha", actual_sha)
 PY
+}
+
+check_health "DuplexSoft" "${VITE_API_URL}" "false"
+check_health "admin-center" "${VITE_API_URL_ADMIN}" "true"

--- a/docs/DEPLOYMENT_ARCHITECTURE.md
+++ b/docs/DEPLOYMENT_ARCHITECTURE.md
@@ -75,4 +75,5 @@ Legado multi-tenant: definir `DX_CONNECT_MULTI_TENANT=true` (e no front `VITE_MU
 - Épico refatoração de código: **#191**
 - Épico operacional legado: **#16**
 - Control-plane vs cliente DuplexSoft: **#875** — stack em [`deploy/admin-center/`](../deploy/admin-center/README.md)
+- Deploy GHA em duas stacks (#880): [`deploy/github-actions.md`](../deploy/github-actions.md)
 - Checklist de servidor: [`PRE_DEPLOY_CHECKLIST.md`](PRE_DEPLOY_CHECKLIST.md)


### PR DESCRIPTION
## Summary
- Deploy passa a atualizar **DuplexSoft** e **admin-center** em separado (#880)
- Dois builds: `dist-duplexsoft` (`VITE_API_URL`) e `dist-admin-center` (`VITE_API_URL_ADMIN` + `VITE_SAAS_CONTROL_PLANE`)
- Abort se `SAAS_CONTROL_PLANE=true` no `.env` do cliente; health exige flags distintas
- Docs em `deploy/github-actions.md` + teste de contrato

## Secrets a criar no GitHub (antes do próximo release)
- `VITE_API_URL_ADMIN` = `https://api.deskrudder.com.br`
- `DEPLOY_FRONTEND_DIST_ADMIN` = `/var/www/dx-connect/admin-center/dist`
- Manter `VITE_API_URL` = API DuplexSoft e `DEPLOY_FRONTEND_DIST` = dist do cliente

## Test plan
- [ ] CI verde
- [ ] Secrets novos configurados no repo
- [ ] Após merge em main + release staging: health comercial `saas=true`, DuplexSoft `saas=false`
- [ ] Landing e painel DuplexSoft com APIs corretas

Closes #880