### PR TITLE
feat(ponto): HE antecipada e teto por colaborador (#966)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Ponto (#966): admin **concede hora extra** com antecedência (resto do dia, até horário ou duração em minutos); teto opcional por colaborador no cadastro; liberações respeitam o teto
 - Ponto (#965): após o fim da jornada, **pegar** chat WhatsApp novo fica bloqueado até um admin liberar **hora extra** (resto do dia ou até um horário); pedidos aparecem em Ponto da equipe e no sino de pendências
 - Ponto (#984): locais de trabalho no **cadastro do atendente** (empresa + extras no mapa OSM); pin da empresa em Configurações → Empresa; raio e ativar/desativar por local; removido o card global de Locais em Ponto da equipe
 - Chat interno (#941 / #S202608-0008): no canal de **setor**, clicar no nome abre modal com membros vinculados e quem está **online**

--- a/backend/alembic/versions/127_ponto_he_teto.py
+++ b/backend/alembic/versions/127_ponto_he_teto.py
@@ -1,0 +1,50 @@
+"""HE antecipada + teto por atendente (#966).
+
+Revision ID: 127_ponto_he_teto
+Revises: 126_ponto_hora_extra
+Create Date: 2026-08-27
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "127_ponto_he_teto"
+down_revision = "126_ponto_hora_extra"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "he_teto_minutos" not in cols:
+            op.add_column(
+                "atendentes",
+                sa.Column("he_teto_minutos", sa.Integer(), nullable=True),
+            )
+
+    if insp.has_table("ponto_hora_extra"):
+        cols = {c["name"] for c in insp.get_columns("ponto_hora_extra")}
+        if "origem" not in cols:
+            op.add_column(
+                "ponto_hora_extra",
+                sa.Column("origem", sa.String(20), nullable=False, server_default="solicitacao"),
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+    if insp.has_table("ponto_hora_extra"):
+        cols = {c["name"] for c in insp.get_columns("ponto_hora_extra")}
+        if "origem" in cols:
+            op.drop_column("ponto_hora_extra", "origem")
+    if insp.has_table("atendentes"):
+        cols = {c["name"] for c in insp.get_columns("atendentes")}
+        if "he_teto_minutos" in cols:
+            op.drop_column("atendentes", "he_teto_minutos")

--- a/backend/app/api/atendentes.py
+++ b/backend/app/api/atendentes.py
@@ -62,6 +62,7 @@ def _atendente_para_read(atendente: Atendente, *, e_financeiro: bool = False) ->
         tolerancia_atraso_minutos=int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0),
         usar_local_empresa=bool(getattr(atendente, "usar_local_empresa", True)),
         local_empresa_raio_metros=getattr(atendente, "local_empresa_raio_metros", None),
+        he_teto_minutos=getattr(atendente, "he_teto_minutos", None),
         saas_setor_ids=[s.id for s in saas],
         saas_setor_nomes=[s.nome for s in saas],
     )
@@ -191,6 +192,7 @@ def criar_atendente(
         tolerancia_atraso_minutos=int(data.tolerancia_atraso_minutos or 0) if modo != "nenhum" else 0,
         usar_local_empresa=bool(getattr(data, "usar_local_empresa", True)),
         local_empresa_raio_metros=getattr(data, "local_empresa_raio_metros", None),
+        he_teto_minutos=getattr(data, "he_teto_minutos", None),
     )
     _aplicar_campos_jornada(
         atendente,

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -27,6 +27,7 @@ from app.schemas.ponto import (
     PontoFeriadoRead,
     PontoHistoricoRead,
     PontoHojeRead,
+    PontoHoraExtraConceder,
     PontoHoraExtraCreate,
     PontoHoraExtraDecisao,
     PontoHoraExtraMeStatus,
@@ -504,5 +505,23 @@ def decidir_hora_extra(
         aprovar=data.aprovar,
         modo=data.modo,
         ate_horario=data.ate_horario,
+        duracao_minutos=data.duracao_minutos,
         decisao_motivo=data.decisao_motivo,
+    )
+
+
+@router.post("/hora-extra/conceder", response_model=PontoHoraExtraRead, status_code=201)
+def conceder_hora_extra(
+    data: PontoHoraExtraConceder,
+    db: Session = Depends(get_db),
+    admin: Atendente = Depends(exigir_admin),
+):
+    return he_svc.conceder_admin(
+        db,
+        admin,
+        atendente_id=data.atendente_id,
+        modo=data.modo,
+        ate_horario=data.ate_horario,
+        duracao_minutos=data.duracao_minutos,
+        motivo=data.motivo,
     )

--- a/backend/app/models/atendente.py
+++ b/backend/app/models/atendente.py
@@ -45,6 +45,8 @@ class Atendente(Base):
     horario_previsto_entrada = Column(String(5), nullable=True)  # HH:MM (ciclo)
     horario_previsto_saida = Column(String(5), nullable=True)
     tolerancia_atraso_minutos = Column(Integer, nullable=False, default=0, server_default="0")
+    # Teto máximo de HE por liberação, em minutos (#966); null = sem teto.
+    he_teto_minutos = Column(Integer, nullable=True)
     # Locais de ponto (#984): empresa + extras por atendente.
     usar_local_empresa = Column(Boolean, nullable=False, default=True, server_default="true")
     local_empresa_raio_metros = Column(Integer, nullable=True)

--- a/backend/app/models/ponto_hora_extra.py
+++ b/backend/app/models/ponto_hora_extra.py
@@ -16,9 +16,11 @@ class PontoHoraExtra(Base):
     # pendente | aprovada | rejeitada | expirada
     estado = Column(String(20), nullable=False, default="pendente", server_default="pendente")
     motivo = Column(String(1000), nullable=True)
-    # resto_do_dia | ate_horario (só quando aprovada)
+    # resto_do_dia | ate_horario | duracao (só quando aprovada)
     modo = Column(String(20), nullable=True)
     ate_em = Column(DateTime(timezone=True), nullable=True)
+    # solicitacao | admin (#966)
+    origem = Column(String(20), nullable=False, default="solicitacao", server_default="solicitacao")
     decidido_por_id = Column(Integer, ForeignKey("atendentes.id", ondelete="SET NULL"), nullable=True)
     decidido_em = Column(DateTime(timezone=True), nullable=True)
     decisao_motivo = Column(String(1000), nullable=True)

--- a/backend/app/schemas/atendente.py
+++ b/backend/app/schemas/atendente.py
@@ -23,6 +23,7 @@ class AtendenteBase(BaseModel):
     tolerancia_atraso_minutos: int = Field(default=0, ge=0, le=120)
     usar_local_empresa: bool = True
     local_empresa_raio_metros: int | None = Field(default=None, ge=20, le=50_000)
+    he_teto_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
 
 
 class AtendenteCreate(AtendenteBase):
@@ -48,6 +49,7 @@ class AtendenteUpdate(BaseModel):
     tolerancia_atraso_minutos: int | None = Field(default=None, ge=0, le=120)
     usar_local_empresa: bool | None = None
     local_empresa_raio_metros: int | None = Field(default=None, ge=20, le=50_000)
+    he_teto_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
 
 
 class AtendenteRead(AtendenteBase):

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -309,6 +309,7 @@ class PontoHoraExtraRead(BaseModel):
     motivo: str | None = None
     modo: str | None = None
     ate_em: datetime | None = None
+    origem: str = "solicitacao"
     decidido_por_id: int | None = None
     decidido_em: datetime | None = None
     decisao_motivo: str | None = None
@@ -319,9 +320,18 @@ class PontoHoraExtraRead(BaseModel):
 
 class PontoHoraExtraDecisao(BaseModel):
     aprovar: bool
-    modo: Literal["resto_do_dia", "ate_horario"] | None = None
+    modo: Literal["resto_do_dia", "ate_horario", "duracao"] | None = None
     ate_horario: str | None = Field(default=None, max_length=5, description="HH:MM se modo=ate_horario")
+    duracao_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
     decisao_motivo: str | None = Field(default=None, max_length=1000)
+
+
+class PontoHoraExtraConceder(BaseModel):
+    atendente_id: int = Field(..., ge=1)
+    modo: Literal["resto_do_dia", "ate_horario", "duracao"]
+    ate_horario: str | None = Field(default=None, max_length=5)
+    duracao_minutos: int | None = Field(default=None, ge=15, le=24 * 60)
+    motivo: str | None = Field(default=None, max_length=1000)
 
 
 class PontoHoraExtraMeStatus(BaseModel):
@@ -329,3 +339,5 @@ class PontoHoraExtraMeStatus(BaseModel):
     pode_pegar_whatsapp: bool
     he_ativa: PontoHoraExtraRead | None = None
     pedido_pendente: PontoHoraExtraRead | None = None
+    he_teto_minutos: int | None = None
+    he_restante_minutos: int | None = None

--- a/backend/app/services/ponto_hora_extra.py
+++ b/backend/app/services/ponto_hora_extra.py
@@ -1,8 +1,8 @@
-"""Hora extra e bloqueio de pegar WhatsApp após jornada (#965)."""
+"""Hora extra WhatsApp após jornada (#965) + antecipada/teto (#966)."""
 
 from __future__ import annotations
 
-from datetime import date, datetime, time, timezone
+from datetime import date, datetime, time, timedelta, timezone
 
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session, joinedload
@@ -14,7 +14,7 @@ from app.schemas.ponto import PontoHoraExtraRead
 from app.services import escala as escala_svc
 from app.services.escala import PONTO_TZ
 
-MODOS_APROVACAO = frozenset({"resto_do_dia", "ate_horario"})
+MODOS_APROVACAO = frozenset({"resto_do_dia", "ate_horario", "duracao"})
 
 
 def _agora_tz(when: datetime | None = None) -> datetime:
@@ -36,7 +36,6 @@ def fora_da_jornada(atendente: Atendente, when: datetime | None = None) -> bool:
     saida = escala_svc.saida_prevista_em(atendente, dia)
     if saida is not None:
         return agora >= saida
-    # Ciclo sem pe/ps: fora do bloco de trabalho.
     return not escala_svc.em_periodo_trabalho(atendente, agora)
 
 
@@ -57,8 +56,8 @@ def he_ativa(db: Session, atendente: Atendente, when: datetime | None = None) ->
         return None
     ate = row.ate_em
     if ate.tzinfo is None:
-        ate = ate.replace(tzinfo=PONTO_TZ)
-    if agora >= ate.astimezone(PONTO_TZ):
+        ate = ate.replace(tzinfo=timezone.utc)
+    if agora.astimezone(timezone.utc) >= ate.astimezone(timezone.utc):
         row.estado = "expirada"
         db.flush()
         return None
@@ -99,11 +98,83 @@ def _to_read(row: PontoHoraExtra) -> PontoHoraExtraRead:
         motivo=row.motivo,
         modo=row.modo,
         ate_em=row.ate_em,
+        origem=getattr(row, "origem", None) or "solicitacao",
         decidido_por_id=row.decidido_por_id,
         decidido_em=row.decidido_em,
         decisao_motivo=row.decisao_motivo,
         created_at=row.created_at,
     )
+
+
+def _teto_minutos(atendente: Atendente) -> int | None:
+    raw = getattr(atendente, "he_teto_minutos", None)
+    if raw is None:
+        return None
+    v = int(raw)
+    return v if v > 0 else None
+
+
+def _aplicar_teto(atendente: Atendente, agora: datetime, ate: datetime) -> datetime:
+    teto = _teto_minutos(atendente)
+    if teto is None:
+        return ate
+    limite = agora + timedelta(minutes=teto)
+    final = min(ate, limite)
+    if final <= agora:
+        raise HTTPException(
+            status_code=400,
+            detail=f"O teto de hora extra deste colaborador é de {teto} min — ajuste o horário ou o teto.",
+        )
+    return final
+
+
+def _calcular_ate_em(
+    atendente: Atendente,
+    agora: datetime,
+    *,
+    modo: str,
+    ate_horario: str | None,
+    duracao_minutos: int | None,
+) -> datetime:
+    m = (modo or "").strip().lower()
+    if m not in MODOS_APROVACAO:
+        raise HTTPException(
+            status_code=400,
+            detail="Escolha modo resto_do_dia, ate_horario ou duracao.",
+        )
+    if m == "resto_do_dia":
+        ate = _fim_resto_do_dia(agora)
+    elif m == "ate_horario":
+        ate = _parse_ate_horario(agora.date(), ate_horario or "")
+        if ate <= agora:
+            raise HTTPException(
+                status_code=400,
+                detail="O horário limite da hora extra deve ser no futuro.",
+            )
+    else:
+        mins = int(duracao_minutos or 0)
+        if mins < 15 or mins > 24 * 60:
+            raise HTTPException(
+                status_code=400,
+                detail="Informe a duração em minutos (entre 15 e 1440).",
+            )
+        ate = agora + timedelta(minutes=mins)
+    return _aplicar_teto(atendente, agora, ate).astimezone(timezone.utc)
+
+
+def _expirar_aprovadas_anteriores(db: Session, atendente_id: int) -> None:
+    agora_utc = datetime.now(timezone.utc)
+    rows = (
+        db.query(PontoHoraExtra)
+        .filter(PontoHoraExtra.atendente_id == atendente_id, PontoHoraExtra.estado == "aprovada")
+        .all()
+    )
+    for r in rows:
+        r.estado = "expirada"
+        if r.ate_em is None or (
+            (r.ate_em if r.ate_em.tzinfo else r.ate_em.replace(tzinfo=timezone.utc)) > agora_utc
+        ):
+            r.ate_em = agora_utc
 
 
 def garantir_pedido_pendente(
@@ -133,6 +204,7 @@ def garantir_pedido_pendente(
         tenant_id=atendente.tenant_id,
         atendente_id=atendente.id,
         estado="pendente",
+        origem="solicitacao",
         motivo=(motivo or "Pedido de hora extra para atendimento WhatsApp.")[:1000],
     )
     db.add(row)
@@ -143,7 +215,7 @@ def garantir_pedido_pendente(
         row.id,
         "create",
         atendente.id,
-        payload={"estado": "pendente"},
+        payload={"estado": "pendente", "origem": "solicitacao"},
     )
     if commit:
         db.commit()
@@ -166,15 +238,13 @@ def solicitar(
     if he_ativa(db, atendente):
         raise HTTPException(status_code=400, detail="Você já tem hora extra ativa.")
     row = garantir_pedido_pendente(db, atendente, motivo=motivo, commit=True)
-    db.refresh(row)
-    if row.atendente is None:
-        row = (
-            db.query(PontoHoraExtra)
-            .options(joinedload(PontoHoraExtra.atendente))
-            .filter(PontoHoraExtra.id == row.id)
-            .first()
-        )
-        assert row is not None
+    row = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.id == row.id)
+        .first()
+    )
+    assert row is not None
     return _to_read(row)
 
 
@@ -216,11 +286,20 @@ def me_status(db: Session, atendente: Atendente) -> dict:
         .order_by(PontoHoraExtra.id.desc())
         .first()
     )
+    restante = None
+    if ativa and ativa.ate_em is not None:
+        agora = _agora_tz()
+        ate = ativa.ate_em
+        if ate.tzinfo is None:
+            ate = ate.replace(tzinfo=timezone.utc)
+        restante = max(0, int((ate.astimezone(PONTO_TZ) - agora).total_seconds() // 60))
     return {
         "fora_da_jornada": fora,
         "pode_pegar_whatsapp": (not fora) or ativa is not None,
         "he_ativa": _to_read(ativa) if ativa else None,
         "pedido_pendente": _to_read(pendente) if pendente else None,
+        "he_teto_minutos": _teto_minutos(atendente),
+        "he_restante_minutos": restante,
     }
 
 
@@ -250,6 +329,7 @@ def decidir(
     aprovar: bool,
     modo: str | None = None,
     ate_horario: str | None = None,
+    duracao_minutos: int | None = None,
     decisao_motivo: str | None = None,
 ) -> PontoHoraExtraRead:
     row = (
@@ -263,6 +343,8 @@ def decidir(
     if row.estado != "pendente":
         raise HTTPException(status_code=400, detail="Este pedido já foi decidido.")
     agora = _agora_tz()
+    alvo = row.atendente
+    assert alvo is not None
     row.decidido_por_id = admin.id
     row.decidido_em = datetime.now(timezone.utc)
     row.decisao_motivo = (decisao_motivo or "").strip()[:1000] or None
@@ -272,23 +354,13 @@ def decidir(
         row.ate_em = None
     else:
         m = (modo or "").strip().lower()
-        if m not in MODOS_APROVACAO:
-            raise HTTPException(
-                status_code=400,
-                detail="Ao aprovar, escolha modo resto_do_dia ou ate_horario.",
-            )
+        ate = _calcular_ate_em(
+            alvo, agora, modo=m, ate_horario=ate_horario, duracao_minutos=duracao_minutos
+        )
+        _expirar_aprovadas_anteriores(db, alvo.id)
         row.estado = "aprovada"
         row.modo = m
-        if m == "resto_do_dia":
-            row.ate_em = _fim_resto_do_dia(agora)
-        else:
-            ate = _parse_ate_horario(agora.date(), ate_horario or "")
-            if ate <= agora:
-                raise HTTPException(
-                    status_code=400,
-                    detail="O horário limite da hora extra deve ser no futuro.",
-                )
-            row.ate_em = ate
+        row.ate_em = ate
     registrar_audit(
         db,
         "ponto_hora_extra",
@@ -299,6 +371,101 @@ def decidir(
     )
     db.commit()
     db.refresh(row)
+    _notificar_admins(db, admin.tenant_id)
+    return _to_read(row)
+
+
+def conceder_admin(
+    db: Session,
+    admin: Atendente,
+    *,
+    atendente_id: int,
+    modo: str,
+    ate_horario: str | None = None,
+    duracao_minutos: int | None = None,
+    motivo: str | None = None,
+) -> PontoHoraExtraRead:
+    """Admin concede HE antecipada (#966) — sem pedido pendente."""
+    alvo = (
+        db.query(Atendente)
+        .filter(
+            Atendente.id == atendente_id,
+            Atendente.tenant_id == admin.tenant_id,
+            Atendente.role != "saas_ops",
+        )
+        .first()
+    )
+    if not alvo:
+        raise HTTPException(status_code=404, detail="Atendente não encontrado")
+    agora = _agora_tz()
+    m = (modo or "").strip().lower()
+    ate = _calcular_ate_em(
+        alvo, agora, modo=m, ate_horario=ate_horario, duracao_minutos=duracao_minutos
+    )
+    _expirar_aprovadas_anteriores(db, alvo.id)
+
+    pendentes = (
+        db.query(PontoHoraExtra)
+        .filter(PontoHoraExtra.atendente_id == alvo.id, PontoHoraExtra.estado == "pendente")
+        .order_by(PontoHoraExtra.id.asc())
+        .all()
+    )
+    row: PontoHoraExtra
+    if pendentes:
+        row = pendentes[0]
+        for extra in pendentes[1:]:
+            extra.estado = "rejeitada"
+            extra.decidido_por_id = admin.id
+            extra.decidido_em = datetime.now(timezone.utc)
+            extra.decisao_motivo = "Substituído por concessão do administrador"
+        row.estado = "aprovada"
+        row.origem = "admin"
+        row.modo = m
+        row.ate_em = ate
+        row.motivo = (motivo or row.motivo or "Hora extra concedida pelo administrador.")[:1000]
+        row.decidido_por_id = admin.id
+        row.decidido_em = datetime.now(timezone.utc)
+        row.decisao_motivo = "Concessão antecipada"
+        registrar_audit(
+            db,
+            "ponto_hora_extra",
+            row.id,
+            "conceder",
+            admin.id,
+            payload={"atendente_id": alvo.id, "modo": m, "ate_em": str(ate), "via": "pendente"},
+        )
+    else:
+        row = PontoHoraExtra(
+            tenant_id=admin.tenant_id,
+            atendente_id=alvo.id,
+            estado="aprovada",
+            origem="admin",
+            modo=m,
+            ate_em=ate,
+            motivo=(motivo or "Hora extra concedida pelo administrador.")[:1000],
+            decidido_por_id=admin.id,
+            decidido_em=datetime.now(timezone.utc),
+            decisao_motivo="Concessão antecipada",
+        )
+        db.add(row)
+        db.flush()
+        registrar_audit(
+            db,
+            "ponto_hora_extra",
+            row.id,
+            "conceder",
+            admin.id,
+            payload={"atendente_id": alvo.id, "modo": m, "ate_em": str(ate)},
+        )
+
+    db.commit()
+    row = (
+        db.query(PontoHoraExtra)
+        .options(joinedload(PontoHoraExtra.atendente))
+        .filter(PontoHoraExtra.id == row.id)
+        .first()
+    )
+    assert row is not None
     _notificar_admins(db, admin.tenant_id)
     return _to_read(row)
 

--- a/backend/tests/test_ponto_he_antecipada_966.py
+++ b/backend/tests/test_ponto_he_antecipada_966.py
@@ -1,0 +1,122 @@
+"""HE antecipada + teto (#966)."""
+
+from datetime import date, datetime, timedelta
+
+from app.services.escala import PONTO_TZ
+
+
+def _patch_jornada_semanal(client, headers, atendente_id: int, *, fim="23:59"):
+    keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    hoje_key = keys[date.today().weekday()]
+    hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
+    hs[hoje_key] = {"ativo": True, "inicio": "06:00", "fim": fim}
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={
+            "modo_jornada": "semanal",
+            "usa_escala": True,
+            "horario_semana": hs,
+            "tolerancia_atraso_minutos": 0,
+        },
+    )
+
+
+def test_conceder_he_antecipada_durante_jornada(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    # fim no futuro → ainda dentro da jornada
+    fim = (datetime.now(PONTO_TZ) + timedelta(hours=3)).strftime("%H:%M")
+    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    r = client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 90, "motivo": "Pico"},
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["estado"] == "aprovada"
+    assert body["origem"] == "admin"
+    assert body["modo"] == "duracao"
+    st = client.get("/v1/ponto/hora-extra/me/status", headers=user)
+    assert st.status_code == 200
+    assert st.json()["he_ativa"] is not None
+    assert st.json()["he_restante_minutos"] is not None
+    assert st.json()["he_restante_minutos"] <= 90
+
+
+def test_teto_limita_concessao(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"he_teto_minutos": 60},
+    ).status_code == 200
+    # Pedido resto do dia seria até 23:59 — teto de 60 min corta
+    r = client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "resto_do_dia"},
+    )
+    assert r.status_code == 201, r.text
+    ate = datetime.fromisoformat(r.json()["ate_em"].replace("Z", "+00:00"))
+    agora = datetime.now(PONTO_TZ)
+    delta_min = (ate.astimezone(PONTO_TZ) - agora).total_seconds() / 60
+    assert delta_min <= 61
+
+
+def test_teto_bloqueia_duracao_maior(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"he_teto_minutos": 30},
+    ).status_code == 200
+    # 30 min teto + modo duracao 30 = ok
+    r_ok = client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 30},
+    )
+    assert r_ok.status_code == 201, r_ok.text
+    # Nova concessão 120 com teto 30: ainda deve criar mas cortada a 30
+    r2 = client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 120},
+    )
+    assert r2.status_code == 201, r2.text
+    ate = datetime.fromisoformat(r2.json()["ate_em"].replace("Z", "+00:00"))
+    agora = datetime.now(PONTO_TZ)
+    assert (ate.astimezone(PONTO_TZ) - agora).total_seconds() / 60 <= 31
+
+
+def test_he_ativa_libera_apos_jornada(client, seed_base, auth_headers, db_session):
+    from app.models.whatsapp_chat import WhatsappChat
+
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    # Concede antes
+    assert client.post(
+        "/v1/ponto/hora-extra/conceder",
+        headers=admin,
+        json={"atendente_id": a1.id, "modo": "duracao", "duracao_minutos": 120},
+    ).status_code == 201
+    # Força fim da jornada no passado
+    fim = (datetime.now(PONTO_TZ) - timedelta(hours=1)).strftime("%H:%M")
+    assert _patch_jornada_semanal(client, admin, a1.id, fim=fim).status_code == 200
+    chat = WhatsappChat(
+        wa_id="5511999999660",
+        protocolo="WPP-TEST-966",
+        estado="aguardando_atendente",
+        setor_id=seed_base["setor1"].id,
+    )
+    db_session.add(chat)
+    db_session.commit()
+    db_session.refresh(chat)
+    r = client.post(f"/v1/whatsapp/chats/{chat.id}/assumir", headers=user)
+    assert r.status_code == 200, r.text

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -774,6 +774,11 @@ export const ponto = {
       method: 'POST',
       body: JSON.stringify(data),
     }),
+  concederHoraExtra: (data: Ponto.HoraExtraConceder) =>
+    api<Ponto.HoraExtra>('/ponto/hora-extra/conceder', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    }),
   exportCsv: async (params?: { atendente_id?: number; desde?: string; ate?: string }) => {
     const token = getAuthToken()
     const headers: Record<string, string> = {}
@@ -2508,6 +2513,7 @@ export namespace Atendentes {
     tolerancia_atraso_minutos?: number;
     usar_local_empresa?: boolean;
     local_empresa_raio_metros?: number | null;
+    he_teto_minutos?: number | null;
     /** Cargos da equipe DeskRudder (painel SaaS); vários por usuário. */
     saas_setor_ids?: number[];
     saas_setor_nomes?: string[];
@@ -2530,6 +2536,7 @@ export namespace Atendentes {
     tolerancia_atraso_minutos?: number;
     usar_local_empresa?: boolean;
     local_empresa_raio_metros?: number | null;
+    he_teto_minutos?: number | null;
   }
   export interface Update {
     email?: string;
@@ -2549,6 +2556,7 @@ export namespace Atendentes {
     tolerancia_atraso_minutos?: number;
     usar_local_empresa?: boolean;
     local_empresa_raio_metros?: number | null;
+    he_teto_minutos?: number | null;
   }
   export interface AvaliacaoResumo {
     media: number | null;
@@ -5008,6 +5016,7 @@ export namespace Ponto {
     motivo?: string | null
     modo?: string | null
     ate_em?: string | null
+    origem?: string
     decidido_por_id?: number | null
     decidido_em?: string | null
     decisao_motivo?: string | null
@@ -5018,15 +5027,25 @@ export namespace Ponto {
   }
   export interface HoraExtraDecisao {
     aprovar: boolean
-    modo?: 'resto_do_dia' | 'ate_horario' | null
+    modo?: 'resto_do_dia' | 'ate_horario' | 'duracao' | null
     ate_horario?: string | null
+    duracao_minutos?: number | null
     decisao_motivo?: string | null
+  }
+  export interface HoraExtraConceder {
+    atendente_id: number
+    modo: 'resto_do_dia' | 'ate_horario' | 'duracao'
+    ate_horario?: string | null
+    duracao_minutos?: number | null
+    motivo?: string | null
   }
   export interface HoraExtraMeStatus {
     fora_da_jornada: boolean
     pode_pegar_whatsapp: boolean
     he_ativa?: HoraExtra | null
     pedido_pendente?: HoraExtra | null
+    he_teto_minutos?: number | null
+    he_restante_minutos?: number | null
   }
 }
 

--- a/frontend/src/pages/AtendenteForm.tsx
+++ b/frontend/src/pages/AtendenteForm.tsx
@@ -59,6 +59,7 @@ export function AtendenteForm() {
   const [toleranciaAtraso, setToleranciaAtraso] = useState('0')
   const [usarLocalEmpresa, setUsarLocalEmpresa] = useState(true)
   const [localEmpresaRaio, setLocalEmpresaRaio] = useState('')
+  const [heTetoMinutos, setHeTetoMinutos] = useState('')
 
   useEffect(() => {
     coletarTodasPaginas<Setores.Setor>((o, l) =>
@@ -106,6 +107,7 @@ export function AtendenteForm() {
         setLocalEmpresaRaio(
           a.local_empresa_raio_metros != null ? String(a.local_empresa_raio_metros) : '',
         )
+        setHeTetoMinutos(a.he_teto_minutos != null ? String(a.he_teto_minutos) : '')
         if (a.escala_horas_trabalho === 12 && a.escala_horas_folga === 36) setPresetEscala('12x36')
         else if (a.escala_horas_trabalho === 6 && a.escala_horas_folga === 18) setPresetEscala('6x18')
         else if (a.escala_horas_trabalho === 24 && a.escala_horas_folga === 48) setPresetEscala('24x48')
@@ -200,6 +202,12 @@ export function AtendenteForm() {
     }
   }
 
+  function payloadHeTeto(): { he_teto_minutos: number | null } {
+    const raw = heTetoMinutos.trim()
+    if (!raw) return { he_teto_minutos: null }
+    return { he_teto_minutos: Math.min(1440, Math.max(15, Number(raw) || 15)) }
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (modoJornada === 'semanal') {
@@ -213,6 +221,7 @@ export function AtendenteForm() {
     try {
       const escala = payloadJornada()
       const locais = payloadLocais()
+      const heTeto = payloadHeTeto()
       if (isEdit && !Number.isNaN(atendenteId)) {
         await atendentes.update(atendenteId, {
           email,
@@ -222,6 +231,7 @@ export function AtendenteForm() {
           setor_ids: setorIds,
           ...escala,
           ...locais,
+          ...heTeto,
           ...(senha ? { senha } : {}),
         })
         toast.showSuccess('Atendente atualizado.')
@@ -237,6 +247,7 @@ export function AtendenteForm() {
           ativo,
           ...escala,
           ...locais,
+          ...heTeto,
         })
         toast.showSuccess('Atendente cadastrado.')
         navigate(`/atendentes/${created.id}/editar`, { replace: true })
@@ -444,6 +455,21 @@ export function AtendenteForm() {
                   </p>
                 </div>
               )}
+            </FormSection>
+            <FormSection title="Hora extra (WhatsApp)">
+              <Input
+                label="Teto por liberação (minutos)"
+                type="number"
+                min={15}
+                max={1440}
+                value={heTetoMinutos}
+                onChange={(e) => setHeTetoMinutos(e.target.value)}
+                placeholder="Sem limite"
+              />
+              <p className="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                Vazio = sem teto. Cada concessão (resto do dia, até horário ou duração) é limitada a esse
+                máximo a partir do momento da liberação.
+              </p>
             </FormSection>
             {isEdit && !Number.isNaN(atendenteId) ? (
               <FormSection title="Locais de trabalho">

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -66,8 +66,12 @@ export function PontoEquipe() {
   const [salvandoAjuste, setSalvandoAjuste] = useState(false)
   const [justifs, setJustifs] = useState<Ponto.Justificativa[]>([])
   const [hesPendentes, setHesPendentes] = useState<Ponto.HoraExtra[]>([])
-  const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario'>('resto_do_dia')
+  const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
   const [heAteHorario, setHeAteHorario] = useState('20:00')
+  const [heDuracaoMin, setHeDuracaoMin] = useState('60')
+  const [heConcederAtendente, setHeConcederAtendente] = useState('')
+  const [heConcederMotivo, setHeConcederMotivo] = useState('')
+  const [concedendoHe, setConcedendoHe] = useState(false)
   const [decidindoHeId, setDecidindoHeId] = useState<number | null>(null)
   const [digest, setDigest] = useState<Ponto.Digest | null>(null)
   const [banco, setBanco] = useState<Ponto.BancoHoras | null>(null)
@@ -261,6 +265,8 @@ export function PontoEquipe() {
         aprovar,
         modo: aprovar ? heModo : null,
         ate_horario: aprovar && heModo === 'ate_horario' ? heAteHorario : null,
+        duracao_minutos:
+          aprovar && heModo === 'duracao' ? Math.max(15, Number(heDuracaoMin) || 60) : null,
         decisao_motivo: aprovar ? null : 'Negado pelo administrador',
       })
       toast.showSuccess(aprovar ? 'Hora extra liberada.' : 'Pedido de hora extra negado.')
@@ -269,6 +275,30 @@ export function PontoEquipe() {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível decidir a hora extra.'))
     } finally {
       setDecidindoHeId(null)
+    }
+  }
+
+  async function concederHe() {
+    if (!heConcederAtendente) {
+      toast.showWarning('Selecione o atendente.')
+      return
+    }
+    setConcedendoHe(true)
+    try {
+      await ponto.concederHoraExtra({
+        atendente_id: Number(heConcederAtendente),
+        modo: heModo,
+        ate_horario: heModo === 'ate_horario' ? heAteHorario : null,
+        duracao_minutos: heModo === 'duracao' ? Math.max(15, Number(heDuracaoMin) || 60) : null,
+        motivo: heConcederMotivo.trim() || null,
+      })
+      toast.showSuccess('Hora extra concedida.')
+      setHeConcederMotivo('')
+      await carregar(true)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível conceder a hora extra.'))
+    } finally {
+      setConcedendoHe(false)
     }
   }
 
@@ -462,17 +492,27 @@ export function PontoEquipe() {
 
         <Card title="Hora extra (WhatsApp após jornada)">
           <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
-            Pedidos para pegar novos chats depois do fim da jornada. Ao liberar, escolha o restante do dia ou até um
-            horário.
+            Conceda HE com antecedência ou libere pedidos após o fim da jornada. Modos: resto do dia, até um horário ou
+            duração em minutos (respeita o teto do colaborador, se houver).
           </p>
           <div className="mb-4 flex flex-wrap items-end gap-3">
             <Select
-              label="Ao aprovar"
+              label="Conceder a"
+              value={heConcederAtendente}
+              onChange={(v) => setHeConcederAtendente(String(v))}
+              options={[
+                { value: '', label: 'Selecione' },
+                ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
+              ]}
+            />
+            <Select
+              label="Modo"
               value={heModo}
-              onChange={(v) => setHeModo(String(v) as 'resto_do_dia' | 'ate_horario')}
+              onChange={(v) => setHeModo(String(v) as 'resto_do_dia' | 'ate_horario' | 'duracao')}
               options={[
                 { value: 'resto_do_dia', label: 'Resto do dia' },
                 { value: 'ate_horario', label: 'Até horário' },
+                { value: 'duracao', label: 'Duração (minutos)' },
               ]}
             />
             {heModo === 'ate_horario' ? (
@@ -483,7 +523,26 @@ export function PontoEquipe() {
                 onChange={(e) => setHeAteHorario(e.target.value)}
               />
             ) : null}
+            {heModo === 'duracao' ? (
+              <Input
+                label="Minutos"
+                type="number"
+                min={15}
+                max={1440}
+                value={heDuracaoMin}
+                onChange={(e) => setHeDuracaoMin(e.target.value)}
+              />
+            ) : null}
+            <Input
+              label="Motivo (opcional)"
+              value={heConcederMotivo}
+              onChange={(e) => setHeConcederMotivo(e.target.value)}
+            />
+            <Button type="button" disabled={concedendoHe} onClick={() => void concederHe()}>
+              Conceder HE
+            </Button>
           </div>
+          <p className="mb-2 text-sm font-medium text-slate-800 dark:text-slate-100">Pedidos pendentes</p>
           {hesPendentes.length === 0 ? (
             <p className="text-sm text-slate-500">Nenhum pedido pendente.</p>
           ) : (


### PR DESCRIPTION
## Summary

- Closes #966 — admin **concede hora extra** com antecedência (sem pedido pendente), com modos `resto_do_dia`, `ate_horario` e `duracao`
- Teto opcional por colaborador (`he_teto_minutos` no cadastro); cada liberação é limitada a `agora + teto`
- Reaproveita o gate WhatsApp de #965; `me/status` expõe teto e minutos restantes
- Fora de v1: teto semanal/mensal (#974), pedido pelo colaborador (#969), SSE dedicado (#982)

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest` `test_ponto_he_antecipada_966.py` + `test_ponto_he_whatsapp_965.py` (8 passed)
- [x] Regressão `test_ponto_jornada_959.py` + `test_ponto_geofence.py` (13 passed)
- [x] `tsc -b` frontend OK
- [ ] Smoke: Ponto da equipe → Conceder HE (duração) a um atendente; conferir liberação no status
- [ ] Smoke: cadastro do atendente → definir teto; conceder resto do dia e ver corte no `ate_em`
- [ ] Após jornada: com HE ativa, assumir chat WhatsApp OK; sem HE, 403

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens **fora do escopo** desta issue — já cobertos por #969 / #974 / #982
- [x] Stubs/campos nullable têm issue de conclusão, se aplicável (teto mensal = #974)
- [ ] Comentário na issue fechada ou no PR lista links dos follow-ups criados
