### PR TITLE
fix(whatsapp): Exportar PDF só em chats finalizados (#945)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Correções
 
+- WhatsApp (#945 / #S202608-0003): **Exportar PDF** só aparece em chats finalizados (encerrado ou aguardando avaliação), não durante o atendimento
 - Deploy: migration do chat interno (#916) usava um ID Alembic maior que 32 caracteres e quebrava o `upgrade` em produção; ID encurtado para caber em `alembic_version`
 
 #### Melhorias

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1762,7 +1762,7 @@ useEffect(() => {
                 </Button>
               )}
 
-              {chat && (
+              {chat && encerrado && (
                 <Button
                   type="button"
                   variant="ghost"
@@ -1821,17 +1821,6 @@ useEffect(() => {
                     </button>
                     {menuMobileAberto && (
                       <div className="absolute right-0 top-full z-30 mt-1 min-w-[12rem] rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900">
-                        <button
-                          type="button"
-                          className="block min-h-11 w-full px-4 py-3 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
-                          disabled={exportandoPdf}
-                          onClick={() => {
-                            setMenuMobileAberto(false)
-                            void exportarPdfChat()
-                          }}
-                        >
-                          {exportandoPdf ? 'A exportar…' : 'Exportar PDF'}
-                        </button>
                         {podeTransferir && (
                           <button
                             type="button"
@@ -1927,7 +1916,7 @@ useEffect(() => {
                           void exportarPdfChat()
                         }}
                       >
-                        {exportandoPdf ? 'A exportar…' : 'Exportar PDF'}
+                        {exportandoPdf ? 'Exportando…' : 'Exportar PDF'}
                       </button>
                     </div>
                   )}


### PR DESCRIPTION
## Summary
- **Exportar PDF** (desktop e menu mobile) só aparece quando o chat está finalizado (`encerrado` ou `aguardando_avaliacao`)
- Copy de loading em pt-BR: «Exportando…»
- Origem SaaS: #S202608-0003

Closes #945

## Test plan
- [ ] Chat em atendimento: sem botão Exportar PDF no header (desktop) nem no menu ⋮ (mobile)
- [ ] Chat encerrado / aguardando avaliação: Exportar PDF visível e gera o PDF
- [ ] Sem regressão nas outras ações do menu (Transferir, Tickets, Encerrar)