### PR TITLE
fix(whatsapp): picker de reação não sobrepõe menu Editar (#947)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Correções
 
+- WhatsApp (#947 / #S202608-0005): ao abrir o menu Editar/Apagar/Reagir (ou editar mensagem), o strip de emojis do hover deixa de cobrir as opções
 - Deploy: migration do chat interno (#916) usava um ID Alembic maior que 32 caracteres e quebrava o `upgrade` em produção; ID encurtado para caber em `alembic_version`
 
 #### Melhorias

--- a/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
+++ b/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
@@ -18,6 +18,8 @@ type Props = {
   podeReagir?: boolean
   /** Balão claro (inbound) — seta escura. */
   tomClaro?: boolean
+  /** Notifica quando menu ou edição estão ativos (#947 / #S202608-0005). */
+  onMenuAbertoChange?: (aberto: boolean) => void
 }
 
 /** Menu de ações no canto do balão (editar / apagar / reagir) — #630 / #749. */
@@ -28,6 +30,7 @@ export function WhatsappMensagemAcoes({
   onReagirMenu,
   podeReagir = false,
   tomClaro = false,
+  onMenuAbertoChange,
 }: Props) {
   const [editando, setEditando] = useState(false)
   const [texto, setTexto] = useState(() => corpoWhatsappSemPrefixo(mensagem.corpo))
@@ -44,6 +47,13 @@ export function WhatsappMensagemAcoes({
   useEffect(() => {
     if (!editando) setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
   }, [mensagem, editando])
+
+  const onMenuAbertoChangeRef = useRef(onMenuAbertoChange)
+  onMenuAbertoChangeRef.current = onMenuAbertoChange
+  useEffect(() => {
+    onMenuAbertoChangeRef.current?.(menuAberto || editando)
+    return () => onMenuAbertoChangeRef.current?.(false)
+  }, [menuAberto, editando])
 
   useEffect(() => {
     if (!menuAberto) return

--- a/frontend/src/components/chat/WhatsappReacoesBar.tsx
+++ b/frontend/src/components/chat/WhatsappReacoesBar.tsx
@@ -11,6 +11,8 @@ type Props = {
   /** Abrir picker a partir do menu da seta (#749). */
   pickerExternoAberto?: boolean
   onPickerExternoClose?: () => void
+  /** Oculta o strip de emojis do hover enquanto o menu Editar/Apagar está aberto (#947). */
+  ocultarPickerHover?: boolean
 }
 
 /** Reações no chat WhatsApp com o cliente (#630 lote 2 / #749). */
@@ -21,6 +23,7 @@ export function WhatsappReacoesBar({
   alinhamento = 'end',
   pickerExternoAberto = false,
   onPickerExternoClose,
+  ocultarPickerHover = false,
 }: Props) {
   const temReacoes = reacoes.length > 0
   const alignEnd = alinhamento === 'end'
@@ -35,34 +38,36 @@ export function WhatsappReacoesBar({
             alignEnd ? 'items-end' : 'items-start'
           } ${temReacoes || mostrarPickerMobile ? 'relative mt-1' : 'relative'}`}
         >
-          {/* Desktop: picker no hover do balão */}
-          <div
-            className={`pointer-events-none absolute bottom-full z-20 mb-1 hidden flex-col md:flex ${
-              alignEnd ? 'right-0 items-end' : 'left-0 items-start'
-            }`}
-          >
+          {/* Desktop: picker no hover do balão (oculto com menu de ações aberto — #947) */}
+          {!ocultarPickerHover ? (
             <div
-              className={`opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 ${
-                pickerHoverAberto ? 'pointer-events-auto opacity-100' : ''
+              className={`pointer-events-none absolute bottom-full z-20 mb-1 hidden flex-col md:flex ${
+                alignEnd ? 'right-0 items-end' : 'left-0 items-start'
               }`}
-              onMouseEnter={() => setPickerHoverAberto(true)}
-              onMouseLeave={() => setPickerHoverAberto(false)}
             >
-              <div className="flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
-                {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
-                  <button
-                    key={emoji}
-                    type="button"
-                    onClick={() => onReagir(emoji)}
-                    className="rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
-                    aria-label={`Reagir com ${emoji}`}
-                  >
-                    {emoji}
-                  </button>
-                ))}
+              <div
+                className={`opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 ${
+                  pickerHoverAberto ? 'pointer-events-auto opacity-100' : ''
+                }`}
+                onMouseEnter={() => setPickerHoverAberto(true)}
+                onMouseLeave={() => setPickerHoverAberto(false)}
+              >
+                <div className="flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
+                  {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
+                    <button
+                      key={emoji}
+                      type="button"
+                      onClick={() => onReagir(emoji)}
+                      className="rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
+                      aria-label={`Reagir com ${emoji}`}
+                    >
+                      {emoji}
+                    </button>
+                  ))}
+                </div>
               </div>
             </div>
-          </div>
+          ) : null}
           {mostrarPickerMobile ? (
             <div className="mt-1 flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md md:hidden dark:border-slate-600 dark:bg-slate-800">
               {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -605,6 +605,8 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
   const enviandoRef = useRef(false)
   const enviandoMidiaRef = useRef(false)
   const [reagirMsgId, setReagirMsgId] = useState<number | null>(null)
+  /** Menu Editar/Apagar/Reagir ou formulário de edição abertos — oculta picker hover (#947). */
+  const [acoesMenuMsgId, setAcoesMenuMsgId] = useState<number | null>(null)
 
   // Estados de WhatsApp Clone (Citação e Zoom)
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
@@ -2196,6 +2198,12 @@ useEffect(() => {
                         podeReagir={podeReagir}
                         onReagirMenu={podeReagir ? () => setReagirMsgId(m.id) : undefined}
                         tomClaro={isInbound}
+                        onMenuAbertoChange={(aberto) => {
+                          setAcoesMenuMsgId((prev) => {
+                            if (aberto) return m.id
+                            return prev === m.id ? null : prev
+                          })
+                        }}
                       />
                     )}
 
@@ -2280,6 +2288,7 @@ useEffect(() => {
                       alinhamento={isInbound ? 'start' : 'end'}
                       pickerExternoAberto={reagirMsgId === m.id}
                       onPickerExternoClose={() => setReagirMsgId(null)}
+                      ocultarPickerHover={acoesMenuMsgId === m.id}
                     />
                   )}
 


### PR DESCRIPTION
## Summary

- Ao abrir o menu da seta (Editar / Apagar / Reagir) ou o formulário de edição, o strip de emojis do hover desktop deixa de aparecer e não cobre mais as opções
- Desktop continua com picker no hover quando o menu está fechado; mobile mantém «Reagir» → picker externo
- Substitui a abordagem do PR #949 (fechado em favor deste fix mínimo)

Closes #947

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] Abrir menu da seta → Editar/Apagar/Reagir usáveis sem strip de emojis por cima
- [ ] Fechar menu + hover no balão (desktop) → picker de reação normal
- [ ] Mobile: «Reagir» no menu ainda abre o picker
- [ ] Editar mensagem: formulário usável sem overlay de emojis

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — nenhum follow-up
- [x] Stubs/campos nullable — N/A
- [x] Comentário na issue fechada ou no PR lista links dos follow-ups criados — N/A
