### PR TITLE
fix(deploy): migrate admin-center sem engolir stdin no SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 #### Melhorias
 
 - Infra (#880): deploy GitHub Actions atualiza **duas** stacks — build/dist DuplexSoft e build/dist comercial; migrate em cada Postgres; health com flags SaaS distintas
+- Infra: `stack-client.sh migrate` fecha o stdin (`-T` + `/dev/null`) para o `docker compose run` não engolir o resto do script SSH no deploy do admin-center
 - Infra (#876 / #877 / #878): painel admin em `api.deskrudder.com.br` + SPA em `deskrudder.com.br`; fila e contas ops migradas para o Postgres comercial; DuplexSoft passa a só **ingerir** sugestões (control-plane desligado nessa instância)
 - Infra (#876): stack `admin-center` sobe com Postgres TLS (self-signed) e `DATABASE_URL` com `sslmode=require`, exigido em produção
 - Fila de sugestões no Cursor: cada ops gera o **próprio token** em Conta / Cursor (`/saas/conta`) e cola no Cursor. Recusar ou comentar fica ligado a essa conta, não a um segredo partilhado da VPS

--- a/backend/tests/test_deploy_dual_stack.py
+++ b/backend/tests/test_deploy_dual_stack.py
@@ -27,6 +27,12 @@ def test_gha_script_atualiza_admin_center_e_bloqueia_saas_no_cliente():
     assert "VITE_API_URL_ADMIN" in SCRIPT
 
 
+def test_stack_client_migrate_fecha_stdin():
+    """Evita docker compose run engolir o resto do script em SSH (bash -s)."""
+    text = (ROOT / "deploy" / "scripts" / "stack-client.sh").read_text(encoding="utf-8")
+    assert "dc run --rm -T backend alembic upgrade head </dev/null" in text
+
+
 def test_docs_listam_secrets_novos():
     assert "VITE_API_URL_ADMIN" in DOCS
     assert "DEPLOY_FRONTEND_DIST_ADMIN" in DOCS

--- a/deploy/github-actions.md
+++ b/deploy/github-actions.md
@@ -82,8 +82,10 @@ O job **`build`** pode ter passado; a falha é só na ligação **runner → VPS
 ### Outros erros comuns
 
 - **`Permission denied (publickey)`**: confira `DEPLOY_SSH_KEY` e `authorized_keys`.
-- **`rsync` falha**: permissões nos dois caminhos de dist.
+- **`rsync` falha**: permissões nos dois caminhos de dist (`chown deploy:www-data` em ambos).
 - **`admin-center não provisionado`**: falta `deploy/admin-center/client.env` no VPS.
 - **`SAAS_CONTROL_PLANE=true` na DuplexSoft**: o deploy aborta de propósito — corrigir `backend/.env` (cutover #878).
 - **Landing fala com API DuplexSoft**: dist admin desatualizado ou `DEPLOY_FRONTEND_DIST_ADMIN` / secret `VITE_API_URL_ADMIN` errados.
 - **404 em rotas novas**: `DEPLOY_GIT_REF=main` desalinhado — remova o secret e redeploye a `staging`.
+- **Admin-center não sobe no deploy (API antiga)**: `stack-client.sh migrate` sem `-T`/`</dev/null` fazia o `docker compose run` consumir o stdin do SSH e engolir o `up` seguinte. O migrate já fecha o stdin; se voltar a acontecer, confira esse padrão.
+- **Health público admin exit 22 no runner**: Cloudflare/rede no IP do GHA; o script valida loopback `127.0.0.1:8001` no VPS como fonte de verdade.

--- a/deploy/scripts/gha-deploy-vps.sh
+++ b/deploy/scripts/gha-deploy-vps.sh
@@ -216,7 +216,7 @@ if [ "$SKIP_MIGRATIONS" != "true" ]; then
 fi
 bash deploy/scripts/stack-client.sh up admin-center
 
-# Health loopback
+# Health loopback (fonte de verdade; público pode falhar via Cloudflare no runner)
 for _ in 1 2 3 4 5 6 7 8 9 10; do
   if curl -sf http://127.0.0.1:8001/health >/tmp/admin_health.json; then
     break
@@ -224,12 +224,10 @@ for _ in 1 2 3 4 5 6 7 8 9 10; do
   sleep 3
 done
 test -s /tmp/admin_health.json
-
-PUBLIC_HEALTH="$(curl -sf "${ADMIN_API_URL%/}/health")"
-echo "Health admin-center: ${PUBLIC_HEALTH}"
-echo "${PUBLIC_HEALTH}" | DX_CONNECT_GIT_SHA="${DX_CONNECT_GIT_SHA}" python3 -c "
+echo "Health admin-center (loopback): $(cat /tmp/admin_health.json)"
+DX_CONNECT_GIT_SHA="${DX_CONNECT_GIT_SHA}" python3 -c "
 import json, os, sys
-body = json.load(sys.stdin)
+body = json.load(open('/tmp/admin_health.json'))
 caps = body.get('capabilities') or {}
 if not caps.get('saas_control_plane'):
     print('::error::admin-center sem saas_control_plane=true.', file=sys.stderr)
@@ -241,6 +239,13 @@ if expected and actual and actual != expected:
     sys.exit(1)
 print('OK: admin-center', actual, 'saas_control_plane=true')
 "
+if [ -n "${ADMIN_API_URL:-}" ]; then
+  if PUBLIC_HEALTH="$(curl -sf --max-time 20 "${ADMIN_API_URL%/}/health")"; then
+    echo "Health admin-center (público): ${PUBLIC_HEALTH}"
+  else
+    echo "::warning::Health público admin-center falhou (Cloudflare/rede); loopback OK."
+  fi
+fi
 REMOTE_SCRIPT
 
 # --- Frontends (dois artefactos) ---
@@ -254,7 +259,10 @@ check_health() {
   local label="$1" url="$2" expect_saas="$3"
   local json
   echo "GET ${url}/health (${label})"
-  json="$(curl -sf "${url%/}/health")"
+  if ! json="$(curl -sf --max-time 20 "${url%/}/health")"; then
+    echo "::error::${label}: curl health falhou (${url%/}/health)."
+    return 1
+  fi
   echo "$json"
   EXPECTED_DEPLOY_SHA="${EXPECTED_DEPLOY_SHA:-}" LABEL="$label" EXPECT_SAAS="$expect_saas" HEALTH_JSON="$json" python3 <<'PY'
 import json, os, sys
@@ -296,4 +304,8 @@ PY
 }
 
 check_health "DuplexSoft" "${VITE_API_URL}" "false"
-check_health "admin-center" "${VITE_API_URL_ADMIN}" "true"
+# admin-center: validação forte já foi no loopback (SSH). Público é soft — Cloudflare
+# no runner GHA às vezes devolve não-200 (curl exit 22) mesmo com API saudável.
+if ! check_health "admin-center" "${VITE_API_URL_ADMIN}" "true"; then
+  echo "::warning::Health público admin-center falhou no runner; loopback SSH já validou saas=true."
+fi

--- a/deploy/scripts/stack-client.sh
+++ b/deploy/scripts/stack-client.sh
@@ -49,7 +49,9 @@ dc() {
 case "$CMD" in
   migrate)
     load_env
-    dc run --rm backend alembic upgrade head
+    # -T + stdin fechado: em SSH/`bash -s` o attach do compose consumiria o resto do script
+    # (mesmo padrão de gha-deploy-vps.sh na stack DuplexSoft).
+    dc run --rm -T backend alembic upgrade head </dev/null
     ;;
   up)
     load_env


### PR DESCRIPTION
## Summary

- Corrige o deploy GHA do **admin-center**: `stack-client.sh migrate` agora usa `-T` + `</dev/null`, para o `docker compose run` não consumir o stdin do SSH e pular o `up`.
- Health do admin-center no VPS passa a validar **loopback** (`127.0.0.1:8001`); o health público no runner vira soft (Cloudflare às vezes devolve exit 22).
- Docs + teste de contrato do script.

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] Produção já reconstruída manualmente: admin-center e DuplexSoft em `c99e0cb` / `26.08.014`
- [ ] CI verde (`changelog` + `backend` com `test_deploy_dual_stack`)
- [ ] Após merge → release `main → staging` para o próximo Deploy Actions validar o caminho completo

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — hotfix de deploy; sem follow-up novo
- [x] Stubs/campos nullable N/A
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados — N/A
