### PR TITLE
feat(whatsapp): contador e divisor de mensagens não lidas (#951)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- WhatsApp / Portal (#951 / #S202608-0004): contador de **mensagens não lidas** na lista Atendendo e divisor «Mensagens não lidas» ao abrir a conversa (continua de onde parou)
 - WhatsApp (mobile): ao **Atender**, o modal de setor fica **centralizado** com lista tocável (sem dropdown cortado no rodapé); o Select genérico também abre para cima quando não há espaço abaixo
 - WhatsApp: seleção de **Empresa do atendimento** no modal — lista deixa de ficar cortada/desproporcional (menu no fluxo do formulário; modal um pouco mais estreito)
 - Configurações (#865): menu reorganizado — **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; Catálogos PDV em **PDV**; Empresa só com dados da instalação; URLs antigas redirecionam

--- a/backend/alembic/versions/124_chat_read_msg_id.py
+++ b/backend/alembic/versions/124_chat_read_msg_id.py
@@ -1,0 +1,48 @@
+"""Cursor de leitura WhatsApp/Portal por id de mensagem (#951).
+
+Revision ID: 124_chat_read_msg_id
+Revises: 123_saas_preco_negociado
+Create Date: 2026-08-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "124_chat_read_msg_id"
+down_revision = "123_saas_preco_negociado"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("whatsapp_chat_reads"):
+        cols = {c["name"] for c in insp.get_columns("whatsapp_chat_reads")}
+        if "last_seen_mensagem_id" not in cols:
+            op.add_column(
+                "whatsapp_chat_reads",
+                sa.Column("last_seen_mensagem_id", sa.Integer(), nullable=True),
+            )
+    if insp.has_table("portal_chat_reads"):
+        cols = {c["name"] for c in insp.get_columns("portal_chat_reads")}
+        if "last_seen_mensagem_id" not in cols:
+            op.add_column(
+                "portal_chat_reads",
+                sa.Column("last_seen_mensagem_id", sa.Integer(), nullable=True),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("whatsapp_chat_reads"):
+        cols = {c["name"] for c in insp.get_columns("whatsapp_chat_reads")}
+        if "last_seen_mensagem_id" in cols:
+            op.drop_column("whatsapp_chat_reads", "last_seen_mensagem_id")
+    if insp.has_table("portal_chat_reads"):
+        cols = {c["name"] for c in insp.get_columns("portal_chat_reads")}
+        if "last_seen_mensagem_id" in cols:
+            op.drop_column("portal_chat_reads", "last_seen_mensagem_id")

--- a/backend/alembic/versions/127_chat_read_msg_id.py
+++ b/backend/alembic/versions/127_chat_read_msg_id.py
@@ -1,7 +1,7 @@
 """Cursor de leitura WhatsApp/Portal por id de mensagem (#951).
 
-Revision ID: 124_chat_read_msg_id
-Revises: 123_saas_preco_negociado
+Revision ID: 127_chat_read_msg_id
+Revises: 126_ponto_hora_extra
 Create Date: 2026-08-25
 """
 
@@ -10,8 +10,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-revision = "124_chat_read_msg_id"
-down_revision = "123_saas_preco_negociado"
+revision = "127_chat_read_msg_id"
+down_revision = "126_ponto_hora_extra"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/api/notificacoes.py
+++ b/backend/app/api/notificacoes.py
@@ -259,22 +259,23 @@ def _wpp_unread_count_for_chat(db: Session, chat_id: int, atendente_id: int) -> 
     c = db.query(WhatsappChat.id, WhatsappChat.created_at, WhatsappChat.atendimento_inicio_at).filter(WhatsappChat.id == chat_id).first()
     if not c:
         return 0
-    ls = (
-        db.query(WhatsappChatRead.last_seen_at)
+    row = (
+        db.query(WhatsappChatRead.last_seen_at, WhatsappChatRead.last_seen_mensagem_id)
         .filter(WhatsappChatRead.chat_id == chat_id, WhatsappChatRead.atendente_id == atendente_id)
-        .scalar()
+        .first()
     )
-    eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
-    n = (
-        db.query(func.count(WhatsappMensagem.id))
-        .filter(
-            WhatsappMensagem.chat_id == chat_id,
-            WhatsappMensagem.direcao == "inbound",
-            WhatsappMensagem.created_at > eff,
-        )
-        .scalar()
+    ls = row[0] if row else None
+    cursor_id = row[1] if row else None
+    q = db.query(func.count(WhatsappMensagem.id)).filter(
+        WhatsappMensagem.chat_id == chat_id,
+        WhatsappMensagem.direcao == "inbound",
     )
-    return int(n or 0)
+    if cursor_id is not None:
+        q = q.filter(WhatsappMensagem.id > cursor_id)
+    else:
+        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
+        q = q.filter(WhatsappMensagem.created_at > eff)
+    return int(q.scalar() or 0)
 
 
 def build_notificacao_itens(

--- a/backend/app/api/portal_chats.py
+++ b/backend/app/api/portal_chats.py
@@ -6,7 +6,9 @@ import logging
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from fastapi.responses import FileResponse
-from sqlalchemy import or_
+from datetime import datetime
+
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload
 
 from app.config import settings
@@ -14,7 +16,7 @@ from app.core.auth import obter_atendente_atual
 from app.core.setor_scope import ids_setores_visiveis_atendente
 from app.database import get_db
 from app.models.atendente import Atendente
-from app.models.portal_chat import PortalChat, PortalMensagem
+from app.models.portal_chat import PortalChat, PortalChatRead as PortalChatReadModel, PortalMensagem
 from app.models.setor import Setor
 from app.schemas.portal_chat import (
     PortalChatDemandaCreate,
@@ -71,7 +73,39 @@ def _ultima_mensagem_preview(db: Session, chat_id: int) -> str | None:
     return _preview_corpo(corpo)
 
 
-def _chat_read(db: Session, c: PortalChat) -> PortalChatRead:
+def _nao_lidas_portal(
+    db: Session, c: PortalChat, atendente_id: int
+) -> tuple[int, datetime | None, int | None]:
+    row = (
+        db.query(PortalChatReadModel.last_seen_at, PortalChatReadModel.last_seen_mensagem_id)
+        .filter(
+            PortalChatReadModel.chat_id == c.id,
+            PortalChatReadModel.atendente_id == atendente_id,
+        )
+        .first()
+    )
+    ls = row[0] if row else None
+    cursor_id = row[1] if row else None
+    q = db.query(func.count(PortalMensagem.id)).filter(
+        PortalMensagem.chat_id == c.id,
+        PortalMensagem.direcao == "inbound",
+    )
+    if cursor_id is not None:
+        q = q.filter(PortalMensagem.id > cursor_id)
+    else:
+        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
+        if eff is None:
+            return 0, ls, cursor_id
+        q = q.filter(PortalMensagem.created_at > eff)
+    return int(q.scalar() or 0), ls, cursor_id
+
+
+def _chat_read(db: Session, c: PortalChat, *, atendente_id: int | None = None) -> PortalChatRead:
+    nao_lidas = 0
+    last_seen: datetime | None = None
+    last_seen_msg: int | None = None
+    if atendente_id is not None:
+        nao_lidas, last_seen, last_seen_msg = _nao_lidas_portal(db, c, atendente_id)
     return PortalChatRead(
         id=c.id,
         protocolo=c.protocolo,
@@ -86,6 +120,9 @@ def _chat_read(db: Session, c: PortalChat) -> PortalChatRead:
         atendimento_inicio_at=c.atendimento_inicio_at,
         encerramento_at=c.encerramento_at,
         ultima_mensagem_preview=_ultima_mensagem_preview(db, c.id),
+        nao_lidas_count=nao_lidas,
+        last_seen_at=last_seen,
+        last_seen_mensagem_id=last_seen_msg,
     )
 
 
@@ -175,7 +212,7 @@ def listar_meus(
     if atendente.role != "admin":
         q = q.filter(PortalChat.atendente_id == atendente.id)
     rows = q.order_by(PortalChat.atendimento_inicio_at.desc().nullslast()).all()
-    return [_chat_read(db, c) for c in rows]
+    return [_chat_read(db, c, atendente_id=atendente.id) for c in rows]
 
 
 @router.get("/{chat_id}", response_model=PortalChatRead)
@@ -186,7 +223,7 @@ def obter_chat(
 ):
     c = _get_chat(db, chat_id)
     exigir_acesso_portal_chat(db, atendente, c)
-    return _chat_read(db, c)
+    return _chat_read(db, c, atendente_id=atendente.id)
 
 
 @router.get("/{chat_id}/mensagens", response_model=list[PortalChatMensagemRead])

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -633,12 +633,51 @@ def _criar_funcionario_rede(
     return f
 
 
-def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False) -> WhatsappChatRead:
+def _nao_lidas_whatsapp(
+    db: Session, c: WhatsappChat, atendente_id: int
+) -> tuple[int, datetime | None, int | None]:
+    """Inbound após o cursor de leitura (#951)."""
+    row = (
+        db.query(WhatsappChatReadModel.last_seen_at, WhatsappChatReadModel.last_seen_mensagem_id)
+        .filter(
+            WhatsappChatReadModel.chat_id == c.id,
+            WhatsappChatReadModel.atendente_id == atendente_id,
+        )
+        .first()
+    )
+    ls = row[0] if row else None
+    cursor_id = row[1] if row else None
+    q = db.query(func.count(WhatsappMensagem.id)).filter(
+        WhatsappMensagem.chat_id == c.id,
+        WhatsappMensagem.direcao == "inbound",
+    )
+    if cursor_id is not None:
+        q = q.filter(WhatsappMensagem.id > cursor_id)
+    else:
+        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
+        if eff is None:
+            return 0, ls, cursor_id
+        q = q.filter(WhatsappMensagem.created_at > eff)
+    return int(q.scalar() or 0), ls, cursor_id
+
+
+def _chat_read(
+    db: Session,
+    c: WhatsappChat,
+    *,
+    revelar_avaliacao: bool = False,
+    atendente_id: int | None = None,
+) -> WhatsappChatRead:
     nota = getattr(c, "avaliacao_nota", None) if revelar_avaliacao else None
     respondida = getattr(c, "avaliacao_respondida_at", None) if revelar_avaliacao else None
     solicitada = bool(getattr(c, "avaliacao_solicitada", False)) if revelar_avaliacao else False
     func = getattr(c, "funcionario_rede", None)
     emp = getattr(c, "empresa", None)
+    nao_lidas = 0
+    last_seen: datetime | None = None
+    last_seen_msg: int | None = None
+    if atendente_id is not None:
+        nao_lidas, last_seen, last_seen_msg = _nao_lidas_whatsapp(db, c, atendente_id)
     return WhatsappChatRead(
         id=c.id,
         protocolo=c.protocolo,
@@ -668,6 +707,9 @@ def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False)
         classificacao_demanda_pendente=bool(getattr(c, "classificacao_demanda_pendente", False)),
         foto_perfil_url=getattr(c, "foto_perfil_url", None),
         foto_perfil_atualizada_em=getattr(c, "foto_perfil_atualizada_em", None),
+        nao_lidas_count=nao_lidas,
+        last_seen_at=last_seen,
+        last_seen_mensagem_id=last_seen_msg,
     )
 
 
@@ -823,7 +865,7 @@ def listar_meus_ativos(
     if atendente.role != "admin":
         q = q.filter(WhatsappChat.atendente_id == atendente.id)
     rows = q.order_by(WhatsappChat.atendimento_inicio_at.desc().nullslast()).all()
-    return [_chat_read(db, c) for c in rows]
+    return [_chat_read(db, c, atendente_id=atendente.id) for c in rows]
 
 
 @router.get("/encerrados", response_model=ListaPaginada[WhatsappChatRead])
@@ -1369,7 +1411,7 @@ def obter(
     if _maybe_refresh_foto_perfil(db, c, force=False):
         db.commit()
         db.refresh(c)
-    return _chat_read(db, c)
+    return _chat_read(db, c, atendente_id=atendente.id)
 
 
 @router.get("/{chat_id}/pdf")
@@ -2205,6 +2247,9 @@ def marcar_chat_visto(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
 
     now = datetime.now(timezone.utc)
+    max_msg_id = (
+        db.query(func.max(WhatsappMensagem.id)).filter(WhatsappMensagem.chat_id == chat_id).scalar()
+    )
     row = (
         db.query(WhatsappChatReadModel)
         .filter(WhatsappChatReadModel.chat_id == chat_id, WhatsappChatReadModel.atendente_id == atendente.id)
@@ -2212,9 +2257,16 @@ def marcar_chat_visto(
     )
     if row:
         row.last_seen_at = now
+        row.last_seen_mensagem_id = max_msg_id
     else:
-        db.add(WhatsappChatReadModel(chat_id=chat_id, atendente_id=atendente.id, last_seen_at=now))
-
+        db.add(
+            WhatsappChatReadModel(
+                chat_id=chat_id,
+                atendente_id=atendente.id,
+                last_seen_at=now,
+                last_seen_mensagem_id=max_msg_id,
+            )
+        )
     # ✓✓ azul no WhatsApp do cliente: só o responsável, em atendimento
     if (
         c.estado == "em_atendimento"

--- a/backend/app/models/portal_chat.py
+++ b/backend/app/models/portal_chat.py
@@ -72,6 +72,7 @@ class PortalChatRead(Base):
     chat_id = Column(Integer, ForeignKey("portal_chats.id", ondelete="CASCADE"), nullable=False, index=True)
     atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
     last_seen_at = Column(DateTime(timezone=True), nullable=False)
+    last_seen_mensagem_id = Column(Integer, nullable=True)
 
     chat = relationship("PortalChat", back_populates="reads")
     atendente = relationship("Atendente")

--- a/backend/app/models/whatsapp_chat_read.py
+++ b/backend/app/models/whatsapp_chat_read.py
@@ -15,6 +15,7 @@ class WhatsappChatRead(Base):
     atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
     chat_id = Column(Integer, ForeignKey("whatsapp_chats.id", ondelete="CASCADE"), nullable=False, index=True)
     last_seen_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    last_seen_mensagem_id = Column(Integer, nullable=True)
 
     atendente = relationship("Atendente", backref="whatsapp_chat_reads")
     chat = relationship("WhatsappChat", backref="read_entries")

--- a/backend/app/schemas/portal_chat.py
+++ b/backend/app/schemas/portal_chat.py
@@ -42,6 +42,9 @@ class PortalChatRead(BaseModel):
     atendimento_inicio_at: datetime | None
     encerramento_at: datetime | None
     ultima_mensagem_preview: str | None = None
+    nao_lidas_count: int = 0
+    last_seen_at: datetime | None = None
+    last_seen_mensagem_id: int | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -83,6 +83,10 @@ class WhatsappChatRead(BaseModel):
     classificacao_demanda_pendente: bool = False
     foto_perfil_url: str | None = None
     foto_perfil_atualizada_em: datetime | None = None
+    # Não lidas do atendente atual (#951 / #S202608-0004)
+    nao_lidas_count: int = 0
+    last_seen_at: datetime | None = None
+    last_seen_mensagem_id: int | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/portal_chat.py
+++ b/backend/app/services/portal_chat.py
@@ -7,6 +7,7 @@ import secrets
 from datetime import datetime, timezone
 
 from fastapi import HTTPException, status
+from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
 from app.core.setor_scope import ids_setores_visiveis_atendente
@@ -257,6 +258,9 @@ def transferir_portal_chat(
 
 def marcar_visto_portal_chat(db: Session, chat_id: int, atendente_id: int) -> None:
     now = datetime.now(timezone.utc)
+    max_msg_id = (
+        db.query(func.max(PortalMensagem.id)).filter(PortalMensagem.chat_id == chat_id).scalar()
+    )
     row = (
         db.query(PortalChatReadRow)
         .filter(PortalChatReadRow.chat_id == chat_id, PortalChatReadRow.atendente_id == atendente_id)
@@ -264,8 +268,16 @@ def marcar_visto_portal_chat(db: Session, chat_id: int, atendente_id: int) -> No
     )
     if row:
         row.last_seen_at = now
+        row.last_seen_mensagem_id = max_msg_id
     else:
-        db.add(PortalChatReadRow(chat_id=chat_id, atendente_id=atendente_id, last_seen_at=now))
+        db.add(
+            PortalChatReadRow(
+                chat_id=chat_id,
+                atendente_id=atendente_id,
+                last_seen_at=now,
+                last_seen_mensagem_id=max_msg_id,
+            )
+        )
 
 
 def listar_mensagens_chat(

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -67,6 +67,39 @@ def test_fila_e_assumir(client, seed_base, auth_headers):
     assert client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json() == []
 
 
+def test_meus_e_visto_contam_nao_lidas(client, seed_base, auth_headers):
+    """#951: nao_lidas_count sobe com inbound e zera após POST /visto."""
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "nl-1"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "nl-1"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511777666555", msg_id="nl-m1", text="oi"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    assert client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"]).status_code == 200
+    assert client.post(f"/v1/whatsapp/chats/{cid}/visto", headers=auth_headers["a1"]).status_code == 204
+
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511777666555", msg_id="nl-m2", text="nova"),
+        headers=h,
+    )
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    row = next(c for c in meus if c["id"] == cid)
+    assert row["nao_lidas_count"] >= 1
+    assert "last_seen_at" in row
+
+    assert client.post(f"/v1/whatsapp/chats/{cid}/visto", headers=auth_headers["a1"]).status_code == 204
+    meus2 = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    row2 = next(c for c in meus2 if c["id"] == cid)
+    assert row2["nao_lidas_count"] == 0
+
+
 def test_listar_encerrados_filtra_e_respeita_rbac(client, seed_base, auth_headers):
     client.patch(
         "/v1/settings/whatsapp",

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1082,6 +1082,10 @@ export namespace WhatsappChats {
   classificacao_demanda_pendente?: boolean
   foto_perfil_url?: string | null
   foto_perfil_atualizada_em?: string | null
+  /** Mensagens inbound não vistas pelo atendente atual (#951). */
+  nao_lidas_count?: number
+  last_seen_at?: string | null
+  last_seen_mensagem_id?: number | null
   }
   export interface EmpresaOpcao {
     id: number
@@ -4591,6 +4595,9 @@ export namespace Kb {
     atendimento_inicio_at: string | null;
     encerramento_at: string | null;
     ultima_mensagem_preview?: string | null;
+    nao_lidas_count?: number;
+    last_seen_at?: string | null;
+    last_seen_mensagem_id?: number | null;
   }
   export interface PortalChatSession {
     visitor_token: string;

--- a/frontend/src/lib/chatHubLista.ts
+++ b/frontend/src/lib/chatHubLista.ts
@@ -18,6 +18,7 @@ export type ChatHubItem = {
   atendente_nome?: string | null
   ultima_mensagem_preview?: string | null
   foto_perfil_url?: string | null
+  nao_lidas_count?: number
 }
 
 export function mapWhatsappChat(c: WhatsappChats.Chat): ChatHubItem {
@@ -34,6 +35,7 @@ export function mapWhatsappChat(c: WhatsappChats.Chat): ChatHubItem {
     atendente_id: c.atendente_id,
     atendente_nome: c.atendente_nome,
     foto_perfil_url: c.foto_perfil_url,
+    nao_lidas_count: c.nao_lidas_count ?? 0,
   }
 }
 
@@ -51,6 +53,7 @@ export function mapPortalChat(c: PortalChats.Chat): ChatHubItem {
     atendente_id: c.atendente_id,
     atendente_nome: c.atendente_nome,
     ultima_mensagem_preview: c.ultima_mensagem_preview,
+    nao_lidas_count: c.nao_lidas_count ?? 0,
   }
 }
 
@@ -87,6 +90,9 @@ export function ordenarFila(items: ChatHubItem[]): ChatHubItem[] {
 
 export function ordenarAtendendo(items: ChatHubItem[]): ChatHubItem[] {
   return [...items].sort((a, b) => {
+    const ua = a.nao_lidas_count ?? 0
+    const ub = b.nao_lidas_count ?? 0
+    if (ub !== ua) return ub - ua
     const ta = a.atendimento_inicio_at || a.created_at
     const tb = b.atendimento_inicio_at || b.created_at
     return (tb ? new Date(tb).getTime() : 0) - (ta ? new Date(ta).getTime() : 0)

--- a/frontend/src/pages/chat/ChatListaAtendendo.tsx
+++ b/frontend/src/pages/chat/ChatListaAtendendo.tsx
@@ -78,16 +78,34 @@ function ChatAtendendoItem({
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-2">
             <div className="flex min-w-0 flex-1 items-center gap-1.5">
-              <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">{item.nome}</p>
+              <p
+                className={`truncate text-sm ${
+                  (item.nao_lidas_count ?? 0) > 0
+                    ? 'font-bold text-slate-900 dark:text-white'
+                    : 'font-semibold text-slate-900 dark:text-white'
+                }`}
+              >
+                {item.nome}
+              </p>
               {variant === 'proprio' && (
                 <span className="shrink-0 rounded-full bg-cyan-100 px-1.5 py-0.5 text-[9px] font-bold uppercase text-cyan-800 dark:bg-cyan-950/60 dark:text-cyan-200">
                   Você
                 </span>
               )}
             </div>
-            {item.estado === 'aguardando_atendente' && (
-              <span className="h-2 w-2 shrink-0 rounded-full bg-amber-500" title="Aguardando" />
-            )}
+            <div className="flex shrink-0 items-center gap-1.5">
+              {(item.nao_lidas_count ?? 0) > 0 && (
+                <span
+                  className="inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-cyan-600 px-1.5 py-0.5 text-[10px] font-bold text-white"
+                  title={`${item.nao_lidas_count} não lida${(item.nao_lidas_count ?? 0) === 1 ? '' : 's'}`}
+                >
+                  {(item.nao_lidas_count ?? 0) > 99 ? '99+' : item.nao_lidas_count}
+                </span>
+              )}
+              {item.estado === 'aguardando_atendente' && (
+                <span className="h-2 w-2 rounded-full bg-amber-500" title="Aguardando" />
+              )}
+            </div>
           </div>
           <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
             <ChatCanalBadge canal={item.canal} />
@@ -185,7 +203,7 @@ export function ChatListaAtendendo() {
     return (
       <ChatHubEmptyState
         title="Nenhum atendimento seu"
-        description="Quando assumires um chat, ele aparece aqui."
+        description="Quando você assumir um chat, ele aparece aqui."
         actions={
           filaCount > 0
             ? [{ type: 'link', to: '/chat/espera', label: `Ir para Aguardando (${filaCount > 99 ? '99+' : filaCount})` }]

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -605,6 +605,8 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
   const enviandoRef = useRef(false)
   const enviandoMidiaRef = useRef(false)
   const [reagirMsgId, setReagirMsgId] = useState<number | null>(null)
+  /** Primeira inbound não lida ao abrir — divisor estilo WhatsApp (#951). */
+  const [divisorNaoLidasMsgId, setDivisorNaoLidasMsgId] = useState<number | null>(null)
 
   // Estados de WhatsApp Clone (Citação e Zoom)
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
@@ -874,9 +876,12 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
 
   // Carregar conversa e mensagens
 
-  const carregar = useCallback(async () => {
+  const carregar = useCallback(async (): Promise<{
+    chat: WhatsappChats.Chat
+    msgs: WhatsappChats.Mensagem[]
+  } | null> => {
 
-    if (!id) return
+    if (!id) return null
 
     const gen = ++carregarGenRef.current
     const el = scrollRef.current
@@ -888,11 +893,12 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
 
       const [c, m] = await Promise.all([whatsappChats.get(id), whatsappChats.mensagens(id)])
 
-      if (gen !== carregarGenRef.current) return
+      if (gen !== carregarGenRef.current) return null
 
       setChat((prev) => mergeWhatsappChat(prev, c))
 
-      setMsgs(whatsappMensagensUnicas(m))
+      const unicas = whatsappMensagensUnicas(m)
+      setMsgs(unicas)
 
       requestAnimationFrame(() => {
         if (!initialScrollRestoredRef.current) return
@@ -905,9 +911,12 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
         }
       })
 
+      return { chat: c, msgs: unicas }
+
     } catch (err) {
 
       toast.showError(mensagemFalhaParaToast(err))
+      return null
 
     }
 
@@ -936,16 +945,56 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
     if (!id) return
 
     setLoading(true)
+    setDivisorNaoLidasMsgId(null)
     viuEmAtendimentoRef.current = false
     inatividadeToastFeitoRef.current = false
 
-    carregar().then(() => whatsappChats.marcarVisto(id)).finally(() => setLoading(false))
+    carregar()
+      .then(async (data) => {
+        if (data && (data.chat.nao_lidas_count ?? 0) > 0) {
+          const cursorId = data.chat.last_seen_mensagem_id
+          let primeira: WhatsappChats.Mensagem | undefined
+          if (cursorId != null) {
+            primeira = data.msgs.find(
+              (m) =>
+                m.direcao === 'inbound' &&
+                !m.evento_sistema &&
+                !m.apagada &&
+                m.id > cursorId,
+            )
+          } else {
+            const eff =
+              data.chat.last_seen_at || data.chat.atendimento_inicio_at || data.chat.created_at || null
+            const effMs = eff ? new Date(eff).getTime() : 0
+            primeira = data.msgs.find(
+              (m) =>
+                m.direcao === 'inbound' &&
+                !m.evento_sistema &&
+                !m.apagada &&
+                m.created_at &&
+                new Date(m.created_at).getTime() > effMs,
+            )
+          }
+          if (primeira) setDivisorNaoLidasMsgId(primeira.id)
+        }
+        await whatsappChats.marcarVisto(id)
+        void carregarSidebar()
+      })
+      .finally(() => setLoading(false))
 
     return () => {
       revokeWhatsappMidiaForChat(Number(id))
     }
 
-  }, [id, carregar])
+  }, [id, carregar, carregarSidebar])
+
+  useEffect(() => {
+    if (!divisorNaoLidasMsgId || loading) return
+    const t = window.setTimeout(() => {
+      document.getElementById('wa-nao-lidas')?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    }, 80)
+    return () => window.clearTimeout(t)
+  }, [divisorNaoLidasMsgId, loading])
 
 
 
@@ -2143,12 +2192,26 @@ useEffect(() => {
               m.evento_sistema === 'comentario_interno' || m.evento_sistema === 'transferencia'
             const isTransferencia = m.evento_sistema === 'transferencia'
 
-           
+            const mostrarDivisorNaoLidas = divisorNaoLidasMsgId === m.id
 
             return (
+              <div key={m.id} className="w-full space-y-4">
+                {mostrarDivisorNaoLidas && (
+                  <div
+                    id="wa-nao-lidas"
+                    className="flex w-full items-center gap-3 py-1"
+                    role="separator"
+                    aria-label="Mensagens não lidas"
+                  >
+                    <div className="h-px flex-1 bg-cyan-500/50" />
+                    <span className="shrink-0 rounded-full bg-cyan-600 px-3 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white shadow-sm">
+                      Mensagens não lidas
+                    </span>
+                    <div className="h-px flex-1 bg-cyan-500/50" />
+                  </div>
+                )}
 
-              <div 
-                key={m.id} 
+              <div
                 id={`msg-${m.wa_message_id || m.id}`}
                 data-wa-msg-id={m.id}
                 onDoubleClick={(e) => duploCliqueResponder(e, m, isSystem)}
@@ -2295,6 +2358,7 @@ useEffect(() => {
                   </button>
                 )}
 
+              </div>
               </div>
 
             )


### PR DESCRIPTION
## Summary
- Contador `nao_lidas_count` em chats WhatsApp/Portal (`/meus` e `GET`)
- Badge na lista **Atendendo** do hub; chats com não lidas sobem na ordenação
- Divisor «Mensagens não lidas» no thread ao abrir (scroll até o marcador)
- Cursor de leitura por `last_seen_mensagem_id` (migration `124`) para não falhar no mesmo segundo

Closes #951

## Test plan
- [ ] Com dois chats seus: resposta do cliente em um deles mostra badge numérico na lista
- [ ] Abrir o chat: aparece a linha «Mensagens não lidas» antes das novas; lista zera o badge após sync
- [ ] `POST /visto` / reabrir: sem divisor se não houver novas
- [ ] Migration `124` sobe limpa (`alembic upgrade head`)
- [ ] `pytest tests/test_whatsapp_chats.py::test_meus_e_visto_contam_nao_lidas`