### PR TITLE
feat(ponto): locais de trabalho por atendente (#984)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### DeskRudder
 
+#### Melhorias
+
+- Ponto (#984): locais de trabalho no **cadastro do atendente** (empresa + extras no mapa OSM); pin da empresa em Configurações → Empresa; raio e ativar/desativar por local; removido o card global de Locais em Ponto da equipe
+
 #### Correções
 
 - WhatsApp (#947 / #S202608-0005): ao abrir o menu Editar/Apagar/Reagir (ou editar mensagem), o strip de emojis do hover deixa de cobrir as opções

--- a/backend/alembic/versions/125_ponto_locais_atendente.py
+++ b/backend/alembic/versions/125_ponto_locais_atendente.py
@@ -1,0 +1,87 @@
+"""Locais de ponto por atendente + pin da empresa (#984).
+
+Revision ID: 125_ponto_locais_atendente
+Revises: 124_ponto_modo_jornada
+Create Date: 2026-08-26
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "125_ponto_locais_atendente"
+down_revision = "124_ponto_modo_jornada"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("empresa_sistema"):
+        cols = {c["name"] for c in insp.get_columns("empresa_sistema")}
+        if "latitude" not in cols:
+            op.add_column("empresa_sistema", sa.Column("latitude", sa.Float(), nullable=True))
+        if "longitude" not in cols:
+            op.add_column("empresa_sistema", sa.Column("longitude", sa.Float(), nullable=True))
+        if "ponto_raio_metros" not in cols:
+            op.add_column(
+                "empresa_sistema",
+                sa.Column("ponto_raio_metros", sa.Integer(), nullable=False, server_default="200"),
+            )
+
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "usar_local_empresa" not in cols:
+            op.add_column(
+                "atendentes",
+                sa.Column("usar_local_empresa", sa.Boolean(), nullable=False, server_default="true"),
+            )
+        if "local_empresa_raio_metros" not in cols:
+            op.add_column(
+                "atendentes",
+                sa.Column("local_empresa_raio_metros", sa.Integer(), nullable=True),
+            )
+
+    if insp.has_table("ponto_locais"):
+        cols = {c["name"] for c in insp.get_columns("ponto_locais")}
+        if "atendente_id" not in cols:
+            op.add_column(
+                "ponto_locais",
+                sa.Column(
+                    "atendente_id",
+                    sa.Integer(),
+                    sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+                    nullable=True,
+                ),
+            )
+            op.create_index("ix_ponto_locais_atendente_id", "ponto_locais", ["atendente_id"])
+        if "endereco" not in cols:
+            op.add_column("ponto_locais", sa.Column("endereco", sa.String(512), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("ponto_locais"):
+        cols = {c["name"] for c in insp.get_columns("ponto_locais")}
+        if "endereco" in cols:
+            op.drop_column("ponto_locais", "endereco")
+        if "atendente_id" in cols:
+            op.drop_index("ix_ponto_locais_atendente_id", table_name="ponto_locais")
+            op.drop_column("ponto_locais", "atendente_id")
+
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        for name in ("local_empresa_raio_metros", "usar_local_empresa"):
+            if name in cols:
+                op.drop_column("atendentes", name)
+
+    if insp.has_table("empresa_sistema"):
+        cols = {c["name"] for c in insp.get_columns("empresa_sistema")}
+        for name in ("ponto_raio_metros", "longitude", "latitude"):
+            if name in cols:
+                op.drop_column("empresa_sistema", name)

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -60,6 +60,8 @@ def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) ->
         horario_previsto_entrada=getattr(atendente, "horario_previsto_entrada", None),
         horario_previsto_saida=getattr(atendente, "horario_previsto_saida", None),
         tolerancia_atraso_minutos=int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0),
+        usar_local_empresa=bool(getattr(atendente, "usar_local_empresa", True)),
+        local_empresa_raio_metros=getattr(atendente, "local_empresa_raio_metros", None),
         saas_setor_ids=[s.id for s in saas],
         saas_setor_nomes=[s.nome for s in saas],
     )
@@ -187,6 +189,8 @@ def criar_atendente(
         role=role,
         ativo=data.ativo,
         tolerancia_atraso_minutos=int(data.tolerancia_atraso_minutos or 0) if modo != "nenhum" else 0,
+        usar_local_empresa=bool(getattr(data, "usar_local_empresa", True)),
+        local_empresa_raio_metros=getattr(data, "local_empresa_raio_metros", None),
     )
     _aplicar_campos_jornada(
         atendente,

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -121,7 +121,7 @@ def minhas_settings_ponto(
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
     ponto_svc.exigir_acesso_ponto(atendente)
-    out = ponto_settings_svc.settings_public_read(db, atendente.tenant_id)
+    out = ponto_settings_svc.settings_public_read(db, atendente)
     db.commit()
     return out
 
@@ -360,10 +360,14 @@ def remover_feriado(
 
 @router.get("/locais", response_model=list[PontoLocalRead])
 def listar_locais(
+    atendente_id: int | None = Query(None),
+    so_orfos: bool = Query(False, description="Só locais legados sem atendente"),
     db: Session = Depends(get_db),
     admin: Atendente = Depends(exigir_admin),
 ):
-    return ponto_settings_svc.listar_locais(db, admin.tenant_id)
+    return ponto_settings_svc.listar_locais(
+        db, admin.tenant_id, atendente_id=atendente_id, so_orfos=so_orfos
+    )
 
 
 @router.post("/locais", response_model=PontoLocalRead, status_code=201)

--- a/backend/app/api/system_settings.py
+++ b/backend/app/api/system_settings.py
@@ -58,6 +58,9 @@ def _company_out(row: EmpresaSistema | None) -> EmpresaSistemaRead:
         cidade=row.cidade,
         estado=row.estado,
         cep=row.cep,
+        latitude=getattr(row, "latitude", None),
+        longitude=getattr(row, "longitude", None),
+        ponto_raio_metros=int(getattr(row, "ponto_raio_metros", None) or 200),
         logo_url=logo_url,
     )
 

--- a/backend/app/models/atendente.py
+++ b/backend/app/models/atendente.py
@@ -45,6 +45,9 @@ class Atendente(Base):
     horario_previsto_entrada = Column(String(5), nullable=True)  # HH:MM (ciclo)
     horario_previsto_saida = Column(String(5), nullable=True)
     tolerancia_atraso_minutos = Column(Integer, nullable=False, default=0, server_default="0")
+    # Locais de ponto (#984): empresa + extras por atendente.
+    usar_local_empresa = Column(Boolean, nullable=False, default=True, server_default="true")
+    local_empresa_raio_metros = Column(Integer, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/app/models/empresa_sistema.py
+++ b/backend/app/models/empresa_sistema.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy import Column, DateTime, Float, Integer, String
 from sqlalchemy.sql import func
 
 from app.database import Base
@@ -26,6 +26,10 @@ class EmpresaSistema(Base):
     cidade = Column(String(100), nullable=True)
     estado = Column(String(2), nullable=True)
     cep = Column(String(10), nullable=True)
+    # Pin do local de trabalho da empresa (#984).
+    latitude = Column(Float, nullable=True)
+    longitude = Column(Float, nullable=True)
+    ponto_raio_metros = Column(Integer, nullable=False, default=200, server_default="200")
     logo_filename = Column(String(255), nullable=True)
     logo_mimetype = Column(String(100), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/ponto_settings.py
+++ b/backend/app/models/ponto_settings.py
@@ -27,7 +27,12 @@ class PontoLocal(Base):
 
     id = Column(Integer, primary_key=True)
     tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    # NULL = legado sem dono (#984); não entra no geofence até reatribuir.
+    atendente_id = Column(
+        Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=True, index=True
+    )
     nome = Column(String(255), nullable=False)
+    endereco = Column(String(512), nullable=True)
     latitude = Column(Float, nullable=False)
     longitude = Column(Float, nullable=False)
     raio_metros = Column(Integer, nullable=False, default=200, server_default="200")

--- a/backend/app/schemas/atendente.py
+++ b/backend/app/schemas/atendente.py
@@ -21,6 +21,8 @@ class AtendenteBase(BaseModel):
     horario_previsto_entrada: str | None = Field(default=None, max_length=5)
     horario_previsto_saida: str | None = Field(default=None, max_length=5)
     tolerancia_atraso_minutos: int = Field(default=0, ge=0, le=120)
+    usar_local_empresa: bool = True
+    local_empresa_raio_metros: int | None = Field(default=None, ge=20, le=50_000)
 
 
 class AtendenteCreate(AtendenteBase):
@@ -44,6 +46,8 @@ class AtendenteUpdate(BaseModel):
     horario_previsto_entrada: str | None = Field(default=None, max_length=5)
     horario_previsto_saida: str | None = Field(default=None, max_length=5)
     tolerancia_atraso_minutos: int | None = Field(default=None, ge=0, le=120)
+    usar_local_empresa: bool | None = None
+    local_empresa_raio_metros: int | None = Field(default=None, ge=20, le=50_000)
 
 
 class AtendenteRead(AtendenteBase):

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -44,7 +44,9 @@ class PontoSettingsPublicRead(BaseModel):
 
 
 class PontoLocalCreate(BaseModel):
+    atendente_id: int = Field(..., ge=1)
     nome: str = Field(..., min_length=1, max_length=255)
+    endereco: str | None = Field(default=None, max_length=512)
     latitude: float = Field(..., ge=-90, le=90)
     longitude: float = Field(..., ge=-180, le=180)
     raio_metros: int = Field(default=200, ge=20, le=50_000)
@@ -53,7 +55,9 @@ class PontoLocalCreate(BaseModel):
 
 class PontoLocalRead(BaseModel):
     id: int
+    atendente_id: int | None = None
     nome: str
+    endereco: str | None = None
     latitude: float
     longitude: float
     raio_metros: int
@@ -63,7 +67,9 @@ class PontoLocalRead(BaseModel):
 
 
 class PontoLocalUpdate(BaseModel):
+    atendente_id: int | None = Field(default=None, ge=1)
     nome: str | None = Field(default=None, min_length=1, max_length=255)
+    endereco: str | None = Field(default=None, max_length=512)
     latitude: float | None = Field(default=None, ge=-90, le=90)
     longitude: float | None = Field(default=None, ge=-180, le=180)
     raio_metros: int | None = Field(default=None, ge=20, le=50_000)

--- a/backend/app/schemas/system_company.py
+++ b/backend/app/schemas/system_company.py
@@ -15,6 +15,9 @@ class EmpresaSistemaRead(BaseModel):
     cidade: str | None = None
     estado: str | None = None
     cep: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    ponto_raio_metros: int = 200
     logo_url: str | None = None
 
 
@@ -32,3 +35,6 @@ class EmpresaSistemaUpdate(BaseModel):
     cidade: str | None = None
     estado: str | None = None
     cep: str | None = None
+    latitude: float | None = Field(default=None, ge=-90, le=90)
+    longitude: float | None = Field(default=None, ge=-180, le=180)
+    ponto_raio_metros: int | None = Field(default=None, ge=20, le=50_000)

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -166,7 +166,7 @@ def bater(
 
     geo_res = geo_svc.validar_batida_geolocalizacao(
         db,
-        atendente.tenant_id,
+        atendente,
         latitude=float(latitude) if has_lat else None,
         longitude=float(longitude) if has_lon else None,
     )

--- a/backend/app/services/ponto_geofence.py
+++ b/backend/app/services/ponto_geofence.py
@@ -1,4 +1,4 @@
-"""Geofence e política de geolocalização (#844)."""
+"""Geofence e política de geolocalização (#844 / #984)."""
 
 from __future__ import annotations
 
@@ -8,9 +8,20 @@ from dataclasses import dataclass
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
-from app.models.ponto_settings import PontoLocal, PontoSettings
+from app.models.atendente import Atendente
+from app.models.empresa_sistema import EmpresaSistema
+from app.models.ponto_settings import PontoLocal
 
 POLITICAS_VALIDAS = frozenset({"opcional", "recomendada", "obrigatoria"})
+
+
+@dataclass
+class LocalEfetivo:
+    id: int | None
+    nome: str
+    latitude: float
+    longitude: float
+    raio_metros: int
 
 
 @dataclass
@@ -31,31 +42,78 @@ def distancia_metros(lat1: float, lon1: float, lat2: float, lon2: float) -> floa
     return 2 * r * math.asin(math.sqrt(a))
 
 
+def _empresa_sistema(db: Session) -> EmpresaSistema | None:
+    return db.query(EmpresaSistema).order_by(EmpresaSistema.id.asc()).first()
+
+
+def locais_efetivos_ativos(db: Session, atendente: Atendente) -> list[LocalEfetivo]:
+    """Locais ativos do atendente: empresa (se ligada + pin) + extras cadastrados."""
+    out: list[LocalEfetivo] = []
+    if bool(getattr(atendente, "usar_local_empresa", True)):
+        emp = _empresa_sistema(db)
+        if emp is not None and emp.latitude is not None and emp.longitude is not None:
+            raio_at = getattr(atendente, "local_empresa_raio_metros", None)
+            raio_emp = getattr(emp, "ponto_raio_metros", None) or 200
+            raio = int(raio_at) if raio_at is not None else int(raio_emp)
+            out.append(
+                LocalEfetivo(
+                    id=None,
+                    nome="Empresa",
+                    latitude=float(emp.latitude),
+                    longitude=float(emp.longitude),
+                    raio_metros=max(20, raio),
+                )
+            )
+    rows = (
+        db.query(PontoLocal)
+        .filter(
+            PontoLocal.tenant_id == atendente.tenant_id,
+            PontoLocal.atendente_id == atendente.id,
+            PontoLocal.ativo.is_(True),
+        )
+        .order_by(PontoLocal.nome.asc())
+        .all()
+    )
+    for loc in rows:
+        out.append(
+            LocalEfetivo(
+                id=int(loc.id),
+                nome=str(loc.nome),
+                latitude=float(loc.latitude),
+                longitude=float(loc.longitude),
+                raio_metros=int(loc.raio_metros or 200),
+            )
+        )
+    return out
+
+
 def locais_ativos(db: Session, tenant_id: int) -> list[PontoLocal]:
+    """Legado: locais da instância ainda atribuídos a alguém e ativos (admin/listagens)."""
     return (
         db.query(PontoLocal)
-        .filter(PontoLocal.tenant_id == tenant_id, PontoLocal.ativo.is_(True))
+        .filter(
+            PontoLocal.tenant_id == tenant_id,
+            PontoLocal.ativo.is_(True),
+            PontoLocal.atendente_id.isnot(None),
+        )
         .order_by(PontoLocal.nome.asc())
         .all()
     )
 
 
-def avaliar_coordenadas(
-    db: Session,
-    tenant_id: int,
+def avaliar_coordenadas_locais(
+    locais: list[LocalEfetivo],
     latitude: float,
     longitude: float,
 ) -> ResultadoGeofence:
-    """Encontra o local mais próximo e se está dentro do raio."""
-    locais = locais_ativos(db, tenant_id)
     if not locais:
         return ResultadoGeofence()
-    melhor: PontoLocal | None = None
+    melhor: LocalEfetivo | None = None
     melhor_dist = float("inf")
-    dentro_de: PontoLocal | None = None
+    dentro_de: LocalEfetivo | None = None
     dist_dentro = float("inf")
     for loc in locais:
-        d = distancia_metros(latitude, longitude, float(loc.latitude), float(loc.longitude))
+        d = distancia_metros(latitude, longitude, loc.latitude, loc.longitude)
         if d < melhor_dist:
             melhor_dist = d
             melhor = loc
@@ -77,9 +135,22 @@ def avaliar_coordenadas(
     )
 
 
+def avaliar_coordenadas(
+    db: Session,
+    atendente: Atendente,
+    latitude: float,
+    longitude: float,
+) -> ResultadoGeofence:
+    return avaliar_coordenadas_locais(
+        locais_efetivos_ativos(db, atendente),
+        latitude,
+        longitude,
+    )
+
+
 def validar_batida_geolocalizacao(
     db: Session,
-    tenant_id: int,
+    atendente: Atendente,
     *,
     latitude: float | None,
     longitude: float | None,
@@ -87,11 +158,11 @@ def validar_batida_geolocalizacao(
     """Aplica política da instância; levanta 400 se obrigatória e inválida."""
     from app.services.ponto_settings import get_or_create_settings
 
-    settings = get_or_create_settings(db, tenant_id)
+    settings = get_or_create_settings(db, atendente.tenant_id)
     politica = (getattr(settings, "politica_geolocalizacao", None) or "opcional").strip().lower()
     if politica not in POLITICAS_VALIDAS:
         politica = "opcional"
-    locais = locais_ativos(db, tenant_id)
+    locais = locais_efetivos_ativos(db, atendente)
     has_coords = latitude is not None and longitude is not None
 
     if politica == "obrigatoria" and locais:
@@ -100,7 +171,7 @@ def validar_batida_geolocalizacao(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Geolocalização obrigatória para bater o ponto nesta instância.",
             )
-        res = avaliar_coordenadas(db, tenant_id, float(latitude), float(longitude))
+        res = avaliar_coordenadas_locais(locais, float(latitude), float(longitude))
         if res.fora_area:
             nome = res.local_nome or "área permitida"
             raise HTTPException(
@@ -112,7 +183,7 @@ def validar_batida_geolocalizacao(
     if not has_coords or not locais:
         return ResultadoGeofence()
 
-    res = avaliar_coordenadas(db, tenant_id, float(latitude), float(longitude))
+    res = avaliar_coordenadas_locais(locais, float(latitude), float(longitude))
     if politica == "recomendada" and res.fora_area:
         return res
     if politica == "opcional":

--- a/backend/app/services/ponto_settings.py
+++ b/backend/app/services/ponto_settings.py
@@ -21,7 +21,7 @@ from app.schemas.ponto import (
     PontoSettingsRead,
     PontoSettingsUpdate,
 )
-from app.services.ponto_geofence import POLITICAS_VALIDAS, locais_ativos
+from app.services.ponto_geofence import POLITICAS_VALIDAS, locais_efetivos_ativos
 
 
 def get_or_create_settings(db: Session, tenant_id: int) -> PontoSettings:
@@ -92,22 +92,39 @@ def settings_update(db: Session, admin: Atendente, data: PontoSettingsUpdate) ->
     return PontoSettingsRead.model_validate(row)
 
 
-def settings_public_read(db: Session, tenant_id: int) -> PontoSettingsPublicRead:
-    row = get_or_create_settings(db, tenant_id)
+def settings_public_read(db: Session, atendente: Atendente) -> PontoSettingsPublicRead:
+    row = get_or_create_settings(db, atendente.tenant_id)
     politica = (getattr(row, "politica_geolocalizacao", None) or "opcional").strip().lower()
     if politica not in POLITICAS_VALIDAS:
         politica = "opcional"
-    tem = len(locais_ativos(db, tenant_id)) > 0
+    tem = len(locais_efetivos_ativos(db, atendente)) > 0
     return PontoSettingsPublicRead(politica_geolocalizacao=politica, tem_locais_ativos=tem)
 
 
-def listar_locais(db: Session, tenant_id: int) -> list[PontoLocalRead]:
-    rows = (
-        db.query(PontoLocal)
-        .filter(PontoLocal.tenant_id == tenant_id)
-        .order_by(PontoLocal.nome.asc(), PontoLocal.id.asc())
-        .all()
+def _atendente_do_tenant(db: Session, tenant_id: int, atendente_id: int) -> Atendente:
+    row = (
+        db.query(Atendente)
+        .filter(Atendente.id == atendente_id, Atendente.tenant_id == tenant_id)
+        .first()
     )
+    if not row or row.role == "saas_ops":
+        raise HTTPException(status_code=404, detail="Atendente não encontrado")
+    return row
+
+
+def listar_locais(
+    db: Session,
+    tenant_id: int,
+    *,
+    atendente_id: int | None = None,
+    so_orfos: bool = False,
+) -> list[PontoLocalRead]:
+    q = db.query(PontoLocal).filter(PontoLocal.tenant_id == tenant_id)
+    if so_orfos:
+        q = q.filter(PontoLocal.atendente_id.is_(None))
+    elif atendente_id is not None:
+        q = q.filter(PontoLocal.atendente_id == atendente_id)
+    rows = q.order_by(PontoLocal.nome.asc(), PontoLocal.id.asc()).all()
     return [PontoLocalRead.model_validate(r) for r in rows]
 
 
@@ -115,9 +132,13 @@ def criar_local(db: Session, admin: Atendente, data: PontoLocalCreate) -> PontoL
     nome = (data.nome or "").strip()
     if not nome:
         raise HTTPException(status_code=400, detail="Informe o nome do local.")
+    alvo = _atendente_do_tenant(db, admin.tenant_id, int(data.atendente_id))
+    endereco = (data.endereco or "").strip() or None
     row = PontoLocal(
         tenant_id=admin.tenant_id,
+        atendente_id=alvo.id,
         nome=nome[:255],
+        endereco=endereco[:512] if endereco else None,
         latitude=float(data.latitude),
         longitude=float(data.longitude),
         raio_metros=int(data.raio_metros or 200),
@@ -131,7 +152,12 @@ def criar_local(db: Session, admin: Atendente, data: PontoLocalCreate) -> PontoL
         row.id,
         "create",
         admin.id,
-        payload={"nome": nome, "latitude": data.latitude, "longitude": data.longitude},
+        payload={
+            "nome": nome,
+            "atendente_id": alvo.id,
+            "latitude": data.latitude,
+            "longitude": data.longitude,
+        },
     )
     db.commit()
     db.refresh(row)
@@ -157,6 +183,12 @@ def atualizar_local(
         if not nome:
             raise HTTPException(status_code=400, detail="Informe o nome do local.")
         payload["nome"] = nome[:255]
+    if "endereco" in payload and payload["endereco"] is not None:
+        end = str(payload["endereco"]).strip()
+        payload["endereco"] = end[:512] if end else None
+    if "atendente_id" in payload and payload["atendente_id"] is not None:
+        alvo = _atendente_do_tenant(db, admin.tenant_id, int(payload["atendente_id"]))
+        payload["atendente_id"] = alvo.id
     for k, v in payload.items():
         setattr(row, k, v)
     registrar_audit(

--- a/backend/tests/test_ponto_geofence.py
+++ b/backend/tests/test_ponto_geofence.py
@@ -1,13 +1,12 @@
-"""Testes de geofence e política de geo (#844)."""
-
-import pytest
+"""Testes de geofence e política de geo (#844 / #984)."""
 
 
-def _criar_local(client, headers, *, lat=-23.55052, lon=-46.633308, raio=500):
+def _criar_local(client, headers, atendente_id: int, *, lat=-23.55052, lon=-46.633308, raio=500):
     return client.post(
         "/v1/ponto/locais",
         headers=headers,
         json={
+            "atendente_id": atendente_id,
             "nome": "Matriz",
             "latitude": lat,
             "longitude": lon,
@@ -24,10 +23,24 @@ def _set_politica(client, headers, politica: str):
     )
 
 
+def _set_empresa_pin(client, headers, *, lat=-23.55052, lon=-46.633308, raio=200):
+    return client.put(
+        "/v1/settings/empresa-sistema",
+        headers=headers,
+        json={
+            "nome": "Empresa Teste",
+            "latitude": lat,
+            "longitude": lon,
+            "ponto_raio_metros": raio,
+        },
+    )
+
+
 def test_ponto_geofence_obrigatoria_dentro(client, seed_base, auth_headers):
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
-    assert _criar_local(client, admin).status_code == 201
+    a1_id = seed_base["a1"].id
+    assert _criar_local(client, admin, a1_id).status_code == 201
     assert _set_politica(client, admin, "obrigatoria").status_code == 200
 
     r = client.post(
@@ -46,7 +59,7 @@ def test_ponto_geofence_obrigatoria_dentro(client, seed_base, auth_headers):
 def test_ponto_geofence_obrigatoria_sem_geo(client, seed_base, auth_headers):
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
-    assert _criar_local(client, admin).status_code == 201
+    assert _criar_local(client, admin, seed_base["a1"].id).status_code == 201
     assert _set_politica(client, admin, "obrigatoria").status_code == 200
 
     r = client.post("/v1/ponto/bater", headers=user, json={"tipo": "entrada"})
@@ -57,7 +70,7 @@ def test_ponto_geofence_obrigatoria_sem_geo(client, seed_base, auth_headers):
 def test_ponto_geofence_obrigatoria_fora(client, seed_base, auth_headers):
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
-    assert _criar_local(client, admin, lat=-23.55, lon=-46.63, raio=100).status_code == 201
+    assert _criar_local(client, admin, seed_base["a1"].id, lat=-23.55, lon=-46.63, raio=100).status_code == 201
     assert _set_politica(client, admin, "obrigatoria").status_code == 200
 
     r = client.post(
@@ -72,7 +85,7 @@ def test_ponto_geofence_obrigatoria_fora(client, seed_base, auth_headers):
 def test_ponto_geofence_recomendada_fora_regista(client, seed_base, auth_headers):
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
-    assert _criar_local(client, admin, lat=-23.55, lon=-46.63, raio=100).status_code == 201
+    assert _criar_local(client, admin, seed_base["a1"].id, lat=-23.55, lon=-46.63, raio=100).status_code == 201
     assert _set_politica(client, admin, "recomendada").status_code == 200
 
     r = client.post(
@@ -84,12 +97,78 @@ def test_ponto_geofence_recomendada_fora_regista(client, seed_base, auth_headers
     assert r.json()["fora_area"] is True
 
 
-def test_ponto_locais_crud(client, seed_base, auth_headers):
+def test_ponto_geofence_local_desativado_nao_conta(client, seed_base, auth_headers):
     admin = auth_headers["admin"]
-    r = _criar_local(client, admin)
+    user = auth_headers["a1"]
+    a1_id = seed_base["a1"].id
+    r = _criar_local(client, admin, a1_id, lat=-23.55, lon=-46.63, raio=100)
     assert r.status_code == 201
     local_id = r.json()["id"]
-    lst = client.get("/v1/ponto/locais", headers=admin)
+    assert client.patch(
+        f"/v1/ponto/locais/{local_id}",
+        headers=admin,
+        json={"ativo": False},
+    ).status_code == 200
+    assert _set_politica(client, admin, "obrigatoria").status_code == 200
+    # Sem locais ativos: política obrigatória não bloqueia (igual a sem locais).
+    r_bat = client.post(
+        "/v1/ponto/bater",
+        headers=user,
+        json={"tipo": "entrada", "latitude": -23.55, "longitude": -46.63},
+    )
+    assert r_bat.status_code == 200, r_bat.text
+
+
+def test_ponto_geofence_empresa_pin(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    assert _set_empresa_pin(client, admin, lat=-23.55, lon=-46.63, raio=150).status_code == 200
+    assert _set_politica(client, admin, "obrigatoria").status_code == 200
+    # usar_local_empresa default true
+    r = client.post(
+        "/v1/ponto/bater",
+        headers=user,
+        json={"tipo": "entrada", "latitude": -23.5501, "longitude": -46.6301},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["fora_area"] is False
+
+
+def test_ponto_geofence_orfao_nao_conta(client, seed_base, auth_headers, db_session):
+    """Locais sem atendente_id (legado) não entram no geofence."""
+    from app.models.ponto_settings import PontoLocal
+
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    row = PontoLocal(
+        tenant_id=seed_base["a1"].tenant_id,
+        atendente_id=None,
+        nome="Legado",
+        latitude=-23.55,
+        longitude=-46.63,
+        raio_metros=500,
+        ativo=True,
+    )
+    db_session.add(row)
+    db_session.commit()
+    assert _set_politica(client, admin, "obrigatoria").status_code == 200
+    r = client.post(
+        "/v1/ponto/bater",
+        headers=user,
+        json={"tipo": "entrada", "latitude": -23.55, "longitude": -46.63},
+    )
+    # Sem locais do atendente: não bloqueia por geofence.
+    assert r.status_code == 200, r.text
+
+
+def test_ponto_locais_crud(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1_id = seed_base["a1"].id
+    r = _criar_local(client, admin, a1_id)
+    assert r.status_code == 201
+    local_id = r.json()["id"]
+    assert r.json()["atendente_id"] == a1_id
+    lst = client.get(f"/v1/ponto/locais?atendente_id={a1_id}", headers=admin)
     assert lst.status_code == 200
     assert any(x["id"] == local_id for x in lst.json())
     r_up = client.patch(
@@ -111,6 +190,11 @@ def test_ponto_me_settings(client, seed_base, auth_headers):
     body = r.json()
     assert body["politica_geolocalizacao"] == "recomendada"
     assert body["tem_locais_ativos"] is False
+
+    assert _criar_local(client, admin, seed_base["a1"].id).status_code == 201
+    r2 = client.get("/v1/ponto/me/settings", headers=auth_headers["a1"])
+    assert r2.status_code == 200
+    assert r2.json()["tem_locais_ativos"] is True
 
 
 def test_ponto_export_pdf_xlsx(client, seed_base, auth_headers, monkeypatch):

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -818,7 +818,8 @@ export const ponto = {
     return res.blob()
   },
   meSettings: () => api<Ponto.SettingsPublic>('/ponto/me/settings'),
-  locais: () => api<Ponto.Local[]>('/ponto/locais'),
+  locais: (params?: { atendente_id?: number; so_orfos?: boolean }) =>
+    api<Ponto.Local[]>(withParams('/ponto/locais', params)),
   criarLocal: (data: Ponto.LocalCreate) =>
     api<Ponto.Local>('/ponto/locais', { method: 'POST', body: JSON.stringify(data) }),
   atualizarLocal: (id: number, data: Ponto.LocalUpdate) =>
@@ -935,6 +936,9 @@ export namespace SystemSettings {
     cidade?: string | null
     estado?: string | null
     cep?: string | null
+    latitude?: number | null
+    longitude?: number | null
+    ponto_raio_metros?: number
     logo_url?: string | null
   }
 
@@ -952,6 +956,9 @@ export namespace SystemSettings {
     cidade?: string | null
     estado?: string | null
     cep?: string | null
+    latitude?: number | null
+    longitude?: number | null
+    ponto_raio_metros?: number | null
   }
 
   export interface TicketEmailGraceOpcao {
@@ -2463,6 +2470,8 @@ export namespace Atendentes {
     horario_previsto_entrada?: string | null;
     horario_previsto_saida?: string | null;
     tolerancia_atraso_minutos?: number;
+    usar_local_empresa?: boolean;
+    local_empresa_raio_metros?: number | null;
     /** Cargos da equipe DeskRudder (painel SaaS); vários por usuário. */
     saas_setor_ids?: number[];
     saas_setor_nomes?: string[];
@@ -2483,6 +2492,8 @@ export namespace Atendentes {
     horario_previsto_entrada?: string | null;
     horario_previsto_saida?: string | null;
     tolerancia_atraso_minutos?: number;
+    usar_local_empresa?: boolean;
+    local_empresa_raio_metros?: number | null;
   }
   export interface Update {
     email?: string;
@@ -2500,6 +2511,8 @@ export namespace Atendentes {
     horario_previsto_entrada?: string | null;
     horario_previsto_saida?: string | null;
     tolerancia_atraso_minutos?: number;
+    usar_local_empresa?: boolean;
+    local_empresa_raio_metros?: number | null;
   }
   export interface AvaliacaoResumo {
     media: number | null;
@@ -4870,21 +4883,27 @@ export namespace Ponto {
   }
   export interface Local {
     id: number
+    atendente_id?: number | null
     nome: string
+    endereco?: string | null
     latitude: number
     longitude: number
     raio_metros: number
     ativo: boolean
   }
   export interface LocalCreate {
+    atendente_id: number
     nome: string
+    endereco?: string | null
     latitude: number
     longitude: number
     raio_metros?: number
     ativo?: boolean
   }
   export interface LocalUpdate {
+    atendente_id?: number | null
     nome?: string
+    endereco?: string | null
     latitude?: number
     longitude?: number
     raio_metros?: number

--- a/frontend/src/components/AtendenteLocaisSection.tsx
+++ b/frontend/src/components/AtendenteLocaisSection.tsx
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ponto,
+  systemSettings,
+  type Ponto,
+  type SystemSettings,
+} from '../api/client'
+import { PontoLocalMapaPicker } from './PontoLocalMapaPicker'
+import { Button } from './ui/Button'
+import { Input } from './ui/Input'
+import { Switch } from './ui/Switch'
+import { useToast } from './ui/Toast'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+
+type Props = {
+  atendenteId: number
+  usarLocalEmpresa: boolean
+  localEmpresaRaio: string
+  onUsarLocalEmpresaChange: (v: boolean) => void
+  onLocalEmpresaRaioChange: (v: string) => void
+}
+
+export function AtendenteLocaisSection({
+  atendenteId,
+  usarLocalEmpresa,
+  localEmpresaRaio,
+  onUsarLocalEmpresaChange,
+  onLocalEmpresaRaioChange,
+}: Props) {
+  const toast = useToast()
+  const [empresa, setEmpresa] = useState<SystemSettings.EmpresaSistema | null>(null)
+  const [locais, setLocais] = useState<Ponto.Local[]>([])
+  const [nome, setNome] = useState('')
+  const [mapa, setMapa] = useState({
+    latitude: null as number | null,
+    longitude: null as number | null,
+    endereco: '',
+    raio_metros: 200,
+  })
+  const [editId, setEditId] = useState<number | null>(null)
+  const [salvando, setSalvando] = useState(false)
+
+  const carregar = useCallback(async () => {
+    const [emp, locs] = await Promise.all([
+      systemSettings.getEmpresaSistema(),
+      ponto.locais({ atendente_id: atendenteId }),
+    ])
+    setEmpresa(emp)
+    setLocais(locs)
+  }, [atendenteId])
+
+  useEffect(() => {
+    void carregar().catch((err) => {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar os locais.'))
+    })
+  }, [carregar, toast])
+
+  const empresaTemPin = empresa?.latitude != null && empresa?.longitude != null
+
+  async function salvarExtra() {
+    if (!nome.trim() || mapa.latitude == null || mapa.longitude == null) {
+      toast.showWarning('Informe nome e pin (lat/lon) do local.')
+      return
+    }
+    setSalvando(true)
+    try {
+      const payload = {
+        nome: nome.trim(),
+        endereco: mapa.endereco?.trim() || null,
+        latitude: mapa.latitude,
+        longitude: mapa.longitude,
+        raio_metros: mapa.raio_metros || 200,
+      }
+      if (editId != null) {
+        await ponto.atualizarLocal(editId, payload)
+        toast.showSuccess('Local atualizado.')
+      } else {
+        await ponto.criarLocal({ ...payload, atendente_id: atendenteId })
+        toast.showSuccess('Local adicionado.')
+      }
+      setEditId(null)
+      setNome('')
+      setMapa({ latitude: null, longitude: null, endereco: '', raio_metros: 200 })
+      await carregar()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o local.'))
+    } finally {
+      setSalvando(false)
+    }
+  }
+
+  async function toggleAtivo(loc: Ponto.Local) {
+    try {
+      await ponto.atualizarLocal(loc.id, { ativo: !loc.ativo })
+      await carregar()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar o local.'))
+    }
+  }
+
+  async function remover(id: number) {
+    if (!confirm('Remover este local?')) return
+    try {
+      await ponto.removerLocal(id)
+      await carregar()
+      toast.showSuccess('Local removido.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível remover o local.'))
+    }
+  }
+
+  function editar(loc: Ponto.Local) {
+    setEditId(loc.id)
+    setNome(loc.nome)
+    setMapa({
+      latitude: loc.latitude,
+      longitude: loc.longitude,
+      endereco: loc.endereco ?? '',
+      raio_metros: loc.raio_metros,
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-slate-200 p-3 dark:border-slate-800">
+        <Switch
+          bare
+          checked={usarLocalEmpresa}
+          onCheckedChange={onUsarLocalEmpresaChange}
+          label="Local da empresa"
+          description={
+            empresaTemPin
+              ? `Pin em ${empresa!.latitude!.toFixed(5)}, ${empresa!.longitude!.toFixed(5)} · raio padrão ${empresa!.ponto_raio_metros ?? 200} m (Configurações → Empresa).`
+              : 'Configure o pin da empresa em Configurações → Empresa para usar este local.'
+          }
+          showStatusPill
+          statusOnText="Ativo"
+          statusOffText="Desligado"
+        />
+        {usarLocalEmpresa ? (
+          <div className="mt-3 max-w-xs">
+            <Input
+              label="Raio neste usuário (m) — opcional"
+              type="number"
+              min={20}
+              max={50000}
+              value={localEmpresaRaio}
+              onChange={(e) => onLocalEmpresaRaioChange(e.target.value)}
+              placeholder={String(empresa?.ponto_raio_metros ?? 200)}
+            />
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              Vazio = usa o raio padrão da empresa. Salve o cadastro para gravar.
+            </p>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="space-y-3">
+        <p className="text-sm font-medium text-slate-800 dark:text-slate-100">Outros locais</p>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          Casa, filial ou remoto. A batida vale se estiver dentro do raio de qualquer local ativo.
+        </p>
+        <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} placeholder="Ex.: Home office" />
+        <PontoLocalMapaPicker value={mapa} onChange={setMapa} />
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" disabled={salvando} onClick={() => void salvarExtra()}>
+            {editId != null ? 'Salvar local' : 'Adicionar local'}
+          </Button>
+          {editId != null ? (
+            <Button
+              type="button"
+              variant="cancel"
+              onClick={() => {
+                setEditId(null)
+                setNome('')
+                setMapa({ latitude: null, longitude: null, endereco: '', raio_metros: 200 })
+              }}
+            >
+              Cancelar edição
+            </Button>
+          ) : null}
+        </div>
+        <ul className="space-y-2 text-sm">
+          {locais.length === 0 ? (
+            <li className="text-slate-500">Nenhum local extra cadastrado.</li>
+          ) : (
+            locais.map((loc) => (
+              <li
+                key={loc.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+              >
+                <span>
+                  <strong>{loc.nome}</strong>
+                  {loc.endereco ? ` · ${loc.endereco}` : ''} · {loc.latitude.toFixed(5)},{' '}
+                  {loc.longitude.toFixed(5)} · raio {loc.raio_metros} m
+                  {!loc.ativo ? ' (desativado)' : ''}
+                </span>
+                <div className="flex flex-wrap gap-2">
+                  <Button type="button" variant="secondary" onClick={() => editar(loc)}>
+                    Editar
+                  </Button>
+                  <Button type="button" variant="secondary" onClick={() => void toggleAtivo(loc)}>
+                    {loc.ativo ? 'Desativar' : 'Ativar'}
+                  </Button>
+                  <Button type="button" variant="ghost" onClick={() => void remover(loc.id)}>
+                    Remover
+                  </Button>
+                </div>
+              </li>
+            ))
+          )}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/AtendenteLocaisSection.tsx
+++ b/frontend/src/components/AtendenteLocaisSection.tsx
@@ -5,7 +5,7 @@ import {
   type Ponto,
   type SystemSettings,
 } from '../api/client'
-import { PontoLocalMapaPicker } from './PontoLocalMapaPicker'
+import { PontoLocalMapaPicker, type PontoLocalMapaValue } from './PontoLocalMapaPicker'
 import { Button } from './ui/Button'
 import { Input } from './ui/Input'
 import { Switch } from './ui/Switch'
@@ -31,7 +31,7 @@ export function AtendenteLocaisSection({
   const [empresa, setEmpresa] = useState<SystemSettings.EmpresaSistema | null>(null)
   const [locais, setLocais] = useState<Ponto.Local[]>([])
   const [nome, setNome] = useState('')
-  const [mapa, setMapa] = useState({
+  const [mapa, setMapa] = useState<PontoLocalMapaValue>({
     latitude: null as number | null,
     longitude: null as number | null,
     endereco: '',

--- a/frontend/src/components/PontoLocalMapaPicker.tsx
+++ b/frontend/src/components/PontoLocalMapaPicker.tsx
@@ -1,0 +1,201 @@
+import { useState } from 'react'
+import { Button } from './ui/Button'
+import { Input } from './ui/Input'
+import { linkMapaOsm } from '../lib/pontoFormat'
+
+export type PontoLocalMapaValue = {
+  latitude: number | null
+  longitude: number | null
+  endereco?: string
+  raio_metros?: number
+}
+
+type Props = {
+  value: PontoLocalMapaValue
+  onChange: (next: PontoLocalMapaValue) => void
+  /** Prefill de busca (ex.: endereço da empresa). */
+  buscaInicial?: string
+  mostrarRaio?: boolean
+  raioLabel?: string
+}
+
+type NominatimHit = {
+  display_name: string
+  lat: string
+  lon: string
+}
+
+function embedUrl(lat: number, lon: number, delta = 0.008): string {
+  const bbox = `${lon - delta},${lat - delta},${lon + delta},${lat + delta}`
+  return `https://www.openstreetmap.org/export/embed.html?bbox=${encodeURIComponent(bbox)}&layer=mapnik&marker=${lat}%2C${lon}`
+}
+
+export function PontoLocalMapaPicker({
+  value,
+  onChange,
+  buscaInicial = '',
+  mostrarRaio = true,
+  raioLabel = 'Raio (m)',
+}: Props) {
+  const [busca, setBusca] = useState(buscaInicial)
+  const [buscando, setBuscando] = useState(false)
+  const [hits, setHits] = useState<NominatimHit[]>([])
+  const [erroBusca, setErroBusca] = useState<string | null>(null)
+
+  const lat = value.latitude
+  const lon = value.longitude
+  const temPin = lat != null && lon != null && Number.isFinite(lat) && Number.isFinite(lon)
+
+  async function buscarNoMapa() {
+    const q = busca.trim()
+    if (!q) {
+      setErroBusca('Informe um endereço para buscar.')
+      return
+    }
+    setBuscando(true)
+    setErroBusca(null)
+    setHits([])
+    try {
+      const url =
+        'https://nominatim.openstreetmap.org/search?' +
+        new URLSearchParams({
+          q,
+          format: 'json',
+          limit: '5',
+          addressdetails: '0',
+        }).toString()
+      const res = await fetch(url, {
+        headers: { Accept: 'application/json' },
+      })
+      if (!res.ok) throw new Error('falha')
+      const data = (await res.json()) as NominatimHit[]
+      if (!data.length) {
+        setErroBusca('Nenhum resultado. Ajuste o endereço ou informe latitude/longitude.')
+        return
+      }
+      setHits(data)
+    } catch {
+      setErroBusca('Não foi possível buscar o endereço. Tente de novo ou use lat/lon.')
+    } finally {
+      setBuscando(false)
+    }
+  }
+
+  function escolherHit(hit: NominatimHit) {
+    const latitude = Number(hit.lat)
+    const longitude = Number(hit.lon)
+    onChange({
+      ...value,
+      latitude,
+      longitude,
+      endereco: hit.display_name,
+    })
+    setBusca(hit.display_name)
+    setHits([])
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-2">
+        <div className="min-w-[12rem] flex-1">
+          <Input
+            label="Buscar endereço no mapa"
+            value={busca}
+            onChange={(e) => setBusca(e.target.value)}
+            placeholder="Rua, número, cidade…"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                void buscarNoMapa()
+              }
+            }}
+          />
+        </div>
+        <Button type="button" variant="secondary" disabled={buscando} onClick={() => void buscarNoMapa()}>
+          {buscando ? 'Buscando…' : 'Buscar'}
+        </Button>
+      </div>
+      {erroBusca ? <p className="text-sm text-amber-700 dark:text-amber-300">{erroBusca}</p> : null}
+      {hits.length > 0 ? (
+        <ul className="max-h-40 space-y-1 overflow-auto rounded-lg border border-slate-200 text-sm dark:border-slate-700">
+          {hits.map((h) => (
+            <li key={`${h.lat}-${h.lon}-${h.display_name}`}>
+              <button
+                type="button"
+                className="w-full px-3 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-800"
+                onClick={() => escolherHit(h)}
+              >
+                {h.display_name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Input
+          label="Latitude"
+          type="number"
+          step="any"
+          value={lat != null ? String(lat) : ''}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              latitude: e.target.value === '' ? null : Number(e.target.value),
+            })
+          }
+        />
+        <Input
+          label="Longitude"
+          type="number"
+          step="any"
+          value={lon != null ? String(lon) : ''}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              longitude: e.target.value === '' ? null : Number(e.target.value),
+            })
+          }
+        />
+        {mostrarRaio ? (
+          <Input
+            label={raioLabel}
+            type="number"
+            min={20}
+            max={50000}
+            value={String(value.raio_metros ?? 200)}
+            onChange={(e) =>
+              onChange({
+                ...value,
+                raio_metros: Number(e.target.value) || 200,
+              })
+            }
+          />
+        ) : null}
+      </div>
+      {temPin ? (
+        <div className="overflow-hidden rounded-xl border border-slate-200 dark:border-slate-700">
+          <iframe
+            title="Mapa do local"
+            className="h-56 w-full border-0"
+            loading="lazy"
+            src={embedUrl(lat!, lon!)}
+          />
+          <div className="border-t border-slate-200 px-3 py-2 text-right text-sm dark:border-slate-700">
+            <a
+              className="text-cyan-700 underline dark:text-cyan-300"
+              href={linkMapaOsm(lat!, lon!)}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Abrir no OpenStreetMap
+            </a>
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          Busque um endereço ou informe latitude e longitude para marcar o pin.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -20,7 +20,7 @@ import {
   horarioSemanaPadrao,
   validarHorarioSemana,
   type HorarioSemana,
-} from '../lib/horarioSemana
+} from '../lib/horarioSemana'
 import { SemPermissao } from './SemPermissao'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -14,12 +14,13 @@ import { FormSection } from '../components/ui/FormSection'
 import { InlineCadastroFooter } from '../components/ui/InlineCadastroPanel'
 import { CadastroFormPageShell } from '../components/ui/CadastroFormPageShell'
 import { HorarioSemanaEditor } from '../components/horario/HorarioSemanaEditor'
+import { AtendenteLocaisSection } from '../components/AtendenteLocaisSection'
 import {
   horarioSemanaFromApi,
   horarioSemanaPadrao,
   validarHorarioSemana,
   type HorarioSemana,
-} from '../lib/horarioSemana'
+} from '../lib/horarioSemana
 import { SemPermissao } from './SemPermissao'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
@@ -56,6 +57,8 @@ export function AtendenteForm() {
   const [horarioEntrada, setHorarioEntrada] = useState('')
   const [horarioSaida, setHorarioSaida] = useState('')
   const [toleranciaAtraso, setToleranciaAtraso] = useState('0')
+  const [usarLocalEmpresa, setUsarLocalEmpresa] = useState(true)
+  const [localEmpresaRaio, setLocalEmpresaRaio] = useState('')
 
   useEffect(() => {
     coletarTodasPaginas<Setores.Setor>((o, l) =>
@@ -99,6 +102,10 @@ export function AtendenteForm() {
         setHorarioEntrada(a.horario_previsto_entrada ?? '')
         setHorarioSaida(a.horario_previsto_saida ?? '')
         setToleranciaAtraso(String(a.tolerancia_atraso_minutos ?? 0))
+        setUsarLocalEmpresa(a.usar_local_empresa !== false)
+        setLocalEmpresaRaio(
+          a.local_empresa_raio_metros != null ? String(a.local_empresa_raio_metros) : '',
+        )
         if (a.escala_horas_trabalho === 12 && a.escala_horas_folga === 36) setPresetEscala('12x36')
         else if (a.escala_horas_trabalho === 6 && a.escala_horas_folga === 18) setPresetEscala('6x18')
         else if (a.escala_horas_trabalho === 24 && a.escala_horas_folga === 48) setPresetEscala('24x48')
@@ -184,6 +191,15 @@ export function AtendenteForm() {
     }
   }
 
+  function payloadLocais() {
+    return {
+      usar_local_empresa: usarLocalEmpresa,
+      local_empresa_raio_metros: localEmpresaRaio.trim()
+        ? Math.max(20, Number(localEmpresaRaio) || 200)
+        : null,
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (modoJornada === 'semanal') {
@@ -196,6 +212,7 @@ export function AtendenteForm() {
     setSaving(true)
     try {
       const escala = payloadJornada()
+      const locais = payloadLocais()
       if (isEdit && !Number.isNaN(atendenteId)) {
         await atendentes.update(atendenteId, {
           email,
@@ -204,6 +221,7 @@ export function AtendenteForm() {
           ativo,
           setor_ids: setorIds,
           ...escala,
+          ...locais,
           ...(senha ? { senha } : {}),
         })
         toast.showSuccess('Atendente atualizado.')
@@ -218,9 +236,10 @@ export function AtendenteForm() {
           setor_ids: setorIds,
           ativo,
           ...escala,
+          ...locais,
         })
         toast.showSuccess('Atendente cadastrado.')
-        navigate(`/atendentes/${created.id}`, { replace: true })
+        navigate(`/atendentes/${created.id}/editar`, { replace: true })
       }
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o atendente.'))
@@ -426,6 +445,23 @@ export function AtendenteForm() {
                 </div>
               )}
             </FormSection>
+            {isEdit && !Number.isNaN(atendenteId) ? (
+              <FormSection title="Locais de trabalho">
+                <AtendenteLocaisSection
+                  atendenteId={atendenteId}
+                  usarLocalEmpresa={usarLocalEmpresa}
+                  localEmpresaRaio={localEmpresaRaio}
+                  onUsarLocalEmpresaChange={setUsarLocalEmpresa}
+                  onLocalEmpresaRaioChange={setLocalEmpresaRaio}
+                />
+              </FormSection>
+            ) : (
+              <FormSection title="Locais de trabalho">
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  Salve o atendente para configurar o local da empresa e locais extras (mapa e raio).
+                </p>
+              </FormSection>
+            )}
           </div>
           <InlineCadastroFooter onCancel={voltarAnterior} saving={saving} />
         </form>

--- a/frontend/src/pages/ConfigEmpresaEmail.tsx
+++ b/frontend/src/pages/ConfigEmpresaEmail.tsx
@@ -10,6 +10,7 @@ import {
 } from '../api/client'
 import { resolveTenantIdFromHostname, tenantAppOrigin } from '../lib/tenant'
 import { nomeParaApiEmpresa } from '../components/empresa/empresaFormCopy'
+import { PontoLocalMapaPicker } from '../components/PontoLocalMapaPicker'
 import { Card } from '../components/ui/Card'
 import { PageContainer } from '../components/ui/PageContainer'
 import { Button } from '../components/ui/Button'
@@ -53,6 +54,10 @@ export function ConfigEmpresaEmail({ embedded = false, section }: ConfigEmpresaE
   const [cidade, setCidade] = useState('')
   const [estado, setEstado] = useState('')
   const [cep, setCep] = useState('')
+  const [empresaLat, setEmpresaLat] = useState<number | null>(null)
+  const [empresaLon, setEmpresaLon] = useState<number | null>(null)
+  const [empresaRaio, setEmpresaRaio] = useState(200)
+  const [empresaEnderecoMapa, setEmpresaEnderecoMapa] = useState('')
   const [salvandoEmpresa, setSalvandoEmpresa] = useState(false)
   const [loadingCnpjConsulta, setLoadingCnpjConsulta] = useState(false)
   const [logoBlobUrl, setLogoBlobUrl] = useState<string | null>(null)
@@ -103,6 +108,15 @@ export function ConfigEmpresaEmail({ embedded = false, section }: ConfigEmpresaE
       setCidade((emp.cidade ?? '').trim())
       setEstado((emp.estado ?? '').trim().toUpperCase().slice(0, 2))
       setCep(emp.cep ? maskCep(digitsOnly(emp.cep)) : '')
+      setEmpresaLat(emp.latitude ?? null)
+      setEmpresaLon(emp.longitude ?? null)
+      setEmpresaRaio(emp.ponto_raio_metros ?? 200)
+      setEmpresaEnderecoMapa(
+        [emp.endereco, emp.numero, emp.bairro, emp.cidade, emp.estado, emp.cep]
+          .map((x) => (x ?? '').trim())
+          .filter(Boolean)
+          .join(', '),
+      )
 
       // logo: precisa de fetch autenticado (não dá pra usar <img src> direto).
       const prevBlob = logoBlobUrlRef.current
@@ -202,6 +216,9 @@ export function ConfigEmpresaEmail({ embedded = false, section }: ConfigEmpresaE
         cidade: cidade.trim() || null,
         estado: estado.trim() || null,
         cep: digitsOnly(cep) || null,
+        latitude: empresaLat,
+        longitude: empresaLon,
+        ponto_raio_metros: empresaRaio,
       }
       if (!cnpjImutavel) {
         payload.cnpj = cnpjTrim
@@ -554,6 +571,31 @@ export function ConfigEmpresaEmail({ embedded = false, section }: ConfigEmpresaE
                     </div>
                   </div>
                 </div>
+              </div>
+              <div>
+                <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Local de trabalho (ponto)
+                </h3>
+                <p className="mb-3 text-sm text-slate-600 dark:text-slate-400">
+                  Marque o pin uma vez. Nos cadastros da equipe dá para ligar/desligar este local e ajustar o raio por
+                  pessoa.
+                </p>
+                <PontoLocalMapaPicker
+                  value={{
+                    latitude: empresaLat,
+                    longitude: empresaLon,
+                    endereco: empresaEnderecoMapa,
+                    raio_metros: empresaRaio,
+                  }}
+                  onChange={(next) => {
+                    setEmpresaLat(next.latitude)
+                    setEmpresaLon(next.longitude)
+                    setEmpresaRaio(next.raio_metros ?? 200)
+                    if (next.endereco) setEmpresaEnderecoMapa(next.endereco)
+                  }}
+                  buscaInicial={empresaEnderecoMapa}
+                  raioLabel="Raio padrão (m)"
+                />
               </div>
             </div>
             <div className="flex flex-wrap gap-3 pt-2">

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -72,12 +72,6 @@ export function PontoEquipe() {
   const [feriadoData, setFeriadoData] = useState('')
   const [feriadoNome, setFeriadoNome] = useState('')
   const [salvandoSettings, setSalvandoSettings] = useState(false)
-  const [locais, setLocais] = useState<Ponto.Local[]>([])
-  const [localNome, setLocalNome] = useState('')
-  const [localLat, setLocalLat] = useState('')
-  const [localLon, setLocalLon] = useState('')
-  const [localRaio, setLocalRaio] = useState('200')
-  const [editLocalId, setEditLocalId] = useState<number | null>(null)
   const [mapaBatida, setMapaBatida] = useState<Ponto.BatidaAdmin | null>(null)
   const agoraCal = new Date()
   const [calAno, setCalAno] = useState(agoraCal.getFullYear())
@@ -89,7 +83,7 @@ export function PontoEquipe() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [hist, dia, js, dig, st, fer, locs] = await Promise.all([
+        const [hist, dia, js, dig, st, fer] = await Promise.all([
           ponto.batidasAdmin({
             atendente_id: atendenteId ? Number(atendenteId) : undefined,
             desde,
@@ -101,7 +95,6 @@ export function PontoEquipe() {
           ponto.digest(),
           ponto.settings(),
           ponto.feriados(new Date().getFullYear()),
-          ponto.locais(),
         ])
         setItems(hist.items)
         setTotal(hist.total)
@@ -110,7 +103,6 @@ export function PontoEquipe() {
         setDigest(dig)
         setSettings(st)
         setFeriados(fer)
-        setLocais(locs)
         setSemPermissao(false)
         if (atendenteId) {
           const bh = await ponto.bancoHorasAdmin(Number(atendenteId), desde, ate)
@@ -277,68 +269,6 @@ export function PontoEquipe() {
     }
   }
 
-  async function adicionarLocal() {
-    if (!localNome.trim() || !localLat || !localLon) {
-      toast.showWarning('Informe nome, latitude e longitude do local.')
-      return
-    }
-    try {
-      if (editLocalId != null) {
-        await ponto.atualizarLocal(editLocalId, {
-          nome: localNome.trim(),
-          latitude: Number(localLat),
-          longitude: Number(localLon),
-          raio_metros: Number(localRaio) || 200,
-        })
-        toast.showSuccess('Local actualizado.')
-        setEditLocalId(null)
-      } else {
-        await ponto.criarLocal({
-          nome: localNome.trim(),
-          latitude: Number(localLat),
-          longitude: Number(localLon),
-          raio_metros: Number(localRaio) || 200,
-        })
-        toast.showSuccess('Local cadastrado.')
-      }
-      setLocalNome('')
-      setLocalLat('')
-      setLocalLon('')
-      setLocalRaio('200')
-      await carregar(true)
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível guardar o local.'))
-    }
-  }
-
-  function iniciarEdicaoLocal(loc: Ponto.Local) {
-    setEditLocalId(loc.id)
-    setLocalNome(loc.nome)
-    setLocalLat(String(loc.latitude))
-    setLocalLon(String(loc.longitude))
-    setLocalRaio(String(loc.raio_metros))
-  }
-
-  async function toggleLocalAtivo(loc: Ponto.Local) {
-    try {
-      await ponto.atualizarLocal(loc.id, { ativo: !loc.ativo })
-      toast.showSuccess(loc.ativo ? 'Local desactivado.' : 'Local activado.')
-      await carregar(true)
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar o local.'))
-    }
-  }
-
-  async function apagarLocal(id: number) {
-    try {
-      await ponto.removerLocal(id)
-      toast.showSuccess('Local removido.')
-      await carregar(true)
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível remover o local.'))
-    }
-  }
-
   async function adicionarFeriado() {
     if (!feriadoData || !feriadoNome.trim()) {
       toast.showWarning('Informe data e nome do feriado.')
@@ -378,7 +308,7 @@ export function PontoEquipe() {
     <PageContainer>
       <PageHeader
         title="Ponto da equipe"
-        subtitle="Visão do dia, batidas, geofence, ajustes auditados e relatórios mensais."
+        subtitle="Visão do dia, batidas, ajustes auditados e relatórios mensais."
       />
 
       <Card className="overflow-hidden border-cyan-200/60 bg-gradient-to-br from-slate-50 via-white to-cyan-50/40 dark:border-cyan-900/40 dark:from-slate-950 dark:via-slate-900 dark:to-cyan-950/20">
@@ -754,8 +684,8 @@ export function PontoEquipe() {
                 ]}
               />
               <p className="text-xs text-slate-500">
-                Com locais cadastrados: opcional regista geo; recomendada avisa fora da área; obrigatória
-                bloqueia sem GPS ou fora do raio.
+                Locais ficam no cadastro de cada pessoa (e pin da empresa em Configurações → Empresa). Opcional
+                registra geo; recomendada avisa fora da área; obrigatória bloqueia sem GPS ou fora do raio.
               </p>
               <Button type="button" disabled={salvandoSettings} onClick={() => void salvarSettings()}>
                 Salvar configurações
@@ -764,80 +694,6 @@ export function PontoEquipe() {
           ) : (
             <p className="text-sm text-slate-500">Carregando…</p>
           )}
-        </Card>
-
-        <Card title="Locais (geofence)">
-          <div className="mb-4 flex flex-wrap items-end gap-3">
-            <Input label="Nome" value={localNome} onChange={(e) => setLocalNome(e.target.value)} />
-            <Input
-              label="Latitude"
-              type="number"
-              step="any"
-              value={localLat}
-              onChange={(e) => setLocalLat(e.target.value)}
-            />
-            <Input
-              label="Longitude"
-              type="number"
-              step="any"
-              value={localLon}
-              onChange={(e) => setLocalLon(e.target.value)}
-            />
-            <Input
-              label="Raio (m)"
-              type="number"
-              min={20}
-              value={localRaio}
-              onChange={(e) => setLocalRaio(e.target.value)}
-            />
-            <Button type="button" onClick={() => void adicionarLocal()}>
-              {editLocalId != null ? 'Salvar alteração' : 'Adicionar local'}
-            </Button>
-            {editLocalId != null ? (
-              <Button
-                type="button"
-                variant="cancel"
-                onClick={() => {
-                  setEditLocalId(null)
-                  setLocalNome('')
-                  setLocalLat('')
-                  setLocalLon('')
-                  setLocalRaio('200')
-                }}
-              >
-                Cancelar edição
-              </Button>
-            ) : null}
-          </div>
-          <ul className="space-y-2 text-sm">
-            {locais.length === 0 ? (
-              <li className="text-slate-500">Nenhum local cadastrado — geofence inactivo.</li>
-            ) : (
-              locais.map((loc) => (
-                <li
-                  key={loc.id}
-                  className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
-                >
-                  <span>
-                    <strong>{loc.nome}</strong> · {loc.latitude.toFixed(5)}, {loc.longitude.toFixed(5)} · raio{' '}
-                    {loc.raio_metros} m
-                    {!loc.ativo ? ' (inactivo)' : ''}
-                  </span>
-                  <div className="flex flex-wrap gap-2">
-                    <Button type="button" variant="secondary" onClick={() => iniciarEdicaoLocal(loc)}>
-                      Editar
-                    </Button>
-                    <Button type="button" variant="secondary" onClick={() => void toggleLocalAtivo(loc)}>
-                      {loc.ativo ? 'Desactivar' : 'Activar'}
-                    </Button>
-                    <Button type="button" variant="ghost" onClick={() => void apagarLocal(loc.id)}>
-                      Remover
-                    </Button>
-                  </div>
-                </li>
-              ))
-            )}
-          </ul>
         </Card>
 
         <Card title="Feriados da instância">
@@ -891,11 +747,7 @@ export function PontoEquipe() {
             : 'Localização'
         }
         subtitulo={mapaBatida ? formatarHora(mapaBatida.registrado_em) : undefined}
-        raioMetros={
-          mapaBatida?.local_id != null
-            ? locais.find((l) => l.id === mapaBatida.local_id)?.raio_metros ?? null
-            : null
-        }
+        raioMetros={null}
       />
     </PageContainer>
   )

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -70,6 +70,8 @@ export default defineConfig(({ mode }) => {
         },
         injectManifest: {
           globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2,webmanifest}'],
+          // App chunk pode passar de 2 MiB; sem isso o build PWA falha no CI.
+          maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
         },
         devOptions: { enabled: true, type: 'module' },
       }),


### PR DESCRIPTION
﻿## Summary
- Locais de geofence passam para o **cadastro do atendente** (abaixo da jornada): local da empresa (ligar/desligar + raio) e extras com mapa OSM
- Pin da empresa em **Configurações → Empresa** (busca de endereço / lat-lon + raio padrão)
- Card Locais removido de Ponto da equipe; política geo permanece
- Locais legados sem `atendente_id` não entram no geofence (reatribuir/remover manual)
- Migration `125_ponto_locais_atendente` após jornada (`124`)

Closes #984

## CHANGELOG (obrigatório se há mudança de produto)
- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final**
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan
- [x] pytest geofence + jornada — 13 passed
- [ ] Admin marca pin da empresa e salva
- [ ] Cadastro: liga empresa, adiciona local, ativa/desativa, raio
- [ ] Política obrigatória: fora do raio bloqueia; dentro passa
- [ ] Local desativado / órfão não conta
- [ ] Ponto da equipe sem card Locais

## Follow-ups / backlog
- [x] Fora de escopo no #967 / #985
- [ ] Lote B #965 após merge
