### PR TITLE
fix(whatsapp): picker de reação não sobrepõe menu Editar (#947)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Correções
 
+- WhatsApp (#947 / #S202608-0005): picker de reação no hover deixa de cobrir o menu Editar/Apagar da mensagem
 - Deploy: migration do chat interno (#916) usava um ID Alembic maior que 32 caracteres e quebrava o `upgrade` em produção; ID encurtado para caber em `alembic_version`
 
 #### Melhorias

--- a/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
+++ b/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
@@ -18,6 +18,8 @@ type Props = {
   podeReagir?: boolean
   /** Balão claro (inbound) — seta escura. */
   tomClaro?: boolean
+  /** Menu ou edição abertos — pai oculta picker de hover (#S202608-0005). */
+  onMenuAbertoChange?: (aberto: boolean) => void
 }
 
 /** Menu de ações no canto do balão (editar / apagar / reagir) — #630 / #749. */
@@ -28,6 +30,7 @@ export function WhatsappMensagemAcoes({
   onReagirMenu,
   podeReagir = false,
   tomClaro = false,
+  onMenuAbertoChange,
 }: Props) {
   const [editando, setEditando] = useState(false)
   const [texto, setTexto] = useState(() => corpoWhatsappSemPrefixo(mensagem.corpo))
@@ -36,6 +39,8 @@ export function WhatsappMensagemAcoes({
   const [confirmarApagar, setConfirmarApagar] = useState(false)
   const [apagando, setApagando] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
+  const onMenuAbertoChangeRef = useRef(onMenuAbertoChange)
+  onMenuAbertoChangeRef.current = onMenuAbertoChange
 
   const podeEditar = Boolean(mensagem.pode_editar && onEditar)
   const podeApagarTodos = Boolean(mensagem.pode_apagar_para_todos && onApagar)
@@ -44,6 +49,11 @@ export function WhatsappMensagemAcoes({
   useEffect(() => {
     if (!editando) setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
   }, [mensagem, editando])
+
+  useEffect(() => {
+    onMenuAbertoChangeRef.current?.(menuAberto || editando)
+    return () => onMenuAbertoChangeRef.current?.(false)
+  }, [menuAberto, editando])
 
   useEffect(() => {
     if (!menuAberto) return

--- a/frontend/src/components/chat/WhatsappReacoesBar.tsx
+++ b/frontend/src/components/chat/WhatsappReacoesBar.tsx
@@ -11,6 +11,8 @@ type Props = {
   /** Abrir picker a partir do menu da seta (#749). */
   pickerExternoAberto?: boolean
   onPickerExternoClose?: () => void
+  /** Menu/edição abertos: não mostrar picker no hover (#S202608-0005 / #947). */
+  ocultarPickerHover?: boolean
 }
 
 /** Reações no chat WhatsApp com o cliente (#630 lote 2 / #749). */
@@ -21,6 +23,7 @@ export function WhatsappReacoesBar({
   alinhamento = 'end',
   pickerExternoAberto = false,
   onPickerExternoClose,
+  ocultarPickerHover = false,
 }: Props) {
   const temReacoes = reacoes.length > 0
   const alignEnd = alinhamento === 'end'
@@ -35,7 +38,8 @@ export function WhatsappReacoesBar({
             alignEnd ? 'items-end' : 'items-start'
           } ${temReacoes || mostrarPickerMobile ? 'relative mt-1' : 'relative'}`}
         >
-          {/* Desktop: picker no hover do balão */}
+          {/* Desktop: picker no hover do balão (oculto com menu de ações aberto) */}
+          {!ocultarPickerHover ? (
           <div
             className={`pointer-events-none absolute bottom-full z-20 mb-1 hidden flex-col md:flex ${
               alignEnd ? 'right-0 items-end' : 'left-0 items-start'
@@ -63,6 +67,7 @@ export function WhatsappReacoesBar({
               </div>
             </div>
           </div>
+          ) : null}
           {mostrarPickerMobile ? (
             <div className="mt-1 flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md md:hidden dark:border-slate-600 dark:bg-slate-800">
               {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -605,6 +605,7 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
   const enviandoRef = useRef(false)
   const enviandoMidiaRef = useRef(false)
   const [reagirMsgId, setReagirMsgId] = useState<number | null>(null)
+  const [acoesMenuMsgId, setAcoesMenuMsgId] = useState<number | null>(null)
 
   // Estados de WhatsApp Clone (Citação e Zoom)
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
@@ -2195,6 +2196,12 @@ useEffect(() => {
                         onApagar={!isInbound ? () => apagarMensagemWhatsapp(m) : undefined}
                         podeReagir={podeReagir}
                         onReagirMenu={podeReagir ? () => setReagirMsgId(m.id) : undefined}
+                        onMenuAbertoChange={(aberto) => {
+                          setAcoesMenuMsgId((prev) => {
+                            if (aberto) return m.id
+                            return prev === m.id ? null : prev
+                          })
+                        }}
                         tomClaro={isInbound}
                       />
                     )}
@@ -2280,6 +2287,7 @@ useEffect(() => {
                       alinhamento={isInbound ? 'start' : 'end'}
                       pickerExternoAberto={reagirMsgId === m.id}
                       onPickerExternoClose={() => setReagirMsgId(null)}
+                      ocultarPickerHover={acoesMenuMsgId === m.id}
                     />
                   )}
 


### PR DESCRIPTION
Fechado sem merge: vamos redesenhar — emojis de reação **dentro** do menu da seta (junto com Editar/Apagar), em vez de só ocultar o picker no hover. Issue #947 permanece aberta.