### PR TITLE
release: main → staging

### DIFF
--- a/.cursor/commands/listar-solicitacoes.md
+++ b/.cursor/commands/listar-solicitacoes.md
@@ -59,14 +59,13 @@ Não imprimir o token.
 
 ## Depois da listagem
 
-Só se o usuário pedir: detalhe (`obter_solicitacao`), alterar status, **definir versão alvo** (`definir_versao_alvo`), implementar, comentar, vincular pedidos ou ligar issue GitHub. Não triar sozinho.
+Só se o usuário pedir: detalhe (`obter_solicitacao`), alterar status, implementar, comentar, vincular pedidos ou ligar issue GitHub. Não triar sozinho.
 
 ### Checklist antes de implementar código (G5 / #957)
 
 - [ ] Protocolo `#S…` confirmado (`obter_solicitacao`)
 - [ ] Status `planejada` ou `em_desenvolvimento`
 - [ ] Issue GitHub ligada (`implementar` — G2)
-- [ ] `versao_alvo` opcional se release já conhecido (G3)
 - [ ] CHANGELOG do PR cita `#S…` para conclusão automática no deploy (G4)
 
 Comentário ao cliente: **português do Brasil**, sem GitHub/`issue #`. Sem pedido explícito de falar com o cliente, use nota interna (`publico_cliente=false`).

--- a/.cursor/commands/listar-solicitacoes.md
+++ b/.cursor/commands/listar-solicitacoes.md
@@ -59,6 +59,14 @@ Não imprimir o token.
 
 ## Depois da listagem
 
-Só se o usuário pedir: detalhe (`obter_solicitacao`), alterar status, comentar, vincular pedidos ou ligar issue GitHub. Não triar sozinho.
+Só se o usuário pedir: detalhe (`obter_solicitacao`), alterar status, **definir versão alvo** (`definir_versao_alvo`), implementar, comentar, vincular pedidos ou ligar issue GitHub. Não triar sozinho.
+
+### Checklist antes de implementar código (G5 / #957)
+
+- [ ] Protocolo `#S…` confirmado (`obter_solicitacao`)
+- [ ] Status `planejada` ou `em_desenvolvimento`
+- [ ] Issue GitHub ligada (`implementar` — G2)
+- [ ] `versao_alvo` opcional se release já conhecido (G3)
+- [ ] CHANGELOG do PR cita `#S…` para conclusão automática no deploy (G4)
 
 Comentário ao cliente: **português do Brasil**, sem GitHub/`issue #`. Sem pedido explícito de falar com o cliente, use nota interna (`publico_cliente=false`).

--- a/.cursor/rules/saas-solicitacoes-cursor.mdc
+++ b/.cursor/rules/saas-solicitacoes-cursor.mdc
@@ -39,9 +39,8 @@ Checklist (MCP ou `/listar-solicitacoes`):
 - [ ] Protocolo `#S…` confirmado
 - [ ] Status `planejada` ou `em_desenvolvimento`
 - [ ] Issue GitHub ligada (`implementar` feito)
-- [ ] `versao_alvo` definida se já souber o release (G3)
 - [ ] Comentários ao cliente: pt-BR, **sem** GitHub/issue #
 
 ## Release
 
-CHANGELOG `[Unreleased]` cita `#S…` e/ou issue. No deploy admin-center, pedidos citados viram `concluida` + versão (G4).
+CHANGELOG `[Unreleased]` cita `#S…` e/ou issue. No deploy admin-center, pedidos citados viram `concluida` + versão liberada visível ao cliente (G4).

--- a/.cursor/rules/saas-solicitacoes-cursor.mdc
+++ b/.cursor/rules/saas-solicitacoes-cursor.mdc
@@ -1,0 +1,47 @@
+---
+description: Fluxo Cursor/MCP para solicitações SaaS — gates G2/G3/G5 (#957)
+globs:
+  - backend/app/services/saas_solicitacao*.py
+  - backend/app/api/saas_solicitacoes.py
+  - backend/scripts/mcp_deskrudder_saas.py
+  - frontend/src/pages/saas/**
+alwaysApply: false
+---
+
+# Solicitações SaaS — Cursor e MCP
+
+## Quando implementar produto
+
+Só codar melhoria/bug de **produto DeskRudder** a partir da fila SaaS quando:
+
+1. Existe **protocolo** `#SYYYYMM-NNNN` (MCP `obter_solicitacao` ou fila `/saas/solicitacoes`)
+2. Pedido em **`planejada`** ou **`em_desenvolvimento`**
+3. **Issue GitHub ligada** — use MCP `implementar` (G2); não avançar para `em_desenvolvimento` sem issue
+4. Título/corpo da issue referencia o protocolo; copie `texto_github_demanda` quando houver grupo
+
+## Pedidos internos de produto
+
+Abrir no **painel SaaS** (origem interna), não criar issue GitHub primeiro. Depois: triagem → implementar → PR com `#S…` no CHANGELOG.
+
+## Exceções GitHub-only (sem protocolo prévio)
+
+Permitido **sem** `#S` antes do código:
+
+- `chore` / deps / CI / docs sem impacto de produto
+- Hotfix urgente em produção
+
+Nesses casos: PR normal; opcional abrir/ligar `#S` post-hoc na fila SaaS.
+
+## Handoff antes de codar
+
+Checklist (MCP ou `/listar-solicitacoes`):
+
+- [ ] Protocolo `#S…` confirmado
+- [ ] Status `planejada` ou `em_desenvolvimento`
+- [ ] Issue GitHub ligada (`implementar` feito)
+- [ ] `versao_alvo` definida se já souber o release (G3)
+- [ ] Comentários ao cliente: pt-BR, **sem** GitHub/issue #
+
+## Release
+
+CHANGELOG `[Unreleased]` cita `#S…` e/ou issue. No deploy admin-center, pedidos citados viram `concluida` + versão (G4).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Docs (#879): MCP aponta a `api.deskrudder.com.br`; runbook para desativar cliente sem derrubar o painel SaaS; arquitetura pós-cutover (admin-center vs compose legado)
+- Painel admin: cabeçalho com **Painel admin SaaS** + usuário logado (nome e cargos); **Equipe** com Usuários / Setores / Minha conta; removido o atalho «Painel atendimento»
+- Equipe SaaS: cadastro de **setores/cargos** (Admin, Desenvolvimento, Comercial, …) sem campo ordem; um usuário pode ter **vários** cargos; o cabeçalho mostra os nomes em vez de só «Ops SaaS»
+- Minha conta: além do token Cursor, o ops edita **nome**, **e-mail** e **senha**
+- Licenças: coluna **Valor/mês** com valor negociado (ou estimativa do catálogo); campo opcional na ficha para negociação diferente do plano
+- Catálogo comercial: **preço por módulo**; plano = soma dos módulos habilitados; licença pode misturar (ex. Essencial + 1 módulo Enterprise); **3 usuários inclusos** + R$ 10/usuário extra (editável no plano)
+- Catálogo comercial: módulos do produto pré-cadastrados; planos Trial / Essencial / Profissional / Enterprise (sem teto de postos nem tickets)
 - Infra (#880): deploy GitHub Actions atualiza **duas** stacks — build/dist DuplexSoft e build/dist comercial; migrate em cada Postgres; health com flags SaaS distintas
 - Infra: `stack-client.sh migrate` fecha o stdin (`-T` + `/dev/null`) para o `docker compose run` não engolir o resto do script SSH no deploy do admin-center
 - Infra (#876 / #877 / #878): painel admin em `api.deskrudder.com.br` + SPA em `deskrudder.com.br`; fila e contas ops migradas para o Postgres comercial; DuplexSoft passa a só **ingerir** sugestões (control-plane desligado nessa instância)
@@ -18,6 +25,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 - Login ops: no primeiro acesso (trocar senha) o painel SaaS já não mostra «não disponível nesta instância»; redirecciona para definir senha nova
 - Sobre (#920): o painel ops lista **todas** as notas da versão, com etiqueta **Produto** ou **DevOps**. O helpdesk nas instâncias continua a ver só as de produto
 - Login do painel admin: em produção deixa de aparecer a dica de desenvolvimento (e-mail local)
+- Sugestões: na fila, chips de **tipo** (Sugestão / Erro) e **fase** (Aguardando, Em desenvolvimento, Finalizadas), com contadores; badges coloridos na lista e no detalhe
 - Sugestões (#923): detalhe com **linha do tempo** (pedido + mensagens ao cliente); notas internas em cartão âmbar; status em passos clicáveis, como nos tickets
 - Sugestões: textos de acompanhamento em português do Brasil; mensagem ao cliente **não pode citar** GitHub nem número de issue (isso fica na nota interna)
 - Painel ops: menu **Equipe** (Usuários + Minha conta); **Sobre** e **Sair** no rodapé, no mesmo padrão do painel de atendimento

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Correções
 
+- WhatsApp (#947 / #S202608-0005): ao abrir o menu Editar/Apagar/Reagir (ou editar mensagem), o strip de emojis do hover deixa de cobrir as opções
 - Deploy: migration do chat interno (#916) usava um ID Alembic maior que 32 caracteres e quebrava o `upgrade` em produção; ID encurtado para caber em `alembic_version`
 
 #### Melhorias

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 #### Melhorias
 
 - Sugestões (#953 / #954): máquina de estados rígida na triagem (só avanços permitidos); **Implementar** cria ou liga issue no GitHub e só então marca em desenvolvimento — o cliente continua sem ver o GitHub
-- Sugestões (#955–#957): **versão alvo** (CalVer) visível em Minhas solicitações; ops define em planejada/desenvolvimento; no deploy admin-center pedidos citados no CHANGELOG (`#S…` / issue) passam a concluída com a versão liberada; rule Cursor para só codar com protocolo + issue ligada
+- Sugestões (#955–#957): quando o pedido é **concluído** no deploy, Minhas solicitações mostra **Disponível a partir da versão X (ou superior)** — a versão vem do release real (CalVer), não há previsão manual em planejada/desenvolvimento; rule Cursor para só codar com protocolo + issue ligada
 - Docs (#879): MCP aponta a `api.deskrudder.com.br`; runbook para desativar cliente sem derrubar o painel SaaS; arquitetura pós-cutover (admin-center vs compose legado)
 - Painel admin: cabeçalho com **Painel admin SaaS** + usuário logado (nome e cargos); **Equipe** com Usuários / Setores / Minha conta; removido o atalho «Painel atendimento»
 - Equipe SaaS: cadastro de **setores/cargos** (Admin, Desenvolvimento, Comercial, …) sem campo ordem; um usuário pode ter **vários** cargos; o cabeçalho mostra os nomes em vez de só «Ops SaaS»

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- WhatsApp / Portal (#943 / #S202608-0002): no modal de **encerrar** atendimento, **Concluir/Encerrar** fica azul (ação principal) e **Cancelar** vermelho — deixa de confundir dois botões iguais
 - WhatsApp (mobile): ao **Atender**, o modal de setor fica **centralizado** com lista tocável (sem dropdown cortado no rodapé); o Select genérico também abre para cima quando não há espaço abaixo
 - WhatsApp: seleção de **Empresa do atendimento** no modal — lista deixa de ficar cortada/desproporcional (menu no fluxo do formulário; modal um pouco mais estreito)
 - Configurações (#865): menu reorganizado — **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; Catálogos PDV em **PDV**; Empresa só com dados da instalação; URLs antigas redirecionam

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Ponto (#959 / #960–#964 / #961–#963): jornada **semanal** (grade Dia/Aberto/Início/Fim como no chat) ou **ciclo** X×Y, ou **nenhum**; entrada só a partir de início−tolerância; atraso só após início+tolerância; fecho por esquecimento (N horas **ou** saída prevista+margem); alertas in-app de falta/atraso para colaborador e admin
 - WhatsApp (mobile): ao **Atender**, o modal de setor fica **centralizado** com lista tocável (sem dropdown cortado no rodapé); o Select genérico também abre para cima quando não há espaço abaixo
 - WhatsApp: seleção de **Empresa do atendimento** no modal — lista deixa de ficar cortada/desproporcional (menu no fluxo do formulário; modal um pouco mais estreito)
 - Configurações (#865): menu reorganizado — **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; Catálogos PDV em **PDV**; Empresa só com dados da instalação; URLs antigas redirecionam

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 ### DeskRudder
 
+#### Melhorias
+
+- Ponto (#984): locais de trabalho no **cadastro do atendente** (empresa + extras no mapa OSM); pin da empresa em Configurações → Empresa; raio e ativar/desativar por local; removido o card global de Locais em Ponto da equipe
+
 #### Correções
 
 - WhatsApp (#947 / #S202608-0005): ao abrir o menu Editar/Apagar/Reagir (ou editar mensagem), o strip de emojis do hover deixa de cobrir as opções

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Ponto (#965): após o fim da jornada, **pegar** chat WhatsApp novo fica bloqueado até um admin liberar **hora extra** (resto do dia ou até um horário); pedidos aparecem em Ponto da equipe e no sino de pendências
 - Ponto (#984): locais de trabalho no **cadastro do atendente** (empresa + extras no mapa OSM); pin da empresa em Configurações → Empresa; raio e ativar/desativar por local; removido o card global de Locais em Ponto da equipe
 
 #### Correções

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Sugestões (#953 / #954): máquina de estados rígida na triagem (só avanços permitidos); **Implementar** cria ou liga issue no GitHub e só então marca em desenvolvimento — o cliente continua sem ver o GitHub
 - Docs (#879): MCP aponta a `api.deskrudder.com.br`; runbook para desativar cliente sem derrubar o painel SaaS; arquitetura pós-cutover (admin-center vs compose legado)
 - Painel admin: cabeçalho com **Painel admin SaaS** + usuário logado (nome e cargos); **Equipe** com Usuários / Setores / Minha conta; removido o atalho «Painel atendimento»
 - Equipe SaaS: cadastro de **setores/cargos** (Admin, Desenvolvimento, Comercial, …) sem campo ordem; um usuário pode ter **vários** cargos; o cabeçalho mostra os nomes em vez de só «Ops SaaS»

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 #### Melhorias
 
 - Sugestões (#953 / #954): máquina de estados rígida na triagem (só avanços permitidos); **Implementar** cria ou liga issue no GitHub e só então marca em desenvolvimento — o cliente continua sem ver o GitHub
+- Sugestões (#955–#957): **versão alvo** (CalVer) visível em Minhas solicitações; ops define em planejada/desenvolvimento; no deploy admin-center pedidos citados no CHANGELOG (`#S…` / issue) passam a concluída com a versão liberada; rule Cursor para só codar com protocolo + issue ligada
 - Docs (#879): MCP aponta a `api.deskrudder.com.br`; runbook para desativar cliente sem derrubar o painel SaaS; arquitetura pós-cutover (admin-center vs compose legado)
 - Painel admin: cabeçalho com **Painel admin SaaS** + usuário logado (nome e cargos); **Equipe** com Usuários / Setores / Minha conta; removido o atalho «Painel atendimento»
 - Equipe SaaS: cadastro de **setores/cargos** (Admin, Desenvolvimento, Comercial, …) sem campo ordem; um usuário pode ter **vários** cargos; o cabeçalho mostra os nomes em vez de só «Ops SaaS»

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- WhatsApp / Portal (#951 / #S202608-0004): contador de **mensagens não lidas** na lista Atendendo e divisor «Mensagens não lidas» ao abrir a conversa (continua de onde parou)
 - WhatsApp (mobile): ao **Atender**, o modal de setor fica **centralizado** com lista tocável (sem dropdown cortado no rodapé); o Select genérico também abre para cima quando não há espaço abaixo
 - WhatsApp: seleção de **Empresa do atendimento** no modal — lista deixa de ficar cortada/desproporcional (menu no fluxo do formulário; modal um pouco mais estreito)
 - Configurações (#865): menu reorganizado — **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; Catálogos PDV em **PDV**; Empresa só com dados da instalação; URLs antigas redirecionam

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Chat interno (#941 / #S202608-0008): no canal de **setor**, clicar no nome abre modal com membros vinculados e quem está **online**
 - WhatsApp (mobile): ao **Atender**, o modal de setor fica **centralizado** com lista tocável (sem dropdown cortado no rodapé); o Select genérico também abre para cima quando não há espaço abaixo
 - WhatsApp: seleção de **Empresa do atendimento** no modal — lista deixa de ficar cortada/desproporcional (menu no fluxo do formulário; modal um pouco mais estreito)
 - Configurações (#865): menu reorganizado — **Equipe** e **Tickets** separados; Tipos de negócio em Comercial/CRM; Catálogos PDV em **PDV**; Empresa só com dados da instalação; URLs antigas redirecionam

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Correções
 
+- WhatsApp (#945 / #S202608-0003): **Exportar PDF** só aparece em chats finalizados (encerrado ou aguardando avaliação), não durante o atendimento
 - Deploy: migration do chat interno (#916) usava um ID Alembic maior que 32 caracteres e quebrava o `upgrade` em produção; ID encurtado para caber em `alembic_version`
 
 #### Melhorias

--- a/backend/alembic/versions/120_saas_setores_ops.py
+++ b/backend/alembic/versions/120_saas_setores_ops.py
@@ -1,0 +1,82 @@
+"""Setores da equipe SaaS no control-plane.
+
+Revision ID: 120_saas_setores_ops
+Revises: 119_chat_canal_setor_backfill
+Create Date: 2026-08-25
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "120_saas_setores_ops"
+down_revision = "119_chat_canal_setor_backfill"
+branch_labels = None
+depends_on = None
+
+_SEED = ("Admin", "Desenvolvimento", "Comercial")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if not insp.has_table("saas_setores"):
+        op.create_table(
+            "saas_setores",
+            sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+            sa.Column("tenant_id", sa.Integer(), sa.ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False),
+            sa.Column("nome", sa.String(length=100), nullable=False),
+            sa.Column("ativo", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+            sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()")),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        )
+        op.create_index("ix_saas_setores_tenant_id", "saas_setores", ["tenant_id"])
+        op.create_unique_constraint("uq_saas_setores_tenant_nome", "saas_setores", ["tenant_id", "nome"])
+    else:
+        idxs = {i["name"] for i in insp.get_indexes("saas_setores")}
+        if "ix_saas_setores_tenant_id" not in idxs:
+            op.create_index("ix_saas_setores_tenant_id", "saas_setores", ["tenant_id"])
+        uqs = {c["name"] for c in insp.get_unique_constraints("saas_setores")}
+        if "uq_saas_setores_tenant_nome" not in uqs:
+            op.create_unique_constraint("uq_saas_setores_tenant_nome", "saas_setores", ["tenant_id", "nome"])
+
+    if not insp.has_table("saas_ops_setor"):
+        op.create_table(
+            "saas_ops_setor",
+            sa.Column(
+                "atendente_id",
+                sa.Integer(),
+                sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+                primary_key=True,
+            ),
+            sa.Column(
+                "saas_setor_id",
+                sa.Integer(),
+                sa.ForeignKey("saas_setores.id", ondelete="CASCADE"),
+                primary_key=True,
+            ),
+        )
+
+    tenants = bind.execute(sa.text("SELECT id FROM tenants")).fetchall()
+    for (tid,) in tenants:
+        for nome in _SEED:
+            bind.execute(
+                sa.text(
+                    "INSERT INTO saas_setores (tenant_id, nome, ativo) "
+                    "VALUES (:tid, :nome, true) "
+                    "ON CONFLICT ON CONSTRAINT uq_saas_setores_tenant_nome DO NOTHING"
+                ),
+                {"tid": tid, "nome": nome},
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("saas_ops_setor"):
+        op.drop_table("saas_ops_setor")
+    if insp.has_table("saas_setores"):
+        idxs = {i["name"] for i in insp.get_indexes("saas_setores")}
+        if "ix_saas_setores_tenant_id" in idxs:
+            op.drop_index("ix_saas_setores_tenant_id", table_name="saas_setores")
+        op.drop_table("saas_setores")

--- a/backend/alembic/versions/121_saas_catalogo_precos.py
+++ b/backend/alembic/versions/121_saas_catalogo_precos.py
@@ -1,0 +1,193 @@
+"""Catálogo comercial ampliado: módulos do produto + planos com preço e max_usuários.
+
+Revision ID: 121_saas_catalogo_precos
+Revises: 120_saas_setores_ops
+Create Date: 2026-08-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "121_saas_catalogo_precos"
+down_revision = "120_saas_setores_ops"
+branch_labels = None
+depends_on = None
+
+# (codigo, nome, descricao)
+_MODULOS = (
+    ("helpdesk", "Helpdesk / tickets", "Tickets e atendimento helpdesk"),
+    ("whatsapp", "WhatsApp", "Canal WhatsApp / Evolution"),
+    ("contratos", "Contratos comerciais", "Contratos comerciais (parte do CRM)"),
+    ("boletos", "Boletos / cobrança", "Emissão e gestão de boletos no fluxo de cobrança"),
+    ("email", "Canal e-mail", "Atendimento e tickets por e-mail"),
+    ("portal", "Portal do posto", "Portal para funcionários da rede / posto"),
+    ("kb", "Base de conhecimento", "Artigos de ajuda e consulta"),
+    ("chat-interno", "Chat interno", "Chat entre a equipe da instância"),
+    ("crm", "CRM / funil / propostas", "Funil comercial, leads e propostas"),
+    ("faturamento", "Faturamento interno", "Faturas internas e fluxo NFS-e"),
+    ("ponto", "Ponto eletrônico", "Batidas, escala e ponto da equipe"),
+    ("sla", "SLA", "Políticas e calendários de SLA"),
+    ("pdv", "Cadastros PDV", "Catálogos e cadastros de PDV / postos"),
+    ("mobile", "App mobile", "App Android (APK) do painel"),
+)
+
+# (codigo, nome, descricao, ordem, preco_mensal, max_usuarios, modulos)
+_PLANOS = (
+    (
+        "trial",
+        "Trial",
+        "Avaliação — helpdesk e WhatsApp",
+        10,
+        0,
+        3,
+        ("helpdesk", "whatsapp"),
+    ),
+    (
+        "essencial",
+        "Essencial",
+        "Atendimento omnichannel essencial (tickets, WhatsApp, e-mail, portal e KB)",
+        20,
+        397,
+        8,
+        ("helpdesk", "whatsapp", "email", "portal", "kb"),
+    ),
+    (
+        "profissional",
+        "Profissional",
+        "Operação completa com CRM, chat interno, SLA e PDV",
+        30,
+        797,
+        20,
+        (
+            "helpdesk",
+            "whatsapp",
+            "email",
+            "portal",
+            "kb",
+            "chat-interno",
+            "crm",
+            "contratos",
+            "sla",
+            "pdv",
+        ),
+    ),
+    (
+        "enterprise",
+        "Enterprise",
+        "Pacote completo — ponto, faturamento, boletos e app mobile",
+        40,
+        1497,
+        50,
+        (
+            "helpdesk",
+            "whatsapp",
+            "email",
+            "portal",
+            "kb",
+            "chat-interno",
+            "crm",
+            "contratos",
+            "sla",
+            "pdv",
+            "ponto",
+            "faturamento",
+            "boletos",
+            "mobile",
+        ),
+    ),
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("saas_modulos") or not insp.has_table("saas_planos"):
+        return
+
+    for codigo, nome, descricao in _MODULOS:
+        bind.execute(
+            sa.text(
+                """
+                INSERT INTO saas_modulos (codigo, nome, descricao, ativo)
+                VALUES (:codigo, :nome, :descricao, true)
+                ON CONFLICT ON CONSTRAINT uq_saas_modulos_codigo DO UPDATE SET
+                    nome = EXCLUDED.nome,
+                    descricao = EXCLUDED.descricao,
+                    ativo = true,
+                    updated_at = now()
+                """
+            ),
+            {"codigo": codigo, "nome": nome, "descricao": descricao},
+        )
+
+    for codigo, nome, descricao, ordem, preco, max_usuarios, _mods in _PLANOS:
+        bind.execute(
+            sa.text(
+                """
+                INSERT INTO saas_planos (
+                    codigo, nome, descricao, ativo, ordem,
+                    preco_mensal, max_postos, max_usuarios
+                )
+                VALUES (
+                    :codigo, :nome, :descricao, true, :ordem,
+                    :preco, NULL, :max_usuarios
+                )
+                ON CONFLICT ON CONSTRAINT uq_saas_planos_codigo DO UPDATE SET
+                    nome = EXCLUDED.nome,
+                    descricao = EXCLUDED.descricao,
+                    ativo = true,
+                    ordem = EXCLUDED.ordem,
+                    preco_mensal = EXCLUDED.preco_mensal,
+                    max_postos = NULL,
+                    max_usuarios = EXCLUDED.max_usuarios,
+                    updated_at = now()
+                """
+            ),
+            {
+                "codigo": codigo,
+                "nome": nome,
+                "descricao": descricao,
+                "ordem": ordem,
+                "preco": preco,
+                "max_usuarios": max_usuarios,
+            },
+        )
+
+    mod_ids = {
+        row[0]: row[1]
+        for row in bind.execute(sa.text("SELECT codigo, id FROM saas_modulos")).fetchall()
+    }
+    plan_ids = {
+        row[0]: row[1]
+        for row in bind.execute(sa.text("SELECT codigo, id FROM saas_planos")).fetchall()
+    }
+
+    for codigo, _n, _d, _o, _p, _u, mods in _PLANOS:
+        pid = plan_ids.get(codigo)
+        if pid is None:
+            continue
+        bind.execute(
+            sa.text("DELETE FROM saas_plano_modulos WHERE plano_id = :pid"),
+            {"pid": pid},
+        )
+        for mc in mods:
+            mid = mod_ids.get(mc)
+            if mid is None:
+                continue
+            bind.execute(
+                sa.text(
+                    """
+                    INSERT INTO saas_plano_modulos (plano_id, modulo_id)
+                    VALUES (:pid, :mid)
+                    ON CONFLICT DO NOTHING
+                    """
+                ),
+                {"pid": pid, "mid": mid},
+            )
+
+
+def downgrade() -> None:
+    """Não remove módulos/planos — catálogo comercial pode ter sido editado em produção."""
+    pass

--- a/backend/alembic/versions/122_saas_preco_modulos.py
+++ b/backend/alembic/versions/122_saas_preco_modulos.py
@@ -1,0 +1,117 @@
+"""Preço por módulo + usuários inclusos / extra nos planos.
+
+Revision ID: 122_saas_preco_modulos
+Revises: 121_saas_catalogo_precos
+Create Date: 2026-08-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "122_saas_preco_modulos"
+down_revision = "121_saas_catalogo_precos"
+branch_labels = None
+depends_on = None
+
+# Preços unitários (R$/mês) — Essencial≈97, Profissional≈197, Enterprise≈347
+_PRECOS_MODULO = {
+    "helpdesk": 29,
+    "whatsapp": 29,
+    "email": 15,
+    "portal": 12,
+    "kb": 12,
+    "chat-interno": 20,
+    "crm": 25,
+    "contratos": 20,
+    "sla": 20,
+    "pdv": 15,
+    "ponto": 40,
+    "faturamento": 40,
+    "boletos": 35,
+    "mobile": 35,
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("saas_modulos") or not insp.has_table("saas_planos"):
+        return
+
+    mod_cols = {c["name"] for c in insp.get_columns("saas_modulos")}
+    if "preco_mensal" not in mod_cols:
+        op.add_column(
+            "saas_modulos",
+            sa.Column("preco_mensal", sa.Numeric(12, 2), nullable=True),
+        )
+
+    plan_cols = {c["name"] for c in insp.get_columns("saas_planos")}
+    if "usuarios_inclusos" not in plan_cols:
+        op.add_column(
+            "saas_planos",
+            sa.Column("usuarios_inclusos", sa.Integer(), nullable=False, server_default="3"),
+        )
+    if "preco_usuario_extra" not in plan_cols:
+        op.add_column(
+            "saas_planos",
+            sa.Column("preco_usuario_extra", sa.Numeric(12, 2), nullable=True, server_default="10"),
+        )
+
+    for codigo, preco in _PRECOS_MODULO.items():
+        bind.execute(
+            sa.text(
+                "UPDATE saas_modulos SET preco_mensal = :preco, updated_at = now() "
+                "WHERE codigo = :codigo"
+            ),
+            {"codigo": codigo, "preco": preco},
+        )
+
+    bind.execute(
+        sa.text(
+            """
+            UPDATE saas_planos SET
+                usuarios_inclusos = 3,
+                preco_usuario_extra = 10,
+                max_postos = NULL,
+                max_usuarios = NULL,
+                updated_at = now()
+            """
+        )
+    )
+
+    # Recalcula preco_mensal do plano = soma dos módulos ligados
+    rows = bind.execute(
+        sa.text(
+            """
+            SELECT p.id, COALESCE(SUM(m.preco_mensal), 0) AS total
+            FROM saas_planos p
+            LEFT JOIN saas_plano_modulos pm ON pm.plano_id = p.id
+            LEFT JOIN saas_modulos m ON m.id = pm.modulo_id
+            GROUP BY p.id
+            """
+        )
+    ).fetchall()
+    for pid, total in rows:
+        bind.execute(
+            sa.text(
+                "UPDATE saas_planos SET preco_mensal = :total, updated_at = now() WHERE id = :pid"
+            ),
+            {"pid": pid, "total": total},
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("saas_planos"):
+        cols = {c["name"] for c in insp.get_columns("saas_planos")}
+        if "preco_usuario_extra" in cols:
+            op.drop_column("saas_planos", "preco_usuario_extra")
+        if "usuarios_inclusos" in cols:
+            op.drop_column("saas_planos", "usuarios_inclusos")
+    if insp.has_table("saas_modulos"):
+        cols = {c["name"] for c in insp.get_columns("saas_modulos")}
+        if "preco_mensal" in cols:
+            op.drop_column("saas_modulos", "preco_mensal")

--- a/backend/alembic/versions/123_saas_preco_negociado.py
+++ b/backend/alembic/versions/123_saas_preco_negociado.py
@@ -1,0 +1,39 @@
+"""Valor mensal negociado por licença SaaS.
+
+Revision ID: 123_saas_preco_negociado
+Revises: 122_saas_preco_modulos
+Create Date: 2026-08-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "123_saas_preco_negociado"
+down_revision = "122_saas_preco_modulos"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("clientes_saas"):
+        return
+    cols = {c["name"] for c in insp.get_columns("clientes_saas")}
+    if "preco_mensal_negociado" not in cols:
+        op.add_column(
+            "clientes_saas",
+            sa.Column("preco_mensal_negociado", sa.Numeric(12, 2), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if not insp.has_table("clientes_saas"):
+        return
+    cols = {c["name"] for c in insp.get_columns("clientes_saas")}
+    if "preco_mensal_negociado" in cols:
+        op.drop_column("clientes_saas", "preco_mensal_negociado")

--- a/backend/alembic/versions/124_chat_read_msg_id.py
+++ b/backend/alembic/versions/124_chat_read_msg_id.py
@@ -1,0 +1,48 @@
+"""Cursor de leitura WhatsApp/Portal por id de mensagem (#951).
+
+Revision ID: 124_chat_read_msg_id
+Revises: 123_saas_preco_negociado
+Create Date: 2026-08-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "124_chat_read_msg_id"
+down_revision = "123_saas_preco_negociado"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("whatsapp_chat_reads"):
+        cols = {c["name"] for c in insp.get_columns("whatsapp_chat_reads")}
+        if "last_seen_mensagem_id" not in cols:
+            op.add_column(
+                "whatsapp_chat_reads",
+                sa.Column("last_seen_mensagem_id", sa.Integer(), nullable=True),
+            )
+    if insp.has_table("portal_chat_reads"):
+        cols = {c["name"] for c in insp.get_columns("portal_chat_reads")}
+        if "last_seen_mensagem_id" not in cols:
+            op.add_column(
+                "portal_chat_reads",
+                sa.Column("last_seen_mensagem_id", sa.Integer(), nullable=True),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("whatsapp_chat_reads"):
+        cols = {c["name"] for c in insp.get_columns("whatsapp_chat_reads")}
+        if "last_seen_mensagem_id" in cols:
+            op.drop_column("whatsapp_chat_reads", "last_seen_mensagem_id")
+    if insp.has_table("portal_chat_reads"):
+        cols = {c["name"] for c in insp.get_columns("portal_chat_reads")}
+        if "last_seen_mensagem_id" in cols:
+            op.drop_column("portal_chat_reads", "last_seen_mensagem_id")

--- a/backend/alembic/versions/124_ponto_modo_jornada.py
+++ b/backend/alembic/versions/124_ponto_modo_jornada.py
@@ -1,0 +1,72 @@
+"""Ponto: modo_jornada, horario_semana e margem de fecho (#959/#960/#961).
+
+Revision ID: 124_ponto_modo_jornada
+Revises: 123_saas_preco_negociado
+Create Date: 2026-08-26
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "124_ponto_modo_jornada"
+down_revision = "123_saas_preco_negociado"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "modo_jornada" not in cols:
+            op.add_column(
+                "atendentes",
+                sa.Column(
+                    "modo_jornada",
+                    sa.String(20),
+                    nullable=False,
+                    server_default="nenhum",
+                ),
+            )
+        if "horario_semana_json" not in cols:
+            op.add_column(
+                "atendentes",
+                sa.Column("horario_semana_json", sa.Text(), nullable=True),
+            )
+        # Backfill: quem já usava ciclo X×Y → modo ciclo
+        op.execute(
+            sa.text(
+                "UPDATE atendentes SET modo_jornada = 'ciclo' "
+                "WHERE usa_escala IS TRUE AND modo_jornada = 'nenhum'"
+            )
+        )
+
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "fecho_margem_pos_saida_minutos" not in cols:
+            op.add_column(
+                "ponto_settings",
+                sa.Column(
+                    "fecho_margem_pos_saida_minutos",
+                    sa.Integer(),
+                    nullable=False,
+                    server_default="30",
+                ),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_settings"):
+        cols = {c["name"] for c in insp.get_columns("ponto_settings")}
+        if "fecho_margem_pos_saida_minutos" in cols:
+            op.drop_column("ponto_settings", "fecho_margem_pos_saida_minutos")
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "horario_semana_json" in cols:
+            op.drop_column("atendentes", "horario_semana_json")
+        if "modo_jornada" in cols:
+            op.drop_column("atendentes", "modo_jornada")

--- a/backend/alembic/versions/125_ponto_locais_atendente.py
+++ b/backend/alembic/versions/125_ponto_locais_atendente.py
@@ -1,0 +1,87 @@
+"""Locais de ponto por atendente + pin da empresa (#984).
+
+Revision ID: 125_ponto_locais_atendente
+Revises: 124_ponto_modo_jornada
+Create Date: 2026-08-26
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "125_ponto_locais_atendente"
+down_revision = "124_ponto_modo_jornada"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("empresa_sistema"):
+        cols = {c["name"] for c in insp.get_columns("empresa_sistema")}
+        if "latitude" not in cols:
+            op.add_column("empresa_sistema", sa.Column("latitude", sa.Float(), nullable=True))
+        if "longitude" not in cols:
+            op.add_column("empresa_sistema", sa.Column("longitude", sa.Float(), nullable=True))
+        if "ponto_raio_metros" not in cols:
+            op.add_column(
+                "empresa_sistema",
+                sa.Column("ponto_raio_metros", sa.Integer(), nullable=False, server_default="200"),
+            )
+
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "usar_local_empresa" not in cols:
+            op.add_column(
+                "atendentes",
+                sa.Column("usar_local_empresa", sa.Boolean(), nullable=False, server_default="true"),
+            )
+        if "local_empresa_raio_metros" not in cols:
+            op.add_column(
+                "atendentes",
+                sa.Column("local_empresa_raio_metros", sa.Integer(), nullable=True),
+            )
+
+    if insp.has_table("ponto_locais"):
+        cols = {c["name"] for c in insp.get_columns("ponto_locais")}
+        if "atendente_id" not in cols:
+            op.add_column(
+                "ponto_locais",
+                sa.Column(
+                    "atendente_id",
+                    sa.Integer(),
+                    sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+                    nullable=True,
+                ),
+            )
+            op.create_index("ix_ponto_locais_atendente_id", "ponto_locais", ["atendente_id"])
+        if "endereco" not in cols:
+            op.add_column("ponto_locais", sa.Column("endereco", sa.String(512), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("ponto_locais"):
+        cols = {c["name"] for c in insp.get_columns("ponto_locais")}
+        if "endereco" in cols:
+            op.drop_column("ponto_locais", "endereco")
+        if "atendente_id" in cols:
+            op.drop_index("ix_ponto_locais_atendente_id", table_name="ponto_locais")
+            op.drop_column("ponto_locais", "atendente_id")
+
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        for name in ("local_empresa_raio_metros", "usar_local_empresa"):
+            if name in cols:
+                op.drop_column("atendentes", name)
+
+    if insp.has_table("empresa_sistema"):
+        cols = {c["name"] for c in insp.get_columns("empresa_sistema")}
+        for name in ("ponto_raio_metros", "longitude", "latitude"):
+            if name in cols:
+                op.drop_column("empresa_sistema", name)

--- a/backend/alembic/versions/126_ponto_hora_extra.py
+++ b/backend/alembic/versions/126_ponto_hora_extra.py
@@ -1,0 +1,61 @@
+"""Hora extra para pegar WhatsApp após jornada (#965).
+
+Revision ID: 126_ponto_hora_extra
+Revises: 125_ponto_locais_atendente
+Create Date: 2026-08-26
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "126_ponto_hora_extra"
+down_revision = "125_ponto_locais_atendente"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_hora_extra"):
+        return
+    op.create_table(
+        "ponto_hora_extra",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column(
+            "tenant_id",
+            sa.Integer(),
+            sa.ForeignKey("tenants.id", ondelete="RESTRICT"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "atendente_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("estado", sa.String(20), nullable=False, server_default="pendente"),
+        sa.Column("motivo", sa.String(1000), nullable=True),
+        sa.Column("modo", sa.String(20), nullable=True),
+        sa.Column("ate_em", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "decidido_por_id",
+            sa.Integer(),
+            sa.ForeignKey("atendentes.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("decidido_em", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("decisao_motivo", sa.String(1000), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_hora_extra"):
+        op.drop_table("ponto_hora_extra")

--- a/backend/alembic/versions/127_chat_read_msg_id.py
+++ b/backend/alembic/versions/127_chat_read_msg_id.py
@@ -1,7 +1,7 @@
 """Cursor de leitura WhatsApp/Portal por id de mensagem (#951).
 
-Revision ID: 124_chat_read_msg_id
-Revises: 123_saas_preco_negociado
+Revision ID: 127_chat_read_msg_id
+Revises: 126_ponto_hora_extra
 Create Date: 2026-08-25
 """
 
@@ -10,8 +10,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-revision = "124_chat_read_msg_id"
-down_revision = "123_saas_preco_negociado"
+revision = "127_chat_read_msg_id"
+down_revision = "126_ponto_hora_extra"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/128_versao_alvo_solic.py
+++ b/backend/alembic/versions/128_versao_alvo_solic.py
@@ -1,0 +1,32 @@
+"""versao_alvo nas solicitações SaaS e instância (#955).
+
+Revision ID: 128_versao_alvo_solic
+Revises: 127_chat_read_msg_id
+Create Date: 2026-08-26
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "128_versao_alvo_solic"
+down_revision = "127_chat_read_msg_id"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "saas_solicitacoes_produto",
+        sa.Column("versao_alvo", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "solicitacoes_melhoria",
+        sa.Column("versao_alvo", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("solicitacoes_melhoria", "versao_alvo")
+    op.drop_column("saas_solicitacoes_produto", "versao_alvo")

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -31,6 +31,7 @@ class OrdenarAtendentesPor(str, Enum):
 
 
 def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) -> AtendenteRead:
+    saas = sorted(getattr(atendente, "saas_setores", None) or [], key=lambda s: (s.nome or "", s.id))
     return AtendenteRead(
         id=atendente.id,
         email=atendente.email,
@@ -49,6 +50,8 @@ def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) ->
         horario_previsto_entrada=getattr(atendente, "horario_previsto_entrada", None),
         horario_previsto_saida=getattr(atendente, "horario_previsto_saida", None),
         tolerancia_atraso_minutos=int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0),
+        saas_setor_ids=[s.id for s in saas],
+        saas_setor_nomes=[s.nome for s in saas],
     )
 
 

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -60,6 +60,8 @@ def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) ->
         horario_previsto_entrada=getattr(atendente, "horario_previsto_entrada", None),
         horario_previsto_saida=getattr(atendente, "horario_previsto_saida", None),
         tolerancia_atraso_minutos=int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0),
+        usar_local_empresa=bool(getattr(atendente, "usar_local_empresa", True)),
+        local_empresa_raio_metros=getattr(atendente, "local_empresa_raio_metros", None),
         saas_setor_ids=[s.id for s in saas],
         saas_setor_nomes=[s.nome for s in saas],
     )
@@ -187,6 +189,8 @@ def criar_atendente(
         role=role,
         ativo=data.ativo,
         tolerancia_atraso_minutos=int(data.tolerancia_atraso_minutos or 0) if modo != "nenhum" else 0,
+        usar_local_empresa=bool(getattr(data, "usar_local_empresa", True)),
+        local_empresa_raio_metros=getattr(data, "local_empresa_raio_metros", None),
     )
     _aplicar_campos_jornada(
         atendente,

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -12,7 +12,13 @@ from app.schemas.ticket_csat import AtendenteAvaliacoesRead, AvaliacaoResumoRead
 from app.schemas.lista_paginada import ListaPaginada
 from app.core.auth import exigir_admin, obter_atendente_atual, validar_role
 from app.services.atendente_avaliacoes import calcular_avaliacoes_atendente
-from app.services.escala import validar_campos_escala, validar_horario_previsto
+from app.services.escala import (
+    horario_semana_dict,
+    horario_semana_para_json,
+    modo_jornada as modo_jornada_de,
+    validar_campos_jornada,
+    validar_horario_previsto,
+)
 from app.core.setor_scope import atendente_e_financeiro, ids_setores_mesmo_nome, ids_setores_visiveis_atendente
 from app.core.security import hash_senha, verificar_senha
 from app.core.audit import registrar_audit
@@ -32,6 +38,8 @@ class OrdenarAtendentesPor(str, Enum):
 
 def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) -> AtendenteRead:
     saas = sorted(getattr(atendente, "saas_setores", None) or [], key=lambda s: (s.nome or "", s.id))
+    modo = modo_jornada_de(atendente)
+    usa = modo in ("semanal", "ciclo")
     return AtendenteRead(
         id=atendente.id,
         email=atendente.email,
@@ -43,7 +51,9 @@ def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) ->
         setor_ids=[s.id for s in atendente.setores],
         e_financeiro=e_financeiro,
         must_change_password=bool(getattr(atendente, "must_change_password", False)),
-        usa_escala=bool(getattr(atendente, "usa_escala", False)),
+        modo_jornada=modo,  # type: ignore[arg-type]
+        usa_escala=usa,
+        horario_semana=horario_semana_dict(atendente),
         escala_horas_trabalho=getattr(atendente, "escala_horas_trabalho", None),
         escala_horas_folga=getattr(atendente, "escala_horas_folga", None),
         escala_inicio_em=getattr(atendente, "escala_inicio_em", None),
@@ -53,6 +63,56 @@ def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) ->
         saas_setor_ids=[s.id for s in saas],
         saas_setor_nomes=[s.nome for s in saas],
     )
+
+
+def _resolver_modo_jornada(data_modo: str | None, usa_escala: bool | None, atual: Atendente | None) -> str:
+    if data_modo is not None:
+        return (data_modo or "nenhum").strip().lower()
+    if usa_escala is not None:
+        return "ciclo" if usa_escala else "nenhum"
+    if atual is not None:
+        return modo_jornada_de(atual)
+    return "nenhum"
+
+
+def _aplicar_campos_jornada(atendente: Atendente, *, modo: str, update: dict) -> None:
+    """Normaliza campos de jornada no dict update / no create."""
+    if modo == "nenhum":
+        atendente.modo_jornada = "nenhum"
+        atendente.usa_escala = False
+        atendente.escala_horas_trabalho = None
+        atendente.escala_horas_folga = None
+        atendente.escala_inicio_em = None
+        atendente.horario_previsto_entrada = None
+        atendente.horario_previsto_saida = None
+        atendente.tolerancia_atraso_minutos = 0
+        atendente.horario_semana_json = None
+        return
+    if modo == "semanal":
+        hs = update.get("horario_semana")
+        if hs is None and atendente.horario_semana_json:
+            hs = horario_semana_dict(atendente)
+        atendente.modo_jornada = "semanal"
+        atendente.usa_escala = True
+        atendente.escala_horas_trabalho = None
+        atendente.escala_horas_folga = None
+        atendente.escala_inicio_em = None
+        atendente.horario_previsto_entrada = None
+        atendente.horario_previsto_saida = None
+        atendente.horario_semana_json = horario_semana_para_json(hs)
+        if "tolerancia_atraso_minutos" in update:
+            atendente.tolerancia_atraso_minutos = int(update["tolerancia_atraso_minutos"] or 0)
+        return
+    # ciclo
+    atendente.modo_jornada = "ciclo"
+    atendente.usa_escala = True
+    atendente.horario_semana_json = None
+    atendente.escala_horas_trabalho = update.get("escala_horas_trabalho")
+    atendente.escala_horas_folga = update.get("escala_horas_folga")
+    atendente.escala_inicio_em = update.get("escala_inicio_em")
+    atendente.horario_previsto_entrada = update.get("horario_previsto_entrada")
+    atendente.horario_previsto_saida = update.get("horario_previsto_saida")
+    atendente.tolerancia_atraso_minutos = int(update.get("tolerancia_atraso_minutos") or 0)
 
 
 @router.get("", response_model=ListaPaginada[AtendenteRead])
@@ -109,13 +169,16 @@ def criar_atendente(
     ):
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="E-mail já cadastrado")
     role = validar_role(data.role)
-    validar_campos_escala(
-        usa_escala=bool(data.usa_escala),
+    modo = _resolver_modo_jornada(data.modo_jornada, data.usa_escala, None)
+    validar_campos_jornada(
+        modo=modo,
         escala_horas_trabalho=data.escala_horas_trabalho,
         escala_horas_folga=data.escala_horas_folga,
         escala_inicio_em=data.escala_inicio_em,
+        horario_semana=data.horario_semana,
     )
-    validar_horario_previsto(data.horario_previsto_entrada, data.horario_previsto_saida)
+    if modo == "ciclo":
+        validar_horario_previsto(data.horario_previsto_entrada, data.horario_previsto_saida)
     atendente = Atendente(
         tenant_id=atendente_logado.tenant_id,
         email=data.email,
@@ -123,15 +186,20 @@ def criar_atendente(
         senha_hash=hash_senha(data.senha),
         role=role,
         ativo=data.ativo,
-        usa_escala=bool(data.usa_escala),
-        escala_horas_trabalho=data.escala_horas_trabalho if data.usa_escala else None,
-        escala_horas_folga=data.escala_horas_folga if data.usa_escala else None,
-        escala_inicio_em=data.escala_inicio_em if data.usa_escala else None,
-        horario_previsto_entrada=data.horario_previsto_entrada if data.usa_escala else None,
-        horario_previsto_saida=data.horario_previsto_saida if data.usa_escala else None,
-        tolerancia_atraso_minutos=(
-            int(data.tolerancia_atraso_minutos or 0) if data.usa_escala else 0
-        ),
+        tolerancia_atraso_minutos=int(data.tolerancia_atraso_minutos or 0) if modo != "nenhum" else 0,
+    )
+    _aplicar_campos_jornada(
+        atendente,
+        modo=modo,
+        update={
+            "horario_semana": data.horario_semana,
+            "escala_horas_trabalho": data.escala_horas_trabalho,
+            "escala_horas_folga": data.escala_horas_folga,
+            "escala_inicio_em": data.escala_inicio_em,
+            "horario_previsto_entrada": data.horario_previsto_entrada,
+            "horario_previsto_saida": data.horario_previsto_saida,
+            "tolerancia_atraso_minutos": data.tolerancia_atraso_minutos,
+        },
     )
     db.add(atendente)
     db.flush()
@@ -265,33 +333,55 @@ def atualizar_atendente(
             if setor:
                 atendente.setores.append(setor)
 
-    usa_escala = update.get("usa_escala", atendente.usa_escala)
+    modo = _resolver_modo_jornada(update.get("modo_jornada"), update.get("usa_escala"), atendente)
     ht = update.get("escala_horas_trabalho", atendente.escala_horas_trabalho)
     hf = update.get("escala_horas_folga", atendente.escala_horas_folga)
     inicio = update.get("escala_inicio_em", atendente.escala_inicio_em)
-    if any(k in update for k in ("usa_escala", "escala_horas_trabalho", "escala_horas_folga", "escala_inicio_em")):
-        validar_campos_escala(
-            usa_escala=bool(usa_escala),
+    hs = update.get("horario_semana")
+    if hs is None and modo == "semanal":
+        hs = horario_semana_dict(atendente)
+    he = update.get("horario_previsto_entrada", getattr(atendente, "horario_previsto_entrada", None))
+    hs_prev = update.get("horario_previsto_saida", getattr(atendente, "horario_previsto_saida", None))
+    tol = update.get(
+        "tolerancia_atraso_minutos",
+        getattr(atendente, "tolerancia_atraso_minutos", 0),
+    )
+    jornada_keys = (
+        "modo_jornada",
+        "usa_escala",
+        "escala_horas_trabalho",
+        "escala_horas_folga",
+        "escala_inicio_em",
+        "horario_semana",
+        "horario_previsto_entrada",
+        "horario_previsto_saida",
+        "tolerancia_atraso_minutos",
+    )
+    if any(k in update for k in jornada_keys):
+        validar_campos_jornada(
+            modo=modo,
             escala_horas_trabalho=ht,
             escala_horas_folga=hf,
             escala_inicio_em=inicio,
+            horario_semana=hs if modo == "semanal" else None,
         )
-        if not usa_escala:
-            update["usa_escala"] = False
-            update["escala_horas_trabalho"] = None
-            update["escala_horas_folga"] = None
-            update["escala_inicio_em"] = None
-            update["horario_previsto_entrada"] = None
-            update["horario_previsto_saida"] = None
-            update["tolerancia_atraso_minutos"] = 0
-
-    he = update.get("horario_previsto_entrada", getattr(atendente, "horario_previsto_entrada", None))
-    hs = update.get("horario_previsto_saida", getattr(atendente, "horario_previsto_saida", None))
-    if any(
-        k in update
-        for k in ("horario_previsto_entrada", "horario_previsto_saida", "tolerancia_atraso_minutos")
-    ):
-        validar_horario_previsto(he, hs)
+        if modo == "ciclo":
+            validar_horario_previsto(he, hs_prev)
+        for k in jornada_keys:
+            update.pop(k, None)
+        _aplicar_campos_jornada(
+            atendente,
+            modo=modo,
+            update={
+                "horario_semana": hs,
+                "escala_horas_trabalho": ht,
+                "escala_horas_folga": hf,
+                "escala_inicio_em": inicio,
+                "horario_previsto_entrada": he,
+                "horario_previsto_saida": hs_prev,
+                "tolerancia_atraso_minutos": tol,
+            },
+        )
 
     for k, v in update.items():
         setattr(atendente, k, v)

--- a/backend/app/api/chat_interno.py
+++ b/backend/app/api/chat_interno.py
@@ -19,6 +19,8 @@ from app.schemas.chat_interno import (
     ConversaRead,
     ConversaSilenciarUpdate,
     GrupoParticipantesUpdate,
+    MembroCanalSetorRead,
+    MembrosCanalSetorListaRead,
     MencaoMensagemRead,
     MensagemInternaCreate,
     MensagemInternaRead,
@@ -418,6 +420,35 @@ def obter_canal_setor(
         return _to_conversa_read(db, conversa, atendente)
     except chat_svc.ChatInternoErro as exc:
         raise _map_chat_erro(exc) from exc
+
+
+@router.get("/setores/{setor_id}/membros", response_model=MembrosCanalSetorListaRead)
+def listar_membros_canal_setor(
+    setor_id: int,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    """Membros vinculados ao setor + flag online (TTL de presença). Quem acessa o canal pode ver."""
+    _assert_acesso_setor(atendente, db, setor_id)
+    try:
+        setor_nome, pares = chat_svc.listar_membros_canal_setor_com_presenca(
+            db,
+            tenant_id=atendente.tenant_id,
+            setor_id=setor_id,
+        )
+    except chat_svc.ChatInternoErro as exc:
+        raise _map_chat_erro(exc) from exc
+    items = [
+        MembroCanalSetorRead(atendente_id=a.id, nome=a.nome, online=online) for a, online in pares
+    ]
+    online_count = sum(1 for _, online in pares if online)
+    return MembrosCanalSetorListaRead(
+        setor_id=setor_id,
+        setor_nome=setor_nome,
+        total=len(items),
+        online_count=online_count,
+        items=items,
+    )
 
 
 @router.post(

--- a/backend/app/api/notificacoes.py
+++ b/backend/app/api/notificacoes.py
@@ -259,22 +259,23 @@ def _wpp_unread_count_for_chat(db: Session, chat_id: int, atendente_id: int) -> 
     c = db.query(WhatsappChat.id, WhatsappChat.created_at, WhatsappChat.atendimento_inicio_at).filter(WhatsappChat.id == chat_id).first()
     if not c:
         return 0
-    ls = (
-        db.query(WhatsappChatRead.last_seen_at)
+    row = (
+        db.query(WhatsappChatRead.last_seen_at, WhatsappChatRead.last_seen_mensagem_id)
         .filter(WhatsappChatRead.chat_id == chat_id, WhatsappChatRead.atendente_id == atendente_id)
-        .scalar()
+        .first()
     )
-    eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
-    n = (
-        db.query(func.count(WhatsappMensagem.id))
-        .filter(
-            WhatsappMensagem.chat_id == chat_id,
-            WhatsappMensagem.direcao == "inbound",
-            WhatsappMensagem.created_at > eff,
-        )
-        .scalar()
+    ls = row[0] if row else None
+    cursor_id = row[1] if row else None
+    q = db.query(func.count(WhatsappMensagem.id)).filter(
+        WhatsappMensagem.chat_id == chat_id,
+        WhatsappMensagem.direcao == "inbound",
     )
-    return int(n or 0)
+    if cursor_id is not None:
+        q = q.filter(WhatsappMensagem.id > cursor_id)
+    else:
+        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
+        q = q.filter(WhatsappMensagem.created_at > eff)
+    return int(q.scalar() or 0)
 
 
 def build_notificacao_itens(

--- a/backend/app/api/notificacoes.py
+++ b/backend/app/api/notificacoes.py
@@ -314,6 +314,23 @@ def build_notificacao_itens(
             )
         )
 
+    if atendente.role == "admin":
+        from app.services.ponto_hora_extra import contar_pendentes_admin
+
+        he_n = contar_pendentes_admin(db, atendente.tenant_id)
+        if he_n > 0:
+            out.append(
+                NotificacaoItem(
+                    tipo="ponto_he_pendente",
+                    ticket_id=None,
+                    titulo="Hora extra",
+                    descricao="Pedidos após o fim da jornada (WhatsApp)",
+                    count=he_n,
+                    href="/equipe/ponto",
+                    created_at=datetime.now(timezone.utc),
+                )
+            )
+
     inbound_last, eff_seen = _wpp_resposta_pendente_exprs(atendente.id)
     stmt_wpp = (
         select(WhatsappChat)
@@ -414,6 +431,11 @@ def build_notificacao_resumo(db: Session, atendente: Atendente) -> NotificacaoRe
     portal_fila = _count_portal_fila(db, atendente)
     portal_resp = _count_portal_respostas_pendentes(db, atendente)
     chat_interno = chat_interno_svc.contar_total_nao_lidas_atendente(db, atendente)
+    he_pend = 0
+    if atendente.role == "admin":
+        from app.services.ponto_hora_extra import contar_pendentes_admin
+
+        he_pend = contar_pendentes_admin(db, atendente.tenant_id)
     return NotificacaoResumo(
         sem_responsavel_count=sem,
         nao_lidas_count=nao,
@@ -422,7 +444,15 @@ def build_notificacao_resumo(db: Session, atendente: Atendente) -> NotificacaoRe
         portal_fila_count=portal_fila,
         portal_respostas_count=portal_resp,
         chat_interno_nao_lidas_count=chat_interno,
-        total_pendencias=sem + nao + wpp_fila + wpp_resp + portal_fila + portal_resp + chat_interno,
+        ponto_he_pendentes_count=he_pend,
+        total_pendencias=sem
+        + nao
+        + wpp_fila
+        + wpp_resp
+        + portal_fila
+        + portal_resp
+        + chat_interno
+        + he_pend,
     )
 
 

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -27,6 +27,10 @@ from app.schemas.ponto import (
     PontoFeriadoRead,
     PontoHistoricoRead,
     PontoHojeRead,
+    PontoHoraExtraCreate,
+    PontoHoraExtraDecisao,
+    PontoHoraExtraMeStatus,
+    PontoHoraExtraRead,
     PontoJustificativaCreate,
     PontoJustificativaDecisao,
     PontoJustificativaRead,
@@ -38,6 +42,7 @@ from app.schemas.ponto import (
     PontoSettingsUpdate,
 )
 from app.services import ponto as ponto_svc
+from app.services import ponto_hora_extra as he_svc
 from app.services import ponto_justificativa as just_svc
 from app.services import ponto_relatorio as ponto_relatorio_svc
 from app.services import ponto_settings as ponto_settings_svc
@@ -445,4 +450,59 @@ def decidir_justificativa(
         estado=data.estado,
         decisao_motivo=data.decisao_motivo,
         aplicar_batidas=data.aplicar_batidas,
+    )
+
+
+@router.get("/hora-extra/me/status", response_model=PontoHoraExtraMeStatus)
+def hora_extra_me_status(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ponto_svc.exigir_acesso_ponto(atendente)
+    return PontoHoraExtraMeStatus(**he_svc.me_status(db, atendente))
+
+
+@router.get("/hora-extra/me", response_model=list[PontoHoraExtraRead])
+def minhas_hora_extra(
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ponto_svc.exigir_acesso_ponto(atendente)
+    return he_svc.listar_me(db, atendente)
+
+
+@router.post("/hora-extra", response_model=PontoHoraExtraRead, status_code=201)
+def solicitar_hora_extra(
+    data: PontoHoraExtraCreate,
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    ponto_svc.exigir_acesso_ponto(atendente)
+    return he_svc.solicitar(db, atendente, motivo=data.motivo)
+
+
+@router.get("/hora-extra", response_model=list[PontoHoraExtraRead])
+def listar_hora_extra_admin(
+    estado: str | None = Query("pendente"),
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return he_svc.listar_admin(db, admin, estado=estado)
+
+
+@router.post("/hora-extra/{he_id}/decidir", response_model=PontoHoraExtraRead)
+def decidir_hora_extra(
+    he_id: int,
+    data: PontoHoraExtraDecisao,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return he_svc.decidir(
+        db,
+        admin,
+        he_id,
+        aprovar=data.aprovar,
+        modo=data.modo,
+        ate_horario=data.ate_horario,
+        decisao_motivo=data.decisao_motivo,
     )

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -121,7 +121,7 @@ def minhas_settings_ponto(
     atendente: Atendente = Depends(obter_atendente_atual),
 ):
     ponto_svc.exigir_acesso_ponto(atendente)
-    out = ponto_settings_svc.settings_public_read(db, atendente.tenant_id)
+    out = ponto_settings_svc.settings_public_read(db, atendente)
     db.commit()
     return out
 
@@ -360,10 +360,14 @@ def remover_feriado(
 
 @router.get("/locais", response_model=list[PontoLocalRead])
 def listar_locais(
+    atendente_id: int | None = Query(None),
+    so_orfos: bool = Query(False, description="Só locais legados sem atendente"),
     db: Session = Depends(get_db),
     admin: Atendente = Depends(exigir_admin),
 ):
-    return ponto_settings_svc.listar_locais(db, admin.tenant_id)
+    return ponto_settings_svc.listar_locais(
+        db, admin.tenant_id, atendente_id=atendente_id, so_orfos=so_orfos
+    )
 
 
 @router.post("/locais", response_model=PontoLocalRead, status_code=201)

--- a/backend/app/api/portal_chats.py
+++ b/backend/app/api/portal_chats.py
@@ -6,7 +6,9 @@ import logging
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from fastapi.responses import FileResponse
-from sqlalchemy import or_
+from datetime import datetime
+
+from sqlalchemy import func, or_
 from sqlalchemy.orm import Session, joinedload
 
 from app.config import settings
@@ -14,7 +16,7 @@ from app.core.auth import obter_atendente_atual
 from app.core.setor_scope import ids_setores_visiveis_atendente
 from app.database import get_db
 from app.models.atendente import Atendente
-from app.models.portal_chat import PortalChat, PortalMensagem
+from app.models.portal_chat import PortalChat, PortalChatRead as PortalChatReadModel, PortalMensagem
 from app.models.setor import Setor
 from app.schemas.portal_chat import (
     PortalChatDemandaCreate,
@@ -71,7 +73,39 @@ def _ultima_mensagem_preview(db: Session, chat_id: int) -> str | None:
     return _preview_corpo(corpo)
 
 
-def _chat_read(db: Session, c: PortalChat) -> PortalChatRead:
+def _nao_lidas_portal(
+    db: Session, c: PortalChat, atendente_id: int
+) -> tuple[int, datetime | None, int | None]:
+    row = (
+        db.query(PortalChatReadModel.last_seen_at, PortalChatReadModel.last_seen_mensagem_id)
+        .filter(
+            PortalChatReadModel.chat_id == c.id,
+            PortalChatReadModel.atendente_id == atendente_id,
+        )
+        .first()
+    )
+    ls = row[0] if row else None
+    cursor_id = row[1] if row else None
+    q = db.query(func.count(PortalMensagem.id)).filter(
+        PortalMensagem.chat_id == c.id,
+        PortalMensagem.direcao == "inbound",
+    )
+    if cursor_id is not None:
+        q = q.filter(PortalMensagem.id > cursor_id)
+    else:
+        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
+        if eff is None:
+            return 0, ls, cursor_id
+        q = q.filter(PortalMensagem.created_at > eff)
+    return int(q.scalar() or 0), ls, cursor_id
+
+
+def _chat_read(db: Session, c: PortalChat, *, atendente_id: int | None = None) -> PortalChatRead:
+    nao_lidas = 0
+    last_seen: datetime | None = None
+    last_seen_msg: int | None = None
+    if atendente_id is not None:
+        nao_lidas, last_seen, last_seen_msg = _nao_lidas_portal(db, c, atendente_id)
     return PortalChatRead(
         id=c.id,
         protocolo=c.protocolo,
@@ -86,6 +120,9 @@ def _chat_read(db: Session, c: PortalChat) -> PortalChatRead:
         atendimento_inicio_at=c.atendimento_inicio_at,
         encerramento_at=c.encerramento_at,
         ultima_mensagem_preview=_ultima_mensagem_preview(db, c.id),
+        nao_lidas_count=nao_lidas,
+        last_seen_at=last_seen,
+        last_seen_mensagem_id=last_seen_msg,
     )
 
 
@@ -175,7 +212,7 @@ def listar_meus(
     if atendente.role != "admin":
         q = q.filter(PortalChat.atendente_id == atendente.id)
     rows = q.order_by(PortalChat.atendimento_inicio_at.desc().nullslast()).all()
-    return [_chat_read(db, c) for c in rows]
+    return [_chat_read(db, c, atendente_id=atendente.id) for c in rows]
 
 
 @router.get("/{chat_id}", response_model=PortalChatRead)
@@ -186,7 +223,7 @@ def obter_chat(
 ):
     c = _get_chat(db, chat_id)
     exigir_acesso_portal_chat(db, atendente, c)
-    return _chat_read(db, c)
+    return _chat_read(db, c, atendente_id=atendente.id)
 
 
 @router.get("/{chat_id}/mensagens", response_model=list[PortalChatMensagemRead])

--- a/backend/app/api/saas.py
+++ b/backend/app/api/saas.py
@@ -554,7 +554,7 @@ def listar_modulos(
     _: None = Depends(exigir_saas_control_plane),
     __: Atendente = Depends(exigir_saas_ops),
 ):
-    return [SaasModuloRead.model_validate(m) for m in saas_catalogo.listar_modulos(db, ativo=ativo)]
+    return [saas_catalogo.serializar_modulo(m) for m in saas_catalogo.listar_modulos(db, ativo=ativo)]
 
 
 @router.post("/modulos", response_model=SaasModuloRead, status_code=201)
@@ -571,7 +571,7 @@ def criar_modulo(
     registrar_audit(db, "saas_modulo", row.id, "create", atendente.id)
     db.commit()
     db.refresh(row)
-    return SaasModuloRead.model_validate(row)
+    return saas_catalogo.serializar_modulo(row)
 
 
 @router.get("/modulos/{modulo_id}", response_model=SaasModuloRead)
@@ -582,7 +582,7 @@ def obter_modulo(
     __: Atendente = Depends(exigir_saas_ops),
 ):
     try:
-        return SaasModuloRead.model_validate(saas_catalogo.obter_modulo(db, modulo_id))
+        return saas_catalogo.serializar_modulo(saas_catalogo.obter_modulo(db, modulo_id))
     except svc.SaasErro as e:
         raise _http_from_saas(e) from e
 
@@ -602,7 +602,7 @@ def atualizar_modulo(
     registrar_audit(db, "saas_modulo", modulo_id, "update", atendente.id)
     db.commit()
     db.refresh(row)
-    return SaasModuloRead.model_validate(row)
+    return saas_catalogo.serializar_modulo(row)
 
 
 @router.post("/modulos/{modulo_id}/ativar", response_model=SaasModuloRead)
@@ -619,7 +619,7 @@ def ativar_modulo(
     registrar_audit(db, "saas_modulo", modulo_id, "ativar", atendente.id)
     db.commit()
     db.refresh(row)
-    return SaasModuloRead.model_validate(row)
+    return saas_catalogo.serializar_modulo(row)
 
 
 @router.post("/modulos/{modulo_id}/desativar", response_model=SaasModuloRead)
@@ -636,4 +636,4 @@ def desativar_modulo(
     registrar_audit(db, "saas_modulo", modulo_id, "desativar", atendente.id)
     db.commit()
     db.refresh(row)
-    return SaasModuloRead.model_validate(row)
+    return saas_catalogo.serializar_modulo(row)

--- a/backend/app/api/saas_ops_conta.py
+++ b/backend/app/api/saas_ops_conta.py
@@ -1,4 +1,4 @@
-"""Conta do ops no control-plane — token Cursor (#915)."""
+"""Conta do ops no control-plane — perfil e token Cursor (#915)."""
 
 from __future__ import annotations
 
@@ -10,7 +10,9 @@ from app.core.auth import exigir_saas_ops
 from app.database import get_db
 from app.models.atendente import Atendente
 from app.schemas.saas_mcp_token import SaasMcpTokenEstado, SaasMcpTokenGerado
+from app.schemas.saas_ops_conta import SaasOpsContaPerfilRead, SaasOpsContaPerfilUpdate
 from app.services import saas_mcp_token as mcp_token
+from app.services import saas_ops_conta as conta_svc
 
 router = APIRouter(prefix="/saas/me", tags=["saas-ops-conta"])
 
@@ -21,6 +23,24 @@ def _exigir_control_plane() -> None:
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Painel SaaS não disponível nesta instância",
         )
+
+
+@router.patch("", response_model=SaasOpsContaPerfilRead)
+def atualizar_perfil(
+    data: SaasOpsContaPerfilUpdate,
+    db: Session = Depends(get_db),
+    _: None = Depends(_exigir_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+):
+    """Atualiza nome e/ou e-mail da conta logada."""
+    row, tokens = conta_svc.atualizar_perfil(db, ops, data)
+    db.commit()
+    db.refresh(row)
+    payload = SaasOpsContaPerfilRead(id=row.id, nome=row.nome, email=row.email)
+    if tokens:
+        payload.access_token = tokens["access_token"]
+        payload.refresh_token = tokens["refresh_token"]
+    return payload
 
 
 @router.get("/mcp-token", response_model=SaasMcpTokenEstado)

--- a/backend/app/api/saas_ops_usuarios.py
+++ b/backend/app/api/saas_ops_usuarios.py
@@ -1,4 +1,4 @@
-"""Equipa do control-plane — contas saas_ops (#883)."""
+"""Equipe do control-plane — contas saas_ops (#883)."""
 
 from __future__ import annotations
 
@@ -66,14 +66,14 @@ def obter_usuario(
 
 
 @router.patch("/{usuario_id}", response_model=SaasOpsUsuarioRead)
-def actualizar_usuario(
+def atualizar_usuario(
     usuario_id: int,
     data: SaasOpsUsuarioUpdate,
     _: None = Depends(exigir_saas_control_plane),
     ops: Atendente = Depends(exigir_saas_ops),
     db: Session = Depends(get_db),
 ):
-    row = svc.actualizar(db, ops, usuario_id, data)
+    row = svc.atualizar(db, ops, usuario_id, data)
     db.commit()
     db.refresh(row)
     return SaasOpsUsuarioRead.model_validate(svc.para_dict(row))

--- a/backend/app/api/saas_setores.py
+++ b/backend/app/api/saas_setores.py
@@ -1,0 +1,62 @@
+"""API — setores (cargos) da equipe SaaS."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
+from app.api.saas import exigir_saas_control_plane
+from app.core.auth import exigir_saas_ops
+from app.database import get_db
+from app.models.atendente import Atendente
+from app.schemas.saas_setor import SaasSetorCreate, SaasSetorRead, SaasSetorUpdate
+from app.services import saas_setores as svc
+
+router = APIRouter(prefix="/saas/setores", tags=["saas-setores"])
+
+
+@router.get("", response_model=list[SaasSetorRead])
+def listar_setores(
+    incluir_inativos: bool = Query(False),
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+    db: Session = Depends(get_db),
+):
+    return svc.listar(db, ops, incluir_inativos=incluir_inativos)
+
+
+@router.post("", response_model=SaasSetorRead, status_code=201)
+def criar_setor(
+    data: SaasSetorCreate,
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+    db: Session = Depends(get_db),
+):
+    row = svc.criar(db, ops, data)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+@router.get("/{setor_id}", response_model=SaasSetorRead)
+def obter_setor(
+    setor_id: int,
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+    db: Session = Depends(get_db),
+):
+    return svc.obter(db, ops, setor_id)
+
+
+@router.patch("/{setor_id}", response_model=SaasSetorRead)
+def atualizar_setor(
+    setor_id: int,
+    data: SaasSetorUpdate,
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_saas_ops),
+    db: Session = Depends(get_db),
+):
+    row = svc.atualizar(db, ops, setor_id, data)
+    db.commit()
+    db.refresh(row)
+    return row

--- a/backend/app/api/saas_solicitacoes.py
+++ b/backend/app/api/saas_solicitacoes.py
@@ -17,6 +17,10 @@ from app.models.atendente import Atendente
 from app.models.cliente_saas import ClienteSaaS
 from app.models.saas_solicitacao_produto import SaasSolicitacaoProduto
 from app.schemas.lista_paginada import ListaPaginada
+from app.services.solicitacao_melhoria_copy import status_da_fase
+from app.services import saas_solicitacao_grupo as grupo
+from app.services import saas_solicitacao_ingest as ingest
+from app.services import saas_solicitacao_triagem as triagem
 from app.schemas.saas_solicitacao import (
     SaasSolicitacaoAnexoRead,
     SaasSolicitacaoComentarioCreate,
@@ -24,13 +28,11 @@ from app.schemas.saas_solicitacao import (
     SaasSolicitacaoGithubUpdate,
     SaasSolicitacaoIngest,
     SaasSolicitacaoListaItem,
+    SaasSolicitacaoResumo,
     SaasSolicitacaoStatusUpdate,
     SaasSolicitacaoSyncResponse,
     SaasSolicitacaoVinculoCreate,
 )
-from app.services import saas_solicitacao_grupo as grupo
-from app.services import saas_solicitacao_ingest as ingest
-from app.services import saas_solicitacao_triagem as triagem
 
 router = APIRouter(prefix="/saas", tags=["saas-solicitacoes"])
 
@@ -127,11 +129,40 @@ def sync_triagem(
     return triagem.listar_sync(db, cliente, since=since)
 
 
+@router.get("/solicitacoes/resumo", response_model=SaasSolicitacaoResumo)
+def resumo_fila(
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    __: Atendente = Depends(exigir_fila_saas),
+):
+    from app.services.solicitacao_melhoria_copy import FASES_STATUS
+
+    rows = db.query(SaasSolicitacaoProduto.tipo, SaasSolicitacaoProduto.status).all()
+    total = len(rows)
+    sugestoes = sum(1 for t, _ in rows if t == "sugestao")
+    problemas = sum(1 for t, _ in rows if t == "problema")
+    aguardando = sum(1 for _, s in rows if s in FASES_STATUS["aguardando"])
+    desenvolvimento = sum(1 for _, s in rows if s in FASES_STATUS["desenvolvimento"])
+    finalizadas = sum(1 for _, s in rows if s in FASES_STATUS["finalizadas"])
+    return SaasSolicitacaoResumo(
+        total=total,
+        sugestoes=sugestoes,
+        problemas=problemas,
+        aguardando=aguardando,
+        desenvolvimento=desenvolvimento,
+        finalizadas=finalizadas,
+    )
+
+
 @router.get("/solicitacoes", response_model=ListaPaginada[SaasSolicitacaoListaItem])
 def listar(
     busca: str | None = Query(None),
     tipo: str | None = Query(None),
     status_filtro: str | None = Query(None, alias="status"),
+    fase: str | None = Query(
+        None,
+        description="Agrupa status: aguardando | desenvolvimento | finalizadas",
+    ),
     slug: str | None = Query(None),
     offset: int = Query(0, ge=0),
     limit: int = Query(_DEFAULT_PAGE, ge=1, le=_MAX_PAGE),
@@ -157,6 +188,11 @@ def listar(
         q = q.filter(SaasSolicitacaoProduto.tipo == tipo.strip())
     if status_filtro and status_filtro.strip():
         q = q.filter(SaasSolicitacaoProduto.status == status_filtro.strip())
+    elif fase and fase.strip():
+        statuses = status_da_fase(fase)
+        if statuses is None:
+            raise HTTPException(status_code=400, detail="Fase inválida")
+        q = q.filter(SaasSolicitacaoProduto.status.in_(list(statuses)))
     if slug and slug.strip():
         q = q.filter(SaasSolicitacaoProduto.instance_slug == slug.strip().lower())
     total = q.count()

--- a/backend/app/api/saas_solicitacoes.py
+++ b/backend/app/api/saas_solicitacoes.py
@@ -33,7 +33,6 @@ from app.schemas.saas_solicitacao import (
     SaasSolicitacaoStatusUpdate,
     SaasSolicitacaoSyncResponse,
     SaasSolicitacaoVinculoCreate,
-    SaasSolicitacaoVersaoAlvoUpdate,
 )
 
 router = APIRouter(prefix="/saas", tags=["saas-solicitacoes"])
@@ -259,18 +258,6 @@ def implementar(
 ):
     """G2: cria/liga issue GitHub e avança para em_desenvolvimento."""
     return triagem.implementar(db, solicitacao_id, ops, data)
-
-
-@router.patch("/solicitacoes/{solicitacao_id}/versao-alvo", response_model=SaasSolicitacaoDetalhe)
-def definir_versao_alvo(
-    solicitacao_id: int,
-    data: SaasSolicitacaoVersaoAlvoUpdate,
-    db: Session = Depends(get_db),
-    _: None = Depends(exigir_saas_control_plane),
-    ops: Atendente = Depends(exigir_fila_saas),
-):
-    """G3: define versão prevista/liberada visível ao cliente."""
-    return triagem.definir_versao_alvo(db, solicitacao_id, ops, data)
 
 
 @router.post("/solicitacoes/{solicitacao_id}/comentarios", response_model=SaasSolicitacaoDetalhe)

--- a/backend/app/api/saas_solicitacoes.py
+++ b/backend/app/api/saas_solicitacoes.py
@@ -26,6 +26,7 @@ from app.schemas.saas_solicitacao import (
     SaasSolicitacaoComentarioCreate,
     SaasSolicitacaoDetalhe,
     SaasSolicitacaoGithubUpdate,
+    SaasSolicitacaoImplementar,
     SaasSolicitacaoIngest,
     SaasSolicitacaoListaItem,
     SaasSolicitacaoResumo,
@@ -245,6 +246,18 @@ def alterar_status(
     ops: Atendente = Depends(exigir_fila_saas),
 ):
     return triagem.alterar_status(db, solicitacao_id, ops, data)
+
+
+@router.post("/solicitacoes/{solicitacao_id}/implementar", response_model=SaasSolicitacaoDetalhe)
+def implementar(
+    solicitacao_id: int,
+    data: SaasSolicitacaoImplementar = SaasSolicitacaoImplementar(),
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_fila_saas),
+):
+    """G2: cria/liga issue GitHub e avança para em_desenvolvimento."""
+    return triagem.implementar(db, solicitacao_id, ops, data)
 
 
 @router.post("/solicitacoes/{solicitacao_id}/comentarios", response_model=SaasSolicitacaoDetalhe)

--- a/backend/app/api/saas_solicitacoes.py
+++ b/backend/app/api/saas_solicitacoes.py
@@ -33,6 +33,7 @@ from app.schemas.saas_solicitacao import (
     SaasSolicitacaoStatusUpdate,
     SaasSolicitacaoSyncResponse,
     SaasSolicitacaoVinculoCreate,
+    SaasSolicitacaoVersaoAlvoUpdate,
 )
 
 router = APIRouter(prefix="/saas", tags=["saas-solicitacoes"])
@@ -258,6 +259,18 @@ def implementar(
 ):
     """G2: cria/liga issue GitHub e avança para em_desenvolvimento."""
     return triagem.implementar(db, solicitacao_id, ops, data)
+
+
+@router.patch("/solicitacoes/{solicitacao_id}/versao-alvo", response_model=SaasSolicitacaoDetalhe)
+def definir_versao_alvo(
+    solicitacao_id: int,
+    data: SaasSolicitacaoVersaoAlvoUpdate,
+    db: Session = Depends(get_db),
+    _: None = Depends(exigir_saas_control_plane),
+    ops: Atendente = Depends(exigir_fila_saas),
+):
+    """G3: define versão prevista/liberada visível ao cliente."""
+    return triagem.definir_versao_alvo(db, solicitacao_id, ops, data)
 
 
 @router.post("/solicitacoes/{solicitacao_id}/comentarios", response_model=SaasSolicitacaoDetalhe)

--- a/backend/app/api/system_settings.py
+++ b/backend/app/api/system_settings.py
@@ -58,6 +58,9 @@ def _company_out(row: EmpresaSistema | None) -> EmpresaSistemaRead:
         cidade=row.cidade,
         estado=row.estado,
         cep=row.cep,
+        latitude=getattr(row, "latitude", None),
+        longitude=getattr(row, "longitude", None),
+        ponto_raio_metros=int(getattr(row, "ponto_raio_metros", None) or 200),
         logo_url=logo_url,
     )
 

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -1279,6 +1279,9 @@ def iniciar_chat_outbound(
                 )
             estado_anterior = existente.estado
             if existente.estado == "aguardando_atendente" or existente.atendente_id is None:
+                from app.services.ponto_hora_extra import exigir_pode_pegar_whatsapp
+
+                exigir_pode_pegar_whatsapp(db, atendente)
                 existente.estado = "em_atendimento"
                 existente.atendente_id = atendente.id
                 existente.atendimento_inicio_at = datetime.now(timezone.utc)
@@ -1311,6 +1314,10 @@ def iniciar_chat_outbound(
             c = db.query(WhatsappChat).options(*_CHAT_LOAD_OPTIONS).filter(WhatsappChat.id == existente.id).first()
             assert c is not None
             return _chat_read(db, c)
+
+        from app.services.ponto_hora_extra import exigir_pode_pegar_whatsapp
+
+        exigir_pode_pegar_whatsapp(db, atendente)
 
         # Garante Evolution configurada se houver mensagem inicial (criar chat sem msg ainda exige settings para uso posterior)
         _settings_envio(db)
@@ -1862,6 +1869,9 @@ def assumir(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
     if c.estado != "aguardando_atendente":
         raise HTTPException(status_code=400, detail="Só é possível assumir chats na fila de espera")
+    from app.services.ponto_hora_extra import exigir_pode_pegar_whatsapp
+
+    exigir_pode_pegar_whatsapp(db, atendente)
     _aplicar_empresa_contexto_chat(db, atendente, c, empresa_id)
     _aplicar_setor_ao_assumir(db, c, atendente, setor_id)
     estado_anterior = c.estado

--- a/backend/app/api/whatsapp_chats.py
+++ b/backend/app/api/whatsapp_chats.py
@@ -633,12 +633,51 @@ def _criar_funcionario_rede(
     return f
 
 
-def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False) -> WhatsappChatRead:
+def _nao_lidas_whatsapp(
+    db: Session, c: WhatsappChat, atendente_id: int
+) -> tuple[int, datetime | None, int | None]:
+    """Inbound após o cursor de leitura (#951)."""
+    row = (
+        db.query(WhatsappChatReadModel.last_seen_at, WhatsappChatReadModel.last_seen_mensagem_id)
+        .filter(
+            WhatsappChatReadModel.chat_id == c.id,
+            WhatsappChatReadModel.atendente_id == atendente_id,
+        )
+        .first()
+    )
+    ls = row[0] if row else None
+    cursor_id = row[1] if row else None
+    q = db.query(func.count(WhatsappMensagem.id)).filter(
+        WhatsappMensagem.chat_id == c.id,
+        WhatsappMensagem.direcao == "inbound",
+    )
+    if cursor_id is not None:
+        q = q.filter(WhatsappMensagem.id > cursor_id)
+    else:
+        eff = ls if ls is not None else (c.atendimento_inicio_at or c.created_at)
+        if eff is None:
+            return 0, ls, cursor_id
+        q = q.filter(WhatsappMensagem.created_at > eff)
+    return int(q.scalar() or 0), ls, cursor_id
+
+
+def _chat_read(
+    db: Session,
+    c: WhatsappChat,
+    *,
+    revelar_avaliacao: bool = False,
+    atendente_id: int | None = None,
+) -> WhatsappChatRead:
     nota = getattr(c, "avaliacao_nota", None) if revelar_avaliacao else None
     respondida = getattr(c, "avaliacao_respondida_at", None) if revelar_avaliacao else None
     solicitada = bool(getattr(c, "avaliacao_solicitada", False)) if revelar_avaliacao else False
     func = getattr(c, "funcionario_rede", None)
     emp = getattr(c, "empresa", None)
+    nao_lidas = 0
+    last_seen: datetime | None = None
+    last_seen_msg: int | None = None
+    if atendente_id is not None:
+        nao_lidas, last_seen, last_seen_msg = _nao_lidas_whatsapp(db, c, atendente_id)
     return WhatsappChatRead(
         id=c.id,
         protocolo=c.protocolo,
@@ -668,6 +707,9 @@ def _chat_read(db: Session, c: WhatsappChat, *, revelar_avaliacao: bool = False)
         classificacao_demanda_pendente=bool(getattr(c, "classificacao_demanda_pendente", False)),
         foto_perfil_url=getattr(c, "foto_perfil_url", None),
         foto_perfil_atualizada_em=getattr(c, "foto_perfil_atualizada_em", None),
+        nao_lidas_count=nao_lidas,
+        last_seen_at=last_seen,
+        last_seen_mensagem_id=last_seen_msg,
     )
 
 
@@ -823,7 +865,7 @@ def listar_meus_ativos(
     if atendente.role != "admin":
         q = q.filter(WhatsappChat.atendente_id == atendente.id)
     rows = q.order_by(WhatsappChat.atendimento_inicio_at.desc().nullslast()).all()
-    return [_chat_read(db, c) for c in rows]
+    return [_chat_read(db, c, atendente_id=atendente.id) for c in rows]
 
 
 @router.get("/encerrados", response_model=ListaPaginada[WhatsappChatRead])
@@ -1369,7 +1411,7 @@ def obter(
     if _maybe_refresh_foto_perfil(db, c, force=False):
         db.commit()
         db.refresh(c)
-    return _chat_read(db, c)
+    return _chat_read(db, c, atendente_id=atendente.id)
 
 
 @router.get("/{chat_id}/pdf")
@@ -2205,6 +2247,9 @@ def marcar_chat_visto(
             raise HTTPException(status_code=403, detail="Sem permissão para este setor")
 
     now = datetime.now(timezone.utc)
+    max_msg_id = (
+        db.query(func.max(WhatsappMensagem.id)).filter(WhatsappMensagem.chat_id == chat_id).scalar()
+    )
     row = (
         db.query(WhatsappChatReadModel)
         .filter(WhatsappChatReadModel.chat_id == chat_id, WhatsappChatReadModel.atendente_id == atendente.id)
@@ -2212,9 +2257,16 @@ def marcar_chat_visto(
     )
     if row:
         row.last_seen_at = now
+        row.last_seen_mensagem_id = max_msg_id
     else:
-        db.add(WhatsappChatReadModel(chat_id=chat_id, atendente_id=atendente.id, last_seen_at=now))
-
+        db.add(
+            WhatsappChatReadModel(
+                chat_id=chat_id,
+                atendente_id=atendente.id,
+                last_seen_at=now,
+                last_seen_mensagem_id=max_msg_id,
+            )
+        )
     # ✓✓ azul no WhatsApp do cliente: só o responsável, em atendimento
     if (
         c.estado == "em_atendimento"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -62,6 +62,7 @@ from app.api import (
     saas_solicitacoes,
     saas_ops_conta,
     saas_ops_usuarios,
+    saas_setores,
     web_push,
     solicitacoes_melhoria,
 )
@@ -647,6 +648,7 @@ app.include_router(saas_leads.router, prefix=API_V1_PREFIX)
 app.include_router(saas_solicitacoes.router, prefix=API_V1_PREFIX)
 app.include_router(saas_ops_conta.router, prefix=API_V1_PREFIX)
 app.include_router(saas_ops_usuarios.router, prefix=API_V1_PREFIX)
+app.include_router(saas_setores.router, prefix=API_V1_PREFIX)
 app.include_router(solicitacoes_melhoria.router, prefix=API_V1_PREFIX)
 
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -73,6 +73,7 @@ from app.models.implantacao_checklist import (
     TicketChecklistItem,
 )
 from app.models.cliente_saas import ClienteSaaS
+from app.models.saas_setor import SaasSetor, saas_ops_setor
 from app.models.saas_alerta_emitido import SaasAlertaEmitido
 from app.models.lead_comercial import LeadComercial
 from app.models.saas_plano import SaasModulo, SaasPlano, SaasPlanoModulo
@@ -96,6 +97,7 @@ __all__ = [
     "SetorDistribuicaoRoundRobin",
     "Atendente",
     "AtendenteSetor",
+    "SaasSetor",
     "PontoBatida",
     "PontoJustificativa",
     "PontoSettings",

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.tipo_negocio import TipoNegocio
 from app.models.atendente import Atendente, AtendenteSetor
 from app.models.ponto_batida import PontoBatida
 from app.models.ponto_justificativa import PontoJustificativa
+from app.models.ponto_hora_extra import PontoHoraExtra
 from app.models.ponto_settings import PontoFeriado, PontoLocal, PontoSettings
 from app.models.setor import Setor
 from app.models.setor_distribuicao_round_robin import SetorDistribuicaoRoundRobin
@@ -100,6 +101,7 @@ __all__ = [
     "SaasSetor",
     "PontoBatida",
     "PontoJustificativa",
+    "PontoHoraExtra",
     "PontoSettings",
     "PontoLocal",
     "PontoFeriado",

--- a/backend/app/models/atendente.py
+++ b/backend/app/models/atendente.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, String, Table, UniqueConstraint
+from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, String, Table, Text, UniqueConstraint
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -35,12 +35,14 @@ class Atendente(Base):
     # Token Cursor MCP pessoal (#915): plaintext só na geração; Bearer resolve este ops.
     mcp_token_hash = Column(String(64), nullable=True, unique=True, index=True)
     mcp_token_gerado_em = Column(DateTime(timezone=True), nullable=True)
-    # Controle de ponto / escala (#761+): flag + ciclo horas trabalhadas × horas de folga.
+    # Controle de ponto / escala (#761+ / #959): nenhum | semanal | ciclo.
     usa_escala = Column(Boolean, nullable=False, default=False, server_default="false")
+    modo_jornada = Column(String(20), nullable=False, default="nenhum", server_default="nenhum")
+    horario_semana_json = Column(Text, nullable=True)
     escala_horas_trabalho = Column(Integer, nullable=True)
     escala_horas_folga = Column(Integer, nullable=True)
     escala_inicio_em = Column(Date, nullable=True)
-    horario_previsto_entrada = Column(String(5), nullable=True)  # HH:MM
+    horario_previsto_entrada = Column(String(5), nullable=True)  # HH:MM (ciclo)
     horario_previsto_saida = Column(String(5), nullable=True)
     tolerancia_atraso_minutos = Column(Integer, nullable=False, default=0, server_default="0")
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/atendente.py
+++ b/backend/app/models/atendente.py
@@ -45,6 +45,9 @@ class Atendente(Base):
     horario_previsto_entrada = Column(String(5), nullable=True)  # HH:MM (ciclo)
     horario_previsto_saida = Column(String(5), nullable=True)
     tolerancia_atraso_minutos = Column(Integer, nullable=False, default=0, server_default="0")
+    # Locais de ponto (#984): empresa + extras por atendente.
+    usar_local_empresa = Column(Boolean, nullable=False, default=True, server_default="true")
+    local_empresa_raio_metros = Column(Integer, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 

--- a/backend/app/models/atendente.py
+++ b/backend/app/models/atendente.py
@@ -51,6 +51,11 @@ class Atendente(Base):
         secondary=atendente_setor,
         back_populates="atendentes",
     )
+    saas_setores = relationship(
+        "SaasSetor",
+        secondary="saas_ops_setor",
+        back_populates="ops",
+    )
     tickets_atendidos = relationship("Ticket", back_populates="atendente")
     historicos = relationship("TicketHistorico", back_populates="atendente")
     ticket_mensagens = relationship("TicketMensagem", back_populates="atendente")

--- a/backend/app/models/cliente_saas.py
+++ b/backend/app/models/cliente_saas.py
@@ -1,6 +1,6 @@
 """Cliente SaaS / licença DeskRudder (control-plane comercial) — #521."""
 
-from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, JSON, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, JSON, Numeric, String, Text, UniqueConstraint
 from sqlalchemy.sql import func
 
 from app.database import Base
@@ -24,6 +24,8 @@ class ClienteSaaS(Base):
     modulos_snapshot = Column(JSON, nullable=True)
     max_postos = Column(Integer, nullable=True)
     max_usuarios = Column(Integer, nullable=True)
+    # Se preenchido, sobrescreve a estimativa (módulos + extras) na ficha comercial.
+    preco_mensal_negociado = Column(Numeric(12, 2), nullable=True)
     data_inicio = Column(Date, nullable=False)
     data_renovacao = Column(Date, nullable=True)
     instancia_url = Column(String(500), nullable=True)

--- a/backend/app/models/empresa_sistema.py
+++ b/backend/app/models/empresa_sistema.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy import Column, DateTime, Float, Integer, String
 from sqlalchemy.sql import func
 
 from app.database import Base
@@ -26,6 +26,10 @@ class EmpresaSistema(Base):
     cidade = Column(String(100), nullable=True)
     estado = Column(String(2), nullable=True)
     cep = Column(String(10), nullable=True)
+    # Pin do local de trabalho da empresa (#984).
+    latitude = Column(Float, nullable=True)
+    longitude = Column(Float, nullable=True)
+    ponto_raio_metros = Column(Integer, nullable=False, default=200, server_default="200")
     logo_filename = Column(String(255), nullable=True)
     logo_mimetype = Column(String(100), nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/ponto_hora_extra.py
+++ b/backend/app/models/ponto_hora_extra.py
@@ -1,0 +1,28 @@
+"""Hora extra para atendimento WhatsApp após jornada (#965)."""
+
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class PontoHoraExtra(Base):
+    __tablename__ = "ponto_hora_extra"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
+    # pendente | aprovada | rejeitada | expirada
+    estado = Column(String(20), nullable=False, default="pendente", server_default="pendente")
+    motivo = Column(String(1000), nullable=True)
+    # resto_do_dia | ate_horario (só quando aprovada)
+    modo = Column(String(20), nullable=True)
+    ate_em = Column(DateTime(timezone=True), nullable=True)
+    decidido_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
+    decidido_em = Column(DateTime(timezone=True), nullable=True)
+    decisao_motivo = Column(String(1000), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    atendente = relationship("Atendente", foreign_keys=[atendente_id])
+    decidido_por = relationship("Atendente", foreign_keys=[decidido_por_id])

--- a/backend/app/models/ponto_settings.py
+++ b/backend/app/models/ponto_settings.py
@@ -27,7 +27,12 @@ class PontoLocal(Base):
 
     id = Column(Integer, primary_key=True)
     tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    # NULL = legado sem dono (#984); não entra no geofence até reatribuir.
+    atendente_id = Column(
+        Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=True, index=True
+    )
     nome = Column(String(255), nullable=False)
+    endereco = Column(String(512), nullable=True)
     latitude = Column(Float, nullable=False)
     longitude = Column(Float, nullable=False)
     raio_metros = Column(Integer, nullable=False, default=200, server_default="200")

--- a/backend/app/models/ponto_settings.py
+++ b/backend/app/models/ponto_settings.py
@@ -14,6 +14,8 @@ class PontoSettings(Base):
     usar_feriados_nacionais = Column(Boolean, nullable=False, default=True, server_default="true")
     fecho_automatico_ativo = Column(Boolean, nullable=False, default=False, server_default="false")
     fecho_apos_horas = Column(Integer, nullable=False, default=14, server_default="14")
+    # Margem após saída prevista do dia (#961); fecho = min(N horas, saída+margem).
+    fecho_margem_pos_saida_minutos = Column(Integer, nullable=False, default=30, server_default="30")
     jornada_diaria_minutos = Column(Integer, nullable=False, default=480, server_default="480")
     # opcional | recomendada | obrigatoria (#844)
     politica_geolocalizacao = Column(String(20), nullable=False, default="opcional", server_default="opcional")

--- a/backend/app/models/portal_chat.py
+++ b/backend/app/models/portal_chat.py
@@ -72,6 +72,7 @@ class PortalChatRead(Base):
     chat_id = Column(Integer, ForeignKey("portal_chats.id", ondelete="CASCADE"), nullable=False, index=True)
     atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
     last_seen_at = Column(DateTime(timezone=True), nullable=False)
+    last_seen_mensagem_id = Column(Integer, nullable=True)
 
     chat = relationship("PortalChat", back_populates="reads")
     atendente = relationship("Atendente")

--- a/backend/app/models/saas_plano.py
+++ b/backend/app/models/saas_plano.py
@@ -27,6 +27,7 @@ class SaasModulo(Base):
     codigo = Column(String(80), nullable=False, index=True)
     nome = Column(String(120), nullable=False)
     descricao = Column(Text, nullable=True)
+    preco_mensal = Column(Numeric(12, 2), nullable=True)
     ativo = Column(Boolean, nullable=False, default=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
@@ -45,6 +46,9 @@ class SaasPlano(Base):
     ativo = Column(Boolean, nullable=False, default=True)
     ordem = Column(Integer, nullable=False, default=0)
     preco_mensal = Column(Numeric(12, 2), nullable=True)
+    # Usuários inclusos no preço dos módulos (padrão 3).
+    usuarios_inclusos = Column(Integer, nullable=False, default=3, server_default="3")
+    preco_usuario_extra = Column(Numeric(12, 2), nullable=True)
     max_postos = Column(Integer, nullable=True)
     max_usuarios = Column(Integer, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/saas_setor.py
+++ b/backend/app/models/saas_setor.py
@@ -1,0 +1,34 @@
+"""Setores (cargos) da equipe DeskRudder no control-plane — Admin, Dev, Comercial, etc."""
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Table, UniqueConstraint
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+saas_ops_setor = Table(
+    "saas_ops_setor",
+    Base.metadata,
+    Column("atendente_id", Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), primary_key=True),
+    Column("saas_setor_id", Integer, ForeignKey("saas_setores.id", ondelete="CASCADE"), primary_key=True),
+)
+
+
+class SaasSetor(Base):
+    """Setor/cargo da equipe ops (não confundir com setor de tickets do helpdesk)."""
+
+    __tablename__ = "saas_setores"
+    __table_args__ = (UniqueConstraint("tenant_id", "nome", name="uq_saas_setores_tenant_nome"),)
+
+    id = Column(Integer, primary_key=True, index=True)
+    tenant_id = Column(Integer, ForeignKey("tenants.id", ondelete="RESTRICT"), nullable=False, index=True)
+    nome = Column(String(100), nullable=False)
+    ativo = Column(Boolean, nullable=False, default=True, server_default="true")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+    ops = relationship(
+        "Atendente",
+        secondary=saas_ops_setor,
+        back_populates="saas_setores",
+    )

--- a/backend/app/models/saas_solicitacao_produto.py
+++ b/backend/app/models/saas_solicitacao_produto.py
@@ -28,6 +28,7 @@ class SaasSolicitacaoProduto(Base):
     descricao = Column(Text, nullable=False)
     status = Column(String(40), nullable=False, default="aberta", server_default="aberta", index=True)
     versao_contexto = Column(String(64), nullable=True)
+    versao_alvo = Column(String(64), nullable=True)
     autor_nome = Column(String(255), nullable=True)
     created_at_origem = Column(DateTime(timezone=True), nullable=True)
     ingested_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)

--- a/backend/app/models/solicitacao_melhoria.py
+++ b/backend/app/models/solicitacao_melhoria.py
@@ -21,6 +21,7 @@ class SolicitacaoMelhoria(Base):
     status = Column(String(40), nullable=False, default="aberta", server_default="aberta", index=True)
     motivo_nao_desenvolvimento = Column(Text, nullable=True)
     versao_contexto = Column(String(64), nullable=True)
+    versao_alvo = Column(String(64), nullable=True)
     github_repo = Column(String(200), nullable=True)
     github_issue_number = Column(Integer, nullable=True)
     github_issue_url = Column(String(500), nullable=True)

--- a/backend/app/models/whatsapp_chat_read.py
+++ b/backend/app/models/whatsapp_chat_read.py
@@ -15,6 +15,7 @@ class WhatsappChatRead(Base):
     atendente_id = Column(Integer, ForeignKey("atendentes.id", ondelete="CASCADE"), nullable=False, index=True)
     chat_id = Column(Integer, ForeignKey("whatsapp_chats.id", ondelete="CASCADE"), nullable=False, index=True)
     last_seen_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    last_seen_mensagem_id = Column(Integer, nullable=True)
 
     atendente = relationship("Atendente", backref="whatsapp_chat_reads")
     chat = relationship("WhatsappChat", backref="read_entries")

--- a/backend/app/schemas/atendente.py
+++ b/backend/app/schemas/atendente.py
@@ -1,5 +1,9 @@
+from typing import Any, Literal
+
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 from datetime import date, datetime
+
+ModoJornada = Literal["nenhum", "semanal", "ciclo"]
 
 
 class AtendenteBase(BaseModel):
@@ -7,7 +11,10 @@ class AtendenteBase(BaseModel):
     nome: str
     role: str = "atendente"  # admin | atendente | comercial | saas_ops
     ativo: bool = True
+    modo_jornada: ModoJornada = "nenhum"
+    # Compat: True se modo semanal|ciclo (preenchido na Read / sync no write)
     usa_escala: bool = False
+    horario_semana: dict[str, Any] | None = None
     escala_horas_trabalho: int | None = Field(default=None, ge=1, le=168)
     escala_horas_folga: int | None = Field(default=None, ge=1, le=720)
     escala_inicio_em: date | None = None
@@ -28,7 +35,9 @@ class AtendenteUpdate(BaseModel):
     role: str | None = None
     ativo: bool | None = None
     setor_ids: list[int] | None = None
+    modo_jornada: ModoJornada | None = None
     usa_escala: bool | None = None
+    horario_semana: dict[str, Any] | None = None
     escala_horas_trabalho: int | None = Field(default=None, ge=1, le=168)
     escala_horas_folga: int | None = Field(default=None, ge=1, le=720)
     escala_inicio_em: date | None = None

--- a/backend/app/schemas/atendente.py
+++ b/backend/app/schemas/atendente.py
@@ -47,6 +47,8 @@ class AtendenteRead(AtendenteBase):
     setor_ids: list[int] = []
     e_financeiro: bool = False
     must_change_password: bool = False
+    saas_setor_ids: list[int] = []
+    saas_setor_nomes: list[str] = []
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/schemas/atendente.py
+++ b/backend/app/schemas/atendente.py
@@ -21,6 +21,8 @@ class AtendenteBase(BaseModel):
     horario_previsto_entrada: str | None = Field(default=None, max_length=5)
     horario_previsto_saida: str | None = Field(default=None, max_length=5)
     tolerancia_atraso_minutos: int = Field(default=0, ge=0, le=120)
+    usar_local_empresa: bool = True
+    local_empresa_raio_metros: int | None = Field(default=None, ge=20, le=50_000)
 
 
 class AtendenteCreate(AtendenteBase):
@@ -44,6 +46,8 @@ class AtendenteUpdate(BaseModel):
     horario_previsto_entrada: str | None = Field(default=None, max_length=5)
     horario_previsto_saida: str | None = Field(default=None, max_length=5)
     tolerancia_atraso_minutos: int | None = Field(default=None, ge=0, le=120)
+    usar_local_empresa: bool | None = None
+    local_empresa_raio_metros: int | None = Field(default=None, ge=20, le=50_000)
 
 
 class AtendenteRead(AtendenteBase):

--- a/backend/app/schemas/chat_interno.py
+++ b/backend/app/schemas/chat_interno.py
@@ -122,3 +122,17 @@ class ConversaInboxRead(BaseModel):
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class MembroCanalSetorRead(BaseModel):
+    atendente_id: int
+    nome: str
+    online: bool = False
+
+
+class MembrosCanalSetorListaRead(BaseModel):
+    setor_id: int
+    setor_nome: str
+    total: int
+    online_count: int
+    items: list[MembroCanalSetorRead]

--- a/backend/app/schemas/notificacoes.py
+++ b/backend/app/schemas/notificacoes.py
@@ -30,6 +30,11 @@ class NotificacaoResumo(BaseModel):
         default=0,
         description="Quantidade de conversas internas com mensagens não lidas",
     )
+    ponto_he_pendentes_count: int = Field(
+        ge=0,
+        default=0,
+        description="Pedidos de hora extra pendentes (só admins)",
+    )
     total_pendencias: int = Field(ge=0, description="Soma usada no badge (sem duplicar fila vs. não lidas)")
 
 
@@ -40,6 +45,7 @@ class NotificacaoItem(BaseModel):
         "wpp_chats_na_fila",
         "wpp_chats_com_resposta",
         "chat_interno",
+        "ponto_he_pendente",
     ]
     ticket_id: int | None = None
     chat_id: int | None = None

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -199,6 +199,7 @@ class PontoSettingsRead(BaseModel):
     usar_feriados_nacionais: bool = True
     fecho_automatico_ativo: bool = False
     fecho_apos_horas: int = 14
+    fecho_margem_pos_saida_minutos: int = 30
     jornada_diaria_minutos: int = 480
     politica_geolocalizacao: PoliticaGeolocalizacao = "opcional"
 
@@ -209,6 +210,7 @@ class PontoSettingsUpdate(BaseModel):
     usar_feriados_nacionais: bool | None = None
     fecho_automatico_ativo: bool | None = None
     fecho_apos_horas: int | None = Field(default=None, ge=4, le=48)
+    fecho_margem_pos_saida_minutos: int | None = Field(default=None, ge=0, le=240)
     jornada_diaria_minutos: int | None = Field(default=None, ge=60, le=1440)
     politica_geolocalizacao: PoliticaGeolocalizacao | None = None
 

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -295,3 +295,37 @@ class PontoJustificativaDecisao(BaseModel):
         motivo: str = Field(..., min_length=3, max_length=500)
 
     aplicar_batidas: list[BatidaAplicar] | None = None
+
+
+class PontoHoraExtraCreate(BaseModel):
+    motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoHoraExtraRead(BaseModel):
+    id: int
+    atendente_id: int
+    atendente_nome: str | None = None
+    estado: str
+    motivo: str | None = None
+    modo: str | None = None
+    ate_em: datetime | None = None
+    decidido_por_id: int | None = None
+    decidido_em: datetime | None = None
+    decisao_motivo: str | None = None
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PontoHoraExtraDecisao(BaseModel):
+    aprovar: bool
+    modo: Literal["resto_do_dia", "ate_horario"] | None = None
+    ate_horario: str | None = Field(default=None, max_length=5, description="HH:MM se modo=ate_horario")
+    decisao_motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoHoraExtraMeStatus(BaseModel):
+    fora_da_jornada: bool
+    pode_pegar_whatsapp: bool
+    he_ativa: PontoHoraExtraRead | None = None
+    pedido_pendente: PontoHoraExtraRead | None = None

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -44,7 +44,9 @@ class PontoSettingsPublicRead(BaseModel):
 
 
 class PontoLocalCreate(BaseModel):
+    atendente_id: int = Field(..., ge=1)
     nome: str = Field(..., min_length=1, max_length=255)
+    endereco: str | None = Field(default=None, max_length=512)
     latitude: float = Field(..., ge=-90, le=90)
     longitude: float = Field(..., ge=-180, le=180)
     raio_metros: int = Field(default=200, ge=20, le=50_000)
@@ -53,7 +55,9 @@ class PontoLocalCreate(BaseModel):
 
 class PontoLocalRead(BaseModel):
     id: int
+    atendente_id: int | None = None
     nome: str
+    endereco: str | None = None
     latitude: float
     longitude: float
     raio_metros: int
@@ -63,7 +67,9 @@ class PontoLocalRead(BaseModel):
 
 
 class PontoLocalUpdate(BaseModel):
+    atendente_id: int | None = Field(default=None, ge=1)
     nome: str | None = Field(default=None, min_length=1, max_length=255)
+    endereco: str | None = Field(default=None, max_length=512)
     latitude: float | None = Field(default=None, ge=-90, le=90)
     longitude: float | None = Field(default=None, ge=-180, le=180)
     raio_metros: int | None = Field(default=None, ge=20, le=50_000)

--- a/backend/app/schemas/portal_chat.py
+++ b/backend/app/schemas/portal_chat.py
@@ -42,6 +42,9 @@ class PortalChatRead(BaseModel):
     atendimento_inicio_at: datetime | None
     encerramento_at: datetime | None
     ultima_mensagem_preview: str | None = None
+    nao_lidas_count: int = 0
+    last_seen_at: datetime | None = None
+    last_seen_mensagem_id: int | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/schemas/saas.py
+++ b/backend/app/schemas/saas.py
@@ -105,6 +105,17 @@ class ClienteSaaSBase(BaseModel):
 
 class ClienteSaaSCreate(ClienteSaaSBase):
     lead_comercial_id: int | None = None
+    modulo_ids: list[int] | None = Field(
+        None, description="Mix custom de módulos; se omitido, usa os do plano"
+    )
+    usuarios_contratados: int | None = Field(
+        None, ge=0, description="Usuários contratados (extra além dos inclusos)"
+    )
+    preco_mensal_negociado: float | None = Field(
+        None,
+        ge=0,
+        description="Valor mensal fechado na negociação; se vazio, usa a estimativa do catálogo",
+    )
 
 
 class ClienteSaaSUpdate(BaseModel):
@@ -119,6 +130,9 @@ class ClienteSaaSUpdate(BaseModel):
     contato_email: str | None = Field(None, max_length=255)
     contato_nome: str | None = Field(None, max_length=200)
     notas: str | None = None
+    modulo_ids: list[int] | None = None
+    usuarios_contratados: int | None = Field(None, ge=0)
+    preco_mensal_negociado: float | None = Field(None, ge=0)
 
     @field_validator("nome")
     @classmethod
@@ -263,6 +277,7 @@ class SaasModuloBrief(BaseModel):
     codigo: str
     nome: str
     ativo: bool = True
+    preco_mensal: float | None = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -287,9 +302,17 @@ class ClienteSaaSRead(ClienteSaaSBase):
     comandos_stack: str | None = None
     dias_para_renovacao: int | None = None
     plano_modulos: list[SaasModuloBrief] = Field(default_factory=list)
+    modulos_contratados: list[SaasModuloBrief] = Field(default_factory=list)
     modulos_snapshot: list[str] = Field(default_factory=list)
     max_postos: int | None = None
     max_usuarios: int | None = None
+    usuarios_inclusos: int | None = None
+    preco_usuario_extra: float | None = None
+    preco_modulos: float | None = None
+    preco_usuarios_extra: float | None = None
+    preco_mensal_estimado: float | None = None
+    preco_mensal_negociado: float | None = None
+    preco_mensal_efetivo: float | None = None
     ingest_token_configurado: bool = False
     created_at: datetime | None = None
     updated_at: datetime | None = None
@@ -336,6 +359,7 @@ class SaasModuloCreate(BaseModel):
     codigo: str = Field(..., min_length=1, max_length=80)
     nome: str = Field(..., min_length=1, max_length=120)
     descricao: str | None = None
+    preco_mensal: float | None = Field(None, ge=0)
 
     @field_validator("codigo")
     @classmethod
@@ -362,6 +386,7 @@ class SaasModuloCreate(BaseModel):
 class SaasModuloUpdate(BaseModel):
     nome: str | None = Field(None, min_length=1, max_length=120)
     descricao: str | None = None
+    preco_mensal: float | None = Field(None, ge=0)
 
     @field_validator("nome")
     @classmethod
@@ -387,6 +412,7 @@ class SaasModuloRead(BaseModel):
     codigo: str
     nome: str
     descricao: str | None = None
+    preco_mensal: float | None = None
     ativo: bool = True
     created_at: datetime | None = None
     updated_at: datetime | None = None
@@ -399,8 +425,8 @@ class SaasPlanoCreate(BaseModel):
     nome: str = Field(..., min_length=1, max_length=120)
     descricao: str | None = None
     ordem: int = 0
-    preco_mensal: float | None = Field(None, ge=0)
-    max_postos: int | None = Field(None, ge=0)
+    usuarios_inclusos: int | None = Field(3, ge=0)
+    preco_usuario_extra: float | None = Field(10, ge=0)
     max_usuarios: int | None = Field(None, ge=0)
     modulo_ids: list[int] = Field(default_factory=list)
 
@@ -430,8 +456,8 @@ class SaasPlanoUpdate(BaseModel):
     nome: str | None = Field(None, min_length=1, max_length=120)
     descricao: str | None = None
     ordem: int | None = None
-    preco_mensal: float | None = Field(None, ge=0)
-    max_postos: int | None = Field(None, ge=0)
+    usuarios_inclusos: int | None = Field(None, ge=0)
+    preco_usuario_extra: float | None = Field(None, ge=0)
     max_usuarios: int | None = Field(None, ge=0)
     modulo_ids: list[int] | None = None
 
@@ -462,6 +488,8 @@ class SaasPlanoRead(BaseModel):
     ativo: bool = True
     ordem: int = 0
     preco_mensal: float | None = None
+    usuarios_inclusos: int = 3
+    preco_usuario_extra: float | None = 10
     max_postos: int | None = None
     max_usuarios: int | None = None
     modulos: list[SaasModuloBrief] = Field(default_factory=list)
@@ -469,3 +497,13 @@ class SaasPlanoRead(BaseModel):
     updated_at: datetime | None = None
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class SaasPrecoEstimativa(BaseModel):
+    preco_modulos: float = 0
+    preco_usuarios_extra: float = 0
+    preco_mensal_total: float = 0
+    usuarios_inclusos: int = 3
+    preco_usuario_extra: float = 10
+    usuarios_contratados: int | None = None
+    modulos: list[SaasModuloBrief] = Field(default_factory=list)

--- a/backend/app/schemas/saas_ops_conta.py
+++ b/backend/app/schemas/saas_ops_conta.py
@@ -1,0 +1,20 @@
+"""Schemas — conta do ops no painel SaaS."""
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SaasOpsContaPerfilUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=255)
+    email: str | None = Field(None, min_length=3, max_length=255)
+
+
+class SaasOpsContaPerfilRead(BaseModel):
+    """Resposta do PATCH /saas/me. Tokens só vêm quando o e-mail muda (JWT usa o e-mail no sub)."""
+
+    id: int
+    nome: str
+    email: str
+    access_token: str | None = None
+    refresh_token: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/saas_ops_usuario.py
+++ b/backend/app/schemas/saas_ops_usuario.py
@@ -1,8 +1,10 @@
-"""Utilizadores do painel SaaS (role saas_ops) — #883."""
+"""Usuários do painel SaaS (role saas_ops) — #883."""
 
 from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.saas_setor import SaasSetorRead
 
 
 class SaasOpsUsuarioRead(BaseModel):
@@ -14,6 +16,8 @@ class SaasOpsUsuarioRead(BaseModel):
     mcp_token_configurado: bool
     mcp_token_gerado_em: datetime | None = None
     created_at: datetime | None = None
+    setor_ids: list[int] = []
+    setores: list[SaasSetorRead] = []
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -21,6 +25,7 @@ class SaasOpsUsuarioRead(BaseModel):
 class SaasOpsUsuarioCreate(BaseModel):
     nome: str = Field(..., min_length=1, max_length=255)
     email: str = Field(..., min_length=3, max_length=255)
+    setor_ids: list[int] = Field(default_factory=list)
 
 
 class SaasOpsUsuarioCriado(SaasOpsUsuarioRead):
@@ -32,6 +37,7 @@ class SaasOpsUsuarioCriado(SaasOpsUsuarioRead):
 class SaasOpsUsuarioUpdate(BaseModel):
     nome: str | None = Field(None, min_length=1, max_length=255)
     ativo: bool | None = None
+    setor_ids: list[int] | None = None
 
 
 class SaasOpsUsuarioSenha(BaseModel):

--- a/backend/app/schemas/saas_setor.py
+++ b/backend/app/schemas/saas_setor.py
@@ -1,0 +1,23 @@
+"""Schemas — setores (cargos) da equipe SaaS."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SaasSetorRead(BaseModel):
+    id: int
+    nome: str
+    ativo: bool
+    created_at: datetime | None = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SaasSetorCreate(BaseModel):
+    nome: str = Field(..., min_length=1, max_length=100)
+
+
+class SaasSetorUpdate(BaseModel):
+    nome: str | None = Field(None, min_length=1, max_length=100)
+    ativo: bool | None = None

--- a/backend/app/schemas/saas_solicitacao.py
+++ b/backend/app/schemas/saas_solicitacao.py
@@ -100,6 +100,15 @@ class SaasSolicitacaoStatusUpdate(BaseModel):
     motivo_nao_desenvolvimento: str | None = Field(None, max_length=4000)
 
 
+class SaasSolicitacaoImplementar(BaseModel):
+    """G2: entra em em_desenvolvimento com issue criada ou ligada."""
+
+    github_issue_url: str | None = Field(None, max_length=500)
+    github_issue_number: int | None = Field(None, ge=1)
+    github_repo: str | None = Field(None, max_length=200)
+    criar_issue: bool = True
+
+
 class SaasSolicitacaoComentarioCreate(BaseModel):
     corpo: str = Field(..., min_length=1, max_length=8000)
     publico_cliente: bool = True

--- a/backend/app/schemas/saas_solicitacao.py
+++ b/backend/app/schemas/saas_solicitacao.py
@@ -110,13 +110,6 @@ class SaasSolicitacaoImplementar(BaseModel):
     criar_issue: bool = True
 
 
-class SaasSolicitacaoVersaoAlvoUpdate(BaseModel):
-    """G3: versão prevista/liberada visível ao cliente nível 2."""
-
-    versao_alvo: str | None = Field(None, max_length=64)
-    comentario_publico: str | None = Field(None, max_length=8000)
-
-
 class SaasSolicitacaoComentarioCreate(BaseModel):
     corpo: str = Field(..., min_length=1, max_length=8000)
     publico_cliente: bool = True

--- a/backend/app/schemas/saas_solicitacao.py
+++ b/backend/app/schemas/saas_solicitacao.py
@@ -124,6 +124,15 @@ class SaasSolicitacaoSyncResponse(BaseModel):
     items: list[SaasSolicitacaoSyncItem] = Field(default_factory=list)
 
 
+class SaasSolicitacaoResumo(BaseModel):
+    total: int = 0
+    sugestoes: int = 0
+    problemas: int = 0
+    aguardando: int = 0
+    desenvolvimento: int = 0
+    finalizadas: int = 0
+
+
 class ClienteSaaSIngestTokenRead(BaseModel):
     slug: str
     token: str

--- a/backend/app/schemas/saas_solicitacao.py
+++ b/backend/app/schemas/saas_solicitacao.py
@@ -34,6 +34,7 @@ class SaasSolicitacaoListaItem(BaseModel):
     status: str
     status_rotulo: str
     versao_contexto: str | None
+    versao_alvo: str | None = None
     autor_nome: str | None
     created_at_origem: datetime | None
     ingested_at: datetime
@@ -109,6 +110,13 @@ class SaasSolicitacaoImplementar(BaseModel):
     criar_issue: bool = True
 
 
+class SaasSolicitacaoVersaoAlvoUpdate(BaseModel):
+    """G3: versão prevista/liberada visível ao cliente nível 2."""
+
+    versao_alvo: str | None = Field(None, max_length=64)
+    comentario_publico: str | None = Field(None, max_length=8000)
+
+
 class SaasSolicitacaoComentarioCreate(BaseModel):
     corpo: str = Field(..., min_length=1, max_length=8000)
     publico_cliente: bool = True
@@ -126,6 +134,7 @@ class SaasSolicitacaoSyncItem(BaseModel):
     status: str
     motivo_nao_desenvolvimento: str | None = None
     protocolo: str | None = None
+    versao_alvo: str | None = None
     comentarios_publicos: list[SaasSolicitacaoSyncComentario] = Field(default_factory=list)
 
 

--- a/backend/app/schemas/solicitacao_melhoria.py
+++ b/backend/app/schemas/solicitacao_melhoria.py
@@ -82,6 +82,8 @@ class SolicitacaoMelhoriaRead(BaseModel):
     status_rotulo: str
     motivo_nao_desenvolvimento: str | None
     versao_contexto: str | None
+    versao_alvo: str | None = None
+    versao_alvo_rotulo: str | None = None
     mensagem_status: str
     created_at: datetime
     updated_at: datetime | None
@@ -104,6 +106,7 @@ class SolicitacaoMelhoriaListaItem(BaseModel):
     titulo: str
     status: str
     status_rotulo: str
+    versao_alvo_rotulo: str | None = None
     autor_nome: str | None
     organizacao_id: int
     created_at: datetime

--- a/backend/app/schemas/system_company.py
+++ b/backend/app/schemas/system_company.py
@@ -15,6 +15,9 @@ class EmpresaSistemaRead(BaseModel):
     cidade: str | None = None
     estado: str | None = None
     cep: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    ponto_raio_metros: int = 200
     logo_url: str | None = None
 
 
@@ -32,3 +35,6 @@ class EmpresaSistemaUpdate(BaseModel):
     cidade: str | None = None
     estado: str | None = None
     cep: str | None = None
+    latitude: float | None = Field(default=None, ge=-90, le=90)
+    longitude: float | None = Field(default=None, ge=-180, le=180)
+    ponto_raio_metros: int | None = Field(default=None, ge=20, le=50_000)

--- a/backend/app/schemas/whatsapp_chat.py
+++ b/backend/app/schemas/whatsapp_chat.py
@@ -83,6 +83,10 @@ class WhatsappChatRead(BaseModel):
     classificacao_demanda_pendente: bool = False
     foto_perfil_url: str | None = None
     foto_perfil_atualizada_em: datetime | None = None
+    # Não lidas do atendente atual (#951 / #S202608-0004)
+    nao_lidas_count: int = 0
+    last_seen_at: datetime | None = None
+    last_seen_mensagem_id: int | None = None
 
     model_config = {"from_attributes": True}
 

--- a/backend/app/services/chat_interno.py
+++ b/backend/app/services/chat_interno.py
@@ -351,19 +351,7 @@ def listar_mencionaveis(
         rows = listar_participantes_grupo(db, conversa.id)
         atendentes = [a for a, _ in rows if a.ativo]
     elif conversa.tipo == TIPO_CONVERSA_SETOR and conversa.setor_id is not None:
-        from app.models.atendente import atendente_setor
-
-        atendentes = (
-            db.query(Atendente)
-            .join(atendente_setor, atendente_setor.c.atendente_id == Atendente.id)
-            .filter(
-                atendente_setor.c.setor_id == conversa.setor_id,
-                Atendente.tenant_id == conversa.tenant_id,
-                Atendente.ativo.is_(True),
-            )
-            .order_by(Atendente.nome.asc())
-            .all()
-        )
+        atendentes = listar_membros_vinculados_setor(db, conversa.tenant_id, conversa.setor_id)
     elif conversa.tipo == TIPO_CONVERSA_DIRETA:
         rows = listar_participantes_grupo(db, conversa.id)
         atendentes = [a for a, _ in rows if a.ativo]
@@ -373,6 +361,50 @@ def listar_mencionaveis(
     if excluir_atendente_id is not None:
         atendentes = [a for a in atendentes if a.id != excluir_atendente_id]
     return atendentes
+
+
+def listar_membros_vinculados_setor(db: Session, tenant_id: int, setor_id: int) -> list[Atendente]:
+    """Atendentes ativos vinculados ao setor (membership do canal de setor)."""
+    from app.models.atendente import atendente_setor
+
+    return (
+        db.query(Atendente)
+        .join(atendente_setor, atendente_setor.c.atendente_id == Atendente.id)
+        .filter(
+            atendente_setor.c.setor_id == setor_id,
+            Atendente.tenant_id == tenant_id,
+            Atendente.ativo.is_(True),
+        )
+        .order_by(Atendente.nome.asc())
+        .all()
+    )
+
+
+def listar_membros_canal_setor_com_presenca(
+    db: Session,
+    *,
+    tenant_id: int,
+    setor_id: int,
+) -> tuple[str, list[tuple[Atendente, bool]]]:
+    """Retorna (nome do setor, [(atendente, online), ...]) ordenado: online primeiro, depois nome."""
+    from app.services.presenca import PRESENCA_TTL_SEC
+
+    setor = db.query(Setor).filter(Setor.id == setor_id, Setor.tenant_id == tenant_id).first()
+    if setor is None:
+        raise ChatInternoErro("Setor não encontrado.")
+
+    membros = listar_membros_vinculados_setor(db, tenant_id, setor_id)
+    agora = datetime.now(timezone.utc)
+    limite = agora - timedelta(seconds=PRESENCA_TTL_SEC)
+    out: list[tuple[Atendente, bool]] = []
+    for a in membros:
+        hb = a.presenca_heartbeat_em
+        if hb is not None and hb.tzinfo is None:
+            hb = hb.replace(tzinfo=timezone.utc)
+        online = bool(hb is not None and hb >= limite)
+        out.append((a, online))
+    out.sort(key=lambda pair: (not pair[1], (pair[0].nome or "").lower()))
+    return setor.nome, out
 
 
 def _token_mencao_no_corpo(corpo: str, token: str) -> bool:

--- a/backend/app/services/escala.py
+++ b/backend/app/services/escala.py
@@ -1,15 +1,20 @@
-"""Regras de escala: ciclo horas trabalhadas × horas de folga (#770)."""
+"""Jornada esperada: ciclo X×Y ou escala semanal (#770 / #959/#960)."""
 
 from __future__ import annotations
 
+import json
 from datetime import date, datetime, time, timedelta
+from typing import Any
 from zoneinfo import ZoneInfo
 
 from fastapi import HTTPException, status
 
+from app.core.business_calendar import WEEKDAY_KEYS, horario_semana_from_json, parse_hhmm
 from app.models.atendente import Atendente
 
 PONTO_TZ = ZoneInfo("America/Sao_Paulo")
+
+MODOS_JORNADA = frozenset({"nenhum", "semanal", "ciclo"})
 
 
 def rotulo_escala(horas_trabalho: int | None, horas_folga: int | None) -> str | None:
@@ -18,13 +23,57 @@ def rotulo_escala(horas_trabalho: int | None, horas_folga: int | None) -> str | 
     return f"{horas_trabalho}×{horas_folga}"
 
 
-def escala_configurada(atendente: Atendente) -> bool:
+def modo_jornada(atendente: Atendente) -> str:
+    raw = (getattr(atendente, "modo_jornada", None) or "").strip().lower()
+    if raw == "semanal":
+        return "semanal"
+    if raw == "ciclo":
+        return "ciclo"
+    # nenhum / vazio / legado: usa_escala + ciclo X×Y ainda conta como ciclo
+    if getattr(atendente, "usa_escala", False) and _ciclo_campos_ok(atendente):
+        return "ciclo"
+    return "nenhum"
+
+
+def _ciclo_campos_ok(atendente: Atendente) -> bool:
     return bool(
-        getattr(atendente, "usa_escala", False)
-        and atendente.escala_horas_trabalho
+        atendente.escala_horas_trabalho
         and atendente.escala_horas_folga
         and atendente.escala_inicio_em
     )
+
+
+def horario_semana_dict(atendente: Atendente) -> dict[str, dict[str, Any]] | None:
+    return horario_semana_from_json(getattr(atendente, "horario_semana_json", None))
+
+
+def _semanal_configurado(atendente: Atendente) -> bool:
+    hs = horario_semana_dict(atendente)
+    if not hs:
+        return False
+    for k in WEEKDAY_KEYS:
+        cfg = hs.get(k)
+        if not isinstance(cfg, dict) or not bool(cfg.get("ativo")):
+            continue
+        ini = parse_hhmm(cfg.get("inicio"))
+        fim = parse_hhmm(cfg.get("fim"))
+        if ini and fim and (ini[0], ini[1]) < (fim[0], fim[1]):
+            return True
+    return False
+
+
+def ciclo_configurado(atendente: Atendente) -> bool:
+    return modo_jornada(atendente) == "ciclo" and _ciclo_campos_ok(atendente)
+
+
+def escala_configurada(atendente: Atendente) -> bool:
+    """True se há jornada esperada (semanal ou ciclo) — gera falta/meta/avisos."""
+    m = modo_jornada(atendente)
+    if m == "ciclo":
+        return _ciclo_campos_ok(atendente)
+    if m == "semanal":
+        return _semanal_configurado(atendente)
+    return False
 
 
 def _inicio_ciclo_local(atendente: Atendente) -> datetime:
@@ -34,7 +83,7 @@ def _inicio_ciclo_local(atendente: Atendente) -> datetime:
 
 def em_periodo_trabalho(atendente: Atendente, when: datetime) -> bool:
     """True se o instante cair na janela de trabalho do ciclo X×Y."""
-    if not escala_configurada(atendente):
+    if not ciclo_configurado(atendente):
         return False
     h_trab = int(atendente.escala_horas_trabalho)  # type: ignore[arg-type]
     h_folga = int(atendente.escala_horas_folga)  # type: ignore[arg-type]
@@ -51,14 +100,53 @@ def em_periodo_trabalho(atendente: Atendente, when: datetime) -> bool:
 
 
 def eh_dia_de_trabalho(atendente: Atendente, dia: date) -> bool:
-    """Dia de trabalho se qualquer hora do dia (TZ negócio) cair no período de trabalho."""
-    if not escala_configurada(atendente):
+    """Dia esperado de trabalho conforme o modo de jornada."""
+    m = modo_jornada(atendente)
+    if m == "ciclo":
+        if not _ciclo_campos_ok(atendente):
+            return False
+        for hour in range(24):
+            moment = datetime.combine(dia, time(hour=hour, minute=0), tzinfo=PONTO_TZ)
+            if em_periodo_trabalho(atendente, moment):
+                return True
         return False
-    for hour in range(24):
-        moment = datetime.combine(dia, time(hour=hour, minute=0), tzinfo=PONTO_TZ)
-        if em_periodo_trabalho(atendente, moment):
-            return True
+    if m == "semanal":
+        hs = horario_semana_dict(atendente)
+        if not hs:
+            return False
+        k = WEEKDAY_KEYS[dia.weekday()]
+        cfg = hs.get(k)
+        return bool(isinstance(cfg, dict) and cfg.get("ativo"))
     return False
+
+
+def horario_previsto_do_dia(
+    atendente: Atendente, dia: date
+) -> tuple[tuple[int, int], tuple[int, int]] | None:
+    """Retorna ((h,m) inicio, (h,m) fim) do dia, ou None se não houver janela."""
+    m = modo_jornada(atendente)
+    if m == "semanal":
+        hs = horario_semana_dict(atendente)
+        if not hs:
+            return None
+        k = WEEKDAY_KEYS[dia.weekday()]
+        cfg = hs.get(k)
+        if not isinstance(cfg, dict) or not cfg.get("ativo"):
+            return None
+        ini = parse_hhmm(cfg.get("inicio"))
+        fim = parse_hhmm(cfg.get("fim"))
+        if ini and fim:
+            return ini, fim
+        return None
+    if m == "ciclo":
+        if not eh_dia_de_trabalho(atendente, dia):
+            return None
+        pe = parse_hhmm(getattr(atendente, "horario_previsto_entrada", None))
+        ps = parse_hhmm(getattr(atendente, "horario_previsto_saida", None))
+        if pe and ps:
+            return pe, ps
+        return None
+    return None
 
 
 def dias_do_mes(ano: int, mes: int) -> list[date]:
@@ -70,6 +158,83 @@ def dias_do_mes(ano: int, mes: int) -> list[date]:
     return out
 
 
+def _validar_horario_semana_payload(hs: dict[str, Any] | None) -> None:
+    if not hs or not isinstance(hs, dict):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Informe o horário semanal (dias ativos com início e fim).",
+        )
+    ativos = 0
+    for k in WEEKDAY_KEYS:
+        cfg = hs.get(k)
+        if not isinstance(cfg, dict):
+            continue
+        if not bool(cfg.get("ativo")):
+            continue
+        ini = parse_hhmm(cfg.get("inicio"))
+        fim = parse_hhmm(cfg.get("fim"))
+        if not ini or not fim:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Horário inválido em {k} (use HH:MM).",
+            )
+        if (ini[0], ini[1]) >= (fim[0], fim[1]):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Em {k}, o início deve ser anterior ao fim.",
+            )
+        ativos += 1
+    if ativos < 1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Marque pelo menos um dia ativo na escala semanal.",
+        )
+
+
+def horario_semana_para_json(hs: dict[str, Any] | None) -> str | None:
+    if not hs:
+        return None
+    return json.dumps(hs, ensure_ascii=False)
+
+
+def validar_campos_jornada(
+    *,
+    modo: str,
+    escala_horas_trabalho: int | None,
+    escala_horas_folga: int | None,
+    escala_inicio_em: date | None,
+    horario_semana: dict[str, Any] | None,
+) -> None:
+    """Valida campos do modo de jornada; levanta HTTP 400 se inválido."""
+    m = (modo or "nenhum").strip().lower()
+    if m not in MODOS_JORNADA:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="modo_jornada deve ser nenhum, semanal ou ciclo.",
+        )
+    if m == "nenhum":
+        return
+    if m == "ciclo":
+        if not escala_horas_trabalho or escala_horas_trabalho < 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Informe as horas trabalhadas da escala (mínimo 1).",
+            )
+        if not escala_horas_folga or escala_horas_folga < 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Informe as horas de folga da escala (mínimo 1).",
+            )
+        if escala_inicio_em is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Informe a data de início da escala.",
+            )
+        return
+    # semanal
+    _validar_horario_semana_payload(horario_semana)
+
+
 def validar_campos_escala(
     *,
     usa_escala: bool,
@@ -77,29 +242,17 @@ def validar_campos_escala(
     escala_horas_folga: int | None,
     escala_inicio_em: date | None,
 ) -> None:
-    """Valida campos; levanta HTTP 400 se inválido."""
-    if not usa_escala:
-        return
-    if not escala_horas_trabalho or escala_horas_trabalho < 1:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Informe as horas trabalhadas da escala (mínimo 1).",
-        )
-    if not escala_horas_folga or escala_horas_folga < 1:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Informe as horas de folga da escala (mínimo 1).",
-        )
-    if escala_inicio_em is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Informe a data de início da escala.",
-        )
+    """Compat legado: usa_escala True ≡ ciclo."""
+    validar_campos_jornada(
+        modo="ciclo" if usa_escala else "nenhum",
+        escala_horas_trabalho=escala_horas_trabalho,
+        escala_horas_folga=escala_horas_folga,
+        escala_inicio_em=escala_inicio_em,
+        horario_semana=None,
+    )
 
 
 def validar_horario_previsto(entrada: str | None, saida: str | None) -> None:
-    from app.core.business_calendar import parse_hhmm
-
     for label, val in (("entrada", entrada), ("saída", saida)):
         if val is None or not str(val).strip():
             continue
@@ -110,18 +263,89 @@ def validar_horario_previsto(entrada: str | None, saida: str | None) -> None:
             )
 
 
-def segundos_esperados_dia(atendente: Atendente) -> int:
-    """Duração esperada de um dia de trabalho (horário previsto ou horas do ciclo)."""
-    from app.core.business_calendar import parse_hhmm
-
-    pe = parse_hhmm(getattr(atendente, "horario_previsto_entrada", None))
-    ps = parse_hhmm(getattr(atendente, "horario_previsto_saida", None))
-    if pe and ps:
+def segundos_esperados_dia(atendente: Atendente, dia: date | None = None) -> int:
+    """Duração esperada de um dia de trabalho."""
+    d = dia or datetime.now(PONTO_TZ).date()
+    janela = horario_previsto_do_dia(atendente, d)
+    if janela:
+        pe, ps = janela
         ini = pe[0] * 3600 + pe[1] * 60
         fim = ps[0] * 3600 + ps[1] * 60
         if fim > ini:
             return fim - ini
-    if atendente.escala_horas_trabalho:
+    if ciclo_configurado(atendente) and atendente.escala_horas_trabalho:
         return int(atendente.escala_horas_trabalho) * 3600
     return 0
 
+
+def liberacao_entrada_em(atendente: Atendente, dia: date) -> datetime | None:
+    """Primeiro instante em que a entrada é permitida (inicio − tolerância)."""
+    janela = horario_previsto_do_dia(atendente, dia)
+    if not janela:
+        return None
+    pe, _ = janela
+    tol = int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0)
+    return datetime.combine(dia, time(hour=pe[0], minute=pe[1]), tzinfo=PONTO_TZ) - timedelta(
+        minutes=tol
+    )
+
+
+def limite_atraso_em(atendente: Atendente, dia: date) -> datetime | None:
+    """Após este instante a entrada conta como atraso (inicio + tolerância)."""
+    janela = horario_previsto_do_dia(atendente, dia)
+    if not janela:
+        return None
+    pe, _ = janela
+    tol = int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0)
+    return datetime.combine(dia, time(hour=pe[0], minute=pe[1]), tzinfo=PONTO_TZ) + timedelta(
+        minutes=tol
+    )
+
+
+def saida_prevista_em(atendente: Atendente, dia: date) -> datetime | None:
+    janela = horario_previsto_do_dia(atendente, dia)
+    if not janela:
+        return None
+    _, ps = janela
+    return datetime.combine(dia, time(hour=ps[0], minute=ps[1]), tzinfo=PONTO_TZ)
+
+
+def validar_janela_entrada(atendente: Atendente, when: datetime) -> None:
+    """Bloqueia entrada antes de inicio−tolerância (#964). Admin/sistema não chamam isto."""
+    if not escala_configurada(atendente):
+        return
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=PONTO_TZ)
+    else:
+        when = when.astimezone(PONTO_TZ)
+    dia = when.date()
+    if not eh_dia_de_trabalho(atendente, dia):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Hoje não é dia de trabalho na sua jornada.",
+        )
+    liberacao = liberacao_entrada_em(atendente, dia)
+    if liberacao is None:
+        return
+    if when < liberacao:
+        tol = int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Entrada liberada a partir de {liberacao.strftime('%H:%M')} "
+                f"(tolerância de {tol} min antes do horário)."
+            ),
+        )
+
+
+def rotulo_jornada(atendente: Atendente) -> str | None:
+    m = modo_jornada(atendente)
+    if m == "ciclo":
+        return rotulo_escala(atendente.escala_horas_trabalho, atendente.escala_horas_folga)
+    if m == "semanal" and _semanal_configurado(atendente):
+        hs = horario_semana_dict(atendente) or {}
+        ativos = [k for k in WEEKDAY_KEYS if isinstance(hs.get(k), dict) and hs[k].get("ativo")]
+        if not ativos:
+            return "semanal"
+        return f"semanal ({', '.join(ativos)})"
+    return None

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -166,7 +166,7 @@ def bater(
 
     geo_res = geo_svc.validar_batida_geolocalizacao(
         db,
-        atendente.tenant_id,
+        atendente,
         latitude=float(latitude) if has_lat else None,
         longitude=float(longitude) if has_lon else None,
     )

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -122,13 +122,13 @@ def estado_atual(db: Session, atendente: Atendente) -> PontoEstadoRead:
     rotulo = None
     if escala_svc.escala_configurada(atendente):
         hoje_esp = escala_svc.eh_dia_de_trabalho(atendente, hoje)
-        rotulo = escala_svc.rotulo_escala(atendente.escala_horas_trabalho, atendente.escala_horas_folga)
+        rotulo = escala_svc.rotulo_jornada(atendente)
     return PontoEstadoRead(
         em_jornada=entrada is not None,
         em_pausa=bool(ultima and ultima.tipo == "pausa_inicio"),
         entrada_aberta_em=entrada.registrado_em if entrada else None,
         ultima_batida=PontoBatidaRead.model_validate(ultima) if ultima else None,
-        usa_escala=bool(getattr(atendente, "usa_escala", False)),
+        usa_escala=escala_svc.escala_configurada(atendente),
         hoje_esperado=hoje_esp,
         escala_rotulo=rotulo,
     )
@@ -181,6 +181,10 @@ def bater(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Já existe uma jornada aberta. Registre a saída antes de uma nova entrada.",
             )
+        origem_chk = (origem or "web").strip().lower()
+        if origem_chk not in ("admin", "sistema"):
+            when_chk = registrado_em or _agora_utc()
+            escala_svc.validar_janela_entrada(atendente, when_chk)
     elif tipo == "saida":
         if not em_jornada:
             raise HTTPException(
@@ -408,17 +412,15 @@ def _primeira_entrada_do_dia(batidas_dia: list[PontoBatida]) -> PontoBatida | No
 
 
 def _atrasado_entrada(atendente: Atendente, entrada: PontoBatida | None) -> bool:
-    """True se há horário previsto e a 1ª entrada passou previsto + tolerância."""
-    from app.core.business_calendar import parse_hhmm
-
+    """True se a 1ª entrada passou inicio + tolerância (dentro da tol = não atraso)."""
     if entrada is None:
         return False
-    pe = parse_hhmm(getattr(atendente, "horario_previsto_entrada", None))
-    if not pe:
+    if not escala_svc.escala_configurada(atendente):
         return False
-    tol = int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0)
     local = _as_utc(entrada.registrado_em).astimezone(PONTO_TZ)
-    limite = local.replace(hour=pe[0], minute=pe[1], second=0, microsecond=0) + timedelta(minutes=tol)
+    limite = escala_svc.limite_atraso_em(atendente, local.date())
+    if limite is None:
+        return False
     return local > limite
 
 
@@ -524,14 +526,14 @@ def calendario(
         trabalhados = sum(i.duracao_segundos or 0 for i in intervalos if not i.aberto)
         esperado_visual = bool(esp and not feriado)
         if usa and esperado_visual:
-            esperados = escala_svc.segundos_esperados_dia(atendente) or meta_default
+            esperados = escala_svc.segundos_esperados_dia(atendente, d) or meta_default
         elif te or ts:
             esperados = meta_default
         elif esperado_visual:
             esperados = meta_default
         else:
             esperados = 0
-        # Sem escala: dia com batidas compara à meta; dia vazio fica neutro
+        # Sem jornada esperada: dia com batidas compara à meta; dia vazio fica neutro
         esperado_para_cor = esperado_visual if usa else bool(te or ts)
         dias_out.append(
             PontoCalendarioDia(
@@ -564,13 +566,8 @@ def calendario(
         atendente_id=atendente.id,
         ano=ano,
         mes=mes,
-        usa_escala=bool(getattr(atendente, "usa_escala", False)),
-        escala_rotulo=escala_svc.rotulo_escala(
-            atendente.escala_horas_trabalho,
-            atendente.escala_horas_folga,
-        )
-        if getattr(atendente, "usa_escala", False)
-        else None,
+        usa_escala=usa,
+        escala_rotulo=escala_svc.rotulo_jornada(atendente) if usa else None,
         jornada_diaria_minutos=jornada_min,
         dias=dias_out,
     )
@@ -694,7 +691,7 @@ def banco_horas(
             dias_feriado += 1
         elif usa and escala_svc.eh_dia_de_trabalho(atendente, d):
             dias_escala += 1
-            esperado += escala_svc.segundos_esperados_dia(atendente)
+            esperado += escala_svc.segundos_esperados_dia(atendente, d)
         d += timedelta(days=1)
 
     hist = historico(db, atendente, desde=desde, ate=ate, offset=0, limit=10_000)
@@ -732,8 +729,9 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     horas_aberta: float | None = None
 
     feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, hoje)
+    jornada_ativa = escala_svc.escala_configurada(atendente)
     esperado = None
-    if escala_svc.escala_configurada(atendente) and not feriado:
+    if jornada_ativa and not feriado:
         esperado = escala_svc.eh_dia_de_trabalho(atendente, hoje)
 
     entrada = _entrada_da_jornada_aberta(db, atendente.id)
@@ -755,9 +753,14 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
         hb = hb.replace(tzinfo=timezone.utc)
     online = bool(hb and hb >= agora - timedelta(seconds=PRESENCA_TTL_SEC))
 
-    if esperado is True and not tem_entrada_hoje and entrada is None:
-        sem_entrada = True
-        msgs.append("Hoje é dia de trabalho na sua escala e ainda não há entrada registrada.")
+    # Modo nenhum: sem avisos de falta/atraso (#959)
+    if jornada_ativa:
+        if esperado is True and not tem_entrada_hoje and entrada is None:
+            sem_entrada = True
+            msgs.append("Hoje é dia de trabalho na sua jornada e ainda não há entrada registrada.")
+
+        if _atrasado_entrada(atendente, primeira):
+            msgs.append("Entrada registrada após o horário previsto (fora da tolerância).")
 
     if online and entrada is None:
         online_sem = True
@@ -771,9 +774,10 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
             msgs.append(
                 f"Jornada aberta há cerca de {horas_aberta:.0f} h — lembre-se de registrar a saída."
             )
-
-    if _atrasado_entrada(atendente, primeira):
-        msgs.append("Entrada registrada após o horário previsto (com tolerância).")
+        elif jornada_ativa:
+            saida_prev = escala_svc.saida_prevista_em(atendente, hoje)
+            if saida_prev is not None and agora.astimezone(PONTO_TZ) >= saida_prev:
+                msgs.append("Horário de saída previsto já passou — registre a saída.")
 
     return PontoAlertasMe(
         sem_entrada_em_dia_escala=sem_entrada,

--- a/backend/app/services/ponto_geofence.py
+++ b/backend/app/services/ponto_geofence.py
@@ -1,4 +1,4 @@
-"""Geofence e política de geolocalização (#844)."""
+"""Geofence e política de geolocalização (#844 / #984)."""
 
 from __future__ import annotations
 
@@ -8,9 +8,20 @@ from dataclasses import dataclass
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
-from app.models.ponto_settings import PontoLocal, PontoSettings
+from app.models.atendente import Atendente
+from app.models.empresa_sistema import EmpresaSistema
+from app.models.ponto_settings import PontoLocal
 
 POLITICAS_VALIDAS = frozenset({"opcional", "recomendada", "obrigatoria"})
+
+
+@dataclass
+class LocalEfetivo:
+    id: int | None
+    nome: str
+    latitude: float
+    longitude: float
+    raio_metros: int
 
 
 @dataclass
@@ -31,31 +42,78 @@ def distancia_metros(lat1: float, lon1: float, lat2: float, lon2: float) -> floa
     return 2 * r * math.asin(math.sqrt(a))
 
 
+def _empresa_sistema(db: Session) -> EmpresaSistema | None:
+    return db.query(EmpresaSistema).order_by(EmpresaSistema.id.asc()).first()
+
+
+def locais_efetivos_ativos(db: Session, atendente: Atendente) -> list[LocalEfetivo]:
+    """Locais ativos do atendente: empresa (se ligada + pin) + extras cadastrados."""
+    out: list[LocalEfetivo] = []
+    if bool(getattr(atendente, "usar_local_empresa", True)):
+        emp = _empresa_sistema(db)
+        if emp is not None and emp.latitude is not None and emp.longitude is not None:
+            raio_at = getattr(atendente, "local_empresa_raio_metros", None)
+            raio_emp = getattr(emp, "ponto_raio_metros", None) or 200
+            raio = int(raio_at) if raio_at is not None else int(raio_emp)
+            out.append(
+                LocalEfetivo(
+                    id=None,
+                    nome="Empresa",
+                    latitude=float(emp.latitude),
+                    longitude=float(emp.longitude),
+                    raio_metros=max(20, raio),
+                )
+            )
+    rows = (
+        db.query(PontoLocal)
+        .filter(
+            PontoLocal.tenant_id == atendente.tenant_id,
+            PontoLocal.atendente_id == atendente.id,
+            PontoLocal.ativo.is_(True),
+        )
+        .order_by(PontoLocal.nome.asc())
+        .all()
+    )
+    for loc in rows:
+        out.append(
+            LocalEfetivo(
+                id=int(loc.id),
+                nome=str(loc.nome),
+                latitude=float(loc.latitude),
+                longitude=float(loc.longitude),
+                raio_metros=int(loc.raio_metros or 200),
+            )
+        )
+    return out
+
+
 def locais_ativos(db: Session, tenant_id: int) -> list[PontoLocal]:
+    """Legado: locais da instância ainda atribuídos a alguém e ativos (admin/listagens)."""
     return (
         db.query(PontoLocal)
-        .filter(PontoLocal.tenant_id == tenant_id, PontoLocal.ativo.is_(True))
+        .filter(
+            PontoLocal.tenant_id == tenant_id,
+            PontoLocal.ativo.is_(True),
+            PontoLocal.atendente_id.isnot(None),
+        )
         .order_by(PontoLocal.nome.asc())
         .all()
     )
 
 
-def avaliar_coordenadas(
-    db: Session,
-    tenant_id: int,
+def avaliar_coordenadas_locais(
+    locais: list[LocalEfetivo],
     latitude: float,
     longitude: float,
 ) -> ResultadoGeofence:
-    """Encontra o local mais próximo e se está dentro do raio."""
-    locais = locais_ativos(db, tenant_id)
     if not locais:
         return ResultadoGeofence()
-    melhor: PontoLocal | None = None
+    melhor: LocalEfetivo | None = None
     melhor_dist = float("inf")
-    dentro_de: PontoLocal | None = None
+    dentro_de: LocalEfetivo | None = None
     dist_dentro = float("inf")
     for loc in locais:
-        d = distancia_metros(latitude, longitude, float(loc.latitude), float(loc.longitude))
+        d = distancia_metros(latitude, longitude, loc.latitude, loc.longitude)
         if d < melhor_dist:
             melhor_dist = d
             melhor = loc
@@ -77,9 +135,22 @@ def avaliar_coordenadas(
     )
 
 
+def avaliar_coordenadas(
+    db: Session,
+    atendente: Atendente,
+    latitude: float,
+    longitude: float,
+) -> ResultadoGeofence:
+    return avaliar_coordenadas_locais(
+        locais_efetivos_ativos(db, atendente),
+        latitude,
+        longitude,
+    )
+
+
 def validar_batida_geolocalizacao(
     db: Session,
-    tenant_id: int,
+    atendente: Atendente,
     *,
     latitude: float | None,
     longitude: float | None,
@@ -87,11 +158,11 @@ def validar_batida_geolocalizacao(
     """Aplica política da instância; levanta 400 se obrigatória e inválida."""
     from app.services.ponto_settings import get_or_create_settings
 
-    settings = get_or_create_settings(db, tenant_id)
+    settings = get_or_create_settings(db, atendente.tenant_id)
     politica = (getattr(settings, "politica_geolocalizacao", None) or "opcional").strip().lower()
     if politica not in POLITICAS_VALIDAS:
         politica = "opcional"
-    locais = locais_ativos(db, tenant_id)
+    locais = locais_efetivos_ativos(db, atendente)
     has_coords = latitude is not None and longitude is not None
 
     if politica == "obrigatoria" and locais:
@@ -100,7 +171,7 @@ def validar_batida_geolocalizacao(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Geolocalização obrigatória para bater o ponto nesta instância.",
             )
-        res = avaliar_coordenadas(db, tenant_id, float(latitude), float(longitude))
+        res = avaliar_coordenadas_locais(locais, float(latitude), float(longitude))
         if res.fora_area:
             nome = res.local_nome or "área permitida"
             raise HTTPException(
@@ -112,7 +183,7 @@ def validar_batida_geolocalizacao(
     if not has_coords or not locais:
         return ResultadoGeofence()
 
-    res = avaliar_coordenadas(db, tenant_id, float(latitude), float(longitude))
+    res = avaliar_coordenadas_locais(locais, float(latitude), float(longitude))
     if politica == "recomendada" and res.fora_area:
         return res
     if politica == "opcional":

--- a/backend/app/services/ponto_hora_extra.py
+++ b/backend/app/services/ponto_hora_extra.py
@@ -57,8 +57,8 @@ def he_ativa(db: Session, atendente: Atendente, when: datetime | None = None) ->
         return None
     ate = row.ate_em
     if ate.tzinfo is None:
-        ate = ate.replace(tzinfo=timezone.utc)
-    if agora.astimezone(timezone.utc) >= ate.astimezone(timezone.utc):
+        ate = ate.replace(tzinfo=PONTO_TZ)
+    if agora >= ate.astimezone(PONTO_TZ):
         row.estado = "expirada"
         db.flush()
         return None

--- a/backend/app/services/ponto_hora_extra.py
+++ b/backend/app/services/ponto_hora_extra.py
@@ -1,0 +1,331 @@
+"""Hora extra e bloqueio de pegar WhatsApp após jornada (#965)."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time, timezone
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session, joinedload
+
+from app.core.audit import registrar_audit
+from app.models.atendente import Atendente
+from app.models.ponto_hora_extra import PontoHoraExtra
+from app.schemas.ponto import PontoHoraExtraRead
+from app.services import escala as escala_svc
+from app.services.escala import PONTO_TZ
+
+MODOS_APROVACAO = frozenset({"resto_do_dia", "ate_horario"})
+
+
+def _agora_tz(when: datetime | None = None) -> datetime:
+    now = when or datetime.now(timezone.utc)
+    if now.tzinfo is None:
+        return now.replace(tzinfo=PONTO_TZ)
+    return now.astimezone(PONTO_TZ)
+
+
+def fora_da_jornada(atendente: Atendente, when: datetime | None = None) -> bool:
+    """True se a pessoa está fora do horário esperado (precisa HE para pegar WhatsApp)."""
+    modo = escala_svc.modo_jornada(atendente)
+    if modo == "nenhum" or not escala_svc.escala_configurada(atendente):
+        return False
+    agora = _agora_tz(when)
+    dia = agora.date()
+    if not escala_svc.eh_dia_de_trabalho(atendente, dia):
+        return True
+    saida = escala_svc.saida_prevista_em(atendente, dia)
+    if saida is not None:
+        return agora >= saida
+    # Ciclo sem pe/ps: fora do bloco de trabalho.
+    return not escala_svc.em_periodo_trabalho(atendente, agora)
+
+
+def he_ativa(db: Session, atendente: Atendente, when: datetime | None = None) -> PontoHoraExtra | None:
+    agora = _agora_tz(when)
+    row = (
+        db.query(PontoHoraExtra)
+        .filter(
+            PontoHoraExtra.atendente_id == atendente.id,
+            PontoHoraExtra.estado == "aprovada",
+        )
+        .order_by(PontoHoraExtra.id.desc())
+        .first()
+    )
+    if not row:
+        return None
+    if row.ate_em is None:
+        return None
+    ate = row.ate_em
+    if ate.tzinfo is None:
+        ate = ate.replace(tzinfo=timezone.utc)
+    if agora.astimezone(timezone.utc) >= ate.astimezone(timezone.utc):
+        row.estado = "expirada"
+        db.flush()
+        return None
+    return row
+
+
+def pode_pegar_whatsapp(db: Session, atendente: Atendente, when: datetime | None = None) -> bool:
+    if not fora_da_jornada(atendente, when):
+        return True
+    return he_ativa(db, atendente, when) is not None
+
+
+def exigir_pode_pegar_whatsapp(db: Session, atendente: Atendente) -> None:
+    """Bloqueia assumir/iniciar WhatsApp fora da jornada sem HE (#965)."""
+    if pode_pegar_whatsapp(db, atendente):
+        return
+    garantir_pedido_pendente(
+        db,
+        atendente,
+        motivo="Tentativa de pegar chat WhatsApp após o fim da jornada.",
+        commit=True,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail=(
+            "Sua jornada já terminou. Peça hora extra a um administrador "
+            "para pegar novos chats no WhatsApp."
+        ),
+    )
+
+
+def _to_read(row: PontoHoraExtra) -> PontoHoraExtraRead:
+    return PontoHoraExtraRead(
+        id=row.id,
+        atendente_id=row.atendente_id,
+        atendente_nome=row.atendente.nome if row.atendente else None,
+        estado=row.estado,
+        motivo=row.motivo,
+        modo=row.modo,
+        ate_em=row.ate_em,
+        decidido_por_id=row.decidido_por_id,
+        decidido_em=row.decidido_em,
+        decisao_motivo=row.decisao_motivo,
+        created_at=row.created_at,
+    )
+
+
+def garantir_pedido_pendente(
+    db: Session,
+    atendente: Atendente,
+    *,
+    motivo: str | None = None,
+    commit: bool = True,
+) -> PontoHoraExtra:
+    existente = (
+        db.query(PontoHoraExtra)
+        .filter(
+            PontoHoraExtra.atendente_id == atendente.id,
+            PontoHoraExtra.estado == "pendente",
+        )
+        .order_by(PontoHoraExtra.id.desc())
+        .first()
+    )
+    if existente:
+        if motivo and not (existente.motivo or "").strip():
+            existente.motivo = (motivo or "")[:1000]
+        if commit:
+            db.commit()
+            db.refresh(existente)
+        return existente
+    row = PontoHoraExtra(
+        tenant_id=atendente.tenant_id,
+        atendente_id=atendente.id,
+        estado="pendente",
+        motivo=(motivo or "Pedido de hora extra para atendimento WhatsApp.")[:1000],
+    )
+    db.add(row)
+    db.flush()
+    registrar_audit(
+        db,
+        "ponto_hora_extra",
+        row.id,
+        "create",
+        atendente.id,
+        payload={"estado": "pendente"},
+    )
+    if commit:
+        db.commit()
+        db.refresh(row)
+        _notificar_admins(db, atendente.tenant_id)
+    return row
+
+
+def solicitar(
+    db: Session,
+    atendente: Atendente,
+    *,
+    motivo: str | None = None,
+) -> PontoHoraExtraRead:
+    if not fora_da_jornada(atendente):
+        raise HTTPException(
+            status_code=400,
+            detail="Você ainda está dentro da jornada — não é necessário pedir hora extra.",
+        )
+    if he_ativa(db, atendente):
+        raise HTTPException(status_code=400, detail="Você já tem hora extra ativa.")
+    row = garantir_pedido_pendente(db, atendente, motivo=motivo, commit=True)
+    db.refresh(row)
+    if row.atendente is None:
+        row = (
+            db.query(PontoHoraExtra)
+            .options(joinedload(PontoHoraExtra.atendente))
+            .filter(PontoHoraExtra.id == row.id)
+            .first()
+        )
+        assert row is not None
+    return _to_read(row)
+
+
+def listar_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    estado: str | None = "pendente",
+) -> list[PontoHoraExtraRead]:
+    q = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.tenant_id == admin.tenant_id)
+    )
+    if estado:
+        q = q.filter(PontoHoraExtra.estado == estado)
+    rows = q.order_by(PontoHoraExtra.created_at.desc(), PontoHoraExtra.id.desc()).limit(100).all()
+    return [_to_read(r) for r in rows]
+
+
+def listar_me(db: Session, atendente: Atendente) -> list[PontoHoraExtraRead]:
+    rows = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.atendente_id == atendente.id)
+        .order_by(PontoHoraExtra.id.desc())
+        .limit(30)
+        .all()
+    )
+    return [_to_read(r) for r in rows]
+
+
+def me_status(db: Session, atendente: Atendente) -> dict:
+    fora = fora_da_jornada(atendente)
+    ativa = he_ativa(db, atendente)
+    pendente = (
+        db.query(PontoHoraExtra)
+        .filter(PontoHoraExtra.atendente_id == atendente.id, PontoHoraExtra.estado == "pendente")
+        .order_by(PontoHoraExtra.id.desc())
+        .first()
+    )
+    return {
+        "fora_da_jornada": fora,
+        "pode_pegar_whatsapp": (not fora) or ativa is not None,
+        "he_ativa": _to_read(ativa) if ativa else None,
+        "pedido_pendente": _to_read(pendente) if pendente else None,
+    }
+
+
+def _fim_resto_do_dia(agora: datetime) -> datetime:
+    dia = agora.astimezone(PONTO_TZ).date()
+    return datetime.combine(dia, time(23, 59, 59), tzinfo=PONTO_TZ)
+
+
+def _parse_ate_horario(dia: date, hhmm: str) -> datetime:
+    parts = (hhmm or "").strip().split(":")
+    if len(parts) < 2:
+        raise HTTPException(status_code=400, detail="Informe o horário no formato HH:MM.")
+    try:
+        h, m = int(parts[0]), int(parts[1])
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail="Horário inválido.") from e
+    if h < 0 or h > 23 or m < 0 or m > 59:
+        raise HTTPException(status_code=400, detail="Horário inválido.")
+    return datetime.combine(dia, time(hour=h, minute=m), tzinfo=PONTO_TZ)
+
+
+def decidir(
+    db: Session,
+    admin: Atendente,
+    he_id: int,
+    *,
+    aprovar: bool,
+    modo: str | None = None,
+    ate_horario: str | None = None,
+    decisao_motivo: str | None = None,
+) -> PontoHoraExtraRead:
+    row = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.id == he_id, PontoHoraExtra.tenant_id == admin.tenant_id)
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Pedido de hora extra não encontrado")
+    if row.estado != "pendente":
+        raise HTTPException(status_code=400, detail="Este pedido já foi decidido.")
+    agora = _agora_tz()
+    row.decidido_por_id = admin.id
+    row.decidido_em = datetime.now(timezone.utc)
+    row.decisao_motivo = (decisao_motivo or "").strip()[:1000] or None
+    if not aprovar:
+        row.estado = "rejeitada"
+        row.modo = None
+        row.ate_em = None
+    else:
+        m = (modo or "").strip().lower()
+        if m not in MODOS_APROVACAO:
+            raise HTTPException(
+                status_code=400,
+                detail="Ao aprovar, escolha modo resto_do_dia ou ate_horario.",
+            )
+        row.estado = "aprovada"
+        row.modo = m
+        if m == "resto_do_dia":
+            row.ate_em = _fim_resto_do_dia(agora)
+        else:
+            ate = _parse_ate_horario(agora.date(), ate_horario or "")
+            if ate <= agora:
+                raise HTTPException(
+                    status_code=400,
+                    detail="O horário limite da hora extra deve ser no futuro.",
+                )
+            row.ate_em = ate
+    registrar_audit(
+        db,
+        "ponto_hora_extra",
+        row.id,
+        "decidir",
+        admin.id,
+        payload={"estado": row.estado, "modo": row.modo, "ate_em": str(row.ate_em)},
+    )
+    db.commit()
+    db.refresh(row)
+    _notificar_admins(db, admin.tenant_id)
+    return _to_read(row)
+
+
+def contar_pendentes_admin(db: Session, tenant_id: int) -> int:
+    return (
+        db.query(PontoHoraExtra)
+        .filter(PontoHoraExtra.tenant_id == tenant_id, PontoHoraExtra.estado == "pendente")
+        .count()
+    )
+
+
+def _notificar_admins(db: Session, tenant_id: int) -> None:
+    try:
+        from app.services.realtime_emit import emit_notificacao_contagem
+
+        ids = [
+            a.id
+            for a in db.query(Atendente)
+            .filter(
+                Atendente.tenant_id == tenant_id,
+                Atendente.role == "admin",
+                Atendente.ativo.is_(True),
+            )
+            .all()
+        ]
+        if ids:
+            emit_notificacao_contagem(db, ids)
+    except Exception:
+        pass

--- a/backend/app/services/ponto_settings.py
+++ b/backend/app/services/ponto_settings.py
@@ -21,7 +21,7 @@ from app.schemas.ponto import (
     PontoSettingsRead,
     PontoSettingsUpdate,
 )
-from app.services.ponto_geofence import POLITICAS_VALIDAS, locais_ativos
+from app.services.ponto_geofence import POLITICAS_VALIDAS, locais_efetivos_ativos
 
 
 def get_or_create_settings(db: Session, tenant_id: int) -> PontoSettings:
@@ -92,22 +92,39 @@ def settings_update(db: Session, admin: Atendente, data: PontoSettingsUpdate) ->
     return PontoSettingsRead.model_validate(row)
 
 
-def settings_public_read(db: Session, tenant_id: int) -> PontoSettingsPublicRead:
-    row = get_or_create_settings(db, tenant_id)
+def settings_public_read(db: Session, atendente: Atendente) -> PontoSettingsPublicRead:
+    row = get_or_create_settings(db, atendente.tenant_id)
     politica = (getattr(row, "politica_geolocalizacao", None) or "opcional").strip().lower()
     if politica not in POLITICAS_VALIDAS:
         politica = "opcional"
-    tem = len(locais_ativos(db, tenant_id)) > 0
+    tem = len(locais_efetivos_ativos(db, atendente)) > 0
     return PontoSettingsPublicRead(politica_geolocalizacao=politica, tem_locais_ativos=tem)
 
 
-def listar_locais(db: Session, tenant_id: int) -> list[PontoLocalRead]:
-    rows = (
-        db.query(PontoLocal)
-        .filter(PontoLocal.tenant_id == tenant_id)
-        .order_by(PontoLocal.nome.asc(), PontoLocal.id.asc())
-        .all()
+def _atendente_do_tenant(db: Session, tenant_id: int, atendente_id: int) -> Atendente:
+    row = (
+        db.query(Atendente)
+        .filter(Atendente.id == atendente_id, Atendente.tenant_id == tenant_id)
+        .first()
     )
+    if not row or row.role == "saas_ops":
+        raise HTTPException(status_code=404, detail="Atendente não encontrado")
+    return row
+
+
+def listar_locais(
+    db: Session,
+    tenant_id: int,
+    *,
+    atendente_id: int | None = None,
+    so_orfos: bool = False,
+) -> list[PontoLocalRead]:
+    q = db.query(PontoLocal).filter(PontoLocal.tenant_id == tenant_id)
+    if so_orfos:
+        q = q.filter(PontoLocal.atendente_id.is_(None))
+    elif atendente_id is not None:
+        q = q.filter(PontoLocal.atendente_id == atendente_id)
+    rows = q.order_by(PontoLocal.nome.asc(), PontoLocal.id.asc()).all()
     return [PontoLocalRead.model_validate(r) for r in rows]
 
 
@@ -115,9 +132,13 @@ def criar_local(db: Session, admin: Atendente, data: PontoLocalCreate) -> PontoL
     nome = (data.nome or "").strip()
     if not nome:
         raise HTTPException(status_code=400, detail="Informe o nome do local.")
+    alvo = _atendente_do_tenant(db, admin.tenant_id, int(data.atendente_id))
+    endereco = (data.endereco or "").strip() or None
     row = PontoLocal(
         tenant_id=admin.tenant_id,
+        atendente_id=alvo.id,
         nome=nome[:255],
+        endereco=endereco[:512] if endereco else None,
         latitude=float(data.latitude),
         longitude=float(data.longitude),
         raio_metros=int(data.raio_metros or 200),
@@ -131,7 +152,12 @@ def criar_local(db: Session, admin: Atendente, data: PontoLocalCreate) -> PontoL
         row.id,
         "create",
         admin.id,
-        payload={"nome": nome, "latitude": data.latitude, "longitude": data.longitude},
+        payload={
+            "nome": nome,
+            "atendente_id": alvo.id,
+            "latitude": data.latitude,
+            "longitude": data.longitude,
+        },
     )
     db.commit()
     db.refresh(row)
@@ -157,6 +183,12 @@ def atualizar_local(
         if not nome:
             raise HTTPException(status_code=400, detail="Informe o nome do local.")
         payload["nome"] = nome[:255]
+    if "endereco" in payload and payload["endereco"] is not None:
+        end = str(payload["endereco"]).strip()
+        payload["endereco"] = end[:512] if end else None
+    if "atendente_id" in payload and payload["atendente_id"] is not None:
+        alvo = _atendente_do_tenant(db, admin.tenant_id, int(payload["atendente_id"]))
+        payload["atendente_id"] = alvo.id
     for k, v in payload.items():
         setattr(row, k, v)
     registrar_audit(

--- a/backend/app/services/ponto_settings.py
+++ b/backend/app/services/ponto_settings.py
@@ -55,6 +55,13 @@ def settings_update(db: Session, admin: Atendente, data: PontoSettingsUpdate) ->
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="fecho_apos_horas deve estar entre 4 e 48.",
             )
+    if "fecho_margem_pos_saida_minutos" in payload:
+        m = payload["fecho_margem_pos_saida_minutos"]
+        if m is None or m < 0 or m > 240:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="fecho_margem_pos_saida_minutos deve estar entre 0 e 240.",
+            )
     if "jornada_diaria_minutos" in payload:
         m = payload["jornada_diaria_minutos"]
         if m is None or m < 60 or m > 1440:
@@ -268,8 +275,14 @@ def remover_feriado(db: Session, admin: Atendente, feriado_id: int) -> None:
 
 
 def processar_fecho_automatico(db: Session, *, limit: int = 100) -> int:
-    """Fecha jornadas abertas além do limite, só onde a política está ativa."""
+    """Fecha jornadas esquecidas: N horas abertas OU após saída prevista + margem (#961)."""
+    from datetime import timedelta
+    from zoneinfo import ZoneInfo
+
+    from app.services import escala as escala_svc
     from app.services import ponto as ponto_svc
+
+    PONTO_TZ = ZoneInfo("America/Sao_Paulo")
 
     settings_rows = (
         db.query(PontoSettings)
@@ -283,7 +296,7 @@ def processar_fecho_automatico(db: Session, *, limit: int = 100) -> int:
     fechados = 0
     for st in settings_rows:
         horas = max(4, int(st.fecho_apos_horas or 14))
-        limite = agora.timestamp() - horas * 3600
+        margem = max(0, int(getattr(st, "fecho_margem_pos_saida_minutos", 30) or 0))
         atendentes = (
             db.query(Atendente)
             .filter(Atendente.tenant_id == st.tenant_id, Atendente.ativo.is_(True))
@@ -296,7 +309,17 @@ def processar_fecho_automatico(db: Session, *, limit: int = 100) -> int:
             if entrada is None:
                 continue
             reg = ponto_svc._as_utc(entrada.registrado_em)
-            if reg.timestamp() > limite:
+            por_horas = (agora - reg).total_seconds() >= horas * 3600
+            criterios: list[str] = []
+            if por_horas:
+                criterios.append("n_horas")
+            dia = reg.astimezone(PONTO_TZ).date()
+            saida_prev = escala_svc.saida_prevista_em(a, dia)
+            if saida_prev is not None:
+                limite_saida = saida_prev + timedelta(minutes=margem)
+                if agora.astimezone(PONTO_TZ) >= limite_saida:
+                    criterios.append("saida_prevista")
+            if not criterios:
                 continue
             if ponto_svc.em_pausa_aberta(db, a.id):
                 ponto_svc.bater(
@@ -319,13 +342,16 @@ def processar_fecho_automatico(db: Session, *, limit: int = 100) -> int:
                 db,
                 "ponto_batida",
                 saida.id,
-                "fecho_automatico",
+                "esquecimento",
                 None,
                 payload={
                     "atendente_id": a.id,
                     "tenant_id": st.tenant_id,
                     "fecho_apos_horas": horas,
+                    "fecho_margem_pos_saida_minutos": margem,
+                    "criterios": criterios,
                     "entrada_em": reg.isoformat(),
+                    "motivo": "esquecimento",
                 },
             )
             fechados += 1

--- a/backend/app/services/portal_chat.py
+++ b/backend/app/services/portal_chat.py
@@ -7,6 +7,7 @@ import secrets
 from datetime import datetime, timezone
 
 from fastapi import HTTPException, status
+from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
 from app.core.setor_scope import ids_setores_visiveis_atendente
@@ -257,6 +258,9 @@ def transferir_portal_chat(
 
 def marcar_visto_portal_chat(db: Session, chat_id: int, atendente_id: int) -> None:
     now = datetime.now(timezone.utc)
+    max_msg_id = (
+        db.query(func.max(PortalMensagem.id)).filter(PortalMensagem.chat_id == chat_id).scalar()
+    )
     row = (
         db.query(PortalChatReadRow)
         .filter(PortalChatReadRow.chat_id == chat_id, PortalChatReadRow.atendente_id == atendente_id)
@@ -264,8 +268,16 @@ def marcar_visto_portal_chat(db: Session, chat_id: int, atendente_id: int) -> No
     )
     if row:
         row.last_seen_at = now
+        row.last_seen_mensagem_id = max_msg_id
     else:
-        db.add(PortalChatReadRow(chat_id=chat_id, atendente_id=atendente_id, last_seen_at=now))
+        db.add(
+            PortalChatReadRow(
+                chat_id=chat_id,
+                atendente_id=atendente_id,
+                last_seen_at=now,
+                last_seen_mensagem_id=max_msg_id,
+            )
+        )
 
 
 def listar_mensagens_chat(

--- a/backend/app/services/saas_catalogo.py
+++ b/backend/app/services/saas_catalogo.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
+
 from sqlalchemy.orm import Session, joinedload
 
 from app.models.saas_plano import SaasModulo, SaasPlano, SaasPlanoModulo
@@ -12,6 +14,29 @@ from app.schemas.saas import (
     SaasPlanoUpdate,
 )
 from app.services.saas_clientes import SaasErro
+
+
+def _num(v) -> float:
+    if v is None:
+        return 0.0
+    return float(v)
+
+
+def soma_preco_modulos(mods: list[SaasModulo]) -> float:
+    return round(sum(_num(m.preco_mensal) for m in mods), 2)
+
+
+def preco_extra_usuarios(
+    *,
+    usuarios_inclusos: int,
+    preco_usuario_extra: float | Decimal | None,
+    usuarios_contratados: int | None,
+) -> float:
+    if usuarios_contratados is None:
+        return 0.0
+    inclusos = max(0, int(usuarios_inclusos or 0))
+    extra = max(0, int(usuarios_contratados) - inclusos)
+    return round(extra * _num(preco_usuario_extra), 2)
 
 
 def obter_modulo(db: Session, modulo_id: int) -> SaasModulo:
@@ -31,7 +56,13 @@ def listar_modulos(db: Session, *, ativo: bool | None = None) -> list[SaasModulo
 def criar_modulo(db: Session, data: SaasModuloCreate) -> SaasModulo:
     if db.query(SaasModulo).filter(SaasModulo.codigo == data.codigo).first():
         raise SaasErro("Já existe um módulo com este código", 409)
-    row = SaasModulo(codigo=data.codigo, nome=data.nome, descricao=data.descricao, ativo=True)
+    row = SaasModulo(
+        codigo=data.codigo,
+        nome=data.nome,
+        descricao=data.descricao,
+        preco_mensal=data.preco_mensal,
+        ativo=True,
+    )
     db.add(row)
     db.flush()
     return row
@@ -43,13 +74,15 @@ def atualizar_modulo(db: Session, modulo_id: int, data: SaasModuloUpdate) -> Saa
     for k, v in payload.items():
         setattr(row, k, v)
     db.flush()
+    if "preco_mensal" in payload:
+        _recalcular_planos_com_modulo(db, row.id)
     return row
 
 
 def ativar_modulo(db: Session, modulo_id: int) -> SaasModulo:
     row = obter_modulo(db, modulo_id)
     if row.ativo:
-        raise SaasErro("Módulo já está activo")
+        raise SaasErro("Módulo já está ativo")
     row.ativo = True
     db.flush()
     return row
@@ -58,7 +91,7 @@ def ativar_modulo(db: Session, modulo_id: int) -> SaasModulo:
 def desativar_modulo(db: Session, modulo_id: int) -> SaasModulo:
     row = obter_modulo(db, modulo_id)
     if not row.ativo:
-        raise SaasErro("Módulo já está inactivo")
+        raise SaasErro("Módulo já está inativo")
     row.ativo = False
     db.flush()
     return row
@@ -96,12 +129,51 @@ def _resolver_modulos(db: Session, modulo_ids: list[int]) -> list[SaasModulo]:
     return [by_id[i] for i in uniq]
 
 
+def resolver_modulos_por_codigos(db: Session, codigos: list[str]) -> list[SaasModulo]:
+    if not codigos:
+        return []
+    uniq = list(dict.fromkeys([c.strip().lower() for c in codigos if c and c.strip()]))
+    rows = db.query(SaasModulo).filter(SaasModulo.codigo.in_(uniq)).all()
+    by_cod = {r.codigo: r for r in rows}
+    missing = [c for c in uniq if c not in by_cod]
+    if missing:
+        raise SaasErro(f"Módulos inválidos: {', '.join(missing)}")
+    return [by_cod[c] for c in uniq]
+
+
+def _modulos_do_plano(plano: SaasPlano) -> list[SaasModulo]:
+    out: list[SaasModulo] = []
+    for link in plano.modulos_links or []:
+        if link.modulo is not None:
+            out.append(link.modulo)
+    return out
+
+
+def _aplicar_preco_plano(plano: SaasPlano) -> None:
+    plano.preco_mensal = soma_preco_modulos(_modulos_do_plano(plano))
+
+
+def _recalcular_planos_com_modulo(db: Session, modulo_id: int) -> None:
+    planos = (
+        db.query(SaasPlano)
+        .options(joinedload(SaasPlano.modulos_links).joinedload(SaasPlanoModulo.modulo))
+        .join(SaasPlanoModulo, SaasPlanoModulo.plano_id == SaasPlano.id)
+        .filter(SaasPlanoModulo.modulo_id == modulo_id)
+        .all()
+    )
+    for plano in planos:
+        _aplicar_preco_plano(plano)
+    db.flush()
+
+
 def _set_modulos(db: Session, plano: SaasPlano, modulo_ids: list[int]) -> None:
     mods = _resolver_modulos(db, modulo_ids)
     plano.modulos_links.clear()
     db.flush()
     for m in mods:
         plano.modulos_links.append(SaasPlanoModulo(plano_id=plano.id, modulo_id=m.id))
+    db.flush()
+    plano.preco_mensal = soma_preco_modulos(mods)
     db.flush()
 
 
@@ -113,8 +185,9 @@ def criar_plano(db: Session, data: SaasPlanoCreate) -> SaasPlano:
         nome=data.nome,
         descricao=data.descricao,
         ordem=data.ordem or 0,
-        preco_mensal=data.preco_mensal,
-        max_postos=data.max_postos,
+        usuarios_inclusos=data.usuarios_inclusos if data.usuarios_inclusos is not None else 3,
+        preco_usuario_extra=data.preco_usuario_extra if data.preco_usuario_extra is not None else 10,
+        max_postos=None,
         max_usuarios=data.max_usuarios,
         ativo=True,
     )
@@ -127,11 +200,16 @@ def criar_plano(db: Session, data: SaasPlanoCreate) -> SaasPlano:
 def atualizar_plano(db: Session, plano_id: int, data: SaasPlanoUpdate) -> SaasPlano:
     row = obter_plano(db, plano_id)
     payload = data.model_dump(exclude_unset=True)
+    # Preço do plano é sempre a soma dos módulos — não aceitar override manual.
+    payload.pop("preco_mensal", None)
+    payload.pop("max_postos", None)
     modulo_ids = payload.pop("modulo_ids", None)
     for k, v in payload.items():
         setattr(row, k, v)
     if modulo_ids is not None:
         _set_modulos(db, row, modulo_ids)
+    else:
+        _aplicar_preco_plano(row)
     db.flush()
     return obter_plano(db, row.id)
 
@@ -139,7 +217,7 @@ def atualizar_plano(db: Session, plano_id: int, data: SaasPlanoUpdate) -> SaasPl
 def ativar_plano(db: Session, plano_id: int) -> SaasPlano:
     row = obter_plano(db, plano_id)
     if row.ativo:
-        raise SaasErro("Plano já está activo")
+        raise SaasErro("Plano já está ativo")
     row.ativo = True
     db.flush()
     return row
@@ -148,10 +226,24 @@ def ativar_plano(db: Session, plano_id: int) -> SaasPlano:
 def desativar_plano(db: Session, plano_id: int) -> SaasPlano:
     row = obter_plano(db, plano_id)
     if not row.ativo:
-        raise SaasErro("Plano já está inactivo")
+        raise SaasErro("Plano já está inativo")
     row.ativo = False
     db.flush()
     return row
+
+
+def serializar_modulo(row: SaasModulo) -> dict:
+    preco = row.preco_mensal
+    return {
+        "id": row.id,
+        "codigo": row.codigo,
+        "nome": row.nome,
+        "descricao": row.descricao,
+        "preco_mensal": float(preco) if preco is not None else None,
+        "ativo": bool(row.ativo),
+        "created_at": row.created_at,
+        "updated_at": row.updated_at,
+    }
 
 
 def serializar_plano(row: SaasPlano) -> dict:
@@ -160,8 +252,18 @@ def serializar_plano(row: SaasPlano) -> dict:
         m = link.modulo
         if m is None:
             continue
-        mods.append({"id": m.id, "codigo": m.codigo, "nome": m.nome, "ativo": bool(m.ativo)})
+        mods.append(
+            {
+                "id": m.id,
+                "codigo": m.codigo,
+                "nome": m.nome,
+                "ativo": bool(m.ativo),
+                "preco_mensal": float(m.preco_mensal) if m.preco_mensal is not None else None,
+            }
+        )
     preco = row.preco_mensal
+    if preco is None:
+        preco = soma_preco_modulos(_modulos_do_plano(row))
     return {
         "id": row.id,
         "codigo": row.codigo,
@@ -170,6 +272,10 @@ def serializar_plano(row: SaasPlano) -> dict:
         "ativo": bool(row.ativo),
         "ordem": int(row.ordem or 0),
         "preco_mensal": float(preco) if preco is not None else None,
+        "usuarios_inclusos": int(row.usuarios_inclusos or 3),
+        "preco_usuario_extra": (
+            float(row.preco_usuario_extra) if row.preco_usuario_extra is not None else 10.0
+        ),
         "max_postos": row.max_postos,
         "max_usuarios": row.max_usuarios,
         "modulos": mods,
@@ -188,8 +294,9 @@ def aplicar_plano_em_cliente(
     plano_id: int | None,
     plano_actual_id: int | None = None,
     permitir_inactivo_se_actual: bool = True,
+    modulo_ids: list[int] | None = None,
 ) -> tuple[int | None, str | None, list[str], int | None, int | None]:
-    """Valida e devolve (plano_id, nome, códigos módulos, max_postos, max_usuarios)."""
+    """Valida e devolve (plano_id, nome, códigos módulos, max_postos, max_usuarios do plano)."""
     if plano_id is None:
         return None, None, [], None, None
     plano = (
@@ -202,16 +309,20 @@ def aplicar_plano_em_cliente(
         raise SaasErro("Plano não encontrado", 404)
     if not plano.ativo:
         if not (permitir_inactivo_se_actual and plano_actual_id == plano.id):
-            raise SaasErro("Plano inactivo — escolha um plano activo")
-    codigos: list[str] = []
-    for link in plano.modulos_links or []:
-        if link.modulo and link.modulo.codigo:
-            codigos.append(link.modulo.codigo)
+            raise SaasErro("Plano inativo — escolha um plano ativo")
+    if modulo_ids is not None:
+        mods = _resolver_modulos(db, modulo_ids)
+        codigos = [m.codigo for m in mods if m.codigo]
+    else:
+        codigos = []
+        for link in plano.modulos_links or []:
+            if link.modulo and link.modulo.codigo:
+                codigos.append(link.modulo.codigo)
     return plano.id, plano.nome, codigos, plano.max_postos, plano.max_usuarios
 
 
 def sincronizar_snapshot_licenca(db: Session, row) -> None:
-    """Actualiza modulos_snapshot e limites a partir do plano_id actual."""
+    """Atualiza modulos_snapshot e limites a partir do plano_id actual (sem sobrescrever mix custom)."""
     from app.models.cliente_saas import ClienteSaaS
 
     if not isinstance(row, ClienteSaaS):
@@ -219,7 +330,11 @@ def sincronizar_snapshot_licenca(db: Session, row) -> None:
     if not row.plano_id:
         row.modulos_snapshot = []
         row.max_postos = None
-        row.max_usuarios = None
+        return
+    # Se já há snapshot custom, só garante limites de postos nulos; usuários contratados ficam.
+    if list(getattr(row, "modulos_snapshot", None) or []):
+        row.max_postos = None
+        db.flush()
         return
     _pid, _nome, codigos, max_p, max_u = aplicar_plano_em_cliente(
         db,
@@ -229,16 +344,61 @@ def sincronizar_snapshot_licenca(db: Session, row) -> None:
     )
     row.modulos_snapshot = codigos
     row.max_postos = max_p
-    row.max_usuarios = max_u
+    if getattr(row, "max_usuarios", None) is None and max_u is not None:
+        row.max_usuarios = max_u
     db.flush()
+
+
+def estimar_preco_mensal(
+    db: Session,
+    *,
+    plano_id: int | None,
+    modulo_ids: list[int] | None,
+    usuarios_contratados: int | None,
+) -> dict:
+    """Calcula preço comercial (módulos + extras de usuário)."""
+    mods: list[SaasModulo] = []
+    inclusos = 3
+    extra_unit = 10.0
+    if plano_id is not None:
+        plano = obter_plano(db, plano_id)
+        inclusos = int(plano.usuarios_inclusos or 3)
+        extra_unit = _num(plano.preco_usuario_extra) if plano.preco_usuario_extra is not None else 10.0
+        if modulo_ids is None:
+            mods = _modulos_do_plano(plano)
+    if modulo_ids is not None:
+        mods = _resolver_modulos(db, modulo_ids)
+    preco_mods = soma_preco_modulos(mods)
+    preco_users = preco_extra_usuarios(
+        usuarios_inclusos=inclusos,
+        preco_usuario_extra=extra_unit,
+        usuarios_contratados=usuarios_contratados,
+    )
+    return {
+        "preco_modulos": preco_mods,
+        "preco_usuarios_extra": preco_users,
+        "preco_mensal_total": round(preco_mods + preco_users, 2),
+        "usuarios_inclusos": inclusos,
+        "preco_usuario_extra": extra_unit,
+        "usuarios_contratados": usuarios_contratados,
+        "modulos": [
+            {
+                "id": m.id,
+                "codigo": m.codigo,
+                "nome": m.nome,
+                "preco_mensal": float(m.preco_mensal) if m.preco_mensal is not None else None,
+            }
+            for m in mods
+        ],
+    }
 
 
 _ACTION_LABELS = {
     "create": "Licença criada",
     "create_from_lead": "Criada a partir de lead",
-    "update": "Dados actualizados",
+    "update": "Dados atualizados",
     "suspender": "Suspensa",
-    "reativar": "Reactivada",
+    "reativar": "Reativada",
     "renovar": "Renovada",
     "registrar_instancia": "URL sincronizada",
     "solicitar_provisionamento": "Provisionamento solicitado",

--- a/backend/app/services/saas_clientes.py
+++ b/backend/app/services/saas_clientes.py
@@ -42,6 +42,8 @@ def criar(db: Session, data: ClienteSaaSCreate) -> ClienteSaaS:
     _garantir_slug_unico(db, data.slug)
     payload = data.model_dump()
     lead_id = payload.pop("lead_comercial_id", None)
+    modulo_ids = payload.pop("modulo_ids", None)
+    usuarios_contratados = payload.pop("usuarios_contratados", None)
     # URL pública é sempre derivada do slug (+ domínio base); não é campo livre.
     payload["instancia_url"] = _url_do_slug(data.slug) or payload.get("instancia_url")
 
@@ -50,15 +52,20 @@ def criar(db: Session, data: ClienteSaaSCreate) -> ClienteSaaS:
     plano_id = payload.pop("plano_id", None)
     # Texto livre `plano` só como fallback legado; preferir plano_id.
     if plano_id is not None:
-        pid, nome, codigos, max_p, max_u = aplicar_plano_em_cliente(db, plano_id=plano_id)
+        pid, nome, codigos, max_p, max_u = aplicar_plano_em_cliente(
+            db, plano_id=plano_id, modulo_ids=modulo_ids
+        )
         payload["plano_id"] = pid
         payload["plano"] = nome
         payload["modulos_snapshot"] = codigos
-        payload["max_postos"] = max_p
-        payload["max_usuarios"] = max_u
+        payload["max_postos"] = None
+        if usuarios_contratados is not None:
+            payload["max_usuarios"] = usuarios_contratados
+        elif max_u is not None:
+            payload["max_usuarios"] = max_u
     elif payload.get("plano"):
         # Trial / legado: tentar resolver por código ou deixar só o rótulo.
-        from app.services.saas_catalogo import obter_plano_por_codigo, sincronizar_snapshot_licenca
+        from app.services.saas_catalogo import obter_plano_por_codigo
 
         p = obter_plano_por_codigo(db, str(payload["plano"]))
         if p is not None:
@@ -88,37 +95,45 @@ def atualizar(db: Session, cliente_id: int, data: ClienteSaaSUpdate) -> ClienteS
         _garantir_slug_unico(db, payload["slug"], excluir_id=cliente_id)
     # instancia_url deixa de ser editável à mão — sempre acompanha o slug.
     payload.pop("instancia_url", None)
+    modulo_ids = payload.pop("modulo_ids", None)
+    usuarios_contratados = payload.pop("usuarios_contratados", None)
 
-    if "plano_id" in payload:
+    if "plano_id" in payload or modulo_ids is not None:
         from app.services.saas_catalogo import aplicar_plano_em_cliente
 
-        pid, nome, codigos, max_p, max_u = aplicar_plano_em_cliente(
+        plano_ref = payload["plano_id"] if "plano_id" in payload else getattr(row, "plano_id", None)
+        pid, nome, codigos, _max_p, max_u = aplicar_plano_em_cliente(
             db,
-            plano_id=payload["plano_id"],
+            plano_id=plano_ref,
             plano_actual_id=getattr(row, "plano_id", None),
+            modulo_ids=modulo_ids,
         )
         payload["plano_id"] = pid
         payload["plano"] = nome
         payload["modulos_snapshot"] = codigos
-        payload["max_postos"] = max_p
-        payload["max_usuarios"] = max_u
+        payload["max_postos"] = None
+        if usuarios_contratados is not None:
+            payload["max_usuarios"] = usuarios_contratados
+        elif "plano_id" in data.model_dump(exclude_unset=True) and max_u is not None:
+            # Troca de plano sem informar usuários — mantém o contratado actual se existir
+            if getattr(row, "max_usuarios", None) is None:
+                payload["max_usuarios"] = max_u
     elif "plano" in payload and payload.get("plano"):
-        from app.services.saas_catalogo import obter_plano_por_codigo, sincronizar_snapshot_licenca
+        from app.services.saas_catalogo import obter_plano_por_codigo
 
         p = obter_plano_por_codigo(db, str(payload["plano"]))
         if p is not None:
             payload["plano_id"] = p.id
             payload["plano"] = p.nome
 
+    if usuarios_contratados is not None and "max_usuarios" not in payload:
+        payload["max_usuarios"] = usuarios_contratados
+
     for k, v in payload.items():
         setattr(row, k, v)
     auto = _url_do_slug(row.slug)
     if auto:
         row.instancia_url = auto
-    if "plano_id" in payload or ("plano" in payload and getattr(row, "plano_id", None)):
-        from app.services.saas_catalogo import sincronizar_snapshot_licenca
-
-        sincronizar_snapshot_licenca(db, row)
     db.flush()
     return row
 
@@ -211,12 +226,54 @@ def serializar_cliente(row: ClienteSaaS) -> dict:
     plano_modulos: list[dict] = []
     plano_id = getattr(row, "plano_id", None)
     sess = object_session(row)
+    usuarios_inclusos = 3
+    preco_usuario_extra = 10.0
     if plano_id and sess is not None:
         try:
             plano = saas_catalogo.obter_plano(sess, plano_id)
-            plano_modulos = saas_catalogo.serializar_plano(plano).get("modulos") or []
+            ser = saas_catalogo.serializar_plano(plano)
+            plano_modulos = ser.get("modulos") or []
+            usuarios_inclusos = int(ser.get("usuarios_inclusos") or 3)
+            preco_usuario_extra = float(ser.get("preco_usuario_extra") or 10)
         except SaasErro:
             plano_modulos = []
+
+    preco_modulos = 0.0
+    snapshot = list(getattr(row, "modulos_snapshot", None) or [])
+    modulos_contratados: list[dict] = []
+    if sess is not None and snapshot:
+        try:
+            mods = saas_catalogo.resolver_modulos_por_codigos(sess, snapshot)
+            preco_modulos = saas_catalogo.soma_preco_modulos(mods)
+            modulos_contratados = [
+                {
+                    "id": m.id,
+                    "codigo": m.codigo,
+                    "nome": m.nome,
+                    "ativo": bool(m.ativo),
+                    "preco_mensal": float(m.preco_mensal) if m.preco_mensal is not None else None,
+                }
+                for m in mods
+            ]
+        except SaasErro:
+            preco_modulos = 0.0
+    elif plano_modulos:
+        preco_modulos = round(
+            sum(float(m.get("preco_mensal") or 0) for m in plano_modulos),
+            2,
+        )
+        modulos_contratados = list(plano_modulos)
+
+    usuarios_contratados = getattr(row, "max_usuarios", None)
+    preco_users = saas_catalogo.preco_extra_usuarios(
+        usuarios_inclusos=usuarios_inclusos,
+        preco_usuario_extra=preco_usuario_extra,
+        usuarios_contratados=usuarios_contratados,
+    )
+    preco_estimado = round(preco_modulos + preco_users, 2)
+    negociado_raw = getattr(row, "preco_mensal_negociado", None)
+    negociado = float(negociado_raw) if negociado_raw is not None else None
+    efetivo = negociado if negociado is not None else preco_estimado
 
     return {
         "id": row.id,
@@ -226,9 +283,17 @@ def serializar_cliente(row: ClienteSaaS) -> dict:
         "plano": row.plano,
         "plano_id": plano_id,
         "plano_modulos": plano_modulos,
-        "modulos_snapshot": list(getattr(row, "modulos_snapshot", None) or []),
+        "modulos_contratados": modulos_contratados,
+        "modulos_snapshot": snapshot,
         "max_postos": getattr(row, "max_postos", None),
-        "max_usuarios": getattr(row, "max_usuarios", None),
+        "max_usuarios": usuarios_contratados,
+        "usuarios_inclusos": usuarios_inclusos,
+        "preco_usuario_extra": preco_usuario_extra,
+        "preco_modulos": preco_modulos,
+        "preco_usuarios_extra": preco_users,
+        "preco_mensal_estimado": preco_estimado,
+        "preco_mensal_negociado": negociado,
+        "preco_mensal_efetivo": efetivo,
         "data_inicio": row.data_inicio,
         "data_renovacao": row.data_renovacao,
         "instancia_url": row.instancia_url,

--- a/backend/app/services/saas_notify.py
+++ b/backend/app/services/saas_notify.py
@@ -59,26 +59,26 @@ def notificar_contacto_entrega(
             mods = []
     mods_txt = ", ".join(mods) if mods else "helpdesk (base)"
     limites = []
-    if getattr(row, "max_postos", None) is not None:
-        limites.append(f"postos: {row.max_postos}")
     if getattr(row, "max_usuarios", None) is not None:
-        limites.append(f"utilizadores: {row.max_usuarios}")
+        limites.append(f"usuários: {row.max_usuarios}")
+    if getattr(row, "max_postos", None) is not None:
+        limites.append(f"postos (legado): {row.max_postos}")
     limites_txt = (", ".join(limites)) if limites else "sem limites comerciais definidos"
     subject = f"DeskRudder — ambiente pronto ({row.nome})"
     body = (
         f"Olá {nome},\n\n"
         f"O ambiente DeskRudder de «{row.nome}» está disponível.\n\n"
         f"Acesso: {url}\n"
-        f"Login da equipa: {url.rstrip('/')}/login\n\n"
+        f"Login da equipe: {url.rstrip('/')}/login\n\n"
         f"Plano: {plano_nome}\n"
         f"Módulos incluídos: {mods_txt}\n"
         f"Limites: {limites_txt}\n\n"
         "As credenciais iniciais (admin) são as definidas no provisionamento "
         f"(SEED_ADMIN_EMAIL no client.env do slug «{row.slug}»). "
-        "Se ainda não as recebeu, a equipa DeskRudder envia-as em seguida.\n\n"
+        "Se ainda não as recebeu, a equipe DeskRudder envia-as em seguida.\n\n"
         "Em ambiente local, o domínio público pode não resolver DNS — "
-        "use a porta API (health) indicada pela equipa DeskRudder.\n\n"
-        "— Equipa DeskRudder\n"
+        "use a porta API (health) indicada pela equipe DeskRudder.\n\n"
+        "— Equipe DeskRudder\n"
     )
     try:
         enviar_mensagem_texto_sistema(db, to_addr=to_addr, subject=subject, body=body)

--- a/backend/app/services/saas_ops_conta.py
+++ b/backend/app/services/saas_ops_conta.py
@@ -1,0 +1,72 @@
+"""Conta do ops no control-plane — perfil e token Cursor."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.core.security import criar_access_token, criar_refresh_token
+from app.models.atendente import Atendente
+from app.schemas.saas_ops_conta import SaasOpsContaPerfilUpdate
+
+
+def _normalizar_email(email: str) -> str:
+    return (email or "").strip().lower()
+
+
+def _validar_email(email: str) -> str:
+    valor = _normalizar_email(email)
+    if "@" not in valor or valor.startswith("@") or valor.endswith("@"):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe um e-mail válido.")
+    return valor
+
+
+def atualizar_perfil(
+    db: Session,
+    actor: Atendente,
+    data: SaasOpsContaPerfilUpdate,
+) -> tuple[Atendente, dict | None]:
+    """Atualiza nome/e-mail da própria conta. Se o e-mail mudar, devolve claims para novos tokens."""
+    update = data.model_dump(exclude_unset=True)
+    if not update:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Nada para atualizar.")
+
+    email_mudou = False
+    if "nome" in update and update["nome"] is not None:
+        nome = update["nome"].strip()
+        if not nome:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe o nome.")
+        actor.nome = nome
+
+    if "email" in update and update["email"] is not None:
+        email = _validar_email(update["email"])
+        if email != _normalizar_email(actor.email):
+            existe = (
+                db.query(Atendente)
+                .filter(
+                    Atendente.tenant_id == actor.tenant_id,
+                    func.lower(Atendente.email) == email,
+                    Atendente.id != actor.id,
+                )
+                .first()
+            )
+            if existe:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="E-mail já cadastrado")
+            actor.email = email
+            actor.token_version = int(actor.token_version or 0) + 1
+            email_mudou = True
+
+    registrar_audit(db, "atendente", actor.id, "update_saas_ops_perfil", actor.id)
+    db.flush()
+
+    tokens = None
+    if email_mudou:
+        ver = int(getattr(actor, "token_version", 0) or 0)
+        claims = {"sub": actor.email, "tid": int(actor.tenant_id), "ver": ver}
+        tokens = {
+            "access_token": criar_access_token(data=claims),
+            "refresh_token": criar_refresh_token(data=claims),
+        }
+    return actor, tokens

--- a/backend/app/services/saas_ops_usuarios.py
+++ b/backend/app/services/saas_ops_usuarios.py
@@ -1,4 +1,4 @@
-"""Cadastro da equipa saas_ops no control-plane (#883)."""
+"""Cadastro da equipe saas_ops no control-plane (#883)."""
 
 from __future__ import annotations
 
@@ -6,12 +6,13 @@ import secrets
 
 from fastapi import HTTPException, status
 from sqlalchemy import func
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.core.audit import registrar_audit
 from app.core.security import hash_senha
 from app.models.atendente import Atendente
 from app.schemas.saas_ops_usuario import SaasOpsUsuarioCreate, SaasOpsUsuarioUpdate
+from app.services import saas_setores as setores_svc
 
 
 def _agora_senha() -> str:
@@ -30,6 +31,7 @@ def _validar_email(email: str) -> str:
 
 
 def para_dict(row: Atendente) -> dict:
+    setores = sorted(getattr(row, "saas_setores", None) or [], key=lambda s: (s.nome or "", s.id))
     return {
         "id": row.id,
         "nome": row.nome,
@@ -39,22 +41,31 @@ def para_dict(row: Atendente) -> dict:
         "mcp_token_configurado": bool((row.mcp_token_hash or "").strip()),
         "mcp_token_gerado_em": row.mcp_token_gerado_em,
         "created_at": row.created_at,
+        "setor_ids": [s.id for s in setores],
+        "setores": [
+            {"id": s.id, "nome": s.nome, "ativo": bool(s.ativo), "created_at": s.created_at} for s in setores
+        ],
     }
 
 
-def _query_ops(db: Session, tenant_id: int):
+def _filtro_ops(db: Session, tenant_id: int):
     return db.query(Atendente).filter(Atendente.tenant_id == tenant_id, Atendente.role == "saas_ops")
 
 
 def _obter_ops(db: Session, tenant_id: int, usuario_id: int) -> Atendente:
-    row = _query_ops(db, tenant_id).filter(Atendente.id == usuario_id).first()
+    row = (
+        _filtro_ops(db, tenant_id)
+        .options(joinedload(Atendente.saas_setores))
+        .filter(Atendente.id == usuario_id)
+        .first()
+    )
     if row is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Utilizador não encontrado")
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Usuário não encontrado")
     return row
 
 
-def _contar_ops_activos(db: Session, tenant_id: int, excluir_id: int | None = None) -> int:
-    q = _query_ops(db, tenant_id).filter(Atendente.ativo.is_(True))
+def _contar_ops_ativos(db: Session, tenant_id: int, excluir_id: int | None = None) -> int:
+    q = _filtro_ops(db, tenant_id).filter(Atendente.ativo.is_(True))
     if excluir_id is not None:
         q = q.filter(Atendente.id != excluir_id)
     return q.count()
@@ -69,14 +80,20 @@ def listar(
     offset: int,
     limit: int,
 ) -> tuple[list[Atendente], int]:
-    q = _query_ops(db, actor.tenant_id)
+    q = _filtro_ops(db, actor.tenant_id)
     if not incluir_inativos:
         q = q.filter(Atendente.ativo.is_(True))
     if busca and busca.strip():
         term = f"%{busca.strip()}%"
         q = q.filter((Atendente.nome.ilike(term)) | (Atendente.email.ilike(term)))
     total = q.count()
-    rows = q.order_by(Atendente.nome.asc(), Atendente.id.asc()).offset(offset).limit(limit).all()
+    rows = (
+        q.options(joinedload(Atendente.saas_setores))
+        .order_by(Atendente.nome.asc(), Atendente.id.asc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
     return rows, total
 
 
@@ -96,6 +113,7 @@ def criar(db: Session, actor: Atendente, data: SaasOpsUsuarioCreate) -> tuple[At
     )
     if existe:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="E-mail já cadastrado")
+    setores = setores_svc.resolver_setores_ativos(db, actor.tenant_id, list(data.setor_ids or []))
     senha = _agora_senha()
     row = Atendente(
         tenant_id=actor.tenant_id,
@@ -106,13 +124,14 @@ def criar(db: Session, actor: Atendente, data: SaasOpsUsuarioCreate) -> tuple[At
         ativo=True,
         must_change_password=True,
     )
+    row.saas_setores = setores
     db.add(row)
     db.flush()
     registrar_audit(db, "atendente", row.id, "create_saas_ops", actor.id)
     return row, senha
 
 
-def actualizar(db: Session, actor: Atendente, usuario_id: int, data: SaasOpsUsuarioUpdate) -> Atendente:
+def atualizar(db: Session, actor: Atendente, usuario_id: int, data: SaasOpsUsuarioUpdate) -> Atendente:
     row = _obter_ops(db, actor.tenant_id, usuario_id)
     update = data.model_dump(exclude_unset=True)
     if "nome" in update and update["nome"] is not None:
@@ -121,19 +140,23 @@ def actualizar(db: Session, actor: Atendente, usuario_id: int, data: SaasOpsUsua
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe o nome.")
         row.nome = nome
     if "ativo" in update and update["ativo"] is not None:
-        activo = bool(update["ativo"])
-        if not activo:
+        ativo = bool(update["ativo"])
+        if not ativo:
             if row.id == actor.id:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Não podes desactivar a tua própria conta.",
+                    detail="Não é possível desativar a sua própria conta.",
                 )
-            if row.ativo and _contar_ops_activos(db, actor.tenant_id, excluir_id=row.id) < 1:
+            if row.ativo and _contar_ops_ativos(db, actor.tenant_id, excluir_id=row.id) < 1:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Não é possível desactivar o último utilizador activo da equipa.",
+                    detail="Não é possível desativar o último usuário ativo da equipe.",
                 )
-        row.ativo = activo
+        row.ativo = ativo
+    if "setor_ids" in update and update["setor_ids"] is not None:
+        row.saas_setores = setores_svc.resolver_setores_ativos(
+            db, actor.tenant_id, list(update["setor_ids"])
+        )
     registrar_audit(db, "atendente", row.id, "update_saas_ops", actor.id)
     db.flush()
     return row
@@ -144,7 +167,7 @@ def redefinir_senha(db: Session, actor: Atendente, usuario_id: int) -> tuple[Ate
     if not row.ativo:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Active a conta antes de gerar uma senha nova.",
+            detail="Ative a conta antes de gerar uma senha nova.",
         )
     senha = _agora_senha()
     row.senha_hash = hash_senha(senha)

--- a/backend/app/services/saas_setores.py
+++ b/backend/app/services/saas_setores.py
@@ -1,0 +1,110 @@
+"""CRUD de setores (cargos) da equipe DeskRudder no control-plane."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from app.core.audit import registrar_audit
+from app.models.atendente import Atendente
+from app.models.saas_setor import SaasSetor
+from app.schemas.saas_setor import SaasSetorCreate, SaasSetorUpdate
+
+
+def _normalizar_nome(nome: str) -> str:
+    return " ".join((nome or "").split()).strip()
+
+
+def listar(
+    db: Session,
+    actor: Atendente,
+    *,
+    incluir_inativos: bool,
+) -> list[SaasSetor]:
+    q = db.query(SaasSetor).filter(SaasSetor.tenant_id == actor.tenant_id)
+    if not incluir_inativos:
+        q = q.filter(SaasSetor.ativo.is_(True))
+    return q.order_by(SaasSetor.nome.asc(), SaasSetor.id.asc()).all()
+
+
+def obter(db: Session, actor: Atendente, setor_id: int) -> SaasSetor:
+    row = (
+        db.query(SaasSetor)
+        .filter(SaasSetor.tenant_id == actor.tenant_id, SaasSetor.id == setor_id)
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Setor não encontrado")
+    return row
+
+
+def criar(db: Session, actor: Atendente, data: SaasSetorCreate) -> SaasSetor:
+    nome = _normalizar_nome(data.nome)
+    if not nome:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe o nome do setor.")
+    existe = (
+        db.query(SaasSetor)
+        .filter(
+            SaasSetor.tenant_id == actor.tenant_id,
+            func.lower(SaasSetor.nome) == nome.lower(),
+        )
+        .first()
+    )
+    if existe:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Já existe um setor com este nome.")
+    row = SaasSetor(tenant_id=actor.tenant_id, nome=nome, ativo=True)
+    db.add(row)
+    db.flush()
+    registrar_audit(db, "saas_setor", row.id, "create", actor.id)
+    return row
+
+
+def atualizar(db: Session, actor: Atendente, setor_id: int, data: SaasSetorUpdate) -> SaasSetor:
+    row = obter(db, actor, setor_id)
+    update = data.model_dump(exclude_unset=True)
+    if "nome" in update and update["nome"] is not None:
+        nome = _normalizar_nome(update["nome"])
+        if not nome:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Informe o nome do setor.")
+        conflito = (
+            db.query(SaasSetor)
+            .filter(
+                SaasSetor.tenant_id == actor.tenant_id,
+                func.lower(SaasSetor.nome) == nome.lower(),
+                SaasSetor.id != row.id,
+            )
+            .first()
+        )
+        if conflito:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Já existe um setor com este nome.",
+            )
+        row.nome = nome
+    if "ativo" in update and update["ativo"] is not None:
+        row.ativo = bool(update["ativo"])
+    registrar_audit(db, "saas_setor", row.id, "update", actor.id)
+    db.flush()
+    return row
+
+
+def resolver_setores_ativos(db: Session, tenant_id: int, setor_ids: list[int]) -> list[SaasSetor]:
+    if not setor_ids:
+        return []
+    ids = sorted({int(i) for i in setor_ids})
+    rows = (
+        db.query(SaasSetor)
+        .filter(
+            SaasSetor.tenant_id == tenant_id,
+            SaasSetor.id.in_(ids),
+            SaasSetor.ativo.is_(True),
+        )
+        .all()
+    )
+    if len(rows) != len(ids):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Um ou mais setores são inválidos ou estão inativos.",
+        )
+    return rows

--- a/backend/app/services/saas_solicitacao_github.py
+++ b/backend/app/services/saas_solicitacao_github.py
@@ -1,0 +1,103 @@
+"""Criar/ligar issue GitHub a partir da solicitação SaaS (#954)."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+import httpx
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from app.config import settings
+from app.models.atendente import Atendente
+from app.models.saas_solicitacao_produto import SaasSolicitacaoProduto, SaasSolicitacaoProdutoComentario
+from app.services.solicitacao_melhoria_github import github_configurado, _headers
+
+logger = logging.getLogger(__name__)
+
+
+def github_repo_produto() -> str:
+    return (settings.GITHUB_REPO_SUGESTOES or "").strip() or "lgustavoss/dx-connect"
+
+
+def montar_corpo_issue_saas(db: Session, row: SaasSolicitacaoProduto) -> str:
+    from app.services import saas_solicitacao_grupo as grupo
+
+    demanda = grupo.texto_github_demanda(db, row)
+    proto = row.protocolo or f"saas-{row.id}"
+    return (
+        f"## Solicitação DeskRudder {proto}\n\n"
+        f"**Tipo:** {row.tipo}\n"
+        f"**Instância:** {row.instance_slug}\n"
+        f"**Autor (origem):** {row.autor_nome or '—'}\n"
+        f"**Versão no envio:** {row.versao_contexto or '—'}\n"
+        f"**Status no SaaS:** {row.status}\n\n"
+        f"### Demanda (grupo)\n{demanda}\n\n"
+        f"### Título\n{row.titulo}\n\n"
+        f"### Descrição\n{row.descricao}\n"
+    )
+
+
+def criar_issue_saas(
+    db: Session,
+    row: SaasSolicitacaoProduto,
+    ops: Atendente,
+) -> SaasSolicitacaoProduto:
+    """Cria issue no GitHub e grava vínculo no pedido (e no grupo). Sem commit."""
+    if not github_configurado():
+        raise HTTPException(
+            status_code=503,
+            detail="Integração GitHub não configurada (GITHUB_TOKEN / GITHUB_REPO_SUGESTOES).",
+        )
+    if row.github_issue_number:
+        raise HTTPException(status_code=400, detail="Esta solicitação já tem issue no GitHub.")
+
+    repo = settings.GITHUB_REPO_SUGESTOES.strip()
+    proto = row.protocolo or f"#{row.id}"
+    url = f"https://api.github.com/repos/{repo}/issues"
+    payload = {
+        "title": f"[{proto}] {row.titulo}"[:240],
+        "body": montar_corpo_issue_saas(db, row),
+        "labels": ["deskrudder-sugestao", row.tipo],
+    }
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            res = client.post(url, headers=_headers(), json=payload)
+    except httpx.HTTPError as exc:
+        logger.warning("GitHub create issue (SaaS) falhou: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="Falha ao contatar o GitHub. Tente novamente.",
+        ) from exc
+
+    if res.status_code >= 400:
+        logger.warning("GitHub rejeitou create issue SaaS: %s", (res.text or "")[:500])
+        raise HTTPException(
+            status_code=502,
+            detail="GitHub rejeitou a criação da issue. Pode tentar de novo.",
+        )
+
+    data = res.json()
+    number = int(data["number"])
+    html = data.get("html_url") or f"https://github.com/{repo}/issues/{number}"
+    row.github_repo = repo
+    row.github_issue_number = number
+    row.github_issue_url = html
+    db.add(row)
+    from app.services import saas_solicitacao_grupo as grupo
+
+    grupo.aplicar_github_no_grupo(db, row, repo=repo, number=number, url=html)
+    db.add(
+        SaasSolicitacaoProdutoComentario(
+            solicitacao_id=row.id,
+            corpo=f"Issue GitHub criada: #{number} (só ops — o cliente não vê).",
+            publico_cliente=False,
+            autor_atendente_id=ops.id,
+            autor_nome=ops.nome,
+        )
+    )
+    row.triagem_atualizada_em = datetime.now(timezone.utc)
+    db.add(row)
+    db.flush()
+    return row

--- a/backend/app/services/saas_solicitacao_ingest.py
+++ b/backend/app/services/saas_solicitacao_ingest.py
@@ -414,6 +414,7 @@ def item_lista(
         status=row.status,
         status_rotulo=rotulo_status(row.status),
         versao_contexto=row.versao_contexto,
+        versao_alvo=row.versao_alvo,
         autor_nome=row.autor_nome,
         created_at_origem=row.created_at_origem,
         ingested_at=row.ingested_at,

--- a/backend/app/services/saas_solicitacao_release.py
+++ b/backend/app/services/saas_solicitacao_release.py
@@ -146,7 +146,7 @@ def concluir_pedidos_release(
     concluidos = 0
     ignorados = 0
     erros = 0
-    comentario = f"Melhoria disponível na versão {versao_n}."
+    comentario = f"Melhoria disponível a partir da versão {versao_n} (ou superior)."
     origem = f"release:{versao_n}"
 
     for row in candidatos:

--- a/backend/app/services/saas_solicitacao_release.py
+++ b/backend/app/services/saas_solicitacao_release.py
@@ -1,0 +1,186 @@
+"""Conclusão automática de solicitações no release CalVer (#956)."""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from app.models.saas_solicitacao_produto import (
+    SaasSolicitacaoProduto,
+    SaasSolicitacaoProdutoComentario,
+)
+from app.services import saas_solicitacao_ingest as ingest
+from app.services.solicitacao_melhoria import (
+    aplicar_comentario_origem_saas,
+    aplicar_status_origem_saas,
+    aplicar_versao_alvo_origem_saas,
+)
+from app.services.solicitacao_melhoria_copy import normalizar_versao_alvo
+from app.services.saas_solicitacao_triagem import _deve_aplicar_local
+
+logger = logging.getLogger(__name__)
+
+_PROTOCOLO_RE = re.compile(r"#S(\d{6})-(\d{4})", re.IGNORECASE)
+_ISSUE_RE = re.compile(r"(?<![A-Za-z0-9])#(\d{3,5})\b")
+
+
+def extrair_referencias_release(textos: list[str]) -> tuple[set[str], set[int]]:
+    """Protocolos #S… e issues GitHub citadas no CHANGELOG/PR."""
+    protocolos: set[str] = set()
+    issues: set[int] = set()
+    for raw in textos:
+        texto = raw or ""
+        for m in _PROTOCOLO_RE.finditer(texto):
+            protocolos.add(f"#S{m.group(1).upper()}-{m.group(2)}")
+        for m in _ISSUE_RE.finditer(texto):
+            issues.add(int(m.group(1)))
+    return protocolos, issues
+
+
+def _agora() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _ids_grupo(db: Session, row: SaasSolicitacaoProduto) -> list[int]:
+    if row.grupo_id is None:
+        return [row.id]
+    return [
+        r.id
+        for r in db.query(SaasSolicitacaoProduto)
+        .filter(SaasSolicitacaoProduto.grupo_id == row.grupo_id)
+        .all()
+    ]
+
+
+def _marcar_concluida_release(
+    db: Session,
+    row: SaasSolicitacaoProduto,
+    *,
+    versao: str,
+    comentario: str,
+    origem_sync: str,
+) -> bool:
+    """Marca pedido concluído com versão. Idempotente. Sem commit."""
+    versao_n = normalizar_versao_alvo(versao)
+    if not versao_n:
+        return False
+    alterou = False
+    if normalizar_versao_alvo(row.versao_alvo) != versao_n:
+        row.versao_alvo = versao_n
+        alterou = True
+    if row.status != "concluida":
+        row.status = "concluida"
+        alterou = True
+    if alterou:
+        row.triagem_atualizada_em = _agora()
+        db.add(row)
+        db.flush()
+    if _deve_aplicar_local(row):
+        aplicar_versao_alvo_origem_saas(db, row.origem_solicitacao_id, versao_n)
+        aplicar_status_origem_saas(
+            db,
+            row.origem_solicitacao_id,
+            status_novo="concluida",
+            motivo_nao_desenvolvimento=None,
+            atendente_id=None,
+        )
+    ja = (
+        db.query(SaasSolicitacaoProdutoComentario)
+        .filter(
+            SaasSolicitacaoProdutoComentario.solicitacao_id == row.id,
+            SaasSolicitacaoProdutoComentario.corpo == comentario,
+            SaasSolicitacaoProdutoComentario.publico_cliente.is_(True),
+        )
+        .first()
+    )
+    if ja is None:
+        db.add(
+            SaasSolicitacaoProdutoComentario(
+                solicitacao_id=row.id,
+                corpo=comentario,
+                publico_cliente=True,
+                autor_nome="DeskRudder",
+            )
+        )
+        db.flush()
+        if _deve_aplicar_local(row):
+            aplicar_comentario_origem_saas(
+                db,
+                row.origem_solicitacao_id,
+                corpo=comentario,
+                origem_externa_id=origem_sync,
+                autor_nome="DeskRudder",
+            )
+        alterou = True
+    return alterou
+
+
+def concluir_pedidos_release(
+    db: Session,
+    *,
+    versao: str,
+    textos_changelog: list[str],
+) -> dict[str, int]:
+    """Resolve pedidos citados no release → concluida + versao_alvo. Falha parcial não aborta."""
+    versao_n = normalizar_versao_alvo(versao)
+    if not versao_n:
+        return {"processados": 0, "concluidos": 0, "ignorados": 0, "erros": 0}
+
+    protocolos, issues = extrair_referencias_release(textos_changelog)
+    if not protocolos and not issues:
+        return {"processados": 0, "concluidos": 0, "ignorados": 0, "erros": 0}
+
+    q = db.query(SaasSolicitacaoProduto)
+    filtros = []
+    if protocolos:
+        filtros.append(SaasSolicitacaoProduto.protocolo.in_(sorted(protocolos)))
+    if issues:
+        filtros.append(SaasSolicitacaoProduto.github_issue_number.in_(sorted(issues)))
+    from sqlalchemy import or_
+
+    candidatos = q.filter(or_(*filtros)).all()
+    vistos: set[int] = set()
+    concluidos = 0
+    ignorados = 0
+    erros = 0
+    comentario = f"Melhoria disponível na versão {versao_n}."
+    origem = f"release:{versao_n}"
+
+    for row in candidatos:
+        if row.status == "nao_sera_desenvolvida":
+            ignorados += 1
+            continue
+        if row.status == "concluida" and normalizar_versao_alvo(row.versao_alvo) == versao_n:
+            ignorados += 1
+            continue
+        for sid in _ids_grupo(db, row):
+            if sid in vistos:
+                continue
+            vistos.add(sid)
+            alvo = ingest.obter(db, sid)
+            try:
+                if _marcar_concluida_release(
+                    db,
+                    alvo,
+                    versao=versao_n,
+                    comentario=comentario,
+                    origem_sync=origem,
+                ):
+                    concluidos += 1
+                else:
+                    ignorados += 1
+            except Exception:
+                erros += 1
+                logger.exception("Falha ao concluir solicitação SaaS id=%s no release %s", sid, versao_n)
+
+    if concluidos or erros:
+        db.commit()
+    return {
+        "processados": len(vistos),
+        "concluidos": concluidos,
+        "ignorados": ignorados,
+        "erros": erros,
+    }

--- a/backend/app/services/saas_solicitacao_triagem.py
+++ b/backend/app/services/saas_solicitacao_triagem.py
@@ -22,6 +22,7 @@ from app.schemas.saas_solicitacao import (
     SaasSolicitacaoComentarioCreate,
     SaasSolicitacaoDetalhe,
     SaasSolicitacaoGithubUpdate,
+    SaasSolicitacaoImplementar,
     SaasSolicitacaoStatusUpdate,
     SaasSolicitacaoSyncComentario,
     SaasSolicitacaoSyncItem,
@@ -33,11 +34,13 @@ from app.services.solicitacao_melhoria import (
     aplicar_protocolo_origem_saas,
     aplicar_status_origem_saas,
 )
-from app.services.solicitacao_melhoria_copy import STATUS_VALIDOS
+from app.services.solicitacao_melhoria_copy import validar_transicao_status
 
 logger = logging.getLogger(__name__)
 
 CACHE_CHAVE_PULL = "saas_triagem_pull"
+
+_GH_ISSUE = re.compile(r"github\.com/([^/\s]+)/([^/\s]+)/issues/(\d+)", re.I)
 
 
 def _agora() -> datetime:
@@ -48,23 +51,28 @@ def _deve_aplicar_local(row: SaasSolicitacaoProduto) -> bool:
     return bool(settings.SAAS_CONTROL_PLANE) and row.instance_slug == ingest.instance_slug_local()
 
 
-def alterar_status(
+def _tem_vinculo_github(row: SaasSolicitacaoProduto) -> bool:
+    return bool(row.github_issue_number and (row.github_issue_url or "").strip())
+
+
+def _aplicar_status_no_row(
     db: Session,
-    solicitacao_id: int,
+    row: SaasSolicitacaoProduto,
     ops: Atendente,
-    data: SaasSolicitacaoStatusUpdate,
-) -> SaasSolicitacaoDetalhe:
-    if data.status not in STATUS_VALIDOS:
-        raise HTTPException(status_code=400, detail="Status inválido")
-    if data.status == "nao_sera_desenvolvida" and not (data.motivo_nao_desenvolvimento or "").strip():
-        raise HTTPException(
-            status_code=400,
-            detail="Informe o motivo quando marcar como não será desenvolvida",
-        )
-    row = ingest.obter(db, solicitacao_id)
-    row.status = data.status
-    if data.status == "nao_sera_desenvolvida":
-        row.motivo_nao_desenvolvimento = (data.motivo_nao_desenvolvimento or "").strip()
+    *,
+    status_novo: str,
+    motivo_nao_desenvolvimento: str | None,
+) -> SaasSolicitacaoProduto:
+    """Valida transição (#953/#954), grava status e propaga à instância local. Sem commit."""
+    validar_transicao_status(
+        row.status,
+        status_novo,
+        tem_vinculo_github=_tem_vinculo_github(row),
+        motivo_nao_desenvolvimento=motivo_nao_desenvolvimento,
+    )
+    row.status = status_novo
+    if status_novo == "nao_sera_desenvolvida":
+        row.motivo_nao_desenvolvimento = (motivo_nao_desenvolvimento or "").strip()
     row.triagem_atualizada_em = _agora()
     db.add(row)
     db.flush()
@@ -77,8 +85,102 @@ def alterar_status(
             motivo_nao_desenvolvimento=row.motivo_nao_desenvolvimento,
             atendente_id=ops.id,
         )
+    return row
+
+
+def alterar_status(
+    db: Session,
+    solicitacao_id: int,
+    ops: Atendente,
+    data: SaasSolicitacaoStatusUpdate,
+) -> SaasSolicitacaoDetalhe:
+    row = ingest.obter(db, solicitacao_id)
+    _aplicar_status_no_row(
+        db,
+        row,
+        ops,
+        status_novo=data.status,
+        motivo_nao_desenvolvimento=data.motivo_nao_desenvolvimento,
+    )
     db.commit()
     return ingest.detalhe(db, ingest.obter(db, row.id))
+
+
+def implementar(
+    db: Session,
+    solicitacao_id: int,
+    ops: Atendente,
+    data: SaasSolicitacaoImplementar,
+) -> SaasSolicitacaoDetalhe:
+    """G2: garante issue GitHub e avança planejada → em_desenvolvimento."""
+    row = ingest.obter(db, solicitacao_id)
+    if row.status != "planejada":
+        raise HTTPException(
+            status_code=400,
+            detail="Só é possível implementar a partir do status Planejada",
+        )
+    url = (data.github_issue_url or "").strip()
+    if url or data.github_issue_number is not None:
+        # Liga (ou re-liga) antes de avançar — sem commit intermediário.
+        _gravar_github(db, row, data)
+    elif not _tem_vinculo_github(row):
+        if not data.criar_issue:
+            raise HTTPException(
+                status_code=400,
+                detail="Indique a URL/número da issue ou permita criar no GitHub",
+            )
+        from app.services.saas_solicitacao_github import criar_issue_saas
+
+        criar_issue_saas(db, row, ops)
+        row = ingest.obter(db, solicitacao_id)
+    _aplicar_status_no_row(
+        db,
+        row,
+        ops,
+        status_novo="em_desenvolvimento",
+        motivo_nao_desenvolvimento=None,
+    )
+    db.commit()
+    return ingest.detalhe(db, ingest.obter(db, row.id))
+
+
+def _gravar_github(
+    db: Session,
+    row: SaasSolicitacaoProduto,
+    data: SaasSolicitacaoGithubUpdate | SaasSolicitacaoImplementar,
+) -> None:
+    """Persiste vínculo GitHub no pedido + grupo. Sem commit."""
+    url = (data.github_issue_url or "").strip()
+    number = data.github_issue_number
+    repo = (data.github_repo or "").strip() or None
+    if url:
+        m = _GH_ISSUE.search(url)
+        if not m:
+            raise HTTPException(status_code=400, detail="URL de issue GitHub inválido")
+        repo = f"{m.group(1)}/{m.group(2)}"
+        number = int(m.group(3))
+        url = f"https://github.com/{repo}/issues/{number}"
+    elif number is not None:
+        from app.services.saas_solicitacao_github import github_repo_produto
+
+        repo = repo or github_repo_produto()
+        url = f"https://github.com/{repo}/issues/{int(number)}"
+    else:
+        raise HTTPException(status_code=400, detail="Indique o URL ou o número da issue")
+    row.github_repo = repo
+    row.github_issue_number = int(number)
+    row.github_issue_url = url
+    db.add(row)
+    from app.services import saas_solicitacao_grupo as grupo
+
+    grupo.aplicar_github_no_grupo(
+        db,
+        row,
+        repo=repo,
+        number=int(number),
+        url=url,
+    )
+    db.flush()
 
 
 _INTERNO_NO_CLIENTE_RE = re.compile(
@@ -131,13 +233,6 @@ def adicionar_comentario(
     return ingest.detalhe(db, ingest.obter(db, row.id))
 
 
-_GH_ISSUE = re.compile(r"github\.com/([^/\s]+)/([^/\s]+)/issues/(\d+)", re.I)
-
-
-def github_repo_produto() -> str:
-    return (settings.GITHUB_REPO_SUGESTOES or "").strip() or "lgustavoss/dx-connect"
-
-
 def ligar_issue_github(
     db: Session,
     solicitacao_id: int,
@@ -145,34 +240,7 @@ def ligar_issue_github(
 ) -> SaasSolicitacaoDetalhe:
     """Grava a issue no pedido SaaS. O cliente da instância não vê o GitHub."""
     row = ingest.obter(db, solicitacao_id)
-    url = (data.github_issue_url or "").strip()
-    number = data.github_issue_number
-    repo = (data.github_repo or "").strip() or None
-    if url:
-        m = _GH_ISSUE.search(url)
-        if not m:
-            raise HTTPException(status_code=400, detail="URL de issue GitHub inválido")
-        repo = f"{m.group(1)}/{m.group(2)}"
-        number = int(m.group(3))
-        url = f"https://github.com/{repo}/issues/{number}"
-    elif number is not None:
-        repo = repo or github_repo_produto()
-        url = f"https://github.com/{repo}/issues/{int(number)}"
-    else:
-        raise HTTPException(status_code=400, detail="Indique o URL ou o número da issue")
-    row.github_repo = repo
-    row.github_issue_number = int(number)
-    row.github_issue_url = url
-    db.add(row)
-    from app.services import saas_solicitacao_grupo as grupo
-
-    grupo.aplicar_github_no_grupo(
-        db,
-        row,
-        repo=repo,
-        number=int(number),
-        url=url,
-    )
+    _gravar_github(db, row, data)
     db.commit()
     return ingest.detalhe(db, ingest.obter(db, row.id))
 

--- a/backend/app/services/saas_solicitacao_triagem.py
+++ b/backend/app/services/saas_solicitacao_triagem.py
@@ -27,7 +27,6 @@ from app.schemas.saas_solicitacao import (
     SaasSolicitacaoSyncComentario,
     SaasSolicitacaoSyncItem,
     SaasSolicitacaoSyncResponse,
-    SaasSolicitacaoVersaoAlvoUpdate,
 )
 from app.services import saas_solicitacao_ingest as ingest
 from app.services.solicitacao_melhoria import (
@@ -36,7 +35,7 @@ from app.services.solicitacao_melhoria import (
     aplicar_status_origem_saas,
     aplicar_versao_alvo_origem_saas,
 )
-from app.services.solicitacao_melhoria_copy import normalizar_versao_alvo, validar_transicao_status
+from app.services.solicitacao_melhoria_copy import validar_transicao_status
 
 logger = logging.getLogger(__name__)
 
@@ -143,57 +142,6 @@ def implementar(
         status_novo="em_desenvolvimento",
         motivo_nao_desenvolvimento=None,
     )
-    db.commit()
-    return ingest.detalhe(db, ingest.obter(db, row.id))
-
-
-def definir_versao_alvo(
-    db: Session,
-    solicitacao_id: int,
-    ops: Atendente,
-    data: SaasSolicitacaoVersaoAlvoUpdate,
-) -> SaasSolicitacaoDetalhe:
-    """G3: versão prevista/liberada visível ao cliente em planejada/em_desenvolvimento."""
-    row = ingest.obter(db, solicitacao_id)
-    if row.status not in ("planejada", "em_desenvolvimento"):
-        raise HTTPException(
-            status_code=400,
-            detail="Só é possível definir versão alvo em Planejada ou Em desenvolvimento",
-        )
-    versao = normalizar_versao_alvo(data.versao_alvo)
-    row.versao_alvo = versao
-    row.triagem_atualizada_em = _agora()
-    db.add(row)
-    db.flush()
-    if _deve_aplicar_local(row):
-        aplicar_versao_alvo_origem_saas(db, row.origem_solicitacao_id, versao)
-    comentario = (data.comentario_publico or "").strip()
-    if comentario:
-        if corpo_publico_cita_trabalho_interno(comentario):
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "Não envie links ou números de issue do GitHub na mensagem ao cliente. "
-                    "Use comentário interno."
-                ),
-            )
-        c = SaasSolicitacaoProdutoComentario(
-            solicitacao_id=row.id,
-            corpo=comentario,
-            publico_cliente=True,
-            autor_atendente_id=ops.id,
-            autor_nome=ops.nome,
-        )
-        db.add(c)
-        db.flush()
-        if _deve_aplicar_local(row):
-            aplicar_comentario_origem_saas(
-                db,
-                row.origem_solicitacao_id,
-                corpo=c.corpo,
-                origem_externa_id=f"saas:{c.id}",
-                autor_nome=c.autor_nome,
-            )
     db.commit()
     return ingest.detalhe(db, ingest.obter(db, row.id))
 

--- a/backend/app/services/saas_solicitacao_triagem.py
+++ b/backend/app/services/saas_solicitacao_triagem.py
@@ -27,14 +27,16 @@ from app.schemas.saas_solicitacao import (
     SaasSolicitacaoSyncComentario,
     SaasSolicitacaoSyncItem,
     SaasSolicitacaoSyncResponse,
+    SaasSolicitacaoVersaoAlvoUpdate,
 )
 from app.services import saas_solicitacao_ingest as ingest
 from app.services.solicitacao_melhoria import (
     aplicar_comentario_origem_saas,
     aplicar_protocolo_origem_saas,
     aplicar_status_origem_saas,
+    aplicar_versao_alvo_origem_saas,
 )
-from app.services.solicitacao_melhoria_copy import validar_transicao_status
+from app.services.solicitacao_melhoria_copy import normalizar_versao_alvo, validar_transicao_status
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +80,7 @@ def _aplicar_status_no_row(
     db.flush()
     if _deve_aplicar_local(row):
         aplicar_protocolo_origem_saas(db, row.origem_solicitacao_id, row.protocolo)
+        aplicar_versao_alvo_origem_saas(db, row.origem_solicitacao_id, row.versao_alvo)
         aplicar_status_origem_saas(
             db,
             row.origem_solicitacao_id,
@@ -140,6 +143,57 @@ def implementar(
         status_novo="em_desenvolvimento",
         motivo_nao_desenvolvimento=None,
     )
+    db.commit()
+    return ingest.detalhe(db, ingest.obter(db, row.id))
+
+
+def definir_versao_alvo(
+    db: Session,
+    solicitacao_id: int,
+    ops: Atendente,
+    data: SaasSolicitacaoVersaoAlvoUpdate,
+) -> SaasSolicitacaoDetalhe:
+    """G3: versão prevista/liberada visível ao cliente em planejada/em_desenvolvimento."""
+    row = ingest.obter(db, solicitacao_id)
+    if row.status not in ("planejada", "em_desenvolvimento"):
+        raise HTTPException(
+            status_code=400,
+            detail="Só é possível definir versão alvo em Planejada ou Em desenvolvimento",
+        )
+    versao = normalizar_versao_alvo(data.versao_alvo)
+    row.versao_alvo = versao
+    row.triagem_atualizada_em = _agora()
+    db.add(row)
+    db.flush()
+    if _deve_aplicar_local(row):
+        aplicar_versao_alvo_origem_saas(db, row.origem_solicitacao_id, versao)
+    comentario = (data.comentario_publico or "").strip()
+    if comentario:
+        if corpo_publico_cita_trabalho_interno(comentario):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Não envie links ou números de issue do GitHub na mensagem ao cliente. "
+                    "Use comentário interno."
+                ),
+            )
+        c = SaasSolicitacaoProdutoComentario(
+            solicitacao_id=row.id,
+            corpo=comentario,
+            publico_cliente=True,
+            autor_atendente_id=ops.id,
+            autor_nome=ops.nome,
+        )
+        db.add(c)
+        db.flush()
+        if _deve_aplicar_local(row):
+            aplicar_comentario_origem_saas(
+                db,
+                row.origem_solicitacao_id,
+                corpo=c.corpo,
+                origem_externa_id=f"saas:{c.id}",
+                autor_nome=c.autor_nome,
+            )
     db.commit()
     return ingest.detalhe(db, ingest.obter(db, row.id))
 
@@ -261,6 +315,7 @@ def payload_sync(row: SaasSolicitacaoProduto) -> SaasSolicitacaoSyncItem:
         status=row.status,
         motivo_nao_desenvolvimento=row.motivo_nao_desenvolvimento,
         protocolo=row.protocolo,
+        versao_alvo=row.versao_alvo,
         comentarios_publicos=publicos,
     )
 
@@ -309,6 +364,7 @@ def listar_sync(
 def aplicar_pacote_sync(db: Session, item: SaasSolicitacaoSyncItem) -> bool:
     """Aplica um item do GET sync na instância. Sem commit."""
     aplicar_protocolo_origem_saas(db, item.origem_solicitacao_id, item.protocolo)
+    aplicar_versao_alvo_origem_saas(db, item.origem_solicitacao_id, item.versao_alvo)
     aplicado = aplicar_status_origem_saas(
         db,
         item.origem_solicitacao_id,

--- a/backend/app/services/solicitacao_melhoria.py
+++ b/backend/app/services/solicitacao_melhoria.py
@@ -30,7 +30,9 @@ from app.services.solicitacao_melhoria_copy import (
     STATUS_VALIDOS,
     TIPOS_VALIDOS,
     mensagem_publica_status,
+    normalizar_versao_alvo,
     rotulo_status,
+    rotulo_versao_alvo_publica,
 )
 
 MSG_TRIAGEM_SAAS = "A triagem de produto é feita no painel SaaS DeskRudder"
@@ -123,6 +125,8 @@ def serializar(row: SolicitacaoMelhoria, *, incluir_github: bool, incluir_intern
         status_rotulo=rotulo_status(row.status),
         motivo_nao_desenvolvimento=row.motivo_nao_desenvolvimento,
         versao_contexto=row.versao_contexto,
+        versao_alvo=row.versao_alvo,
+        versao_alvo_rotulo=rotulo_versao_alvo_publica(row.status, row.versao_alvo),
         mensagem_status=mensagem_publica_status(row.status, motivo=row.motivo_nao_desenvolvimento),
         created_at=row.created_at,
         updated_at=row.updated_at,
@@ -360,6 +364,25 @@ def aplicar_protocolo_origem_saas(
     return row
 
 
+def aplicar_versao_alvo_origem_saas(
+    db: Session,
+    solicitacao_id: int,
+    versao_alvo: str | None,
+) -> SolicitacaoMelhoria | None:
+    """Espelha versao_alvo do control-plane na instância. Sem commit."""
+    versao = normalizar_versao_alvo(versao_alvo)
+    row = db.query(SolicitacaoMelhoria).filter(SolicitacaoMelhoria.id == solicitacao_id).first()
+    if not row:
+        return None
+    atual = normalizar_versao_alvo(row.versao_alvo)
+    if atual == versao:
+        return row
+    row.versao_alvo = versao
+    db.add(row)
+    db.flush()
+    return row
+
+
 def aplicar_comentario_origem_saas(
     db: Session,
     solicitacao_id: int,
@@ -449,6 +472,7 @@ def item_lista(row: SolicitacaoMelhoria, *, incluir_github: bool) -> Solicitacao
         titulo=row.titulo,
         status=row.status,
         status_rotulo=rotulo_status(row.status),
+        versao_alvo_rotulo=rotulo_versao_alvo_publica(row.status, row.versao_alvo),
         autor_nome=row.autor_nome,
         organizacao_id=row.organizacao_id,
         created_at=row.created_at,

--- a/backend/app/services/solicitacao_melhoria_copy.py
+++ b/backend/app/services/solicitacao_melhoria_copy.py
@@ -28,6 +28,23 @@ STATUS_FINAIS = frozenset({"concluida", "nao_sera_desenvolvida"})
 STATUS_VALIDOS = frozenset(STATUS_LABELS.keys())
 TIPOS_VALIDOS = frozenset({"sugestao", "problema"})
 
+# Transições permitidas na triagem (#953). Sync SaaS→instância aplica o status
+# já validado no control-plane (pode "saltar" se o pull atrasar).
+STATUS_TRANSICOES: dict[str, frozenset[str]] = {
+    "aberta": frozenset({"em_analise", "nao_sera_desenvolvida"}),
+    "em_analise": frozenset({"planejada", "nao_sera_desenvolvida"}),
+    "planejada": frozenset({"em_desenvolvimento", "nao_sera_desenvolvida"}),
+    "em_desenvolvimento": frozenset({"concluida", "nao_sera_desenvolvida"}),
+    "concluida": frozenset(),
+    "nao_sera_desenvolvida": frozenset(),
+}
+
+MSG_TRANSICAO_INVALIDA = "Transição de status não permitida"
+MSG_GITHUB_OBRIGATORIO = (
+    "Para marcar como em desenvolvimento, vincule ou crie uma issue no GitHub "
+    "(ação Implementar)."
+)
+
 # Fases para filtro rápido no painel ops (agrupa status)
 FASES_STATUS: dict[str, frozenset[str]] = {
     "aguardando": frozenset({"aberta", "em_analise", "planejada"}),
@@ -40,6 +57,44 @@ FASES_VALIDAS = frozenset(FASES_STATUS.keys())
 def status_da_fase(fase: str) -> frozenset[str] | None:
     key = (fase or "").strip().lower()
     return FASES_STATUS.get(key)
+
+
+def proximos_status(de: str) -> frozenset[str]:
+    return STATUS_TRANSICOES.get(de, frozenset())
+
+
+def validar_transicao_status(
+    de: str,
+    para: str,
+    *,
+    tem_vinculo_github: bool = False,
+    motivo_nao_desenvolvimento: str | None = None,
+) -> None:
+    """Rejeita saltos ilegais na triagem ops (#953 / #954). Idempotente se de==para."""
+    from fastapi import HTTPException
+
+    if para not in STATUS_VALIDOS:
+        raise HTTPException(status_code=400, detail="Status inválido")
+    if de == para:
+        if para == "nao_sera_desenvolvida" and not (motivo_nao_desenvolvimento or "").strip():
+            raise HTTPException(
+                status_code=400,
+                detail="Informe o motivo quando marcar como não será desenvolvida",
+            )
+        return
+    permitidos = STATUS_TRANSICOES.get(de)
+    if permitidos is None or para not in permitidos:
+        raise HTTPException(
+            status_code=400,
+            detail=f"{MSG_TRANSICAO_INVALIDA}: {rotulo_status(de)} → {rotulo_status(para)}",
+        )
+    if para == "nao_sera_desenvolvida" and not (motivo_nao_desenvolvimento or "").strip():
+        raise HTTPException(
+            status_code=400,
+            detail="Informe o motivo quando marcar como não será desenvolvida",
+        )
+    if para == "em_desenvolvimento" and not tem_vinculo_github:
+        raise HTTPException(status_code=400, detail=MSG_GITHUB_OBRIGATORIO)
 
 
 def mensagem_publica_status(status: str, *, motivo: str | None = None) -> str:

--- a/backend/app/services/solicitacao_melhoria_copy.py
+++ b/backend/app/services/solicitacao_melhoria_copy.py
@@ -114,12 +114,8 @@ def normalizar_versao_alvo(valor: str | None) -> str | None:
 
 
 def rotulo_versao_alvo_publica(status: str, versao: str | None) -> str | None:
-    """Rótulo amigável para Minhas solicitações (#955)."""
+    """Rótulo para Minhas solicitações — só quando concluída (#955)."""
     v = normalizar_versao_alvo(versao)
-    if not v:
+    if not v or status != "concluida":
         return None
-    if status == "concluida":
-        return f"Disponível na {v}"
-    if status in ("planejada", "em_desenvolvimento"):
-        return f"Prevista para {v}"
-    return None
+    return f"Disponível a partir da versão {v} (ou superior)"

--- a/backend/app/services/solicitacao_melhoria_copy.py
+++ b/backend/app/services/solicitacao_melhoria_copy.py
@@ -28,6 +28,19 @@ STATUS_FINAIS = frozenset({"concluida", "nao_sera_desenvolvida"})
 STATUS_VALIDOS = frozenset(STATUS_LABELS.keys())
 TIPOS_VALIDOS = frozenset({"sugestao", "problema"})
 
+# Fases para filtro rápido no painel ops (agrupa status)
+FASES_STATUS: dict[str, frozenset[str]] = {
+    "aguardando": frozenset({"aberta", "em_analise", "planejada"}),
+    "desenvolvimento": frozenset({"em_desenvolvimento"}),
+    "finalizadas": frozenset(STATUS_FINAIS),
+}
+FASES_VALIDAS = frozenset(FASES_STATUS.keys())
+
+
+def status_da_fase(fase: str) -> frozenset[str] | None:
+    key = (fase or "").strip().lower()
+    return FASES_STATUS.get(key)
+
 
 def mensagem_publica_status(status: str, *, motivo: str | None = None) -> str:
     base = STATUS_MENSAGENS.get(status, "O estado do seu pedido foi atualizado.")

--- a/backend/app/services/solicitacao_melhoria_copy.py
+++ b/backend/app/services/solicitacao_melhoria_copy.py
@@ -106,3 +106,20 @@ def mensagem_publica_status(status: str, *, motivo: str | None = None) -> str:
 
 def rotulo_status(status: str) -> str:
     return STATUS_LABELS.get(status, status.replace("_", " "))
+
+
+def normalizar_versao_alvo(valor: str | None) -> str | None:
+    v = (valor or "").strip()
+    return v[:64] if v else None
+
+
+def rotulo_versao_alvo_publica(status: str, versao: str | None) -> str | None:
+    """Rótulo amigável para Minhas solicitações (#955)."""
+    v = normalizar_versao_alvo(versao)
+    if not v:
+        return None
+    if status == "concluida":
+        return f"Disponível na {v}"
+    if status in ("planejada", "em_desenvolvimento"):
+        return f"Prevista para {v}"
+    return None

--- a/backend/scripts/concluir_solicitacoes_release.py
+++ b/backend/scripts/concluir_solicitacoes_release.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Marca solicitações citadas no release CalVer como concluídas (#956).
+
+Uso (control-plane, após migrate):
+  python scripts/concluir_solicitacoes_release.py --version 2026.08.26
+
+Lê bullets de ## [Unreleased] no CHANGELOG (antes do finalize no CI).
+Idempotente — re-run seguro.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS))
+
+from prepare_release import (  # noqa: E402
+    CHANGELOG_FILE,
+    MANIFEST_FILE,
+    parse_changelog_unreleased,
+)
+
+_BACKEND = Path(__file__).resolve().parents[1]
+if str(_BACKEND) not in sys.path:
+    sys.path.insert(0, str(_BACKEND))
+
+from app.config import settings  # noqa: E402
+from app.database import SessionLocal  # noqa: E402
+from app.services.saas_solicitacao_release import concluir_pedidos_release  # noqa: E402
+
+
+def _textos_release(versao: str) -> list[str]:
+    """Bullets do release: [Unreleased] (pré-finalize) ou manifest/CHANGELOG publicado."""
+    changelog = CHANGELOG_FILE.read_text(encoding="utf-8") if CHANGELOG_FILE.is_file() else ""
+    unreleased = parse_changelog_unreleased(changelog, warn_legacy=False)
+    if unreleased:
+        return [c["text"] for c in unreleased if c.get("text")]
+
+    if MANIFEST_FILE.is_file():
+        manifest = json.loads(MANIFEST_FILE.read_text(encoding="utf-8"))
+        for rel in reversed(manifest.get("releases") or []):
+            if rel.get("version") == versao:
+                out: list[str] = []
+                for ch in rel.get("changes") or []:
+                    if isinstance(ch, dict) and ch.get("text"):
+                        out.append(str(ch["text"]))
+                if out:
+                    return out
+
+    m = re.search(
+        rf"## \[{re.escape(versao)}\].*?(?=\n## \[|\Z)",
+        changelog,
+        re.DOTALL | re.IGNORECASE,
+    )
+    if m:
+        return [ln[2:].strip() for ln in m.group(0).splitlines() if ln.strip().startswith("- ")]
+    return []
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--version", required=True, help="Versão CalVer publicada")
+    ap.add_argument("--dry-run", action="store_true", help="Só lista referências, não grava")
+    args = ap.parse_args()
+
+    if not settings.SAAS_CONTROL_PLANE:
+        print("Skip: SAAS_CONTROL_PLANE=false (só roda no admin-center).")
+        return 0
+
+    textos = _textos_release(args.version)
+    if not textos:
+        print("Nenhum bullet em [Unreleased] — nada a concluir.")
+        return 0
+
+    if args.dry_run:
+        from app.services.saas_solicitacao_release import extrair_referencias_release
+
+        protocolos, issues = extrair_referencias_release(textos)
+        print(f"Protocolos: {sorted(protocolos)}")
+        print(f"Issues: {sorted(issues)}")
+        return 0
+
+    db = SessionLocal()
+    try:
+        stats = concluir_pedidos_release(db, versao=args.version, textos_changelog=textos)
+    finally:
+        db.close()
+
+    print(
+        f"Solicitações release {args.version}: "
+        f"processados={stats['processados']} concluidos={stats['concluidos']} "
+        f"ignorados={stats['ignorados']} erros={stats['erros']}"
+    )
+    if stats["erros"]:
+        print("::warning::Alguns pedidos não foram concluídos — ver logs do backend.", file=sys.stderr)
+    return 0 if stats["erros"] == 0 else 0  # não derruba deploy
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/mcp_deskrudder_saas.py
+++ b/backend/scripts/mcp_deskrudder_saas.py
@@ -110,6 +110,23 @@ TOOLS = [
         },
     },
     {
+        "name": "definir_versao_alvo",
+        "description": (
+            "Define versão CalVer prevista/liberada visível ao cliente (G3). "
+            "Só em planejada ou em_desenvolvimento. Comentário público opcional."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer", "minimum": 1},
+                "protocolo": {"type": "string"},
+                "slug": {"type": "string"},
+                "versao_alvo": {"type": "string", "description": "Ex.: 2026.08.26 — vazio para limpar"},
+                "comentario_publico": {"type": "string"},
+            },
+        },
+    },
+    {
         "name": "implementar",
         "description": (
             "A partir de planejada: cria ou liga issue GitHub e marca em_desenvolvimento. "
@@ -320,6 +337,15 @@ def call_tool(name: str, args: dict) -> object:
         if motivo:
             payload["motivo_nao_desenvolvimento"] = motivo
         _, body = _api("PATCH", f"/v1/saas/solicitacoes/{sid}/status", payload)
+        return body
+    if name == "definir_versao_alvo":
+        sid = _id_fila(args)
+        payload: dict[str, object] = {}
+        if "versao_alvo" in args:
+            payload["versao_alvo"] = (args.get("versao_alvo") or "").strip() or None
+        if args.get("comentario_publico"):
+            payload["comentario_publico"] = str(args["comentario_publico"])
+        _, body = _api("PATCH", f"/v1/saas/solicitacoes/{sid}/versao-alvo", payload)
         return body
     if name == "implementar":
         sid = _id_fila(args)

--- a/backend/scripts/mcp_deskrudder_saas.py
+++ b/backend/scripts/mcp_deskrudder_saas.py
@@ -110,23 +110,6 @@ TOOLS = [
         },
     },
     {
-        "name": "definir_versao_alvo",
-        "description": (
-            "Define versão CalVer prevista/liberada visível ao cliente (G3). "
-            "Só em planejada ou em_desenvolvimento. Comentário público opcional."
-        ),
-        "inputSchema": {
-            "type": "object",
-            "properties": {
-                "id": {"type": "integer", "minimum": 1},
-                "protocolo": {"type": "string"},
-                "slug": {"type": "string"},
-                "versao_alvo": {"type": "string", "description": "Ex.: 2026.08.26 — vazio para limpar"},
-                "comentario_publico": {"type": "string"},
-            },
-        },
-    },
-    {
         "name": "implementar",
         "description": (
             "A partir de planejada: cria ou liga issue GitHub e marca em_desenvolvimento. "
@@ -337,15 +320,6 @@ def call_tool(name: str, args: dict) -> object:
         if motivo:
             payload["motivo_nao_desenvolvimento"] = motivo
         _, body = _api("PATCH", f"/v1/saas/solicitacoes/{sid}/status", payload)
-        return body
-    if name == "definir_versao_alvo":
-        sid = _id_fila(args)
-        payload: dict[str, object] = {}
-        if "versao_alvo" in args:
-            payload["versao_alvo"] = (args.get("versao_alvo") or "").strip() or None
-        if args.get("comentario_publico"):
-            payload["comentario_publico"] = str(args["comentario_publico"])
-        _, body = _api("PATCH", f"/v1/saas/solicitacoes/{sid}/versao-alvo", payload)
         return body
     if name == "implementar":
         sid = _id_fila(args)

--- a/backend/scripts/mcp_deskrudder_saas.py
+++ b/backend/scripts/mcp_deskrudder_saas.py
@@ -91,9 +91,11 @@ TOOLS = [
     {
         "name": "alterar_status",
         "description": (
-            "Atualiza a triagem. O cliente vê o status em Minhas solicitações. "
-            "Valores: aberta, em_analise, planejada, em_desenvolvimento, concluida, nao_sera_desenvolvida. "
-            "nao_sera_desenvolvida exige motivo visível ao cliente, em português do Brasil."
+            "Atualiza a triagem com máquina de estados rígida. "
+            "Fluxo: aberta→em_analise→planejada→em_desenvolvimento→concluida; "
+            "de qualquer etapa (exceto finais) pode ir a nao_sera_desenvolvida (+ motivo). "
+            "em_desenvolvimento exige issue GitHub já ligada — preferir a tool implementar. "
+            "O cliente vê o status em Minhas solicitações (sem GitHub)."
         ),
         "inputSchema": {
             "type": "object",
@@ -105,6 +107,28 @@ TOOLS = [
                 "motivo_nao_desenvolvimento": {"type": "string"},
             },
             "required": ["status"],
+        },
+    },
+    {
+        "name": "implementar",
+        "description": (
+            "A partir de planejada: cria ou liga issue GitHub e marca em_desenvolvimento. "
+            "Passe github_issue_url (ou número) para ligar; senão cria via API GitHub "
+            "(GITHUB_TOKEN no control-plane). O cliente NÃO vê o GitHub."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer", "minimum": 1},
+                "protocolo": {"type": "string"},
+                "slug": {"type": "string"},
+                "github_issue_url": {"type": "string"},
+                "github_issue_number": {"type": "integer"},
+                "criar_issue": {
+                    "type": "boolean",
+                    "description": "Se true (padrão) e sem URL, cria a issue no GitHub",
+                },
+            },
         },
     },
     {
@@ -296,6 +320,17 @@ def call_tool(name: str, args: dict) -> object:
         if motivo:
             payload["motivo_nao_desenvolvimento"] = motivo
         _, body = _api("PATCH", f"/v1/saas/solicitacoes/{sid}/status", payload)
+        return body
+    if name == "implementar":
+        sid = _id_fila(args)
+        payload: dict[str, object] = {}
+        if args.get("github_issue_url"):
+            payload["github_issue_url"] = args["github_issue_url"]
+        if args.get("github_issue_number") is not None:
+            payload["github_issue_number"] = int(args["github_issue_number"])
+        if "criar_issue" in args:
+            payload["criar_issue"] = bool(args["criar_issue"])
+        _, body = _api("POST", f"/v1/saas/solicitacoes/{sid}/implementar", payload or None)
         return body
     if name == "comentar_solicitacao":
         sid = _id_fila(args)

--- a/backend/tests/test_chat_interno_api.py
+++ b/backend/tests/test_chat_interno_api.py
@@ -299,3 +299,42 @@ def test_vincular_setor_mostra_canal_na_inbox(client, seed_base, auth_headers, d
     assert r_un.status_code == 200, r_un.text
     inbox2 = client.get("/v1/chat-interno/conversas", headers=auth_headers["a1"]).json()
     assert not any(c["id"] == canal.id for c in inbox2 if c["tipo"] == "setor")
+
+
+def test_membros_canal_setor_lista_e_403(client, seed_base, auth_headers, db_session):
+    """#941 / #S202608-0008 — membros do canal + online; 403 fora do setor."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.services.presenca import PRESENCA_TTL_SEC
+
+    setor1 = seed_base["setor1"].id
+    setor2 = seed_base["setor2"].id
+    a1 = seed_base["a1"]
+    a1.presenca_heartbeat_em = datetime.now(timezone.utc)
+    db_session.add(a1)
+    db_session.commit()
+
+    r = client.get(f"/v1/chat-interno/setores/{setor1}/membros", headers=auth_headers["a1"])
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["setor_id"] == setor1
+    assert body["total"] >= 1
+    ids = {m["atendente_id"] for m in body["items"]}
+    assert a1.id in ids
+    me = next(m for m in body["items"] if m["atendente_id"] == a1.id)
+    assert me["online"] is True
+    assert body["online_count"] >= 1
+
+    a1.presenca_heartbeat_em = datetime.now(timezone.utc) - timedelta(seconds=PRESENCA_TTL_SEC + 30)
+    db_session.add(a1)
+    db_session.commit()
+    r2 = client.get(f"/v1/chat-interno/setores/{setor1}/membros", headers=auth_headers["a1"])
+    assert r2.status_code == 200
+    me2 = next(m for m in r2.json()["items"] if m["atendente_id"] == a1.id)
+    assert me2["online"] is False
+
+    r403 = client.get(f"/v1/chat-interno/setores/{setor2}/membros", headers=auth_headers["a1"])
+    assert r403.status_code == 403
+
+    r_admin = client.get(f"/v1/chat-interno/setores/{setor2}/membros", headers=auth_headers["admin"])
+    assert r_admin.status_code == 200

--- a/backend/tests/test_ponto_geofence.py
+++ b/backend/tests/test_ponto_geofence.py
@@ -1,13 +1,12 @@
-"""Testes de geofence e política de geo (#844)."""
-
-import pytest
+"""Testes de geofence e política de geo (#844 / #984)."""
 
 
-def _criar_local(client, headers, *, lat=-23.55052, lon=-46.633308, raio=500):
+def _criar_local(client, headers, atendente_id: int, *, lat=-23.55052, lon=-46.633308, raio=500):
     return client.post(
         "/v1/ponto/locais",
         headers=headers,
         json={
+            "atendente_id": atendente_id,
             "nome": "Matriz",
             "latitude": lat,
             "longitude": lon,
@@ -24,10 +23,24 @@ def _set_politica(client, headers, politica: str):
     )
 
 
+def _set_empresa_pin(client, headers, *, lat=-23.55052, lon=-46.633308, raio=200):
+    return client.put(
+        "/v1/settings/empresa-sistema",
+        headers=headers,
+        json={
+            "nome": "Empresa Teste",
+            "latitude": lat,
+            "longitude": lon,
+            "ponto_raio_metros": raio,
+        },
+    )
+
+
 def test_ponto_geofence_obrigatoria_dentro(client, seed_base, auth_headers):
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
-    assert _criar_local(client, admin).status_code == 201
+    a1_id = seed_base["a1"].id
+    assert _criar_local(client, admin, a1_id).status_code == 201
     assert _set_politica(client, admin, "obrigatoria").status_code == 200
 
     r = client.post(
@@ -46,7 +59,7 @@ def test_ponto_geofence_obrigatoria_dentro(client, seed_base, auth_headers):
 def test_ponto_geofence_obrigatoria_sem_geo(client, seed_base, auth_headers):
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
-    assert _criar_local(client, admin).status_code == 201
+    assert _criar_local(client, admin, seed_base["a1"].id).status_code == 201
     assert _set_politica(client, admin, "obrigatoria").status_code == 200
 
     r = client.post("/v1/ponto/bater", headers=user, json={"tipo": "entrada"})
@@ -57,7 +70,7 @@ def test_ponto_geofence_obrigatoria_sem_geo(client, seed_base, auth_headers):
 def test_ponto_geofence_obrigatoria_fora(client, seed_base, auth_headers):
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
-    assert _criar_local(client, admin, lat=-23.55, lon=-46.63, raio=100).status_code == 201
+    assert _criar_local(client, admin, seed_base["a1"].id, lat=-23.55, lon=-46.63, raio=100).status_code == 201
     assert _set_politica(client, admin, "obrigatoria").status_code == 200
 
     r = client.post(
@@ -72,7 +85,7 @@ def test_ponto_geofence_obrigatoria_fora(client, seed_base, auth_headers):
 def test_ponto_geofence_recomendada_fora_regista(client, seed_base, auth_headers):
     admin = auth_headers["admin"]
     user = auth_headers["a1"]
-    assert _criar_local(client, admin, lat=-23.55, lon=-46.63, raio=100).status_code == 201
+    assert _criar_local(client, admin, seed_base["a1"].id, lat=-23.55, lon=-46.63, raio=100).status_code == 201
     assert _set_politica(client, admin, "recomendada").status_code == 200
 
     r = client.post(
@@ -84,12 +97,78 @@ def test_ponto_geofence_recomendada_fora_regista(client, seed_base, auth_headers
     assert r.json()["fora_area"] is True
 
 
-def test_ponto_locais_crud(client, seed_base, auth_headers):
+def test_ponto_geofence_local_desativado_nao_conta(client, seed_base, auth_headers):
     admin = auth_headers["admin"]
-    r = _criar_local(client, admin)
+    user = auth_headers["a1"]
+    a1_id = seed_base["a1"].id
+    r = _criar_local(client, admin, a1_id, lat=-23.55, lon=-46.63, raio=100)
     assert r.status_code == 201
     local_id = r.json()["id"]
-    lst = client.get("/v1/ponto/locais", headers=admin)
+    assert client.patch(
+        f"/v1/ponto/locais/{local_id}",
+        headers=admin,
+        json={"ativo": False},
+    ).status_code == 200
+    assert _set_politica(client, admin, "obrigatoria").status_code == 200
+    # Sem locais ativos: política obrigatória não bloqueia (igual a sem locais).
+    r_bat = client.post(
+        "/v1/ponto/bater",
+        headers=user,
+        json={"tipo": "entrada", "latitude": -23.55, "longitude": -46.63},
+    )
+    assert r_bat.status_code == 200, r_bat.text
+
+
+def test_ponto_geofence_empresa_pin(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    assert _set_empresa_pin(client, admin, lat=-23.55, lon=-46.63, raio=150).status_code == 200
+    assert _set_politica(client, admin, "obrigatoria").status_code == 200
+    # usar_local_empresa default true
+    r = client.post(
+        "/v1/ponto/bater",
+        headers=user,
+        json={"tipo": "entrada", "latitude": -23.5501, "longitude": -46.6301},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["fora_area"] is False
+
+
+def test_ponto_geofence_orfao_nao_conta(client, seed_base, auth_headers, db_session):
+    """Locais sem atendente_id (legado) não entram no geofence."""
+    from app.models.ponto_settings import PontoLocal
+
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    row = PontoLocal(
+        tenant_id=seed_base["a1"].tenant_id,
+        atendente_id=None,
+        nome="Legado",
+        latitude=-23.55,
+        longitude=-46.63,
+        raio_metros=500,
+        ativo=True,
+    )
+    db_session.add(row)
+    db_session.commit()
+    assert _set_politica(client, admin, "obrigatoria").status_code == 200
+    r = client.post(
+        "/v1/ponto/bater",
+        headers=user,
+        json={"tipo": "entrada", "latitude": -23.55, "longitude": -46.63},
+    )
+    # Sem locais do atendente: não bloqueia por geofence.
+    assert r.status_code == 200, r.text
+
+
+def test_ponto_locais_crud(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1_id = seed_base["a1"].id
+    r = _criar_local(client, admin, a1_id)
+    assert r.status_code == 201
+    local_id = r.json()["id"]
+    assert r.json()["atendente_id"] == a1_id
+    lst = client.get(f"/v1/ponto/locais?atendente_id={a1_id}", headers=admin)
     assert lst.status_code == 200
     assert any(x["id"] == local_id for x in lst.json())
     r_up = client.patch(
@@ -111,6 +190,11 @@ def test_ponto_me_settings(client, seed_base, auth_headers):
     body = r.json()
     assert body["politica_geolocalizacao"] == "recomendada"
     assert body["tem_locais_ativos"] is False
+
+    assert _criar_local(client, admin, seed_base["a1"].id).status_code == 201
+    r2 = client.get("/v1/ponto/me/settings", headers=auth_headers["a1"])
+    assert r2.status_code == 200
+    assert r2.json()["tem_locais_ativos"] is True
 
 
 def test_ponto_export_pdf_xlsx(client, seed_base, auth_headers, monkeypatch):

--- a/backend/tests/test_ponto_he_whatsapp_965.py
+++ b/backend/tests/test_ponto_he_whatsapp_965.py
@@ -1,0 +1,115 @@
+"""Bloqueio de pegar WhatsApp após jornada + HE admin (#965)."""
+
+from datetime import date, datetime, timedelta
+
+from app.services.escala import PONTO_TZ
+
+
+def _patch_jornada_semanal(client, headers, atendente_id: int, *, fim="12:00"):
+    """Grade só hoje com saída no passado (fim cedo) para forçar fora da jornada."""
+    keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    hoje_key = keys[date.today().weekday()]
+    hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
+    hs[hoje_key] = {"ativo": True, "inicio": "06:00", "fim": fim}
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={
+            "modo_jornada": "semanal",
+            "usa_escala": True,
+            "horario_semana": hs,
+            "tolerancia_atraso_minutos": 0,
+        },
+    )
+
+
+def _criar_chat_fila(db_session, seed_base, *, wa_suffix: str):
+    from app.models.whatsapp_chat import WhatsappChat
+
+    chat = WhatsappChat(
+        wa_id=f"551199999{wa_suffix}",
+        protocolo=f"WPP-TEST-965-{wa_suffix}",
+        estado="aguardando_atendente",
+        setor_id=seed_base["setor1"].id,
+    )
+    db_session.add(chat)
+    db_session.commit()
+    db_session.refresh(chat)
+    return chat.id
+
+
+def test_assumir_bloqueado_apos_jornada(client, seed_base, auth_headers, db_session):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    fim = (datetime.now(PONTO_TZ) - timedelta(hours=1)).strftime("%H:%M")
+    r_patch = _patch_jornada_semanal(client, admin, a1.id, fim=fim)
+    assert r_patch.status_code == 200, r_patch.text
+    chat_id = _criar_chat_fila(db_session, seed_base, wa_suffix="650")
+    r = client.post(f"/v1/whatsapp/chats/{chat_id}/assumir", headers=user)
+    assert r.status_code == 403, r.text
+    assert "jornada" in r.json()["detail"].lower()
+    pend = client.get("/v1/ponto/hora-extra?estado=pendente", headers=admin)
+    assert pend.status_code == 200
+    assert any(x["atendente_id"] == a1.id for x in pend.json())
+
+
+def test_assumir_ok_com_he(client, seed_base, auth_headers, db_session):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    fim = (datetime.now(PONTO_TZ) - timedelta(hours=1)).strftime("%H:%M")
+    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    chat_id = _criar_chat_fila(db_session, seed_base, wa_suffix="651")
+    assert client.post(f"/v1/whatsapp/chats/{chat_id}/assumir", headers=user).status_code == 403
+    pend = client.get("/v1/ponto/hora-extra?estado=pendente", headers=admin).json()
+    he_id = next(x["id"] for x in pend if x["atendente_id"] == a1.id)
+    dec = client.post(
+        f"/v1/ponto/hora-extra/{he_id}/decidir",
+        headers=admin,
+        json={"aprovar": True, "modo": "resto_do_dia"},
+    )
+    assert dec.status_code == 200, dec.text
+    assert dec.json()["estado"] == "aprovada"
+    chat_id2 = _criar_chat_fila(db_session, seed_base, wa_suffix="652")
+    r = client.post(f"/v1/whatsapp/chats/{chat_id2}/assumir", headers=user)
+    assert r.status_code == 200, r.text
+
+
+def test_assumir_ok_modo_nenhum(client, seed_base, auth_headers, db_session):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"modo_jornada": "nenhum", "usa_escala": False},
+    ).status_code == 200
+    chat_id = _criar_chat_fila(db_session, seed_base, wa_suffix="653")
+    r = client.post(f"/v1/whatsapp/chats/{chat_id}/assumir", headers=user)
+    assert r.status_code == 200, r.text
+
+
+def test_he_rejeitada(client, seed_base, auth_headers, db_session):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    fim = (datetime.now(PONTO_TZ) - timedelta(hours=2)).strftime("%H:%M")
+    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    sol = client.post(
+        "/v1/ponto/hora-extra",
+        headers=user,
+        json={"motivo": "Pico de demanda"},
+    )
+    assert sol.status_code == 201, sol.text
+    he_id = sol.json()["id"]
+    dec = client.post(
+        f"/v1/ponto/hora-extra/{he_id}/decidir",
+        headers=admin,
+        json={"aprovar": False, "decisao_motivo": "Sem necessidade"},
+    )
+    assert dec.status_code == 200
+    assert dec.json()["estado"] == "rejeitada"
+    st = client.get("/v1/ponto/hora-extra/me/status", headers=user)
+    assert st.status_code == 200
+    assert st.json()["pode_pegar_whatsapp"] is False

--- a/backend/tests/test_ponto_jornada_959.py
+++ b/backend/tests/test_ponto_jornada_959.py
@@ -1,0 +1,150 @@
+"""Ponto jornada semanal, janela de entrada e fecho por esquecimento (#959 Lote A)."""
+
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.ponto_batida import PontoBatida
+from app.services import escala as escala_svc
+from app.services import ponto as ponto_svc
+from app.services.ponto import _atrasado_entrada
+from app.services.ponto_settings import get_or_create_settings, processar_fecho_automatico
+
+TZ = ZoneInfo("America/Sao_Paulo")
+
+HS_SEG_SEX = {
+    "seg": {"ativo": True, "inicio": "08:00", "fim": "18:00"},
+    "ter": {"ativo": True, "inicio": "08:00", "fim": "18:00"},
+    "qua": {"ativo": True, "inicio": "08:00", "fim": "18:00"},
+    "qui": {"ativo": True, "inicio": "08:00", "fim": "18:00"},
+    "sex": {"ativo": True, "inicio": "08:00", "fim": "17:00"},
+    "sab": {"ativo": False, "inicio": "08:00", "fim": "12:00"},
+    "dom": {"ativo": False, "inicio": "08:00", "fim": "12:00"},
+}
+
+
+def test_jornada_semanal_seg_sex_e_modo_nenhum(client, seed_base, auth_headers, db_session):
+    a1 = seed_base["a1"]
+    r = client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=auth_headers["admin"],
+        json={"modo_jornada": "semanal", "horario_semana": HS_SEG_SEX, "tolerancia_atraso_minutos": 15},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["modo_jornada"] == "semanal"
+    assert body["usa_escala"] is True
+    assert body["horario_semana"]["sex"]["fim"] == "17:00"
+
+    db_session.expire_all()
+    db_session.refresh(a1)
+    assert escala_svc.eh_dia_de_trabalho(a1, date(2026, 8, 26)) is True  # qua
+    assert escala_svc.eh_dia_de_trabalho(a1, date(2026, 8, 29)) is False  # sáb
+    assert escala_svc.eh_dia_de_trabalho(a1, date(2026, 8, 30)) is False  # dom
+
+    r2 = client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=auth_headers["admin"],
+        json={"modo_jornada": "nenhum"},
+    )
+    assert r2.status_code == 200
+    db_session.expire_all()
+    db_session.refresh(a1)
+    assert escala_svc.escala_configurada(a1) is False
+    cal = client.get(
+        "/v1/ponto/me/calendario",
+        headers=auth_headers["a1"],
+        params={"ano": 2026, "mes": 8},
+    )
+    assert cal.status_code == 200
+    dia = next(d for d in cal.json()["dias"] if d["data"] == "2026-08-26")
+    assert dia["status"] == "livre"
+
+
+def test_entrada_janela_e_atraso_na_tolerancia(client, seed_base, auth_headers, db_session):
+    a1 = seed_base["a1"]
+    a1.modo_jornada = "semanal"
+    a1.usa_escala = True
+    a1.tolerancia_atraso_minutos = 15
+    a1.horario_semana_json = json.dumps(HS_SEG_SEX, ensure_ascii=False)
+    db_session.flush()
+
+    early = datetime(2026, 8, 26, 7, 0, tzinfo=TZ)
+    with pytest.raises(HTTPException) as ei:
+        escala_svc.validar_janela_entrada(a1, early)
+    assert ei.value.status_code == 400
+
+    escala_svc.validar_janela_entrada(a1, datetime(2026, 8, 26, 7, 50, tzinfo=TZ))
+
+    bat_ok = PontoBatida(
+        tenant_id=a1.tenant_id,
+        atendente_id=a1.id,
+        tipo="entrada",
+        registrado_em=datetime(2026, 8, 26, 8, 10, tzinfo=TZ),
+        origem="admin",
+        anulada=False,
+    )
+    assert _atrasado_entrada(a1, bat_ok) is False
+
+    bat_late = PontoBatida(
+        tenant_id=a1.tenant_id,
+        atendente_id=a1.id,
+        tipo="entrada",
+        registrado_em=datetime(2026, 8, 26, 8, 20, tzinfo=TZ),
+        origem="admin",
+        anulada=False,
+    )
+    assert _atrasado_entrada(a1, bat_late) is True
+
+
+def test_fecho_por_saida_prevista(client, seed_base, auth_headers, db_session):
+    a1 = seed_base["a1"]
+    agora_local = datetime.now(TZ)
+    fim_dt = agora_local - timedelta(minutes=45)
+    ini_dt = agora_local - timedelta(hours=8)
+    ini = ini_dt.strftime("%H:%M")
+    fim = fim_dt.strftime("%H:%M")
+    if ini >= fim:
+        ini = "00:00"
+        fim = "00:15"
+        ini_dt = agora_local.replace(hour=0, minute=0, second=0, microsecond=0)
+        # se ainda estamos antes de 00:15, força fim no passado relativo
+        if agora_local.hour == 0 and agora_local.minute < 15:
+            fim = "00:01"
+
+    weekday_keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    k = weekday_keys[agora_local.weekday()]
+    hs = {d: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for d in weekday_keys}
+    hs[k] = {"ativo": True, "inicio": ini, "fim": fim}
+
+    a1.modo_jornada = "semanal"
+    a1.usa_escala = True
+    a1.tolerancia_atraso_minutos = 0
+    a1.horario_semana_json = json.dumps(hs, ensure_ascii=False)
+
+    st = get_or_create_settings(db_session, a1.tenant_id)
+    st.fecho_automatico_ativo = True
+    st.fecho_apos_horas = 48
+    st.fecho_margem_pos_saida_minutos = 0
+    db_session.flush()
+
+    ponto_svc.bater(
+        db_session,
+        a1,
+        "entrada",
+        origem="admin",
+        registrado_em=ini_dt,
+        commit=False,
+    )
+    db_session.flush()
+
+    n = processar_fecho_automatico(db_session, limit=10)
+    assert n >= 1
+    db_session.commit()
+    me = client.get("/v1/ponto/me", headers=auth_headers["a1"])
+    assert me.json()["em_jornada"] is False

--- a/backend/tests/test_saas_catalogo.py
+++ b/backend/tests/test_saas_catalogo.py
@@ -154,3 +154,142 @@ def test_planos_modulos_crud_e_licenca(client, auth_headers, db_session, monkeyp
     desativar_mod = client.post(f"/v1/saas/modulos/{mid}/desativar", headers=h)
     assert desativar_mod.status_code == 200
     assert desativar_mod.json()["ativo"] is False
+
+
+def test_plano_preco_soma_modulos_e_mix_licenca(client, auth_headers, db_session, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    h = auth_headers["ops"]
+    seed = _seed_catalogo(db_session)
+
+    # Preço no módulo recalcula planos que o usam
+    patch_mod = client.patch(
+        f"/v1/saas/modulos/{seed['helpdesk'].id}",
+        headers=h,
+        json={"preco_mensal": 100},
+    )
+    assert patch_mod.status_code == 200, patch_mod.text
+    assert float(patch_mod.json()["preco_mensal"]) == 100.0
+
+    client.patch(
+        f"/v1/saas/modulos/{seed['boletos'].id}",
+        headers=h,
+        json={"preco_mensal": 50},
+    )
+    client.patch(
+        f"/v1/saas/modulos/{seed['contratos'].id}",
+        headers=h,
+        json={"preco_mensal": 80},
+    )
+
+    criado = client.post(
+        "/v1/saas/planos",
+        headers=h,
+        json={
+            "codigo": "essencial-test",
+            "nome": "Essencial Test",
+            "ordem": 15,
+            "usuarios_inclusos": 3,
+            "preco_usuario_extra": 10,
+            "modulo_ids": [seed["helpdesk"].id, seed["boletos"].id],
+        },
+    )
+    assert criado.status_code == 201, criado.text
+    body = criado.json()
+    assert float(body["preco_mensal"]) == 150.0
+    assert body["usuarios_inclusos"] == 3
+    assert float(body["preco_usuario_extra"]) == 10.0
+    assert body["max_postos"] is None
+
+    # Mix: plano essencial + módulo enterprise (contratos)
+    lic = client.post(
+        "/v1/saas/clientes",
+        headers=h,
+        json={
+            "nome": "Mix Co",
+            "slug": "mix-co",
+            "status": "ativo",
+            "data_inicio": str(date.today()),
+            "plano_id": body["id"],
+            "modulo_ids": [
+                seed["helpdesk"].id,
+                seed["boletos"].id,
+                seed["contratos"].id,
+            ],
+            "usuarios_contratados": 5,
+        },
+    )
+    assert lic.status_code == 201, lic.text
+    lic_body = lic.json()
+    assert set(lic_body["modulos_snapshot"]) == {"helpdesk", "boletos", "contratos"}
+    assert lic_body["max_usuarios"] == 5
+    # 100+50+80 módulos + 2 extras * 10
+    assert float(lic_body["preco_modulos"]) == 230.0
+    assert float(lic_body["preco_usuarios_extra"]) == 20.0
+    assert float(lic_body["preco_mensal_estimado"]) == 250.0
+    assert len(lic_body["modulos_contratados"]) == 3
+
+    # Valor negociado sobrescreve a estimativa na ficha comercial
+    neg = client.patch(
+        f"/v1/saas/clientes/{lic_body['id']}",
+        headers=h,
+        json={"preco_mensal_negociado": 199},
+    )
+    assert neg.status_code == 200, neg.text
+    assert float(neg.json()["preco_mensal_negociado"]) == 199.0
+    assert float(neg.json()["preco_mensal_estimado"]) == 250.0
+    assert float(neg.json()["preco_mensal_efetivo"]) == 199.0
+
+    limpa = client.patch(
+        f"/v1/saas/clientes/{lic_body['id']}",
+        headers=h,
+        json={"preco_mensal_negociado": None},
+    )
+    assert limpa.status_code == 200
+    assert limpa.json()["preco_mensal_negociado"] is None
+    assert float(limpa.json()["preco_mensal_efetivo"]) == 250.0
+
+
+def test_plano_preco_e_max_usuarios_sem_postos(client, auth_headers, db_session, monkeypatch):
+    """Compat: max_usuarios ainda pode ser setado no plano; preço vem dos módulos."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    h = auth_headers["ops"]
+    seed = _seed_catalogo(db_session)
+
+    client.patch(
+        f"/v1/saas/modulos/{seed['helpdesk'].id}",
+        headers=h,
+        json={"preco_mensal": 397},
+    )
+
+    criado = client.post(
+        "/v1/saas/planos",
+        headers=h,
+        json={
+            "codigo": "essencial-legacy",
+            "nome": "Essencial Legacy",
+            "ordem": 15,
+            "max_usuarios": 8,
+            "modulo_ids": [seed["helpdesk"].id],
+        },
+    )
+    assert criado.status_code == 201, criado.text
+    body = criado.json()
+    assert float(body["preco_mensal"]) == 397.0
+    assert body["max_usuarios"] == 8
+    assert body["max_postos"] is None
+
+    limpo = client.patch(
+        f"/v1/saas/planos/{body['id']}",
+        headers=h,
+        json={"max_usuarios": 20, "usuarios_inclusos": 5, "preco_usuario_extra": 12},
+    )
+    assert limpo.status_code == 200, limpo.text
+    assert limpo.json()["max_postos"] is None
+    assert limpo.json()["max_usuarios"] == 20
+    assert limpo.json()["usuarios_inclusos"] == 5
+    assert float(limpo.json()["preco_usuario_extra"]) == 12.0
+    assert float(limpo.json()["preco_mensal"]) == 397.0

--- a/backend/tests/test_saas_licenca_completa.py
+++ b/backend/tests/test_saas_licenca_completa.py
@@ -58,7 +58,8 @@ def test_plano_preco_limites_e_snapshot(client, auth_headers, db_session, monkey
     assert r.status_code == 201, r.text
     body = r.json()
     assert sorted(body.get("modulos_snapshot") or []) == ["helpdesk", "whatsapp"]
-    assert body["max_postos"] == 10
+    # Sem teto de postos na licença (só usuários do plano / contratados)
+    assert body["max_postos"] is None
     assert body["max_usuarios"] == 5
     assert body["plano"] == "Pro Licença"
 
@@ -100,4 +101,5 @@ def test_converter_lead_com_plano_id(client, auth_headers, db_session, monkeypat
     body = conv.json()
     assert body["plano_id"] == plano.id
     assert sorted(body.get("modulos_snapshot") or []) == ["helpdesk", "whatsapp"]
-    assert body["max_postos"] == 3
+    assert body["max_postos"] is None
+    assert body["max_usuarios"] == 2

--- a/backend/tests/test_saas_ops_conta_perfil.py
+++ b/backend/tests/test_saas_ops_conta_perfil.py
@@ -1,0 +1,63 @@
+"""Perfil da conta ops (nome / e-mail) em Minha conta."""
+
+from __future__ import annotations
+
+
+def test_saas_me_atualizar_nome_e_email(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    h = auth_headers["ops"]
+
+    nome = client.patch("/v1/saas/me", headers=h, json={"nome": "Ops Renomeado"})
+    assert nome.status_code == 200, nome.text
+    assert nome.json()["nome"] == "Ops Renomeado"
+    assert nome.json()["access_token"] is None
+
+    novo_email = "ops.renomeado@test.local"
+    email = client.patch("/v1/saas/me", headers=h, json={"email": novo_email})
+    assert email.status_code == 200, email.text
+    assert email.json()["email"] == novo_email
+    assert email.json()["access_token"]
+    assert email.json()["refresh_token"]
+
+    # Token antigo (sub = e-mail anterior) deixa de valer
+    stale = client.get("/v1/saas/me/mcp-token", headers=h)
+    assert stale.status_code == 401
+
+    h_novo = {
+        "Authorization": f"Bearer {email.json()['access_token']}",
+        "X-Dx-Tenant-Id": "1",
+    }
+    ok = client.get("/v1/saas/me/mcp-token", headers=h_novo)
+    assert ok.status_code == 200, ok.text
+
+    me = client.get("/v1/atendentes/me", headers=h_novo)
+    assert me.status_code == 200
+    assert me.json()["email"] == novo_email
+    assert me.json()["nome"] == "Ops Renomeado"
+
+
+def test_saas_me_email_duplicado(client, seed_base, auth_headers, db_session, monkeypatch):
+    from app.config import settings
+    from app.core.security import hash_senha
+    from app.models.atendente import Atendente
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    outro = Atendente(
+        tenant_id=seed_base["tenant"].id,
+        email="ops.outro@test.local",
+        nome="Outro",
+        senha_hash=hash_senha("ops123456"),
+        role="saas_ops",
+        ativo=True,
+    )
+    db_session.add(outro)
+    db_session.commit()
+
+    r = client.patch(
+        "/v1/saas/me",
+        headers=auth_headers["ops"],
+        json={"email": "ops.outro@test.local"},
+    )
+    assert r.status_code == 400

--- a/backend/tests/test_saas_setores.py
+++ b/backend/tests/test_saas_setores.py
@@ -1,0 +1,88 @@
+"""Setores (cargos) da equipe SaaS + vínculo N:N com usuários ops."""
+
+from __future__ import annotations
+
+from app.core.security import criar_access_token
+
+
+def _headers_ops(email: str) -> dict[str, str]:
+    tok = criar_access_token({"sub": email, "tid": 1})
+    return {"Authorization": f"Bearer {tok}", "X-Dx-Tenant-Id": "1"}
+
+
+def test_saas_setores_crud_e_vinculo_multiplo(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+
+    assert client.get("/v1/saas/setores", headers=auth_headers["admin"]).status_code == 403
+
+    a = client.post("/v1/saas/setores", headers=auth_headers["ops"], json={"nome": "  Admin  "})
+    assert a.status_code == 201, a.text
+    assert a.json()["nome"] == "Admin"
+
+    d = client.post("/v1/saas/setores", headers=auth_headers["ops"], json={"nome": "Desenvolvimento"})
+    assert d.status_code == 201, d.text
+    c = client.post("/v1/saas/setores", headers=auth_headers["ops"], json={"nome": "Comercial"})
+    assert c.status_code == 201, c.text
+
+    dup = client.post("/v1/saas/setores", headers=auth_headers["ops"], json={"nome": "admin"})
+    assert dup.status_code == 400
+
+    lista = client.get("/v1/saas/setores", headers=auth_headers["ops"])
+    assert lista.status_code == 200
+    nomes = [x["nome"] for x in lista.json()]
+    assert nomes == sorted(nomes)
+    assert "Admin" in nomes
+
+    criado = client.post(
+        "/v1/saas/usuarios",
+        headers=auth_headers["ops"],
+        json={
+            "nome": "Luis Multi",
+            "email": "luis.multi@test.local",
+            "setor_ids": [a.json()["id"], d.json()["id"]],
+        },
+    )
+    assert criado.status_code == 201, criado.text
+    body = criado.json()
+    assert sorted(body["setor_ids"]) == sorted([a.json()["id"], d.json()["id"]])
+    assert {s["nome"] for s in body["setores"]} == {"Admin", "Desenvolvimento"}
+
+    patch = client.patch(
+        f"/v1/saas/usuarios/{body['id']}",
+        headers=auth_headers["ops"],
+        json={"setor_ids": [c.json()["id"], a.json()["id"]]},
+    )
+    assert patch.status_code == 200, patch.text
+    assert {s["nome"] for s in patch.json()["setores"]} == {"Admin", "Comercial"}
+
+    login = client.post(
+        "/v1/auth/login",
+        json={"email": body["email"], "senha": body["senha_temporaria"]},
+    )
+    assert login.status_code == 200
+    me = client.get("/v1/atendentes/me", headers=_headers_ops(body["email"]))
+    assert me.status_code == 200, me.text
+    assert set(me.json()["saas_setor_nomes"]) == {"Admin", "Comercial"}
+
+
+def test_saas_setores_inativo_nao_vincula(client, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    s = client.post("/v1/saas/setores", headers=auth_headers["ops"], json={"nome": "Temporário"}).json()
+    off = client.patch(
+        f"/v1/saas/setores/{s['id']}",
+        headers=auth_headers["ops"],
+        json={"ativo": False},
+    )
+    assert off.status_code == 200
+    assert off.json()["ativo"] is False
+
+    bad = client.post(
+        "/v1/saas/usuarios",
+        headers=auth_headers["ops"],
+        json={"nome": "X", "email": "x.setores@test.local", "setor_ids": [s["id"]]},
+    )
+    assert bad.status_code == 400

--- a/backend/tests/test_saas_solicitacoes.py
+++ b/backend/tests/test_saas_solicitacoes.py
@@ -956,7 +956,8 @@ def test_implementar_cria_issue_quando_configurado(client, seed_base, auth_heade
     assert cliente.get("github_issue_url") in (None, "")
 
 
-def test_definir_versao_alvo_sync_cliente(client, seed_base, auth_headers, monkeypatch):
+def test_versao_alvo_rotulo_so_apos_release(client, seed_base, auth_headers, monkeypatch):
+    """Versão só aparece ao cliente quando concluída (G4), não em planejada."""
     from app.config import settings
 
     monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
@@ -966,37 +967,12 @@ def test_definir_versao_alvo_sync_cliente(client, seed_base, auth_headers, monke
     saas_id = _saas_id_de_origem(client, h, sid)
     _avancar_status(client, h, saas_id, "em_analise", "planejada")
 
-    ok = client.patch(
-        f"/v1/saas/solicitacoes/{saas_id}/versao-alvo",
-        headers=h,
-        json={"versao_alvo": "2026.09.01", "comentario_publico": "Entra na próxima versão."},
-    )
-    assert ok.status_code == 200, ok.text
-    assert ok.json()["versao_alvo"] == "2026.09.01"
-
     minhas = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["a1"]).json()
-    assert minhas["versao_alvo"] == "2026.09.01"
-    assert minhas["versao_alvo_rotulo"] == "Prevista para 2026.09.01"
-    assert any("próxima versão" in c["corpo"] for c in minhas["comentarios"])
+    assert minhas.get("versao_alvo_rotulo") in (None, "")
 
-    client.post(
-        f"/v1/saas/solicitacoes/{saas_id}/implementar",
-        headers=h,
-        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/9551"},
-    )
-    ok2 = client.patch(
+    inexistente = client.patch(
         f"/v1/saas/solicitacoes/{saas_id}/versao-alvo",
-        headers=h,
-        json={"versao_alvo": "2026.10.01"},
-    )
-    assert ok2.status_code == 200
-    assert ok2.json()["versao_alvo"] == "2026.10.01"
-
-    sid2 = _criar_solicitacao(client, auth_headers["a1"]).json()["id"]
-    saas_aberta = _saas_id_de_origem(client, h, sid2)
-    bloq = client.patch(
-        f"/v1/saas/solicitacoes/{saas_aberta}/versao-alvo",
         headers=h,
         json={"versao_alvo": "2026.09.01"},
     )
-    assert bloq.status_code == 400
+    assert inexistente.status_code == 404

--- a/backend/tests/test_saas_solicitacoes.py
+++ b/backend/tests/test_saas_solicitacoes.py
@@ -954,3 +954,49 @@ def test_implementar_cria_issue_quando_configurado(client, seed_base, auth_heade
     assert r.json()["github_issue_number"] == 4242
     cliente = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["a1"]).json()
     assert cliente.get("github_issue_url") in (None, "")
+
+
+def test_definir_versao_alvo_sync_cliente(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
+    sid = _criar_solicitacao(client, auth_headers["a1"]).json()["id"]
+    h = auth_headers["ops"]
+    saas_id = _saas_id_de_origem(client, h, sid)
+    _avancar_status(client, h, saas_id, "em_analise", "planejada")
+
+    ok = client.patch(
+        f"/v1/saas/solicitacoes/{saas_id}/versao-alvo",
+        headers=h,
+        json={"versao_alvo": "2026.09.01", "comentario_publico": "Entra na próxima versão."},
+    )
+    assert ok.status_code == 200, ok.text
+    assert ok.json()["versao_alvo"] == "2026.09.01"
+
+    minhas = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["a1"]).json()
+    assert minhas["versao_alvo"] == "2026.09.01"
+    assert minhas["versao_alvo_rotulo"] == "Prevista para 2026.09.01"
+    assert any("próxima versão" in c["corpo"] for c in minhas["comentarios"])
+
+    client.post(
+        f"/v1/saas/solicitacoes/{saas_id}/implementar",
+        headers=h,
+        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/9551"},
+    )
+    ok2 = client.patch(
+        f"/v1/saas/solicitacoes/{saas_id}/versao-alvo",
+        headers=h,
+        json={"versao_alvo": "2026.10.01"},
+    )
+    assert ok2.status_code == 200
+    assert ok2.json()["versao_alvo"] == "2026.10.01"
+
+    sid2 = _criar_solicitacao(client, auth_headers["a1"]).json()["id"]
+    saas_aberta = _saas_id_de_origem(client, h, sid2)
+    bloq = client.patch(
+        f"/v1/saas/solicitacoes/{saas_aberta}/versao-alvo",
+        headers=h,
+        json={"versao_alvo": "2026.09.01"},
+    )
+    assert bloq.status_code == 400

--- a/backend/tests/test_saas_solicitacoes.py
+++ b/backend/tests/test_saas_solicitacoes.py
@@ -747,4 +747,62 @@ def test_vincular_pedidos_iguais_peso_e_nao_vaza_ao_cliente(client, seed_base, a
     assert len(gone.json()["grupo"]) == 1
 
 
+def test_fila_filtro_fase_tipo_e_resumo(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
+    h = auth_headers["ops"]
+
+    sid_sug = _criar_solicitacao(client, auth_headers["a1"]).json()["id"]
+    sid_err = _criar_solicitacao(
+        client,
+        auth_headers["a1"],
+        tipo="problema",
+        titulo="Erro ao abrir o chat",
+        descricao="O chat interno trava ao carregar a lista de conversas.",
+    ).json()["id"]
+
+    lista = client.get("/v1/saas/solicitacoes", headers=h).json()["items"]
+    saas_sug = next(i["id"] for i in lista if i["origem_solicitacao_id"] == sid_sug)
+    saas_err = next(i["id"] for i in lista if i["origem_solicitacao_id"] == sid_err)
+
+    client.patch(
+        f"/v1/saas/solicitacoes/{saas_sug}/status",
+        headers=h,
+        json={"status": "em_desenvolvimento"},
+    )
+    client.patch(
+        f"/v1/saas/solicitacoes/{saas_err}/status",
+        headers=h,
+        json={"status": "concluida"},
+    )
+
+    aguardando = client.get("/v1/saas/solicitacoes?fase=aguardando", headers=h)
+    assert aguardando.status_code == 200
+    ids_ag = {i["id"] for i in aguardando.json()["items"]}
+    assert saas_sug not in ids_ag
+    assert saas_err not in ids_ag
+
+    dev = client.get("/v1/saas/solicitacoes?fase=desenvolvimento", headers=h)
+    assert {i["id"] for i in dev.json()["items"]} >= {saas_sug}
+
+    fin = client.get("/v1/saas/solicitacoes?fase=finalizadas", headers=h)
+    assert {i["id"] for i in fin.json()["items"]} >= {saas_err}
+
+    so_erro = client.get("/v1/saas/solicitacoes?tipo=problema", headers=h)
+    assert all(i["tipo"] == "problema" for i in so_erro.json()["items"])
+    assert saas_err in {i["id"] for i in so_erro.json()["items"]}
+
+    resumo = client.get("/v1/saas/solicitacoes/resumo", headers=h)
+    assert resumo.status_code == 200, resumo.text
+    body = resumo.json()
+    assert body["total"] >= 2
+    assert body["sugestoes"] >= 1
+    assert body["problemas"] >= 1
+    assert body["desenvolvimento"] >= 1
+    assert body["finalizadas"] >= 1
+
+    bad = client.get("/v1/saas/solicitacoes?fase=xyz", headers=h)
+    assert bad.status_code == 400
 

--- a/backend/tests/test_saas_solicitacoes.py
+++ b/backend/tests/test_saas_solicitacoes.py
@@ -18,6 +18,25 @@ def _criar_solicitacao(client, headers, **kw):
     return client.post("/v1/solicitacoes-melhoria", headers=headers, json=body)
 
 
+def _saas_id_de_origem(client, headers, origem_id: int) -> int:
+    lista = client.get("/v1/saas/solicitacoes", headers=headers).json()["items"]
+    return next(i["id"] for i in lista if i["origem_solicitacao_id"] == origem_id)
+
+
+def _avancar_status(client, headers, saas_id: int, *passos: str) -> dict:
+    """Avança status válidos em sequência (G1)."""
+    body = {}
+    for st in passos:
+        r = client.patch(
+            f"/v1/saas/solicitacoes/{saas_id}/status",
+            headers=headers,
+            json={"status": st},
+        )
+        assert r.status_code == 200, f"{st}: {r.text}"
+        body = r.json()
+    return body
+
+
 def _cliente(client, headers, slug="duplex-soft"):
     r = client.post(
         "/v1/saas/clientes",
@@ -509,11 +528,7 @@ def test_sync_get_autenticado(client, seed_base, auth_headers, monkeypatch):
         headers={"Authorization": f"Bearer {token}"},
     )
     saas_id = ingest.json()["id"]
-    client.patch(
-        f"/v1/saas/solicitacoes/{saas_id}/status",
-        headers=h,
-        json={"status": "planejada"},
-    )
+    _avancar_status(client, h, saas_id, "em_analise", "planejada")
     client.post(
         f"/v1/saas/solicitacoes/{saas_id}/comentarios",
         headers=h,
@@ -602,13 +617,8 @@ def test_mcp_token_lista_status_e_liga_github(client, seed_base, auth_headers, m
     busca = client.get("/v1/saas/solicitacoes", headers=mcp, params={"busca": item["protocolo"]})
     assert busca.status_code == 200
     assert any(i["id"] == saas_id for i in busca.json()["items"])
-    st = client.patch(
-        f"/v1/saas/solicitacoes/{saas_id}/status",
-        headers=mcp,
-        json={"status": "planejada"},
-    )
-    assert st.status_code == 200, st.text
-    assert st.json()["status"] == "planejada"
+    st = _avancar_status(client, mcp, saas_id, "em_analise", "planejada")
+    assert st["status"] == "planejada"
     gh = client.patch(
         f"/v1/saas/solicitacoes/{saas_id}/github",
         headers=mcp,
@@ -635,7 +645,7 @@ def test_mcp_stdio_initialize_e_tools():
     assert "português do Brasil" in init["result"]["instructions"]
     listed = mod.handle({"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
     names = {t["name"] for t in listed["result"]["tools"]}
-    assert {"listar_solicitacoes", "obter_solicitacao", "alterar_status", "comentar_solicitacao", "ligar_issue_github", "vincular_solicitacao", "desvincular_solicitacao"} <= names
+    assert {"listar_solicitacoes", "obter_solicitacao", "alterar_status", "implementar", "comentar_solicitacao", "ligar_issue_github", "vincular_solicitacao", "desvincular_solicitacao"} <= names
     comentar = next(t for t in listed["result"]["tools"] if t["name"] == "comentar_solicitacao")
     assert "português do Brasil" in comentar["description"]
 
@@ -767,16 +777,30 @@ def test_fila_filtro_fase_tipo_e_resumo(client, seed_base, auth_headers, monkeyp
     saas_sug = next(i["id"] for i in lista if i["origem_solicitacao_id"] == sid_sug)
     saas_err = next(i["id"] for i in lista if i["origem_solicitacao_id"] == sid_err)
 
-    client.patch(
-        f"/v1/saas/solicitacoes/{saas_sug}/status",
+    _avancar_status(client, h, saas_sug, "em_analise", "planejada")
+    lig = client.patch(
+        f"/v1/saas/solicitacoes/{saas_sug}/github",
         headers=h,
-        json={"status": "em_desenvolvimento"},
+        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/9001"},
     )
-    client.patch(
-        f"/v1/saas/solicitacoes/{saas_err}/status",
+    assert lig.status_code == 200, lig.text
+    impl = client.post(
+        f"/v1/saas/solicitacoes/{saas_sug}/implementar",
         headers=h,
-        json={"status": "concluida"},
+        json={},
     )
+    assert impl.status_code == 200, impl.text
+    assert impl.json()["status"] == "em_desenvolvimento"
+
+    _avancar_status(client, h, saas_err, "em_analise", "planejada")
+    lig2 = client.patch(
+        f"/v1/saas/solicitacoes/{saas_err}/github",
+        headers=h,
+        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/9002"},
+    )
+    assert lig2.status_code == 200, lig2.text
+    assert client.post(f"/v1/saas/solicitacoes/{saas_err}/implementar", headers=h, json={}).status_code == 200
+    _avancar_status(client, h, saas_err, "concluida")
 
     aguardando = client.get("/v1/saas/solicitacoes?fase=aguardando", headers=h)
     assert aguardando.status_code == 200
@@ -806,3 +830,127 @@ def test_fila_filtro_fase_tipo_e_resumo(client, seed_base, auth_headers, monkeyp
     bad = client.get("/v1/saas/solicitacoes?fase=xyz", headers=h)
     assert bad.status_code == 400
 
+
+
+def test_transicao_status_ilegais_400(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
+    sid = _criar_solicitacao(client, auth_headers["a1"]).json()["id"]
+    h = auth_headers["ops"]
+    saas_id = _saas_id_de_origem(client, h, sid)
+
+    for st in ("planejada", "em_desenvolvimento", "concluida"):
+        r = client.patch(
+            f"/v1/saas/solicitacoes/{saas_id}/status",
+            headers=h,
+            json={"status": st},
+        )
+        assert r.status_code == 400, st
+
+    _avancar_status(client, h, saas_id, "em_analise")
+    assert (
+        client.patch(
+            f"/v1/saas/solicitacoes/{saas_id}/status",
+            headers=h,
+            json={"status": "aberta"},
+        ).status_code
+        == 400
+    )
+    _avancar_status(client, h, saas_id, "planejada")
+    sem_gh = client.patch(
+        f"/v1/saas/solicitacoes/{saas_id}/status",
+        headers=h,
+        json={"status": "em_desenvolvimento"},
+    )
+    assert sem_gh.status_code == 400
+    assert "GitHub" in (sem_gh.json().get("detail") or "")
+
+    client.patch(
+        f"/v1/saas/solicitacoes/{saas_id}/github",
+        headers=h,
+        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/9100"},
+    )
+    assert client.post(f"/v1/saas/solicitacoes/{saas_id}/implementar", headers=h, json={}).status_code == 200
+    _avancar_status(client, h, saas_id, "concluida")
+    assert (
+        client.patch(
+            f"/v1/saas/solicitacoes/{saas_id}/status",
+            headers=h,
+            json={"status": "em_analise"},
+        ).status_code
+        == 400
+    )
+
+
+def test_implementar_liga_github_e_avanca(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
+    sid = _criar_solicitacao(client, auth_headers["a1"]).json()["id"]
+    h = auth_headers["ops"]
+    saas_id = _saas_id_de_origem(client, h, sid)
+    _avancar_status(client, h, saas_id, "em_analise", "planejada")
+
+    cedo = client.post(f"/v1/saas/solicitacoes/{saas_id}/implementar", headers=h, json={"criar_issue": False})
+    assert cedo.status_code == 400
+
+    ok = client.post(
+        f"/v1/saas/solicitacoes/{saas_id}/implementar",
+        headers=h,
+        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/954"},
+    )
+    assert ok.status_code == 200, ok.text
+    body = ok.json()
+    assert body["status"] == "em_desenvolvimento"
+    assert body["github_issue_number"] == 954
+    assert "954" in (body["github_issue_url"] or "")
+
+    minhas = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["a1"]).json()
+    assert minhas["status"] == "em_desenvolvimento"
+    assert minhas.get("github_issue_url") in (None, "")
+    assert any(hist["status_novo"] == "em_desenvolvimento" for hist in minhas["historico"])
+
+
+def test_implementar_cria_issue_quando_configurado(client, seed_base, auth_headers, monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
+    monkeypatch.setattr(settings, "GITHUB_TOKEN", "fake-token")
+    monkeypatch.setattr(settings, "GITHUB_REPO_SUGESTOES", "lgustavoss/dx-connect")
+
+    class _Resp:
+        status_code = 201
+
+        def json(self):
+            return {
+                "number": 4242,
+                "html_url": "https://github.com/lgustavoss/dx-connect/issues/4242",
+            }
+
+    class _Client:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def post(self, url, headers=None, json=None):
+            assert "lgustavoss/dx-connect" in url
+            return _Resp()
+
+    monkeypatch.setattr("app.services.saas_solicitacao_github.httpx.Client", lambda timeout=30.0: _Client())
+
+    sid = _criar_solicitacao(client, auth_headers["a1"]).json()["id"]
+    h = auth_headers["ops"]
+    saas_id = _saas_id_de_origem(client, h, sid)
+    _avancar_status(client, h, saas_id, "em_analise", "planejada")
+    r = client.post(f"/v1/saas/solicitacoes/{saas_id}/implementar", headers=h, json={})
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "em_desenvolvimento"
+    assert r.json()["github_issue_number"] == 4242
+    cliente = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["a1"]).json()
+    assert cliente.get("github_issue_url") in (None, "")

--- a/backend/tests/test_solicitacao_release.py
+++ b/backend/tests/test_solicitacao_release.py
@@ -1,0 +1,66 @@
+"""Release CalVer → conclusão de solicitações SaaS (#956)."""
+
+from __future__ import annotations
+
+from app.models.saas_solicitacao_produto import SaasSolicitacaoProduto
+from app.services.saas_solicitacao_release import concluir_pedidos_release, extrair_referencias_release
+
+
+def test_extrair_referencias_protocolo_e_issue():
+    texto = "Chat (#941 / #S202608-0008): modal membros · Closes #952"
+    protocolos, issues = extrair_referencias_release([texto])
+    assert "#S202608-0008" in protocolos
+    assert 941 in issues
+    assert 952 in issues
+
+
+def test_concluir_pedidos_release_idempotente(client, seed_base, auth_headers, monkeypatch, db_session):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
+    monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
+    sid = client.post(
+        "/v1/solicitacoes-melhoria",
+        headers=auth_headers["a1"],
+        json={
+            "tipo": "sugestao",
+            "titulo": "Release hook",
+            "descricao": "Teste conclusão automática no deploy.",
+        },
+    ).json()["id"]
+    h = auth_headers["ops"]
+    lista = client.get("/v1/saas/solicitacoes", headers=h).json()["items"]
+    row = next(i for i in lista if i["origem_solicitacao_id"] == sid)
+    saas_id = row["id"]
+    protocolo = row["protocolo"]
+    assert protocolo
+
+    for st in ("em_analise", "planejada"):
+        client.patch(
+            f"/v1/saas/solicitacoes/{saas_id}/status",
+            headers=h,
+            json={"status": st},
+        )
+    client.post(
+        f"/v1/saas/solicitacoes/{saas_id}/implementar",
+        headers=h,
+        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/9560"},
+    )
+
+    texto = f"Melhoria ({protocolo}): conclusão automática (#9560)"
+    stats = concluir_pedidos_release(db_session, versao="2026.08.99", textos_changelog=[texto])
+    assert stats["concluidos"] >= 1
+
+    db_session.expire_all()
+    saas = db_session.get(SaasSolicitacaoProduto, saas_id)
+    assert saas.status == "concluida"
+    assert saas.versao_alvo == "2026.08.99"
+
+    minhas = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["a1"]).json()
+    assert minhas["status"] == "concluida"
+    assert minhas["versao_alvo"] == "2026.08.99"
+    assert minhas["versao_alvo_rotulo"] == "Disponível na 2026.08.99"
+
+    stats2 = concluir_pedidos_release(db_session, versao="2026.08.99", textos_changelog=[texto])
+    assert stats2["concluidos"] == 0
+    assert stats2["ignorados"] >= 1

--- a/backend/tests/test_solicitacao_release.py
+++ b/backend/tests/test_solicitacao_release.py
@@ -59,7 +59,7 @@ def test_concluir_pedidos_release_idempotente(client, seed_base, auth_headers, m
     minhas = client.get(f"/v1/solicitacoes-melhoria/{sid}", headers=auth_headers["a1"]).json()
     assert minhas["status"] == "concluida"
     assert minhas["versao_alvo"] == "2026.08.99"
-    assert minhas["versao_alvo_rotulo"] == "Disponível na 2026.08.99"
+    assert minhas["versao_alvo_rotulo"] == "Disponível a partir da versão 2026.08.99 (ou superior)"
 
     stats2 = concluir_pedidos_release(db_session, versao="2026.08.99", textos_changelog=[texto])
     assert stats2["concluidos"] == 0

--- a/backend/tests/test_solicitacao_status_transicao.py
+++ b/backend/tests/test_solicitacao_status_transicao.py
@@ -1,0 +1,62 @@
+"""Máquina de estados das solicitações (#953)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.solicitacao_melhoria_copy import (
+    MSG_GITHUB_OBRIGATORIO,
+    MSG_TRANSICAO_INVALIDA,
+    STATUS_TRANSICOES,
+    validar_transicao_status,
+)
+
+
+def test_grafo_completo_v1():
+    assert STATUS_TRANSICOES["aberta"] == frozenset({"em_analise", "nao_sera_desenvolvida"})
+    assert STATUS_TRANSICOES["em_analise"] == frozenset({"planejada", "nao_sera_desenvolvida"})
+    assert STATUS_TRANSICOES["planejada"] == frozenset({"em_desenvolvimento", "nao_sera_desenvolvida"})
+    assert STATUS_TRANSICOES["em_desenvolvimento"] == frozenset({"concluida", "nao_sera_desenvolvida"})
+    assert STATUS_TRANSICOES["concluida"] == frozenset()
+    assert STATUS_TRANSICOES["nao_sera_desenvolvida"] == frozenset()
+
+
+@pytest.mark.parametrize(
+    "de,para",
+    [
+        ("aberta", "planejada"),
+        ("aberta", "em_desenvolvimento"),
+        ("aberta", "concluida"),
+        ("em_analise", "aberta"),
+        ("em_analise", "em_desenvolvimento"),
+        ("planejada", "aberta"),
+        ("planejada", "em_analise"),
+        ("concluida", "aberta"),
+        ("nao_sera_desenvolvida", "em_analise"),
+    ],
+)
+def test_saltos_ilegais(de, para):
+    with pytest.raises(HTTPException) as ei:
+        validar_transicao_status(de, para, tem_vinculo_github=True, motivo_nao_desenvolvimento="x")
+    assert ei.value.status_code == 400
+    assert MSG_TRANSICAO_INVALIDA in str(ei.value.detail)
+
+
+def test_em_desenvolvimento_exige_github():
+    with pytest.raises(HTTPException) as ei:
+        validar_transicao_status("planejada", "em_desenvolvimento", tem_vinculo_github=False)
+    assert ei.value.status_code == 400
+    assert MSG_GITHUB_OBRIGATORIO in str(ei.value.detail)
+    validar_transicao_status("planejada", "em_desenvolvimento", tem_vinculo_github=True)
+
+
+def test_rejeicao_exige_motivo():
+    with pytest.raises(HTTPException) as ei:
+        validar_transicao_status("aberta", "nao_sera_desenvolvida", motivo_nao_desenvolvimento="  ")
+    assert ei.value.status_code == 400
+    validar_transicao_status("aberta", "nao_sera_desenvolvida", motivo_nao_desenvolvimento="Fora do escopo agora.")
+
+
+def test_idempotente_mesmo_status():
+    validar_transicao_status("em_analise", "em_analise")

--- a/backend/tests/test_solicitacoes_melhoria.py
+++ b/backend/tests/test_solicitacoes_melhoria.py
@@ -130,11 +130,26 @@ def test_status_final_bloqueia_resposta_cliente(client, seed_base, auth_headers,
     monkeypatch.setattr(settings, "SAAS_CONTROL_PLANE", True)
     monkeypatch.setattr(settings, "SAAS_INSTANCE_SLUG", "local")
     sid = _criar(client, auth_headers["a1"]).json()["id"]
-    lista = client.get("/v1/saas/solicitacoes", headers=auth_headers["ops"]).json()["items"]
+    h = auth_headers["ops"]
+    lista = client.get("/v1/saas/solicitacoes", headers=h).json()["items"]
     saas_id = next(i["id"] for i in lista if i["origem_solicitacao_id"] == sid)
+    for st in ("em_analise", "planejada"):
+        r = client.patch(
+            f"/v1/saas/solicitacoes/{saas_id}/status",
+            headers=h,
+            json={"status": st},
+        )
+        assert r.status_code == 200, r.text
+    client.patch(
+        f"/v1/saas/solicitacoes/{saas_id}/github",
+        headers=h,
+        json={"github_issue_url": "https://github.com/lgustavoss/dx-connect/issues/9101"},
+    )
+    impl = client.post(f"/v1/saas/solicitacoes/{saas_id}/implementar", headers=h, json={})
+    assert impl.status_code == 200, impl.text
     r_status = client.patch(
         f"/v1/saas/solicitacoes/{saas_id}/status",
-        headers=auth_headers["ops"],
+        headers=h,
         json={"status": "concluida"},
     )
     assert r_status.status_code == 200, r_status.text

--- a/backend/tests/test_whatsapp_chats.py
+++ b/backend/tests/test_whatsapp_chats.py
@@ -67,6 +67,39 @@ def test_fila_e_assumir(client, seed_base, auth_headers):
     assert client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json() == []
 
 
+def test_meus_e_visto_contam_nao_lidas(client, seed_base, auth_headers):
+    """#951: nao_lidas_count sobe com inbound e zera após POST /visto."""
+    client.patch(
+        "/v1/settings/whatsapp",
+        json={"webhook_secret": "nl-1"},
+        headers=auth_headers["admin"],
+    )
+    h = {"X-Dx-Webhook-Secret": "nl-1"}
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511777666555", msg_id="nl-m1", text="oi"),
+        headers=h,
+    )
+    cid = client.get("/v1/whatsapp/chats/fila", headers=auth_headers["a1"]).json()[0]["id"]
+    assert client.post(f"/v1/whatsapp/chats/{cid}/assumir", headers=auth_headers["a1"]).status_code == 200
+    assert client.post(f"/v1/whatsapp/chats/{cid}/visto", headers=auth_headers["a1"]).status_code == 204
+
+    client.post(
+        "/v1/webhooks/evolution",
+        json=_webhook_body(wa_id="5511777666555", msg_id="nl-m2", text="nova"),
+        headers=h,
+    )
+    meus = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    row = next(c for c in meus if c["id"] == cid)
+    assert row["nao_lidas_count"] >= 1
+    assert "last_seen_at" in row
+
+    assert client.post(f"/v1/whatsapp/chats/{cid}/visto", headers=auth_headers["a1"]).status_code == 204
+    meus2 = client.get("/v1/whatsapp/chats/meus", headers=auth_headers["a1"]).json()
+    row2 = next(c for c in meus2 if c["id"] == cid)
+    assert row2["nao_lidas_count"] == 0
+
+
 def test_listar_encerrados_filtra_e_respeita_rbac(client, seed_base, auth_headers):
     client.patch(
         "/v1/settings/whatsapp",

--- a/deploy/admin-center/README.md
+++ b/deploy/admin-center/README.md
@@ -49,8 +49,15 @@ Painel DuplexSoft continua em `/opt/dx-connect/frontend/dist` (API `api-duplexso
 1. Migrar tabelas SaaS + mídia `solicitacao_media` + `protocol_sequences` (`kind=S`) + contas `saas_ops` para o Postgres do `admin-center`
 2. Criar licença `clientes_saas` slug `duplexsoft` e token de ingest
 3. Na DuplexSoft (`backend/.env`): `SAAS_CONTROL_PLANE=false`, `SAAS_INSTANCE_SLUG=duplexsoft`, `SAAS_CONTROL_PLANE_INGEST_URL` + `SAAS_INSTANCE_INGEST_TOKEN`
-4. Desactivar contas `saas_ops` na BD DuplexSoft (ficam só na comercial)
+4. Desativar contas `saas_ops` na BD DuplexSoft (ficam só na comercial)
 5. Health esperado: `api.deskrudder.com.br` → `saas_control_plane: true`; `api-duplexsoft…` → `false`
+
+## Desativar um cliente
+
+Runbook completo (pré/pós health, MCP, o que **não** parar):  
+[`docs/SAAS_CONTROL_PLANE.md`](../../docs/SAAS_CONTROL_PLANE.md#runbook-desativar-cliente-sem-derrubar-o-saas)
+
+Resumo: `stack-client.sh down <slug>` **ou** `docker compose … stop` na DuplexSoft — **nunca** `down admin-center`.
 
 ## O que este diretório versiona
 

--- a/deploy/clients/README.md
+++ b/deploy/clients/README.md
@@ -7,7 +7,9 @@ Cada cliente pagante tem:
 - **Um container** da API (`dx-connect-api-{slug}`)
 - **Porta loopback** distinta (`127.0.0.1:8002`, `8003`, …) para o Nginx fazer proxy
 
-O **painel admin** DeskRudder (`/saas`) **não** fica em `clients/`. Pasta: [`../admin-center/`](../admin-center/README.md) (`provision-control-plane.sh`). Hosts: `deskrudder.com.br` e `api.deskrudder.com.br`. Não rode `provision-client.sh --slug deskrudder` nem `--slug admin-center`.
+O **painel admin** DeskRudder (`/saas`) **não** fica em `clients/`. Pasta: [`../admin-center/`](../admin-center/README.md) (`provision-control-plane.sh`). Hosts: `deskrudder.com.br` e `api.deskrudder.com.br`. Porta **8001** reservada. Não rode `provision-client.sh --slug deskrudder` nem `--slug admin-center`.
+
+A **DuplexSoft** em produção ainda usa o compose legado na raiz (`docker-compose.prod.yml`, porta **8000**). Clientes **novos** usam este diretório (`provision-client.sh`, portas **8002+**). Deploy GHA atualiza as duas stacks — ver [`../github-actions.md`](../github-actions.md).
 
 Direção de produto: [`docs/DEPLOYMENT_ARCHITECTURE.md`](../../docs/DEPLOYMENT_ARCHITECTURE.md) · Issue **#191** (Fase 1 + Fase 2 single-tenant no código).
 
@@ -15,7 +17,7 @@ Direção de produto: [`docs/DEPLOYMENT_ARCHITECTURE.md`](../../docs/DEPLOYMENT_
 
 ```text
 deploy/clients/
-  README.md                 # este ficheiro
+  README.md                 # este arquivo
   _template/                # modelos (versionados no Git)
   .gitignore                # ignora pastas de clientes geradas
   duplexsoft/               # exemplo — gerado no VPS, NÃO commitar
@@ -31,52 +33,53 @@ Na **raiz do repositório** (Linux/macOS/Git Bash no Windows):
 
 ```bash
 bash deploy/scripts/provision-client.sh \
-  --slug duplexsoft \
+  --slug exemplo \
   --base-domain deskrudder.com.br \
-  --api-port 8001
+  --api-port 8002
 ```
 
-Isto cria `deploy/clients/duplexsoft/` com `client.env` (senhas geradas), `docker-compose.yml` e ficheiros Nginx/frontend de exemplo.
+Isto cria `deploy/clients/exemplo/` com `client.env` (senhas geradas), `docker-compose.yml` e arquivos Nginx/frontend de exemplo. **Não** use porta `8001` (admin-center).
 
 ### 1. Rever `client.env`
 
-Edite `deploy/clients/duplexsoft/client.env`:
+Edite `deploy/clients/exemplo/client.env`:
 
 - `CORS_ORIGINS` / `ALLOWED_HOSTS` alinhados aos domínios reais (`CORS_ORIGINS` = origem HTTPS da PWA **e** `https://localhost` para o APK Capacitor)
 - Par **VAPID** (`WEB_PUSH_VAPID_*`) desta stack — gerar uma vez; vazio = push desligado (`docs/OPERATIONS.md`)
-- `DX_CONNECT_MULTI_TENANT=false` (padrão) e `CLIENT_APP_HOST={slug}.connect...`
-- `RESEND_API_KEY`, e-mail transaccional, webhooks
+- `DX_CONNECT_MULTI_TENANT=false` (padrão) e `CLIENT_APP_HOST={slug}.deskrudder.com.br`
+- `SAAS_CONTROL_PLANE=false` + `SAAS_INSTANCE_SLUG` + ingest (URL/token da comercial) — ver [`docs/SAAS_CONTROL_PLANE.md`](../../docs/SAAS_CONTROL_PLANE.md)
+- `RESEND_API_KEY`, e-mail transacional, webhooks
 - `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD` para o primeiro admin
 
 ### 2. Subir stack + migrações + seed
 
 ```bash
-bash deploy/scripts/stack-client.sh migrate duplexsoft
-bash deploy/scripts/stack-client.sh up duplexsoft
-bash deploy/scripts/stack-client.sh seed duplexsoft
+bash deploy/scripts/stack-client.sh migrate exemplo
+bash deploy/scripts/stack-client.sh up exemplo
+bash deploy/scripts/stack-client.sh seed exemplo
 ```
 
 Confirme:
 
 ```bash
-bash deploy/scripts/stack-client.sh health duplexsoft
+bash deploy/scripts/stack-client.sh health exemplo
 ```
 
 ### 3. Frontend
 
 ```bash
-# Ajuste VITE_API_URL e VITE_CLIENT_APP_HOST em deploy/clients/duplexsoft/frontend.env.production.example
+# Ajuste VITE_API_URL e VITE_CLIENT_APP_HOST em deploy/clients/exemplo/frontend.env.production.example
 # ou copie para frontend/.env.production antes do build
 cd frontend && npm ci && npm run build
-sudo mkdir -p /var/www/dx-connect/clients/duplexsoft/dist
-sudo rsync -a dist/ /var/www/dx-connect/clients/duplexsoft/dist/
+sudo mkdir -p /var/www/dx-connect/clients/exemplo/dist
+sudo rsync -a dist/ /var/www/dx-connect/clients/exemplo/dist/
 ```
 
 ### 4. Nginx + DNS
 
-1. Copie `deploy/clients/duplexsoft/nginx.site.conf` para `/etc/nginx/sites-available/`.
+1. Copie `deploy/clients/exemplo/nginx.site.conf` para `/etc/nginx/sites-available/`.
 2. Ajuste `FRONTEND_DIST` se necessário.
-3. Aponte DNS `duplexsoft.connect...` e `api-duplexsoft.connect...` para a VPS.
+3. Aponte DNS `{slug}.deskrudder.com.br` e `api-{slug}.deskrudder.com.br` para a VPS.
 4. `sudo nginx -t && sudo systemctl reload nginx`
 5. TLS (Certbot) e atualize `CORS_ORIGINS` / `VITE_API_URL` para `https://`.
 
@@ -93,7 +96,13 @@ sudo rsync -a dist/ /var/www/dx-connect/clients/duplexsoft/dist/
 
 ## Portas API na mesma VPS
 
-Registe numa folha interna qual `CLIENT_API_PORT` cada slug usa (8001, 8002, …). O Nginx faz proxy para `127.0.0.1:PORTA`.
+| Porta | Uso |
+|-------|-----|
+| `8000` | DuplexSoft (compose legado) |
+| `8001` | admin-center (control-plane) |
+| `8002+` | clientes em `deploy/clients/<slug>/` |
+
+Registre numa folha interna qual `CLIENT_API_PORT` cada slug usa. O Nginx faz proxy para `127.0.0.1:PORTA`.
 
 ## Atualizar código de um cliente
 
@@ -102,25 +111,27 @@ No VPS, no clone do repositório:
 ```bash
 git pull
 export DX_CONNECT_GIT_SHA=$(git rev-parse --short HEAD)
-bash deploy/scripts/stack-client.sh migrate duplexsoft
-bash deploy/scripts/stack-client.sh up duplexsoft
+bash deploy/scripts/stack-client.sh migrate exemplo
+bash deploy/scripts/stack-client.sh up exemplo
 ```
 
 ### Volume `/app/data` (anexos e mídia)
 
 O template monta `backend_data` → `/app/data`. Sem esse volume, cada rebuild apaga anexos de ticket, mídia WhatsApp/chat interno, KB e logos — o metadado fica na BD e o download devolve **404**.
 
-Clientes já provisionados **antes** deste volume: copie o bloco `volumes` do `_template/docker-compose.stack.yml` para o `docker-compose.yml` do cliente e faça `up` de novo. Ficheiros já perdidos não voltam; é preciso reenviar anexos.
+Clientes já provisionados **antes** deste volume: copie o bloco `volumes` do `_template/docker-compose.stack.yml` para o `docker-compose.yml` do cliente e faça `up` de novo. Arquivos já perdidos não voltam; é preciso reenviar anexos.
 
 ## Backup da base do cliente
 
 ```bash
-docker exec dx-connect-db-duplexsoft pg_dump -U dxconnect dxconnect_duplexsoft > backup-duplexsoft-$(date +%F).sql
+docker exec dx-connect-db-exemplo pg_dump -U dxconnect dxconnect_exemplo > backup-exemplo-$(date +%F).sql
 ```
 
-(ajuste user/db conforme `client.env`)
+(ajuste user/db/slug conforme `client.env`)
 
 ## Relacionado
 
-- Deploy CI legado (um ambiente staging): [`deploy/github-actions.md`](../github-actions.md)
-- `docker-compose.prod.yml` — API só, Postgres no host (modelo antigo single-tenant na mesma máquina)
+- Deploy CI (duas stacks): [`deploy/github-actions.md`](../github-actions.md)
+- Control-plane + runbook desativar cliente: [`docs/SAAS_CONTROL_PLANE.md`](../../docs/SAAS_CONTROL_PLANE.md)
+- `docker-compose.prod.yml` — API DuplexSoft legado (Postgres no host / stack antiga na mesma máquina)
+- Desativar cliente sem derrubar SaaS: âncora `#runbook-desativar-cliente-sem-derrubar-o-saas` no doc do control-plane

--- a/deploy/scripts/gha-deploy-vps.sh
+++ b/deploy/scripts/gha-deploy-vps.sh
@@ -213,6 +213,14 @@ fi
 
 if [ "$SKIP_MIGRATIONS" != "true" ]; then
   bash deploy/scripts/stack-client.sh migrate admin-center
+  if [ -n "${DX_CONNECT_VERSION:-}" ]; then
+    (
+      cd deploy/admin-center
+      docker compose --env-file client.env -f docker-compose.yml run --rm -T backend \
+        python scripts/concluir_solicitacoes_release.py --version "${DX_CONNECT_VERSION}" \
+        < /dev/null
+    ) || echo "::warning::concluir_solicitacoes_release falhou (deploy continua)"
+  fi
 fi
 bash deploy/scripts/stack-client.sh up admin-center
 

--- a/docs/DEPLOYMENT_ARCHITECTURE.md
+++ b/docs/DEPLOYMENT_ARCHITECTURE.md
@@ -77,3 +77,16 @@ Legado multi-tenant: definir `DX_CONNECT_MULTI_TENANT=true` (e no front `VITE_MU
 - Control-plane vs cliente DuplexSoft: **#875** — stack em [`deploy/admin-center/`](../deploy/admin-center/README.md)
 - Deploy GHA em duas stacks (#880): [`deploy/github-actions.md`](../deploy/github-actions.md)
 - Checklist de servidor: [`PRE_DEPLOY_CHECKLIST.md`](PRE_DEPLOY_CHECKLIST.md)
+
+## Produção DeskRudder (pós-#875)
+
+Na mesma VPS convivem **dois** Postgres e **duas** APIs (modelo B):
+
+| Papel | Pasta / compose | Porta | Hosts |
+|-------|-----------------|-------|--------|
+| **Control-plane** (licenças, fila, MCP, `/saas`) | `deploy/admin-center/` | `127.0.0.1:8001` | `api.deskrudder.com.br`, SPA em `deskrudder.com.br` |
+| **Cliente DuplexSoft** (helpdesk) | `docker-compose.prod.yml` + `backend/.env` (legado; futuros clientes em `deploy/clients/<slug>/`) | `127.0.0.1:8000` | `duplexsoft…`, `api-duplexsoft…` |
+
+- A comercial **não** é o `docker-compose.prod.yml` único nem um slug em `clients/deskrudder`.
+- Novos clientes pagantes: `provision-client.sh` → `deploy/clients/<slug>/` (portas a partir de **8002**; **8001** está reservada ao admin-center).
+- Parar ou apagar a stack DuplexSoft **não** pode derrubar o painel SaaS — ver runbook em [`docs/SAAS_CONTROL_PLANE.md`](SAAS_CONTROL_PLANE.md#runbook-desativar-cliente-sem-derrubar-o-saas).

--- a/docs/SAAS_CONTROL_PLANE.md
+++ b/docs/SAAS_CONTROL_PLANE.md
@@ -104,6 +104,10 @@ Quem **usa** o DeskRudder (admin/atendente da instância) abre sugestão ou prob
 
 A **triagem** (status e respostas) é feita por `saas_ops` no detalhe `/saas/solicitacoes/{id}`. O protocolo `#SYYYYMM-NNNN` é **único no produto**: a instância comercial (control-plane, Postgres próprio na VPS) emite o número no ingest; o cliente vê o mesmo valor em Minhas solicitações após o sync. Pedidos iguais de vários clientes ligam-se **só no painel SaaS** (`POST …/vinculos`); o peso é o número de clientes no grupo e **não** volta à instância. No GitHub, o título usa um protocolo; o corpo leva `texto_github_demanda` (lista de protocolos). Comentários **públicos** e o status voltam à instância; notas internas e o grupo ficam só no SaaS. O admin da instância **não** altera status nem envia notas de produto.
 
+**Máquina de estados (G1 #953):** só transições `aberta→em_analise→planejada→em_desenvolvimento→concluida`, com `nao_sera_desenvolvida` (+ motivo) a partir de qualquer etapa não final. Saltos ilegais → HTTP 400. Sync SaaS→instância aplica o status já validado no control-plane (e o histórico na instância continua a registar).
+
+**Implementar (G2 #954):** `POST …/solicitacoes/{id}/implementar` a partir de `planejada` cria issue (API GitHub) ou liga URL/número e avança para `em_desenvolvimento`. Sem vínculo GitHub não entra nesse status. O cliente nível 2 **nunca** vê URL/número da issue.
+
 O **posto** (portal) não entra neste fluxo. Análise no Cursor e issues GitHub **não** fazem parte deste lote (#857).
 
 ### Instância (`SAAS_CONTROL_PLANE=false`)
@@ -129,8 +133,9 @@ No control-plane (`SAAS_CONTROL_PLANE=true`), a abertura grava directo na tabela
 - `GET /v1/saas/ingest/solicitacoes/sync` — mesmo token; devolve status + comentários públicos daquele slug (`?since=` opcional).
 - `GET /v1/saas/solicitacoes` e `GET /v1/saas/solicitacoes/{id}` — `saas_ops` (JWT) ou token Cursor pessoal (`/saas/conta`) / `SAAS_MCP_TOKEN` legado.
 - `PATCH …/solicitacoes/{id}/github` — liga a issue criada no GitHub ao pedido (e ao grupo, se houver). Só ops / MCP; o cliente não vê.
+- `POST …/solicitacoes/{id}/implementar` — G2: cria ou liga issue e marca `em_desenvolvimento` (só a partir de `planejada`).
 - `POST …/solicitacoes/{id}/vinculos` e `DELETE …/vinculos/{membro_id}` — grupo de pedidos iguais (peso). Só ops / MCP.
-- `PATCH /v1/saas/solicitacoes/{id}/status` e `POST /v1/saas/solicitacoes/{id}/comentarios` — triagem.
+- `PATCH /v1/saas/solicitacoes/{id}/status` e `POST /v1/saas/solicitacoes/{id}/comentarios` — triagem (máquina de estados G1).
 - `POST /v1/saas/me/mcp-token` — gera o token Cursor desta conta (plaintext uma vez). `GET` estado; `DELETE` revoga.
 - `GET/POST /v1/saas/usuarios` e `PATCH /v1/saas/usuarios/{id}` — equipa `saas_ops` (nome, e-mail, activo). `POST …/senha-temporaria` devolve senha uma vez. Não são atendentes da instância do cliente.
 - `POST /v1/saas/clientes/{id}/gerar-token-ingest` — devolve o plaintext **uma vez** e escreve no `client.env` se a pasta do cliente já existir.
@@ -160,7 +165,7 @@ O script corre no PC do ops. A fila é a da instância comercial (`SAAS_CONTROL_
 
 O `SAAS_MCP_TOKEN` no `.env` da VPS ainda é aceite como **legado** (não identifica a pessoa). Prefira o token do painel.
 
-Ferramentas: listar, obter, alterar status, comentar, vincular pedidos iguais, ligar issue GitHub (aceitam `id` ou protocolo). Sem OpenAI e sem `CURSOR_API_KEY` no DeskRudder. O GitHub MCP (criar issues) é à parte e também é por instalação do Cursor.
+Ferramentas: listar, obter, alterar status (máquina G1), **implementar** (G2), comentar, vincular pedidos iguais, ligar issue GitHub (aceitam `id` ou protocolo). Sem OpenAI e sem `CURSOR_API_KEY` no DeskRudder. Criar issue pode ser via `implementar` (token GitHub no control-plane) ou MCP GitHub à parte + `ligar_issue_github`.
 
 ## Runbook: desativar cliente sem derrubar o SaaS
 

--- a/docs/SAAS_CONTROL_PLANE.md
+++ b/docs/SAAS_CONTROL_PLANE.md
@@ -88,13 +88,15 @@ A **URL pública** da instância não é escolhida livremente: o ops/cliente def
 
 ## Planos e módulos (catálogo comercial)
 
-- UI: `/saas/planos`, `/saas/modulos` — CRUD, activar/desactivar; plano associa `modulo_ids`.
-- Licença: campo `plano_id` (select); `plano` fica como rótulo denormalizado do nome.
-- Seed (migration `091`): módulos `helpdesk`, `whatsapp`, `contratos`, `boletos`; planos `trial`, `profissional`, `enterprise`.
-- Planos podem ter `preco_mensal`, `max_postos`, `max_usuarios` (migration `092`).
-- Ao atribuir/aprovar plano, a licença grava `modulos_snapshot` + limites (congelados na ficha comercial).
-- No provisionamento, `SAAS_MODULOS` é escrito no `client.env` a partir do snapshot; o `/health` da instância expõe `capabilities.modulo_*` lidos dessa env.
-- Enforcement fino de features no produto cliente (UI/RBAC por módulo) fica para follow-up — hoje o snapshot + env são a fonte de verdade comercial/ops.
+- UI: `/saas/planos`, `/saas/modulos` — CRUD, ativar/desativar; plano associa `modulo_ids`.
+- **Preço no módulo** (`saas_modulos.preco_mensal`); o `preco_mensal` do plano é sempre a **soma** dos módulos do pacote (recalcula ao editar preço ou composição).
+- Plano também define `usuarios_inclusos` (default 3) e `preco_usuario_extra` (default R$ 10).
+- Licença: `plano_id` (rótulo comercial) + `modulo_ids` opcional para **mix custom** (ex.: Essencial + 1 módulo Enterprise) + `usuarios_contratados` → grava em `max_usuarios` / `modulos_snapshot`.
+- **Valor mensal negociado** (`preco_mensal_negociado`): opcional na licença; se preenchido, vira o valor comercial efetivo (`preco_mensal_efetivo`); senão usa a estimativa do catálogo (módulos + extras).
+- Estimativa na ficha: `preco_modulos` + extras de usuário = `preco_mensal_estimado`.
+- Seed (migrations `091` + `121` + `122` + `123`): módulos com preço; planos pela soma; coluna de valor negociado na licença.
+- No provisionamento, `SAAS_MODULOS` vem do snapshot; `/health` expõe `capabilities.modulo_*`.
+- Enforcement fino de features no produto cliente e bloqueio hard de usuários além do contratado ficam para follow-up.
 
 ## Fila de sugestões das instâncias (#855 / #856)
 
@@ -159,6 +161,54 @@ O script corre no PC do ops. A fila é a da instância comercial (`SAAS_CONTROL_
 O `SAAS_MCP_TOKEN` no `.env` da VPS ainda é aceite como **legado** (não identifica a pessoa). Prefira o token do painel.
 
 Ferramentas: listar, obter, alterar status, comentar, vincular pedidos iguais, ligar issue GitHub (aceitam `id` ou protocolo). Sem OpenAI e sem `CURSOR_API_KEY` no DeskRudder. O GitHub MCP (criar issues) é à parte e também é por instalação do Cursor.
+
+## Runbook: desativar cliente sem derrubar o SaaS
+
+Objetivo: tirar do ar (ou suspender) **só** a instância do cliente. O control-plane continua a servir licenças, fila, MCP e `/saas`.
+
+### Pré-cheque (comercial viva)
+
+```bash
+curl -sf https://api.deskrudder.com.br/health   # saas_control_plane: true
+curl -sf -o /dev/null -w "%{http_code}\n" https://deskrudder.com.br/login/admin
+```
+
+No Cursor: `/listar-solicitacoes` (ou MCP `deskrudder-saas`) ainda lista a fila — prova de que o MCP aponta a `api.deskrudder.com.br`, não a `api-duplexsoft`.
+
+### Suspender pelo painel (recomendado)
+
+1. `/saas/licencas` → cliente → **Suspender** (marca licença + fila de `stack down` se provisionada).
+2. No host, se `SAAS_PROVISION_EXEC_ENABLED=false`, correr os comandos `down` mostrados no detalhe (ou `stack-client.sh down <slug>`).
+3. **Não** pare o stack `admin-center` nem remova Nginx de `api.deskrudder.com.br` / `deskrudder.com.br`.
+
+### Parar só a DuplexSoft (legado `docker-compose.prod.yml`)
+
+Na VPS, como usuário de deploy:
+
+```bash
+cd /opt/dx-connect
+docker compose --env-file backend/.env -f docker-compose.prod.yml stop
+# ou: down — remove containers; volumes/Postgres do host ficam conforme o compose
+```
+
+**Não** execute `stack-client.sh down admin-center`.
+
+### Pós-cheque
+
+| Check | Esperado |
+|-------|----------|
+| `https://api.deskrudder.com.br/health` | `200`, `saas_control_plane: true` |
+| `https://deskrudder.com.br/saas/...` (logado) | painel ops responde |
+| MCP / `/listar-solicitacoes` | fila comercial acessível |
+| `https://api-duplexsoft…/health` (se parou o cliente) | falha / indisponível — **ok** |
+| Postgres `dx-connect-db-admin-center` | `Up` / healthy |
+
+A **fila de sugestões** e as contas `saas_ops` vivem só no Postgres do admin-center. A BD do cliente não é fonte de verdade do control-plane; desligar o cliente não apaga a fila.
+
+### Reativar
+
+- Licença: **Reativar** no painel + `stack-client.sh up <slug>` (ou `docker compose … up -d` no legado DuplexSoft).
+- Confirmar health do cliente e, se aplicável, **Confirmar stack** no detalhe da licença.
 
 ## Histórico da licença
 
@@ -286,6 +336,6 @@ Worker `saas-renovacoes` (intervalo `SAAS_RENEWAL_WORKER_INTERVAL_SECONDS`):
 
 ## Referências
 
-- Épico: `#519`
-- Issues: DR-01…DR-08 em `.github/planning-issue-bodies/`
-- Deploy por cliente: `docs/DEPLOYMENT_ARCHITECTURE.md`, `deploy/clients/README.md`
+- Épico cutover: **#875** (filhas #876–#880; docs #879)
+- Deploy por cliente: `docs/DEPLOYMENT_ARCHITECTURE.md`, `deploy/clients/README.md`, `deploy/admin-center/README.md`
+- MCP example: `.cursor/mcp.json.example` (`DESKRUDDER_API_URL=https://api.deskrudder.com.br`)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,6 +101,8 @@ import { SaasSobre } from './pages/saas/SaasSobre'
 import { SaasConta } from './pages/saas/SaasConta'
 import { SaasUsuarios } from './pages/saas/SaasUsuarios'
 import { SaasUsuarioForm } from './pages/saas/SaasUsuarioForm'
+import { SaasSetoresPage } from './pages/saas/SaasSetores'
+import { SaasSetorForm } from './pages/saas/SaasSetorForm'
 import { KbPublicLayout } from './pages/kb-public/KbPublicLayout'
 import { KbPublicHome } from './pages/kb-public/KbPublicHome'
 import { KbPublicArtigo } from './pages/kb-public/KbPublicArtigo'
@@ -324,6 +326,9 @@ function AppRoutes() {
         <Route path="usuarios/novo" element={<SaasUsuarioForm />} />
         <Route path="usuarios/:id" element={<SaasUsuarioForm />} />
         <Route path="usuarios" element={<SaasUsuarios />} />
+        <Route path="setores/novo" element={<SaasSetorForm />} />
+        <Route path="setores/:id" element={<SaasSetorForm />} />
+        <Route path="setores" element={<SaasSetoresPage />} />
         <Route path="conta" element={<SaasConta />} />
         <Route path="sobre" element={<SaasSobre />} />
       </Route>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2444,6 +2444,7 @@ export namespace Setores {
 }
 
 export namespace Atendentes {
+  export type ModoJornada = 'nenhum' | 'semanal' | 'ciclo'
   export interface Atendente {
     id: number;
     email: string;
@@ -2453,7 +2454,9 @@ export namespace Atendentes {
     setor_ids: number[];
     e_financeiro?: boolean;
     must_change_password?: boolean;
+    modo_jornada?: ModoJornada;
     usa_escala?: boolean;
+    horario_semana?: Record<string, { ativo?: boolean; inicio?: string; fim?: string }> | null;
     escala_horas_trabalho?: number | null;
     escala_horas_folga?: number | null;
     escala_inicio_em?: string | null;
@@ -2471,7 +2474,9 @@ export namespace Atendentes {
     role?: string;
     ativo?: boolean;
     setor_ids?: number[];
+    modo_jornada?: ModoJornada;
     usa_escala?: boolean;
+    horario_semana?: Record<string, { ativo?: boolean; inicio?: string; fim?: string }> | null;
     escala_horas_trabalho?: number | null;
     escala_horas_folga?: number | null;
     escala_inicio_em?: string | null;
@@ -2486,7 +2491,9 @@ export namespace Atendentes {
     role?: string;
     ativo?: boolean;
     setor_ids?: number[];
+    modo_jornada?: ModoJornada;
     usa_escala?: boolean;
+    horario_semana?: Record<string, { ativo?: boolean; inicio?: string; fim?: string }> | null;
     escala_horas_trabalho?: number | null;
     escala_horas_folga?: number | null;
     escala_inicio_em?: string | null;
@@ -4845,6 +4852,7 @@ export namespace Ponto {
     usar_feriados_nacionais: boolean
     fecho_automatico_ativo: boolean
     fecho_apos_horas: number
+    fecho_margem_pos_saida_minutos: number
     jornada_diaria_minutos: number
     politica_geolocalizacao: PoliticaGeolocalizacao
   }
@@ -4856,6 +4864,7 @@ export namespace Ponto {
     usar_feriados_nacionais?: boolean
     fecho_automatico_ativo?: boolean
     fecho_apos_horas?: number
+    fecho_margem_pos_saida_minutos?: number
     jornada_diaria_minutos?: number
     politica_geolocalizacao?: PoliticaGeolocalizacao
   }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -760,6 +760,20 @@ export const ponto = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
+  horaExtraMeStatus: () => api<Ponto.HoraExtraMeStatus>('/ponto/hora-extra/me/status'),
+  minhasHoraExtra: () => api<Ponto.HoraExtra[]>('/ponto/hora-extra/me'),
+  solicitarHoraExtra: (data?: Ponto.HoraExtraCreate) =>
+    api<Ponto.HoraExtra>('/ponto/hora-extra', {
+      method: 'POST',
+      body: JSON.stringify(data ?? {}),
+    }),
+  horaExtraAdmin: (estado?: string) =>
+    api<Ponto.HoraExtra[]>(withParams('/ponto/hora-extra', { estado })),
+  decidirHoraExtra: (id: number, data: Ponto.HoraExtraDecisao) =>
+    api<Ponto.HoraExtra>(`/ponto/hora-extra/${id}/decidir`, {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   exportCsv: async (params?: { atendente_id?: number; desde?: string; ate?: string }) => {
     const token = getAuthToken()
     const headers: Record<string, string> = {}
@@ -1752,6 +1766,7 @@ export namespace Notificacoes {
     portal_fila_count: number;
     portal_respostas_count: number;
     chat_interno_nao_lidas_count: number;
+    ponto_he_pendentes_count?: number;
     total_pendencias: number;
   }
   export interface Item {
@@ -1760,7 +1775,8 @@ export namespace Notificacoes {
       | 'mensagens_nao_lidas'
       | 'wpp_chats_na_fila'
       | 'wpp_chats_com_resposta'
-      | 'chat_interno';
+      | 'chat_interno'
+      | 'ponto_he_pendente';
     ticket_id: number | null;
     chat_id?: number | null;
     conversa_id?: number | null;
@@ -4960,6 +4976,34 @@ export namespace Ponto {
     estado: 'aprovada' | 'rejeitada'
     decisao_motivo: string
     aplicar_batidas?: { tipo: Tipo; registrado_em: string; motivo: string }[]
+  }
+  export interface HoraExtra {
+    id: number
+    atendente_id: number
+    atendente_nome?: string | null
+    estado: string
+    motivo?: string | null
+    modo?: string | null
+    ate_em?: string | null
+    decidido_por_id?: number | null
+    decidido_em?: string | null
+    decisao_motivo?: string | null
+    created_at?: string | null
+  }
+  export interface HoraExtraCreate {
+    motivo?: string | null
+  }
+  export interface HoraExtraDecisao {
+    aprovar: boolean
+    modo?: 'resto_do_dia' | 'ate_horario' | null
+    ate_horario?: string | null
+    decisao_motivo?: string | null
+  }
+  export interface HoraExtraMeStatus {
+    fora_da_jornada: boolean
+    pode_pegar_whatsapp: boolean
+    he_ativa?: HoraExtra | null
+    pedido_pendente?: HoraExtra | null
   }
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -84,6 +84,13 @@ export function clearAuthToken(): void {
   localStorage.removeItem(REFRESH_TOKEN_KEY)
 }
 
+/** Mantém o storage onde a sessão já estava (local vs session). */
+export function persistAuthTokens(tokens: { access_token: string; refresh_token?: string | null }) {
+  const inLocal = Boolean(localStorage.getItem(TOKEN_KEY) || localStorage.getItem(REFRESH_TOKEN_KEY))
+  clearAuthToken()
+  setTokens(tokens, inLocal)
+}
+
 /** Invalida sessão e força novo login (evita voltar com «Back» para páginas autenticadas). */
 export function invalidateSessionAndRedirectToLogin(): void {
   clearAuthToken()
@@ -2453,6 +2460,9 @@ export namespace Atendentes {
     horario_previsto_entrada?: string | null;
     horario_previsto_saida?: string | null;
     tolerancia_atraso_minutos?: number;
+    /** Cargos da equipe DeskRudder (painel SaaS); vários por usuário. */
+    saas_setor_ids?: number[];
+    saas_setor_nomes?: string[];
   }
   export interface Create {
     email: string;
@@ -5246,12 +5256,14 @@ export const saasSolicitacoes = {
     busca?: string;
     tipo?: string;
     status?: string;
+    fase?: string;
     slug?: string;
     ordenar_por?: 'ingested_at' | 'created_at_origem' | 'titulo';
     ordem?: 'asc' | 'desc';
     offset?: number;
     limit?: number;
   }) => listPaginated<SaasSolicitacoesProduto.ListaItem>('/saas/solicitacoes', params),
+  resumo: () => api<SaasSolicitacoesProduto.Resumo>('/saas/solicitacoes/resumo'),
   get: (id: number) => api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}`),
   alterarStatus: (id: number, data: SaasSolicitacoesProduto.StatusUpdate) =>
     api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/status`, {
@@ -5282,9 +5294,18 @@ export namespace SaasOpsConta {
   export interface McpGerado extends McpEstado {
     token: string
   }
+  export interface Perfil {
+    id: number
+    nome: string
+    email: string
+    access_token?: string | null
+    refresh_token?: string | null
+  }
 }
 
 export const saasOpsConta = {
+  atualizarPerfil: (data: { nome?: string; email?: string }) =>
+    api<SaasOpsConta.Perfil>('/saas/me', { method: 'PATCH', body: JSON.stringify(data) }),
   mcpToken: () => api<SaasOpsConta.McpEstado>('/saas/me/mcp-token'),
   gerarMcpToken: () =>
     api<SaasOpsConta.McpGerado>('/saas/me/mcp-token', { method: 'POST', body: JSON.stringify({}) }),
@@ -5293,6 +5314,12 @@ export const saasOpsConta = {
 };
 
 export namespace SaasOpsUsuarios {
+  export interface SetorRef {
+    id: number
+    nome: string
+    ativo: boolean
+    created_at: string | null
+  }
   export interface Usuario {
     id: number
     nome: string
@@ -5302,6 +5329,8 @@ export namespace SaasOpsUsuarios {
     mcp_token_configurado: boolean
     mcp_token_gerado_em: string | null
     created_at: string | null
+    setor_ids: number[]
+    setores: SetorRef[]
   }
   export interface Criado extends Usuario {
     senha_temporaria: string
@@ -5316,9 +5345,9 @@ export const saasOpsUsuarios = {
     limit?: number
   }) => listPaginated<SaasOpsUsuarios.Usuario>('/saas/usuarios', params),
   get: (id: number) => api<SaasOpsUsuarios.Usuario>(`/saas/usuarios/${id}`),
-  create: (data: { nome: string; email: string }) =>
+  create: (data: { nome: string; email: string; setor_ids?: number[] }) =>
     api<SaasOpsUsuarios.Criado>('/saas/usuarios', { method: 'POST', body: JSON.stringify(data) }),
-  update: (id: number, data: { nome?: string; ativo?: boolean }) =>
+  update: (id: number, data: { nome?: string; ativo?: boolean; setor_ids?: number[] }) =>
     api<SaasOpsUsuarios.Usuario>(`/saas/usuarios/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
   senhaTemporaria: (id: number) =>
     api<{ senha_temporaria: string }>(`/saas/usuarios/${id}/senha-temporaria`, {
@@ -5327,7 +5356,34 @@ export const saasOpsUsuarios = {
     }),
 };
 
+export namespace SaasSetores {
+  export interface Setor {
+    id: number
+    nome: string
+    ativo: boolean
+    created_at: string | null
+  }
+}
+
+export const saasSetores = {
+  list: (params?: { incluir_inativos?: boolean }) =>
+    api<SaasSetores.Setor[]>(withParams('/saas/setores', params)),
+  get: (id: number) => api<SaasSetores.Setor>(`/saas/setores/${id}`),
+  create: (data: { nome: string }) =>
+    api<SaasSetores.Setor>('/saas/setores', { method: 'POST', body: JSON.stringify(data) }),
+  update: (id: number, data: { nome?: string; ativo?: boolean }) =>
+    api<SaasSetores.Setor>(`/saas/setores/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+};
+
 export namespace SaasSolicitacoesProduto {
+  export interface Resumo {
+    total: number;
+    sugestoes: number;
+    problemas: number;
+    aguardando: number;
+    desenvolvimento: number;
+    finalizadas: number;
+  }
   export interface ListaItem {
     id: number;
     cliente_saas_id?: number | null;
@@ -5483,10 +5539,30 @@ export namespace SaasClientes {
     status: Status;
     plano?: string | null;
     plano_id?: number | null;
-    plano_modulos?: Array<{ id: number; codigo: string; nome: string; ativo?: boolean }>;
+    plano_modulos?: Array<{
+      id: number;
+      codigo: string;
+      nome: string;
+      ativo?: boolean;
+      preco_mensal?: number | null;
+    }>;
+    modulos_contratados?: Array<{
+      id: number;
+      codigo: string;
+      nome: string;
+      ativo?: boolean;
+      preco_mensal?: number | null;
+    }>;
     modulos_snapshot?: string[];
     max_postos?: number | null;
     max_usuarios?: number | null;
+    usuarios_inclusos?: number | null;
+    preco_usuario_extra?: number | null;
+    preco_modulos?: number | null;
+    preco_usuarios_extra?: number | null;
+    preco_mensal_estimado?: number | null;
+    preco_mensal_negociado?: number | null;
+    preco_mensal_efetivo?: number | null;
     data_inicio: string;
     data_renovacao?: string | null;
     instancia_url?: string | null;
@@ -5519,6 +5595,9 @@ export namespace SaasClientes {
     status?: Status;
     plano?: string | null;
     plano_id?: number | null;
+    modulo_ids?: number[] | null;
+    usuarios_contratados?: number | null;
+    preco_mensal_negociado?: number | null;
     data_inicio: string;
     data_renovacao?: string | null;
     instancia_url?: string | null;
@@ -5536,6 +5615,7 @@ export namespace SaasCatalogo {
     codigo: string;
     nome: string;
     descricao?: string | null;
+    preco_mensal?: number | null;
     ativo: boolean;
     created_at?: string | null;
     updated_at?: string | null;
@@ -5545,6 +5625,7 @@ export namespace SaasCatalogo {
     codigo: string;
     nome: string;
     ativo?: boolean;
+    preco_mensal?: number | null;
   }
   export interface Plano {
     id: number;
@@ -5554,6 +5635,8 @@ export namespace SaasCatalogo {
     ativo: boolean;
     ordem: number;
     preco_mensal?: number | null;
+    usuarios_inclusos?: number;
+    preco_usuario_extra?: number | null;
     max_postos?: number | null;
     max_usuarios?: number | null;
     modulos: ModuloBrief[];
@@ -5565,8 +5648,8 @@ export namespace SaasCatalogo {
     nome: string;
     descricao?: string | null;
     ordem?: number;
-    preco_mensal?: number | null;
-    max_postos?: number | null;
+    usuarios_inclusos?: number | null;
+    preco_usuario_extra?: number | null;
     max_usuarios?: number | null;
     modulo_ids?: number[];
   }
@@ -5575,6 +5658,7 @@ export namespace SaasCatalogo {
     codigo: string;
     nome: string;
     descricao?: string | null;
+    preco_mensal?: number | null;
   }
   export type ModuloUpdate = Partial<Omit<ModuloCreate, 'codigo'>>;
 }

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1825,6 +1825,20 @@ export namespace ChatInterno {
     papel: 'admin' | 'membro';
   }
 
+  export interface MembroCanalSetor {
+    atendente_id: number;
+    nome: string;
+    online: boolean;
+  }
+
+  export interface MembrosCanalSetorLista {
+    setor_id: number;
+    setor_nome: string;
+    total: number;
+    online_count: number;
+    items: MembroCanalSetor[];
+  }
+
   export interface ConversaInbox {
     id: number;
     tipo: ConversaTipo;
@@ -1988,6 +2002,8 @@ export const chatInterno = {
     }),
   obterCanalSetor: (setorId: number) =>
     api<ChatInterno.Conversa>(`/chat-interno/setores/${setorId}/canal`),
+  listarMembrosCanalSetor: (setorId: number) =>
+    api<ChatInterno.MembrosCanalSetorLista>(`/chat-interno/setores/${setorId}/membros`),
   publicarCanalSetor: (setorId: number, corpo: string) =>
     api<ChatInterno.Mensagem>(`/chat-interno/setores/${setorId}/canal/mensagens`, {
       method: 'POST',

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1082,6 +1082,10 @@ export namespace WhatsappChats {
   classificacao_demanda_pendente?: boolean
   foto_perfil_url?: string | null
   foto_perfil_atualizada_em?: string | null
+  /** Mensagens inbound não vistas pelo atendente atual (#951). */
+  nao_lidas_count?: number
+  last_seen_at?: string | null
+  last_seen_mensagem_id?: number | null
   }
   export interface EmpresaOpcao {
     id: number
@@ -4591,6 +4595,9 @@ export namespace Kb {
     atendimento_inicio_at: string | null;
     encerramento_at: string | null;
     ultima_mensagem_preview?: string | null;
+    nao_lidas_count?: number;
+    last_seen_at?: string | null;
+    last_seen_mensagem_id?: number | null;
   }
   export interface PortalChatSession {
     visitor_token: string;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5373,11 +5373,6 @@ export const saasSolicitacoes = {
       method: 'POST',
       body: JSON.stringify(data ?? {}),
     }),
-  definirVersaoAlvo: (id: number, data: SaasSolicitacoesProduto.VersaoAlvoUpdate) =>
-    api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/versao-alvo`, {
-      method: 'PATCH',
-      body: JSON.stringify(data),
-    }),
   ligarGithub: (id: number, data: SaasSolicitacoesProduto.GithubUpdate) =>
     api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/github`, {
       method: 'PATCH',
@@ -5569,10 +5564,6 @@ export namespace SaasSolicitacoesProduto {
   export interface ComentarioCreate {
     corpo: string;
     publico_cliente: boolean;
-  }
-  export interface VersaoAlvoUpdate {
-    versao_alvo?: string | null;
-    comentario_publico?: string | null;
   }
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5270,6 +5270,16 @@ export const saasSolicitacoes = {
       method: 'PATCH',
       body: JSON.stringify(data),
     }),
+  implementar: (id: number, data?: SaasSolicitacoesProduto.Implementar) =>
+    api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/implementar`, {
+      method: 'POST',
+      body: JSON.stringify(data ?? {}),
+    }),
+  ligarGithub: (id: number, data: SaasSolicitacoesProduto.GithubUpdate) =>
+    api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/github`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
   comentar: (id: number, data: SaasSolicitacoesProduto.ComentarioCreate) =>
     api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/comentarios`, {
       method: 'POST',
@@ -5440,6 +5450,17 @@ export namespace SaasSolicitacoesProduto {
   export interface StatusUpdate {
     status: string;
     motivo_nao_desenvolvimento?: string | null;
+  }
+  export interface GithubUpdate {
+    github_issue_url?: string | null;
+    github_issue_number?: number | null;
+    github_repo?: string | null;
+  }
+  export interface Implementar {
+    github_issue_url?: string | null;
+    github_issue_number?: number | null;
+    github_repo?: string | null;
+    criar_issue?: boolean;
   }
   export interface ComentarioCreate {
     corpo: string;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -818,7 +818,8 @@ export const ponto = {
     return res.blob()
   },
   meSettings: () => api<Ponto.SettingsPublic>('/ponto/me/settings'),
-  locais: () => api<Ponto.Local[]>('/ponto/locais'),
+  locais: (params?: { atendente_id?: number; so_orfos?: boolean }) =>
+    api<Ponto.Local[]>(withParams('/ponto/locais', params)),
   criarLocal: (data: Ponto.LocalCreate) =>
     api<Ponto.Local>('/ponto/locais', { method: 'POST', body: JSON.stringify(data) }),
   atualizarLocal: (id: number, data: Ponto.LocalUpdate) =>
@@ -935,6 +936,9 @@ export namespace SystemSettings {
     cidade?: string | null
     estado?: string | null
     cep?: string | null
+    latitude?: number | null
+    longitude?: number | null
+    ponto_raio_metros?: number
     logo_url?: string | null
   }
 
@@ -952,6 +956,9 @@ export namespace SystemSettings {
     cidade?: string | null
     estado?: string | null
     cep?: string | null
+    latitude?: number | null
+    longitude?: number | null
+    ponto_raio_metros?: number | null
   }
 
   export interface TicketEmailGraceOpcao {
@@ -2463,6 +2470,8 @@ export namespace Atendentes {
     horario_previsto_entrada?: string | null;
     horario_previsto_saida?: string | null;
     tolerancia_atraso_minutos?: number;
+    usar_local_empresa?: boolean;
+    local_empresa_raio_metros?: number | null;
     /** Cargos da equipe DeskRudder (painel SaaS); vários por usuário. */
     saas_setor_ids?: number[];
     saas_setor_nomes?: string[];
@@ -2483,6 +2492,8 @@ export namespace Atendentes {
     horario_previsto_entrada?: string | null;
     horario_previsto_saida?: string | null;
     tolerancia_atraso_minutos?: number;
+    usar_local_empresa?: boolean;
+    local_empresa_raio_metros?: number | null;
   }
   export interface Update {
     email?: string;
@@ -2500,6 +2511,8 @@ export namespace Atendentes {
     horario_previsto_entrada?: string | null;
     horario_previsto_saida?: string | null;
     tolerancia_atraso_minutos?: number;
+    usar_local_empresa?: boolean;
+    local_empresa_raio_metros?: number | null;
   }
   export interface AvaliacaoResumo {
     media: number | null;
@@ -4870,21 +4883,27 @@ export namespace Ponto {
   }
   export interface Local {
     id: number
+    atendente_id?: number | null
     nome: string
+    endereco?: string | null
     latitude: number
     longitude: number
     raio_metros: number
     ativo: boolean
   }
   export interface LocalCreate {
+    atendente_id: number
     nome: string
+    endereco?: string | null
     latitude: number
     longitude: number
     raio_metros?: number
     ativo?: boolean
   }
   export interface LocalUpdate {
+    atendente_id?: number | null
     nome?: string
+    endereco?: string | null
     latitude?: number
     longitude?: number
     raio_metros?: number

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -5081,6 +5081,7 @@ export namespace SolicitacoesMelhoria {
     titulo: string
     status: Status | string
     status_rotulo: string
+    versao_alvo_rotulo?: string | null
     autor_nome?: string | null
     organizacao_id: number
     created_at: string
@@ -5121,6 +5122,8 @@ export namespace SolicitacoesMelhoria {
     status_rotulo: string
     motivo_nao_desenvolvimento?: string | null
     versao_contexto?: string | null
+    versao_alvo?: string | null
+    versao_alvo_rotulo?: string | null
     mensagem_status: string
     created_at: string
     updated_at?: string | null
@@ -5370,6 +5373,11 @@ export const saasSolicitacoes = {
       method: 'POST',
       body: JSON.stringify(data ?? {}),
     }),
+  definirVersaoAlvo: (id: number, data: SaasSolicitacoesProduto.VersaoAlvoUpdate) =>
+    api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/versao-alvo`, {
+      method: 'PATCH',
+      body: JSON.stringify(data),
+    }),
   ligarGithub: (id: number, data: SaasSolicitacoesProduto.GithubUpdate) =>
     api<SaasSolicitacoesProduto.Detalhe>(`/saas/solicitacoes/${id}/github`, {
       method: 'PATCH',
@@ -5501,6 +5509,7 @@ export namespace SaasSolicitacoesProduto {
     status: string;
     status_rotulo: string;
     versao_contexto?: string | null;
+    versao_alvo?: string | null;
     autor_nome?: string | null;
     created_at_origem?: string | null;
     ingested_at: string;
@@ -5560,6 +5569,10 @@ export namespace SaasSolicitacoesProduto {
   export interface ComentarioCreate {
     corpo: string;
     publico_cliente: boolean;
+  }
+  export interface VersaoAlvoUpdate {
+    versao_alvo?: string | null;
+    comentario_publico?: string | null;
   }
 }
 

--- a/frontend/src/components/AtendenteLocaisSection.tsx
+++ b/frontend/src/components/AtendenteLocaisSection.tsx
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+  ponto,
+  systemSettings,
+  type Ponto,
+  type SystemSettings,
+} from '../api/client'
+import { PontoLocalMapaPicker } from './PontoLocalMapaPicker'
+import { Button } from './ui/Button'
+import { Input } from './ui/Input'
+import { Switch } from './ui/Switch'
+import { useToast } from './ui/Toast'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+
+type Props = {
+  atendenteId: number
+  usarLocalEmpresa: boolean
+  localEmpresaRaio: string
+  onUsarLocalEmpresaChange: (v: boolean) => void
+  onLocalEmpresaRaioChange: (v: string) => void
+}
+
+export function AtendenteLocaisSection({
+  atendenteId,
+  usarLocalEmpresa,
+  localEmpresaRaio,
+  onUsarLocalEmpresaChange,
+  onLocalEmpresaRaioChange,
+}: Props) {
+  const toast = useToast()
+  const [empresa, setEmpresa] = useState<SystemSettings.EmpresaSistema | null>(null)
+  const [locais, setLocais] = useState<Ponto.Local[]>([])
+  const [nome, setNome] = useState('')
+  const [mapa, setMapa] = useState({
+    latitude: null as number | null,
+    longitude: null as number | null,
+    endereco: '',
+    raio_metros: 200,
+  })
+  const [editId, setEditId] = useState<number | null>(null)
+  const [salvando, setSalvando] = useState(false)
+
+  const carregar = useCallback(async () => {
+    const [emp, locs] = await Promise.all([
+      systemSettings.getEmpresaSistema(),
+      ponto.locais({ atendente_id: atendenteId }),
+    ])
+    setEmpresa(emp)
+    setLocais(locs)
+  }, [atendenteId])
+
+  useEffect(() => {
+    void carregar().catch((err) => {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar os locais.'))
+    })
+  }, [carregar, toast])
+
+  const empresaTemPin = empresa?.latitude != null && empresa?.longitude != null
+
+  async function salvarExtra() {
+    if (!nome.trim() || mapa.latitude == null || mapa.longitude == null) {
+      toast.showWarning('Informe nome e pin (lat/lon) do local.')
+      return
+    }
+    setSalvando(true)
+    try {
+      const payload = {
+        nome: nome.trim(),
+        endereco: mapa.endereco?.trim() || null,
+        latitude: mapa.latitude,
+        longitude: mapa.longitude,
+        raio_metros: mapa.raio_metros || 200,
+      }
+      if (editId != null) {
+        await ponto.atualizarLocal(editId, payload)
+        toast.showSuccess('Local atualizado.')
+      } else {
+        await ponto.criarLocal({ ...payload, atendente_id: atendenteId })
+        toast.showSuccess('Local adicionado.')
+      }
+      setEditId(null)
+      setNome('')
+      setMapa({ latitude: null, longitude: null, endereco: '', raio_metros: 200 })
+      await carregar()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o local.'))
+    } finally {
+      setSalvando(false)
+    }
+  }
+
+  async function toggleAtivo(loc: Ponto.Local) {
+    try {
+      await ponto.atualizarLocal(loc.id, { ativo: !loc.ativo })
+      await carregar()
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar o local.'))
+    }
+  }
+
+  async function remover(id: number) {
+    if (!confirm('Remover este local?')) return
+    try {
+      await ponto.removerLocal(id)
+      await carregar()
+      toast.showSuccess('Local removido.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível remover o local.'))
+    }
+  }
+
+  function editar(loc: Ponto.Local) {
+    setEditId(loc.id)
+    setNome(loc.nome)
+    setMapa({
+      latitude: loc.latitude,
+      longitude: loc.longitude,
+      endereco: loc.endereco ?? '',
+      raio_metros: loc.raio_metros,
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-lg border border-slate-200 p-3 dark:border-slate-800">
+        <Switch
+          bare
+          checked={usarLocalEmpresa}
+          onCheckedChange={onUsarLocalEmpresaChange}
+          label="Local da empresa"
+          description={
+            empresaTemPin
+              ? `Pin em ${empresa!.latitude!.toFixed(5)}, ${empresa!.longitude!.toFixed(5)} · raio padrão ${empresa!.ponto_raio_metros ?? 200} m (Configurações → Empresa).`
+              : 'Configure o pin da empresa em Configurações → Empresa para usar este local.'
+          }
+          showStatusPill
+          statusOnText="Ativo"
+          statusOffText="Desligado"
+        />
+        {usarLocalEmpresa ? (
+          <div className="mt-3 max-w-xs">
+            <Input
+              label="Raio neste usuário (m) — opcional"
+              type="number"
+              min={20}
+              max={50000}
+              value={localEmpresaRaio}
+              onChange={(e) => onLocalEmpresaRaioChange(e.target.value)}
+              placeholder={String(empresa?.ponto_raio_metros ?? 200)}
+            />
+            <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+              Vazio = usa o raio padrão da empresa. Salve o cadastro para gravar.
+            </p>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="space-y-3">
+        <p className="text-sm font-medium text-slate-800 dark:text-slate-100">Outros locais</p>
+        <p className="text-xs text-slate-500 dark:text-slate-400">
+          Casa, filial ou remoto. A batida vale se estiver dentro do raio de qualquer local ativo.
+        </p>
+        <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} placeholder="Ex.: Home office" />
+        <PontoLocalMapaPicker value={mapa} onChange={setMapa} />
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" disabled={salvando} onClick={() => void salvarExtra()}>
+            {editId != null ? 'Salvar local' : 'Adicionar local'}
+          </Button>
+          {editId != null ? (
+            <Button
+              type="button"
+              variant="cancel"
+              onClick={() => {
+                setEditId(null)
+                setNome('')
+                setMapa({ latitude: null, longitude: null, endereco: '', raio_metros: 200 })
+              }}
+            >
+              Cancelar edição
+            </Button>
+          ) : null}
+        </div>
+        <ul className="space-y-2 text-sm">
+          {locais.length === 0 ? (
+            <li className="text-slate-500">Nenhum local extra cadastrado.</li>
+          ) : (
+            locais.map((loc) => (
+              <li
+                key={loc.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+              >
+                <span>
+                  <strong>{loc.nome}</strong>
+                  {loc.endereco ? ` · ${loc.endereco}` : ''} · {loc.latitude.toFixed(5)},{' '}
+                  {loc.longitude.toFixed(5)} · raio {loc.raio_metros} m
+                  {!loc.ativo ? ' (desativado)' : ''}
+                </span>
+                <div className="flex flex-wrap gap-2">
+                  <Button type="button" variant="secondary" onClick={() => editar(loc)}>
+                    Editar
+                  </Button>
+                  <Button type="button" variant="secondary" onClick={() => void toggleAtivo(loc)}>
+                    {loc.ativo ? 'Desativar' : 'Ativar'}
+                  </Button>
+                  <Button type="button" variant="ghost" onClick={() => void remover(loc.id)}>
+                    Remover
+                  </Button>
+                </div>
+              </li>
+            ))
+          )}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/AtendenteLocaisSection.tsx
+++ b/frontend/src/components/AtendenteLocaisSection.tsx
@@ -5,7 +5,7 @@ import {
   type Ponto,
   type SystemSettings,
 } from '../api/client'
-import { PontoLocalMapaPicker } from './PontoLocalMapaPicker'
+import { PontoLocalMapaPicker, type PontoLocalMapaValue } from './PontoLocalMapaPicker'
 import { Button } from './ui/Button'
 import { Input } from './ui/Input'
 import { Switch } from './ui/Switch'
@@ -31,7 +31,7 @@ export function AtendenteLocaisSection({
   const [empresa, setEmpresa] = useState<SystemSettings.EmpresaSistema | null>(null)
   const [locais, setLocais] = useState<Ponto.Local[]>([])
   const [nome, setNome] = useState('')
-  const [mapa, setMapa] = useState({
+  const [mapa, setMapa] = useState<PontoLocalMapaValue>({
     latitude: null as number | null,
     longitude: null as number | null,
     endereco: '',

--- a/frontend/src/components/PontoLocalMapaPicker.tsx
+++ b/frontend/src/components/PontoLocalMapaPicker.tsx
@@ -1,0 +1,201 @@
+import { useState } from 'react'
+import { Button } from './ui/Button'
+import { Input } from './ui/Input'
+import { linkMapaOsm } from '../lib/pontoFormat'
+
+export type PontoLocalMapaValue = {
+  latitude: number | null
+  longitude: number | null
+  endereco?: string
+  raio_metros?: number
+}
+
+type Props = {
+  value: PontoLocalMapaValue
+  onChange: (next: PontoLocalMapaValue) => void
+  /** Prefill de busca (ex.: endereço da empresa). */
+  buscaInicial?: string
+  mostrarRaio?: boolean
+  raioLabel?: string
+}
+
+type NominatimHit = {
+  display_name: string
+  lat: string
+  lon: string
+}
+
+function embedUrl(lat: number, lon: number, delta = 0.008): string {
+  const bbox = `${lon - delta},${lat - delta},${lon + delta},${lat + delta}`
+  return `https://www.openstreetmap.org/export/embed.html?bbox=${encodeURIComponent(bbox)}&layer=mapnik&marker=${lat}%2C${lon}`
+}
+
+export function PontoLocalMapaPicker({
+  value,
+  onChange,
+  buscaInicial = '',
+  mostrarRaio = true,
+  raioLabel = 'Raio (m)',
+}: Props) {
+  const [busca, setBusca] = useState(buscaInicial)
+  const [buscando, setBuscando] = useState(false)
+  const [hits, setHits] = useState<NominatimHit[]>([])
+  const [erroBusca, setErroBusca] = useState<string | null>(null)
+
+  const lat = value.latitude
+  const lon = value.longitude
+  const temPin = lat != null && lon != null && Number.isFinite(lat) && Number.isFinite(lon)
+
+  async function buscarNoMapa() {
+    const q = busca.trim()
+    if (!q) {
+      setErroBusca('Informe um endereço para buscar.')
+      return
+    }
+    setBuscando(true)
+    setErroBusca(null)
+    setHits([])
+    try {
+      const url =
+        'https://nominatim.openstreetmap.org/search?' +
+        new URLSearchParams({
+          q,
+          format: 'json',
+          limit: '5',
+          addressdetails: '0',
+        }).toString()
+      const res = await fetch(url, {
+        headers: { Accept: 'application/json' },
+      })
+      if (!res.ok) throw new Error('falha')
+      const data = (await res.json()) as NominatimHit[]
+      if (!data.length) {
+        setErroBusca('Nenhum resultado. Ajuste o endereço ou informe latitude/longitude.')
+        return
+      }
+      setHits(data)
+    } catch {
+      setErroBusca('Não foi possível buscar o endereço. Tente de novo ou use lat/lon.')
+    } finally {
+      setBuscando(false)
+    }
+  }
+
+  function escolherHit(hit: NominatimHit) {
+    const latitude = Number(hit.lat)
+    const longitude = Number(hit.lon)
+    onChange({
+      ...value,
+      latitude,
+      longitude,
+      endereco: hit.display_name,
+    })
+    setBusca(hit.display_name)
+    setHits([])
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-2">
+        <div className="min-w-[12rem] flex-1">
+          <Input
+            label="Buscar endereço no mapa"
+            value={busca}
+            onChange={(e) => setBusca(e.target.value)}
+            placeholder="Rua, número, cidade…"
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                void buscarNoMapa()
+              }
+            }}
+          />
+        </div>
+        <Button type="button" variant="secondary" disabled={buscando} onClick={() => void buscarNoMapa()}>
+          {buscando ? 'Buscando…' : 'Buscar'}
+        </Button>
+      </div>
+      {erroBusca ? <p className="text-sm text-amber-700 dark:text-amber-300">{erroBusca}</p> : null}
+      {hits.length > 0 ? (
+        <ul className="max-h-40 space-y-1 overflow-auto rounded-lg border border-slate-200 text-sm dark:border-slate-700">
+          {hits.map((h) => (
+            <li key={`${h.lat}-${h.lon}-${h.display_name}`}>
+              <button
+                type="button"
+                className="w-full px-3 py-2 text-left hover:bg-slate-50 dark:hover:bg-slate-800"
+                onClick={() => escolherHit(h)}
+              >
+                {h.display_name}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Input
+          label="Latitude"
+          type="number"
+          step="any"
+          value={lat != null ? String(lat) : ''}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              latitude: e.target.value === '' ? null : Number(e.target.value),
+            })
+          }
+        />
+        <Input
+          label="Longitude"
+          type="number"
+          step="any"
+          value={lon != null ? String(lon) : ''}
+          onChange={(e) =>
+            onChange({
+              ...value,
+              longitude: e.target.value === '' ? null : Number(e.target.value),
+            })
+          }
+        />
+        {mostrarRaio ? (
+          <Input
+            label={raioLabel}
+            type="number"
+            min={20}
+            max={50000}
+            value={String(value.raio_metros ?? 200)}
+            onChange={(e) =>
+              onChange({
+                ...value,
+                raio_metros: Number(e.target.value) || 200,
+              })
+            }
+          />
+        ) : null}
+      </div>
+      {temPin ? (
+        <div className="overflow-hidden rounded-xl border border-slate-200 dark:border-slate-700">
+          <iframe
+            title="Mapa do local"
+            className="h-56 w-full border-0"
+            loading="lazy"
+            src={embedUrl(lat!, lon!)}
+          />
+          <div className="border-t border-slate-200 px-3 py-2 text-right text-sm dark:border-slate-700">
+            <a
+              className="text-cyan-700 underline dark:text-cyan-300"
+              href={linkMapaOsm(lat!, lon!)}
+              target="_blank"
+              rel="noreferrer"
+            >
+              Abrir no OpenStreetMap
+            </a>
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-slate-500 dark:text-slate-400">
+          Busque um endereço ou informe latitude e longitude para marcar o pin.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/chat-interno/ChatInternoSetorMembrosModal.tsx
+++ b/frontend/src/components/chat-interno/ChatInternoSetorMembrosModal.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react'
+import { chatInterno, type ChatInterno } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { useAuth } from '../../contexts/AuthContext'
+import { useToast } from '../ui/Toast'
+import { MODAL_OVERLAY, MODAL_PANEL_SCROLLABLE } from '../../lib/modalPanel'
+
+type Props = {
+  open: boolean
+  setorId: number
+  tituloSetor?: string
+  onClose: () => void
+}
+
+/** Modal read-only: membros do canal de setor + quem está online (#S202608-0008 / #941). */
+export function ChatInternoSetorMembrosModal({ open, setorId, tituloSetor, onClose }: Props) {
+  const { user } = useAuth()
+  const toast = useToast()
+  const [carregando, setCarregando] = useState(false)
+  const [dados, setDados] = useState<ChatInterno.MembrosCanalSetorLista | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setCarregando(true)
+    setDados(null)
+    let cancelado = false
+    void chatInterno
+      .listarMembrosCanalSetor(setorId)
+      .then((lista) => {
+        if (!cancelado) setDados(lista)
+      })
+      .catch((err) => {
+        if (cancelado) return
+        toast.showError(mensagemFalhaParaToast(err))
+        onClose()
+      })
+      .finally(() => {
+        if (!cancelado) setCarregando(false)
+      })
+    return () => {
+      cancelado = true
+    }
+  }, [open, setorId]) // toast/onClose estáveis o suficiente para o fetch do modal
+
+  if (!open) return null
+
+  const titulo = dados?.setor_nome || tituloSetor || 'Canal do setor'
+  const onlineCount = dados?.online_count ?? 0
+  const total = dados?.total ?? 0
+
+  return (
+    <div className={MODAL_OVERLAY} role="presentation" onMouseDown={(e) => e.target === e.currentTarget && onClose()}>
+      <div
+        className={`${MODAL_PANEL_SCROLLABLE} max-w-md`}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="setor-membros-titulo"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-start justify-between gap-3 border-b border-slate-100 px-5 py-4 dark:border-slate-800">
+          <div className="min-w-0">
+            <h2 id="setor-membros-titulo" className="text-lg font-bold text-slate-900 dark:text-white">
+              {titulo}
+            </h2>
+            <p className="mt-0.5 text-sm text-slate-500">
+              {carregando
+                ? 'Carregando membros…'
+                : `${total} ${total === 1 ? 'membro' : 'membros'}${total > 0 ? ` · ${onlineCount} online` : ''}`}
+            </p>
+          </div>
+          <button
+            type="button"
+            className="flex size-9 shrink-0 items-center justify-center rounded-lg text-xl text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
+            onClick={onClose}
+            aria-label="Fechar"
+          >
+            &times;
+          </button>
+        </div>
+        <div className="dx-scrollbar max-h-[min(60dvh,24rem)] overflow-y-auto px-5 py-4">
+          {carregando ? (
+            <p className="py-6 text-center text-sm text-slate-400 animate-pulse">Carregando…</p>
+          ) : !dados || dados.items.length === 0 ? (
+            <p className="py-6 text-center text-sm text-slate-500">
+              Nenhum usuário vinculado a este setor.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {dados.items.map((m) => {
+                const isSelf = m.atendente_id === user?.id
+                return (
+                  <li
+                    key={m.atendente_id}
+                    className="flex items-center gap-3 rounded-xl border border-slate-200 px-3 py-2.5 dark:border-slate-700"
+                  >
+                    <span
+                      className={`size-2.5 shrink-0 rounded-full ${
+                        m.online ? 'bg-emerald-500' : 'bg-slate-300 dark:bg-slate-600'
+                      }`}
+                      title={m.online ? 'Online' : 'Offline'}
+                      aria-hidden
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium text-slate-900 dark:text-slate-100">
+                        {m.nome}
+                        {isSelf ? <span className="ml-1 font-normal text-slate-500">(você)</span> : null}
+                      </p>
+                      <p className="text-xs text-slate-500">{m.online ? 'Online' : 'Offline'}</p>
+                    </div>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/ChatEncerrarModal.tsx
+++ b/frontend/src/components/chat/ChatEncerrarModal.tsx
@@ -142,13 +142,13 @@ export function ChatEncerrarModal<TChat extends { estado: string }>({
     try {
       if (acao === 'registrar') {
         if (form.naturezaId === '') {
-          toast.showWarning('Selecione a natureza da demanda ou marque encerrar sem registar.')
+          toast.showWarning('Selecione a natureza da demanda ou marque encerrar sem registrar.')
           return
         }
         await api.registrarDemanda(chatId, demandaFormPayload(form))
       } else if (acao === 'sem_demanda') {
         if (!demandaOpcional && !confirmarSemDemanda) {
-          toast.showWarning('Confirme que deseja encerrar sem registar demanda.')
+          toast.showWarning('Confirme que deseja encerrar sem registrar demanda.')
           return
         }
       } else if (acao === 'nova') {
@@ -181,14 +181,14 @@ export function ChatEncerrarModal<TChat extends { estado: string }>({
 
   if (demandaOpcional) {
     mensagemIntro = chatJaEncerrado
-      ? 'Este atendimento foi encerrado automaticamente por inatividade do cliente. Registar demanda é opcional.'
-      : 'O cliente está inativo. Pode encerrar sem registar demanda ou classificar opcionalmente.'
+      ? 'Este atendimento foi encerrado automaticamente por inatividade do cliente. Registrar demanda é opcional.'
+      : 'O cliente está inativo. Pode encerrar sem registrar demanda ou classificar opcionalmente.'
   } else if (semDemandas) {
     mensagemIntro =
-      'Registe o motivo do atendimento antes de encerrar, ou confirme explicitamente o encerramento sem demanda.'
+      'Registre o motivo do atendimento antes de encerrar, ou confirme explicitamente o encerramento sem demanda.'
   } else if (posRegistro) {
     mensagemIntro =
-      'Houve conversa após o último registo de demanda. Escolha se mantém, corrige ou acrescenta outra demanda.'
+      'Houve conversa após o último registro de demanda. Escolha se mantém, corrige ou acrescenta outra demanda.'
   }
 
   const mostrarForm = acao === 'registrar' || acao === 'nova' || (acao === 'editar' && posRegistro != null)
@@ -233,7 +233,7 @@ export function ChatEncerrarModal<TChat extends { estado: string }>({
             <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-950 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-100">
               <p className="font-semibold">Conversa continuou após a última demanda</p>
               <p className="mt-1">
-                «{rotuloDemanda(posRegistro.ultimaDemanda)}» registada às{' '}
+                «{rotuloDemanda(posRegistro.ultimaDemanda)}» registrada às{' '}
                 {formatarHoraDemanda(posRegistro.ultimaDemanda.created_at)}.
               </p>
               <p className="mt-1">
@@ -251,7 +251,7 @@ export function ChatEncerrarModal<TChat extends { estado: string }>({
               {demandaOpcional ? (
                 <>
                   <p className="text-xs text-slate-500">
-                    Registar demanda é opcional neste encerramento por inatividade.
+                    Registrar demanda é opcional neste encerramento por inatividade.
                   </p>
                   <label className="flex cursor-pointer items-center gap-2 text-sm">
                     <input
@@ -260,7 +260,7 @@ export function ChatEncerrarModal<TChat extends { estado: string }>({
                       checked={acao === 'sem_demanda'}
                       onChange={() => selecionarAcao('sem_demanda')}
                     />
-                    {chatJaEncerrado ? 'Concluir sem registar demanda' : 'Encerrar sem registar demanda'}
+                    {chatJaEncerrado ? 'Concluir sem registrar demanda' : 'Encerrar sem registrar demanda'}
                   </label>
                   <label className="flex cursor-pointer items-center gap-2 text-sm">
                     <input
@@ -269,7 +269,7 @@ export function ChatEncerrarModal<TChat extends { estado: string }>({
                       checked={acao === 'registrar'}
                       onChange={() => selecionarAcao('registrar')}
                     />
-                    Registar demanda (opcional)
+                    Registrar demanda (opcional)
                   </label>
                 </>
               ) : (
@@ -281,7 +281,7 @@ export function ChatEncerrarModal<TChat extends { estado: string }>({
                       checked={acao === 'registrar'}
                       onChange={() => selecionarAcao('registrar')}
                     />
-                    Registar demanda e encerrar
+                    Registrar demanda e encerrar
                   </label>
                   <label className="flex cursor-pointer items-center gap-2 text-sm">
                     <input
@@ -290,7 +290,7 @@ export function ChatEncerrarModal<TChat extends { estado: string }>({
                       checked={acao === 'sem_demanda'}
                       onChange={() => selecionarAcao('sem_demanda')}
                     />
-                    Encerrar sem registar demanda
+                    Encerrar sem registrar demanda
                   </label>
                   {acao === 'sem_demanda' && (
                     <CheckboxField
@@ -338,7 +338,7 @@ export function ChatEncerrarModal<TChat extends { estado: string }>({
             </div>
           ) : (
             <p className="text-xs text-slate-500">
-              As demandas registadas cobrem esta sessão. Confirme para encerrar.
+              As demandas registradas cobrem esta sessão. Confirme para encerrar.
             </p>
           )}
 
@@ -350,7 +350,7 @@ export function ChatEncerrarModal<TChat extends { estado: string }>({
             <Button variant="cancel" onClick={onClose} disabled={salvando}>
               Cancelar
             </Button>
-            <Button variant="danger" onClick={() => void executarEncerramento()} loading={salvando}>
+            <Button variant="primary" onClick={() => void executarEncerramento()} loading={salvando}>
               {rotuloBotaoEncerrar}
             </Button>
           </div>

--- a/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
+++ b/frontend/src/components/chat/WhatsappMensagemAcoes.tsx
@@ -18,6 +18,8 @@ type Props = {
   podeReagir?: boolean
   /** Balão claro (inbound) — seta escura. */
   tomClaro?: boolean
+  /** Notifica quando menu ou edição estão ativos (#947 / #S202608-0005). */
+  onMenuAbertoChange?: (aberto: boolean) => void
 }
 
 /** Menu de ações no canto do balão (editar / apagar / reagir) — #630 / #749. */
@@ -28,6 +30,7 @@ export function WhatsappMensagemAcoes({
   onReagirMenu,
   podeReagir = false,
   tomClaro = false,
+  onMenuAbertoChange,
 }: Props) {
   const [editando, setEditando] = useState(false)
   const [texto, setTexto] = useState(() => corpoWhatsappSemPrefixo(mensagem.corpo))
@@ -44,6 +47,13 @@ export function WhatsappMensagemAcoes({
   useEffect(() => {
     if (!editando) setTexto(corpoWhatsappSemPrefixo(mensagem.corpo))
   }, [mensagem, editando])
+
+  const onMenuAbertoChangeRef = useRef(onMenuAbertoChange)
+  onMenuAbertoChangeRef.current = onMenuAbertoChange
+  useEffect(() => {
+    onMenuAbertoChangeRef.current?.(menuAberto || editando)
+    return () => onMenuAbertoChangeRef.current?.(false)
+  }, [menuAberto, editando])
 
   useEffect(() => {
     if (!menuAberto) return

--- a/frontend/src/components/chat/WhatsappReacoesBar.tsx
+++ b/frontend/src/components/chat/WhatsappReacoesBar.tsx
@@ -11,6 +11,8 @@ type Props = {
   /** Abrir picker a partir do menu da seta (#749). */
   pickerExternoAberto?: boolean
   onPickerExternoClose?: () => void
+  /** Oculta o strip de emojis do hover enquanto o menu Editar/Apagar está aberto (#947). */
+  ocultarPickerHover?: boolean
 }
 
 /** Reações no chat WhatsApp com o cliente (#630 lote 2 / #749). */
@@ -21,6 +23,7 @@ export function WhatsappReacoesBar({
   alinhamento = 'end',
   pickerExternoAberto = false,
   onPickerExternoClose,
+  ocultarPickerHover = false,
 }: Props) {
   const temReacoes = reacoes.length > 0
   const alignEnd = alinhamento === 'end'
@@ -35,34 +38,36 @@ export function WhatsappReacoesBar({
             alignEnd ? 'items-end' : 'items-start'
           } ${temReacoes || mostrarPickerMobile ? 'relative mt-1' : 'relative'}`}
         >
-          {/* Desktop: picker no hover do balão */}
-          <div
-            className={`pointer-events-none absolute bottom-full z-20 mb-1 hidden flex-col md:flex ${
-              alignEnd ? 'right-0 items-end' : 'left-0 items-start'
-            }`}
-          >
+          {/* Desktop: picker no hover do balão (oculto com menu de ações aberto — #947) */}
+          {!ocultarPickerHover ? (
             <div
-              className={`opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 ${
-                pickerHoverAberto ? 'pointer-events-auto opacity-100' : ''
+              className={`pointer-events-none absolute bottom-full z-20 mb-1 hidden flex-col md:flex ${
+                alignEnd ? 'right-0 items-end' : 'left-0 items-start'
               }`}
-              onMouseEnter={() => setPickerHoverAberto(true)}
-              onMouseLeave={() => setPickerHoverAberto(false)}
             >
-              <div className="flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
-                {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
-                  <button
-                    key={emoji}
-                    type="button"
-                    onClick={() => onReagir(emoji)}
-                    className="rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
-                    aria-label={`Reagir com ${emoji}`}
-                  >
-                    {emoji}
-                  </button>
-                ))}
+              <div
+                className={`opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 ${
+                  pickerHoverAberto ? 'pointer-events-auto opacity-100' : ''
+                }`}
+                onMouseEnter={() => setPickerHoverAberto(true)}
+                onMouseLeave={() => setPickerHoverAberto(false)}
+              >
+                <div className="flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md dark:border-slate-600 dark:bg-slate-800">
+                  {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (
+                    <button
+                      key={emoji}
+                      type="button"
+                      onClick={() => onReagir(emoji)}
+                      className="rounded-full px-1.5 py-0.5 text-base leading-none hover:bg-slate-100 dark:hover:bg-slate-700"
+                      aria-label={`Reagir com ${emoji}`}
+                    >
+                      {emoji}
+                    </button>
+                  ))}
+                </div>
               </div>
             </div>
-          </div>
+          ) : null}
           {mostrarPickerMobile ? (
             <div className="mt-1 flex items-center gap-0.5 rounded-full border border-slate-200 bg-white px-1 py-0.5 shadow-md md:hidden dark:border-slate-600 dark:bg-slate-800">
               {EMOJIS_REACAO_CHAT_INTERNO.map((emoji) => (

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -19,7 +19,7 @@ interface AuthContextValue {
   isComercialOuAdmin: boolean
   /** Admin ou atendente do setor Financeiro (faturamento interno). */
   isFinanceiroOuAdmin: boolean
-  /** Equipa comercial DeskRudder (control-plane SaaS). */
+  /** Equipe comercial DeskRudder (control-plane SaaS). */
   isSaasOps: boolean
 }
 

--- a/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
+++ b/frontend/src/hooks/useAlertaFilaSemResponsavel.ts
@@ -54,6 +54,7 @@ let currentResumo: Notificacoes.Resumo = {
   portal_fila_count: 0,
   portal_respostas_count: 0,
   chat_interno_nao_lidas_count: 0,
+  ponto_he_pendentes_count: 0,
   total_pendencias: 0,
 }
 let prevSemResponsavel: number | null = null

--- a/frontend/src/lib/chatHubLista.ts
+++ b/frontend/src/lib/chatHubLista.ts
@@ -18,6 +18,7 @@ export type ChatHubItem = {
   atendente_nome?: string | null
   ultima_mensagem_preview?: string | null
   foto_perfil_url?: string | null
+  nao_lidas_count?: number
 }
 
 export function mapWhatsappChat(c: WhatsappChats.Chat): ChatHubItem {
@@ -34,6 +35,7 @@ export function mapWhatsappChat(c: WhatsappChats.Chat): ChatHubItem {
     atendente_id: c.atendente_id,
     atendente_nome: c.atendente_nome,
     foto_perfil_url: c.foto_perfil_url,
+    nao_lidas_count: c.nao_lidas_count ?? 0,
   }
 }
 
@@ -51,6 +53,7 @@ export function mapPortalChat(c: PortalChats.Chat): ChatHubItem {
     atendente_id: c.atendente_id,
     atendente_nome: c.atendente_nome,
     ultima_mensagem_preview: c.ultima_mensagem_preview,
+    nao_lidas_count: c.nao_lidas_count ?? 0,
   }
 }
 
@@ -87,6 +90,9 @@ export function ordenarFila(items: ChatHubItem[]): ChatHubItem[] {
 
 export function ordenarAtendendo(items: ChatHubItem[]): ChatHubItem[] {
   return [...items].sort((a, b) => {
+    const ua = a.nao_lidas_count ?? 0
+    const ub = b.nao_lidas_count ?? 0
+    if (ub !== ua) return ub - ua
     const ta = a.atendimento_inicio_at || a.created_at
     const tb = b.atendimento_inicio_at || b.created_at
     return (tb ? new Date(tb).getTime() : 0) - (ta ? new Date(ta).getTime() : 0)

--- a/frontend/src/lib/saasSolicitacoes.ts
+++ b/frontend/src/lib/saasSolicitacoes.ts
@@ -11,6 +11,27 @@ export const SAAS_SOLICITACAO_STATUS = [
 
 export type SaasSolicitacaoStatus = (typeof SAAS_SOLICITACAO_STATUS)[number]['value']
 
+/** Fases para filtro rápido (agrupa vários status). */
+export const SAAS_SOLICITACAO_FASES = [
+  {
+    value: 'aguardando',
+    label: 'Aguardando',
+    hint: 'Recebida, em análise ou planejada',
+  },
+  {
+    value: 'desenvolvimento',
+    label: 'Em desenvolvimento',
+    hint: 'Já em andamento',
+  },
+  {
+    value: 'finalizadas',
+    label: 'Finalizadas',
+    hint: 'Concluída ou não será desenvolvida',
+  },
+] as const
+
+export type SaasSolicitacaoFase = (typeof SAAS_SOLICITACAO_FASES)[number]['value']
+
 const BADGE: Record<string, string> = {
   aberta:
     'bg-slate-100 text-slate-800 ring-slate-200/80 dark:bg-slate-800/70 dark:text-slate-100 dark:ring-slate-600/70',
@@ -35,6 +56,18 @@ export function classesBadgeStatusSolicitacao(value: string): string {
     BADGE[value] ??
     'bg-slate-100 text-slate-800 ring-slate-200/80 dark:bg-slate-800/70 dark:text-slate-100 dark:ring-slate-600/70'
   )
+}
+
+/** Painel ops: “problema” do cliente = erro reportado. */
+export function rotuloTipoSolicitacao(tipo: string): string {
+  return tipo === 'problema' ? 'Erro' : 'Sugestão'
+}
+
+export function classesBadgeTipoSolicitacao(tipo: string): string {
+  if (tipo === 'problema') {
+    return 'bg-rose-50 text-rose-900 ring-rose-200/90 dark:bg-rose-950/45 dark:text-rose-100 dark:ring-rose-800/60'
+  }
+  return 'bg-sky-50 text-sky-900 ring-sky-200/90 dark:bg-sky-950/45 dark:text-sky-100 dark:ring-sky-800/60'
 }
 
 /** GitHub / issue #N não deve ir na mensagem visível ao cliente. */

--- a/frontend/src/lib/saasSolicitacoes.ts
+++ b/frontend/src/lib/saasSolicitacoes.ts
@@ -11,6 +11,25 @@ export const SAAS_SOLICITACAO_STATUS = [
 
 export type SaasSolicitacaoStatus = (typeof SAAS_SOLICITACAO_STATUS)[number]['value']
 
+/** Máquina de estados G1 (#953) — espelha o backend. */
+export const SAAS_STATUS_TRANSICOES: Record<string, readonly string[]> = {
+  aberta: ['em_analise', 'nao_sera_desenvolvida'],
+  em_analise: ['planejada', 'nao_sera_desenvolvida'],
+  planejada: ['em_desenvolvimento', 'nao_sera_desenvolvida'],
+  em_desenvolvimento: ['concluida', 'nao_sera_desenvolvida'],
+  concluida: [],
+  nao_sera_desenvolvida: [],
+}
+
+export function proximosStatusSolicitacao(atual: string): readonly string[] {
+  return SAAS_STATUS_TRANSICOES[atual] ?? []
+}
+
+export function podeAvancarStatus(de: string, para: string): boolean {
+  if (de === para) return true
+  return proximosStatusSolicitacao(de).includes(para)
+}
+
 /** Fases para filtro rápido (agrupa vários status). */
 export const SAAS_SOLICITACAO_FASES = [
   {

--- a/frontend/src/lib/saasSolicitacoes.ts
+++ b/frontend/src/lib/saasSolicitacoes.ts
@@ -82,13 +82,11 @@ export function rotuloTipoSolicitacao(tipo: string): string {
   return tipo === 'problema' ? 'Erro' : 'Sugestão'
 }
 
-/** Rótulo amigável de versão alvo para o cliente (#955). */
+/** Rótulo de versão liberada — só quando concluída (#955). */
 export function rotuloVersaoAlvo(status: string, versao: string | null | undefined): string | null {
   const v = (versao || '').trim()
-  if (!v) return null
-  if (status === 'concluida') return `Disponível na ${v}`
-  if (status === 'planejada' || status === 'em_desenvolvimento') return `Prevista para ${v}`
-  return null
+  if (!v || status !== 'concluida') return null
+  return `Disponível a partir da versão ${v} (ou superior)`
 }
 
 export function classesBadgeTipoSolicitacao(tipo: string): string {

--- a/frontend/src/lib/saasSolicitacoes.ts
+++ b/frontend/src/lib/saasSolicitacoes.ts
@@ -82,6 +82,15 @@ export function rotuloTipoSolicitacao(tipo: string): string {
   return tipo === 'problema' ? 'Erro' : 'Sugestão'
 }
 
+/** Rótulo amigável de versão alvo para o cliente (#955). */
+export function rotuloVersaoAlvo(status: string, versao: string | null | undefined): string | null {
+  const v = (versao || '').trim()
+  if (!v) return null
+  if (status === 'concluida') return `Disponível na ${v}`
+  if (status === 'planejada' || status === 'em_desenvolvimento') return `Prevista para ${v}`
+  return null
+}
+
 export function classesBadgeTipoSolicitacao(tipo: string): string {
   if (tipo === 'problema') {
     return 'bg-rose-50 text-rose-900 ring-rose-200/90 dark:bg-rose-950/45 dark:text-rose-100 dark:ring-rose-800/60'

--- a/frontend/src/lib/tratarBloqueioJornadaAssumir.ts
+++ b/frontend/src/lib/tratarBloqueioJornadaAssumir.ts
@@ -1,0 +1,31 @@
+import { ApiError, ponto } from '../api/client'
+import { mensagemFalhaParaToast } from '../api/errorMessage'
+
+type ToastLike = {
+  showError: (msg: string) => void
+  showSuccess?: (msg: string) => void
+  showWarning?: (msg: string) => void
+}
+
+/** Trata 403 de jornada/HE ao assumir WhatsApp; opcionalmente solicita HE. */
+export async function tratarBloqueioJornadaAoAssumir(
+  err: unknown,
+  toast: ToastLike,
+): Promise<boolean> {
+  if (!(err instanceof ApiError) || err.status !== 403) return false
+  const detail = String((err.body as { detail?: string } | null)?.detail ?? err.message ?? '')
+  const isJornada =
+    /jornada/i.test(detail) || /hora extra/i.test(detail) || /pegar novos chats/i.test(detail)
+  if (!isJornada) return false
+  toast.showError(detail || 'Sua jornada terminou. Peça hora extra a um administrador.')
+  try {
+    await ponto.solicitarHoraExtra({ motivo: 'Pedido ao tentar atender WhatsApp após a jornada.' })
+    toast.showSuccess?.('Pedido de hora extra enviado aos administradores.')
+  } catch (e2) {
+    // Pedido pode já existir — só avisa.
+    if (!(e2 instanceof ApiError && e2.status === 400)) {
+      toast.showWarning?.(mensagemFalhaParaToast(e2, 'Não foi possível registrar o pedido de HE.'))
+    }
+  }
+  return true
+}

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -20,7 +20,7 @@ import {
   horarioSemanaPadrao,
   validarHorarioSemana,
   type HorarioSemana,
-} from '../lib/horarioSemana
+} from '../lib/horarioSemana'
 import { SemPermissao } from './SemPermissao'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { ApiError, atendentes, setores, type Setores } from '../api/client'
+import { ApiError, atendentes, setores, type Atendentes, type Setores } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { Card } from '../components/ui/Card'
 import { Input } from '../components/ui/Input'
@@ -13,9 +13,18 @@ import { useVoltarAnterior } from '../hooks/useVoltarAnterior'
 import { FormSection } from '../components/ui/FormSection'
 import { InlineCadastroFooter } from '../components/ui/InlineCadastroPanel'
 import { CadastroFormPageShell } from '../components/ui/CadastroFormPageShell'
+import { HorarioSemanaEditor } from '../components/horario/HorarioSemanaEditor'
+import {
+  horarioSemanaFromApi,
+  horarioSemanaPadrao,
+  validarHorarioSemana,
+  type HorarioSemana,
+} from '../lib/horarioSemana'
 import { SemPermissao } from './SemPermissao'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
+
+type ModoJornada = Atendentes.ModoJornada
 
 export function AtendenteForm() {
   const { id } = useParams<{ id?: string }>()
@@ -38,7 +47,8 @@ export function AtendenteForm() {
   const [role, setRole] = useState<'admin' | 'atendente' | 'comercial'>('atendente')
   const [ativo, setAtivo] = useState(true)
   const [setorIds, setSetorIds] = useState<number[]>([])
-  const [usaEscala, setUsaEscala] = useState(false)
+  const [modoJornada, setModoJornada] = useState<ModoJornada>('nenhum')
+  const [horarioSemana, setHorarioSemana] = useState<HorarioSemana>(() => horarioSemanaPadrao())
   const [escalaHorasTrabalho, setEscalaHorasTrabalho] = useState('12')
   const [escalaHorasFolga, setEscalaHorasFolga] = useState('36')
   const [escalaInicioEm, setEscalaInicioEm] = useState('')
@@ -75,7 +85,14 @@ export function AtendenteForm() {
         setRole((a.role as 'admin' | 'atendente' | 'comercial') || 'atendente')
         setAtivo(a.ativo)
         setSetorIds(a.setor_ids ?? [])
-        setUsaEscala(Boolean(a.usa_escala))
+        const modo: ModoJornada =
+          a.modo_jornada === 'semanal' || a.modo_jornada === 'ciclo' || a.modo_jornada === 'nenhum'
+            ? a.modo_jornada
+            : a.usa_escala
+              ? 'ciclo'
+              : 'nenhum'
+        setModoJornada(modo)
+        setHorarioSemana(horarioSemanaFromApi(a.horario_semana ?? undefined))
         setEscalaHorasTrabalho(a.escala_horas_trabalho != null ? String(a.escala_horas_trabalho) : '12')
         setEscalaHorasFolga(a.escala_horas_folga != null ? String(a.escala_horas_folga) : '36')
         setEscalaInicioEm(a.escala_inicio_em ?? '')
@@ -127,10 +144,12 @@ export function AtendenteForm() {
     }
   }
 
-  function payloadEscala() {
-    if (!usaEscala) {
+  function payloadJornada(): Atendentes.Create | Atendentes.Update {
+    if (modoJornada === 'nenhum') {
       return {
+        modo_jornada: 'nenhum',
         usa_escala: false,
+        horario_semana: null,
         escala_horas_trabalho: null,
         escala_horas_folga: null,
         escala_inicio_em: null,
@@ -139,8 +158,23 @@ export function AtendenteForm() {
         tolerancia_atraso_minutos: 0,
       }
     }
+    if (modoJornada === 'semanal') {
+      return {
+        modo_jornada: 'semanal',
+        usa_escala: true,
+        horario_semana: horarioSemana,
+        escala_horas_trabalho: null,
+        escala_horas_folga: null,
+        escala_inicio_em: null,
+        horario_previsto_entrada: null,
+        horario_previsto_saida: null,
+        tolerancia_atraso_minutos: Math.max(0, Number(toleranciaAtraso) || 0),
+      }
+    }
     return {
+      modo_jornada: 'ciclo',
       usa_escala: true,
+      horario_semana: null,
       escala_horas_trabalho: Number(escalaHorasTrabalho) || null,
       escala_horas_folga: Number(escalaHorasFolga) || null,
       escala_inicio_em: escalaInicioEm || null,
@@ -152,9 +186,16 @@ export function AtendenteForm() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
+    if (modoJornada === 'semanal') {
+      const erroHs = validarHorarioSemana(horarioSemana)
+      if (erroHs) {
+        toast.showWarning(erroHs)
+        return
+      }
+    }
     setSaving(true)
     try {
-      const escala = payloadEscala()
+      const escala = payloadJornada()
       if (isEdit && !Number.isNaN(atendenteId)) {
         await atendentes.update(atendenteId, {
           email,
@@ -284,18 +325,35 @@ export function AtendenteForm() {
                 statusOffText="Inativo"
               />
             </FormSection>
-            <FormSection title="Escala de trabalho">
-              <Switch
-                bare
-                checked={usaEscala}
-                onCheckedChange={setUsaEscala}
-                label="Usa escala"
-                description="Quando ativo, o sistema calcula dias de trabalho e folga a partir do ciclo horas × horas."
-                showStatusPill
-                statusOnText="Sim"
-                statusOffText="Não"
+            <FormSection title="Jornada de trabalho">
+              <Select
+                label="Modo de jornada"
+                value={modoJornada}
+                onChange={(v) => setModoJornada(String(v) as ModoJornada)}
+                options={[
+                  { value: 'nenhum', label: 'Nenhum (sem falta nem avisos de horário)' },
+                  { value: 'semanal', label: 'Escala semanal (dias da semana)' },
+                  { value: 'ciclo', label: 'Escala ciclo (ex.: 12×36)' },
+                ]}
               />
-              {usaEscala && (
+              {modoJornada === 'semanal' && (
+                <div className="mt-4 space-y-3">
+                  <HorarioSemanaEditor value={horarioSemana} onChange={setHorarioSemana} />
+                  <Input
+                    label="Tolerância (min) — antes e depois do início"
+                    type="number"
+                    min={0}
+                    max={120}
+                    value={toleranciaAtraso}
+                    onChange={(e) => setToleranciaAtraso(e.target.value)}
+                  />
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    Entrada liberada a partir de início menos a tolerância. Dentro da tolerância não conta
+                    atraso.
+                  </p>
+                </div>
+              )}
+              {modoJornada === 'ciclo' && (
                 <div className="mt-4 space-y-3">
                   <Select
                     label="Preset"
@@ -353,7 +411,7 @@ export function AtendenteForm() {
                       onChange={(e) => setHorarioSaida(e.target.value)}
                     />
                     <Input
-                      label="Tolerância atraso (min)"
+                      label="Tolerância (min)"
                       type="number"
                       min={0}
                       max={120}
@@ -362,8 +420,8 @@ export function AtendenteForm() {
                     />
                   </div>
                   <p className="text-xs text-slate-500 dark:text-slate-400">
-                    Ciclo contínuo a partir desta data (ex.: 12 h de trabalho e 36 h de folga, repetindo). Horário
-                    previsto é opcional e sinaliza atraso na conformidade.
+                    Ciclo contínuo a partir desta data. A tolerância vale antes e depois do horário de
+                    entrada.
                   </p>
                 </div>
               )}

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -14,12 +14,13 @@ import { FormSection } from '../components/ui/FormSection'
 import { InlineCadastroFooter } from '../components/ui/InlineCadastroPanel'
 import { CadastroFormPageShell } from '../components/ui/CadastroFormPageShell'
 import { HorarioSemanaEditor } from '../components/horario/HorarioSemanaEditor'
+import { AtendenteLocaisSection } from '../components/AtendenteLocaisSection'
 import {
   horarioSemanaFromApi,
   horarioSemanaPadrao,
   validarHorarioSemana,
   type HorarioSemana,
-} from '../lib/horarioSemana'
+} from '../lib/horarioSemana
 import { SemPermissao } from './SemPermissao'
 import { CarregamentoFalhou } from '../components/ui/CarregamentoFalhou'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../api/errorMessage'
@@ -56,6 +57,8 @@ export function AtendenteForm() {
   const [horarioEntrada, setHorarioEntrada] = useState('')
   const [horarioSaida, setHorarioSaida] = useState('')
   const [toleranciaAtraso, setToleranciaAtraso] = useState('0')
+  const [usarLocalEmpresa, setUsarLocalEmpresa] = useState(true)
+  const [localEmpresaRaio, setLocalEmpresaRaio] = useState('')
 
   useEffect(() => {
     coletarTodasPaginas<Setores.Setor>((o, l) =>
@@ -99,6 +102,10 @@ export function AtendenteForm() {
         setHorarioEntrada(a.horario_previsto_entrada ?? '')
         setHorarioSaida(a.horario_previsto_saida ?? '')
         setToleranciaAtraso(String(a.tolerancia_atraso_minutos ?? 0))
+        setUsarLocalEmpresa(a.usar_local_empresa !== false)
+        setLocalEmpresaRaio(
+          a.local_empresa_raio_metros != null ? String(a.local_empresa_raio_metros) : '',
+        )
         if (a.escala_horas_trabalho === 12 && a.escala_horas_folga === 36) setPresetEscala('12x36')
         else if (a.escala_horas_trabalho === 6 && a.escala_horas_folga === 18) setPresetEscala('6x18')
         else if (a.escala_horas_trabalho === 24 && a.escala_horas_folga === 48) setPresetEscala('24x48')
@@ -184,6 +191,15 @@ export function AtendenteForm() {
     }
   }
 
+  function payloadLocais() {
+    return {
+      usar_local_empresa: usarLocalEmpresa,
+      local_empresa_raio_metros: localEmpresaRaio.trim()
+        ? Math.max(20, Number(localEmpresaRaio) || 200)
+        : null,
+    }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (modoJornada === 'semanal') {
@@ -196,6 +212,7 @@ export function AtendenteForm() {
     setSaving(true)
     try {
       const escala = payloadJornada()
+      const locais = payloadLocais()
       if (isEdit && !Number.isNaN(atendenteId)) {
         await atendentes.update(atendenteId, {
           email,
@@ -204,6 +221,7 @@ export function AtendenteForm() {
           ativo,
           setor_ids: setorIds,
           ...escala,
+          ...locais,
           ...(senha ? { senha } : {}),
         })
         toast.showSuccess('Atendente atualizado.')
@@ -218,9 +236,10 @@ export function AtendenteForm() {
           setor_ids: setorIds,
           ativo,
           ...escala,
+          ...locais,
         })
         toast.showSuccess('Atendente cadastrado.')
-        navigate(`/atendentes/${created.id}`, { replace: true })
+        navigate(`/atendentes/${created.id}/editar`, { replace: true })
       }
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o atendente.'))
@@ -426,6 +445,23 @@ export function AtendenteForm() {
                 </div>
               )}
             </FormSection>
+            {isEdit && !Number.isNaN(atendenteId) ? (
+              <FormSection title="Locais de trabalho">
+                <AtendenteLocaisSection
+                  atendenteId={atendenteId}
+                  usarLocalEmpresa={usarLocalEmpresa}
+                  localEmpresaRaio={localEmpresaRaio}
+                  onUsarLocalEmpresaChange={setUsarLocalEmpresa}
+                  onLocalEmpresaRaioChange={setLocalEmpresaRaio}
+                />
+              </FormSection>
+            ) : (
+              <FormSection title="Locais de trabalho">
+                <p className="text-sm text-slate-500 dark:text-slate-400">
+                  Salve o atendente para configurar o local da empresa e locais extras (mapa e raio).
+                </p>
+              </FormSection>
+            )}
           </div>
           <InlineCadastroFooter onCancel={voltarAnterior} saving={saving} />
         </form>

--- a/frontend/src/pages/ConfigEmpresaEmail.tsx
+++ b/frontend/src/pages/ConfigEmpresaEmail.tsx
@@ -10,6 +10,7 @@ import {
 } from '../api/client'
 import { resolveTenantIdFromHostname, tenantAppOrigin } from '../lib/tenant'
 import { nomeParaApiEmpresa } from '../components/empresa/empresaFormCopy'
+import { PontoLocalMapaPicker } from '../components/PontoLocalMapaPicker'
 import { Card } from '../components/ui/Card'
 import { PageContainer } from '../components/ui/PageContainer'
 import { Button } from '../components/ui/Button'
@@ -53,6 +54,10 @@ export function ConfigEmpresaEmail({ embedded = false, section }: ConfigEmpresaE
   const [cidade, setCidade] = useState('')
   const [estado, setEstado] = useState('')
   const [cep, setCep] = useState('')
+  const [empresaLat, setEmpresaLat] = useState<number | null>(null)
+  const [empresaLon, setEmpresaLon] = useState<number | null>(null)
+  const [empresaRaio, setEmpresaRaio] = useState(200)
+  const [empresaEnderecoMapa, setEmpresaEnderecoMapa] = useState('')
   const [salvandoEmpresa, setSalvandoEmpresa] = useState(false)
   const [loadingCnpjConsulta, setLoadingCnpjConsulta] = useState(false)
   const [logoBlobUrl, setLogoBlobUrl] = useState<string | null>(null)
@@ -103,6 +108,15 @@ export function ConfigEmpresaEmail({ embedded = false, section }: ConfigEmpresaE
       setCidade((emp.cidade ?? '').trim())
       setEstado((emp.estado ?? '').trim().toUpperCase().slice(0, 2))
       setCep(emp.cep ? maskCep(digitsOnly(emp.cep)) : '')
+      setEmpresaLat(emp.latitude ?? null)
+      setEmpresaLon(emp.longitude ?? null)
+      setEmpresaRaio(emp.ponto_raio_metros ?? 200)
+      setEmpresaEnderecoMapa(
+        [emp.endereco, emp.numero, emp.bairro, emp.cidade, emp.estado, emp.cep]
+          .map((x) => (x ?? '').trim())
+          .filter(Boolean)
+          .join(', '),
+      )
 
       // logo: precisa de fetch autenticado (não dá pra usar <img src> direto).
       const prevBlob = logoBlobUrlRef.current
@@ -202,6 +216,9 @@ export function ConfigEmpresaEmail({ embedded = false, section }: ConfigEmpresaE
         cidade: cidade.trim() || null,
         estado: estado.trim() || null,
         cep: digitsOnly(cep) || null,
+        latitude: empresaLat,
+        longitude: empresaLon,
+        ponto_raio_metros: empresaRaio,
       }
       if (!cnpjImutavel) {
         payload.cnpj = cnpjTrim
@@ -554,6 +571,31 @@ export function ConfigEmpresaEmail({ embedded = false, section }: ConfigEmpresaE
                     </div>
                   </div>
                 </div>
+              </div>
+              <div>
+                <h3 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                  Local de trabalho (ponto)
+                </h3>
+                <p className="mb-3 text-sm text-slate-600 dark:text-slate-400">
+                  Marque o pin uma vez. Nos cadastros da equipe dá para ligar/desligar este local e ajustar o raio por
+                  pessoa.
+                </p>
+                <PontoLocalMapaPicker
+                  value={{
+                    latitude: empresaLat,
+                    longitude: empresaLon,
+                    endereco: empresaEnderecoMapa,
+                    raio_metros: empresaRaio,
+                  }}
+                  onChange={(next) => {
+                    setEmpresaLat(next.latitude)
+                    setEmpresaLon(next.longitude)
+                    setEmpresaRaio(next.raio_metros ?? 200)
+                    if (next.endereco) setEmpresaEnderecoMapa(next.endereco)
+                  }}
+                  buscaInicial={empresaEnderecoMapa}
+                  raioLabel="Raio padrão (m)"
+                />
               </div>
             </div>
             <div className="flex flex-wrap gap-3 pt-2">

--- a/frontend/src/pages/MinhasSolicitacoes.tsx
+++ b/frontend/src/pages/MinhasSolicitacoes.tsx
@@ -105,6 +105,11 @@ export function MinhasSolicitacoesPage() {
           <p className="rounded-lg bg-slate-50 p-3 text-sm text-slate-600 dark:bg-slate-800/60 dark:text-slate-300">
             {detalhe.mensagem_status}
           </p>
+          {detalhe.versao_alvo_rotulo ? (
+            <p className="rounded-lg bg-emerald-50 p-3 text-sm font-medium text-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-100">
+              {detalhe.versao_alvo_rotulo}
+            </p>
+          ) : null}
           {detalhe.status === 'nao_sera_desenvolvida' && detalhe.motivo_nao_desenvolvimento ? (
             <p className="text-sm text-slate-600 dark:text-slate-300">
               <span className="font-medium">Motivo: </span>
@@ -201,6 +206,7 @@ export function MinhasSolicitacoesPage() {
                 </div>
                 <p className="mt-1 text-xs text-slate-400">
                   {item.tipo === 'problema' ? 'Problema' : 'Sugestão'} · {fmt(item.created_at)}
+                  {item.versao_alvo_rotulo ? ` · ${item.versao_alvo_rotulo}` : ''}
                 </p>
               </Card>
             </Link>

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -65,6 +65,10 @@ export function PontoEquipe() {
   const [ajusteMotivo, setAjusteMotivo] = useState('')
   const [salvandoAjuste, setSalvandoAjuste] = useState(false)
   const [justifs, setJustifs] = useState<Ponto.Justificativa[]>([])
+  const [hesPendentes, setHesPendentes] = useState<Ponto.HoraExtra[]>([])
+  const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario'>('resto_do_dia')
+  const [heAteHorario, setHeAteHorario] = useState('20:00')
+  const [decidindoHeId, setDecidindoHeId] = useState<number | null>(null)
   const [digest, setDigest] = useState<Ponto.Digest | null>(null)
   const [banco, setBanco] = useState<Ponto.BancoHoras | null>(null)
   const [settings, setSettings] = useState<Ponto.Settings | null>(null)
@@ -83,7 +87,7 @@ export function PontoEquipe() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [hist, dia, js, dig, st, fer] = await Promise.all([
+        const [hist, dia, js, dig, st, fer, hes] = await Promise.all([
           ponto.batidasAdmin({
             atendente_id: atendenteId ? Number(atendenteId) : undefined,
             desde,
@@ -95,6 +99,7 @@ export function PontoEquipe() {
           ponto.digest(),
           ponto.settings(),
           ponto.feriados(new Date().getFullYear()),
+          ponto.horaExtraAdmin('pendente'),
         ])
         setItems(hist.items)
         setTotal(hist.total)
@@ -103,6 +108,7 @@ export function PontoEquipe() {
         setDigest(dig)
         setSettings(st)
         setFeriados(fer)
+        setHesPendentes(hes)
         setSemPermissao(false)
         if (atendenteId) {
           const bh = await ponto.bancoHorasAdmin(Number(atendenteId), desde, ate)
@@ -245,6 +251,24 @@ export function PontoEquipe() {
       await carregar(true)
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível decidir.'))
+    }
+  }
+
+  async function decidirHe(id: number, aprovar: boolean) {
+    setDecidindoHeId(id)
+    try {
+      await ponto.decidirHoraExtra(id, {
+        aprovar,
+        modo: aprovar ? heModo : null,
+        ate_horario: aprovar && heModo === 'ate_horario' ? heAteHorario : null,
+        decisao_motivo: aprovar ? null : 'Negado pelo administrador',
+      })
+      toast.showSuccess(aprovar ? 'Hora extra liberada.' : 'Pedido de hora extra negado.')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível decidir a hora extra.'))
+    } finally {
+      setDecidindoHeId(null)
     }
   }
 
@@ -428,6 +452,67 @@ export function PontoEquipe() {
                     </Button>
                     <Button type="button" variant="ghost" onClick={() => void decidirJust(j.id, 'rejeitada')}>
                       Rejeitar
+                    </Button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+
+        <Card title="Hora extra (WhatsApp após jornada)">
+          <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
+            Pedidos para pegar novos chats depois do fim da jornada. Ao liberar, escolha o restante do dia ou até um
+            horário.
+          </p>
+          <div className="mb-4 flex flex-wrap items-end gap-3">
+            <Select
+              label="Ao aprovar"
+              value={heModo}
+              onChange={(v) => setHeModo(String(v) as 'resto_do_dia' | 'ate_horario')}
+              options={[
+                { value: 'resto_do_dia', label: 'Resto do dia' },
+                { value: 'ate_horario', label: 'Até horário' },
+              ]}
+            />
+            {heModo === 'ate_horario' ? (
+              <Input
+                label="Até (HH:MM)"
+                type="time"
+                value={heAteHorario}
+                onChange={(e) => setHeAteHorario(e.target.value)}
+              />
+            ) : null}
+          </div>
+          {hesPendentes.length === 0 ? (
+            <p className="text-sm text-slate-500">Nenhum pedido pendente.</p>
+          ) : (
+            <ul className="space-y-3">
+              {hesPendentes.map((h) => (
+                <li
+                  key={h.id}
+                  className="flex flex-wrap items-start justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                >
+                  <div className="text-sm">
+                    <p className="font-medium">{h.atendente_nome ?? h.atendente_id}</p>
+                    <p className="text-slate-600 dark:text-slate-300">{h.motivo || 'Sem motivo informado'}</p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      disabled={decidindoHeId === h.id}
+                      onClick={() => void decidirHe(h.id, true)}
+                    >
+                      Liberar
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      disabled={decidindoHeId === h.id}
+                      onClick={() => void decidirHe(h.id, false)}
+                    >
+                      Negar
                     </Button>
                   </div>
                 </li>

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -264,6 +264,7 @@ export function PontoEquipe() {
         usar_feriados_nacionais: settings.usar_feriados_nacionais,
         fecho_automatico_ativo: settings.fecho_automatico_ativo,
         fecho_apos_horas: settings.fecho_apos_horas,
+        fecho_margem_pos_saida_minutos: settings.fecho_margem_pos_saida_minutos ?? 30,
         jornada_diaria_minutos: settings.jornada_diaria_minutos,
         politica_geolocalizacao: settings.politica_geolocalizacao,
       })
@@ -407,6 +408,19 @@ export function PontoEquipe() {
                 hint="pendentes"
               />
             </div>
+            {(digest?.itens ?? []).some((i) => i.status === 'falta' || i.atrasado) ? (
+              <ul className="space-y-1 text-sm text-amber-900 dark:text-amber-100">
+                {(digest?.itens ?? [])
+                  .filter((i) => i.status === 'falta' || i.atrasado)
+                  .map((i) => (
+                    <li key={`alerta-${i.atendente_id}`}>
+                      <span className="font-medium">{i.nome}</span>
+                      {i.status === 'falta' ? ' — falta' : null}
+                      {i.atrasado ? ' — atraso' : null}
+                    </li>
+                  ))}
+              </ul>
+            ) : null}
           </div>
         )}
       </Card>
@@ -682,10 +696,10 @@ export function PontoEquipe() {
                     setSettings({ ...settings, fecho_automatico_ativo: e.target.checked })
                   }
                 />
-                Fechar jornada automaticamente após N horas (desligado por padrão)
+                Fechar jornada esquecida automaticamente (desligado por padrão)
               </label>
               <Input
-                label="Horas para fecho automático"
+                label="Horas abertas para fecho (critério 1)"
                 type="number"
                 min={4}
                 max={48}
@@ -694,6 +708,23 @@ export function PontoEquipe() {
                   setSettings({ ...settings, fecho_apos_horas: Number(e.target.value) || 14 })
                 }
               />
+              <Input
+                label="Margem após saída prevista, minutos (critério 2)"
+                type="number"
+                min={0}
+                max={240}
+                value={String(settings.fecho_margem_pos_saida_minutos ?? 30)}
+                onChange={(e) =>
+                  setSettings({
+                    ...settings,
+                    fecho_margem_pos_saida_minutos: Number(e.target.value) || 0,
+                  })
+                }
+              />
+              <p className="text-xs text-slate-500 dark:text-slate-400">
+                Fecha pelo critério que ocorrer primeiro (N horas abertas ou saída prevista + margem),
+                com motivo esquecimento.
+              </p>
               <Input
                 label="Jornada diária (minutos) — meta do calendário"
                 type="number"

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -72,12 +72,6 @@ export function PontoEquipe() {
   const [feriadoData, setFeriadoData] = useState('')
   const [feriadoNome, setFeriadoNome] = useState('')
   const [salvandoSettings, setSalvandoSettings] = useState(false)
-  const [locais, setLocais] = useState<Ponto.Local[]>([])
-  const [localNome, setLocalNome] = useState('')
-  const [localLat, setLocalLat] = useState('')
-  const [localLon, setLocalLon] = useState('')
-  const [localRaio, setLocalRaio] = useState('200')
-  const [editLocalId, setEditLocalId] = useState<number | null>(null)
   const [mapaBatida, setMapaBatida] = useState<Ponto.BatidaAdmin | null>(null)
   const agoraCal = new Date()
   const [calAno, setCalAno] = useState(agoraCal.getFullYear())
@@ -89,7 +83,7 @@ export function PontoEquipe() {
   const carregar = useCallback(
     async (silencioso = false) => {
       try {
-        const [hist, dia, js, dig, st, fer, locs] = await Promise.all([
+        const [hist, dia, js, dig, st, fer] = await Promise.all([
           ponto.batidasAdmin({
             atendente_id: atendenteId ? Number(atendenteId) : undefined,
             desde,
@@ -101,7 +95,6 @@ export function PontoEquipe() {
           ponto.digest(),
           ponto.settings(),
           ponto.feriados(new Date().getFullYear()),
-          ponto.locais(),
         ])
         setItems(hist.items)
         setTotal(hist.total)
@@ -110,7 +103,6 @@ export function PontoEquipe() {
         setDigest(dig)
         setSettings(st)
         setFeriados(fer)
-        setLocais(locs)
         setSemPermissao(false)
         if (atendenteId) {
           const bh = await ponto.bancoHorasAdmin(Number(atendenteId), desde, ate)
@@ -277,68 +269,6 @@ export function PontoEquipe() {
     }
   }
 
-  async function adicionarLocal() {
-    if (!localNome.trim() || !localLat || !localLon) {
-      toast.showWarning('Informe nome, latitude e longitude do local.')
-      return
-    }
-    try {
-      if (editLocalId != null) {
-        await ponto.atualizarLocal(editLocalId, {
-          nome: localNome.trim(),
-          latitude: Number(localLat),
-          longitude: Number(localLon),
-          raio_metros: Number(localRaio) || 200,
-        })
-        toast.showSuccess('Local actualizado.')
-        setEditLocalId(null)
-      } else {
-        await ponto.criarLocal({
-          nome: localNome.trim(),
-          latitude: Number(localLat),
-          longitude: Number(localLon),
-          raio_metros: Number(localRaio) || 200,
-        })
-        toast.showSuccess('Local cadastrado.')
-      }
-      setLocalNome('')
-      setLocalLat('')
-      setLocalLon('')
-      setLocalRaio('200')
-      await carregar(true)
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível guardar o local.'))
-    }
-  }
-
-  function iniciarEdicaoLocal(loc: Ponto.Local) {
-    setEditLocalId(loc.id)
-    setLocalNome(loc.nome)
-    setLocalLat(String(loc.latitude))
-    setLocalLon(String(loc.longitude))
-    setLocalRaio(String(loc.raio_metros))
-  }
-
-  async function toggleLocalAtivo(loc: Ponto.Local) {
-    try {
-      await ponto.atualizarLocal(loc.id, { ativo: !loc.ativo })
-      toast.showSuccess(loc.ativo ? 'Local desactivado.' : 'Local activado.')
-      await carregar(true)
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar o local.'))
-    }
-  }
-
-  async function apagarLocal(id: number) {
-    try {
-      await ponto.removerLocal(id)
-      toast.showSuccess('Local removido.')
-      await carregar(true)
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível remover o local.'))
-    }
-  }
-
   async function adicionarFeriado() {
     if (!feriadoData || !feriadoNome.trim()) {
       toast.showWarning('Informe data e nome do feriado.')
@@ -378,7 +308,7 @@ export function PontoEquipe() {
     <PageContainer>
       <PageHeader
         title="Ponto da equipe"
-        subtitle="Visão do dia, batidas, geofence, ajustes auditados e relatórios mensais."
+        subtitle="Visão do dia, batidas, ajustes auditados e relatórios mensais."
       />
 
       <Card className="overflow-hidden border-cyan-200/60 bg-gradient-to-br from-slate-50 via-white to-cyan-50/40 dark:border-cyan-900/40 dark:from-slate-950 dark:via-slate-900 dark:to-cyan-950/20">
@@ -754,8 +684,8 @@ export function PontoEquipe() {
                 ]}
               />
               <p className="text-xs text-slate-500">
-                Com locais cadastrados: opcional regista geo; recomendada avisa fora da área; obrigatória
-                bloqueia sem GPS ou fora do raio.
+                Locais ficam no cadastro de cada pessoa (e pin da empresa em Configurações → Empresa). Opcional
+                registra geo; recomendada avisa fora da área; obrigatória bloqueia sem GPS ou fora do raio.
               </p>
               <Button type="button" disabled={salvandoSettings} onClick={() => void salvarSettings()}>
                 Salvar configurações
@@ -764,80 +694,6 @@ export function PontoEquipe() {
           ) : (
             <p className="text-sm text-slate-500">Carregando…</p>
           )}
-        </Card>
-
-        <Card title="Locais (geofence)">
-          <div className="mb-4 flex flex-wrap items-end gap-3">
-            <Input label="Nome" value={localNome} onChange={(e) => setLocalNome(e.target.value)} />
-            <Input
-              label="Latitude"
-              type="number"
-              step="any"
-              value={localLat}
-              onChange={(e) => setLocalLat(e.target.value)}
-            />
-            <Input
-              label="Longitude"
-              type="number"
-              step="any"
-              value={localLon}
-              onChange={(e) => setLocalLon(e.target.value)}
-            />
-            <Input
-              label="Raio (m)"
-              type="number"
-              min={20}
-              value={localRaio}
-              onChange={(e) => setLocalRaio(e.target.value)}
-            />
-            <Button type="button" onClick={() => void adicionarLocal()}>
-              {editLocalId != null ? 'Salvar alteração' : 'Adicionar local'}
-            </Button>
-            {editLocalId != null ? (
-              <Button
-                type="button"
-                variant="cancel"
-                onClick={() => {
-                  setEditLocalId(null)
-                  setLocalNome('')
-                  setLocalLat('')
-                  setLocalLon('')
-                  setLocalRaio('200')
-                }}
-              >
-                Cancelar edição
-              </Button>
-            ) : null}
-          </div>
-          <ul className="space-y-2 text-sm">
-            {locais.length === 0 ? (
-              <li className="text-slate-500">Nenhum local cadastrado — geofence inactivo.</li>
-            ) : (
-              locais.map((loc) => (
-                <li
-                  key={loc.id}
-                  className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
-                >
-                  <span>
-                    <strong>{loc.nome}</strong> · {loc.latitude.toFixed(5)}, {loc.longitude.toFixed(5)} · raio{' '}
-                    {loc.raio_metros} m
-                    {!loc.ativo ? ' (inactivo)' : ''}
-                  </span>
-                  <div className="flex flex-wrap gap-2">
-                    <Button type="button" variant="secondary" onClick={() => iniciarEdicaoLocal(loc)}>
-                      Editar
-                    </Button>
-                    <Button type="button" variant="secondary" onClick={() => void toggleLocalAtivo(loc)}>
-                      {loc.ativo ? 'Desactivar' : 'Activar'}
-                    </Button>
-                    <Button type="button" variant="ghost" onClick={() => void apagarLocal(loc.id)}>
-                      Remover
-                    </Button>
-                  </div>
-                </li>
-              ))
-            )}
-          </ul>
         </Card>
 
         <Card title="Feriados da instância">
@@ -891,11 +747,7 @@ export function PontoEquipe() {
             : 'Localização'
         }
         subtitulo={mapaBatida ? formatarHora(mapaBatida.registrado_em) : undefined}
-        raioMetros={
-          mapaBatida?.local_id != null
-            ? locais.find((l) => l.id === mapaBatida.local_id)?.raio_metros ?? null
-            : null
-        }
+        raioMetros={null}
       />
     </PageContainer>
   )

--- a/frontend/src/pages/chat-interno/ChatInternoThread.tsx
+++ b/frontend/src/pages/chat-interno/ChatInternoThread.tsx
@@ -4,6 +4,7 @@ import { ApiError, atendentes, chatInterno, type ChatInterno } from '../../api/c
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { ChatInternoComposerBar } from '../../components/chat-interno/ChatInternoComposerBar'
 import { ChatInternoGrupoMembrosModal } from '../../components/chat-interno/ChatInternoGrupoMembrosModal'
+import { ChatInternoSetorMembrosModal } from '../../components/chat-interno/ChatInternoSetorMembrosModal'
 import { ChatInternoConteudoMensagem } from '../../components/chat-interno/ChatInternoConteudoMensagem'
 import { ChatInternoMensagemAcoes } from '../../components/chat-interno/ChatInternoMensagemAcoes'
 import { ChatInternoReacoesBar } from '../../components/chat-interno/ChatInternoReacoesBar'
@@ -279,6 +280,7 @@ export function ChatInternoThread({ conversaIdProp }: ChatInternoThreadProps = {
   const [limpando, setLimpando] = useState(false)
   const [grupoDetalhe, setGrupoDetalhe] = useState<ChatInterno.Conversa | null>(null)
   const [modalMembros, setModalMembros] = useState(false)
+  const [modalMembrosSetor, setModalMembrosSetor] = useState(false)
   const [mencionaveis, setMencionaveis] = useState<MencaoCandidato[]>([])
   const [silenciando, setSilenciando] = useState(false)
   const [hoverMsgId, setHoverMsgId] = useState<number | null>(null)
@@ -553,6 +555,16 @@ export function ChatInternoThread({ conversaIdProp }: ChatInternoThreadProps = {
             <h2 className="truncate text-lg font-bold text-slate-900 dark:text-white">{titulo}</h2>
             <p className="truncate text-sm text-slate-500">{subtitulo}</p>
           </button>
+        ) : isSetor ? (
+          <button
+            type="button"
+            onClick={() => setModalMembrosSetor(true)}
+            className="min-w-0 flex-1 rounded-lg text-left transition hover:bg-slate-50 dark:hover:bg-slate-800/60"
+            aria-label="Ver membros do setor"
+          >
+            <h2 className="truncate text-lg font-bold text-slate-900 dark:text-white">{titulo}</h2>
+            <p className="truncate text-sm text-slate-500">{subtitulo}</p>
+          </button>
         ) : (
           <div className="min-w-0 flex-1">
             <h2 className="truncate text-lg font-bold text-slate-900 dark:text-white">{titulo}</h2>
@@ -613,6 +625,15 @@ export function ChatInternoThread({ conversaIdProp }: ChatInternoThreadProps = {
             setGrupoDetalhe(conv)
             void refreshInbox(true)
           }}
+        />
+      )}
+
+      {isSetor && meta?.setor_id != null && (
+        <ChatInternoSetorMembrosModal
+          open={modalMembrosSetor}
+          setorId={meta.setor_id}
+          tituloSetor={titulo}
+          onClose={() => setModalMembrosSetor(false)}
         />
       )}
 

--- a/frontend/src/pages/chat/ChatListaAtendendo.tsx
+++ b/frontend/src/pages/chat/ChatListaAtendendo.tsx
@@ -78,16 +78,34 @@ function ChatAtendendoItem({
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-2">
             <div className="flex min-w-0 flex-1 items-center gap-1.5">
-              <p className="truncate text-sm font-semibold text-slate-900 dark:text-white">{item.nome}</p>
+              <p
+                className={`truncate text-sm ${
+                  (item.nao_lidas_count ?? 0) > 0
+                    ? 'font-bold text-slate-900 dark:text-white'
+                    : 'font-semibold text-slate-900 dark:text-white'
+                }`}
+              >
+                {item.nome}
+              </p>
               {variant === 'proprio' && (
                 <span className="shrink-0 rounded-full bg-cyan-100 px-1.5 py-0.5 text-[9px] font-bold uppercase text-cyan-800 dark:bg-cyan-950/60 dark:text-cyan-200">
                   Você
                 </span>
               )}
             </div>
-            {item.estado === 'aguardando_atendente' && (
-              <span className="h-2 w-2 shrink-0 rounded-full bg-amber-500" title="Aguardando" />
-            )}
+            <div className="flex shrink-0 items-center gap-1.5">
+              {(item.nao_lidas_count ?? 0) > 0 && (
+                <span
+                  className="inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-cyan-600 px-1.5 py-0.5 text-[10px] font-bold text-white"
+                  title={`${item.nao_lidas_count} não lida${(item.nao_lidas_count ?? 0) === 1 ? '' : 's'}`}
+                >
+                  {(item.nao_lidas_count ?? 0) > 99 ? '99+' : item.nao_lidas_count}
+                </span>
+              )}
+              {item.estado === 'aguardando_atendente' && (
+                <span className="h-2 w-2 rounded-full bg-amber-500" title="Aguardando" />
+              )}
+            </div>
           </div>
           <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
             <ChatCanalBadge canal={item.canal} />
@@ -185,7 +203,7 @@ export function ChatListaAtendendo() {
     return (
       <ChatHubEmptyState
         title="Nenhum atendimento seu"
-        description="Quando assumires um chat, ele aparece aqui."
+        description="Quando você assumir um chat, ele aparece aqui."
         actions={
           filaCount > 0
             ? [{ type: 'link', to: '/chat/espera', label: `Ir para Aguardando (${filaCount > 99 ? '99+' : filaCount})` }]

--- a/frontend/src/pages/chat/ChatListaEspera.tsx
+++ b/frontend/src/pages/chat/ChatListaEspera.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '../../contexts/AuthContext'
 import { useChatHub } from '../../contexts/ChatHubContext'
 import { useEventStream } from '../../contexts/EventStreamContext'
 import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
+import { tratarBloqueioJornadaAoAssumir } from '../../lib/tratarBloqueioJornadaAssumir'
 import { chatAtivoIgual } from '../../lib/chatHubPaths'
 import { exibirProtocolo } from '../../lib/exibirProtocolo'
 import {
@@ -118,6 +119,9 @@ export function ChatListaEspera({ ignorarBusca = false, onChatAssumido, onVerCha
         navigate(chatHubItemLink('atendendo'))
       }
     } catch (err) {
+      if (item.canal === 'whatsapp' && (await tratarBloqueioJornadaAoAssumir(err, toast))) {
+        return
+      }
       const msg =
         err instanceof ApiError && err.status === 400
           ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'

--- a/frontend/src/pages/saas/SaasConta.tsx
+++ b/frontend/src/pages/saas/SaasConta.tsx
@@ -1,13 +1,22 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { saasOpsConta, ApiError, type SaasOpsConta } from '../../api/client'
+import {
+  atendentes,
+  saasOpsConta,
+  ApiError,
+  persistAuthTokens,
+  type SaasOpsConta,
+} from '../../api/client'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/errorMessage'
 import { Button } from '../../components/ui/Button'
+import { CadastroFormPageShell } from '../../components/ui/CadastroFormPageShell'
 import { Card } from '../../components/ui/Card'
 import { CarregamentoFalhou } from '../../components/ui/CarregamentoFalhou'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
+import { IconEye, IconEyeOff } from '../../components/ui/IconEye'
+import { Input } from '../../components/ui/Input'
 import { useToast } from '../../components/ui/Toast'
-import { VoltarButton } from '../../components/ui/VoltarButton'
+import { useAuth } from '../../contexts/AuthContext'
 import { useVoltarAnterior } from '../../hooks/useVoltarAnterior'
 import { SemPermissao } from '../SemPermissao'
 import { SAAS_LICENCAS_PATH } from '../../lib/saasControlPlane'
@@ -23,9 +32,13 @@ function formatWhen(iso: string | null | undefined): string {
 
 export function SaasConta() {
   const toast = useToast()
+  const { user, refreshUser } = useAuth()
   const voltarAnterior = useVoltarAnterior(SAAS_LICENCAS_PATH)
+
   const [loading, setLoading] = useState(true)
-  const [busy, setBusy] = useState(false)
+  const [busyPerfil, setBusyPerfil] = useState(false)
+  const [busySenha, setBusySenha] = useState(false)
+  const [busyToken, setBusyToken] = useState(false)
   const [forbidden, setForbidden] = useState(false)
   const [indisponivel, setIndisponivel] = useState(false)
   const [falha, setFalha] = useState<{ titulo: string; detalhe?: string } | null>(null)
@@ -33,6 +46,22 @@ export function SaasConta() {
   const [plaintext, setPlaintext] = useState<string | null>(null)
   const [confirmarGerar, setConfirmarGerar] = useState(false)
   const [confirmarRevogar, setConfirmarRevogar] = useState(false)
+
+  const [nome, setNome] = useState('')
+  const [email, setEmail] = useState('')
+
+  const [senhaAtual, setSenhaAtual] = useState('')
+  const [senhaNova, setSenhaNova] = useState('')
+  const [senhaConf, setSenhaConf] = useState('')
+  const [mostrarAtual, setMostrarAtual] = useState(false)
+  const [mostrarNova, setMostrarNova] = useState(false)
+  const [mostrarConf, setMostrarConf] = useState(false)
+
+  useEffect(() => {
+    if (!user) return
+    setNome(user.nome ?? '')
+    setEmail(user.email ?? '')
+  }, [user])
 
   const carregar = useCallback(() => {
     setLoading(true)
@@ -60,8 +89,62 @@ export function SaasConta() {
     carregar()
   }, [carregar])
 
+  async function salvarPerfil(e: React.FormEvent) {
+    e.preventDefault()
+    if (!nome.trim() || !email.trim()) {
+      toast.showError('Informe nome e e-mail.')
+      return
+    }
+    setBusyPerfil(true)
+    try {
+      const row = await saasOpsConta.atualizarPerfil({
+        nome: nome.trim(),
+        email: email.trim(),
+      })
+      if (row.access_token) {
+        persistAuthTokens({
+          access_token: row.access_token,
+          refresh_token: row.refresh_token,
+        })
+      }
+      setNome(row.nome)
+      setEmail(row.email)
+      await refreshUser()
+      toast.showSuccess('Dados da conta atualizados.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar os dados.'))
+    } finally {
+      setBusyPerfil(false)
+    }
+  }
+
+  async function salvarSenha(e: React.FormEvent) {
+    e.preventDefault()
+    if (senhaNova.length < 8) {
+      toast.showError('A nova senha deve ter pelo menos 8 caracteres.')
+      return
+    }
+    if (senhaNova !== senhaConf) {
+      toast.showError('A confirmação não coincide com a nova senha.')
+      return
+    }
+    setBusySenha(true)
+    try {
+      await atendentes.trocarSenha(senhaAtual, senhaNova)
+      setSenhaAtual('')
+      setSenhaNova('')
+      setSenhaConf('')
+      await refreshUser()
+      toast.showSuccess('Senha alterada.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar a senha.'))
+    } finally {
+      setBusySenha(false)
+    }
+  }
+
   async function gerar() {
-    setBusy(true)
+    setBusyToken(true)
     try {
       const row = await saasOpsConta.gerarMcpToken()
       setEstado({ configurado: row.configurado, gerado_em: row.gerado_em })
@@ -74,13 +157,13 @@ export function SaasConta() {
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível gerar o token.'))
     } finally {
-      setBusy(false)
+      setBusyToken(false)
       setConfirmarGerar(false)
     }
   }
 
   async function revogar() {
-    setBusy(true)
+    setBusyToken(true)
     try {
       const row = await saasOpsConta.revogarMcpToken()
       setEstado(row)
@@ -89,7 +172,7 @@ export function SaasConta() {
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível revogar o token.'))
     } finally {
-      setBusy(false)
+      setBusyToken(false)
       setConfirmarRevogar(false)
     }
   }
@@ -100,7 +183,7 @@ export function SaasConta() {
       await navigator.clipboard.writeText(plaintext)
       toast.showSuccess('Token copiado.')
     } catch {
-      toast.showError('Não foi possível copiar. Seleccione o token e copie manualmente.')
+      toast.showError('Não foi possível copiar. Selecione o token e copie manualmente.')
     }
   }
 
@@ -118,7 +201,7 @@ export function SaasConta() {
     return (
       <SemPermissao
         title="Painel SaaS não disponível nesta instância."
-        detail="O token Cursor só existe no control-plane DeskRudder."
+        detail="A conta e o token Cursor só existem no control-plane DeskRudder."
         voltarPara="/login/admin"
         voltarLabel="Voltar ao login admin"
       />
@@ -136,8 +219,96 @@ export function SaasConta() {
   }
 
   return (
-    <div className="mx-auto max-w-2xl space-y-4">
-      <VoltarButton onClick={voltarAnterior} />
+    <CadastroFormPageShell onVoltar={voltarAnterior}>
+      <div className="space-y-4">
+      <Card title="Dados da conta" description="Nome e e-mail usados no login do painel admin (/login/admin).">
+        <form onSubmit={(ev) => void salvarPerfil(ev)} className="space-y-4">
+          <Input label="Nome" value={nome} onChange={(ev) => setNome(ev.target.value)} required />
+          <Input
+            label="E-mail"
+            type="email"
+            value={email}
+            onChange={(ev) => setEmail(ev.target.value)}
+            required
+            autoComplete="username"
+          />
+          <div className="flex justify-end">
+            <Button type="submit" loading={busyPerfil}>
+              Salvar dados
+            </Button>
+          </div>
+        </form>
+      </Card>
+
+      <Card title="Alterar senha" description="Informe a senha atual e defina uma nova (mínimo 8 caracteres).">
+        <form onSubmit={(ev) => void salvarSenha(ev)} className="space-y-4" noValidate>
+          <Input
+            label="Senha atual"
+            type={mostrarAtual ? 'text' : 'password'}
+            value={senhaAtual}
+            onChange={(ev) => setSenhaAtual(ev.target.value)}
+            autoComplete="current-password"
+            required
+            endAdornment={
+              <button
+                type="button"
+                onClick={() => setMostrarAtual((v) => !v)}
+                className="inline-flex size-9 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/30 dark:text-slate-400 dark:hover:bg-white/10 dark:hover:text-slate-200"
+                aria-label={mostrarAtual ? 'Ocultar senha atual' : 'Mostrar senha atual'}
+                aria-pressed={mostrarAtual}
+              >
+                {mostrarAtual ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
+              </button>
+            }
+          />
+          <Input
+            label="Nova senha"
+            type={mostrarNova ? 'text' : 'password'}
+            value={senhaNova}
+            onChange={(ev) => setSenhaNova(ev.target.value)}
+            autoComplete="new-password"
+            minLength={8}
+            required
+            endAdornment={
+              <button
+                type="button"
+                onClick={() => setMostrarNova((v) => !v)}
+                className="inline-flex size-9 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/30 dark:text-slate-400 dark:hover:bg-white/10 dark:hover:text-slate-200"
+                aria-label={mostrarNova ? 'Ocultar nova senha' : 'Mostrar nova senha'}
+                aria-pressed={mostrarNova}
+              >
+                {mostrarNova ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
+              </button>
+            }
+          />
+          <Input
+            label="Confirmar nova senha"
+            type={mostrarConf ? 'text' : 'password'}
+            value={senhaConf}
+            onChange={(ev) => setSenhaConf(ev.target.value)}
+            autoComplete="new-password"
+            minLength={8}
+            required
+            endAdornment={
+              <button
+                type="button"
+                onClick={() => setMostrarConf((v) => !v)}
+                className="inline-flex size-9 items-center justify-center rounded-md text-slate-500 transition-colors hover:bg-slate-100 hover:text-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/30 dark:text-slate-400 dark:hover:bg-white/10 dark:hover:text-slate-200"
+                aria-label={mostrarConf ? 'Ocultar confirmação' : 'Mostrar confirmação'}
+                aria-pressed={mostrarConf}
+              >
+                {mostrarConf ? <IconEyeOff ariaHidden={false} /> : <IconEye ariaHidden={false} />}
+              </button>
+            }
+          />
+          <div className="flex justify-end">
+            <Button type="submit" loading={busySenha}>
+              Alterar senha
+            </Button>
+          </div>
+        </form>
+      </Card>
+
       <Card
         title="Integração Cursor"
         description="O token identifica a sua conta ops nas sugestões (recusar, comentar, ligar issue). Cada pessoa gera o próprio. Novas contas são criadas em Usuários."
@@ -151,7 +322,7 @@ export function SaasConta() {
                 ? `Token ativo. Gerado em ${formatWhen(estado.gerado_em)}.`
                 : 'Ainda não há token nesta conta.'}{' '}
               <Link to="/saas/usuarios" className="font-medium text-sky-700 underline dark:text-sky-300">
-                Gerir equipe
+                Gerenciar equipe
               </Link>
             </p>
             {plaintext ? (
@@ -179,7 +350,7 @@ export function SaasConta() {
             <div className="flex flex-wrap gap-2">
               <Button
                 type="button"
-                loading={busy}
+                loading={busyToken}
                 onClick={() => {
                   if (estado.configurado) {
                     setConfirmarGerar(true)
@@ -191,7 +362,7 @@ export function SaasConta() {
                 {estado.configurado ? 'Regenerar token' : 'Gerar token'}
               </Button>
               {estado.configurado ? (
-                <Button type="button" variant="danger" loading={busy} onClick={() => setConfirmarRevogar(true)}>
+                <Button type="button" variant="danger" loading={busyToken} onClick={() => setConfirmarRevogar(true)}>
                   Revogar
                 </Button>
               ) : null}
@@ -199,13 +370,14 @@ export function SaasConta() {
           </div>
         )}
       </Card>
+
       <ConfirmDialog
         open={confirmarGerar}
         title="Regenerar token Cursor?"
-        message="O token que está no Cursor deixa de funcionar. Terá de colar o novo valor no mcp.json."
+        message="O token que está no Cursor deixa de funcionar. Você terá de colar o novo valor no mcp.json."
         confirmLabel="Regenerar"
         variant="danger"
-        loading={busy}
+        loading={busyToken}
         onConfirm={() => void gerar()}
         onCancel={() => setConfirmarGerar(false)}
       />
@@ -215,10 +387,11 @@ export function SaasConta() {
         message="O Cursor deixa de autenticar nesta conta até gerar um token novo."
         confirmLabel="Revogar"
         variant="danger"
-        loading={busy}
+        loading={busyToken}
         onConfirm={() => void revogar()}
         onCancel={() => setConfirmarRevogar(false)}
       />
-    </div>
+      </div>
+    </CadastroFormPageShell>
   )
 }

--- a/frontend/src/pages/saas/SaasLayout.tsx
+++ b/frontend/src/pages/saas/SaasLayout.tsx
@@ -1,4 +1,4 @@
-import { Link, NavLink, Navigate, Outlet, useLocation } from 'react-router-dom'
+import { NavLink, Navigate, Outlet, useLocation } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import { BrandLogo } from '../../brand'
 import { useAuth } from '../../contexts/AuthContext'
@@ -21,6 +21,23 @@ const menuIcon = (
   </svg>
 )
 
+const chevronIcon = (
+  <svg className="size-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+  </svg>
+)
+
+const usersIcon = (
+  <svg className="size-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M17 20h5v-2a4 4 0 00-4-4h-1M9 20H4v-2a4 4 0 014-4h1m4-4a4 4 0 100-8 4 4 0 000 8zm6 4a3 3 0 100-6 3 3 0 000 6z"
+    />
+  </svg>
+)
+
 const navLinkClass = ({ isActive }: { isActive: boolean }) =>
   [
     'flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition',
@@ -28,6 +45,17 @@ const navLinkClass = ({ isActive }: { isActive: boolean }) =>
       ? 'bg-sky-50 text-sky-800 ring-1 ring-sky-600/20 dark:bg-sky-500/15 dark:text-sky-100 dark:ring-sky-400/30'
       : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-white/5 dark:hover:text-white',
   ].join(' ')
+
+function perfilExibicao(user: { role?: string; saas_setor_nomes?: string[] } | null | undefined): string {
+  const nomes = (user?.saas_setor_nomes ?? []).map((n) => n.trim()).filter(Boolean)
+  if (nomes.length > 0) return nomes.join(' · ')
+  const role = user?.role
+  if (role === 'admin') return 'Administrador'
+  if (role === 'atendente') return 'Atendente'
+  if (role === 'comercial') return 'Comercial'
+  if (role === 'saas_ops') return 'Ops SaaS'
+  return role?.trim() || '—'
+}
 
 /**
  * Shell dedicado do control-plane SaaS — sem tickets/chat do painel de atendimento.
@@ -39,6 +67,11 @@ export function SaasLayout() {
   const location = useLocation()
   const [sidebarExpanded, setSidebarExpanded] = useState(true)
   const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false)
+  const equipePath =
+    location.pathname.startsWith('/saas/usuarios') ||
+    location.pathname.startsWith('/saas/setores') ||
+    location.pathname.startsWith('/saas/conta')
+  const [equipeOpen, setEquipeOpen] = useState(equipePath)
   const [planeOk, setPlaneOk] = useState<boolean | null>(null)
   const [versionLabel, setVersionLabel] = useState<string | null>(() => {
     const fromEnv =
@@ -47,6 +80,12 @@ export function SaasLayout() {
     return fromEnv ? (fromEnv.startsWith('v') ? fromEnv : `v${fromEnv}`) : null
   })
   const logoOnDark = resolved === 'dark'
+  const cargoLabel = perfilExibicao(user)
+  const menuExpandido = sidebarExpanded || sidebarMobileOpen
+
+  useEffect(() => {
+    if (equipePath) setEquipeOpen(true)
+  }, [equipePath])
 
   useEffect(() => {
     let cancelled = false
@@ -136,61 +175,105 @@ export function SaasLayout() {
         ].join(' ')}
       >
         <div
-          className={`flex items-center gap-3 border-b border-slate-200 px-4 py-4 dark:border-slate-800 ${sidebarExpanded ? '' : 'md:justify-center'}`}
+          className={`flex h-16 min-h-[64px] shrink-0 items-center border-b border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-950 ${sidebarExpanded ? 'px-4' : 'justify-center md:px-2'}`}
         >
           <BrandLogo
             variant={sidebarExpanded ? 'full' : 'mark'}
-            size="sm"
+            size={sidebarExpanded ? 'sidebar' : 'sm'}
             markVariant={logoOnDark ? 'onDark' : 'default'}
-            className="min-w-0"
+            className={sidebarExpanded ? 'min-w-0 w-full' : 'min-w-0'}
           />
-        </div>
-        <div
-          className={`border-b border-slate-200 px-4 py-3 dark:border-slate-800 ${sidebarExpanded ? '' : 'md:px-2 md:text-center'}`}
-        >
-          <p className="text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-sky-700 dark:text-sky-300/90">
-            {sidebarExpanded ? 'Painel admin SaaS' : 'SaaS'}
-          </p>
-          {sidebarExpanded ? (
-            <p className="mt-1 text-xs text-slate-500 dark:text-slate-500">Licenças, planos, leads e sugestões</p>
-          ) : null}
         </div>
         <nav className="flex flex-1 flex-col gap-1 overflow-y-auto p-3" onClick={() => setSidebarMobileOpen(false)}>
           <NavLink to={SAAS_LICENCAS_PATH} className={navLinkClass} end={false}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Licenças' : 'Lic'}</span>
+            <span className="truncate">{menuExpandido ? 'Licenças' : 'Lic'}</span>
           </NavLink>
           <NavLink to="/saas/planos" className={navLinkClass}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Planos' : 'Plan'}</span>
+            <span className="truncate">{menuExpandido ? 'Planos' : 'Plan'}</span>
           </NavLink>
           <NavLink to="/saas/leads" className={navLinkClass}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Leads comerciais' : 'Leads'}</span>
+            <span className="truncate">{menuExpandido ? 'Leads comerciais' : 'Leads'}</span>
           </NavLink>
           <NavLink to="/saas/solicitacoes" className={navLinkClass}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Sugestões' : 'Sug'}</span>
+            <span className="truncate">{menuExpandido ? 'Sugestões' : 'Sug'}</span>
           </NavLink>
-          {sidebarExpanded || sidebarMobileOpen ? (
-            <p className="mt-3 px-3 pt-2 text-[0.65rem] font-semibold uppercase tracking-[0.14em] text-slate-400 dark:text-slate-500">
-              Equipe
-            </p>
+
+          {menuExpandido ? (
+            <div className="mt-2" onClick={(e) => e.stopPropagation()}>
+              <button
+                type="button"
+                onClick={() => setEquipeOpen((o) => !o)}
+                className={[
+                  'flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm font-medium transition touch-manipulation min-h-[44px]',
+                  equipePath
+                    ? 'text-slate-800 dark:text-slate-100'
+                    : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900 dark:text-slate-300 dark:hover:bg-white/5 dark:hover:text-white',
+                ].join(' ')}
+                aria-expanded={equipeOpen}
+                aria-controls="saas-nav-equipe"
+              >
+                {usersIcon}
+                <span className="min-w-0 flex-1 truncate">Equipe</span>
+                <span className={`shrink-0 text-slate-400 transition-transform ${equipeOpen ? 'rotate-180' : ''}`}>
+                  {chevronIcon}
+                </span>
+              </button>
+              <ul
+                id="saas-nav-equipe"
+                className={`min-w-0 space-y-0.5 overflow-hidden transition-all duration-200 ${
+                  equipeOpen ? 'mt-1 max-h-56 opacity-100' : 'max-h-0 opacity-0'
+                }`}
+                role="group"
+              >
+                <li className="min-w-0 border-l border-slate-200 pl-3 ml-4 dark:border-slate-700">
+                  <NavLink
+                    to="/saas/usuarios"
+                    className={navLinkClass}
+                    onClick={() => setSidebarMobileOpen(false)}
+                  >
+                    <span className="truncate">Usuários</span>
+                  </NavLink>
+                </li>
+                <li className="min-w-0 border-l border-slate-200 pl-3 ml-4 dark:border-slate-700">
+                  <NavLink
+                    to="/saas/setores"
+                    className={navLinkClass}
+                    onClick={() => setSidebarMobileOpen(false)}
+                  >
+                    <span className="truncate">Setores</span>
+                  </NavLink>
+                </li>
+                <li className="min-w-0 border-l border-slate-200 pl-3 ml-4 dark:border-slate-700">
+                  <NavLink to="/saas/conta" className={navLinkClass} onClick={() => setSidebarMobileOpen(false)}>
+                    <span className="truncate">Minha conta</span>
+                  </NavLink>
+                </li>
+              </ul>
+            </div>
           ) : (
-            <div className="my-2 hidden border-t border-slate-200 dark:border-slate-800 md:block" />
+            <>
+              <div className="my-2 hidden border-t border-slate-200 dark:border-slate-800 md:block" />
+              <NavLink to="/saas/usuarios" className={navLinkClass} title="Usuários">
+                <span className="truncate">Usr</span>
+              </NavLink>
+              <NavLink to="/saas/setores" className={navLinkClass} title="Setores">
+                <span className="truncate">Set</span>
+              </NavLink>
+              <NavLink to="/saas/conta" className={navLinkClass} title="Minha conta">
+                <span className="truncate">Conta</span>
+              </NavLink>
+            </>
           )}
-          <NavLink to="/saas/usuarios" className={navLinkClass}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Usuários' : 'Usr'}</span>
-          </NavLink>
-          <NavLink to="/saas/conta" className={navLinkClass}>
-            <span className="truncate">{sidebarExpanded || sidebarMobileOpen ? 'Minha conta' : 'Conta'}</span>
-          </NavLink>
         </nav>
         <div className={`shrink-0 border-t border-slate-200 p-2 dark:border-slate-800 ${sidebarExpanded ? '' : 'md:px-2'}`}>
-          {(sidebarExpanded || sidebarMobileOpen) ? (
+          {menuExpandido ? (
             <div className="flex items-center gap-3 px-3 py-2 text-slate-600 dark:text-slate-400">
               <span className="flex size-8 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-cyan-500 to-blue-600 text-xs font-semibold text-white shadow-sm shadow-cyan-500/25">
                 {user.nome?.charAt(0)?.toUpperCase() ?? '?'}
               </span>
               <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{user.nome}</p>
-                <p className="truncate text-xs text-slate-500 dark:text-slate-400">Ops SaaS</p>
+                <p className="truncate text-xs text-slate-500 dark:text-slate-400">{cargoLabel}</p>
               </div>
             </div>
           ) : null}
@@ -199,19 +282,11 @@ export function SaasLayout() {
             onClick={handleLogout}
             title="Sair"
             className={`mt-2 flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium text-slate-600 hover:bg-slate-100 active:bg-slate-200 touch-manipulation min-h-[44px] dark:text-slate-400 dark:hover:bg-slate-800 dark:active:bg-slate-700 ${
-              sidebarExpanded || sidebarMobileOpen ? '' : 'md:justify-center md:px-2'
+              menuExpandido ? '' : 'md:justify-center md:px-2'
             }`}
           >
             {logoutIcon}
-            <span
-              className={
-                sidebarExpanded || sidebarMobileOpen
-                  ? 'min-w-0 truncate'
-                  : 'min-w-0 truncate md:hidden'
-              }
-            >
-              Sair
-            </span>
+            <span className={menuExpandido ? 'min-w-0 truncate' : 'min-w-0 truncate md:hidden'}>Sair</span>
           </button>
           <NavLink
             to="/saas/sobre"
@@ -220,13 +295,13 @@ export function SaasLayout() {
             className={({ isActive }) =>
               [
                 'mt-2 flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-xs font-medium text-slate-500 hover:bg-slate-100 hover:text-slate-700 dark:text-slate-400 dark:hover:bg-slate-800/80 dark:hover:text-slate-200',
-                sidebarExpanded || sidebarMobileOpen ? '' : 'md:justify-center md:px-2',
+                menuExpandido ? '' : 'md:justify-center md:px-2',
                 isActive ? 'bg-slate-100 text-slate-800 dark:bg-slate-800/80 dark:text-slate-100' : '',
               ].join(' ')
             }
           >
-            <span className={`truncate ${sidebarExpanded || sidebarMobileOpen ? '' : 'md:text-[10px]'}`}>
-              {sidebarExpanded || sidebarMobileOpen
+            <span className={`truncate ${menuExpandido ? '' : 'md:text-[10px]'}`}>
+              {menuExpandido
                 ? versionLabel
                   ? `Sobre · ${versionLabel}`
                   : 'Sobre'
@@ -237,7 +312,7 @@ export function SaasLayout() {
       </aside>
 
       <div className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden md:col-start-2">
-        <header className="z-30 flex h-16 shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-800 dark:bg-slate-950 md:px-6">
+        <header className="z-30 flex h-16 min-h-[64px] w-full shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-800 dark:bg-slate-950 md:gap-3 md:px-6">
           <button
             type="button"
             onClick={() => {
@@ -247,23 +322,24 @@ export function SaasLayout() {
                 setSidebarMobileOpen((o) => !o)
               }
             }}
-            className="flex size-10 items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 dark:text-slate-300 dark:hover:bg-slate-800 md:size-9"
+            className="flex size-10 shrink-0 items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 active:bg-slate-200 touch-manipulation dark:text-slate-300 dark:hover:bg-slate-800 md:size-9"
             aria-label="Abrir ou recolher menu"
           >
             {menuIcon}
           </button>
-          <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-200">
-              Control-plane DeskRudder
+          <div className="min-w-0 flex-1 leading-tight">
+            <p className="truncate text-sm font-semibold uppercase tracking-[0.08em] text-sky-800 dark:text-sky-200">
+              Painel admin SaaS
+            </p>
+            <p className="hidden truncate text-xs text-slate-500 dark:text-slate-400 sm:block">
+              Licenças, planos, leads e sugestões
             </p>
           </div>
           <ThemeToggle />
-          <Link
-            to="/login"
-            className="hidden rounded-lg px-3 py-1.5 text-xs font-medium text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 dark:text-slate-400 dark:hover:bg-white/5 dark:hover:text-slate-200 sm:inline"
-          >
-            Painel atendimento
-          </Link>
+          <div className="hidden min-w-0 max-w-[12rem] shrink text-right leading-tight sm:block md:max-w-[16rem]">
+            <p className="truncate text-sm font-medium text-slate-800 dark:text-slate-100">{user.nome}</p>
+            <p className="truncate text-xs text-slate-500 dark:text-slate-400">{cargoLabel}</p>
+          </div>
         </header>
         <main className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto p-4 md:p-6">
           <Outlet />

--- a/frontend/src/pages/saas/SaasLicencaDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasLicencaDetalhe.tsx
@@ -315,30 +315,79 @@ export function SaasLicencaDetalhe() {
         <dl>
           <DetailRow label="ID" value={String(item.id)} mono />
           <DetailRow label="Slug" value={item.slug} mono />
-          <DetailRow label="Plano" value={item.plano || '—'} />
-          {item.plano_modulos && item.plano_modulos.length > 0 ? (
+          <DetailRow label="Plano base" value={item.plano || '—'} />
+          {(item.modulos_contratados && item.modulos_contratados.length > 0) ||
+          (item.modulos_snapshot && item.modulos_snapshot.length > 0) ? (
+            <DetailRow
+              label="Módulos contratados"
+              value={
+                item.modulos_contratados && item.modulos_contratados.length > 0
+                  ? item.modulos_contratados.map((m) => m.nome).join(', ')
+                  : (item.modulos_snapshot ?? []).join(', ')
+              }
+            />
+          ) : item.plano_modulos && item.plano_modulos.length > 0 ? (
             <DetailRow
               label="Módulos do plano"
               value={item.plano_modulos.map((m) => m.nome).join(', ')}
             />
           ) : null}
-          {item.modulos_snapshot && item.modulos_snapshot.length > 0 ? (
-            <DetailRow label="Snapshot módulos" value={item.modulos_snapshot.join(', ')} mono />
-          ) : null}
           <DetailRow
-            label="Limites"
+            label="Usuários"
             value={
-              item.max_postos != null || item.max_usuarios != null
-                ? [
-                    item.max_postos != null ? `${item.max_postos} postos` : null,
-                    item.max_usuarios != null ? `${item.max_usuarios} utilizadores` : null,
-                  ]
-                    .filter(Boolean)
-                    .join(' · ')
+              item.max_usuarios != null
+                ? `${item.max_usuarios} contratados${
+                    item.usuarios_inclusos != null
+                      ? ` (${item.usuarios_inclusos} inclusos no plano)`
+                      : ''
+                  }`
                 : '—'
             }
           />
-          <DetailRow label="Contacto" value={item.contato_nome || '—'} />
+          <DetailRow
+            label="Valor mensal"
+            value={
+              item.preco_mensal_efetivo != null
+                ? `R$ ${Number(item.preco_mensal_efetivo).toLocaleString('pt-BR', {
+                    minimumFractionDigits: 0,
+                    maximumFractionDigits: 2,
+                  })}/mês${
+                    item.preco_mensal_negociado != null
+                      ? ' (negociado)'
+                      : ' (catálogo)'
+                  }`
+                : '—'
+            }
+          />
+          {item.preco_mensal_negociado != null && item.preco_mensal_estimado != null ? (
+            <DetailRow
+              label="Estimativa catálogo"
+              value={`R$ ${Number(item.preco_mensal_estimado).toLocaleString('pt-BR', {
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 2,
+              })}/mês`}
+            />
+          ) : item.preco_mensal_estimado != null && item.preco_mensal_negociado == null ? (
+            <DetailRow
+              label="Detalhe catálogo"
+              value={
+                item.preco_modulos != null || item.preco_usuarios_extra != null
+                  ? `módulos R$ ${Number(item.preco_modulos ?? 0).toLocaleString('pt-BR', {
+                      minimumFractionDigits: 0,
+                      maximumFractionDigits: 2,
+                    })}${
+                      Number(item.preco_usuarios_extra ?? 0) > 0
+                        ? ` + extras R$ ${Number(item.preco_usuarios_extra).toLocaleString('pt-BR', {
+                            minimumFractionDigits: 0,
+                            maximumFractionDigits: 2,
+                          })}`
+                        : ''
+                    }`
+                  : '—'
+              }
+            />
+          ) : null}
+          <DetailRow label="Contato" value={item.contato_nome || '—'} />
           <DetailRow label="E-mail" value={item.contato_email || '—'} />
           <DetailRow label="Início" value={formatDate(item.data_inicio)} />
           <DetailRow

--- a/frontend/src/pages/saas/SaasLicencaForm.tsx
+++ b/frontend/src/pages/saas/SaasLicencaForm.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
-import { ApiError, saasClientes, saasPlanos, type SaasCatalogo } from '../../api/client'
+import { ApiError, saasClientes, saasModulos, saasPlanos, type SaasCatalogo } from '../../api/client'
 import { Card } from '../../components/ui/Card'
 import { Input } from '../../components/ui/Input'
 import { Select } from '../../components/ui/Select'
@@ -55,6 +55,11 @@ export function SaasLicencaForm() {
   const [status, setStatus] = useState<StatusClienteSaaS>('trial')
   const [planoId, setPlanoId] = useState<number | ''>('')
   const [planosOpts, setPlanosOpts] = useState<SaasCatalogo.Plano[]>([])
+  const [modulosOpts, setModulosOpts] = useState<SaasCatalogo.Modulo[]>([])
+  const [moduloIds, setModuloIds] = useState<number[]>([])
+  const [usuariosContratados, setUsuariosContratados] = useState('3')
+  const [precoNegociado, setPrecoNegociado] = useState('')
+  const [pendingSnap, setPendingSnap] = useState<string[] | null>(null)
   const [dataInicio, setDataInicio] = useState(todayIso)
   const [dataRenovacao, setDataRenovacao] = useState('')
   const [contatoNome, setContatoNome] = useState('')
@@ -62,6 +67,14 @@ export function SaasLicencaForm() {
   const [notas, setNotas] = useState('')
   const [leadComercialId, setLeadComercialId] = useState<number | null>(null)
   const [baseDomain, setBaseDomain] = useState(saasBaseDomain())
+
+  function formatPreco(v: number): string {
+    return `R$ ${v.toLocaleString('pt-BR', { minimumFractionDigits: 0, maximumFractionDigits: 2 })}`
+  }
+
+  function toggleModulo(mid: number) {
+    setModuloIds((prev) => (prev.includes(mid) ? prev.filter((x) => x !== mid) : [...prev, mid]))
+  }
 
   useEffect(() => {
     if (isEdit) return
@@ -103,19 +116,61 @@ export function SaasLicencaForm() {
 
   useEffect(() => {
     let cancelled = false
-    saasPlanos
-      .list()
-      .then((planos) => {
+    Promise.all([saasPlanos.list(), saasModulos.list()])
+      .then(([planos, mods]) => {
         if (cancelled) return
         setPlanosOpts(planos)
+        setModulosOpts(mods)
       })
       .catch(() => {
-        /* select vazio */
+        /* selects vazios */
       })
     return () => {
       cancelled = true
     }
   }, [])
+
+  const planoSelecionado = useMemo(
+    () => (planoId === '' ? null : planosOpts.find((p) => p.id === Number(planoId)) ?? null),
+    [planoId, planosOpts],
+  )
+
+  const inclusos = planoSelecionado?.usuarios_inclusos ?? 3
+  const extraUnit = Number(planoSelecionado?.preco_usuario_extra ?? 10)
+  const precoMods = useMemo(() => {
+    return (
+      Math.round(
+        modulosOpts
+          .filter((m) => moduloIds.includes(m.id))
+          .reduce((acc, m) => acc + Number(m.preco_mensal || 0), 0) * 100,
+      ) / 100
+    )
+  }, [modulosOpts, moduloIds])
+  const usersN = parseInt(usuariosContratados, 10)
+  const usersExtra = Number.isFinite(usersN) ? Math.max(0, usersN - inclusos) : 0
+  const precoUsers = Math.round(usersExtra * extraUnit * 100) / 100
+  const precoTotal = Math.round((precoMods + precoUsers) * 100) / 100
+
+  function aplicarModulosDoPlano(pid: number | '') {
+    if (pid === '') {
+      setModuloIds([])
+      return
+    }
+    const plano = planosOpts.find((p) => p.id === Number(pid))
+    if (plano) setModuloIds(plano.modulos.map((m) => m.id))
+  }
+
+  useEffect(() => {
+    if (pendingSnap == null) return
+    if (!modulosOpts.length && !planosOpts.length) return
+    if (pendingSnap.length && modulosOpts.length) {
+      setModuloIds(modulosOpts.filter((m) => pendingSnap.includes(m.codigo)).map((m) => m.id))
+    } else if (planoId !== '' && planosOpts.length) {
+      aplicarModulosDoPlano(planoId)
+    }
+    setPendingSnap(null)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- sync único após load da licença
+  }, [pendingSnap, modulosOpts, planosOpts, planoId])
 
   useEffect(() => {
     if (!isEdit) return
@@ -138,6 +193,15 @@ export function SaasLicencaForm() {
         setSlugTouched(true)
         setStatus(c.status)
         setPlanoId(c.plano_id ?? '')
+        setUsuariosContratados(
+          c.max_usuarios != null
+            ? String(c.max_usuarios)
+            : String(c.usuarios_inclusos ?? 3),
+        )
+        setPrecoNegociado(
+          c.preco_mensal_negociado != null ? String(c.preco_mensal_negociado) : '',
+        )
+        setPendingSnap(c.modulos_snapshot ?? [])
         setDataInicio(c.data_inicio.slice(0, 10))
         setDataRenovacao(c.data_renovacao ? c.data_renovacao.slice(0, 10) : '')
         setContatoNome(c.contato_nome ?? '')
@@ -178,11 +242,18 @@ export function SaasLicencaForm() {
     setSaving(true)
     try {
       const urlAuto = urlInstanciaFromSlug(slug.trim().toLowerCase(), baseDomain) || null
+      const usersParsed = parseInt(usuariosContratados, 10)
+      const negociadoParsed =
+        precoNegociado.trim() === '' ? null : Number(precoNegociado)
       const payload = {
         nome: nome.trim(),
         slug: slug.trim().toLowerCase(),
         status,
         plano_id: planoId === '' ? null : Number(planoId),
+        modulo_ids: moduloIds,
+        usuarios_contratados: Number.isFinite(usersParsed) ? usersParsed : null,
+        preco_mensal_negociado:
+          negociadoParsed != null && Number.isFinite(negociadoParsed) ? negociadoParsed : null,
         data_inicio: dataInicio,
         data_renovacao: dataRenovacao.trim() || null,
         instancia_url: urlAuto,
@@ -288,30 +359,102 @@ export function SaasLicencaForm() {
                 options={STATUS_CLIENTE_SAAS.map((s) => ({ value: s.value, label: s.label }))}
               />
               <Select
-                label="Plano"
+                label="Plano base"
                 value={planoId}
-                onChange={(v) => setPlanoId(v === '' ? '' : Number(v))}
+                onChange={(v) => {
+                  const next = v === '' ? '' : Number(v)
+                  setPlanoId(next)
+                  aplicarModulosDoPlano(next)
+                  const plano = next === '' ? null : planosOpts.find((p) => p.id === next)
+                  if (plano?.usuarios_inclusos != null) {
+                    setUsuariosContratados(String(plano.usuarios_inclusos))
+                  }
+                }}
                 includeEmpty
                 emptyLabel="Sem plano"
                 options={planosOpts
                   .filter((p) => p.ativo || p.id === planoId)
                   .map((p) => ({
                     value: p.id,
-                    label: p.ativo ? p.nome : `${p.nome} (inactivo)`,
+                    label: p.ativo ? p.nome : `${p.nome} (inativo)`,
                   }))}
               />
               <p className="text-xs text-slate-500 dark:text-slate-400">
-                Catálogo em Licenças → Planos. Só planos activos (excepto o já atribuído).
+                Ao trocar o plano, os módulos do pacote são pré-selecionados. Você pode incluir
+                módulos extras (ex.: Essencial + um módulo Enterprise).
               </p>
             </FormSection>
-            <FormSection title="Contacto">
+            <FormSection title="Módulos e usuários">
+              <div className="space-y-2">
+                <span className="text-sm font-medium text-slate-700 dark:text-slate-200">
+                  Módulos contratados
+                </span>
+                <ul className="max-h-56 space-y-1 overflow-y-auto rounded-xl border border-slate-200 p-2 dark:border-slate-700">
+                  {modulosOpts
+                    .filter((m) => m.ativo || moduloIds.includes(m.id))
+                    .map((m) => (
+                      <li key={m.id}>
+                        <label className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-sm hover:bg-slate-50 dark:hover:bg-slate-800/60">
+                          <input
+                            type="checkbox"
+                            checked={moduloIds.includes(m.id)}
+                            onChange={() => toggleModulo(m.id)}
+                            className="rounded border-slate-300 text-sky-600 focus:ring-sky-400"
+                          />
+                          <span className="min-w-0 flex-1 text-slate-800 dark:text-slate-100">
+                            {m.nome}
+                            {!m.ativo ? (
+                              <span className="ml-1 text-xs text-amber-600">(inativo)</span>
+                            ) : null}
+                          </span>
+                          <span className="tabular-nums text-xs text-slate-500">
+                            {formatPreco(Number(m.preco_mensal || 0))}
+                          </span>
+                        </label>
+                      </li>
+                    ))}
+                </ul>
+              </div>
               <Input
-                label="Nome do contacto"
+                label="Usuários contratados"
+                type="number"
+                min={0}
+                value={usuariosContratados}
+                onChange={(e) => setUsuariosContratados(e.target.value)}
+                hint={`${inclusos} inclusos no plano; extras a ${formatPreco(extraUnit)}/mês cada.`}
+              />
+              <Input
+                label="Valor mensal negociado (R$)"
+                type="number"
+                step="0.01"
+                min={0}
+                value={precoNegociado}
+                onChange={(e) => setPrecoNegociado(e.target.value)}
+                hint="Opcional. Se preenchido, vale na ficha comercial em vez da estimativa do catálogo."
+              />
+              <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900/40">
+                <p className="font-medium text-slate-800 dark:text-slate-100">
+                  {precoNegociado.trim() !== '' && Number.isFinite(Number(precoNegociado))
+                    ? `Valor negociado: ${formatPreco(Number(precoNegociado))}`
+                    : `Estimativa do catálogo: ${formatPreco(precoTotal)}`}
+                </p>
+                <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                  Catálogo: módulos {formatPreco(precoMods)}
+                  {usersExtra > 0
+                    ? ` + ${usersExtra} usuário(s) extra ${formatPreco(precoUsers)}`
+                    : ''}
+                  {precoNegociado.trim() !== '' ? ` (estimativa ${formatPreco(precoTotal)})` : ''}
+                </p>
+              </div>
+            </FormSection>
+            <FormSection title="Contato">
+              <Input
+                label="Nome do contato"
                 value={contatoNome}
                 onChange={(e) => setContatoNome(e.target.value)}
               />
               <Input
-                label="E-mail do contacto"
+                label="E-mail do contato"
                 type="email"
                 value={contatoEmail}
                 onChange={(e) => setContatoEmail(e.target.value)}

--- a/frontend/src/pages/saas/SaasLicencas.tsx
+++ b/frontend/src/pages/saas/SaasLicencas.tsx
@@ -243,7 +243,7 @@ export function SaasLicencas({ embedded = false }: { embedded?: boolean }) {
       actions={<Button onClick={() => navigate('/saas/licencas/novo')}>Nova licença</Button>}
     >
       {resumo ? (
-        <div className="mb-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        <div className="mb-4 grid w-full grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-[repeat(5,minmax(0,1fr))]">
           <ResumoCard
             label="Clientes"
             value={String(resumo.clientes_total)}
@@ -252,21 +252,21 @@ export function SaasLicencas({ embedded = false }: { embedded?: boolean }) {
           <ResumoCard
             label="Renovação"
             value={String(resumo.vencendo_em_breve)}
-            hint={`${resumo.vencidas_ativas} vencida(s) · janela ${resumo.janela_renovacao_dias}d · clicar para filtrar`}
+            hint={`${resumo.vencidas_ativas} vencida(s) · ${resumo.janela_renovacao_dias}d`}
             tone={resumo.vencidas_ativas > 0 || resumo.vencendo_em_breve > 0 ? 'warn' : undefined}
             onClick={() => aplicarAtalhoResumo('renovacao')}
           />
           <ResumoCard
             label="Provisionamento"
             value={String(resumo.provisionamento_pendente)}
-            hint={`${resumo.provisionamento_falha} falha(s) · clicar para filtrar fila`}
+            hint={`${resumo.provisionamento_falha} falha(s) na fila`}
             tone={resumo.provisionamento_falha > 0 || resumo.provisionamento_pendente > 0 ? 'warn' : undefined}
             onClick={() => aplicarAtalhoResumo('provisionamento')}
           />
           <ResumoCard
             label="Aprovações"
             value={String(resumo.aprovacoes_pendentes ?? 0)}
-            hint="go-live pendente · clicar para filtrar"
+            hint="go-live pendente"
             tone={(resumo.aprovacoes_pendentes ?? 0) > 0 ? 'warn' : undefined}
             onClick={() => aplicarAtalhoResumo('aprovacoes')}
           />
@@ -349,96 +349,101 @@ export function SaasLicencas({ embedded = false }: { embedded?: boolean }) {
           total={total}
           onPageChange={setPage}
           disabled={loading}
-          extra={
-            <div className="flex min-w-0 flex-wrap gap-2">
-              <div className="min-w-[9rem] shrink-0">
-                <Select
-                  aria-label="Filtrar por status"
-                  value={statusFiltro}
-                  onChange={(v) => patchFiltros({ status: String(v) || null })}
-                  options={STATUS_CLIENTE_SAAS.map((s) => ({ value: s.value, label: s.label }))}
-                  includeEmpty
-                  emptyLabel="Todos"
-                  placeholder="Status"
-                  disabled={loading}
-                />
-              </div>
-              <div className="min-w-[9rem] shrink-0">
-                <Select
-                  aria-label="Filtrar por plano"
-                  value={planoFiltro}
-                  onChange={(v) => patchFiltros({ plano_id: v === '' ? null : String(v) })}
-                  options={planos.map((p) => ({ value: String(p.id), label: p.nome }))}
-                  includeEmpty
-                  emptyLabel="Todos os planos"
-                  placeholder="Plano"
-                  disabled={loading}
-                />
-              </div>
-              <div className="min-w-[10rem] shrink-0">
-                <Select
-                  aria-label="Filtrar por aprovação"
-                  value={aprovacaoFiltro}
-                  onChange={(v) => patchFiltros({ aprovacao_status: String(v) || null })}
-                  options={APROVACAO_OPTS}
-                  includeEmpty
-                  emptyLabel="Qualquer aprovação"
-                  placeholder="Aprovação"
-                  disabled={loading}
-                />
-              </div>
-              <div className="min-w-[10rem] shrink-0">
-                <Select
-                  aria-label="Filtrar por provisionamento"
-                  value={provFila ? 'fila' : provStatusFiltro}
-                  onChange={(v) => {
-                    const s = String(v)
-                    if (s === 'fila') {
-                      patchFiltros({ provisionamento_fila: '1', provisionamento_status: null })
-                    } else if (!s) {
-                      patchFiltros({ provisionamento_fila: null, provisionamento_status: null })
-                    } else {
-                      patchFiltros({ provisionamento_fila: null, provisionamento_status: s })
-                    }
-                  }}
-                  options={[{ value: 'fila', label: 'Em fila / falha' }, ...PROV_OPTS]}
-                  includeEmpty
-                  emptyLabel="Qualquer prov."
-                  placeholder="Provisionamento"
-                  disabled={loading}
-                />
-              </div>
-              {(statusFiltro ||
-                planoFiltro ||
-                aprovacaoFiltro ||
-                provStatusFiltro ||
-                provFila ||
-                vencendo ||
-                vencidas) && (
-                <Button
-                  variant="secondary"
-                  disabled={loading}
-                  onClick={() =>
-                    patchFiltros({
-                      status: null,
-                      plano_id: null,
-                      aprovacao_status: null,
-                      provisionamento_status: null,
-                      provisionamento_fila: null,
-                      vencendo: null,
-                      vencidas: null,
-                    })
-                  }
-                >
-                  Limpar filtros
-                </Button>
-              )}
-            </div>
-          }
         />
+        <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-[repeat(4,minmax(0,1fr))_auto]">
+          <Select
+            label="Status"
+            labelStyle="overline"
+            className="min-w-0"
+            aria-label="Filtrar por status"
+            value={statusFiltro}
+            onChange={(v) => patchFiltros({ status: String(v) || null })}
+            options={STATUS_CLIENTE_SAAS.map((s) => ({ value: s.value, label: s.label }))}
+            includeEmpty
+            emptyLabel="Todos"
+            placeholder="Todos"
+            disabled={loading}
+          />
+          <Select
+            label="Plano"
+            labelStyle="overline"
+            className="min-w-0"
+            aria-label="Filtrar por plano"
+            value={planoFiltro}
+            onChange={(v) => patchFiltros({ plano_id: v === '' ? null : String(v) })}
+            options={planos.map((p) => ({ value: String(p.id), label: p.nome }))}
+            includeEmpty
+            emptyLabel="Todos"
+            placeholder="Todos"
+            disabled={loading}
+          />
+          <Select
+            label="Aprovação"
+            labelStyle="overline"
+            className="min-w-0"
+            aria-label="Filtrar por aprovação"
+            value={aprovacaoFiltro}
+            onChange={(v) => patchFiltros({ aprovacao_status: String(v) || null })}
+            options={APROVACAO_OPTS}
+            includeEmpty
+            emptyLabel="Qualquer"
+            placeholder="Qualquer"
+            disabled={loading}
+          />
+          <Select
+            label="Provisionamento"
+            labelStyle="overline"
+            className="min-w-0"
+            aria-label="Filtrar por provisionamento"
+            value={provFila ? 'fila' : provStatusFiltro}
+            onChange={(v) => {
+              const s = String(v)
+              if (s === 'fila') {
+                patchFiltros({ provisionamento_fila: '1', provisionamento_status: null })
+              } else if (!s) {
+                patchFiltros({ provisionamento_fila: null, provisionamento_status: null })
+              } else {
+                patchFiltros({ provisionamento_fila: null, provisionamento_status: s })
+              }
+            }}
+            options={[{ value: 'fila', label: 'Em fila / falha' }, ...PROV_OPTS]}
+            includeEmpty
+            emptyLabel="Qualquer"
+            placeholder="Qualquer"
+            disabled={loading}
+          />
+          {(statusFiltro ||
+            planoFiltro ||
+            aprovacaoFiltro ||
+            provStatusFiltro ||
+            provFila ||
+            vencendo ||
+            vencidas) && (
+            <div className="flex items-end sm:col-span-2 lg:col-span-4 xl:col-span-1">
+              <Button
+                variant="secondary"
+                className="w-full xl:w-auto"
+                disabled={loading}
+                onClick={() =>
+                  patchFiltros({
+                    status: null,
+                    plano_id: null,
+                    aprovacao_status: null,
+                    provisionamento_status: null,
+                    provisionamento_fila: null,
+                    vencendo: null,
+                    vencidas: null,
+                  })
+                }
+              >
+                Limpar filtros
+              </Button>
+            </div>
+          )}
+        </div>
         {vencendo || vencidas ? (
           <p className="mb-3 text-xs text-amber-800 dark:text-amber-200">
-            Filtro activo:{' '}
+            Filtro ativo:{' '}
             {vencendo ? 'renovação na janela de alerta' : null}
             {vencendo && vencidas ? ' · ' : null}
             {vencidas ? 'renovação vencida' : null}
@@ -469,6 +474,9 @@ export function SaasLicencas({ embedded = false }: { embedded?: boolean }) {
                   />
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
                     Plano
+                  </th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
+                    Valor/mês
                   </th>
                   <CabecalhoOrdenavel
                     coluna="status"
@@ -527,6 +535,21 @@ export function SaasLicencas({ embedded = false }: { embedded?: boolean }) {
                       </td>
                       <td className="px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-300">
                         {item.plano || '—'}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3.5 tabular-nums text-slate-700 sm:px-6 dark:text-slate-200">
+                        {item.preco_mensal_efetivo != null
+                          ? `R$ ${Number(item.preco_mensal_efetivo).toLocaleString('pt-BR', {
+                              minimumFractionDigits: 0,
+                              maximumFractionDigits: 2,
+                            })}`
+                          : '—'}
+                        {item.preco_mensal_negociado != null ? (
+                          <span className="mt-0.5 block text-[11px] text-amber-700 dark:text-amber-300">
+                            Negociado
+                          </span>
+                        ) : item.preco_mensal_estimado != null ? (
+                          <span className="mt-0.5 block text-[11px] text-slate-400">Catálogo</span>
+                        ) : null}
                       </td>
                       <td className="whitespace-nowrap px-4 py-3.5 sm:px-6">
                         <span
@@ -611,32 +634,32 @@ function ResumoCard({
 }) {
   const body = (
     <div
-      className={`rounded-2xl border px-4 py-3 ${
+      className={`flex h-full min-h-[6.75rem] w-full min-w-0 flex-col rounded-2xl border px-4 py-3 ${
         tone === 'warn'
           ? 'border-amber-200 bg-amber-50/80 dark:border-amber-800/40 dark:bg-amber-950/30'
           : 'border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900/40'
       } ${onClick || linkTo ? 'transition hover:ring-2 hover:ring-sky-400/40' : ''}`}
     >
-      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+      <p className="shrink-0 truncate text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
         {label}
       </p>
-      <p className="mt-1 text-2xl font-semibold tabular-nums text-slate-900 dark:text-slate-50">{value}</p>
-      <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">{hint}</p>
+      <p className="mt-1 shrink-0 text-2xl font-semibold tabular-nums text-slate-900 dark:text-slate-50">{value}</p>
+      <p className="mt-auto pt-2 text-xs leading-snug text-slate-500 line-clamp-2 dark:text-slate-400">{hint}</p>
     </div>
   )
   if (linkTo) {
     return (
-      <Link to={linkTo} className="block">
+      <Link to={linkTo} className="block h-full w-full min-w-0">
         {body}
       </Link>
     )
   }
   if (onClick) {
     return (
-      <button type="button" className="block w-full text-left" onClick={onClick}>
+      <button type="button" className="block h-full w-full min-w-0 text-left" onClick={onClick}>
         {body}
       </button>
     )
   }
-  return body
+  return <div className="h-full w-full min-w-0">{body}</div>
 }

--- a/frontend/src/pages/saas/SaasModulos.tsx
+++ b/frontend/src/pages/saas/SaasModulos.tsx
@@ -9,6 +9,14 @@ import { ConfigListPageShell } from '../../components/config/ConfigListPageShell
 import { SemPermissao } from '../SemPermissao'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 
+function formatPreco(v: number | null | undefined): string {
+  if (v == null) return '—'
+  return `R$ ${Number(v).toLocaleString('pt-BR', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  })}`
+}
+
 export function SaasModulos() {
   const navigate = useNavigate()
   const toast = useToast()
@@ -18,10 +26,12 @@ export function SaasModulos() {
   const [indisponivel, setIndisponivel] = useState(false)
   const [actingId, setActingId] = useState<number | null>(null)
   const [saving, setSaving] = useState(false)
+  const [formOpen, setFormOpen] = useState(false)
 
   const [codigo, setCodigo] = useState('')
   const [nome, setNome] = useState('')
   const [descricao, setDescricao] = useState('')
+  const [precoMensal, setPrecoMensal] = useState('')
   const [editId, setEditId] = useState<number | null>(null)
 
   const carregar = useCallback(() => {
@@ -52,6 +62,17 @@ export function SaasModulos() {
     setCodigo('')
     setNome('')
     setDescricao('')
+    setPrecoMensal('')
+    setFormOpen(false)
+  }
+
+  function startCreate() {
+    setEditId(null)
+    setCodigo('')
+    setNome('')
+    setDescricao('')
+    setPrecoMensal('')
+    setFormOpen(true)
   }
 
   function startEdit(m: SaasCatalogo.Modulo) {
@@ -59,30 +80,36 @@ export function SaasModulos() {
     setCodigo(m.codigo)
     setNome(m.nome)
     setDescricao(m.descricao ?? '')
+    setPrecoMensal(m.preco_mensal != null ? String(m.preco_mensal) : '')
+    setFormOpen(true)
   }
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setSaving(true)
     try {
+      const precoN = precoMensal.trim() === '' ? null : Number(precoMensal)
+      const preco = precoN != null && Number.isFinite(precoN) ? precoN : null
       if (editId != null) {
         await saasModulos.update(editId, {
           nome: nome.trim(),
           descricao: descricao.trim() || null,
+          preco_mensal: preco,
         })
-        toast.showSuccess('Módulo actualizado.')
+        toast.showSuccess('Módulo atualizado. Planos que o usam recalculam o preço.')
       } else {
         await saasModulos.create({
           codigo: codigo.trim().toLowerCase(),
           nome: nome.trim(),
           descricao: descricao.trim() || null,
+          preco_mensal: preco,
         })
         toast.showSuccess('Módulo criado.')
       }
       resetForm()
       carregar()
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível guardar o módulo.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o módulo.'))
     } finally {
       setSaving(false)
     }
@@ -93,7 +120,7 @@ export function SaasModulos() {
     try {
       if (item.ativo) await saasModulos.desativar(item.id)
       else await saasModulos.ativar(item.id)
-      toast.showSuccess(item.ativo ? 'Módulo desactivado.' : 'Módulo activado.')
+      toast.showSuccess(item.ativo ? 'Módulo desativado.' : 'Módulo ativado.')
       carregar()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar o módulo.'))
@@ -112,6 +139,8 @@ export function SaasModulos() {
     )
   }
 
+  const editando = editId != null
+
   return (
     <ConfigListPageShell
       forbidden={forbidden}
@@ -123,90 +152,162 @@ export function SaasModulos() {
         />
       }
       title="Módulos"
-      subtitle="Peças do catálogo comercial que podem ser associadas a planos."
+      subtitle="Preço mensal de cada módulo — o plano soma os habilitados."
       actions={
-        <Button variant="secondary" onClick={() => navigate('/saas/planos')}>
-          Voltar aos planos
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="secondary" onClick={() => navigate('/saas/planos')}>
+            Voltar aos planos
+          </Button>
+          {!formOpen ? (
+            <Button onClick={startCreate}>Novo módulo</Button>
+          ) : null}
+        </div>
       }
     >
-      <div className="space-y-6">
-        <Card title={editId != null ? 'Editar módulo' : 'Novo módulo'}>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="grid gap-4 sm:grid-cols-2">
-              <Input
-                label="Código"
-                value={codigo}
-                onChange={(e) => setCodigo(e.target.value)}
-                required
-                disabled={editId != null}
-                hint="Ex.: contratos"
-              />
-              <Input label="Nome" value={nome} onChange={(e) => setNome(e.target.value)} required />
-            </div>
-            <Input
-              label="Descrição"
-              value={descricao}
-              onChange={(e) => setDescricao(e.target.value)}
-            />
-            <div className="flex flex-wrap gap-2">
-              <Button type="submit" disabled={saving}>
-                {editId != null ? 'Guardar' : 'Criar'}
-              </Button>
-              {editId != null ? (
-                <Button type="button" variant="cancel" disabled={saving} onClick={resetForm}>
-                  Cancelar edição
+      <div className="space-y-4">
+        {formOpen ? (
+          <Card title={editando ? 'Editar módulo' : 'Novo módulo'}>
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <div className="grid gap-4 sm:grid-cols-12">
+                <div className="sm:col-span-5">
+                  <Input
+                    label="Nome"
+                    value={nome}
+                    onChange={(e) => setNome(e.target.value)}
+                    required
+                    placeholder="Ex.: Contratos"
+                    autoFocus
+                  />
+                </div>
+                <div className="sm:col-span-4">
+                  <Input
+                    label="Código"
+                    value={codigo}
+                    onChange={(e) => setCodigo(e.target.value)}
+                    required
+                    disabled={editando}
+                    placeholder="contratos"
+                    className="font-mono text-sm"
+                  />
+                </div>
+                <div className="sm:col-span-3">
+                  <Input
+                    label="Preço (R$/mês)"
+                    type="number"
+                    step="0.01"
+                    min={0}
+                    value={precoMensal}
+                    onChange={(e) => setPrecoMensal(e.target.value)}
+                    placeholder="0"
+                  />
+                </div>
+                <div className="sm:col-span-12">
+                  <Input
+                    label="Descrição"
+                    value={descricao}
+                    onChange={(e) => setDescricao(e.target.value)}
+                    placeholder="Opcional"
+                  />
+                </div>
+              </div>
+              <div className="flex flex-wrap items-center gap-2 border-t border-slate-100 pt-4 dark:border-slate-800">
+                <Button type="submit" disabled={saving}>
+                  {editando ? 'Salvar' : 'Criar módulo'}
                 </Button>
-              ) : null}
-            </div>
-          </form>
-        </Card>
+                <Button type="button" variant="cancel" disabled={saving} onClick={resetForm}>
+                  Cancelar
+                </Button>
+              </div>
+            </form>
+          </Card>
+        ) : null}
 
         <Card>
           {loading ? (
-            <div className="h-32 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+            <div className="h-40 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
           ) : list.length === 0 ? (
-            <p className="py-6 text-center text-sm text-slate-500">Nenhum módulo.</p>
+            <div className="px-2 py-10 text-center">
+              <p className="text-sm text-slate-500 dark:text-slate-400">Nenhum módulo cadastrado.</p>
+              {!formOpen ? (
+                <Button className="mt-4" onClick={startCreate}>
+                  Novo módulo
+                </Button>
+              ) : null}
+            </div>
           ) : (
-            <ul className="divide-y divide-slate-100 dark:divide-slate-800">
-              {list.map((m) => (
-                <li
-                  key={m.id}
-                  className="flex flex-wrap items-center justify-between gap-3 px-1 py-3 sm:px-2"
-                >
-                  <div>
-                    <p className="font-medium text-slate-800 dark:text-slate-100">
-                      {m.nome}{' '}
-                      <span className="font-mono text-xs font-normal text-slate-500">{m.codigo}</span>
-                    </p>
-                    {m.descricao ? (
-                      <p className="text-xs text-slate-500">{m.descricao}</p>
-                    ) : null}
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <span
-                      className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${
-                        m.ativo
-                          ? 'bg-emerald-50 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300'
-                          : 'bg-slate-100 text-slate-600'
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-slate-100 text-sm dark:divide-slate-800">
+                <thead>
+                  <tr className="text-left">
+                    <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 sm:px-6">
+                      Nome
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 sm:px-6">
+                      Código
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 sm:px-6">
+                      Preço
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-slate-500 sm:px-6">
+                      Situação
+                    </th>
+                    <th className="w-px px-4 py-3 text-right text-xs font-semibold uppercase tracking-wide text-slate-500 sm:px-6">
+                      <span className="sr-only">Ações</span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                  {list.map((m) => (
+                    <tr
+                      key={m.id}
+                      className={`hover:bg-slate-50 dark:hover:bg-white/5 ${
+                        editId === m.id ? 'bg-sky-50/60 dark:bg-sky-950/20' : ''
                       }`}
                     >
-                      {m.ativo ? 'Activo' : 'Inactivo'}
-                    </span>
-                    <Button variant="secondary" onClick={() => startEdit(m)}>
-                      Editar
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      disabled={actingId === m.id}
-                      onClick={() => void toggleAtivo(m)}
-                    >
-                      {m.ativo ? 'Desactivar' : 'Activar'}
-                    </Button>
-                  </div>
-                </li>
-              ))}
-            </ul>
+                      <td className="px-4 py-3.5 sm:px-6">
+                        <span className="font-medium text-slate-800 dark:text-slate-100">{m.nome}</span>
+                        {m.descricao ? (
+                          <span className="mt-0.5 block max-w-md truncate text-xs text-slate-500">
+                            {m.descricao}
+                          </span>
+                        ) : null}
+                      </td>
+                      <td className="px-4 py-3.5 font-mono text-xs text-slate-600 sm:px-6 dark:text-slate-300">
+                        {m.codigo}
+                      </td>
+                      <td className="whitespace-nowrap px-4 py-3.5 tabular-nums text-slate-700 sm:px-6 dark:text-slate-200">
+                        {formatPreco(m.preco_mensal)}
+                      </td>
+                      <td className="px-4 py-3.5 sm:px-6">
+                        <span
+                          className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${
+                            m.ativo
+                              ? 'bg-emerald-50 text-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300'
+                              : 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
+                          }`}
+                        >
+                          {m.ativo ? 'Ativo' : 'Inativo'}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3.5 text-right sm:px-6">
+                        <div className="flex items-center justify-end gap-2">
+                          <Button variant="secondary" onClick={() => startEdit(m)}>
+                            Editar
+                          </Button>
+                          <Button
+                            variant="secondary"
+                            disabled={actingId === m.id}
+                            onClick={() => void toggleAtivo(m)}
+                          >
+                            {m.ativo ? 'Desativar' : 'Ativar'}
+                          </Button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           )}
         </Card>
       </div>

--- a/frontend/src/pages/saas/SaasPlanoForm.tsx
+++ b/frontend/src/pages/saas/SaasPlanoForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { ApiError, saasModulos, saasPlanos, type SaasCatalogo } from '../../api/client'
 import { Card } from '../../components/ui/Card'
@@ -12,6 +12,10 @@ import { CadastroFormPageShell } from '../../components/ui/CadastroFormPageShell
 import { SemPermissao } from '../SemPermissao'
 import { CarregamentoFalhou } from '../../components/ui/CarregamentoFalhou'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/errorMessage'
+
+function formatPreco(v: number): string {
+  return `R$ ${v.toLocaleString('pt-BR', { minimumFractionDigits: 0, maximumFractionDigits: 2 })}`
+}
 
 export function SaasPlanoForm() {
   const { id } = useParams<{ id?: string }>()
@@ -31,12 +35,19 @@ export function SaasPlanoForm() {
   const [nome, setNome] = useState('')
   const [descricao, setDescricao] = useState('')
   const [ordem, setOrdem] = useState('0')
-  const [precoMensal, setPrecoMensal] = useState('')
-  const [maxPostos, setMaxPostos] = useState('')
-  const [maxUsuarios, setMaxUsuarios] = useState('')
+  const [usuariosInclusos, setUsuariosInclusos] = useState('3')
+  const [precoUsuarioExtra, setPrecoUsuarioExtra] = useState('10')
   const [ativo, setAtivo] = useState(true)
   const [moduloIds, setModuloIds] = useState<number[]>([])
   const [modulos, setModulos] = useState<SaasCatalogo.Modulo[]>([])
+
+  const precoModulos = useMemo(() => {
+    return Math.round(
+      modulos
+        .filter((m) => moduloIds.includes(m.id))
+        .reduce((acc, m) => acc + Number(m.preco_mensal || 0), 0) * 100,
+    ) / 100
+  }, [modulos, moduloIds])
 
   useEffect(() => {
     let cancelled = false
@@ -71,9 +82,10 @@ export function SaasPlanoForm() {
         setNome(p.nome)
         setDescricao(p.descricao ?? '')
         setOrdem(String(p.ordem ?? 0))
-        setPrecoMensal(p.preco_mensal != null ? String(p.preco_mensal) : '')
-        setMaxPostos(p.max_postos != null ? String(p.max_postos) : '')
-        setMaxUsuarios(p.max_usuarios != null ? String(p.max_usuarios) : '')
+        setUsuariosInclusos(String(p.usuarios_inclusos ?? 3))
+        setPrecoUsuarioExtra(
+          p.preco_usuario_extra != null ? String(p.preco_usuario_extra) : '10',
+        )
         setAtivo(p.ativo)
         setModuloIds(p.modulos.map((m) => m.id))
       })
@@ -112,38 +124,30 @@ export function SaasPlanoForm() {
     setSaving(true)
     try {
       const ordemN = parseInt(ordem, 10)
-      const precoN = precoMensal.trim() === '' ? null : Number(precoMensal)
-      const postosN = maxPostos.trim() === '' ? null : parseInt(maxPostos, 10)
-      const usersN = maxUsuarios.trim() === '' ? null : parseInt(maxUsuarios, 10)
-      const comerciais = {
-        preco_mensal: precoN != null && Number.isFinite(precoN) ? precoN : null,
-        max_postos: postosN != null && Number.isFinite(postosN) ? postosN : null,
-        max_usuarios: usersN != null && Number.isFinite(usersN) ? usersN : null,
+      const inclusosN = parseInt(usuariosInclusos, 10)
+      const extraN = Number(precoUsuarioExtra)
+      const payload = {
+        nome: nome.trim(),
+        descricao: descricao.trim() || null,
+        ordem: Number.isFinite(ordemN) ? ordemN : 0,
+        usuarios_inclusos: Number.isFinite(inclusosN) ? inclusosN : 3,
+        preco_usuario_extra: Number.isFinite(extraN) ? extraN : 10,
+        modulo_ids: moduloIds,
       }
       if (isEdit && !Number.isNaN(planoId)) {
-        await saasPlanos.update(planoId, {
-          nome: nome.trim(),
-          descricao: descricao.trim() || null,
-          ordem: Number.isFinite(ordemN) ? ordemN : 0,
-          modulo_ids: moduloIds,
-          ...comerciais,
-        })
-        toast.showSuccess('Plano actualizado.')
+        await saasPlanos.update(planoId, payload)
+        toast.showSuccess('Plano atualizado.')
         navigate(`/saas/planos/${planoId}`, { replace: true })
       } else {
         const created = await saasPlanos.create({
           codigo: codigo.trim().toLowerCase(),
-          nome: nome.trim(),
-          descricao: descricao.trim() || null,
-          ordem: Number.isFinite(ordemN) ? ordemN : 0,
-          modulo_ids: moduloIds,
-          ...comerciais,
+          ...payload,
         })
         toast.showSuccess('Plano criado.')
         navigate(`/saas/planos/${created.id}`, { replace: true })
       }
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível guardar o plano.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o plano.'))
     } finally {
       setSaving(false)
     }
@@ -156,7 +160,7 @@ export function SaasPlanoForm() {
       if (ativo) await saasPlanos.desativar(planoId)
       else await saasPlanos.ativar(planoId)
       setAtivo(!ativo)
-      toast.showSuccess(ativo ? 'Plano desactivado.' : 'Plano activado.')
+      toast.showSuccess(ativo ? 'Plano desativado.' : 'Plano ativado.')
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar o estado.'))
     } finally {
@@ -225,28 +229,30 @@ export function SaasPlanoForm() {
                 onChange={(e) => setOrdem(e.target.value)}
                 hint="Menor aparece primeiro na lista"
               />
+              <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm dark:border-slate-700 dark:bg-slate-900/40">
+                <p className="font-medium text-slate-800 dark:text-slate-100">
+                  Preço base (soma dos módulos): {formatPreco(precoModulos)}
+                </p>
+                <p className="mt-1 text-xs text-slate-500">
+                  Calculado automaticamente. Altere o preço em Módulos.
+                </p>
+              </div>
               <Input
-                label="Preço mensal (R$)"
+                label="Usuários inclusos"
+                type="number"
+                min={0}
+                value={usuariosInclusos}
+                onChange={(e) => setUsuariosInclusos(e.target.value)}
+                hint="Inclusos no preço dos módulos (padrão 3)"
+              />
+              <Input
+                label="Preço por usuário extra (R$)"
                 type="number"
                 step="0.01"
                 min={0}
-                value={precoMensal}
-                onChange={(e) => setPrecoMensal(e.target.value)}
-                hint="Opcional — só catálogo comercial (sem cobrança automática)"
-              />
-              <Input
-                label="Máx. postos"
-                type="number"
-                min={0}
-                value={maxPostos}
-                onChange={(e) => setMaxPostos(e.target.value)}
-              />
-              <Input
-                label="Máx. utilizadores"
-                type="number"
-                min={0}
-                value={maxUsuarios}
-                onChange={(e) => setMaxUsuarios(e.target.value)}
+                value={precoUsuarioExtra}
+                onChange={(e) => setPrecoUsuarioExtra(e.target.value)}
+                hint="Cobrado por usuário acima dos inclusos"
               />
               <label className="block space-y-1.5">
                 <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Descrição</span>
@@ -266,18 +272,17 @@ export function SaasPlanoForm() {
                         : 'bg-slate-100 text-slate-600'
                     }`}
                   >
-                    {ativo ? 'Activo' : 'Inactivo'}
+                    {ativo ? 'Ativo' : 'Inativo'}
                   </span>
                   <Button type="button" variant="secondary" disabled={saving} onClick={() => void toggleAtivo()}>
-                    {ativo ? 'Desactivar' : 'Activar'}
+                    {ativo ? 'Desativar' : 'Ativar'}
                   </Button>
                 </div>
               ) : null}
             </FormSection>
             <FormSection title="Módulos incluídos">
               <p className="text-sm text-slate-500 dark:text-slate-400">
-                Gravados no snapshot da licença e em <code className="text-xs">SAAS_MODULOS</code> no{' '}
-                <code className="text-xs">client.env</code> no provisionamento (capabilities no /health).
+                O preço do plano é a soma destes módulos. Na licença dá para ligar módulos extras (ex.: Essencial + ponto).
               </p>
               {modulos.length === 0 ? (
                 <p className="text-sm text-amber-700 dark:text-amber-300">
@@ -303,12 +308,17 @@ export function SaasPlanoForm() {
                           onChange={() => toggleModulo(m.id)}
                           disabled={!m.ativo && !moduloIds.includes(m.id)}
                         />
-                        <span>
-                          <span className="block text-sm font-medium text-slate-800 dark:text-slate-100">
-                            {m.nome}
-                            {!m.ativo ? (
-                              <span className="ml-2 text-xs font-normal text-slate-400">(inactivo)</span>
-                            ) : null}
+                        <span className="min-w-0 flex-1">
+                          <span className="flex flex-wrap items-baseline justify-between gap-2">
+                            <span className="text-sm font-medium text-slate-800 dark:text-slate-100">
+                              {m.nome}
+                              {!m.ativo ? (
+                                <span className="ml-2 text-xs font-normal text-slate-400">(inativo)</span>
+                              ) : null}
+                            </span>
+                            <span className="text-xs tabular-nums text-slate-600 dark:text-slate-300">
+                              {m.preco_mensal != null ? formatPreco(Number(m.preco_mensal)) : '—'}
+                            </span>
                           </span>
                           <span className="font-mono text-xs text-slate-500">{m.codigo}</span>
                         </span>

--- a/frontend/src/pages/saas/SaasPlanos.tsx
+++ b/frontend/src/pages/saas/SaasPlanos.tsx
@@ -48,7 +48,7 @@ export function SaasPlanos() {
     try {
       if (item.ativo) await saasPlanos.desativar(item.id)
       else await saasPlanos.ativar(item.id)
-      toast.showSuccess(item.ativo ? 'Plano desactivado.' : 'Plano activado.')
+      toast.showSuccess(item.ativo ? 'Plano desativado.' : 'Plano ativado.')
       carregar()
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível alterar o plano.'))
@@ -78,7 +78,7 @@ export function SaasPlanos() {
         />
       }
       title="Planos"
-      subtitle="Catálogo comercial — o que cada plano inclui (sem ligar features na instância)."
+      subtitle="Pacotes = soma dos módulos. Cada plano define usuários inclusos e preço por usuário extra."
       actions={
         <div className="flex flex-wrap gap-2">
           <Button variant="secondary" onClick={() => navigate('/saas/modulos')}>
@@ -100,6 +100,8 @@ export function SaasPlanos() {
                 <tr className="text-left">
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Nome</th>
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Código</th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Preço base</th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Inclusos</th>
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Módulos</th>
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Estado</th>
                   <th className="w-px px-4 py-3 text-right text-xs font-semibold uppercase text-slate-500 sm:px-6">
@@ -117,6 +119,21 @@ export function SaasPlanos() {
                       ) : null}
                     </td>
                     <td className="px-4 py-3.5 font-mono text-xs sm:px-6">{item.codigo}</td>
+                    <td className="whitespace-nowrap px-4 py-3.5 tabular-nums text-slate-600 sm:px-6 dark:text-slate-300">
+                      {item.preco_mensal != null
+                        ? `R$ ${Number(item.preco_mensal).toLocaleString('pt-BR', {
+                            minimumFractionDigits: 0,
+                            maximumFractionDigits: 2,
+                          })}`
+                        : '—'}
+                      <span className="mt-0.5 block text-[11px] text-slate-400">
+                        {item.usuarios_inclusos ?? 3} incl. · +R${' '}
+                        {Number(item.preco_usuario_extra ?? 10).toLocaleString('pt-BR')}/extra
+                      </span>
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3.5 tabular-nums text-slate-600 sm:px-6 dark:text-slate-300">
+                      {item.usuarios_inclusos ?? 3}
+                    </td>
                     <td className="px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-300">
                       {item.modulos.length
                         ? item.modulos.map((m) => m.nome).join(', ')
@@ -130,7 +147,7 @@ export function SaasPlanos() {
                             : 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-400'
                         }`}
                       >
-                        {item.ativo ? 'Activo' : 'Inactivo'}
+                        {item.ativo ? 'Ativo' : 'Inativo'}
                       </span>
                     </td>
                     <td className="px-4 py-3.5 text-right sm:px-6">
@@ -140,7 +157,7 @@ export function SaasPlanos() {
                           disabled={actingId === item.id}
                           onClick={() => void toggleAtivo(item)}
                         >
-                          {item.ativo ? 'Desactivar' : 'Activar'}
+                          {item.ativo ? 'Desativar' : 'Ativar'}
                         </Button>
                         <ListaAcoesVerEditar
                           onVer={() => navigate(`/saas/planos/${item.id}`)}

--- a/frontend/src/pages/saas/SaasSetorForm.tsx
+++ b/frontend/src/pages/saas/SaasSetorForm.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { ApiError, saasSetores } from '../../api/client'
+import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/errorMessage'
+import { CadastroFormPageShell } from '../../components/ui/CadastroFormPageShell'
+import { CarregamentoFalhou } from '../../components/ui/CarregamentoFalhou'
+import { FormSection } from '../../components/ui/FormSection'
+import { InlineCadastroFooter } from '../../components/ui/InlineCadastroPanel'
+import { Input } from '../../components/ui/Input'
+import { Switch } from '../../components/ui/Switch'
+import { useToast } from '../../components/ui/Toast'
+import { useVoltarAnterior } from '../../hooks/useVoltarAnterior'
+import { SemPermissao } from '../SemPermissao'
+
+export function SaasSetorForm() {
+  const { id } = useParams<{ id?: string }>()
+  const navigate = useNavigate()
+  const toast = useToast()
+  const voltarAnterior = useVoltarAnterior('/saas/setores')
+
+  const setorId = id ? parseInt(id, 10) : NaN
+  const isEdit = id != null
+
+  const [loading, setLoading] = useState(isEdit)
+  const [saving, setSaving] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [indisponivel, setIndisponivel] = useState(false)
+  const [inexistente, setInexistente] = useState<{ detalhe?: string } | null>(null)
+  const [nome, setNome] = useState('')
+  const [ativo, setAtivo] = useState(true)
+
+  useEffect(() => {
+    if (!isEdit) return
+    if (!id || Number.isNaN(setorId)) {
+      setInexistente({ detalhe: 'O identificador na URL é inválido.' })
+      setLoading(false)
+      return
+    }
+    let cancelled = false
+    setLoading(true)
+    setForbidden(false)
+    setIndisponivel(false)
+    setInexistente(null)
+    saasSetores
+      .get(setorId)
+      .then((row) => {
+        if (cancelled) return
+        setNome(row.nome)
+        setAtivo(row.ativo)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setIndisponivel(true)
+          return
+        }
+        setInexistente(interpretarFalhaCarregamento(err, 'Setor não encontrado.'))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [id, isEdit, setorId])
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!nome.trim()) {
+      toast.showError('Informe o nome do setor.')
+      return
+    }
+    setSaving(true)
+    try {
+      if (isEdit) {
+        await saasSetores.update(setorId, { nome: nome.trim(), ativo })
+        toast.showSuccess('Setor atualizado.')
+      } else {
+        await saasSetores.create({ nome: nome.trim() })
+        toast.showSuccess('Setor criado.')
+      }
+      navigate('/saas/setores')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o setor.'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (forbidden) {
+    return (
+      <SemPermissao
+        title="Conta exclusiva da equipe SaaS."
+        detail="Entre com a conta ops em /login/admin."
+        voltarPara="/login/admin"
+        voltarLabel="Voltar ao login admin"
+      />
+    )
+  }
+  if (indisponivel) {
+    return (
+      <SemPermissao
+        title="Painel SaaS não disponível nesta instância."
+        voltarPara="/login/admin"
+        voltarLabel="Voltar ao login admin"
+      />
+    )
+  }
+  if (inexistente) {
+    return (
+      <CarregamentoFalhou
+        titulo={inexistente.detalhe ? 'Setor não encontrado.' : 'Não foi possível carregar.'}
+        detalhe={inexistente.detalhe}
+        onVoltar={voltarAnterior}
+      />
+    )
+  }
+
+  return (
+    <CadastroFormPageShell onVoltar={voltarAnterior}>
+      <form onSubmit={(ev) => void onSubmit(ev)} className="space-y-4">
+        <FormSection
+          title={isEdit ? 'Editar setor' : 'Novo setor'}
+          description="Cargo da equipe DeskRudder (ex.: Admin, Desenvolvimento, Comercial). Sem ordem fixa — a lista é alfabética."
+        >
+          {loading ? (
+            <p className="text-sm text-slate-500">Carregando…</p>
+          ) : (
+            <div className="space-y-4">
+              <Input label="Nome" value={nome} onChange={(ev) => setNome(ev.target.value)} required />
+              {isEdit ? (
+                <Switch
+                  checked={ativo}
+                  onCheckedChange={setAtivo}
+                  label="Setor ativo"
+                  showStatusPill
+                  description="Inativos não podem ser vinculados a novos usuários."
+                />
+              ) : null}
+            </div>
+          )}
+        </FormSection>
+        <InlineCadastroFooter
+          onCancel={voltarAnterior}
+          saving={saving}
+          submitLabel={isEdit ? 'Salvar' : 'Criar'}
+        />
+      </form>
+    </CadastroFormPageShell>
+  )
+}

--- a/frontend/src/pages/saas/SaasSetores.tsx
+++ b/frontend/src/pages/saas/SaasSetores.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ApiError, saasSetores, type SaasSetores } from '../../api/client'
+import { mensagemFalhaParaToast } from '../../api/errorMessage'
+import { ConfigListPageShell } from '../../components/config/ConfigListPageShell'
+import { Button } from '../../components/ui/Button'
+import { Card } from '../../components/ui/Card'
+import { FiltroInativos } from '../../components/ui/FiltroInativos'
+import { useToast } from '../../components/ui/Toast'
+import { SemPermissao } from '../SemPermissao'
+
+export function SaasSetoresPage() {
+  const navigate = useNavigate()
+  const toast = useToast()
+  const [list, setList] = useState<SaasSetores.Setor[]>([])
+  const [loading, setLoading] = useState(true)
+  const [incluirInativos, setIncluirInativos] = useState(false)
+  const [forbidden, setForbidden] = useState(false)
+  const [indisponivel, setIndisponivel] = useState(false)
+
+  const load = useCallback(() => {
+    setLoading(true)
+    setForbidden(false)
+    setIndisponivel(false)
+    saasSetores
+      .list({ incluir_inativos: incluirInativos })
+      .then(setList)
+      .catch((err) => {
+        setList([])
+        if (err instanceof ApiError && err.status === 403) {
+          setForbidden(true)
+          return
+        }
+        if (err instanceof ApiError && err.status === 404) {
+          setIndisponivel(true)
+          return
+        }
+        toast.showError(mensagemFalhaParaToast(err, 'Não encontramos os setores.'))
+      })
+      .finally(() => setLoading(false))
+  }, [incluirInativos, toast])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  if (indisponivel) {
+    return (
+      <SemPermissao
+        title="Painel SaaS não disponível nesta instância."
+        detail="Os cargos da equipe DeskRudder só existem no control-plane."
+        voltarPara="/login/admin"
+        voltarLabel="Voltar ao login admin"
+      />
+    )
+  }
+
+  return (
+    <ConfigListPageShell
+      forbidden={forbidden}
+      denied={
+        <SemPermissao
+          title="Você não tem permissão para gerir os setores."
+          voltarPara="/login/admin"
+          voltarLabel="Voltar ao login admin"
+        />
+      }
+      title="Setores"
+      actions={<Button onClick={() => navigate('/saas/setores/novo')}>Novo setor</Button>}
+    >
+      <Card
+        title="Cargos da equipe"
+        description="Admin, Desenvolvimento, Comercial, etc. Um usuário pode ter vários cargos. Não altera permissões no painel (todos continuam ops)."
+      >
+        <div className="mb-4">
+          <FiltroInativos incluirInativos={incluirInativos} onChange={setIncluirInativos} />
+        </div>
+        {loading ? (
+          <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
+        ) : list.length === 0 ? (
+          <p className="text-slate-500 dark:text-slate-400">Nenhum setor cadastrado.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[320px] text-left text-sm">
+              <thead>
+                <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
+                    Nome
+                  </th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
+                    Situação
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                {list.map((s) => (
+                  <tr
+                    key={s.id}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => navigate(`/saas/setores/${s.id}`)}
+                    onKeyDown={(ev) => {
+                      if (ev.key === 'Enter' || ev.key === ' ') {
+                        ev.preventDefault()
+                        navigate(`/saas/setores/${s.id}`)
+                      }
+                    }}
+                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5 focus:outline-none focus-visible:bg-slate-100/80 dark:focus-visible:bg-slate-800/60"
+                  >
+                    <td className="px-4 py-3.5 font-medium text-slate-800 sm:px-6 dark:text-slate-100">{s.nome}</td>
+                    <td className="px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400">
+                      {s.ativo ? 'Ativo' : 'Inativo'}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </ConfigListPageShell>
+  )
+}

--- a/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
@@ -12,8 +12,10 @@ import { useVoltarAnterior } from '../../hooks/useVoltarAnterior'
 import { SolicitacaoDescricao } from '../../components/release/SolicitacaoDescricao'
 import {
   classesBadgeStatusSolicitacao,
+  classesBadgeTipoSolicitacao,
   mencionaTrabalhoInterno,
   rotuloStatusSolicitacao,
+  rotuloTipoSolicitacao,
   SAAS_SOLICITACAO_STATUS,
 } from '../../lib/saasSolicitacoes'
 import { SemPermissao } from '../SemPermissao'
@@ -28,10 +30,6 @@ function formatWhen(iso: string | null | undefined): string {
   } catch {
     return iso
   }
-}
-
-function rotuloTipo(tipo: string): string {
-  return tipo === 'problema' ? 'Problema' : 'Sugestão'
 }
 
 function StatusBadge({ status, rotulo }: { status: string; rotulo?: string }) {
@@ -277,8 +275,10 @@ export function SaasSolicitacaoDetalhe() {
               {item.protocolo || 'Sem protocolo'}
             </p>
             <span className="text-slate-300 dark:text-slate-600">·</span>
-            <span className="text-xs font-semibold uppercase tracking-wider text-slate-400">
-              {rotuloTipo(item.tipo)}
+            <span
+              className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeTipoSolicitacao(item.tipo)}`}
+            >
+              {rotuloTipoSolicitacao(item.tipo)}
             </span>
             <StatusBadge status={item.status} rotulo={item.status_rotulo} />
           </div>

--- a/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
@@ -18,6 +18,7 @@ import {
   proximosStatusSolicitacao,
   rotuloStatusSolicitacao,
   rotuloTipoSolicitacao,
+  rotuloVersaoAlvo,
   SAAS_SOLICITACAO_STATUS,
 } from '../../lib/saasSolicitacoes'
 import { SemPermissao } from '../SemPermissao'
@@ -64,11 +65,14 @@ export function SaasSolicitacaoDetalhe() {
   const [candidatos, setCandidatos] = useState<SaasSolicitacoesProduto.ListaItem[]>([])
   const [githubUrl, setGithubUrl] = useState('')
   const [mostrarImplementar, setMostrarImplementar] = useState(false)
+  const [versaoAlvo, setVersaoAlvo] = useState('')
+  const [comentarioVersao, setComentarioVersao] = useState('')
 
   const aplicarDetalhe = useCallback((row: SaasSolicitacoesProduto.Detalhe) => {
     setItem(row)
     setNovoStatus(row.status)
     setMotivo(row.motivo_nao_desenvolvimento || '')
+    setVersaoAlvo(row.versao_alvo || '')
   }, [])
 
   useEffect(() => {
@@ -198,6 +202,24 @@ export function SaasSolicitacaoDetalhe() {
     }
   }
 
+  async function salvarVersaoAlvo() {
+    if (!item) return
+    setBusy(true)
+    try {
+      const atualizado = await saasSolicitacoes.definirVersaoAlvo(item.id, {
+        versao_alvo: versaoAlvo.trim() || null,
+        comentario_publico: comentarioVersao.trim() || null,
+      })
+      aplicarDetalhe(atualizado)
+      setComentarioVersao('')
+      toast.showSuccess('Versão alvo atualizada — o cliente vê em Minhas solicitações.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a versão'))
+    } finally {
+      setBusy(false)
+    }
+  }
+
   async function enviarComentario() {
     if (!item || !comentario.trim()) return
     const publico = tipoMensagem === 'publico'
@@ -305,6 +327,8 @@ export function SaasSolicitacaoDetalhe() {
   const statusFluxo = SAAS_SOLICITACAO_STATUS.filter((s) => s.value !== 'nao_sera_desenvolvida')
   const podeRejeitar = proximos.has('nao_sera_desenvolvida') || item.status === 'nao_sera_desenvolvida'
   const podeImplementar = item.status === 'planejada'
+  const podeDefinirVersao = item.status === 'planejada' || item.status === 'em_desenvolvimento'
+  const rotuloVersaoCliente = rotuloVersaoAlvo(item.status, item.versao_alvo)
 
   return (
     <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
@@ -473,6 +497,39 @@ export function SaasSolicitacaoDetalhe() {
               Aberto {formatWhen(item.created_at_origem)} · no SaaS {formatWhen(item.ingested_at)}
             </p>
           </Card>
+
+          {podeDefinirVersao || item.versao_alvo ? (
+            <Card
+              title="Versão alvo"
+              description="Visível ao cliente em Minhas solicitações (sem GitHub)."
+            >
+              {rotuloVersaoCliente ? (
+                <p className="mb-3 text-sm font-medium text-emerald-800 dark:text-emerald-200">
+                  {rotuloVersaoCliente}
+                </p>
+              ) : null}
+              {podeDefinirVersao ? (
+                <div className="space-y-2">
+                  <Input
+                    label="CalVer prevista"
+                    placeholder="2026.08.26"
+                    value={versaoAlvo}
+                    onChange={(e) => setVersaoAlvo(e.target.value)}
+                  />
+                  <textarea
+                    className={TEXTAREA_FIELD_CLASS}
+                    rows={2}
+                    value={comentarioVersao}
+                    onChange={(e) => setComentarioVersao(e.target.value)}
+                    placeholder="Comentário público opcional ao definir a versão"
+                  />
+                  <Button type="button" variant="primary" loading={busy} onClick={() => void salvarVersaoAlvo()}>
+                    Salvar versão
+                  </Button>
+                </div>
+              ) : null}
+            </Card>
+          ) : null}
 
           {item.github_issue_url && !mostrarImplementar ? (
             <Card title="Issue no GitHub" description="Só neste painel — o cliente não vê o link.">

--- a/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
@@ -65,14 +65,11 @@ export function SaasSolicitacaoDetalhe() {
   const [candidatos, setCandidatos] = useState<SaasSolicitacoesProduto.ListaItem[]>([])
   const [githubUrl, setGithubUrl] = useState('')
   const [mostrarImplementar, setMostrarImplementar] = useState(false)
-  const [versaoAlvo, setVersaoAlvo] = useState('')
-  const [comentarioVersao, setComentarioVersao] = useState('')
 
   const aplicarDetalhe = useCallback((row: SaasSolicitacoesProduto.Detalhe) => {
     setItem(row)
     setNovoStatus(row.status)
     setMotivo(row.motivo_nao_desenvolvimento || '')
-    setVersaoAlvo(row.versao_alvo || '')
   }, [])
 
   useEffect(() => {
@@ -202,24 +199,6 @@ export function SaasSolicitacaoDetalhe() {
     }
   }
 
-  async function salvarVersaoAlvo() {
-    if (!item) return
-    setBusy(true)
-    try {
-      const atualizado = await saasSolicitacoes.definirVersaoAlvo(item.id, {
-        versao_alvo: versaoAlvo.trim() || null,
-        comentario_publico: comentarioVersao.trim() || null,
-      })
-      aplicarDetalhe(atualizado)
-      setComentarioVersao('')
-      toast.showSuccess('Versão alvo atualizada — o cliente vê em Minhas solicitações.')
-    } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar a versão'))
-    } finally {
-      setBusy(false)
-    }
-  }
-
   async function enviarComentario() {
     if (!item || !comentario.trim()) return
     const publico = tipoMensagem === 'publico'
@@ -327,7 +306,6 @@ export function SaasSolicitacaoDetalhe() {
   const statusFluxo = SAAS_SOLICITACAO_STATUS.filter((s) => s.value !== 'nao_sera_desenvolvida')
   const podeRejeitar = proximos.has('nao_sera_desenvolvida') || item.status === 'nao_sera_desenvolvida'
   const podeImplementar = item.status === 'planejada'
-  const podeDefinirVersao = item.status === 'planejada' || item.status === 'em_desenvolvimento'
   const rotuloVersaoCliente = rotuloVersaoAlvo(item.status, item.versao_alvo)
 
   return (
@@ -498,36 +476,12 @@ export function SaasSolicitacaoDetalhe() {
             </p>
           </Card>
 
-          {podeDefinirVersao || item.versao_alvo ? (
+          {rotuloVersaoCliente ? (
             <Card
-              title="Versão alvo"
-              description="Visível ao cliente em Minhas solicitações (sem GitHub)."
+              title="Versão liberada"
+              description="O cliente vê em Minhas solicitações quando o pedido está concluído."
             >
-              {rotuloVersaoCliente ? (
-                <p className="mb-3 text-sm font-medium text-emerald-800 dark:text-emerald-200">
-                  {rotuloVersaoCliente}
-                </p>
-              ) : null}
-              {podeDefinirVersao ? (
-                <div className="space-y-2">
-                  <Input
-                    label="CalVer prevista"
-                    placeholder="2026.08.26"
-                    value={versaoAlvo}
-                    onChange={(e) => setVersaoAlvo(e.target.value)}
-                  />
-                  <textarea
-                    className={TEXTAREA_FIELD_CLASS}
-                    rows={2}
-                    value={comentarioVersao}
-                    onChange={(e) => setComentarioVersao(e.target.value)}
-                    placeholder="Comentário público opcional ao definir a versão"
-                  />
-                  <Button type="button" variant="primary" loading={busy} onClick={() => void salvarVersaoAlvo()}>
-                    Salvar versão
-                  </Button>
-                </div>
-              ) : null}
+              <p className="text-sm font-medium text-emerald-800 dark:text-emerald-200">{rotuloVersaoCliente}</p>
             </Card>
           ) : null}
 

--- a/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
+++ b/frontend/src/pages/saas/SaasSolicitacaoDetalhe.tsx
@@ -14,13 +14,14 @@ import {
   classesBadgeStatusSolicitacao,
   classesBadgeTipoSolicitacao,
   mencionaTrabalhoInterno,
+  podeAvancarStatus,
+  proximosStatusSolicitacao,
   rotuloStatusSolicitacao,
   rotuloTipoSolicitacao,
   SAAS_SOLICITACAO_STATUS,
 } from '../../lib/saasSolicitacoes'
 import { SemPermissao } from '../SemPermissao'
 
-const STATUS_FLUXO = SAAS_SOLICITACAO_STATUS.filter((s) => s.value !== 'nao_sera_desenvolvida')
 const STATUS_REJEITAR = SAAS_SOLICITACAO_STATUS.find((s) => s.value === 'nao_sera_desenvolvida')!
 
 function formatWhen(iso: string | null | undefined): string {
@@ -61,6 +62,8 @@ export function SaasSolicitacaoDetalhe() {
   const [tipoMensagem, setTipoMensagem] = useState<'publico' | 'interno'>('publico')
   const [buscaIgual, setBuscaIgual] = useState('')
   const [candidatos, setCandidatos] = useState<SaasSolicitacoesProduto.ListaItem[]>([])
+  const [githubUrl, setGithubUrl] = useState('')
+  const [mostrarImplementar, setMostrarImplementar] = useState(false)
 
   const aplicarDetalhe = useCallback((row: SaasSolicitacoesProduto.Detalhe) => {
     setItem(row)
@@ -149,6 +152,15 @@ export function SaasSolicitacaoDetalhe() {
     setNovoStatus(status)
     if (status === 'nao_sera_desenvolvida') return
     if (item && status === item.status) return
+    if (status === 'em_desenvolvimento') {
+      setMostrarImplementar(true)
+      return
+    }
+    if (item && !podeAvancarStatus(item.status, status)) {
+      toast.showError('Essa transição de status não é permitida. Avance passo a passo.')
+      setNovoStatus(item.status)
+      return
+    }
     await persistirStatus(status)
   }
 
@@ -158,6 +170,32 @@ export function SaasSolicitacaoDetalhe() {
       return
     }
     await persistirStatus('nao_sera_desenvolvida', motivo)
+  }
+
+  async function confirmarImplementar(opts: { criarIssue: boolean; url?: string }) {
+    if (!item) return
+    setBusy(true)
+    try {
+      const data: SaasSolicitacoesProduto.Implementar = {
+        criar_issue: opts.criarIssue,
+      }
+      const url = (opts.url ?? githubUrl).trim()
+      if (url) {
+        data.github_issue_url = url
+        data.criar_issue = false
+      } else if (item.github_issue_url) {
+        data.criar_issue = false
+      }
+      const atualizado = await saasSolicitacoes.implementar(item.id, data)
+      aplicarDetalhe(atualizado)
+      setMostrarImplementar(false)
+      setGithubUrl('')
+      toast.showSuccess('Em desenvolvimento. Issue ligada — o cliente não vê o GitHub.')
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível implementar'))
+    } finally {
+      setBusy(false)
+    }
   }
 
   async function enviarComentario() {
@@ -263,6 +301,10 @@ export function SaasSolicitacaoDetalhe() {
   )
   const rejeitarPendente = novoStatus === 'nao_sera_desenvolvida' && item.status !== 'nao_sera_desenvolvida'
   const internoActivo = tipoMensagem === 'interno'
+  const proximos = new Set(proximosStatusSolicitacao(item.status))
+  const statusFluxo = SAAS_SOLICITACAO_STATUS.filter((s) => s.value !== 'nao_sera_desenvolvida')
+  const podeRejeitar = proximos.has('nao_sera_desenvolvida') || item.status === 'nao_sera_desenvolvida'
+  const podeImplementar = item.status === 'planejada'
 
   return (
     <div className="mx-auto w-full min-w-0 max-w-6xl space-y-6 pb-10">
@@ -299,17 +341,22 @@ export function SaasSolicitacaoDetalhe() {
 
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_21rem] xl:items-start">
         <aside className="space-y-6 xl:col-start-2 xl:row-start-1">
-          <Card title="Status" description="O cliente vê este andamento em Minhas solicitações.">
+          <Card title="Status" description="O cliente vê este andamento em Minhas solicitações. Só avanços permitidos.">
             <nav className="space-y-1.5" aria-label="Status da triagem">
-              {STATUS_FLUXO.map((s) => {
-                const activo = novoStatus === s.value
+              {statusFluxo.map((s) => {
+                const activo = novoStatus === s.value || (mostrarImplementar && s.value === 'em_desenvolvimento')
+                const atual = item.status === s.value
+                const permitido =
+                  atual ||
+                  proximos.has(s.value) ||
+                  (s.value === 'em_desenvolvimento' && podeImplementar)
                 return (
                   <button
                     key={s.value}
                     type="button"
-                    disabled={busy}
+                    disabled={busy || (!permitido && !atual)}
                     onClick={() => void escolherStatus(s.value)}
-                    className={`flex w-full items-center gap-2.5 rounded-xl border px-3 py-2 text-left text-sm transition disabled:opacity-60 ${
+                    className={`flex w-full items-center gap-2.5 rounded-xl border px-3 py-2 text-left text-sm transition disabled:cursor-not-allowed disabled:opacity-45 ${
                       activo
                         ? 'border-cyan-300 bg-cyan-50/90 ring-1 ring-cyan-400/25 dark:border-cyan-700/60 dark:bg-cyan-950/35 dark:ring-cyan-600/30'
                         : 'border-slate-200 bg-white hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 dark:hover:bg-slate-800/50'
@@ -321,7 +368,7 @@ export function SaasSolicitacaoDetalhe() {
                     <span className={`min-w-0 flex-1 font-medium ${activo ? 'text-slate-900 dark:text-slate-50' : 'text-slate-700 dark:text-slate-200'}`}>
                       {s.label}
                     </span>
-                    {item.status === s.value ? (
+                    {atual ? (
                       <span className="text-[10px] font-semibold uppercase tracking-wide text-cyan-700 dark:text-cyan-300">
                         atual
                       </span>
@@ -332,9 +379,9 @@ export function SaasSolicitacaoDetalhe() {
               <div className="my-2 border-t border-slate-100 dark:border-slate-800" />
               <button
                 type="button"
-                disabled={busy}
+                disabled={busy || !podeRejeitar}
                 onClick={() => void escolherStatus(STATUS_REJEITAR.value)}
-                className={`flex w-full items-center gap-2.5 rounded-xl border px-3 py-2 text-left text-sm transition disabled:opacity-60 ${
+                className={`flex w-full items-center gap-2.5 rounded-xl border px-3 py-2 text-left text-sm transition disabled:cursor-not-allowed disabled:opacity-45 ${
                   novoStatus === STATUS_REJEITAR.value
                     ? 'border-rose-300 bg-rose-50/90 ring-1 ring-rose-400/25 dark:border-rose-800/60 dark:bg-rose-950/35 dark:ring-rose-700/30'
                     : 'border-slate-200 bg-white hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 dark:hover:bg-slate-800/50'
@@ -353,6 +400,61 @@ export function SaasSolicitacaoDetalhe() {
                 ) : null}
               </button>
             </nav>
+            {mostrarImplementar || (podeImplementar && novoStatus === 'em_desenvolvimento') ? (
+              <div className="mt-3 space-y-2 rounded-xl border border-cyan-200 bg-cyan-50/50 p-3 dark:border-cyan-800/50 dark:bg-cyan-950/30">
+                <p className="text-xs font-medium text-cyan-900 dark:text-cyan-100">
+                  Implementar exige issue no GitHub (o cliente não vê o link).
+                </p>
+                {item.github_issue_url ? (
+                  <p className="text-xs text-slate-600 dark:text-slate-300">
+                    Já ligada:{' '}
+                    <a
+                      href={item.github_issue_url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="font-medium text-cyan-700 underline dark:text-cyan-400"
+                    >
+                      #{item.github_issue_number}
+                    </a>
+                  </p>
+                ) : (
+                  <Input
+                    label="URL da issue (opcional)"
+                    placeholder="https://github.com/org/repo/issues/123"
+                    value={githubUrl}
+                    onChange={(e) => setGithubUrl(e.target.value)}
+                  />
+                )}
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant="primary"
+                    loading={busy}
+                    onClick={() =>
+                      void confirmarImplementar({
+                        criarIssue: !item.github_issue_url && !githubUrl.trim(),
+                        url: githubUrl,
+                      })
+                    }
+                  >
+                    {item.github_issue_url || githubUrl.trim()
+                      ? 'Ligar e implementar'
+                      : 'Criar issue e implementar'}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    disabled={busy}
+                    onClick={() => {
+                      setMostrarImplementar(false)
+                      setNovoStatus(item.status)
+                    }}
+                  >
+                    Cancelar
+                  </Button>
+                </div>
+              </div>
+            ) : null}
             {novoStatus === 'nao_sera_desenvolvida' ? (
               <div className="mt-3 space-y-2">
                 <textarea
@@ -372,7 +474,7 @@ export function SaasSolicitacaoDetalhe() {
             </p>
           </Card>
 
-          {item.github_issue_url ? (
+          {item.github_issue_url && !mostrarImplementar ? (
             <Card title="Issue no GitHub" description="Só neste painel — o cliente não vê o link.">
               <a
                 href={item.github_issue_url}

--- a/frontend/src/pages/saas/SaasSolicitacoes.tsx
+++ b/frontend/src/pages/saas/SaasSolicitacoes.tsx
@@ -1,25 +1,19 @@
-import { useCallback, useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useCallback, useEffect, useState, type ReactNode } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { ApiError, saasSolicitacoes, type SaasSolicitacoesProduto } from '../../api/client'
 import { mensagemFalhaParaToast } from '../../api/errorMessage'
 import { ConfigListPageShell } from '../../components/config/ConfigListPageShell'
 import { BarraBuscaPaginacao, PAGE_SIZE_PADRAO } from '../../components/ui/BarraBuscaPaginacao'
 import { Card } from '../../components/ui/Card'
-import { Select } from '../../components/ui/Select'
 import { useToast } from '../../components/ui/Toast'
 import {
   classesBadgeStatusSolicitacao,
+  classesBadgeTipoSolicitacao,
   rotuloStatusSolicitacao,
-  SAAS_SOLICITACAO_STATUS,
+  rotuloTipoSolicitacao,
+  SAAS_SOLICITACAO_FASES,
 } from '../../lib/saasSolicitacoes'
 import { SemPermissao } from '../SemPermissao'
-
-const TIPO_OPTS = [
-  { value: 'sugestao', label: 'Sugestão' },
-  { value: 'problema', label: 'Problema' },
-]
-
-const STATUS_OPTS = SAAS_SOLICITACAO_STATUS.map((s) => ({ value: s.value, label: s.label }))
 
 function formatWhen(iso: string | null | undefined): string {
   if (!iso) return '—'
@@ -30,23 +24,81 @@ function formatWhen(iso: string | null | undefined): string {
   }
 }
 
-function rotuloTipo(tipo: string): string {
-  return tipo === 'problema' ? 'Problema' : 'Sugestão'
+function Chip({
+  active,
+  onClick,
+  children,
+  count,
+  tone,
+}: {
+  active: boolean
+  onClick: () => void
+  children: ReactNode
+  count?: number
+  tone?: 'sky' | 'rose' | 'default'
+}) {
+  const toneActive =
+    tone === 'sky'
+      ? 'border-sky-500 bg-sky-50 text-sky-900 dark:border-sky-400 dark:bg-sky-950/50 dark:text-sky-100'
+      : tone === 'rose'
+        ? 'border-rose-500 bg-rose-50 text-rose-900 dark:border-rose-400 dark:bg-rose-950/50 dark:text-rose-100'
+        : 'border-cyan-500 bg-cyan-50 text-cyan-950 dark:border-cyan-400 dark:bg-cyan-950/40 dark:text-cyan-50'
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors ${
+        active
+          ? toneActive
+          : 'border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900/40 dark:text-slate-300 dark:hover:border-slate-600 dark:hover:bg-slate-800/60'
+      }`}
+    >
+      {children}
+      {count != null ? (
+        <span
+          className={`tabular-nums text-xs ${
+            active ? 'opacity-80' : 'text-slate-400 dark:text-slate-500'
+          }`}
+        >
+          {count}
+        </span>
+      ) : null}
+    </button>
+  )
 }
 
 export function SaasSolicitacoes() {
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   const toast = useToast()
   const [list, setList] = useState<SaasSolicitacoesProduto.ListaItem[]>([])
+  const [resumo, setResumo] = useState<SaasSolicitacoesProduto.Resumo | null>(null)
   const [total, setTotal] = useState(0)
   const [page, setPage] = useState(1)
   const [busca, setBusca] = useState('')
   const [debouncedBusca, setDebouncedBusca] = useState('')
-  const [tipoFiltro, setTipoFiltro] = useState('')
-  const [statusFiltro, setStatusFiltro] = useState('')
   const [loading, setLoading] = useState(true)
   const [forbidden, setForbidden] = useState(false)
   const [indisponivel, setIndisponivel] = useState(false)
+
+  const tipoFiltro = searchParams.get('tipo') || ''
+  const faseFiltro = searchParams.get('fase') || ''
+
+  function patchFiltros(next: Record<string, string | null>) {
+    setSearchParams(
+      (prev) => {
+        const p = new URLSearchParams(prev)
+        for (const [k, v] of Object.entries(next)) {
+          if (v == null || v === '') p.delete(k)
+          else p.set(k, v)
+        }
+        return p
+      },
+      { replace: true },
+    )
+    setPage(1)
+  }
 
   useEffect(() => {
     const t = setTimeout(() => setDebouncedBusca(busca.trim()), 400)
@@ -55,7 +107,14 @@ export function SaasSolicitacoes() {
 
   useEffect(() => {
     setPage(1)
-  }, [debouncedBusca, tipoFiltro, statusFiltro])
+  }, [debouncedBusca])
+
+  const loadResumo = useCallback(() => {
+    saasSolicitacoes
+      .resumo()
+      .then(setResumo)
+      .catch(() => setResumo(null))
+  }, [])
 
   const load = useCallback(() => {
     setLoading(true)
@@ -65,7 +124,7 @@ export function SaasSolicitacoes() {
       .list({
         busca: debouncedBusca || undefined,
         tipo: tipoFiltro || undefined,
-        status: statusFiltro || undefined,
+        fase: faseFiltro || undefined,
         offset: (page - 1) * PAGE_SIZE_PADRAO,
         limit: PAGE_SIZE_PADRAO,
       })
@@ -87,11 +146,12 @@ export function SaasSolicitacoes() {
         setTotal(0)
       })
       .finally(() => setLoading(false))
-  }, [debouncedBusca, page, tipoFiltro, statusFiltro, toast])
+  }, [debouncedBusca, page, tipoFiltro, faseFiltro, toast])
 
   useEffect(() => {
     load()
-  }, [load])
+    loadResumo()
+  }, [load, loadResumo])
 
   if (indisponivel) {
     return (
@@ -114,122 +174,190 @@ export function SaasSolicitacoes() {
           voltarLabel="Voltar para o Dashboard"
         />
       }
-      title="Sugestões das instâncias"
-      subtitle="Pedidos abertos pelos clientes nas Release Notes. Altere o status e responda no detalhe — o cliente vê o andamento em Minhas solicitações."
+      title="Sugestões e erros"
+      subtitle="Pedidos das instâncias. Filtre por tipo e fase para ver o que aguarda, o que está em desenvolvimento e o que já fechou."
     >
-      <Card>
-        <BarraBuscaPaginacao
-          busca={busca}
-          onBuscaChange={setBusca}
-          placeholder="Buscar por protocolo, título, cliente, slug ou autor…"
-          page={page}
-          total={total}
-          onPageChange={setPage}
-          disabled={loading}
-          extra={
-            <div className="flex min-w-0 flex-wrap gap-2">
-              <div className="min-w-[9rem] shrink-0">
-                <Select
-                  aria-label="Filtrar por tipo"
-                  value={tipoFiltro}
-                  onChange={(v) => setTipoFiltro(String(v))}
-                  options={TIPO_OPTS}
-                  includeEmpty
-                  emptyLabel="Todos os tipos"
-                  disabled={loading}
-                />
-              </div>
-              <div className="min-w-[10rem] shrink-0">
-                <Select
-                  aria-label="Filtrar por status"
-                  value={statusFiltro}
-                  onChange={(v) => setStatusFiltro(String(v))}
-                  options={STATUS_OPTS}
-                  includeEmpty
-                  emptyLabel="Todos os status"
-                  disabled={loading}
-                />
+      <div className="space-y-4">
+        <Card>
+          <div className="space-y-4">
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Tipo
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <Chip
+                  active={!tipoFiltro}
+                  count={resumo?.total}
+                  onClick={() => patchFiltros({ tipo: null })}
+                >
+                  Todos
+                </Chip>
+                <Chip
+                  active={tipoFiltro === 'sugestao'}
+                  count={resumo?.sugestoes}
+                  tone="sky"
+                  onClick={() =>
+                    patchFiltros({ tipo: tipoFiltro === 'sugestao' ? null : 'sugestao' })
+                  }
+                >
+                  Sugestões
+                </Chip>
+                <Chip
+                  active={tipoFiltro === 'problema'}
+                  count={resumo?.problemas}
+                  tone="rose"
+                  onClick={() =>
+                    patchFiltros({ tipo: tipoFiltro === 'problema' ? null : 'problema' })
+                  }
+                >
+                  Erros
+                </Chip>
               </div>
             </div>
-          }
-        />
-        {loading ? (
-          <p className="text-slate-500 dark:text-slate-400">Carregando...</p>
-        ) : list.length === 0 ? (
-          <p className="text-slate-500 dark:text-slate-400">Nenhuma solicitação ainda.</p>
-        ) : (
-          <div className="overflow-x-auto">
-            <table className="w-full min-w-[720px] text-left text-sm">
-              <thead>
-                <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Protocolo</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Cliente</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Tipo</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Título</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Autor</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Peso</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Status</th>
-                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">Quando</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
-                {list.map((item) => (
-                  <tr
-                    key={item.id}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => navigate(`/saas/solicitacoes/${item.id}`)}
-                    onKeyDown={(ev) => {
-                      if (ev.key === 'Enter' || ev.key === ' ') {
-                        ev.preventDefault()
-                        navigate(`/saas/solicitacoes/${item.id}`)
-                      }
-                    }}
-                    className="cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5"
+
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                Fase
+              </p>
+              <div className="flex flex-wrap gap-2">
+                <Chip
+                  active={!faseFiltro}
+                  onClick={() => patchFiltros({ fase: null })}
+                >
+                  Todas
+                </Chip>
+                {SAAS_SOLICITACAO_FASES.map((f) => (
+                  <Chip
+                    key={f.value}
+                    active={faseFiltro === f.value}
+                    count={
+                      f.value === 'aguardando'
+                        ? resumo?.aguardando
+                        : f.value === 'desenvolvimento'
+                          ? resumo?.desenvolvimento
+                          : resumo?.finalizadas
+                    }
+                    onClick={() =>
+                      patchFiltros({ fase: faseFiltro === f.value ? null : f.value })
+                    }
                   >
-                    <td className="px-4 py-3 font-mono text-sm text-cyan-800 dark:text-cyan-300 sm:px-6">
-                      {item.protocolo || '—'}
-                    </td>
-                    <td className="px-4 py-3 sm:px-6">
-                      <p className="font-medium text-slate-900 dark:text-slate-50">
-                        {item.cliente_nome || item.instance_slug}
-                      </p>
-                      <p className="font-mono text-xs text-slate-500">{item.instance_slug}</p>
-                    </td>
-                    <td className="px-4 py-3 text-slate-600 dark:text-slate-300 sm:px-6">{rotuloTipo(item.tipo)}</td>
-                    <td className="px-4 py-3 sm:px-6">
-                      <p className="font-medium text-slate-800 dark:text-slate-100">{item.titulo}</p>
-                      {item.versao_contexto ? (
-                        <p className="text-xs text-slate-500">v{item.versao_contexto}</p>
-                      ) : null}
-                    </td>
-                    <td className="px-4 py-3 text-slate-600 dark:text-slate-300 sm:px-6">{item.autor_nome || '—'}</td>
-                    <td className="px-4 py-3 text-slate-600 dark:text-slate-300 sm:px-6">
-                      {(item.peso_clientes || 1) > 1 ? (
-                        <span className="font-medium text-cyan-800 dark:text-cyan-300">
-                          {item.peso_clientes} clientes
-                        </span>
-                      ) : (
-                        '1'
-                      )}
-                    </td>
-                    <td className="px-4 py-3 sm:px-6">
-                      <span
-                        className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeStatusSolicitacao(item.status)}`}
-                      >
-                        {item.status_rotulo || rotuloStatusSolicitacao(item.status)}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-slate-500 sm:px-6">
-                      {formatWhen(item.created_at_origem || item.ingested_at)}
-                    </td>
-                  </tr>
+                    {f.label}
+                  </Chip>
                 ))}
-              </tbody>
-            </table>
+              </div>
+              {faseFiltro ? (
+                <p className="mt-2 text-xs text-slate-500 dark:text-slate-400">
+                  {SAAS_SOLICITACAO_FASES.find((f) => f.value === faseFiltro)?.hint}
+                </p>
+              ) : null}
+            </div>
           </div>
-        )}
-      </Card>
+        </Card>
+
+        <Card>
+          <BarraBuscaPaginacao
+            busca={busca}
+            onBuscaChange={setBusca}
+            placeholder="Buscar por protocolo, título, cliente, slug ou autor…"
+            page={page}
+            total={total}
+            onPageChange={setPage}
+            disabled={loading}
+          />
+          {loading ? (
+            <div className="h-32 animate-pulse rounded-xl bg-slate-100 dark:bg-slate-800/50" />
+          ) : list.length === 0 ? (
+            <p className="px-2 py-8 text-center text-sm text-slate-500 dark:text-slate-400">
+              Nenhum pedido neste filtro.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[720px] text-left text-sm">
+                <thead>
+                  <tr className="border-b border-slate-100 bg-slate-50/60 dark:border-slate-800 dark:bg-slate-800/40">
+                    <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">
+                      Tipo
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">
+                      Protocolo
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">
+                      Cliente
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">
+                      Título
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">
+                      Status
+                    </th>
+                    <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6">
+                      Quando
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 dark:divide-slate-800">
+                  {list.map((item) => (
+                    <tr
+                      key={item.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => navigate(`/saas/solicitacoes/${item.id}`)}
+                      onKeyDown={(ev) => {
+                        if (ev.key === 'Enter' || ev.key === ' ') {
+                          ev.preventDefault()
+                          navigate(`/saas/solicitacoes/${item.id}`)
+                        }
+                      }}
+                      className={`cursor-pointer transition-colors hover:bg-slate-50 dark:hover:bg-white/5 ${
+                        item.tipo === 'problema'
+                          ? 'border-l-2 border-l-rose-400/80'
+                          : 'border-l-2 border-l-sky-400/60'
+                      }`}
+                    >
+                      <td className="px-4 py-3 sm:px-6">
+                        <span
+                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeTipoSolicitacao(item.tipo)}`}
+                        >
+                          {rotuloTipoSolicitacao(item.tipo)}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 font-mono text-sm text-cyan-800 dark:text-cyan-300 sm:px-6">
+                        {item.protocolo || '—'}
+                      </td>
+                      <td className="px-4 py-3 sm:px-6">
+                        <p className="font-medium text-slate-900 dark:text-slate-50">
+                          {item.cliente_nome || item.instance_slug}
+                        </p>
+                        <p className="font-mono text-xs text-slate-500">{item.instance_slug}</p>
+                      </td>
+                      <td className="px-4 py-3 sm:px-6">
+                        <p className="font-medium text-slate-800 dark:text-slate-100">{item.titulo}</p>
+                        <p className="mt-0.5 text-xs text-slate-500">
+                          {item.autor_nome || '—'}
+                          {(item.peso_clientes || 1) > 1
+                            ? ` · ${item.peso_clientes} clientes`
+                            : ''}
+                          {item.versao_contexto ? ` · v${item.versao_contexto}` : ''}
+                        </p>
+                      </td>
+                      <td className="px-4 py-3 sm:px-6">
+                        <span
+                          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset ${classesBadgeStatusSolicitacao(item.status)}`}
+                        >
+                          {item.status_rotulo || rotuloStatusSolicitacao(item.status)}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-slate-500 sm:px-6">
+                        {formatWhen(item.created_at_origem || item.ingested_at)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Card>
+      </div>
     </ConfigListPageShell>
   )
 }

--- a/frontend/src/pages/saas/SaasUsuarioForm.tsx
+++ b/frontend/src/pages/saas/SaasUsuarioForm.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
-import { ApiError, saasOpsUsuarios } from '../../api/client'
+import { ApiError, saasOpsUsuarios, saasSetores, type SaasSetores } from '../../api/client'
 import { interpretarFalhaCarregamento, mensagemFalhaParaToast } from '../../api/errorMessage'
 import { Button } from '../../components/ui/Button'
 import { CadastroFormPageShell } from '../../components/ui/CadastroFormPageShell'
 import { CarregamentoFalhou } from '../../components/ui/CarregamentoFalhou'
+import { CheckboxField } from '../../components/ui/CheckboxField'
 import { ConfirmDialog } from '../../components/ui/ConfirmDialog'
 import { FormSection } from '../../components/ui/FormSection'
 import { InlineCadastroFooter } from '../../components/ui/InlineCadastroPanel'
@@ -37,6 +38,23 @@ export function SaasUsuarioForm() {
   const [tokenConfigurado, setTokenConfigurado] = useState(false)
   const [senhaTemporaria, setSenhaTemporaria] = useState<string | null>(null)
   const [confirmarReset, setConfirmarReset] = useState(false)
+  const [setoresList, setSetoresList] = useState<SaasSetores.Setor[]>([])
+  const [setorIds, setSetorIds] = useState<number[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    saasSetores
+      .list()
+      .then((rows) => {
+        if (!cancelled) setSetoresList(rows)
+      })
+      .catch(() => {
+        if (!cancelled) setSetoresList([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
     if (!isEdit) return
@@ -58,6 +76,7 @@ export function SaasUsuarioForm() {
         setEmail(row.email)
         setAtivo(row.ativo)
         setTokenConfigurado(row.mcp_token_configurado)
+        setSetorIds(row.setor_ids ?? [])
       })
       .catch((err) => {
         if (cancelled) return
@@ -79,13 +98,17 @@ export function SaasUsuarioForm() {
     }
   }, [id, isEdit, usuarioId])
 
+  function toggleSetor(setorId: number) {
+    setSetorIds((prev) => (prev.includes(setorId) ? prev.filter((x) => x !== setorId) : [...prev, setorId]))
+  }
+
   async function copiarSenha() {
     if (!senhaTemporaria) return
     try {
       await navigator.clipboard.writeText(senhaTemporaria)
       toast.showSuccess('Senha copiada.')
     } catch {
-      toast.showError('Não foi possível copiar. Seleccione a senha e copie manualmente.')
+      toast.showError('Não foi possível copiar. Selecione a senha e copie manualmente.')
     }
   }
 
@@ -98,18 +121,28 @@ export function SaasUsuarioForm() {
     setSaving(true)
     try {
       if (isEdit) {
-        const row = await saasOpsUsuarios.update(usuarioId, { nome: nome.trim(), ativo })
+        const row = await saasOpsUsuarios.update(usuarioId, {
+          nome: nome.trim(),
+          ativo,
+          setor_ids: setorIds,
+        })
         setAtivo(row.ativo)
+        setSetorIds(row.setor_ids ?? [])
         toast.showSuccess('Usuário atualizado.')
         navigate('/saas/usuarios')
         return
       }
-      const row = await saasOpsUsuarios.create({ nome: nome.trim(), email: email.trim() })
+      const row = await saasOpsUsuarios.create({
+        nome: nome.trim(),
+        email: email.trim(),
+        setor_ids: setorIds,
+      })
       setSenhaTemporaria(row.senha_temporaria)
       setEmail(row.email)
+      setSetorIds(row.setor_ids ?? [])
       toast.showSuccess('Usuário criado. Copie a senha temporária agora.')
     } catch (err) {
-      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível guardar o utilizador.'))
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o usuário.'))
     } finally {
       setSaving(false)
     }
@@ -162,7 +195,7 @@ export function SaasUsuarioForm() {
     <CadastroFormPageShell onVoltar={voltarAnterior}>
       <form onSubmit={(ev) => void onSubmit(ev)} className="space-y-4">
         <FormSection
-          title={isEdit ? 'Editar utilizador' : 'Novo utilizador'}
+          title={isEdit ? 'Editar usuário' : 'Novo usuário'}
           description="Esta conta entra no painel DeskRudder (/login/admin). Não é um atendente da instância do cliente."
         >
           {loading ? (
@@ -178,6 +211,34 @@ export function SaasUsuarioForm() {
                 required
                 disabled={isEdit}
               />
+              <div>
+                <p className="mb-2 text-sm font-medium text-slate-700 dark:text-slate-200">Cargos</p>
+                <p className="mb-2 text-xs text-slate-500 dark:text-slate-400">
+                  Pode marcar mais de um. Cadastre novos em Equipe → Setores.
+                </p>
+                {setoresList.length === 0 ? (
+                  <p className="text-sm text-slate-500">
+                    Nenhum setor ativo.{' '}
+                    <Link to="/saas/setores/novo" className="font-medium text-sky-700 underline dark:text-sky-300">
+                      Criar setor
+                    </Link>
+                  </p>
+                ) : (
+                  <div className="max-h-44 overflow-auto rounded-lg border border-slate-200 p-3 dark:border-slate-800/80">
+                    <div className="flex flex-wrap gap-2">
+                      {setoresList.map((s) => (
+                        <CheckboxField
+                          key={s.id}
+                          checked={setorIds.includes(s.id)}
+                          onChange={() => toggleSetor(s.id)}
+                        >
+                          {s.nome}
+                        </CheckboxField>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
               {isEdit ? (
                 <Switch
                   checked={ativo}

--- a/frontend/src/pages/saas/SaasUsuarios.tsx
+++ b/frontend/src/pages/saas/SaasUsuarios.tsx
@@ -118,6 +118,9 @@ export function SaasUsuarios() {
                     Nome
                   </th>
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
+                    Cargos
+                  </th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
                     E-mail
                   </th>
                   <th className="px-4 py-3 text-xs font-semibold uppercase text-slate-500 sm:px-6 dark:text-slate-400">
@@ -156,6 +159,11 @@ export function SaasUsuarios() {
                           </span>
                         ) : null}
                       </div>
+                    </td>
+                    <td className="max-w-[14rem] px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400">
+                      {(u.setores ?? []).length > 0
+                        ? (u.setores ?? []).map((s) => s.nome).join(', ')
+                        : '—'}
                     </td>
                     <td className="max-w-[16rem] truncate px-4 py-3.5 text-slate-600 sm:px-6 dark:text-slate-400" title={u.email}>
                       {u.email}

--- a/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappAtendendo.tsx
@@ -5,6 +5,7 @@ import { AssumirWhatsappSetorModal } from '../../components/chat/AssumirWhatsapp
 import { WhatsappAvatar } from '../../components/chat/WhatsappAvatar'
 import { marcarWhatsappChatAtivo, whatsappConversaLink, WHATSAPP_LIST_PATHS } from '../../lib/whatsappListReturn'
 import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
+import { tratarBloqueioJornadaAoAssumir } from '../../lib/tratarBloqueioJornadaAssumir'
 import { refetchPendenciasResumo } from '../../hooks/useAlertaFilaSemResponsavel'
 import { useAuth } from '../../contexts/AuthContext'
 import { useEventStream } from '../../contexts/EventStreamContext'
@@ -107,6 +108,9 @@ export function WhatsappAtendendo() {
       await load(true)
       void refetchPendenciasResumo()
     } catch (err) {
+      if (await tratarBloqueioJornadaAoAssumir(err, toast)) {
+        return
+      }
       const msg =
         err instanceof ApiError && err.status === 400
           ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1762,7 +1762,7 @@ useEffect(() => {
                 </Button>
               )}
 
-              {chat && (
+              {chat && encerrado && (
                 <Button
                   type="button"
                   variant="ghost"
@@ -1821,17 +1821,6 @@ useEffect(() => {
                     </button>
                     {menuMobileAberto && (
                       <div className="absolute right-0 top-full z-30 mt-1 min-w-[12rem] rounded-xl border border-slate-200 bg-white py-1 shadow-lg dark:border-slate-700 dark:bg-slate-900">
-                        <button
-                          type="button"
-                          className="block min-h-11 w-full px-4 py-3 text-left text-sm text-slate-700 hover:bg-slate-50 dark:text-slate-200 dark:hover:bg-slate-800"
-                          disabled={exportandoPdf}
-                          onClick={() => {
-                            setMenuMobileAberto(false)
-                            void exportarPdfChat()
-                          }}
-                        >
-                          {exportandoPdf ? 'A exportar…' : 'Exportar PDF'}
-                        </button>
                         {podeTransferir && (
                           <button
                             type="button"
@@ -1927,7 +1916,7 @@ useEffect(() => {
                           void exportarPdfChat()
                         }}
                       >
-                        {exportandoPdf ? 'A exportar…' : 'Exportar PDF'}
+                        {exportandoPdf ? 'Exportando…' : 'Exportar PDF'}
                       </button>
                     </div>
                   )}

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -35,6 +35,7 @@ import { WhatsappMensagemAcoes } from '../../components/chat/WhatsappMensagemAco
 import { WhatsappReacoesBar } from '../../components/chat/WhatsappReacoesBar'
 import { CopiarWaIdButton } from '../../components/chat/CopiarWaIdButton'
 import { precisaEscolherSetorAoAssumir } from '../../lib/assumirWhatsappSetor'
+import { tratarBloqueioJornadaAoAssumir } from '../../lib/tratarBloqueioJornadaAssumir'
 
 import { Card } from '../../components/ui/Card'
 import { ChatBottomSheet } from '../../components/ui/ChatBottomSheet'
@@ -1300,6 +1301,9 @@ useEffect(() => {
       abrirChat('whatsapp', chat.id)
       navigate(chatWhatsappLink('atendendo'), { replace: true })
     } catch (err) {
+      if (await tratarBloqueioJornadaAoAssumir(err, toast)) {
+        return
+      }
       const msg =
         err instanceof ApiError && err.status === 400
           ? (err.body as { detail?: string })?.detail || 'Erro ao assumir.'

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -605,6 +605,8 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
   const enviandoRef = useRef(false)
   const enviandoMidiaRef = useRef(false)
   const [reagirMsgId, setReagirMsgId] = useState<number | null>(null)
+  /** Menu Editar/Apagar/Reagir ou formulário de edição abertos — oculta picker hover (#947). */
+  const [acoesMenuMsgId, setAcoesMenuMsgId] = useState<number | null>(null)
 
   // Estados de WhatsApp Clone (Citação e Zoom)
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
@@ -2196,6 +2198,12 @@ useEffect(() => {
                         podeReagir={podeReagir}
                         onReagirMenu={podeReagir ? () => setReagirMsgId(m.id) : undefined}
                         tomClaro={isInbound}
+                        onMenuAbertoChange={(aberto) => {
+                          setAcoesMenuMsgId((prev) => {
+                            if (aberto) return m.id
+                            return prev === m.id ? null : prev
+                          })
+                        }}
                       />
                     )}
 
@@ -2280,6 +2288,7 @@ useEffect(() => {
                       alinhamento={isInbound ? 'start' : 'end'}
                       pickerExternoAberto={reagirMsgId === m.id}
                       onPickerExternoClose={() => setReagirMsgId(null)}
+                      ocultarPickerHover={acoesMenuMsgId === m.id}
                     />
                   )}
 

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -605,6 +605,8 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
   const enviandoRef = useRef(false)
   const enviandoMidiaRef = useRef(false)
   const [reagirMsgId, setReagirMsgId] = useState<number | null>(null)
+  /** Primeira inbound não lida ao abrir — divisor estilo WhatsApp (#951). */
+  const [divisorNaoLidasMsgId, setDivisorNaoLidasMsgId] = useState<number | null>(null)
 
   // Estados de WhatsApp Clone (Citação e Zoom)
   const [msgRespondida, setMsgRespondida] = useState<WhatsappChats.Mensagem | null>(null)
@@ -874,9 +876,12 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
 
   // Carregar conversa e mensagens
 
-  const carregar = useCallback(async () => {
+  const carregar = useCallback(async (): Promise<{
+    chat: WhatsappChats.Chat
+    msgs: WhatsappChats.Mensagem[]
+  } | null> => {
 
-    if (!id) return
+    if (!id) return null
 
     const gen = ++carregarGenRef.current
     const el = scrollRef.current
@@ -888,11 +893,12 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
 
       const [c, m] = await Promise.all([whatsappChats.get(id), whatsappChats.mensagens(id)])
 
-      if (gen !== carregarGenRef.current) return
+      if (gen !== carregarGenRef.current) return null
 
       setChat((prev) => mergeWhatsappChat(prev, c))
 
-      setMsgs(whatsappMensagensUnicas(m))
+      const unicas = whatsappMensagensUnicas(m)
+      setMsgs(unicas)
 
       requestAnimationFrame(() => {
         if (!initialScrollRestoredRef.current) return
@@ -905,9 +911,12 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
         }
       })
 
+      return { chat: c, msgs: unicas }
+
     } catch (err) {
 
       toast.showError(mensagemFalhaParaToast(err))
+      return null
 
     }
 
@@ -936,16 +945,56 @@ export function WhatsappConversa({ chatIdProp }: WhatsappConversaProps = {}) {
     if (!id) return
 
     setLoading(true)
+    setDivisorNaoLidasMsgId(null)
     viuEmAtendimentoRef.current = false
     inatividadeToastFeitoRef.current = false
 
-    carregar().then(() => whatsappChats.marcarVisto(id)).finally(() => setLoading(false))
+    carregar()
+      .then(async (data) => {
+        if (data && (data.chat.nao_lidas_count ?? 0) > 0) {
+          const cursorId = data.chat.last_seen_mensagem_id
+          let primeira: WhatsappChats.Mensagem | undefined
+          if (cursorId != null) {
+            primeira = data.msgs.find(
+              (m) =>
+                m.direcao === 'inbound' &&
+                !m.evento_sistema &&
+                !m.apagada &&
+                m.id > cursorId,
+            )
+          } else {
+            const eff =
+              data.chat.last_seen_at || data.chat.atendimento_inicio_at || data.chat.created_at || null
+            const effMs = eff ? new Date(eff).getTime() : 0
+            primeira = data.msgs.find(
+              (m) =>
+                m.direcao === 'inbound' &&
+                !m.evento_sistema &&
+                !m.apagada &&
+                m.created_at &&
+                new Date(m.created_at).getTime() > effMs,
+            )
+          }
+          if (primeira) setDivisorNaoLidasMsgId(primeira.id)
+        }
+        await whatsappChats.marcarVisto(id)
+        void carregarSidebar()
+      })
+      .finally(() => setLoading(false))
 
     return () => {
       revokeWhatsappMidiaForChat(Number(id))
     }
 
-  }, [id, carregar])
+  }, [id, carregar, carregarSidebar])
+
+  useEffect(() => {
+    if (!divisorNaoLidasMsgId || loading) return
+    const t = window.setTimeout(() => {
+      document.getElementById('wa-nao-lidas')?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    }, 80)
+    return () => window.clearTimeout(t)
+  }, [divisorNaoLidasMsgId, loading])
 
 
 
@@ -2143,12 +2192,26 @@ useEffect(() => {
               m.evento_sistema === 'comentario_interno' || m.evento_sistema === 'transferencia'
             const isTransferencia = m.evento_sistema === 'transferencia'
 
-           
+            const mostrarDivisorNaoLidas = divisorNaoLidasMsgId === m.id
 
             return (
+              <div key={m.id} className="w-full space-y-4">
+                {mostrarDivisorNaoLidas && (
+                  <div
+                    id="wa-nao-lidas"
+                    className="flex w-full items-center gap-3 py-1"
+                    role="separator"
+                    aria-label="Mensagens não lidas"
+                  >
+                    <div className="h-px flex-1 bg-cyan-500/50" />
+                    <span className="shrink-0 rounded-full bg-cyan-600 px-3 py-0.5 text-[10px] font-bold uppercase tracking-wide text-white shadow-sm">
+                      Mensagens não lidas
+                    </span>
+                    <div className="h-px flex-1 bg-cyan-500/50" />
+                  </div>
+                )}
 
-              <div 
-                key={m.id} 
+              <div
                 id={`msg-${m.wa_message_id || m.id}`}
                 data-wa-msg-id={m.id}
                 onDoubleClick={(e) => duploCliqueResponder(e, m, isSystem)}
@@ -2295,6 +2358,7 @@ useEffect(() => {
                   </button>
                 )}
 
+              </div>
               </div>
 
             )

--- a/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappEncerrarModal.tsx
@@ -73,7 +73,7 @@ export function WhatsappEncerrarModal({
 
   const semDemandas = demandas.length === 0
   const demandasResolvidas = demandas.filter((d) => d.desfecho === 'resolvido_sessao')
-  // Pós-inatividade também pede registo (como Encerrar manual); só permite skip com confirmação.
+  // Pós-inatividade também pede registro (como Encerrar manual); só permite skip com confirmação.
   const demandaOpcional = false
 
   useEffect(() => {
@@ -144,13 +144,13 @@ export function WhatsappEncerrarModal({
     try {
       if (acao === 'registrar') {
         if (form.naturezaId === '') {
-          toast.showWarning('Selecione a natureza da demanda ou marque encerrar sem registar.')
+          toast.showWarning('Selecione a natureza da demanda ou marque encerrar sem registrar.')
           return
         }
         await whatsappChats.registrarDemanda(chatId, demandaFormPayload(form))
       } else if (acao === 'sem_demanda') {
         if (!demandaOpcional && !confirmarSemDemanda) {
-          toast.showWarning('Confirme que deseja encerrar sem registar demanda.')
+          toast.showWarning('Confirme que deseja encerrar sem registrar demanda.')
           return
         }
       } else if (acao === 'nova') {
@@ -163,8 +163,8 @@ export function WhatsappEncerrarModal({
         await whatsappChats.atualizarDemanda(chatId, posRegistro.ultimaDemanda.id, demandaFormPayload(form))
       }
 
-      // Pós-inatividade: qualquer conclusão (manter/editar/sem demanda/registar) limpa o pendente.
-      // Idempotente se registar demanda já tiver limpo a flag.
+      // Pós-inatividade: qualquer conclusão (manter/editar/sem demanda/registrar) limpa o pendente.
+      // Idempotente se registrar demanda já tiver limpo a flag.
       if (chatJaEncerrado && encerramentoPorInatividade) {
         const atualizado = await whatsappChats.concluirClassificacaoDemanda(chatId)
         onDemandasChange?.()
@@ -193,14 +193,14 @@ export function WhatsappEncerrarModal({
 
   if (chatJaEncerrado && encerramentoPorInatividade) {
     mensagemIntro = semDemandas
-      ? 'Este atendimento foi encerrado automaticamente por inatividade. Registe a demanda da sessão, ou confirme explicitamente concluir sem demanda.'
+      ? 'Este atendimento foi encerrado automaticamente por inatividade. Registre a demanda da sessão, ou confirme explicitamente concluir sem demanda.'
       : 'Este atendimento foi encerrado automaticamente por inatividade. Revise as demandas antes de concluir.'
   } else if (semDemandas) {
     mensagemIntro =
-      'Registe o motivo do atendimento antes de encerrar, ou confirme explicitamente o encerramento sem demanda.'
+      'Registre o motivo do atendimento antes de encerrar, ou confirme explicitamente o encerramento sem demanda.'
   } else if (posRegistro) {
     mensagemIntro =
-      'Houve conversa após o último registo de demanda. Escolha se mantém, corrige ou acrescenta outra demanda.'
+      'Houve conversa após o último registro de demanda. Escolha se mantém, corrige ou acrescenta outra demanda.'
   }
 
   const mostrarForm =
@@ -246,7 +246,7 @@ export function WhatsappEncerrarModal({
             <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-950 dark:border-amber-900/50 dark:bg-amber-950/30 dark:text-amber-100">
               <p className="font-semibold">Conversa continuou após a última demanda</p>
               <p className="mt-1">
-                «{rotuloDemanda(posRegistro.ultimaDemanda)}» registada às{' '}
+                «{rotuloDemanda(posRegistro.ultimaDemanda)}» registrada às{' '}
                 {formatarHoraDemanda(posRegistro.ultimaDemanda.created_at)}.
               </p>
               <p className="mt-1">
@@ -268,7 +268,7 @@ export function WhatsappEncerrarModal({
                   checked={acao === 'registrar'}
                   onChange={() => selecionarAcao('registrar')}
                 />
-                {chatJaEncerrado ? 'Registar demanda e concluir' : 'Registar demanda e encerrar'}
+                {chatJaEncerrado ? 'Registrar demanda e concluir' : 'Registrar demanda e encerrar'}
               </label>
               <label className="flex cursor-pointer items-center gap-2 text-sm">
                 <input
@@ -277,7 +277,7 @@ export function WhatsappEncerrarModal({
                   checked={acao === 'sem_demanda'}
                   onChange={() => selecionarAcao('sem_demanda')}
                 />
-                {chatJaEncerrado ? 'Concluir sem registar demanda' : 'Encerrar sem registar demanda'}
+                {chatJaEncerrado ? 'Concluir sem registrar demanda' : 'Encerrar sem registrar demanda'}
               </label>
               {acao === 'sem_demanda' && (
                 <CheckboxField
@@ -323,7 +323,7 @@ export function WhatsappEncerrarModal({
             </div>
           ) : (
             <p className="text-xs text-slate-500">
-              As demandas registadas cobrem esta sessão. Confirme para encerrar.
+              As demandas registradas cobrem esta sessão. Confirme para encerrar.
             </p>
           )}
 
@@ -335,7 +335,7 @@ export function WhatsappEncerrarModal({
             <Button variant="cancel" onClick={onClose} disabled={salvando}>
               Cancelar
             </Button>
-            <Button variant="danger" onClick={() => void executarEncerramento()} loading={salvando}>
+            <Button variant="primary" onClick={() => void executarEncerramento()} loading={salvando}>
               {rotuloBotaoEncerrar}
             </Button>
           </div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -70,6 +70,8 @@ export default defineConfig(({ mode }) => {
         },
         injectManifest: {
           globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2,webmanifest}'],
+          // App chunk pode passar de 2 MiB; sem isso o build PWA falha no CI.
+          maximumFileSizeToCacheInBytes: 3 * 1024 * 1024,
         },
         devOptions: { enabled: true, type: 'module' },
       }),


### PR DESCRIPTION
## Summary

Release acumulado da `main` — lote SaaS + helpdesk DeskRudder (ver `CHANGELOG.md` → `[Unreleased]`).

**SaaS Control Plane**
- Triagem de sugestões: máquina de estados rígida, Implementar com issue GitHub (G2), versão ao cliente só quando concluída no deploy (G4)
- Painel admin: equipe/setores, catálogo comercial, licenças, MCP/Cursor por ops, cutover admin-center (#876–#880)
- UX da fila: protocolo, timeline, chips de fase/tipo, regras pt-BR sem GitHub ao cliente

**DeskRudder (instâncias)**
- **Ponto:** jornada semanal/ciclo, locais por atendente, geo/offline, bloqueio WhatsApp pós-jornada + HE admin (#959–#965, #984)
- **WhatsApp:** não lidas (#951), PDF só encerrado (#945), reação vs menu (#947), cores modal encerrar (#943)
- **Chat interno:** canais por setor (#916), membros online no setor (#941)
- **Sugestões:** Minhas solicitações + sync SaaS (#855–#856), protocolo `#S…`
- Diversos: CRM/contratos, mobile APK, UI responsiva, faturamento, etc.

Conflitos resolvidos: `CHANGELOG.md` ([Unreleased] da main + histórico publicado da staging), `client.ts` (#951).

## Test plan

- [ ] Deploy admin-center: migrate + health; fila SaaS e login ops
- [ ] Sugestão: triagem → implementar → CHANGELOG com `#S…` → conclusão automática no deploy com versão
- [ ] Minhas solicitações: versão só em pedido concluído
- [ ] Ponto: jornada semanal, locais no atendente, bloqueio WhatsApp + liberação HE
- [ ] WhatsApp: contador não lidas, PDF só encerrado, modal encerrar (azul/vermelho)
- [ ] Chat setor: modal membros + online
- [ ] Smoke login helpdesk + uma conversa WhatsApp + Meu ponto
