### PR TITLE
fix(saas): versão alvo só ao concluir no release (#955)

### DIFF
--- a/.cursor/commands/listar-solicitacoes.md
+++ b/.cursor/commands/listar-solicitacoes.md
@@ -59,14 +59,13 @@ Não imprimir o token.
 
 ## Depois da listagem
 
-Só se o usuário pedir: detalhe (`obter_solicitacao`), alterar status, **definir versão alvo** (`definir_versao_alvo`), implementar, comentar, vincular pedidos ou ligar issue GitHub. Não triar sozinho.
+Só se o usuário pedir: detalhe (`obter_solicitacao`), alterar status, implementar, comentar, vincular pedidos ou ligar issue GitHub. Não triar sozinho.
 
 ### Checklist antes de implementar código (G5 / #957)
 
 - [ ] Protocolo `#S…` confirmado (`obter_solicitacao`)
 - [ ] Status `planejada` ou `em_desenvolvimento`
 - [ ] Issue GitHub ligada (`implementar` — G2)
-- [ ] `versao_alvo` opcional se release já conhecido (G3)
 - [ ] CHANGELOG do PR cita `#S…` para conclusão automática no deploy (G4)
 
 Comentário ao cliente: **português do Brasil**, sem GitHub/`issue #`. Sem pedido explícito de falar com o cliente, use nota interna (`publico_cliente=false`).

--- a/.cursor/rules/saas-solicitacoes-cursor.mdc
+++ b/.cursor/rules/saas-solicitacoes-cursor.mdc
@@ -39,9 +39,8 @@ Checklist (MCP ou `/listar-solicitacoes`):
 - [ ] Protocolo `#S…` confirmado
 - [ ] Status `planejada` ou `em_desenvolvimento`
 - [ ] Issue GitHub ligada (`implementar` feito)
-- [ ] `versao_alvo` definida se já souber o release (G3)
 - [ ] Comentários ao cliente: pt-BR, **sem** GitHub/issue #
 
 ## Release
 
-CHANGELOG `[Unreleased]` cita `#S…` e/ou issue. No deploy admin-center, pedidos citados viram `concluida` + versão (G4).
+CHANGELOG `[Unreleased]` cita `#S…` e/ou issue. No deploy admin-center, pedidos citados viram `concluida` + versão liberada visível ao cliente (G4).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 #### Melhorias
 
 - Sugestões (#953 / #954): máquina de estados rígida na triagem (só avanços permitidos); **Implementar** cria ou liga issue no GitHub e só então marca em desenvolvimento — o cliente continua sem ver o GitHub
-- Sugestões (#955–#957): **versão alvo** (CalVer) visível em Minhas solicitações; ops define em planejada/desenvolvimento; no deploy admin-center pedidos citados no CHANGELOG (`#S…` / issue) passam a concluída com a versão liberada; rule Cursor para só codar com protocolo + issue ligada
+- Sugestões (#955–#957): quando o pedido é **concluído** no deploy, Minhas solicitações mostra **Disponível a partir da versão X (ou superior)** — a versão vem do release real (CalVer), não há previsão manual em planejada/desenvolvimento; rule Cursor para só codar com protocolo + issue ligada
 - Docs (#879): MCP aponta a `api.deskrudder.com.br`; runbook para desativar cliente sem derrubar o painel SaaS; arquitetura pós-cutover (admin-center vs compose legado)
 - Painel admin: cabeçalho com **Painel admin SaaS** + usuário logado (nome e cargos); **Equipe** com Usuários / Setores / Minha conta; removido o atalho «Painel atendimento»
 - Equipe SaaS: cadastro de **setores/cargos** (Admin, Desenvolvimento, Comercial, …) sem campo ordem; um usuário pode ter **vários** cargos; o cabeçalho mostra os nomes em vez de só «Ops SaaS»

--- a/backend/app/api/saas_solicitacoes.py
+++ b/backend/app/api/saas_solicitacoes.py
@@ -33,7 +33,6 @@ from app.schemas.saas_solicitacao import (
     SaasSolicitacaoStatusUpdate,
     SaasSolicitacaoSyncResponse,
     SaasSolicitacaoVinculoCreate,
-    SaasSolicitacaoVersaoAlvoUpdate,
 )
 
 router = APIRouter(prefix="/saas", tags=["saas-solicitacoes"])
@@ -259,18 +258,6 @@ def implementar(
 ):
     """G2: cria/liga issue GitHub e avança para em_desenvolvimento."""
     return triagem.implementar(db, solicitacao_id, ops, data)
-
-
-@router.patch("/solicitacoes/{solicitacao_id}/versao-alvo", response_model=SaasSolicitacaoDetalhe)
-def definir_versao_alvo(
-    solicitacao_id: int,
-    data: SaasSolicitacaoVersaoAlvoUpdate,
-    db: Session = Depends(get_db),
-    _: None = Depends(exigir_saas_control_plane),
-    ops: Atendente = Depends(exigir_fila_saas),
-):
-    """G3: define versão prevista/liberada visível ao cliente."""
-    return triagem.definir_versao_alvo(db, solicitacao_id, ops, data)
 
 
 @router.post("/solicitacoes/{solicitacao_id}/comentarios", response_model=SaasSolicitacaoDetalhe)

--- a/backend/app/schemas/saas_solicitacao.py
+++ b/backend/app/schemas/saas_solicitacao.py
@@ -110,13 +110,6 @@ class SaasSolicitacaoImplementar(BaseModel):
     criar_issue: bool = True
 
 
-class SaasSolicitacaoVersaoAlvoUpdate(BaseModel):
-    """G3: versão prevista/liberada visível ao cliente nível 2."""
-
-    versao_alvo: str | None = Field(None, max_length=64)
-    comentario_publico: str | None = Field(None, max_length=8000)
-
-
 class SaasSolicitacaoComentarioCreate(BaseModel):
     corpo: str = Field(..., min_length=1, max_length=8000)
     publico_cliente: bool = True

--- a/backend/app/services/saas_solicitacao_release.py
+++ b/backend/app/services/saas_solicitacao_release.py
@@ -146,7 +146,7 @@ def concluir_pedidos_release(
     concluidos = 0
     ignorados = 0
     erros = 0
-    comentario = f"Melhoria disponível na versão {versao_n}."
+    comentario = f"Melhoria disponível a partir da versão {versao_n} (ou superior)."
     origem = f"release:{versao_n}"
 
     for row in candidatos:

--- a/backend/app/services/saas_solicitacao_triagem.py
+++ b/backend/app/services/saas_solicitacao_triagem.py
@@ -27,7 +27,6 @@ from app.schemas.saas_solicitacao import (
     SaasSolicitacaoSyncComentario,
     SaasSolicitacaoSyncItem,
     SaasSolicitacaoSyncResponse,
-    SaasSolicitacaoVersaoAlvoUpdate,
 )
 from app.services import saas_solicitacao_ingest as ingest
 from app.services.solicitacao_melhoria import (
@@ -36,7 +35,7 @@ from app.services.solicitacao_melhoria import (
     aplicar_status_origem_saas,
     aplicar_versao_alvo_origem_saas,
 )
-from app.services.solicitacao_melhoria_copy import normalizar_versao_alvo, validar_transicao_status
+from app.services.solicitacao_melhoria_copy import validar_transicao_status
 
 logger = logging.getLogger(__name__)
 
@@ -143,57 +142,6 @@ def implementar(
         status_novo="em_desenvolvimento",
         motivo_nao_desenvolvimento=None,
     )
-    db.commit()
-    return ingest.detalhe(db, ingest.obter(db, row.id))
-
-
-def definir_versao_alvo(
-    db: Session,
-    solicitacao_id: int,
-    ops: Atendente,
-    data: SaasSolicitacaoVersaoAlvoUpdate,
-) -> SaasSolicitacaoDetalhe:
-    """G3: versão prevista/liberada visível ao cliente em planejada/em_desenvolvimento."""
-    row = ingest.obter(db, solicitacao_id)
-    if row.status not in ("planejada", "em_desenvolvimento"):
-        raise HTTPException(
-            status_code=400,
-            detail="Só é possível definir versão alvo em Planejada ou Em desenvolvimento",
-        )
-    versao = normalizar_versao_alvo(data.versao_alvo)
-    row.versao_alvo = versao
-    row.triagem_atualizada_em = _agora()
-    db.add(row)
-    db.flush()
-    if _deve_aplicar_local(row):
-        aplicar_versao_alvo_origem_saas(db, row.origem_solicitacao_id, versao)
-    comentario = (data.comentario_publico or "").strip()
-    if comentario:
-        if corpo_publico_cita_trabalho_interno(comentario):
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "Não envie links ou números de issue do GitHub na mensagem ao cliente. "
-                    "Use comentário interno."
-                ),
-            )
-        c = SaasSolicitacaoProdutoComentario(
-            solicitacao_id=row.id,
-            corpo=comentario,
-            publico_cliente=True,
-            autor_atendente_id=ops.id,
-            autor_nome=ops.nome,
-        )
-        db.add(c)
-        db.flush()
-        if _deve_aplicar_local(row):
-            aplicar_comentario_origem_saas(
-                db,
-                row.origem_solicitacao_id,
-                corpo=c.corpo,
-                origem_externa_id=f"saas:{c.id}",
-                autor_nome=c.autor_nome,
-            )
     db.commit()
     return ingest.detalhe(db, ingest.obter(db, row.id))
 

--- a/backend/app/services/solicitacao_melhoria_copy.py
+++ b/backend/app/services/solicitacao_melhoria_copy.py
@@ -114,12 +114,8 @@ def normalizar_versao_alvo(valor: str | None) -> str | None:
 
 
 def rotulo_versao_alvo_publica(status: str, versao: str | None) -> str | None:
-    """Rótulo amigável para Minhas solicitações (#955)."""
+    """Rótulo para Minhas solicitações — só quando concluída (#955)."""
     v = normalizar_versao_alvo(versao)
-    if not v:
+    if not v or status != "concluida":
         return None
-    if status == "concluida":
-        return f"Disponível na {v}"
-    if status in ("planejada", "em_desenvolvimento"):
-        return f"Prevista para {v}"
-    return None
+    return f"Disponível a partir da versão {v} (ou superior)"

--- a/backend/scripts/mcp_deskrudder_saas.py
+++ b/backend/scripts/mcp_deskrudder_saas.py
@@ -110,23 +110,6 @@ TOOLS = [
         },
     },
     {
-        "name": "definir_versao_alvo",
-        "description": (
-            "Define versão CalVer prevista/liberada visível ao cliente (G3). "
-            "Só em planejada ou em_desenvolvimento. Comentário público opcional."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "id": {"type": "integer", "minimum": 1},
-                "protocolo": {"type": "string"},
-                "slug": {"type": "string"},
-                "versao_alvo": {"type": "string", "description": "Ex.: 2026.08.26 — vazio para limpar"},
-                "comentario_publico": {"type": "string"},
-            },
-        },
-    },
-    {
         "name": "implementar",
         "description": (
             "A partir de planejada: cria ou liga issue GitHub e marca em_desenvolvimento. "
@@ -337,15 +320,6 @@ def call_tool(name: str, args: dict) -> object:
         if motivo:
             payload["motivo_nao_desenvolvimento"] = motivo
         _, body = _api("PATCH", f"/v1/saas/solicitacoes/{sid}/status", payload)
-        return body
-    if name == "definir_versao_alvo":
-        sid = _id_fila(args)
-        payload: dict[str, object] = {}
-        if "versao_alvo" in args:
-            payload["versao_alvo"] = (args.get("versao_alvo") or "").strip() or None
-        if args.get("comentario_publico"):
-            payload["comentario_publico"] = str(args["comentario_publico"])
-        _, body = _api("PATCH", f"/v1/saas/solicitacoes/{sid}/versao-alvo", payload)
         return body
     if name == "implementar":
         sid = _id_fila(args)

--- a/backend/tests/test_saas_solicitacoes.py
+++ b/backend/tests/test_saas_solicitacoes.py
@@ -956,7 +956,8 @@ def test_implementar_cria_issue_quando_configurado(client, seed_base, auth_heade
     assert cliente.get("github_issue_url") in (None, "")
 
 
-def test_definir_versao_alvo_sync_cliente(client, seed_base, auth_headers, monkeypatch):
+def test_versao_alvo_rotulo_so_apos_release(client, seed_base, auth_headers, monkeypatch):
+    """Versão só aparece ao cliente quando concluída (G4), não em planejada."""
     from app.config import settings
 
     monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
@@ -966,37 +967,12 @@ def test_definir_versao_alvo_sync_cliente(client, seed_base, auth_headers, monke
     saas_id = _saas_id_de_origem(client, h, sid)
     _avancar_status(client, h, saas_id, "em_analise", "planejada")
 
-    ok = client.patch(
-        f"/v1/saas/solicitacoes/{saas_id}/versao-alvo",
-        headers=h,
-        json={"versao_alvo": "2026.09.01", "comentario_publico": "Entra na próxima versão."},
-    )
-    assert ok.status_code == 200, ok.text
-    assert ok.json()["versao_alvo"] == "2026.09.01"
-
     minhas = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["a1"]).json()
-    assert minhas["versao_alvo"] == "2026.09.01"
-    assert minhas["versao_alvo_rotulo"] == "Prevista para 2026.09.01"
-    assert any("próxima versão" in c["corpo"] for c in minhas["comentarios"])
+    assert minhas.get("versao_alvo_rotulo") in (None, "")
 
-    client.post(
-        f"/v1/saas/solicitacoes/{saas_id}/implementar",
-        headers=h,
-        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/9551"},
-    )
-    ok2 = client.patch(
+    inexistente = client.patch(
         f"/v1/saas/solicitacoes/{saas_id}/versao-alvo",
-        headers=h,
-        json={"versao_alvo": "2026.10.01"},
-    )
-    assert ok2.status_code == 200
-    assert ok2.json()["versao_alvo"] == "2026.10.01"
-
-    sid2 = _criar_solicitacao(client, auth_headers["a1"]).json()["id"]
-    saas_aberta = _saas_id_de_origem(client, h, sid2)
-    bloq = client.patch(
-        f"/v1/saas/solicitacoes/{saas_aberta}/versao-alvo",
         headers=h,
         json={"versao_alvo": "2026.09.01"},
     )
-    assert bloq.status_code == 400
+    assert inexistente.status_code == 404

--- a/backend/tests/test_solicitacao_release.py
+++ b/backend/tests/test_solicitacao_release.py
@@ -59,7 +59,7 @@ def test_concluir_pedidos_release_idempotente(client, seed_base, auth_headers, m
     minhas = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["a1"]).json()
     assert minhas["status"] == "concluida"
     assert minhas["versao_alvo"] == "2026.08.99"
-    assert minhas["versao_alvo_rotulo"] == "Disponível na 2026.08.99"
+    assert minhas["versao_alvo_rotulo"] == "Disponível a partir da versão 2026.08.99 (ou superior)"
 
     stats2 = concluir_pedidos_release(db_session, versao="2026.08.99", textos_changelog=[texto])
     assert stats2["concluidos"] == 0

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5373,11 +5373,6 @@ export const saasSolicitacoes = {
       method: 'POST',
       body: JSON.stringify(data ?? {}),
     }),
-  definirVersaoAlvo: (id: number, data: SaasSolicitacoesProduto.VersaoAlvoUpdate) =>
-    api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/versao-alvo`, {
-      method: 'PATCH',
-      body: JSON.stringify(data),
-    }),
   ligarGithub: (id: number, data: SaasSolicitacoesProduto.GithubUpdate) =>
     api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/github`, {
       method: 'PATCH',
@@ -5569,10 +5564,6 @@ export namespace SaasSolicitacoesProduto {
   export interface ComentarioCreate {
     corpo: string;
     publico_cliente: boolean;
-  }
-  export interface VersaoAlvoUpdate {
-    versao_alvo?: string | null;
-    comentario_publico?: string | null;
   }
 }
 

--- a/frontend/src/lib/saasSolicitacoes.ts
+++ b/frontend/src/lib/saasSolicitacoes.ts
@@ -82,13 +82,11 @@ export function rotuloTipoSolicitacao(tipo: string): string {
   return tipo === 'problema' ? 'Erro' : 'Sugestão'
 }
 
-/** Rótulo amigável de versão alvo para o cliente (#955). */
+/** Rótulo de versão liberada — só quando concluída (#955). */
 export function rotuloVersaoAlvo(status: string, versao: string | null | undefined): string | null {
   const v = (versao || '').trim()
-  if (!v) return null
-  if (status === 'concluida') return `Disponível na ${v}`
-  if (status === 'planejada' || status === 'em_desenvolvimento') return `Prevista para ${v}`
-  return null
+  if (!v || status !== 'concluida') return null
+  return `Disponível a partir da versão ${v} (ou superior)`
 }
 
 export function classesBadgeTipoSolicitacao(tipo: string): string {

--- a/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
@@ -65,14 +65,11 @@ export function SaasSolicitacaoDetalhe() {
   const [candidatos, setCandidatos] = useState<SaasSolicitacoesProduto.ListaItem[]>([])
   const [githubUrl, setGithubUrl] = useState('')
   const [mostrarImplementar, setMostrarImplementar] = useState(false)
-  const [versaoAlvo, setVersaoAlvo] = useState('')
-  const [comentarioVersao, setComentarioVersao] = useState('')
 
   const aplicarDetalhe = useCallback((row: SaasSolicitacoesProduto.Detalhe) => {
     setItem(row)
     setNovoStatus(row.status)
     setMotivo(row.motivo_nao_desenvolvimento || '')
-    setVersaoAlvo(row.versao_alvo || '')
   }, [])
 
   useEffect(() => {
@@ -202,24 +199,6 @@ export function SaasSolicitacaoDetalhe() {
     }
   }
 
-  async function salvarVersaoAlvo() {
-    if (!item) return
-    setBusy(true)
-    try {
-      const atualizado = await saasSolicitacoes.definirVersaoAlvo(item.id, {
-        versao_alvo: versaoAlvo.trim() || null,
-        comentario_publico: comentarioVersao.trim() || null,
-      })
-      aplicarDetalhe(atualizado)
-      setComentarioVersao('')
-      toast.showSuccess('Versão alvo atualizada — o cliente vê em Minhas solicitações.')
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a versão'))
-    } finally {
-      setBusy(false)
-    }
-  }
-
   async function enviarComentario() {
     if (!item || !comentario.trim()) return
     const publico = tipoMensagem === 'publico'
@@ -327,7 +306,6 @@ export function SaasSolicitacaoDetalhe() {
   const statusFluxo = SAAS_SOLICITACAO_STATUS.filter((s) => s.value !== 'nao_sera_desenvolvida')
   const podeRejeitar = proximos.has('nao_sera_desenvolvida') || item.status === 'nao_sera_desenvolvida'
   const podeImplementar = item.status === 'planejada'
-  const podeDefinirVersao = item.status === 'planejada' || item.status === 'em_desenvolvimento'
   const rotuloVersaoCliente = rotuloVersaoAlvo(item.status, item.versao_alvo)
 
   return (
@@ -498,36 +476,12 @@ export function SaasSolicitacaoDetalhe() {
             </p>
           </Card>
 
-          {podeDefinirVersao || item.versao_alvo ? (
+          {rotuloVersaoCliente ? (
             <Card
-              title="Versão alvo"
-              description="Visível ao cliente em Minhas solicitações (sem GitHub)."
+              title="Versão liberada"
+              description="O cliente vê em Minhas solicitações quando o pedido está concluído."
             >
-              {rotuloVersaoCliente ? (
-                <p className="mb-3 text-sm font-medium text-emerald-800 dark:text-emerald-200">
-                  {rotuloVersaoCliente}
-                </p>
-              ) : null}
-              {podeDefinirVersao ? (
-                <div className="space-y-2">
-                  <Input
-                    label="CalVer prevista"
-                    placeholder="2026.08.26"
-                    value={versaoAlvo}
-                    onChange={(e) => setVersaoAlvo(e.target.value)}
-                  />
-                  <textarea
-                    className={TEXTAREA_FIELD_CLASS}
-                    rows={2}
-                    value={comentarioVersao}
-                    onChange={(e) => setComentarioVersao(e.target.value)}
-                    placeholder="Comentário público opcional ao definir a versão"
-                  />
-                  <Button type="button" variant="primary" loading={busy} onClick={() => void salvarVersaoAlvo()}>
-                    Salvar versão
-                  </Button>
-                </div>
-              ) : null}
+              <p className="text-sm font-medium text-emerald-800 dark:text-emerald-200">{rotuloVersaoCliente}</p>
             </Card>
           ) : null}
 


### PR DESCRIPTION
## Summary

- Ajuste de produto (#955): versão CalVer **só aparece ao cliente** quando o pedido está **concluída**, preenchida automaticamente no deploy (G4)
- Remove previsão manual em planejada/desenvolvimento: endpoint `PATCH …/versao-alvo`, MCP `definir_versao_alvo` e card editável no painel ops
- Copy ao cliente: «Disponível a partir da versão X (ou superior)»

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest tests/test_saas_solicitacoes.py::test_versao_alvo_rotulo_so_apos_release tests/test_solicitacao_release.py -q`
- [ ] Minhas solicitações: pedido em planejada/desenvolvimento **sem** rótulo de versão
- [ ] Após conclusão no release: rótulo «Disponível a partir da versão … (ou superior)»
- [ ] Painel ops: sem card de editar versão; só leitura quando concluída

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Ajuste refinado de #955 — sem follow-up adicional
- [ ] N/A stubs
