### PR TITLE
fix(whatsapp): Reagir no menu mostra emojis no hover (#947)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Correções
 
+- WhatsApp (#947 / #S202608-0005): no menu da mensagem, **Reagir** mostra os emojis ao passar o mouse (ou toque); remove o picker flutuante que cobria Editar/Apagar
 - Deploy: migration do chat interno (#916) usava um ID Alembic maior que 32 caracteres e quebrava o `upgrade` em produção; ID encurtado para caber em `alembic_version`
 
 #### Melhorias

--- a/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
+++ b/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import type { WhatsappChats } from '../../api/client'
+import { EMOJIS_REACAO_CHAT_INTERNO } from '../../lib/chatInternoReacoes'
 import { ConfirmDialog } from '../ui/ConfirmDialog'
 import { TEXTAREA_FIELD_CLASS } from '../ui/Input'
 
@@ -13,8 +14,8 @@ type Props = {
   mensagem: WhatsappChats.Mensagem
   onEditar?: (novoCorpo: string) => Promise<void>
   onApagar?: () => Promise<void>
-  /** Abrir picker de reação (#749). */
-  onReagirMenu?: () => void
+  /** Escolher emoji de reação (#947 / #S202608-0005). */
+  onReagir?: (emoji: string) => void
   podeReagir?: boolean
   /** Balão claro (inbound) — seta escura. */
   tomClaro?: boolean
@@ -25,7 +26,7 @@ export function WhatsappMensagemAcoes({
   mensagem,
   onEditar,
   onApagar,
-  onReagirMenu,
+  onReagir,
   podeReagir = false,
   tomClaro = false,
 }: Props) {
@@ -33,17 +34,22 @@ export function WhatsappMensagemAcoes({
   const [texto, setTexto] = useState(() => corpoWhatsappSemPrefixo(mensagem.corpo))
   const [salvando, setSalvando] = useState(false)
   const [menuAberto, setMenuAberto] = useState(false)
+  const [reagirAberto, setReagirAberto] = useState(false)
   const [confirmarApagar, setConfirmarApagar] = useState(false)
   const [apagando, setApagando] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
 
   const podeEditar = Boolean(mensagem.pode_editar && onEditar)
   const podeApagarTodos = Boolean(mensagem.pode_apagar_para_todos && onApagar)
-  const temAcoes = podeEditar || podeApagarTodos || (podeReagir && Boolean(onReagirMenu))
+  const temAcoes = podeEditar || podeApagarTodos || (podeReagir && Boolean(onReagir))
 
   useEffect(() => {
     if (!editando) setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
   }, [mensagem, editando])
+
+  useEffect(() => {
+    if (!menuAberto) setReagirAberto(false)
+  }, [menuAberto])
 
   useEffect(() => {
     if (!menuAberto) return
@@ -58,6 +64,12 @@ export function WhatsappMensagemAcoes({
 
   const itemClass =
     'block w-full px-3 py-1.5 text-left text-xs font-medium text-slate-700 hover:bg-slate-100 dark:text-slate-100 dark:hover:bg-slate-700'
+
+  function escolherEmoji(emoji: string) {
+    onReagir?.(emoji)
+    setReagirAberto(false)
+    setMenuAberto(false)
+  }
 
   return (
     <>
@@ -103,20 +115,47 @@ export function WhatsappMensagemAcoes({
         {menuAberto && !editando && (
           <div
             role="menu"
-            className="absolute right-0 top-full mt-1 min-w-[8rem] overflow-hidden rounded-lg bg-white py-1 shadow-lg ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-600"
+            className="absolute right-0 top-full z-30 mt-1 min-w-[8rem] overflow-visible rounded-lg bg-white py-1 shadow-lg ring-1 ring-slate-200 dark:bg-slate-800 dark:ring-slate-600"
           >
-            {podeReagir && onReagirMenu && (
-              <button
-                type="button"
-                role="menuitem"
-                className={itemClass}
-                onClick={() => {
-                  setMenuAberto(false)
-                  onReagirMenu()
-                }}
+            {podeReagir && onReagir && (
+              <div
+                className="relative"
+                onMouseEnter={() => setReagirAberto(true)}
+                onMouseLeave={() => setReagirAberto(false)}
               >
-                Reagir
-              </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  aria-expanded={reagirAberto}
+                  aria-haspopup="true"
+                  className={`${itemClass} flex items-center justify-between gap-2`}
+                  onClick={() => setReagirAberto((o) => !o)}
+                >
+                  <span>Reagir</span>
+                  <span className="text-[10px] text-slate-400" aria-hidden>
+                    ▸
+                  </span>
+                </button>
+                {reagirAberto && (
+                  <div
+                    role="group"
+                    aria-label="Escolher reação"
+                    className="absolute right-full top-0 z-40 mr-1 flex items-center gap-0.5 rounded-lg border border-slate-200 bg-white px-1 py-0.5 shadow-lg dark:border-slate-600 dark:bg-slate-800"
+                  >
+                    {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
+                      <button
+                        key={emoji}
+                        type="button"
+                        onClick={() => escolherEmoji(emoji)}
+                        className="min-h-9 min-w-9 rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 md:min-h-0 md:min-w-0 dark:hover:bg-slate-700"
+                        aria-label={`Reagir com ${emoji}`}
+                      >
+                        {emoji}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             )}
             {podeEditar && onEditar && (
               <button

--- a/frontend/src/components/chat/WhatsappReacoesBar.tsx
+++ b/frontend/src/components/chat/WhatsappReacoesBar.tsx
@@ -1,6 +1,4 @@
-import { useState } from 'react'
 import type { WhatsappChats } from '../../api/client'
-import { EMOJIS_REACAO_CHAT_INTERNO } from '../../lib/chatInternoReacoes'
 
 type Props = {
   reacoes: WhatsappChats.ReacaoMensagem[]
@@ -8,109 +6,44 @@ type Props = {
   /** false = só chips (cliente reagiu; atendente sem permissão) */
   podeReagir?: boolean
   alinhamento?: 'start' | 'end'
-  /** Abrir picker a partir do menu da seta (#749). */
-  pickerExternoAberto?: boolean
-  onPickerExternoClose?: () => void
 }
 
-/** Reações no chat WhatsApp com o cliente (#630 lote 2 / #749). */
+/** Chips de reações já aplicadas (#630 lote 2). Picker fica no menu da seta (#947). */
 export function WhatsappReacoesBar({
   reacoes,
   onReagir,
   podeReagir = false,
   alinhamento = 'end',
-  pickerExternoAberto = false,
-  onPickerExternoClose,
 }: Props) {
-  const temReacoes = reacoes.length > 0
+  if (reacoes.length === 0) return null
+
   const alignEnd = alinhamento === 'end'
-  const [pickerHoverAberto, setPickerHoverAberto] = useState(false)
-  const mostrarPickerMobile = pickerExternoAberto
 
   return (
-    <>
-      {podeReagir && onReagir ? (
-        <div
-          className={`z-20 flex flex-col ${
-            alignEnd ? 'items-end' : 'items-start'
-          } ${temReacoes || mostrarPickerMobile ? 'relative mt-1' : 'relative'}`}
+    <div
+      className={`relative z-[1] mt-1 flex flex-wrap gap-1 ${
+        alignEnd ? 'justify-end' : 'justify-start'
+      }`}
+    >
+      {reacoes.map((r) => (
+        <button
+          key={r.emoji}
+          type="button"
+          disabled={!podeReagir || !onReagir}
+          onClick={() => onReagir?.(r.emoji)}
+          className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] shadow-sm transition ${
+            r.reagiu_eu
+              ? 'border-cyan-400/60 bg-white text-slate-800 dark:bg-slate-800 dark:text-slate-100'
+              : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 disabled:hover:bg-white dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200'
+          } ${!podeReagir ? 'cursor-default' : ''}`}
+          title={
+            r.reagiu_eu ? 'Remover sua reação' : podeReagir ? 'Reagir' : r.tem_cliente ? 'Cliente' : 'Reação'
+          }
         >
-          {/* Desktop: picker no hover do balão */}
-          <div
-            className={`pointer-events-none absolute bottom-full z-20 mb-1 hidden flex-col md:flex ${
-              alignEnd ? 'right-0 items-end' : 'left-0 items-start'
-            }`}
-          >
-            <div
-              className={`opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 ${
-                pickerHoverAberto ? 'pointer-events-auto opacity-100' : ''
-              }`}
-              onMouseEnter={() => setPickerHoverAberto(true)}
-              onMouseLeave={() => setPickerHoverAberto(false)}
-            >
-              <div className="flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
-                {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
-                  <button
-                    key={emoji}
-                    type="button"
-                    onClick={() => onReagir(emoji)}
-                    className="rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
-                    aria-label={`Reagir com ${emoji}`}
-                  >
-                    {emoji}
-                  </button>
-                ))}
-              </div>
-            </div>
-          </div>
-          {mostrarPickerMobile ? (
-            <div className="mt-1 flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md md:hidden dark:border-slate-600 dark:bg-slate-800">
-              {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
-                <button
-                  key={emoji}
-                  type="button"
-                  onClick={() => {
-                    onReagir(emoji)
-                    onPickerExternoClose?.()
-                  }}
-                  className="min-h-9 min-w-9 rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
-                  aria-label={`Reagir com ${emoji}`}
-                >
-                  {emoji}
-                </button>
-              ))}
-            </div>
-          ) : null}
-        </div>
-      ) : null}
-
-      {temReacoes ? (
-        <div
-          className={`relative z-[1] mt-1 flex flex-wrap gap-1 ${
-            alignEnd ? 'justify-end' : 'justify-start'
-          }`}
-        >
-          {reacoes.map((r) => (
-            <button
-              key={r.emoji}
-              type="button"
-              disabled={!podeReagir || !onReagir}
-              onClick={() => onReagir?.(r.emoji)}
-              className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] shadow-sm transition ${
-                r.reagiu_eu
-                  ? 'border-cyan-400/60 bg-white text-slate-800 dark:bg-slate-800 dark:text-slate-100'
-                  : 'border-slate-200 bg-white text-slate-700 hover:bg-slate-50 disabled:hover:bg-white dark:border-slate-600 dark:bg-slate-800 dark:text-slate-200'
-              } ${!podeReagir ? 'cursor-default' : ''}`}
-              title={
-                r.reagiu_eu ? 'Remover sua reação' : podeReagir ? 'Reagir' : r.tem_cliente ? 'Cliente' : 'Reação'
-              }
-            >
-              <span>{r.emoji}</span>
-              <span className="font-medium tabular-nums">{r.count}</span>
-            </button>
-          ))}
-        </div>
-      ) : null}
-    </>
+          <span>{r.emoji}</span>
+          <span className="font-medium tabular-nums">{r.count}</span>
+        </button>
+      ))}
+    </div>
   )
 }

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -604,7 +604,6 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
   const [enviando, setEnviando] = useState(false)
   const enviandoRef = useRef(false)
   const enviandoMidiaRef = useRef(false)
-  const [reagirMsgId, setReagirMsgId] = useState<number | null>(null)
 
   // Estados de WhatsApp Clone (Citação e Zoom)
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
@@ -2194,7 +2193,7 @@ useEffect(() => {
                         onEditar={!isInbound ? (texto) => editarMensagemWhatsapp(m, texto) : undefined}
                         onApagar={!isInbound ? () => apagarMensagemWhatsapp(m) : undefined}
                         podeReagir={podeReagir}
-                        onReagirMenu={podeReagir ? () => setReagirMsgId(m.id) : undefined}
+                        onReagir={podeReagir ? (emoji) => void reagirMensagem(m, emoji) : undefined}
                         tomClaro={isInbound}
                       />
                     )}
@@ -2278,8 +2277,6 @@ useEffect(() => {
                       podeReagir={podeReagir}
                       onReagir={podeReagir ? (emoji) => void reagirMensagem(m, emoji) : undefined}
                       alinhamento={isInbound ? 'start' : 'end'}
-                      pickerExternoAberto={reagirMsgId === m.id}
-                      onPickerExternoClose={() => setReagirMsgId(null)}
                     />
                   )}
 


### PR DESCRIPTION
## Summary
- Item **Reagir** no menu da seta: hover (desktop) ou toque (mobile) abre a faixa de emojis ao lado
- Remove o picker flutuante no hover do balão (causa da sobreposição sobre Editar/Apagar)
- Chips de reações já aplicadas continuam abaixo do balão
- Substitui o PR #948 (fechado sem merge)

Closes #947

## Test plan
- [ ] Abrir menu da seta → passar o mouse em **Reagir** → emojis aparecem; escolher aplica a reação
- [ ] Editar/Apagar ficam usáveis sem overlay de emojis no balão
- [ ] Mobile: tocar em Reagir abre/fecha os emojis; escolher fecha o menu
- [ ] Reações existentes (chips) ainda permitem toggle