### PR TITLE
feat(chat-interno): membros e online no canal de setor (#941)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Chat interno (#941 / #S202608-0008): no canal de **setor**, clicar no nome abre modal com membros vinculados e quem está **online**
 - WhatsApp (mobile): ao **Atender**, o modal de setor fica **centralizado** com lista tocável (sem dropdown cortado no rodapé); o Select genérico também abre para cima quando não há espaço abaixo
 - WhatsApp: seleção de **Empresa do atendimento** no modal — lista deixa de ficar cortada/desproporcional (menu no fluxo do formulário; modal um pouco mais estreito)
 - Configurações (#865): menu reorganizado — **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; Catálogos PDV em **PDV**; Empresa só com dados da instalação; URLs antigas redirecionam

--- a/backend/app/api/chat_interno.py
+++ b/backend/app/api/chat_interno.py
@@ -19,6 +19,8 @@ from app.schemas.chat_interno import (
     ConversaRead,
     ConversaSilenciarUpdate,
     GrupoParticipantesUpdate,
+    MembroCanalSetorRead,
+    MembrosCanalSetorListaRead,
     MencaoMensagemRead,
     MensagemInternaCreate,
     MensagemInternaRead,
@@ -418,6 +420,35 @@ def obter_canal_setor(
         return _to_conversa_read(db, conversa, atendente)
     except chat_svc.ChatInternoErro as exc:
         raise _map_chat_erro(exc) from exc
+
+
+@router.get("/setores/{setor_id}/membros", response_model=MembrosCanalSetorListaRead)
+def listar_membros_canal_setor(
+    setor_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Membros vinculados ao setor + flag online (TTL de presença). Quem acessa o canal pode ver."""
+    _assert_acesso_setor(atendente, db, setor_id)
+    try:
+        setor_nome, pares = chat_svc.listar_membros_canal_setor_com_presenca(
+            db,
+            tenant_id=atendente.tenant_id,
+            setor_id=setor_id,
+        )
+    except chat_svc.ChatInternoErro as exc:
+        raise _map_chat_erro(exc) from exc
+    items = [
+        MembroCanalSetorRead(atendente_id=a.id, nome=a.nome, online=online) for a, online in pares
+    ]
+    online_count = sum(1 for _, online in pares if online)
+    return MembrosCanalSetorListaRead(
+        setor_id=setor_id,
+        setor_nome=setor_nome,
+        total=len(items),
+        online_count=online_count,
+        items=items,
+    )
 
 
 @router.post(

--- a/backend/app/schemas/chat_interno.py
+++ b/backend/app/schemas/chat_interno.py
@@ -122,3 +122,17 @@ class ConversaInboxRead(BaseModel):
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class MembroCanalSetorRead(BaseModel):
+    atendente_id: int
+    nome: str
+    online: bool = False
+
+
+class MembrosCanalSetorListaRead(BaseModel):
+    setor_id: int
+    setor_nome: str
+    total: int
+    online_count: int
+    items: list[MembroCanalSetorRead]

--- a/backend/app/services/chat_interno.py
+++ b/backend/app/services/chat_interno.py
@@ -351,19 +351,7 @@ def listar_mencionaveis(
         rows = listar_participantes_grupo(db, conversa.id)
         atendentes = [a for a, _ in rows if a.ativo]
     elif conversa.tipo == TIPO_CONVERSA_SETOR and conversa.setor_id is not None:
-        from app.models.atendente import atendente_setor
-
-        atendentes = (
-            db.query(Atendente)
-            .join(atendente_setor, atendente_setor.c.atendente_id == Atendente.id)
-            .filter(
-                atendente_setor.c.setor_id == conversa.setor_id,
-                Atendente.tenant_id == conversa.tenant_id,
-                Atendente.ativo.is_(True),
-            )
-            .order_by(Atendente.nome.asc())
-            .all()
-        )
+        atendentes = listar_membros_vinculados_setor(db, conversa.tenant_id, conversa.setor_id)
     elif conversa.tipo == TIPO_CONVERSA_DIRETA:
         rows = listar_participantes_grupo(db, conversa.id)
         atendentes = [a for a, _ in rows if a.ativo]
@@ -373,6 +361,50 @@ def listar_mencionaveis(
     if excluir_atendente_id is not None:
         atendentes = [a for a in atendentes if a.id != excluir_atendente_id]
     return atendentes
+
+
+def listar_membros_vinculados_setor(db: Session, tenant_id: int, setor_id: int) -> list[Atendente]:
+    """Atendentes ativos vinculados ao setor (membership do canal de setor)."""
+    from app.models.atendente import atendente_setor
+
+    return (
+        db.query(Atendente)
+        .join(atendente_setor, atendente_setor.c.atendente_id == Atendente.id)
+        .filter(
+            atendente_setor.c.setor_id == setor_id,
+            Atendente.tenant_id == tenant_id,
+            Atendente.ativo.is_(True),
+        )
+        .order_by(Atendente.nome.asc())
+        .all()
+    )
+
+
+def listar_membros_canal_setor_com_presenca(
+    db: Session,
+    *,
+    tenant_id: int,
+    setor_id: int,
+) -> tuple[str, list[tuple[Atendente, bool]]]:
+    """Retorna (nome do setor, [(atendente, online), ...]) ordenado: online primeiro, depois nome."""
+    from app.services.presenca import PRESENCA_TTL_SEC
+
+    setor = db.query(Setor).filter(Setor.id == setor_id, Setor.tenant_id == tenant_id).first()
+    if setor is None:
+        raise ChatInternoErro("Setor não encontrado.")
+
+    membros = listar_membros_vinculados_setor(db, tenant_id, setor_id)
+    agora = datetime.now(timezone.utc)
+    limite = agora - timedelta(seconds=PRESENCA_TTL_SEC)
+    out: list[tuple[Atendente, bool]] = []
+    for a in membros:
+        hb = a.presenca_heartbeat_em
+        if hb is not None and hb.tzinfo is None:
+            hb = hb.replace(tzinfo=timezone.utc)
+        online = bool(hb is not None and hb >= limite)
+        out.append((a, online))
+    out.sort(key=lambda pair: (not pair[1], (pair[0].nome or "").lower()))
+    return setor.nome, out
 
 
 def _token_mencao_no_corpo(corpo: str, token: str) -> bool:

--- a/backend/tests/test_chat_interno_api.py
+++ b/backend/tests/test_chat_interno_api.py
@@ -299,3 +299,42 @@ def test_vincular_setor_mostra_canal_na_inbox(client, seed_base, auth_headers, d
     assert r_un.status_code == 200, r_un.text
     inbox2 = client.get("/v1/chat-interno/conversas", headers=auth_headers["a1"]).json()
     assert not any(c["id"] == canal.id for c in inbox2 if c["tipo"] == "setor")
+
+
+def test_membros_canal_setor_lista_e_403(client, seed_base, auth_headers, db_session):
+    """#941 / #S202608-0008 — membros do canal + online; 403 fora do setor."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.services.presenca import PRESENCA_TTL_SEC
+
+    setor1 = seed_base["setor1"].id
+    setor2 = seed_base["setor2"].id
+    a1 = seed_base["a1"]
+    a1.presenca_heartbeat_em = datetime.now(timezone.utc)
+    db_session.add(a1)
+    db_session.commit()
+
+    r = client.get(f"/v1/chat-interno/setores/{setor1}/membros", headers=auth_headers["a1"])
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["setor_id"] == setor1
+    assert body["total"] >= 1
+    ids = {m["atendente_id"] for m in body["items"]}
+    assert a1.id in ids
+    me = next(m for m in body["items"] if m["atendente_id"] == a1.id)
+    assert me["online"] is True
+    assert body["online_count"] >= 1
+
+    a1.presenca_heartbeat_em = datetime.now(timezone.utc) - timedelta(seconds=PRESENCA_TTL_SEC + 30)
+    db_session.add(a1)
+    db_session.commit()
+    r2 = client.get(f"/v1/chat-interno/setores/{setor1}/membros", headers=auth_headers["a1"])
+    assert r2.status_code == 200
+    me2 = next(m for m in r2.json()["items"] if m["atendente_id"] == a1.id)
+    assert me2["online"] is False
+
+    r403 = client.get(f"/v1/chat-interno/setores/{setor2}/membros", headers=auth_headers["a1"])
+    assert r403.status_code == 403
+
+    r_admin = client.get(f"/v1/chat-interno/setores/{setor2}/membros", headers=auth_headers["admin"])
+    assert r_admin.status_code == 200

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1825,6 +1825,20 @@ export namespace ChatInterno {
     papel: 'admin' | 'membro';
   }
 
+  export interface MembroCanalSetor {
+    atendente_id: number;
+    nome: string;
+    online: boolean;
+  }
+
+  export interface MembrosCanalSetorLista {
+    setor_id: number;
+    setor_nome: string;
+    total: number;
+    online_count: number;
+    items: MembroCanalSetor[];
+  }
+
   export interface ConversaInbox {
     id: number;
     tipo: ConversaTipo;
@@ -1988,6 +2002,8 @@ export const chatInterno = {
     }),
   obterCanalSetor: (setorId: number) =>
     api<ChatInterno.Conversa>(`/chat-interno/setores/${setorId}/canal`),
+  listarMembrosCanalSetor: (setorId: number) =>
+    api<ChatInterno.MembrosCanalSetorLista>(`/chat-interno/setores/${setorId}/membros`),
   publicarCanalSetor: (setorId: number, corpo: string) =>
     api<ChatInterno.Mensagem>(`/chat-interno/setores/${setorId}/canal/mensagens`, {
       method: 'POST',

--- a/frontend/src/components/chat-interno/ChatInternoSetorMembrosModal.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoSetorMembrosModal.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react'
+import { chatInterno, type ChatInterno } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useAuth } from '../../contexts/AuthContext'
+import { useToast } from '../ui/Toast'
+import { MODAL_OVERLAY, MODAL_PANEL_SCROLLABLE } from '../../lib/modalPanel'
+
+type Props = {
+  open: boolean
+  setorId: number
+  tituloSetor?: string
+  onClose: () => void
+}
+
+/** Modal read-only: membros do canal de setor + quem está online (#S202608-0008 / #941). */
+export function ChatInternoSetorMembrosModal({ open, setorId, tituloSetor, onClose }: Props) {
+  const { user } = useAuth()
+  const toast = useToast()
+  const [carregando, setCarregando] = useState(false)
+  const [dados, setDados] = useState<ChatInterno.MembrosCanalSetorLista | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setCarregando(true)
+    setDados(null)
+    let cancelado = false
+    void chatInterno
+      .listarMembrosCanalSetor(setorId)
+      .then((lista) => {
+        if (!cancelado) setDados(lista)
+      })
+      .catch((err) => {
+        if (cancelado) return
+        toast.showError(mensagemFalhaParaToast(err))
+        onClose()
+      })
+      .finally(() => {
+        if (!cancelado) setCarregando(false)
+      })
+    return () => {
+      cancelado = true
+    }
+  }, [open, setorId]) // toast/onClose estáveis o suficiente para o fetch do modal
+
+  if (!open) return null
+
+  const titulo = dados?.setor_nome || tituloSetor || 'Canal do setor'
+  const onlineCount = dados?.online_count ?? 0
+  const total = dados?.total ?? 0
+
+  return (
+    <div className={MODAL_OVERLAY} role="presentation" onMouseDown={(e) => e.target === e.currentTarget && onClose()}>
+      <div
+        className={`${MODAL_PANEL_SCROLLABLE} max-w-md`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="setor-membros-titulo"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-3 border-b border-slate-100 px-5 py-4 dark:border-slate-800">
+          <div className="min-w-0">
+            <h2 id="setor-membros-titulo" className="text-lg font-bold text-slate-900 dark:text-white">
+              {titulo}
+            </h2>
+            <p className="mt-0.5 text-sm text-slate-500">
+              {carregando
+                ? 'Carregando membros…'
+                : `${total} ${total === 1 ? 'membro' : 'membros'}${total > 0 ? ` · ${onlineCount} online` : ''}`}
+            </p>
+          </div>
+          <button
+            type="button"
+            className="flex size-9 shrink-0 items-center justify-center rounded-lg text-xl text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
+            onClick={onClose}
+            aria-label="Fechar"
+          >
+            &times;
+          </button>
+        </div>
+        <div className="dx-scrollbar max-h-[min(60dvh,24rem)] overflow-y-auto px-5 py-4">
+          {carregando ? (
+            <p className="py-6 text-center text-sm text-slate-400 animate-pulse">Carregando…</p>
+          ) : !dados || dados.items.length === 0 ? (
+            <p className="py-6 text-center text-sm text-slate-500">
+              Nenhum usuário vinculado a este setor.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {dados.items.map((m) => {
+                const isSelf = m.atendente_id === user?.id
+                return (
+                  <li
+                    key={m.atendente_id}
+                    className="flex items-center gap-3 rounded-xl border border-slate-200 px-3 py-2.5 dark:border-slate-700"
+                  >
+                    <span
+                      className={`size-2.5 shrink-0 rounded-full ${
+                        m.online ? 'bg-emerald-500' : 'bg-slate-300 dark:bg-slate-600'
+                      }`}
+                      title={m.online ? 'Online' : 'Offline'}
+                      aria-hidden
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+                        {m.nome}
+                        {isSelf ? <span className="ml-1 font-normal text-slate-500">(você)</span> : null}
+                      </p>
+                      <p className="text-xs text-slate-500">{m.online ? 'Online' : 'Offline'}</p>
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -4,6 +4,7 @@ import { ApiError, atendentes, chatInterno, type ChatInterno } from '../../api/c
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { ChatInternoComposerBar } from '../../components/chat-interno/ChatInternoComposerBar'
 import { ChatInternoGrupoMembrosModal } from '../../components/chat-interno/ChatInternoGrupoMembrosModal'
+import { ChatInternoSetorMembrosModal } from '../../components/chat-interno/ChatInternoSetorMembrosModal'
 import { ChatInternoConteudoMensagem } from '../../components/chat-interno/ChatInternoConteudoMensagem'
 import { ChatInternoMensagemAcoes } from '../../components/chat-interno/ChatInternoMensagemAcoes'
 import { ChatInternoReacoesBar } from '../../components/chat-interno/ChatInternoReacoesBar'
@@ -279,6 +280,7 @@ export function ChatInternoThread({ conversaIdProp }: ChatInternoThreadProps = {
   const [limpando, setLimpando] = useState(false)
   const [grupoDetalhe, setGrupoDetalhe] = useState<ChatInterno.Conversa | null>(null)
   const [modalMembros, setModalMembros] = useState(false)
+  const [modalMembrosSetor, setModalMembrosSetor] = useState(false)
   const [mencionaveis, setMencionaveis] = useState<MencaoCandidato[]>([])
   const [silenciando, setSilenciando] = useState(false)
   const [hoverMsgId, setHoverMsgId] = useState<number | null>(null)
@@ -553,6 +555,16 @@ export function ChatInternoThread({ conversaIdProp }: ChatInternoThreadProps = {
             <h2 className="truncate text-lg font-bold text-slate-900 dark:text-white">{titulo}</h2>
             <p className="truncate text-sm text-slate-500">{subtitulo}</p>
           </button>
+        ) : isSetor ? (
+          <button
+            type="button"
+            onClick={() => setModalMembrosSetor(true)}
+            className="min-w-0 flex-1 rounded-lg text-left transition hover:bg-slate-50 dark:hover:bg-slate-800/60"
+            aria-label="Ver membros do setor"
+          >
+            <h2 className="truncate text-lg font-bold text-slate-900 dark:text-white">{titulo}</h2>
+            <p className="truncate text-sm text-slate-500">{subtitulo}</p>
+          </button>
         ) : (
           <div className="min-w-0 flex-1">
             <h2 className="truncate text-lg font-bold text-slate-900 dark:text-white">{titulo}</h2>
@@ -613,6 +625,15 @@ export function ChatInternoThread({ conversaIdProp }: ChatInternoThreadProps = {
             setGrupoDetalhe(conv)
             void refreshInbox(true)
           }}
+        />
+      )}
+
+      {isSetor && meta?.setor_id != null && (
+        <ChatInternoSetorMembrosModal
+          open={modalMembrosSetor}
+          setorId={meta.setor_id}
+          tituloSetor={titulo}
+          onClose={() => setModalMembrosSetor(false)}
         />
       )}
 


### PR DESCRIPTION
## Summary
- Fecha [#941](https://github.com/lgustavoss/dx-connect/issues/941) / demanda SaaS **#S202608-0008**
- `GET /v1/chat-interno/setores/{id}/membros` — vinculados ativos + flag online (TTL presença), RBAC por setor
- Título do canal de setor clicável → modal read-only com membros e quem está online

## Test plan
- [ ] Chat Interno → Setores → abrir canal
- [ ] Clicar no nome do setor no header → modal com lista
- [ ] Quem está com o painel aberto aparece **Online**
- [ ] Atendente sem vínculo no setor: API 403
- [ ] `pytest tests/test_chat_interno_api.py::test_membros_canal_setor_lista_e_403`

Closes #941