### PR TITLE
feat(saas): gates G1+G2 nas solicitações (#953 #954)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Sugestões (#953 / #954): máquina de estados rígida na triagem (só avanços permitidos); **Implementar** cria ou liga issue no GitHub e só então marca em desenvolvimento — o cliente continua sem ver o GitHub
 - Docs (#879): MCP aponta a `api.deskrudder.com.br`; runbook para desativar cliente sem derrubar o painel SaaS; arquitetura pós-cutover (admin-center vs compose legado)
 - Painel admin: cabeçalho com **Painel admin SaaS** + usuário logado (nome e cargos); **Equipe** com Usuários / Setores / Minha conta; removido o atalho «Painel atendimento»
 - Equipe SaaS: cadastro de **setores/cargos** (Admin, Desenvolvimento, Comercial, …) sem campo ordem; um usuário pode ter **vários** cargos; o cabeçalho mostra os nomes em vez de só «Ops SaaS»

--- a/backend/app/api/saas_solicitacoes.py
+++ b/backend/app/api/saas_solicitacoes.py
@@ -26,6 +26,7 @@ from app.schemas.saas_solicitacao import (
     SaasSolicitacaoComentarioCreate,
     SaasSolicitacaoDetalhe,
     SaasSolicitacaoGithubUpdate,
+    SaasSolicitacaoImplementar,
     SaasSolicitacaoIngest,
     SaasSolicitacaoListaItem,
     SaasSolicitacaoResumo,
@@ -245,6 +246,18 @@ def alterar_status(
     ops: Atendente = Depends(exigir_fila_saas),
 ):
     return triagem.alterar_status(db, solicitacao_id, ops, data)
+
+
+@router.post("/solicitacoes/{solicitacao_id}/implementar", response_model=SaasSolicitacaoDetalhe)
+def implementar(
+    solicitacao_id: int,
+    data: SaasSolicitacaoImplementar = SaasSolicitacaoImplementar(),
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_fila_saas),
+):
+    """G2: cria/liga issue GitHub e avança para em_desenvolvimento."""
+    return triagem.implementar(db, solicitacao_id, ops, data)
 
 
 @router.post("/solicitacoes/{solicitacao_id}/comentarios", response_model=SaasSolicitacaoDetalhe)

--- a/backend/app/schemas/saas_solicitacao.py
+++ b/backend/app/schemas/saas_solicitacao.py
@@ -100,6 +100,15 @@ class SaasSolicitacaoStatusUpdate(BaseModel):
     motivo_nao_desenvolvimento: str | None = Field(None, max_length=4000)
 
 
+class SaasSolicitacaoImplementar(BaseModel):
+    """G2: entra em em_desenvolvimento com issue criada ou ligada."""
+
+    github_issue_url: str | None = Field(None, max_length=500)
+    github_issue_number: int | None = Field(None, ge=1)
+    github_repo: str | None = Field(None, max_length=200)
+    criar_issue: bool = True
+
+
 class SaasSolicitacaoComentarioCreate(BaseModel):
     corpo: str = Field(..., min_length=1, max_length=8000)
     publico_cliente: bool = True

--- a/backend/app/services/saas_solicitacao_github.py
+++ b/backend/app/services/saas_solicitacao_github.py
@@ -1,0 +1,103 @@
+"""Criar/ligar issue GitHub a partir da solicitação SaaS (#954)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+import httpx
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.atendente import Atendente
+from app.models.saas_solicitacao_produto import SaasSolicitacaoProduto, SaasSolicitacaoProdutoComentario
+from app.services.solicitacao_melhoria_github import github_configurado, _headers
+
+logger = logging.getLogger(__name__)
+
+
+def github_repo_produto() -> str:
+    return (settings.GITHUB_REPO_SUGESTOES or "").strip() or "lgustavoss/dx-connect"
+
+
+def montar_corpo_issue_saas(db: Session, row: SaasSolicitacaoProduto) -> str:
+    from app.services import saas_solicitacao_grupo as grupo
+
+    demanda = grupo.texto_github_demanda(db, row)
+    proto = row.protocolo or f"saas-{row.id}"
+    return (
+        f"## Solicitação DeskRudder {proto}\n\n"
+        f"**Tipo:** {row.tipo}\n"
+        f"**Instância:** {row.instance_slug}\n"
+        f"**Autor (origem):** {row.autor_nome or '—'}\n"
+        f"**Versão no envio:** {row.versao_contexto or '—'}\n"
+        f"**Status no SaaS:** {row.status}\n\n"
+        f"### Demanda (grupo)\n{demanda}\n\n"
+        f"### Título\n{row.titulo}\n\n"
+        f"### Descrição\n{row.descricao}\n"
+    )
+
+
+def criar_issue_saas(
+    db: Session,
+    row: SaasSolicitacaoProduto,
+    ops: Atendente,
+) -> SaasSolicitacaoProduto:
+    """Cria issue no GitHub e grava vínculo no pedido (e no grupo). Sem commit."""
+    if not github_configurado():
+        raise HTTPException(
+            status_code=503,
+            detail="Integração GitHub não configurada (GITHUB_TOKEN / GITHUB_REPO_SUGESTOES).",
+        )
+    if row.github_issue_number:
+        raise HTTPException(status_code=400, detail="Esta solicitação já tem issue no GitHub.")
+
+    repo = settings.GITHUB_REPO_SUGESTOES.strip()
+    proto = row.protocolo or f"#{row.id}"
+    url = f"https://api.github.com/repos/{repo}/issues"
+    payload = {
+        "title": f"[{proto}] {row.titulo}"[:240],
+        "body": montar_corpo_issue_saas(db, row),
+        "labels": ["deskrudder-sugestao", row.tipo],
+    }
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            res = client.post(url, headers=_headers(), json=payload)
+    except httpx.HTTPError as exc:
+        logger.warning("GitHub create issue (SaaS) falhou: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="Falha ao contatar o GitHub. Tente novamente.",
+        ) from exc
+
+    if res.status_code >= 400:
+        logger.warning("GitHub rejeitou create issue SaaS: %s", (res.text or "")[:500])
+        raise HTTPException(
+            status_code=502,
+            detail="GitHub rejeitou a criação da issue. Pode tentar de novo.",
+        )
+
+    data = res.json()
+    number = int(data["number"])
+    html = data.get("html_url") or f"https://github.com/{repo}/issues/{number}"
+    row.github_repo = repo
+    row.github_issue_number = number
+    row.github_issue_url = html
+    db.add(row)
+    from app.services import saas_solicitacao_grupo as grupo
+
+    grupo.aplicar_github_no_grupo(db, row, repo=repo, number=number, url=html)
+    db.add(
+        SaasSolicitacaoProdutoComentario(
+            solicitacao_id=row.id,
+            corpo=f"Issue GitHub criada: #{number} (só ops — o cliente não vê).",
+            publico_cliente=False,
+            autor_atendente_id=ops.id,
+            autor_nome=ops.nome,
+        )
+    )
+    row.triagem_atualizada_em = datetime.now(timezone.utc)
+    db.add(row)
+    db.flush()
+    return row

--- a/backend/app/services/saas_solicitacao_triagem.py
+++ b/backend/app/services/saas_solicitacao_triagem.py
@@ -22,6 +22,7 @@ from app.schemas.saas_solicitacao import (
     SaasSolicitacaoComentarioCreate,
     SaasSolicitacaoDetalhe,
     SaasSolicitacaoGithubUpdate,
+    SaasSolicitacaoImplementar,
     SaasSolicitacaoStatusUpdate,
     SaasSolicitacaoSyncComentario,
     SaasSolicitacaoSyncItem,
@@ -33,11 +34,13 @@ from app.services.solicitacao_melhoria import (
     aplicar_protocolo_origem_saas,
     aplicar_status_origem_saas,
 )
-from app.services.solicitacao_melhoria_copy import STATUS_VALIDOS
+from app.services.solicitacao_melhoria_copy import validar_transicao_status
 
 logger = logging.getLogger(__name__)
 
 CACHE_CHAVE_PULL = "saas_triagem_pull"
+
+_GH_ISSUE = re.compile(r"github\.com/([^/\s]+)/([^/\s]+)/issues/(\d+)", re.I)
 
 
 def _agora() -> datetime:
@@ -48,23 +51,28 @@ def _deve_aplicar_local(row: SaasSolicitacaoProduto) -> bool:
     return bool(settings.SAAS_CONTROL_PLANE) and row.instance_slug == ingest.instance_slug_local()
 
 
-def alterar_status(
+def _tem_vinculo_github(row: SaasSolicitacaoProduto) -> bool:
+    return bool(row.github_issue_number and (row.github_issue_url or "").strip())
+
+
+def _aplicar_status_no_row(
     db: Session,
-    solicitacao_id: int,
+    row: SaasSolicitacaoProduto,
     ops: Atendente,
-    data: SaasSolicitacaoStatusUpdate,
-) -> SaasSolicitacaoDetalhe:
-    if data.status not in STATUS_VALIDOS:
-        raise HTTPException(status_code=400, detail="Status inválido")
-    if data.status == "nao_sera_desenvolvida" and not (data.motivo_nao_desenvolvimento or "").strip():
-        raise HTTPException(
-            status_code=400,
-            detail="Informe o motivo quando marcar como não será desenvolvida",
-        )
-    row = ingest.obter(db, solicitacao_id)
-    row.status = data.status
-    if data.status == "nao_sera_desenvolvida":
-        row.motivo_nao_desenvolvimento = (data.motivo_nao_desenvolvimento or "").strip()
+    *,
+    status_novo: str,
+    motivo_nao_desenvolvimento: str | None,
+) -> SaasSolicitacaoProduto:
+    """Valida transição (#953/#954), grava status e propaga à instância local. Sem commit."""
+    validar_transicao_status(
+        row.status,
+        status_novo,
+        tem_vinculo_github=_tem_vinculo_github(row),
+        motivo_nao_desenvolvimento=motivo_nao_desenvolvimento,
+    )
+    row.status = status_novo
+    if status_novo == "nao_sera_desenvolvida":
+        row.motivo_nao_desenvolvimento = (motivo_nao_desenvolvimento or "").strip()
     row.triagem_atualizada_em = _agora()
     db.add(row)
     db.flush()
@@ -77,8 +85,102 @@ def alterar_status(
             motivo_nao_desenvolvimento=row.motivo_nao_desenvolvimento,
             atendente_id=ops.id,
         )
+    return row
+
+
+def alterar_status(
+    db: Session,
+    solicitacao_id: int,
+    ops: Atendente,
+    data: SaasSolicitacaoStatusUpdate,
+) -> SaasSolicitacaoDetalhe:
+    row = ingest.obter(db, solicitacao_id)
+    _aplicar_status_no_row(
+        db,
+        row,
+        ops,
+        status_novo=data.status,
+        motivo_nao_desenvolvimento=data.motivo_nao_desenvolvimento,
+    )
     db.commit()
     return ingest.detalhe(db, ingest.obter(db, row.id))
+
+
+def implementar(
+    db: Session,
+    solicitacao_id: int,
+    ops: Atendente,
+    data: SaasSolicitacaoImplementar,
+) -> SaasSolicitacaoDetalhe:
+    """G2: garante issue GitHub e avança planejada → em_desenvolvimento."""
+    row = ingest.obter(db, solicitacao_id)
+    if row.status != "planejada":
+        raise HTTPException(
+            status_code=400,
+            detail="Só é possível implementar a partir do status Planejada",
+        )
+    url = (data.github_issue_url or "").strip()
+    if url or data.github_issue_number is not None:
+        # Liga (ou re-liga) antes de avançar — sem commit intermediário.
+        _gravar_github(db, row, data)
+    elif not _tem_vinculo_github(row):
+        if not data.criar_issue:
+            raise HTTPException(
+                status_code=400,
+                detail="Indique a URL/número da issue ou permita criar no GitHub",
+            )
+        from app.services.saas_solicitacao_github import criar_issue_saas
+
+        criar_issue_saas(db, row, ops)
+        row = ingest.obter(db, solicitacao_id)
+    _aplicar_status_no_row(
+        db,
+        row,
+        ops,
+        status_novo="em_desenvolvimento",
+        motivo_nao_desenvolvimento=None,
+    )
+    db.commit()
+    return ingest.detalhe(db, ingest.obter(db, row.id))
+
+
+def _gravar_github(
+    db: Session,
+    row: SaasSolicitacaoProduto,
+    data: SaasSolicitacaoGithubUpdate | SaasSolicitacaoImplementar,
+) -> None:
+    """Persiste vínculo GitHub no pedido + grupo. Sem commit."""
+    url = (data.github_issue_url or "").strip()
+    number = data.github_issue_number
+    repo = (data.github_repo or "").strip() or None
+    if url:
+        m = _GH_ISSUE.search(url)
+        if not m:
+            raise HTTPException(status_code=400, detail="URL de issue GitHub inválido")
+        repo = f"{m.group(1)}/{m.group(2)}"
+        number = int(m.group(3))
+        url = f"https://github.com/{repo}/issues/{number}"
+    elif number is not None:
+        from app.services.saas_solicitacao_github import github_repo_produto
+
+        repo = repo or github_repo_produto()
+        url = f"https://github.com/{repo}/issues/{int(number)}"
+    else:
+        raise HTTPException(status_code=400, detail="Indique o URL ou o número da issue")
+    row.github_repo = repo
+    row.github_issue_number = int(number)
+    row.github_issue_url = url
+    db.add(row)
+    from app.services import saas_solicitacao_grupo as grupo
+
+    grupo.aplicar_github_no_grupo(
+        db,
+        row,
+        repo=repo,
+        number=int(number),
+        url=url,
+    )
+    db.flush()
 
 
 _INTERNO_NO_CLIENTE_RE = re.compile(
@@ -131,13 +233,6 @@ def adicionar_comentario(
     return ingest.detalhe(db, ingest.obter(db, row.id))
 
 
-_GH_ISSUE = re.compile(r"github\.com/([^/\s]+)/([^/\s]+)/issues/(\d+)", re.I)
-
-
-def github_repo_produto() -> str:
-    return (settings.GITHUB_REPO_SUGESTOES or "").strip() or "lgustavoss/dx-connect"
-
-
 def ligar_issue_github(
     db: Session,
     solicitacao_id: int,
@@ -145,34 +240,7 @@ def ligar_issue_github(
 ) -> SaasSolicitacaoDetalhe:
     """Grava a issue no pedido SaaS. O cliente da instância não vê o GitHub."""
     row = ingest.obter(db, solicitacao_id)
-    url = (data.github_issue_url or "").strip()
-    number = data.github_issue_number
-    repo = (data.github_repo or "").strip() or None
-    if url:
-        m = _GH_ISSUE.search(url)
-        if not m:
-            raise HTTPException(status_code=400, detail="URL de issue GitHub inválido")
-        repo = f"{m.group(1)}/{m.group(2)}"
-        number = int(m.group(3))
-        url = f"https://github.com/{repo}/issues/{number}"
-    elif number is not None:
-        repo = repo or github_repo_produto()
-        url = f"https://github.com/{repo}/issues/{int(number)}"
-    else:
-        raise HTTPException(status_code=400, detail="Indique o URL ou o número da issue")
-    row.github_repo = repo
-    row.github_issue_number = int(number)
-    row.github_issue_url = url
-    db.add(row)
-    from app.services import saas_solicitacao_grupo as grupo
-
-    grupo.aplicar_github_no_grupo(
-        db,
-        row,
-        repo=repo,
-        number=int(number),
-        url=url,
-    )
+    _gravar_github(db, row, data)
     db.commit()
     return ingest.detalhe(db, ingest.obter(db, row.id))
 

--- a/backend/app/services/solicitacao_melhoria_copy.py
+++ b/backend/app/services/solicitacao_melhoria_copy.py
@@ -28,6 +28,23 @@ STATUS_FINAIS = frozenset({"concluida", "nao_sera_desenvolvida"})
 STATUS_VALIDOS = frozenset(STATUS_LABELS.keys())
 TIPOS_VALIDOS = frozenset({"sugestao", "problema"})
 
+# Transições permitidas na triagem (#953). Sync SaaS→instância aplica o status
+# já validado no control-plane (pode "saltar" se o pull atrasar).
+STATUS_TRANSICOES: dict[str, frozenset[str]] = {
+    "aberta": frozenset({"em_analise", "nao_sera_desenvolvida"}),
+    "em_analise": frozenset({"planejada", "nao_sera_desenvolvida"}),
+    "planejada": frozenset({"em_desenvolvimento", "nao_sera_desenvolvida"}),
+    "em_desenvolvimento": frozenset({"concluida", "nao_sera_desenvolvida"}),
+    "concluida": frozenset(),
+    "nao_sera_desenvolvida": frozenset(),
+}
+
+MSG_TRANSICAO_INVALIDA = "Transição de status não permitida"
+MSG_GITHUB_OBRIGATORIO = (
+    "Para marcar como em desenvolvimento, vincule ou crie uma issue no GitHub "
+    "(ação Implementar)."
+)
+
 # Fases para filtro rápido no painel ops (agrupa status)
 FASES_STATUS: dict[str, frozenset[str]] = {
     "aguardando": frozenset({"aberta", "em_analise", "planejada"}),
@@ -40,6 +57,44 @@ FASES_VALIDAS = frozenset(FASES_STATUS.keys())
 def status_da_fase(fase: str) -> frozenset[str] | None:
     key = (fase or "").strip().lower()
     return FASES_STATUS.get(key)
+
+
+def proximos_status(de: str) -> frozenset[str]:
+    return STATUS_TRANSICOES.get(de, frozenset())
+
+
+def validar_transicao_status(
+    de: str,
+    para: str,
+    *,
+    tem_vinculo_github: bool = False,
+    motivo_nao_desenvolvimento: str | None = None,
+) -> None:
+    """Rejeita saltos ilegais na triagem ops (#953 / #954). Idempotente se de==para."""
+    from fastapi import HTTPException
+
+    if para not in STATUS_VALIDOS:
+        raise HTTPException(status_code=400, detail="Status inválido")
+    if de == para:
+        if para == "nao_sera_desenvolvida" and not (motivo_nao_desenvolvimento or "").strip():
+            raise HTTPException(
+                status_code=400,
+                detail="Informe o motivo quando marcar como não será desenvolvida",
+            )
+        return
+    permitidos = STATUS_TRANSICOES.get(de)
+    if permitidos is None or para not in permitidos:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{MSG_TRANSICAO_INVALIDA}: {rotulo_status(de)} → {rotulo_status(para)}",
+        )
+    if para == "nao_sera_desenvolvida" and not (motivo_nao_desenvolvimento or "").strip():
+        raise HTTPException(
+            status_code=400,
+            detail="Informe o motivo quando marcar como não será desenvolvida",
+        )
+    if para == "em_desenvolvimento" and not tem_vinculo_github:
+        raise HTTPException(status_code=400, detail=MSG_GITHUB_OBRIGATORIO)
 
 
 def mensagem_publica_status(status: str, *, motivo: str | None = None) -> str:

--- a/backend/scripts/mcp_deskrudder_saas.py
+++ b/backend/scripts/mcp_deskrudder_saas.py
@@ -91,9 +91,11 @@ TOOLS = [
     {
         "name": "alterar_status",
         "description": (
-            "Atualiza a triagem. O cliente vê o status em Minhas solicitações. "
-            "Valores: aberta, em_analise, planejada, em_desenvolvimento, concluida, nao_sera_desenvolvida. "
-            "nao_sera_desenvolvida exige motivo visível ao cliente, em português do Brasil."
+            "Atualiza a triagem com máquina de estados rígida. "
+            "Fluxo: aberta→em_analise→planejada→em_desenvolvimento→concluida; "
+            "de qualquer etapa (exceto finais) pode ir a nao_sera_desenvolvida (+ motivo). "
+            "em_desenvolvimento exige issue GitHub já ligada — preferir a tool implementar. "
+            "O cliente vê o status em Minhas solicitações (sem GitHub)."
         ),
         "inputSchema": {
             "type": "object",
@@ -105,6 +107,28 @@ TOOLS = [
                 "motivo_nao_desenvolvimento": {"type": "string"},
             },
             "required": ["status"],
+        },
+    },
+    {
+        "name": "implementar",
+        "description": (
+            "A partir de planejada: cria ou liga issue GitHub e marca em_desenvolvimento. "
+            "Passe github_issue_url (ou número) para ligar; senão cria via API GitHub "
+            "(GITHUB_TOKEN no control-plane). O cliente NÃO vê o GitHub."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer", "minimum": 1},
+                "protocolo": {"type": "string"},
+                "slug": {"type": "string"},
+                "github_issue_url": {"type": "string"},
+                "github_issue_number": {"type": "integer"},
+                "criar_issue": {
+                    "type": "boolean",
+                    "description": "Se true (padrão) e sem URL, cria a issue no GitHub",
+                },
+            },
         },
     },
     {
@@ -296,6 +320,17 @@ def call_tool(name: str, args: dict) -> object:
         if motivo:
             payload["motivo_nao_desenvolvimento"] = motivo
         _, body = _api("PATCH", f"/v1/saas/solicitacoes/{sid}/status", payload)
+        return body
+    if name == "implementar":
+        sid = _id_fila(args)
+        payload: dict[str, object] = {}
+        if args.get("github_issue_url"):
+            payload["github_issue_url"] = args["github_issue_url"]
+        if args.get("github_issue_number") is not None:
+            payload["github_issue_number"] = int(args["github_issue_number"])
+        if "criar_issue" in args:
+            payload["criar_issue"] = bool(args["criar_issue"])
+        _, body = _api("POST", f"/v1/saas/solicitacoes/{sid}/implementar", payload or None)
         return body
     if name == "comentar_solicitacao":
         sid = _id_fila(args)

--- a/backend/tests/test_saas_solicitacoes.py
+++ b/backend/tests/test_saas_solicitacoes.py
@@ -18,6 +18,25 @@ def _criar_solicitacao(client, headers, **kw):
     return client.post("/v1/solicitacoes-melhoria", headers=headers, json=body)
 
 
+def _saas_id_de_origem(client, headers, origem_id: int) -> int:
+    lista = client.get("/v1/saas/solicitacoes", headers=headers).json()["items"]
+    return next(i["id"] for i in lista if i["origem_solicitacao_id"] == origem_id)
+
+
+def _avancar_status(client, headers, saas_id: int, *passos: str) -> dict:
+    """Avança status válidos em sequência (G1)."""
+    body = {}
+    for st in passos:
+        r = client.patch(
+            f"/v1/saas/solicitacoes/{saas_id}/status",
+            headers=headers,
+            json={"status": st},
+        )
+        assert r.status_code == 200, f"{st}: {r.text}"
+        body = r.json()
+    return body
+
+
 def _cliente(client, headers, slug="duplex-soft"):
     r = client.post(
         "/v1/saas/clientes",
@@ -509,11 +528,7 @@ def test_sync_get_autenticado(client, seed_base, auth_headers, monkeypatch):
         headers={"Authorization": f"Bearer {token}"},
     )
     saas_id = ingest.json()["id"]
-    client.patch(
-        f"/v1/saas/solicitacoes/{saas_id}/status",
-        headers=h,
-        json={"status": "planejada"},
-    )
+    _avancar_status(client, h, saas_id, "em_analise", "planejada")
     client.post(
         f"/v1/saas/solicitacoes/{saas_id}/comentarios",
         headers=h,
@@ -602,13 +617,8 @@ def test_mcp_token_lista_status_e_liga_github(client, seed_base, auth_headers, m
     busca = client.get("/v1/saas/solicitacoes", headers=mcp, params={"busca": item["protocolo"]})
     assert busca.status_code == 200
     assert any(i["id"] == saas_id for i in busca.json()["items"])
-    st = client.patch(
-        f"/v1/saas/solicitacoes/{saas_id}/status",
-        headers=mcp,
-        json={"status": "planejada"},
-    )
-    assert st.status_code == 200, st.text
-    assert st.json()["status"] == "planejada"
+    st = _avancar_status(client, mcp, saas_id, "em_analise", "planejada")
+    assert st["status"] == "planejada"
     gh = client.patch(
         f"/v1/saas/solicitacoes/{saas_id}/github",
         headers=mcp,
@@ -635,7 +645,7 @@ def test_mcp_stdio_initialize_e_tools():
     assert "português do Brasil" in init["result"]["instructions"]
     listed = mod.handle({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
     names = {t["name"] for t in listed["result"]["tools"]}
-    assert {"listar_solicitacoes", "obter_solicitacao", "alterar_status", "comentar_solicitacao", "ligar_issue_github", "vincular_solicitacao", "desvincular_solicitacao"} <= names
+    assert {"listar_solicitacoes", "obter_solicitacao", "alterar_status", "implementar", "comentar_solicitacao", "ligar_issue_github", "vincular_solicitacao", "desvincular_solicitacao"} <= names
     comentar = next(t for t in listed["result"]["tools"] if t["name"] == "comentar_solicitacao")
     assert "português do Brasil" in comentar["description"]
 
@@ -767,16 +777,30 @@ def test_fila_filtro_fase_tipo_e_resumo(client, seed_base, auth_headers, monkeyp
     saas_sug = next(i["id"] for i in lista if i["origem_solicitacao_id"] == sid_sug)
     saas_err = next(i["id"] for i in lista if i["origem_solicitacao_id"] == sid_err)
 
-    client.patch(
-        f"/v1/saas/solicitacoes/{saas_sug}/status",
+    _avancar_status(client, h, saas_sug, "em_analise", "planejada")
+    lig = client.patch(
+        f"/v1/saas/solicitacoes/{saas_sug}/github",
         headers=h,
-        json={"status": "em_desenvolvimento"},
+        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/9001"},
     )
-    client.patch(
-        f"/v1/saas/solicitacoes/{saas_err}/status",
+    assert lig.status_code == 200, lig.text
+    impl = client.post(
+        f"/v1/saas/solicitacoes/{saas_sug}/implementar",
         headers=h,
-        json={"status": "concluida"},
+        json={},
     )
+    assert impl.status_code == 200, impl.text
+    assert impl.json()["status"] == "em_desenvolvimento"
+
+    _avancar_status(client, h, saas_err, "em_analise", "planejada")
+    lig2 = client.patch(
+        f"/v1/saas/solicitacoes/{saas_err}/github",
+        headers=h,
+        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/9002"},
+    )
+    assert lig2.status_code == 200, lig2.text
+    assert client.post(f"/v1/saas/solicitacoes/{saas_err}/implementar", headers=h, json={}).status_code == 200
+    _avancar_status(client, h, saas_err, "concluida")
 
     aguardando = client.get("/v1/saas/solicitacoes?fase=aguardando", headers=h)
     assert aguardando.status_code == 200
@@ -806,3 +830,127 @@ def test_fila_filtro_fase_tipo_e_resumo(client, seed_base, auth_headers, monkeyp
     bad = client.get("/v1/saas/solicitacoes?fase=xyz", headers=h)
     assert bad.status_code == 400
 
+
+
+def test_transicao_status_ilegais_400(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
+    sid = _criar_solicitacao(client, auth_headers["a1"]).json()["id"]
+    h = auth_headers["ops"]
+    saas_id = _saas_id_de_origem(client, h, sid)
+
+    for st in ("planejada", "em_desenvolvimento", "concluida"):
+        r = client.patch(
+            f"/v1/saas/solicitacoes/{saas_id}/status",
+            headers=h,
+            json={"status": st},
+        )
+        assert r.status_code == 400, st
+
+    _avancar_status(client, h, saas_id, "em_analise")
+    assert (
+        client.patch(
+            f"/v1/saas/solicitacoes/{saas_id}/status",
+            headers=h,
+            json={"status": "aberta"},
+        ).status_code
+        == 400
+    )
+    _avancar_status(client, h, saas_id, "planejada")
+    sem_gh = client.patch(
+        f"/v1/saas/solicitacoes/{saas_id}/status",
+        headers=h,
+        json={"status": "em_desenvolvimento"},
+    )
+    assert sem_gh.status_code == 400
+    assert "GitHub" in (sem_gh.json().get("detail") or "")
+
+    client.patch(
+        f"/v1/saas/solicitacoes/{saas_id}/github",
+        headers=h,
+        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/9100"},
+    )
+    assert client.post(f"/v1/saas/solicitacoes/{saas_id}/implementar", headers=h, json={}).status_code == 200
+    _avancar_status(client, h, saas_id, "concluida")
+    assert (
+        client.patch(
+            f"/v1/saas/solicitacoes/{saas_id}/status",
+            headers=h,
+            json={"status": "em_analise"},
+        ).status_code
+        == 400
+    )
+
+
+def test_implementar_liga_github_e_avanca(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
+    sid = _criar_solicitacao(client, auth_headers["a1"]).json()["id"]
+    h = auth_headers["ops"]
+    saas_id = _saas_id_de_origem(client, h, sid)
+    _avancar_status(client, h, saas_id, "em_analise", "planejada")
+
+    cedo = client.post(f"/v1/saas/solicitacoes/{saas_id}/implementar", headers=h, json={"criar_issue": False})
+    assert cedo.status_code == 400
+
+    ok = client.post(
+        f"/v1/saas/solicitacoes/{saas_id}/implementar",
+        headers=h,
+        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/954"},
+    )
+    assert ok.status_code == 200, ok.text
+    body = ok.json()
+    assert body["status"] == "em_desenvolvimento"
+    assert body["github_issue_number"] == 954
+    assert "954" in (body["github_issue_url"] or "")
+
+    minhas = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["a1"]).json()
+    assert minhas["status"] == "em_desenvolvimento"
+    assert minhas.get("github_issue_url") in (None, "")
+    assert any(hist["status_novo"] == "em_desenvolvimento" for hist in minhas["historico"])
+
+
+def test_implementar_cria_issue_quando_configurado(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
+    monkeypatch.setattr(settings, "GITHUB_TOKEN", "fake-token")
+    monkeypatch.setattr(settings, "GITHUB_REPO_SUGESTOES", "lgustavoss/dx-connect")
+
+    class _Resp:
+        status_code = 201
+
+        def json(self):
+            return {
+                "number": 4242,
+                "html_url": "https://github.com/lgustavoss/dx-connect/issues/4242",
+            }
+
+    class _Client:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def post(self, url, headers=None, json=None):
+            assert "lgustavoss/dx-connect" in url
+            return _Resp()
+
+    monkeypatch.setattr("app.services.saas_solicitacao_github.httpx.Client", lambda timeout=30.0: _Client())
+
+    sid = _criar_solicitacao(client, auth_headers["a1"]).json()["id"]
+    h = auth_headers["ops"]
+    saas_id = _saas_id_de_origem(client, h, sid)
+    _avancar_status(client, h, saas_id, "em_analise", "planejada")
+    r = client.post(f"/v1/saas/solicitacoes/{saas_id}/implementar", headers=h, json={})
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "em_desenvolvimento"
+    assert r.json()["github_issue_number"] == 4242
+    cliente = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["a1"]).json()
+    assert cliente.get("github_issue_url") in (None, "")

--- a/backend/tests/test_solicitacao_status_transicao.py
+++ b/backend/tests/test_solicitacao_status_transicao.py
@@ -1,0 +1,62 @@
+"""Máquina de estados das solicitações (#953)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.solicitacao_melhoria_copy import (
+    MSG_GITHUB_OBRIGATORIO,
+    MSG_TRANSICAO_INVALIDA,
+    STATUS_TRANSICOES,
+    validar_transicao_status,
+)
+
+
+def test_grafo_completo_v1():
+    assert STATUS_TRANSICOES["aberta"] == frozenset({"em_analise", "nao_sera_desenvolvida"})
+    assert STATUS_TRANSICOES["em_analise"] == frozenset({"planejada", "nao_sera_desenvolvida"})
+    assert STATUS_TRANSICOES["planejada"] == frozenset({"em_desenvolvimento", "nao_sera_desenvolvida"})
+    assert STATUS_TRANSICOES["em_desenvolvimento"] == frozenset({"concluida", "nao_sera_desenvolvida"})
+    assert STATUS_TRANSICOES["concluida"] == frozenset()
+    assert STATUS_TRANSICOES["nao_sera_desenvolvida"] == frozenset()
+
+
+@pytest.mark.parametrize(
+    "de,para",
+    [
+        ("aberta", "planejada"),
+        ("aberta", "em_desenvolvimento"),
+        ("aberta", "concluida"),
+        ("em_analise", "aberta"),
+        ("em_analise", "em_desenvolvimento"),
+        ("planejada", "aberta"),
+        ("planejada", "em_analise"),
+        ("concluida", "aberta"),
+        ("nao_sera_desenvolvida", "em_analise"),
+    ],
+)
+def test_saltos_ilegais(de, para):
+    with pytest.raises(HTTPException) as ei:
+        validar_transicao_status(de, para, tem_vinculo_github=True, motivo_nao_desenvolvimento="x")
+    assert ei.value.status_code == 400
+    assert MSG_TRANSICAO_INVALIDA in str(ei.value.detail)
+
+
+def test_em_desenvolvimento_exige_github():
+    with pytest.raises(HTTPException) as ei:
+        validar_transicao_status("planejada", "em_desenvolvimento", tem_vinculo_github=False)
+    assert ei.value.status_code == 400
+    assert MSG_GITHUB_OBRIGATORIO in str(ei.value.detail)
+    validar_transicao_status("planejada", "em_desenvolvimento", tem_vinculo_github=True)
+
+
+def test_rejeicao_exige_motivo():
+    with pytest.raises(HTTPException) as ei:
+        validar_transicao_status("aberta", "nao_sera_desenvolvida", motivo_nao_desenvolvimento="  ")
+    assert ei.value.status_code == 400
+    validar_transicao_status("aberta", "nao_sera_desenvolvida", motivo_nao_desenvolvimento="Fora do escopo agora.")
+
+
+def test_idempotente_mesmo_status():
+    validar_transicao_status("em_analise", "em_analise")

--- a/backend/tests/test_solicitacoes_melhoria.py
+++ b/backend/tests/test_solicitacoes_melhoria.py
@@ -130,11 +130,26 @@ def test_status_final_bloqueia_resposta_cliente(client, seed_base, auth_headers,
     monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
     monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
     sid = _criar(client, auth_headers["a1"]).json()["id"]
-    lista = client.get("/v1/saas/solicitacoes", headers=auth_headers["ops"]).json()["items"]
+    h = auth_headers["ops"]
+    lista = client.get("/v1/saas/solicitacoes", headers=h).json()["items"]
     saas_id = next(i["id"] for i in lista if i["origem_solicitacao_id"] == sid)
+    for st in ("em_analise", "planejada"):
+        r = client.patch(
+            f"/v1/saas/solicitacoes/{saas_id}/status",
+            headers=h,
+            json={"status": st},
+        )
+        assert r.status_code == 200, r.text
+    client.patch(
+        f"/v1/saas/solicitacoes/{saas_id}/github",
+        headers=h,
+        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/9101"},
+    )
+    impl = client.post(f"/v1/saas/solicitacoes/{saas_id}/implementar", headers=h, json={})
+    assert impl.status_code == 200, impl.text
     r_status = client.patch(
         f"/v1/saas/solicitacoes/{saas_id}/status",
-        headers=auth_headers["ops"],
+        headers=h,
         json={"status": "concluida"},
     )
     assert r_status.status_code == 200, r_status.text

--- a/docs/SAAS_CONTROL_PLANE.md
+++ b/docs/SAAS_CONTROL_PLANE.md
@@ -104,6 +104,10 @@ Quem **usa** o DeskRudder (admin/atendente da instância) abre sugestão ou prob
 
 A **triagem** (status e respostas) é feita por `saas_ops` no detalhe `/saas/solicitacoes/{id}`. O protocolo `#SYYYYMM-NNNN` é **único no produto**: a instância comercial (control-plane, Postgres próprio na VPS) emite o número no ingest; o cliente vê o mesmo valor em Minhas solicitações após o sync. Pedidos iguais de vários clientes ligam-se **só no painel SaaS** (`POST …/vinculos`); o peso é o número de clientes no grupo e **não** volta à instância. No GitHub, o título usa um protocolo; o corpo leva `texto_github_demanda` (lista de protocolos). Comentários **públicos** e o status voltam à instância; notas internas e o grupo ficam só no SaaS. O admin da instância **não** altera status nem envia notas de produto.
 
+**Máquina de estados (G1 #953):** só transições `aberta→em_analise→planejada→em_desenvolvimento→concluida`, com `nao_sera_desenvolvida` (+ motivo) a partir de qualquer etapa não final. Saltos ilegais → HTTP 400. Sync SaaS→instância aplica o status já validado no control-plane (e o histórico na instância continua a registar).
+
+**Implementar (G2 #954):** `POST …/solicitacoes/{id}/implementar` a partir de `planejada` cria issue (API GitHub) ou liga URL/número e avança para `em_desenvolvimento`. Sem vínculo GitHub não entra nesse status. O cliente nível 2 **nunca** vê URL/número da issue.
+
 O **posto** (portal) não entra neste fluxo. Análise no Cursor e issues GitHub **não** fazem parte deste lote (#857).
 
 ### Instância (`SAAS_CONTROL_PLANE=false`)
@@ -129,8 +133,9 @@ No control-plane (`SAAS_CONTROL_PLANE=true`), a abertura grava directo na tabela
 - `GET /v1/saas/ingest/solicitacoes/sync` — mesmo token; devolve status + comentários públicos daquele slug (`?since=` opcional).
 - `GET /v1/saas/solicitacoes` e `GET /v1/saas/solicitacoes/{id}` — `saas_ops` (JWT) ou token Cursor pessoal (`/saas/conta`) / `SAAS_MCP_TOKEN` legado.
 - `PATCH …/solicitacoes/{id}/github` — liga a issue criada no GitHub ao pedido (e ao grupo, se houver). Só ops / MCP; o cliente não vê.
+- `POST …/solicitacoes/{id}/implementar` — G2: cria ou liga issue e marca `em_desenvolvimento` (só a partir de `planejada`).
 - `POST …/solicitacoes/{id}/vinculos` e `DELETE …/vinculos/{membro_id}` — grupo de pedidos iguais (peso). Só ops / MCP.
-- `PATCH /v1/saas/solicitacoes/{id}/status` e `POST /v1/saas/solicitacoes/{id}/comentarios` — triagem.
+- `PATCH /v1/saas/solicitacoes/{id}/status` e `POST /v1/saas/solicitacoes/{id}/comentarios` — triagem (máquina de estados G1).
 - `POST /v1/saas/me/mcp-token` — gera o token Cursor desta conta (plaintext uma vez). `GET` estado; `DELETE` revoga.
 - `GET/POST /v1/saas/usuarios` e `PATCH /v1/saas/usuarios/{id}` — equipa `saas_ops` (nome, e-mail, activo). `POST …/senha-temporaria` devolve senha uma vez. Não são atendentes da instância do cliente.
 - `POST /v1/saas/clientes/{id}/gerar-token-ingest` — devolve o plaintext **uma vez** e escreve no `client.env` se a pasta do cliente já existir.
@@ -160,7 +165,7 @@ O script corre no PC do ops. A fila é a da instância comercial (`SAAS_CONTROL_
 
 O `SAAS_MCP_TOKEN` no `.env` da VPS ainda é aceite como **legado** (não identifica a pessoa). Prefira o token do painel.
 
-Ferramentas: listar, obter, alterar status, comentar, vincular pedidos iguais, ligar issue GitHub (aceitam `id` ou protocolo). Sem OpenAI e sem `CURSOR_API_KEY` no DeskRudder. O GitHub MCP (criar issues) é à parte e também é por instalação do Cursor.
+Ferramentas: listar, obter, alterar status (máquina G1), **implementar** (G2), comentar, vincular pedidos iguais, ligar issue GitHub (aceitam `id` ou protocolo). Sem OpenAI e sem `CURSOR_API_KEY` no DeskRudder. Criar issue pode ser via `implementar` (token GitHub no control-plane) ou MCP GitHub à parte + `ligar_issue_github`.
 
 ## Runbook: desativar cliente sem derrubar o SaaS
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5270,6 +5270,16 @@ export const saasSolicitacoes = {
       method: 'PATCH',
       body: JSON.stringify(data),
     }),
+  implementar: (id: number, data?: SaasSolicitacoesProduto.Implementar) =>
+    api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/implementar`, {
+      method: 'POST',
+      body: JSON.stringify(data ?? {}),
+    }),
+  ligarGithub: (id: number, data: SaasSolicitacoesProduto.GithubUpdate) =>
+    api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/github`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
   comentar: (id: number, data: SaasSolicitacoesProduto.ComentarioCreate) =>
     api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/comentarios`, {
       method: 'POST',
@@ -5440,6 +5450,17 @@ export namespace SaasSolicitacoesProduto {
   export interface StatusUpdate {
     status: string;
     motivo_nao_desenvolvimento?: string | null;
+  }
+  export interface GithubUpdate {
+    github_issue_url?: string | null;
+    github_issue_number?: number | null;
+    github_repo?: string | null;
+  }
+  export interface Implementar {
+    github_issue_url?: string | null;
+    github_issue_number?: number | null;
+    github_repo?: string | null;
+    criar_issue?: boolean;
   }
   export interface ComentarioCreate {
     corpo: string;

--- a/frontend/src/lib/saasSolicitacoes.ts
+++ b/frontend/src/lib/saasSolicitacoes.ts
@@ -11,6 +11,25 @@ export const SAAS_SOLICITACAO_STATUS = [
 
 export type SaasSolicitacaoStatus = (typeof SAAS_SOLICITACAO_STATUS)[number]['value']
 
+/** Máquina de estados G1 (#953) — espelha o backend. */
+export const SAAS_STATUS_TRANSICOES: Record<string, readonly string[]> = {
+  aberta: ['em_analise', 'nao_sera_desenvolvida'],
+  em_analise: ['planejada', 'nao_sera_desenvolvida'],
+  planejada: ['em_desenvolvimento', 'nao_sera_desenvolvida'],
+  em_desenvolvimento: ['concluida', 'nao_sera_desenvolvida'],
+  concluida: [],
+  nao_sera_desenvolvida: [],
+}
+
+export function proximosStatusSolicitacao(atual: string): readonly string[] {
+  return SAAS_STATUS_TRANSICOES[atual] ?? []
+}
+
+export function podeAvancarStatus(de: string, para: string): boolean {
+  if (de === para) return true
+  return proximosStatusSolicitacao(de).includes(para)
+}
+
 /** Fases para filtro rápido (agrupa vários status). */
 export const SAAS_SOLICITACAO_FASES = [
   {

--- a/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
@@ -14,13 +14,14 @@ import {
   classesBadgeStatusSolicitacao,
   classesBadgeTipoSolicitacao,
   mencionaTrabalhoInterno,
+  podeAvancarStatus,
+  proximosStatusSolicitacao,
   rotuloStatusSolicitacao,
   rotuloTipoSolicitacao,
   SAAS_SOLICITACAO_STATUS,
 } from '../../lib/saasSolicitacoes'
 import { SemPermissao } from '../SemPermissao'
 
-const STATUS_FLUXO = SAAS_SOLICITACAO_STATUS.filter((s) => s.value !== 'nao_sera_desenvolvida')
 const STATUS_REJEITAR = SAAS_SOLICITACAO_STATUS.find((s) => s.value === 'nao_sera_desenvolvida')!
 
 function formatWhen(iso: string | null | undefined): string {
@@ -61,6 +62,8 @@ export function SaasSolicitacaoDetalhe() {
   const [tipoMensagem, setTipoMensagem] = useState<'publico' | 'interno'>('publico')
   const [buscaIgual, setBuscaIgual] = useState('')
   const [candidatos, setCandidatos] = useState<SaasSolicitacoesProduto.ListaItem[]>([])
+  const [githubUrl, setGithubUrl] = useState('')
+  const [mostrarImplementar, setMostrarImplementar] = useState(false)
 
   const aplicarDetalhe = useCallback((row: SaasSolicitacoesProduto.Detalhe) => {
     setItem(row)
@@ -149,6 +152,15 @@ export function SaasSolicitacaoDetalhe() {
     setNovoStatus(status)
     if (status === 'nao_sera_desenvolvida') return
     if (item && status === item.status) return
+    if (status === 'em_desenvolvimento') {
+      setMostrarImplementar(true)
+      return
+    }
+    if (item && !podeAvancarStatus(item.status, status)) {
+      toast.showError('Essa transição de status não é permitida. Avance passo a passo.')
+      setNovoStatus(item.status)
+      return
+    }
     await persistirStatus(status)
   }
 
@@ -158,6 +170,32 @@ export function SaasSolicitacaoDetalhe() {
       return
     }
     await persistirStatus('nao_sera_desenvolvida', motivo)
+  }
+
+  async function confirmarImplementar(opts: { criarIssue: boolean; url?: string }) {
+    if (!item) return
+    setBusy(true)
+    try {
+      const data: SaasSolicitacoesProduto.Implementar = {
+        criar_issue: opts.criarIssue,
+      }
+      const url = (opts.url ?? githubUrl).trim()
+      if (url) {
+        data.github_issue_url = url
+        data.criar_issue = false
+      } else if (item.github_issue_url) {
+        data.criar_issue = false
+      }
+      const atualizado = await saasSolicitacoes.implementar(item.id, data)
+      aplicarDetalhe(atualizado)
+      setMostrarImplementar(false)
+      setGithubUrl('')
+      toast.showSuccess('Em desenvolvimento. Issue ligada — o cliente não vê o GitHub.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível implementar'))
+    } finally {
+      setBusy(false)
+    }
   }
 
   async function enviarComentario() {
@@ -263,6 +301,10 @@ export function SaasSolicitacaoDetalhe() {
   )
   const rejeitarPendente = novoStatus === 'nao_sera_desenvolvida' && item.status !== 'nao_sera_desenvolvida'
   const internoActivo = tipoMensagem === 'interno'
+  const proximos = new Set(proximosStatusSolicitacao(item.status))
+  const statusFluxo = SAAS_SOLICITACAO_STATUS.filter((s) => s.value !== 'nao_sera_desenvolvida')
+  const podeRejeitar = proximos.has('nao_sera_desenvolvida') || item.status === 'nao_sera_desenvolvida'
+  const podeImplementar = item.status === 'planejada'
 
   return (
     <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
@@ -299,17 +341,22 @@ export function SaasSolicitacaoDetalhe() {
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_21rem] xl:items-start">
         <aside className="space-y-6 xl:col-start-2 xl:row-start-1">
-          <Card title="Status" description="O cliente vê este andamento em Minhas solicitações.">
+          <Card title="Status" description="O cliente vê este andamento em Minhas solicitações. Só avanços permitidos.">
             <nav className="space-y-1.5" aria-label="Status da triagem">
-              {STATUS_FLUXO.map((s) => {
-                const activo = novoStatus === s.value
+              {statusFluxo.map((s) => {
+                const activo = novoStatus === s.value || (mostrarImplementar && s.value === 'em_desenvolvimento')
+                const atual = item.status === s.value
+                const permitido =
+                  atual ||
+                  proximos.has(s.value) ||
+                  (s.value === 'em_desenvolvimento' && podeImplementar)
                 return (
                   <button
                     key={s.value}
                     type="button"
-                    disabled={busy}
+                    disabled={busy || (!permitido && !atual)}
                     onClick={() => void escolherStatus(s.value)}
-                    className={`flex w-full items-center gap-2.5 rounded-xl border px-3 py-2 text-left text-sm transition disabled:opacity-60 ${
+                    className={`flex w-full items-center gap-2.5 rounded-xl border px-3 py-2 text-left text-sm transition disabled:cursor-not-allowed disabled:opacity-45 ${
                       activo
                         ? 'border-cyan-300 bg-cyan-50/90 ring-1 ring-cyan-400/25 dark:border-cyan-700/60 dark:bg-cyan-950/35 dark:ring-cyan-600/30'
                         : 'border-slate-200 bg-white hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 dark:hover:bg-slate-800/50'
@@ -321,7 +368,7 @@ export function SaasSolicitacaoDetalhe() {
                     <span className={`min-w-0 flex-1 font-medium ${activo ? 'text-slate-900 dark:text-slate-50' : 'text-slate-700 dark:text-slate-200'}`}>
                       {s.label}
                     </span>
-                    {item.status === s.value ? (
+                    {atual ? (
                       <span className="text-[10px] font-semibold uppercase tracking-wide text-cyan-700 dark:text-cyan-300">
                         atual
                       </span>
@@ -332,9 +379,9 @@ export function SaasSolicitacaoDetalhe() {
               <div className="my-2 border-t border-slate-100 dark:border-slate-800" />
               <button
                 type="button"
-                disabled={busy}
+                disabled={busy || !podeRejeitar}
                 onClick={() => void escolherStatus(STATUS_REJEITAR.value)}
-                className={`flex w-full items-center gap-2.5 rounded-xl border px-3 py-2 text-left text-sm transition disabled:opacity-60 ${
+                className={`flex w-full items-center gap-2.5 rounded-xl border px-3 py-2 text-left text-sm transition disabled:cursor-not-allowed disabled:opacity-45 ${
                   novoStatus === STATUS_REJEITAR.value
                     ? 'border-rose-300 bg-rose-50/90 ring-1 ring-rose-400/25 dark:border-rose-800/60 dark:bg-rose-950/35 dark:ring-rose-700/30'
                     : 'border-slate-200 bg-white hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 dark:hover:bg-slate-800/50'
@@ -353,6 +400,61 @@ export function SaasSolicitacaoDetalhe() {
                 ) : null}
               </button>
             </nav>
+            {mostrarImplementar || (podeImplementar && novoStatus === 'em_desenvolvimento') ? (
+              <div className="mt-3 space-y-2 rounded-xl border border-cyan-200 bg-cyan-50/50 p-3 dark:border-cyan-800/50 dark:bg-cyan-950/30">
+                <p className="text-xs font-medium text-cyan-900 dark:text-cyan-100">
+                  Implementar exige issue no GitHub (o cliente não vê o link).
+                </p>
+                {item.github_issue_url ? (
+                  <p className="text-xs text-slate-600 dark:text-slate-300">
+                    Já ligada:{' '}
+                    <a
+                      href={item.github_issue_url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-medium text-cyan-700 underline dark:text-cyan-400"
+                    >
+                      #{item.github_issue_number}
+                    </a>
+                  </p>
+                ) : (
+                  <Input
+                    label="URL da issue (opcional)"
+                    placeholder="https://github.com/org/repo/issues/123"
+                    value={githubUrl}
+                    onChange={(e) => setGithubUrl(e.target.value)}
+                  />
+                )}
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant="primary"
+                    loading={busy}
+                    onClick={() =>
+                      void confirmarImplementar({
+                        criarIssue: !item.github_issue_url && !githubUrl.trim(),
+                        url: githubUrl,
+                      })
+                    }
+                  >
+                    {item.github_issue_url || githubUrl.trim()
+                      ? 'Ligar e implementar'
+                      : 'Criar issue e implementar'}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    disabled={busy}
+                    onClick={() => {
+                      setMostrarImplementar(false)
+                      setNovoStatus(item.status)
+                    }}
+                  >
+                    Cancelar
+                  </Button>
+                </div>
+              </div>
+            ) : null}
             {novoStatus === 'nao_sera_desenvolvida' ? (
               <div className="mt-3 space-y-2">
                 <textarea
@@ -372,7 +474,7 @@ export function SaasSolicitacaoDetalhe() {
             </p>
           </Card>
 
-          {item.github_issue_url ? (
+          {item.github_issue_url && !mostrarImplementar ? (
             <Card title="Issue no GitHub" description="Só neste painel — o cliente não vê o link.">
               <a
                 href={item.github_issue_url}


### PR DESCRIPTION
## Summary

- **G1 (#953):** máquina de estados rígida na triagem SaaS — só transições permitidas (`aberta → em_analise → planejada → em_desenvolvimento → concluida` + rejeição com motivo); saltos ilegais retornam HTTP 400; histórico na instância preservado via sync.
- **G2 (#954):** ação **Implementar** (`POST /v1/saas/solicitacoes/{id}/implementar`) cria ou liga issue GitHub e só então avança para `em_desenvolvimento`; cliente continua sem ver URL/número da issue.
- UI ops: passos de status desabilitados quando inválidos + painel Implementar; MCP com tool `implementar`.

Closes #953
Closes #954

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest tests/test_solicitacao_status_transicao.py tests/test_saas_solicitacoes.py tests/test_solicitacoes_melhoria.py` — 50 passed
- [x] `npm run build` (frontend)
- [ ] Smoke manual: detalhe `/saas/solicitacoes/{id}` — avançar passo a passo; Implementar com URL ou criar issue; confirmar que cliente em Minhas solicitações não vê GitHub

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] G3–G5 (#955–#957) permanecem no épico #808 para lotes seguintes
- [x] Sync instância não revalida grafo (fonte da verdade = control-plane) — comportamento documentado em `docs/SAAS_CONTROL_PLANE.md`
