### PR TITLE
release: main → staging (deploy stdin + WhatsApp mobile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- WhatsApp (mobile): ao **Atender**, o modal de setor fica **centralizado** com lista tocável (sem dropdown cortado no rodapé); o Select genérico também abre para cima quando não há espaço abaixo
 - Infra (#876): stacks de cliente (`deploy/clients/`) também sobem Postgres com TLS e `sslmode=require` em produção
 
 ## [26.08.013] - 2026-08-25
@@ -42,7 +43,6 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
-- WhatsApp (mobile): ao **Atender**, o modal de setor fica **centralizado** com lista tocável (sem dropdown cortado no rodapé); o Select genérico também abre para cima quando não há espaço abaixo
 - WhatsApp: seleção de **Empresa do atendimento** no modal — lista deixa de ficar cortada/desproporcional (menu no fluxo do formulário; modal um pouco mais estreito)
 - Configurações (#865): menu reorganizado — **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; Catálogos PDV em **PDV**; Empresa só com dados da instalação; URLs antigas redirecionam
 - Chat interno (#916): cada setor ativo passa a ter canal próprio (criação ao cadastrar/ativar + backfill); canais vazios aparecem em Interno → Setores; o vínculo do atendente ao setor basta para ver o canal; admin vê todos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 #### Melhorias
 
 - Infra (#880): deploy GitHub Actions atualiza **duas** stacks — build/dist DuplexSoft e build/dist comercial; migrate em cada Postgres; health com flags SaaS distintas
+- Infra: `stack-client.sh migrate` fecha o stdin (`-T` + `/dev/null`) para o `docker compose run` não engolir o resto do script SSH no deploy do admin-center
 - Infra (#876 / #877 / #878): painel admin em `api.deskrudder.com.br` + SPA em `deskrudder.com.br`; fila e contas ops migradas para o Postgres comercial; DuplexSoft passa a só **ingerir** sugestões (control-plane desligado nessa instância)
 - Infra (#876): stack `admin-center` sobe com Postgres TLS (self-signed) e `DATABASE_URL` com `sslmode=require`, exigido em produção
 - Fila de sugestões no Cursor: cada ops gera o **próprio token** em Conta / Cursor (`/saas/conta`) e cola no Cursor. Recusar ou comentar fica ligado a essa conta, não a um segredo partilhado da VPS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- WhatsApp (mobile): ao **Atender**, o modal de setor fica **centralizado** com lista tocável (sem dropdown cortado no rodapé); o Select genérico também abre para cima quando não há espaço abaixo
 - WhatsApp: selecção de **Empresa do atendimento** no modal — lista deixa de ficar cortada/desproporcional (menu no fluxo do formulário; modal um pouco mais estreito)
 - Configurações (#865): menu reorganizado — **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; Catálogos PDV em **PDV**; Empresa só com dados da instalação; URLs antigas redirecionam
 - Chat interno (#916): cada setor activo passa a ter canal próprio (criação ao cadastrar/activar + backfill); canais vazios aparecem em Interno → Setores; o vínculo do atendente ao setor basta para ver o canal; admin vê todos

--- a/backend/tests/test_deploy_dual_stack.py
+++ b/backend/tests/test_deploy_dual_stack.py
@@ -27,6 +27,12 @@ def test_gha_script_atualiza_admin_center_e_bloqueia_saas_no_cliente():
     assert "VITE_API_URL_ADMIN" in SCRIPT
 
 
+def test_stack_client_migrate_fecha_stdin():
+    """Evita docker compose run engolir o resto do script em SSH (bash -s)."""
+    text = (ROOT / "deploy" / "scripts" / "stack-client.sh").read_text(encoding="utf-8")
+    assert "dc run --rm -T backend alembic upgrade head </dev/null" in text
+
+
 def test_docs_listam_secrets_novos():
     assert "VITE_API_URL_ADMIN" in DOCS
     assert "DEPLOY_FRONTEND_DIST_ADMIN" in DOCS

--- a/deploy/github-actions.md
+++ b/deploy/github-actions.md
@@ -82,8 +82,10 @@ O job **`build`** pode ter passado; a falha é só na ligação **runner → VPS
 ### Outros erros comuns
 
 - **`Permission denied (publickey)`**: confira `DEPLOY_SSH_KEY` e `authorized_keys`.
-- **`rsync` falha**: permissões nos dois caminhos de dist.
+- **`rsync` falha**: permissões nos dois caminhos de dist (`chown deploy:www-data` em ambos).
 - **`admin-center não provisionado`**: falta `deploy/admin-center/client.env` no VPS.
 - **`SAAS_CONTROL_PLANE=true` na DuplexSoft**: o deploy aborta de propósito — corrigir `backend/.env` (cutover #878).
 - **Landing fala com API DuplexSoft**: dist admin desatualizado ou `DEPLOY_FRONTEND_DIST_ADMIN` / secret `VITE_API_URL_ADMIN` errados.
 - **404 em rotas novas**: `DEPLOY_GIT_REF=main` desalinhado — remova o secret e redeploye a `staging`.
+- **Admin-center não sobe no deploy (API antiga)**: `stack-client.sh migrate` sem `-T`/`</dev/null` fazia o `docker compose run` consumir o stdin do SSH e engolir o `up` seguinte. O migrate já fecha o stdin; se voltar a acontecer, confira esse padrão.
+- **Health público admin exit 22 no runner**: Cloudflare/rede no IP do GHA; o script valida loopback `127.0.0.1:8001` no VPS como fonte de verdade.

--- a/deploy/scripts/gha-deploy-vps.sh
+++ b/deploy/scripts/gha-deploy-vps.sh
@@ -216,7 +216,7 @@ if [ "$SKIP_MIGRATIONS" != "true" ]; then
 fi
 bash deploy/scripts/stack-client.sh up admin-center
 
-# Health loopback
+# Health loopback (fonte de verdade; público pode falhar via Cloudflare no runner)
 for _ in 1 2 3 4 5 6 7 8 9 10; do
   if curl -sf http://127.0.0.1:8001/health >/tmp/admin_health.json; then
     break
@@ -224,12 +224,10 @@ for _ in 1 2 3 4 5 6 7 8 9 10; do
   sleep 3
 done
 test -s /tmp/admin_health.json
-
-PUBLIC_HEALTH="$(curl -sf "${ADMIN_API_URL%/}/health")"
-echo "Health admin-center: ${PUBLIC_HEALTH}"
-echo "${PUBLIC_HEALTH}" | DX_CONNECT_GIT_SHA="${DX_CONNECT_GIT_SHA}" python3 -c "
+echo "Health admin-center (loopback): $(cat /tmp/admin_health.json)"
+DX_CONNECT_GIT_SHA="${DX_CONNECT_GIT_SHA}" python3 -c "
 import json, os, sys
-body = json.load(sys.stdin)
+body = json.load(open('/tmp/admin_health.json'))
 caps = body.get('capabilities') or {}
 if not caps.get('saas_control_plane'):
     print('::error::admin-center sem saas_control_plane=true.', file=sys.stderr)
@@ -241,6 +239,13 @@ if expected and actual and actual != expected:
     sys.exit(1)
 print('OK: admin-center', actual, 'saas_control_plane=true')
 "
+if [ -n "${ADMIN_API_URL:-}" ]; then
+  if PUBLIC_HEALTH="$(curl -sf --max-time 20 "${ADMIN_API_URL%/}/health")"; then
+    echo "Health admin-center (público): ${PUBLIC_HEALTH}"
+  else
+    echo "::warning::Health público admin-center falhou (Cloudflare/rede); loopback OK."
+  fi
+fi
 REMOTE_SCRIPT
 
 # --- Frontends (dois artefactos) ---
@@ -254,7 +259,10 @@ check_health() {
   local label="$1" url="$2" expect_saas="$3"
   local json
   echo "GET ${url}/health (${label})"
-  json="$(curl -sf "${url%/}/health")"
+  if ! json="$(curl -sf --max-time 20 "${url%/}/health")"; then
+    echo "::error::${label}: curl health falhou (${url%/}/health)."
+    return 1
+  fi
   echo "$json"
   EXPECTED_DEPLOY_SHA="${EXPECTED_DEPLOY_SHA:-}" LABEL="$label" EXPECT_SAAS="$expect_saas" HEALTH_JSON="$json" python3 <<'PY'
 import json, os, sys
@@ -296,4 +304,8 @@ PY
 }
 
 check_health "DuplexSoft" "${VITE_API_URL}" "false"
-check_health "admin-center" "${VITE_API_URL_ADMIN}" "true"
+# admin-center: validação forte já foi no loopback (SSH). Público é soft — Cloudflare
+# no runner GHA às vezes devolve não-200 (curl exit 22) mesmo com API saudável.
+if ! check_health "admin-center" "${VITE_API_URL_ADMIN}" "true"; then
+  echo "::warning::Health público admin-center falhou no runner; loopback SSH já validou saas=true."
+fi

--- a/deploy/scripts/stack-client.sh
+++ b/deploy/scripts/stack-client.sh
@@ -49,7 +49,9 @@ dc() {
 case "$CMD" in
   migrate)
     load_env
-    dc run --rm backend alembic upgrade head
+    # -T + stdin fechado: em SSH/`bash -s` o attach do compose consumiria o resto do script
+    # (mesmo padrão de gha-deploy-vps.sh na stack DuplexSoft).
+    dc run --rm -T backend alembic upgrade head </dev/null
     ;;
   up)
     load_env

--- a/frontend/src/components/chat/AssumirWhatsappSetorModal.tsx
+++ b/frontend/src/components/chat/AssumirWhatsappSetorModal.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from 'react'
 import { setores, type Setores } from '../../api/client'
 import { coletarTodasPaginas } from '../../api/collectPages'
 import { Button } from '../ui/Button'
-import { Select } from '../ui/Select'
 
 type Props = {
   open: boolean
@@ -64,47 +63,68 @@ export function AssumirWhatsappSetorModal({
 
   return (
     <div
-      className="fixed inset-0 z-[180] flex items-end justify-center bg-black/50 p-0 backdrop-blur-sm md:items-center md:p-4"
+      className="fixed inset-0 z-[180] flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
       role="dialog"
       aria-modal
       aria-labelledby="assumir-setor-titulo"
       onClick={onClose}
     >
       <div
-        className="w-full max-w-md rounded-t-2xl bg-white p-5 shadow-xl md:rounded-2xl dark:bg-slate-900"
+        className="flex max-h-[min(85dvh,var(--vv-height,85dvh))] w-full max-w-md flex-col overflow-hidden rounded-2xl bg-white shadow-xl dark:bg-slate-900"
         onClick={(e) => e.stopPropagation()}
       >
-        <h2 id="assumir-setor-titulo" className="text-lg font-bold text-slate-900 dark:text-white">
-          Escolher setor
-        </h2>
-        <p className="mt-1 text-sm text-slate-500">
-          Você atende em mais de um setor. Selecione o setor deste atendimento — ele aparece no
-          prefixo das mensagens no WhatsApp do cliente.
-        </p>
-        <div className="mt-4">
-          <Select
-            label="Setor"
-            value={setorId}
-            onChange={(v) => setSetorId(v === '' ? '' : Number(v))}
-            options={opcoes}
-            placeholder={carregando ? 'Carregando…' : 'Selecione o setor'}
-            includeEmpty
-            emptyLabel="Selecione…"
-            disabled={carregando || loading || opcoes.length === 0}
-          />
-          {!carregando && erroCarga && (
-            <p className="mt-2 text-sm text-red-600 dark:text-red-400">
+        <div className="shrink-0 px-5 pt-5">
+          <h2 id="assumir-setor-titulo" className="text-lg font-bold text-slate-900 dark:text-white">
+            Escolher setor
+          </h2>
+          <p className="mt-1 text-sm text-slate-500">
+            Você atende em mais de um setor. Selecione o setor deste atendimento — ele aparece no
+            prefixo das mensagens no WhatsApp do cliente.
+          </p>
+        </div>
+        <div className="dx-scrollbar mt-4 min-h-0 flex-1 overflow-y-auto px-5">
+          <p className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-300">Setor</p>
+          {carregando ? (
+            <p className="py-3 text-sm text-slate-500">Carregando…</p>
+          ) : erroCarga ? (
+            <p className="py-2 text-sm text-red-600 dark:text-red-400">
               Não foi possível carregar os setores. Feche e tente de novo.
             </p>
-          )}
-          {!carregando && !erroCarga && opcoes.length === 0 && (
-            <p className="mt-2 text-sm text-amber-700 dark:text-amber-300">
+          ) : opcoes.length === 0 ? (
+            <p className="py-2 text-sm text-amber-700 dark:text-amber-300">
               Nenhum setor ativo encontrado no seu vínculo. Peça a um admin para rever os setores do
               seu usuário.
             </p>
+          ) : (
+            <div
+              role="radiogroup"
+              aria-label="Setor do atendimento"
+              className="flex flex-col gap-2 pb-1"
+            >
+              {opcoes.map((o) => {
+                const selected = setorId === o.value
+                return (
+                  <button
+                    key={o.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={selected}
+                    disabled={loading}
+                    onClick={() => setSetorId(o.value)}
+                    className={`flex min-h-11 w-full items-center rounded-xl px-3 py-2.5 text-left text-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/40 disabled:opacity-50 ${
+                      selected
+                        ? 'bg-slate-900 font-medium text-white dark:bg-cyan-600 dark:text-white'
+                        : 'bg-slate-50 text-slate-800 ring-1 ring-slate-200/90 hover:bg-slate-100 dark:bg-slate-800/60 dark:text-slate-100 dark:ring-slate-700 dark:hover:bg-slate-800'
+                    }`}
+                  >
+                    <span className="min-w-0 flex-1 break-words">{o.label}</span>
+                  </button>
+                )
+              })}
+            </div>
           )}
         </div>
-        <div className="mt-5 flex justify-end gap-2">
+        <div className="flex shrink-0 justify-end gap-2 border-t border-slate-100 px-5 py-4 dark:border-slate-800">
           <Button type="button" variant="cancel" onClick={onClose} disabled={loading}>
             Cancelar
           </Button>

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -75,10 +75,15 @@ export function Select({
     if (!el) return
     const r = el.getBoundingClientRect()
     const gap = 6
-    const below = r.bottom + gap
-    const maxH = Math.min(280, Math.max(120, window.innerHeight - below - 12))
+    const margin = 12
+    const vh = window.visualViewport?.height ?? window.innerHeight
+    const spaceBelow = vh - r.bottom - gap - margin
+    const spaceAbove = r.top - gap - margin
+    // Em bottom sheets no mobile quase não há espaço abaixo — abre para cima.
+    const openBelow = spaceBelow >= 140 || spaceBelow >= spaceAbove
+    const maxH = Math.min(280, Math.max(96, openBelow ? spaceBelow : spaceAbove))
     setMenuPos({
-      top: below,
+      top: openBelow ? r.bottom + gap : Math.max(margin, r.top - gap - maxH),
       left: r.left,
       width: r.width,
       maxH,


### PR DESCRIPTION
## Summary

Release `main` → `staging` com:

- **Deploy (#938):** `stack-client.sh migrate` fecha o stdin para o admin-center subir de verdade no GHA (não engolir o `up` no SSH)
- **WhatsApp (#933):** modal de setor ao **Atender** centralizado no mobile; Select abre para cima quando falta espaço
- Itens ainda em `[Unreleased]` da control-plane (#880 dual stack, cutover #876/#877/#878, TLS Postgres) que a staging ainda não publicou em versão CalVer

## Test plan

- [ ] CI do PR verde
- [ ] Após merge: Deploy Actions nas duas stacks (DuplexSoft `saas=false` + admin-center `saas=true`)
- [ ] Health público + landing `deskrudder.com.br` / helpdesk DuplexSoft
- [ ] Mobile: Atender no WhatsApp → modal de setor utilizável
