### PR TITLE
fix(chat): navbar no desktop e botoes so para o responsavel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versão CalVer (`YY.MM.NNN`) é atribuída automaticamente no deploy de `staging
 
 #### Correções
 
+- Atendimentos (#996 / #S202608-0007): na tela de chats, a barra superior (menu, notificações) volta a aparecer no computador; no celular continua oculta com a conversa aberta
+- Atendimentos (#998 / #S202608-0009): quem só acompanha o chat deixa de ver **Encerrar** e **Registrar demanda** — esses botões ficam só com o responsável
 - Sobre: deixa de listar itens **Interno / Infra** (deploy, LICENSE, docs internos) — só Melhorias e Correções de produto
 - Sobre: versão **26.08.015** sem repetir notas já publicadas em releases anteriores
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -77,7 +77,7 @@ function LayoutInner() {
     return () => window.removeEventListener(TICKET_ATIVO_EVENT, sync)
   }, [location.pathname])
 
-  /** Conversa aberta no hub — ocultar chrome da app no telemóvel (#753). */
+  /** Conversa aberta no hub — ocultar chrome da app só no celular (#753 / #S202608-0007). */
   const [chatDetalheAberto, setChatDetalheAberto] = useState(
     () => isChatHub && lerChatAtivoSession() != null,
   )
@@ -124,9 +124,10 @@ function LayoutInner() {
       />
 
       <div className="flex h-full min-h-0 min-w-0 w-full flex-col overflow-hidden md:col-start-2 md:row-start-1">
+        {/* Com conversa aberta, esconde a barra só no celular (#996 / #S202608-0007). */}
         <header
           className={`z-30 flex h-16 min-h-[64px] w-full min-w-0 shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 shadow-sm dark:border-slate-800 dark:bg-slate-950 md:gap-3 md:px-6 ${
-            ocultarHeaderMobile ? 'hidden' : ''
+            ocultarHeaderMobile ? 'max-md:hidden' : ''
           }`}
         >
           <button

--- a/frontend/src/pages/chat/PortalConversa.tsx
+++ b/frontend/src/pages/chat/PortalConversa.tsx
@@ -353,7 +353,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
   const isAdmin = user?.role === 'admin'
   const podeTransferir = !encerrado && (isResponsavel || isAdmin)
   const podeEnviar = chat.estado === 'em_atendimento' && isResponsavel && !encerrado
-  const podeEncerrar = !encerrado && chat.estado === 'em_atendimento' && (isResponsavel || isAdmin)
+  const podeEncerrar = !encerrado && chat.estado === 'em_atendimento' && isResponsavel
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-white dark:bg-slate-950">
@@ -451,7 +451,7 @@ export function PortalConversa({ chatIdProp }: PortalConversaProps = {}) {
           key={`${chat.id}-${demandasReloadKey}`}
           chatId={chat.id}
           api={portalDemandasApi}
-          podeRegistrar={isResponsavel || isAdmin}
+          podeRegistrar={isResponsavel}
           onDemandasChange={() => {
             setDemandasReloadKey((k) => k + 1)
             void carregarDemandasTimeline()

--- a/frontend/src/pages/whatsapp/WhatsappConversa.tsx
+++ b/frontend/src/pages/whatsapp/WhatsappConversa.tsx
@@ -1505,7 +1505,7 @@ useEffect(() => {
     }
   }
 
-  const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && (isResponsavel || isAdmin)
+  const podeEncerrar = !encerrado && chat?.estado === 'em_atendimento' && isResponsavel
 
   async function exportarPdfChat() {
     if (!chat || exportandoPdf) return
@@ -1536,7 +1536,7 @@ useEffect(() => {
     podeDefinirEmpresa && !chat?.empresa_id && (chat?.empresas_opcoes?.length ?? 0) > 1
 
   const mostrarBannerDemandaInatividade =
-    Boolean(chat?.classificacao_demanda_pendente) && (isResponsavel || isAdmin)
+    Boolean(chat?.classificacao_demanda_pendente) && isResponsavel
 
   const podeDigitarMensagem = !encerrado && !chat?.classificacao_demanda_pendente && (modoInterno || podeEnviar)
 
@@ -2129,7 +2129,7 @@ useEffect(() => {
             <WhatsappDemandasPanel
               key={chat.id}
               chatId={chat.id}
-              podeRegistrar={isResponsavel || isAdmin}
+              podeRegistrar={isResponsavel}
               onDemandasChange={refrescarTimelineDemandas}
             />
           </div>


### PR DESCRIPTION
## Summary

- Restaura a barra superior (menu, notificações) no computador quando há conversa aberta; no celular ela continua oculta (`#996` / `#S202608-0007`).
- Quem só acompanha o chat deixa de ver **Encerrar** e **Registrar demanda** — os botões ficam só com o responsável, no WhatsApp e no Portal (`#998` / `#S202608-0009`).

Closes #996
Closes #998

## CHANGELOG (obrigatório se há mudança de produto)

- [x] Atualizei `CHANGELOG.md` → seção **`[Unreleased]`** com bullets em linguagem para o **usuário final** (não mensagens de commit)
- [x] Cada entrega do lote tem pelo menos um bullet (Melhorias / Correções / Interno)

## Test plan

- [ ] Abrir um chat no computador e confirmar que menu, perfil e notificações continuam visíveis no topo
- [ ] Abrir o mesmo chat no celular e confirmar que a barra da app some com a conversa aberta
- [ ] Como admin (ou colega), abrir um chat que está com outro atendente: sem **Encerrar** e sem **Registrar demanda**; Transferir e Tickets continuam
- [ ] Como responsável do chat: **Encerrar** e **Registrar demanda** continuam disponíveis
- [ ] Repetir o acompanhamento no chat do Portal

## Follow-ups / backlog (obrigatório ao fechar issue ou épico)

- [x] Fora de escopo: hover em empresas (`#S202608-0001` / #921) e contador de não lidas que não zera (`#S202608-0010`) ficam em outros lotes
- [x] Sem stubs/campos nullable neste lote
- [x] API de encerrar/registrar para admin não foi restringida — só a UI (follow-up se o time quiser trava no backend)
