### PR TITLE
feat(ponto): jornada semanal, janela de entrada e fecho (#959)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Ponto (#959 / #960–#964 / #961–#963): jornada **semanal** (grade Dia/Aberto/Início/Fim como no chat) ou **ciclo** X×Y, ou **nenhum**; entrada só a partir de início−tolerância; atraso só após início+tolerância; fecho por esquecimento (N horas **ou** saída prevista+margem); alertas in-app de falta/atraso para colaborador e admin
 - WhatsApp (mobile): ao **Atender**, o modal de setor fica **centralizado** com lista tocável (sem dropdown cortado no rodapé); o Select genérico também abre para cima quando não há espaço abaixo
 - WhatsApp: seleção de **Empresa do atendimento** no modal — lista deixa de ficar cortada/desproporcional (menu no fluxo do formulário; modal um pouco mais estreito)
 - Configurações (#865): menu reorganizado — **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; Catálogos PDV em **PDV**; Empresa só com dados da instalação; URLs antigas redirecionam

--- a/backend/alembic/versions/124_ponto_modo_jornada.py
+++ b/backend/alembic/versions/124_ponto_modo_jornada.py
@@ -1,0 +1,72 @@
+"""Ponto: modo_jornada, horario_semana e margem de fecho (#959/#960/#961).
+
+Revision ID: 124_ponto_modo_jornada
+Revises: 123_saas_preco_negociado
+Create Date: 2026-08-26
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "124_ponto_modo_jornada"
+down_revision = "123_saas_preco_negociado"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "modo_jornada" not in cols:
+            op.add_column(
+                "atendentes",
+                sa.Column(
+                    "modo_jornada",
+                    sa.String(20),
+                    nullable=False,
+                    server_default="nenhum",
+                ),
+            )
+        if "horario_semana_json" not in cols:
+            op.add_column(
+                "atendentes",
+                sa.Column("horario_semana_json", sa.Text(), nullable=True),
+            )
+        # Backfill: quem já usava ciclo X×Y → modo ciclo
+        op.execute(
+            sa.text(
+                "UPDATE atendentes SET modo_jornada = 'ciclo' "
+                "WHERE usa_escala IS TRUE AND modo_jornada = 'nenhum'"
+            )
+        )
+
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "fecho_margem_pos_saida_minutos" not in cols:
+            op.add_column(
+                "ponto_settings",
+                sa.Column(
+                    "fecho_margem_pos_saida_minutos",
+                    sa.Integer(),
+                    nullable=False,
+                    server_default="30",
+                ),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "fecho_margem_pos_saida_minutos" in cols:
+            op.drop_column("ponto_settings", "fecho_margem_pos_saida_minutos")
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "horario_semana_json" in cols:
+            op.drop_column("atendentes", "horario_semana_json")
+        if "modo_jornada" in cols:
+            op.drop_column("atendentes", "modo_jornada")

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -12,7 +12,13 @@ from app.schemas.ticket_csat import AtendenteAvaliacoesRead, AvaliacaoResumoRead
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import exigir_admin, obter_atendente_atual, validar_role
 from app.services.atendente_avaliacoes import calcular_avaliacoes_atendente
-from app.services.escala import validar_campos_escala, validar_horario_previsto
+from app.services.escala import (
+    horario_semana_dict,
+    horario_semana_para_json,
+    modo_jornada as modo_jornada_de,
+    validar_campos_jornada,
+    validar_horario_previsto,
+)
 from app.core.setor_scope import atendente_e_financeiro, ids_setores_mesmo_nome, ids_setores_visiveis_atendente
 from app.core.security import hash_senha, verificar_senha
 from app.core.audit import registrar_audit
@@ -32,6 +38,8 @@ class OrdenarAtendentesPor(str, Enum):
 
 def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) -> AtendenteRead:
     saas = sorted(getattr(atendente, "saas_setores", None) or [], key=lambda s: (s.nome or "", s.id))
+    modo = modo_jornada_de(atendente)
+    usa = modo in ("semanal", "ciclo")
     return AtendenteRead(
         id=atendente.id,
         email=atendente.email,
@@ -43,7 +51,9 @@ def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) ->
         setor_ids=[s.id for s in atendente.setores],
         e_financeiro=e_financeiro,
         must_change_password=bool(getattr(atendente, "must_change_password", False)),
-        usa_escala=bool(getattr(atendente, "usa_escala", False)),
+        modo_jornada=modo,  # type: ignore[arg-type]
+        usa_escala=usa,
+        horario_semana=horario_semana_dict(atendente),
         escala_horas_trabalho=getattr(atendente, "escala_horas_trabalho", None),
         escala_horas_folga=getattr(atendente, "escala_horas_folga", None),
         escala_inicio_em=getattr(atendente, "escala_inicio_em", None),
@@ -53,6 +63,56 @@ def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) ->
         saas_setor_ids=[s.id for s in saas],
         saas_setor_nomes=[s.nome for s in saas],
     )
+
+
+def _resolver_modo_jornada(data_modo: str | None, usa_escala: bool | None, atual: Atendente | None) -> str:
+    if data_modo is not None:
+        return (data_modo or "nenhum").strip().lower()
+    if usa_escala is not None:
+        return "ciclo" if usa_escala else "nenhum"
+    if atual is not None:
+        return modo_jornada_de(atual)
+    return "nenhum"
+
+
+def _aplicar_campos_jornada(atendente: Atendente, *, modo: str, update: dict) -> None:
+    """Normaliza campos de jornada no dict update / no create."""
+    if modo == "nenhum":
+        atendente.modo_jornada = "nenhum"
+        atendente.usa_escala = False
+        atendente.escala_horas_trabalho = None
+        atendente.escala_horas_folga = None
+        atendente.escala_inicio_em = None
+        atendente.horario_previsto_entrada = None
+        atendente.horario_previsto_saida = None
+        atendente.tolerancia_atraso_minutos = 0
+        atendente.horario_semana_json = None
+        return
+    if modo == "semanal":
+        hs = update.get("horario_semana")
+        if hs is None and atendente.horario_semana_json:
+            hs = horario_semana_dict(atendente)
+        atendente.modo_jornada = "semanal"
+        atendente.usa_escala = True
+        atendente.escala_horas_trabalho = None
+        atendente.escala_horas_folga = None
+        atendente.escala_inicio_em = None
+        atendente.horario_previsto_entrada = None
+        atendente.horario_previsto_saida = None
+        atendente.horario_semana_json = horario_semana_para_json(hs)
+        if "tolerancia_atraso_minutos" in update:
+            atendente.tolerancia_atraso_minutos = int(update["tolerancia_atraso_minutos"] or 0)
+        return
+    # ciclo
+    atendente.modo_jornada = "ciclo"
+    atendente.usa_escala = True
+    atendente.horario_semana_json = None
+    atendente.escala_horas_trabalho = update.get("escala_horas_trabalho")
+    atendente.escala_horas_folga = update.get("escala_horas_folga")
+    atendente.escala_inicio_em = update.get("escala_inicio_em")
+    atendente.horario_previsto_entrada = update.get("horario_previsto_entrada")
+    atendente.horario_previsto_saida = update.get("horario_previsto_saida")
+    atendente.tolerancia_atraso_minutos = int(update.get("tolerancia_atraso_minutos") or 0)
 
 
 @router.get("", response_model=ListaPaginada[AtendenteRead])
@@ -109,13 +169,16 @@ def criar_atendente(
     ):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="E-mail já cadastrado")
     role = validar_role(data.role)
-    validar_campos_escala(
-        usa_escala=bool(data.usa_escala),
+    modo = _resolver_modo_jornada(data.modo_jornada, data.usa_escala, None)
+    validar_campos_jornada(
+        modo=modo,
         escala_horas_trabalho=data.escala_horas_trabalho,
         escala_horas_folga=data.escala_horas_folga,
         escala_inicio_em=data.escala_inicio_em,
+        horario_semana=data.horario_semana,
     )
-    validar_horario_previsto(data.horario_previsto_entrada, data.horario_previsto_saida)
+    if modo == "ciclo":
+        validar_horario_previsto(data.horario_previsto_entrada, data.horario_previsto_saida)
     atendente = Atendente(
         tenant_id=atendente_logado.tenant_id,
         email=data.email,
@@ -123,15 +186,20 @@ def criar_atendente(
         senha_hash=hash_senha(data.senha),
         role=role,
         ativo=data.ativo,
-        usa_escala=bool(data.usa_escala),
-        escala_horas_trabalho=data.escala_horas_trabalho if data.usa_escala else None,
-        escala_horas_folga=data.escala_horas_folga if data.usa_escala else None,
-        escala_inicio_em=data.escala_inicio_em if data.usa_escala else None,
-        horario_previsto_entrada=data.horario_previsto_entrada if data.usa_escala else None,
-        horario_previsto_saida=data.horario_previsto_saida if data.usa_escala else None,
-        tolerancia_atraso_minutos=(
-            int(data.tolerancia_atraso_minutos or 0) if data.usa_escala else 0
-        ),
+        tolerancia_atraso_minutos=int(data.tolerancia_atraso_minutos or 0) if modo != "nenhum" else 0,
+    )
+    _aplicar_campos_jornada(
+        atendente,
+        modo=modo,
+        update={
+            "horario_semana": data.horario_semana,
+            "escala_horas_trabalho": data.escala_horas_trabalho,
+            "escala_horas_folga": data.escala_horas_folga,
+            "escala_inicio_em": data.escala_inicio_em,
+            "horario_previsto_entrada": data.horario_previsto_entrada,
+            "horario_previsto_saida": data.horario_previsto_saida,
+            "tolerancia_atraso_minutos": data.tolerancia_atraso_minutos,
+        },
     )
     db.add(atendente)
     db.flush()
@@ -265,33 +333,55 @@ def atualizar_atendente(
             if setor:
                 atendente.setores.append(setor)
 
-    usa_escala = update.get("usa_escala", atendente.usa_escala)
+    modo = _resolver_modo_jornada(update.get("modo_jornada"), update.get("usa_escala"), atendente)
     ht = update.get("escala_horas_trabalho", atendente.escala_horas_trabalho)
     hf = update.get("escala_horas_folga", atendente.escala_horas_folga)
     inicio = update.get("escala_inicio_em", atendente.escala_inicio_em)
-    if any(k in update for k in ("usa_escala", "escala_horas_trabalho", "escala_horas_folga", "escala_inicio_em")):
-        validar_campos_escala(
-            usa_escala=bool(usa_escala),
+    hs = update.get("horario_semana")
+    if hs is None and modo == "semanal":
+        hs = horario_semana_dict(atendente)
+    he = update.get("horario_previsto_entrada", getattr(atendente, "horario_previsto_entrada", None))
+    hs_prev = update.get("horario_previsto_saida", getattr(atendente, "horario_previsto_saida", None))
+    tol = update.get(
+        "tolerancia_atraso_minutos",
+        getattr(atendente, "tolerancia_atraso_minutos", 0),
+    )
+    jornada_keys = (
+        "modo_jornada",
+        "usa_escala",
+        "escala_horas_trabalho",
+        "escala_horas_folga",
+        "escala_inicio_em",
+        "horario_semana",
+        "horario_previsto_entrada",
+        "horario_previsto_saida",
+        "tolerancia_atraso_minutos",
+    )
+    if any(k in update for k in jornada_keys):
+        validar_campos_jornada(
+            modo=modo,
             escala_horas_trabalho=ht,
             escala_horas_folga=hf,
             escala_inicio_em=inicio,
+            horario_semana=hs if modo == "semanal" else None,
         )
-        if not usa_escala:
-            update["usa_escala"] = False
-            update["escala_horas_trabalho"] = None
-            update["escala_horas_folga"] = None
-            update["escala_inicio_em"] = None
-            update["horario_previsto_entrada"] = None
-            update["horario_previsto_saida"] = None
-            update["tolerancia_atraso_minutos"] = 0
-
-    he = update.get("horario_previsto_entrada", getattr(atendente, "horario_previsto_entrada", None))
-    hs = update.get("horario_previsto_saida", getattr(atendente, "horario_previsto_saida", None))
-    if any(
-        k in update
-        for k in ("horario_previsto_entrada", "horario_previsto_saida", "tolerancia_atraso_minutos")
-    ):
-        validar_horario_previsto(he, hs)
+        if modo == "ciclo":
+            validar_horario_previsto(he, hs_prev)
+        for k in jornada_keys:
+            update.pop(k, None)
+        _aplicar_campos_jornada(
+            atendente,
+            modo=modo,
+            update={
+                "horario_semana": hs,
+                "escala_horas_trabalho": ht,
+                "escala_horas_folga": hf,
+                "escala_inicio_em": inicio,
+                "horario_previsto_entrada": he,
+                "horario_previsto_saida": hs_prev,
+                "tolerancia_atraso_minutos": tol,
+            },
+        )
 
     for k, v in update.items():
         setattr(atendente, k, v)

--- a/backend/app/models/atendente.py
+++ b/backend/app/models/atendente.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, String, Table, UniqueConstraint
+from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, String, Table, Text, UniqueConstraint
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -35,12 +35,14 @@ class Atendente(Base):
     # Token Cursor MCP pessoal (#915): plaintext só na geração; Bearer resolve este ops.
     mcp_token_hash = Column(String(64), nullable=True, unique=True, index=True)
     mcp_token_gerado_em = Column(DateTime(timezone=True), nullable=True)
-    # Controle de ponto / escala (#761+): flag + ciclo horas trabalhadas × horas de folga.
+    # Controle de ponto / escala (#761+ / #959): nenhum | semanal | ciclo.
     usa_escala = Column(Boolean, nullable=False, default=False, server_default="false")
+    modo_jornada = Column(String(20), nullable=False, default="nenhum", server_default="nenhum")
+    horario_semana_json = Column(Text, nullable=True)
     escala_horas_trabalho = Column(Integer, nullable=True)
     escala_horas_folga = Column(Integer, nullable=True)
     escala_inicio_em = Column(Date, nullable=True)
-    horario_previsto_entrada = Column(String(5), nullable=True)  # HH:MM
+    horario_previsto_entrada = Column(String(5), nullable=True)  # HH:MM (ciclo)
     horario_previsto_saida = Column(String(5), nullable=True)
     tolerancia_atraso_minutos = Column(Integer, nullable=False, default=0, server_default="0")
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/ponto_settings.py
+++ b/backend/app/models/ponto_settings.py
@@ -14,6 +14,8 @@ class PontoSettings(Base):
     usar_feriados_nacionais = Column(Boolean, nullable=False, default=True, server_default="true")
     fecho_automatico_ativo = Column(Boolean, nullable=False, default=False, server_default="false")
     fecho_apos_horas = Column(Integer, nullable=False, default=14, server_default="14")
+    # Margem após saída prevista do dia (#961); fecho = min(N horas, saída+margem).
+    fecho_margem_pos_saida_minutos = Column(Integer, nullable=False, default=30, server_default="30")
     jornada_diaria_minutos = Column(Integer, nullable=False, default=480, server_default="480")
     # opcional | recomendada | obrigatoria (#844)
     politica_geolocalizacao = Column(String(20), nullable=False, default="opcional", server_default="opcional")

--- a/backend/app/schemas/atendente.py
+++ b/backend/app/schemas/atendente.py
@@ -1,5 +1,9 @@
+from typing import Any, Literal
+
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 from datetime import date, datetime
+
+ModoJornada = Literal["nenhum", "semanal", "ciclo"]
 
 
 class AtendenteBase(BaseModel):
@@ -7,7 +11,10 @@ class AtendenteBase(BaseModel):
     nome: str
     role: str = "atendente"  # admin | atendente | comercial | saas_ops
     ativo: bool = True
+    modo_jornada: ModoJornada = "nenhum"
+    # Compat: True se modo semanal|ciclo (preenchido na Read / sync no write)
     usa_escala: bool = False
+    horario_semana: dict[str, Any] | None = None
     escala_horas_trabalho: int | None = Field(default=None, ge=1, le=168)
     escala_horas_folga: int | None = Field(default=None, ge=1, le=720)
     escala_inicio_em: date | None = None
@@ -28,7 +35,9 @@ class AtendenteUpdate(BaseModel):
     role: str | None = None
     ativo: bool | None = None
     setor_ids: list[int] | None = None
+    modo_jornada: ModoJornada | None = None
     usa_escala: bool | None = None
+    horario_semana: dict[str, Any] | None = None
     escala_horas_trabalho: int | None = Field(default=None, ge=1, le=168)
     escala_horas_folga: int | None = Field(default=None, ge=1, le=720)
     escala_inicio_em: date | None = None

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -199,6 +199,7 @@ class PontoSettingsRead(BaseModel):
     usar_feriados_nacionais: bool = True
     fecho_automatico_ativo: bool = False
     fecho_apos_horas: int = 14
+    fecho_margem_pos_saida_minutos: int = 30
     jornada_diaria_minutos: int = 480
     politica_geolocalizacao: PoliticaGeolocalizacao = "opcional"
 
@@ -209,6 +210,7 @@ class PontoSettingsUpdate(BaseModel):
     usar_feriados_nacionais: bool | None = None
     fecho_automatico_ativo: bool | None = None
     fecho_apos_horas: int | None = Field(default=None, ge=4, le=48)
+    fecho_margem_pos_saida_minutos: int | None = Field(default=None, ge=0, le=240)
     jornada_diaria_minutos: int | None = Field(default=None, ge=60, le=1440)
     politica_geolocalizacao: PoliticaGeolocalizacao | None = None
 

--- a/backend/app/services/escala.py
+++ b/backend/app/services/escala.py
@@ -1,15 +1,20 @@
-"""Regras de escala: ciclo horas trabalhadas × horas de folga (#770)."""
+"""Jornada esperada: ciclo X×Y ou escala semanal (#770 / #959/#960)."""
 
 from __future__ import annotations
 
+import json
 from datetime import date, datetime, time, timedelta
+from typing import Any
 from zoneinfo import ZoneInfo
 
 from fastapi import HTTPException, status
 
+from app.core.business_calendar import WEEKDAY_KEYS, horario_semana_from_json, parse_hhmm
 from app.models.atendente import Atendente
 
 PONTO_TZ = ZoneInfo("America/Sao_Paulo")
+
+MODOS_JORNADA = frozenset({"nenhum", "semanal", "ciclo"})
 
 
 def rotulo_escala(horas_trabalho: int | None, horas_folga: int | None) -> str | None:
@@ -18,13 +23,57 @@ def rotulo_escala(horas_trabalho: int | None, horas_folga: int | None) -> str | 
     return f"{horas_trabalho}×{horas_folga}"
 
 
-def escala_configurada(atendente: Atendente) -> bool:
+def modo_jornada(atendente: Atendente) -> str:
+    raw = (getattr(atendente, "modo_jornada", None) or "").strip().lower()
+    if raw == "semanal":
+        return "semanal"
+    if raw == "ciclo":
+        return "ciclo"
+    # nenhum / vazio / legado: usa_escala + ciclo X×Y ainda conta como ciclo
+    if getattr(atendente, "usa_escala", False) and _ciclo_campos_ok(atendente):
+        return "ciclo"
+    return "nenhum"
+
+
+def _ciclo_campos_ok(atendente: Atendente) -> bool:
     return bool(
-        getattr(atendente, "usa_escala", False)
-        and atendente.escala_horas_trabalho
+        atendente.escala_horas_trabalho
         and atendente.escala_horas_folga
         and atendente.escala_inicio_em
     )
+
+
+def horario_semana_dict(atendente: Atendente) -> dict[str, dict[str, Any]] | None:
+    return horario_semana_from_json(getattr(atendente, "horario_semana_json", None))
+
+
+def _semanal_configurado(atendente: Atendente) -> bool:
+    hs = horario_semana_dict(atendente)
+    if not hs:
+        return False
+    for k in WEEKDAY_KEYS:
+        cfg = hs.get(k)
+        if not isinstance(cfg, dict) or not bool(cfg.get("ativo")):
+            continue
+        ini = parse_hhmm(cfg.get("inicio"))
+        fim = parse_hhmm(cfg.get("fim"))
+        if ini and fim and (ini[0], ini[1]) < (fim[0], fim[1]):
+            return True
+    return False
+
+
+def ciclo_configurado(atendente: Atendente) -> bool:
+    return modo_jornada(atendente) == "ciclo" and _ciclo_campos_ok(atendente)
+
+
+def escala_configurada(atendente: Atendente) -> bool:
+    """True se há jornada esperada (semanal ou ciclo) — gera falta/meta/avisos."""
+    m = modo_jornada(atendente)
+    if m == "ciclo":
+        return _ciclo_campos_ok(atendente)
+    if m == "semanal":
+        return _semanal_configurado(atendente)
+    return False
 
 
 def _inicio_ciclo_local(atendente: Atendente) -> datetime:
@@ -34,7 +83,7 @@ def _inicio_ciclo_local(atendente: Atendente) -> datetime:
 
 def em_periodo_trabalho(atendente: Atendente, when: datetime) -> bool:
     """True se o instante cair na janela de trabalho do ciclo X×Y."""
-    if not escala_configurada(atendente):
+    if not ciclo_configurado(atendente):
         return False
     h_trab = int(atendente.escala_horas_trabalho)  # type: ignore[arg-type]
     h_folga = int(atendente.escala_horas_folga)  # type: ignore[arg-type]
@@ -51,14 +100,53 @@ def em_periodo_trabalho(atendente: Atendente, when: datetime) -> bool:
 
 
 def eh_dia_de_trabalho(atendente: Atendente, dia: date) -> bool:
-    """Dia de trabalho se qualquer hora do dia (TZ negócio) cair no período de trabalho."""
-    if not escala_configurada(atendente):
+    """Dia esperado de trabalho conforme o modo de jornada."""
+    m = modo_jornada(atendente)
+    if m == "ciclo":
+        if not _ciclo_campos_ok(atendente):
+            return False
+        for hour in range(24):
+            moment = datetime.combine(dia, time(hour=hour, minute=0), tzinfo=PONTO_TZ)
+            if em_periodo_trabalho(atendente, moment):
+                return True
         return False
-    for hour in range(24):
-        moment = datetime.combine(dia, time(hour=hour, minute=0), tzinfo=PONTO_TZ)
-        if em_periodo_trabalho(atendente, moment):
-            return True
+    if m == "semanal":
+        hs = horario_semana_dict(atendente)
+        if not hs:
+            return False
+        k = WEEKDAY_KEYS[dia.weekday()]
+        cfg = hs.get(k)
+        return bool(isinstance(cfg, dict) and cfg.get("ativo"))
     return False
+
+
+def horario_previsto_do_dia(
+    atendente: Atendente, dia: date
+) -> tuple[tuple[int, int], tuple[int, int]] | None:
+    """Retorna ((h,m) inicio, (h,m) fim) do dia, ou None se não houver janela."""
+    m = modo_jornada(atendente)
+    if m == "semanal":
+        hs = horario_semana_dict(atendente)
+        if not hs:
+            return None
+        k = WEEKDAY_KEYS[dia.weekday()]
+        cfg = hs.get(k)
+        if not isinstance(cfg, dict) or not cfg.get("ativo"):
+            return None
+        ini = parse_hhmm(cfg.get("inicio"))
+        fim = parse_hhmm(cfg.get("fim"))
+        if ini and fim:
+            return ini, fim
+        return None
+    if m == "ciclo":
+        if not eh_dia_de_trabalho(atendente, dia):
+            return None
+        pe = parse_hhmm(getattr(atendente, "horario_previsto_entrada", None))
+        ps = parse_hhmm(getattr(atendente, "horario_previsto_saida", None))
+        if pe and ps:
+            return pe, ps
+        return None
+    return None
 
 
 def dias_do_mes(ano: int, mes: int) -> list[date]:
@@ -70,6 +158,83 @@ def dias_do_mes(ano: int, mes: int) -> list[date]:
     return out
 
 
+def _validar_horario_semana_payload(hs: dict[str, Any] | None) -> None:
+    if not hs or not isinstance(hs, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Informe o horário semanal (dias ativos com início e fim).",
+        )
+    ativos = 0
+    for k in WEEKDAY_KEYS:
+        cfg = hs.get(k)
+        if not isinstance(cfg, dict):
+            continue
+        if not bool(cfg.get("ativo")):
+            continue
+        ini = parse_hhmm(cfg.get("inicio"))
+        fim = parse_hhmm(cfg.get("fim"))
+        if not ini or not fim:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Horário inválido em {k} (use HH:MM).",
+            )
+        if (ini[0], ini[1]) >= (fim[0], fim[1]):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Em {k}, o início deve ser anterior ao fim.",
+            )
+        ativos += 1
+    if ativos < 1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Marque pelo menos um dia ativo na escala semanal.",
+        )
+
+
+def horario_semana_para_json(hs: dict[str, Any] | None) -> str | None:
+    if not hs:
+        return None
+    return json.dumps(hs, ensure_ascii=False)
+
+
+def validar_campos_jornada(
+    *,
+    modo: str,
+    escala_horas_trabalho: int | None,
+    escala_horas_folga: int | None,
+    escala_inicio_em: date | None,
+    horario_semana: dict[str, Any] | None,
+) -> None:
+    """Valida campos do modo de jornada; levanta HTTP 400 se inválido."""
+    m = (modo or "nenhum").strip().lower()
+    if m not in MODOS_JORNADA:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="modo_jornada deve ser nenhum, semanal ou ciclo.",
+        )
+    if m == "nenhum":
+        return
+    if m == "ciclo":
+        if not escala_horas_trabalho or escala_horas_trabalho < 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Informe as horas trabalhadas da escala (mínimo 1).",
+            )
+        if not escala_horas_folga or escala_horas_folga < 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Informe as horas de folga da escala (mínimo 1).",
+            )
+        if escala_inicio_em is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Informe a data de início da escala.",
+            )
+        return
+    # semanal
+    _validar_horario_semana_payload(horario_semana)
+
+
 def validar_campos_escala(
     *,
     usa_escala: bool,
@@ -77,29 +242,17 @@ def validar_campos_escala(
     escala_horas_folga: int | None,
     escala_inicio_em: date | None,
 ) -> None:
-    """Valida campos; levanta HTTP 400 se inválido."""
-    if not usa_escala:
-        return
-    if not escala_horas_trabalho or escala_horas_trabalho < 1:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Informe as horas trabalhadas da escala (mínimo 1).",
-        )
-    if not escala_horas_folga or escala_horas_folga < 1:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Informe as horas de folga da escala (mínimo 1).",
-        )
-    if escala_inicio_em is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Informe a data de início da escala.",
-        )
+    """Compat legado: usa_escala True ≡ ciclo."""
+    validar_campos_jornada(
+        modo="ciclo" if usa_escala else "nenhum",
+        escala_horas_trabalho=escala_horas_trabalho,
+        escala_horas_folga=escala_horas_folga,
+        escala_inicio_em=escala_inicio_em,
+        horario_semana=None,
+    )
 
 
 def validar_horario_previsto(entrada: str | None, saida: str | None) -> None:
-    from app.core.business_calendar import parse_hhmm
-
     for label, val in (("entrada", entrada), ("saída", saida)):
         if val is None or not str(val).strip():
             continue
@@ -110,18 +263,89 @@ def validar_horario_previsto(entrada: str | None, saida: str | None) -> None:
             )
 
 
-def segundos_esperados_dia(atendente: Atendente) -> int:
-    """Duração esperada de um dia de trabalho (horário previsto ou horas do ciclo)."""
-    from app.core.business_calendar import parse_hhmm
-
-    pe = parse_hhmm(getattr(atendente, "horario_previsto_entrada", None))
-    ps = parse_hhmm(getattr(atendente, "horario_previsto_saida", None))
-    if pe and ps:
+def segundos_esperados_dia(atendente: Atendente, dia: date | None = None) -> int:
+    """Duração esperada de um dia de trabalho."""
+    d = dia or datetime.now(PONTO_TZ).date()
+    janela = horario_previsto_do_dia(atendente, d)
+    if janela:
+        pe, ps = janela
         ini = pe[0] * 3600 + pe[1] * 60
         fim = ps[0] * 3600 + ps[1] * 60
         if fim > ini:
             return fim - ini
-    if atendente.escala_horas_trabalho:
+    if ciclo_configurado(atendente) and atendente.escala_horas_trabalho:
         return int(atendente.escala_horas_trabalho) * 3600
     return 0
 
+
+def liberacao_entrada_em(atendente: Atendente, dia: date) -> datetime | None:
+    """Primeiro instante em que a entrada é permitida (inicio − tolerância)."""
+    janela = horario_previsto_do_dia(atendente, dia)
+    if not janela:
+        return None
+    pe, _ = janela
+    tol = int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0)
+    return datetime.combine(dia, time(hour=pe[0], minute=pe[1]), tzinfo=PONTO_TZ) - timedelta(
+        minutes=tol
+    )
+
+
+def limite_atraso_em(atendente: Atendente, dia: date) -> datetime | None:
+    """Após este instante a entrada conta como atraso (inicio + tolerância)."""
+    janela = horario_previsto_do_dia(atendente, dia)
+    if not janela:
+        return None
+    pe, _ = janela
+    tol = int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0)
+    return datetime.combine(dia, time(hour=pe[0], minute=pe[1]), tzinfo=PONTO_TZ) + timedelta(
+        minutes=tol
+    )
+
+
+def saida_prevista_em(atendente: Atendente, dia: date) -> datetime | None:
+    janela = horario_previsto_do_dia(atendente, dia)
+    if not janela:
+        return None
+    _, ps = janela
+    return datetime.combine(dia, time(hour=ps[0], minute=ps[1]), tzinfo=PONTO_TZ)
+
+
+def validar_janela_entrada(atendente: Atendente, when: datetime) -> None:
+    """Bloqueia entrada antes de inicio−tolerância (#964). Admin/sistema não chamam isto."""
+    if not escala_configurada(atendente):
+        return
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=PONTO_TZ)
+    else:
+        when = when.astimezone(PONTO_TZ)
+    dia = when.date()
+    if not eh_dia_de_trabalho(atendente, dia):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Hoje não é dia de trabalho na sua jornada.",
+        )
+    liberacao = liberacao_entrada_em(atendente, dia)
+    if liberacao is None:
+        return
+    if when < liberacao:
+        tol = int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Entrada liberada a partir de {liberacao.strftime('%H:%M')} "
+                f"(tolerância de {tol} min antes do horário)."
+            ),
+        )
+
+
+def rotulo_jornada(atendente: Atendente) -> str | None:
+    m = modo_jornada(atendente)
+    if m == "ciclo":
+        return rotulo_escala(atendente.escala_horas_trabalho, atendente.escala_horas_folga)
+    if m == "semanal" and _semanal_configurado(atendente):
+        hs = horario_semana_dict(atendente) or {}
+        ativos = [k for k in WEEKDAY_KEYS if isinstance(hs.get(k), dict) and hs[k].get("ativo")]
+        if not ativos:
+            return "semanal"
+        return f"semanal ({', '.join(ativos)})"
+    return None

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -122,13 +122,13 @@ def estado_atual(db: Session, atendente: Atendente) -> PontoEstadoRead:
     rotulo = None
     if escala_svc.escala_configurada(atendente):
         hoje_esp = escala_svc.eh_dia_de_trabalho(atendente, hoje)
-        rotulo = escala_svc.rotulo_escala(atendente.escala_horas_trabalho, atendente.escala_horas_folga)
+        rotulo = escala_svc.rotulo_jornada(atendente)
     return PontoEstadoRead(
         em_jornada=entrada is not None,
         em_pausa=bool(ultima and ultima.tipo == "pausa_inicio"),
         entrada_aberta_em=entrada.registrado_em if entrada else None,
         ultima_batida=PontoBatidaRead.model_validate(ultima) if ultima else None,
-        usa_escala=bool(getattr(atendente, "usa_escala", False)),
+        usa_escala=escala_svc.escala_configurada(atendente),
         hoje_esperado=hoje_esp,
         escala_rotulo=rotulo,
     )
@@ -181,6 +181,10 @@ def bater(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Já existe uma jornada aberta. Registre a saída antes de uma nova entrada.",
             )
+        origem_chk = (origem or "web").strip().lower()
+        if origem_chk not in ("admin", "sistema"):
+            when_chk = registrado_em or _agora_utc()
+            escala_svc.validar_janela_entrada(atendente, when_chk)
     elif tipo == "saida":
         if not em_jornada:
             raise HTTPException(
@@ -408,17 +412,15 @@ def _primeira_entrada_do_dia(batidas_dia: list[PontoBatida]) -> PontoBatida | No
 
 
 def _atrasado_entrada(atendente: Atendente, entrada: PontoBatida | None) -> bool:
-    """True se há horário previsto e a 1ª entrada passou previsto + tolerância."""
-    from app.core.business_calendar import parse_hhmm
-
+    """True se a 1ª entrada passou inicio + tolerância (dentro da tol = não atraso)."""
     if entrada is None:
         return False
-    pe = parse_hhmm(getattr(atendente, "horario_previsto_entrada", None))
-    if not pe:
+    if not escala_svc.escala_configurada(atendente):
         return False
-    tol = int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0)
     local = _as_utc(entrada.registrado_em).astimezone(PONTO_TZ)
-    limite = local.replace(hour=pe[0], minute=pe[1], second=0, microsecond=0) + timedelta(minutes=tol)
+    limite = escala_svc.limite_atraso_em(atendente, local.date())
+    if limite is None:
+        return False
     return local > limite
 
 
@@ -524,14 +526,14 @@ def calendario(
         trabalhados = sum(i.duracao_segundos or 0 for i in intervalos if not i.aberto)
         esperado_visual = bool(esp and not feriado)
         if usa and esperado_visual:
-            esperados = escala_svc.segundos_esperados_dia(atendente) or meta_default
+            esperados = escala_svc.segundos_esperados_dia(atendente, d) or meta_default
         elif te or ts:
             esperados = meta_default
         elif esperado_visual:
             esperados = meta_default
         else:
             esperados = 0
-        # Sem escala: dia com batidas compara à meta; dia vazio fica neutro
+        # Sem jornada esperada: dia com batidas compara à meta; dia vazio fica neutro
         esperado_para_cor = esperado_visual if usa else bool(te or ts)
         dias_out.append(
             PontoCalendarioDia(
@@ -564,13 +566,8 @@ def calendario(
         atendente_id=atendente.id,
         ano=ano,
         mes=mes,
-        usa_escala=bool(getattr(atendente, "usa_escala", False)),
-        escala_rotulo=escala_svc.rotulo_escala(
-            atendente.escala_horas_trabalho,
-            atendente.escala_horas_folga,
-        )
-        if getattr(atendente, "usa_escala", False)
-        else None,
+        usa_escala=usa,
+        escala_rotulo=escala_svc.rotulo_jornada(atendente) if usa else None,
         jornada_diaria_minutos=jornada_min,
         dias=dias_out,
     )
@@ -694,7 +691,7 @@ def banco_horas(
             dias_feriado += 1
         elif usa and escala_svc.eh_dia_de_trabalho(atendente, d):
             dias_escala += 1
-            esperado += escala_svc.segundos_esperados_dia(atendente)
+            esperado += escala_svc.segundos_esperados_dia(atendente, d)
         d += timedelta(days=1)
 
     hist = historico(db, atendente, desde=desde, ate=ate, offset=0, limit=10_000)
@@ -732,8 +729,9 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     horas_aberta: float | None = None
 
     feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, hoje)
+    jornada_ativa = escala_svc.escala_configurada(atendente)
     esperado = None
-    if escala_svc.escala_configurada(atendente) and not feriado:
+    if jornada_ativa and not feriado:
         esperado = escala_svc.eh_dia_de_trabalho(atendente, hoje)
 
     entrada = _entrada_da_jornada_aberta(db, atendente.id)
@@ -755,9 +753,14 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
         hb = hb.replace(tzinfo=timezone.utc)
     online = bool(hb and hb >= agora - timedelta(seconds=PRESENCA_TTL_SEC))
 
-    if esperado is True and not tem_entrada_hoje and entrada is None:
-        sem_entrada = True
-        msgs.append("Hoje é dia de trabalho na sua escala e ainda não há entrada registrada.")
+    # Modo nenhum: sem avisos de falta/atraso (#959)
+    if jornada_ativa:
+        if esperado is True and not tem_entrada_hoje and entrada is None:
+            sem_entrada = True
+            msgs.append("Hoje é dia de trabalho na sua jornada e ainda não há entrada registrada.")
+
+        if _atrasado_entrada(atendente, primeira):
+            msgs.append("Entrada registrada após o horário previsto (fora da tolerância).")
 
     if online and entrada is None:
         online_sem = True
@@ -771,9 +774,10 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
             msgs.append(
                 f"Jornada aberta há cerca de {horas_aberta:.0f} h — lembre-se de registrar a saída."
             )
-
-    if _atrasado_entrada(atendente, primeira):
-        msgs.append("Entrada registrada após o horário previsto (com tolerância).")
+        elif jornada_ativa:
+            saida_prev = escala_svc.saida_prevista_em(atendente, hoje)
+            if saida_prev is not None and agora.astimezone(PONTO_TZ) >= saida_prev:
+                msgs.append("Horário de saída previsto já passou — registre a saída.")
 
     return PontoAlertasMe(
         sem_entrada_em_dia_escala=sem_entrada,

--- a/backend/app/services/ponto_settings.py
+++ b/backend/app/services/ponto_settings.py
@@ -55,6 +55,13 @@ def settings_update(db: Session, admin: Atendente, data: PontoSettingsUpdate) ->
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="fecho_apos_horas deve estar entre 4 e 48.",
             )
+    if "fecho_margem_pos_saida_minutos" in payload:
+        m = payload["fecho_margem_pos_saida_minutos"]
+        if m is None or m < 0 or m > 240:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="fecho_margem_pos_saida_minutos deve estar entre 0 e 240.",
+            )
     if "jornada_diaria_minutos" in payload:
         m = payload["jornada_diaria_minutos"]
         if m is None or m < 60 or m > 1440:
@@ -268,8 +275,14 @@ def remover_feriado(db: Session, admin: Atendente, feriado_id: int) -> None:
 
 
 def processar_fecho_automatico(db: Session, *, limit: int = 100) -> int:
-    """Fecha jornadas abertas além do limite, só onde a política está ativa."""
+    """Fecha jornadas esquecidas: N horas abertas OU após saída prevista + margem (#961)."""
+    from datetime import timedelta
+    from zoneinfo import ZoneInfo
+
+    from app.services import escala as escala_svc
     from app.services import ponto as ponto_svc
+
+    PONTO_TZ = ZoneInfo("America/Sao_Paulo")
 
     settings_rows = (
         db.query(PontoSettings)
@@ -283,7 +296,7 @@ def processar_fecho_automatico(db: Session, *, limit: int = 100) -> int:
     fechados = 0
     for st in settings_rows:
         horas = max(4, int(st.fecho_apos_horas or 14))
-        limite = agora.timestamp() - horas * 3600
+        margem = max(0, int(getattr(st, "fecho_margem_pos_saida_minutos", 30) or 0))
         atendentes = (
             db.query(Atendente)
             .filter(Atendente.tenant_id == st.tenant_id, Atendente.ativo.is_(True))
@@ -296,7 +309,17 @@ def processar_fecho_automatico(db: Session, *, limit: int = 100) -> int:
             if entrada is None:
                 continue
             reg = ponto_svc._as_utc(entrada.registrado_em)
-            if reg.timestamp() > limite:
+            por_horas = (agora - reg).total_seconds() >= horas * 3600
+            criterios: list[str] = []
+            if por_horas:
+                criterios.append("n_horas")
+            dia = reg.astimezone(PONTO_TZ).date()
+            saida_prev = escala_svc.saida_prevista_em(a, dia)
+            if saida_prev is not None:
+                limite_saida = saida_prev + timedelta(minutes=margem)
+                if agora.astimezone(PONTO_TZ) >= limite_saida:
+                    criterios.append("saida_prevista")
+            if not criterios:
                 continue
             if ponto_svc.em_pausa_aberta(db, a.id):
                 ponto_svc.bater(
@@ -319,13 +342,16 @@ def processar_fecho_automatico(db: Session, *, limit: int = 100) -> int:
                 db,
                 "ponto_batida",
                 saida.id,
-                "fecho_automatico",
+                "esquecimento",
                 None,
                 payload={
                     "atendente_id": a.id,
                     "tenant_id": st.tenant_id,
                     "fecho_apos_horas": horas,
+                    "fecho_margem_pos_saida_minutos": margem,
+                    "criterios": criterios,
                     "entrada_em": reg.isoformat(),
+                    "motivo": "esquecimento",
                 },
             )
             fechados += 1

--- a/backend/tests/test_ponto_jornada_959.py
+++ b/backend/tests/test_ponto_jornada_959.py
@@ -1,0 +1,150 @@
+"""Ponto jornada semanal, janela de entrada e fecho por esquecimento (#959 Lote A)."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.ponto_batida import PontoBatida
+from app.services import escala as escala_svc
+from app.services import ponto as ponto_svc
+from app.services.ponto import _atrasado_entrada
+from app.services.ponto_settings import get_or_create_settings, processar_fecho_automatico
+
+TZ = ZoneInfo("America/Sao_Paulo")
+
+HS_SEG_SEX = {
+    "seg": {"ativo": True, "inicio": "08:00", "fim": "18:00"},
+    "ter": {"ativo": True, "inicio": "08:00", "fim": "18:00"},
+    "qua": {"ativo": True, "inicio": "08:00", "fim": "18:00"},
+    "qui": {"ativo": True, "inicio": "08:00", "fim": "18:00"},
+    "sex": {"ativo": True, "inicio": "08:00", "fim": "17:00"},
+    "sab": {"ativo": False, "inicio": "08:00", "fim": "12:00"},
+    "dom": {"ativo": False, "inicio": "08:00", "fim": "12:00"},
+}
+
+
+def test_jornada_semanal_seg_sex_e_modo_nenhum(client, seed_base, auth_headers, db_session):
+    a1 = seed_base["a1"]
+    r = client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=auth_headers["admin"],
+        json={"modo_jornada": "semanal", "horario_semana": HS_SEG_SEX, "tolerancia_atraso_minutos": 15},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["modo_jornada"] == "semanal"
+    assert body["usa_escala"] is True
+    assert body["horario_semana"]["sex"]["fim"] == "17:00"
+
+    db_session.expire_all()
+    db_session.refresh(a1)
+    assert escala_svc.eh_dia_de_trabalho(a1, date(2026, 8, 26)) is True  # qua
+    assert escala_svc.eh_dia_de_trabalho(a1, date(2026, 8, 29)) is False  # sáb
+    assert escala_svc.eh_dia_de_trabalho(a1, date(2026, 8, 30)) is False  # dom
+
+    r2 = client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=auth_headers["admin"],
+        json={"modo_jornada": "nenhum"},
+    )
+    assert r2.status_code == 200
+    db_session.expire_all()
+    db_session.refresh(a1)
+    assert escala_svc.escala_configurada(a1) is False
+    cal = client.get(
+        "/v1/ponto/me/calendario",
+        headers=auth_headers["a1"],
+        params={"ano": 2026, "mes": 8},
+    )
+    assert cal.status_code == 200
+    dia = next(d for d in cal.json()["dias"] if d["data"] == "2026-08-26")
+    assert dia["status"] == "livre"
+
+
+def test_entrada_janela_e_atraso_na_tolerancia(client, seed_base, auth_headers, db_session):
+    a1 = seed_base["a1"]
+    a1.modo_jornada = "semanal"
+    a1.usa_escala = True
+    a1.tolerancia_atraso_minutos = 15
+    a1.horario_semana_json = json.dumps(HS_SEG_SEX, ensure_ascii=False)
+    db_session.flush()
+
+    early = datetime(2026, 8, 26, 7, 0, tzinfo=TZ)
+    with pytest.raises(HTTPException) as ei:
+        escala_svc.validar_janela_entrada(a1, early)
+    assert ei.value.status_code == 400
+
+    escala_svc.validar_janela_entrada(a1, datetime(2026, 8, 26, 7, 50, tzinfo=TZ))
+
+    bat_ok = PontoBatida(
+        tenant_id=a1.tenant_id,
+        atendente_id=a1.id,
+        tipo="entrada",
+        registrado_em=datetime(2026, 8, 26, 8, 10, tzinfo=TZ),
+        origem="admin",
+        anulada=False,
+    )
+    assert _atrasado_entrada(a1, bat_ok) is False
+
+    bat_late = PontoBatida(
+        tenant_id=a1.tenant_id,
+        atendente_id=a1.id,
+        tipo="entrada",
+        registrado_em=datetime(2026, 8, 26, 8, 20, tzinfo=TZ),
+        origem="admin",
+        anulada=False,
+    )
+    assert _atrasado_entrada(a1, bat_late) is True
+
+
+def test_fecho_por_saida_prevista(client, seed_base, auth_headers, db_session):
+    a1 = seed_base["a1"]
+    agora_local = datetime.now(TZ)
+    fim_dt = agora_local - timedelta(minutes=45)
+    ini_dt = agora_local - timedelta(hours=8)
+    ini = ini_dt.strftime("%H:%M")
+    fim = fim_dt.strftime("%H:%M")
+    if ini >= fim:
+        ini = "00:00"
+        fim = "00:15"
+        ini_dt = agora_local.replace(hour=0, minute=0, second=0, microsecond=0)
+        # se ainda estamos antes de 00:15, força fim no passado relativo
+        if agora_local.hour == 0 and agora_local.minute < 15:
+            fim = "00:01"
+
+    weekday_keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    k = weekday_keys[agora_local.weekday()]
+    hs = {d: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for d in weekday_keys}
+    hs[k] = {"ativo": True, "inicio": ini, "fim": fim}
+
+    a1.modo_jornada = "semanal"
+    a1.usa_escala = True
+    a1.tolerancia_atraso_minutos = 0
+    a1.horario_semana_json = json.dumps(hs, ensure_ascii=False)
+
+    st = get_or_create_settings(db_session, a1.tenant_id)
+    st.fecho_automatico_ativo = True
+    st.fecho_apos_horas = 48
+    st.fecho_margem_pos_saida_minutos = 0
+    db_session.flush()
+
+    ponto_svc.bater(
+        db_session,
+        a1,
+        "entrada",
+        origem="admin",
+        registrado_em=ini_dt,
+        commit=False,
+    )
+    db_session.flush()
+
+    n = processar_fecho_automatico(db_session, limit=10)
+    assert n >= 1
+    db_session.commit()
+    me = client.get("/v1/ponto/me", headers=auth_headers["a1"])
+    assert me.json()["em_jornada"] is False

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2444,6 +2444,7 @@ export namespace Setores {
 }
 
 export namespace Atendentes {
+  export type ModoJornada = 'nenhum' | 'semanal' | 'ciclo'
   export interface Atendente {
     id: number;
     email: string;
@@ -2453,7 +2454,9 @@ export namespace Atendentes {
     setor_ids: number[];
     e_financeiro?: boolean;
     must_change_password?: boolean;
+    modo_jornada?: ModoJornada;
     usa_escala?: boolean;
+    horario_semana?: Record<string, { ativo?: boolean; inicio?: string; fim?: string }> | null;
     escala_horas_trabalho?: number | null;
     escala_horas_folga?: number | null;
     escala_inicio_em?: string | null;
@@ -2471,7 +2474,9 @@ export namespace Atendentes {
     role?: string;
     ativo?: boolean;
     setor_ids?: number[];
+    modo_jornada?: ModoJornada;
     usa_escala?: boolean;
+    horario_semana?: Record<string, { ativo?: boolean; inicio?: string; fim?: string }> | null;
     escala_horas_trabalho?: number | null;
     escala_horas_folga?: number | null;
     escala_inicio_em?: string | null;
@@ -2486,7 +2491,9 @@ export namespace Atendentes {
     role?: string;
     ativo?: boolean;
     setor_ids?: number[];
+    modo_jornada?: ModoJornada;
     usa_escala?: boolean;
+    horario_semana?: Record<string, { ativo?: boolean; inicio?: string; fim?: string }> | null;
     escala_horas_trabalho?: number | null;
     escala_horas_folga?: number | null;
     escala_inicio_em?: string | null;
@@ -4845,6 +4852,7 @@ export namespace Ponto {
     usar_feriados_nacionais: boolean
     fecho_automatico_ativo: boolean
     fecho_apos_horas: number
+    fecho_margem_pos_saida_minutos: number
     jornada_diaria_minutos: number
     politica_geolocalizacao: PoliticaGeolocalizacao
   }
@@ -4856,6 +4864,7 @@ export namespace Ponto {
     usar_feriados_nacionais?: boolean
     fecho_automatico_ativo?: boolean
     fecho_apos_horas?: number
+    fecho_margem_pos_saida_minutos?: number
     jornada_diaria_minutos?: number
     politica_geolocalizacao?: PoliticaGeolocalizacao
   }

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { ApiError, atendentes, setores, type Setores } from '../api/client'
+import { ApiError, atendentes, setores, type Atendentes, type Setores } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
 import { Input } from '../components/ui/Input'
@@ -13,9 +13,18 @@ import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { FormSection } from '../components/ui/FormSection'
 import { InlineCadastroFooter } from '../components/ui/InlineCadastroPanel'
 import { CadastroFormPageShell } from '../components/ui/CadastroFormPageShell'
+import { HorarioSemanaEditor } from '../components/horario/HorarioSemanaEditor'
+import {
+  horarioSemanaFromApi,
+  horarioSemanaPadrao,
+  validarHorarioSemana,
+  type HorarioSemana,
+} from '../lib/horarioSemana'
 import { SemPermissao } from './SemPermissao'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
+
+type ModoJornada = Atendentes.ModoJornada
 
 export function AtendenteForm() {
   const { id } = useParams<{ id?: string }>()
@@ -38,7 +47,8 @@ export function AtendenteForm() {
   const [role, setRole] = useState<'admin' | 'atendente' | 'comercial'>('atendente')
   const [ativo, setAtivo] = useState(true)
   const [setorIds, setSetorIds] = useState<number[]>([])
-  const [usaEscala, setUsaEscala] = useState(false)
+  const [modoJornada, setModoJornada] = useState<ModoJornada>('nenhum')
+  const [horarioSemana, setHorarioSemana] = useState<HorarioSemana>(() => horarioSemanaPadrao())
   const [escalaHorasTrabalho, setEscalaHorasTrabalho] = useState('12')
   const [escalaHorasFolga, setEscalaHorasFolga] = useState('36')
   const [escalaInicioEm, setEscalaInicioEm] = useState('')
@@ -75,7 +85,14 @@ export function AtendenteForm() {
         setRole((a.role as 'admin' | 'atendente' | 'comercial') || 'atendente')
         setAtivo(a.ativo)
         setSetorIds(a.setor_ids ?? [])
-        setUsaEscala(Boolean(a.usa_escala))
+        const modo: ModoJornada =
+          a.modo_jornada === 'semanal' || a.modo_jornada === 'ciclo' || a.modo_jornada === 'nenhum'
+            ? a.modo_jornada
+            : a.usa_escala
+              ? 'ciclo'
+              : 'nenhum'
+        setModoJornada(modo)
+        setHorarioSemana(horarioSemanaFromApi(a.horario_semana ?? undefined))
         setEscalaHorasTrabalho(a.escala_horas_trabalho != null ? String(a.escala_horas_trabalho) : '12')
         setEscalaHorasFolga(a.escala_horas_folga != null ? String(a.escala_horas_folga) : '36')
         setEscalaInicioEm(a.escala_inicio_em ?? '')
@@ -127,10 +144,12 @@ export function AtendenteForm() {
     }
   }
 
-  function payloadEscala() {
-    if (!usaEscala) {
+  function payloadJornada(): Atendentes.Create | Atendentes.Update {
+    if (modoJornada === 'nenhum') {
       return {
+        modo_jornada: 'nenhum',
         usa_escala: false,
+        horario_semana: null,
         escala_horas_trabalho: null,
         escala_horas_folga: null,
         escala_inicio_em: null,
@@ -139,8 +158,23 @@ export function AtendenteForm() {
         tolerancia_atraso_minutos: 0,
       }
     }
+    if (modoJornada === 'semanal') {
+      return {
+        modo_jornada: 'semanal',
+        usa_escala: true,
+        horario_semana: horarioSemana,
+        escala_horas_trabalho: null,
+        escala_horas_folga: null,
+        escala_inicio_em: null,
+        horario_previsto_entrada: null,
+        horario_previsto_saida: null,
+        tolerancia_atraso_minutos: Math.max(0, Number(toleranciaAtraso) || 0),
+      }
+    }
     return {
+      modo_jornada: 'ciclo',
       usa_escala: true,
+      horario_semana: null,
       escala_horas_trabalho: Number(escalaHorasTrabalho) || null,
       escala_horas_folga: Number(escalaHorasFolga) || null,
       escala_inicio_em: escalaInicioEm || null,
@@ -152,9 +186,16 @@ export function AtendenteForm() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    if (modoJornada === 'semanal') {
+      const erroHs = validarHorarioSemana(horarioSemana)
+      if (erroHs) {
+        toast.showWarning(erroHs)
+        return
+      }
+    }
     setSaving(true)
     try {
-      const escala = payloadEscala()
+      const escala = payloadJornada()
       if (isEdit && !Number.isNaN(atendenteId)) {
         await atendentes.update(atendenteId, {
           email,
@@ -284,18 +325,35 @@ export function AtendenteForm() {
                 statusOffText="Inativo"
               />
             </FormSection>
-            <FormSection title="Escala de trabalho">
-              <Switch
-                bare
-                checked={usaEscala}
-                onCheckedChange={setUsaEscala}
-                label="Usa escala"
-                description="Quando ativo, o sistema calcula dias de trabalho e folga a partir do ciclo horas × horas."
-                showStatusPill
-                statusOnText="Sim"
-                statusOffText="Não"
+            <FormSection title="Jornada de trabalho">
+              <Select
+                label="Modo de jornada"
+                value={modoJornada}
+                onChange={(v) => setModoJornada(String(v) as ModoJornada)}
+                options={[
+                  { value: 'nenhum', label: 'Nenhum (sem falta nem avisos de horário)' },
+                  { value: 'semanal', label: 'Escala semanal (dias da semana)' },
+                  { value: 'ciclo', label: 'Escala ciclo (ex.: 12×36)' },
+                ]}
               />
-              {usaEscala && (
+              {modoJornada === 'semanal' && (
+                <div className="mt-4 space-y-3">
+                  <HorarioSemanaEditor value={horarioSemana} onChange={setHorarioSemana} />
+                  <Input
+                    label="Tolerância (min) — antes e depois do início"
+                    type="number"
+                    min={0}
+                    max={120}
+                    value={toleranciaAtraso}
+                    onChange={(e) => setToleranciaAtraso(e.target.value)}
+                  />
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    Entrada liberada a partir de início menos a tolerância. Dentro da tolerância não conta
+                    atraso.
+                  </p>
+                </div>
+              )}
+              {modoJornada === 'ciclo' && (
                 <div className="mt-4 space-y-3">
                   <Select
                     label="Preset"
@@ -353,7 +411,7 @@ export function AtendenteForm() {
                       onChange={(e) => setHorarioSaida(e.target.value)}
                     />
                     <Input
-                      label="Tolerância atraso (min)"
+                      label="Tolerância (min)"
                       type="number"
                       min={0}
                       max={120}
@@ -362,8 +420,8 @@ export function AtendenteForm() {
                     />
                   </div>
                   <p className="text-xs text-slate-500 dark:text-slate-400">
-                    Ciclo contínuo a partir desta data (ex.: 12 h de trabalho e 36 h de folga, repetindo). Horário
-                    previsto é opcional e sinaliza atraso na conformidade.
+                    Ciclo contínuo a partir desta data. A tolerância vale antes e depois do horário de
+                    entrada.
                   </p>
                 </div>
               )}

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -264,6 +264,7 @@ export function PontoEquipe() {
         usar_feriados_nacionais: settings.usar_feriados_nacionais,
         fecho_automatico_ativo: settings.fecho_automatico_ativo,
         fecho_apos_horas: settings.fecho_apos_horas,
+        fecho_margem_pos_saida_minutos: settings.fecho_margem_pos_saida_minutos ?? 30,
         jornada_diaria_minutos: settings.jornada_diaria_minutos,
         politica_geolocalizacao: settings.politica_geolocalizacao,
       })
@@ -407,6 +408,19 @@ export function PontoEquipe() {
                 hint="pendentes"
               />
             </div>
+            {(digest?.itens ?? []).some((i) => i.status === 'falta' || i.atrasado) ? (
+              <ul className="space-y-1 text-sm text-amber-900 dark:text-amber-100">
+                {(digest?.itens ?? [])
+                  .filter((i) => i.status === 'falta' || i.atrasado)
+                  .map((i) => (
+                    <li key={`alerta-${i.atendente_id}`}>
+                      <span className="font-medium">{i.nome}</span>
+                      {i.status === 'falta' ? ' — falta' : null}
+                      {i.atrasado ? ' — atraso' : null}
+                    </li>
+                  ))}
+              </ul>
+            ) : null}
           </div>
         )}
       </Card>
@@ -682,10 +696,10 @@ export function PontoEquipe() {
                     setSettings({ ...settings, fecho_automatico_ativo: e.target.checked })
                   }
                 />
-                Fechar jornada automaticamente após N horas (desligado por padrão)
+                Fechar jornada esquecida automaticamente (desligado por padrão)
               </label>
               <Input
-                label="Horas para fecho automático"
+                label="Horas abertas para fecho (critério 1)"
                 type="number"
                 min={4}
                 max={48}
@@ -694,6 +708,23 @@ export function PontoEquipe() {
                   setSettings({ ...settings, fecho_apos_horas: Number(e.target.value) || 14 })
                 }
               />
+              <Input
+                label="Margem após saída prevista, minutos (critério 2)"
+                type="number"
+                min={0}
+                max={240}
+                value={String(settings.fecho_margem_pos_saida_minutos ?? 30)}
+                onChange={(e) =>
+                  setSettings({
+                    ...settings,
+                    fecho_margem_pos_saida_minutos: Number(e.target.value) || 0,
+                  })
+                }
+              />
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                Fecha pelo critério que ocorrer primeiro (N horas abertas ou saída prevista + margem),
+                com motivo esquecimento.
+              </p>
               <Input
                 label="Jornada diária (minutos) — meta do calendário"
                 type="number"


### PR DESCRIPTION
## Summary
- Modo de jornada no cadastro: **nenhum** / **semanal** (grade Dia/Aberto/Início/Fim como no chat) / **ciclo** X×Y
- Entrada só a partir de início−tolerância; atraso só após início+tolerância; fecho por esquecimento (N horas **ou** saída prevista+margem)
- Alertas in-app de falta/atraso (colaborador + digest admin) e settings de fecho na equipe

Closes #960
Closes #961
Closes #962
Closes #963
Closes #964

Épico: #959 · SaaS `#S202608-0006` (fecho/esquecimento). **Fora deste PR:** #965 / #966 (WhatsApp/HE).

## CHANGELOG (obrigatório se há mudança de produto)
- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**

## Test plan
- [ ] Migration `124_ponto_modo_jornada` sobe limpa (`alembic heads` único)
- [ ] Cadastro: gravar jornada semanal (ex. seg–sex) e ciclo; modo nenhum não gera falta
- [ ] Entrada antes de início−tol bloqueada; dentro da tol sem badge de atraso
- [ ] Fecho automático: critério saída+margem e/ou N horas (motivo esquecimento)
- [ ] Banner Meu ponto + digest Ponto da equipe listam faltas/atrasos
- [ ] `pytest` ponto + suíte; `tsc -b` frontend

## Follow-ups / backlog
- [x] #965 bloquear pegar WhatsApp + HE admin
- [x] #966 HE antecipada + teto
- [x] Épico #967 (#968–#982) backlog RH/profissionalismo