### PR TITLE
feat(ponto): bloquear pegar WhatsApp após jornada + HE admin (#965)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Ponto (#965): após o fim da jornada, **pegar** chat WhatsApp novo fica bloqueado até um admin liberar **hora extra** (resto do dia ou até um horário); pedidos aparecem em Ponto da equipe e no sino de pendências
 - Ponto (#984): locais de trabalho no **cadastro do atendente** (empresa + extras no mapa OSM); pin da empresa em Configurações → Empresa; raio e ativar/desativar por local; removido o card global de Locais em Ponto da equipe
 
 #### Correções

--- a/backend/alembic/versions/126_ponto_hora_extra.py
+++ b/backend/alembic/versions/126_ponto_hora_extra.py
@@ -1,0 +1,61 @@
+"""Hora extra para pegar WhatsApp após jornada (#965).
+
+Revision ID: 126_ponto_hora_extra
+Revises: 125_ponto_locais_atendente
+Create Date: 2026-08-26
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "126_ponto_hora_extra"
+down_revision = "125_ponto_locais_atendente"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_hora_extra"):
+        return
+    op.create_table(
+        "ponto_hora_extra",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "tenant_id",
+            sa.Integer(),
+            sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "atendente_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("estado", sa.String(20), nullable=False, server_default="pendente"),
+        sa.Column("motivo", sa.String(1000), nullable=True),
+        sa.Column("modo", sa.String(20), nullable=True),
+        sa.Column("ate_em", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "decidido_por_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("decidido_em", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("decisao_motivo", sa.String(1000), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_hora_extra"):
+        op.drop_table("ponto_hora_extra")

--- a/backend/app/api/notificacoes.py
+++ b/backend/app/api/notificacoes.py
@@ -314,6 +314,23 @@ def build_notificacao_itens(
             )
         )
 
+    if atendente.role == "admin":
+        from app.services.ponto_hora_extra import contar_pendentes_admin
+
+        he_n = contar_pendentes_admin(db, atendente.tenant_id)
+        if he_n > 0:
+            out.append(
+                NotificacaoItem(
+                    tipo="ponto_he_pendente",
+                    ticket_id=None,
+                    titulo="Hora extra",
+                    descricao="Pedidos após o fim da jornada (WhatsApp)",
+                    count=he_n,
+                    href="/equipe/ponto",
+                    created_at=datetime.now(timezone.utc),
+                )
+            )
+
     inbound_last, eff_seen = _wpp_resposta_pendente_exprs(atendente.id)
     stmt_wpp = (
         select(WhatsappChat)
@@ -414,6 +431,11 @@ def build_notificacao_resumo(db: Session, atendente: Atendente) -> NotificacaoRe
     portal_fila = _count_portal_fila(db, atendente)
     portal_resp = _count_portal_respostas_pendentes(db, atendente)
     chat_interno = chat_interno_svc.contar_total_nao_lidas_atendente(db, atendente)
+    he_pend = 0
+    if atendente.role == "admin":
+        from app.services.ponto_hora_extra import contar_pendentes_admin
+
+        he_pend = contar_pendentes_admin(db, atendente.tenant_id)
     return NotificacaoResumo(
         sem_responsavel_count=sem,
         nao_lidas_count=nao,
@@ -422,7 +444,15 @@ def build_notificacao_resumo(db: Session, atendente: Atendente) -> NotificacaoRe
         portal_fila_count=portal_fila,
         portal_respostas_count=portal_resp,
         chat_interno_nao_lidas_count=chat_interno,
-        total_pendencias=sem + nao + wpp_fila + wpp_resp + portal_fila + portal_resp + chat_interno,
+        ponto_he_pendentes_count=he_pend,
+        total_pendencias=sem
+        + nao
+        + wpp_fila
+        + wpp_resp
+        + portal_fila
+        + portal_resp
+        + chat_interno
+        + he_pend,
     )
 
 

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -27,6 +27,10 @@ from app.schemas.ponto import (
     PontoFeriadoRead,
     PontoHistoricoRead,
     PontoHojeRead,
+    PontoHoraExtraCreate,
+    PontoHoraExtraDecisao,
+    PontoHoraExtraMeStatus,
+    PontoHoraExtraRead,
     PontoJustificativaCreate,
     PontoJustificativaDecisao,
     PontoJustificativaRead,
@@ -38,6 +42,7 @@ from app.schemas.ponto import (
     PontoSettingsUpdate,
 )
 from app.services import ponto as ponto_svc
+from app.services import ponto_hora_extra as he_svc
 from app.services import ponto_justificativa as just_svc
 from app.services import ponto_relatorio as ponto_relatorio_svc
 from app.services import ponto_settings as ponto_settings_svc
@@ -445,4 +450,59 @@ def decidir_justificativa(
         estado=data.estado,
         decisao_motivo=data.decisao_motivo,
         aplicar_batidas=data.aplicar_batidas,
+    )
+
+
+@router.get("/hora-extra/me/status", response_model=PontoHoraExtraMeStatus)
+def hora_extra_me_status(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ponto_svc.exigir_acesso_ponto(atendente)
+    return PontoHoraExtraMeStatus(**he_svc.me_status(db, atendente))
+
+
+@router.get("/hora-extra/me", response_model=list[PontoHoraExtraRead])
+def minhas_hora_extra(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ponto_svc.exigir_acesso_ponto(atendente)
+    return he_svc.listar_me(db, atendente)
+
+
+@router.post("/hora-extra", response_model=PontoHoraExtraRead, status_code=201)
+def solicitar_hora_extra(
+    data: PontoHoraExtraCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ponto_svc.exigir_acesso_ponto(atendente)
+    return he_svc.solicitar(db, atendente, motivo=data.motivo)
+
+
+@router.get("/hora-extra", response_model=list[PontoHoraExtraRead])
+def listar_hora_extra_admin(
+    estado: str | None = Query("pendente"),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return he_svc.listar_admin(db, admin, estado=estado)
+
+
+@router.post("/hora-extra/{he_id}/decidir", response_model=PontoHoraExtraRead)
+def decidir_hora_extra(
+    he_id: int,
+    data: PontoHoraExtraDecisao,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return he_svc.decidir(
+        db,
+        admin,
+        he_id,
+        aprovar=data.aprovar,
+        modo=data.modo,
+        ate_horario=data.ate_horario,
+        decisao_motivo=data.decisao_motivo,
     )

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -1279,6 +1279,9 @@ def iniciar_chat_outbound(
                 )
             estado_anterior = existente.estado
             if existente.estado == "aguardando_atendente" or existente.atendente_id is None:
+                from app.services.ponto_hora_extra import exigir_pode_pegar_whatsapp
+
+                exigir_pode_pegar_whatsapp(db, atendente)
                 existente.estado = "em_atendimento"
                 existente.atendente_id = atendente.id
                 existente.atendimento_inicio_at = datetime.now(timezone.utc)
@@ -1311,6 +1314,10 @@ def iniciar_chat_outbound(
             c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == existente.id).first()
             assert c is not None
             return _chat_read(db, c)
+
+        from app.services.ponto_hora_extra import exigir_pode_pegar_whatsapp
+
+        exigir_pode_pegar_whatsapp(db, atendente)
 
         # Garante Evolution configurada se houver mensagem inicial (criar chat sem msg ainda exige settings para uso posterior)
         _settings_envio(db)
@@ -1862,6 +1869,9 @@ def assumir(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
     if c.estado != "aguardando_atendente":
         raise HTTPException(status_code=400, detail="Só é possível assumir chats na fila de espera")
+    from app.services.ponto_hora_extra import exigir_pode_pegar_whatsapp
+
+    exigir_pode_pegar_whatsapp(db, atendente)
     _aplicar_empresa_contexto_chat(db, atendente, c, empresa_id)
     _aplicar_setor_ao_assumir(db, c, atendente, setor_id)
     estado_anterior = c.estado

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.tipo_negocio import TipoNegocio
 from app.models.atendente import Atendente, AtendenteSetor
 from app.models.ponto_batida import PontoBatida
 from app.models.ponto_justificativa import PontoJustificativa
+from app.models.ponto_hora_extra import PontoHoraExtra
 from app.models.ponto_settings import PontoFeriado, PontoLocal, PontoSettings
 from app.models.setor import Setor
 from app.models.setor_distribuicao_round_robin import SetorDistribuicaoRoundRobin
@@ -100,6 +101,7 @@ __all__ = [
     "SaasSetor",
     "PontoBatida",
     "PontoJustificativa",
+    "PontoHoraExtra",
     "PontoSettings",
     "PontoLocal",
     "PontoFeriado",

--- a/backend/app/models/ponto_hora_extra.py
+++ b/backend/app/models/ponto_hora_extra.py
@@ -1,0 +1,28 @@
+"""Hora extra para atendimento WhatsApp após jornada (#965)."""
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class PontoHoraExtra(Base):
+    __tablename__ = "ponto_hora_extra"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    # pendente | aprovada | rejeitada | expirada
+    estado = Column(String(20), nullable=False, default="pendente", server_default="pendente")
+    motivo = Column(String(1000), nullable=True)
+    # resto_do_dia | ate_horario (só quando aprovada)
+    modo = Column(String(20), nullable=True)
+    ate_em = Column(DateTime(timezone=True), nullable=True)
+    decidido_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    decidido_em = Column(DateTime(timezone=True), nullable=True)
+    decisao_motivo = Column(String(1000), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    atendente = relationship("Atendente", foreign_keys=[atendente_id])
+    decidido_por = relationship("Atendente", foreign_keys=[decidido_por_id])

--- a/backend/app/schemas/notificacoes.py
+++ b/backend/app/schemas/notificacoes.py
@@ -30,6 +30,11 @@ class NotificacaoResumo(BaseModel):
         default=0,
         description="Quantidade de conversas internas com mensagens não lidas",
     )
+    ponto_he_pendentes_count: int = Field(
+        ge=0,
+        default=0,
+        description="Pedidos de hora extra pendentes (só admins)",
+    )
     total_pendencias: int = Field(ge=0, description="Soma usada no badge (sem duplicar fila vs. não lidas)")
 
 
@@ -40,6 +45,7 @@ class NotificacaoItem(BaseModel):
         "wpp_chats_na_fila",
         "wpp_chats_com_resposta",
         "chat_interno",
+        "ponto_he_pendente",
     ]
     ticket_id: int | None = None
     chat_id: int | None = None

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -295,3 +295,37 @@ class PontoJustificativaDecisao(BaseModel):
         motivo: str = Field(..., min_length=3, max_length=500)
 
     aplicar_batidas: list[BatidaAplicar] | None = None
+
+
+class PontoHoraExtraCreate(BaseModel):
+    motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoHoraExtraRead(BaseModel):
+    id: int
+    atendente_id: int
+    atendente_nome: str | None = None
+    estado: str
+    motivo: str | None = None
+    modo: str | None = None
+    ate_em: datetime | None = None
+    decidido_por_id: int | None = None
+    decidido_em: datetime | None = None
+    decisao_motivo: str | None = None
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PontoHoraExtraDecisao(BaseModel):
+    aprovar: bool
+    modo: Literal["resto_do_dia", "ate_horario"] | None = None
+    ate_horario: str | None = Field(default=None, max_length=5, description="HH:MM se modo=ate_horario")
+    decisao_motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoHoraExtraMeStatus(BaseModel):
+    fora_da_jornada: bool
+    pode_pegar_whatsapp: bool
+    he_ativa: PontoHoraExtraRead | None = None
+    pedido_pendente: PontoHoraExtraRead | None = None

--- a/backend/app/services/ponto_hora_extra.py
+++ b/backend/app/services/ponto_hora_extra.py
@@ -1,0 +1,331 @@
+"""Hora extra e bloqueio de pegar WhatsApp após jornada (#965)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timezone
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.audit import registrar_audit
+from app.models.atendente import Atendente
+from app.models.ponto_hora_extra import PontoHoraExtra
+from app.schemas.ponto import PontoHoraExtraRead
+from app.services import escala as escala_svc
+from app.services.escala import PONTO_TZ
+
+MODOS_APROVACAO = frozenset({"resto_do_dia", "ate_horario"})
+
+
+def _agora_tz(when: datetime | None = None) -> datetime:
+    now = when or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=PONTO_TZ)
+    return now.astimezone(PONTO_TZ)
+
+
+def fora_da_jornada(atendente: Atendente, when: datetime | None = None) -> bool:
+    """True se a pessoa está fora do horário esperado (precisa HE para pegar WhatsApp)."""
+    modo = escala_svc.modo_jornada(atendente)
+    if modo == "nenhum" or not escala_svc.escala_configurada(atendente):
+        return False
+    agora = _agora_tz(when)
+    dia = agora.date()
+    if not escala_svc.eh_dia_de_trabalho(atendente, dia):
+        return True
+    saida = escala_svc.saida_prevista_em(atendente, dia)
+    if saida is not None:
+        return agora >= saida
+    # Ciclo sem pe/ps: fora do bloco de trabalho.
+    return not escala_svc.em_periodo_trabalho(atendente, agora)
+
+
+def he_ativa(db: Session, atendente: Atendente, when: datetime | None = None) -> PontoHoraExtra | None:
+    agora = _agora_tz(when)
+    row = (
+        db.query(PontoHoraExtra)
+        .filter(
+            PontoHoraExtra.atendente_id == atendente.id,
+            PontoHoraExtra.estado == "aprovada",
+        )
+        .order_by(PontoHoraExtra.id.desc())
+        .first()
+    )
+    if not row:
+        return None
+    if row.ate_em is None:
+        return None
+    ate = row.ate_em
+    if ate.tzinfo is None:
+        ate = ate.replace(tzinfo=timezone.utc)
+    if agora.astimezone(timezone.utc) >= ate.astimezone(timezone.utc):
+        row.estado = "expirada"
+        db.flush()
+        return None
+    return row
+
+
+def pode_pegar_whatsapp(db: Session, atendente: Atendente, when: datetime | None = None) -> bool:
+    if not fora_da_jornada(atendente, when):
+        return True
+    return he_ativa(db, atendente, when) is not None
+
+
+def exigir_pode_pegar_whatsapp(db: Session, atendente: Atendente) -> None:
+    """Bloqueia assumir/iniciar WhatsApp fora da jornada sem HE (#965)."""
+    if pode_pegar_whatsapp(db, atendente):
+        return
+    garantir_pedido_pendente(
+        db,
+        atendente,
+        motivo="Tentativa de pegar chat WhatsApp após o fim da jornada.",
+        commit=True,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=(
+            "Sua jornada já terminou. Peça hora extra a um administrador "
+            "para pegar novos chats no WhatsApp."
+        ),
+    )
+
+
+def _to_read(row: PontoHoraExtra) -> PontoHoraExtraRead:
+    return PontoHoraExtraRead(
+        id=row.id,
+        atendente_id=row.atendente_id,
+        atendente_nome=row.atendente.nome if row.atendente else None,
+        estado=row.estado,
+        motivo=row.motivo,
+        modo=row.modo,
+        ate_em=row.ate_em,
+        decidido_por_id=row.decidido_por_id,
+        decidido_em=row.decidido_em,
+        decisao_motivo=row.decisao_motivo,
+        created_at=row.created_at,
+    )
+
+
+def garantir_pedido_pendente(
+    db: Session,
+    atendente: Atendente,
+    *,
+    motivo: str | None = None,
+    commit: bool = True,
+) -> PontoHoraExtra:
+    existente = (
+        db.query(PontoHoraExtra)
+        .filter(
+            PontoHoraExtra.atendente_id == atendente.id,
+            PontoHoraExtra.estado == "pendente",
+        )
+        .order_by(PontoHoraExtra.id.desc())
+        .first()
+    )
+    if existente:
+        if motivo and not (existente.motivo or "").strip():
+            existente.motivo = (motivo or "")[:1000]
+        if commit:
+            db.commit()
+            db.refresh(existente)
+        return existente
+    row = PontoHoraExtra(
+        tenant_id=atendente.tenant_id,
+        atendente_id=atendente.id,
+        estado="pendente",
+        motivo=(motivo or "Pedido de hora extra para atendimento WhatsApp.")[:1000],
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(
+        db,
+        "ponto_hora_extra",
+        row.id,
+        "create",
+        atendente.id,
+        payload={"estado": "pendente"},
+    )
+    if commit:
+        db.commit()
+        db.refresh(row)
+        _notificar_admins(db, atendente.tenant_id)
+    return row
+
+
+def solicitar(
+    db: Session,
+    atendente: Atendente,
+    *,
+    motivo: str | None = None,
+) -> PontoHoraExtraRead:
+    if not fora_da_jornada(atendente):
+        raise HTTPException(
+            status_code=400,
+            detail="Você ainda está dentro da jornada — não é necessário pedir hora extra.",
+        )
+    if he_ativa(db, atendente):
+        raise HTTPException(status_code=400, detail="Você já tem hora extra ativa.")
+    row = garantir_pedido_pendente(db, atendente, motivo=motivo, commit=True)
+    db.refresh(row)
+    if row.atendente is None:
+        row = (
+            db.query(PontoHoraExtra)
+            .options(joinedload(PontoHoraExtra.atendente))
+            .filter(PontoHoraExtra.id == row.id)
+            .first()
+        )
+        assert row is not None
+    return _to_read(row)
+
+
+def listar_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    estado: str | None = "pendente",
+) -> list[PontoHoraExtraRead]:
+    q = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.tenant_id == admin.tenant_id)
+    )
+    if estado:
+        q = q.filter(PontoHoraExtra.estado == estado)
+    rows = q.order_by(PontoHoraExtra.created_at.desc(), PontoHoraExtra.id.desc()).limit(100).all()
+    return [_to_read(r) for r in rows]
+
+
+def listar_me(db: Session, atendente: Atendente) -> list[PontoHoraExtraRead]:
+    rows = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.atendente_id == atendente.id)
+        .order_by(PontoHoraExtra.id.desc())
+        .limit(30)
+        .all()
+    )
+    return [_to_read(r) for r in rows]
+
+
+def me_status(db: Session, atendente: Atendente) -> dict:
+    fora = fora_da_jornada(atendente)
+    ativa = he_ativa(db, atendente)
+    pendente = (
+        db.query(PontoHoraExtra)
+        .filter(PontoHoraExtra.atendente_id == atendente.id, PontoHoraExtra.estado == "pendente")
+        .order_by(PontoHoraExtra.id.desc())
+        .first()
+    )
+    return {
+        "fora_da_jornada": fora,
+        "pode_pegar_whatsapp": (not fora) or ativa is not None,
+        "he_ativa": _to_read(ativa) if ativa else None,
+        "pedido_pendente": _to_read(pendente) if pendente else None,
+    }
+
+
+def _fim_resto_do_dia(agora: datetime) -> datetime:
+    dia = agora.astimezone(PONTO_TZ).date()
+    return datetime.combine(dia, time(23, 59, 59), tzinfo=PONTO_TZ)
+
+
+def _parse_ate_horario(dia: date, hhmm: str) -> datetime:
+    parts = (hhmm or "").strip().split(":")
+    if len(parts) < 2:
+        raise HTTPException(status_code=400, detail="Informe o horário no formato HH:MM.")
+    try:
+        h, m = int(parts[0]), int(parts[1])
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail="Horário inválido.") from e
+    if h < 0 or h > 23 or m < 0 or m > 59:
+        raise HTTPException(status_code=400, detail="Horário inválido.")
+    return datetime.combine(dia, time(hour=h, minute=m), tzinfo=PONTO_TZ)
+
+
+def decidir(
+    db: Session,
+    admin: Atendente,
+    he_id: int,
+    *,
+    aprovar: bool,
+    modo: str | None = None,
+    ate_horario: str | None = None,
+    decisao_motivo: str | None = None,
+) -> PontoHoraExtraRead:
+    row = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.id == he_id, PontoHoraExtra.tenant_id == admin.tenant_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Pedido de hora extra não encontrado")
+    if row.estado != "pendente":
+        raise HTTPException(status_code=400, detail="Este pedido já foi decidido.")
+    agora = _agora_tz()
+    row.decidido_por_id = admin.id
+    row.decidido_em = datetime.now(timezone.utc)
+    row.decisao_motivo = (decisao_motivo or "").strip()[:1000] or None
+    if not aprovar:
+        row.estado = "rejeitada"
+        row.modo = None
+        row.ate_em = None
+    else:
+        m = (modo or "").strip().lower()
+        if m not in MODOS_APROVACAO:
+            raise HTTPException(
+                status_code=400,
+                detail="Ao aprovar, escolha modo resto_do_dia ou ate_horario.",
+            )
+        row.estado = "aprovada"
+        row.modo = m
+        if m == "resto_do_dia":
+            row.ate_em = _fim_resto_do_dia(agora)
+        else:
+            ate = _parse_ate_horario(agora.date(), ate_horario or "")
+            if ate <= agora:
+                raise HTTPException(
+                    status_code=400,
+                    detail="O horário limite da hora extra deve ser no futuro.",
+                )
+            row.ate_em = ate
+    registrar_audit(
+        db,
+        "ponto_hora_extra",
+        row.id,
+        "decidir",
+        admin.id,
+        payload={"estado": row.estado, "modo": row.modo, "ate_em": str(row.ate_em)},
+    )
+    db.commit()
+    db.refresh(row)
+    _notificar_admins(db, admin.tenant_id)
+    return _to_read(row)
+
+
+def contar_pendentes_admin(db: Session, tenant_id: int) -> int:
+    return (
+        db.query(PontoHoraExtra)
+        .filter(PontoHoraExtra.tenant_id == tenant_id, PontoHoraExtra.estado == "pendente")
+        .count()
+    )
+
+
+def _notificar_admins(db: Session, tenant_id: int) -> None:
+    try:
+        from app.services.realtime_emit import emit_notificacao_contagem
+
+        ids = [
+            a.id
+            for a in db.query(Atendente)
+            .filter(
+                Atendente.tenant_id == tenant_id,
+                Atendente.role == "admin",
+                Atendente.ativo.is_(True),
+            )
+            .all()
+        ]
+        if ids:
+            emit_notificacao_contagem(db, ids)
+    except Exception:
+        pass

--- a/backend/tests/test_ponto_he_whatsapp_965.py
+++ b/backend/tests/test_ponto_he_whatsapp_965.py
@@ -1,0 +1,115 @@
+"""Bloqueio de pegar WhatsApp após jornada + HE admin (#965)."""
+
+from datetime import date, datetime, timedelta
+
+from app.services.escala import PONTO_TZ
+
+
+def _patch_jornada_semanal(client, headers, atendente_id: int, *, fim="12:00"):
+    """Grade só hoje com saída no passado (fim cedo) para forçar fora da jornada."""
+    keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    hoje_key = keys[date.today().weekday()]
+    hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
+    hs[hoje_key] = {"ativo": True, "inicio": "06:00", "fim": fim}
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={
+            "modo_jornada": "semanal",
+            "usa_escala": True,
+            "horario_semana": hs,
+            "tolerancia_atraso_minutos": 0,
+        },
+    )
+
+
+def _criar_chat_fila(db_session, seed_base, *, wa_suffix: str):
+    from app.models.whatsapp_chat import WhatsappChat
+
+    chat = WhatsappChat(
+        wa_id=f"551199999{wa_suffix}",
+        protocolo=f"WPP-TEST-965-{wa_suffix}",
+        estado="aguardando_atendente",
+        setor_id=seed_base["setor1"].id,
+    )
+    db_session.add(chat)
+    db_session.commit()
+    db_session.refresh(chat)
+    return chat.id
+
+
+def test_assumir_bloqueado_apos_jornada(client, seed_base, auth_headers, db_session):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    fim = (datetime.now(PONTO_TZ) - timedelta(hours=1)).strftime("%H:%M")
+    r_patch = _patch_jornada_semanal(client, admin, a1.id, fim=fim)
+    assert r_patch.status_code == 200, r_patch.text
+    chat_id = _criar_chat_fila(db_session, seed_base, wa_suffix="650")
+    r = client.post(f"/v1/whatsapp/chats/{chat_id}/assumir", headers=user)
+    assert r.status_code == 403, r.text
+    assert "jornada" in r.json()["detail"].lower()
+    pend = client.get("/v1/ponto/hora-extra?estado=pendente", headers=admin)
+    assert pend.status_code == 200
+    assert any(x["atendente_id"] == a1.id for x in pend.json())
+
+
+def test_assumir_ok_com_he(client, seed_base, auth_headers, db_session):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    fim = (datetime.now(PONTO_TZ) - timedelta(hours=1)).strftime("%H:%M")
+    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    chat_id = _criar_chat_fila(db_session, seed_base, wa_suffix="651")
+    assert client.post(f"/v1/whatsapp/chats/{chat_id}/assumir", headers=user).status_code == 403
+    pend = client.get("/v1/ponto/hora-extra?estado=pendente", headers=admin).json()
+    he_id = next(x["id"] for x in pend if x["atendente_id"] == a1.id)
+    dec = client.post(
+        f"/v1/ponto/hora-extra/{he_id}/decidir",
+        headers=admin,
+        json={"aprovar": True, "modo": "resto_do_dia"},
+    )
+    assert dec.status_code == 200, dec.text
+    assert dec.json()["estado"] == "aprovada"
+    chat_id2 = _criar_chat_fila(db_session, seed_base, wa_suffix="652")
+    r = client.post(f"/v1/whatsapp/chats/{chat_id2}/assumir", headers=user)
+    assert r.status_code == 200, r.text
+
+
+def test_assumir_ok_modo_nenhum(client, seed_base, auth_headers, db_session):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"modo_jornada": "nenhum", "usa_escala": False},
+    ).status_code == 200
+    chat_id = _criar_chat_fila(db_session, seed_base, wa_suffix="653")
+    r = client.post(f"/v1/whatsapp/chats/{chat_id}/assumir", headers=user)
+    assert r.status_code == 200, r.text
+
+
+def test_he_rejeitada(client, seed_base, auth_headers, db_session):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    fim = (datetime.now(PONTO_TZ) - timedelta(hours=2)).strftime("%H:%M")
+    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    sol = client.post(
+        "/v1/ponto/hora-extra",
+        headers=user,
+        json={"motivo": "Pico de demanda"},
+    )
+    assert sol.status_code == 201, sol.text
+    he_id = sol.json()["id"]
+    dec = client.post(
+        f"/v1/ponto/hora-extra/{he_id}/decidir",
+        headers=admin,
+        json={"aprovar": False, "decisao_motivo": "Sem necessidade"},
+    )
+    assert dec.status_code == 200
+    assert dec.json()["estado"] == "rejeitada"
+    st = client.get("/v1/ponto/hora-extra/me/status", headers=user)
+    assert st.status_code == 200
+    assert st.json()["pode_pegar_whatsapp"] is False

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -760,6 +760,20 @@ export const ponto = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
+  horaExtraMeStatus: () => api<Ponto.HoraExtraMeStatus>('/ponto/hora-extra/me/status'),
+  minhasHoraExtra: () => api<Ponto.HoraExtra[]>('/ponto/hora-extra/me'),
+  solicitarHoraExtra: (data?: Ponto.HoraExtraCreate) =>
+    api<Ponto.HoraExtra>('/ponto/hora-extra', {
+      method: 'POST',
+      body: JSON.stringify(data ?? {}),
+    }),
+  horaExtraAdmin: (estado?: string) =>
+    api<Ponto.HoraExtra[]>(withParams('/ponto/hora-extra', { estado })),
+  decidirHoraExtra: (id: number, data: Ponto.HoraExtraDecisao) =>
+    api<Ponto.HoraExtra>(`/ponto/hora-extra/${id}/decidir`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   exportCsv: async (params?: { atendente_id?: number; desde?: string; ate?: string }) => {
     const token = getAuthToken()
     const headers: Record<string, string> = {}
@@ -1752,6 +1766,7 @@ export namespace Notificacoes {
     portal_fila_count: number;
     portal_respostas_count: number;
     chat_interno_nao_lidas_count: number;
+    ponto_he_pendentes_count?: number;
     total_pendencias: number;
   }
   export interface Item {
@@ -1760,7 +1775,8 @@ export namespace Notificacoes {
       | 'mensagens_nao_lidas'
       | 'wpp_chats_na_fila'
       | 'wpp_chats_com_resposta'
-      | 'chat_interno';
+      | 'chat_interno'
+      | 'ponto_he_pendente';
     ticket_id: number | null;
     chat_id?: number | null;
     conversa_id?: number | null;
@@ -4960,6 +4976,34 @@ export namespace Ponto {
     estado: 'aprovada' | 'rejeitada'
     decisao_motivo: string
     aplicar_batidas?: { tipo: Tipo; registrado_em: string; motivo: string }[]
+  }
+  export interface HoraExtra {
+    id: number
+    atendente_id: number
+    atendente_nome?: string | null
+    estado: string
+    motivo?: string | null
+    modo?: string | null
+    ate_em?: string | null
+    decidido_por_id?: number | null
+    decidido_em?: string | null
+    decisao_motivo?: string | null
+    created_at?: string | null
+  }
+  export interface HoraExtraCreate {
+    motivo?: string | null
+  }
+  export interface HoraExtraDecisao {
+    aprovar: boolean
+    modo?: 'resto_do_dia' | 'ate_horario' | null
+    ate_horario?: string | null
+    decisao_motivo?: string | null
+  }
+  export interface HoraExtraMeStatus {
+    fora_da_jornada: boolean
+    pode_pegar_whatsapp: boolean
+    he_ativa?: HoraExtra | null
+    pedido_pendente?: HoraExtra | null
   }
 }
 

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -54,6 +54,7 @@ let currentResumo: Notificacoes.Resumo = {
   portal_fila_count: 0,
   portal_respostas_count: 0,
   chat_interno_nao_lidas_count: 0,
+  ponto_he_pendentes_count: 0,
   total_pendencias: 0,
 }
 let prevSemResponsavel: number | null = null

--- a/frontend/src/lib/tratarBloqueioJornadaAssumir.ts
+++ b/frontend/src/lib/tratarBloqueioJornadaAssumir.ts
@@ -1,0 +1,31 @@
+import { ApiError, ponto } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+
+type ToastLike = {
+  showError: (msg: string) => void
+  showSuccess?: (msg: string) => void
+  showWarning?: (msg: string) => void
+}
+
+/** Trata 403 de jornada/HE ao assumir WhatsApp; opcionalmente solicita HE. */
+export async function tratarBloqueioJornadaAoAssumir(
+  err: unknown,
+  toast: ToastLike,
+): Promise<boolean> {
+  if (!(err instanceof ApiError) || err.status !== 403) return false
+  const detail = String((err.body as { detail?: string } | null)?.detail ?? err.message ?? '')
+  const isJornada =
+    /jornada/i.test(detail) || /hora extra/i.test(detail) || /pegar novos chats/i.test(detail)
+  if (!isJornada) return false
+  toast.showError(detail || 'Sua jornada terminou. Peça hora extra a um administrador.')
+  try {
+    await ponto.solicitarHoraExtra({ motivo: 'Pedido ao tentar atender WhatsApp após a jornada.' })
+    toast.showSuccess?.('Pedido de hora extra enviado aos administradores.')
+  } catch (e2) {
+    // Pedido pode já existir — só avisa.
+    if (!(e2 instanceof ApiError && e2.status === 400)) {
+      toast.showWarning?.(mensagemFalhaParaToast(e2, 'Não foi possível registrar o pedido de HE.'))
+    }
+  }
+  return true
+}

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -65,6 +65,10 @@ export function PontoEquipe() {
   const [ajusteMotivo, setAjusteMotivo] = useState('')
   const [salvandoAjuste, setSalvandoAjuste] = useState(false)
   const [justifs, setJustifs] = useState<Ponto.Justificativa[]>([])
+  const [hesPendentes, setHesPendentes] = useState<Ponto.HoraExtra[]>([])
+  const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario'>('resto_do_dia')
+  const [heAteHorario, setHeAteHorario] = useState('20:00')
+  const [decidindoHeId, setDecidindoHeId] = useState<number | null>(null)
   const [digest, setDigest] = useState<Ponto.Digest | null>(null)
   const [banco, setBanco] = useState<Ponto.BancoHoras | null>(null)
   const [settings, setSettings] = useState<Ponto.Settings | null>(null)
@@ -83,7 +87,7 @@ export function PontoEquipe() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [hist, dia, js, dig, st, fer] = await Promise.all([
+        const [hist, dia, js, dig, st, fer, hes] = await Promise.all([
           ponto.batidasAdmin({
             atendente_id: atendenteId ? Number(atendenteId) : undefined,
             desde,
@@ -95,6 +99,7 @@ export function PontoEquipe() {
           ponto.digest(),
           ponto.settings(),
           ponto.feriados(new Date().getFullYear()),
+          ponto.horaExtraAdmin('pendente'),
         ])
         setItems(hist.items)
         setTotal(hist.total)
@@ -103,6 +108,7 @@ export function PontoEquipe() {
         setDigest(dig)
         setSettings(st)
         setFeriados(fer)
+        setHesPendentes(hes)
         setSemPermissao(false)
         if (atendenteId) {
           const bh = await ponto.bancoHorasAdmin(Number(atendenteId), desde, ate)
@@ -245,6 +251,24 @@ export function PontoEquipe() {
       await carregar(true)
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível decidir.'))
+    }
+  }
+
+  async function decidirHe(id: number, aprovar: boolean) {
+    setDecidindoHeId(id)
+    try {
+      await ponto.decidirHoraExtra(id, {
+        aprovar,
+        modo: aprovar ? heModo : null,
+        ate_horario: aprovar && heModo === 'ate_horario' ? heAteHorario : null,
+        decisao_motivo: aprovar ? null : 'Negado pelo administrador',
+      })
+      toast.showSuccess(aprovar ? 'Hora extra liberada.' : 'Pedido de hora extra negado.')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível decidir a hora extra.'))
+    } finally {
+      setDecidindoHeId(null)
     }
   }
 
@@ -428,6 +452,67 @@ export function PontoEquipe() {
                     </Button>
                     <Button type="button" variant="ghost" onClick={() => void decidirJust(j.id, 'rejeitada')}>
                       Rejeitar
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+
+        <Card title="Hora extra (WhatsApp após jornada)">
+          <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
+            Pedidos para pegar novos chats depois do fim da jornada. Ao liberar, escolha o restante do dia ou até um
+            horário.
+          </p>
+          <div className="mb-4 flex flex-wrap items-end gap-3">
+            <Select
+              label="Ao aprovar"
+              value={heModo}
+              onChange={(v) => setHeModo(String(v) as 'resto_do_dia' | 'ate_horario')}
+              options={[
+                { value: 'resto_do_dia', label: 'Resto do dia' },
+                { value: 'ate_horario', label: 'Até horário' },
+              ]}
+            />
+            {heModo === 'ate_horario' ? (
+              <Input
+                label="Até (HH:MM)"
+                type="time"
+                value={heAteHorario}
+                onChange={(e) => setHeAteHorario(e.target.value)}
+              />
+            ) : null}
+          </div>
+          {hesPendentes.length === 0 ? (
+            <p className="text-sm text-slate-500">Nenhum pedido pendente.</p>
+          ) : (
+            <ul className="space-y-3">
+              {hesPendentes.map((h) => (
+                <li
+                  key={h.id}
+                  className="flex flex-wrap items-start justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                >
+                  <div className="text-sm">
+                    <p className="font-medium">{h.atendente_nome ?? h.atendente_id}</p>
+                    <p className="text-slate-600 dark:text-slate-300">{h.motivo || 'Sem motivo informado'}</p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      disabled={decidindoHeId === h.id}
+                      onClick={() => void decidirHe(h.id, true)}
+                    >
+                      Liberar
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      disabled={decidindoHeId === h.id}
+                      onClick={() => void decidirHe(h.id, false)}
+                    >
+                      Negar
                     </Button>
                   </div>
                 </li>

--- a/frontend/src/pages/chat/ChatListaEspera.tsx
+++ b/frontend/src/pages/chat/ChatListaEspera.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '../../contexts/AuthContext'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { useEventStream } from '../../contexts/EventStreamContext'
 import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
+import { tratarBloqueioJornadaAoAssumir } from '../../lib/tratarBloqueioJornadaAssumir'
 import { chatAtivoIgual } from '../../lib/chatHubPaths'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import {
@@ -118,6 +119,9 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
         navigate(chatHubItemLink('atendendo'))
       }
     } catch (err) {
+      if (item.canal === 'whatsapp' && (await tratarBloqueioJornadaAoAssumir(err, toast))) {
+        return
+      }
       const msg =
         err instanceof ApiError && err.status === 400
           ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -5,6 +5,7 @@ import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsapp
 import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
 import { marcarWhatsappChatAtivo, whatsappConversaLink, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
 import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
+import { tratarBloqueioJornadaAoAssumir } from '../../lib/tratarBloqueioJornadaAssumir'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
 import { useAuth } from '../../contexts/AuthContext'
 import { useEventStream } from '../../contexts/EventStreamContext'
@@ -107,6 +108,9 @@ export function WhatsappAtendendo() {
       await load(true)
       void refetchPendenciasResumo()
     } catch (err) {
+      if (await tratarBloqueioJornadaAoAssumir(err, toast)) {
+        return
+      }
       const msg =
         err instanceof ApiError && err.status === 400
           ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -35,6 +35,7 @@ import { WhatsappMensagemAcoes } from '../../components/chat/WhatsappMensagemAco
 import { WhatsappReacoesBar } from '../../components/chat/WhatsappReacoesBar'
 import { CopiarWaIdButton } from '../../components/chat/CopiarWaIdButton'
 import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
+import { tratarBloqueioJornadaAoAssumir } from '../../lib/tratarBloqueioJornadaAssumir'
 
 import { Card } from '../../components/ui/Card'
 import { ChatBottomSheet } from '../../components/ui/ChatBottomSheet'
@@ -1300,6 +1301,9 @@ useEffect(() => {
       abrirChat('whatsapp', chat.id)
       navigate(chatWhatsappLink('atendendo'), { replace: true })
     } catch (err) {
+      if (await tratarBloqueioJornadaAoAssumir(err, toast)) {
+        return
+      }
       const msg =
         err instanceof ApiError && err.status === 400
           ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'


### PR DESCRIPTION
﻿## Summary
- Após o fim da jornada (semanal/ciclo), **pegar** chat WhatsApp novo (assumir / iniciar) fica bloqueado sem hora extra
- Admin libera HE em Ponto da equipe: **resto do dia** ou **até horário**; pedidos no sino de pendências
- Modo jornada `nenhum`: sem restrição; chats já em atendimento seguem normais
- Migration `126_ponto_hora_extra`

Closes #965

## CHANGELOG
- [x] Atualizei `CHANGELOG.md` → `[Unreleased]`

## Test plan
- [x] pytest HE + jornada + geofence + ponto — 33 passed
- [x] Fora da jornada sem HE → assumir 403 + pedido pendente
- [x] HE aprovada → assumir 200
- [x] Modo nenhum → sem bloqueio
- [x] HE rejeitada → continua bloqueado
- [x] Contagem `ponto_he_pendentes` no resumo admin
- [x] `tsc -b` ok
- [ ] Smoke UI: Atender após jornada → toast + pedido; admin libera em Ponto da equipe

## Follow-ups
- [x] #966 HE antecipada + teto (fora deste PR)
