### PR TITLE
feat(ponto): Lote C — lembretes, resumo semanal e ajustes (#968/#972/#971)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Melhorias
 
+- Ponto (#968 / #972 / #971): lembrete in-app de entrada/saída na janela de tolerância; resumo semanal em Meu ponto (previsto × feito, atrasos, HE, banco); motivo obrigatório reforçado e histórico/export de ajustes admin (também no PDF/Excel mensal)
 - Ponto (#966): admin **concede hora extra** com antecedência (resto do dia, até horário ou duração em minutos); teto opcional por colaborador no cadastro; liberações respeitam o teto
 - Ponto (#965): após o fim da jornada, **pegar** chat WhatsApp novo fica bloqueado até um admin liberar **hora extra** (resto do dia ou até um horário); pedidos aparecem em Ponto da equipe e no sino de pendências
 - Ponto (#984): locais de trabalho no **cadastro do atendente** (empresa + extras no mapa OSM); pin da empresa em Configurações → Empresa; raio e ativar/desativar por local; removido o card global de Locais em Ponto da equipe

--- a/backend/alembic/versions/129_merge_he_teto_versao.py
+++ b/backend/alembic/versions/129_merge_he_teto_versao.py
@@ -1,0 +1,21 @@
+"""Merge heads: HE teto (#966) + versao_alvo solic (#955).
+
+Revision ID: 129_merge_he_teto_versao
+Revises: 127_ponto_he_teto, 128_versao_alvo_solic
+Create Date: 2026-08-27
+"""
+
+from __future__ import annotations
+
+revision = "129_merge_he_teto_versao"
+down_revision = ("127_ponto_he_teto", "128_versao_alvo_solic")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/api/ponto.py
+++ b/backend/app/api/ponto.py
@@ -38,6 +38,7 @@ from app.schemas.ponto import (
     PontoLocalCreate,
     PontoLocalRead,
     PontoLocalUpdate,
+    PontoResumoSemanaRead,
     PontoSettingsPublicRead,
     PontoSettingsRead,
     PontoSettingsUpdate,
@@ -297,6 +298,15 @@ def meu_banco_horas(
 ):
     ponto_svc.exigir_acesso_ponto(atendente)
     return ponto_svc.banco_horas(db, atendente, desde=desde, ate=ate)
+
+
+@router.get("/me/resumo-semana", response_model=PontoResumoSemanaRead)
+def meu_resumo_semana(
+    ref: date | None = Query(None, description="Qualquer dia da semana (padrão: hoje)"),
+    db: Session = Depends(get_db),
+    atendente: Atendente = Depends(obter_atendente_atual),
+):
+    return ponto_svc.resumo_semana(db, atendente, ref=ref)
 
 
 @router.get("/banco-horas", response_model=PontoBancoHorasRead)

--- a/backend/app/schemas/ponto.py
+++ b/backend/app/schemas/ponto.py
@@ -254,13 +254,29 @@ class PontoAnularBody(BaseModel):
 
 
 class PontoAlertasMe(BaseModel):
-    """Lembretes ao utilizador — sem batida automática (#773 / #769)."""
+    """Lembretes ao usuário — sem batida automática (#773 / #769 / #968)."""
 
     sem_entrada_em_dia_escala: bool = False
     online_sem_ponto: bool = False
     jornada_aberta_longa: bool = False
     horas_jornada_aberta: float | None = None
+    lembrete_entrada_tolerancia: bool = False
+    lembrete_saida_tolerancia: bool = False
     mensagens: list[str] = []
+
+
+class PontoResumoSemanaRead(BaseModel):
+    """Resumo semanal do colaborador (#972)."""
+
+    desde: date
+    ate: date
+    segundos_esperados: int
+    segundos_realizados: int
+    saldo_segundos: int
+    atrasos: int
+    he_minutos: int
+    dias_escala: int
+    dias_feriado: int = 0
 
 
 class PontoJustificativaCreate(BaseModel):

--- a/backend/app/services/escala.py
+++ b/backend/app/services/escala.py
@@ -310,6 +310,15 @@ def saida_prevista_em(atendente: Atendente, dia: date) -> datetime | None:
     return datetime.combine(dia, time(hour=ps[0], minute=ps[1]), tzinfo=PONTO_TZ)
 
 
+def liberacao_saida_lembrete_em(atendente: Atendente, dia: date) -> datetime | None:
+    """Início do lembrete de saída (fim − tolerância) (#968)."""
+    saida = saida_prevista_em(atendente, dia)
+    if saida is None:
+        return None
+    tol = int(getattr(atendente, "tolerancia_atraso_minutos", 0) or 0)
+    return saida - timedelta(minutes=tol)
+
+
 def validar_janela_entrada(atendente: Atendente, when: datetime) -> None:
     """Bloqueia entrada antes de inicio−tolerância (#964). Admin/sistema não chamam isto."""
     if not escala_configurada(atendente):

--- a/backend/app/services/ponto.py
+++ b/backend/app/services/ponto.py
@@ -722,11 +722,14 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
     exigir_acesso_ponto(atendente)
     hoje = datetime.now(PONTO_TZ).date()
     agora = _agora_utc()
+    agora_local = agora.astimezone(PONTO_TZ)
     msgs: list[str] = []
     sem_entrada = False
     online_sem = False
     jornada_longa = False
     horas_aberta: float | None = None
+    lembrete_entrada = False
+    lembrete_saida = False
 
     feriado = ponto_settings_svc.eh_feriado(db, atendente.tenant_id, hoje)
     jornada_ativa = escala_svc.escala_configurada(atendente)
@@ -753,18 +756,29 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
         hb = hb.replace(tzinfo=timezone.utc)
     online = bool(hb and hb >= agora - timedelta(seconds=PRESENCA_TTL_SEC))
 
-    # Modo nenhum: sem avisos de falta/atraso (#959)
+    # Modo nenhum: sem avisos de falta/atraso/lembretes de tolerância (#959 / #968)
     if jornada_ativa:
         if esperado is True and not tem_entrada_hoje and entrada is None:
-            sem_entrada = True
-            msgs.append("Hoje é dia de trabalho na sua jornada e ainda não há entrada registrada.")
+            liberacao = escala_svc.liberacao_entrada_em(atendente, hoje)
+            if liberacao is not None and agora_local >= liberacao:
+                sem_entrada = True
+                lembrete_entrada = True
+                limite = escala_svc.limite_atraso_em(atendente, hoje)
+                if limite is not None and agora_local <= limite:
+                    msgs.append("Janela de entrada — registre o ponto agora.")
+                else:
+                    msgs.append(
+                        "Hoje é dia de trabalho na sua jornada e ainda não há entrada registrada."
+                    )
 
         if _atrasado_entrada(atendente, primeira):
             msgs.append("Entrada registrada após o horário previsto (fora da tolerância).")
 
     if online and entrada is None:
         online_sem = True
-        if "ainda não há entrada" not in " ".join(msgs).lower():
+        if "ainda não há entrada" not in " ".join(msgs).lower() and "Janela de entrada" not in " ".join(
+            msgs
+        ):
             msgs.append("Você está online no painel sem jornada de ponto aberta.")
 
     if entrada is not None:
@@ -775,16 +789,118 @@ def alertas_me(db: Session, atendente: Atendente) -> "PontoAlertasMe":
                 f"Jornada aberta há cerca de {horas_aberta:.0f} h — lembre-se de registrar a saída."
             )
         elif jornada_ativa:
+            inicio_saida = escala_svc.liberacao_saida_lembrete_em(atendente, hoje)
             saida_prev = escala_svc.saida_prevista_em(atendente, hoje)
-            if saida_prev is not None and agora.astimezone(PONTO_TZ) >= saida_prev:
-                msgs.append("Horário de saída previsto já passou — registre a saída.")
+            if inicio_saida is not None and agora_local >= inicio_saida:
+                lembrete_saida = True
+                if saida_prev is not None and agora_local >= saida_prev:
+                    msgs.append("Horário de saída previsto já passou — registre a saída.")
+                else:
+                    msgs.append("Janela de saída — registre o ponto ao encerrar.")
 
     return PontoAlertasMe(
         sem_entrada_em_dia_escala=sem_entrada,
         online_sem_ponto=online_sem,
         jornada_aberta_longa=jornada_longa,
         horas_jornada_aberta=horas_aberta,
+        lembrete_entrada_tolerancia=lembrete_entrada,
+        lembrete_saida_tolerancia=lembrete_saida,
         mensagens=msgs,
+    )
+
+
+def _semana_bounds(ref: date) -> tuple[date, date]:
+    """Segunda a domingo da semana que contém `ref` (pt-BR / ISO weekday)."""
+    desde = ref - timedelta(days=ref.weekday())
+    return desde, desde + timedelta(days=6)
+
+
+def _contar_atrasos_periodo(
+    db: Session,
+    atendente: Atendente,
+    *,
+    desde: date,
+    ate: date,
+) -> int:
+    if not escala_svc.escala_configurada(atendente):
+        return 0
+    n = 0
+    d = desde
+    while d <= ate:
+        if ponto_settings_svc.eh_feriado(db, atendente.tenant_id, d):
+            d += timedelta(days=1)
+            continue
+        if not escala_svc.eh_dia_de_trabalho(atendente, d):
+            d += timedelta(days=1)
+            continue
+        ini, fim = _bounds_periodo(d, d)
+        bats = (
+            _q_ativas(db)
+            .filter(
+                PontoBatida.atendente_id == atendente.id,
+                PontoBatida.registrado_em >= ini,
+                PontoBatida.registrado_em < fim,
+            )
+            .all()
+        )
+        if _atrasado_entrada(atendente, _primeira_entrada_do_dia(bats)):
+            n += 1
+        d += timedelta(days=1)
+    return n
+
+
+def _he_minutos_periodo(db: Session, atendente: Atendente, *, desde: date, ate: date) -> int:
+    from app.models.ponto_hora_extra import PontoHoraExtra
+
+    ini, fim = _bounds_periodo(desde, ate)
+    rows = (
+        db.query(PontoHoraExtra)
+        .filter(
+            PontoHoraExtra.atendente_id == atendente.id,
+            PontoHoraExtra.estado.in_(("aprovada", "expirada")),
+            PontoHoraExtra.ate_em.isnot(None),
+            PontoHoraExtra.decidido_em.isnot(None),
+            PontoHoraExtra.decidido_em >= ini,
+            PontoHoraExtra.decidido_em < fim,
+        )
+        .all()
+    )
+    total = 0
+    for r in rows:
+        dec = r.decidido_em
+        ate_em = r.ate_em
+        if dec is None or ate_em is None:
+            continue
+        if dec.tzinfo is None:
+            dec = dec.replace(tzinfo=timezone.utc)
+        if ate_em.tzinfo is None:
+            ate_em = ate_em.replace(tzinfo=timezone.utc)
+        total += max(0, int((ate_em - dec).total_seconds() // 60))
+    return total
+
+
+def resumo_semana(
+    db: Session,
+    atendente: Atendente,
+    *,
+    ref: date | None = None,
+) -> "PontoResumoSemanaRead":
+    from app.schemas.ponto import PontoResumoSemanaRead
+
+    exigir_acesso_ponto(atendente)
+    dia_ref = ref or datetime.now(PONTO_TZ).date()
+    desde, ate = _semana_bounds(dia_ref)
+    bh = banco_horas(db, atendente, desde=desde, ate=ate)
+    return PontoResumoSemanaRead(
+        desde=desde,
+        ate=ate,
+        segundos_esperados=bh.segundos_esperados,
+        segundos_realizados=bh.segundos_realizados,
+        saldo_segundos=bh.saldo_segundos,
+        atrasos=_contar_atrasos_periodo(db, atendente, desde=desde, ate=ate),
+        he_minutos=_he_minutos_periodo(db, atendente, desde=desde, ate=ate),
+        dias_escala=bh.dias_escala,
+        dias_feriado=bh.dias_feriado,
     )
 
 
@@ -812,6 +928,12 @@ def admin_criar_batida(
     alvo = _atendente_do_tenant(db, admin.tenant_id, atendente_id)
     if tipo not in TIPOS_VALIDOS:
         raise HTTPException(status_code=400, detail="Tipo inválido")
+    motivo_limpo = (motivo or "").strip()
+    if len(motivo_limpo) < 3:
+        raise HTTPException(
+            status_code=400,
+            detail="Informe o motivo do ajuste (mínimo 3 caracteres).",
+        )
     batida = PontoBatida(
         tenant_id=admin.tenant_id,
         atendente_id=alvo.id,
@@ -829,7 +951,7 @@ def admin_criar_batida(
         "create_ajuste",
         admin.id,
         payload={
-            "motivo": motivo,
+            "motivo": motivo_limpo,
             "atendente_id": alvo.id,
             "tipo": tipo,
             "registrado_em": _as_utc(registrado_em).isoformat(),
@@ -857,6 +979,12 @@ def admin_atualizar_batida(
     )
     if not batida or batida.anulada:
         raise HTTPException(status_code=404, detail="Batida não encontrada")
+    motivo_limpo = (motivo or "").strip()
+    if len(motivo_limpo) < 3:
+        raise HTTPException(
+            status_code=400,
+            detail="Informe o motivo do ajuste (mínimo 3 caracteres).",
+        )
     antes = {"tipo": batida.tipo, "registrado_em": batida.registrado_em.isoformat()}
     if tipo is not None:
         if tipo not in TIPOS_VALIDOS:
@@ -871,7 +999,11 @@ def admin_atualizar_batida(
         batida.id,
         "update_ajuste",
         admin.id,
-        payload={"motivo": motivo, "antes": antes, "depois": {"tipo": batida.tipo, "registrado_em": batida.registrado_em.isoformat()}},
+        payload={
+            "motivo": motivo_limpo,
+            "antes": antes,
+            "depois": {"tipo": batida.tipo, "registrado_em": batida.registrado_em.isoformat()},
+        },
     )
     db.commit()
     db.refresh(batida)
@@ -886,6 +1018,12 @@ def admin_anular_batida(db: Session, admin: Atendente, batida_id: int, *, motivo
     )
     if not batida or batida.anulada:
         raise HTTPException(status_code=404, detail="Batida não encontrada")
+    motivo_limpo = (motivo or "").strip()
+    if len(motivo_limpo) < 3:
+        raise HTTPException(
+            status_code=400,
+            detail="Informe o motivo da anulação (mínimo 3 caracteres).",
+        )
     batida.anulada = True
     registrar_audit(
         db,
@@ -894,7 +1032,7 @@ def admin_anular_batida(db: Session, admin: Atendente, batida_id: int, *, motivo
         "anular",
         admin.id,
         payload={
-            "motivo": motivo,
+            "motivo": motivo_limpo,
             "tipo": batida.tipo,
             "registrado_em": batida.registrado_em.isoformat(),
             "atendente_id": batida.atendente_id,

--- a/backend/app/services/ponto_relatorio.py
+++ b/backend/app/services/ponto_relatorio.py
@@ -1,14 +1,16 @@
-"""Relatório mensal de ponto — PDF e Excel (#844)."""
+"""Relatório mensal de ponto — PDF e Excel (#844 / #971)."""
 
 from __future__ import annotations
 
 import io
 from datetime import date, datetime, timezone
+
 from html import escape
 
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, joinedload
 
 from app.models.atendente import Atendente
+from app.models.audit_log import AuditLog
 from app.models.ponto_batida import PontoBatida
 from app.services.comercial_proposta import html_para_pdf
 from app.services.ponto import PONTO_TZ, _as_utc, _bounds_periodo, _intervalos_de_batidas, _q_ativas
@@ -28,6 +30,44 @@ MESES_PT = (
     "Novembro",
     "Dezembro",
 )
+
+
+def _coletar_ajustes_audit(
+    db: Session,
+    admin: Atendente,
+    *,
+    desde: date | None,
+    ate: date | None,
+) -> list[AuditLog]:
+    q = (
+        db.query(AuditLog)
+        .options(joinedload(AuditLog.atendente))
+        .filter(
+            AuditLog.entity_type == "ponto_batida",
+            AuditLog.action.in_(("create_ajuste", "update_ajuste", "anular")),
+        )
+    )
+    # AuditLog é global por instância; filtrar por autores do tenant
+    ids = [
+        row[0]
+        for row in db.query(Atendente.id).filter(Atendente.tenant_id == admin.tenant_id).all()
+    ]
+    if ids:
+        q = q.filter(AuditLog.atendente_id.in_(ids))
+    inicio, fim = _bounds_periodo(desde, ate)
+    if inicio is not None:
+        q = q.filter(AuditLog.created_at >= inicio)
+    if fim is not None:
+        q = q.filter(AuditLog.created_at < fim)
+    return q.order_by(AuditLog.created_at.asc(), AuditLog.id.asc()).limit(2000).all()
+
+
+def _rotulo_acao_ajuste(action: str) -> str:
+    return {
+        "create_ajuste": "Criação",
+        "update_ajuste": "Alteração",
+        "anular": "Anulação",
+    }.get(action, action)
 
 
 def _coletar_intervalos(
@@ -108,12 +148,33 @@ def export_pdf_mensal(
             "</tr>"
         )
 
+    ajustes_html = ""
+    for log in _coletar_ajustes_audit(db, admin, desde=desde, ate=ate):
+        payload = log.payload_json or {}
+        motivo = escape(str(payload.get("motivo") or "—"))
+        quando = (
+            _as_utc(log.created_at).astimezone(PONTO_TZ).strftime("%d/%m/%Y %H:%M")
+            if log.created_at
+            else "—"
+        )
+        autor = escape(log.atendente.nome if log.atendente else "—")
+        ajustes_html += (
+            "<tr>"
+            f"<td>{quando}</td>"
+            f"<td>{autor}</td>"
+            f"<td>{escape(_rotulo_acao_ajuste(log.action))}</td>"
+            f"<td>{log.entity_id}</td>"
+            f"<td>{motivo}</td>"
+            "</tr>"
+        )
+
     html = f"""<!DOCTYPE html>
 <html lang="pt-BR">
 <head><meta charset="utf-8"><title>Relatório de ponto</title>
 <style>
   body {{ font-family: sans-serif; font-size: 11px; color: #111; }}
   h1 {{ font-size: 18px; margin-bottom: 4px; }}
+  h2 {{ font-size: 14px; margin-top: 20px; }}
   .meta {{ color: #555; margin-bottom: 16px; }}
   table {{ width: 100%; border-collapse: collapse; }}
   th, td {{ border: 1px solid #ccc; padding: 4px 6px; text-align: left; }}
@@ -129,9 +190,16 @@ def export_pdf_mensal(
       <th>Atendente</th><th>Data</th><th>Entrada</th><th>Saída</th>
       <th>Pausas (min)</th><th>Trabalhado (min)</th><th>Aberto</th>
     </tr></thead>
-    <tbody>{rows_html or '<tr><td colspan="7">Sem registos no período.</td></tr>'}</tbody>
+    <tbody>{rows_html or '<tr><td colspan="7">Sem registros no período.</td></tr>'}</tbody>
   </table>
   <p class="total">Total trabalhado (fechado): {round(total_min / 60, 2)} h ({round(total_min, 0)} min)</p>
+  <h2>Ajustes administrativos</h2>
+  <table>
+    <thead><tr>
+      <th>Quando</th><th>Autor</th><th>Ação</th><th>Batida</th><th>Motivo</th>
+    </tr></thead>
+    <tbody>{ajustes_html or '<tr><td colspan="5">Sem ajustes no período.</td></tr>'}</tbody>
+  </table>
 </body>
 </html>"""
     return html_para_pdf(html)
@@ -180,6 +248,24 @@ def export_xlsx_mensal(
         )
     ws.append([])
     ws.append(["Total trabalhado (h)", round(total_min / 60, 2)])
+
+    ws_aj = wb.create_sheet("Ajustes")
+    ws_aj.append(["Quando", "Autor", "Ação", "Batida ID", "Motivo", "Payload"])
+    for log in _coletar_ajustes_audit(db, admin, desde=desde, ate=ate):
+        payload = log.payload_json or {}
+        ws_aj.append(
+            [
+                _as_utc(log.created_at).astimezone(PONTO_TZ).strftime("%Y-%m-%d %H:%M")
+                if log.created_at
+                else "",
+                log.atendente.nome if log.atendente else "",
+                _rotulo_acao_ajuste(log.action),
+                log.entity_id,
+                payload.get("motivo") or "",
+                str(payload),
+            ]
+        )
+
     buf = io.BytesIO()
     wb.save(buf)
     return buf.getvalue()

--- a/backend/tests/test_ponto_lote_c_968_971_972.py
+++ b/backend/tests/test_ponto_lote_c_968_971_972.py
@@ -1,0 +1,121 @@
+"""Lote C ponto: lembretes tolerância (#968), resumo semanal (#972), ajustes (#971)."""
+
+from datetime import date, datetime, timedelta, timezone
+
+from app.services.escala import PONTO_TZ
+
+
+def _patch_jornada_hoje(client, headers, atendente_id: int, *, inicio="08:00", fim="18:00", tol=30):
+    keys = ["seg", "ter", "qua", "qui", "sex", "sab", "dom"]
+    hoje_key = keys[date.today().weekday()]
+    hs = {k: {"ativo": False, "inicio": "08:00", "fim": "18:00"} for k in keys}
+    hs[hoje_key] = {"ativo": True, "inicio": inicio, "fim": fim}
+    return client.patch(
+        f"/v1/atendentes/{atendente_id}",
+        headers=headers,
+        json={
+            "modo_jornada": "semanal",
+            "usa_escala": True,
+            "horario_semana": hs,
+            "tolerancia_atraso_minutos": tol,
+        },
+    )
+
+
+def test_lembrete_entrada_na_janela_tolerancia(client, seed_base, auth_headers, monkeypatch):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    agora = datetime.now(PONTO_TZ)
+    # Coloca início da jornada 10 min no futuro e tol=30 → já estamos em inicio−tol
+    inicio = (agora + timedelta(minutes=10)).strftime("%H:%M")
+    fim = (agora + timedelta(hours=8)).strftime("%H:%M")
+    assert _patch_jornada_hoje(client, admin, a1.id, inicio=inicio, fim=fim, tol=30).status_code == 200
+    r = client.get("/v1/ponto/me/alertas", headers=user)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["lembrete_entrada_tolerancia"] is True
+    assert any("Janela de entrada" in m for m in body["mensagens"])
+
+
+def test_lembrete_saida_antes_do_fim(client, seed_base, auth_headers, db_session):
+    from app.models.ponto_batida import PontoBatida
+
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    agora = datetime.now(PONTO_TZ)
+    # fim daqui a 10 min, tol 30 → já na janela de saída
+    inicio = (agora - timedelta(hours=8)).strftime("%H:%M")
+    fim = (agora + timedelta(minutes=10)).strftime("%H:%M")
+    assert _patch_jornada_hoje(client, admin, a1.id, inicio=inicio, fim=fim, tol=30).status_code == 200
+    db_session.add(
+        PontoBatida(
+            tenant_id=a1.tenant_id,
+            atendente_id=a1.id,
+            tipo="entrada",
+            registrado_em=datetime.now(timezone.utc) - timedelta(hours=7),
+            origem="app",
+        )
+    )
+    db_session.commit()
+    r = client.get("/v1/ponto/me/alertas", headers=user)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["lembrete_saida_tolerancia"] is True
+    assert any("saída" in m.lower() for m in body["mensagens"])
+
+
+def test_modo_nenhum_sem_lembrete_tolerancia(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    user = auth_headers["a1"]
+    a1 = seed_base["a1"]
+    assert client.patch(
+        f"/v1/atendentes/{a1.id}",
+        headers=admin,
+        json={"modo_jornada": "nenhum", "usa_escala": False},
+    ).status_code == 200
+    r = client.get("/v1/ponto/me/alertas", headers=user)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["lembrete_entrada_tolerancia"] is False
+    assert body["lembrete_saida_tolerancia"] is False
+
+
+def test_resumo_semana_proprio(client, seed_base, auth_headers):
+    user = auth_headers["a1"]
+    r = client.get("/v1/ponto/me/resumo-semana", headers=user)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "desde" in body and "ate" in body
+    assert "atrasos" in body
+    assert "he_minutos" in body
+    assert "saldo_segundos" in body
+    assert body["segundos_esperados"] >= 0
+
+
+def test_ajuste_motivo_obrigatorio_strip(client, seed_base, auth_headers):
+    admin = auth_headers["admin"]
+    a1 = seed_base["a1"]
+    r = client.post(
+        "/v1/ponto/batidas",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "tipo": "entrada",
+            "registrado_em": datetime.now(timezone.utc).isoformat(),
+            "motivo": "  ",
+        },
+    )
+    assert r.status_code == 422
+    r_ok = client.post(
+        "/v1/ponto/batidas",
+        headers=admin,
+        json={
+            "atendente_id": a1.id,
+            "tipo": "entrada",
+            "registrado_em": datetime.now(timezone.utc).isoformat(),
+            "motivo": "Correção de esquecimento",
+        },
+    )
+    assert r_ok.status_code == 201, r_ok.text

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -717,6 +717,8 @@ export const ponto = {
     api<Ponto.Calendario>(withParams('/ponto/me/calendario', { ano, mes })),
   meuBancoHoras: (desde: string, ate: string) =>
     api<Ponto.BancoHoras>(withParams('/ponto/me/banco-horas', { desde, ate })),
+  meuResumoSemana: (ref?: string) =>
+    api<Ponto.ResumoSemana>(withParams('/ponto/me/resumo-semana', ref ? { ref } : {})),
   bancoHorasAdmin: (atendenteId: number, desde: string, ate: string) =>
     api<Ponto.BancoHoras>(
       withParams('/ponto/banco-horas', { atendente_id: atendenteId, desde, ate }),
@@ -4972,7 +4974,20 @@ export namespace Ponto {
     online_sem_ponto: boolean
     jornada_aberta_longa: boolean
     horas_jornada_aberta: number | null
+    lembrete_entrada_tolerancia?: boolean
+    lembrete_saida_tolerancia?: boolean
     mensagens: string[]
+  }
+  export interface ResumoSemana {
+    desde: string
+    ate: string
+    segundos_esperados: number
+    segundos_realizados: number
+    saldo_segundos: number
+    atrasos: number
+    he_minutos: number
+    dias_escala: number
+    dias_feriado?: number
   }
   export interface AjusteCreate {
     atendente_id: number

--- a/frontend/src/components/PontoAlertasBanner.tsx
+++ b/frontend/src/components/PontoAlertasBanner.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import { ponto } from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 
-/** Banner de lembretes de ponto (#773 / #769) — sem batida automática. */
+/** Banner de lembretes de ponto (#773 / #769 / #968) — sem batida automática. */
 export function PontoAlertasBanner() {
   const { user } = useAuth()
   const [mensagens, setMensagens] = useState<string[]>([])
@@ -12,16 +12,30 @@ export function PontoAlertasBanner() {
   useEffect(() => {
     if (!user || user.must_change_password || user.role === 'saas_ops') return
     let cancelled = false
-    void ponto
-      .alertas()
-      .then((a) => {
-        if (!cancelled) setMensagens(a.mensagens ?? [])
-      })
-      .catch(() => {
-        /* silencioso — não bloquear o painel */
-      })
+
+    const carregar = () => {
+      void ponto
+        .alertas()
+        .then((a) => {
+          if (cancelled) return
+          setMensagens(a.mensagens ?? [])
+          if ((a.mensagens ?? []).length === 0) setDismissed(false)
+        })
+        .catch(() => {
+          /* silencioso — não bloquear o painel */
+        })
+    }
+
+    carregar()
+    const id = window.setInterval(carregar, 60_000)
+    const onVis = () => {
+      if (document.visibilityState === 'visible') carregar()
+    }
+    document.addEventListener('visibilitychange', onVis)
     return () => {
       cancelled = true
+      window.clearInterval(id)
+      document.removeEventListener('visibilitychange', onVis)
     }
   }, [user])
 

--- a/frontend/src/pages/MeuPonto.tsx
+++ b/frontend/src/pages/MeuPonto.tsx
@@ -58,6 +58,8 @@ export function MeuPonto() {
   const [justMotivo, setJustMotivo] = useState('')
   const [enviandoJust, setEnviandoJust] = useState(false)
   const [banco, setBanco] = useState<Ponto.BancoHoras | null>(null)
+  const [refSemana, setRefSemana] = useState(hojeIso)
+  const [resumoSemana, setResumoSemana] = useState<Ponto.ResumoSemana | null>(null)
   const agora = new Date()
   const [calAno, setCalAno] = useState(agora.getFullYear())
   const [calMes, setCalMes] = useState(agora.getMonth() + 1)
@@ -129,9 +131,27 @@ export function MeuPonto() {
     [calAno, calMes, toast],
   )
 
+  const carregarResumoSemana = useCallback(
+    async (silencioso = false) => {
+      try {
+        const rs = await ponto.meuResumoSemana(refSemana)
+        setResumoSemana(rs)
+      } catch (err) {
+        if (!silencioso) {
+          toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar o resumo da semana.'))
+        }
+      }
+    },
+    [refSemana, toast],
+  )
+
   useEffect(() => {
     void carregar()
   }, [carregar])
+
+  useEffect(() => {
+    void carregarResumoSemana(true)
+  }, [carregarResumoSemana])
 
   useEffect(() => {
     void carregarCalendario()
@@ -229,7 +249,7 @@ export function MeuPonto() {
         }
         toast.showSuccess(msgs[tipo])
       }
-      await Promise.all([carregar(true), carregarCalendario(true)])
+      await Promise.all([carregar(true), carregarCalendario(true), carregarResumoSemana(true)])
     } catch (err) {
       if (isLikelyOfflineError(err)) {
         enqueuePontoBatida({ tipo, ...geo })
@@ -485,6 +505,76 @@ export function MeuPonto() {
           tone={banco && banco.saldo_segundos < 0 ? 'warn' : 'good'}
         />
       </div>
+
+      <Card className="mt-4" title="Resumo da semana">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <p className="text-sm text-slate-600 dark:text-slate-300">
+            {resumoSemana
+              ? `${resumoSemana.desde} → ${resumoSemana.ate}`
+              : 'Carregando…'}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                const d = new Date(`${refSemana}T12:00:00`)
+                d.setDate(d.getDate() - 7)
+                setRefSemana(d.toISOString().slice(0, 10))
+              }}
+            >
+              Semana anterior
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => {
+                const d = new Date(`${refSemana}T12:00:00`)
+                d.setDate(d.getDate() + 7)
+                const iso = d.toISOString().slice(0, 10)
+                setRefSemana(iso > hojeIso() ? hojeIso() : iso)
+              }}
+            >
+              Próxima semana
+            </Button>
+          </div>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <PontoMetricCard
+            label="Previsto × feito"
+            value={
+              resumoSemana
+                ? `${formatarDuracao(resumoSemana.segundos_realizados)} / ${formatarDuracao(resumoSemana.segundos_esperados)}`
+                : '—'
+            }
+            tone="info"
+          />
+          <PontoMetricCard
+            label="Atrasos"
+            value={String(resumoSemana?.atrasos ?? 0)}
+            tone={resumoSemana && resumoSemana.atrasos > 0 ? 'warn' : 'neutral'}
+          />
+          <PontoMetricCard
+            label="Hora extra"
+            value={
+              resumoSemana
+                ? `${resumoSemana.he_minutos} min`
+                : '—'
+            }
+            hint="Liberações aprovadas na semana"
+            tone="neutral"
+          />
+          <PontoMetricCard
+            label="Saldo (banco)"
+            value={
+              resumoSemana
+                ? `${resumoSemana.saldo_segundos >= 0 ? '+' : '−'}${formatarDuracao(Math.abs(resumoSemana.saldo_segundos))}`
+                : '—'
+            }
+            tone={resumoSemana && resumoSemana.saldo_segundos < 0 ? 'warn' : 'good'}
+          />
+        </div>
+      </Card>
 
       <div className="mt-4 grid gap-4 lg:grid-cols-2">
         <Card title="Calendário do mês">

--- a/frontend/src/pages/PontoEquipe.tsx
+++ b/frontend/src/pages/PontoEquipe.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { ApiError, atendentes, ponto, type Atendentes, type Ponto } from '../api/client'
+import { ApiError, atendentes, audit, ponto, type Atendentes, type Audit, type Ponto } from '../api/client'
 import { coletarTodasPaginas } from '../api/collectPages'
 import { mensagemFalhaParaToast } from '../api/errorMessage'
 import { PontoCalendarioMes } from '../components/PontoCalendarioMes'
@@ -64,6 +64,11 @@ export function PontoEquipe() {
   const [ajusteQuando, setAjusteQuando] = useState(toDatetimeLocalValue())
   const [ajusteMotivo, setAjusteMotivo] = useState('')
   const [salvandoAjuste, setSalvandoAjuste] = useState(false)
+  const [ajustesAudit, setAjustesAudit] = useState<Audit.AuditLogEntry[]>([])
+  const [ajusteAutorId, setAjusteAutorId] = useState('')
+  const [ajusteAuditDesde, setAjusteAuditDesde] = useState(inicioMesIso)
+  const [ajusteAuditAte, setAjusteAuditAte] = useState(hojeIso)
+  const [carregandoAjustes, setCarregandoAjustes] = useState(false)
   const [justifs, setJustifs] = useState<Ponto.Justificativa[]>([])
   const [hesPendentes, setHesPendentes] = useState<Ponto.HoraExtra[]>([])
   const [heModo, setHeModo] = useState<'resto_do_dia' | 'ate_horario' | 'duracao'>('resto_do_dia')
@@ -145,6 +150,34 @@ export function PontoEquipe() {
     void carregar()
   }, [carregar])
 
+  const carregarAjustesAudit = useCallback(async () => {
+    setCarregandoAjustes(true)
+    try {
+      const page = await audit.list({
+        entity_type: 'ponto_batida',
+        atendente_id: ajusteAutorId ? Number(ajusteAutorId) : undefined,
+        de: ajusteAuditDesde,
+        ate: ajusteAuditAte,
+        ordenar_por: 'created_at',
+        ordem: 'desc',
+        limit: 50,
+      })
+      setAjustesAudit(
+        page.items.filter((x) =>
+          ['create_ajuste', 'update_ajuste', 'anular'].includes(x.action),
+        ),
+      )
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível carregar o histórico de ajustes.'))
+    } finally {
+      setCarregandoAjustes(false)
+    }
+  }, [ajusteAuditAte, ajusteAuditDesde, ajusteAutorId, toast])
+
+  useEffect(() => {
+    void carregarAjustesAudit()
+  }, [carregarAjustesAudit])
+
   useEffect(() => {
     if (!atendenteId) {
       setCalendario(null)
@@ -211,8 +244,12 @@ export function PontoEquipe() {
   }
 
   async function salvarAjuste() {
-    if (!ajusteAtendente || !ajusteMotivo.trim()) {
-      toast.showWarning('Informe atendente e motivo do ajuste.')
+    if (!ajusteAtendente) {
+      toast.showWarning('Selecione o atendente.')
+      return
+    }
+    if (ajusteMotivo.trim().length < 3) {
+      toast.showWarning('Informe o motivo do ajuste (mínimo 3 caracteres).')
       return
     }
     setSalvandoAjuste(true)
@@ -226,7 +263,7 @@ export function PontoEquipe() {
       })
       toast.showSuccess('Ajuste registrado.')
       setAjusteMotivo('')
-      await carregar(true)
+      await Promise.all([carregar(true), carregarAjustesAudit()])
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível salvar o ajuste.'))
     } finally {
@@ -235,14 +272,36 @@ export function PontoEquipe() {
   }
 
   async function anularBatida(id: number) {
-    const motivo = window.prompt('Motivo da anulação (obrigatório):')
-    if (!motivo || motivo.trim().length < 3) return
+    const motivo = window.prompt('Motivo da anulação (obrigatório, mín. 3 caracteres):')
+    if (!motivo || motivo.trim().length < 3) {
+      toast.showWarning('Anulação cancelada — motivo obrigatório.')
+      return
+    }
     try {
       await ponto.anular(id, motivo.trim())
       toast.showSuccess('Batida anulada.')
-      await carregar(true)
+      await Promise.all([carregar(true), carregarAjustesAudit()])
     } catch (err) {
       toast.showError(mensagemFalhaParaToast(err, 'Não foi possível anular.'))
+    }
+  }
+
+  async function exportarAjustesCsv() {
+    try {
+      const blob = await audit.exportCsv({
+        entity_type: 'ponto_batida',
+        atendente_id: ajusteAutorId ? Number(ajusteAutorId) : undefined,
+        de: ajusteAuditDesde,
+        ate: ajusteAuditAte,
+      })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `ajustes-ponto-${ajusteAuditDesde}-${ajusteAuditAte}.csv`
+      a.click()
+      URL.revokeObjectURL(url)
+    } catch (err) {
+      toast.showError(mensagemFalhaParaToast(err, 'Não foi possível exportar os ajustes.'))
     }
   }
 
@@ -581,6 +640,10 @@ export function PontoEquipe() {
         </Card>
 
         <Card title="Ajuste manual">
+          <p className="mb-3 text-sm text-slate-600 dark:text-slate-300">
+            Toda alteração de batida exige <strong>motivo</strong> (mínimo 3 caracteres) e fica no histórico
+            auditado abaixo e no relatório mensal (PDF/Excel).
+          </p>
           <div className="flex flex-wrap items-end gap-3">
             <Select
               label="Atendente"
@@ -609,15 +672,83 @@ export function PontoEquipe() {
               onChange={(e) => setAjusteQuando(e.target.value)}
             />
             <Input
-              label="Motivo"
+              label="Motivo do ajuste (obrigatório)"
               value={ajusteMotivo}
               onChange={(e) => setAjusteMotivo(e.target.value)}
-              placeholder="Obrigatório"
+              placeholder="Ex.: esquecimento — mínimo 3 caracteres"
             />
-            <Button type="button" disabled={salvandoAjuste} onClick={() => void salvarAjuste()}>
+            <Button
+              type="button"
+              disabled={salvandoAjuste || ajusteMotivo.trim().length < 3 || !ajusteAtendente}
+              onClick={() => void salvarAjuste()}
+            >
               Registrar ajuste
             </Button>
           </div>
+        </Card>
+
+        <Card title="Histórico de ajustes">
+          <div className="mb-3 flex flex-wrap items-end gap-3">
+            <Select
+              label="Autor"
+              value={ajusteAutorId}
+              onChange={(v) => setAjusteAutorId(String(v))}
+              options={[
+                { value: '', label: 'Todos' },
+                ...equipe.map((a) => ({ value: String(a.id), label: a.nome })),
+              ]}
+            />
+            <Input
+              label="De"
+              type="date"
+              value={ajusteAuditDesde}
+              onChange={(e) => setAjusteAuditDesde(e.target.value)}
+            />
+            <Input
+              label="Até"
+              type="date"
+              value={ajusteAuditAte}
+              onChange={(e) => setAjusteAuditAte(e.target.value)}
+            />
+            <Button type="button" variant="secondary" disabled={carregandoAjustes} onClick={() => void carregarAjustesAudit()}>
+              Filtrar
+            </Button>
+            <Button type="button" variant="secondary" onClick={() => void exportarAjustesCsv()}>
+              Exportar CSV
+            </Button>
+          </div>
+          {ajustesAudit.length === 0 ? (
+            <p className="text-sm text-slate-500">Nenhum ajuste no período.</p>
+          ) : (
+            <ul className="max-h-64 space-y-2 overflow-y-auto text-sm">
+              {ajustesAudit.map((log) => {
+                const payload = (log.payload_json ?? {}) as Record<string, unknown>
+                const motivo = typeof payload.motivo === 'string' ? payload.motivo : '—'
+                const acao =
+                  log.action === 'create_ajuste'
+                    ? 'Criação'
+                    : log.action === 'update_ajuste'
+                      ? 'Alteração'
+                      : log.action === 'anular'
+                        ? 'Anulação'
+                        : log.action
+                return (
+                  <li
+                    key={log.id}
+                    className="rounded-lg border border-slate-200 px-3 py-2 dark:border-slate-800"
+                  >
+                    <p className="font-medium text-slate-800 dark:text-slate-100">
+                      {acao} · batida #{log.entity_id} · {log.atendente_nome ?? log.atendente_id}
+                    </p>
+                    <p className="text-slate-600 dark:text-slate-300">{motivo}</p>
+                    <p className="text-xs text-slate-500">
+                      {log.created_at ? new Date(log.created_at).toLocaleString('pt-BR') : '—'}
+                    </p>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
         </Card>
 
         <Card title="Histórico">


### PR DESCRIPTION
## Summary

- Closes #968 — lembretes in-app de entrada/saída na janela de tolerância (fim−tol / início−tol); banner com refresh periódico
- Closes #972 — resumo semanal em **Meu ponto** (previsto × feito, atrasos, HE, banco) com navegação de semana
- Closes #971 — motivo obrigatório reforçado; histórico filtrável + CSV de ajustes; seção no PDF/Excel mensal
- Corrige cadeia Alembic: merge `129` dos heads `127_ponto_he_teto` + `128_versao_alvo_solic`

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [x] `pytest` `test_ponto_lote_c_968_971_972.py` (5 passed)
- [x] Smoke API local: alertas, resumo-semana, ajuste 422/201, audit, PDF/XLSX
- [x] UI: Meu ponto → Resumo da semana; Ponto da equipe → Motivo + Histórico de ajustes
- [x] `alembic heads` → único head `129_merge_he_teto_versao`
- [ ] Smoke pós-merge: `alembic upgrade head` em ambiente de testes

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Revisei itens fora do escopo — próximos no épico #967 (#969, #985, #976, …)
- [x] Sem stubs novos nesta entrega
- [x] Follow-ups já rastreados no épico #967
