### PR TITLE
feat(saas): catálogo por módulo, valor negociado e fila ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Docs (#879): MCP aponta a `api.deskrudder.com.br`; runbook para desativar cliente sem derrubar o painel SaaS; arquitetura pós-cutover (admin-center vs compose legado)
+- Painel admin: cabeçalho com **Painel admin SaaS** + usuário logado (nome e cargos); **Equipe** com Usuários / Setores / Minha conta; removido o atalho «Painel atendimento»
+- Equipe SaaS: cadastro de **setores/cargos** (Admin, Desenvolvimento, Comercial, …) sem campo ordem; um usuário pode ter **vários** cargos; o cabeçalho mostra os nomes em vez de só «Ops SaaS»
+- Minha conta: além do token Cursor, o ops edita **nome**, **e-mail** e **senha**
+- Licenças: coluna **Valor/mês** com valor negociado (ou estimativa do catálogo); campo opcional na ficha para negociação diferente do plano
+- Catálogo comercial: **preço por módulo**; plano = soma dos módulos habilitados; licença pode misturar (ex. Essencial + 1 módulo Enterprise); **3 usuários inclusos** + R$ 10/usuário extra (editável no plano)
+- Catálogo comercial: módulos do produto pré-cadastrados; planos Trial / Essencial / Profissional / Enterprise (sem teto de postos nem tickets)
 - Infra (#880): deploy GitHub Actions atualiza **duas** stacks — build/dist DuplexSoft e build/dist comercial; migrate em cada Postgres; health com flags SaaS distintas
 - Infra: `stack-client.sh migrate` fecha o stdin (`-T` + `/dev/null`) para o `docker compose run` não engolir o resto do script SSH no deploy do admin-center
 - Infra (#876 / #877 / #878): painel admin em `api.deskrudder.com.br` + SPA em `deskrudder.com.br`; fila e contas ops migradas para o Postgres comercial; DuplexSoft passa a só **ingerir** sugestões (control-plane desligado nessa instância)
@@ -18,6 +25,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Login ops: no primeiro acesso (trocar senha) o painel SaaS já não mostra «não disponível nesta instância»; redirecciona para definir senha nova
 - Sobre (#920): o painel ops lista **todas** as notas da versão, com etiqueta **Produto** ou **DevOps**. O helpdesk nas instâncias continua a ver só as de produto
 - Login do painel admin: em produção deixa de aparecer a dica de desenvolvimento (e-mail local)
+- Sugestões: na fila, chips de **tipo** (Sugestão / Erro) e **fase** (Aguardando, Em desenvolvimento, Finalizadas), com contadores; badges coloridos na lista e no detalhe
 - Sugestões (#923): detalhe com **linha do tempo** (pedido + mensagens ao cliente); notas internas em cartão âmbar; status em passos clicáveis, como nos tickets
 - Sugestões: textos de acompanhamento em português do Brasil; mensagem ao cliente **não pode citar** GitHub nem número de issue (isso fica na nota interna)
 - Painel ops: menu **Equipe** (Usuários + Minha conta); **Sobre** e **Sair** no rodapé, no mesmo padrão do painel de atendimento

--- a/backend/alembic/versions/120_saas_setores_ops.py
+++ b/backend/alembic/versions/120_saas_setores_ops.py
@@ -1,0 +1,82 @@
+"""Setores da equipe SaaS no control-plane.
+
+Revision ID: 120_saas_setores_ops
+Revises: 119_chat_canal_setor_backfill
+Create Date: 2026-08-25
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "120_saas_setores_ops"
+down_revision = "119_chat_canal_setor_backfill"
+branch_labels = None
+depends_on = None
+
+_SEED = ("Admin", "Desenvolvimento", "Comercial")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if not insp.has_table("saas_setores"):
+        op.create_table(
+            "saas_setores",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False),
+            sa.Column("nome", sa.String(length=100), nullable=False),
+            sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.create_index("ix_saas_setores_tenant_id", "saas_setores", ["tenant_id"])
+        op.create_unique_constraint("uq_saas_setores_tenant_nome", "saas_setores", ["tenant_id", "nome"])
+    else:
+        idxs = {i["name"] for i in insp.get_indexes("saas_setores")}
+        if "ix_saas_setores_tenant_id" not in idxs:
+            op.create_index("ix_saas_setores_tenant_id", "saas_setores", ["tenant_id"])
+        uqs = {c["name"] for c in insp.get_unique_constraints("saas_setores")}
+        if "uq_saas_setores_tenant_nome" not in uqs:
+            op.create_unique_constraint("uq_saas_setores_tenant_nome", "saas_setores", ["tenant_id", "nome"])
+
+    if not insp.has_table("saas_ops_setor"):
+        op.create_table(
+            "saas_ops_setor",
+            sa.Column(
+                "atendente_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+                primary_key=True,
+            ),
+            sa.Column(
+                "saas_setor_id",
+                sa.Integer(),
+                sa.ForeignKey("saas_setores.id", ondelete="CASCADE"),
+                primary_key=True,
+            ),
+        )
+
+    tenants = bind.execute(sa.text("SELECT id FROM tenants")).fetchall()
+    for (tid,) in tenants:
+        for nome in _SEED:
+            bind.execute(
+                sa.text(
+                    "INSERT INTO saas_setores (tenant_id, nome, ativo) "
+                    "VALUES (:tid, :nome, true) "
+                    "ON CONFLICT ON CONSTRAINT uq_saas_setores_tenant_nome DO NOTHING"
+                ),
+                {"tid": tid, "nome": nome},
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("saas_ops_setor"):
+        op.drop_table("saas_ops_setor")
+    if insp.has_table("saas_setores"):
+        idxs = {i["name"] for i in insp.get_indexes("saas_setores")}
+        if "ix_saas_setores_tenant_id" in idxs:
+            op.drop_index("ix_saas_setores_tenant_id", table_name="saas_setores")
+        op.drop_table("saas_setores")

--- a/backend/alembic/versions/121_saas_catalogo_precos.py
+++ b/backend/alembic/versions/121_saas_catalogo_precos.py
@@ -1,0 +1,193 @@
+"""Catálogo comercial ampliado: módulos do produto + planos com preço e max_usuários.
+
+Revision ID: 121_saas_catalogo_precos
+Revises: 120_saas_setores_ops
+Create Date: 2026-08-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "121_saas_catalogo_precos"
+down_revision = "120_saas_setores_ops"
+branch_labels = None
+depends_on = None
+
+# (codigo, nome, descricao)
+_MODULOS = (
+    ("helpdesk", "Helpdesk / tickets", "Tickets e atendimento helpdesk"),
+    ("whatsapp", "WhatsApp", "Canal WhatsApp / Evolution"),
+    ("contratos", "Contratos comerciais", "Contratos comerciais (parte do CRM)"),
+    ("boletos", "Boletos / cobrança", "Emissão e gestão de boletos no fluxo de cobrança"),
+    ("email", "Canal e-mail", "Atendimento e tickets por e-mail"),
+    ("portal", "Portal do posto", "Portal para funcionários da rede / posto"),
+    ("kb", "Base de conhecimento", "Artigos de ajuda e consulta"),
+    ("chat-interno", "Chat interno", "Chat entre a equipe da instância"),
+    ("crm", "CRM / funil / propostas", "Funil comercial, leads e propostas"),
+    ("faturamento", "Faturamento interno", "Faturas internas e fluxo NFS-e"),
+    ("ponto", "Ponto eletrônico", "Batidas, escala e ponto da equipe"),
+    ("sla", "SLA", "Políticas e calendários de SLA"),
+    ("pdv", "Cadastros PDV", "Catálogos e cadastros de PDV / postos"),
+    ("mobile", "App mobile", "App Android (APK) do painel"),
+)
+
+# (codigo, nome, descricao, ordem, preco_mensal, max_usuarios, modulos)
+_PLANOS = (
+    (
+        "trial",
+        "Trial",
+        "Avaliação — helpdesk e WhatsApp",
+        10,
+        0,
+        3,
+        ("helpdesk", "whatsapp"),
+    ),
+    (
+        "essencial",
+        "Essencial",
+        "Atendimento omnichannel essencial (tickets, WhatsApp, e-mail, portal e KB)",
+        20,
+        397,
+        8,
+        ("helpdesk", "whatsapp", "email", "portal", "kb"),
+    ),
+    (
+        "profissional",
+        "Profissional",
+        "Operação completa com CRM, chat interno, SLA e PDV",
+        30,
+        797,
+        20,
+        (
+            "helpdesk",
+            "whatsapp",
+            "email",
+            "portal",
+            "kb",
+            "chat-interno",
+            "crm",
+            "contratos",
+            "sla",
+            "pdv",
+        ),
+    ),
+    (
+        "enterprise",
+        "Enterprise",
+        "Pacote completo — ponto, faturamento, boletos e app mobile",
+        40,
+        1497,
+        50,
+        (
+            "helpdesk",
+            "whatsapp",
+            "email",
+            "portal",
+            "kb",
+            "chat-interno",
+            "crm",
+            "contratos",
+            "sla",
+            "pdv",
+            "ponto",
+            "faturamento",
+            "boletos",
+            "mobile",
+        ),
+    ),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("saas_modulos") or not insp.has_table("saas_planos"):
+        return
+
+    for codigo, nome, descricao in _MODULOS:
+        bind.execute(
+            sa.text(
+                """
+                INSERT INTO saas_modulos (codigo, nome, descricao, ativo)
+                VALUES (:codigo, :nome, :descricao, true)
+                ON CONFLICT ON CONSTRAINT uq_saas_modulos_codigo DO UPDATE SET
+                    nome = EXCLUDED.nome,
+                    descricao = EXCLUDED.descricao,
+                    ativo = true,
+                    updated_at = now()
+                """
+            ),
+            {"codigo": codigo, "nome": nome, "descricao": descricao},
+        )
+
+    for codigo, nome, descricao, ordem, preco, max_usuarios, _mods in _PLANOS:
+        bind.execute(
+            sa.text(
+                """
+                INSERT INTO saas_planos (
+                    codigo, nome, descricao, ativo, ordem,
+                    preco_mensal, max_postos, max_usuarios
+                )
+                VALUES (
+                    :codigo, :nome, :descricao, true, :ordem,
+                    :preco, NULL, :max_usuarios
+                )
+                ON CONFLICT ON CONSTRAINT uq_saas_planos_codigo DO UPDATE SET
+                    nome = EXCLUDED.nome,
+                    descricao = EXCLUDED.descricao,
+                    ativo = true,
+                    ordem = EXCLUDED.ordem,
+                    preco_mensal = EXCLUDED.preco_mensal,
+                    max_postos = NULL,
+                    max_usuarios = EXCLUDED.max_usuarios,
+                    updated_at = now()
+                """
+            ),
+            {
+                "codigo": codigo,
+                "nome": nome,
+                "descricao": descricao,
+                "ordem": ordem,
+                "preco": preco,
+                "max_usuarios": max_usuarios,
+            },
+        )
+
+    mod_ids = {
+        row[0]: row[1]
+        for row in bind.execute(sa.text("SELECT codigo, id FROM saas_modulos")).fetchall()
+    }
+    plan_ids = {
+        row[0]: row[1]
+        for row in bind.execute(sa.text("SELECT codigo, id FROM saas_planos")).fetchall()
+    }
+
+    for codigo, _n, _d, _o, _p, _u, mods in _PLANOS:
+        pid = plan_ids.get(codigo)
+        if pid is None:
+            continue
+        bind.execute(
+            sa.text("DELETE FROM saas_plano_modulos WHERE plano_id = :pid"),
+            {"pid": pid},
+        )
+        for mc in mods:
+            mid = mod_ids.get(mc)
+            if mid is None:
+                continue
+            bind.execute(
+                sa.text(
+                    """
+                    INSERT INTO saas_plano_modulos (plano_id, modulo_id)
+                    VALUES (:pid, :mid)
+                    ON CONFLICT DO NOTHING
+                    """
+                ),
+                {"pid": pid, "mid": mid},
+            )
+
+
+def downgrade() -> None:
+    """Não remove módulos/planos — catálogo comercial pode ter sido editado em produção."""
+    pass

--- a/backend/alembic/versions/122_saas_preco_modulos.py
+++ b/backend/alembic/versions/122_saas_preco_modulos.py
@@ -1,0 +1,117 @@
+"""Preço por módulo + usuários inclusos / extra nos planos.
+
+Revision ID: 122_saas_preco_modulos
+Revises: 121_saas_catalogo_precos
+Create Date: 2026-08-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "122_saas_preco_modulos"
+down_revision = "121_saas_catalogo_precos"
+branch_labels = None
+depends_on = None
+
+# Preços unitários (R$/mês) — Essencial≈97, Profissional≈197, Enterprise≈347
+_PRECOS_MODULO = {
+    "helpdesk": 29,
+    "whatsapp": 29,
+    "email": 15,
+    "portal": 12,
+    "kb": 12,
+    "chat-interno": 20,
+    "crm": 25,
+    "contratos": 20,
+    "sla": 20,
+    "pdv": 15,
+    "ponto": 40,
+    "faturamento": 40,
+    "boletos": 35,
+    "mobile": 35,
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("saas_modulos") or not insp.has_table("saas_planos"):
+        return
+
+    mod_cols = {c["name"] for c in insp.get_columns("saas_modulos")}
+    if "preco_mensal" not in mod_cols:
+        op.add_column(
+            "saas_modulos",
+            sa.Column("preco_mensal", sa.Numeric(12, 2), nullable=True),
+        )
+
+    plan_cols = {c["name"] for c in insp.get_columns("saas_planos")}
+    if "usuarios_inclusos" not in plan_cols:
+        op.add_column(
+            "saas_planos",
+            sa.Column("usuarios_inclusos", sa.Integer(), nullable=False, server_default="3"),
+        )
+    if "preco_usuario_extra" not in plan_cols:
+        op.add_column(
+            "saas_planos",
+            sa.Column("preco_usuario_extra", sa.Numeric(12, 2), nullable=True, server_default="10"),
+        )
+
+    for codigo, preco in _PRECOS_MODULO.items():
+        bind.execute(
+            sa.text(
+                "UPDATE saas_modulos SET preco_mensal = :preco, updated_at = now() "
+                "WHERE codigo = :codigo"
+            ),
+            {"codigo": codigo, "preco": preco},
+        )
+
+    bind.execute(
+        sa.text(
+            """
+            UPDATE saas_planos SET
+                usuarios_inclusos = 3,
+                preco_usuario_extra = 10,
+                max_postos = NULL,
+                max_usuarios = NULL,
+                updated_at = now()
+            """
+        )
+    )
+
+    # Recalcula preco_mensal do plano = soma dos módulos ligados
+    rows = bind.execute(
+        sa.text(
+            """
+            SELECT p.id, COALESCE(SUM(m.preco_mensal), 0) AS total
+            FROM saas_planos p
+            LEFT JOIN saas_plano_modulos pm ON pm.plano_id = p.id
+            LEFT JOIN saas_modulos m ON m.id = pm.modulo_id
+            GROUP BY p.id
+            """
+        )
+    ).fetchall()
+    for pid, total in rows:
+        bind.execute(
+            sa.text(
+                "UPDATE saas_planos SET preco_mensal = :total, updated_at = now() WHERE id = :pid"
+            ),
+            {"pid": pid, "total": total},
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("saas_planos"):
+        cols = {c["name"] for c in insp.get_columns("saas_planos")}
+        if "preco_usuario_extra" in cols:
+            op.drop_column("saas_planos", "preco_usuario_extra")
+        if "usuarios_inclusos" in cols:
+            op.drop_column("saas_planos", "usuarios_inclusos")
+    if insp.has_table("saas_modulos"):
+        cols = {c["name"] for c in insp.get_columns("saas_modulos")}
+        if "preco_mensal" in cols:
+            op.drop_column("saas_modulos", "preco_mensal")

--- a/backend/alembic/versions/123_saas_preco_negociado.py
+++ b/backend/alembic/versions/123_saas_preco_negociado.py
@@ -1,0 +1,39 @@
+"""Valor mensal negociado por licença SaaS.
+
+Revision ID: 123_saas_preco_negociado
+Revises: 122_saas_preco_modulos
+Create Date: 2026-08-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "123_saas_preco_negociado"
+down_revision = "122_saas_preco_modulos"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("clientes_saas"):
+        return
+    cols = {c["name"] for c in insp.get_columns("clientes_saas")}
+    if "preco_mensal_negociado" not in cols:
+        op.add_column(
+            "clientes_saas",
+            sa.Column("preco_mensal_negociado", sa.Numeric(12, 2), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("clientes_saas"):
+        return
+    cols = {c["name"] for c in insp.get_columns("clientes_saas")}
+    if "preco_mensal_negociado" in cols:
+        op.drop_column("clientes_saas", "preco_mensal_negociado")

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -31,6 +31,7 @@ class OrdenarAtendentesPor(str, Enum):
 
 
 def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) -> AtendenteRead:
+    saas = sorted(getattr(atendente, "saas_setores", None) or [], key=lambda s: (s.nome or "", s.id))
     return AtendenteRead(
         id=atendente.id,
         email=atendente.email,
@@ -49,6 +50,8 @@ def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) ->
         horario_previsto_entrada=getattr(atendente, "horario_previsto_entrada", None),
         horario_previsto_saida=getattr(atendente, "horario_previsto_saida", None),
         tolerancia_atraso_minutos=int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0),
+        saas_setor_ids=[s.id for s in saas],
+        saas_setor_nomes=[s.nome for s in saas],
     )
 
 

--- a/backend/app/api/saas.py
+++ b/backend/app/api/saas.py
@@ -554,7 +554,7 @@ def listar_modulos(
     _: None = Depends(exigir_saas_control_plane),
     __: Atendente = Depends(exigir_saas_ops),
 ):
-    return [SaasModuloRead.model_validate(m) for m in saas_catalogo.listar_modulos(db, ativo=ativo)]
+    return [saas_catalogo.serializar_modulo(m) for m in saas_catalogo.listar_modulos(db, ativo=ativo)]
 
 
 @router.post("/modulos", response_model=SaasModuloRead, status_code=201)
@@ -571,7 +571,7 @@ def criar_modulo(
     registrar_audit(db, "saas_modulo", row.id, "create", atendente.id)
     db.commit()
     db.refresh(row)
-    return SaasModuloRead.model_validate(row)
+    return saas_catalogo.serializar_modulo(row)
 
 
 @router.get("/modulos/{modulo_id}", response_model=SaasModuloRead)
@@ -582,7 +582,7 @@ def obter_modulo(
     __: Atendente = Depends(exigir_saas_ops),
 ):
     try:
-        return SaasModuloRead.model_validate(saas_catalogo.obter_modulo(db, modulo_id))
+        return saas_catalogo.serializar_modulo(saas_catalogo.obter_modulo(db, modulo_id))
     except svc.SaasErro as e:
         raise _http_from_saas(e) from e
 
@@ -602,7 +602,7 @@ def atualizar_modulo(
     registrar_audit(db, "saas_modulo", modulo_id, "update", atendente.id)
     db.commit()
     db.refresh(row)
-    return SaasModuloRead.model_validate(row)
+    return saas_catalogo.serializar_modulo(row)
 
 
 @router.post("/modulos/{modulo_id}/ativar", response_model=SaasModuloRead)
@@ -619,7 +619,7 @@ def ativar_modulo(
     registrar_audit(db, "saas_modulo", modulo_id, "ativar", atendente.id)
     db.commit()
     db.refresh(row)
-    return SaasModuloRead.model_validate(row)
+    return saas_catalogo.serializar_modulo(row)
 
 
 @router.post("/modulos/{modulo_id}/desativar", response_model=SaasModuloRead)
@@ -636,4 +636,4 @@ def desativar_modulo(
     registrar_audit(db, "saas_modulo", modulo_id, "desativar", atendente.id)
     db.commit()
     db.refresh(row)
-    return SaasModuloRead.model_validate(row)
+    return saas_catalogo.serializar_modulo(row)

--- a/backend/app/api/saas_ops_conta.py
+++ b/backend/app/api/saas_ops_conta.py
@@ -1,4 +1,4 @@
-"""Conta do ops no control-plane — token Cursor (#915)."""
+"""Conta do ops no control-plane — perfil e token Cursor (#915)."""
 
 from __future__ import annotations
 
@@ -10,7 +10,9 @@ from app.core.auth import exigir_saas_ops
 from app.database import get_db
 from app.models.atendente import Atendente
 from app.schemas.saas_mcp_token import SaasMcpTokenEstado, SaasMcpTokenGerado
+from app.schemas.saas_ops_conta import SaasOpsContaPerfilRead, SaasOpsContaPerfilUpdate
 from app.services import saas_mcp_token as mcp_token
+from app.services import saas_ops_conta as conta_svc
 
 router = APIRouter(prefix="/saas/me", tags=["saas-ops-conta"])
 
@@ -21,6 +23,24 @@ def _exigir_control_plane() -> None:
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Painel SaaS não disponível nesta instância",
         )
+
+
+@router.patch("", response_model=SaasOpsContaPerfilRead)
+def atualizar_perfil(
+    data: SaasOpsContaPerfilUpdate,
+    db: Session = Depends(get_db),
+    _: None = Depends(_exigir_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+):
+    """Atualiza nome e/ou e-mail da conta logada."""
+    row, tokens = conta_svc.atualizar_perfil(db, ops, data)
+    db.commit()
+    db.refresh(row)
+    payload = SaasOpsContaPerfilRead(id=row.id, nome=row.nome, email=row.email)
+    if tokens:
+        payload.access_token = tokens["access_token"]
+        payload.refresh_token = tokens["refresh_token"]
+    return payload
 
 
 @router.get("/mcp-token", response_model=SaasMcpTokenEstado)

--- a/backend/app/api/saas_ops_usuarios.py
+++ b/backend/app/api/saas_ops_usuarios.py
@@ -1,4 +1,4 @@
-"""Equipa do control-plane — contas saas_ops (#883)."""
+"""Equipe do control-plane — contas saas_ops (#883)."""
 
 from __future__ import annotations
 
@@ -66,14 +66,14 @@ def obter_usuario(
 
 
 @router.patch("/{usuario_id}", response_model=SaasOpsUsuarioRead)
-def actualizar_usuario(
+def atualizar_usuario(
     usuario_id: int,
     data: SaasOpsUsuarioUpdate,
     _: None = Depends(exigir_saas_control_plane),
     ops: Atendente = Depends(exigir_saas_ops),
     db: Session = Depends(get_db),
 ):
-    row = svc.actualizar(db, ops, usuario_id, data)
+    row = svc.atualizar(db, ops, usuario_id, data)
     db.commit()
     db.refresh(row)
     return SaasOpsUsuarioRead.model_validate(svc.para_dict(row))

--- a/backend/app/api/saas_setores.py
+++ b/backend/app/api/saas_setores.py
@@ -1,0 +1,62 @@
+"""API — setores (cargos) da equipe SaaS."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.api.saas import exigir_saas_control_plane
+from app.core.auth import exigir_saas_ops
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.schemas.saas_setor import SaasSetorCreate, SaasSetorRead, SaasSetorUpdate
+from app.services import saas_setores as svc
+
+router = APIRouter(prefix="/saas/setores", tags=["saas-setores"])
+
+
+@router.get("", response_model=list[SaasSetorRead])
+def listar_setores(
+    incluir_inativos: bool = Query(False),
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+    db: Session = Depends(get_db),
+):
+    return svc.listar(db, ops, incluir_inativos=incluir_inativos)
+
+
+@router.post("", response_model=SaasSetorRead, status_code=201)
+def criar_setor(
+    data: SaasSetorCreate,
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+    db: Session = Depends(get_db),
+):
+    row = svc.criar(db, ops, data)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.get("/{setor_id}", response_model=SaasSetorRead)
+def obter_setor(
+    setor_id: int,
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+    db: Session = Depends(get_db),
+):
+    return svc.obter(db, ops, setor_id)
+
+
+@router.patch("/{setor_id}", response_model=SaasSetorRead)
+def atualizar_setor(
+    setor_id: int,
+    data: SaasSetorUpdate,
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+    db: Session = Depends(get_db),
+):
+    row = svc.atualizar(db, ops, setor_id, data)
+    db.commit()
+    db.refresh(row)
+    return row

--- a/backend/app/api/saas_solicitacoes.py
+++ b/backend/app/api/saas_solicitacoes.py
@@ -17,6 +17,10 @@ from app.models.atendente import Atendente
 from app.models.cliente_saas import ClienteSaaS
 from app.models.saas_solicitacao_produto import SaasSolicitacaoProduto
 from app.schemas.lista_paginada import ListaPaginada
+from app.services.solicitacao_melhoria_copy import status_da_fase
+from app.services import saas_solicitacao_grupo as grupo
+from app.services import saas_solicitacao_ingest as ingest
+from app.services import saas_solicitacao_triagem as triagem
 from app.schemas.saas_solicitacao import (
     SaasSolicitacaoAnexoRead,
     SaasSolicitacaoComentarioCreate,
@@ -24,13 +28,11 @@ from app.schemas.saas_solicitacao import (
     SaasSolicitacaoGithubUpdate,
     SaasSolicitacaoIngest,
     SaasSolicitacaoListaItem,
+    SaasSolicitacaoResumo,
     SaasSolicitacaoStatusUpdate,
     SaasSolicitacaoSyncResponse,
     SaasSolicitacaoVinculoCreate,
 )
-from app.services import saas_solicitacao_grupo as grupo
-from app.services import saas_solicitacao_ingest as ingest
-from app.services import saas_solicitacao_triagem as triagem
 
 router = APIRouter(prefix="/saas", tags=["saas-solicitacoes"])
 
@@ -127,11 +129,40 @@ def sync_triagem(
     return triagem.listar_sync(db, cliente, since=since)
 
 
+@router.get("/solicitacoes/resumo", response_model=SaasSolicitacaoResumo)
+def resumo_fila(
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    __: Atendente = Depends(exigir_fila_saas),
+):
+    from app.services.solicitacao_melhoria_copy import FASES_STATUS
+
+    rows = db.query(SaasSolicitacaoProduto.tipo, SaasSolicitacaoProduto.status).all()
+    total = len(rows)
+    sugestoes = sum(1 for t, _ in rows if t == "sugestao")
+    problemas = sum(1 for t, _ in rows if t == "problema")
+    aguardando = sum(1 for _, s in rows if s in FASES_STATUS["aguardando"])
+    desenvolvimento = sum(1 for _, s in rows if s in FASES_STATUS["desenvolvimento"])
+    finalizadas = sum(1 for _, s in rows if s in FASES_STATUS["finalizadas"])
+    return SaasSolicitacaoResumo(
+        total=total,
+        sugestoes=sugestoes,
+        problemas=problemas,
+        aguardando=aguardando,
+        desenvolvimento=desenvolvimento,
+        finalizadas=finalizadas,
+    )
+
+
 @router.get("/solicitacoes", response_model=ListaPaginada[SaasSolicitacaoListaItem])
 def listar(
     busca: str | None = Query(None),
     tipo: str | None = Query(None),
     status_filtro: str | None = Query(None, alias="status"),
+    fase: str | None = Query(
+        None,
+        description="Agrupa status: aguardando | desenvolvimento | finalizadas",
+    ),
     slug: str | None = Query(None),
     offset: int = Query(0, ge=0),
     limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
@@ -157,6 +188,11 @@ def listar(
         q = q.filter(SaasSolicitacaoProduto.tipo == tipo.strip())
     if status_filtro and status_filtro.strip():
         q = q.filter(SaasSolicitacaoProduto.status == status_filtro.strip())
+    elif fase and fase.strip():
+        statuses = status_da_fase(fase)
+        if statuses is None:
+            raise HTTPException(status_code=400, detail="Fase inválida")
+        q = q.filter(SaasSolicitacaoProduto.status.in_(list(statuses)))
     if slug and slug.strip():
         q = q.filter(SaasSolicitacaoProduto.instance_slug == slug.strip().lower())
     total = q.count()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -62,6 +62,7 @@ from app.api import (
     saas_solicitacoes,
     saas_ops_conta,
     saas_ops_usuarios,
+    saas_setores,
     web_push,
     solicitacoes_melhoria,
 )
@@ -647,6 +648,7 @@ app.include_router(saas_leads.router, prefix=API_V1_PREFIX)
 app.include_router(saas_solicitacoes.router, prefix=API_V1_PREFIX)
 app.include_router(saas_ops_conta.router, prefix=API_V1_PREFIX)
 app.include_router(saas_ops_usuarios.router, prefix=API_V1_PREFIX)
+app.include_router(saas_setores.router, prefix=API_V1_PREFIX)
 app.include_router(solicitacoes_melhoria.router, prefix=API_V1_PREFIX)
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -73,6 +73,7 @@ from app.models.implantacao_checklist import (
     TicketChecklistItem,
 )
 from app.models.cliente_saas import ClienteSaaS
+from app.models.saas_setor import SaasSetor, saas_ops_setor
 from app.models.saas_alerta_emitido import SaasAlertaEmitido
 from app.models.lead_comercial import LeadComercial
 from app.models.saas_plano import SaasModulo, SaasPlano, SaasPlanoModulo
@@ -96,6 +97,7 @@ __all__ = [
     "SetorDistribuicaoRoundRobin",
     "Atendente",
     "AtendenteSetor",
+    "SaasSetor",
     "PontoBatida",
     "PontoJustificativa",
     "PontoSettings",

--- a/backend/app/models/atendente.py
+++ b/backend/app/models/atendente.py
@@ -51,6 +51,11 @@ class Atendente(Base):
         secondary=atendente_setor,
         back_populates="atendentes",
     )
+    saas_setores = relationship(
+        "SaasSetor",
+        secondary="saas_ops_setor",
+        back_populates="ops",
+    )
     tickets_atendidos = relationship("Ticket", back_populates="atendente")
     historicos = relationship("TicketHistorico", back_populates="atendente")
     ticket_mensagens = relationship("TicketMensagem", back_populates="atendente")

--- a/backend/app/models/cliente_saas.py
+++ b/backend/app/models/cliente_saas.py
@@ -1,6 +1,6 @@
 """Cliente SaaS / licença DeskRudder (control-plane comercial) — #521."""
 
-from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, JSON, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, JSON, Numeric, String, Text, UniqueConstraint
 from sqlalchemy.sql import func
 
 from app.database import Base
@@ -24,6 +24,8 @@ class ClienteSaaS(Base):
     modulos_snapshot = Column(JSON, nullable=True)
     max_postos = Column(Integer, nullable=True)
     max_usuarios = Column(Integer, nullable=True)
+    # Se preenchido, sobrescreve a estimativa (módulos + extras) na ficha comercial.
+    preco_mensal_negociado = Column(Numeric(12, 2), nullable=True)
     data_inicio = Column(Date, nullable=False)
     data_renovacao = Column(Date, nullable=True)
     instancia_url = Column(String(500), nullable=True)

--- a/backend/app/models/saas_plano.py
+++ b/backend/app/models/saas_plano.py
@@ -27,6 +27,7 @@ class SaasModulo(Base):
     codigo = Column(String(80), nullable=False, index=True)
     nome = Column(String(120), nullable=False)
     descricao = Column(Text, nullable=True)
+    preco_mensal = Column(Numeric(12, 2), nullable=True)
     ativo = Column(Boolean, nullable=False, default=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
@@ -45,6 +46,9 @@ class SaasPlano(Base):
     ativo = Column(Boolean, nullable=False, default=True)
     ordem = Column(Integer, nullable=False, default=0)
     preco_mensal = Column(Numeric(12, 2), nullable=True)
+    # Usuários inclusos no preço dos módulos (padrão 3).
+    usuarios_inclusos = Column(Integer, nullable=False, default=3, server_default="3")
+    preco_usuario_extra = Column(Numeric(12, 2), nullable=True)
     max_postos = Column(Integer, nullable=True)
     max_usuarios = Column(Integer, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/saas_setor.py
+++ b/backend/app/models/saas_setor.py
@@ -1,0 +1,34 @@
+"""Setores (cargos) da equipe DeskRudder no control-plane — Admin, Dev, Comercial, etc."""
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Table, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+saas_ops_setor = Table(
+    "saas_ops_setor",
+    Base.metadata,
+    Column("atendente_id", Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), primary_key=True),
+    Column("saas_setor_id", Integer, ForeignKey("saas_setores.id", ondelete="CASCADE"), primary_key=True),
+)
+
+
+class SaasSetor(Base):
+    """Setor/cargo da equipe ops (não confundir com setor de tickets do helpdesk)."""
+
+    __tablename__ = "saas_setores"
+    __table_args__ = (UniqueConstraint("tenant_id", "nome", name="uq_saas_setores_tenant_nome"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    nome = Column(String(100), nullable=False)
+    ativo = Column(Boolean, nullable=False, default=True, server_default="true")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    ops = relationship(
+        "Atendente",
+        secondary=saas_ops_setor,
+        back_populates="saas_setores",
+    )

--- a/backend/app/schemas/atendente.py
+++ b/backend/app/schemas/atendente.py
@@ -47,6 +47,8 @@ class AtendenteRead(AtendenteBase):
     setor_ids: list[int] = []
     e_financeiro: bool = False
     must_change_password: bool = False
+    saas_setor_ids: list[int] = []
+    saas_setor_nomes: list[str] = []
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/schemas/saas.py
+++ b/backend/app/schemas/saas.py
@@ -105,6 +105,17 @@ class ClienteSaaSBase(BaseModel):
 
 class ClienteSaaSCreate(ClienteSaaSBase):
     lead_comercial_id: int | None = None
+    modulo_ids: list[int] | None = Field(
+        None, description="Mix custom de módulos; se omitido, usa os do plano"
+    )
+    usuarios_contratados: int | None = Field(
+        None, ge=0, description="Usuários contratados (extra além dos inclusos)"
+    )
+    preco_mensal_negociado: float | None = Field(
+        None,
+        ge=0,
+        description="Valor mensal fechado na negociação; se vazio, usa a estimativa do catálogo",
+    )
 
 
 class ClienteSaaSUpdate(BaseModel):
@@ -119,6 +130,9 @@ class ClienteSaaSUpdate(BaseModel):
     contato_email: str | None = Field(None, max_length=255)
     contato_nome: str | None = Field(None, max_length=200)
     notas: str | None = None
+    modulo_ids: list[int] | None = None
+    usuarios_contratados: int | None = Field(None, ge=0)
+    preco_mensal_negociado: float | None = Field(None, ge=0)
 
     @field_validator("nome")
     @classmethod
@@ -263,6 +277,7 @@ class SaasModuloBrief(BaseModel):
     codigo: str
     nome: str
     ativo: bool = True
+    preco_mensal: float | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -287,9 +302,17 @@ class ClienteSaaSRead(ClienteSaaSBase):
     comandos_stack: str | None = None
     dias_para_renovacao: int | None = None
     plano_modulos: list[SaasModuloBrief] = Field(default_factory=list)
+    modulos_contratados: list[SaasModuloBrief] = Field(default_factory=list)
     modulos_snapshot: list[str] = Field(default_factory=list)
     max_postos: int | None = None
     max_usuarios: int | None = None
+    usuarios_inclusos: int | None = None
+    preco_usuario_extra: float | None = None
+    preco_modulos: float | None = None
+    preco_usuarios_extra: float | None = None
+    preco_mensal_estimado: float | None = None
+    preco_mensal_negociado: float | None = None
+    preco_mensal_efetivo: float | None = None
     ingest_token_configurado: bool = False
     created_at: datetime | None = None
     updated_at: datetime | None = None
@@ -336,6 +359,7 @@ class SaasModuloCreate(BaseModel):
     codigo: str = Field(..., min_length=1, max_length=80)
     nome: str = Field(..., min_length=1, max_length=120)
     descricao: str | None = None
+    preco_mensal: float | None = Field(None, ge=0)
 
     @field_validator("codigo")
     @classmethod
@@ -362,6 +386,7 @@ class SaasModuloCreate(BaseModel):
 class SaasModuloUpdate(BaseModel):
     nome: str | None = Field(None, min_length=1, max_length=120)
     descricao: str | None = None
+    preco_mensal: float | None = Field(None, ge=0)
 
     @field_validator("nome")
     @classmethod
@@ -387,6 +412,7 @@ class SaasModuloRead(BaseModel):
     codigo: str
     nome: str
     descricao: str | None = None
+    preco_mensal: float | None = None
     ativo: bool = True
     created_at: datetime | None = None
     updated_at: datetime | None = None
@@ -399,8 +425,8 @@ class SaasPlanoCreate(BaseModel):
     nome: str = Field(..., min_length=1, max_length=120)
     descricao: str | None = None
     ordem: int = 0
-    preco_mensal: float | None = Field(None, ge=0)
-    max_postos: int | None = Field(None, ge=0)
+    usuarios_inclusos: int | None = Field(3, ge=0)
+    preco_usuario_extra: float | None = Field(10, ge=0)
     max_usuarios: int | None = Field(None, ge=0)
     modulo_ids: list[int] = Field(default_factory=list)
 
@@ -430,8 +456,8 @@ class SaasPlanoUpdate(BaseModel):
     nome: str | None = Field(None, min_length=1, max_length=120)
     descricao: str | None = None
     ordem: int | None = None
-    preco_mensal: float | None = Field(None, ge=0)
-    max_postos: int | None = Field(None, ge=0)
+    usuarios_inclusos: int | None = Field(None, ge=0)
+    preco_usuario_extra: float | None = Field(None, ge=0)
     max_usuarios: int | None = Field(None, ge=0)
     modulo_ids: list[int] | None = None
 
@@ -462,6 +488,8 @@ class SaasPlanoRead(BaseModel):
     ativo: bool = True
     ordem: int = 0
     preco_mensal: float | None = None
+    usuarios_inclusos: int = 3
+    preco_usuario_extra: float | None = 10
     max_postos: int | None = None
     max_usuarios: int | None = None
     modulos: list[SaasModuloBrief] = Field(default_factory=list)
@@ -469,3 +497,13 @@ class SaasPlanoRead(BaseModel):
     updated_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class SaasPrecoEstimativa(BaseModel):
+    preco_modulos: float = 0
+    preco_usuarios_extra: float = 0
+    preco_mensal_total: float = 0
+    usuarios_inclusos: int = 3
+    preco_usuario_extra: float = 10
+    usuarios_contratados: int | None = None
+    modulos: list[SaasModuloBrief] = Field(default_factory=list)

--- a/backend/app/schemas/saas_ops_conta.py
+++ b/backend/app/schemas/saas_ops_conta.py
@@ -1,0 +1,20 @@
+"""Schemas — conta do ops no painel SaaS."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SaasOpsContaPerfilUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=255)
+    email: str | None = Field(None, min_length=3, max_length=255)
+
+
+class SaasOpsContaPerfilRead(BaseModel):
+    """Resposta do PATCH /saas/me. Tokens só vêm quando o e-mail muda (JWT usa o e-mail no sub)."""
+
+    id: int
+    nome: str
+    email: str
+    access_token: str | None = None
+    refresh_token: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/saas_ops_usuario.py
+++ b/backend/app/schemas/saas_ops_usuario.py
@@ -1,8 +1,10 @@
-"""Utilizadores do painel SaaS (role saas_ops) — #883."""
+"""Usuários do painel SaaS (role saas_ops) — #883."""
 
 from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.saas_setor import SaasSetorRead
 
 
 class SaasOpsUsuarioRead(BaseModel):
@@ -14,6 +16,8 @@ class SaasOpsUsuarioRead(BaseModel):
     mcp_token_configurado: bool
     mcp_token_gerado_em: datetime | None = None
     created_at: datetime | None = None
+    setor_ids: list[int] = []
+    setores: list[SaasSetorRead] = []
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -21,6 +25,7 @@ class SaasOpsUsuarioRead(BaseModel):
 class SaasOpsUsuarioCreate(BaseModel):
     nome: str = Field(..., min_length=1, max_length=255)
     email: str = Field(..., min_length=3, max_length=255)
+    setor_ids: list[int] = Field(default_factory=list)
 
 
 class SaasOpsUsuarioCriado(SaasOpsUsuarioRead):
@@ -32,6 +37,7 @@ class SaasOpsUsuarioCriado(SaasOpsUsuarioRead):
 class SaasOpsUsuarioUpdate(BaseModel):
     nome: str | None = Field(None, min_length=1, max_length=255)
     ativo: bool | None = None
+    setor_ids: list[int] | None = None
 
 
 class SaasOpsUsuarioSenha(BaseModel):

--- a/backend/app/schemas/saas_setor.py
+++ b/backend/app/schemas/saas_setor.py
@@ -1,0 +1,23 @@
+"""Schemas — setores (cargos) da equipe SaaS."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SaasSetorRead(BaseModel):
+    id: int
+    nome: str
+    ativo: bool
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SaasSetorCreate(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=100)
+
+
+class SaasSetorUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=100)
+    ativo: bool | None = None

--- a/backend/app/schemas/saas_solicitacao.py
+++ b/backend/app/schemas/saas_solicitacao.py
@@ -124,6 +124,15 @@ class SaasSolicitacaoSyncResponse(BaseModel):
     items: list[SaasSolicitacaoSyncItem] = Field(default_factory=list)
 
 
+class SaasSolicitacaoResumo(BaseModel):
+    total: int = 0
+    sugestoes: int = 0
+    problemas: int = 0
+    aguardando: int = 0
+    desenvolvimento: int = 0
+    finalizadas: int = 0
+
+
 class ClienteSaaSIngestTokenRead(BaseModel):
     slug: str
     token: str

--- a/backend/app/services/saas_catalogo.py
+++ b/backend/app/services/saas_catalogo.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 from sqlalchemy.orm import Session, joinedload
 
 from app.models.saas_plano import SaasModulo, SaasPlano, SaasPlanoModulo
@@ -12,6 +14,29 @@ from app.schemas.saas import (
     SaasPlanoUpdate,
 )
 from app.services.saas_clientes import SaasErro
+
+
+def _num(v) -> float:
+    if v is None:
+        return 0.0
+    return float(v)
+
+
+def soma_preco_modulos(mods: list[SaasModulo]) -> float:
+    return round(sum(_num(m.preco_mensal) for m in mods), 2)
+
+
+def preco_extra_usuarios(
+    *,
+    usuarios_inclusos: int,
+    preco_usuario_extra: float | Decimal | None,
+    usuarios_contratados: int | None,
+) -> float:
+    if usuarios_contratados is None:
+        return 0.0
+    inclusos = max(0, int(usuarios_inclusos or 0))
+    extra = max(0, int(usuarios_contratados) - inclusos)
+    return round(extra * _num(preco_usuario_extra), 2)
 
 
 def obter_modulo(db: Session, modulo_id: int) -> SaasModulo:
@@ -31,7 +56,13 @@ def listar_modulos(db: Session, *, ativo: bool | None = None) -> list[SaasModulo
 def criar_modulo(db: Session, data: SaasModuloCreate) -> SaasModulo:
     if db.query(SaasModulo).filter(SaasModulo.codigo == data.codigo).first():
         raise SaasErro("Já existe um módulo com este código", 409)
-    row = SaasModulo(codigo=data.codigo, nome=data.nome, descricao=data.descricao, ativo=True)
+    row = SaasModulo(
+        codigo=data.codigo,
+        nome=data.nome,
+        descricao=data.descricao,
+        preco_mensal=data.preco_mensal,
+        ativo=True,
+    )
     db.add(row)
     db.flush()
     return row
@@ -43,13 +74,15 @@ def atualizar_modulo(db: Session, modulo_id: int, data: SaasModuloUpdate) -> Saa
     for k, v in payload.items():
         setattr(row, k, v)
     db.flush()
+    if "preco_mensal" in payload:
+        _recalcular_planos_com_modulo(db, row.id)
     return row
 
 
 def ativar_modulo(db: Session, modulo_id: int) -> SaasModulo:
     row = obter_modulo(db, modulo_id)
     if row.ativo:
-        raise SaasErro("Módulo já está activo")
+        raise SaasErro("Módulo já está ativo")
     row.ativo = True
     db.flush()
     return row
@@ -58,7 +91,7 @@ def ativar_modulo(db: Session, modulo_id: int) -> SaasModulo:
 def desativar_modulo(db: Session, modulo_id: int) -> SaasModulo:
     row = obter_modulo(db, modulo_id)
     if not row.ativo:
-        raise SaasErro("Módulo já está inactivo")
+        raise SaasErro("Módulo já está inativo")
     row.ativo = False
     db.flush()
     return row
@@ -96,12 +129,51 @@ def _resolver_modulos(db: Session, modulo_ids: list[int]) -> list[SaasModulo]:
     return [by_id[i] for i in uniq]
 
 
+def resolver_modulos_por_codigos(db: Session, codigos: list[str]) -> list[SaasModulo]:
+    if not codigos:
+        return []
+    uniq = list(dict.fromkeys([c.strip().lower() for c in codigos if c and c.strip()]))
+    rows = db.query(SaasModulo).filter(SaasModulo.codigo.in_(uniq)).all()
+    by_cod = {r.codigo: r for r in rows}
+    missing = [c for c in uniq if c not in by_cod]
+    if missing:
+        raise SaasErro(f"Módulos inválidos: {', '.join(missing)}")
+    return [by_cod[c] for c in uniq]
+
+
+def _modulos_do_plano(plano: SaasPlano) -> list[SaasModulo]:
+    out: list[SaasModulo] = []
+    for link in plano.modulos_links or []:
+        if link.modulo is not None:
+            out.append(link.modulo)
+    return out
+
+
+def _aplicar_preco_plano(plano: SaasPlano) -> None:
+    plano.preco_mensal = soma_preco_modulos(_modulos_do_plano(plano))
+
+
+def _recalcular_planos_com_modulo(db: Session, modulo_id: int) -> None:
+    planos = (
+        db.query(SaasPlano)
+        .options(joinedload(SaasPlano.modulos_links).joinedload(SaasPlanoModulo.modulo))
+        .join(SaasPlanoModulo, SaasPlanoModulo.plano_id == SaasPlano.id)
+        .filter(SaasPlanoModulo.modulo_id == modulo_id)
+        .all()
+    )
+    for plano in planos:
+        _aplicar_preco_plano(plano)
+    db.flush()
+
+
 def _set_modulos(db: Session, plano: SaasPlano, modulo_ids: list[int]) -> None:
     mods = _resolver_modulos(db, modulo_ids)
     plano.modulos_links.clear()
     db.flush()
     for m in mods:
         plano.modulos_links.append(SaasPlanoModulo(plano_id=plano.id, modulo_id=m.id))
+    db.flush()
+    plano.preco_mensal = soma_preco_modulos(mods)
     db.flush()
 
 
@@ -113,8 +185,9 @@ def criar_plano(db: Session, data: SaasPlanoCreate) -> SaasPlano:
         nome=data.nome,
         descricao=data.descricao,
         ordem=data.ordem or 0,
-        preco_mensal=data.preco_mensal,
-        max_postos=data.max_postos,
+        usuarios_inclusos=data.usuarios_inclusos if data.usuarios_inclusos is not None else 3,
+        preco_usuario_extra=data.preco_usuario_extra if data.preco_usuario_extra is not None else 10,
+        max_postos=None,
         max_usuarios=data.max_usuarios,
         ativo=True,
     )
@@ -127,11 +200,16 @@ def criar_plano(db: Session, data: SaasPlanoCreate) -> SaasPlano:
 def atualizar_plano(db: Session, plano_id: int, data: SaasPlanoUpdate) -> SaasPlano:
     row = obter_plano(db, plano_id)
     payload = data.model_dump(exclude_unset=True)
+    # Preço do plano é sempre a soma dos módulos — não aceitar override manual.
+    payload.pop("preco_mensal", None)
+    payload.pop("max_postos", None)
     modulo_ids = payload.pop("modulo_ids", None)
     for k, v in payload.items():
         setattr(row, k, v)
     if modulo_ids is not None:
         _set_modulos(db, row, modulo_ids)
+    else:
+        _aplicar_preco_plano(row)
     db.flush()
     return obter_plano(db, row.id)
 
@@ -139,7 +217,7 @@ def atualizar_plano(db: Session, plano_id: int, data: SaasPlanoUpdate) -> SaasPl
 def ativar_plano(db: Session, plano_id: int) -> SaasPlano:
     row = obter_plano(db, plano_id)
     if row.ativo:
-        raise SaasErro("Plano já está activo")
+        raise SaasErro("Plano já está ativo")
     row.ativo = True
     db.flush()
     return row
@@ -148,10 +226,24 @@ def ativar_plano(db: Session, plano_id: int) -> SaasPlano:
 def desativar_plano(db: Session, plano_id: int) -> SaasPlano:
     row = obter_plano(db, plano_id)
     if not row.ativo:
-        raise SaasErro("Plano já está inactivo")
+        raise SaasErro("Plano já está inativo")
     row.ativo = False
     db.flush()
     return row
+
+
+def serializar_modulo(row: SaasModulo) -> dict:
+    preco = row.preco_mensal
+    return {
+        "id": row.id,
+        "codigo": row.codigo,
+        "nome": row.nome,
+        "descricao": row.descricao,
+        "preco_mensal": float(preco) if preco is not None else None,
+        "ativo": bool(row.ativo),
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+    }
 
 
 def serializar_plano(row: SaasPlano) -> dict:
@@ -160,8 +252,18 @@ def serializar_plano(row: SaasPlano) -> dict:
         m = link.modulo
         if m is None:
             continue
-        mods.append({"id": m.id, "codigo": m.codigo, "nome": m.nome, "ativo": bool(m.ativo)})
+        mods.append(
+            {
+                "id": m.id,
+                "codigo": m.codigo,
+                "nome": m.nome,
+                "ativo": bool(m.ativo),
+                "preco_mensal": float(m.preco_mensal) if m.preco_mensal is not None else None,
+            }
+        )
     preco = row.preco_mensal
+    if preco is None:
+        preco = soma_preco_modulos(_modulos_do_plano(row))
     return {
         "id": row.id,
         "codigo": row.codigo,
@@ -170,6 +272,10 @@ def serializar_plano(row: SaasPlano) -> dict:
         "ativo": bool(row.ativo),
         "ordem": int(row.ordem or 0),
         "preco_mensal": float(preco) if preco is not None else None,
+        "usuarios_inclusos": int(row.usuarios_inclusos or 3),
+        "preco_usuario_extra": (
+            float(row.preco_usuario_extra) if row.preco_usuario_extra is not None else 10.0
+        ),
         "max_postos": row.max_postos,
         "max_usuarios": row.max_usuarios,
         "modulos": mods,
@@ -188,8 +294,9 @@ def aplicar_plano_em_cliente(
     plano_id: int | None,
     plano_actual_id: int | None = None,
     permitir_inactivo_se_actual: bool = True,
+    modulo_ids: list[int] | None = None,
 ) -> tuple[int | None, str | None, list[str], int | None, int | None]:
-    """Valida e devolve (plano_id, nome, códigos módulos, max_postos, max_usuarios)."""
+    """Valida e devolve (plano_id, nome, códigos módulos, max_postos, max_usuarios do plano)."""
     if plano_id is None:
         return None, None, [], None, None
     plano = (
@@ -202,16 +309,20 @@ def aplicar_plano_em_cliente(
         raise SaasErro("Plano não encontrado", 404)
     if not plano.ativo:
         if not (permitir_inactivo_se_actual and plano_actual_id == plano.id):
-            raise SaasErro("Plano inactivo — escolha um plano activo")
-    codigos: list[str] = []
-    for link in plano.modulos_links or []:
-        if link.modulo and link.modulo.codigo:
-            codigos.append(link.modulo.codigo)
+            raise SaasErro("Plano inativo — escolha um plano ativo")
+    if modulo_ids is not None:
+        mods = _resolver_modulos(db, modulo_ids)
+        codigos = [m.codigo for m in mods if m.codigo]
+    else:
+        codigos = []
+        for link in plano.modulos_links or []:
+            if link.modulo and link.modulo.codigo:
+                codigos.append(link.modulo.codigo)
     return plano.id, plano.nome, codigos, plano.max_postos, plano.max_usuarios
 
 
 def sincronizar_snapshot_licenca(db: Session, row) -> None:
-    """Actualiza modulos_snapshot e limites a partir do plano_id actual."""
+    """Atualiza modulos_snapshot e limites a partir do plano_id actual (sem sobrescrever mix custom)."""
     from app.models.cliente_saas import ClienteSaaS
 
     if not isinstance(row, ClienteSaaS):
@@ -219,7 +330,11 @@ def sincronizar_snapshot_licenca(db: Session, row) -> None:
     if not row.plano_id:
         row.modulos_snapshot = []
         row.max_postos = None
-        row.max_usuarios = None
+        return
+    # Se já há snapshot custom, só garante limites de postos nulos; usuários contratados ficam.
+    if list(getattr(row, "modulos_snapshot", None) or []):
+        row.max_postos = None
+        db.flush()
         return
     _pid, _nome, codigos, max_p, max_u = aplicar_plano_em_cliente(
         db,
@@ -229,16 +344,61 @@ def sincronizar_snapshot_licenca(db: Session, row) -> None:
     )
     row.modulos_snapshot = codigos
     row.max_postos = max_p
-    row.max_usuarios = max_u
+    if getattr(row, "max_usuarios", None) is None and max_u is not None:
+        row.max_usuarios = max_u
     db.flush()
+
+
+def estimar_preco_mensal(
+    db: Session,
+    *,
+    plano_id: int | None,
+    modulo_ids: list[int] | None,
+    usuarios_contratados: int | None,
+) -> dict:
+    """Calcula preço comercial (módulos + extras de usuário)."""
+    mods: list[SaasModulo] = []
+    inclusos = 3
+    extra_unit = 10.0
+    if plano_id is not None:
+        plano = obter_plano(db, plano_id)
+        inclusos = int(plano.usuarios_inclusos or 3)
+        extra_unit = _num(plano.preco_usuario_extra) if plano.preco_usuario_extra is not None else 10.0
+        if modulo_ids is None:
+            mods = _modulos_do_plano(plano)
+    if modulo_ids is not None:
+        mods = _resolver_modulos(db, modulo_ids)
+    preco_mods = soma_preco_modulos(mods)
+    preco_users = preco_extra_usuarios(
+        usuarios_inclusos=inclusos,
+        preco_usuario_extra=extra_unit,
+        usuarios_contratados=usuarios_contratados,
+    )
+    return {
+        "preco_modulos": preco_mods,
+        "preco_usuarios_extra": preco_users,
+        "preco_mensal_total": round(preco_mods + preco_users, 2),
+        "usuarios_inclusos": inclusos,
+        "preco_usuario_extra": extra_unit,
+        "usuarios_contratados": usuarios_contratados,
+        "modulos": [
+            {
+                "id": m.id,
+                "codigo": m.codigo,
+                "nome": m.nome,
+                "preco_mensal": float(m.preco_mensal) if m.preco_mensal is not None else None,
+            }
+            for m in mods
+        ],
+    }
 
 
 _ACTION_LABELS = {
     "create": "Licença criada",
     "create_from_lead": "Criada a partir de lead",
-    "update": "Dados actualizados",
+    "update": "Dados atualizados",
     "suspender": "Suspensa",
-    "reativar": "Reactivada",
+    "reativar": "Reativada",
     "renovar": "Renovada",
     "registrar_instancia": "URL sincronizada",
     "solicitar_provisionamento": "Provisionamento solicitado",

--- a/backend/app/services/saas_clientes.py
+++ b/backend/app/services/saas_clientes.py
@@ -42,6 +42,8 @@ def criar(db: Session, data: ClienteSaaSCreate) -> ClienteSaaS:
     _garantir_slug_unico(db, data.slug)
     payload = data.model_dump()
     lead_id = payload.pop("lead_comercial_id", None)
+    modulo_ids = payload.pop("modulo_ids", None)
+    usuarios_contratados = payload.pop("usuarios_contratados", None)
     # URL pública é sempre derivada do slug (+ domínio base); não é campo livre.
     payload["instancia_url"] = _url_do_slug(data.slug) or payload.get("instancia_url")
 
@@ -50,15 +52,20 @@ def criar(db: Session, data: ClienteSaaSCreate) -> ClienteSaaS:
     plano_id = payload.pop("plano_id", None)
     # Texto livre `plano` só como fallback legado; preferir plano_id.
     if plano_id is not None:
-        pid, nome, codigos, max_p, max_u = aplicar_plano_em_cliente(db, plano_id=plano_id)
+        pid, nome, codigos, max_p, max_u = aplicar_plano_em_cliente(
+            db, plano_id=plano_id, modulo_ids=modulo_ids
+        )
         payload["plano_id"] = pid
         payload["plano"] = nome
         payload["modulos_snapshot"] = codigos
-        payload["max_postos"] = max_p
-        payload["max_usuarios"] = max_u
+        payload["max_postos"] = None
+        if usuarios_contratados is not None:
+            payload["max_usuarios"] = usuarios_contratados
+        elif max_u is not None:
+            payload["max_usuarios"] = max_u
     elif payload.get("plano"):
         # Trial / legado: tentar resolver por código ou deixar só o rótulo.
-        from app.services.saas_catalogo import obter_plano_por_codigo, sincronizar_snapshot_licenca
+        from app.services.saas_catalogo import obter_plano_por_codigo
 
         p = obter_plano_por_codigo(db, str(payload["plano"]))
         if p is not None:
@@ -88,37 +95,45 @@ def atualizar(db: Session, cliente_id: int, data: ClienteSaaSUpdate) -> ClienteS
         _garantir_slug_unico(db, payload["slug"], excluir_id=cliente_id)
     # instancia_url deixa de ser editável à mão — sempre acompanha o slug.
     payload.pop("instancia_url", None)
+    modulo_ids = payload.pop("modulo_ids", None)
+    usuarios_contratados = payload.pop("usuarios_contratados", None)
 
-    if "plano_id" in payload:
+    if "plano_id" in payload or modulo_ids is not None:
         from app.services.saas_catalogo import aplicar_plano_em_cliente
 
-        pid, nome, codigos, max_p, max_u = aplicar_plano_em_cliente(
+        plano_ref = payload["plano_id"] if "plano_id" in payload else getattr(row, "plano_id", None)
+        pid, nome, codigos, _max_p, max_u = aplicar_plano_em_cliente(
             db,
-            plano_id=payload["plano_id"],
+            plano_id=plano_ref,
             plano_actual_id=getattr(row, "plano_id", None),
+            modulo_ids=modulo_ids,
         )
         payload["plano_id"] = pid
         payload["plano"] = nome
         payload["modulos_snapshot"] = codigos
-        payload["max_postos"] = max_p
-        payload["max_usuarios"] = max_u
+        payload["max_postos"] = None
+        if usuarios_contratados is not None:
+            payload["max_usuarios"] = usuarios_contratados
+        elif "plano_id" in data.model_dump(exclude_unset=True) and max_u is not None:
+            # Troca de plano sem informar usuários — mantém o contratado actual se existir
+            if getattr(row, "max_usuarios", None) is None:
+                payload["max_usuarios"] = max_u
     elif "plano" in payload and payload.get("plano"):
-        from app.services.saas_catalogo import obter_plano_por_codigo, sincronizar_snapshot_licenca
+        from app.services.saas_catalogo import obter_plano_por_codigo
 
         p = obter_plano_por_codigo(db, str(payload["plano"]))
         if p is not None:
             payload["plano_id"] = p.id
             payload["plano"] = p.nome
 
+    if usuarios_contratados is not None and "max_usuarios" not in payload:
+        payload["max_usuarios"] = usuarios_contratados
+
     for k, v in payload.items():
         setattr(row, k, v)
     auto = _url_do_slug(row.slug)
     if auto:
         row.instancia_url = auto
-    if "plano_id" in payload or ("plano" in payload and getattr(row, "plano_id", None)):
-        from app.services.saas_catalogo import sincronizar_snapshot_licenca
-
-        sincronizar_snapshot_licenca(db, row)
     db.flush()
     return row
 
@@ -211,12 +226,54 @@ def serializar_cliente(row: ClienteSaaS) -> dict:
     plano_modulos: list[dict] = []
     plano_id = getattr(row, "plano_id", None)
     sess = object_session(row)
+    usuarios_inclusos = 3
+    preco_usuario_extra = 10.0
     if plano_id and sess is not None:
         try:
             plano = saas_catalogo.obter_plano(sess, plano_id)
-            plano_modulos = saas_catalogo.serializar_plano(plano).get("modulos") or []
+            ser = saas_catalogo.serializar_plano(plano)
+            plano_modulos = ser.get("modulos") or []
+            usuarios_inclusos = int(ser.get("usuarios_inclusos") or 3)
+            preco_usuario_extra = float(ser.get("preco_usuario_extra") or 10)
         except SaasErro:
             plano_modulos = []
+
+    preco_modulos = 0.0
+    snapshot = list(getattr(row, "modulos_snapshot", None) or [])
+    modulos_contratados: list[dict] = []
+    if sess is not None and snapshot:
+        try:
+            mods = saas_catalogo.resolver_modulos_por_codigos(sess, snapshot)
+            preco_modulos = saas_catalogo.soma_preco_modulos(mods)
+            modulos_contratados = [
+                {
+                    "id": m.id,
+                    "codigo": m.codigo,
+                    "nome": m.nome,
+                    "ativo": bool(m.ativo),
+                    "preco_mensal": float(m.preco_mensal) if m.preco_mensal is not None else None,
+                }
+                for m in mods
+            ]
+        except SaasErro:
+            preco_modulos = 0.0
+    elif plano_modulos:
+        preco_modulos = round(
+            sum(float(m.get("preco_mensal") or 0) for m in plano_modulos),
+            2,
+        )
+        modulos_contratados = list(plano_modulos)
+
+    usuarios_contratados = getattr(row, "max_usuarios", None)
+    preco_users = saas_catalogo.preco_extra_usuarios(
+        usuarios_inclusos=usuarios_inclusos,
+        preco_usuario_extra=preco_usuario_extra,
+        usuarios_contratados=usuarios_contratados,
+    )
+    preco_estimado = round(preco_modulos + preco_users, 2)
+    negociado_raw = getattr(row, "preco_mensal_negociado", None)
+    negociado = float(negociado_raw) if negociado_raw is not None else None
+    efetivo = negociado if negociado is not None else preco_estimado
 
     return {
         "id": row.id,
@@ -226,9 +283,17 @@ def serializar_cliente(row: ClienteSaaS) -> dict:
         "plano": row.plano,
         "plano_id": plano_id,
         "plano_modulos": plano_modulos,
-        "modulos_snapshot": list(getattr(row, "modulos_snapshot", None) or []),
+        "modulos_contratados": modulos_contratados,
+        "modulos_snapshot": snapshot,
         "max_postos": getattr(row, "max_postos", None),
-        "max_usuarios": getattr(row, "max_usuarios", None),
+        "max_usuarios": usuarios_contratados,
+        "usuarios_inclusos": usuarios_inclusos,
+        "preco_usuario_extra": preco_usuario_extra,
+        "preco_modulos": preco_modulos,
+        "preco_usuarios_extra": preco_users,
+        "preco_mensal_estimado": preco_estimado,
+        "preco_mensal_negociado": negociado,
+        "preco_mensal_efetivo": efetivo,
         "data_inicio": row.data_inicio,
         "data_renovacao": row.data_renovacao,
         "instancia_url": row.instancia_url,

--- a/backend/app/services/saas_notify.py
+++ b/backend/app/services/saas_notify.py
@@ -59,26 +59,26 @@ def notificar_contacto_entrega(
             mods = []
     mods_txt = ", ".join(mods) if mods else "helpdesk (base)"
     limites = []
-    if getattr(row, "max_postos", None) is not None:
-        limites.append(f"postos: {row.max_postos}")
     if getattr(row, "max_usuarios", None) is not None:
-        limites.append(f"utilizadores: {row.max_usuarios}")
+        limites.append(f"usuários: {row.max_usuarios}")
+    if getattr(row, "max_postos", None) is not None:
+        limites.append(f"postos (legado): {row.max_postos}")
     limites_txt = (", ".join(limites)) if limites else "sem limites comerciais definidos"
     subject = f"DeskRudder — ambiente pronto ({row.nome})"
     body = (
         f"Olá {nome},\n\n"
         f"O ambiente DeskRudder de «{row.nome}» está disponível.\n\n"
         f"Acesso: {url}\n"
-        f"Login da equipa: {url.rstrip('/')}/login\n\n"
+        f"Login da equipe: {url.rstrip('/')}/login\n\n"
         f"Plano: {plano_nome}\n"
         f"Módulos incluídos: {mods_txt}\n"
         f"Limites: {limites_txt}\n\n"
         "As credenciais iniciais (admin) são as definidas no provisionamento "
         f"(SEED_ADMIN_EMAIL no client.env do slug «{row.slug}»). "
-        "Se ainda não as recebeu, a equipa DeskRudder envia-as em seguida.\n\n"
+        "Se ainda não as recebeu, a equipe DeskRudder envia-as em seguida.\n\n"
         "Em ambiente local, o domínio público pode não resolver DNS — "
-        "use a porta API (health) indicada pela equipa DeskRudder.\n\n"
-        "— Equipa DeskRudder\n"
+        "use a porta API (health) indicada pela equipe DeskRudder.\n\n"
+        "— Equipe DeskRudder\n"
     )
     try:
         enviar_mensagem_texto_sistema(db, to_addr=to_addr, subject=subject, body=body)

--- a/backend/app/services/saas_ops_conta.py
+++ b/backend/app/services/saas_ops_conta.py
@@ -1,0 +1,72 @@
+"""Conta do ops no control-plane — perfil e token Cursor."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.core.security import criar_access_token, criar_refresh_token
+from app.models.atendente import Atendente
+from app.schemas.saas_ops_conta import SaasOpsContaPerfilUpdate
+
+
+def _normalizar_email(email: str) -> str:
+    return (email or "").strip().lower()
+
+
+def _validar_email(email: str) -> str:
+    valor = _normalizar_email(email)
+    if "@" not in valor or valor.startswith("@") or valor.endswith("@"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe um e-mail válido.")
+    return valor
+
+
+def atualizar_perfil(
+    db: Session,
+    actor: Atendente,
+    data: SaasOpsContaPerfilUpdate,
+) -> tuple[Atendente, dict | None]:
+    """Atualiza nome/e-mail da própria conta. Se o e-mail mudar, devolve claims para novos tokens."""
+    update = data.model_dump(exclude_unset=True)
+    if not update:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nada para atualizar.")
+
+    email_mudou = False
+    if "nome" in update and update["nome"] is not None:
+        nome = update["nome"].strip()
+        if not nome:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe o nome.")
+        actor.nome = nome
+
+    if "email" in update and update["email"] is not None:
+        email = _validar_email(update["email"])
+        if email != _normalizar_email(actor.email):
+            existe = (
+                db.query(Atendente)
+                .filter(
+                    Atendente.tenant_id == actor.tenant_id,
+                    func.lower(Atendente.email) == email,
+                    Atendente.id != actor.id,
+                )
+                .first()
+            )
+            if existe:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="E-mail já cadastrado")
+            actor.email = email
+            actor.token_version = int(actor.token_version or 0) + 1
+            email_mudou = True
+
+    registrar_audit(db, "atendente", actor.id, "update_saas_ops_perfil", actor.id)
+    db.flush()
+
+    tokens = None
+    if email_mudou:
+        ver = int(getattr(actor, "token_version", 0) or 0)
+        claims = {"sub": actor.email, "tid": int(actor.tenant_id), "ver": ver}
+        tokens = {
+            "access_token": criar_access_token(data=claims),
+            "refresh_token": criar_refresh_token(data=claims),
+        }
+    return actor, tokens

--- a/backend/app/services/saas_ops_usuarios.py
+++ b/backend/app/services/saas_ops_usuarios.py
@@ -1,4 +1,4 @@
-"""Cadastro da equipa saas_ops no control-plane (#883)."""
+"""Cadastro da equipe saas_ops no control-plane (#883)."""
 
 from __future__ import annotations
 
@@ -6,12 +6,13 @@ import secrets
 
 from fastapi import HTTPException, status
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.core.audit import registrar_audit
 from app.core.security import hash_senha
 from app.models.atendente import Atendente
 from app.schemas.saas_ops_usuario import SaasOpsUsuarioCreate, SaasOpsUsuarioUpdate
+from app.services import saas_setores as setores_svc
 
 
 def _agora_senha() -> str:
@@ -30,6 +31,7 @@ def _validar_email(email: str) -> str:
 
 
 def para_dict(row: Atendente) -> dict:
+    setores = sorted(getattr(row, "saas_setores", None) or [], key=lambda s: (s.nome or "", s.id))
     return {
         "id": row.id,
         "nome": row.nome,
@@ -39,22 +41,31 @@ def para_dict(row: Atendente) -> dict:
         "mcp_token_configurado": bool((row.mcp_token_hash or "").strip()),
         "mcp_token_gerado_em": row.mcp_token_gerado_em,
         "created_at": row.created_at,
+        "setor_ids": [s.id for s in setores],
+        "setores": [
+            {"id": s.id, "nome": s.nome, "ativo": bool(s.ativo), "created_at": s.created_at} for s in setores
+        ],
     }
 
 
-def _query_ops(db: Session, tenant_id: int):
+def _filtro_ops(db: Session, tenant_id: int):
     return db.query(Atendente).filter(Atendente.tenant_id == tenant_id, Atendente.role == "saas_ops")
 
 
 def _obter_ops(db: Session, tenant_id: int, usuario_id: int) -> Atendente:
-    row = _query_ops(db, tenant_id).filter(Atendente.id == usuario_id).first()
+    row = (
+        _filtro_ops(db, tenant_id)
+        .options(joinedload(Atendente.saas_setores))
+        .filter(Atendente.id == usuario_id)
+        .first()
+    )
     if row is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Utilizador não encontrado")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Usuário não encontrado")
     return row
 
 
-def _contar_ops_activos(db: Session, tenant_id: int, excluir_id: int | None = None) -> int:
-    q = _query_ops(db, tenant_id).filter(Atendente.ativo.is_(True))
+def _contar_ops_ativos(db: Session, tenant_id: int, excluir_id: int | None = None) -> int:
+    q = _filtro_ops(db, tenant_id).filter(Atendente.ativo.is_(True))
     if excluir_id is not None:
         q = q.filter(Atendente.id != excluir_id)
     return q.count()
@@ -69,14 +80,20 @@ def listar(
     offset: int,
     limit: int,
 ) -> tuple[list[Atendente], int]:
-    q = _query_ops(db, actor.tenant_id)
+    q = _filtro_ops(db, actor.tenant_id)
     if not incluir_inativos:
         q = q.filter(Atendente.ativo.is_(True))
     if busca and busca.strip():
         term = f"%{busca.strip()}%"
         q = q.filter((Atendente.nome.ilike(term)) | (Atendente.email.ilike(term)))
     total = q.count()
-    rows = q.order_by(Atendente.nome.asc(), Atendente.id.asc()).offset(offset).limit(limit).all()
+    rows = (
+        q.options(joinedload(Atendente.saas_setores))
+        .order_by(Atendente.nome.asc(), Atendente.id.asc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
     return rows, total
 
 
@@ -96,6 +113,7 @@ def criar(db: Session, actor: Atendente, data: SaasOpsUsuarioCreate) -> tuple[At
     )
     if existe:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="E-mail já cadastrado")
+    setores = setores_svc.resolver_setores_ativos(db, actor.tenant_id, list(data.setor_ids or []))
     senha = _agora_senha()
     row = Atendente(
         tenant_id=actor.tenant_id,
@@ -106,13 +124,14 @@ def criar(db: Session, actor: Atendente, data: SaasOpsUsuarioCreate) -> tuple[At
         ativo=True,
         must_change_password=True,
     )
+    row.saas_setores = setores
     db.add(row)
     db.flush()
     registrar_audit(db, "atendente", row.id, "create_saas_ops", actor.id)
     return row, senha
 
 
-def actualizar(db: Session, actor: Atendente, usuario_id: int, data: SaasOpsUsuarioUpdate) -> Atendente:
+def atualizar(db: Session, actor: Atendente, usuario_id: int, data: SaasOpsUsuarioUpdate) -> Atendente:
     row = _obter_ops(db, actor.tenant_id, usuario_id)
     update = data.model_dump(exclude_unset=True)
     if "nome" in update and update["nome"] is not None:
@@ -121,19 +140,23 @@ def actualizar(db: Session, actor: Atendente, usuario_id: int, data: SaasOpsUsua
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe o nome.")
         row.nome = nome
     if "ativo" in update and update["ativo"] is not None:
-        activo = bool(update["ativo"])
-        if not activo:
+        ativo = bool(update["ativo"])
+        if not ativo:
             if row.id == actor.id:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Não podes desactivar a tua própria conta.",
+                    detail="Não é possível desativar a sua própria conta.",
                 )
-            if row.ativo and _contar_ops_activos(db, actor.tenant_id, excluir_id=row.id) < 1:
+            if row.ativo and _contar_ops_ativos(db, actor.tenant_id, excluir_id=row.id) < 1:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Não é possível desactivar o último utilizador activo da equipa.",
+                    detail="Não é possível desativar o último usuário ativo da equipe.",
                 )
-        row.ativo = activo
+        row.ativo = ativo
+    if "setor_ids" in update and update["setor_ids"] is not None:
+        row.saas_setores = setores_svc.resolver_setores_ativos(
+            db, actor.tenant_id, list(update["setor_ids"])
+        )
     registrar_audit(db, "atendente", row.id, "update_saas_ops", actor.id)
     db.flush()
     return row
@@ -144,7 +167,7 @@ def redefinir_senha(db: Session, actor: Atendente, usuario_id: int) -> tuple[Ate
     if not row.ativo:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Active a conta antes de gerar uma senha nova.",
+            detail="Ative a conta antes de gerar uma senha nova.",
         )
     senha = _agora_senha()
     row.senha_hash = hash_senha(senha)

--- a/backend/app/services/saas_setores.py
+++ b/backend/app/services/saas_setores.py
@@ -1,0 +1,110 @@
+"""CRUD de setores (cargos) da equipe DeskRudder no control-plane."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.models.atendente import Atendente
+from app.models.saas_setor import SaasSetor
+from app.schemas.saas_setor import SaasSetorCreate, SaasSetorUpdate
+
+
+def _normalizar_nome(nome: str) -> str:
+    return " ".join((nome or "").split()).strip()
+
+
+def listar(
+    db: Session,
+    actor: Atendente,
+    *,
+    incluir_inativos: bool,
+) -> list[SaasSetor]:
+    q = db.query(SaasSetor).filter(SaasSetor.tenant_id == actor.tenant_id)
+    if not incluir_inativos:
+        q = q.filter(SaasSetor.ativo.is_(True))
+    return q.order_by(SaasSetor.nome.asc(), SaasSetor.id.asc()).all()
+
+
+def obter(db: Session, actor: Atendente, setor_id: int) -> SaasSetor:
+    row = (
+        db.query(SaasSetor)
+        .filter(SaasSetor.tenant_id == actor.tenant_id, SaasSetor.id == setor_id)
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Setor não encontrado")
+    return row
+
+
+def criar(db: Session, actor: Atendente, data: SaasSetorCreate) -> SaasSetor:
+    nome = _normalizar_nome(data.nome)
+    if not nome:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe o nome do setor.")
+    existe = (
+        db.query(SaasSetor)
+        .filter(
+            SaasSetor.tenant_id == actor.tenant_id,
+            func.lower(SaasSetor.nome) == nome.lower(),
+        )
+        .first()
+    )
+    if existe:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Já existe um setor com este nome.")
+    row = SaasSetor(tenant_id=actor.tenant_id, nome=nome, ativo=True)
+    db.add(row)
+    db.flush()
+    registrar_audit(db, "saas_setor", row.id, "create", actor.id)
+    return row
+
+
+def atualizar(db: Session, actor: Atendente, setor_id: int, data: SaasSetorUpdate) -> SaasSetor:
+    row = obter(db, actor, setor_id)
+    update = data.model_dump(exclude_unset=True)
+    if "nome" in update and update["nome"] is not None:
+        nome = _normalizar_nome(update["nome"])
+        if not nome:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe o nome do setor.")
+        conflito = (
+            db.query(SaasSetor)
+            .filter(
+                SaasSetor.tenant_id == actor.tenant_id,
+                func.lower(SaasSetor.nome) == nome.lower(),
+                SaasSetor.id != row.id,
+            )
+            .first()
+        )
+        if conflito:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Já existe um setor com este nome.",
+            )
+        row.nome = nome
+    if "ativo" in update and update["ativo"] is not None:
+        row.ativo = bool(update["ativo"])
+    registrar_audit(db, "saas_setor", row.id, "update", actor.id)
+    db.flush()
+    return row
+
+
+def resolver_setores_ativos(db: Session, tenant_id: int, setor_ids: list[int]) -> list[SaasSetor]:
+    if not setor_ids:
+        return []
+    ids = sorted({int(i) for i in setor_ids})
+    rows = (
+        db.query(SaasSetor)
+        .filter(
+            SaasSetor.tenant_id == tenant_id,
+            SaasSetor.id.in_(ids),
+            SaasSetor.ativo.is_(True),
+        )
+        .all()
+    )
+    if len(rows) != len(ids):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Um ou mais setores são inválidos ou estão inativos.",
+        )
+    return rows

--- a/backend/app/services/solicitacao_melhoria_copy.py
+++ b/backend/app/services/solicitacao_melhoria_copy.py
@@ -28,6 +28,19 @@ STATUS_FINAIS = frozenset({"concluida", "nao_sera_desenvolvida"})
 STATUS_VALIDOS = frozenset(STATUS_LABELS.keys())
 TIPOS_VALIDOS = frozenset({"sugestao", "problema"})
 
+# Fases para filtro rápido no painel ops (agrupa status)
+FASES_STATUS: dict[str, frozenset[str]] = {
+    "aguardando": frozenset({"aberta", "em_analise", "planejada"}),
+    "desenvolvimento": frozenset({"em_desenvolvimento"}),
+    "finalizadas": frozenset(STATUS_FINAIS),
+}
+FASES_VALIDAS = frozenset(FASES_STATUS.keys())
+
+
+def status_da_fase(fase: str) -> frozenset[str] | None:
+    key = (fase or "").strip().lower()
+    return FASES_STATUS.get(key)
+
 
 def mensagem_publica_status(status: str, *, motivo: str | None = None) -> str:
     base = STATUS_MENSAGENS.get(status, "O estado do seu pedido foi atualizado.")

--- a/backend/tests/test_saas_catalogo.py
+++ b/backend/tests/test_saas_catalogo.py
@@ -154,3 +154,142 @@ def test_planos_modulos_crud_e_licenca(client, auth_headers, db_session, monkeyp
     desativar_mod = client.post(f"/v1/saas/modulos/{mid}/desativar", headers=h)
     assert desativar_mod.status_code == 200
     assert desativar_mod.json()["ativo"] is False
+
+
+def test_plano_preco_soma_modulos_e_mix_licenca(client, auth_headers, db_session, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    h = auth_headers["ops"]
+    seed = _seed_catalogo(db_session)
+
+    # Preço no módulo recalcula planos que o usam
+    patch_mod = client.patch(
+        f"/v1/saas/modulos/{seed['helpdesk'].id}",
+        headers=h,
+        json={"preco_mensal": 100},
+    )
+    assert patch_mod.status_code == 200, patch_mod.text
+    assert float(patch_mod.json()["preco_mensal"]) == 100.0
+
+    client.patch(
+        f"/v1/saas/modulos/{seed['boletos'].id}",
+        headers=h,
+        json={"preco_mensal": 50},
+    )
+    client.patch(
+        f"/v1/saas/modulos/{seed['contratos'].id}",
+        headers=h,
+        json={"preco_mensal": 80},
+    )
+
+    criado = client.post(
+        "/v1/saas/planos",
+        headers=h,
+        json={
+            "codigo": "essencial-test",
+            "nome": "Essencial Test",
+            "ordem": 15,
+            "usuarios_inclusos": 3,
+            "preco_usuario_extra": 10,
+            "modulo_ids": [seed["helpdesk"].id, seed["boletos"].id],
+        },
+    )
+    assert criado.status_code == 201, criado.text
+    body = criado.json()
+    assert float(body["preco_mensal"]) == 150.0
+    assert body["usuarios_inclusos"] == 3
+    assert float(body["preco_usuario_extra"]) == 10.0
+    assert body["max_postos"] is None
+
+    # Mix: plano essencial + módulo enterprise (contratos)
+    lic = client.post(
+        "/v1/saas/clientes",
+        headers=h,
+        json={
+            "nome": "Mix Co",
+            "slug": "mix-co",
+            "status": "ativo",
+            "data_inicio": str(date.today()),
+            "plano_id": body["id"],
+            "modulo_ids": [
+                seed["helpdesk"].id,
+                seed["boletos"].id,
+                seed["contratos"].id,
+            ],
+            "usuarios_contratados": 5,
+        },
+    )
+    assert lic.status_code == 201, lic.text
+    lic_body = lic.json()
+    assert set(lic_body["modulos_snapshot"]) == {"helpdesk", "boletos", "contratos"}
+    assert lic_body["max_usuarios"] == 5
+    # 100+50+80 módulos + 2 extras * 10
+    assert float(lic_body["preco_modulos"]) == 230.0
+    assert float(lic_body["preco_usuarios_extra"]) == 20.0
+    assert float(lic_body["preco_mensal_estimado"]) == 250.0
+    assert len(lic_body["modulos_contratados"]) == 3
+
+    # Valor negociado sobrescreve a estimativa na ficha comercial
+    neg = client.patch(
+        f"/v1/saas/clientes/{lic_body['id']}",
+        headers=h,
+        json={"preco_mensal_negociado": 199},
+    )
+    assert neg.status_code == 200, neg.text
+    assert float(neg.json()["preco_mensal_negociado"]) == 199.0
+    assert float(neg.json()["preco_mensal_estimado"]) == 250.0
+    assert float(neg.json()["preco_mensal_efetivo"]) == 199.0
+
+    limpa = client.patch(
+        f"/v1/saas/clientes/{lic_body['id']}",
+        headers=h,
+        json={"preco_mensal_negociado": None},
+    )
+    assert limpa.status_code == 200
+    assert limpa.json()["preco_mensal_negociado"] is None
+    assert float(limpa.json()["preco_mensal_efetivo"]) == 250.0
+
+
+def test_plano_preco_e_max_usuarios_sem_postos(client, auth_headers, db_session, monkeypatch):
+    """Compat: max_usuarios ainda pode ser setado no plano; preço vem dos módulos."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    h = auth_headers["ops"]
+    seed = _seed_catalogo(db_session)
+
+    client.patch(
+        f"/v1/saas/modulos/{seed['helpdesk'].id}",
+        headers=h,
+        json={"preco_mensal": 397},
+    )
+
+    criado = client.post(
+        "/v1/saas/planos",
+        headers=h,
+        json={
+            "codigo": "essencial-legacy",
+            "nome": "Essencial Legacy",
+            "ordem": 15,
+            "max_usuarios": 8,
+            "modulo_ids": [seed["helpdesk"].id],
+        },
+    )
+    assert criado.status_code == 201, criado.text
+    body = criado.json()
+    assert float(body["preco_mensal"]) == 397.0
+    assert body["max_usuarios"] == 8
+    assert body["max_postos"] is None
+
+    limpo = client.patch(
+        f"/v1/saas/planos/{body['id']}",
+        headers=h,
+        json={"max_usuarios": 20, "usuarios_inclusos": 5, "preco_usuario_extra": 12},
+    )
+    assert limpo.status_code == 200, limpo.text
+    assert limpo.json()["max_postos"] is None
+    assert limpo.json()["max_usuarios"] == 20
+    assert limpo.json()["usuarios_inclusos"] == 5
+    assert float(limpo.json()["preco_usuario_extra"]) == 12.0
+    assert float(limpo.json()["preco_mensal"]) == 397.0

--- a/backend/tests/test_saas_licenca_completa.py
+++ b/backend/tests/test_saas_licenca_completa.py
@@ -58,7 +58,8 @@ def test_plano_preco_limites_e_snapshot(client, auth_headers, db_session, monkey
     assert r.status_code == 201, r.text
     body = r.json()
     assert sorted(body.get("modulos_snapshot") or []) == ["helpdesk", "whatsapp"]
-    assert body["max_postos"] == 10
+    # Sem teto de postos na licença (só usuários do plano / contratados)
+    assert body["max_postos"] is None
     assert body["max_usuarios"] == 5
     assert body["plano"] == "Pro Licença"
 
@@ -100,4 +101,5 @@ def test_converter_lead_com_plano_id(client, auth_headers, db_session, monkeypat
     body = conv.json()
     assert body["plano_id"] == plano.id
     assert sorted(body.get("modulos_snapshot") or []) == ["helpdesk", "whatsapp"]
-    assert body["max_postos"] == 3
+    assert body["max_postos"] is None
+    assert body["max_usuarios"] == 2

--- a/backend/tests/test_saas_ops_conta_perfil.py
+++ b/backend/tests/test_saas_ops_conta_perfil.py
@@ -1,0 +1,63 @@
+"""Perfil da conta ops (nome / e-mail) em Minha conta."""
+
+from __future__ import annotations
+
+
+def test_saas_me_atualizar_nome_e_email(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    h = auth_headers["ops"]
+
+    nome = client.patch("/v1/saas/me", headers=h, json={"nome": "Ops Renomeado"})
+    assert nome.status_code == 200, nome.text
+    assert nome.json()["nome"] == "Ops Renomeado"
+    assert nome.json()["access_token"] is None
+
+    novo_email = "ops.renomeado@test.local"
+    email = client.patch("/v1/saas/me", headers=h, json={"email": novo_email})
+    assert email.status_code == 200, email.text
+    assert email.json()["email"] == novo_email
+    assert email.json()["access_token"]
+    assert email.json()["refresh_token"]
+
+    # Token antigo (sub = e-mail anterior) deixa de valer
+    stale = client.get("/v1/saas/me/mcp-token", headers=h)
+    assert stale.status_code == 401
+
+    h_novo = {
+        "Authorization": f"Bearer {email.json()['access_token']}",
+        "X-Dx-Tenant-Id": "1",
+    }
+    ok = client.get("/v1/saas/me/mcp-token", headers=h_novo)
+    assert ok.status_code == 200, ok.text
+
+    me = client.get("/v1/atendentes/me", headers=h_novo)
+    assert me.status_code == 200
+    assert me.json()["email"] == novo_email
+    assert me.json()["nome"] == "Ops Renomeado"
+
+
+def test_saas_me_email_duplicado(client, seed_base, auth_headers, db_session, monkeypatch):
+    from app.config import settings
+    from app.core.security import hash_senha
+    from app.models.atendente import Atendente
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    outro = Atendente(
+        tenant_id=seed_base["tenant"].id,
+        email="ops.outro@test.local",
+        nome="Outro",
+        senha_hash=hash_senha("ops123456"),
+        role="saas_ops",
+        ativo=True,
+    )
+    db_session.add(outro)
+    db_session.commit()
+
+    r = client.patch(
+        "/v1/saas/me",
+        headers=auth_headers["ops"],
+        json={"email": "ops.outro@test.local"},
+    )
+    assert r.status_code == 400

--- a/backend/tests/test_saas_setores.py
+++ b/backend/tests/test_saas_setores.py
@@ -1,0 +1,88 @@
+"""Setores (cargos) da equipe SaaS + vínculo N:N com usuários ops."""
+
+from __future__ import annotations
+
+from app.core.security import criar_access_token
+
+
+def _headers_ops(email: str) -> dict[str, str]:
+    tok = criar_access_token({"sub": email, "tid": 1})
+    return {"Authorization": f"Bearer {tok}", "X-Dx-Tenant-Id": "1"}
+
+
+def test_saas_setores_crud_e_vinculo_multiplo(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+
+    assert client.get("/v1/saas/setores", headers=auth_headers["admin"]).status_code == 403
+
+    a = client.post("/v1/saas/setores", headers=auth_headers["ops"], json={"nome": "  Admin  "})
+    assert a.status_code == 201, a.text
+    assert a.json()["nome"] == "Admin"
+
+    d = client.post("/v1/saas/setores", headers=auth_headers["ops"], json={"nome": "Desenvolvimento"})
+    assert d.status_code == 201, d.text
+    c = client.post("/v1/saas/setores", headers=auth_headers["ops"], json={"nome": "Comercial"})
+    assert c.status_code == 201, c.text
+
+    dup = client.post("/v1/saas/setores", headers=auth_headers["ops"], json={"nome": "admin"})
+    assert dup.status_code == 400
+
+    lista = client.get("/v1/saas/setores", headers=auth_headers["ops"])
+    assert lista.status_code == 200
+    nomes = [x["nome"] for x in lista.json()]
+    assert nomes == sorted(nomes)
+    assert "Admin" in nomes
+
+    criado = client.post(
+        "/v1/saas/usuarios",
+        headers=auth_headers["ops"],
+        json={
+            "nome": "Luis Multi",
+            "email": "luis.multi@test.local",
+            "setor_ids": [a.json()["id"], d.json()["id"]],
+        },
+    )
+    assert criado.status_code == 201, criado.text
+    body = criado.json()
+    assert sorted(body["setor_ids"]) == sorted([a.json()["id"], d.json()["id"]])
+    assert {s["nome"] for s in body["setores"]} == {"Admin", "Desenvolvimento"}
+
+    patch = client.patch(
+        f"/v1/saas/usuarios/{body['id']}",
+        headers=auth_headers["ops"],
+        json={"setor_ids": [c.json()["id"], a.json()["id"]]},
+    )
+    assert patch.status_code == 200, patch.text
+    assert {s["nome"] for s in patch.json()["setores"]} == {"Admin", "Comercial"}
+
+    login = client.post(
+        "/v1/auth/login",
+        json={"email": body["email"], "senha": body["senha_temporaria"]},
+    )
+    assert login.status_code == 200
+    me = client.get("/v1/atendentes/me", headers=_headers_ops(body["email"]))
+    assert me.status_code == 200, me.text
+    assert set(me.json()["saas_setor_nomes"]) == {"Admin", "Comercial"}
+
+
+def test_saas_setores_inativo_nao_vincula(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    s = client.post("/v1/saas/setores", headers=auth_headers["ops"], json={"nome": "Temporário"}).json()
+    off = client.patch(
+        f"/v1/saas/setores/{s['id']}",
+        headers=auth_headers["ops"],
+        json={"ativo": False},
+    )
+    assert off.status_code == 200
+    assert off.json()["ativo"] is False
+
+    bad = client.post(
+        "/v1/saas/usuarios",
+        headers=auth_headers["ops"],
+        json={"nome": "X", "email": "x.setores@test.local", "setor_ids": [s["id"]]},
+    )
+    assert bad.status_code == 400

--- a/backend/tests/test_saas_solicitacoes.py
+++ b/backend/tests/test_saas_solicitacoes.py
@@ -747,4 +747,62 @@ def test_vincular_pedidos_iguais_peso_e_nao_vaza_ao_cliente(client, seed_base, a
     assert len(gone.json()["grupo"]) == 1
 
 
+def test_fila_filtro_fase_tipo_e_resumo(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
+    h = auth_headers["ops"]
+
+    sid_sug = _criar_solicitacao(client, auth_headers["a1"]).json()["id"]
+    sid_err = _criar_solicitacao(
+        client,
+        auth_headers["a1"],
+        tipo="problema",
+        titulo="Erro ao abrir o chat",
+        descricao="O chat interno trava ao carregar a lista de conversas.",
+    ).json()["id"]
+
+    lista = client.get("/v1/saas/solicitacoes", headers=h).json()["items"]
+    saas_sug = next(i["id"] for i in lista if i["origem_solicitacao_id"] == sid_sug)
+    saas_err = next(i["id"] for i in lista if i["origem_solicitacao_id"] == sid_err)
+
+    client.patch(
+        f"/v1/saas/solicitacoes/{saas_sug}/status",
+        headers=h,
+        json={"status": "em_desenvolvimento"},
+    )
+    client.patch(
+        f"/v1/saas/solicitacoes/{saas_err}/status",
+        headers=h,
+        json={"status": "concluida"},
+    )
+
+    aguardando = client.get("/v1/saas/solicitacoes?fase=aguardando", headers=h)
+    assert aguardando.status_code == 200
+    ids_ag = {i["id"] for i in aguardando.json()["items"]}
+    assert saas_sug not in ids_ag
+    assert saas_err not in ids_ag
+
+    dev = client.get("/v1/saas/solicitacoes?fase=desenvolvimento", headers=h)
+    assert {i["id"] for i in dev.json()["items"]} >= {saas_sug}
+
+    fin = client.get("/v1/saas/solicitacoes?fase=finalizadas", headers=h)
+    assert {i["id"] for i in fin.json()["items"]} >= {saas_err}
+
+    so_erro = client.get("/v1/saas/solicitacoes?tipo=problema", headers=h)
+    assert all(i["tipo"] == "problema" for i in so_erro.json()["items"])
+    assert saas_err in {i["id"] for i in so_erro.json()["items"]}
+
+    resumo = client.get("/v1/saas/solicitacoes/resumo", headers=h)
+    assert resumo.status_code == 200, resumo.text
+    body = resumo.json()
+    assert body["total"] >= 2
+    assert body["sugestoes"] >= 1
+    assert body["problemas"] >= 1
+    assert body["desenvolvimento"] >= 1
+    assert body["finalizadas"] >= 1
+
+    bad = client.get("/v1/saas/solicitacoes?fase=xyz", headers=h)
+    assert bad.status_code == 400
 

--- a/deploy/admin-center/README.md
+++ b/deploy/admin-center/README.md
@@ -49,8 +49,15 @@ Painel DuplexSoft continua em `/opt/dx-connect/frontend/dist` (API `api-duplexso
 1. Migrar tabelas SaaS + mídia `solicitacao_media` + `protocol_sequences` (`kind=S`) + contas `saas_ops` para o Postgres do `admin-center`
 2. Criar licença `clientes_saas` slug `duplexsoft` e token de ingest
 3. Na DuplexSoft (`backend/.env`): `SAAS_CONTROL_PLANE=false`, `SAAS_INSTANCE_SLUG=duplexsoft`, `SAAS_CONTROL_PLANE_INGEST_URL` + `SAAS_INSTANCE_INGEST_TOKEN`
-4. Desactivar contas `saas_ops` na BD DuplexSoft (ficam só na comercial)
+4. Desativar contas `saas_ops` na BD DuplexSoft (ficam só na comercial)
 5. Health esperado: `api.deskrudder.com.br` → `saas_control_plane: true`; `api-duplexsoft…` → `false`
+
+## Desativar um cliente
+
+Runbook completo (pré/pós health, MCP, o que **não** parar):  
+[`docs/SAAS_CONTROL_PLANE.md`](../../docs/SAAS_CONTROL_PLANE.md#runbook-desativar-cliente-sem-derrubar-o-saas)
+
+Resumo: `stack-client.sh down <slug>` **ou** `docker compose … stop` na DuplexSoft — **nunca** `down admin-center`.
 
 ## O que este diretório versiona
 

--- a/deploy/clients/README.md
+++ b/deploy/clients/README.md
@@ -7,7 +7,9 @@ Cada cliente pagante tem:
 - **Um container** da API (`dx-connect-api-{slug}`)
 - **Porta loopback** distinta (`127.0.0.1:8002`, `8003`, …) para o Nginx fazer proxy
 
-O **painel admin** DeskRudder (`/saas`) **não** fica em `clients/`. Pasta: [`../admin-center/`](../admin-center/README.md) (`provision-control-plane.sh`). Hosts: `deskrudder.com.br` e `api.deskrudder.com.br`. Não rode `provision-client.sh --slug deskrudder` nem `--slug admin-center`.
+O **painel admin** DeskRudder (`/saas`) **não** fica em `clients/`. Pasta: [`../admin-center/`](../admin-center/README.md) (`provision-control-plane.sh`). Hosts: `deskrudder.com.br` e `api.deskrudder.com.br`. Porta **8001** reservada. Não rode `provision-client.sh --slug deskrudder` nem `--slug admin-center`.
+
+A **DuplexSoft** em produção ainda usa o compose legado na raiz (`docker-compose.prod.yml`, porta **8000**). Clientes **novos** usam este diretório (`provision-client.sh`, portas **8002+**). Deploy GHA atualiza as duas stacks — ver [`../github-actions.md`](../github-actions.md).
 
 Direção de produto: [`docs/DEPLOYMENT_ARCHITECTURE.md`](../../docs/DEPLOYMENT_ARCHITECTURE.md) · Issue **#191** (Fase 1 + Fase 2 single-tenant no código).
 
@@ -15,7 +17,7 @@ Direção de produto: [`docs/DEPLOYMENT_ARCHITECTURE.md`](../../docs/DEPLOYMENT_
 
 ```text
 deploy/clients/
-  README.md                 # este ficheiro
+  README.md                 # este arquivo
   _template/                # modelos (versionados no Git)
   .gitignore                # ignora pastas de clientes geradas
   duplexsoft/               # exemplo — gerado no VPS, NÃO commitar
@@ -31,52 +33,53 @@ Na **raiz do repositório** (Linux/macOS/Git Bash no Windows):
 
 ```bash
 bash deploy/scripts/provision-client.sh \
-  --slug duplexsoft \
+  --slug exemplo \
   --base-domain deskrudder.com.br \
-  --api-port 8001
+  --api-port 8002
 ```
 
-Isto cria `deploy/clients/duplexsoft/` com `client.env` (senhas geradas), `docker-compose.yml` e ficheiros Nginx/frontend de exemplo.
+Isto cria `deploy/clients/exemplo/` com `client.env` (senhas geradas), `docker-compose.yml` e arquivos Nginx/frontend de exemplo. **Não** use porta `8001` (admin-center).
 
 ### 1. Rever `client.env`
 
-Edite `deploy/clients/duplexsoft/client.env`:
+Edite `deploy/clients/exemplo/client.env`:
 
 - `CORS_ORIGINS` / `ALLOWED_HOSTS` alinhados aos domínios reais (`CORS_ORIGINS` = origem HTTPS da PWA **e** `https://localhost` para o APK Capacitor)
 - Par **VAPID** (`WEB_PUSH_VAPID_*`) desta stack — gerar uma vez; vazio = push desligado (`docs/OPERATIONS.md`)
-- `DX_CONNECT_MULTI_TENANT=false` (padrão) e `CLIENT_APP_HOST={slug}.connect...`
-- `RESEND_API_KEY`, e-mail transaccional, webhooks
+- `DX_CONNECT_MULTI_TENANT=false` (padrão) e `CLIENT_APP_HOST={slug}.deskrudder.com.br`
+- `SAAS_CONTROL_PLANE=false` + `SAAS_INSTANCE_SLUG` + ingest (URL/token da comercial) — ver [`docs/SAAS_CONTROL_PLANE.md`](../../docs/SAAS_CONTROL_PLANE.md)
+- `RESEND_API_KEY`, e-mail transacional, webhooks
 - `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD` para o primeiro admin
 
 ### 2. Subir stack + migrações + seed
 
 ```bash
-bash deploy/scripts/stack-client.sh migrate duplexsoft
-bash deploy/scripts/stack-client.sh up duplexsoft
-bash deploy/scripts/stack-client.sh seed duplexsoft
+bash deploy/scripts/stack-client.sh migrate exemplo
+bash deploy/scripts/stack-client.sh up exemplo
+bash deploy/scripts/stack-client.sh seed exemplo
 ```
 
 Confirme:
 
 ```bash
-bash deploy/scripts/stack-client.sh health duplexsoft
+bash deploy/scripts/stack-client.sh health exemplo
 ```
 
 ### 3. Frontend
 
 ```bash
-# Ajuste VITE_API_URL e VITE_CLIENT_APP_HOST em deploy/clients/duplexsoft/frontend.env.production.example
+# Ajuste VITE_API_URL e VITE_CLIENT_APP_HOST em deploy/clients/exemplo/frontend.env.production.example
 # ou copie para frontend/.env.production antes do build
 cd frontend && npm ci && npm run build
-sudo mkdir -p /var/www/dx-connect/clients/duplexsoft/dist
-sudo rsync -a dist/ /var/www/dx-connect/clients/duplexsoft/dist/
+sudo mkdir -p /var/www/dx-connect/clients/exemplo/dist
+sudo rsync -a dist/ /var/www/dx-connect/clients/exemplo/dist/
 ```
 
 ### 4. Nginx + DNS
 
-1. Copie `deploy/clients/duplexsoft/nginx.site.conf` para `/etc/nginx/sites-available/`.
+1. Copie `deploy/clients/exemplo/nginx.site.conf` para `/etc/nginx/sites-available/`.
 2. Ajuste `FRONTEND_DIST` se necessário.
-3. Aponte DNS `duplexsoft.connect...` e `api-duplexsoft.connect...` para a VPS.
+3. Aponte DNS `{slug}.deskrudder.com.br` e `api-{slug}.deskrudder.com.br` para a VPS.
 4. `sudo nginx -t && sudo systemctl reload nginx`
 5. TLS (Certbot) e atualize `CORS_ORIGINS` / `VITE_API_URL` para `https://`.
 
@@ -93,7 +96,13 @@ sudo rsync -a dist/ /var/www/dx-connect/clients/duplexsoft/dist/
 
 ## Portas API na mesma VPS
 
-Registe numa folha interna qual `CLIENT_API_PORT` cada slug usa (8001, 8002, …). O Nginx faz proxy para `127.0.0.1:PORTA`.
+| Porta | Uso |
+|-------|-----|
+| `8000` | DuplexSoft (compose legado) |
+| `8001` | admin-center (control-plane) |
+| `8002+` | clientes em `deploy/clients/<slug>/` |
+
+Registre numa folha interna qual `CLIENT_API_PORT` cada slug usa. O Nginx faz proxy para `127.0.0.1:PORTA`.
 
 ## Atualizar código de um cliente
 
@@ -102,25 +111,27 @@ No VPS, no clone do repositório:
 ```bash
 git pull
 export DX_CONNECT_GIT_SHA=$(git rev-parse --short HEAD)
-bash deploy/scripts/stack-client.sh migrate duplexsoft
-bash deploy/scripts/stack-client.sh up duplexsoft
+bash deploy/scripts/stack-client.sh migrate exemplo
+bash deploy/scripts/stack-client.sh up exemplo
 ```
 
 ### Volume `/app/data` (anexos e mídia)
 
 O template monta `backend_data` → `/app/data`. Sem esse volume, cada rebuild apaga anexos de ticket, mídia WhatsApp/chat interno, KB e logos — o metadado fica na BD e o download devolve **404**.
 
-Clientes já provisionados **antes** deste volume: copie o bloco `volumes` do `_template/docker-compose.stack.yml` para o `docker-compose.yml` do cliente e faça `up` de novo. Ficheiros já perdidos não voltam; é preciso reenviar anexos.
+Clientes já provisionados **antes** deste volume: copie o bloco `volumes` do `_template/docker-compose.stack.yml` para o `docker-compose.yml` do cliente e faça `up` de novo. Arquivos já perdidos não voltam; é preciso reenviar anexos.
 
 ## Backup da base do cliente
 
 ```bash
-docker exec dx-connect-db-duplexsoft pg_dump -U dxconnect dxconnect_duplexsoft > backup-duplexsoft-$(date +%F).sql
+docker exec dx-connect-db-exemplo pg_dump -U dxconnect dxconnect_exemplo > backup-exemplo-$(date +%F).sql
 ```
 
-(ajuste user/db conforme `client.env`)
+(ajuste user/db/slug conforme `client.env`)
 
 ## Relacionado
 
-- Deploy CI legado (um ambiente staging): [`deploy/github-actions.md`](../github-actions.md)
-- `docker-compose.prod.yml` — API só, Postgres no host (modelo antigo single-tenant na mesma máquina)
+- Deploy CI (duas stacks): [`deploy/github-actions.md`](../github-actions.md)
+- Control-plane + runbook desativar cliente: [`docs/SAAS_CONTROL_PLANE.md`](../../docs/SAAS_CONTROL_PLANE.md)
+- `docker-compose.prod.yml` — API DuplexSoft legado (Postgres no host / stack antiga na mesma máquina)
+- Desativar cliente sem derrubar SaaS: âncora `#runbook-desativar-cliente-sem-derrubar-o-saas` no doc do control-plane

--- a/docs/DEPLOYMENT_ARCHITECTURE.md
+++ b/docs/DEPLOYMENT_ARCHITECTURE.md
@@ -77,3 +77,16 @@ Legado multi-tenant: definir `DX_CONNECT_MULTI_TENANT=true` (e no front `VITE_MU
 - Control-plane vs cliente DuplexSoft: **#875** — stack em [`deploy/admin-center/`](../deploy/admin-center/README.md)
 - Deploy GHA em duas stacks (#880): [`deploy/github-actions.md`](../deploy/github-actions.md)
 - Checklist de servidor: [`PRE_DEPLOY_CHECKLIST.md`](PRE_DEPLOY_CHECKLIST.md)
+
+## Produção DeskRudder (pós-#875)
+
+Na mesma VPS convivem **dois** Postgres e **duas** APIs (modelo B):
+
+| Papel | Pasta / compose | Porta | Hosts |
+|-------|-----------------|-------|--------|
+| **Control-plane** (licenças, fila, MCP, `/saas`) | `deploy/admin-center/` | `127.0.0.1:8001` | `api.deskrudder.com.br`, SPA em `deskrudder.com.br` |
+| **Cliente DuplexSoft** (helpdesk) | `docker-compose.prod.yml` + `backend/.env` (legado; futuros clientes em `deploy/clients/<slug>/`) | `127.0.0.1:8000` | `duplexsoft…`, `api-duplexsoft…` |
+
+- A comercial **não** é o `docker-compose.prod.yml` único nem um slug em `clients/deskrudder`.
+- Novos clientes pagantes: `provision-client.sh` → `deploy/clients/<slug>/` (portas a partir de **8002**; **8001** está reservada ao admin-center).
+- Parar ou apagar a stack DuplexSoft **não** pode derrubar o painel SaaS — ver runbook em [`docs/SAAS_CONTROL_PLANE.md`](SAAS_CONTROL_PLANE.md#runbook-desativar-cliente-sem-derrubar-o-saas).

--- a/docs/SAAS_CONTROL_PLANE.md
+++ b/docs/SAAS_CONTROL_PLANE.md
@@ -88,13 +88,15 @@ A **URL pública** da instância não é escolhida livremente: o ops/cliente def
 
 ## Planos e módulos (catálogo comercial)
 
-- UI: `/saas/planos`, `/saas/modulos` — CRUD, activar/desactivar; plano associa `modulo_ids`.
-- Licença: campo `plano_id` (select); `plano` fica como rótulo denormalizado do nome.
-- Seed (migration `091`): módulos `helpdesk`, `whatsapp`, `contratos`, `boletos`; planos `trial`, `profissional`, `enterprise`.
-- Planos podem ter `preco_mensal`, `max_postos`, `max_usuarios` (migration `092`).
-- Ao atribuir/aprovar plano, a licença grava `modulos_snapshot` + limites (congelados na ficha comercial).
-- No provisionamento, `SAAS_MODULOS` é escrito no `client.env` a partir do snapshot; o `/health` da instância expõe `capabilities.modulo_*` lidos dessa env.
-- Enforcement fino de features no produto cliente (UI/RBAC por módulo) fica para follow-up — hoje o snapshot + env são a fonte de verdade comercial/ops.
+- UI: `/saas/planos`, `/saas/modulos` — CRUD, ativar/desativar; plano associa `modulo_ids`.
+- **Preço no módulo** (`saas_modulos.preco_mensal`); o `preco_mensal` do plano é sempre a **soma** dos módulos do pacote (recalcula ao editar preço ou composição).
+- Plano também define `usuarios_inclusos` (default 3) e `preco_usuario_extra` (default R$ 10).
+- Licença: `plano_id` (rótulo comercial) + `modulo_ids` opcional para **mix custom** (ex.: Essencial + 1 módulo Enterprise) + `usuarios_contratados` → grava em `max_usuarios` / `modulos_snapshot`.
+- **Valor mensal negociado** (`preco_mensal_negociado`): opcional na licença; se preenchido, vira o valor comercial efetivo (`preco_mensal_efetivo`); senão usa a estimativa do catálogo (módulos + extras).
+- Estimativa na ficha: `preco_modulos` + extras de usuário = `preco_mensal_estimado`.
+- Seed (migrations `091` + `121` + `122` + `123`): módulos com preço; planos pela soma; coluna de valor negociado na licença.
+- No provisionamento, `SAAS_MODULOS` vem do snapshot; `/health` expõe `capabilities.modulo_*`.
+- Enforcement fino de features no produto cliente e bloqueio hard de usuários além do contratado ficam para follow-up.
 
 ## Fila de sugestões das instâncias (#855 / #856)
 
@@ -159,6 +161,54 @@ O script corre no PC do ops. A fila é a da instância comercial (`SAAS_CONTROL_
 O `SAAS_MCP_TOKEN` no `.env` da VPS ainda é aceite como **legado** (não identifica a pessoa). Prefira o token do painel.
 
 Ferramentas: listar, obter, alterar status, comentar, vincular pedidos iguais, ligar issue GitHub (aceitam `id` ou protocolo). Sem OpenAI e sem `CURSOR_API_KEY` no DeskRudder. O GitHub MCP (criar issues) é à parte e também é por instalação do Cursor.
+
+## Runbook: desativar cliente sem derrubar o SaaS
+
+Objetivo: tirar do ar (ou suspender) **só** a instância do cliente. O control-plane continua a servir licenças, fila, MCP e `/saas`.
+
+### Pré-cheque (comercial viva)
+
+```bash
+curl -sf https://api.deskrudder.com.br/health   # saas_control_plane: true
+curl -sf -o /dev/null -w "%{http_code}\n" https://deskrudder.com.br/login/admin
+```
+
+No Cursor: `/listar-solicitacoes` (ou MCP `deskrudder-saas`) ainda lista a fila — prova de que o MCP aponta a `api.deskrudder.com.br`, não a `api-duplexsoft`.
+
+### Suspender pelo painel (recomendado)
+
+1. `/saas/licencas` → cliente → **Suspender** (marca licença + fila de `stack down` se provisionada).
+2. No host, se `SAAS_PROVISION_EXEC_ENABLED=false`, correr os comandos `down` mostrados no detalhe (ou `stack-client.sh down <slug>`).
+3. **Não** pare o stack `admin-center` nem remova Nginx de `api.deskrudder.com.br` / `deskrudder.com.br`.
+
+### Parar só a DuplexSoft (legado `docker-compose.prod.yml`)
+
+Na VPS, como usuário de deploy:
+
+```bash
+cd /opt/dx-connect
+docker compose --env-file backend/.env -f docker-compose.prod.yml stop
+# ou: down — remove containers; volumes/Postgres do host ficam conforme o compose
+```
+
+**Não** execute `stack-client.sh down admin-center`.
+
+### Pós-cheque
+
+| Check | Esperado |
+|-------|----------|
+| `https://api.deskrudder.com.br/health` | `200`, `saas_control_plane: true` |
+| `https://deskrudder.com.br/saas/...` (logado) | painel ops responde |
+| MCP / `/listar-solicitacoes` | fila comercial acessível |
+| `https://api-duplexsoft…/health` (se parou o cliente) | falha / indisponível — **ok** |
+| Postgres `dx-connect-db-admin-center` | `Up` / healthy |
+
+A **fila de sugestões** e as contas `saas_ops` vivem só no Postgres do admin-center. A BD do cliente não é fonte de verdade do control-plane; desligar o cliente não apaga a fila.
+
+### Reativar
+
+- Licença: **Reativar** no painel + `stack-client.sh up <slug>` (ou `docker compose … up -d` no legado DuplexSoft).
+- Confirmar health do cliente e, se aplicável, **Confirmar stack** no detalhe da licença.
 
 ## Histórico da licença
 
@@ -286,6 +336,6 @@ Worker `saas-renovacoes` (intervalo `SAAS_RENEWAL_WORKER_INTERVAL_SECONDS`):
 
 ## Referências
 
-- Épico: `#519`
-- Issues: DR-01…DR-08 em `.github/planning-issue-bodies/`
-- Deploy por cliente: `docs/DEPLOYMENT_ARCHITECTURE.md`, `deploy/clients/README.md`
+- Épico cutover: **#875** (filhas #876–#880; docs #879)
+- Deploy por cliente: `docs/DEPLOYMENT_ARCHITECTURE.md`, `deploy/clients/README.md`, `deploy/admin-center/README.md`
+- MCP example: `.cursor/mcp.json.example` (`DESKRUDDER_API_URL=https://api.deskrudder.com.br`)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,6 +101,8 @@ import { SaasSobre } from './pages/saas/SaasSobre'
 import { SaasConta } from './pages/saas/SaasConta'
 import { SaasUsuarios } from './pages/saas/SaasUsuarios'
 import { SaasUsuarioForm } from './pages/saas/SaasUsuarioForm'
+import { SaasSetoresPage } from './pages/saas/SaasSetores'
+import { SaasSetorForm } from './pages/saas/SaasSetorForm'
 import { KbPublicLayout } from './pages/kb-public/KbPublicLayout'
 import { KbPublicHome } from './pages/kb-public/KbPublicHome'
 import { KbPublicArtigo } from './pages/kb-public/KbPublicArtigo'
@@ -324,6 +326,9 @@ function AppRoutes() {
         <Route path="usuarios/novo" element={<SaasUsuarioForm />} />
         <Route path="usuarios/:id" element={<SaasUsuarioForm />} />
         <Route path="usuarios" element={<SaasUsuarios />} />
+        <Route path="setores/novo" element={<SaasSetorForm />} />
+        <Route path="setores/:id" element={<SaasSetorForm />} />
+        <Route path="setores" element={<SaasSetoresPage />} />
         <Route path="conta" element={<SaasConta />} />
         <Route path="sobre" element={<SaasSobre />} />
       </Route>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -84,6 +84,13 @@ export function clearAuthToken(): void {
   localStorage.removeItem(REFRESH_TOKEN_KEY)
 }
 
+/** Mantém o storage onde a sessão já estava (local vs session). */
+export function persistAuthTokens(tokens: { access_token: string; refresh_token?: string | null }) {
+  const inLocal = Boolean(localStorage.getItem(TOKEN_KEY) || localStorage.getItem(REFRESH_TOKEN_KEY))
+  clearAuthToken()
+  setTokens(tokens, inLocal)
+}
+
 /** Invalida sessão e força novo login (evita voltar com «Back» para páginas autenticadas). */
 export function invalidateSessionAndRedirectToLogin(): void {
   clearAuthToken()
@@ -2453,6 +2460,9 @@ export namespace Atendentes {
     horario_previsto_entrada?: string | null;
     horario_previsto_saida?: string | null;
     tolerancia_atraso_minutos?: number;
+    /** Cargos da equipe DeskRudder (painel SaaS); vários por usuário. */
+    saas_setor_ids?: number[];
+    saas_setor_nomes?: string[];
   }
   export interface Create {
     email: string;
@@ -5246,12 +5256,14 @@ export const saasSolicitacoes = {
     busca?: string;
     tipo?: string;
     status?: string;
+    fase?: string;
     slug?: string;
     ordenar_por?: 'ingested_at' | 'created_at_origem' | 'titulo';
     ordem?: 'asc' | 'desc';
     offset?: number;
     limit?: number;
   }) => listPaginated<SaasSolicitacoesProduto.ListaItem>('/saas/solicitacoes', params),
+  resumo: () => api<SaasSolicitacoesProduto.Resumo>('/saas/solicitacoes/resumo'),
   get: (id: number) => api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}`),
   alterarStatus: (id: number, data: SaasSolicitacoesProduto.StatusUpdate) =>
     api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/status`, {
@@ -5282,9 +5294,18 @@ export namespace SaasOpsConta {
   export interface McpGerado extends McpEstado {
     token: string
   }
+  export interface Perfil {
+    id: number
+    nome: string
+    email: string
+    access_token?: string | null
+    refresh_token?: string | null
+  }
 }
 
 export const saasOpsConta = {
+  atualizarPerfil: (data: { nome?: string; email?: string }) =>
+    api<SaasOpsConta.Perfil>('/saas/me', { method: 'PATCH', body: JSON.stringify(data) }),
   mcpToken: () => api<SaasOpsConta.McpEstado>('/saas/me/mcp-token'),
   gerarMcpToken: () =>
     api<SaasOpsConta.McpGerado>('/saas/me/mcp-token', { method: 'POST', body: JSON.stringify({}) }),
@@ -5293,6 +5314,12 @@ export const saasOpsConta = {
 };
 
 export namespace SaasOpsUsuarios {
+  export interface SetorRef {
+    id: number
+    nome: string
+    ativo: boolean
+    created_at: string | null
+  }
   export interface Usuario {
     id: number
     nome: string
@@ -5302,6 +5329,8 @@ export namespace SaasOpsUsuarios {
     mcp_token_configurado: boolean
     mcp_token_gerado_em: string | null
     created_at: string | null
+    setor_ids: number[]
+    setores: SetorRef[]
   }
   export interface Criado extends Usuario {
     senha_temporaria: string
@@ -5316,9 +5345,9 @@ export const saasOpsUsuarios = {
     limit?: number
   }) => listPaginated<SaasOpsUsuarios.Usuario>('/saas/usuarios', params),
   get: (id: number) => api<SaasOpsUsuarios.Usuario>(`/saas/usuarios/${id}`),
-  create: (data: { nome: string; email: string }) =>
+  create: (data: { nome: string; email: string; setor_ids?: number[] }) =>
     api<SaasOpsUsuarios.Criado>('/saas/usuarios', { method: 'POST', body: JSON.stringify(data) }),
-  update: (id: number, data: { nome?: string; ativo?: boolean }) =>
+  update: (id: number, data: { nome?: string; ativo?: boolean; setor_ids?: number[] }) =>
     api<SaasOpsUsuarios.Usuario>(`/saas/usuarios/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
   senhaTemporaria: (id: number) =>
     api<{ senha_temporaria: string }>(`/saas/usuarios/${id}/senha-temporaria`, {
@@ -5327,7 +5356,34 @@ export const saasOpsUsuarios = {
     }),
 };
 
+export namespace SaasSetores {
+  export interface Setor {
+    id: number
+    nome: string
+    ativo: boolean
+    created_at: string | null
+  }
+}
+
+export const saasSetores = {
+  list: (params?: { incluir_inativos?: boolean }) =>
+    api<SaasSetores.Setor[]>(withParams('/saas/setores', params)),
+  get: (id: number) => api<SaasSetores.Setor>(`/saas/setores/${id}`),
+  create: (data: { nome: string }) =>
+    api<SaasSetores.Setor>('/saas/setores', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id: number, data: { nome?: string; ativo?: boolean }) =>
+    api<SaasSetores.Setor>(`/saas/setores/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+};
+
 export namespace SaasSolicitacoesProduto {
+  export interface Resumo {
+    total: number;
+    sugestoes: number;
+    problemas: number;
+    aguardando: number;
+    desenvolvimento: number;
+    finalizadas: number;
+  }
   export interface ListaItem {
     id: number;
     cliente_saas_id?: number | null;
@@ -5483,10 +5539,30 @@ export namespace SaasClientes {
     status: Status;
     plano?: string | null;
     plano_id?: number | null;
-    plano_modulos?: Array<{ id: number; codigo: string; nome: string; ativo?: boolean }>;
+    plano_modulos?: Array<{
+      id: number;
+      codigo: string;
+      nome: string;
+      ativo?: boolean;
+      preco_mensal?: number | null;
+    }>;
+    modulos_contratados?: Array<{
+      id: number;
+      codigo: string;
+      nome: string;
+      ativo?: boolean;
+      preco_mensal?: number | null;
+    }>;
     modulos_snapshot?: string[];
     max_postos?: number | null;
     max_usuarios?: number | null;
+    usuarios_inclusos?: number | null;
+    preco_usuario_extra?: number | null;
+    preco_modulos?: number | null;
+    preco_usuarios_extra?: number | null;
+    preco_mensal_estimado?: number | null;
+    preco_mensal_negociado?: number | null;
+    preco_mensal_efetivo?: number | null;
     data_inicio: string;
     data_renovacao?: string | null;
     instancia_url?: string | null;
@@ -5519,6 +5595,9 @@ export namespace SaasClientes {
     status?: Status;
     plano?: string | null;
     plano_id?: number | null;
+    modulo_ids?: number[] | null;
+    usuarios_contratados?: number | null;
+    preco_mensal_negociado?: number | null;
     data_inicio: string;
     data_renovacao?: string | null;
     instancia_url?: string | null;
@@ -5536,6 +5615,7 @@ export namespace SaasCatalogo {
     codigo: string;
     nome: string;
     descricao?: string | null;
+    preco_mensal?: number | null;
     ativo: boolean;
     created_at?: string | null;
     updated_at?: string | null;
@@ -5545,6 +5625,7 @@ export namespace SaasCatalogo {
     codigo: string;
     nome: string;
     ativo?: boolean;
+    preco_mensal?: number | null;
   }
   export interface Plano {
     id: number;
@@ -5554,6 +5635,8 @@ export namespace SaasCatalogo {
     ativo: boolean;
     ordem: number;
     preco_mensal?: number | null;
+    usuarios_inclusos?: number;
+    preco_usuario_extra?: number | null;
     max_postos?: number | null;
     max_usuarios?: number | null;
     modulos: ModuloBrief[];
@@ -5565,8 +5648,8 @@ export namespace SaasCatalogo {
     nome: string;
     descricao?: string | null;
     ordem?: number;
-    preco_mensal?: number | null;
-    max_postos?: number | null;
+    usuarios_inclusos?: number | null;
+    preco_usuario_extra?: number | null;
     max_usuarios?: number | null;
     modulo_ids?: number[];
   }
@@ -5575,6 +5658,7 @@ export namespace SaasCatalogo {
     codigo: string;
     nome: string;
     descricao?: string | null;
+    preco_mensal?: number | null;
   }
   export type ModuloUpdate = Partial<Omit<ModuloCreate, 'codigo'>>;
 }

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -19,7 +19,7 @@ interface AuthContextValue {
   isComercialOuAdmin: boolean
   /** Admin ou atendente do setor Financeiro (faturamento interno). */
   isFinanceiroOuAdmin: boolean
-  /** Equipa comercial DeskRudder (control-plane SaaS). */
+  /** Equipe comercial DeskRudder (control-plane SaaS). */
   isSaasOps: boolean
 }
 

--- a/frontend/src/lib/saasSolicitacoes.ts
+++ b/frontend/src/lib/saasSolicitacoes.ts
@@ -11,6 +11,27 @@ export const SAAS_SOLICITACAO_STATUS = [
 
 export type SaasSolicitacaoStatus = (typeof SAAS_SOLICITACAO_STATUS)[number]['value']
 
+/** Fases para filtro rápido (agrupa vários status). */
+export const SAAS_SOLICITACAO_FASES = [
+  {
+    value: 'aguardando',
+    label: 'Aguardando',
+    hint: 'Recebida, em análise ou planejada',
+  },
+  {
+    value: 'desenvolvimento',
+    label: 'Em desenvolvimento',
+    hint: 'Já em andamento',
+  },
+  {
+    value: 'finalizadas',
+    label: 'Finalizadas',
+    hint: 'Concluída ou não será desenvolvida',
+  },
+] as const
+
+export type SaasSolicitacaoFase = (typeof SAAS_SOLICITACAO_FASES)[number]['value']
+
 const BADGE: Record<string, string> = {
   aberta:
     'bg-slate-100 text-slate-800 ring-slate-200/80 dark:bg-slate-800/70 dark:text-slate-100 dark:ring-slate-600/70',
@@ -35,6 +56,18 @@ export function classesBadgeStatusSolicitacao(value: string): string {
     BADGE[value] ??
     'bg-slate-100 text-slate-800 ring-slate-200/80 dark:bg-slate-800/70 dark:text-slate-100 dark:ring-slate-600/70'
   )
+}
+
+/** Painel ops: “problema” do cliente = erro reportado. */
+export function rotuloTipoSolicitacao(tipo: string): string {
+  return tipo === 'problema' ? 'Erro' : 'Sugestão'
+}
+
+export function classesBadgeTipoSolicitacao(tipo: string): string {
+  if (tipo === 'problema') {
+    return 'bg-rose-50 text-rose-900 ring-rose-200/90 dark:bg-rose-950/45 dark:text-rose-100 dark:ring-rose-800/60'
+  }
+  return 'bg-sky-50 text-sky-900 ring-sky-200/90 dark:bg-sky-950/45 dark:text-sky-100 dark:ring-sky-800/60'
 }
 
 /** GitHub / issue #N não deve ir na mensagem visível ao cliente. */

--- a/frontend/src/pages/saas/SaasConta.tsx
+++ b/frontend/src/pages/saas/SaasConta.tsx
@@ -1,13 +1,22 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { saasOpsConta, ApiError, type SaasOpsConta } from '../../api/client'
+import {
+  atendentes,
+  saasOpsConta,
+  ApiError,
+  persistAuthTokens,
+  type SaasOpsConta,
+} from '../../api/client'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/errorMessage'
 import { Button } from '../../components/ui/Button'
+import { CadastroFormPageShell } from '../../components/ui/CadastroFormPageShell'
 import { Card } from '../../components/ui/Card'
 import { CarregamentoFalhou } from '../../components/ui/CarregamentoFalhou'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import { IconEye, IconEyeOff } from '../../components/ui/IconEye'
+import { Input } from '../../components/ui/Input'
 import { useToast } from '../../components/ui/Toast'
-import { VoltarButton } from '../../components/ui/VoltarButton'
+import { useAuth } from '../../contexts/AuthContext'
 import { useVoltarAnterior } from '../../hooks/useVoltarAnterior'
 import { SemPermissao } from '../SemPermissao'
 import { SAAS_LICENCAS_PATH } from '../../lib/saasControlPlane'
@@ -23,9 +32,13 @@ function formatWhen(iso: string | null | undefined): string {
 
 export function SaasConta() {
   const toast = useToast()
+  const { user, refreshUser } = useAuth()
   const voltarAnterior = useVoltarAnterior(SAAS_LICENCAS_PATH)
+
   const [loading, setLoading] = useState(true)
-  const [busy, setBusy] = useState(false)
+  const [busyPerfil, setBusyPerfil] = useState(false)
+  const [busySenha, setBusySenha] = useState(false)
+  const [busyToken, setBusyToken] = useState(false)
   const [forbidden, setForbidden] = useState(false)
   const [indisponivel, setIndisponivel] = useState(false)
   const [falha, setFalha] = useState<{ titulo: string; detalhe?: string } | null>(null)
@@ -33,6 +46,22 @@ export function SaasConta() {
   const [plaintext, setPlaintext] = useState<string | null>(null)
   const [confirmarGerar, setConfirmarGerar] = useState(false)
   const [confirmarRevogar, setConfirmarRevogar] = useState(false)
+
+  const [nome, setNome] = useState('')
+  const [email, setEmail] = useState('')
+
+  const [senhaAtual, setSenhaAtual] = useState('')
+  const [senhaNova, setSenhaNova] = useState('')
+  const [senhaConf, setSenhaConf] = useState('')
+  const [mostrarAtual, setMostrarAtual] = useState(false)
+  const [mostrarNova, setMostrarNova] = useState(false)
+  const [mostrarConf, setMostrarConf] = useState(false)
+
+  useEffect(() => {
+    if (!user) return
+    setNome(user.nome ?? '')
+    setEmail(user.email ?? '')
+  }, [user])
 
   const carregar = useCallback(() => {
     setLoading(true)
@@ -60,8 +89,62 @@ export function SaasConta() {
     carregar()
   }, [carregar])
 
+  async function salvarPerfil(e: React.FormEvent) {
+    e.preventDefault()
+    if (!nome.trim() || !email.trim()) {
+      toast.showError('Informe nome e e-mail.')
+      return
+    }
+    setBusyPerfil(true)
+    try {
+      const row = await saasOpsConta.atualizarPerfil({
+        nome: nome.trim(),
+        email: email.trim(),
+      })
+      if (row.access_token) {
+        persistAuthTokens({
+          access_token: row.access_token,
+          refresh_token: row.refresh_token,
+        })
+      }
+      setNome(row.nome)
+      setEmail(row.email)
+      await refreshUser()
+      toast.showSuccess('Dados da conta atualizados.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar os dados.'))
+    } finally {
+      setBusyPerfil(false)
+    }
+  }
+
+  async function salvarSenha(e: React.FormEvent) {
+    e.preventDefault()
+    if (senhaNova.length < 8) {
+      toast.showError('A nova senha deve ter pelo menos 8 caracteres.')
+      return
+    }
+    if (senhaNova !== senhaConf) {
+      toast.showError('A confirmação não coincide com a nova senha.')
+      return
+    }
+    setBusySenha(true)
+    try {
+      await atendentes.trocarSenha(senhaAtual, senhaNova)
+      setSenhaAtual('')
+      setSenhaNova('')
+      setSenhaConf('')
+      await refreshUser()
+      toast.showSuccess('Senha alterada.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar a senha.'))
+    } finally {
+      setBusySenha(false)
+    }
+  }
+
   async function gerar() {
-    setBusy(true)
+    setBusyToken(true)
     try {
       const row = await saasOpsConta.gerarMcpToken()
       setEstado({ configurado: row.configurado, gerado_em: row.gerado_em })
@@ -74,13 +157,13 @@ export function SaasConta() {
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível gerar o token.'))
     } finally {
-      setBusy(false)
+      setBusyToken(false)
       setConfirmarGerar(false)
     }
   }
 
   async function revogar() {
-    setBusy(true)
+    setBusyToken(true)
     try {
       const row = await saasOpsConta.revogarMcpToken()
       setEstado(row)
@@ -89,7 +172,7 @@ export function SaasConta() {
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível revogar o token.'))
     } finally {
-      setBusy(false)
+      setBusyToken(false)
       setConfirmarRevogar(false)
     }
   }
@@ -100,7 +183,7 @@ export function SaasConta() {
       await navigator.clipboard.writeText(plaintext)
       toast.showSuccess('Token copiado.')
     } catch {
-      toast.showError('Não foi possível copiar. Seleccione o token e copie manualmente.')
+      toast.showError('Não foi possível copiar. Selecione o token e copie manualmente.')
     }
   }
 
@@ -118,7 +201,7 @@ export function SaasConta() {
     return (
       <SemPermissao
         title="Painel SaaS não disponível nesta instância."
-        detail="O token Cursor só existe no control-plane DeskRudder."
+        detail="A conta e o token Cursor só existem no control-plane DeskRudder."
         voltarPara="/login/admin"
         voltarLabel="Voltar ao login admin"
       />
@@ -136,8 +219,96 @@ export function SaasConta() {
   }
 
   return (
-    <div className="mx-auto max-w-2xl space-y-4">
-      <VoltarButton onClick={voltarAnterior} />
+    <CadastroFormPageShell onVoltar={voltarAnterior}>
+      <div className="space-y-4">
+      <Card title="Dados da conta" description="Nome e e-mail usados no login do painel admin (/login/admin).">
+        <form onSubmit={(ev) => void salvarPerfil(ev)} className="space-y-4">
+          <Input label="Nome" value={nome} onChange={(ev) => setNome(ev.target.value)} required />
+          <Input
+            label="E-mail"
+            type="email"
+            value={email}
+            onChange={(ev) => setEmail(ev.target.value)}
+            required
+            autoComplete="username"
+          />
+          <div className="flex justify-end">
+            <Button type="submit" loading={busyPerfil}>
+              Salvar dados
+            </Button>
+          </div>
+        </form>
+      </Card>
+
+      <Card title="Alterar senha" description="Informe a senha atual e defina uma nova (mínimo 8 caracteres).">
+        <form onSubmit={(ev) => void salvarSenha(ev)} className="space-y-4" noValidate>
+          <Input
+            label="Senha atual"
+            type={mostrarAtual ? 'text' : 'password'}
+            value={senhaAtual}
+            onChange={(ev) => setSenhaAtual(ev.target.value)}
+            autoComplete="current-password"
+            required
+            endAdornment={
+              <button
+                type="button"
+                onClick={() => setMostrarAtual((v) => !v)}
+                className="inline-flex size-9 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/30 dark:text-slate-400 dark:hover:bg-white/10 dark:hover:text-slate-200"
+                aria-label={mostrarAtual ? 'Ocultar senha atual' : 'Mostrar senha atual'}
+                aria-pressed={mostrarAtual}
+              >
+                {mostrarAtual ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
+              </button>
+            }
+          />
+          <Input
+            label="Nova senha"
+            type={mostrarNova ? 'text' : 'password'}
+            value={senhaNova}
+            onChange={(ev) => setSenhaNova(ev.target.value)}
+            autoComplete="new-password"
+            minLength={8}
+            required
+            endAdornment={
+              <button
+                type="button"
+                onClick={() => setMostrarNova((v) => !v)}
+                className="inline-flex size-9 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/30 dark:text-slate-400 dark:hover:bg-white/10 dark:hover:text-slate-200"
+                aria-label={mostrarNova ? 'Ocultar nova senha' : 'Mostrar nova senha'}
+                aria-pressed={mostrarNova}
+              >
+                {mostrarNova ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
+              </button>
+            }
+          />
+          <Input
+            label="Confirmar nova senha"
+            type={mostrarConf ? 'text' : 'password'}
+            value={senhaConf}
+            onChange={(ev) => setSenhaConf(ev.target.value)}
+            autoComplete="new-password"
+            minLength={8}
+            required
+            endAdornment={
+              <button
+                type="button"
+                onClick={() => setMostrarConf((v) => !v)}
+                className="inline-flex size-9 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/30 dark:text-slate-400 dark:hover:bg-white/10 dark:hover:text-slate-200"
+                aria-label={mostrarConf ? 'Ocultar confirmação' : 'Mostrar confirmação'}
+                aria-pressed={mostrarConf}
+              >
+                {mostrarConf ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
+              </button>
+            }
+          />
+          <div className="flex justify-end">
+            <Button type="submit" loading={busySenha}>
+              Alterar senha
+            </Button>
+          </div>
+        </form>
+      </Card>
+
       <Card
         title="Integração Cursor"
         description="O token identifica a sua conta ops nas sugestões (recusar, comentar, ligar issue). Cada pessoa gera o próprio. Novas contas são criadas em Usuários."
@@ -151,7 +322,7 @@ export function SaasConta() {
                 ? `Token ativo. Gerado em ${formatWhen(estado.gerado_em)}.`
                 : 'Ainda não há token nesta conta.'}{' '}
               <Link to="/saas/usuarios" className="font-medium text-sky-700 underline dark:text-sky-300">
-                Gerir equipe
+                Gerenciar equipe
               </Link>
             </p>
             {plaintext ? (
@@ -179,7 +350,7 @@ export function SaasConta() {
             <div className="flex flex-wrap gap-2">
               <Button
                 type="button"
-                loading={busy}
+                loading={busyToken}
                 onClick={() => {
                   if (estado.configurado) {
                     setConfirmarGerar(true)
@@ -191,7 +362,7 @@ export function SaasConta() {
                 {estado.configurado ? 'Regenerar token' : 'Gerar token'}
               </Button>
               {estado.configurado ? (
-                <Button type="button" variant="danger" loading={busy} onClick={() => setConfirmarRevogar(true)}>
+                <Button type="button" variant="danger" loading={busyToken} onClick={() => setConfirmarRevogar(true)}>
                   Revogar
                 </Button>
               ) : null}
@@ -199,13 +370,14 @@ export function SaasConta() {
           </div>
         )}
       </Card>
+
       <ConfirmDialog
         open={confirmarGerar}
         title="Regenerar token Cursor?"
-        message="O token que está no Cursor deixa de funcionar. Terá de colar o novo valor no mcp.json."
+        message="O token que está no Cursor deixa de funcionar. Você terá de colar o novo valor no mcp.json."
         confirmLabel="Regenerar"
         variant="danger"
-        loading={busy}
+        loading={busyToken}
         onConfirm={() => void gerar()}
         onCancel={() => setConfirmarGerar(false)}
       />
@@ -215,10 +387,11 @@ export function SaasConta() {
         message="O Cursor deixa de autenticar nesta conta até gerar um token novo."
         confirmLabel="Revogar"
         variant="danger"
-        loading={busy}
+        loading={busyToken}
         onConfirm={() => void revogar()}
         onCancel={() => setConfirmarRevogar(false)}
       />
-    </div>
+      </div>
+    </CadastroFormPageShell>
   )
 }

--- a/frontend/src/pages/saas/SaasLayout.tsx
+++ b/frontend/src/pages/saas/SaasLayout.tsx
@@ -1,4 +1,4 @@
-import { Link, NavLink, Navigate, Outlet, useLocation } from 'react-router-dom'
+import { NavLink, Navigate, Outlet, useLocation } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import { BrandLogo } from '../../brand'
 import { useAuth } from '../../contexts/AuthContext'
@@ -21,6 +21,23 @@ const menuIcon = (
   </svg>
 )
 
+const chevronIcon = (
+  <svg className="size-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+  </svg>
+)
+
+const usersIcon = (
+  <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M17 20h5v-2a4 4 0 00-4-4h-1M9 20H4v-2a4 4 0 014-4h1m4-4a4 4 0 100-8 4 4 0 000 8zm6 4a3 3 0 100-6 3 3 0 000 6z"
+    />
+  </svg>
+)
+
 const navLinkClass = ({ isActive }: { isActive: boolean }) =>
   [
     'flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition',
@@ -28,6 +45,17 @@ const navLinkClass = ({ isActive }: { isActive: boolean }) =>
       ? 'bg-sky-50 text-sky-800 ring-1 ring-sky-600/20 dark:bg-sky-500/15 dark:text-sky-100 dark:ring-sky-400/30'
       : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-white/5 dark:hover:text-white',
   ].join(' ')
+
+function perfilExibicao(user: { role?: string; saas_setor_nomes?: string[] } | null | undefined): string {
+  const nomes = (user?.saas_setor_nomes ?? []).map((n) => n.trim()).filter(Boolean)
+  if (nomes.length > 0) return nomes.join(' · ')
+  const role = user?.role
+  if (role === 'admin') return 'Administrador'
+  if (role === 'atendente') return 'Atendente'
+  if (role === 'comercial') return 'Comercial'
+  if (role === 'saas_ops') return 'Ops SaaS'
+  return role?.trim() || '—'
+}
 
 /**
  * Shell dedicado do control-plane SaaS — sem tickets/chat do painel de atendimento.
@@ -39,6 +67,11 @@ export function SaasLayout() {
   const location = useLocation()
   const [sidebarExpanded, setSidebarExpanded] = useState(true)
   const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false)
+  const equipePath =
+    location.pathname.startsWith('/saas/usuarios') ||
+    location.pathname.startsWith('/saas/setores') ||
+    location.pathname.startsWith('/saas/conta')
+  const [equipeOpen, setEquipeOpen] = useState(equipePath)
   const [planeOk, setPlaneOk] = useState<boolean | null>(null)
   const [versionLabel, setVersionLabel] = useState<string | null>(() => {
     const fromEnv =
@@ -47,6 +80,12 @@ export function SaasLayout() {
     return fromEnv ? (fromEnv.startsWith('v') ? fromEnv : `v${fromEnv}`) : null
   })
   const logoOnDark = resolved === 'dark'
+  const cargoLabel = perfilExibicao(user)
+  const menuExpandido = sidebarExpanded || sidebarMobileOpen
+
+  useEffect(() => {
+    if (equipePath) setEquipeOpen(true)
+  }, [equipePath])
 
   useEffect(() => {
     let cancelled = false
@@ -136,61 +175,105 @@ export function SaasLayout() {
         ].join(' ')}
       >
         <div
-          className={`flex items-center gap-3 border-b border-slate-200 px-4 py-4 dark:border-slate-800 ${sidebarExpanded ? '' : 'md:justify-center'}`}
+          className={`flex h-16 min-h-[64px] shrink-0 items-center border-b border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-950 ${sidebarExpanded ? 'px-4' : 'justify-center md:px-2'}`}
         >
           <BrandLogo
             variant={sidebarExpanded ? 'full' : 'mark'}
-            size="sm"
+            size={sidebarExpanded ? 'sidebar' : 'sm'}
             markVariant={logoOnDark ? 'onDark' : 'default'}
-            className="min-w-0"
+            className={sidebarExpanded ? 'min-w-0 w-full' : 'min-w-0'}
           />
-        </div>
-        <div
-          className={`border-b border-slate-200 px-4 py-3 dark:border-slate-800 ${sidebarExpanded ? '' : 'md:px-2 md:text-center'}`}
-        >
-          <p className="text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-sky-700 dark:text-sky-300/90">
-            {sidebarExpanded ? 'Painel admin SaaS' : 'SaaS'}
-          </p>
-          {sidebarExpanded ? (
-            <p className="mt-1 text-xs text-slate-500 dark:text-slate-500">Licenças, planos, leads e sugestões</p>
-          ) : null}
         </div>
         <nav className="flex flex-1 flex-col gap-1 overflow-y-auto p-3" onClick={() => setSidebarMobileOpen(false)}>
           <NavLink to={SAAS_LICENCAS_PATH} className={navLinkClass} end={false}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Licenças' : 'Lic'}</span>
+            <span className="truncate">{menuExpandido ? 'Licenças' : 'Lic'}</span>
           </NavLink>
           <NavLink to="/saas/planos" className={navLinkClass}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Planos' : 'Plan'}</span>
+            <span className="truncate">{menuExpandido ? 'Planos' : 'Plan'}</span>
           </NavLink>
           <NavLink to="/saas/leads" className={navLinkClass}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Leads comerciais' : 'Leads'}</span>
+            <span className="truncate">{menuExpandido ? 'Leads comerciais' : 'Leads'}</span>
           </NavLink>
           <NavLink to="/saas/solicitacoes" className={navLinkClass}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Sugestões' : 'Sug'}</span>
+            <span className="truncate">{menuExpandido ? 'Sugestões' : 'Sug'}</span>
           </NavLink>
-          {sidebarExpanded || sidebarMobileOpen ? (
-            <p className="mt-3 px-3 pt-2 text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-slate-400 dark:text-slate-500">
-              Equipe
-            </p>
+
+          {menuExpandido ? (
+            <div className="mt-2" onClick={(e) => e.stopPropagation()}>
+              <button
+                type="button"
+                onClick={() => setEquipeOpen((o) => !o)}
+                className={[
+                  'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm font-medium transition touch-manipulation min-h-[44px]',
+                  equipePath
+                    ? 'text-slate-800 dark:text-slate-100'
+                    : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-white/5 dark:hover:text-white',
+                ].join(' ')}
+                aria-expanded={equipeOpen}
+                aria-controls="saas-nav-equipe"
+              >
+                {usersIcon}
+                <span className="min-w-0 flex-1 truncate">Equipe</span>
+                <span className={`shrink-0 text-slate-400 transition-transform ${equipeOpen ? 'rotate-180' : ''}`}>
+                  {chevronIcon}
+                </span>
+              </button>
+              <ul
+                id="saas-nav-equipe"
+                className={`min-w-0 space-y-0.5 overflow-hidden transition-all duration-200 ${
+                  equipeOpen ? 'mt-1 max-h-56 opacity-100' : 'max-h-0 opacity-0'
+                }`}
+                role="group"
+              >
+                <li className="min-w-0 border-l border-slate-200 pl-3 ml-4 dark:border-slate-700">
+                  <NavLink
+                    to="/saas/usuarios"
+                    className={navLinkClass}
+                    onClick={() => setSidebarMobileOpen(false)}
+                  >
+                    <span className="truncate">Usuários</span>
+                  </NavLink>
+                </li>
+                <li className="min-w-0 border-l border-slate-200 pl-3 ml-4 dark:border-slate-700">
+                  <NavLink
+                    to="/saas/setores"
+                    className={navLinkClass}
+                    onClick={() => setSidebarMobileOpen(false)}
+                  >
+                    <span className="truncate">Setores</span>
+                  </NavLink>
+                </li>
+                <li className="min-w-0 border-l border-slate-200 pl-3 ml-4 dark:border-slate-700">
+                  <NavLink to="/saas/conta" className={navLinkClass} onClick={() => setSidebarMobileOpen(false)}>
+                    <span className="truncate">Minha conta</span>
+                  </NavLink>
+                </li>
+              </ul>
+            </div>
           ) : (
-            <div className="my-2 hidden border-t border-slate-200 dark:border-slate-800 md:block" />
+            <>
+              <div className="my-2 hidden border-t border-slate-200 dark:border-slate-800 md:block" />
+              <NavLink to="/saas/usuarios" className={navLinkClass} title="Usuários">
+                <span className="truncate">Usr</span>
+              </NavLink>
+              <NavLink to="/saas/setores" className={navLinkClass} title="Setores">
+                <span className="truncate">Set</span>
+              </NavLink>
+              <NavLink to="/saas/conta" className={navLinkClass} title="Minha conta">
+                <span className="truncate">Conta</span>
+              </NavLink>
+            </>
           )}
-          <NavLink to="/saas/usuarios" className={navLinkClass}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Usuários' : 'Usr'}</span>
-          </NavLink>
-          <NavLink to="/saas/conta" className={navLinkClass}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Minha conta' : 'Conta'}</span>
-          </NavLink>
         </nav>
         <div className={`shrink-0 border-t border-slate-200 p-2 dark:border-slate-800 ${sidebarExpanded ? '' : 'md:px-2'}`}>
-          {(sidebarExpanded || sidebarMobileOpen) ? (
+          {menuExpandido ? (
             <div className="flex items-center gap-3 px-3 py-2 text-slate-600 dark:text-slate-400">
               <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-cyan-500 to-blue-600 text-xs font-semibold text-white shadow-sm shadow-cyan-500/25">
                 {user.nome?.charAt(0)?.toUpperCase() ?? '?'}
               </span>
               <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{user.nome}</p>
-                <p className="truncate text-xs text-slate-500 dark:text-slate-400">Ops SaaS</p>
+                <p className="truncate text-xs text-slate-500 dark:text-slate-400">{cargoLabel}</p>
               </div>
             </div>
           ) : null}
@@ -199,19 +282,11 @@ export function SaasLayout() {
             onClick={handleLogout}
             title="Sair"
             className={`mt-2 flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium text-slate-600 hover:bg-slate-100 active:bg-slate-200 touch-manipulation min-h-[44px] dark:text-slate-400 dark:hover:bg-slate-800 dark:active:bg-slate-700 ${
-              sidebarExpanded || sidebarMobileOpen ? '' : 'md:justify-center md:px-2'
+              menuExpandido ? '' : 'md:justify-center md:px-2'
             }`}
           >
             {logoutIcon}
-            <span
-              className={
-                sidebarExpanded || sidebarMobileOpen
-                  ? 'min-w-0 truncate'
-                  : 'min-w-0 truncate md:hidden'
-              }
-            >
-              Sair
-            </span>
+            <span className={menuExpandido ? 'min-w-0 truncate' : 'min-w-0 truncate md:hidden'}>Sair</span>
           </button>
           <NavLink
             to="/saas/sobre"
@@ -220,13 +295,13 @@ export function SaasLayout() {
             className={({ isActive }) =>
               [
                 'mt-2 flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs font-medium text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800/80 dark:hover:text-slate-200',
-                sidebarExpanded || sidebarMobileOpen ? '' : 'md:justify-center md:px-2',
+                menuExpandido ? '' : 'md:justify-center md:px-2',
                 isActive ? 'bg-slate-100 text-slate-800 dark:bg-slate-800/80 dark:text-slate-100' : '',
               ].join(' ')
             }
           >
-            <span className={`truncate ${sidebarExpanded || sidebarMobileOpen ? '' : 'md:text-[10px]'}`}>
-              {sidebarExpanded || sidebarMobileOpen
+            <span className={`truncate ${menuExpandido ? '' : 'md:text-[10px]'}`}>
+              {menuExpandido
                 ? versionLabel
                   ? `Sobre · ${versionLabel}`
                   : 'Sobre'
@@ -237,7 +312,7 @@ export function SaasLayout() {
       </aside>
 
       <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden md:col-start-2">
-        <header className="z-30 flex h-16 shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-800 dark:bg-slate-950 md:px-6">
+        <header className="z-30 flex h-16 min-h-[64px] w-full shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-800 dark:bg-slate-950 md:gap-3 md:px-6">
           <button
             type="button"
             onClick={() => {
@@ -247,23 +322,24 @@ export function SaasLayout() {
                 setSidebarMobileOpen((o) => !o)
               }
             }}
-            className="flex size-10 items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800 md:size-9"
+            className="flex size-10 shrink-0 items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 active:bg-slate-200 touch-manipulation dark:text-slate-300 dark:hover:bg-slate-800 md:size-9"
             aria-label="Abrir ou recolher menu"
           >
             {menuIcon}
           </button>
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-200">
-              Control-plane DeskRudder
+          <div className="min-w-0 flex-1 leading-tight">
+            <p className="truncate text-sm font-semibold uppercase tracking-[0.08em] text-sky-800 dark:text-sky-200">
+              Painel admin SaaS
+            </p>
+            <p className="hidden truncate text-xs text-slate-500 dark:text-slate-400 sm:block">
+              Licenças, planos, leads e sugestões
             </p>
           </div>
           <ThemeToggle />
-          <Link
-            to="/login"
-            className="hidden rounded-lg px-3 py-1.5 text-xs font-medium text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-white/5 dark:hover:text-slate-200 sm:inline"
-          >
-            Painel atendimento
-          </Link>
+          <div className="hidden min-w-0 max-w-[12rem] shrink text-right leading-tight sm:block md:max-w-[16rem]">
+            <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{user.nome}</p>
+            <p className="truncate text-xs text-slate-500 dark:text-slate-400">{cargoLabel}</p>
+          </div>
         </header>
         <main className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto p-4 md:p-6">
           <Outlet />

--- a/frontend/src/pages/saas/SaasLicencaDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasLicencaDetalhe.tsx
@@ -315,30 +315,79 @@ export function SaasLicencaDetalhe() {
         <dl>
           <DetailRow label="ID" value={String(item.id)} mono />
           <DetailRow label="Slug" value={item.slug} mono />
-          <DetailRow label="Plano" value={item.plano || '—'} />
-          {item.plano_modulos && item.plano_modulos.length > 0 ? (
+          <DetailRow label="Plano base" value={item.plano || '—'} />
+          {(item.modulos_contratados && item.modulos_contratados.length > 0) ||
+          (item.modulos_snapshot && item.modulos_snapshot.length > 0) ? (
+            <DetailRow
+              label="Módulos contratados"
+              value={
+                item.modulos_contratados && item.modulos_contratados.length > 0
+                  ? item.modulos_contratados.map((m) => m.nome).join(', ')
+                  : (item.modulos_snapshot ?? []).join(', ')
+              }
+            />
+          ) : item.plano_modulos && item.plano_modulos.length > 0 ? (
             <DetailRow
               label="Módulos do plano"
               value={item.plano_modulos.map((m) => m.nome).join(', ')}
             />
           ) : null}
-          {item.modulos_snapshot && item.modulos_snapshot.length > 0 ? (
-            <DetailRow label="Snapshot módulos" value={item.modulos_snapshot.join(', ')} mono />
-          ) : null}
           <DetailRow
-            label="Limites"
+            label="Usuários"
             value={
-              item.max_postos != null || item.max_usuarios != null
-                ? [
-                    item.max_postos != null ? `${item.max_postos} postos` : null,
-                    item.max_usuarios != null ? `${item.max_usuarios} utilizadores` : null,
-                  ]
-                    .filter(Boolean)
-                    .join(' · ')
+              item.max_usuarios != null
+                ? `${item.max_usuarios} contratados${
+                    item.usuarios_inclusos != null
+                      ? ` (${item.usuarios_inclusos} inclusos no plano)`
+                      : ''
+                  }`
                 : '—'
             }
           />
-          <DetailRow label="Contacto" value={item.contato_nome || '—'} />
+          <DetailRow
+            label="Valor mensal"
+            value={
+              item.preco_mensal_efetivo != null
+                ? `R$ ${Number(item.preco_mensal_efetivo).toLocaleString('pt-BR', {
+                    minimumFractionDigits: 0,
+                    maximumFractionDigits: 2,
+                  })}/mês${
+                    item.preco_mensal_negociado != null
+                      ? ' (negociado)'
+                      : ' (catálogo)'
+                  }`
+                : '—'
+            }
+          />
+          {item.preco_mensal_negociado != null && item.preco_mensal_estimado != null ? (
+            <DetailRow
+              label="Estimativa catálogo"
+              value={`R$ ${Number(item.preco_mensal_estimado).toLocaleString('pt-BR', {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 2,
+              })}/mês`}
+            />
+          ) : item.preco_mensal_estimado != null && item.preco_mensal_negociado == null ? (
+            <DetailRow
+              label="Detalhe catálogo"
+              value={
+                item.preco_modulos != null || item.preco_usuarios_extra != null
+                  ? `módulos R$ ${Number(item.preco_modulos ?? 0).toLocaleString('pt-BR', {
+                      minimumFractionDigits: 0,
+                      maximumFractionDigits: 2,
+                    })}${
+                      Number(item.preco_usuarios_extra ?? 0) > 0
+                        ? ` + extras R$ ${Number(item.preco_usuarios_extra).toLocaleString('pt-BR', {
+                            minimumFractionDigits: 0,
+                            maximumFractionDigits: 2,
+                          })}`
+                        : ''
+                    }`
+                  : '—'
+              }
+            />
+          ) : null}
+          <DetailRow label="Contato" value={item.contato_nome || '—'} />
           <DetailRow label="E-mail" value={item.contato_email || '—'} />
           <DetailRow label="Início" value={formatDate(item.data_inicio)} />
           <DetailRow

--- a/frontend/src/pages/saas/SaasLicencaForm.tsx
+++ b/frontend/src/pages/saas/SaasLicencaForm.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
-import { ApiError, saasClientes, saasPlanos, type SaasCatalogo } from '../../api/client'
+import { ApiError, saasClientes, saasModulos, saasPlanos, type SaasCatalogo } from '../../api/client'
 import { Card } from '../../components/ui/Card'
 import { Input } from '../../components/ui/Input'
 import { Select } from '../../components/ui/Select'
@@ -55,6 +55,11 @@ export function SaasLicencaForm() {
   const [status, setStatus] = useState<StatusClienteSaaS>('trial')
   const [planoId, setPlanoId] = useState<number | ''>('')
   const [planosOpts, setPlanosOpts] = useState<SaasCatalogo.Plano[]>([])
+  const [modulosOpts, setModulosOpts] = useState<SaasCatalogo.Modulo[]>([])
+  const [moduloIds, setModuloIds] = useState<number[]>([])
+  const [usuariosContratados, setUsuariosContratados] = useState('3')
+  const [precoNegociado, setPrecoNegociado] = useState('')
+  const [pendingSnap, setPendingSnap] = useState<string[] | null>(null)
   const [dataInicio, setDataInicio] = useState(todayIso)
   const [dataRenovacao, setDataRenovacao] = useState('')
   const [contatoNome, setContatoNome] = useState('')
@@ -62,6 +67,14 @@ export function SaasLicencaForm() {
   const [notas, setNotas] = useState('')
   const [leadComercialId, setLeadComercialId] = useState<number | null>(null)
   const [baseDomain, setBaseDomain] = useState(saasBaseDomain())
+
+  function formatPreco(v: number): string {
+    return `R$ ${v.toLocaleString('pt-BR', { minimumFractionDigits: 0, maximumFractionDigits: 2 })}`
+  }
+
+  function toggleModulo(mid: number) {
+    setModuloIds((prev) => (prev.includes(mid) ? prev.filter((x) => x !== mid) : [...prev, mid]))
+  }
 
   useEffect(() => {
     if (isEdit) return
@@ -103,19 +116,61 @@ export function SaasLicencaForm() {
 
   useEffect(() => {
     let cancelled = false
-    saasPlanos
-      .list()
-      .then((planos) => {
+    Promise.all([saasPlanos.list(), saasModulos.list()])
+      .then(([planos, mods]) => {
         if (cancelled) return
         setPlanosOpts(planos)
+        setModulosOpts(mods)
       })
       .catch(() => {
-        /* select vazio */
+        /* selects vazios */
       })
     return () => {
       cancelled = true
     }
   }, [])
+
+  const planoSelecionado = useMemo(
+    () => (planoId === '' ? null : planosOpts.find((p) => p.id === Number(planoId)) ?? null),
+    [planoId, planosOpts],
+  )
+
+  const inclusos = planoSelecionado?.usuarios_inclusos ?? 3
+  const extraUnit = Number(planoSelecionado?.preco_usuario_extra ?? 10)
+  const precoMods = useMemo(() => {
+    return (
+      Math.round(
+        modulosOpts
+          .filter((m) => moduloIds.includes(m.id))
+          .reduce((acc, m) => acc + Number(m.preco_mensal || 0), 0) * 100,
+      ) / 100
+    )
+  }, [modulosOpts, moduloIds])
+  const usersN = parseInt(usuariosContratados, 10)
+  const usersExtra = Number.isFinite(usersN) ? Math.max(0, usersN - inclusos) : 0
+  const precoUsers = Math.round(usersExtra * extraUnit * 100) / 100
+  const precoTotal = Math.round((precoMods + precoUsers) * 100) / 100
+
+  function aplicarModulosDoPlano(pid: number | '') {
+    if (pid === '') {
+      setModuloIds([])
+      return
+    }
+    const plano = planosOpts.find((p) => p.id === Number(pid))
+    if (plano) setModuloIds(plano.modulos.map((m) => m.id))
+  }
+
+  useEffect(() => {
+    if (pendingSnap == null) return
+    if (!modulosOpts.length && !planosOpts.length) return
+    if (pendingSnap.length && modulosOpts.length) {
+      setModuloIds(modulosOpts.filter((m) => pendingSnap.includes(m.codigo)).map((m) => m.id))
+    } else if (planoId !== '' && planosOpts.length) {
+      aplicarModulosDoPlano(planoId)
+    }
+    setPendingSnap(null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- sync único após load da licença
+  }, [pendingSnap, modulosOpts, planosOpts, planoId])
 
   useEffect(() => {
     if (!isEdit) return
@@ -138,6 +193,15 @@ export function SaasLicencaForm() {
         setSlugTouched(true)
         setStatus(c.status)
         setPlanoId(c.plano_id ?? '')
+        setUsuariosContratados(
+          c.max_usuarios != null
+            ? String(c.max_usuarios)
+            : String(c.usuarios_inclusos ?? 3),
+        )
+        setPrecoNegociado(
+          c.preco_mensal_negociado != null ? String(c.preco_mensal_negociado) : '',
+        )
+        setPendingSnap(c.modulos_snapshot ?? [])
         setDataInicio(c.data_inicio.slice(0, 10))
         setDataRenovacao(c.data_renovacao ? c.data_renovacao.slice(0, 10) : '')
         setContatoNome(c.contato_nome ?? '')
@@ -178,11 +242,18 @@ export function SaasLicencaForm() {
     setSaving(true)
     try {
       const urlAuto = urlInstanciaFromSlug(slug.trim().toLowerCase(), baseDomain) || null
+      const usersParsed = parseInt(usuariosContratados, 10)
+      const negociadoParsed =
+        precoNegociado.trim() === '' ? null : Number(precoNegociado)
       const payload = {
         nome: nome.trim(),
         slug: slug.trim().toLowerCase(),
         status,
         plano_id: planoId === '' ? null : Number(planoId),
+        modulo_ids: moduloIds,
+        usuarios_contratados: Number.isFinite(usersParsed) ? usersParsed : null,
+        preco_mensal_negociado:
+          negociadoParsed != null && Number.isFinite(negociadoParsed) ? negociadoParsed : null,
         data_inicio: dataInicio,
         data_renovacao: dataRenovacao.trim() || null,
         instancia_url: urlAuto,
@@ -288,30 +359,102 @@ export function SaasLicencaForm() {
                 options={STATUS_CLIENTE_SAAS.map((s) => ({ value: s.value, label: s.label }))}
               />
               <Select
-                label="Plano"
+                label="Plano base"
                 value={planoId}
-                onChange={(v) => setPlanoId(v === '' ? '' : Number(v))}
+                onChange={(v) => {
+                  const next = v === '' ? '' : Number(v)
+                  setPlanoId(next)
+                  aplicarModulosDoPlano(next)
+                  const plano = next === '' ? null : planosOpts.find((p) => p.id === next)
+                  if (plano?.usuarios_inclusos != null) {
+                    setUsuariosContratados(String(plano.usuarios_inclusos))
+                  }
+                }}
                 includeEmpty
                 emptyLabel="Sem plano"
                 options={planosOpts
                   .filter((p) => p.ativo || p.id === planoId)
                   .map((p) => ({
                     value: p.id,
-                    label: p.ativo ? p.nome : `${p.nome} (inactivo)`,
+                    label: p.ativo ? p.nome : `${p.nome} (inativo)`,
                   }))}
               />
               <p className="text-xs text-slate-500 dark:text-slate-400">
-                Catálogo em Licenças → Planos. Só planos activos (excepto o já atribuído).
+                Ao trocar o plano, os módulos do pacote são pré-selecionados. Você pode incluir
+                módulos extras (ex.: Essencial + um módulo Enterprise).
               </p>
             </FormSection>
-            <FormSection title="Contacto">
+            <FormSection title="Módulos e usuários">
+              <div className="space-y-2">
+                <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                  Módulos contratados
+                </span>
+                <ul className="max-h-56 space-y-1 overflow-y-auto rounded-xl border border-slate-200 p-2 dark:border-slate-700">
+                  {modulosOpts
+                    .filter((m) => m.ativo || moduloIds.includes(m.id))
+                    .map((m) => (
+                      <li key={m.id}>
+                        <label className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-sm hover:bg-slate-50 dark:hover:bg-slate-800/60">
+                          <input
+                            type="checkbox"
+                            checked={moduloIds.includes(m.id)}
+                            onChange={() => toggleModulo(m.id)}
+                            className="rounded border-slate-300 text-sky-600 focus:ring-sky-400"
+                          />
+                          <span className="min-w-0 flex-1 text-slate-800 dark:text-slate-100">
+                            {m.nome}
+                            {!m.ativo ? (
+                              <span className="ml-1 text-xs text-amber-600">(inativo)</span>
+                            ) : null}
+                          </span>
+                          <span className="tabular-nums text-xs text-slate-500">
+                            {formatPreco(Number(m.preco_mensal || 0))}
+                          </span>
+                        </label>
+                      </li>
+                    ))}
+                </ul>
+              </div>
               <Input
-                label="Nome do contacto"
+                label="Usuários contratados"
+                type="number"
+                min={0}
+                value={usuariosContratados}
+                onChange={(e) => setUsuariosContratados(e.target.value)}
+                hint={`${inclusos} inclusos no plano; extras a ${formatPreco(extraUnit)}/mês cada.`}
+              />
+              <Input
+                label="Valor mensal negociado (R$)"
+                type="number"
+                step="0.01"
+                min={0}
+                value={precoNegociado}
+                onChange={(e) => setPrecoNegociado(e.target.value)}
+                hint="Opcional. Se preenchido, vale na ficha comercial em vez da estimativa do catálogo."
+              />
+              <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900/40">
+                <p className="font-medium text-slate-800 dark:text-slate-100">
+                  {precoNegociado.trim() !== '' && Number.isFinite(Number(precoNegociado))
+                    ? `Valor negociado: ${formatPreco(Number(precoNegociado))}`
+                    : `Estimativa do catálogo: ${formatPreco(precoTotal)}`}
+                </p>
+                <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  Catálogo: módulos {formatPreco(precoMods)}
+                  {usersExtra > 0
+                    ? ` + ${usersExtra} usuário(s) extra ${formatPreco(precoUsers)}`
+                    : ''}
+                  {precoNegociado.trim() !== '' ? ` (estimativa ${formatPreco(precoTotal)})` : ''}
+                </p>
+              </div>
+            </FormSection>
+            <FormSection title="Contato">
+              <Input
+                label="Nome do contato"
                 value={contatoNome}
                 onChange={(e) => setContatoNome(e.target.value)}
               />
               <Input
-                label="E-mail do contacto"
+                label="E-mail do contato"
                 type="email"
                 value={contatoEmail}
                 onChange={(e) => setContatoEmail(e.target.value)}

--- a/frontend/src/pages/saas/SaasLicencas.tsx
+++ b/frontend/src/pages/saas/SaasLicencas.tsx
@@ -243,7 +243,7 @@ export function SaasLicencas({ embedded = false }: { embedded?: boolean }) {
       actions={<Button onClick={() => navigate('/saas/licencas/novo')}>Nova licença</Button>}
     >
       {resumo ? (
-        <div className="mb-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        <div className="mb-4 grid w-full grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-[repeat(5,minmax(0,1fr))]">
           <ResumoCard
             label="Clientes"
             value={String(resumo.clientes_total)}
@@ -252,21 +252,21 @@ export function SaasLicencas({ embedded = false }: { embedded?: boolean }) {
           <ResumoCard
             label="Renovação"
             value={String(resumo.vencendo_em_breve)}
-            hint={`${resumo.vencidas_ativas} vencida(s) · janela ${resumo.janela_renovacao_dias}d · clicar para filtrar`}
+            hint={`${resumo.vencidas_ativas} vencida(s) · ${resumo.janela_renovacao_dias}d`}
             tone={resumo.vencidas_ativas > 0 || resumo.vencendo_em_breve > 0 ? 'warn' : undefined}
             onClick={() => aplicarAtalhoResumo('renovacao')}
           />
           <ResumoCard
             label="Provisionamento"
             value={String(resumo.provisionamento_pendente)}
-            hint={`${resumo.provisionamento_falha} falha(s) · clicar para filtrar fila`}
+            hint={`${resumo.provisionamento_falha} falha(s) na fila`}
             tone={resumo.provisionamento_falha > 0 || resumo.provisionamento_pendente > 0 ? 'warn' : undefined}
             onClick={() => aplicarAtalhoResumo('provisionamento')}
           />
           <ResumoCard
             label="Aprovações"
             value={String(resumo.aprovacoes_pendentes ?? 0)}
-            hint="go-live pendente · clicar para filtrar"
+            hint="go-live pendente"
             tone={(resumo.aprovacoes_pendentes ?? 0) > 0 ? 'warn' : undefined}
             onClick={() => aplicarAtalhoResumo('aprovacoes')}
           />
@@ -349,96 +349,101 @@ export function SaasLicencas({ embedded = false }: { embedded?: boolean }) {
           total={total}
           onPageChange={setPage}
           disabled={loading}
-          extra={
-            <div className="flex min-w-0 flex-wrap gap-2">
-              <div className="min-w-[9rem] shrink-0">
-                <Select
-                  aria-label="Filtrar por status"
-                  value={statusFiltro}
-                  onChange={(v) => patchFiltros({ status: String(v) || null })}
-                  options={STATUS_CLIENTE_SAAS.map((s) => ({ value: s.value, label: s.label }))}
-                  includeEmpty
-                  emptyLabel="Todos"
-                  placeholder="Status"
-                  disabled={loading}
-                />
-              </div>
-              <div className="min-w-[9rem] shrink-0">
-                <Select
-                  aria-label="Filtrar por plano"
-                  value={planoFiltro}
-                  onChange={(v) => patchFiltros({ plano_id: v === '' ? null : String(v) })}
-                  options={planos.map((p) => ({ value: String(p.id), label: p.nome }))}
-                  includeEmpty
-                  emptyLabel="Todos os planos"
-                  placeholder="Plano"
-                  disabled={loading}
-                />
-              </div>
-              <div className="min-w-[10rem] shrink-0">
-                <Select
-                  aria-label="Filtrar por aprovação"
-                  value={aprovacaoFiltro}
-                  onChange={(v) => patchFiltros({ aprovacao_status: String(v) || null })}
-                  options={APROVACAO_OPTS}
-                  includeEmpty
-                  emptyLabel="Qualquer aprovação"
-                  placeholder="Aprovação"
-                  disabled={loading}
-                />
-              </div>
-              <div className="min-w-[10rem] shrink-0">
-                <Select
-                  aria-label="Filtrar por provisionamento"
-                  value={provFila ? 'fila' : provStatusFiltro}
-                  onChange={(v) => {
-                    const s = String(v)
-                    if (s === 'fila') {
-                      patchFiltros({ provisionamento_fila: '1', provisionamento_status: null })
-                    } else if (!s) {
-                      patchFiltros({ provisionamento_fila: null, provisionamento_status: null })
-                    } else {
-                      patchFiltros({ provisionamento_fila: null, provisionamento_status: s })
-                    }
-                  }}
-                  options={[{ value: 'fila', label: 'Em fila / falha' }, ...PROV_OPTS]}
-                  includeEmpty
-                  emptyLabel="Qualquer prov."
-                  placeholder="Provisionamento"
-                  disabled={loading}
-                />
-              </div>
-              {(statusFiltro ||
-                planoFiltro ||
-                aprovacaoFiltro ||
-                provStatusFiltro ||
-                provFila ||
-                vencendo ||
-                vencidas) && (
-                <Button
-                  variant="secondary"
-                  disabled={loading}
-                  onClick={() =>
-                    patchFiltros({
-                      status: null,
-                      plano_id: null,
-                      aprovacao_status: null,
-                      provisionamento_status: null,
-                      provisionamento_fila: null,
-                      vencendo: null,
-                      vencidas: null,
-                    })
-                  }
-                >
-                  Limpar filtros
-                </Button>
-              )}
-            </div>
-          }
         />
+        <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-[repeat(4,minmax(0,1fr))_auto]">
+          <Select
+            label="Status"
+            labelStyle="overline"
+            className="min-w-0"
+            aria-label="Filtrar por status"
+            value={statusFiltro}
+            onChange={(v) => patchFiltros({ status: String(v) || null })}
+            options={STATUS_CLIENTE_SAAS.map((s) => ({ value: s.value, label: s.label }))}
+            includeEmpty
+            emptyLabel="Todos"
+            placeholder="Todos"
+            disabled={loading}
+          />
+          <Select
+            label="Plano"
+            labelStyle="overline"
+            className="min-w-0"
+            aria-label="Filtrar por plano"
+            value={planoFiltro}
+            onChange={(v) => patchFiltros({ plano_id: v === '' ? null : String(v) })}
+            options={planos.map((p) => ({ value: String(p.id), label: p.nome }))}
+            includeEmpty
+            emptyLabel="Todos"
+            placeholder="Todos"
+            disabled={loading}
+          />
+          <Select
+            label="Aprovação"
+            labelStyle="overline"
+            className="min-w-0"
+            aria-label="Filtrar por aprovação"
+            value={aprovacaoFiltro}
+            onChange={(v) => patchFiltros({ aprovacao_status: String(v) || null })}
+            options={APROVACAO_OPTS}
+            includeEmpty
+            emptyLabel="Qualquer"
+            placeholder="Qualquer"
+            disabled={loading}
+          />
+          <Select
+            label="Provisionamento"
+            labelStyle="overline"
+            className="min-w-0"
+            aria-label="Filtrar por provisionamento"
+            value={provFila ? 'fila' : provStatusFiltro}
+            onChange={(v) => {
+              const s = String(v)
+              if (s === 'fila') {
+                patchFiltros({ provisionamento_fila: '1', provisionamento_status: null })
+              } else if (!s) {
+                patchFiltros({ provisionamento_fila: null, provisionamento_status: null })
+              } else {
+                patchFiltros({ provisionamento_fila: null, provisionamento_status: s })
+              }
+            }}
+            options={[{ value: 'fila', label: 'Em fila / falha' }, ...PROV_OPTS]}
+            includeEmpty
+            emptyLabel="Qualquer"
+            placeholder="Qualquer"
+            disabled={loading}
+          />
+          {(statusFiltro ||
+            planoFiltro ||
+            aprovacaoFiltro ||
+            provStatusFiltro ||
+            provFila ||
+            vencendo ||
+            vencidas) && (
+            <div className="flex items-end sm:col-span-2 lg:col-span-4 xl:col-span-1">
+              <Button
+                variant="secondary"
+                className="w-full xl:w-auto"
+                disabled={loading}
+                onClick={() =>
+                  patchFiltros({
+                    status: null,
+                    plano_id: null,
+                    aprovacao_status: null,
+                    provisionamento_status: null,
+                    provisionamento_fila: null,
+                    vencendo: null,
+                    vencidas: null,
+                  })
+                }
+              >
+                Limpar filtros
+              </Button>
+            </div>
+          )}
+        </div>
         {vencendo || vencidas ? (
           <p className="mb-3 text-xs text-amber-800 dark:text-amber-200">
-            Filtro activo:{' '}
+            Filtro ativo:{' '}
             {vencendo ? 'renovação na janela de alerta' : null}
             {vencendo && vencidas ? ' · ' : null}
             {vencidas ? 'renovação vencida' : null}
@@ -469,6 +474,9 @@ export function SaasLicencas({ embedded = false }: { embedded?: boolean }) {
                   />
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
                     Plano
+                  </th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
+                    Valor/mês
                   </th>
                   <CabecalhoOrdenavel
                     coluna="status"
@@ -527,6 +535,21 @@ export function SaasLicencas({ embedded = false }: { embedded?: boolean }) {
                       </td>
                       <td className="px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-300">
                         {item.plano || '—'}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3.5 tabular-nums text-slate-700 sm:px-6 dark:text-slate-200">
+                        {item.preco_mensal_efetivo != null
+                          ? `R$ ${Number(item.preco_mensal_efetivo).toLocaleString('pt-BR', {
+                              minimumFractionDigits: 0,
+                              maximumFractionDigits: 2,
+                            })}`
+                          : '—'}
+                        {item.preco_mensal_negociado != null ? (
+                          <span className="mt-0.5 block text-[11px] text-amber-700 dark:text-amber-300">
+                            Negociado
+                          </span>
+                        ) : item.preco_mensal_estimado != null ? (
+                          <span className="mt-0.5 block text-[11px] text-slate-400">Catálogo</span>
+                        ) : null}
                       </td>
                       <td className="whitespace-nowrap px-4 py-3.5 sm:px-6">
                         <span
@@ -611,32 +634,32 @@ function ResumoCard({
 }) {
   const body = (
     <div
-      className={`rounded-2xl border px-4 py-3 ${
+      className={`flex h-full min-h-[6.75rem] w-full min-w-0 flex-col rounded-2xl border px-4 py-3 ${
         tone === 'warn'
           ? 'border-amber-200 bg-amber-50/80 dark:border-amber-800/40 dark:bg-amber-950/30'
           : 'border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900/40'
       } ${onClick || linkTo ? 'transition hover:ring-2 hover:ring-sky-400/40' : ''}`}
     >
-      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <p className="shrink-0 truncate text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
         {label}
       </p>
-      <p className="mt-1 text-2xl font-semibold tabular-nums text-slate-900 dark:text-slate-50">{value}</p>
-      <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{hint}</p>
+      <p className="mt-1 shrink-0 text-2xl font-semibold tabular-nums text-slate-900 dark:text-slate-50">{value}</p>
+      <p className="mt-auto pt-2 text-xs leading-snug text-slate-500 line-clamp-2 dark:text-slate-400">{hint}</p>
     </div>
   )
   if (linkTo) {
     return (
-      <Link to={linkTo} className="block">
+      <Link to={linkTo} className="block h-full w-full min-w-0">
         {body}
       </Link>
     )
   }
   if (onClick) {
     return (
-      <button type="button" className="block w-full text-left" onClick={onClick}>
+      <button type="button" className="block h-full w-full min-w-0 text-left" onClick={onClick}>
         {body}
       </button>
     )
   }
-  return body
+  return <div className="h-full w-full min-w-0">{body}</div>
 }

--- a/frontend/src/pages/saas/SaasModulos.tsx
+++ b/frontend/src/pages/saas/SaasModulos.tsx
@@ -9,6 +9,14 @@ import { ConfigListPageShell } from '../../components/config/ConfigListPageShell
 import { SemPermissao } from '../SemPermissao'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 
+function formatPreco(v: number | null | undefined): string {
+  if (v == null) return '—'
+  return `R$ ${Number(v).toLocaleString('pt-BR', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  })}`
+}
+
 export function SaasModulos() {
   const navigate = useNavigate()
   const toast = useToast()
@@ -18,10 +26,12 @@ export function SaasModulos() {
   const [indisponivel, setIndisponivel] = useState(false)
   const [actingId, setActingId] = useState<number | null>(null)
   const [saving, setSaving] = useState(false)
+  const [formOpen, setFormOpen] = useState(false)
 
   const [codigo, setCodigo] = useState('')
   const [nome, setNome] = useState('')
   const [descricao, setDescricao] = useState('')
+  const [precoMensal, setPrecoMensal] = useState('')
   const [editId, setEditId] = useState<number | null>(null)
 
   const carregar = useCallback(() => {
@@ -52,6 +62,17 @@ export function SaasModulos() {
     setCodigo('')
     setNome('')
     setDescricao('')
+    setPrecoMensal('')
+    setFormOpen(false)
+  }
+
+  function startCreate() {
+    setEditId(null)
+    setCodigo('')
+    setNome('')
+    setDescricao('')
+    setPrecoMensal('')
+    setFormOpen(true)
   }
 
   function startEdit(m: SaasCatalogo.Modulo) {
@@ -59,30 +80,36 @@ export function SaasModulos() {
     setCodigo(m.codigo)
     setNome(m.nome)
     setDescricao(m.descricao ?? '')
+    setPrecoMensal(m.preco_mensal != null ? String(m.preco_mensal) : '')
+    setFormOpen(true)
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setSaving(true)
     try {
+      const precoN = precoMensal.trim() === '' ? null : Number(precoMensal)
+      const preco = precoN != null && Number.isFinite(precoN) ? precoN : null
       if (editId != null) {
         await saasModulos.update(editId, {
           nome: nome.trim(),
           descricao: descricao.trim() || null,
+          preco_mensal: preco,
         })
-        toast.showSuccess('Módulo actualizado.')
+        toast.showSuccess('Módulo atualizado. Planos que o usam recalculam o preço.')
       } else {
         await saasModulos.create({
           codigo: codigo.trim().toLowerCase(),
           nome: nome.trim(),
           descricao: descricao.trim() || null,
+          preco_mensal: preco,
         })
         toast.showSuccess('Módulo criado.')
       }
       resetForm()
       carregar()
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível guardar o módulo.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o módulo.'))
     } finally {
       setSaving(false)
     }
@@ -93,7 +120,7 @@ export function SaasModulos() {
     try {
       if (item.ativo) await saasModulos.desativar(item.id)
       else await saasModulos.ativar(item.id)
-      toast.showSuccess(item.ativo ? 'Módulo desactivado.' : 'Módulo activado.')
+      toast.showSuccess(item.ativo ? 'Módulo desativado.' : 'Módulo ativado.')
       carregar()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar o módulo.'))
@@ -112,6 +139,8 @@ export function SaasModulos() {
     )
   }
 
+  const editando = editId != null
+
   return (
     <ConfigListPageShell
       forbidden={forbidden}
@@ -123,90 +152,162 @@ export function SaasModulos() {
         />
       }
       title="Módulos"
-      subtitle="Peças do catálogo comercial que podem ser associadas a planos."
+      subtitle="Preço mensal de cada módulo — o plano soma os habilitados."
       actions={
-        <Button variant="secondary" onClick={() => navigate('/saas/planos')}>
-          Voltar aos planos
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="secondary" onClick={() => navigate('/saas/planos')}>
+            Voltar aos planos
+          </Button>
+          {!formOpen ? (
+            <Button onClick={startCreate}>Novo módulo</Button>
+          ) : null}
+        </div>
       }
     >
-      <div className="space-y-6">
-        <Card title={editId != null ? 'Editar módulo' : 'Novo módulo'}>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="grid gap-4 sm:grid-cols-2">
-              <Input
-                label="Código"
-                value={codigo}
-                onChange={(e) => setCodigo(e.target.value)}
-                required
-                disabled={editId != null}
-                hint="Ex.: contratos"
-              />
-              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-            </div>
-            <Input
-              label="Descrição"
-              value={descricao}
-              onChange={(e) => setDescricao(e.target.value)}
-            />
-            <div className="flex flex-wrap gap-2">
-              <Button type="submit" disabled={saving}>
-                {editId != null ? 'Guardar' : 'Criar'}
-              </Button>
-              {editId != null ? (
-                <Button type="button" variant="cancel" disabled={saving} onClick={resetForm}>
-                  Cancelar edição
+      <div className="space-y-4">
+        {formOpen ? (
+          <Card title={editando ? 'Editar módulo' : 'Novo módulo'}>
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <div className="grid gap-4 sm:grid-cols-12">
+                <div className="sm:col-span-5">
+                  <Input
+                    label="Nome"
+                    value={nome}
+                    onChange={(e) => setNome(e.target.value)}
+                    required
+                    placeholder="Ex.: Contratos"
+                    autoFocus
+                  />
+                </div>
+                <div className="sm:col-span-4">
+                  <Input
+                    label="Código"
+                    value={codigo}
+                    onChange={(e) => setCodigo(e.target.value)}
+                    required
+                    disabled={editando}
+                    placeholder="contratos"
+                    className="font-mono text-sm"
+                  />
+                </div>
+                <div className="sm:col-span-3">
+                  <Input
+                    label="Preço (R$/mês)"
+                    type="number"
+                    step="0.01"
+                    min={0}
+                    value={precoMensal}
+                    onChange={(e) => setPrecoMensal(e.target.value)}
+                    placeholder="0"
+                  />
+                </div>
+                <div className="sm:col-span-12">
+                  <Input
+                    label="Descrição"
+                    value={descricao}
+                    onChange={(e) => setDescricao(e.target.value)}
+                    placeholder="Opcional"
+                  />
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-2 border-t border-slate-100 pt-4 dark:border-slate-800">
+                <Button type="submit" disabled={saving}>
+                  {editando ? 'Salvar' : 'Criar módulo'}
                 </Button>
-              ) : null}
-            </div>
-          </form>
-        </Card>
+                <Button type="button" variant="cancel" disabled={saving} onClick={resetForm}>
+                  Cancelar
+                </Button>
+              </div>
+            </form>
+          </Card>
+        ) : null}
 
         <Card>
           {loading ? (
-            <div className="h-32 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+            <div className="h-40 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
           ) : list.length === 0 ? (
-            <p className="py-6 text-center text-sm text-slate-500">Nenhum módulo.</p>
+            <div className="px-2 py-10 text-center">
+              <p className="text-sm text-slate-500 dark:text-slate-400">Nenhum módulo cadastrado.</p>
+              {!formOpen ? (
+                <Button className="mt-4" onClick={startCreate}>
+                  Novo módulo
+                </Button>
+              ) : null}
+            </div>
           ) : (
-            <ul className="divide-y divide-slate-100 dark:divide-slate-800">
-              {list.map((m) => (
-                <li
-                  key={m.id}
-                  className="flex flex-wrap items-center justify-between gap-3 px-1 py-3 sm:px-2"
-                >
-                  <div>
-                    <p className="font-medium text-slate-800 dark:text-slate-100">
-                      {m.nome}{' '}
-                      <span className="font-mono text-xs font-normal text-slate-500">{m.codigo}</span>
-                    </p>
-                    {m.descricao ? (
-                      <p className="text-xs text-slate-500">{m.descricao}</p>
-                    ) : null}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span
-                      className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                        m.ativo
-                          ? 'bg-emerald-50 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300'
-                          : 'bg-slate-100 text-slate-600'
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-slate-100 text-sm dark:divide-slate-800">
+                <thead>
+                  <tr className="text-left">
+                    <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 sm:px-6">
+                      Nome
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 sm:px-6">
+                      Código
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 sm:px-6">
+                      Preço
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 sm:px-6">
+                      Situação
+                    </th>
+                    <th className="w-px px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500 sm:px-6">
+                      <span className="sr-only">Ações</span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                  {list.map((m) => (
+                    <tr
+                      key={m.id}
+                      className={`hover:bg-slate-50 dark:hover:bg-white/5 ${
+                        editId === m.id ? 'bg-sky-50/60 dark:bg-sky-950/20' : ''
                       }`}
                     >
-                      {m.ativo ? 'Activo' : 'Inactivo'}
-                    </span>
-                    <Button variant="secondary" onClick={() => startEdit(m)}>
-                      Editar
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      disabled={actingId === m.id}
-                      onClick={() => void toggleAtivo(m)}
-                    >
-                      {m.ativo ? 'Desactivar' : 'Activar'}
-                    </Button>
-                  </div>
-                </li>
-              ))}
-            </ul>
+                      <td className="px-4 py-3.5 sm:px-6">
+                        <span className="font-medium text-slate-800 dark:text-slate-100">{m.nome}</span>
+                        {m.descricao ? (
+                          <span className="mt-0.5 block max-w-md truncate text-xs text-slate-500">
+                            {m.descricao}
+                          </span>
+                        ) : null}
+                      </td>
+                      <td className="px-4 py-3.5 font-mono text-xs text-slate-600 sm:px-6 dark:text-slate-300">
+                        {m.codigo}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3.5 tabular-nums text-slate-700 sm:px-6 dark:text-slate-200">
+                        {formatPreco(m.preco_mensal)}
+                      </td>
+                      <td className="px-4 py-3.5 sm:px-6">
+                        <span
+                          className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                            m.ativo
+                              ? 'bg-emerald-50 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300'
+                              : 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
+                          }`}
+                        >
+                          {m.ativo ? 'Ativo' : 'Inativo'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3.5 text-right sm:px-6">
+                        <div className="flex items-center justify-end gap-2">
+                          <Button variant="secondary" onClick={() => startEdit(m)}>
+                            Editar
+                          </Button>
+                          <Button
+                            variant="secondary"
+                            disabled={actingId === m.id}
+                            onClick={() => void toggleAtivo(m)}
+                          >
+                            {m.ativo ? 'Desativar' : 'Ativar'}
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
         </Card>
       </div>

--- a/frontend/src/pages/saas/SaasPlanoForm.tsx
+++ b/frontend/src/pages/saas/SaasPlanoForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ApiError, saasModulos, saasPlanos, type SaasCatalogo } from '../../api/client'
 import { Card } from '../../components/ui/Card'
@@ -12,6 +12,10 @@ import { CadastroFormPageShell } from '../../components/ui/CadastroFormPageShell
 import { SemPermissao } from '../SemPermissao'
 import { CarregamentoFalhou } from '../../components/ui/CarregamentoFalhou'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/errorMessage'
+
+function formatPreco(v: number): string {
+  return `R$ ${v.toLocaleString('pt-BR', { minimumFractionDigits: 0, maximumFractionDigits: 2 })}`
+}
 
 export function SaasPlanoForm() {
   const { id } = useParams<{ id?: string }>()
@@ -31,12 +35,19 @@ export function SaasPlanoForm() {
   const [nome, setNome] = useState('')
   const [descricao, setDescricao] = useState('')
   const [ordem, setOrdem] = useState('0')
-  const [precoMensal, setPrecoMensal] = useState('')
-  const [maxPostos, setMaxPostos] = useState('')
-  const [maxUsuarios, setMaxUsuarios] = useState('')
+  const [usuariosInclusos, setUsuariosInclusos] = useState('3')
+  const [precoUsuarioExtra, setPrecoUsuarioExtra] = useState('10')
   const [ativo, setAtivo] = useState(true)
   const [moduloIds, setModuloIds] = useState<number[]>([])
   const [modulos, setModulos] = useState<SaasCatalogo.Modulo[]>([])
+
+  const precoModulos = useMemo(() => {
+    return Math.round(
+      modulos
+        .filter((m) => moduloIds.includes(m.id))
+        .reduce((acc, m) => acc + Number(m.preco_mensal || 0), 0) * 100,
+    ) / 100
+  }, [modulos, moduloIds])
 
   useEffect(() => {
     let cancelled = false
@@ -71,9 +82,10 @@ export function SaasPlanoForm() {
         setNome(p.nome)
         setDescricao(p.descricao ?? '')
         setOrdem(String(p.ordem ?? 0))
-        setPrecoMensal(p.preco_mensal != null ? String(p.preco_mensal) : '')
-        setMaxPostos(p.max_postos != null ? String(p.max_postos) : '')
-        setMaxUsuarios(p.max_usuarios != null ? String(p.max_usuarios) : '')
+        setUsuariosInclusos(String(p.usuarios_inclusos ?? 3))
+        setPrecoUsuarioExtra(
+          p.preco_usuario_extra != null ? String(p.preco_usuario_extra) : '10',
+        )
         setAtivo(p.ativo)
         setModuloIds(p.modulos.map((m) => m.id))
       })
@@ -112,38 +124,30 @@ export function SaasPlanoForm() {
     setSaving(true)
     try {
       const ordemN = parseInt(ordem, 10)
-      const precoN = precoMensal.trim() === '' ? null : Number(precoMensal)
-      const postosN = maxPostos.trim() === '' ? null : parseInt(maxPostos, 10)
-      const usersN = maxUsuarios.trim() === '' ? null : parseInt(maxUsuarios, 10)
-      const comerciais = {
-        preco_mensal: precoN != null && Number.isFinite(precoN) ? precoN : null,
-        max_postos: postosN != null && Number.isFinite(postosN) ? postosN : null,
-        max_usuarios: usersN != null && Number.isFinite(usersN) ? usersN : null,
+      const inclusosN = parseInt(usuariosInclusos, 10)
+      const extraN = Number(precoUsuarioExtra)
+      const payload = {
+        nome: nome.trim(),
+        descricao: descricao.trim() || null,
+        ordem: Number.isFinite(ordemN) ? ordemN : 0,
+        usuarios_inclusos: Number.isFinite(inclusosN) ? inclusosN : 3,
+        preco_usuario_extra: Number.isFinite(extraN) ? extraN : 10,
+        modulo_ids: moduloIds,
       }
       if (isEdit && !Number.isNaN(planoId)) {
-        await saasPlanos.update(planoId, {
-          nome: nome.trim(),
-          descricao: descricao.trim() || null,
-          ordem: Number.isFinite(ordemN) ? ordemN : 0,
-          modulo_ids: moduloIds,
-          ...comerciais,
-        })
-        toast.showSuccess('Plano actualizado.')
+        await saasPlanos.update(planoId, payload)
+        toast.showSuccess('Plano atualizado.')
         navigate(`/saas/planos/${planoId}`, { replace: true })
       } else {
         const created = await saasPlanos.create({
           codigo: codigo.trim().toLowerCase(),
-          nome: nome.trim(),
-          descricao: descricao.trim() || null,
-          ordem: Number.isFinite(ordemN) ? ordemN : 0,
-          modulo_ids: moduloIds,
-          ...comerciais,
+          ...payload,
         })
         toast.showSuccess('Plano criado.')
         navigate(`/saas/planos/${created.id}`, { replace: true })
       }
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível guardar o plano.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o plano.'))
     } finally {
       setSaving(false)
     }
@@ -156,7 +160,7 @@ export function SaasPlanoForm() {
       if (ativo) await saasPlanos.desativar(planoId)
       else await saasPlanos.ativar(planoId)
       setAtivo(!ativo)
-      toast.showSuccess(ativo ? 'Plano desactivado.' : 'Plano activado.')
+      toast.showSuccess(ativo ? 'Plano desativado.' : 'Plano ativado.')
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar o estado.'))
     } finally {
@@ -225,28 +229,30 @@ export function SaasPlanoForm() {
                 onChange={(e) => setOrdem(e.target.value)}
                 hint="Menor aparece primeiro na lista"
               />
+              <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900/40">
+                <p className="font-medium text-slate-800 dark:text-slate-100">
+                  Preço base (soma dos módulos): {formatPreco(precoModulos)}
+                </p>
+                <p className="mt-1 text-xs text-slate-500">
+                  Calculado automaticamente. Altere o preço em Módulos.
+                </p>
+              </div>
               <Input
-                label="Preço mensal (R$)"
+                label="Usuários inclusos"
+                type="number"
+                min={0}
+                value={usuariosInclusos}
+                onChange={(e) => setUsuariosInclusos(e.target.value)}
+                hint="Inclusos no preço dos módulos (padrão 3)"
+              />
+              <Input
+                label="Preço por usuário extra (R$)"
                 type="number"
                 step="0.01"
                 min={0}
-                value={precoMensal}
-                onChange={(e) => setPrecoMensal(e.target.value)}
-                hint="Opcional — só catálogo comercial (sem cobrança automática)"
-              />
-              <Input
-                label="Máx. postos"
-                type="number"
-                min={0}
-                value={maxPostos}
-                onChange={(e) => setMaxPostos(e.target.value)}
-              />
-              <Input
-                label="Máx. utilizadores"
-                type="number"
-                min={0}
-                value={maxUsuarios}
-                onChange={(e) => setMaxUsuarios(e.target.value)}
+                value={precoUsuarioExtra}
+                onChange={(e) => setPrecoUsuarioExtra(e.target.value)}
+                hint="Cobrado por usuário acima dos inclusos"
               />
               <label className="block space-y-1.5">
                 <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Descrição</span>
@@ -266,18 +272,17 @@ export function SaasPlanoForm() {
                         : 'bg-slate-100 text-slate-600'
                     }`}
                   >
-                    {ativo ? 'Activo' : 'Inactivo'}
+                    {ativo ? 'Ativo' : 'Inativo'}
                   </span>
                   <Button type="button" variant="secondary" disabled={saving} onClick={() => void toggleAtivo()}>
-                    {ativo ? 'Desactivar' : 'Activar'}
+                    {ativo ? 'Desativar' : 'Ativar'}
                   </Button>
                 </div>
               ) : null}
             </FormSection>
             <FormSection title="Módulos incluídos">
               <p className="text-sm text-slate-500 dark:text-slate-400">
-                Gravados no snapshot da licença e em <code className="text-xs">SAAS_MODULOS</code> no{' '}
-                <code className="text-xs">client.env</code> no provisionamento (capabilities no /health).
+                O preço do plano é a soma destes módulos. Na licença dá para ligar módulos extras (ex.: Essencial + ponto).
               </p>
               {modulos.length === 0 ? (
                 <p className="text-sm text-amber-700 dark:text-amber-300">
@@ -303,12 +308,17 @@ export function SaasPlanoForm() {
                           onChange={() => toggleModulo(m.id)}
                           disabled={!m.ativo && !moduloIds.includes(m.id)}
                         />
-                        <span>
-                          <span className="block text-sm font-medium text-slate-800 dark:text-slate-100">
-                            {m.nome}
-                            {!m.ativo ? (
-                              <span className="ml-2 text-xs font-normal text-slate-400">(inactivo)</span>
-                            ) : null}
+                        <span className="min-w-0 flex-1">
+                          <span className="flex flex-wrap items-baseline justify-between gap-2">
+                            <span className="text-sm font-medium text-slate-800 dark:text-slate-100">
+                              {m.nome}
+                              {!m.ativo ? (
+                                <span className="ml-2 text-xs font-normal text-slate-400">(inativo)</span>
+                              ) : null}
+                            </span>
+                            <span className="text-xs tabular-nums text-slate-600 dark:text-slate-300">
+                              {m.preco_mensal != null ? formatPreco(Number(m.preco_mensal)) : '—'}
+                            </span>
                           </span>
                           <span className="font-mono text-xs text-slate-500">{m.codigo}</span>
                         </span>

--- a/frontend/src/pages/saas/SaasPlanos.tsx
+++ b/frontend/src/pages/saas/SaasPlanos.tsx
@@ -48,7 +48,7 @@ export function SaasPlanos() {
     try {
       if (item.ativo) await saasPlanos.desativar(item.id)
       else await saasPlanos.ativar(item.id)
-      toast.showSuccess(item.ativo ? 'Plano desactivado.' : 'Plano activado.')
+      toast.showSuccess(item.ativo ? 'Plano desativado.' : 'Plano ativado.')
       carregar()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar o plano.'))
@@ -78,7 +78,7 @@ export function SaasPlanos() {
         />
       }
       title="Planos"
-      subtitle="Catálogo comercial — o que cada plano inclui (sem ligar features na instância)."
+      subtitle="Pacotes = soma dos módulos. Cada plano define usuários inclusos e preço por usuário extra."
       actions={
         <div className="flex flex-wrap gap-2">
           <Button variant="secondary" onClick={() => navigate('/saas/modulos')}>
@@ -100,6 +100,8 @@ export function SaasPlanos() {
                 <tr className="text-left">
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Nome</th>
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Código</th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Preço base</th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Inclusos</th>
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Módulos</th>
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Estado</th>
                   <th className="w-px px-4 py-3 text-right text-xs font-semibold uppercase text-slate-500 sm:px-6">
@@ -117,6 +119,21 @@ export function SaasPlanos() {
                       ) : null}
                     </td>
                     <td className="px-4 py-3.5 font-mono text-xs sm:px-6">{item.codigo}</td>
+                    <td className="whitespace-nowrap px-4 py-3.5 tabular-nums text-slate-600 sm:px-6 dark:text-slate-300">
+                      {item.preco_mensal != null
+                        ? `R$ ${Number(item.preco_mensal).toLocaleString('pt-BR', {
+                            minimumFractionDigits: 0,
+                            maximumFractionDigits: 2,
+                          })}`
+                        : '—'}
+                      <span className="mt-0.5 block text-[11px] text-slate-400">
+                        {item.usuarios_inclusos ?? 3} incl. · +R${' '}
+                        {Number(item.preco_usuario_extra ?? 10).toLocaleString('pt-BR')}/extra
+                      </span>
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3.5 tabular-nums text-slate-600 sm:px-6 dark:text-slate-300">
+                      {item.usuarios_inclusos ?? 3}
+                    </td>
                     <td className="px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-300">
                       {item.modulos.length
                         ? item.modulos.map((m) => m.nome).join(', ')
@@ -130,7 +147,7 @@ export function SaasPlanos() {
                             : 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
                         }`}
                       >
-                        {item.ativo ? 'Activo' : 'Inactivo'}
+                        {item.ativo ? 'Ativo' : 'Inativo'}
                       </span>
                     </td>
                     <td className="px-4 py-3.5 text-right sm:px-6">
@@ -140,7 +157,7 @@ export function SaasPlanos() {
                           disabled={actingId === item.id}
                           onClick={() => void toggleAtivo(item)}
                         >
-                          {item.ativo ? 'Desactivar' : 'Activar'}
+                          {item.ativo ? 'Desativar' : 'Ativar'}
                         </Button>
                         <ListaAcoesVerEditar
                           onVer={() => navigate(`/saas/planos/${item.id}`)}

--- a/frontend/src/pages/saas/SaasSetorForm.tsx
+++ b/frontend/src/pages/saas/SaasSetorForm.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ApiError, saasSetores } from '../../api/client'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/errorMessage'
+import { CadastroFormPageShell } from '../../components/ui/CadastroFormPageShell'
+import { CarregamentoFalhou } from '../../components/ui/CarregamentoFalhou'
+import { FormSection } from '../../components/ui/FormSection'
+import { InlineCadastroFooter } from '../../components/ui/InlineCadastroPanel'
+import { Input } from '../../components/ui/Input'
+import { Switch } from '../../components/ui/Switch'
+import { useToast } from '../../components/ui/Toast'
+import { useVoltarAnterior } from '../../hooks/useVoltarAnterior'
+import { SemPermissao } from '../SemPermissao'
+
+export function SaasSetorForm() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const voltarAnterior = useVoltarAnterior('/saas/setores')
+
+  const setorId = id ? parseInt(id, 10) : NaN
+  const isEdit = id != null
+
+  const [loading, setLoading] = useState(isEdit)
+  const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [indisponivel, setIndisponivel] = useState(false)
+  const [inexistente, setInexistente] = useState<{ detalhe?: string } | null>(null)
+  const [nome, setNome] = useState('')
+  const [ativo, setAtivo] = useState(true)
+
+  useEffect(() => {
+    if (!isEdit) return
+    if (!id || Number.isNaN(setorId)) {
+      setInexistente({ detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setIndisponivel(false)
+    setInexistente(null)
+    saasSetores
+      .get(setorId)
+      .then((row) => {
+        if (cancelled) return
+        setNome(row.nome)
+        setAtivo(row.ativo)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setIndisponivel(true)
+          return
+        }
+        setInexistente(interpretarFalhaCarregamento(err, 'Setor não encontrado.'))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, isEdit, setorId])
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!nome.trim()) {
+      toast.showError('Informe o nome do setor.')
+      return
+    }
+    setSaving(true)
+    try {
+      if (isEdit) {
+        await saasSetores.update(setorId, { nome: nome.trim(), ativo })
+        toast.showSuccess('Setor atualizado.')
+      } else {
+        await saasSetores.create({ nome: nome.trim() })
+        toast.showSuccess('Setor criado.')
+      }
+      navigate('/saas/setores')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o setor.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Conta exclusiva da equipe SaaS."
+        detail="Entre com a conta ops em /login/admin."
+        voltarPara="/login/admin"
+        voltarLabel="Voltar ao login admin"
+      />
+    )
+  }
+  if (indisponivel) {
+    return (
+      <SemPermissao
+        title="Painel SaaS não disponível nesta instância."
+        voltarPara="/login/admin"
+        voltarLabel="Voltar ao login admin"
+      />
+    )
+  }
+  if (inexistente) {
+    return (
+      <CarregamentoFalhou
+        titulo={inexistente.detalhe ? 'Setor não encontrado.' : 'Não foi possível carregar.'}
+        detalhe={inexistente.detalhe}
+        onVoltar={voltarAnterior}
+      />
+    )
+  }
+
+  return (
+    <CadastroFormPageShell onVoltar={voltarAnterior}>
+      <form onSubmit={(ev) => void onSubmit(ev)} className="space-y-4">
+        <FormSection
+          title={isEdit ? 'Editar setor' : 'Novo setor'}
+          description="Cargo da equipe DeskRudder (ex.: Admin, Desenvolvimento, Comercial). Sem ordem fixa — a lista é alfabética."
+        >
+          {loading ? (
+            <p className="text-sm text-slate-500">Carregando…</p>
+          ) : (
+            <div className="space-y-4">
+              <Input label="Nome" value={nome} onChange={(ev) => setNome(ev.target.value)} required />
+              {isEdit ? (
+                <Switch
+                  checked={ativo}
+                  onCheckedChange={setAtivo}
+                  label="Setor ativo"
+                  showStatusPill
+                  description="Inativos não podem ser vinculados a novos usuários."
+                />
+              ) : null}
+            </div>
+          )}
+        </FormSection>
+        <InlineCadastroFooter
+          onCancel={voltarAnterior}
+          saving={saving}
+          submitLabel={isEdit ? 'Salvar' : 'Criar'}
+        />
+      </form>
+    </CadastroFormPageShell>
+  )
+}

--- a/frontend/src/pages/saas/SaasSetores.tsx
+++ b/frontend/src/pages/saas/SaasSetores.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ApiError, saasSetores, type SaasSetores } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { ConfigListPageShell } from '../../components/config/ConfigListPageShell'
+import { Button } from '../../components/ui/Button'
+import { Card } from '../../components/ui/Card'
+import { FiltroInativos } from '../../components/ui/FiltroInativos'
+import { useToast } from '../../components/ui/Toast'
+import { SemPermissao } from '../SemPermissao'
+
+export function SaasSetoresPage() {
+  const navigate = useNavigate()
+  const toast = useToast()
+  const [list, setList] = useState<SaasSetores.Setor[]>([])
+  const [loading, setLoading] = useState(true)
+  const [incluirInativos, setIncluirInativos] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [indisponivel, setIndisponivel] = useState(false)
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    setIndisponivel(false)
+    saasSetores
+      .list({ incluir_inativos: incluirInativos })
+      .then(setList)
+      .catch((err) => {
+        setList([])
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setIndisponivel(true)
+          return
+        }
+        toast.showError(mensagemFalhaParaToast(err, 'Não encontramos os setores.'))
+      })
+      .finally(() => setLoading(false))
+  }, [incluirInativos, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  if (indisponivel) {
+    return (
+      <SemPermissao
+        title="Painel SaaS não disponível nesta instância."
+        detail="Os cargos da equipe DeskRudder só existem no control-plane."
+        voltarPara="/login/admin"
+        voltarLabel="Voltar ao login admin"
+      />
+    )
+  }
+
+  return (
+    <ConfigListPageShell
+      forbidden={forbidden}
+      denied={
+        <SemPermissao
+          title="Você não tem permissão para gerir os setores."
+          voltarPara="/login/admin"
+          voltarLabel="Voltar ao login admin"
+        />
+      }
+      title="Setores"
+      actions={<Button onClick={() => navigate('/saas/setores/novo')}>Novo setor</Button>}
+    >
+      <Card
+        title="Cargos da equipe"
+        description="Admin, Desenvolvimento, Comercial, etc. Um usuário pode ter vários cargos. Não altera permissões no painel (todos continuam ops)."
+      >
+        <div className="mb-4">
+          <FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />
+        </div>
+        {loading ? (
+          <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
+        ) : list.length === 0 ? (
+          <p className="text-slate-500 dark:text-slate-400">Nenhum setor cadastrado.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[320px] text-left text-sm">
+              <thead>
+                <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
+                    Nome
+                  </th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
+                    Situação
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                {list.map((s) => (
+                  <tr
+                    key={s.id}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => navigate(`/saas/setores/${s.id}`)}
+                    onKeyDown={(ev) => {
+                      if (ev.key === 'Enter' || ev.key === ' ') {
+                        ev.preventDefault()
+                        navigate(`/saas/setores/${s.id}`)
+                      }
+                    }}
+                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
+                  >
+                    <td className="px-4 py-3.5 font-medium text-slate-800 sm:px-6 dark:text-slate-100">{s.nome}</td>
+                    <td className="px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400">
+                      {s.ativo ? 'Ativo' : 'Inativo'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </ConfigListPageShell>
+  )
+}

--- a/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
@@ -12,8 +12,10 @@ import { useVoltarAnterior } from '../../hooks/useVoltarAnterior'
 import { SolicitacaoDescricao } from '../../components/release/SolicitacaoDescricao'
 import {
   classesBadgeStatusSolicitacao,
+  classesBadgeTipoSolicitacao,
   mencionaTrabalhoInterno,
   rotuloStatusSolicitacao,
+  rotuloTipoSolicitacao,
   SAAS_SOLICITACAO_STATUS,
 } from '../../lib/saasSolicitacoes'
 import { SemPermissao } from '../SemPermissao'
@@ -28,10 +30,6 @@ function formatWhen(iso: string | null | undefined): string {
   } catch {
     return iso
   }
-}
-
-function rotuloTipo(tipo: string): string {
-  return tipo === 'problema' ? 'Problema' : 'Sugestão'
 }
 
 function StatusBadge({ status, rotulo }: { status: string; rotulo?: string }) {
@@ -277,8 +275,10 @@ export function SaasSolicitacaoDetalhe() {
               {item.protocolo || 'Sem protocolo'}
             </p>
             <span className="text-slate-300 dark:text-slate-600">·</span>
-            <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-              {rotuloTipo(item.tipo)}
+            <span
+              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeTipoSolicitacao(item.tipo)}`}
+            >
+              {rotuloTipoSolicitacao(item.tipo)}
             </span>
             <StatusBadge status={item.status} rotulo={item.status_rotulo} />
           </div>

--- a/frontend/src/pages/saas/SaasSolicitacoes.tsx
+++ b/frontend/src/pages/saas/SaasSolicitacoes.tsx
@@ -1,25 +1,19 @@
-import { useCallback, useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { ApiError, saasSolicitacoes, type SaasSolicitacoesProduto } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { ConfigListPageShell } from '../../components/config/ConfigListPageShell'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../../components/ui/BarraBuscaPaginacao'
 import { Card } from '../../components/ui/Card'
-import { Select } from '../../components/ui/Select'
 import { useToast } from '../../components/ui/Toast'
 import {
   classesBadgeStatusSolicitacao,
+  classesBadgeTipoSolicitacao,
   rotuloStatusSolicitacao,
-  SAAS_SOLICITACAO_STATUS,
+  rotuloTipoSolicitacao,
+  SAAS_SOLICITACAO_FASES,
 } from '../../lib/saasSolicitacoes'
 import { SemPermissao } from '../SemPermissao'
-
-const TIPO_OPTS = [
-  { value: 'sugestao', label: 'Sugestão' },
-  { value: 'problema', label: 'Problema' },
-]
-
-const STATUS_OPTS = SAAS_SOLICITACAO_STATUS.map((s) => ({ value: s.value, label: s.label }))
 
 function formatWhen(iso: string | null | undefined): string {
   if (!iso) return '—'
@@ -30,23 +24,81 @@ function formatWhen(iso: string | null | undefined): string {
   }
 }
 
-function rotuloTipo(tipo: string): string {
-  return tipo === 'problema' ? 'Problema' : 'Sugestão'
+function Chip({
+  active,
+  onClick,
+  children,
+  count,
+  tone,
+}: {
+  active: boolean
+  onClick: () => void
+  children: ReactNode
+  count?: number
+  tone?: 'sky' | 'rose' | 'default'
+}) {
+  const toneActive =
+    tone === 'sky'
+      ? 'border-sky-500 bg-sky-50 text-sky-900 dark:border-sky-400 dark:bg-sky-950/50 dark:text-sky-100'
+      : tone === 'rose'
+        ? 'border-rose-500 bg-rose-50 text-rose-900 dark:border-rose-400 dark:bg-rose-950/50 dark:text-rose-100'
+        : 'border-cyan-500 bg-cyan-50 text-cyan-950 dark:border-cyan-400 dark:bg-cyan-950/40 dark:text-cyan-50'
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors ${
+        active
+          ? toneActive
+          : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300 dark:hover:border-slate-600 dark:hover:bg-slate-800/60'
+      }`}
+    >
+      {children}
+      {count != null ? (
+        <span
+          className={`tabular-nums text-xs ${
+            active ? 'opacity-80' : 'text-slate-400 dark:text-slate-500'
+          }`}
+        >
+          {count}
+        </span>
+      ) : null}
+    </button>
+  )
 }
 
 export function SaasSolicitacoes() {
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const toast = useToast()
   const [list, setList] = useState<SaasSolicitacoesProduto.ListaItem[]>([])
+  const [resumo, setResumo] = useState<SaasSolicitacoesProduto.Resumo | null>(null)
   const [total, setTotal] = useState(0)
   const [page, setPage] = useState(1)
   const [busca, setBusca] = useState('')
   const [debouncedBusca, setDebouncedBusca] = useState('')
-  const [tipoFiltro, setTipoFiltro] = useState('')
-  const [statusFiltro, setStatusFiltro] = useState('')
   const [loading, setLoading] = useState(true)
   const [forbidden, setForbidden] = useState(false)
   const [indisponivel, setIndisponivel] = useState(false)
+
+  const tipoFiltro = searchParams.get('tipo') || ''
+  const faseFiltro = searchParams.get('fase') || ''
+
+  function patchFiltros(next: Record<string, string | null>) {
+    setSearchParams(
+      (prev) => {
+        const p = new URLSearchParams(prev)
+        for (const [k, v] of Object.entries(next)) {
+          if (v == null || v === '') p.delete(k)
+          else p.set(k, v)
+        }
+        return p
+      },
+      { replace: true },
+    )
+    setPage(1)
+  }
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -55,7 +107,14 @@ export function SaasSolicitacoes() {
 
   useEffect(() => {
     setPage(1)
-  }, [debouncedBusca, tipoFiltro, statusFiltro])
+  }, [debouncedBusca])
+
+  const loadResumo = useCallback(() => {
+    saasSolicitacoes
+      .resumo()
+      .then(setResumo)
+      .catch(() => setResumo(null))
+  }, [])
 
   const load = useCallback(() => {
     setLoading(true)
@@ -65,7 +124,7 @@ export function SaasSolicitacoes() {
       .list({
         busca: debouncedBusca || undefined,
         tipo: tipoFiltro || undefined,
-        status: statusFiltro || undefined,
+        fase: faseFiltro || undefined,
         offset: (page - 1) * PAGE_SIZE_PADRAO,
         limit: PAGE_SIZE_PADRAO,
       })
@@ -87,11 +146,12 @@ export function SaasSolicitacoes() {
         setTotal(0)
       })
       .finally(() => setLoading(false))
-  }, [debouncedBusca, page, tipoFiltro, statusFiltro, toast])
+  }, [debouncedBusca, page, tipoFiltro, faseFiltro, toast])
 
   useEffect(() => {
     load()
-  }, [load])
+    loadResumo()
+  }, [load, loadResumo])
 
   if (indisponivel) {
     return (
@@ -114,122 +174,190 @@ export function SaasSolicitacoes() {
           voltarLabel="Voltar para o Dashboard"
         />
       }
-      title="Sugestões das instâncias"
-      subtitle="Pedidos abertos pelos clientes nas Release Notes. Altere o status e responda no detalhe — o cliente vê o andamento em Minhas solicitações."
+      title="Sugestões e erros"
+      subtitle="Pedidos das instâncias. Filtre por tipo e fase para ver o que aguarda, o que está em desenvolvimento e o que já fechou."
     >
-      <Card>
-        <BarraBuscaPaginacao
-          busca={busca}
-          onBuscaChange={setBusca}
-          placeholder="Buscar por protocolo, título, cliente, slug ou autor…"
-          page={page}
-          total={total}
-          onPageChange={setPage}
-          disabled={loading}
-          extra={
-            <div className="flex min-w-0 flex-wrap gap-2">
-              <div className="min-w-[9rem] shrink-0">
-                <Select
-                  aria-label="Filtrar por tipo"
-                  value={tipoFiltro}
-                  onChange={(v) => setTipoFiltro(String(v))}
-                  options={TIPO_OPTS}
-                  includeEmpty
-                  emptyLabel="Todos os tipos"
-                  disabled={loading}
-                />
-              </div>
-              <div className="min-w-[10rem] shrink-0">
-                <Select
-                  aria-label="Filtrar por status"
-                  value={statusFiltro}
-                  onChange={(v) => setStatusFiltro(String(v))}
-                  options={STATUS_OPTS}
-                  includeEmpty
-                  emptyLabel="Todos os status"
-                  disabled={loading}
-                />
+      <div className="space-y-4">
+        <Card>
+          <div className="space-y-4">
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Tipo
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <Chip
+                  active={!tipoFiltro}
+                  count={resumo?.total}
+                  onClick={() => patchFiltros({ tipo: null })}
+                >
+                  Todos
+                </Chip>
+                <Chip
+                  active={tipoFiltro === 'sugestao'}
+                  count={resumo?.sugestoes}
+                  tone="sky"
+                  onClick={() =>
+                    patchFiltros({ tipo: tipoFiltro === 'sugestao' ? null : 'sugestao' })
+                  }
+                >
+                  Sugestões
+                </Chip>
+                <Chip
+                  active={tipoFiltro === 'problema'}
+                  count={resumo?.problemas}
+                  tone="rose"
+                  onClick={() =>
+                    patchFiltros({ tipo: tipoFiltro === 'problema' ? null : 'problema' })
+                  }
+                >
+                  Erros
+                </Chip>
               </div>
             </div>
-          }
-        />
-        {loading ? (
-          <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
-        ) : list.length === 0 ? (
-          <p className="text-slate-500 dark:text-slate-400">Nenhuma solicitação ainda.</p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full min-w-[720px] text-left text-sm">
-              <thead>
-                <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Protocolo</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Cliente</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Tipo</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Título</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Autor</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Peso</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Status</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Quando</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
-                {list.map((item) => (
-                  <tr
-                    key={item.id}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => navigate(`/saas/solicitacoes/${item.id}`)}
-                    onKeyDown={(ev) => {
-                      if (ev.key === 'Enter' || ev.key === ' ') {
-                        ev.preventDefault()
-                        navigate(`/saas/solicitacoes/${item.id}`)
-                      }
-                    }}
-                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5"
+
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Fase
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <Chip
+                  active={!faseFiltro}
+                  onClick={() => patchFiltros({ fase: null })}
+                >
+                  Todas
+                </Chip>
+                {SAAS_SOLICITACAO_FASES.map((f) => (
+                  <Chip
+                    key={f.value}
+                    active={faseFiltro === f.value}
+                    count={
+                      f.value === 'aguardando'
+                        ? resumo?.aguardando
+                        : f.value === 'desenvolvimento'
+                          ? resumo?.desenvolvimento
+                          : resumo?.finalizadas
+                    }
+                    onClick={() =>
+                      patchFiltros({ fase: faseFiltro === f.value ? null : f.value })
+                    }
                   >
-                    <td className="px-4 py-3 font-mono text-sm text-cyan-800 dark:text-cyan-300 sm:px-6">
-                      {item.protocolo || '—'}
-                    </td>
-                    <td className="px-4 py-3 sm:px-6">
-                      <p className="font-medium text-slate-900 dark:text-slate-50">
-                        {item.cliente_nome || item.instance_slug}
-                      </p>
-                      <p className="font-mono text-xs text-slate-500">{item.instance_slug}</p>
-                    </td>
-                    <td className="px-4 py-3 text-slate-600 dark:text-slate-300 sm:px-6">{rotuloTipo(item.tipo)}</td>
-                    <td className="px-4 py-3 sm:px-6">
-                      <p className="font-medium text-slate-800 dark:text-slate-100">{item.titulo}</p>
-                      {item.versao_contexto ? (
-                        <p className="text-xs text-slate-500">v{item.versao_contexto}</p>
-                      ) : null}
-                    </td>
-                    <td className="px-4 py-3 text-slate-600 dark:text-slate-300 sm:px-6">{item.autor_nome || '—'}</td>
-                    <td className="px-4 py-3 text-slate-600 dark:text-slate-300 sm:px-6">
-                      {(item.peso_clientes || 1) > 1 ? (
-                        <span className="font-medium text-cyan-800 dark:text-cyan-300">
-                          {item.peso_clientes} clientes
-                        </span>
-                      ) : (
-                        '1'
-                      )}
-                    </td>
-                    <td className="px-4 py-3 sm:px-6">
-                      <span
-                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeStatusSolicitacao(item.status)}`}
-                      >
-                        {item.status_rotulo || rotuloStatusSolicitacao(item.status)}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-slate-500 sm:px-6">
-                      {formatWhen(item.created_at_origem || item.ingested_at)}
-                    </td>
-                  </tr>
+                    {f.label}
+                  </Chip>
                 ))}
-              </tbody>
-            </table>
+              </div>
+              {faseFiltro ? (
+                <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                  {SAAS_SOLICITACAO_FASES.find((f) => f.value === faseFiltro)?.hint}
+                </p>
+              ) : null}
+            </div>
           </div>
-        )}
-      </Card>
+        </Card>
+
+        <Card>
+          <BarraBuscaPaginacao
+            busca={busca}
+            onBuscaChange={setBusca}
+            placeholder="Buscar por protocolo, título, cliente, slug ou autor…"
+            page={page}
+            total={total}
+            onPageChange={setPage}
+            disabled={loading}
+          />
+          {loading ? (
+            <div className="h-32 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+          ) : list.length === 0 ? (
+            <p className="px-2 py-8 text-center text-sm text-slate-500 dark:text-slate-400">
+              Nenhum pedido neste filtro.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[720px] text-left text-sm">
+                <thead>
+                  <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+                    <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">
+                      Tipo
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">
+                      Protocolo
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">
+                      Cliente
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">
+                      Título
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">
+                      Status
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">
+                      Quando
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                  {list.map((item) => (
+                    <tr
+                      key={item.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => navigate(`/saas/solicitacoes/${item.id}`)}
+                      onKeyDown={(ev) => {
+                        if (ev.key === 'Enter' || ev.key === ' ') {
+                          ev.preventDefault()
+                          navigate(`/saas/solicitacoes/${item.id}`)
+                        }
+                      }}
+                      className={`cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5 ${
+                        item.tipo === 'problema'
+                          ? 'border-l-2 border-l-rose-400/80'
+                          : 'border-l-2 border-l-sky-400/60'
+                      }`}
+                    >
+                      <td className="px-4 py-3 sm:px-6">
+                        <span
+                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeTipoSolicitacao(item.tipo)}`}
+                        >
+                          {rotuloTipoSolicitacao(item.tipo)}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 font-mono text-sm text-cyan-800 dark:text-cyan-300 sm:px-6">
+                        {item.protocolo || '—'}
+                      </td>
+                      <td className="px-4 py-3 sm:px-6">
+                        <p className="font-medium text-slate-900 dark:text-slate-50">
+                          {item.cliente_nome || item.instance_slug}
+                        </p>
+                        <p className="font-mono text-xs text-slate-500">{item.instance_slug}</p>
+                      </td>
+                      <td className="px-4 py-3 sm:px-6">
+                        <p className="font-medium text-slate-800 dark:text-slate-100">{item.titulo}</p>
+                        <p className="mt-0.5 text-xs text-slate-500">
+                          {item.autor_nome || '—'}
+                          {(item.peso_clientes || 1) > 1
+                            ? ` · ${item.peso_clientes} clientes`
+                            : ''}
+                          {item.versao_contexto ? ` · v${item.versao_contexto}` : ''}
+                        </p>
+                      </td>
+                      <td className="px-4 py-3 sm:px-6">
+                        <span
+                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeStatusSolicitacao(item.status)}`}
+                        >
+                          {item.status_rotulo || rotuloStatusSolicitacao(item.status)}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-slate-500 sm:px-6">
+                        {formatWhen(item.created_at_origem || item.ingested_at)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
+      </div>
     </ConfigListPageShell>
   )
 }

--- a/frontend/src/pages/saas/SaasUsuarioForm.tsx
+++ b/frontend/src/pages/saas/SaasUsuarioForm.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { ApiError, saasOpsUsuarios } from '../../api/client'
+import { ApiError, saasOpsUsuarios, saasSetores, type SaasSetores } from '../../api/client'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/errorMessage'
 import { Button } from '../../components/ui/Button'
 import { CadastroFormPageShell } from '../../components/ui/CadastroFormPageShell'
 import { CarregamentoFalhou } from '../../components/ui/CarregamentoFalhou'
+import { CheckboxField } from '../../components/ui/CheckboxField'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
 import { FormSection } from '../../components/ui/FormSection'
 import { InlineCadastroFooter } from '../../components/ui/InlineCadastroPanel'
@@ -37,6 +38,23 @@ export function SaasUsuarioForm() {
   const [tokenConfigurado, setTokenConfigurado] = useState(false)
   const [senhaTemporaria, setSenhaTemporaria] = useState<string | null>(null)
   const [confirmarReset, setConfirmarReset] = useState(false)
+  const [setoresList, setSetoresList] = useState<SaasSetores.Setor[]>([])
+  const [setorIds, setSetorIds] = useState<number[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    saasSetores
+      .list()
+      .then((rows) => {
+        if (!cancelled) setSetoresList(rows)
+      })
+      .catch(() => {
+        if (!cancelled) setSetoresList([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
     if (!isEdit) return
@@ -58,6 +76,7 @@ export function SaasUsuarioForm() {
         setEmail(row.email)
         setAtivo(row.ativo)
         setTokenConfigurado(row.mcp_token_configurado)
+        setSetorIds(row.setor_ids ?? [])
       })
       .catch((err) => {
         if (cancelled) return
@@ -79,13 +98,17 @@ export function SaasUsuarioForm() {
     }
   }, [id, isEdit, usuarioId])
 
+  function toggleSetor(setorId: number) {
+    setSetorIds((prev) => (prev.includes(setorId) ? prev.filter((x) => x !== setorId) : [...prev, setorId]))
+  }
+
   async function copiarSenha() {
     if (!senhaTemporaria) return
     try {
       await navigator.clipboard.writeText(senhaTemporaria)
       toast.showSuccess('Senha copiada.')
     } catch {
-      toast.showError('Não foi possível copiar. Seleccione a senha e copie manualmente.')
+      toast.showError('Não foi possível copiar. Selecione a senha e copie manualmente.')
     }
   }
 
@@ -98,18 +121,28 @@ export function SaasUsuarioForm() {
     setSaving(true)
     try {
       if (isEdit) {
-        const row = await saasOpsUsuarios.update(usuarioId, { nome: nome.trim(), ativo })
+        const row = await saasOpsUsuarios.update(usuarioId, {
+          nome: nome.trim(),
+          ativo,
+          setor_ids: setorIds,
+        })
         setAtivo(row.ativo)
+        setSetorIds(row.setor_ids ?? [])
         toast.showSuccess('Usuário atualizado.')
         navigate('/saas/usuarios')
         return
       }
-      const row = await saasOpsUsuarios.create({ nome: nome.trim(), email: email.trim() })
+      const row = await saasOpsUsuarios.create({
+        nome: nome.trim(),
+        email: email.trim(),
+        setor_ids: setorIds,
+      })
       setSenhaTemporaria(row.senha_temporaria)
       setEmail(row.email)
+      setSetorIds(row.setor_ids ?? [])
       toast.showSuccess('Usuário criado. Copie a senha temporária agora.')
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível guardar o utilizador.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o usuário.'))
     } finally {
       setSaving(false)
     }
@@ -162,7 +195,7 @@ export function SaasUsuarioForm() {
     <CadastroFormPageShell onVoltar={voltarAnterior}>
       <form onSubmit={(ev) => void onSubmit(ev)} className="space-y-4">
         <FormSection
-          title={isEdit ? 'Editar utilizador' : 'Novo utilizador'}
+          title={isEdit ? 'Editar usuário' : 'Novo usuário'}
           description="Esta conta entra no painel DeskRudder (/login/admin). Não é um atendente da instância do cliente."
         >
           {loading ? (
@@ -178,6 +211,34 @@ export function SaasUsuarioForm() {
                 required
                 disabled={isEdit}
               />
+              <div>
+                <p className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-200">Cargos</p>
+                <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
+                  Pode marcar mais de um. Cadastre novos em Equipe → Setores.
+                </p>
+                {setoresList.length === 0 ? (
+                  <p className="text-sm text-slate-500">
+                    Nenhum setor ativo.{' '}
+                    <Link to="/saas/setores/novo" className="font-medium text-sky-700 underline dark:text-sky-300">
+                      Criar setor
+                    </Link>
+                  </p>
+                ) : (
+                  <div className="max-h-44 overflow-auto rounded-lg border border-slate-200 p-3 dark:border-slate-800/80">
+                    <div className="flex flex-wrap gap-2">
+                      {setoresList.map((s) => (
+                        <CheckboxField
+                          key={s.id}
+                          checked={setorIds.includes(s.id)}
+                          onChange={() => toggleSetor(s.id)}
+                        >
+                          {s.nome}
+                        </CheckboxField>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
               {isEdit ? (
                 <Switch
                   checked={ativo}

--- a/frontend/src/pages/saas/SaasUsuarios.tsx
+++ b/frontend/src/pages/saas/SaasUsuarios.tsx
@@ -118,6 +118,9 @@ export function SaasUsuarios() {
                     Nome
                   </th>
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
+                    Cargos
+                  </th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
                     E-mail
                   </th>
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
@@ -156,6 +159,11 @@ export function SaasUsuarios() {
                           </span>
                         ) : null}
                       </div>
+                    </td>
+                    <td className="max-w-[14rem] px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400">
+                      {(u.setores ?? []).length > 0
+                        ? (u.setores ?? []).map((s) => s.nome).join(', ')
+                        : '—'}
                     </td>
                     <td className="max-w-[16rem] truncate px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400" title={u.email}>
                       {u.email}


### PR DESCRIPTION
## Summary

- Catálogo comercial: preço por **módulo**; plano = soma; licença com mix de módulos + usuários inclusos/extra
- Licenças: valor mensal **negociado** (opcional) sobrescreve a estimativa do catálogo; coluna Valor/mês na lista
- Equipe ops: setores/cargos N:N; Minha conta edita nome/e-mail/senha além do token Cursor
- Sugestões: filtros por tipo (Sugestão/Erro) e fase (Aguardando / Em desenvolvimento / Finalizadas)
- Docs de deploy/control-plane alinhados ao cutover admin-center

## CHANGELOG

- [x] Atualizei `CHANGELOG.md` → `[Unreleased]` com bullets em linguagem para o usuário final

## Test plan

- [ ] `alembic upgrade head` (migrations 120–123) no control-plane
- [ ] `/saas/modulos` — editar preço; `/saas/planos` recalcula soma
- [ ] `/saas/licencas` — criar/editar com mix de módulos, usuários e valor negociado; lista mostra Catálogo vs Negociado
- [ ] `/saas/setores` + usuário ops com vários cargos; `/saas/conta` nome/e-mail/senha
- [ ] `/saas/solicitacoes` — chips tipo/fase com contadores
- [ ] CI backend + frontend verde

## Follow-ups / backlog

- [ ] Enforcement hard de `max_usuarios` / features por módulo na instância (já documentado como follow-up)
- [ ] Sem issue única deste lote; trabalho acumulado no painel SaaS pós-cutover
